### PR TITLE
Keep database content blocks stable across edits and reloads

### DIFF
--- a/templates/content/actions/_blocks-field-identity.ts
+++ b/templates/content/actions/_blocks-field-identity.ts
@@ -1,0 +1,350 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+
+import { getDb, schema } from "../server/db/index.js";
+import {
+  blocksContentHash,
+  blocksFieldId,
+  exposeBlocksFieldIdentity,
+  legacyBlocksFieldIdentity,
+  materializeLegacyBlocksFieldIdentity,
+  reconcileBlocksFieldIdentity,
+  type BlocksFieldIdentity,
+  type StoredBlocksFieldIdentity,
+} from "../shared/blocks-field-identity.js";
+
+type ContentDb = ReturnType<typeof getDb>;
+
+function nanoid(size = 12): string {
+  const chars =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  let id = "";
+  const bytes = crypto.getRandomValues(new Uint8Array(size));
+  for (const byte of bytes) id += chars[byte % chars.length];
+  return id;
+}
+
+function groups<T>(values: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}
+
+async function loadStoredIdentity(
+  db: ContentDb,
+  fieldId: string,
+): Promise<StoredBlocksFieldIdentity | null> {
+  const [field] = await db
+    .select()
+    .from(schema.documentBlockFields)
+    .where(eq(schema.documentBlockFields.id, fieldId));
+  if (!field) return null;
+  const blocks = await db
+    .select()
+    .from(schema.documentBlocks)
+    .where(eq(schema.documentBlocks.fieldId, fieldId))
+    .orderBy(asc(schema.documentBlocks.sortIndex));
+  return {
+    fieldId,
+    revision: field.revision,
+    contentHash: field.contentHash,
+    blocks: blocks.map((block) => ({
+      id: block.id,
+      parentId: block.parentId,
+      kind: block.kind,
+      position: block.position,
+      addressable: block.addressable,
+      contentHash: block.contentHash,
+      markdown: block.markdown,
+      state: block.state === "deleted" ? "deleted" : "live",
+      deletedAtRevision: block.deletedAtRevision,
+      recoveredAtRevision: block.recoveredAtRevision,
+    })),
+  };
+}
+
+export async function readBlocksFieldIdentity(args: {
+  db?: ContentDb;
+  documentId: string;
+  propertyId: string;
+  markdown: string;
+}): Promise<BlocksFieldIdentity> {
+  const fieldId = blocksFieldId(args.documentId, args.propertyId);
+  const stored = await loadStoredIdentity(args.db ?? getDb(), fieldId);
+  return stored
+    ? exposeBlocksFieldIdentity(stored, args.markdown)
+    : legacyBlocksFieldIdentity(args);
+}
+
+export async function readBlocksFieldIdentities(args: {
+  db?: ContentDb;
+  fields: Array<{
+    documentId: string;
+    propertyId: string;
+    markdown: string;
+  }>;
+}): Promise<Map<string, BlocksFieldIdentity>> {
+  const db = args.db ?? getDb();
+  const inputs = new Map(
+    args.fields.map((field) => [
+      blocksFieldId(field.documentId, field.propertyId),
+      field,
+    ]),
+  );
+  const storedFields: Array<typeof schema.documentBlockFields.$inferSelect> =
+    [];
+  for (const ids of groups([...inputs.keys()], 200)) {
+    if (ids.length === 0) continue;
+    storedFields.push(
+      ...(await db
+        .select()
+        .from(schema.documentBlockFields)
+        .where(inArray(schema.documentBlockFields.id, ids))),
+    );
+  }
+  const storedById = new Map(storedFields.map((field) => [field.id, field]));
+  const storedBlocks: Array<typeof schema.documentBlocks.$inferSelect> = [];
+  for (const ids of groups(
+    storedFields.map((field) => field.id),
+    200,
+  )) {
+    if (ids.length === 0) continue;
+    storedBlocks.push(
+      ...(await db
+        .select()
+        .from(schema.documentBlocks)
+        .where(inArray(schema.documentBlocks.fieldId, ids))
+        .orderBy(asc(schema.documentBlocks.sortIndex))),
+    );
+  }
+  const blocksByField = new Map<
+    string,
+    Array<typeof schema.documentBlocks.$inferSelect>
+  >();
+  for (const block of storedBlocks) {
+    const values = blocksByField.get(block.fieldId) ?? [];
+    values.push(block);
+    blocksByField.set(block.fieldId, values);
+  }
+
+  const result = new Map<string, BlocksFieldIdentity>();
+  for (const [fieldId, input] of inputs) {
+    const field = storedById.get(fieldId);
+    if (!field) {
+      result.set(fieldId, legacyBlocksFieldIdentity(input));
+      continue;
+    }
+    result.set(
+      fieldId,
+      exposeBlocksFieldIdentity(
+        {
+          fieldId,
+          revision: field.revision,
+          contentHash: field.contentHash,
+          blocks: (blocksByField.get(fieldId) ?? []).map((block) => ({
+            id: block.id,
+            parentId: block.parentId,
+            kind: block.kind,
+            position: block.position,
+            addressable: block.addressable,
+            contentHash: block.contentHash,
+            markdown: block.markdown,
+            state: block.state === "deleted" ? "deleted" : "live",
+            deletedAtRevision: block.deletedAtRevision,
+            recoveredAtRevision: block.recoveredAtRevision,
+          })),
+        },
+        input.markdown,
+      ),
+    );
+  }
+  return result;
+}
+
+export async function persistBlocksFieldIdentity(args: {
+  db: ContentDb;
+  ownerEmail: string;
+  documentId: string;
+  propertyId: string;
+  previousMarkdown: string;
+  markdown: string;
+  expectedRevision?: number;
+  now: string;
+}): Promise<StoredBlocksFieldIdentity> {
+  const fieldId = blocksFieldId(args.documentId, args.propertyId);
+  const stored = await loadStoredIdentity(args.db, fieldId);
+  const actualRevision = stored?.revision ?? 0;
+  if (
+    args.expectedRevision !== undefined &&
+    args.expectedRevision !== actualRevision
+  ) {
+    throw new Error(
+      `Blocks field revision conflict: expected ${args.expectedRevision}, current ${actualRevision}`,
+    );
+  }
+
+  let previous =
+    stored ??
+    materializeLegacyBlocksFieldIdentity({
+      documentId: args.documentId,
+      propertyId: args.propertyId,
+      markdown: args.previousMarkdown,
+    });
+
+  // A legacy whole-field writer may have changed Markdown without updating the
+  // sidecar. Reconcile exact unique blocks first and report the resulting extra
+  // revision instead of silently pretending continuity was complete.
+  if (previous.contentHash !== blocksContentHash(args.previousMarkdown)) {
+    previous = reconcileBlocksFieldIdentity({
+      documentId: args.documentId,
+      propertyId: args.propertyId,
+      previous,
+      markdown: args.previousMarkdown,
+      createId: () => `block_${nanoid(16)}`,
+    });
+  }
+
+  let next = reconcileBlocksFieldIdentity({
+    documentId: args.documentId,
+    propertyId: args.propertyId,
+    previous,
+    markdown: args.markdown,
+    createId: () => `block_${nanoid(16)}`,
+  });
+
+  if (next.blocks.length > 0) {
+    const existingOwners = await args.db
+      .select({
+        id: schema.documentBlocks.id,
+        fieldId: schema.documentBlocks.fieldId,
+      })
+      .from(schema.documentBlocks)
+      .where(
+        inArray(
+          schema.documentBlocks.id,
+          next.blocks.map((block) => block.id),
+        ),
+      );
+    const remappedIds = new Map<string, string>();
+    const reserved = new Set(next.blocks.map((block) => block.id));
+    for (const existing of existingOwners) {
+      if (existing.fieldId === fieldId) continue;
+      let replacement = `block_${nanoid(16)}`;
+      while (reserved.has(replacement)) replacement = `block_${nanoid(16)}`;
+      reserved.add(replacement);
+      remappedIds.set(existing.id, replacement);
+    }
+    if (remappedIds.size > 0) {
+      next = {
+        ...next,
+        blocks: next.blocks.map((block) => ({
+          ...block,
+          id: remappedIds.get(block.id) ?? block.id,
+          parentId: block.parentId
+            ? (remappedIds.get(block.parentId) ?? block.parentId)
+            : null,
+        })),
+      };
+    }
+  }
+
+  if (stored) {
+    const applied = await args.db
+      .update(schema.documentBlockFields)
+      .set({
+        revision: next.revision,
+        contentHash: next.contentHash,
+        updatedAt: args.now,
+      })
+      .where(
+        and(
+          eq(schema.documentBlockFields.id, fieldId),
+          eq(schema.documentBlockFields.revision, actualRevision),
+        ),
+      )
+      .returning({ id: schema.documentBlockFields.id });
+    if (applied.length === 0) {
+      throw new Error(
+        `Blocks field revision conflict: expected ${actualRevision}, current revision changed`,
+      );
+    }
+  } else {
+    const inserted = await args.db
+      .insert(schema.documentBlockFields)
+      .values({
+        id: fieldId,
+        ownerEmail: args.ownerEmail,
+        documentId: args.documentId,
+        propertyId: args.propertyId,
+        revision: next.revision,
+        contentHash: next.contentHash,
+        createdAt: args.now,
+        updatedAt: args.now,
+      })
+      .onConflictDoNothing()
+      .returning({ id: schema.documentBlockFields.id });
+    if (inserted.length === 0) {
+      throw new Error(
+        "Blocks field revision conflict: concurrent first materialization",
+      );
+    }
+  }
+  await args.db
+    .delete(schema.documentBlocks)
+    .where(eq(schema.documentBlocks.fieldId, fieldId));
+  if (next.blocks.length > 0) {
+    await args.db.insert(schema.documentBlocks).values(
+      next.blocks.map((block, sortIndex) => ({
+        id: block.id,
+        ownerEmail: args.ownerEmail,
+        fieldId,
+        parentId: block.parentId,
+        kind: block.kind,
+        position: block.position,
+        sortIndex,
+        addressable: block.addressable,
+        contentHash: block.contentHash,
+        markdown: block.markdown,
+        state: block.state,
+        deletedAtRevision: block.deletedAtRevision,
+        recoveredAtRevision: block.recoveredAtRevision,
+        createdAt: args.now,
+        updatedAt: args.now,
+      })),
+    );
+  }
+  return next;
+}
+
+export async function deleteBlocksFieldIdentity(args: {
+  db: ContentDb;
+  documentId?: string;
+  propertyId?: string;
+}): Promise<void> {
+  if (!args.documentId && !args.propertyId) return;
+  const clauses = [];
+  if (args.documentId) {
+    clauses.push(eq(schema.documentBlockFields.documentId, args.documentId));
+  }
+  if (args.propertyId) {
+    clauses.push(eq(schema.documentBlockFields.propertyId, args.propertyId));
+  }
+  const fields = await args.db
+    .select({ id: schema.documentBlockFields.id })
+    .from(schema.documentBlockFields)
+    .where(clauses.length === 1 ? clauses[0] : and(...clauses));
+  if (fields.length === 0) return;
+  await args.db.delete(schema.documentBlocks).where(
+    inArray(
+      schema.documentBlocks.fieldId,
+      fields.map((field) => field.id),
+    ),
+  );
+  await args.db.delete(schema.documentBlockFields).where(
+    inArray(
+      schema.documentBlockFields.id,
+      fields.map((field) => field.id),
+    ),
+  );
+}

--- a/templates/content/actions/_blocks-field-identity.ts
+++ b/templates/content/actions/_blocks-field-identity.ts
@@ -20,6 +20,15 @@ export interface PrimaryBlocksField {
   ownerEmail: string;
 }
 
