### PR TITLE
chore: ignore local .pnpm-store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ packages/core/corpus.tmp-*/
 # Local output of `preview-dashboard-report.ts` — contains real internal
 # analytics data and is meant for local inspection only, never committed.
 .report-preview/
+
+# Local pnpm store (used for cached dependencies)
+.pnpm-store/


### PR DESCRIPTION
## Summary
- Ignore `.pnpm-store/` so local pnpm dependency caches are never committed.

## Test plan
- [ ] Confirm `.pnpm-store/` is ignored via `git check-ignore -v .pnpm-store/`
- [ ] Confirm no other files changed in this PR


Made with [Cursor](https://cursor.com)