### PR TITLE
Keep Clips playback comment cards visible for three seconds

### DIFF
--- a/templates/clips/app/components/player/playback-comment-overlay.test.tsx
+++ b/templates/clips/app/components/player/playback-comment-overlay.test.tsx
@@ -30,7 +30,7 @@ const comment: PlaybackComment = {
 };
 
 describe("playback comment timing", () => {
-  it("shows a root comment from its timestamp for one second", () => {
+  it("shows a root comment from its timestamp for three seconds", () => {
     expect(getActivePlaybackComments([comment], 11_999)).toEqual([]);
     expect(getActivePlaybackComments([comment], 12_000)).toEqual([comment]);
     expect(
@@ -48,11 +48,11 @@ describe("playback comment timing", () => {
   });
 
   it("scales the media-time window with playback speed", () => {
-    expect(getPlaybackCommentVisibleMs(2.5)).toBe(2_500);
-    expect(getActivePlaybackComments([comment], 12_000 + 2_499, 2.5)).toEqual([
+    expect(getPlaybackCommentVisibleMs(2.5)).toBe(7_500);
+    expect(getActivePlaybackComments([comment], 12_000 + 7_499, 2.5)).toEqual([
       comment,
     ]);
-    expect(getActivePlaybackComments([comment], 12_000 + 2_500, 2.5)).toEqual(
+    expect(getActivePlaybackComments([comment], 12_000 + 7_500, 2.5)).toEqual(
       [],
     );
   });

--- a/templates/clips/app/components/player/playback-comment-overlay.tsx
+++ b/templates/clips/app/components/player/playback-comment-overlay.tsx
@@ -3,7 +3,7 @@ import { useAvatarUrl } from "@agent-native/core/client/hooks";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
 
-export const PLAYBACK_COMMENT_VISIBLE_MS = 1_000;
+export const PLAYBACK_COMMENT_VISIBLE_MS = 3_000;
 
 export function getPlaybackCommentVisibleMs(playbackRate = 1): number {
   const safePlaybackRate =

--- a/templates/clips/changelog/2026-08-11-timestamped-comments-stay-on-the-video-for-three-seconds-wh.md
+++ b/templates/clips/changelog/2026-08-11-timestamped-comments-stay-on-the-video-for-three-seconds-wh.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-11
+---
+
+Timestamped comments stay on the video for three seconds while it plays.


### PR DESCRIPTION
### Summary
Extends timestamped comment overlays on the Clips video player so each root comment stays readable for three seconds of real playback time instead of one.

### Problem
While a clip was playing, comment cards on the video disappeared after only one second. At any playback speed that was too brief to read, so the overlay felt fleeting rather than useful.

### Solution
Raise the fixed visibility window from 1s to 3s of wall-clock time. Keep the existing timing model (media-time window scaled by playback rate) and the existing single-card UI with “+N other comments” for overlapping roots—no new dismiss/hover behavior.
### Caveat
If a comment that is stamped at `0:15` is visible for 3 seconds and user goes back to `0:17` in the progress bar, then that comment will still show for 1 second even though user did not go to `0:15`.

This is the easiest solution for now and experience can improve later if needed. 

Made with [Cursor](https://cursor.com)