### PR TITLE
Centralize product docs links and fix broken UI URLs

### DIFF
--- a/.changeset/product-docs-url-helper.md
+++ b/.changeset/product-docs-url-helper.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+"@agent-native/skills": patch
+---
+
+Centralize product docs links behind `docsUrl` / `Docs` and retarget Settings, Team, onboarding, and template help links at live agent-native.com docs pages.

--- a/.changeset/product-docs-url-helper.md
+++ b/.changeset/product-docs-url-helper.md
@@ -4,4 +4,4 @@
 "@agent-native/skills": patch
 ---
 
-Centralize product docs links behind `docsUrl` / `Docs` and retarget Settings, Team, onboarding, and template help links at live agent-native.com docs pages.
+Centralize product docs links behind `docsUrl()` and retarget Settings, Team, onboarding, and template help links at live agent-native.com docs pages.

--- a/packages/core/src/cli/skills-content/help.ts
+++ b/packages/core/src/cli/skills-content/help.ts
@@ -1,3 +1,5 @@
+import { Docs } from "../../shared/docs-url.js";
+
 export const HELP = `npx @agent-native/core@latest skills
 
 Usage:
@@ -69,7 +71,7 @@ write those files.
 When installing visual-recap interactively, the CLI offers to add the optional PR
 Visual Recap GitHub Action. Pass --with-github-action to write it directly, then
 run "npx @agent-native/core@latest recap setup" / "npx @agent-native/core@latest recap doctor" to configure and
-verify GitHub Actions. Docs: https://www.agent-native.com/docs/pr-visual-recap.
+verify GitHub Actions. Docs: ${Docs.prVisualRecap()}.
 
 The status/update commands inspect copied Agent Native skill folders and refresh
 their instruction files from the current @agent-native/core package. In generated

--- a/packages/core/src/cli/skills-content/help.ts
+++ b/packages/core/src/cli/skills-content/help.ts
@@ -1,4 +1,4 @@
-import { Docs } from "../../shared/docs-url.js";
+import { docsUrl } from "../../shared/docs-url.js";
 
 export const HELP = `npx @agent-native/core@latest skills
 
@@ -71,7 +71,7 @@ write those files.
 When installing visual-recap interactively, the CLI offers to add the optional PR
 Visual Recap GitHub Action. Pass --with-github-action to write it directly, then
 run "npx @agent-native/core@latest recap setup" / "npx @agent-native/core@latest recap doctor" to configure and
-verify GitHub Actions. Docs: ${Docs.prVisualRecap()}.
+verify GitHub Actions. Docs: ${docsUrl("pr-visual-recap")}.
 
 The status/update commands inspect copied Agent Native skill folders and refresh
 their instruction files from the current @agent-native/core package. In generated

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -15,7 +15,7 @@ import {
   MCP_LEGACY_ROUTE_PREFIX,
   MCP_PUBLIC_ROUTE_PREFIX,
 } from "../mcp/route-paths.js";
