### PR TITLE
fix: surface Dispatch app-settings authz as 403

### DIFF
--- a/.changeset/dispatch-app-settings-authz-403.md
+++ b/.changeset/dispatch-app-settings-authz-403.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Surface app-creation settings authorization failures as HTTP 403 with the real message instead of a generic internal server error.

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -399,9 +399,11 @@ describe("listWorkspaceApps", () => {
             name: "Todo Board",
           }),
       ),
-    ).rejects.toThrow(
-      "Only organization owners and admins can update app creation settings.",
-    );
+    ).rejects.toMatchObject({
+      message:
+        "Only organization owners and admins can update app creation settings.",
+      statusCode: 403,
+    });
     expect(
       mocks.settings.get("workspace-app-metadata:org:org-123"),
     ).toBeUndefined();

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -74,6 +74,8 @@ const pendingBuilderProjectProvisioning = new Map<
 >();
 
 class AppCreationSettingsAuthorizationError extends Error {
+  statusCode = 403;
+
   constructor() {
     super(APP_CREATION_SETTINGS_AUTHORIZATION_MESSAGE);
     this.name = "AppCreationSettingsAuthorizationError";


### PR DESCRIPTION
## Summary
- `AppCreationSettingsAuthorizationError` now sets `statusCode = 403`, matching other Dispatch authz errors.
- Non-admin edits to workspace app name/description return the real message instead of a generic Internal server error.
- Admin-only gate is unchanged; this is a client-facing error surfacing fix.

## Test plan
- [x] `pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/app-creation-store.spec.ts` (22 passed)
- [ ] As an org member (not owner/admin) on Dispatch Apps → Edit app details → Save
- [ ] Confirm toast/network show 403 with "Only organization owners and admins can update app creation settings."
- [ ] As an org owner/admin, confirm Save still succeeds


Made with [Cursor](https://cursor.com)