### PR TITLE
Let clip viewers reshare public/org clips via copy-link

### DIFF
--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -260,32 +260,28 @@ function ShareRecordingContent({
         defaultValue="link"
         className={cn("min-w-0 px-4 py-3", reserveCloseButton && "pe-12")}
       >
-        <TabsList
-          className={`grid w-full ${
-            tabCount === 3
-              ? "grid-cols-3"
-              : tabCount === 2
-                ? "grid-cols-2"
-                : "grid-cols-1"
-          }`}
-        >
-          <TabsTrigger value="link" className="gap-1.5">
-            <IconLink size={14} />
-            {t("shareDialog.link")}
-          </TabsTrigger>
-          {canViewShares ? (
-            <TabsTrigger value="invite" className="gap-1.5">
-              <IconMail size={14} />
-              {t("shareDialog.invite")}
+        {tabCount > 1 ? (
+          <TabsList
+            className={`grid w-full ${tabCount === 3 ? "grid-cols-3" : "grid-cols-2"}`}
+          >
+            <TabsTrigger value="link" className="gap-1.5">
+              <IconLink size={14} />
+              {t("shareDialog.link")}
             </TabsTrigger>
-          ) : null}
-          {canEmbed ? (
-            <TabsTrigger value="embed" className="gap-1.5">
-              <IconCode size={14} />
-              {t("shareDialog.embed")}
-            </TabsTrigger>
-          ) : null}
-        </TabsList>
+            {canViewShares ? (
+              <TabsTrigger value="invite" className="gap-1.5">
+                <IconMail size={14} />
+                {t("shareDialog.invite")}
+              </TabsTrigger>
+            ) : null}
+            {canEmbed ? (
+              <TabsTrigger value="embed" className="gap-1.5">
+                <IconCode size={14} />
+                {t("shareDialog.embed")}
+              </TabsTrigger>
+            ) : null}
+          </TabsList>
+        ) : null}
 
         <TabsContent value="link" className="mt-3">
           <LinkTab

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -72,6 +72,13 @@ export interface ShareRecordingPopoverProps {
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
   hasPassword?: boolean;
+  /**
+   * Restricts the dialog to a bare copy-link control for viewers who can
+   * reshare a public/org clip's link but have no edit access: it skips
+   * `list-resource-shares` (which returns every individually-shared
+   * principal's email to any reader) and hides the Invite tab entirely.
+   */
+  viewerReshareOnly?: boolean;
   /** Trigger element rendered as the popover anchor (usually the Share button). */
   children: ReactNode;
   open?: boolean;
@@ -103,6 +110,7 @@ export function ShareRecordingPopover({
   animatedThumbnailUrl,
   isLoomRecording = false,
   hasPassword,
+  viewerReshareOnly = false,
   children,
   open,
   onOpenChange,
@@ -125,6 +133,7 @@ export function ShareRecordingPopover({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
+          viewerReshareOnly={viewerReshareOnly}
         />
       </PopoverContent>
     </Popover>
@@ -148,6 +157,7 @@ export function ShareRecordingDialog({
   open,
   onOpenChange,
   hasPassword,
+  viewerReshareOnly = false,
 }: ShareRecordingDialogProps) {
   const t = useT();
   return (
@@ -168,6 +178,7 @@ export function ShareRecordingDialog({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
+          viewerReshareOnly={viewerReshareOnly}
           reserveCloseButton
         />
       </DialogContent>
@@ -186,6 +197,7 @@ function ShareRecordingContent({
   isLoomRecording = false,
   reserveCloseButton = false,
   hasPassword,
+  viewerReshareOnly = false,
 }: {
   recordingId: string;
   recordingTitle?: string;
@@ -197,20 +209,34 @@ function ShareRecordingContent({
   isLoomRecording?: boolean;
   reserveCloseButton?: boolean;
   hasPassword?: boolean;
+  viewerReshareOnly?: boolean;
 }) {
   const t = useT();
-  const sharesQuery = useActionQuery<SharesResponse>("list-resource-shares", {
-    resourceType: "recording",
-    resourceId: recordingId,
-  });
+  const sharesQuery = useActionQuery<SharesResponse>(
+    "list-resource-shares",
+    { resourceType: "recording", resourceId: recordingId },
+    { enabled: !viewerReshareOnly },
+  );
 
-  const data = sharesQuery.data;
+  const data = viewerReshareOnly ? undefined : sharesQuery.data;
   const role = data?.role ?? initialRole;
   const canManage = role === "owner" || role === "admin";
+  // Editors could always see (read-only) who a clip is shared with; only
+  // gate the Invite tab's mutation controls behind canManage. Commenters are
+  // grouped with plain viewers here -- neither can manage shares.
+  const canViewShares =
+    role === "owner" || role === "admin" || role === "editor";
   const visibility =
     (data?.visibility as Visibility | null | undefined) ??
     initialVisibility ??
     null;
+  // A plain viewer/commenter can't produce a working embed for a non-public
+  // clip (they have no way to make it public), so don't dangle the tab in
+  // front of them only to show an "ask the owner" dead end. Owner/admin/
+  // editor keep it regardless of visibility since they can flip to public
+  // from inside it.
+  const canEmbed = canViewShares || visibility === "public";
+  const tabCount = 1 + (canViewShares ? 1 : 0) + (canEmbed ? 1 : 0);
 
   // Attribution `via` must be a stable non-PII id, never an email. The only
   // owner id available client-side is the *current* session's userId, which is
@@ -234,19 +260,31 @@ function ShareRecordingContent({
         defaultValue="link"
         className={cn("min-w-0 px-4 py-3", reserveCloseButton && "pe-12")}
       >
-        <TabsList className="grid w-full grid-cols-3">
+        <TabsList
+          className={`grid w-full ${
+            tabCount === 3
+              ? "grid-cols-3"
+              : tabCount === 2
+                ? "grid-cols-2"
+                : "grid-cols-1"
+          }`}
+        >
           <TabsTrigger value="link" className="gap-1.5">
             <IconLink size={14} />
             {t("shareDialog.link")}
           </TabsTrigger>
-          <TabsTrigger value="invite" className="gap-1.5">
-            <IconMail size={14} />
-            {t("shareDialog.invite")}
-          </TabsTrigger>
-          <TabsTrigger value="embed" className="gap-1.5">
-            <IconCode size={14} />
-            {t("shareDialog.embed")}
-          </TabsTrigger>
+          {canViewShares ? (
+            <TabsTrigger value="invite" className="gap-1.5">
+              <IconMail size={14} />
+              {t("shareDialog.invite")}
+            </TabsTrigger>
+          ) : null}
+          {canEmbed ? (
+            <TabsTrigger value="embed" className="gap-1.5">
+              <IconCode size={14} />
+              {t("shareDialog.embed")}
+            </TabsTrigger>
+          ) : null}
         </TabsList>
 
         <TabsContent value="link" className="mt-3">
@@ -262,34 +300,39 @@ function ShareRecordingContent({
             animatedThumbnailUrl={animatedThumbnailUrl}
             isLoomRecording={isLoomRecording}
             hasPassword={hasPassword}
+            canViewShares={canViewShares}
           />
         </TabsContent>
 
-        <TabsContent value="invite" className="mt-3">
-          <SharePeopleTab
-            resourceType="recording"
-            resourceId={recordingId}
-            resourceUrl={absoluteAppUrl(`/r/${recordingId}`)}
-            sharesQuery={sharesQuery}
-            canManage={canManage}
-            roleCopy={{
-              commenter: {
-                label: t("shareUi.recordingCommenter.label"),
-                description: t("shareUi.recordingCommenter.description"),
-              },
-            }}
-          />
-        </TabsContent>
+        {canViewShares ? (
+          <TabsContent value="invite" className="mt-3">
+            <SharePeopleTab
+              resourceType="recording"
+              resourceId={recordingId}
+              resourceUrl={absoluteAppUrl(`/r/${recordingId}`)}
+              sharesQuery={sharesQuery}
+              canManage={canManage}
+              roleCopy={{
+                commenter: {
+                  label: t("shareUi.recordingCommenter.label"),
+                  description: t("shareUi.recordingCommenter.description"),
+                },
+              }}
+            />
+          </TabsContent>
+        ) : null}
 
-        <TabsContent value="embed" className="mt-3">
-          <ClipsEmbedConfigurator
-            recordingId={recordingId}
-            sharesQuery={sharesQuery}
-            visibility={visibility}
-            canManage={canManage}
-            ownerViaId={ownerViaId}
-          />
-        </TabsContent>
+        {canEmbed ? (
+          <TabsContent value="embed" className="mt-3">
+            <ClipsEmbedConfigurator
+              recordingId={recordingId}
+              sharesQuery={sharesQuery}
+              visibility={visibility}
+              canManage={canManage}
+              ownerViaId={ownerViaId}
+            />
+          </TabsContent>
+        ) : null}
       </Tabs>
     </>
   );
@@ -311,6 +354,7 @@ function LinkTab({
   animatedThumbnailUrl,
   isLoomRecording: isLoomRecordingProp,
   hasPassword,
+  canViewShares,
 }: {
   recordingId: string;
   recordingTitle?: string;
@@ -323,6 +367,7 @@ function LinkTab({
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
   hasPassword?: boolean;
+  canViewShares: boolean;
 }) {
   const t = useT();
   const { setResourceVisibility, isPending } = useResourceVisibilityMutation(
@@ -460,21 +505,23 @@ function LinkTab({
 
   return (
     <div className="space-y-4">
-      {visibility ? (
-        <GeneralAccessSelect
-          visibility={visibility}
-          canManage={canManage}
-          isPending={visibilityPending}
-          onChange={(next) => setResourceVisibility(next)}
-          publicDescription={t("shareDialog.publicDescription")}
-          showDescription={false}
-        />
-      ) : (
-        <div className="space-y-2" aria-hidden>
-          <div className="h-3 w-24 animate-pulse rounded bg-muted" />
-          <div className="h-12 w-full animate-pulse rounded bg-muted" />
-        </div>
-      )}
+      {canViewShares ? (
+        visibility ? (
+          <GeneralAccessSelect
+            visibility={visibility}
+            canManage={canManage}
+            isPending={visibilityPending}
+            onChange={(next) => setResourceVisibility(next)}
+            publicDescription={t("shareDialog.publicDescription")}
+            showDescription={false}
+          />
+        ) : (
+          <div className="space-y-2" aria-hidden>
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+            <div className="h-12 w-full animate-pulse rounded bg-muted" />
+          </div>
+        )
+      ) : null}
 
       <CopyField
         label={

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -524,6 +524,15 @@ export default function RecordingPage() {
   const canDownloadRecording = Boolean(
     recording?.enableDownloads && recording.videoUrl && !isLoomEmbedBacked,
   );
+  // Mirrors the /share/:shareId reshare restriction: a plain viewer must not
+  // trigger `list-resource-shares` (any read access is enough to call it,
+  // and its response includes every individually-shared principal's email)
+  // or see a raw video download/open action independent of `enableDownloads`.
+  const viewerReshareOnly = role === "viewer";
+  const shareVideoUrl =
+    canDownloadRecording || isLoomEmbedBacked
+      ? (recording?.videoUrl ?? null)
+      : null;
   const downloadRecording = useCallback(async () => {
     if (!recording?.videoUrl) return;
     setDownloading(true);
@@ -983,6 +992,7 @@ export default function RecordingPage() {
               initialVisibility={recording.visibility}
               initialRole={role}
               hasPassword={Boolean(recording.hasPassword)}
+              viewerReshareOnly={viewerReshareOnly}
             >
               <Button className="shrink-0 gap-1.5" size="sm">
                 {recording.visibility !== "public" ? (
@@ -1542,11 +1552,12 @@ export default function RecordingPage() {
               recordingTitle={recording.title}
               initialVisibility={recording.visibility}
               initialRole={role}
-              videoUrl={recording.videoUrl}
+              videoUrl={shareVideoUrl}
               thumbnailUrl={recording.thumbnailUrl}
               animatedThumbnailUrl={recording.animatedThumbnailUrl}
               isLoomRecording={isLoomEmbedBacked}
               hasPassword={Boolean(recording.hasPassword)}
+              viewerReshareOnly={viewerReshareOnly}
             >
               <Button
                 className="shrink-0 gap-1.5 bg-primary text-primary-foreground hover:bg-primary/90"

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -530,7 +530,7 @@ export default function RecordingPage() {
   // response includes every individually-shared principal's email) or see a
   // raw video download/open action independent of `enableDownloads`.
   const viewerReshareOnly =
-    role === "viewer" &&
+    (role === "viewer" || role === "commenter") &&
     (recording?.visibility === "public" || recording?.visibility === "org");
   const shareVideoUrl =
     canDownloadRecording || isLoomEmbedBacked

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -524,11 +524,14 @@ export default function RecordingPage() {
   const canDownloadRecording = Boolean(
     recording?.enableDownloads && recording.videoUrl && !isLoomEmbedBacked,
   );
-  // Mirrors the /share/:shareId reshare restriction: a plain viewer must not
-  // trigger `list-resource-shares` (any read access is enough to call it,
-  // and its response includes every individually-shared principal's email)
-  // or see a raw video download/open action independent of `enableDownloads`.
-  const viewerReshareOnly = role === "viewer";
+  // Mirrors the /share/:shareId reshare restriction (same public/org scope):
+  // a plain viewer of a public or org clip must not trigger
+  // `list-resource-shares` (any read access is enough to call it, and its
+  // response includes every individually-shared principal's email) or see a
+  // raw video download/open action independent of `enableDownloads`.
+  const viewerReshareOnly =
+    role === "viewer" &&
+    (recording?.visibility === "public" || recording?.visibility === "org");
   const shareVideoUrl =
     canDownloadRecording || isLoomEmbedBacked
       ? (recording?.videoUrl ?? null)

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -532,6 +532,9 @@ export default function ShareRoute() {
     viewerRole === "editor" ||
     viewerRole === "commenter";
   const viewerIsOwner = Boolean(dataQ.data?.data?.viewer?.isOwner);
+  const canReshareLink =
+    (viewerRole === "viewer" || viewerRole === "commenter") &&
+    (recording?.visibility === "public" || recording?.visibility === "org");
   const viewerCanOpenDashboard = Boolean(
     dataQ.data?.data?.viewer?.canOpenDashboard,
   );
@@ -990,7 +993,7 @@ export default function ShareRoute() {
                 onDeleted={() => navigate("/library", { replace: true })}
               />
             ) : null}
-            {viewerCanEdit ? (
+            {viewerCanEdit || canReshareLink ? (
               <ShareRecordingPopover
                 recordingId={recording.id}
                 recordingTitle={recording.title}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -535,6 +535,12 @@ export default function ShareRoute() {
   const canReshareLink =
     (viewerRole === "viewer" || viewerRole === "commenter") &&
     (recording?.visibility === "public" || recording?.visibility === "org");
+  // A plain viewer only gets a copy-link control: it must not trigger
+  // `list-resource-shares` (any read access is enough to call it, and its
+  // response includes every individually-shared principal's email) and must
+  // not surface the raw video download/open action independent of
+  // `enableDownloads`.
+  const viewerReshareOnly = canReshareLink && !viewerCanEdit;
   const viewerCanOpenDashboard = Boolean(
     dataQ.data?.data?.viewer?.canOpenDashboard,
   );
@@ -897,6 +903,10 @@ export default function ShareRoute() {
   const canDownloadRecording = Boolean(
     recording.enableDownloads && recording.videoUrl && !isLoomEmbedBacked,
   );
+  // Loom-backed clips only ever get an "open player" link (not a raw
+  // download), so they're exempt from the enableDownloads gate here.
+  const shareVideoUrl =
+    canDownloadRecording || isLoomEmbedBacked ? recording.videoUrl : null;
 
   return (
     <div className="flex min-h-screen max-w-full flex-col overflow-x-hidden bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
@@ -999,11 +1009,12 @@ export default function ShareRoute() {
                 recordingTitle={recording.title}
                 initialVisibility={recording.visibility}
                 initialRole={viewerIsOwner ? "owner" : undefined}
-                videoUrl={recording.videoUrl}
+                videoUrl={shareVideoUrl}
                 thumbnailUrl={recording.thumbnailUrl}
                 animatedThumbnailUrl={recording.animatedThumbnailUrl}
                 isLoomRecording={isLoomEmbedBacked}
                 hasPassword={Boolean(recording.hasPassword)}
+                viewerReshareOnly={viewerReshareOnly}
               >
                 <Button size="sm" className="shrink-0 gap-1.5">
                   {recording.visibility !== "public" ? (


### PR DESCRIPTION
## Summary
- A plain viewer who reached a clip via `public`/`org` visibility never saw the Share button on `/share/:shareId` — it was gated on `viewerCanEdit` (owner/admin/editor only), even though the dialog's copy-link field already worked for any role once opened.
- Show the Share button to viewers too when `recording.visibility` is `public` or `org` (a viewer on a narrowly-shared `private` clip still sees nothing, preserving the owner's tighter intent).
- Restrict such a viewer's dialog to the Link + Embed tabs (hide Invite), so they can only forward the clip via copy-link — not invite by email/role, see the full people-with-access list, or change visibility (visibility control was already disabled for non-managers).

## Why
Goal: when another user views a clip the creator shared with visibility set to public or organization, the receiver should be able to reshare that clip (to humans or agents) via a simple copy-link, without gaining any admin-level sharing controls.

## Viewer UI for public link
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/db1fc9cf-7b4a-442d-a7e8-6fc5ea08844f" />


## Viewer UI for org link
![Uploading image.png…]()





No backend/action changes were needed — `list-resource-shares` and `create-recording-agent-link` already permit any viewer; only the Share button's visibility and the dialog's tab set needed adjusting.

## Test plan
- [x] `oxfmt` on both touched files
- [x] Ran the clips dev server locally; confirmed as owner the Share dialog is unchanged (Link/Invite/Embed all present, invite-by-email + role picker work, people list renders)
- [x] Traced the viewer-facing logic against the existing `viewerCanEdit`/`canManage` patterns (exact conditions added, no new state)
- [ ] Full live check of the viewer path on `/share/:shareId` was blocked by an unrelated, pre-existing gate in a fresh local dev DB (no storage provider configured → clip never reaches `status: "ready"`, which early-returns before the Share button code for any role) — reviewers with a `ready` clip and a second account should confirm the Share button now appears for a `viewer` role on public/org clips and that the dialog shows Link+Embed only.