-import { Docs } from "../shared/docs-url.js";
+import { docsUrl } from "../shared/docs-url.js";
 import {
   buildAppSkillPack,
   ensureAppSkill,
@@ -2447,7 +2447,7 @@ function prVisualRecapWorkflowDisplayPath(): string {
   return path.join(".github", "workflows", "pr-visual-recap.yml");
 }
 
-const PR_VISUAL_RECAP_DOCS_URL = Docs.prVisualRecap();
+const PR_VISUAL_RECAP_DOCS_URL = docsUrl("pr-visual-recap");
 
 function prVisualRecapInstallCommand(): string {
   return "npx @agent-native/core@latest skills add visual-recap --with-github-action";

--- a/packages/core/src/cli/skills.ts
+++ b/packages/core/src/cli/skills.ts
@@ -15,6 +15,7 @@ import {
   MCP_LEGACY_ROUTE_PREFIX,
   MCP_PUBLIC_ROUTE_PREFIX,
 } from "../mcp/route-paths.js";
+import { Docs } from "../shared/docs-url.js";
 import {
   buildAppSkillPack,
   ensureAppSkill,
@@ -2446,8 +2447,7 @@ function prVisualRecapWorkflowDisplayPath(): string {
   return path.join(".github", "workflows", "pr-visual-recap.yml");
 }
 
-const PR_VISUAL_RECAP_DOCS_URL =
-  "https://www.agent-native.com/docs/pr-visual-recap";
+const PR_VISUAL_RECAP_DOCS_URL = Docs.prVisualRecap();
 
 function prVisualRecapInstallCommand(): string {
   return "npx @agent-native/core@latest skills add visual-recap --with-github-action";

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 
+import { Docs } from "../shared/docs-url.js";
 import { getWorkspaceAppIdValidationError } from "../shared/workspace-app-id.js";
 import { sendToAgentChat } from "./agent-chat.js";
 import { agentNativePath, appBasePath } from "./api-path.js";
@@ -79,8 +80,7 @@ const ERROR_FAILURE_REASONS = new Set([
   "builder-not-connected",
   "credential-store-unavailable",
 ]);
-const LOCAL_APP_DOCS_URL =
-  "https://agent-native.com/docs/multi-app-workspace#adding-a-new-app";
+const LOCAL_APP_DOCS_URL = Docs.multiAppAdding();
 
 function isErrorFailureReason(reason: string | null): boolean {
   return !!reason && ERROR_FAILURE_REASONS.has(reason);

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 
-import { Docs } from "../shared/docs-url.js";
+import { docsUrl } from "../shared/docs-url.js";
 import { getWorkspaceAppIdValidationError } from "../shared/workspace-app-id.js";
 import { sendToAgentChat } from "./agent-chat.js";
 import { agentNativePath, appBasePath } from "./api-path.js";
@@ -80,7 +80,9 @@ const ERROR_FAILURE_REASONS = new Set([
   "builder-not-connected",
   "credential-store-unavailable",
 ]);
-const LOCAL_APP_DOCS_URL = Docs.multiAppAdding();
+const LOCAL_APP_DOCS_URL = docsUrl("multi-app-workspace", {
+  hash: "adding-a-new-app",
+});
 
 function isErrorFailureReason(reason: string | null): boolean {
   return !!reason && ERROR_FAILURE_REASONS.has(reason);

--- a/packages/core/src/client/agent-page/AgentTabsPage.spec.ts
+++ b/packages/core/src/client/agent-page/AgentTabsPage.spec.ts
@@ -8,8 +8,8 @@ import {
 describe("Agent access documentation links", () => {
   it("points MCP and A2A access fields to their protocol docs", () => {
     expect(AGENT_ACCESS_DOCS_HREF).toEqual({
-      mcp: "https://agent-native.com/docs/mcp-protocol",
-      a2a: "https://agent-native.com/docs/a2a-protocol",
+      mcp: "https://www.agent-native.com/docs/mcp-protocol",
+      a2a: "https://www.agent-native.com/docs/a2a-protocol",
     });
   });
 });
@@ -17,14 +17,15 @@ describe("Agent access documentation links", () => {
 describe("Agent resource documentation links", () => {
   it("provides a specific docs destination for every resource page", () => {
     expect(AGENT_RESOURCE_DOCS_HREF).toEqual({
-      files: "https://agent-native.com/docs/agent-resources#resources-tab",
-      instructions: "https://agent-native.com/docs/agent-resources#agents-md",
-      agents: "https://agent-native.com/docs/agent-resources#custom-agents",
-      memory: "https://agent-native.com/docs/agent-resources#memory",
-      skills: "https://agent-native.com/docs/skills-guide",
-      learnings: "https://agent-native.com/docs/agent-resources#memory",
+      files: "https://www.agent-native.com/docs/agent-resources#resources-tab",
+      instructions:
+        "https://www.agent-native.com/docs/agent-resources#agents-md",
+      agents: "https://www.agent-native.com/docs/agent-resources#custom-agents",
+      memory: "https://www.agent-native.com/docs/agent-resources#memory",
+      skills: "https://www.agent-native.com/docs/skills-guide",
+      learnings: "https://www.agent-native.com/docs/agent-resources#memory",
       "remote-agents":
-        "https://agent-native.com/docs/agent-resources#remote-vs-custom-agents",
+        "https://www.agent-native.com/docs/agent-resources#remote-vs-custom-agents",
     });
   });
 });

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -27,7 +27,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { Docs, docsUrl } from "../../shared/docs-url.js";
+import { docsUrl } from "../../shared/docs-url.js";
 import {
   MCP_CONNECT_GUIDES,
   MCP_CONNECT_MCP_URL_TEMPLATE,
@@ -148,7 +148,7 @@ export const AGENT_RESOURCE_DOCS_HREF: Record<ResourceView, string> = {
   instructions: docsUrl("agent-resources", { hash: "agents-md" }),
   agents: docsUrl("agent-resources", { hash: "custom-agents" }),
   memory: docsUrl("agent-resources", { hash: "memory" }),
-  skills: Docs.skillsGuide(),
+  skills: docsUrl("skills-guide"),
   learnings: docsUrl("agent-resources", { hash: "memory" }),
   "remote-agents": docsUrl("agent-resources", {
     hash: "remote-vs-custom-agents",
@@ -468,8 +468,8 @@ interface AccessUrls {
 }
 
 export const AGENT_ACCESS_DOCS_HREF = {
-  mcp: Docs.mcpProtocol(),
-  a2a: Docs.a2aProtocol(),
+  mcp: docsUrl("mcp-protocol"),
+  a2a: docsUrl("a2a-protocol"),
 } as const;
 
 interface CopyFieldProps {

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -27,6 +27,7 @@ import {
   type ReactNode,
 } from "react";
 
+import { Docs, docsUrl } from "../../shared/docs-url.js";
 import {
   MCP_CONNECT_GUIDES,
   MCP_CONNECT_MCP_URL_TEMPLATE,
@@ -143,14 +144,15 @@ function EmptySlot({ label }: { label: string }) {
 }
 
 export const AGENT_RESOURCE_DOCS_HREF: Record<ResourceView, string> = {
-  files: "https://agent-native.com/docs/agent-resources#resources-tab",
-  instructions: "https://agent-native.com/docs/agent-resources#agents-md",
-  agents: "https://agent-native.com/docs/agent-resources#custom-agents",
-  memory: "https://agent-native.com/docs/agent-resources#memory",
-  skills: "https://agent-native.com/docs/skills-guide",
-  learnings: "https://agent-native.com/docs/agent-resources#memory",
-  "remote-agents":
-    "https://agent-native.com/docs/agent-resources#remote-vs-custom-agents",
+  files: docsUrl("agent-resources", { hash: "resources-tab" }),
+  instructions: docsUrl("agent-resources", { hash: "agents-md" }),
+  agents: docsUrl("agent-resources", { hash: "custom-agents" }),
+  memory: docsUrl("agent-resources", { hash: "memory" }),
+  skills: Docs.skillsGuide(),
+  learnings: docsUrl("agent-resources", { hash: "memory" }),
+  "remote-agents": docsUrl("agent-resources", {
+    hash: "remote-vs-custom-agents",
+  }),
 };
 
 const RESOURCE_TAB_COPY: Record<
@@ -466,8 +468,8 @@ interface AccessUrls {
 }
 
 export const AGENT_ACCESS_DOCS_HREF = {
-  mcp: "https://agent-native.com/docs/mcp-protocol",
-  a2a: "https://agent-native.com/docs/a2a-protocol",
+  mcp: Docs.mcpProtocol(),
+  a2a: Docs.a2aProtocol(),
 } as const;
 
 interface CopyFieldProps {

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.spec.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.spec.tsx
@@ -190,7 +190,7 @@ describe("ExtensionsSidebarSection", () => {
     expect(popover?.dataset.collisionPadding).toBe("8");
 
     const docsLink = popover?.querySelector(
-      'a[href="https://agent-native.com/docs/extensions"]',
+      'a[href="https://www.agent-native.com/docs/extensions"]',
     ) as HTMLAnchorElement | null;
     expect(docsLink).not.toBeNull();
     expect(docsLink?.getAttribute("aria-label")).toBe("Learn more");

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -18,7 +18,7 @@ import { useState, useCallback, useMemo } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
 import { extensionPath, isExtensionPathname } from "../../extensions/path.js";
-import { Docs } from "../../shared/docs-url.js";
+import { docsUrl } from "../../shared/docs-url.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { agentNativePath } from "../api-path.js";
 import {
@@ -933,7 +933,7 @@ export function ExtensionsSidebarSection() {
                     {copy.open}
                   </Link>
                   <a
-                    href={Docs.extensions()}
+                    href={docsUrl("extensions")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex h-8 items-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
@@ -975,7 +975,7 @@ export function ExtensionsSidebarSection() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <a
-                        href={Docs.extensions()}
+                        href={docsUrl("extensions")}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -18,6 +18,7 @@ import { useState, useCallback, useMemo } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
 
 import { extensionPath, isExtensionPathname } from "../../extensions/path.js";
+import { Docs } from "../../shared/docs-url.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { agentNativePath } from "../api-path.js";
 import {
@@ -932,7 +933,7 @@ export function ExtensionsSidebarSection() {
                     {copy.open}
                   </Link>
                   <a
-                    href="https://agent-native.com/docs/extensions"
+                    href={Docs.extensions()}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex h-8 items-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
@@ -974,7 +975,7 @@ export function ExtensionsSidebarSection() {
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <a
-                        href="https://agent-native.com/docs/extensions"
+                        href={Docs.extensions()}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -185,7 +185,7 @@ describe("FirstRunOnboarding", () => {
     );
     expect(
       document.body.querySelector(
-        'a[href="https://agent-native.com/docs/environment-variables"]',
+        'a[href="https://www.agent-native.com/docs/environment-variables"]',
       ),
     ).toBeTruthy();
 

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -15,7 +15,7 @@ import type {
   OnboardingAppProfile,
   OnboardingCapability,
 } from "../../onboarding/types.js";
-import { Docs } from "../../shared/docs-url.js";
+import { docsUrl } from "../../shared/docs-url.js";
 import { appPath } from "../api-path.js";
 import {
   Tooltip,
@@ -473,7 +473,7 @@ export function FirstRunOnboarding({
               in <code className="rounded bg-muted px-1">.env</code> to make
               that provider available to everyone using this app.{" "}
               <a
-                href={Docs.environmentVariables()}
+                href={docsUrl("environment-variables")}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-1 text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -15,6 +15,7 @@ import type {
   OnboardingAppProfile,
   OnboardingCapability,
 } from "../../onboarding/types.js";
+import { Docs } from "../../shared/docs-url.js";
 import { appPath } from "../api-path.js";
 import {
   Tooltip,
@@ -472,7 +473,7 @@ export function FirstRunOnboarding({
               in <code className="rounded bg-muted px-1">.env</code> to make
               that provider available to everyone using this app.{" "}
               <a
-                href="https://agent-native.com/docs/environment-variables"
+                href={Docs.environmentVariables()}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-1 text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"

--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -66,8 +66,8 @@ import {
 // database code into the browser bundle.
 import type { AppRolesDescriptor } from "../../org/app-roles.js";
 import type { DomainMatchOrg } from "../../org/types.js";
+import { docsUrl } from "../../shared/docs-url.js";
 import type { WorkspaceUserGroup } from "../../workspace-connections/groups.js";
-import { Docs, docsUrl } from "../../shared/docs-url.js";
 import {
   Dialog,
   DialogContent,
@@ -2332,9 +2332,10 @@ function AuthProviderSettingsSection({
         description={
           <OrganizationDescription
             help="Require Google sign-in for every member. Enabling this revokes current sessions and rejects future password or non-Google sign-ins."
-            docsUrl={Docs.authSocialProviders({
+            docsUrl={docsUrl("authentication", {
               campaign: "organization_settings",
               content: "organization_sign_in",
+              hash: "social-providers",
             })}
           >
             Choose how members sign in.

--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -67,7 +67,7 @@ import {
 import type { AppRolesDescriptor } from "../../org/app-roles.js";
 import type { DomainMatchOrg } from "../../org/types.js";
 import type { WorkspaceUserGroup } from "../../workspace-connections/groups.js";
-import { Docs } from "../../shared/docs-url.js";
+import { Docs, docsUrl } from "../../shared/docs-url.js";
 import {
   Dialog,
   DialogContent,
@@ -2062,7 +2062,7 @@ function DomainSettingsSection({
       description={
         <OrganizationDescription
           help={`Anyone who signs up with an email at this domain joins the organization automatically. Only your own email domain (${ownDomain || "—"}) can be used; free email providers are not allowed.`}
-          docsUrl={Docs.organizationsTeams({
+          docsUrl={docsUrl("organizations-teams-permissions", {
             campaign: "organization_settings",
             content: "domain_auto_join",
           })}
@@ -2199,7 +2199,7 @@ function WorkspaceUrlSettingsSection({
       description={
         <OrganizationDescription
           help="Members who land on another deployment can be sent to this workspace URL instead of an empty app."
-          docsUrl={Docs.deployment({
+          docsUrl={docsUrl("deployment", {
             campaign: "organization_settings",
             content: "workspace_url",
           })}

--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -67,6 +67,7 @@ import {
 import type { AppRolesDescriptor } from "../../org/app-roles.js";
 import type { DomainMatchOrg } from "../../org/types.js";
 import type { WorkspaceUserGroup } from "../../workspace-connections/groups.js";
+import { Docs } from "../../shared/docs-url.js";
 import {
   Dialog,
   DialogContent,
@@ -2061,7 +2062,10 @@ function DomainSettingsSection({
       description={
         <OrganizationDescription
           help={`Anyone who signs up with an email at this domain joins the organization automatically. Only your own email domain (${ownDomain || "—"}) can be used; free email providers are not allowed.`}
-          docsUrl="https://www.builder.io/c/docs/agent-native-authentication?utm_source=agent-native&utm_medium=product&utm_campaign=organization_settings&utm_content=domain_auto_join"
+          docsUrl={Docs.organizationsTeams({
+            campaign: "organization_settings",
+            content: "domain_auto_join",
+          })}
         >
           Automatically add members with your work email.
         </OrganizationDescription>
@@ -2195,7 +2199,10 @@ function WorkspaceUrlSettingsSection({
       description={
         <OrganizationDescription
           help="Members who land on another deployment can be sent to this workspace URL instead of an empty app."
-          docsUrl="https://www.builder.io/c/docs/agent-native-deployment?utm_source=agent-native&utm_medium=product&utm_campaign=organization_settings&utm_content=workspace_url"
+          docsUrl={Docs.deployment({
+            campaign: "organization_settings",
+            content: "workspace_url",
+          })}
         >
           Send members to this workspace from another deployment.
         </OrganizationDescription>
@@ -2325,7 +2332,10 @@ function AuthProviderSettingsSection({
         description={
           <OrganizationDescription
             help="Require Google sign-in for every member. Enabling this revokes current sessions and rejects future password or non-Google sign-ins."
-            docsUrl="https://www.builder.io/c/docs/agent-native-authentication?utm_source=agent-native&utm_medium=product&utm_campaign=organization_settings&utm_content=organization_sign_in"
+            docsUrl={Docs.authSocialProviders({
+              campaign: "organization_settings",
+              content: "organization_sign_in",
+            })}
           >
             Choose how members sign in.
           </OrganizationDescription>

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -54,6 +54,7 @@ import React, {
 
 import { PROVIDER_ENV_PLACEHOLDERS } from "../../agent/engine/provider-env-vars.js";
 import { buildSettingsRoute } from "../../navigation/index.js";
+import { Docs } from "../../shared/docs-url.js";
 import {
   saveAgentEngineProviderSettings,
   setAgentEngineProvider,
@@ -3179,7 +3180,10 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
-                      docsUrl="https://www.builder.io/c/docs/agent-native-deployment?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=deployment_settings"
+                      docsUrl={Docs.deployment({
+                        campaign: "onboarding",
+                        content: "deployment_settings",
+                      })}
                       dim={connected}
                       bare
                       popover
@@ -3226,7 +3230,10 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Set DATABASE_URL in your .env to connect a supported database."
-                      docsUrl="https://www.builder.io/c/docs/agent-native-database?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=database_settings"
+                      docsUrl={Docs.database({
+                        campaign: "onboarding",
+                        content: "database_settings",
+                      })}
                       dim={connected}
                       bare
                       popover
@@ -3273,7 +3280,10 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Use an S3-compatible bucket with a stable public URL for durable chat attachments."
-                      docsUrl="https://www.builder.io/c/docs/agent-native-file-uploads?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=file_upload_settings"
+                      docsUrl={Docs.fileUploads({
+                        campaign: "onboarding",
+                        content: "file_upload_settings",
+                      })}
                       dim={connected}
                       bare
                       popover
@@ -3322,7 +3332,10 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Configure Better Auth and optional Google or GitHub providers."
-                      docsUrl="https://www.builder.io/c/docs/agent-native-authentication?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=authentication_settings"
+                      docsUrl={Docs.authentication({
+                        campaign: "onboarding",
+                        content: "authentication_settings",
+                      })}
                       dim={connected}
                       bare
                       popover
@@ -3461,7 +3474,10 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
-                docsUrl="https://www.builder.io/c/docs/agent-native-deployment?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=deployment_settings"
+                docsUrl={Docs.deployment({
+                  campaign: "onboarding",
+                  content: "deployment_settings",
+                })}
                 dim={connected}
               />
             </div>
@@ -3493,7 +3509,10 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Set DATABASE_URL in your .env to connect Neon, Supabase, Turso, any Postgres/SQLite database, or local PGlite with pglite:./data/pglite."
-                docsUrl="https://www.builder.io/c/docs/agent-native-database?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=database_settings"
+                docsUrl={Docs.database({
+                  campaign: "onboarding",
+                  content: "database_settings",
+                })}
                 dim={connected}
               />
             </div>
@@ -3525,7 +3544,10 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Object storage keeps uploaded files durable and their URLs reusable throughout the thread. Connect Builder or use an S3-compatible bucket below."
-                docsUrl="https://www.builder.io/c/docs/agent-native-file-uploads?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=file_upload_settings"
+                docsUrl={Docs.fileUploads({
+                  campaign: "onboarding",
+                  content: "file_upload_settings",
+                })}
                 dim={connected}
               >
                 <FileStorageSettingsForm />
@@ -3559,7 +3581,10 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Configure Better Auth with BETTER_AUTH_SECRET and optional Google/GitHub OAuth providers."
-                docsUrl="https://www.builder.io/c/docs/agent-native-authentication?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=authentication_settings"
+                docsUrl={Docs.authentication({
+                  campaign: "onboarding",
+                  content: "authentication_settings",
+                })}
                 dim={connected}
               />
             </div>

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -54,7 +54,7 @@ import React, {
 
 import { PROVIDER_ENV_PLACEHOLDERS } from "../../agent/engine/provider-env-vars.js";
 import { buildSettingsRoute } from "../../navigation/index.js";
-import { Docs } from "../../shared/docs-url.js";
+import { docsUrl } from "../../shared/docs-url.js";
 import {
   saveAgentEngineProviderSettings,
   setAgentEngineProvider,
@@ -3180,7 +3180,7 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
-                      docsUrl={Docs.deployment({
+                      docsUrl={docsUrl("deployment", {
                         campaign: "onboarding",
                         content: "deployment_settings",
                       })}
@@ -3230,7 +3230,7 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Set DATABASE_URL in your .env to connect a supported database."
-                      docsUrl={Docs.database({
+                      docsUrl={docsUrl("database", {
                         campaign: "onboarding",
                         content: "database_settings",
                       })}
@@ -3280,7 +3280,7 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Use an S3-compatible bucket with a stable public URL for durable chat attachments."
-                      docsUrl={Docs.fileUploads({
+                      docsUrl={docsUrl("file-uploads", {
                         campaign: "onboarding",
                         content: "file_upload_settings",
                       })}
@@ -3332,7 +3332,7 @@ function SettingsPanelContent({
                     <ManualSetupCard
                       title="Set up manually"
                       hint="Configure Better Auth and optional Google or GitHub providers."
-                      docsUrl={Docs.authentication({
+                      docsUrl={docsUrl("authentication", {
                         campaign: "onboarding",
                         content: "authentication_settings",
                       })}
@@ -3474,7 +3474,7 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
-                docsUrl={Docs.deployment({
+                docsUrl={docsUrl("deployment", {
                   campaign: "onboarding",
                   content: "deployment_settings",
                 })}
@@ -3509,7 +3509,7 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Set DATABASE_URL in your .env to connect Neon, Supabase, Turso, any Postgres/SQLite database, or local PGlite with pglite:./data/pglite."
-                docsUrl={Docs.database({
+                docsUrl={docsUrl("database", {
                   campaign: "onboarding",
                   content: "database_settings",
                 })}
@@ -3544,7 +3544,7 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Object storage keeps uploaded files durable and their URLs reusable throughout the thread. Connect Builder or use an S3-compatible bucket below."
-                docsUrl={Docs.fileUploads({
+                docsUrl={docsUrl("file-uploads", {
                   campaign: "onboarding",
                   content: "file_upload_settings",
                 })}
@@ -3581,7 +3581,7 @@ function SettingsPanelContent({
               />
               <ManualSetupCard
                 hint="Configure Better Auth with BETTER_AUTH_SECRET and optional Google/GitHub OAuth providers."
-                docsUrl={Docs.authentication({
+                docsUrl={docsUrl("authentication", {
                   campaign: "onboarding",
                   content: "authentication_settings",
                 })}

--- a/packages/core/src/integrations/catalog.ts
+++ b/packages/core/src/integrations/catalog.ts
@@ -6,6 +6,8 @@
  * availability and support maturity before offering a connection flow.
  */
 
+import { Docs, docsUrl } from "../shared/docs-url.js";
+
 export const INTEGRATION_CATEGORIES = [
   "channel",
   "provider",
@@ -121,7 +123,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Managed installations select encrypted credentials by workspace; legacy manual installs should use SLACK_ALLOWED_TEAM_IDS.",
     ],
     documentation: {
-      href: "/docs/messaging#slack",
+      href: Docs.messaging("slack"),
       externalHref: "https://api.slack.com/apps",
       externalLabel: "Open Slack apps",
     },
@@ -185,7 +187,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Production deployments must allowlist Microsoft Entra tenant IDs; proactive messaging without an inbound conversation reference is not implemented.",
     ],
     documentation: {
-      href: "/docs/messaging#microsoft-teams",
+      href: Docs.messaging("microsoft-teams"),
       externalHref: "https://dev.botframework.com/",
       externalLabel: "Open Bot Framework",
     },
@@ -247,7 +249,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Interaction tokens are retained only while the queued task is active and normally expire after 15 minutes.",
     ],
     documentation: {
-      href: "/docs/messaging#discord",
+      href: Docs.messaging("discord"),
       externalHref: "https://discord.com/developers/applications",
       externalLabel: "Open Discord applications",
     },
@@ -297,7 +299,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Webhook verification requires TELEGRAM_WEBHOOK_SECRET for production-safe setup.",
     ],
     documentation: {
-      href: "/docs/messaging#telegram",
+      href: Docs.messaging("telegram"),
       externalHref: "https://t.me/BotFather",
       externalLabel: "Open BotFather",
     },
@@ -347,7 +349,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Meta pricing and the customer-service conversation window can limit replies; template-message flows are not implemented by this adapter.",
     ],
     documentation: {
-      href: "/docs/messaging#whatsapp",
+      href: Docs.messaging("whatsapp"),
       externalHref: "https://developers.facebook.com/apps",
       externalLabel: "Open Meta developer console",
     },
@@ -405,7 +407,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Email replies preserve RFC email threads and reply-all when the agent was CC'd.",
     ],
     documentation: {
-      href: "/docs/messaging#email",
+      href: Docs.messaging("email"),
       externalHref: "https://resend.com/webhooks",
       externalLabel: "Open Resend webhooks",
     },
@@ -467,7 +469,7 @@ const AUTOMATION_CATALOG = [
       "Use a configured webhook URL or n8n credential; never put an n8n URL or credential in an agent prompt.",
     ],
     documentation: {
-      href: "/docs/automation-connectors#n8n",
+      href: docsUrl("automation-connectors", { hash: "n8n" }),
       externalHref:
         "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/",
       externalLabel: "Open n8n Webhook docs",
@@ -512,7 +514,7 @@ const AUTOMATION_CATALOG = [
       "Zapier MCP is a separately configured remote MCP connection with its own account and authorization flow.",
     ],
     documentation: {
-      href: "/docs/automation-connectors#zapier",
+      href: docsUrl("automation-connectors", { hash: "zapier" }),
       externalHref: "https://docs.zapier.com/mcp/home",
       externalLabel: "Open Zapier MCP docs",
     },

--- a/packages/core/src/integrations/catalog.ts
+++ b/packages/core/src/integrations/catalog.ts
@@ -6,7 +6,7 @@
  * availability and support maturity before offering a connection flow.
  */
 
-import { Docs, docsUrl } from "../shared/docs-url.js";
+import { docsUrl } from "../shared/docs-url.js";
 
 export const INTEGRATION_CATEGORIES = [
   "channel",
@@ -123,7 +123,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Managed installations select encrypted credentials by workspace; legacy manual installs should use SLACK_ALLOWED_TEAM_IDS.",
     ],
     documentation: {
-      href: Docs.messaging("slack"),
+      href: docsUrl("messaging", { hash: "slack" }),
       externalHref: "https://api.slack.com/apps",
       externalLabel: "Open Slack apps",
     },
@@ -187,7 +187,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Production deployments must allowlist Microsoft Entra tenant IDs; proactive messaging without an inbound conversation reference is not implemented.",
     ],
     documentation: {
-      href: Docs.messaging("microsoft-teams"),
+      href: docsUrl("messaging", { hash: "microsoft-teams" }),
       externalHref: "https://dev.botframework.com/",
       externalLabel: "Open Bot Framework",
     },
@@ -249,7 +249,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Interaction tokens are retained only while the queued task is active and normally expire after 15 minutes.",
     ],
     documentation: {
-      href: Docs.messaging("discord"),
+      href: docsUrl("messaging", { hash: "discord" }),
       externalHref: "https://discord.com/developers/applications",
       externalLabel: "Open Discord applications",
     },
@@ -299,7 +299,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Webhook verification requires TELEGRAM_WEBHOOK_SECRET for production-safe setup.",
     ],
     documentation: {
-      href: Docs.messaging("telegram"),
+      href: docsUrl("messaging", { hash: "telegram" }),
       externalHref: "https://t.me/BotFather",
       externalLabel: "Open BotFather",
     },
@@ -349,7 +349,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Meta pricing and the customer-service conversation window can limit replies; template-message flows are not implemented by this adapter.",
     ],
     documentation: {
-      href: Docs.messaging("whatsapp"),
+      href: docsUrl("messaging", { hash: "whatsapp" }),
       externalHref: "https://developers.facebook.com/apps",
       externalLabel: "Open Meta developer console",
     },
@@ -407,7 +407,7 @@ const BUILT_IN_CHANNEL_CATALOG = [
       "Email replies preserve RFC email threads and reply-all when the agent was CC'd.",
     ],
     documentation: {
-      href: Docs.messaging("email"),
+      href: docsUrl("messaging", { hash: "email" }),
       externalHref: "https://resend.com/webhooks",
       externalLabel: "Open Resend webhooks",
     },

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -179,6 +179,7 @@ import {
 import { normalizeDatabaseToolsMode } from "../scripts/db/tool-mode.js";
 import type { ResolvedKeyReference } from "../secrets/substitution.js";
 import { getSetting, putSetting } from "../settings/store.js";
+import { Docs } from "../shared/docs-url.js";
 import {
   handleSharedThreadRequest,
   type SharedThreadRouteDependencies,
@@ -4401,8 +4402,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           } = { skills };
 
           if (skills.length === 0) {
-            result.hint =
-              "No skills found. Add skill files under skills/ in Resources. Learn more: https://agent-native.com/docs/resources#skills";
+            result.hint = `No skills found. Add skill files under skills/ in Resources. Learn more: ${Docs.agentResourcesSkills()}`;
           }
 
           return result;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -179,7 +179,7 @@ import {
 import { normalizeDatabaseToolsMode } from "../scripts/db/tool-mode.js";
 import type { ResolvedKeyReference } from "../secrets/substitution.js";
 import { getSetting, putSetting } from "../settings/store.js";
-import { Docs } from "../shared/docs-url.js";
+import { docsUrl } from "../shared/docs-url.js";
 import {
   handleSharedThreadRequest,
   type SharedThreadRouteDependencies,
@@ -4402,7 +4402,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
           } = { skills };
 
           if (skills.length === 0) {
-            result.hint = `No skills found. Add skill files under skills/ in Resources. Learn more: ${Docs.agentResourcesSkills()}`;
+            result.hint = `No skills found. Add skill files under skills/ in Resources. Learn more: ${docsUrl("agent-resources", { hash: "skills" })}`;
           }
 
           return result;

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -15,6 +15,7 @@ import {
   SUPPORTED_LOCALES,
   type LocaleCode,
 } from "../localization/shared.js";
+import { Docs } from "../shared/docs-url.js";
 import {
   PASSWORD_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
@@ -1663,7 +1664,7 @@ ${localeMenuItemsHtml}
     <button type="button" class="btn-local-dev btn-primary" id="local-dev-btn" title="${esc(t("localDevDescription"))}"${i18nAttr("localDevButton")} data-i18n-title="localDevDescription" aria-describedby="local-dev-description">${esc(t("localDevButton"))}</button>
     <p class="local-dev-description" id="local-dev-description">
       <span${i18nAttr("localDevDescription")}>${esc(t("localDevDescription"))}</span>
-      <a class="local-dev-help" id="local-dev-help" href="https://www.agent-native.com/docs/authentication#local-development-sign-in" target="_blank" rel="noreferrer" aria-label="${esc(t("localDevHelp"))}" title="${esc(t("localDevHelp"))}" data-i18n-title="localDevHelp"${i18nAriaAttr("localDevHelp")}><span class="local-dev-help-glyph" aria-hidden="true">?</span></a>
+      <a class="local-dev-help" id="local-dev-help" href="${Docs.authLocalDev()}" target="_blank" rel="noreferrer" aria-label="${esc(t("localDevHelp"))}" title="${esc(t("localDevHelp"))}" data-i18n-title="localDevHelp"${i18nAriaAttr("localDevHelp")}><span class="local-dev-help-glyph" aria-hidden="true">?</span></a>
     </p>
     <button type="button" class="local-dev-full-options" id="local-dev-full-options" hidden${i18nAttr("localDevFullOptions")}>${esc(t("localDevFullOptions"))}</button>
     <p class="msg error" id="local-dev-msg" role="status" aria-live="polite"></p>

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -15,7 +15,7 @@ import {
   SUPPORTED_LOCALES,
   type LocaleCode,
 } from "../localization/shared.js";
-import { Docs } from "../shared/docs-url.js";
+import { docsUrl } from "../shared/docs-url.js";
 import {
   PASSWORD_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
@@ -1664,7 +1664,7 @@ ${localeMenuItemsHtml}
     <button type="button" class="btn-local-dev btn-primary" id="local-dev-btn" title="${esc(t("localDevDescription"))}"${i18nAttr("localDevButton")} data-i18n-title="localDevDescription" aria-describedby="local-dev-description">${esc(t("localDevButton"))}</button>
     <p class="local-dev-description" id="local-dev-description">
       <span${i18nAttr("localDevDescription")}>${esc(t("localDevDescription"))}</span>
-      <a class="local-dev-help" id="local-dev-help" href="${Docs.authLocalDev()}" target="_blank" rel="noreferrer" aria-label="${esc(t("localDevHelp"))}" title="${esc(t("localDevHelp"))}" data-i18n-title="localDevHelp"${i18nAriaAttr("localDevHelp")}><span class="local-dev-help-glyph" aria-hidden="true">?</span></a>
+      <a class="local-dev-help" id="local-dev-help" href="${docsUrl("authentication", { hash: "local-development-sign-in" })}" target="_blank" rel="noreferrer" aria-label="${esc(t("localDevHelp"))}" title="${esc(t("localDevHelp"))}" data-i18n-title="localDevHelp"${i18nAriaAttr("localDevHelp")}><span class="local-dev-help-glyph" aria-hidden="true">?</span></a>
     </p>
     <button type="button" class="local-dev-full-options" id="local-dev-full-options" hidden${i18nAttr("localDevFullOptions")}>${esc(t("localDevFullOptions"))}</button>
     <p class="msg error" id="local-dev-msg" role="status" aria-live="polite"></p>

--- a/packages/core/src/shared/docs-url.spec.ts
+++ b/packages/core/src/shared/docs-url.spec.ts
@@ -25,21 +25,18 @@ describe("docsUrl", () => {
     );
   });
 
-  it("exposes named Docs helpers for product surfaces", () => {
-    expect(Docs.authentication()).toBe(
-      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/authentication`,
-    );
+  it("keeps named Docs helpers for non-obvious slug/hash targets", () => {
     expect(Docs.trackingErrors()).toBe(
       `${AGENT_NATIVE_DOCS_ORIGIN}/docs/tracking#posthog-error-tracking`,
-    );
-    expect(Docs.messaging("slack")).toBe(
-      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/messaging#slack`,
     );
     expect(Docs.templateClipsBrowserLogs()).toBe(
       `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-clips-capture-everywhere#browser-logs-with-the-chrome-extension`,
     );
     expect(Docs.templatePlanLocalFiles()).toBe(
       `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-plan-local-and-desktop#local-files`,
+    );
+    expect(Docs.multiAppAdding()).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/multi-app-workspace#adding-a-new-app`,
     );
   });
 });

--- a/packages/core/src/shared/docs-url.spec.ts
+++ b/packages/core/src/shared/docs-url.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { AGENT_NATIVE_DOCS_ORIGIN, Docs, docsUrl } from "./docs-url.js";
+import { AGENT_NATIVE_DOCS_ORIGIN, docsUrl } from "./docs-url.js";
 
 describe("docsUrl", () => {
   it("builds absolute docs paths from content slugs", () => {
@@ -23,20 +23,12 @@ describe("docsUrl", () => {
     ).toBe(
       `${AGENT_NATIVE_DOCS_ORIGIN}/docs/deployment?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=deployment_settings`,
     );
-  });
-
-  it("keeps named Docs helpers for non-obvious slug/hash targets", () => {
-    expect(Docs.trackingErrors()).toBe(
-      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/tracking#posthog-error-tracking`,
-    );
-    expect(Docs.templateClipsBrowserLogs()).toBe(
+    expect(
+      docsUrl("template-clips-capture-everywhere", {
+        hash: "browser-logs-with-the-chrome-extension",
+      }),
+    ).toBe(
       `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-clips-capture-everywhere#browser-logs-with-the-chrome-extension`,
-    );
-    expect(Docs.templatePlanLocalFiles()).toBe(
-      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-plan-local-and-desktop#local-files`,
-    );
-    expect(Docs.multiAppAdding()).toBe(
-      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/multi-app-workspace#adding-a-new-app`,
     );
   });
 });

--- a/packages/core/src/shared/docs-url.spec.ts
+++ b/packages/core/src/shared/docs-url.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_NATIVE_DOCS_ORIGIN, Docs, docsUrl } from "./docs-url.js";
+
+describe("docsUrl", () => {
+  it("builds absolute docs paths from content slugs", () => {
+    expect(docsUrl("deployment")).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/deployment`,
+    );
+    expect(docsUrl("getting-started")).toBe(`${AGENT_NATIVE_DOCS_ORIGIN}/docs`);
+    expect(docsUrl("")).toBe(`${AGENT_NATIVE_DOCS_ORIGIN}/docs`);
+  });
+
+  it("attaches hashes and optional UTM params", () => {
+    expect(docsUrl("tracking", { hash: "session-replay" })).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/tracking#session-replay`,
+    );
+    expect(
+      docsUrl("deployment", {
+        campaign: "onboarding",
+        content: "deployment_settings",
+      }),
+    ).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/deployment?utm_source=agent-native&utm_medium=product&utm_campaign=onboarding&utm_content=deployment_settings`,
+    );
+  });
+
+  it("exposes named Docs helpers for product surfaces", () => {
+    expect(Docs.authentication()).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/authentication`,
+    );
+    expect(Docs.trackingErrors()).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/tracking#posthog-error-tracking`,
+    );
+    expect(Docs.messaging("slack")).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/messaging#slack`,
+    );
+    expect(Docs.templateClipsBrowserLogs()).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-clips-capture-everywhere#browser-logs-with-the-chrome-extension`,
+    );
+    expect(Docs.templatePlanLocalFiles()).toBe(
+      `${AGENT_NATIVE_DOCS_ORIGIN}/docs/template-plan-local-and-desktop#local-files`,
+    );
+  });
+});

--- a/packages/core/src/shared/docs-url.ts
+++ b/packages/core/src/shared/docs-url.ts
@@ -1,0 +1,115 @@
+/**
+ * Absolute links into the public Agent-Native docs site.
+ *
+ * Product UI and templates should call `docsUrl` / `Docs` instead of hardcoding
+ * `https://www.agent-native.com/docs/...` strings so slug renames and UTM
+ * conventions stay in one place. Relative `/docs/...` paths resolve against the
+ * app origin and 404 — always use this helper for outbound docs links.
+ */
+
+export const AGENT_NATIVE_DOCS_ORIGIN = "https://www.agent-native.com";
+
+export type DocsUrlOptions = {
+  hash?: string;
+  /** UTM medium; defaults to `product` when any UTM field is set. */
+  medium?: string;
+  /** UTM campaign; defaults to `docs` when any UTM field is set. */
+  campaign?: string;
+  content?: string | null;
+};
+
+function applyDocsUtm(params: URLSearchParams, options: DocsUrlOptions): void {
+  const wantsUtm =
+    options.medium != null ||
+    options.campaign != null ||
+    options.content != null;
+  if (!wantsUtm) return;
+  params.set("utm_source", "agent-native");
+  params.set("utm_medium", options.medium ?? "product");
+  params.set("utm_campaign", options.campaign ?? "docs");
+  if (options.content) params.set("utm_content", options.content);
+}
+
+/**
+ * Build an absolute docs URL for a content slug (the MDX stem under
+ * `packages/core/docs/content/`).
+ *
+ * `getting-started` maps to `/docs` (the docs home).
+ */
+export function docsUrl(slug: string, options: DocsUrlOptions = {}): string {
+  const normalized = slug.replace(/^\/+/, "").replace(/\/+$/, "");
+  const path =
+    normalized === "" || normalized === "getting-started"
+      ? "/docs"
+      : `/docs/${normalized}`;
+  const url = new URL(path, AGENT_NATIVE_DOCS_ORIGIN);
+  applyDocsUtm(url.searchParams, options);
+  if (options.hash) {
+    url.hash = options.hash.replace(/^#/, "");
+  }
+  return url.toString();
+}
+
+/** Named entry points for common product-UI docs targets. */
+export const Docs = {
+  home: (options?: DocsUrlOptions) => docsUrl("getting-started", options),
+  deployment: (options?: DocsUrlOptions) => docsUrl("deployment", options),
+  database: (options?: DocsUrlOptions) => docsUrl("database", options),
+  fileUploads: (options?: DocsUrlOptions) => docsUrl("file-uploads", options),
+  authentication: (options?: DocsUrlOptions) =>
+    docsUrl("authentication", options),
+  authLocalDev: (options?: DocsUrlOptions) =>
+    docsUrl("authentication", {
+      ...options,
+      hash: "local-development-sign-in",
+    }),
+  authSocialProviders: (options?: DocsUrlOptions) =>
+    docsUrl("authentication", { ...options, hash: "social-providers" }),
+  environmentVariables: (options?: DocsUrlOptions) =>
+    docsUrl("environment-variables", options),
+  extensions: (options?: DocsUrlOptions) => docsUrl("extensions", options),
+  organizationsTeams: (options?: DocsUrlOptions) =>
+    docsUrl("organizations-teams-permissions", options),
+  multiAppWorkspace: (options?: DocsUrlOptions) =>
+    docsUrl("multi-app-workspace", options),
+  multiAppAdding: (options?: DocsUrlOptions) =>
+    docsUrl("multi-app-workspace", { ...options, hash: "adding-a-new-app" }),
+  agentResources: (options?: DocsUrlOptions) =>
+    docsUrl("agent-resources", options),
+  agentResourcesSkills: (options?: DocsUrlOptions) =>
+    docsUrl("agent-resources", { ...options, hash: "skills" }),
+  skillsGuide: (options?: DocsUrlOptions) => docsUrl("skills-guide", options),
+  mcpProtocol: (options?: DocsUrlOptions) => docsUrl("mcp-protocol", options),
+  a2aProtocol: (options?: DocsUrlOptions) => docsUrl("a2a-protocol", options),
+  messaging: (channel?: string, options?: DocsUrlOptions) =>
+    docsUrl("messaging", channel ? { ...options, hash: channel } : options),
+  tracking: (options?: DocsUrlOptions) => docsUrl("tracking", options),
+  trackingErrors: (options?: DocsUrlOptions) =>
+    docsUrl("tracking", { ...options, hash: "posthog-error-tracking" }),
+  trackingSessionReplay: (options?: DocsUrlOptions) =>
+    docsUrl("tracking", { ...options, hash: "session-replay" }),
+  templateClips: (options?: DocsUrlOptions) =>
+    docsUrl("template-clips", options),
+  templateClipsSharing: (options?: DocsUrlOptions) =>
+    docsUrl("template-clips-sharing-and-teams", options),
+  templateClipsBrowserLogs: (options?: DocsUrlOptions) =>
+    docsUrl("template-clips-capture-everywhere", {
+      ...options,
+      hash: "browser-logs-with-the-chrome-extension",
+    }),
+  templateClipsRewind: (options?: DocsUrlOptions) =>
+    docsUrl("template-clips-capture-everywhere", {
+      ...options,
+      hash: "rewind-quick-save",
+    }),
+  templatePlan: (options?: DocsUrlOptions) => docsUrl("template-plan", options),
+  templatePlanLocalFiles: (options?: DocsUrlOptions) =>
+    docsUrl("template-plan-local-and-desktop", {
+      ...options,
+      hash: "local-files",
+    }),
+  templateDesign: (options?: DocsUrlOptions) =>
+    docsUrl("template-design", options),
+  prVisualRecap: (options?: DocsUrlOptions) =>
+    docsUrl("pr-visual-recap", options),
+} as const;

--- a/packages/core/src/shared/docs-url.ts
+++ b/packages/core/src/shared/docs-url.ts
@@ -1,10 +1,12 @@
 /**
  * Absolute links into the public Agent-Native docs site.
  *
- * Product UI and templates should call `docsUrl` / `Docs` instead of hardcoding
- * `https://www.agent-native.com/docs/...` strings so slug renames and UTM
- * conventions stay in one place. Relative `/docs/...` paths resolve against the
- * app origin and 404 — always use this helper for outbound docs links.
+ * Prefer `docsUrl("content-slug")` at call sites so the path is visible inline
+ * (`docsUrl("template-design")` → `/docs/template-design`). Use named `Docs.*`
+ * helpers only when the target is awkward to spell at the call site — a hash
+ * that does not match the nearby label, or a slug that would otherwise be easy
+ * to get wrong. Relative `/docs/...` paths resolve against the app origin and
+ * 404 — always use this helper for outbound docs links.
  */
 
 export const AGENT_NATIVE_DOCS_ORIGIN = "https://www.agent-native.com";
@@ -50,14 +52,12 @@ export function docsUrl(slug: string, options: DocsUrlOptions = {}): string {
   return url.toString();
 }
 
-/** Named entry points for common product-UI docs targets. */
+/**
+ * Named helpers for docs targets that are hard to infer from a bare slug —
+ * non-obvious hashes or slug/name mismatches. Prefer `docsUrl("slug")` for
+ * everything else.
+ */
 export const Docs = {
-  home: (options?: DocsUrlOptions) => docsUrl("getting-started", options),
-  deployment: (options?: DocsUrlOptions) => docsUrl("deployment", options),
-  database: (options?: DocsUrlOptions) => docsUrl("database", options),
-  fileUploads: (options?: DocsUrlOptions) => docsUrl("file-uploads", options),
-  authentication: (options?: DocsUrlOptions) =>
-    docsUrl("authentication", options),
   authLocalDev: (options?: DocsUrlOptions) =>
     docsUrl("authentication", {
       ...options,
@@ -65,33 +65,14 @@ export const Docs = {
     }),
   authSocialProviders: (options?: DocsUrlOptions) =>
     docsUrl("authentication", { ...options, hash: "social-providers" }),
-  environmentVariables: (options?: DocsUrlOptions) =>
-    docsUrl("environment-variables", options),
-  extensions: (options?: DocsUrlOptions) => docsUrl("extensions", options),
-  organizationsTeams: (options?: DocsUrlOptions) =>
-    docsUrl("organizations-teams-permissions", options),
-  multiAppWorkspace: (options?: DocsUrlOptions) =>
-    docsUrl("multi-app-workspace", options),
   multiAppAdding: (options?: DocsUrlOptions) =>
     docsUrl("multi-app-workspace", { ...options, hash: "adding-a-new-app" }),
-  agentResources: (options?: DocsUrlOptions) =>
-    docsUrl("agent-resources", options),
   agentResourcesSkills: (options?: DocsUrlOptions) =>
     docsUrl("agent-resources", { ...options, hash: "skills" }),
-  skillsGuide: (options?: DocsUrlOptions) => docsUrl("skills-guide", options),
-  mcpProtocol: (options?: DocsUrlOptions) => docsUrl("mcp-protocol", options),
-  a2aProtocol: (options?: DocsUrlOptions) => docsUrl("a2a-protocol", options),
-  messaging: (channel?: string, options?: DocsUrlOptions) =>
-    docsUrl("messaging", channel ? { ...options, hash: channel } : options),
-  tracking: (options?: DocsUrlOptions) => docsUrl("tracking", options),
   trackingErrors: (options?: DocsUrlOptions) =>
     docsUrl("tracking", { ...options, hash: "posthog-error-tracking" }),
   trackingSessionReplay: (options?: DocsUrlOptions) =>
     docsUrl("tracking", { ...options, hash: "session-replay" }),
-  templateClips: (options?: DocsUrlOptions) =>
-    docsUrl("template-clips", options),
-  templateClipsSharing: (options?: DocsUrlOptions) =>
-    docsUrl("template-clips-sharing-and-teams", options),
   templateClipsBrowserLogs: (options?: DocsUrlOptions) =>
     docsUrl("template-clips-capture-everywhere", {
       ...options,
@@ -102,14 +83,9 @@ export const Docs = {
       ...options,
       hash: "rewind-quick-save",
     }),
-  templatePlan: (options?: DocsUrlOptions) => docsUrl("template-plan", options),
   templatePlanLocalFiles: (options?: DocsUrlOptions) =>
     docsUrl("template-plan-local-and-desktop", {
       ...options,
       hash: "local-files",
     }),
-  templateDesign: (options?: DocsUrlOptions) =>
-    docsUrl("template-design", options),
-  prVisualRecap: (options?: DocsUrlOptions) =>
-    docsUrl("pr-visual-recap", options),
 } as const;

--- a/packages/core/src/shared/docs-url.ts
+++ b/packages/core/src/shared/docs-url.ts
@@ -1,12 +1,10 @@
 /**
  * Absolute links into the public Agent-Native docs site.
  *
- * Prefer `docsUrl("content-slug")` at call sites so the path is visible inline
- * (`docsUrl("template-design")` → `/docs/template-design`). Use named `Docs.*`
- * helpers only when the target is awkward to spell at the call site — a hash
- * that does not match the nearby label, or a slug that would otherwise be easy
- * to get wrong. Relative `/docs/...` paths resolve against the app origin and
- * 404 — always use this helper for outbound docs links.
+ * Call `docsUrl("content-slug")` at call sites so the path is visible inline
+ * (`docsUrl("template-design")` → `/docs/template-design`). Relative
+ * `/docs/...` paths resolve against the app origin and 404 — always use this
+ * helper for outbound docs links.
  */
 
 export const AGENT_NATIVE_DOCS_ORIGIN = "https://www.agent-native.com";
@@ -51,41 +49,3 @@ export function docsUrl(slug: string, options: DocsUrlOptions = {}): string {
   }
   return url.toString();
 }
-
-/**
- * Named helpers for docs targets that are hard to infer from a bare slug —
- * non-obvious hashes or slug/name mismatches. Prefer `docsUrl("slug")` for
- * everything else.
- */
-export const Docs = {
-  authLocalDev: (options?: DocsUrlOptions) =>
-    docsUrl("authentication", {
-      ...options,
-      hash: "local-development-sign-in",
-    }),
-  authSocialProviders: (options?: DocsUrlOptions) =>
-    docsUrl("authentication", { ...options, hash: "social-providers" }),
-  multiAppAdding: (options?: DocsUrlOptions) =>
-    docsUrl("multi-app-workspace", { ...options, hash: "adding-a-new-app" }),
-  agentResourcesSkills: (options?: DocsUrlOptions) =>
-    docsUrl("agent-resources", { ...options, hash: "skills" }),
-  trackingErrors: (options?: DocsUrlOptions) =>
-    docsUrl("tracking", { ...options, hash: "posthog-error-tracking" }),
-  trackingSessionReplay: (options?: DocsUrlOptions) =>
-    docsUrl("tracking", { ...options, hash: "session-replay" }),
-  templateClipsBrowserLogs: (options?: DocsUrlOptions) =>
-    docsUrl("template-clips-capture-everywhere", {
-      ...options,
-      hash: "browser-logs-with-the-chrome-extension",
-    }),
-  templateClipsRewind: (options?: DocsUrlOptions) =>
-    docsUrl("template-clips-capture-everywhere", {
-      ...options,
-      hash: "rewind-quick-save",
-    }),
-  templatePlanLocalFiles: (options?: DocsUrlOptions) =>
-    docsUrl("template-plan-local-and-desktop", {
-      ...options,
-      hash: "local-files",
-    }),
-} as const;

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -28,6 +28,12 @@ export {
 export { injectDocumentMarkup } from "./html-document.js";
 export { withBuilderUtmTrackingParams } from "./builder-link-tracking.js";
 export {
+  AGENT_NATIVE_DOCS_ORIGIN,
+  Docs,
+  docsUrl,
+  type DocsUrlOptions,
+} from "./docs-url.js";
+export {
   buildRuntimeConfigPrompt,
   formatRuntimeConfigReport,
   getRuntimeConfigReport,

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -29,7 +29,6 @@ export { injectDocumentMarkup } from "./html-document.js";
 export { withBuilderUtmTrackingParams } from "./builder-link-tracking.js";
 export {
   AGENT_NATIVE_DOCS_ORIGIN,
-  Docs,
   docsUrl,
   type DocsUrlOptions,
 } from "./docs-url.js";

--- a/packages/core/src/templates/default/app/routes/_index.tsx
+++ b/packages/core/src/templates/default/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { Docs } from "@agent-native/core/shared";
 import { useTheme } from "next-themes";
 import { Link } from "react-router";
 
@@ -41,7 +42,7 @@ export default function IndexPage() {
 
         <div className="grid grid-cols-2 gap-3 text-left">
           <a
-            href="https://agent-native.com/docs"
+            href={Docs.home()}
             target="_blank"
             rel="noopener noreferrer"
             className="group rounded-lg border border-border/50 px-4 py-3 hover:bg-accent/50 transition-colors"

--- a/packages/core/src/templates/default/app/routes/_index.tsx
+++ b/packages/core/src/templates/default/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import { useTheme } from "next-themes";
 import { Link } from "react-router";
 
@@ -42,7 +42,7 @@ export default function IndexPage() {
 
         <div className="grid grid-cols-2 gap-3 text-left">
           <a
-            href={Docs.home()}
+            href={docsUrl("getting-started")}
             target="_blank"
             rel="noopener noreferrer"
             className="group rounded-lg border border-border/50 px-4 py-3 hover:bg-accent/50 transition-colors"

--- a/packages/dispatch/src/components/create-app-popover.spec.tsx
+++ b/packages/dispatch/src/components/create-app-popover.spec.tsx
@@ -197,7 +197,7 @@ describe("CreateAppFlow", () => {
     );
     expect(localLink?.textContent).toContain("Create locally");
     expect(localLink?.href).toBe(
-      "https://agent-native.com/docs/multi-app-workspace#adding-a-new-app",
+      "https://www.agent-native.com/docs/multi-app-workspace#adding-a-new-app",
     );
   });
 

--- a/packages/dispatch/src/components/create-app-popover.tsx
+++ b/packages/dispatch/src/components/create-app-popover.tsx
@@ -9,7 +9,7 @@ import { isInBuilderFrame } from "@agent-native/core/client/host";
 import { useBuilderConnectFlow } from "@agent-native/core/client/settings/useBuilderStatus";
 import {
   buildChatFirstAppCreationPrompt,
-  Docs,
+  docsUrl,
   getWorkspaceAppIdValidationError,
   titleFromChatFirstAppPrompt,
 } from "@agent-native/core/shared";
@@ -92,7 +92,9 @@ const ERROR_FAILURE_REASONS = new Set([
   "credential-store-unavailable",
   "settings-management-required",
 ]);
-const LOCAL_APP_DOCS_URL = Docs.multiAppAdding();
+const LOCAL_APP_DOCS_URL = docsUrl("multi-app-workspace", {
+  hash: "adding-a-new-app",
+});
 
 function isErrorFailureReason(reason: string | null): boolean {
   return !!reason && ERROR_FAILURE_REASONS.has(reason);

--- a/packages/dispatch/src/components/create-app-popover.tsx
+++ b/packages/dispatch/src/components/create-app-popover.tsx
@@ -9,6 +9,7 @@ import { isInBuilderFrame } from "@agent-native/core/client/host";
 import { useBuilderConnectFlow } from "@agent-native/core/client/settings/useBuilderStatus";
 import {
   buildChatFirstAppCreationPrompt,
+  Docs,
   getWorkspaceAppIdValidationError,
   titleFromChatFirstAppPrompt,
 } from "@agent-native/core/shared";
@@ -91,8 +92,7 @@ const ERROR_FAILURE_REASONS = new Set([
   "credential-store-unavailable",
   "settings-management-required",
 ]);
-const LOCAL_APP_DOCS_URL =
-  "https://agent-native.com/docs/multi-app-workspace#adding-a-new-app";
+const LOCAL_APP_DOCS_URL = Docs.multiAppAdding();
 
 function isErrorFailureReason(reason: string | null): boolean {
   return !!reason && ERROR_FAILURE_REASONS.has(reason);

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { Docs } from "@agent-native/core/shared";
+
 import { resolveAppForSkill, type BuiltInAppMcp } from "./built-in-apps.js";
 import { registerMcpServer } from "./connect.js";
 import type { ClientId } from "./mcp-config-writers.js";
@@ -1591,8 +1593,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const PR_VISUAL_RECAP_DOCS_URL =
-  "https://www.agent-native.com/docs/pr-visual-recap";
+const PR_VISUAL_RECAP_DOCS_URL = Docs.prVisualRecap();
 
 function prVisualRecapWorkflowPath(baseDir: string): string {
   return path.join(baseDir, ".github", "workflows", "pr-visual-recap.yml");

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 
 import { resolveAppForSkill, type BuiltInAppMcp } from "./built-in-apps.js";
 import { registerMcpServer } from "./connect.js";
@@ -1593,7 +1593,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const PR_VISUAL_RECAP_DOCS_URL = Docs.prVisualRecap();
+const PR_VISUAL_RECAP_DOCS_URL = docsUrl("pr-visual-recap");
 
 function prVisualRecapWorkflowPath(baseDir: string): string {
   return path.join(baseDir, ".github", "workflows", "pr-visual-recap.yml");

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -12,6 +12,7 @@ import {
 import { oauthRedirectUri } from "@agent-native/core/client/host";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
 import { useOrgRole } from "@agent-native/core/client/org";
+import { Docs } from "@agent-native/core/shared";
 import {
   getDefaultMcpIntegrations,
   McpIntegrationLogo,
@@ -1903,7 +1904,7 @@ function FirstPartyAnalyticsCard() {
                 each one happened.
               </p>
               <a
-                href="https://www.agent-native.com/docs/tracking#error-capture"
+                href={Docs.trackingErrors()}
                 target="_blank"
                 rel="noreferrer"
                 className="mt-2 inline-flex items-center gap-1 font-medium text-primary hover:underline"

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -12,7 +12,7 @@ import {
 import { oauthRedirectUri } from "@agent-native/core/client/host";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
 import { useOrgRole } from "@agent-native/core/client/org";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   getDefaultMcpIntegrations,
   McpIntegrationLogo,
@@ -1904,7 +1904,7 @@ function FirstPartyAnalyticsCard() {
                 each one happened.
               </p>
               <a
-                href={Docs.trackingErrors()}
+                href={docsUrl("tracking", { hash: "posthog-error-tracking" })}
                 target="_blank"
                 rel="noreferrer"
                 className="mt-2 inline-flex items-center gap-1 font-medium text-primary hover:underline"

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -12,11 +12,11 @@ import {
 import { oauthRedirectUri } from "@agent-native/core/client/host";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
 import { useOrgRole } from "@agent-native/core/client/org";
-import { docsUrl } from "@agent-native/core/shared";
 import {
   getDefaultMcpIntegrations,
   McpIntegrationLogo,
 } from "@agent-native/core/client/resources";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconCheck,
   IconChevronDown,

--- a/templates/analytics/app/pages/monitoring/errors/IssueList.tsx
+++ b/templates/analytics/app/pages/monitoring/errors/IssueList.tsx
@@ -1,4 +1,5 @@
 import { CodeSurface } from "@agent-native/core/blocks";
+import { Docs } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
   IconBug,
@@ -28,8 +29,7 @@ import {
   useStatusLabel,
 } from "./utils";
 
-const ERROR_CAPTURE_DOCS_URL =
-  "https://www.agent-native.com/docs/tracking#error-capture";
+const ERROR_CAPTURE_DOCS_URL = Docs.trackingErrors();
 
 const ERROR_CAPTURE_SNIPPET = `// Agent Native templates already call configureTracking().
 import { configureTracking, captureException } from "@agent-native/core/client/observability";

--- a/templates/analytics/app/pages/monitoring/errors/IssueList.tsx
+++ b/templates/analytics/app/pages/monitoring/errors/IssueList.tsx
@@ -1,5 +1,5 @@
 import { CodeSurface } from "@agent-native/core/blocks";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
   IconBug,
@@ -29,7 +29,9 @@ import {
   useStatusLabel,
 } from "./utils";
 
-const ERROR_CAPTURE_DOCS_URL = Docs.trackingErrors();
+const ERROR_CAPTURE_DOCS_URL = docsUrl("tracking", {
+  hash: "posthog-error-tracking",
+});
 
 const ERROR_CAPTURE_SNIPPET = `// Agent Native templates already call configureTracking().
 import { configureTracking, captureException } from "@agent-native/core/client/observability";

--- a/templates/analytics/app/pages/sessions/SessionsPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionsPage.tsx
@@ -6,6 +6,7 @@ import {
   useBuilderConnectFlow,
   useBuilderStatus,
 } from "@agent-native/core/client/settings";
+import { Docs } from "@agent-native/core/shared";
 import {
   IconCheck,
   IconChevronDown,
@@ -58,8 +59,7 @@ import { cn } from "@/lib/utils";
 
 type ReplayRange = "24h" | "7d" | "30d" | "90d" | "all";
 
-const SESSION_REPLAY_DOCS_URL =
-  "https://www.agent-native.com/docs/tracking#session-replay";
+const SESSION_REPLAY_DOCS_URL = Docs.trackingSessionReplay();
 
 const S3_STORAGE_FIELDS = [
   {

--- a/templates/analytics/app/pages/sessions/SessionsPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionsPage.tsx
@@ -6,7 +6,7 @@ import {
   useBuilderConnectFlow,
   useBuilderStatus,
 } from "@agent-native/core/client/settings";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconCheck,
   IconChevronDown,
@@ -59,7 +59,9 @@ import { cn } from "@/lib/utils";
 
 type ReplayRange = "24h" | "7d" | "30d" | "90d" | "all";
 
-const SESSION_REPLAY_DOCS_URL = Docs.trackingSessionReplay();
+const SESSION_REPLAY_DOCS_URL = docsUrl("tracking", {
+  hash: "session-replay",
+});
 
 const S3_STORAGE_FIELDS = [
   {

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -19,7 +19,7 @@ import {
 } from "@agent-native/core/client/navigation";
 import { getThemeInitScript } from "@agent-native/core/client/ui";
 import { resolveLocaleFromRequest } from "@agent-native/core/server";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconHierarchy2,
   IconCheck,
@@ -226,7 +226,9 @@ const CLIPS_COMMAND_DOCS = [
     title: "Use the Chrome extension for browser logs",
     description:
       "Record a browser tab with redacted console logs, JavaScript exceptions, and fetch/XHR diagnostics.",
-    href: Docs.templateClipsBrowserLogs(),
+    href: docsUrl("template-clips-capture-everywhere", {
+      hash: "browser-logs-with-the-chrome-extension",
+    }),
     keywords: [
       "logs",
       "browser logs",

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -19,6 +19,7 @@ import {
 } from "@agent-native/core/client/navigation";
 import { getThemeInitScript } from "@agent-native/core/client/ui";
 import { resolveLocaleFromRequest } from "@agent-native/core/server";
+import { Docs } from "@agent-native/core/shared";
 import {
   IconHierarchy2,
   IconCheck,
@@ -225,7 +226,7 @@ const CLIPS_COMMAND_DOCS = [
     title: "Use the Chrome extension for browser logs",
     description:
       "Record a browser tab with redacted console logs, JavaScript exceptions, and fetch/XHR diagnostics.",
-    href: "https://www.agent-native.com/docs/template-clips#browser-logs-and-developer-diagnostics",
+    href: Docs.templateClipsBrowserLogs(),
     keywords: [
       "logs",
       "browser logs",

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -8,7 +8,7 @@ import {
 import { useSession, getBrowserTabId } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { buildSignInReturnHref } from "@agent-native/core/client/ui";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
   IconArrowLeft,
@@ -290,7 +290,7 @@ const STORAGE_KEY_PREFIX = "clips-share-pw-";
 const CLIPS_SOURCE_URL =
   "https://github.com/BuilderIO/agent-native/tree/main/templates/clips";
 const CLIPS_TEMPLATE_URL = "https://www.agent-native.com/templates/clips";
-const CLIPS_AGENT_DOCS_URL = Docs.templateClipsSharing();
+const CLIPS_AGENT_DOCS_URL = docsUrl("template-clips-sharing-and-teams");
 const UPLOAD_STUCK_TIMEOUT_MS = 5 * 60 * 1000;
 const PROCESSING_STUCK_TIMEOUT_MS = 12 * 60 * 1000;
 const READY_MEDIA_SETTLE_POLL_MS = 20 * 1000;

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -8,6 +8,7 @@ import {
 import { useSession, getBrowserTabId } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { buildSignInReturnHref } from "@agent-native/core/client/ui";
+import { Docs } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
   IconArrowLeft,
@@ -289,8 +290,7 @@ const STORAGE_KEY_PREFIX = "clips-share-pw-";
 const CLIPS_SOURCE_URL =
   "https://github.com/BuilderIO/agent-native/tree/main/templates/clips";
 const CLIPS_TEMPLATE_URL = "https://www.agent-native.com/templates/clips";
-const CLIPS_AGENT_DOCS_URL =
-  "https://www.agent-native.com/docs/template-clips#agent-readable-clips";
+const CLIPS_AGENT_DOCS_URL = Docs.templateClipsSharing();
 const UPLOAD_STUCK_TIMEOUT_MS = 5 * 60 * 1000;
 const PROCESSING_STUCK_TIMEOUT_MS = 12 * 60 * 1000;
 const READY_MEDIA_SETTLE_POLL_MS = 20 * 1000;

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -377,7 +377,7 @@ const MIC_ON_KEY = "clips:mic-on";
 const SYSTEM_AUDIO_KEY = "clips:system-audio";
 const READINESS_REVIEWED_KEY = "clips:readiness-reviewed";
 const REWIND_DOCS_URL =
-  "https://www.agent-native.com/docs/template-clips#agent-readable-clips";
+  "https://www.agent-native.com/docs/template-clips-capture-everywhere#rewind-quick-save";
 
 // Sensible defaults so the user never has to type a URL on first launch.
 // Dev builds point at the local dev server; production builds point at the

--- a/templates/design/app/components/design/DesignImportPanel.test.ts
+++ b/templates/design/app/components/design/DesignImportPanel.test.ts
@@ -91,7 +91,7 @@ describe("DesignImportPanel", () => {
   it("shows visual-edit setup without the broken agent button", () => {
     expect(source).toContain("VISUAL_EDIT_INSTALL_COMMAND");
     expect(source).toContain("VISUAL_EDIT_CONNECT_COMMAND");
-    expect(source).toContain('href="/docs/template-design"');
+    expect(source).toContain("href={Docs.templateDesign()}");
     expect(source).not.toContain("sendToDesignAgentChat");
     expect(source).not.toContain("useVisualEditNow");
   });

--- a/templates/design/app/components/design/DesignImportPanel.test.ts
+++ b/templates/design/app/components/design/DesignImportPanel.test.ts
@@ -91,7 +91,7 @@ describe("DesignImportPanel", () => {
   it("shows visual-edit setup without the broken agent button", () => {
     expect(source).toContain("VISUAL_EDIT_INSTALL_COMMAND");
     expect(source).toContain("VISUAL_EDIT_CONNECT_COMMAND");
-    expect(source).toContain("href={Docs.templateDesign()}");
+    expect(source).toContain('href={docsUrl("template-design")}');
     expect(source).not.toContain("sendToDesignAgentChat");
     expect(source).not.toContain("useVisualEditNow");
   });

--- a/templates/design/app/components/design/DesignImportPanel.tsx
+++ b/templates/design/app/components/design/DesignImportPanel.tsx
@@ -1,5 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
+import { Docs } from "@agent-native/core/shared";
 import { parseFigmaFileKey } from "@shared/figma-url";
 import {
   IconBrandFigma,
@@ -696,7 +697,7 @@ export function DesignImportPanel(p: DesignImportPanelProps) {
               <p className="text-[11px] leading-snug text-muted-foreground">
                 {t("designEditor.import.visualEditGuidance")}{" "}
                 <a
-                  href="/docs/template-design"
+                  href={Docs.templateDesign()}
                   target="_blank"
                   rel="noreferrer"
                   className="font-medium text-foreground underline-offset-2 hover:underline"

--- a/templates/design/app/components/design/DesignImportPanel.tsx
+++ b/templates/design/app/components/design/DesignImportPanel.tsx
@@ -1,6 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import { parseFigmaFileKey } from "@shared/figma-url";
 import {
   IconBrandFigma,
@@ -697,7 +697,7 @@ export function DesignImportPanel(p: DesignImportPanelProps) {
               <p className="text-[11px] leading-snug text-muted-foreground">
                 {t("designEditor.import.visualEditGuidance")}{" "}
                 <a
-                  href={Docs.templateDesign()}
+                  href={docsUrl("template-design")}
                   target="_blank"
                   rel="noreferrer"
                   className="font-medium text-foreground underline-offset-2 hover:underline"

--- a/templates/design/app/components/design/TweaksPanel.test.tsx
+++ b/templates/design/app/components/design/TweaksPanel.test.tsx
@@ -20,6 +20,6 @@ describe("TweaksPanelContent", () => {
     expect(html).toContain("data-tweaks-help");
     expect(html).toContain("designEditor.tweaksHelp");
     expect(html).toContain("designEditor.tweaksDocs");
-    expect(html).toContain("/docs/template-design#tweaks");
+    expect(html).toContain("https://www.agent-native.com/docs/template-design");
   });
 });

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
+import { Docs } from "@agent-native/core/shared";
 import { VisualTweakControl } from "@agent-native/toolkit/design-tweaks";
 import type { TweakDefinition } from "@shared/api";
 import {
@@ -80,7 +81,7 @@ export function TweaksPanelContent({
       >
         {t("designEditor.tweaksHelp")}{" "}
         <a
-          href="/docs/template-design#tweaks"
+          href={Docs.templateDesign()}
           target="_blank"
           rel="noreferrer"
           className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline"

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
-import { Docs } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import { VisualTweakControl } from "@agent-native/toolkit/design-tweaks";
 import type { TweakDefinition } from "@shared/api";
 import {
@@ -81,7 +81,7 @@ export function TweaksPanelContent({
       >
         {t("designEditor.tweaksHelp")}{" "}
         <a
-          href={Docs.templateDesign()}
+          href={docsUrl("template-design")}
           target="_blank"
           rel="noreferrer"
           className="font-medium text-foreground/80 underline-offset-2 hover:text-foreground hover:underline"

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -23,6 +23,7 @@ import {
   ErrorReportActions,
   type ErrorReportDebugItem,
 } from "@agent-native/core/client/ui";
+import { Docs } from "@agent-native/core/shared";
 import {
   useSetHeaderActions,
   useSetPageTitle,
@@ -388,8 +389,8 @@ const ENABLE_PLAN_STATUS_FEATURE = false;
 const GITHUB_LIGHT_CANVAS_BACKGROUND = "#ffffff";
 const GITHUB_DARK_CANVAS_BACKGROUND = "#0d1117";
 const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
-const PLAN_DOCS_URL = "https://www.agent-native.com/docs/template-plan";
-const LOCAL_FILES_DOCS_URL = `${PLAN_DOCS_URL}#local-files`;
+const PLAN_DOCS_URL = Docs.templatePlan();
+const LOCAL_FILES_DOCS_URL = Docs.templatePlanLocalFiles();
 const AUTO_DEV_COMMENT_EMAILS = new Set(["dev@local.test", "dev@local"]);
 const CURRENT_USER_FALLBACK_NAME = "You";
 const CURRENT_USER_FALLBACK_INITIALS = "You";

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -23,7 +23,7 @@ import {
   ErrorReportActions,
   type ErrorReportDebugItem,
 } from "@agent-native/core/client/ui";
-import { Docs, docsUrl } from "@agent-native/core/shared";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   useSetHeaderActions,
   useSetPageTitle,
@@ -390,7 +390,9 @@ const GITHUB_LIGHT_CANVAS_BACKGROUND = "#ffffff";
 const GITHUB_DARK_CANVAS_BACKGROUND = "#0d1117";
 const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
 const PLAN_DOCS_URL = docsUrl("template-plan");
-const LOCAL_FILES_DOCS_URL = Docs.templatePlanLocalFiles();
+const LOCAL_FILES_DOCS_URL = docsUrl("template-plan-local-and-desktop", {
+  hash: "local-files",
+});
 const AUTO_DEV_COMMENT_EMAILS = new Set(["dev@local.test", "dev@local"]);
 const CURRENT_USER_FALLBACK_NAME = "You";
 const CURRENT_USER_FALLBACK_INITIALS = "You";

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -23,7 +23,7 @@ import {
   ErrorReportActions,
   type ErrorReportDebugItem,
 } from "@agent-native/core/client/ui";
-import { Docs } from "@agent-native/core/shared";
+import { Docs, docsUrl } from "@agent-native/core/shared";
 import {
   useSetHeaderActions,
   useSetPageTitle,
@@ -389,7 +389,7 @@ const ENABLE_PLAN_STATUS_FEATURE = false;
 const GITHUB_LIGHT_CANVAS_BACKGROUND = "#ffffff";
 const GITHUB_DARK_CANVAS_BACKGROUND = "#0d1117";
 const LOCAL_PLAN_OWNER_EMAIL = "local@agent-native.local";
-const PLAN_DOCS_URL = Docs.templatePlan();
+const PLAN_DOCS_URL = docsUrl("template-plan");
 const LOCAL_FILES_DOCS_URL = Docs.templatePlanLocalFiles();
 const AUTO_DEV_COMMENT_EMAILS = new Set(["dev@local.test", "dev@local"]);
 const CURRENT_USER_FALLBACK_NAME = "You";


### PR DESCRIPTION
## Summary
- Add shared `docsUrl` / `Docs` helpers in `@agent-native/core/shared` so product UI and templates stop hardcoding docs URLs.
- Retarget Settings, Team, onboarding, agent tabs, Dispatch, and template help links from broken Builder `agent-native-*` / relative `/docs/...` paths to live `www.agent-native.com/docs` pages.
- Fix soft-broken hashes (error tracking, clips browser logs/rewind/sharing, plan local-files, design docs).

## Test plan
- [ ] Open Settings → Hosting / Database / File uploads / Authentication and confirm “Set up manually” docs links open the matching live docs pages (no 404).
- [ ] Open Team settings org/domain help links and confirm they land on organizations/auth/deployment docs.
- [ ] Spot-check Agent resources, Extensions, First-run onboarding, and Dispatch local-app docs links.
- [ ] Spot-check Analytics error/session docs, Clips share/browser-logs links, Design tweaks/import docs, Plan local-files docs.
- [ ] `pnpm --filter @agent-native/core exec vitest run src/shared/docs-url.spec.ts src/client/agent-page/AgentTabsPage.spec.ts`
- [ ] `pnpm --filter @agent-native/dispatch exec vitest run src/components/create-app-popover.spec.tsx`


Made with [Cursor](https://cursor.com)