+export class BlocksFieldRevisionConflictError extends Error {
+  readonly statusCode = 409;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "BlocksFieldRevisionConflictError";
+  }
+}
+
 function nanoid(size = 12): string {
   const chars =
     "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -265,7 +274,7 @@ export async function persistBlocksFieldIdentity(args: {
     args.expectedRevision !== undefined &&
     args.expectedRevision !== actualRevision
   ) {
-    throw new Error(
+    throw new BlocksFieldRevisionConflictError(
       `Blocks field revision conflict: expected ${args.expectedRevision}, current ${actualRevision}`,
     );
   }
@@ -351,7 +360,7 @@ export async function persistBlocksFieldIdentity(args: {
       )
       .returning({ id: schema.documentBlockFields.id });
     if (applied.length === 0) {
-      throw new Error(
+      throw new BlocksFieldRevisionConflictError(
         `Blocks field revision conflict: expected ${actualRevision}, current revision changed`,
       );
     }
@@ -371,7 +380,7 @@ export async function persistBlocksFieldIdentity(args: {
       .onConflictDoNothing()
       .returning({ id: schema.documentBlockFields.id });
     if (inserted.length === 0) {
-      throw new Error(
+      throw new BlocksFieldRevisionConflictError(
         "Blocks field revision conflict: concurrent first materialization",
       );
     }

--- a/templates/content/actions/_blocks-field-identity.ts
+++ b/templates/content/actions/_blocks-field-identity.ts
@@ -41,32 +41,80 @@ export async function lockPrimaryBlocksFields(
   db: ContentDb,
   documentId: string,
 ): Promise<PrimaryBlocksField[]> {
-  const memberships = await db
-    .select({ id: schema.contentDatabaseItems.id })
-    .from(schema.contentDatabaseItems)
-    .where(eq(schema.contentDatabaseItems.documentId, documentId));
+  return (
+    (await lockPrimaryBlocksFieldsForDocuments(db, [documentId])).get(
+      documentId,
+    ) ?? []
+  );
+}
+
+export async function lockPrimaryBlocksFieldsForDocuments(
+  db: ContentDb,
+  documentIds: string[],
+): Promise<Map<string, PrimaryBlocksField[]>> {
+  const uniqueDocumentIds = [...new Set(documentIds)];
+  const memberships: Array<{
+    id: string;
+    documentId: string;
+  }> = [];
+  for (const documentIdGroup of groups(uniqueDocumentIds, 90)) {
+    memberships.push(
+      ...(await db
+        .select({
+          id: schema.contentDatabaseItems.id,
+          documentId: schema.contentDatabaseItems.documentId,
+        })
+        .from(schema.contentDatabaseItems)
+        .where(
+          inArray(schema.contentDatabaseItems.documentId, documentIdGroup),
+        )),
+    );
+  }
   const membershipIds = memberships.map((membership) => membership.id);
   await lockDatabaseMemberships(db, membershipIds);
-  if (membershipIds.length === 0) return [];
+  if (membershipIds.length === 0) return new Map();
 
-  const fields = await db
-    .select({
-      propertyId: schema.contentDatabases.primaryBlocksPropertyId,
-      ownerEmail: schema.contentDatabases.ownerEmail,
-    })
-    .from(schema.contentDatabaseItems)
-    .innerJoin(
-      schema.contentDatabases,
-      eq(schema.contentDatabases.id, schema.contentDatabaseItems.databaseId),
-    )
-    .where(inArray(schema.contentDatabaseItems.id, membershipIds));
-  return [
-    ...new Map(
-      fields.flatMap((field) =>
-        field.propertyId ? [[field.propertyId, field.ownerEmail] as const] : [],
-      ),
-    ),
-  ].map(([propertyId, ownerEmail]) => ({ propertyId, ownerEmail }));
+  const fields: Array<{
+    documentId: string;
+    propertyId: string | null;
+    ownerEmail: string;
+  }> = [];
+  for (const membershipIdGroup of groups(membershipIds, 90)) {
+    fields.push(
+      ...(await db
+        .select({
+          documentId: schema.contentDatabaseItems.documentId,
+          propertyId: schema.contentDatabases.primaryBlocksPropertyId,
+          ownerEmail: schema.contentDatabases.ownerEmail,
+        })
+        .from(schema.contentDatabaseItems)
+        .innerJoin(
+          schema.contentDatabases,
+          eq(
+            schema.contentDatabases.id,
+            schema.contentDatabaseItems.databaseId,
+          ),
+        )
+        .where(inArray(schema.contentDatabaseItems.id, membershipIdGroup))),
+    );
+  }
+  const fieldsByDocument = new Map<string, Map<string, string>>();
+  for (const field of fields) {
+    if (!field.propertyId) continue;
+    const documentFields =
+      fieldsByDocument.get(field.documentId) ?? new Map<string, string>();
+    documentFields.set(field.propertyId, field.ownerEmail);
+    fieldsByDocument.set(field.documentId, documentFields);
+  }
+  return new Map(
+    [...fieldsByDocument].map(([id, documentFields]) => [
+      id,
+      [...documentFields].map(([propertyId, ownerEmail]) => ({
+        propertyId,
+        ownerEmail,
+      })),
+    ]),
+  );
 }
 
 async function loadStoredIdentity(

--- a/templates/content/actions/_blocks-field-identity.ts
+++ b/templates/content/actions/_blocks-field-identity.ts
@@ -11,8 +11,14 @@ import {
   type BlocksFieldIdentity,
   type StoredBlocksFieldIdentity,
 } from "../shared/blocks-field-identity.js";
+import { lockDatabaseMemberships } from "./_database-membership-lock.js";
 
 type ContentDb = ReturnType<typeof getDb>;
+
+export interface PrimaryBlocksField {
+  propertyId: string;
+  ownerEmail: string;
+}
 
 function nanoid(size = 12): string {
   const chars =
@@ -29,6 +35,38 @@ function groups<T>(values: T[], size: number): T[][] {
     result.push(values.slice(index, index + size));
   }
   return result;
+}
+
+export async function lockPrimaryBlocksFields(
+  db: ContentDb,
+  documentId: string,
+): Promise<PrimaryBlocksField[]> {
+  const memberships = await db
+    .select({ id: schema.contentDatabaseItems.id })
+    .from(schema.contentDatabaseItems)
+    .where(eq(schema.contentDatabaseItems.documentId, documentId));
+  const membershipIds = memberships.map((membership) => membership.id);
+  await lockDatabaseMemberships(db, membershipIds);
+  if (membershipIds.length === 0) return [];
+
+  const fields = await db
+    .select({
+      propertyId: schema.contentDatabases.primaryBlocksPropertyId,
+      ownerEmail: schema.contentDatabases.ownerEmail,
+    })
+    .from(schema.contentDatabaseItems)
+    .innerJoin(
+      schema.contentDatabases,
+      eq(schema.contentDatabases.id, schema.contentDatabaseItems.databaseId),
+    )
+    .where(inArray(schema.contentDatabaseItems.id, membershipIds));
+  return [
+    ...new Map(
+      fields.flatMap((field) =>
+        field.propertyId ? [[field.propertyId, field.ownerEmail] as const] : [],
+      ),
+    ),
+  ].map(([propertyId, ownerEmail]) => ({ propertyId, ownerEmail }));
 }
 
 async function loadStoredIdentity(
@@ -320,15 +358,34 @@ export async function persistBlocksFieldIdentity(args: {
 export async function deleteBlocksFieldIdentity(args: {
   db: ContentDb;
   documentId?: string;
+  documentIds?: string[];
   propertyId?: string;
+  propertyIds?: string[];
 }): Promise<void> {
-  if (!args.documentId && !args.propertyId) return;
+  if (
+    !args.documentId &&
+    !args.documentIds?.length &&
+    !args.propertyId &&
+    !args.propertyIds?.length
+  ) {
+    return;
+  }
   const clauses = [];
   if (args.documentId) {
     clauses.push(eq(schema.documentBlockFields.documentId, args.documentId));
   }
+  if (args.documentIds?.length) {
+    clauses.push(
+      inArray(schema.documentBlockFields.documentId, args.documentIds),
+    );
+  }
   if (args.propertyId) {
     clauses.push(eq(schema.documentBlockFields.propertyId, args.propertyId));
+  }
+  if (args.propertyIds?.length) {
+    clauses.push(
+      inArray(schema.documentBlockFields.propertyId, args.propertyIds),
+    );
   }
   const fields = await args.db
     .select({ id: schema.documentBlockFields.id })

--- a/templates/content/actions/_database-utils.ts
+++ b/templates/content/actions/_database-utils.ts
@@ -38,6 +38,7 @@ import {
   parsePropertyValue,
   type DocumentPropertyType,
 } from "../shared/properties.js";
+import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import { favoriteDocumentIds } from "./_content-favorites.js";
 import {
   listContentOrganizationMemberships,
@@ -1407,15 +1408,21 @@ export async function deleteDatabaseDataForDocument(
       .from(schema.documentPropertyDefinitions)
       .where(eq(schema.documentPropertyDefinitions.databaseId, database.id));
 
-    for (const definition of definitions) {
+    const definitionIds = definitions.map((definition) => definition.id);
+    if (definitionIds.length > 0) {
+      await deleteBlocksFieldIdentity({ db, propertyIds: definitionIds });
       await db
         .delete(schema.documentPropertyValues)
-        .where(eq(schema.documentPropertyValues.propertyId, definition.id));
+        .where(
+          inArray(schema.documentPropertyValues.propertyId, definitionIds),
+        );
       // Independent Blocks-field content is keyed by property id; drop it so
       // deleting a database leaves no orphaned document_block_field_contents.
       await db
         .delete(schema.documentBlockFieldContents)
-        .where(eq(schema.documentBlockFieldContents.propertyId, definition.id));
+        .where(
+          inArray(schema.documentBlockFieldContents.propertyId, definitionIds),
+        );
     }
     const sources = await db
       .select({ id: schema.contentDatabaseSources.id })
@@ -1472,6 +1479,7 @@ export async function deleteDatabaseDataForDocument(
     db,
   );
   if (item) {
+    await deleteBlocksFieldIdentity({ db, documentId });
     await db
       .delete(schema.contentDatabaseItemKeyClaims)
       .where(eq(schema.contentDatabaseItemKeyClaims.documentId, documentId));

--- a/templates/content/actions/_property-utils.ts
+++ b/templates/content/actions/_property-utils.ts
@@ -21,6 +21,7 @@ import type {
   ContentDatabaseOpenPagesIn,
   DocumentProperty,
 } from "../shared/api.js";
+import { blocksFieldId } from "../shared/blocks-field-identity.js";
 import {
   DEFAULT_BLOCKS_FIELD_NAME,
   defaultPropertyOptions,
@@ -42,6 +43,7 @@ import {
   type DocumentPropertyValue,
 } from "../shared/properties.js";
 import { chunks } from "./_batch-utils.js";
+import { readBlocksFieldIdentities } from "./_blocks-field-identity.js";
 import {
   propertyDefinitionsPositionScope,
   withPositionLock,
@@ -540,10 +542,46 @@ export async function listPropertiesForDatabase(
     ? await blockFieldContentsForDocument(valueDocument.id)
     : new Map<string, string>();
 
+  const blocksFieldIdentityById = valueDocument
+    ? await readBlocksFieldIdentities({
+        db,
+        fields: definitions.flatMap((definition) => {
+          const type = definition.type as DocumentPropertyType;
+          if (!isBlocksPropertyType(type)) return [];
+          const options = parsePropertyOptions(definition.optionsJson);
+          return [
+            {
+              documentId: valueDocument.id,
+              propertyId: definition.id,
+              markdown: resolveBlocksFieldValue({
+                options,
+                documentBody: valueDocument.content,
+                blockFieldContent: blockContentByPropertyId.get(definition.id),
+              }),
+            },
+          ];
+        }),
+      })
+    : new Map();
+
   const properties = definitions.map((definition) => {
     const type = definition.type as DocumentPropertyType;
     const storedValue = valueByPropertyId.get(definition.id);
     const options = parsePropertyOptions(definition.optionsJson);
+    const value =
+      valueDocument && isComputedPropertyType(type) && type !== "formula"
+        ? computedPropertyValue(type, valueDocument, {
+            databaseRowNumber: rowNumberByDocumentId.get(valueDocument.id),
+          })
+        : valueDocument && isBlocksPropertyType(type)
+          ? // Each Blocks field reads from exactly one place: the primary from
+            // the document body, additional fields from their own store.
+            resolveBlocksFieldValue({
+              options,
+              documentBody: valueDocument.content,
+              blockFieldContent: blockContentByPropertyId.get(definition.id),
+            })
+          : parsePropertyValue(storedValue?.valueJson);
     return {
       definition: {
         id: definition.id,
@@ -560,21 +598,15 @@ export async function listPropertiesForDatabase(
         createdAt: definition.createdAt,
         updatedAt: definition.updatedAt,
       },
-      value:
-        valueDocument && isComputedPropertyType(type) && type !== "formula"
-          ? computedPropertyValue(type, valueDocument, {
-              databaseRowNumber: rowNumberByDocumentId.get(valueDocument.id),
-            })
-          : valueDocument && isBlocksPropertyType(type)
-            ? // Each Blocks field reads from exactly one place: the primary from
-              // the document body, additional fields from their own store.
-              resolveBlocksFieldValue({
-                options,
-                documentBody: valueDocument.content,
-                blockFieldContent: blockContentByPropertyId.get(definition.id),
-              })
-            : parsePropertyValue(storedValue?.valueJson),
+      value,
       editable: !definition.systemRole && !isComputedPropertyType(type),
+      ...(valueDocument && isBlocksPropertyType(type)
+        ? {
+            blocksField: blocksFieldIdentityById.get(
+              blocksFieldId(valueDocument.id, definition.id),
+            ),
+          }
+        : {}),
     };
   });
 
@@ -724,32 +756,64 @@ export async function listPropertiesForDatabaseDocuments(
     }
   }
 
+  const blocksFieldIdentityById = await readBlocksFieldIdentities({
+    db,
+    fields: valueDocuments.flatMap((document) =>
+      definitions.flatMap((definition) => {
+        const type = definition.type as DocumentPropertyType;
+        if (!isBlocksPropertyType(type)) return [];
+        const options = parsePropertyOptions(definition.optionsJson);
+        return [
+          {
+            documentId: document.id,
+            propertyId: definition.id,
+            markdown: resolveBlocksFieldValue({
+              options,
+              documentBody: document.content,
+              blockFieldContent: blockContentByDocumentAndProperty.get(
+                propertyValueKey(document.id, definition.id),
+              ),
+            }),
+          },
+        ];
+      }),
+    ),
+  });
+
   for (const document of valueDocuments) {
     const properties = definitions.map((definition) => {
       const propertyDefinition = serializePropertyDefinition(definition);
       const storedValue = valueByDocumentAndProperty.get(
         propertyValueKey(document.id, definition.id),
       );
+      const value =
+        isComputedPropertyType(propertyDefinition.type) &&
+        propertyDefinition.type !== "formula"
+          ? computedPropertyValue(propertyDefinition.type, document, {
+              databaseRowNumber: rowNumberByDocumentId.get(document.id),
+            })
+          : isBlocksPropertyType(propertyDefinition.type)
+            ? resolveBlocksFieldValue({
+                options: propertyDefinition.options,
+                documentBody: document.content,
+                blockFieldContent: blockContentByDocumentAndProperty.get(
+                  propertyValueKey(document.id, definition.id),
+                ),
+              })
+            : parsePropertyValue(storedValue?.valueJson);
       return {
         definition: propertyDefinition,
-        value:
-          isComputedPropertyType(propertyDefinition.type) &&
-          propertyDefinition.type !== "formula"
-            ? computedPropertyValue(propertyDefinition.type, document, {
-                databaseRowNumber: rowNumberByDocumentId.get(document.id),
-              })
-            : isBlocksPropertyType(propertyDefinition.type)
-              ? resolveBlocksFieldValue({
-                  options: propertyDefinition.options,
-                  documentBody: document.content,
-                  blockFieldContent: blockContentByDocumentAndProperty.get(
-                    propertyValueKey(document.id, definition.id),
-                  ),
-                })
-              : parsePropertyValue(storedValue?.valueJson),
+        value,
         editable:
           !definition.systemRole &&
           !isComputedPropertyType(propertyDefinition.type),
+        ...(isBlocksPropertyType(propertyDefinition.type)
+          ? {
+              blocksField: blocksFieldIdentityById.get(
+                blocksFieldId(document.id, definition.id),
+              ),
+            }
+          : {}),
       };
     });
 

--- a/templates/content/actions/_property-utils.ts
+++ b/templates/content/actions/_property-utils.ts
@@ -1,10 +1,15 @@
-import { accessFilter, assertAccess } from "@agent-native/core/sharing";
+import {
+  accessFilter,
+  assertAccess,
+  resolveAccess,
+} from "@agent-native/core/sharing";
 import {
   and,
   asc,
   eq,
   inArray,
   isNull,
+  or,
   sql,
   type InferSelectModel,
 } from "drizzle-orm";
@@ -506,6 +511,44 @@ export async function listPropertiesForDocument(
   // never here. A viewer opening a shared/legacy row must not trigger writes on
   // another owner's database.
   return listPropertiesForDatabase(database.id, document);
+}
+
+export async function listPropertiesForAllDocumentDatabases(
+  document: DocumentRow,
+) {
+  const db = getDb();
+  const memberships = await db
+    .select({ databaseId: schema.contentDatabaseItems.databaseId })
+    .from(schema.contentDatabaseItems)
+    .where(eq(schema.contentDatabaseItems.documentId, document.id));
+  const membershipIds = memberships.map((membership) => membership.databaseId);
+  const databases = await db
+    .select({
+      id: schema.contentDatabases.id,
+      documentId: schema.contentDatabases.documentId,
+    })
+    .from(schema.contentDatabases)
+    .where(
+      and(
+        isNull(schema.contentDatabases.deletedAt),
+        membershipIds.length > 0
+          ? or(
+              eq(schema.contentDatabases.documentId, document.id),
+              inArray(schema.contentDatabases.id, membershipIds),
+            )
+          : eq(schema.contentDatabases.documentId, document.id),
+      ),
+    )
+    .orderBy(asc(schema.contentDatabases.id));
+
+  const properties = [];
+  for (const database of databases) {
+    if (!(await resolveAccess("document", database.documentId))) continue;
+    properties.push(
+      ...(await listPropertiesForDatabase(database.id, document)),
+    );
+  }
+  return properties;
 }
 
 export async function listPropertiesForDatabase(

--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -41,6 +41,7 @@ let databaseUtils: typeof import("./_database-utils.js");
 let createInlineContentDatabaseAction: typeof import("./create-inline-content-database.js").default;
 let updateDocumentAction: typeof import("./update-document.js").default;
 let editDocumentAction: typeof import("./edit-document.js").default;
+let setDocumentPropertyAction: typeof import("./set-document-property.js").default;
 let createContentDatabaseAction: typeof import("./create-content-database.js").default;
 let createContentDatabaseModule: typeof import("./create-content-database.js");
 let getContentDatabaseAction: typeof import("./get-content-database.js").default;
@@ -64,6 +65,8 @@ beforeAll(async () => {
   ).default;
   updateDocumentAction = (await import("./update-document.js")).default;
   editDocumentAction = (await import("./edit-document.js")).default;
+  setDocumentPropertyAction = (await import("./set-document-property.js"))
+    .default;
   createContentDatabaseModule = await import("./create-content-database.js");
   createContentDatabaseAction = createContentDatabaseModule.default;
   getContentDatabaseAction = (await import("./get-content-database.js"))
@@ -854,6 +857,31 @@ describe("database Blocks field identity sidecar", () => {
     expect(field.revision).toBe(1);
   });
 
+  it("allows concurrent first materialization of distinct fields with the same preferred ID", async () => {
+    const { documentId } = await createDatabaseRow();
+    const db = getDb();
+    const markdown = '<registry-block blockId="shared-preferred-id" />';
+    const attempts = await Promise.all(
+      ["first", "second"].map((suffix) =>
+        db.transaction((tx: any) =>
+          identityUtils.persistBlocksFieldIdentity({
+            db: tx,
+            ownerEmail: OWNER,
+            documentId,
+            propertyId: `${suffix}_${documentId}`,
+            previousMarkdown: "",
+            markdown,
+            expectedRevision: 0,
+            now: new Date().toISOString(),
+          }),
+        ),
+      ),
+    );
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]?.blocks[0]?.id).not.toBe(attempts[1]?.blocks[0]?.id);
+  });
+
   it("revisions every primary membership and cleans up only the removed database", async () => {
     const first = await createDatabaseRow();
     const second = await createDatabaseRow();
@@ -912,6 +940,15 @@ describe("database Blocks field identity sidecar", () => {
         replace: "After edited",
       }),
     );
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      setDocumentPropertyAction.run({
+        documentId: rowDocumentId,
+        databaseId: first.databaseId,
+        propertyId: firstPropertyId,
+        value: "After set through one membership",
+        expectedBlocksFieldRevision: 2,
+      }),
+    );
     const beforeRemoval = await db
       .select()
       .from(schema.documentBlockFields)
@@ -922,8 +959,8 @@ describe("database Blocks field identity sidecar", () => {
       ),
     ).toEqual(
       new Map([
-        [firstPropertyId, 2],
-        [secondPropertyId, 2],
+        [firstPropertyId, 3],
+        [secondPropertyId, 3],
       ]),
     );
 
@@ -956,7 +993,7 @@ describe("database Blocks field identity sidecar", () => {
       .from(schema.documentBlockFields)
       .where(eq(schema.documentBlockFields.documentId, rowDocumentId));
     expect(afterRemoval).toEqual([
-      expect.objectContaining({ propertyId: secondPropertyId, revision: 2 }),
+      expect.objectContaining({ propertyId: secondPropertyId, revision: 3 }),
     ]);
   });
 });
@@ -1005,9 +1042,11 @@ describe("cascade cleanup of block-field content on delete (finding 7)", () => {
 
   it("deletes block-field rows by property id when a database is deleted", async () => {
     const { databaseId, documentId } = await createDatabaseRow();
+    const survivorDatabase = await createDatabaseRow();
     const db = getDb();
     const now = new Date().toISOString();
     const propertyId = `def_${databaseId}`;
+    const survivorDocumentId = `survivor_${databaseId}`;
     await db.insert(schema.documentPropertyDefinitions).values({
       id: propertyId,
       ownerEmail: OWNER,
@@ -1027,6 +1066,32 @@ describe("cascade cleanup of block-field content on delete (finding 7)", () => {
       content: "orphan-me",
       now,
     });
+    await db.insert(schema.documents).values({
+      id: survivorDocumentId,
+      ownerEmail: OWNER,
+      title: "Surviving row",
+      content: "survives",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseItems).values({
+      id: `survivor_item_${databaseId}`,
+      ownerEmail: OWNER,
+      databaseId: survivorDatabase.databaseId,
+      documentId: survivorDocumentId,
+      position: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await identityUtils.persistBlocksFieldIdentity({
+      db,
+      ownerEmail: OWNER,
+      documentId: survivorDocumentId,
+      propertyId,
+      previousMarkdown: "",
+      markdown: "historical field",
+      now,
+    });
 
     // documentId is the database PAGE document → hits the database-delete branch.
     await databaseUtils.deleteDatabaseDataForDocument(documentId, OWNER);
@@ -1036,6 +1101,16 @@ describe("cascade cleanup of block-field content on delete (finding 7)", () => {
       .from(schema.documentBlockFieldContents)
       .where(eq(schema.documentBlockFieldContents.propertyId, propertyId));
     expect(remaining).toHaveLength(0);
+    const [survivor] = await db
+      .select({ id: schema.documents.id })
+      .from(schema.documents)
+      .where(eq(schema.documents.id, survivorDocumentId));
+    expect(survivor?.id).toBe(survivorDocumentId);
+    const remainingIdentity = await db
+      .select()
+      .from(schema.documentBlockFields)
+      .where(eq(schema.documentBlockFields.propertyId, propertyId));
+    expect(remainingIdentity).toHaveLength(0);
   });
 });
 

--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -17,6 +17,13 @@ import {
   isPrimaryBlocksField,
 } from "../shared/properties.js";
 
+vi.mock("@agent-native/creative-context/server", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@agent-native/creative-context/server")
+  >()),
+  getGenerationCreativeContext: vi.fn(async () => null),
+}));
+
 // A unique on-disk SQLite file in the OS temp dir, removed after the run. Kept
 // out of the repo working tree and isolated from the process-wide getDbExec
 // singleton other test files share.
@@ -33,6 +40,7 @@ let identityUtils: typeof import("./_blocks-field-identity.js");
 let databaseUtils: typeof import("./_database-utils.js");
 let createInlineContentDatabaseAction: typeof import("./create-inline-content-database.js").default;
 let updateDocumentAction: typeof import("./update-document.js").default;
+let editDocumentAction: typeof import("./edit-document.js").default;
 let createContentDatabaseAction: typeof import("./create-content-database.js").default;
 let createContentDatabaseModule: typeof import("./create-content-database.js");
 let getContentDatabaseAction: typeof import("./get-content-database.js").default;
@@ -55,6 +63,7 @@ beforeAll(async () => {
     await import("./create-inline-content-database.js")
   ).default;
   updateDocumentAction = (await import("./update-document.js")).default;
+  editDocumentAction = (await import("./edit-document.js")).default;
   createContentDatabaseModule = await import("./create-content-database.js");
   createContentDatabaseAction = createContentDatabaseModule.default;
   getContentDatabaseAction = (await import("./get-content-database.js"))
@@ -896,6 +905,13 @@ describe("database Blocks field identity sidecar", () => {
     await runWithRequestContext({ userEmail: OWNER }, () =>
       updateDocumentAction.run({ id: rowDocumentId, content: "After" }),
     );
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      editDocumentAction.run({
+        id: rowDocumentId,
+        find: "After",
+        replace: "After edited",
+      }),
+    );
     const beforeRemoval = await db
       .select()
       .from(schema.documentBlockFields)
@@ -906,10 +922,28 @@ describe("database Blocks field identity sidecar", () => {
       ),
     ).toEqual(
       new Map([
-        [firstPropertyId, 1],
-        [secondPropertyId, 1],
+        [firstPropertyId, 2],
+        [secondPropertyId, 2],
       ]),
     );
+
+    const [rowDocument] = await db
+      .select()
+      .from(schema.documents)
+      .where(eq(schema.documents.id, rowDocumentId));
+    const exportedProperties = await runWithRequestContext(
+      { userEmail: OWNER },
+      () => propertyUtils.listPropertiesForAllDocumentDatabases(rowDocument),
+    );
+    expect(
+      new Set(
+        exportedProperties
+          .filter((property) =>
+            isPrimaryBlocksField(property.definition.options),
+          )
+          .map((property) => property.definition.databaseId),
+      ),
+    ).toEqual(new Set([first.databaseId, second.databaseId]));
 
     await runWithRequestContext({ userEmail: OWNER }, () =>
       removeDatabaseItemsAction.run({
@@ -922,7 +956,7 @@ describe("database Blocks field identity sidecar", () => {
       .from(schema.documentBlockFields)
       .where(eq(schema.documentBlockFields.documentId, rowDocumentId));
     expect(afterRemoval).toEqual([
-      expect.objectContaining({ propertyId: secondPropertyId, revision: 1 }),
+      expect.objectContaining({ propertyId: secondPropertyId, revision: 2 }),
     ]);
   });
 });

--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -817,7 +817,10 @@ describe("database Blocks field identity sidecar", () => {
           now: new Date().toISOString(),
         });
       }),
-    ).rejects.toThrow("Blocks field revision conflict");
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("Blocks field revision conflict"),
+      statusCode: 409,
+    });
 
     const [document] = await db
       .select({ content: schema.documents.content })

--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -29,6 +29,7 @@ type Schema = typeof import("../server/db/schema.js");
 let getDb: () => any;
 let schema: Schema;
 let propertyUtils: typeof import("./_property-utils.js");
+let identityUtils: typeof import("./_blocks-field-identity.js");
 let databaseUtils: typeof import("./_database-utils.js");
 let createInlineContentDatabaseAction: typeof import("./create-inline-content-database.js").default;
 let updateDocumentAction: typeof import("./update-document.js").default;
@@ -38,6 +39,7 @@ let getContentDatabaseAction: typeof import("./get-content-database.js").default
 let getDocumentAction: typeof import("./get-document.js").default;
 let configureDocumentPropertyAction: typeof import("./configure-document-property.js").default;
 let addDatabaseItemAction: typeof import("./add-database-item.js").default;
+let removeDatabaseItemsAction: typeof import("./remove-database-items.js").default;
 
 const OWNER = "owner@example.com";
 
@@ -47,6 +49,7 @@ beforeAll(async () => {
   getDb = dbModule.getDb;
   schema = dbModule.schema;
   propertyUtils = await import("./_property-utils.js");
+  identityUtils = await import("./_blocks-field-identity.js");
   databaseUtils = await import("./_database-utils.js");
   createInlineContentDatabaseAction = (
     await import("./create-inline-content-database.js")
@@ -61,6 +64,8 @@ beforeAll(async () => {
     await import("./configure-document-property.js")
   ).default;
   addDatabaseItemAction = (await import("./add-database-item.js")).default;
+  removeDatabaseItemsAction = (await import("./remove-database-items.js"))
+    .default;
   const plugin = (await import("../server/plugins/db.js")).default;
   await plugin(undefined as any);
 }, 60000); // cold-import of the db module + migrations exceeds the default 10s hook timeout
@@ -651,6 +656,274 @@ describe("writeBlockFieldContent — upsert race (finding 4)", () => {
     expect(
       await propertyUtils.readBlockFieldContent(documentId, propertyId),
     ).toBe("v2");
+  });
+});
+
+describe("database Blocks field identity sidecar", () => {
+  it("preserves ordered IDs, independent revisions, and bounded recovery", async () => {
+    const { documentId } = await createDatabaseRow();
+    const db = getDb();
+    const primaryPropertyId = `primary_${documentId}`;
+    const additionalPropertyId = `additional_${documentId}`;
+
+    async function save(args: {
+      propertyId: string;
+      previousMarkdown: string;
+      markdown: string;
+      expectedRevision: number;
+    }) {
+      const now = new Date().toISOString();
+      return db.transaction(async (tx: any) => {
+        const state = await identityUtils.persistBlocksFieldIdentity({
+          db: tx,
+          ownerEmail: OWNER,
+          documentId,
+          propertyId: args.propertyId,
+          previousMarkdown: args.previousMarkdown,
+          markdown: args.markdown,
+          expectedRevision: args.expectedRevision,
+          now,
+        });
+        if (args.propertyId === primaryPropertyId) {
+          await tx
+            .update(schema.documents)
+            .set({ content: args.markdown, updatedAt: now })
+            .where(eq(schema.documents.id, documentId));
+        }
+        return state;
+      });
+    }
+
+    const edited = await save({
+      propertyId: primaryPropertyId,
+      previousMarkdown: "body text",
+      markdown: "Alpha\nBeta",
+      expectedRevision: 0,
+    });
+    const [alphaId, betaId] = edited.blocks
+      .filter((block) => block.state === "live")
+      .map((block) => block.id);
+    expect(edited.revision).toBe(1);
+
+    const reordered = await save({
+      propertyId: primaryPropertyId,
+      previousMarkdown: "Alpha\nBeta",
+      markdown: "Beta\nAlpha edited",
+      expectedRevision: 1,
+    });
+    expect(
+      reordered.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    ).toEqual([betaId, alphaId]);
+
+    const deleted = await save({
+      propertyId: primaryPropertyId,
+      previousMarkdown: "Beta\nAlpha edited",
+      markdown: "Alpha edited",
+      expectedRevision: 2,
+    });
+    expect(deleted.blocks.find((block) => block.id === betaId)).toEqual(
+      expect.objectContaining({ state: "deleted", deletedAtRevision: 3 }),
+    );
+
+    const recovered = await save({
+      propertyId: primaryPropertyId,
+      previousMarkdown: "Alpha edited",
+      markdown: "Alpha edited\nBeta",
+      expectedRevision: 3,
+    });
+    expect(
+      recovered.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    ).toContain(betaId);
+
+    const additional = await save({
+      propertyId: additionalPropertyId,
+      previousMarkdown: "",
+      markdown: "Alpha edited\nBeta",
+      expectedRevision: 0,
+    });
+    expect(additional.fieldId).not.toBe(recovered.fieldId);
+    expect(additional.revision).toBe(1);
+    expect(additional.blocks.map((block) => block.id)).not.toEqual(
+      recovered.blocks.map((block) => block.id),
+    );
+
+    const reloaded = await identityUtils.readBlocksFieldIdentity({
+      documentId,
+      propertyId: primaryPropertyId,
+      markdown: "Alpha edited\nBeta",
+    });
+    expect(reloaded.revision).toBe(4);
+    expect(reloaded.identityStatus).toBe("materialized");
+    expect(reloaded.blocks.map((block) => block.id)).toEqual(
+      recovered.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    );
+  });
+
+  it("rejects a stale field revision without changing canonical Markdown", async () => {
+    const { documentId } = await createDatabaseRow();
+    const db = getDb();
+    const propertyId = `conflict_${documentId}`;
+    const now = new Date().toISOString();
+    await identityUtils.persistBlocksFieldIdentity({
+      db,
+      ownerEmail: OWNER,
+      documentId,
+      propertyId,
+      previousMarkdown: "body text",
+      markdown: "Current",
+      expectedRevision: 0,
+      now,
+    });
+    await db
+      .update(schema.documents)
+      .set({ content: "Current", updatedAt: now })
+      .where(eq(schema.documents.id, documentId));
+
+    await expect(
+      db.transaction(async (tx: any) => {
+        await tx
+          .update(schema.documents)
+          .set({ content: "Stale overwrite" })
+          .where(eq(schema.documents.id, documentId));
+        await identityUtils.persistBlocksFieldIdentity({
+          db: tx,
+          ownerEmail: OWNER,
+          documentId,
+          propertyId,
+          previousMarkdown: "Current",
+          markdown: "Stale overwrite",
+          expectedRevision: 0,
+          now: new Date().toISOString(),
+        });
+      }),
+    ).rejects.toThrow("Blocks field revision conflict");
+
+    const [document] = await db
+      .select({ content: schema.documents.content })
+      .from(schema.documents)
+      .where(eq(schema.documents.id, documentId));
+    expect(document.content).toBe("Current");
+  });
+
+  it("allows only one concurrent first materialization", async () => {
+    const { documentId } = await createDatabaseRow();
+    const db = getDb();
+    const propertyId = `first_${documentId}`;
+    const attempts = await Promise.allSettled(
+      ["First", "Second"].map((markdown) =>
+        db.transaction((tx: any) =>
+          identityUtils.persistBlocksFieldIdentity({
+            db: tx,
+            ownerEmail: OWNER,
+            documentId,
+            propertyId,
+            previousMarkdown: "body text",
+            markdown,
+            expectedRevision: 0,
+            now: new Date().toISOString(),
+          }),
+        ),
+      ),
+    );
+
+    expect(
+      attempts.filter((attempt) => attempt.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      attempts.filter((attempt) => attempt.status === "rejected"),
+    ).toHaveLength(1);
+    const [field] = await db
+      .select()
+      .from(schema.documentBlockFields)
+      .where(eq(schema.documentBlockFields.propertyId, propertyId));
+    expect(field.revision).toBe(1);
+  });
+
+  it("revisions every primary membership and cleans up only the removed database", async () => {
+    const first = await createDatabaseRow();
+    const second = await createDatabaseRow();
+    const db = getDb();
+    const now = new Date().toISOString();
+    const firstPropertyId = await propertyUtils.seedDefaultBlocksField({
+      databaseId: first.databaseId,
+      ownerEmail: OWNER,
+      orgId: null,
+      now,
+    });
+    const secondPropertyId = await propertyUtils.seedDefaultBlocksField({
+      databaseId: second.databaseId,
+      ownerEmail: OWNER,
+      orgId: null,
+      now,
+    });
+    const rowDocumentId = `multi_membership_${counter}`;
+    const firstItemId = `item_first_${counter}`;
+    await db.insert(schema.documents).values({
+      id: rowDocumentId,
+      ownerEmail: OWNER,
+      title: "Shared row",
+      content: "Before",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseItems).values([
+      {
+        id: firstItemId,
+        ownerEmail: OWNER,
+        databaseId: first.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: `item_second_${counter}`,
+        ownerEmail: OWNER,
+        databaseId: second.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      updateDocumentAction.run({ id: rowDocumentId, content: "After" }),
+    );
+    const beforeRemoval = await db
+      .select()
+      .from(schema.documentBlockFields)
+      .where(eq(schema.documentBlockFields.documentId, rowDocumentId));
+    expect(
+      new Map(
+        beforeRemoval.map((field: any) => [field.propertyId, field.revision]),
+      ),
+    ).toEqual(
+      new Map([
+        [firstPropertyId, 1],
+        [secondPropertyId, 1],
+      ]),
+    );
+
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      removeDatabaseItemsAction.run({
+        databaseId: first.databaseId,
+        itemIds: [firstItemId],
+      }),
+    );
+    const afterRemoval = await db
+      .select()
+      .from(schema.documentBlockFields)
+      .where(eq(schema.documentBlockFields.documentId, rowDocumentId));
+    expect(afterRemoval).toEqual([
+      expect.objectContaining({ propertyId: secondPropertyId, revision: 1 }),
+    ]);
   });
 });
 

--- a/templates/content/actions/blocks-seeding.db.test.ts
+++ b/templates/content/actions/blocks-seeding.db.test.ts
@@ -49,6 +49,7 @@ let getDocumentAction: typeof import("./get-document.js").default;
 let configureDocumentPropertyAction: typeof import("./configure-document-property.js").default;
 let addDatabaseItemAction: typeof import("./add-database-item.js").default;
 let removeDatabaseItemsAction: typeof import("./remove-database-items.js").default;
+let deleteDocumentPropertyAction: typeof import("./delete-document-property.js").default;
 
 const OWNER = "owner@example.com";
 
@@ -77,6 +78,8 @@ beforeAll(async () => {
   ).default;
   addDatabaseItemAction = (await import("./add-database-item.js")).default;
   removeDatabaseItemsAction = (await import("./remove-database-items.js"))
+    .default;
+  deleteDocumentPropertyAction = (await import("./delete-document-property.js"))
     .default;
   const plugin = (await import("../server/plugins/db.js")).default;
   await plugin(undefined as any);
@@ -995,6 +998,84 @@ describe("database Blocks field identity sidecar", () => {
     expect(afterRemoval).toEqual([
       expect.objectContaining({ propertyId: secondPropertyId, revision: 3 }),
     ]);
+  });
+
+  it("preserves a shared body and surviving identity when one primary property is deleted", async () => {
+    const first = await createDatabaseRow();
+    const second = await createDatabaseRow();
+    const db = getDb();
+    const now = new Date().toISOString();
+    const firstPropertyId = await propertyUtils.seedDefaultBlocksField({
+      databaseId: first.databaseId,
+      ownerEmail: OWNER,
+      orgId: null,
+      now,
+    });
+    const secondPropertyId = await propertyUtils.seedDefaultBlocksField({
+      databaseId: second.databaseId,
+      ownerEmail: OWNER,
+      orgId: null,
+      now,
+    });
+    const rowDocumentId = `delete_shared_primary_${counter}`;
+    await db.insert(schema.documents).values({
+      id: rowDocumentId,
+      ownerEmail: OWNER,
+      title: "Shared row",
+      content: "Before",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.contentDatabaseItems).values([
+      {
+        id: `delete_first_${counter}`,
+        ownerEmail: OWNER,
+        databaseId: first.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: `delete_second_${counter}`,
+        ownerEmail: OWNER,
+        databaseId: second.databaseId,
+        documentId: rowDocumentId,
+        position: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      updateDocumentAction.run({ id: rowDocumentId, content: "Shared body" }),
+    );
+
+    await runWithRequestContext({ userEmail: OWNER }, () =>
+      deleteDocumentPropertyAction.run({
+        documentId: rowDocumentId,
+        databaseId: first.databaseId,
+        propertyId: firstPropertyId,
+      }),
+    );
+
+    const [rowDocument] = await db
+      .select({ content: schema.documents.content })
+      .from(schema.documents)
+      .where(eq(schema.documents.id, rowDocumentId));
+    expect(rowDocument?.content).toBe("Shared body");
+    const identities = await db
+      .select()
+      .from(schema.documentBlockFields)
+      .where(eq(schema.documentBlockFields.documentId, rowDocumentId));
+    expect(identities).toEqual([
+      expect.objectContaining({ propertyId: secondPropertyId, revision: 1 }),
+    ]);
+    const surviving = await identityUtils.readBlocksFieldIdentity({
+      documentId: rowDocumentId,
+      propertyId: secondPropertyId,
+      markdown: "Shared body",
+    });
+    expect(surviving.identityStatus).toBe("materialized");
   });
 });
 

--- a/templates/content/actions/configure-document-property.ts
+++ b/templates/content/actions/configure-document-property.ts
@@ -16,6 +16,7 @@ import {
   normalizePropertyVisibility,
   type DocumentPropertyType,
 } from "../shared/properties.js";
+import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import { lockContentDatabaseMutation } from "./_content-database-mutation-lock.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
 import {
@@ -233,6 +234,10 @@ export default defineAction({
             ) &&
             !isBlocksPropertyType(type)
           ) {
+            await deleteBlocksFieldIdentity({
+              db: tx as unknown as ReturnType<typeof getDb>,
+              propertyId: args.id!,
+            });
             await tx
               .delete(schema.documentBlockFieldContents)
               .where(

--- a/templates/content/actions/delete-document-property.ts
+++ b/templates/content/actions/delete-document-property.ts
@@ -11,6 +11,7 @@ import {
   parsePropertyOptions,
   type DocumentPropertyType,
 } from "../shared/properties.js";
+import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import { lockContentDatabaseMutation } from "./_content-database-mutation-lock.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
 import {
@@ -117,6 +118,10 @@ export default defineAction({
         .where(eq(schema.documentPropertyDefinitions.id, propertyId));
 
       if (isBlocks) {
+        await deleteBlocksFieldIdentity({
+          db: tx as unknown as ReturnType<typeof getDb>,
+          propertyId,
+        });
         await tx
           .delete(schema.documentBlockFieldContents)
           .where(eq(schema.documentBlockFieldContents.propertyId, propertyId));

--- a/templates/content/actions/delete-document-property.ts
+++ b/templates/content/actions/delete-document-property.ts
@@ -11,7 +11,10 @@ import {
   parsePropertyOptions,
   type DocumentPropertyType,
 } from "../shared/properties.js";
-import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
+import {
+  deleteBlocksFieldIdentity,
+  lockPrimaryBlocksFieldsForDocuments,
+} from "./_blocks-field-identity.js";
 import { lockContentDatabaseMutation } from "./_content-database-mutation-lock.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
 import {
@@ -66,14 +69,6 @@ export default defineAction({
         tx as unknown as ReturnType<typeof getDb>,
         database.id,
       );
-      const memberships = await tx
-        .select({ id: schema.contentDatabaseItems.id })
-        .from(schema.contentDatabaseItems)
-        .where(eq(schema.contentDatabaseItems.databaseId, database.id));
-      await lockDatabaseMemberships(
-        tx,
-        memberships.map((membership) => membership.id),
-      );
       const [lockedDefinition] = await tx
         .select()
         .from(schema.documentPropertyDefinitions)
@@ -101,6 +96,25 @@ export default defineAction({
         isPrimaryBlocksField(
           parsePropertyOptions(lockedDefinition.optionsJson),
         );
+      const items = await tx
+        .select({
+          id: schema.contentDatabaseItems.id,
+          documentId: schema.contentDatabaseItems.documentId,
+        })
+        .from(schema.contentDatabaseItems)
+        .where(eq(schema.contentDatabaseItems.databaseId, database.id));
+      const primaryFieldsByDocument = isPrimaryBlocks
+        ? await lockPrimaryBlocksFieldsForDocuments(
+            tx as unknown as ReturnType<typeof getDb>,
+            items.map((item) => item.documentId),
+          )
+        : new Map();
+      if (!isPrimaryBlocks) {
+        await lockDatabaseMemberships(
+          tx,
+          items.map((item) => item.id),
+        );
+      }
 
       await tx
         .delete(schema.documentPropertyValues)
@@ -135,20 +149,22 @@ export default defineAction({
             })
             .where(eq(schema.contentDatabases.id, database.id));
 
-          const items = await tx
-            .select({ documentId: schema.contentDatabaseItems.documentId })
-            .from(schema.contentDatabaseItems)
-            .where(eq(schema.contentDatabaseItems.databaseId, database.id));
-          if (items.length > 0) {
+          const documentsWithoutSurvivingPrimary = items
+            .filter(
+              (item) =>
+                !(primaryFieldsByDocument.get(item.documentId) ?? []).some(
+                  (field: { propertyId: string }) =>
+                    field.propertyId !== propertyId,
+                ),
+            )
+            .map((item) => item.documentId);
+          if (documentsWithoutSurvivingPrimary.length > 0) {
             const now = new Date().toISOString();
             await tx
               .update(schema.documents)
               .set({ content: "", updatedAt: now })
               .where(
-                inArray(
-                  schema.documents.id,
-                  items.map((item) => item.documentId),
-                ),
+                inArray(schema.documents.id, documentsWithoutSurvivingPrimary),
               );
           }
         }

--- a/templates/content/actions/delete-document.test.ts
+++ b/templates/content/actions/delete-document.test.ts
@@ -88,6 +88,14 @@ const { schema } = vi.hoisted(() => ({
       propertyId: "documentBlockFieldContents.propertyId",
       documentId: "documentBlockFieldContents.documentId",
     },
+    documentBlockFields: {
+      id: "documentBlockFields.id",
+      documentId: "documentBlockFields.documentId",
+      propertyId: "documentBlockFields.propertyId",
+    },
+    documentBlocks: {
+      fieldId: "documentBlocks.fieldId",
+    },
     documentSyncLinks: {
       documentId: "documentSyncLinks.documentId",
       ownerEmail: "documentSyncLinks.ownerEmail",

--- a/templates/content/actions/delete-document.ts
+++ b/templates/content/actions/delete-document.ts
@@ -696,6 +696,7 @@ async function deleteCollectedDocuments(
   });
 
   await deleteWhereIn(propertyDefinitionIds, async (propertyIdBatch) => {
+    await deleteBlocksFieldIdentity({ db, propertyIds: propertyIdBatch });
     await db
       .delete(schema.documentPropertyValues)
       .where(
@@ -731,9 +732,7 @@ async function deleteCollectedDocuments(
   });
 
   await deleteWhereIn(documentIds, async (documentIdBatch) => {
-    for (const documentId of documentIdBatch) {
-      await deleteBlocksFieldIdentity({ db, documentId });
-    }
+    await deleteBlocksFieldIdentity({ db, documentIds: documentIdBatch });
     await db
       .delete(schema.contentDatabaseBodyHydrationQueue)
       .where(

--- a/templates/content/actions/delete-document.ts
+++ b/templates/content/actions/delete-document.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { chunks } from "./_batch-utils.js";
+import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import {
   lockContentDatabaseMutation,
   touchContentDatabase,
@@ -730,6 +731,9 @@ async function deleteCollectedDocuments(
   });
 
   await deleteWhereIn(documentIds, async (documentIdBatch) => {
+    for (const documentId of documentIdBatch) {
+      await deleteBlocksFieldIdentity({ db, documentId });
+    }
     await db
       .delete(schema.contentDatabaseBodyHydrationQueue)
       .where(

--- a/templates/content/actions/edit-document.ts
+++ b/templates/content/actions/edit-document.ts
@@ -17,6 +17,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
 
 interface TextEdit {
   find: string;
@@ -235,11 +236,44 @@ export default defineAction({
     // Persist. The fresh updatedAt is the signal the open editor uses to tell an
     // intentional external edit apart from a stale autosave echo.
     const db = getDb();
+    const now = new Date().toISOString();
     await db.transaction(async (tx: any) => {
       await tx
         .update(schema.documents)
-        .set({ content, updatedAt: new Date().toISOString() })
+        .set({ content, updatedAt: now })
         .where(eq(schema.documents.id, id));
+      const primaryBlocksFields = await tx
+        .select({
+          propertyId: schema.contentDatabases.primaryBlocksPropertyId,
+          ownerEmail: schema.contentDatabases.ownerEmail,
+        })
+        .from(schema.contentDatabaseItems)
+        .innerJoin(
+          schema.contentDatabases,
+          eq(
+            schema.contentDatabases.id,
+            schema.contentDatabaseItems.databaseId,
+          ),
+        )
+        .where(eq(schema.contentDatabaseItems.documentId, id));
+      const primaryFieldsById = new Map<string, string>(
+        primaryBlocksFields.flatMap((field) =>
+          field.propertyId
+            ? [[field.propertyId, field.ownerEmail] as const]
+            : [],
+        ),
+      );
+      for (const [propertyId, ownerEmail] of primaryFieldsById) {
+        await persistBlocksFieldIdentity({
+          db: tx as unknown as ReturnType<typeof getDb>,
+          ownerEmail,
+          documentId: id,
+          propertyId,
+          previousMarkdown: existing.content ?? "",
+          markdown: content,
+          now,
+        });
+      }
       if (creativeContext) {
         await recordGenerationCreativeContext(
           {

--- a/templates/content/actions/edit-document.ts
+++ b/templates/content/actions/edit-document.ts
@@ -257,10 +257,11 @@ export default defineAction({
         )
         .where(eq(schema.contentDatabaseItems.documentId, id));
       const primaryFieldsById = new Map<string, string>(
-        primaryBlocksFields.flatMap((field) =>
-          field.propertyId
-            ? [[field.propertyId, field.ownerEmail] as const]
-            : [],
+        primaryBlocksFields.flatMap(
+          (field: { propertyId: string | null; ownerEmail: string }) =>
+            field.propertyId
+              ? [[field.propertyId, field.ownerEmail] as const]
+              : [],
         ),
       );
       for (const [propertyId, ownerEmail] of primaryFieldsById) {

--- a/templates/content/actions/edit-document.ts
+++ b/templates/content/actions/edit-document.ts
@@ -17,7 +17,10 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
+import {
+  lockPrimaryBlocksFields,
+  persistBlocksFieldIdentity,
+} from "./_blocks-field-identity.js";
 
 interface TextEdit {
   find: string;
@@ -238,38 +241,17 @@ export default defineAction({
     const db = getDb();
     const now = new Date().toISOString();
     await db.transaction(async (tx: any) => {
+      const primaryBlocksFields = await lockPrimaryBlocksFields(tx, id);
       await tx
         .update(schema.documents)
         .set({ content, updatedAt: now })
         .where(eq(schema.documents.id, id));
-      const primaryBlocksFields = await tx
-        .select({
-          propertyId: schema.contentDatabases.primaryBlocksPropertyId,
-          ownerEmail: schema.contentDatabases.ownerEmail,
-        })
-        .from(schema.contentDatabaseItems)
-        .innerJoin(
-          schema.contentDatabases,
-          eq(
-            schema.contentDatabases.id,
-            schema.contentDatabaseItems.databaseId,
-          ),
-        )
-        .where(eq(schema.contentDatabaseItems.documentId, id));
-      const primaryFieldsById = new Map<string, string>(
-        primaryBlocksFields.flatMap(
-          (field: { propertyId: string | null; ownerEmail: string }) =>
-            field.propertyId
-              ? [[field.propertyId, field.ownerEmail] as const]
-              : [],
-        ),
-      );
-      for (const [propertyId, ownerEmail] of primaryFieldsById) {
+      for (const field of primaryBlocksFields) {
         await persistBlocksFieldIdentity({
           db: tx as unknown as ReturnType<typeof getDb>,
-          ownerEmail,
+          ownerEmail: field.ownerEmail,
           documentId: id,
-          propertyId,
+          propertyId: field.propertyId,
           previousMarkdown: existing.content ?? "",
           markdown: content,
           now,

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -10,7 +10,7 @@ import {
   isPrimaryBlocksField,
 } from "../shared/properties.js";
 import "../server/db/index.js";
-import { listPropertiesForDocument } from "./_property-utils.js";
+import { listPropertiesForAllDocumentDatabases } from "./_property-utils.js";
 
 export default defineAction({
   description:
@@ -39,10 +39,15 @@ export default defineAction({
     if (!access) throw new Error(`Document "${id}" not found`);
 
     const doc = access.resource;
-    const properties = await listPropertiesForDocument(doc);
+    const properties = await listPropertiesForAllDocumentDatabases(doc);
     const blocksFields = properties
       .filter((property) => isBlocksPropertyType(property.definition.type))
       .map((property) => {
+        if (!property.definition.databaseId) {
+          throw new Error(
+            `Blocks field "${property.definition.id}" is not attached to a database`,
+          );
+        }
         if (!property.blocksField) {
           throw new Error(
             `Blocks field "${property.definition.id}" has no identity state`,
@@ -60,6 +65,7 @@ export default defineAction({
             ? property.blocksField
             : { ...property.blocksField, identityStatus: "stale" as const };
         return {
+          databaseId: property.definition.databaseId,
           propertyId: property.definition.id,
           name: property.definition.name,
           position: property.definition.position,

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -3,8 +3,14 @@ import { buildDeepLink } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 
+import { blocksContentHash } from "../shared/blocks-field-identity.js";
 import { buildDocumentExport } from "../shared/document-export.js";
+import {
+  isBlocksPropertyType,
+  isPrimaryBlocksField,
+} from "../shared/properties.js";
 import "../server/db/index.js";
+import { listPropertiesForDocument } from "./_property-utils.js";
 
 export default defineAction({
   description:
@@ -33,12 +39,41 @@ export default defineAction({
     if (!access) throw new Error(`Document "${id}" not found`);
 
     const doc = access.resource;
+    const properties = await listPropertiesForDocument(doc);
+    const blocksFields = properties
+      .filter((property) => isBlocksPropertyType(property.definition.type))
+      .map((property) => {
+        if (!property.blocksField) {
+          throw new Error(
+            `Blocks field "${property.definition.id}" has no identity state`,
+          );
+        }
+        const markdown =
+          content !== undefined &&
+          isPrimaryBlocksField(property.definition.options)
+            ? content
+            : typeof property.value === "string"
+              ? property.value
+              : "";
+        const identity =
+          blocksContentHash(markdown) === property.blocksField.contentHash
+            ? property.blocksField
+            : { ...property.blocksField, identityStatus: "stale" as const };
+        return {
+          propertyId: property.definition.id,
+          name: property.definition.name,
+          position: property.definition.position,
+          markdown,
+          identity,
+        };
+      });
     const payload = buildDocumentExport({
       id: doc.id,
       title: title ?? doc.title,
       content: content ?? doc.content,
       updatedAt: doc.updatedAt,
       format,
+      blocksFields,
     });
 
     return {

--- a/templates/content/actions/migrate-content-database-rows.postgres.integration.test.ts
+++ b/templates/content/actions/migrate-content-database-rows.postgres.integration.test.ts
@@ -303,6 +303,34 @@ postgresSuite("migrate-content-database-rows PostgreSQL locking", () => {
     }
   });
 
+  it("materializes distinct fields concurrently without global block-ID contention", async () => {
+    const seed = await fixture();
+    const markdown = '<registry-block blockId="shared-preferred-id" />';
+    try {
+      const states = await Promise.all(
+        ["first", "second"].map((suffix) =>
+          getDb().transaction((tx: any) =>
+            blocksFieldIdentity.persistBlocksFieldIdentity({
+              db: tx,
+              ownerEmail: OWNER,
+              documentId: seed.documentId,
+              propertyId: `${suffix}_${seed.documentId}`,
+              previousMarkdown: "",
+              markdown,
+              expectedRevision: 0,
+              now: new Date().toISOString(),
+            }),
+          ),
+        ),
+      );
+
+      expect(states).toHaveLength(2);
+      expect(states[0]?.blocks[0]?.id).not.toBe(states[1]?.blocks[0]?.id);
+    } finally {
+      await cleanupFixture(seed);
+    }
+  });
+
   it("rejects stale plans before requesting an editor flush", async () => {
     const seed = await fixture();
     try {

--- a/templates/content/actions/migrate-content-database-rows.postgres.integration.test.ts
+++ b/templates/content/actions/migrate-content-database-rows.postgres.integration.test.ts
@@ -30,6 +30,7 @@ let deleteContentDatabase: typeof import("./delete-content-database.js").default
 let restoreDocument: typeof import("./restore-document.js").default;
 let restoreContentDatabase: typeof import("./restore-content-database.js").default;
 let permanentlyDeleteDocument: typeof import("./permanently-delete-document.js").default;
+let blocksFieldIdentity: typeof import("./_blocks-field-identity.js");
 
 beforeAll(async () => {
   if (!POSTGRES_URL) return;
@@ -58,6 +59,7 @@ beforeAll(async () => {
     .default;
   permanentlyDeleteDocument = (await import("./permanently-delete-document.js"))
     .default;
+  blocksFieldIdentity = await import("./_blocks-field-identity.js");
   await (await import("../server/plugins/db.js")).default(undefined as any);
 }, 60_000);
 
@@ -196,6 +198,10 @@ async function fixture() {
 
 async function cleanupFixture(seed: Awaited<ReturnType<typeof fixture>>) {
   await getDb().transaction(async (tx: any) => {
+    await blocksFieldIdentity.deleteBlocksFieldIdentity({
+      db: tx,
+      documentId: seed.documentId,
+    });
     await tx
       .delete(schema.contentDatabaseMigrationReceipts)
       .where(
@@ -246,6 +252,57 @@ async function waitForPostgresLockWait(minimum: number) {
 const postgresSuite = POSTGRES_URL ? describe : describe.skip;
 
 postgresSuite("migrate-content-database-rows PostgreSQL locking", () => {
+  it("persists the same field identity and revision contract on PostgreSQL", async () => {
+    const seed = await fixture();
+    const propertyId = `blocks_${seed.documentId}`;
+    const now = new Date().toISOString();
+    try {
+      const first = await getDb().transaction((tx: any) =>
+        blocksFieldIdentity.persistBlocksFieldIdentity({
+          db: tx,
+          ownerEmail: OWNER,
+          documentId: seed.documentId,
+          propertyId,
+          previousMarkdown: "# Before",
+          markdown: "Alpha\nBeta",
+          expectedRevision: 0,
+          now,
+        }),
+      );
+      const second = await getDb().transaction((tx: any) =>
+        blocksFieldIdentity.persistBlocksFieldIdentity({
+          db: tx,
+          ownerEmail: OWNER,
+          documentId: seed.documentId,
+          propertyId,
+          previousMarkdown: "Alpha\nBeta",
+          markdown: "Beta\nAlpha edited",
+          expectedRevision: 1,
+          now: new Date().toISOString(),
+        }),
+      );
+
+      expect(second.revision).toBe(2);
+      expect(
+        second.blocks
+          .filter((block) => block.state === "live")
+          .map((block) => block.id),
+      ).toEqual([
+        first.blocks.find((block) => block.markdown === "Beta")?.id,
+        first.blocks.find((block) => block.markdown === "Alpha")?.id,
+      ]);
+      const reloaded = await blocksFieldIdentity.readBlocksFieldIdentity({
+        documentId: seed.documentId,
+        propertyId,
+        markdown: "Beta\nAlpha edited",
+      });
+      expect(reloaded.identityStatus).toBe("materialized");
+      expect(reloaded.revision).toBe(2);
+    } finally {
+      await cleanupFixture(seed);
+    }
+  });
+
   it("rejects stale plans before requesting an editor flush", async () => {
     const seed = await fixture();
     try {

--- a/templates/content/actions/remove-database-items.ts
+++ b/templates/content/actions/remove-database-items.ts
@@ -4,6 +4,7 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { and, eq, inArray } from "drizzle-orm";
 
 import { getDb, schema } from "../server/db/index.js";
+import { deleteBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import {
   lockContentDatabaseMutation,
   touchContentDatabase,
@@ -132,6 +133,15 @@ export default defineAction({
             )
         ).map((property) => property.id);
         if (removedDocumentIds.length > 0 && propertyIds.length > 0) {
+          for (const removedDocumentId of removedDocumentIds) {
+            for (const propertyId of propertyIds) {
+              await deleteBlocksFieldIdentity({
+                db: tx as unknown as ReturnType<typeof getDb>,
+                documentId: removedDocumentId,
+                propertyId,
+              });
+            }
+          }
           await tx
             .delete(schema.documentPropertyValues)
             .where(

--- a/templates/content/actions/set-document-property.ts
+++ b/templates/content/actions/set-document-property.ts
@@ -12,7 +12,10 @@ import {
   parsePropertyOptions,
   type DocumentPropertyType,
 } from "../shared/properties.js";
-import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
+import {
+  lockPrimaryBlocksFields,
+  persistBlocksFieldIdentity,
+} from "./_blocks-field-identity.js";
 import { lockContentDatabaseMutation } from "./_content-database-mutation-lock.js";
 import { resolveContentDocumentAccess } from "./_content-document-access.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
@@ -93,7 +96,10 @@ export default defineAction({
         parsePropertyOptions(definition.optionsJson),
       );
       await db.transaction(async (tx) => {
-        await lockDatabaseMemberships(tx, [membership.id]);
+        const primaryBlocksFields = await lockPrimaryBlocksFields(
+          tx as unknown as ReturnType<typeof getDb>,
+          documentId,
+        );
         const [lockedDefinition] = await tx
           .select()
           .from(schema.documentPropertyDefinitions)
@@ -168,16 +174,33 @@ export default defineAction({
               set: { content, updatedAt: now },
             });
         }
-        await persistBlocksFieldIdentity({
-          db: tx as unknown as ReturnType<typeof getDb>,
-          ownerEmail: database.ownerEmail,
-          documentId,
-          propertyId,
-          previousMarkdown: previousContent,
-          markdown: content,
-          expectedRevision: expectedBlocksFieldRevision,
-          now,
-        });
+        const identityFields =
+          target === "document_body"
+            ? primaryBlocksFields
+            : [{ propertyId, ownerEmail: database.ownerEmail }];
+        if (
+          target === "document_body" &&
+          !identityFields.some((field) => field.propertyId === propertyId)
+        ) {
+          throw new Error(
+            "Primary Blocks membership changed before the operation completed.",
+          );
+        }
+        for (const field of identityFields) {
+          await persistBlocksFieldIdentity({
+            db: tx as unknown as ReturnType<typeof getDb>,
+            ownerEmail: field.ownerEmail,
+            documentId,
+            propertyId: field.propertyId,
+            previousMarkdown: previousContent,
+            markdown: content,
+            expectedRevision:
+              field.propertyId === propertyId
+                ? expectedBlocksFieldRevision
+                : undefined,
+            now,
+          });
+        }
       });
       return {
         documentId,

--- a/templates/content/actions/set-document-property.ts
+++ b/templates/content/actions/set-document-property.ts
@@ -12,6 +12,7 @@ import {
   parsePropertyOptions,
   type DocumentPropertyType,
 } from "../shared/properties.js";
+import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import { lockContentDatabaseMutation } from "./_content-database-mutation-lock.js";
 import { resolveContentDocumentAccess } from "./_content-document-access.js";
 import { lockDatabaseMemberships } from "./_database-membership-lock.js";
@@ -34,8 +35,15 @@ export default defineAction({
       ),
     propertyId: z.string().describe("Property definition ID"),
     value: z.unknown().describe("Value for the property type"),
+    expectedBlocksFieldRevision: z.number().int().nonnegative().optional(),
   }),
-  run: async ({ documentId, databaseId, propertyId, value }) => {
+  run: async ({
+    documentId,
+    databaseId,
+    propertyId,
+    value,
+    expectedBlocksFieldRevision,
+  }) => {
     const db = getDb();
     const [definition] = await db
       .select()
@@ -116,12 +124,31 @@ export default defineAction({
         target = blocksStorageTarget(
           parsePropertyOptions(lockedDefinition.optionsJson),
         );
+        let previousContent = "";
         if (target === "document_body") {
+          const [currentDocument] = await tx
+            .select({ content: schema.documents.content })
+            .from(schema.documents)
+            .where(eq(schema.documents.id, documentId));
+          if (!currentDocument) {
+            throw new Error(`Document "${documentId}" not found`);
+          }
+          previousContent = currentDocument.content;
           await tx
             .update(schema.documents)
             .set({ content, updatedAt: now })
             .where(eq(schema.documents.id, documentId));
         } else {
+          const [currentField] = await tx
+            .select({ content: schema.documentBlockFieldContents.content })
+            .from(schema.documentBlockFieldContents)
+            .where(
+              and(
+                eq(schema.documentBlockFieldContents.documentId, documentId),
+                eq(schema.documentBlockFieldContents.propertyId, propertyId),
+              ),
+            );
+          previousContent = currentField?.content ?? "";
           await tx
             .insert(schema.documentBlockFieldContents)
             .values({
@@ -141,6 +168,16 @@ export default defineAction({
               set: { content, updatedAt: now },
             });
         }
+        await persistBlocksFieldIdentity({
+          db: tx as unknown as ReturnType<typeof getDb>,
+          ownerEmail: database.ownerEmail,
+          documentId,
+          propertyId,
+          previousMarkdown: previousContent,
+          markdown: content,
+          expectedRevision: expectedBlocksFieldRevision,
+          now,
+        });
       });
       return {
         documentId,

--- a/templates/content/actions/update-document.ts
+++ b/templates/content/actions/update-document.ts
@@ -19,7 +19,10 @@ import {
   parseDocumentHideFromSearch,
 } from "../server/lib/documents.js";
 import type { DocumentUpdateResponse } from "../shared/api.js";
-import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
+import {
+  lockPrimaryBlocksFields,
+  persistBlocksFieldIdentity,
+} from "./_blocks-field-identity.js";
 import { BUILDER_CMS_BODY_CONTENT_KEY } from "./_builder-cms-source-adapter.js";
 import { reconcileInlineDatabasesForDocument } from "./_content-database-lifecycle.js";
 import { resolveContentDocumentAccess } from "./_content-document-access.js";
@@ -502,6 +505,12 @@ export default defineAction({
       if (iconChanged) updates.icon = args.icon;
       let contentCasConflict = false;
       await db.transaction(async (tx) => {
+        const primaryBlocksFields = contentChanged
+          ? await lockPrimaryBlocksFields(
+              tx as unknown as ReturnType<typeof getDb>,
+              id,
+            )
+          : [];
         if (useContentCas) {
           const applied = await tx
             .update(schema.documents)
@@ -525,30 +534,12 @@ export default defineAction({
         }
 
         if (contentChanged && content !== undefined) {
-          const primaryBlocksFields = await tx
-            .select({
-              propertyId: schema.contentDatabases.primaryBlocksPropertyId,
-            })
-            .from(schema.contentDatabaseItems)
-            .innerJoin(
-              schema.contentDatabases,
-              eq(
-                schema.contentDatabases.id,
-                schema.contentDatabaseItems.databaseId,
-              ),
-            )
-            .where(eq(schema.contentDatabaseItems.documentId, id));
-          const primaryPropertyIds = new Set(
-            primaryBlocksFields.flatMap((field) =>
-              field.propertyId ? [field.propertyId] : [],
-            ),
-          );
-          for (const propertyId of primaryPropertyIds) {
+          for (const field of primaryBlocksFields) {
             await persistBlocksFieldIdentity({
               db: tx as unknown as ReturnType<typeof getDb>,
-              ownerEmail,
+              ownerEmail: field.ownerEmail,
               documentId: id,
-              propertyId,
+              propertyId: field.propertyId,
               previousMarkdown: existing.content,
               markdown: content,
               now: updates.updatedAt as string,

--- a/templates/content/actions/update-document.ts
+++ b/templates/content/actions/update-document.ts
@@ -19,6 +19,7 @@ import {
   parseDocumentHideFromSearch,
 } from "../server/lib/documents.js";
 import type { DocumentUpdateResponse } from "../shared/api.js";
+import { persistBlocksFieldIdentity } from "./_blocks-field-identity.js";
 import { BUILDER_CMS_BODY_CONTENT_KEY } from "./_builder-cms-source-adapter.js";
 import { reconcileInlineDatabasesForDocument } from "./_content-database-lifecycle.js";
 import { resolveContentDocumentAccess } from "./_content-document-access.js";
@@ -521,6 +522,38 @@ export default defineAction({
             .update(schema.documents)
             .set(updates)
             .where(eq(schema.documents.id, id));
+        }
+
+        if (contentChanged && content !== undefined) {
+          const primaryBlocksFields = await tx
+            .select({
+              propertyId: schema.contentDatabases.primaryBlocksPropertyId,
+            })
+            .from(schema.contentDatabaseItems)
+            .innerJoin(
+              schema.contentDatabases,
+              eq(
+                schema.contentDatabases.id,
+                schema.contentDatabaseItems.databaseId,
+              ),
+            )
+            .where(eq(schema.contentDatabaseItems.documentId, id));
+          const primaryPropertyIds = new Set(
+            primaryBlocksFields.flatMap((field) =>
+              field.propertyId ? [field.propertyId] : [],
+            ),
+          );
+          for (const propertyId of primaryPropertyIds) {
+            await persistBlocksFieldIdentity({
+              db: tx as unknown as ReturnType<typeof getDb>,
+              ownerEmail,
+              documentId: id,
+              propertyId,
+              previousMarkdown: existing.content,
+              markdown: content,
+              now: updates.updatedAt as string,
+            });
+          }
         }
 
         if (titleChanged || contentChanged) {

--- a/templates/content/app/components/editor/DocumentBlockFields.tsx
+++ b/templates/content/app/components/editor/DocumentBlockFields.tsx
@@ -59,10 +59,12 @@ function isBlocksFieldRevisionConflict(error: unknown): boolean {
   }
   if (!error || typeof error !== "object") return false;
   const candidate = error as {
+    status?: unknown;
     message?: unknown;
     error?: unknown;
     cause?: unknown;
   };
+  if (candidate.status === 409) return true;
   return [candidate.message, candidate.error, candidate.cause].some(
     (value) =>
       typeof value === "string" &&
@@ -690,7 +692,11 @@ export function useBlockFieldEditor({
     expectedBlocksFieldRevision: number;
   }) => Promise<unknown>;
   onRevisionConflict?: () => void;
-}): { content: string; onChange: (markdown: string) => void } {
+}): {
+  content: string;
+  editorResetVersion: number;
+  onChange: (markdown: string) => void;
+} {
   const key = `${documentId}:${propertyId}`;
 
   // The shared controller calls the freshest save impl through a per-key ref. The
@@ -719,6 +725,8 @@ export function useBlockFieldEditor({
     return response;
   };
 
+  const controllerRef = useRef<BlockFieldSaveController | null>(null);
+
   // Build (but do not yet ref-count) the controller factory for this key. The
   // formal acquire/release happens in the effect below; we only need the factory
   // here so the first acquire can create the instance.
@@ -732,6 +740,10 @@ export function useBlockFieldEditor({
       onError: (error) => {
         if (isBlocksFieldRevisionConflict(error)) {
           rejectedRevisionRef.current = revisionRef.current;
+          // A stale payload is not a retryable draft. If this editor unmounts
+          // before the invalidated query returns, flush must not replay it
+          // against the newly advanced revision and overwrite the winner.
+          controllerRef.current?.discardPending();
           onRevisionConflictRef.current?.();
         }
         console.error("Failed to save Blocks field content", {
@@ -754,7 +766,6 @@ export function useBlockFieldEditor({
   // `factory`/`implRef` are intentionally not effect deps: the impl ref is updated
   // every render, and the identity key forces a remount for a DIFFERENT key, so
   // within one mount the key is stable and we acquire exactly once.
-  const controllerRef = useRef<BlockFieldSaveController | null>(null);
   useEffect(() => {
     controllerRef.current = acquireBlockFieldSaveController(key, factory);
     return () => {
@@ -789,6 +800,7 @@ export function useBlockFieldEditor({
     }
     return initialContent;
   });
+  const [editorResetVersion, setEditorResetVersion] = useState(0);
 
   // Adopt fresh server content when it is a GENUINELY newer external update (e.g.
   // an agent edit) — not when it is merely stale server props lagging a local
@@ -817,6 +829,10 @@ export function useBlockFieldEditor({
       setContent(initialContent);
       controller.mark(initialContent);
       rejectedRevisionRef.current = null;
+      // VisualEditor owns an imperative TipTap instance. Reset it only for this
+      // explicit conflict recovery so the accepted server value replaces the
+      // rejected draft without disrupting ordinary save cursor/undo state.
+      setEditorResetVersion((version) => version + 1);
       return;
     }
     // Never adopt over a dirty local edit.
@@ -850,7 +866,7 @@ export function useBlockFieldEditor({
     controllerRef.current?.change(markdown);
   }
 
-  return { content, onChange };
+  return { content, editorResetVersion, onChange };
 }
 
 /**
@@ -878,7 +894,7 @@ function AdditionalBlockEditor({
   const propertyId = property.definition.id;
   const initialContent =
     typeof property.value === "string" ? property.value : "";
-  const { content, onChange } = useBlockFieldEditor({
+  const { content, editorResetVersion, onChange } = useBlockFieldEditor({
     documentId,
     propertyId,
     initialContent,
@@ -890,7 +906,7 @@ function AdditionalBlockEditor({
 
   return (
     <VisualEditor
-      key={propertyId}
+      key={`${propertyId}:${editorResetVersion}`}
       documentId={documentId}
       content={content}
       onChange={onChange}

--- a/templates/content/app/components/editor/DocumentBlockFields.tsx
+++ b/templates/content/app/components/editor/DocumentBlockFields.tsx
@@ -657,15 +657,18 @@ export function useBlockFieldEditor({
   documentId,
   propertyId,
   initialContent,
+  initialRevision,
   save,
 }: {
   documentId: string;
   propertyId: string;
   initialContent: string;
+  initialRevision: number;
   save: (request: {
     documentId: string;
     propertyId: string;
     value: string;
+    expectedBlocksFieldRevision: number;
   }) => Promise<unknown>;
 }): { content: string; onChange: (markdown: string) => void } {
   const key = `${documentId}:${propertyId}`;
@@ -674,7 +677,24 @@ export function useBlockFieldEditor({
   // save TARGET (documentId:propertyId) is fixed by the key; only the function
   // identity changes per mount, never the field it writes to.
   const implRef = blockFieldSaveImplRef(key);
-  implRef.current = (value: string) => save({ documentId, propertyId, value });
+  const revisionRef = useRef(initialRevision);
+  if (initialRevision > revisionRef.current) {
+    revisionRef.current = initialRevision;
+  }
+  implRef.current = async (value: string) => {
+    const response = await save({
+      documentId,
+      propertyId,
+      value,
+      expectedBlocksFieldRevision: revisionRef.current,
+    });
+    const nextRevision = (
+      response as DocumentPropertiesResponse
+    )?.properties?.find((candidate) => candidate.definition.id === propertyId)
+      ?.blocksField?.revision;
+    if (typeof nextRevision === "number") revisionRef.current = nextRevision;
+    return response;
+  };
 
   // Build (but do not yet ref-count) the controller factory for this key. The
   // formal acquire/release happens in the effect below; we only need the factory
@@ -823,6 +843,7 @@ function AdditionalBlockEditor({
     documentId,
     propertyId,
     initialContent,
+    initialRevision: property.blocksField?.revision ?? 0,
     save: setProperty.mutateAsync,
   });
 

--- a/templates/content/app/components/editor/DocumentBlockFields.tsx
+++ b/templates/content/app/components/editor/DocumentBlockFields.tsx
@@ -743,7 +743,10 @@ export function useBlockFieldEditor({
           // A stale payload is not a retryable draft. If this editor unmounts
           // before the invalidated query returns, flush must not replay it
           // against the newly advanced revision and overwrite the winner.
-          controllerRef.current?.discardPending();
+          // The request can reject after this hook unmounts. The per-field
+          // controller outlives that mount, so clear the rejected payload at
+          // the shared boundary instead of relying on the instance ref.
+          peekBlockFieldSaveController(key)?.discardPending();
           onRevisionConflictRef.current?.();
         }
         console.error("Failed to save Blocks field content", {
@@ -823,6 +826,13 @@ export function useBlockFieldEditor({
     if (!controller) return;
     const rejectedRevision = rejectedRevisionRef.current;
     if (rejectedRevision !== null && initialRevision > rejectedRevision) {
+      if (controller.pending !== controller.lastSaved) {
+        // The user typed again while the winner was being refetched. Preserve
+        // that newer draft; revisionRef already reflects initialRevision, so
+        // its pending save will use the newly accepted boundary.
+        rejectedRevisionRef.current = null;
+        return;
+      }
       // The server rejected our stale revision and the invalidated query has
       // now delivered the winner. The rejected draft is not retryable against
       // the new baseline: adopt the accepted value and clear the dirty latch.

--- a/templates/content/app/components/editor/DocumentBlockFields.tsx
+++ b/templates/content/app/components/editor/DocumentBlockFields.tsx
@@ -16,6 +16,7 @@ import {
   type ReactNode,
   type PointerEvent as ReactPointerEvent,
 } from "react";
+import { toast } from "sonner";
 
 import {
   documentPropertiesResponseMatchesScope,
@@ -659,6 +660,7 @@ export function useBlockFieldEditor({
   initialContent,
   initialRevision,
   save,
+  onRevisionConflict,
 }: {
   documentId: string;
   propertyId: string;
@@ -670,6 +672,7 @@ export function useBlockFieldEditor({
     value: string;
     expectedBlocksFieldRevision: number;
   }) => Promise<unknown>;
+  onRevisionConflict?: () => void;
 }): { content: string; onChange: (markdown: string) => void } {
   const key = `${documentId}:${propertyId}`;
 
@@ -678,6 +681,9 @@ export function useBlockFieldEditor({
   // identity changes per mount, never the field it writes to.
   const implRef = blockFieldSaveImplRef(key);
   const revisionRef = useRef(initialRevision);
+  const rejectedRevisionRef = useRef<number | null>(null);
+  const onRevisionConflictRef = useRef(onRevisionConflict);
+  onRevisionConflictRef.current = onRevisionConflict;
   if (initialRevision > revisionRef.current) {
     revisionRef.current = initialRevision;
   }
@@ -706,12 +712,17 @@ export function useBlockFieldEditor({
       // saves across ALL editor instances for the key (there is only ever one
       // controller per key), so no cross-instance serialization lane is needed.
       save: (value) => implRef.current(value),
-      onError: (error) =>
+      onError: (error) => {
+        if (String(error).includes("Blocks field revision conflict")) {
+          rejectedRevisionRef.current = revisionRef.current;
+          onRevisionConflictRef.current?.();
+        }
         console.error("Failed to save Blocks field content", {
           documentId,
           propertyId,
           error,
-        }),
+        });
+      },
     });
 
   // Acquire the ONE shared controller for this field key, and release it on
@@ -781,6 +792,16 @@ export function useBlockFieldEditor({
   useEffect(() => {
     const controller = controllerRef.current;
     if (!controller) return;
+    const rejectedRevision = rejectedRevisionRef.current;
+    if (rejectedRevision !== null && initialRevision > rejectedRevision) {
+      // The server rejected our stale revision and the invalidated query has
+      // now delivered the winner. The rejected draft is not retryable against
+      // the new baseline: adopt the accepted value and clear the dirty latch.
+      setContent(initialContent);
+      controller.mark(initialContent);
+      rejectedRevisionRef.current = null;
+      return;
+    }
     // Never adopt over a dirty local edit.
     if (controller.pending !== controller.lastSaved) return;
     if (initialContent === controller.lastSaved) {
@@ -800,10 +821,10 @@ export function useBlockFieldEditor({
     }
     // else: server props are stale, lagging a local save the server hasn't
     // echoed yet. Keep showing lastSaved and wait for the echo above to clear
-    // the latch. (Cross-client concurrent same-field edits remain last-write-
-    // wins for v1; true coherence needs the deferred server-side versioning.)
+    // the latch. Concurrent writes are guarded by the field revision; a
+    // rejected stale write follows the explicit conflict branch above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialContent]);
+  }, [initialContent, initialRevision]);
 
   function onChange(markdown: string) {
     setContent(markdown);
@@ -831,6 +852,7 @@ function AdditionalBlockEditor({
   property: DocumentProperty;
   canEdit: boolean;
 }) {
+  const t = useT();
   const setProperty = useSetDocumentProperty(
     documentId,
     property.definition.databaseId!,
@@ -845,6 +867,8 @@ function AdditionalBlockEditor({
     initialContent,
     initialRevision: property.blocksField?.revision ?? 0,
     save: setProperty.mutateAsync,
+    onRevisionConflict: () =>
+      toast.error(t("editor.blocksFieldRevisionConflict")),
   });
 
   return (

--- a/templates/content/app/components/editor/DocumentBlockFields.tsx
+++ b/templates/content/app/components/editor/DocumentBlockFields.tsx
@@ -53,6 +53,23 @@ interface DocumentBlockFieldsProps {
   primaryEditor: ReactNode;
 }
 
+function isBlocksFieldRevisionConflict(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.message.includes("Blocks field revision conflict");
+  }
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    message?: unknown;
+    error?: unknown;
+    cause?: unknown;
+  };
+  return [candidate.message, candidate.error, candidate.cause].some(
+    (value) =>
+      typeof value === "string" &&
+      value.includes("Blocks field revision conflict"),
+  );
+}
+
 export function blockFieldsFromProperties(
   properties: DocumentProperty[],
 ): DocumentProperty[] {
@@ -713,7 +730,7 @@ export function useBlockFieldEditor({
       // controller per key), so no cross-instance serialization lane is needed.
       save: (value) => implRef.current(value),
       onError: (error) => {
-        if (String(error).includes("Blocks field revision conflict")) {
+        if (isBlocksFieldRevisionConflict(error)) {
           rejectedRevisionRef.current = revisionRef.current;
           onRevisionConflictRef.current?.();
         }

--- a/templates/content/app/components/editor/blockFieldSaveController.ts
+++ b/templates/content/app/components/editor/blockFieldSaveController.ts
@@ -40,6 +40,8 @@ export interface BlockFieldSaveController {
   cancel(): void;
   /** Adopt `content` as the confirmed-saved baseline (no save scheduled). */
   mark(content: string): void;
+  /** Drop a rejected pending write so an unmount flush cannot retry it. */
+  discardPending(): void;
   /** The value last CONFIRMED persisted. */
   readonly lastSaved: string;
   /** The latest value the user has typed (may differ from lastSaved). */
@@ -160,6 +162,10 @@ export function createBlockFieldSaveController(args: {
       // The baseline is now server-provided content, not a local save the server
       // hasn't echoed — so server props are no longer "behind" this controller.
       hasSavedLocally = false;
+    },
+    discardPending() {
+      clearTimer();
+      pending = lastSaved;
     },
     get lastSaved() {
       return lastSaved;

--- a/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
+++ b/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
@@ -40,23 +40,28 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     documentId,
     propertyId,
     initialContent,
+    initialRevision = 0,
     save,
     onReady,
     onContent,
+    onRevisionConflict,
   }: {
     documentId: string;
     propertyId: string;
     initialContent: string;
+    initialRevision?: number;
     save: (req: SaveCall) => Promise<unknown>;
     onReady: (onChange: (markdown: string) => void) => void;
     onContent?: (content: string) => void;
+    onRevisionConflict?: () => void;
   }) {
     const { content, onChange } = useBlockFieldEditor({
       documentId,
       propertyId,
       initialContent,
-      initialRevision: 0,
+      initialRevision,
       save,
+      onRevisionConflict,
     });
     onReady(onChange);
     onContent?.(content);
@@ -706,5 +711,97 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     // The dirty edit is preserved (seeded from the controller's pending), not
     // reset to the server base.
     expect(seenContent).toBe("dirty edit in progress");
+  });
+
+  it("adopts the accepted server winner after a stale revision is rejected", async () => {
+    vi.useFakeTimers();
+    const calls: SaveCall[] = [];
+    const onRevisionConflict = vi.fn();
+    const save = (req: SaveCall) => {
+      calls.push(req);
+      if (calls.length === 1) {
+        return Promise.reject(new Error("Blocks field revision conflict"));
+      }
+      return Promise.resolve({
+        properties: [
+          {
+            definition: { id: "field" },
+            blocksField: { revision: 12 },
+          },
+        ],
+      });
+    };
+
+    let onChange!: (markdown: string) => void;
+    const ready = (fn: (markdown: string) => void) => {
+      onChange = fn;
+    };
+    let seenContent = "";
+    const onContent = (content: string) => {
+      seenContent = content;
+    };
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root!.render(
+        createElement(Harness, {
+          key: "doc:field",
+          documentId: "doc",
+          propertyId: "field",
+          initialContent: "server base",
+          initialRevision: 10,
+          save,
+          onReady: ready,
+          onContent,
+          onRevisionConflict,
+        }),
+      );
+    });
+    act(() => onChange("stale local draft"));
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onRevisionConflict).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.expectedBlocksFieldRevision).toBe(10);
+
+    // The mutation invalidates the field query after rejection. Once that
+    // refetch carries a newer revision, the editor must display the accepted
+    // server value instead of leaving the rejected draft looking current.
+    act(() => {
+      root!.render(
+        createElement(Harness, {
+          key: "doc:field",
+          documentId: "doc",
+          propertyId: "field",
+          initialContent: "accepted server winner",
+          initialRevision: 11,
+          save,
+          onReady: ready,
+          onContent,
+          onRevisionConflict,
+        }),
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(seenContent).toBe("accepted server winner");
+
+    act(() => onChange("edit after conflict"));
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(calls[1]).toMatchObject({
+      value: "edit after conflict",
+      expectedBlocksFieldRevision: 11,
+    });
   });
 });

--- a/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
+++ b/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
@@ -814,9 +814,12 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
   it("does not retry a rejected stale draft when unmounted before refetch", async () => {
     vi.useFakeTimers();
     const calls: SaveCall[] = [];
+    let rejectSave!: (error: unknown) => void;
     const save = (req: SaveCall) => {
       calls.push(req);
-      return Promise.reject({ status: 409 });
+      return new Promise((_resolve, reject) => {
+        rejectSave = reject;
+      });
     };
     let onChange!: (markdown: string) => void;
 
@@ -842,14 +845,84 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     await act(async () => {
       vi.advanceTimersByTime(600);
       await Promise.resolve();
-      await Promise.resolve();
     });
 
+    // Collapse before the in-flight request reports its conflict. The shared
+    // controller must still discard that rejected payload after this hook's
+    // instance ref has gone away.
     await act(async () => {
       root!.render(createElement("div", null));
+      rejectSave({ status: 409 });
       await Promise.resolve();
       await Promise.resolve();
     });
     expect(calls).toHaveLength(1);
+  });
+
+  it("preserves a newer draft typed while the conflict winner refetches", async () => {
+    vi.useFakeTimers();
+    const calls: SaveCall[] = [];
+    const save = (req: SaveCall) => {
+      calls.push(req);
+      if (calls.length === 1) return Promise.reject({ status: 409 });
+      return Promise.resolve({
+        properties: [
+          {
+            definition: { id: "field" },
+            blocksField: { revision: 12 },
+          },
+        ],
+      });
+    };
+    let onChange!: (markdown: string) => void;
+    let seenContent = "";
+    let seenEditorResetVersion = -1;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const render = (initialContent: string, initialRevision: number) =>
+      root!.render(
+        createElement(Harness, {
+          key: "doc:field",
+          documentId: "doc",
+          propertyId: "field",
+          initialContent,
+          initialRevision,
+          save,
+          onReady: (fn) => {
+            onChange = fn;
+          },
+          onContent: (content, editorResetVersion) => {
+            seenContent = content;
+            seenEditorResetVersion = editorResetVersion;
+          },
+        }),
+      );
+
+    act(() => render("server base", 10));
+    act(() => onChange("rejected draft"));
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => onChange("newer local draft"));
+    act(() => render("accepted server winner", 11));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(seenContent).toBe("newer local draft");
+    expect(seenEditorResetVersion).toBe(0);
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(calls[1]).toMatchObject({
+      value: "newer local draft",
+      expectedBlocksFieldRevision: 11,
+    });
   });
 });

--- a/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
+++ b/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
@@ -52,10 +52,10 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     initialRevision?: number;
     save: (req: SaveCall) => Promise<unknown>;
     onReady: (onChange: (markdown: string) => void) => void;
-    onContent?: (content: string) => void;
+    onContent?: (content: string, editorResetVersion: number) => void;
     onRevisionConflict?: () => void;
   }) {
-    const { content, onChange } = useBlockFieldEditor({
+    const { content, editorResetVersion, onChange } = useBlockFieldEditor({
       documentId,
       propertyId,
       initialContent,
@@ -64,7 +64,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       onRevisionConflict,
     });
     onReady(onChange);
-    onContent?.(content);
+    onContent?.(content, editorResetVersion);
     return null;
   }
 
@@ -721,11 +721,8 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       calls.push(req);
       if (calls.length === 1) {
         // The action transport can cross a worker/realm boundary and reject
-        // with an Error-shaped object rather than an instanceof Error value.
-        return Promise.reject({
-          message:
-            "Action set-document-property failed: Blocks field revision conflict",
-        });
+        // with only the HTTP status preserved on a plain object.
+        return Promise.reject({ status: 409 });
       }
       return Promise.resolve({
         properties: [
@@ -742,8 +739,10 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       onChange = fn;
     };
     let seenContent = "";
-    const onContent = (content: string) => {
+    let seenEditorResetVersion = -1;
+    const onContent = (content: string, editorResetVersion: number) => {
       seenContent = content;
+      seenEditorResetVersion = editorResetVersion;
     };
 
     container = document.createElement("div");
@@ -774,6 +773,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
 
     expect(onRevisionConflict).toHaveBeenCalledTimes(1);
     expect(calls[0]?.expectedBlocksFieldRevision).toBe(10);
+    expect(seenEditorResetVersion).toBe(0);
 
     // The mutation invalidates the field query after rejection. Once that
     // refetch carries a newer revision, the editor must display the accepted
@@ -797,6 +797,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       await Promise.resolve();
     });
     expect(seenContent).toBe("accepted server winner");
+    expect(seenEditorResetVersion).toBe(1);
 
     act(() => onChange("edit after conflict"));
     await act(async () => {
@@ -808,5 +809,47 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       value: "edit after conflict",
       expectedBlocksFieldRevision: 11,
     });
+  });
+
+  it("does not retry a rejected stale draft when unmounted before refetch", async () => {
+    vi.useFakeTimers();
+    const calls: SaveCall[] = [];
+    const save = (req: SaveCall) => {
+      calls.push(req);
+      return Promise.reject({ status: 409 });
+    };
+    let onChange!: (markdown: string) => void;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        createElement(Harness, {
+          key: "doc:field",
+          documentId: "doc",
+          propertyId: "field",
+          initialContent: "server base",
+          initialRevision: 10,
+          save,
+          onReady: (fn) => {
+            onChange = fn;
+          },
+        }),
+      );
+    });
+    act(() => onChange("stale local draft"));
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      root!.render(createElement("div", null));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(calls).toHaveLength(1);
   });
 });

--- a/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
+++ b/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
@@ -11,7 +11,12 @@ import { useBlockFieldEditor } from "./DocumentBlockFields";
 // A save record we can assert against: which (documentId, propertyId) each
 // write targeted, and with what value. Resolves immediately so single-flight +
 // trailing logic settles within an act().
-type SaveCall = { documentId: string; propertyId: string; value: string };
+type SaveCall = {
+  documentId: string;
+  propertyId: string;
+  value: string;
+  expectedBlocksFieldRevision: number;
+};
 
 describe("useBlockFieldEditor (identity-safe save wiring)", () => {
   let container: HTMLDivElement | null = null;
@@ -50,6 +55,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       documentId,
       propertyId,
       initialContent,
+      initialRevision: 0,
       save,
     });
     onReady(onChange);
@@ -116,6 +122,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       documentId: "doc-new",
       propertyId: "summary",
       value: "new doc text",
+      expectedBlocksFieldRevision: 0,
     });
     // The new field's write never leaked to the old field.
     expect(
@@ -182,6 +189,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       documentId: "doc-old",
       propertyId: "outline",
       value: "unsaved old-field edit",
+      expectedBlocksFieldRevision: 0,
     });
     // It did NOT get misrouted to the new field.
     expect(calls.some((c) => c.documentId === "doc-new")).toBe(false);
@@ -452,6 +460,7 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
       documentId: "doc",
       propertyId: "field",
       value: "saved value",
+      expectedBlocksFieldRevision: 0,
     });
 
     // REMOUNT while the server query has NOT yet refetched — initialContent is
@@ -631,7 +640,12 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     expect(seenContent).toBe("agent edit");
     // Only the original local save happened; adopting never saves.
     expect(calls).toEqual([
-      { documentId: "doc", propertyId: "field", value: "mine" },
+      {
+        documentId: "doc",
+        propertyId: "field",
+        value: "mine",
+        expectedBlocksFieldRevision: 0,
+      },
     ]);
   });
 

--- a/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
+++ b/templates/content/app/components/editor/useBlockFieldEditor.test.tsx
@@ -720,7 +720,12 @@ describe("useBlockFieldEditor (identity-safe save wiring)", () => {
     const save = (req: SaveCall) => {
       calls.push(req);
       if (calls.length === 1) {
-        return Promise.reject(new Error("Blocks field revision conflict"));
+        // The action transport can cross a worker/realm boundary and reject
+        // with an Error-shaped object rather than an instanceof Error value.
+        return Promise.reject({
+          message:
+            "Action set-document-property failed: Blocks field revision conflict",
+        });
       }
       return Promise.resolve({
         properties: [

--- a/templates/content/app/hooks/use-document-properties.test.ts
+++ b/templates/content/app/hooks/use-document-properties.test.ts
@@ -118,4 +118,37 @@ describe("useSetDocumentProperty", () => {
       ]),
     );
   });
+
+  it("refetches the field revision after a rejected stale write", () => {
+    const queryClient = {
+      cancelQueries: vi.fn(),
+      getQueriesData: vi.fn(() => []),
+      setQueriesData: vi.fn(),
+      setQueryData: vi.fn(),
+      invalidateQueries: vi.fn(),
+    };
+    useQueryClient.mockReturnValue(queryClient);
+    useActionMutation.mockImplementation((_name, options) => options);
+
+    useSetDocumentProperty("row-1", "database-1", "database-page-1");
+    const options = useActionMutation.mock.calls[0][1];
+    options.onError(
+      new Error("Blocks field revision conflict"),
+      {
+        documentId: "row-1",
+        propertyId: "notes",
+        value: "stale edit",
+        expectedBlocksFieldRevision: 2,
+      },
+      { previous: [] },
+    );
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [
+        "action",
+        "list-document-properties",
+        { documentId: "row-1", databaseId: "database-1" },
+      ],
+    });
+  });
 });

--- a/templates/content/app/hooks/use-document-properties.ts
+++ b/templates/content/app/hooks/use-document-properties.ts
@@ -132,7 +132,7 @@ export function useSetDocumentProperty(
       );
       return { previous };
     },
-    onError: (_error, _variables, context) => {
+    onError: (_error, variables, context) => {
       const rollback = context as
         | {
             previous?: Array<[readonly unknown[], unknown]>;
@@ -141,6 +141,9 @@ export function useSetDocumentProperty(
       for (const [queryKey, data] of rollback?.previous ?? []) {
         queryClient.setQueryData(queryKey, data);
       }
+      queryClient.invalidateQueries({
+        queryKey: documentPropertiesQueryKey(variables.documentId, databaseId),
+      });
     },
     onSuccess: (data, variables) => {
       const savedValue =

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -3113,6 +3113,8 @@ const enUS = {
     searchLanguages: "Search languages...",
     noBlocksFields: "No Blocks fields. Add one from the property menu.",
     noDocumentSelected: "No document selected",
+    blocksFieldRevisionConflict:
+      "This Blocks field changed elsewhere. Your edit wasn't saved; the latest version is now shown.",
     couldNotReadLocalSourceFile: "Could not read local source file",
     couldNotSaveLocalFile: "Could not save local file",
     collabConnectingReadOnly:
@@ -5613,6 +5615,8 @@ const databaseExactEnglishMessagesByLocale = {
 const editorMessagesByLocale = {
   "zh-CN": {
     noDocumentSelected: "未选择文档",
+    blocksFieldRevisionConflict:
+      "此 Blocks 字段已在其他位置更改。你的编辑未保存；现已显示最新版本。",
     collabConnectingReadOnly: "正在连接实时编辑器。显示只读快照。",
     liveDocumentSaveBeforeSyncFailed: "实时文档无法在同步前保存。",
     builderBodySyncing: "内容仍在从 Builder 同步",
@@ -5959,6 +5963,8 @@ const editorMessagesByLocale = {
   },
   "es-ES": {
     noDocumentSelected: "Ningún documento seleccionado",
+    blocksFieldRevisionConflict:
+      "Este campo de bloques cambió en otro lugar. Tu edición no se guardó; ahora se muestra la versión más reciente.",
     collabConnectingReadOnly:
       "Conectando el editor en vivo. Mostrando una instantánea de solo lectura.",
     liveDocumentSaveBeforeSyncFailed:
@@ -6318,6 +6324,8 @@ const editorMessagesByLocale = {
   },
   "fr-FR": {
     noDocumentSelected: "Aucun document sélectionné",
+    blocksFieldRevisionConflict:
+      "Ce champ de blocs a été modifié ailleurs. Votre modification n’a pas été enregistrée ; la dernière version est maintenant affichée.",
     collabConnectingReadOnly:
       "Connexion de l'éditeur en direct. Affichage d'un instantané en lecture seule.",
     liveDocumentSaveBeforeSyncFailed:
@@ -6682,6 +6690,8 @@ const editorMessagesByLocale = {
   },
   "de-DE": {
     noDocumentSelected: "Kein Dokument ausgewählt",
+    blocksFieldRevisionConflict:
+      "Dieses Blocks-Feld wurde an anderer Stelle geändert. Deine Bearbeitung wurde nicht gespeichert; jetzt wird die neueste Version angezeigt.",
     collabConnectingReadOnly:
       "Live-Editor wird verbunden. Schreibgeschützte Momentaufnahme wird angezeigt.",
     liveDocumentSaveBeforeSyncFailed:
@@ -7049,6 +7059,8 @@ const editorMessagesByLocale = {
   },
   "ja-JP": {
     noDocumentSelected: "ドキュメントが選択されていません",
+    blocksFieldRevisionConflict:
+      "このブロックフィールドは別の場所で変更されました。編集内容は保存されず、最新バージョンが表示されています。",
     collabConnectingReadOnly:
       "ライブエディターに接続中。読み取り専用のスナップショットを表示しています。",
     liveDocumentSaveBeforeSyncFailed:
@@ -7405,6 +7417,8 @@ const editorMessagesByLocale = {
   },
   "ko-KR": {
     noDocumentSelected: "선택한 문서가 없습니다.",
+    blocksFieldRevisionConflict:
+      "이 블록 필드가 다른 곳에서 변경되었습니다. 편집 내용은 저장되지 않았으며 최신 버전이 표시됩니다.",
     collabConnectingReadOnly:
       "라이브 편집기에 연결하는 중입니다. 읽기 전용 스냅샷을 표시합니다.",
     liveDocumentSaveBeforeSyncFailed:
@@ -7760,6 +7774,8 @@ const editorMessagesByLocale = {
   },
   "pt-BR": {
     noDocumentSelected: "Nenhum documento selecionado",
+    blocksFieldRevisionConflict:
+      "Este campo de blocos foi alterado em outro lugar. Sua edição não foi salva; a versão mais recente agora está sendo exibida.",
     collabConnectingReadOnly:
       "Conectando o editor ao vivo. Exibindo um instantâneo somente leitura.",
     liveDocumentSaveBeforeSyncFailed:
@@ -8121,6 +8137,8 @@ const editorMessagesByLocale = {
   },
   "hi-IN": {
     noDocumentSelected: "कोई दस्तावेज़ चयनित नहीं",
+    blocksFieldRevisionConflict:
+      "यह ब्लॉक फ़ील्ड कहीं और बदल गया है। आपका संपादन सहेजा नहीं गया; अब नवीनतम संस्करण दिखाया जा रहा है।",
     collabConnectingReadOnly:
       "लाइव संपादक कनेक्ट हो रहा है। केवल-पठन स्नैपशॉट दिखाया जा रहा है।",
     liveDocumentSaveBeforeSyncFailed:
@@ -8472,6 +8490,8 @@ const editorMessagesByLocale = {
   },
   "ar-SA": {
     noDocumentSelected: "لم يتم تحديد أي مستند",
+    blocksFieldRevisionConflict:
+      "تم تغيير حقل الكتل هذا في مكان آخر. لم يتم حفظ تعديلك؛ ويظهر الآن أحدث إصدار.",
     collabConnectingReadOnly:
       "جارٍ الاتصال بالمحرر المباشر. يتم عرض لقطة للقراءة فقط.",
     liveDocumentSaveBeforeSyncFailed: "تعذّر حفظ المستند المباشر قبل المزامنة.",

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -101,6 +101,8 @@ const messages = {
     searchLanguages: "搜尋語言...",
     noBlocksFields: "沒有 Blocks 欄位。請從屬性選單新增一個。",
     noDocumentSelected: "未選取檔案",
+    blocksFieldRevisionConflict:
+      "此 Blocks 欄位已在其他位置變更。你的編輯未儲存；現在顯示的是最新版本。",
     couldNotReadLocalSourceFile: "無法讀取本機來源檔案",
     couldNotSaveLocalFile: "無法儲存本機檔案",
     collabConnectingReadOnly: "正在連接即時編輯器。顯示唯讀快照。",

--- a/templates/content/changelog/2026-08-10-database-blocks-fields-now-keep-logical-block-identity-throu.md
+++ b/templates/content/changelog/2026-08-10-database-blocks-fields-now-keep-logical-block-identity-throu.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-10
+---
+
+Database Blocks fields now keep logical block identity through editing, reordering, deletion recovery, and reloads

--- a/templates/content/changelog/2026-08-13-blocks-field-conflicts-now-keep-the-newer-saved-version-visi.md
+++ b/templates/content/changelog/2026-08-13-blocks-field-conflicts-now-keep-the-newer-saved-version-visi.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-13
+---
+
+Blocks field conflicts now keep the newer saved version visible instead of leaving a rejected edit on screen

--- a/templates/content/docs/product/capabilities/content.object.block.md
+++ b/templates/content/docs/product/capabilities/content.object.block.md
@@ -6,7 +6,7 @@ name: "Blocks"
 user_promise: "A Block is a stable addressable unit of rich content inside its owning field."
 primary_user_job: "Edit and point to a meaningful part of content without fragile position-only anchors."
 kind: "primitive"
-state: "approved_shape"
+state: "in_progress"
 publicness: "public"
 availability: "universal"
 dependencies: []
@@ -21,9 +21,10 @@ proof_requirements:
     "Comment anchors retain historical target context",
     "Shared Action/UI editing, conflict, undo, and reload behavior",
   ]
-evidence: []
+evidence:
+  ["shared/blocks-field-identity.ts", "actions/blocks-seeding.db.test.ts"]
 superseded_by: null
-last_reviewed: "2026-07-29"
+last_reviewed: "2026-08-10"
 ---
 
 # Blocks
@@ -62,7 +63,7 @@ Given a Block reference in another Page, when an authorized reader opens it, the
 
 ## Current evidence
 
-The current editor stores rich document content and supports anchored comments, but the repository does not yet demonstrate stable universal Block IDs, reference serialization, or recovery across all typed Block operations. This remains `approved_shape`.
+Database Blocks fields now have a field-scoped ordered identity sidecar with deterministic legacy IDs, persisted revisions, and bounded tombstone recovery. Deterministic tests cover editing, reorder, insertion, deletion, recovery, reload, and field independence. Agent-facing exact Block actions, reference/comment anchors, actor-aware history, and real-interface proof remain incomplete, so this is `in_progress`, not verified.
 
 ## Proof plan
 

--- a/templates/content/docs/product/capabilities/content.object.blocks-field.md
+++ b/templates/content/docs/product/capabilities/content.object.blocks-field.md
@@ -6,7 +6,7 @@ name: "Blocks fields"
 user_promise: "Every editable rich-content body uses one Blocks-field grammar and keeps its own stable revision boundary."
 primary_user_job: "Write rich content in Pages and collaboration surfaces without each body inventing incompatible editing and history rules."
 kind: "primitive"
-state: "approved_shape"
+state: "in_progress"
 publicness: "public"
 availability: "universal"
 dependencies: ["content.object.block"]
@@ -24,9 +24,14 @@ proof_requirements:
     "Owner-scoped access and typed rendering including unavailable content",
     "Shared Action/UI behavior for concurrency, history, and portable output",
   ]
-evidence: []
+evidence:
+  [
+    "server/db/schema.ts",
+    "actions/_blocks-field-identity.ts",
+    "actions/blocks-seeding.db.test.ts",
+  ]
 superseded_by: null
-last_reviewed: "2026-07-29"
+last_reviewed: "2026-08-10"
 ---
 
 # Blocks fields
@@ -65,7 +70,7 @@ Given a Page with two Blocks fields, when an authorized editor restores one fiel
 
 ## Current evidence
 
-The document editor proves rich Page-body editing and comments provide collaboration substrate. The repository does not yet prove one generalized Blocks-field grammar or independent field history across all owners; this remains `approved_shape`.
+Primary and additional database Blocks properties now retain distinct field identities, ordered Block identities, and independent monotonic revisions around their existing Markdown stores. Export reports each field and its identity status without changing plain NFM. Comment/Discussion owners, attributable history, arbitrary restore, shared mutation actions, and real-interface proof remain incomplete, so this is `in_progress`, not verified.
 
 ## Proof plan
 

--- a/templates/content/docs/product/encyclopedia.md
+++ b/templates/content/docs/product/encyclopedia.md
@@ -16,8 +16,8 @@ This index summarizes the atomic product contracts beneath the public roadmap. E
 | Verified         |     3 |
 | Failing          |     1 |
 | Stale            |     0 |
-| In Progress      |    16 |
-| Approved Shape   |    91 |
+| In Progress      |    18 |
+| Approved Shape   |    89 |
 | Exploring        |     8 |
 | Deferred         |     0 |
 | Superseded       |     5 |
@@ -358,8 +358,8 @@ graph LR
 
 | Capability                                                                       | State          | User promise                                                                                                              |
 | -------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [Blocks](capabilities/content.object.block.md)                                   | Approved Shape | A Block is a stable addressable unit of rich content inside its owning field.                                             |
-| [Blocks fields](capabilities/content.object.blocks-field.md)                     | Approved Shape | Every editable rich-content body uses one Blocks-field grammar and keeps its own stable revision boundary.                |
+| [Blocks](capabilities/content.object.block.md)                                   | In Progress    | A Block is a stable addressable unit of rich content inside its owning field.                                             |
+| [Blocks fields](capabilities/content.object.blocks-field.md)                     | In Progress    | Every editable rich-content body uses one Blocks-field grammar and keeps its own stable revision boundary.                |
 | [Databases](capabilities/content.object.database.md)                             | Verified       | Database as a Page-backed typed collection                                                                                |
 | [Multiple Database memberships](capabilities/content.object.multi-membership.md) | In Progress    | One Page can belong to several Databases without copies or a hidden primary home.                                         |
 | [Pages](capabilities/content.object.page.md)                                     | Verified       | A durable Page keeps its identity, body, properties, access, discussion, and portable representation wherever it appears. |

--- a/templates/content/server/db/schema.ts
+++ b/templates/content/server/db/schema.ts
@@ -523,4 +523,65 @@ export const documentBlockFieldContents = table(
   },
 );
 
+// Stable identity and revision boundary for one database Blocks property. The
+// Markdown body remains in documents.content or document_block_field_contents;
+// this row binds the ordered identity sidecar to those exact bytes.
+export const documentBlockFields = table(
+  "document_block_fields",
+  {
+    id: text("id").primaryKey(),
+    ownerEmail: text("owner_email").notNull().default("local@localhost"),
+    documentId: text("document_id").notNull(),
+    propertyId: text("property_id").notNull(),
+    revision: integer("revision").notNull().default(0),
+    contentHash: text("content_hash").notNull(),
+    createdAt: text("created_at").notNull().default(now()),
+    updatedAt: text("updated_at").notNull().default(now()),
+  },
+  (field) => [
+    uniqueIndex("document_block_fields_document_property_unique").on(
+      field.documentId,
+      field.propertyId,
+    ),
+    index("document_block_fields_owner_document_idx").on(
+      field.ownerEmail,
+      field.documentId,
+    ),
+  ],
+);
+
+// Ordered block identity index plus bounded tombstones. This is deliberately
+// not an actor-aware history log: it records only current nodes and the minimum
+// deleted fragment needed for editor undo to recover the same logical ID.
+export const documentBlocks = table(
+  "document_blocks",
+  {
+    id: text("id").primaryKey(),
+    ownerEmail: text("owner_email").notNull().default("local@localhost"),
+    fieldId: text("field_id").notNull(),
+    parentId: text("parent_id"),
+    kind: text("kind").notNull(),
+    position: integer("position").notNull(),
+    sortIndex: integer("sort_index").notNull(),
+    addressable: integer("addressable", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    contentHash: text("content_hash").notNull(),
+    markdown: text("markdown").notNull().default(""),
+    state: text("state").notNull().default("live"),
+    deletedAtRevision: integer("deleted_at_revision"),
+    recoveredAtRevision: integer("recovered_at_revision"),
+    createdAt: text("created_at").notNull().default(now()),
+    updatedAt: text("updated_at").notNull().default(now()),
+  },
+  (block) => [
+    index("document_blocks_field_state_sort_idx").on(
+      block.fieldId,
+      block.state,
+      block.sortIndex,
+    ),
+    index("document_blocks_parent_idx").on(block.parentId),
+  ],
+);
+
 export const documentShares = createSharesTable("document_shares");

--- a/templates/content/server/plugins/db.ts
+++ b/templates/content/server/plugins/db.ts
@@ -956,6 +956,49 @@ export const runContentMigrations = runMigrations(
       CREATE INDEX IF NOT EXISTS content_database_migration_receipts_owner_database_idx
         ON content_database_migration_receipts (owner_email, database_id)`,
     },
+    {
+      version: 81,
+      name: "content-block-field-identities",
+      sql: `CREATE TABLE IF NOT EXISTS document_block_fields (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+        document_id TEXT NOT NULL,
+        property_id TEXT NOT NULL,
+        revision INTEGER NOT NULL DEFAULT 0,
+        content_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS document_block_fields_document_property_unique
+        ON document_block_fields (document_id, property_id);
+      CREATE INDEX IF NOT EXISTS document_block_fields_owner_document_idx
+        ON document_block_fields (owner_email, document_id)`,
+    },
+    {
+      version: 82,
+      name: "content-block-identities-and-tombstones",
+      sql: `CREATE TABLE IF NOT EXISTS document_blocks (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+        field_id TEXT NOT NULL,
+        parent_id TEXT,
+        kind TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        sort_index INTEGER NOT NULL,
+        addressable INTEGER NOT NULL DEFAULT 1,
+        content_hash TEXT NOT NULL,
+        markdown TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL DEFAULT 'live',
+        deleted_at_revision INTEGER,
+        recovered_at_revision INTEGER,
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+      CREATE INDEX IF NOT EXISTS document_blocks_field_state_sort_idx
+        ON document_blocks (field_id, state, sort_index);
+      CREATE INDEX IF NOT EXISTS document_blocks_parent_idx
+        ON document_blocks (parent_id)`,
+    },
   ],
   { table: "content_migrations" },
 );

--- a/templates/content/server/plugins/db.ts
+++ b/templates/content/server/plugins/db.ts
@@ -1007,7 +1007,7 @@ export const runContentMigrations = runMigrations(
       name: "content-block-addressable-postgres-boolean",
       sql: {
         postgres: `ALTER TABLE document_blocks ALTER COLUMN addressable DROP DEFAULT;
-        ALTER TABLE document_blocks ALTER COLUMN addressable TYPE boolean USING (addressable::int != 0);
+        ALTER TABLE document_blocks ALTER COLUMN addressable TYPE boolean USING addressable::text::boolean;
         ALTER TABLE document_blocks ALTER COLUMN addressable SET DEFAULT true`,
       },
     },

--- a/templates/content/server/plugins/db.ts
+++ b/templates/content/server/plugins/db.ts
@@ -999,6 +999,18 @@ export const runContentMigrations = runMigrations(
       CREATE INDEX IF NOT EXISTS document_blocks_parent_idx
         ON document_blocks (parent_id)`,
     },
+    // The portable schema maps integer({ mode: "boolean" }) to BOOLEAN on
+    // Postgres, while the raw INTEGER migration above is adapted to BIGINT.
+    // Convert the stored column before Drizzle sends boolean values.
+    {
+      version: 83,
+      name: "content-block-addressable-postgres-boolean",
+      sql: {
+        postgres: `ALTER TABLE document_blocks ALTER COLUMN addressable DROP DEFAULT;
+        ALTER TABLE document_blocks ALTER COLUMN addressable TYPE boolean USING (addressable::int != 0);
+        ALTER TABLE document_blocks ALTER COLUMN addressable SET DEFAULT true`,
+      },
+    },
   ],
   { table: "content_migrations" },
 );

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -1,3 +1,4 @@
+import type { BlocksFieldIdentity } from "./blocks-field-identity";
 import type {
   DocumentPropertyOptions,
   DocumentPropertyOption,
@@ -190,6 +191,7 @@ export interface DocumentProperty {
   definition: DocumentPropertyDefinition;
   value: DocumentPropertyValue;
   editable: boolean;
+  blocksField?: BlocksFieldIdentity;
 }
 
 export interface DocumentPropertiesResponse {
@@ -214,6 +216,7 @@ export interface SetDocumentPropertyRequest {
   databaseId: string;
   propertyId: string;
   value: DocumentPropertyValue;
+  expectedBlocksFieldRevision?: number;
 }
 
 export interface DuplicateDocumentPropertyRequest {

--- a/templates/content/shared/blocks-field-identity.spec.ts
+++ b/templates/content/shared/blocks-field-identity.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BLOCK_TOMBSTONE_REVISION_WINDOW,
+  MAX_BLOCK_TOMBSTONES_PER_FIELD,
   blocksFieldId,
   exposeBlocksFieldIdentity,
   legacyBlocksFieldIdentity,
@@ -154,6 +156,85 @@ describe("Blocks field identity", () => {
     expect(
       exposeBlocksFieldIdentity(recovered, "Keep\nRecover me").tombstones,
     ).not.toContainEqual(expect.objectContaining({ id: recoverId }));
+  });
+
+  it("consumes a tombstone once when identical blocks are restored", () => {
+    const initial = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Keep\nRepeat",
+    });
+    const repeatId = initial.blocks[1]!.id;
+    const deleted = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: initial,
+      markdown: "Keep",
+      createId: idFactory(),
+    });
+    const restoredTwice = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: deleted,
+      markdown: "Keep\nRepeat\nRepeat",
+      createId: idFactory(),
+    });
+    const repeatIds = restoredTwice.blocks
+      .filter((block) => block.state === "live" && block.markdown === "Repeat")
+      .map((block) => block.id);
+
+    expect(repeatIds).toContain(repeatId);
+    expect(new Set(repeatIds).size).toBe(2);
+  });
+
+  it("bounds tombstone recovery by revision age and total count", () => {
+    let state = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Keep\nOld deletion",
+    });
+    state = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: state,
+      markdown: "Keep",
+      createId: idFactory(),
+    });
+    for (
+      let revision = 0;
+      revision < BLOCK_TOMBSTONE_REVISION_WINDOW;
+      revision++
+    ) {
+      state = reconcileBlocksFieldIdentity({
+        documentId: "doc-1",
+        propertyId: "content",
+        previous: state,
+        markdown: revision % 2 === 0 ? "Keep edited" : "Keep",
+        createId: idFactory(),
+      });
+    }
+    expect(
+      state.blocks.filter((block) => block.state === "deleted"),
+    ).toHaveLength(0);
+
+    const many = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-many",
+      propertyId: "content",
+      markdown: Array.from(
+        { length: MAX_BLOCK_TOMBSTONES_PER_FIELD + 1 },
+        (_, index) => `Block ${index}`,
+      ).join("\n"),
+    });
+    const allDeleted = reconcileBlocksFieldIdentity({
+      documentId: "doc-many",
+      propertyId: "content",
+      previous: many,
+      markdown: "",
+      createId: idFactory(),
+    });
+    expect(
+      allDeleted.blocks.filter((block) => block.state === "deleted"),
+    ).toHaveLength(MAX_BLOCK_TOMBSTONES_PER_FIELD);
   });
 
   it("preserves honest IDs when siblings are reordered and edited together", () => {

--- a/templates/content/shared/blocks-field-identity.spec.ts
+++ b/templates/content/shared/blocks-field-identity.spec.ts
@@ -42,6 +42,46 @@ describe("Blocks field identity", () => {
     expect(first.identityStatus).toBe("legacy");
   });
 
+  it("field-scopes identical preferred and generated IDs at first materialization", () => {
+    const markdown = '<registry-block blockId="shared-id" />';
+    const first = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown,
+    });
+    const second = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "notes",
+      markdown,
+    });
+
+    expect(first.blocks[0]?.id).not.toBe(second.blocks[0]?.id);
+
+    const firstInserted = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: materializeLegacyBlocksFieldIdentity({
+        documentId: "doc-1",
+        propertyId: "content",
+        markdown: "",
+      }),
+      markdown: "New block",
+      createId: () => "same-generated-id",
+    });
+    const secondInserted = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "notes",
+      previous: materializeLegacyBlocksFieldIdentity({
+        documentId: "doc-1",
+        propertyId: "notes",
+        markdown: "",
+      }),
+      markdown: "New block",
+      createId: () => "same-generated-id",
+    });
+    expect(firstInserted.blocks[0]?.id).not.toBe(secondInserted.blocks[0]?.id);
+  });
+
   it("preserves IDs through edit, reorder, insertion, split, and merge rules", () => {
     const createId = idFactory();
     const initial = materializeLegacyBlocksFieldIdentity({

--- a/templates/content/shared/blocks-field-identity.spec.ts
+++ b/templates/content/shared/blocks-field-identity.spec.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  blocksFieldId,
+  exposeBlocksFieldIdentity,
+  legacyBlocksFieldIdentity,
+  materializeLegacyBlocksFieldIdentity,
+  reconcileBlocksFieldIdentity,
+} from "./blocks-field-identity.js";
+
+function idFactory() {
+  let next = 0;
+  return () => `new_block_${++next}`;
+}
+
+describe("Blocks field identity", () => {
+  it("assigns deterministic but field-scoped identities without changing NFM", () => {
+    const first = legacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Alpha\nBeta",
+    });
+    const repeated = legacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Alpha\nBeta",
+    });
+    const additional = legacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "notes",
+      markdown: "Alpha\nBeta",
+    });
+
+    expect(repeated).toEqual(first);
+    expect(additional.fieldId).not.toBe(first.fieldId);
+    expect(additional.blocks.map((block) => block.id)).not.toEqual(
+      first.blocks.map((block) => block.id),
+    );
+    expect(first.revision).toBe(0);
+    expect(first.identityStatus).toBe("legacy");
+  });
+
+  it("preserves IDs through edit, reorder, insertion, split, and merge rules", () => {
+    const createId = idFactory();
+    const initial = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Alpha\nBeta",
+    });
+    const [alphaId, betaId] = initial.blocks.map((block) => block.id);
+
+    const edited = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: initial,
+      markdown: "Alpha edited\nBeta",
+      createId,
+    });
+    expect(
+      edited.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    ).toEqual([alphaId, betaId]);
+
+    const reordered = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: edited,
+      markdown: "Beta\nAlpha edited",
+      createId,
+    });
+    expect(
+      reordered.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    ).toEqual([betaId, alphaId]);
+
+    const inserted = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: reordered,
+      markdown: "Intro\nBeta\nAlpha edited",
+      createId,
+    });
+    const insertedLive = inserted.blocks.filter(
+      (block) => block.state === "live",
+    );
+    expect(insertedLive.slice(1).map((block) => block.id)).toEqual([
+      betaId,
+      alphaId,
+    ]);
+
+    const split = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: inserted,
+      markdown: "In\ntro\nBeta\nAlpha edited",
+      createId,
+    });
+    const splitLive = split.blocks.filter((block) => block.state === "live");
+    expect(splitLive[0]?.id).toBe(insertedLive[0]?.id);
+    expect(splitLive[1]?.id).not.toBe(insertedLive[0]?.id);
+
+    const merged = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: split,
+      markdown: "Intro\nBeta\nAlpha edited",
+      createId,
+    });
+    const mergedPublic = exposeBlocksFieldIdentity(
+      merged,
+      "Intro\nBeta\nAlpha edited",
+    );
+    expect(mergedPublic.blocks[0]?.id).toBe(splitLive[0]?.id);
+    expect(mergedPublic.tombstones).toContainEqual(
+      expect.objectContaining({ id: splitLive[1]?.id }),
+    );
+  });
+
+  it("reserves a deleted ID and recovers it only for an exact tombstoned block", () => {
+    const createId = idFactory();
+    const initial = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Keep\nRecover me",
+    });
+    const recoverId = initial.blocks[1]!.id;
+    const deleted = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: initial,
+      markdown: "Keep",
+      createId,
+    });
+    expect(
+      exposeBlocksFieldIdentity(deleted, "Keep").tombstones,
+    ).toContainEqual(
+      expect.objectContaining({ id: recoverId, deletedAtRevision: 1 }),
+    );
+
+    const recovered = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: deleted,
+      markdown: "Keep\nRecover me",
+      createId,
+    });
+    expect(
+      exposeBlocksFieldIdentity(recovered, "Keep\nRecover me").blocks.map(
+        (block) => block.id,
+      ),
+    ).toContain(recoverId);
+    expect(
+      exposeBlocksFieldIdentity(recovered, "Keep\nRecover me").tombstones,
+    ).not.toContainEqual(expect.objectContaining({ id: recoverId }));
+  });
+
+  it("preserves honest IDs when siblings are reordered and edited together", () => {
+    const initial = materializeLegacyBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      markdown: "Alpha paragraph\nBeta paragraph",
+    });
+    const [alphaId, betaId] = initial.blocks.map((block) => block.id);
+    const reconciled = reconcileBlocksFieldIdentity({
+      documentId: "doc-1",
+      propertyId: "content",
+      previous: initial,
+      markdown: "Beta paragraph edited\nAlpha paragraph edited",
+      createId: idFactory(),
+    });
+
+    expect(
+      reconciled.blocks
+        .filter((block) => block.state === "live")
+        .map((block) => block.id),
+    ).toEqual([betaId, alphaId]);
+  });
+
+  it("represents nested live NFM block kinds as an ordered parented graph", () => {
+    const identity = legacyBlocksFieldIdentity({
+      documentId: "doc-kinds",
+      propertyId: "content",
+      markdown: [
+        "# Heading",
+        "> Quote",
+        "- List item",
+        "\t- Nested item",
+        "[ ] Task",
+        "---",
+        "```ts",
+        "const stable = true",
+        "```",
+        '<callout icon="💡">',
+        "\tInside",
+        "</callout>",
+      ].join("\n"),
+    });
+    const kinds = new Set(identity.blocks.map((block) => block.kind));
+
+    expect(kinds).toEqual(
+      expect.objectContaining(
+        new Set([
+          "heading",
+          "blockquote",
+          "bulletList",
+          "listItem",
+          "paragraph",
+          "taskList",
+          "taskItem",
+          "horizontalRule",
+          "codeBlock",
+          "notionCallout",
+        ]),
+      ),
+    );
+    expect(identity.blocks.some((block) => block.parentId !== null)).toBe(true);
+    expect(new Set(identity.blocks.map((block) => block.id)).size).toBe(
+      identity.blocks.length,
+    );
+    expect(identity.fieldId).toBe(blocksFieldId("doc-kinds", "content"));
+  });
+});

--- a/templates/content/shared/blocks-field-identity.ts
+++ b/templates/content/shared/blocks-field-identity.ts
@@ -1,6 +1,8 @@
 import { docToNfm, nfmToDoc, type PMNode } from "./nfm.js";
 
 export const BLOCKS_FIELD_IDENTITY_VERSION = 1;
+export const BLOCK_TOMBSTONE_REVISION_WINDOW = 20;
+export const MAX_BLOCK_TOMBSTONES_PER_FIELD = 500;
 
 export type BlocksFieldIdentityStatus = "legacy" | "materialized" | "stale";
 
@@ -439,7 +441,10 @@ export function reconcileBlocksFieldIdentity(args: {
       );
       if (recoveredIndex !== undefined) {
         previous = previousDeleted[recoveredIndex];
-        if (previous) recoveredIds.add(previous.id);
+        if (previous) {
+          recoveredIds.add(previous.id);
+          recoverable.delete(`${snapshot.kind}\0${snapshot.contentHash}`);
+        }
       }
     }
     let id = previous?.id ?? snapshot.preferredId ?? args.createId();
@@ -470,15 +475,26 @@ export function reconcileBlocksFieldIdentity(args: {
       deletedAtRevision: nextRevision,
       recoveredAtRevision: null,
     }));
-  const retainedTombstones = previousDeleted.filter(
-    (block) => !recoveredIds.has(block.id),
-  );
+  const oldestRecoverableRevision =
+    nextRevision - BLOCK_TOMBSTONE_REVISION_WINDOW;
+  const retainedTombstones = [...previousDeleted, ...deletedNow]
+    .filter(
+      (block) =>
+        !recoveredIds.has(block.id) &&
+        block.deletedAtRevision !== null &&
+        block.deletedAtRevision > oldestRecoverableRevision,
+    )
+    .sort(
+      (left, right) =>
+        (right.deletedAtRevision ?? 0) - (left.deletedAtRevision ?? 0),
+    )
+    .slice(0, MAX_BLOCK_TOMBSTONES_PER_FIELD);
 
   return {
     fieldId: args.previous.fieldId,
     revision: nextRevision,
     contentHash: blocksContentHash(args.markdown),
-    blocks: [...nextBlocks, ...retainedTombstones, ...deletedNow],
+    blocks: [...nextBlocks, ...retainedTombstones],
   };
 }
 

--- a/templates/content/shared/blocks-field-identity.ts
+++ b/templates/content/shared/blocks-field-identity.ts
@@ -1,0 +1,525 @@
+import { docToNfm, nfmToDoc, type PMNode } from "./nfm.js";
+
+export const BLOCKS_FIELD_IDENTITY_VERSION = 1;
+
+export type BlocksFieldIdentityStatus = "legacy" | "materialized" | "stale";
+
+export interface BlocksFieldBlock {
+  id: string;
+  parentId: string | null;
+  kind: string;
+  position: number;
+  addressable: boolean;
+}
+
+export interface BlocksFieldTombstone {
+  id: string;
+  kind: string;
+  deletedAtRevision: number;
+}
+
+export interface BlocksFieldIdentity {
+  version: typeof BLOCKS_FIELD_IDENTITY_VERSION;
+  fieldId: string;
+  revision: number;
+  contentHash: string;
+  identityStatus: BlocksFieldIdentityStatus;
+  blocks: BlocksFieldBlock[];
+  tombstones: BlocksFieldTombstone[];
+  recoveryMode: "editor-undo-with-tombstones";
+}
+
+export interface StoredBlocksFieldBlock extends BlocksFieldBlock {
+  contentHash: string;
+  markdown: string;
+  deletedAtRevision: number | null;
+  recoveredAtRevision: number | null;
+  state: "live" | "deleted";
+}
+
+export interface StoredBlocksFieldIdentity {
+  fieldId: string;
+  revision: number;
+  contentHash: string;
+  blocks: StoredBlocksFieldBlock[];
+}
+
+interface BlockSnapshot {
+  path: string;
+  parentPath: string | null;
+  kind: string;
+  position: number;
+  addressable: boolean;
+  contentHash: string;
+  markdown: string;
+  preferredId: string | null;
+}
+
+const BLOCK_NODE_TYPES = new Set([
+  "paragraph",
+  "heading",
+  "horizontalRule",
+  "codeBlock",
+  "blockquote",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "taskList",
+  "taskItem",
+  "notionToggle",
+  "notionCallout",
+  "notionColumns",
+  "notionColumn",
+  "notionSyncedBlock",
+  "table",
+  "tableRow",
+  "tableHeader",
+  "tableCell",
+  "image",
+  "video",
+  "audio",
+  "notionBlockAtom",
+  "registryBlock",
+  "contentReference",
+  "localMdxComponent",
+]);
+
+const NON_ADDRESSABLE_NODE_TYPES = new Set([
+  "bulletList",
+  "orderedList",
+  "taskList",
+  "tableRow",
+  "tableHeader",
+  "tableCell",
+]);
+
+function hashString(value: string): string {
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    first ^= code;
+    first = Math.imul(first, 0x01000193);
+    second ^= code + index;
+    second = Math.imul(second, 0x85ebca6b);
+  }
+  return `${(first >>> 0).toString(16).padStart(8, "0")}${(second >>> 0)
+    .toString(16)
+    .padStart(8, "0")}`;
+}
+
+export function blocksFieldId(documentId: string, propertyId: string): string {
+  return `blocks_field_${hashString(`${documentId}\0${propertyId}`)}`;
+}
+
+export function blocksContentHash(markdown: string): string {
+  return `nfm_${hashString(markdown)}`;
+}
+
+function stableNodeValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableNodeValue);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => key !== "blockId")
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stableNodeValue(child)]),
+  );
+}
+
+function nodeMarkdown(node: PMNode): string {
+  return docToNfm({ type: "doc", content: [node] });
+}
+
+function snapshotMarkdown(markdown: string): BlockSnapshot[] {
+  const snapshots: BlockSnapshot[] = [];
+  const doc = nfmToDoc(markdown);
+
+  function visit(nodes: PMNode[] | undefined, parentPath: string | null) {
+    let blockPosition = 0;
+    for (let index = 0; index < (nodes?.length ?? 0); index++) {
+      const node = nodes![index]!;
+      if (!BLOCK_NODE_TYPES.has(node.type)) continue;
+      const path =
+        parentPath === null
+          ? `${blockPosition}`
+          : `${parentPath}.${blockPosition}`;
+      const canonical = JSON.stringify(stableNodeValue(node));
+      snapshots.push({
+        path,
+        parentPath,
+        kind: node.type,
+        position: blockPosition,
+        addressable: !NON_ADDRESSABLE_NODE_TYPES.has(node.type),
+        contentHash: `block_${hashString(canonical)}`,
+        markdown: nodeMarkdown(node),
+        preferredId:
+          node.type === "registryBlock" &&
+          typeof node.attrs?.blockId === "string"
+            ? node.attrs.blockId
+            : null,
+      });
+      visit(node.content, path);
+      blockPosition++;
+    }
+  }
+
+  visit(doc.content, null);
+  return snapshots;
+}
+
+function deterministicBlockId(
+  fieldId: string,
+  snapshot: Pick<BlockSnapshot, "path" | "kind" | "contentHash">,
+): string {
+  return `block_${hashString(
+    `${fieldId}\0${snapshot.path}\0${snapshot.kind}\0${snapshot.contentHash}`,
+  )}`;
+}
+
+function publicIdentity(
+  stored: StoredBlocksFieldIdentity,
+  identityStatus: BlocksFieldIdentityStatus,
+): BlocksFieldIdentity {
+  return {
+    version: BLOCKS_FIELD_IDENTITY_VERSION,
+    fieldId: stored.fieldId,
+    revision: stored.revision,
+    contentHash: stored.contentHash,
+    identityStatus,
+    blocks: stored.blocks
+      .filter((block) => block.state === "live")
+      .map(({ id, parentId, kind, position, addressable }) => ({
+        id,
+        parentId,
+        kind,
+        position,
+        addressable,
+      })),
+    tombstones: stored.blocks
+      .filter(
+        (
+          block,
+        ): block is StoredBlocksFieldBlock & {
+          deletedAtRevision: number;
+        } => block.state === "deleted" && block.deletedAtRevision !== null,
+      )
+      .map(({ id, kind, deletedAtRevision }) => ({
+        id,
+        kind,
+        deletedAtRevision,
+      })),
+    recoveryMode: "editor-undo-with-tombstones",
+  };
+}
+
+export function legacyBlocksFieldIdentity(args: {
+  documentId: string;
+  propertyId: string;
+  markdown: string;
+}): BlocksFieldIdentity {
+  const fieldId = blocksFieldId(args.documentId, args.propertyId);
+  const snapshots = snapshotMarkdown(args.markdown);
+  const idByPath = new Map<string, string>();
+  const usedIds = new Set<string>();
+  const blocks: StoredBlocksFieldBlock[] = snapshots.map((snapshot) => {
+    const preferred = snapshot.preferredId;
+    const id =
+      preferred && !usedIds.has(preferred)
+        ? preferred
+        : deterministicBlockId(fieldId, snapshot);
+    usedIds.add(id);
+    idByPath.set(snapshot.path, id);
+    return {
+      id,
+      parentId: snapshot.parentPath
+        ? (idByPath.get(snapshot.parentPath) ?? null)
+        : null,
+      kind: snapshot.kind,
+      position: snapshot.position,
+      addressable: snapshot.addressable,
+      contentHash: snapshot.contentHash,
+      markdown: snapshot.markdown,
+      state: "live",
+      deletedAtRevision: null,
+      recoveredAtRevision: null,
+    };
+  });
+  return publicIdentity(
+    {
+      fieldId,
+      revision: 0,
+      contentHash: blocksContentHash(args.markdown),
+      blocks,
+    },
+    "legacy",
+  );
+}
+
+function uniqueIndexByKey<T>(
+  values: T[],
+  key: (value: T) => string,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  const index = new Map<string, number>();
+  values.forEach((value, valueIndex) => {
+    const valueKey = key(value);
+    counts.set(valueKey, (counts.get(valueKey) ?? 0) + 1);
+    index.set(valueKey, valueIndex);
+  });
+  for (const [valueKey, count] of counts) {
+    if (count !== 1) index.delete(valueKey);
+  }
+  return index;
+}
+
+function characterBigrams(value: string): Set<string> {
+  const normalized = value.toLocaleLowerCase().replace(/\s+/g, " ").trim();
+  if (normalized.length < 2) return new Set(normalized ? [normalized] : []);
+  const result = new Set<string>();
+  for (let index = 0; index < normalized.length - 1; index++) {
+    result.add(normalized.slice(index, index + 2));
+  }
+  return result;
+}
+
+function editSimilarity(left: string, right: string): number {
+  const leftBigrams = characterBigrams(left);
+  const rightBigrams = characterBigrams(right);
+  if (leftBigrams.size === 0 || rightBigrams.size === 0) return 0;
+  let shared = 0;
+  for (const bigram of leftBigrams) {
+    if (rightBigrams.has(bigram)) shared++;
+  }
+  return (2 * shared) / (leftBigrams.size + rightBigrams.size);
+}
+
+export function reconcileBlocksFieldIdentity(args: {
+  documentId: string;
+  propertyId: string;
+  previous: StoredBlocksFieldIdentity;
+  markdown: string;
+  createId: () => string;
+}): StoredBlocksFieldIdentity {
+  const nextRevision = args.previous.revision + 1;
+  const snapshots = snapshotMarkdown(args.markdown);
+  const previousLive = args.previous.blocks.filter(
+    (block) => block.state === "live",
+  );
+  const previousDeleted = args.previous.blocks.filter(
+    (block) => block.state === "deleted",
+  );
+  const matchedPrevious = new Set<number>();
+  const assigned = new Map<number, StoredBlocksFieldBlock>();
+  const usedIds = new Set(args.previous.blocks.map((block) => block.id));
+
+  const previousExact = uniqueIndexByKey(
+    previousLive,
+    (block) => `${block.kind}\0${block.contentHash}`,
+  );
+  const nextExact = uniqueIndexByKey(
+    snapshots,
+    (snapshot) => `${snapshot.kind}\0${snapshot.contentHash}`,
+  );
+  for (const [key, previousIndex] of previousExact) {
+    const nextIndex = nextExact.get(key);
+    if (nextIndex === undefined) continue;
+    matchedPrevious.add(previousIndex);
+    assigned.set(nextIndex, previousLive[previousIndex]!);
+  }
+
+  // Split keeps the leading fragment's ID; merge keeps the receiving block's
+  // ID. These are the only cardinality-changing cases where position conveys
+  // more identity than text similarity.
+  const unmatchedKinds = new Set([
+    ...previousLive
+      .filter((_block, index) => !matchedPrevious.has(index))
+      .map((block) => block.kind),
+    ...snapshots
+      .filter((_snapshot, index) => !assigned.has(index))
+      .map((snapshot) => snapshot.kind),
+  ]);
+  for (const kind of unmatchedKinds) {
+    const previousIndexes = previousLive.flatMap((block, index) =>
+      !matchedPrevious.has(index) && block.kind === kind ? [index] : [],
+    );
+    const nextIndexes = snapshots.flatMap((snapshot, index) =>
+      !assigned.has(index) && snapshot.kind === kind ? [index] : [],
+    );
+    if (previousIndexes.length !== 1 && nextIndexes.length !== 1) {
+      continue;
+    }
+    if (previousIndexes.length === 0 || nextIndexes.length === 0) continue;
+    const samePosition = nextIndexes.find(
+      (nextIndex) =>
+        snapshots[nextIndex]!.position ===
+        previousLive[previousIndexes[0]!]!.position,
+    );
+    if (samePosition === undefined) continue;
+    matchedPrevious.add(previousIndexes[0]!);
+    assigned.set(samePosition, previousLive[previousIndexes[0]!]!);
+  }
+
+  // A reorder and a text edit can happen in one editor transaction. Pair only
+  // mutual, sufficiently similar best matches before considering position; an
+  // ambiguous match is left for the conservative positional rule below.
+  const bestNextForPrevious = new Map<
+    number,
+    { index: number; score: number }
+  >();
+  const bestPreviousForNext = new Map<
+    number,
+    { index: number; score: number }
+  >();
+  for (
+    let previousIndex = 0;
+    previousIndex < previousLive.length;
+    previousIndex++
+  ) {
+    if (matchedPrevious.has(previousIndex)) continue;
+    const previous = previousLive[previousIndex]!;
+    for (let nextIndex = 0; nextIndex < snapshots.length; nextIndex++) {
+      if (assigned.has(nextIndex)) continue;
+      const snapshot = snapshots[nextIndex]!;
+      if (previous.kind !== snapshot.kind) continue;
+      const score = editSimilarity(previous.markdown, snapshot.markdown);
+      if (score < 0.45) continue;
+      const previousBest = bestNextForPrevious.get(previousIndex);
+      if (!previousBest || score > previousBest.score) {
+        bestNextForPrevious.set(previousIndex, { index: nextIndex, score });
+      }
+      const nextBest = bestPreviousForNext.get(nextIndex);
+      if (!nextBest || score > nextBest.score) {
+        bestPreviousForNext.set(nextIndex, { index: previousIndex, score });
+      }
+    }
+  }
+  for (const [previousIndex, nextBest] of bestNextForPrevious) {
+    const previousBest = bestPreviousForNext.get(nextBest.index);
+    if (previousBest?.index !== previousIndex) continue;
+    matchedPrevious.add(previousIndex);
+    assigned.set(nextBest.index, previousLive[previousIndex]!);
+  }
+
+  for (let nextIndex = 0; nextIndex < snapshots.length; nextIndex++) {
+    if (assigned.has(nextIndex)) continue;
+    const snapshot = snapshots[nextIndex]!;
+    const samePosition = previousLive.findIndex(
+      (block, previousIndex) =>
+        !matchedPrevious.has(previousIndex) &&
+        block.kind === snapshot.kind &&
+        block.position === snapshot.position,
+    );
+    if (samePosition !== -1) {
+      matchedPrevious.add(samePosition);
+      assigned.set(nextIndex, previousLive[samePosition]!);
+      continue;
+    }
+    const sameKind = previousLive.findIndex(
+      (block, previousIndex) =>
+        !matchedPrevious.has(previousIndex) && block.kind === snapshot.kind,
+    );
+    if (sameKind !== -1) {
+      matchedPrevious.add(sameKind);
+      assigned.set(nextIndex, previousLive[sameKind]!);
+    }
+  }
+
+  const recoverable = uniqueIndexByKey(
+    previousDeleted,
+    (block) => `${block.kind}\0${block.contentHash}`,
+  );
+  const recoveredIds = new Set<string>();
+  const idByPath = new Map<string, string>();
+  const nextBlocks = snapshots.map((snapshot, nextIndex) => {
+    let previous = assigned.get(nextIndex);
+    if (!previous) {
+      const recoveredIndex = recoverable.get(
+        `${snapshot.kind}\0${snapshot.contentHash}`,
+      );
+      if (recoveredIndex !== undefined) {
+        previous = previousDeleted[recoveredIndex];
+        if (previous) recoveredIds.add(previous.id);
+      }
+    }
+    let id = previous?.id ?? snapshot.preferredId ?? args.createId();
+    while (usedIds.has(id) && id !== previous?.id) id = args.createId();
+    usedIds.add(id);
+    idByPath.set(snapshot.path, id);
+    return {
+      id,
+      parentId: snapshot.parentPath
+        ? (idByPath.get(snapshot.parentPath) ?? null)
+        : null,
+      kind: snapshot.kind,
+      position: snapshot.position,
+      addressable: snapshot.addressable,
+      contentHash: snapshot.contentHash,
+      markdown: snapshot.markdown,
+      state: "live" as const,
+      deletedAtRevision: null,
+      recoveredAtRevision: recoveredIds.has(id) ? nextRevision : null,
+    };
+  });
+
+  const deletedNow = previousLive
+    .filter((_block, index) => !matchedPrevious.has(index))
+    .map((block) => ({
+      ...block,
+      state: "deleted" as const,
+      deletedAtRevision: nextRevision,
+      recoveredAtRevision: null,
+    }));
+  const retainedTombstones = previousDeleted.filter(
+    (block) => !recoveredIds.has(block.id),
+  );
+
+  return {
+    fieldId: args.previous.fieldId,
+    revision: nextRevision,
+    contentHash: blocksContentHash(args.markdown),
+    blocks: [...nextBlocks, ...retainedTombstones, ...deletedNow],
+  };
+}
+
+export function exposeBlocksFieldIdentity(
+  stored: StoredBlocksFieldIdentity,
+  markdown: string,
+): BlocksFieldIdentity {
+  const currentHash = blocksContentHash(markdown);
+  if (currentHash === stored.contentHash) {
+    return publicIdentity(stored, "materialized");
+  }
+  let provisionalIndex = 0;
+  const reconciled = reconcileBlocksFieldIdentity({
+    documentId: "stale-read",
+    propertyId: stored.fieldId,
+    previous: stored,
+    markdown,
+    createId: () =>
+      `block_${hashString(`${stored.fieldId}\0${markdown}\0${provisionalIndex++}`)}`,
+  });
+  return publicIdentity({ ...reconciled, revision: stored.revision }, "stale");
+}
+
+export function materializeLegacyBlocksFieldIdentity(args: {
+  documentId: string;
+  propertyId: string;
+  markdown: string;
+}): StoredBlocksFieldIdentity {
+  const publicState = legacyBlocksFieldIdentity(args);
+  const snapshots = snapshotMarkdown(args.markdown);
+  return {
+    fieldId: publicState.fieldId,
+    revision: 0,
+    contentHash: publicState.contentHash,
+    blocks: publicState.blocks.map((block, index) => ({
+      ...block,
+      contentHash: snapshots[index]!.contentHash,
+      markdown: snapshots[index]!.markdown,
+      state: "live",
+      deletedAtRevision: null,
+      recoveredAtRevision: null,
+    })),
+  };
+}

--- a/templates/content/shared/blocks-field-identity.ts
+++ b/templates/content/shared/blocks-field-identity.ts
@@ -179,6 +179,10 @@ function deterministicBlockId(
   )}`;
 }
 
+function fieldScopedBlockId(fieldId: string, candidateId: string): string {
+  return `block_${hashString(fieldId)}_${hashString(candidateId)}`;
+}
+
 function publicIdentity(
   stored: StoredBlocksFieldIdentity,
   identityStatus: BlocksFieldIdentityStatus,
@@ -225,7 +229,9 @@ export function legacyBlocksFieldIdentity(args: {
   const idByPath = new Map<string, string>();
   const usedIds = new Set<string>();
   const blocks: StoredBlocksFieldBlock[] = snapshots.map((snapshot) => {
-    const preferred = snapshot.preferredId;
+    const preferred = snapshot.preferredId
+      ? fieldScopedBlockId(fieldId, snapshot.preferredId)
+      : null;
     const id =
       preferred && !usedIds.has(preferred)
         ? preferred
@@ -447,8 +453,15 @@ export function reconcileBlocksFieldIdentity(args: {
         }
       }
     }
-    let id = previous?.id ?? snapshot.preferredId ?? args.createId();
-    while (usedIds.has(id) && id !== previous?.id) id = args.createId();
+    let id =
+      previous?.id ??
+      fieldScopedBlockId(
+        args.previous.fieldId,
+        snapshot.preferredId ?? args.createId(),
+      );
+    while (usedIds.has(id) && id !== previous?.id) {
+      id = fieldScopedBlockId(args.previous.fieldId, args.createId());
+    }
     usedIds.add(id);
     idByPath.set(snapshot.path, id);
     return {

--- a/templates/content/shared/document-export.spec.ts
+++ b/templates/content/shared/document-export.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { legacyBlocksFieldIdentity } from "./blocks-field-identity";
 import {
   buildDocumentExport,
   exportFilename,
@@ -8,6 +9,56 @@ import {
 import { KATEX_STYLESHEET_URL } from "./math-rendering";
 
 describe("document export", () => {
+  it("carries ordered Blocks fields in a non-rendering identity manifest", () => {
+    const markdown = "Alpha\nBeta";
+    const blocksFields = [
+      {
+        propertyId: "content",
+        name: "Content",
+        position: 0,
+        markdown,
+        identity: legacyBlocksFieldIdentity({
+          documentId: "doc_123",
+          propertyId: "content",
+          markdown,
+        }),
+      },
+      {
+        propertyId: "notes",
+        name: "Notes",
+        position: 1,
+        markdown: "Private notes",
+        identity: legacyBlocksFieldIdentity({
+          documentId: "doc_123",
+          propertyId: "notes",
+          markdown: "Private notes",
+        }),
+      },
+    ];
+    const exported = buildDocumentExport({
+      id: "doc_123",
+      title: "Identity export",
+      content: markdown,
+      format: "markdown",
+      blocksFields,
+    });
+
+    expect(exported.blocksFields).toEqual(blocksFields);
+    expect(exported.content).toContain("<!-- agent-native-blocks:");
+    expect(exported.content).toContain('"propertyId":"notes"');
+
+    const html = buildDocumentExport({
+      id: "doc_123",
+      title: "Identity export",
+      content: markdown,
+      format: "html",
+      blocksFields,
+    });
+    expect(html.content).toContain(
+      '<script type="application/json" id="agent-native-blocks">',
+    );
+    expect(html.content).not.toContain("agent-native-blocks:</article>");
+  });
   it("creates stable filenames from page titles", () => {
     expect(exportFilename("Q2 Launch / PRD", "markdown")).toBe(
       "q2-launch-prd.md",

--- a/templates/content/shared/document-export.spec.ts
+++ b/templates/content/shared/document-export.spec.ts
@@ -13,6 +13,7 @@ describe("document export", () => {
     const markdown = "Alpha\nBeta";
     const blocksFields = [
       {
+        databaseId: "database-1",
         propertyId: "content",
         name: "Content",
         position: 0,
@@ -24,6 +25,7 @@ describe("document export", () => {
         }),
       },
       {
+        databaseId: "database-1",
         propertyId: "notes",
         name: "Notes",
         position: 1,

--- a/templates/content/shared/document-export.ts
+++ b/templates/content/shared/document-export.ts
@@ -14,6 +14,7 @@ export interface DocumentExportInput {
 }
 
 export interface BlocksFieldExport {
+  databaseId: string;
   propertyId: string;
   name: string;
   position: number;

--- a/templates/content/shared/document-export.ts
+++ b/templates/content/shared/document-export.ts
@@ -1,3 +1,4 @@
+import type { BlocksFieldIdentity } from "./blocks-field-identity.js";
 import { matchInlineMathAt } from "./inline-math.js";
 import { KATEX_STYLESHEET_URL, renderMathToHtml } from "./math-rendering.js";
 
@@ -9,6 +10,15 @@ export interface DocumentExportInput {
   content?: string | null;
   updatedAt?: string | null;
   format: DocumentExportFormat;
+  blocksFields?: BlocksFieldExport[];
+}
+
+export interface BlocksFieldExport {
+  propertyId: string;
+  name: string;
+  position: number;
+  markdown: string;
+  identity: BlocksFieldIdentity;
 }
 
 export interface DocumentExportPayload {
@@ -19,6 +29,15 @@ export interface DocumentExportPayload {
   mimeType: string;
   content: string;
   print: boolean;
+  blocksFields?: BlocksFieldExport[];
+}
+
+function serializeBlocksFieldsManifest(fields: BlocksFieldExport[]): string {
+  return JSON.stringify({ version: 1, fields })
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/--/g, "\\u002d\\u002d");
 }
 
 const EXTENSION_BY_FORMAT: Record<DocumentExportFormat, string> = {
@@ -638,7 +657,10 @@ export function buildDocumentExport(
   const filename = exportFilename(title, input.format);
   const markdown = markdownWithTitle(title, input.content);
   const isHtmlLike = input.format === "html" || input.format === "pdf";
-  const content = isHtmlLike
+  const manifest = input.blocksFields?.length
+    ? serializeBlocksFieldsManifest(input.blocksFields)
+    : null;
+  let content = isHtmlLike
     ? buildHtmlDocument({
         title,
         content: input.content ?? "",
@@ -646,6 +668,14 @@ export function buildDocumentExport(
         print: input.format === "pdf",
       })
     : markdown;
+  if (manifest) {
+    content = isHtmlLike
+      ? content.replace(
+          "</body>",
+          `<script type="application/json" id="agent-native-blocks">${manifest}</script>\n</body>`,
+        )
+      : `${content.trimEnd()}\n\n<!-- agent-native-blocks:${manifest} -->\n`;
+  }
 
   return {
     id: input.id,
@@ -655,5 +685,6 @@ export function buildDocumentExport(
     mimeType: MIME_BY_FORMAT[input.format],
     content,
     print: input.format === "pdf",
+    ...(input.blocksFields?.length ? { blocksFields: input.blocksFields } : {}),
   };
 }


### PR DESCRIPTION
## Problem

A Content database row can have more than one rich-text area: its main content and any additional rich-text properties. This PR calls each of those areas a **Blocks field**.

Before this change, a Blocks field was stored primarily as Markdown. Its text and order survived, but an individual paragraph, heading, list item, callout, or other block did not have a dependable identity across editing, reordering, deletion, undo, and reload. Additional Blocks fields could also accept an older save after a newer one, silently replacing the newer content.

After this change, each Blocks field has its own revision and ordered logical block identities. Ordinary edits and reordering retain IDs, nearby exact deletion/undo can recover them, and revision-aware stale writes fail as conflicts instead of clobbering newer work.

## Approach

Markdown remains the canonical, portable content. An additive sidecar stores the field revision plus the ordered identities of its live blocks.

When a block is deleted, the sidecar keeps a **tombstone**: a small record of the deleted block's ID, kind, and exact Markdown fragment. The supported editor undo path can reuse that ID when it restores the exact fragment. Recovery is deliberately **bounded**: one tombstone can be consumed once, and a field retains at most 500 tombstones from its latest 20 revisions. This is not general document history or actor-aware attribution.

New block IDs are derived from both the Blocks field and an allocation candidate. That makes first writes to different fields independent even when their Markdown contains the same embedded preferred ID. Existing stored IDs are not rewritten. Primary body writes lock current database memberships and revise every primary Blocks field that reads that shared body, preventing a concurrent membership removal from leaving or recreating an orphaned sidecar.

This PR establishes the persistence contract only. It does not add PR #3's individual block-action API.

## What changed

- Added two additive SQL tables for each field's revision/content fingerprint and its ordered live blocks/tombstones.
- Added deterministic revision-zero identities for existing Markdown-only values. Reads remain pure; sidecars materialize lazily on a supported save.
- Persisted Markdown and identity changes in the same transaction for primary and additional Blocks fields, including multi-database rows and `edit-document`.
- Added optimistic revision checks. A stale browser save now receives a typed conflict, drops the rejected payload, adopts the accepted winner in the editor, and cannot replay that payload during collapse, remount, or reload. A newer draft typed while the conflict refetch is in flight is preserved and rebased on the new revision.
- Serialized primary body writes with membership removal and advanced every primary membership's independent revision.
- Removed identity sidecars by property when a database/property is deleted and by document when a row is deleted. Surviving memberships keep their own identities.
- Preserved the shared body when deleting one primary Blocks property from a row that still has another primary membership, while retaining the surviving sidecar as materialized.
- Exported identity manifests for all accessible database memberships without changing the canonical Markdown body.

## Safety and compatibility

The migrations are additive and perform no eager backfill. Existing rows continue to read from their current Markdown stores. Rolling back leaves the new tables unused; no user content must be converted because Markdown remains authoritative.

Mixed-version operation has a real limitation: an older application can still edit Markdown without updating the sidecar or supplying a revision. A newer version reports the sidecar as stale and reconciles it on the next supported write, but stale-write protection is not complete while old writers remain active.

Tombstones retain exact deleted fragments until recovery, expiry, displacement by the cap, or field deletion. They are not durable history. Large bulk removals and very large same-kind fuzzy reconciliations remain performance follow-ups; they do not change the representation contract.

## Verification

Current head: `79349e2cbbb798bb417404b7a5c04d1173c10f5e`.

- A task-owned authenticated browser fixture exercised Markdown-only materialization; primary and additional Blocks fields; edit, insert, reorder, delete, exact bounded recovery, revision independence, stale-write rejection, winner adoption, reload, multi-membership behavior, property deletion, database deletion, and UI refresh. IDs and order remained stable across reload. The rejected stale payload never reached storage or replayed after reload.
- Fixture cleanup was independently read back from SQLite: all declared documents, databases, memberships, property definitions, field contents, identity fields, and orphan block rows were absent, and the UI Trash was empty.
- 48 focused identity/controller/SQLite tests pass on this head. They include transported 409 conflicts, accepted-winner adoption, no retry after unmount, preservation of a newer draft during conflict refetch, and typed persistence conflicts.
- Content TypeScript checking and all 50 repository guards pass locally. Exact-head CI is fully green, including Content DB, Content parity, PostgreSQL locking/concurrency, typecheck, build, lint/format, security, all fast-test lanes, scaffold and SSR checks, product impact, and the trusted acceptance substrate.
- One bounded independent review of the conflict repair found no P0/P1/P2 correctness issue. The final follow-up adds deterministic coverage for the two subsequently reported conflict timing variants without changing the field representation contract.

The standalone generated-Chat smoke was rerun once locally. That local run reached the generated Vite server and then failed dependency optimization because its fresh install paired `@tiptap/extension-list@3.30.0` with `@tiptap/core@3.28.0`; this PR changes no Chat files, package manifests, or lockfile. The repository's isolated exact-head generated-Chat CI job subsequently passed.

The browser acceptance used an isolated SQLite fixture. PostgreSQL identity/concurrency remains covered by the isolated CI lane, not by this local browser run. No Slack, provider, production, customer, or Alice-canonical data was touched.

## Review focus

- Does field-scoped allocation close cross-field global-key races without changing existing stored IDs or same-field conflict semantics?
- Do membership locks and multi-primary revision updates cover every supported body-write path without coupling independent additional fields?
- Does property/document cleanup remove only the deleted ownership boundary while preserving surviving memberships?
- Does conflict recovery reject stale content without replaying it or discarding a newer local draft?
- Are additive migration, mixed-version, rollback, tombstone retention, and Markdown portability described and implemented honestly?

```yaml
content_product_impact:
  lane: contract_fulfillment
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.object.block
    - content.object.blocks-field
  record_change: included
  proof:
    - focused identity and SQLite lifecycle coverage
    - isolated PostgreSQL concurrency coverage in CI
    - authenticated disposable browser acceptance
    - full 50-check repository guard suite
    - bounded exact-head persistence review
  rationale: This fulfills the approved database Blocks identity slice while keeping broader actions references comments and actor-aware history explicitly incomplete.
```
