### PR TITLE
fix: harden framework and template workflows

### DIFF
--- a/.changeset/fix-chat-share-popover-handoff.md
+++ b/.changeset/fix-chat-share-popover-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the chat share popover mounted outside the overflow menu before opening it.

--- a/.changeset/fix-magic-link-signup-attribution.md
+++ b/.changeset/fix-magic-link-signup-attribution.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve signup analytics attribution through Better Auth magic-link verification.

--- a/.changeset/hide-workspace-notice-in-workspace.md
+++ b/.changeset/hide-workspace-notice-in-workspace.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Hide the workspace destination notice inside workspace apps and present it as an amber warning banner elsewhere.

--- a/.changeset/retry-chat-completion-handoff.md
+++ b/.changeset/retry-chat-completion-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Retry transient chat completion persistence failures before handing off background continuations.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -1025,7 +1025,7 @@ export default function CodeAgentsApp({
   }, [host]);
 
   const loadRemoteConnectorStatus = useCallback(async () => {
-    if (!host.getRemoteConnectorStatus) return;
+    if (!isActive || !host.getRemoteConnectorStatus) return;
     try {
       const result = await withHostCallTimeout(
         host.getRemoteConnectorStatus(),
@@ -1036,10 +1036,10 @@ export default function CodeAgentsApp({
     } catch (err) {
       setRemoteConnectorError(err instanceof Error ? err.message : String(err));
     }
-  }, [host]);
+  }, [host, isActive]);
 
   const loadHostMetadata = useCallback(async () => {
-    if (!host.getHostMetadata) return;
+    if (!isActive || !host.getHostMetadata) return;
     try {
       const result = await host.getHostMetadata();
       setHostMetadata(result);
@@ -1049,7 +1049,7 @@ export default function CodeAgentsApp({
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [host]);
+  }, [host, isActive]);
 
   const runComputerSetupAction = useCallback(
     async (action: CodeAgentComputerSetupAction) => {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -51,6 +51,7 @@ import {
   resolveSkillReferenceContent,
   runAgentLoop,
   runAgentLoopWithMainChatInternalContinuations,
+  runCompletionCallbackWithDatabaseRetry,
   shouldChainBackgroundContinuation,
   MAX_IDENTICAL_TOOL_CALLS,
   MAX_SAME_ERROR_ACROSS_ARGUMENTS,
@@ -64,6 +65,24 @@ import {
 import type { ActiveRun } from "./run-manager.js";
 import { attachToolSearch, searchToolRegistry } from "./tool-search.js";
 import type { AgentChatEvent, RunEvent } from "./types.js";
+
+describe("runCompletionCallbackWithDatabaseRetry", () => {
+  it("retries transient database failures before giving up the completion boundary", async () => {
+    const callback = vi
+      .fn()
+      .mockRejectedValueOnce({
+        code: "ECHECKOUTTIMEOUT",
+        message: "database checkout timed out",
+      })
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn(async (_ms: number) => {});
+
+    await runCompletionCallbackWithDatabaseRetry(callback, { sleep });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(250);
+  });
+});
 
 function actionEntry(opts: {
   description?: string;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -20,7 +20,7 @@ import {
 } from "../action.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import { isReadOnlyShellCommand } from "../coding-tools/index.js";
-import { getDbExec } from "../db/client.js";
+import { getDbExec, isTransientDatabaseError } from "../db/client.js";
 import { extensionIdFromPathname } from "../extensions/path.js";
 import { preUploadAttachments } from "../file-upload/pre-upload-attachments.js";
 import { isMcpActionResult } from "../mcp-client/app-result.js";
@@ -1188,6 +1188,35 @@ export async function resolveAgentOwnerEmail(
 }
 
 const MAX_RETRIES = 3;
+const COMPLETION_DATABASE_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
+
+/**
+ * A transient database failure in the completion callback used to prevent a
+ * background continuation from ever being handed off. Keep the retry bounded
+ * and database-only so a permanent persistence error still fails loudly.
+ */
+export async function runCompletionCallbackWithDatabaseRetry(
+  callback: () => void | Promise<void>,
+  options?: { sleep?: (ms: number) => Promise<void> },
+): Promise<void> {
+  const sleep =
+    options?.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await callback();
+      return;
+    } catch (error) {
+      const retryDelay = COMPLETION_DATABASE_RETRY_DELAYS_MS[attempt];
+      if (!isTransientDatabaseError(error) || retryDelay === undefined) {
+        throw error;
+      }
+      await sleep(retryDelay);
+    }
+  }
+}
+
 /**
  * Retry budget override for `builder_gateway_error` — the no-detail Builder
  * gateway fallback. Production data shows this code is almost never
@@ -9181,7 +9210,9 @@ export function createProductionAgentHandler(
       options.onRunComplete || trackedProgressRunId
         ? async (run: ActiveRun) => {
             try {
-              await options.onRunComplete?.(run, threadId);
+              await runCompletionCallbackWithDatabaseRetry(() =>
+                options.onRunComplete?.(run, threadId),
+              );
             } catch (err) {
               await completeTrackedProgressRun(run, err);
               throw err;

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -2430,6 +2430,42 @@ describe("run manager soft timeout", () => {
     consoleError.mockRestore();
   });
 
+  it("does not advertise a continuation when completion persistence fails before handoff", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const events: AgentChatEvent[] = [];
+    const run = startRun(
+      "run-completion-boundary-failed",
+      "thread-completion-boundary-failed",
+      async (send) => {
+        send({ type: "text", text: "partial response" });
+        send({ type: "auto_continue", reason: "stream_ended" });
+      },
+      async () => {
+        throw new Error("thread_data write failed");
+      },
+      { softTimeoutMs: 0 },
+    );
+    run.subscribers.add((event) => events.push(event.event));
+
+    await run.finalized;
+
+    expect(events).toContainEqual({
+      type: "error",
+      error: "Agent response could not be saved.",
+    });
+    expect(events).not.toContainEqual({
+      type: "auto_continue",
+      reason: "stream_ended",
+    });
+    expect(setRunTerminalReason).toHaveBeenCalledWith(
+      "run-completion-boundary-failed",
+      "completion_error",
+    );
+    consoleError.mockRestore();
+  });
+
   it("normalizes missing SQL abort reasons to user aborts", async () => {
     vi.mocked(getRunAbortState).mockResolvedValue({ aborted: true });
     let abortReason: unknown;

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -675,6 +675,13 @@ function terminalReasonForRun(
   abortReason: string | undefined,
   completionError: unknown,
 ): string {
+  if (
+    finalStatus !== "aborted" &&
+    completionError &&
+    terminalEvent?.type === "auto_continue"
+  ) {
+    return "completion_error";
+  }
   if (terminalEvent?.type === "auto_continue") {
     return terminalEvent.reason || "auto_continue";
   }
@@ -1633,13 +1640,18 @@ export function startRun(
             : terminalEventForCompletion?.event.type === "error" ||
                 terminalEventForCompletion?.event.type === "missing_api_key"
               ? terminalEventForCompletion.event
-              : terminalEventForCompletion?.event.type === "auto_continue"
+              : terminalEventForCompletion?.event.type === "auto_continue" &&
+                  run.continuationTerminalEvent
                 ? // The run was checkpointed at a soft-timeout/loop boundary and
                   // is recoverable: the partial turn is in agent_run_events and
-                  // the continuation run will re-attempt the thread_data save.
+                  // the handed-off continuation run will re-attempt the
+                  // thread_data save.
                   // Even though the completion save failed (finalStatus stays
                   // "errored" for SQL/diagnostics), re-emit the auto_continue so
-                  // the client resumes instead of seeing a dead chat.
+                  // the client resumes instead of seeing a dead chat. A
+                  // pending auto_continue without this handoff marker is not
+                  // recoverable: advertising it makes the client poll a dead
+                  // run until it reports background_run_lost.
                   terminalEventForCompletion.event
                 : {
                     type: "error",

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -307,7 +307,7 @@ describe("AgentPanel header overflow actions", () => {
     expect(overflowMenu).toContain(
       "<DropdownMenuShortcut>{widenChatHint}</DropdownMenuShortcut>",
     );
-    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(2);
+    expect(overflowMenu.match(/deferAgentPanelOverlayOpen/g)).toHaveLength(3);
     expect(overflowMenu).toContain('t("agentPanel.openFullView")');
     expect(overflowMenu).toContain("onSelect={onFullViewRequest}");
     expect(source).toContain("onFullViewRequest={onFullscreenRequest}");
@@ -324,10 +324,12 @@ describe("AgentPanel header overflow actions", () => {
       source.indexOf("const renderPageChatOverlay"),
     );
 
-    expect(overflowMenu).toContain('resourceType="chat_thread"');
-    expect(overflowMenu).toContain('trigger="label-icon"');
-    expect(overflowMenu).toContain('triggerClassName="w-full justify-start"');
+    expect(overflowMenu).toContain("<IconShare3");
+    expect(overflowMenu).toContain("setShareFromMenuOpen(true)");
+    expect(overflowMenu).not.toContain('trigger="label-icon"');
     expect(overflowMenu).toContain("activeTabMessageCount <= 0");
+    expect(source).toContain("defaultOpen={onCollapse && shareFromMenuOpen}");
+    expect(source).toContain("onCollapse ? setShareFromMenuOpen : undefined");
   });
 });
 

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -37,6 +37,7 @@ import {
   IconArrowsHorizontal,
   IconArrowsMaximize,
   IconExternalLink,
+  IconShare3,
 } from "@tabler/icons-react";
 import React, {
   useState,
@@ -1252,6 +1253,7 @@ function AgentPanelInner({
 
   const [headerMenuOpen, setHeaderMenuOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [shareFromMenuOpen, setShareFromMenuOpen] = useState(false);
 
   const getChatThreadShareUrl = useCallback(
     (threadId: string) => {
@@ -1342,7 +1344,7 @@ function AgentPanelInner({
             <SetupButton />
           </Suspense>
         )}
-        {!onCollapse &&
+        {(!onCollapse || shareFromMenuOpen) &&
           (() => {
             const activeTab =
               mode === "chat" && activeChatSessionId
@@ -1363,6 +1365,8 @@ function AgentPanelInner({
                 shareUrl={getChatThreadShareUrl(activeTab.id)}
                 trigger="icon"
                 triggerClassName="h-7 w-7"
+                defaultOpen={onCollapse && shareFromMenuOpen}
+                onOpenChange={onCollapse ? setShareFromMenuOpen : undefined}
               />
             );
           })()}
@@ -1483,17 +1487,20 @@ function AgentPanelInner({
                     return null;
                   }
                   return (
-                    <div className="p-1">
-                      <ShareButton
-                        resourceType="chat_thread"
-                        resourceId={activeTab.id}
-                        allowedRoles={["viewer", "editor", "admin"]}
-                        resourceTitle={activeTab.label || "Chat"}
-                        shareUrl={getChatThreadShareUrl(activeTab.id)}
-                        trigger="label-icon"
-                        triggerClassName="w-full justify-start"
-                      />
-                    </div>
+                    // ShareButton's content is portalled, so open it only
+                    // after the menu releases its dismissable layer.
+                    <DropdownMenuItem
+                      onSelect={(event) =>
+                        deferAgentPanelOverlayOpen(
+                          event,
+                          () => setHeaderMenuOpen(false),
+                          () => setShareFromMenuOpen(true),
+                        )
+                      }
+                    >
+                      <IconShare3 size={14} className="shrink-0" />
+                      Share
+                    </DropdownMenuItem>
                   );
                 })()}
               </>
@@ -1671,6 +1678,7 @@ function AgentPanelInner({
       openRunThread,
       selectCli,
       selectedCli,
+      shareFromMenuOpen,
       storageKey,
       switchMode,
       t,

--- a/packages/core/src/client/org/WorkspaceNotice.spec.tsx
+++ b/packages/core/src/client/org/WorkspaceNotice.spec.tsx
@@ -6,10 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   useOrg: vi.fn(),
+  isLocalDevelopmentOrigin: vi.fn(),
+  shouldOfferWorkspace: vi.fn(),
+  isWorkspaceAppEnvironment: vi.fn(),
 }));
 
+vi.mock("../../org/workspace-url.js", () => ({
+  isLocalDevelopmentOrigin: mocks.isLocalDevelopmentOrigin,
+  shouldOfferWorkspace: mocks.shouldOfferWorkspace,
+}));
 vi.mock("./hooks.js", () => ({
   useOrg: mocks.useOrg,
+}));
+vi.mock("./workspace-app-links.js", () => ({
+  isWorkspaceAppEnvironment: mocks.isWorkspaceAppEnvironment,
 }));
 
 import { WorkspaceNotice } from "./WorkspaceNotice.js";
@@ -27,6 +37,9 @@ describe("WorkspaceNotice", () => {
         workspaceUrl: "https://workspace.example.com",
       },
     });
+    mocks.isLocalDevelopmentOrigin.mockReturnValue(true);
+    mocks.shouldOfferWorkspace.mockReturnValue(true);
+    mocks.isWorkspaceAppEnvironment.mockReturnValue(false);
     window.history.replaceState({}, "", "http://localhost:3000/apps");
     window.localStorage.clear();
     container = document.createElement("div");
@@ -47,5 +60,30 @@ describe("WorkspaceNotice", () => {
 
     expect(container.textContent).toBe("");
     expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("does not show the workspace CTA inside a workspace app", () => {
+    mocks.isLocalDevelopmentOrigin.mockReturnValue(false);
+    mocks.isWorkspaceAppEnvironment.mockReturnValue(true);
+
+    act(() => {
+      root.render(<WorkspaceNotice />);
+    });
+
+    expect(container.textContent).toBe("");
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  it("uses the warning treatment when shown on another hosted app", () => {
+    mocks.isLocalDevelopmentOrigin.mockReturnValue(false);
+
+    act(() => {
+      root.render(<WorkspaceNotice />);
+    });
+
+    const banner = container.querySelector('[role="status"]');
+    expect(banner).not.toBeNull();
+    expect(banner?.className).toContain("bg-amber-500/10");
+    expect(banner?.textContent).toContain("Go there");
   });
 });

--- a/packages/core/src/client/org/WorkspaceNotice.tsx
+++ b/packages/core/src/client/org/WorkspaceNotice.tsx
@@ -1,4 +1,4 @@
-import { IconExternalLink } from "@tabler/icons-react";
+import { IconAlertTriangle, IconExternalLink } from "@tabler/icons-react";
 import { useState } from "react";
 
 import {
@@ -6,6 +6,7 @@ import {
   shouldOfferWorkspace,
 } from "../../org/workspace-url.js";
 import { useOrg } from "./hooks.js";
+import { isWorkspaceAppEnvironment } from "./workspace-app-links.js";
 
 const DISMISS_KEY_PREFIX = "agent-native:workspace-notice-dismissed:";
 
@@ -44,7 +45,12 @@ export function WorkspaceNotice({ className }: { className?: string }) {
   const workspaceUrl = org?.workspaceUrl ?? null;
 
   if (typeof window === "undefined") return null;
-  if (isLocalDevelopmentOrigin(window.location.href)) return null;
+  if (
+    isLocalDevelopmentOrigin(window.location.href) ||
+    isWorkspaceAppEnvironment()
+  ) {
+    return null;
+  }
   if (!workspaceUrl || dismissedNow || readDismissed(workspaceUrl)) return null;
   if (!shouldOfferWorkspace(window.location.href, workspaceUrl)) return null;
 
@@ -52,10 +58,16 @@ export function WorkspaceNotice({ className }: { className?: string }) {
 
   return (
     <div
-      className={`border-b border-border bg-blue-50 dark:bg-blue-950/30 px-3 py-2.5 sm:px-4 ${className ?? ""}`}
+      role="status"
+      aria-live="polite"
+      className={`border-b border-amber-500/30 bg-amber-500/10 px-3 py-3 text-amber-900 dark:text-amber-200 sm:px-4 ${className ?? ""}`}
     >
-      <div className="flex items-center justify-between gap-4 text-sm">
-        <span className="min-w-0 flex-1 text-foreground">
+      <div className="flex flex-wrap items-start gap-x-3 gap-y-2 text-sm">
+        <IconAlertTriangle
+          aria-hidden="true"
+          className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400"
+        />
+        <span className="min-w-0 flex-1 leading-5">
           <span className="font-medium">{org?.orgName}</span> has its own
           workspace at <span className="font-medium">{workspaceHost}</span>.
           Your team&apos;s apps live there, not here.
@@ -63,7 +75,7 @@ export function WorkspaceNotice({ className }: { className?: string }) {
         <div className="flex shrink-0 items-center gap-2">
           <a
             href={workspaceUrl}
-            className="inline-flex items-center gap-1.5 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white no-underline hover:bg-green-700"
+            className="inline-flex items-center gap-1.5 rounded-md border border-amber-600 bg-amber-600 px-3 py-1.5 text-xs font-medium text-primary-foreground no-underline hover:bg-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             <IconExternalLink className="h-3 w-3" />
             Go there
@@ -78,7 +90,7 @@ export function WorkspaceNotice({ className }: { className?: string }) {
               }
               setDismissedNow(true);
             }}
-            className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground cursor-pointer"
+            className="cursor-pointer rounded-md border border-amber-500/40 bg-background/60 px-3 py-1.5 text-xs font-medium text-amber-900 hover:bg-amber-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-amber-800 dark:bg-amber-950/20 dark:text-amber-100 dark:hover:bg-amber-900/40"
           >
             Stay here
           </button>

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -557,10 +557,17 @@ describe("ShareButton", () => {
     });
 
     const text = container.textContent ?? "";
-    expect(text).toContain("People with editing access");
     expect(text).toContain("General editing access");
-    expect(text.indexOf("Public response link")).toBeLessThan(
-      text.indexOf("People with editing access"),
+    const manageAccess = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Manage access",
+    );
+    if (!manageAccess) throw new Error("Manage access button not found");
+    act(() => manageAccess.click());
+    expect(container.textContent).toContain("People with editing access");
+    expect(
+      (container.textContent ?? "").indexOf("Public response link"),
+    ).toBeLessThan(
+      (container.textContent ?? "").indexOf("People with editing access"),
     );
   });
 

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -1,3 +1,8 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@agent-native/toolkit/ui";
 import * as Select from "@radix-ui/react-select";
 import {
   IconLock,
@@ -25,11 +30,6 @@ import type {
   UIEvent as ReactUIEvent,
 } from "react";
 
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@agent-native/toolkit/ui";
 import { writeClipboardText } from "../clipboard.js";
 import {
   Popover,
@@ -402,7 +402,7 @@ function SharePanel(
   const [advancedOpen, setAdvancedOpen] = useState(!showShareLinks);
   useEffect(() => {
     setAdvancedOpen(!showShareLinks);
-  }, [resourceId, showShareLinks]);
+  }, [props.resourceId, showShareLinks]);
   const extraTabs = props.shareTabs?.tabs ?? [];
   const hasTabs = extraTabs.length > 0;
   const shareTabLabel = props.shareTabs?.shareLabel ?? "Share link";
@@ -440,152 +440,193 @@ function SharePanel(
 
       {showShareLinks && shareUrlPlacement === "top" ? shareLinks : null}
 
-      {canManage ? (
-        <div className="mb-4 space-y-2">
-          <div className="flex items-stretch gap-2">
-            <MemberAutocomplete
-              value={inviteEmail}
-              open={suggestionsOpen}
-              onOpenChange={setSuggestionsOpen}
-              onValueChange={(next) => {
-                onInviteEmailChange(next);
-                if (shareError) setShareError(null);
-              }}
-              onSelectMember={(member) => {
-                onInviteEmailChange(member.email);
-                setSuggestionsOpen(false);
-                if (shareError) setShareError(null);
-              }}
-              onSubmit={handleAdd}
-              placeholder={
-                policy.requireOrgMemberForUserShares
-                  ? "Add people from your organization"
-                  : "Add people by email"
-              }
-              suggestions={memberSuggestions}
-              search={memberSearch}
-            />
-            <RoleSelect
-              value={role}
-              onChange={setRole}
-              roleCopy={props.roleCopy}
-              allowedRoles={props.allowedRoles}
-            />
-            <button
-              type="button"
-              onClick={handleAdd}
-              disabled={!hasInviteEmail}
-              className={BUTTON_PRIMARY_SM}
-            >
-              Add
-            </button>
-          </div>
-          {shareError ? (
-            <div
-              role="alert"
-              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
-            >
-              {shareError}
-            </div>
-          ) : null}
-          {hasInviteEmail ? (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground">
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={notifyPeople}
-                  onChange={(e) => setNotifyPeople(e.target.checked)}
-                  className="h-4 w-4 rounded border-input accent-primary"
-                />
-                Notify people
-              </label>
-              {notifyPeople ? (
-                <button
-                  type="button"
-                  aria-expanded={messageOpen}
-                  onClick={() => setMessageOpen(!messageOpen)}
-                  className="rounded-sm px-1 py-0.5 font-medium text-foreground underline decoration-border underline-offset-2 transition-colors hover:bg-accent hover:text-accent-foreground"
-                >
-                  {messageOpen ? "Hide message" : "Add a message"}
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-          {hasInviteEmail && notifyPeople && messageOpen ? (
-            <div className="rounded-md border border-border/70 bg-muted/20 p-2.5">
-              <textarea
-                aria-label="Message"
-                placeholder="Add a short note (optional)"
-                value={shareMessage}
-                onChange={(event) => setShareMessage(event.target.value)}
-                maxLength={500}
-                rows={3}
-                className="w-full resize-y rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-              />
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      <div className="mb-2 text-sm font-semibold">{peopleAccessLabel}</div>
-      <ul className="mb-4 flex flex-col gap-1 list-none p-0 m-0">
-        {data?.ownerEmail ? (
-          <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
-            <Avatar label={displayName(data.ownerEmail, knownMembers)} />
-            <span className="flex-1 min-w-0 truncate">
-              {displayName(data.ownerEmail, knownMembers)}
-            </span>
-            <span className="text-xs text-muted-foreground">Owner</span>
-          </li>
-        ) : null}
-        {shares.map((s) => (
-          <li
-            key={keyOf(s)}
-            className={cn(
-              "flex items-center gap-3 px-1 py-1.5 text-sm",
-              inFlight.has(keyOf(s)) && "opacity-60",
-            )}
+      <Collapsible
+        open={advancedOpen}
+        onOpenChange={setAdvancedOpen}
+        className="mb-4 overflow-hidden rounded-md border border-border"
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex min-h-10 w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
           >
-            <Avatar
-              label={principalLabel(s, knownMembers)}
-              org={s.principalType === "org"}
-            />
-            <span className="flex-1 min-w-0 truncate">
-              {principalLabel(s, knownMembers)}
-            </span>
-            {canManage ? (
-              <RoleSelect
-                value={s.role}
-                onChange={(r) => handleChangeRole(s, r)}
-                disabled={inFlight.has(keyOf(s))}
-                plain
-                roleCopy={props.roleCopy}
-                allowedRoles={props.allowedRoles}
+            <span className="flex min-w-0 items-center gap-2 truncate">
+              <IconUsersGroup
+                aria-hidden
+                size={15}
+                strokeWidth={1.8}
+                className="shrink-0 text-muted-foreground"
               />
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                {roleMeta(s.role, props.roleCopy).label}
-              </span>
-            )}
+              {canManage ? "Manage access" : peopleAccessLabel}
+            </span>
+            <IconChevronDown
+              aria-hidden
+              size={16}
+              strokeWidth={1.8}
+              className={cn(
+                "shrink-0 text-muted-foreground transition-transform",
+                advancedOpen && "rotate-180",
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="border-t border-border px-3 py-3">
+          <div className="space-y-4">
             {canManage ? (
-              <button
-                type="button"
-                aria-label="Remove"
-                onClick={() => handleRemove(s)}
-                disabled={inFlight.has(keyOf(s))}
-                className={BUTTON_GHOST_ICON}
-              >
-                <IconTrash size={14} />
-              </button>
+              <div className="space-y-2">
+                <div className="flex items-stretch gap-2">
+                  <MemberAutocomplete
+                    value={inviteEmail}
+                    open={suggestionsOpen}
+                    onOpenChange={setSuggestionsOpen}
+                    onValueChange={(next) => {
+                      onInviteEmailChange(next);
+                      if (shareError) setShareError(null);
+                    }}
+                    onSelectMember={(member) => {
+                      onInviteEmailChange(member.email);
+                      setSuggestionsOpen(false);
+                      if (shareError) setShareError(null);
+                    }}
+                    onSubmit={handleAdd}
+                    placeholder={
+                      policy.requireOrgMemberForUserShares
+                        ? "Add people from your organization"
+                        : "Add people by email"
+                    }
+                    suggestions={memberSuggestions}
+                    search={memberSearch}
+                  />
+                  <RoleSelect
+                    value={role}
+                    onChange={setRole}
+                    roleCopy={props.roleCopy}
+                    allowedRoles={props.allowedRoles}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAdd}
+                    disabled={!hasInviteEmail}
+                    className={BUTTON_PRIMARY_SM}
+                  >
+                    Add
+                  </button>
+                </div>
+                {shareError ? (
+                  <div
+                    role="alert"
+                    className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                  >
+                    {shareError}
+                  </div>
+                ) : null}
+                {hasInviteEmail ? (
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground">
+                    <label className="inline-flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={notifyPeople}
+                        onChange={(e) => setNotifyPeople(e.target.checked)}
+                        className="h-4 w-4 rounded border-input accent-primary"
+                      />
+                      Notify people
+                    </label>
+                    {notifyPeople ? (
+                      <button
+                        type="button"
+                        aria-expanded={messageOpen}
+                        onClick={() => setMessageOpen(!messageOpen)}
+                        className="rounded-sm px-1 py-0.5 font-medium text-foreground underline decoration-border underline-offset-2 transition-colors hover:bg-accent hover:text-accent-foreground"
+                      >
+                        {messageOpen ? "Hide message" : "Add a message"}
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+                {hasInviteEmail && notifyPeople && messageOpen ? (
+                  <div className="rounded-md border border-border/70 bg-muted/20 p-2.5">
+                    <textarea
+                      aria-label="Message"
+                      placeholder="Add a short note (optional)"
+                      value={shareMessage}
+                      onChange={(event) => setShareMessage(event.target.value)}
+                      maxLength={500}
+                      rows={3}
+                      className="w-full resize-y rounded-md border border-input bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+                    />
+                  </div>
+                ) : null}
+              </div>
             ) : null}
-          </li>
-        ))}
-        {!shares.length && !data?.ownerEmail ? (
-          <li className="px-1 py-1.5 text-sm text-muted-foreground">
-            No one has access yet.
-          </li>
-        ) : null}
-      </ul>
+
+            <div>
+              <div className="mb-2 text-sm font-semibold">
+                {peopleAccessLabel}
+              </div>
+              <ul className="flex flex-col gap-1 list-none p-0 m-0">
+                {data?.ownerEmail ? (
+                  <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
+                    <Avatar
+                      label={displayName(data.ownerEmail, knownMembers)}
+                    />
+                    <span className="flex-1 min-w-0 truncate">
+                      {displayName(data.ownerEmail, knownMembers)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">Owner</span>
+                  </li>
+                ) : null}
+                {shares.map((s) => (
+                  <li
+                    key={keyOf(s)}
+                    className={cn(
+                      "flex items-center gap-3 px-1 py-1.5 text-sm",
+                      inFlight.has(keyOf(s)) && "opacity-60",
+                    )}
+                  >
+                    <Avatar
+                      label={principalLabel(s, knownMembers)}
+                      org={s.principalType === "org"}
+                    />
+                    <span className="flex-1 min-w-0 truncate">
+                      {principalLabel(s, knownMembers)}
+                    </span>
+                    {canManage ? (
+                      <RoleSelect
+                        value={s.role}
+                        onChange={(r) => handleChangeRole(s, r)}
+                        disabled={inFlight.has(keyOf(s))}
+                        plain
+                        roleCopy={props.roleCopy}
+                        allowedRoles={props.allowedRoles}
+                      />
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        {roleMeta(s.role, props.roleCopy).label}
+                      </span>
+                    )}
+                    {canManage ? (
+                      <button
+                        type="button"
+                        aria-label="Remove"
+                        onClick={() => handleRemove(s)}
+                        disabled={inFlight.has(keyOf(s))}
+                        className={BUTTON_GHOST_ICON}
+                      >
+                        <IconTrash size={14} />
+                      </button>
+                    ) : null}
+                  </li>
+                ))}
+                {!shares.length && !data?.ownerEmail ? (
+                  <li className="px-1 py-1.5 text-sm text-muted-foreground">
+                    No one has access yet.
+                  </li>
+                ) : null}
+              </ul>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
 
       <div className="mb-2 text-sm font-semibold">{generalAccessLabel}</div>
       <div className="mb-4 flex items-center gap-3">
@@ -604,7 +645,7 @@ function SharePanel(
             allowPublic={policy.allowPublic}
           />
           <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-            <span>{meta.description}</span>
+            <span className="sr-only">{meta.description}</span>
             {visibility === "org" && props.hideInSearchControl ? (
               <AdvancedAccessPopover
                 control={props.hideInSearchControl}

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -25,6 +25,11 @@ import type {
   UIEvent as ReactUIEvent,
 } from "react";
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@agent-native/toolkit/ui";
 import { writeClipboardText } from "../clipboard.js";
 import {
   Popover,
@@ -72,8 +77,8 @@ export interface ShareButtonProps {
   shareUrlLabel?: string;
   /** Optional helper text for the primary copyable link section. */
   shareUrlDescription?: ReactNode;
-  /** Where to render share links in the popover. Defaults to the bottom,
-   *  matching the historical Google-Docs-style share dialog. */
+  /** Where to render share links in the popover. Defaults to the top,
+   *  keeping the copyable link as the primary share action. */
   shareUrlPlacement?: "top" | "bottom";
   /** Whether to render copyable share URL fields. Defaults to true. */
   showShareLinks?: boolean;
@@ -393,7 +398,11 @@ function SharePanel(
     (Boolean(props.shareUrl) ||
       Boolean(props.shareUrlPlaceholder) ||
       Boolean(props.secondaryShareUrl));
-  const shareUrlPlacement = props.shareUrlPlacement ?? "bottom";
+  const shareUrlPlacement = props.shareUrlPlacement ?? "top";
+  const [advancedOpen, setAdvancedOpen] = useState(!showShareLinks);
+  useEffect(() => {
+    setAdvancedOpen(!showShareLinks);
+  }, [resourceId, showShareLinks]);
   const extraTabs = props.shareTabs?.tabs ?? [];
   const hasTabs = extraTabs.length > 0;
   const shareTabLabel = props.shareTabs?.shareLabel ?? "Share link";

--- a/packages/core/src/client/sharing/ShareDialog.tsx
+++ b/packages/core/src/client/sharing/ShareDialog.tsx
@@ -9,9 +9,15 @@ import {
   TextField,
 } from "@agent-native/toolkit/design-system";
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@agent-native/toolkit/ui";
+import {
   IconCheck,
   IconCode,
   IconCopy,
+  IconChevronDown,
   IconLink,
   IconLock,
   IconMail,
@@ -19,7 +25,7 @@ import {
   IconUsersGroup,
   IconWorld,
 } from "@tabler/icons-react";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { cn } from "../utils.js";
 import {
@@ -210,7 +216,13 @@ function LinkTab({
 }) {
   const Icon = VIS_ICONS[controller.visibility.value];
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
+      <CopyField
+        field="share-link"
+        label={controller.labels.shareLink}
+        value={controller.shareUrl!}
+        controller={controller}
+      />
       <div>
         <div className="mb-2 text-sm font-semibold">
           {controller.labels.generalAccess}
@@ -224,18 +236,12 @@ function LinkTab({
           </span>
           <div className="min-w-0 flex-1">
             <VisibilitySelect controller={controller} />
-            <div className="mt-0.5 text-xs text-muted-foreground">
+            <div className="sr-only text-xs text-muted-foreground">
               {controller.visibility.description}
             </div>
           </div>
         </div>
       </div>
-      <CopyField
-        field="share-link"
-        label={controller.labels.shareLink}
-        value={controller.shareUrl!}
-        controller={controller}
-      />
       {extras}
     </div>
   );
@@ -249,97 +255,127 @@ function InviteTab({
   showVisibility: boolean;
 }) {
   const Icon = VIS_ICONS[controller.visibility.value];
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   return (
-    <div className="space-y-4">
-      {controller.canManage ? (
-        <div className="space-y-2">
-          <div className="flex items-stretch gap-2">
-            <input
-              type="email"
-              placeholder={controller.labels.addPeopleByEmail}
-              value={controller.invite.email}
-              onChange={(event) =>
-                controller.invite.setEmail(event.currentTarget.value)
-              }
-              onKeyDown={(event) => {
-                if (event.key === "Enter") controller.invite.submit();
-              }}
-              autoComplete="off"
-              className="flex-1 min-w-0 h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+    <div className="space-y-3">
+      <Collapsible
+        open={advancedOpen}
+        onOpenChange={setAdvancedOpen}
+        className="overflow-hidden rounded-md border border-border"
+      >
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex min-h-10 w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+          >
+            <span className="truncate">
+              {controller.labels.peopleWithAccess}
+            </span>
+            <IconChevronDown
+              aria-hidden
+              size={16}
+              strokeWidth={1.8}
+              className={cn(
+                "shrink-0 text-muted-foreground transition-transform",
+                advancedOpen && "rotate-180",
+              )}
             />
-            <RoleSelect controller={controller} />
-          </div>
-          {controller.invite.showNotifyPeople ? (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground">
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={controller.invite.notifyPeople}
-                  onChange={(event) =>
-                    controller.invite.setNotifyPeople(
-                      event.currentTarget.checked,
-                    )
-                  }
-                  className="h-4 w-4 rounded border-input accent-primary"
-                />
-                {controller.labels.notifyPeople}
-              </label>
-              {controller.invite.notifyPeople ? (
-                <ActionButton
-                  type="button"
-                  emphasis="ghost"
-                  aria-expanded={controller.invite.messageOpen}
-                  onPress={() =>
-                    controller.invite.setMessageOpen(
-                      !controller.invite.messageOpen,
-                    )
-                  }
-                  className="!h-auto !rounded-sm !px-1 !py-0.5 text-xs font-medium !text-foreground underline decoration-border underline-offset-2 hover:!bg-accent hover:!text-accent-foreground active:!scale-100"
-                >
-                  {controller.invite.messageOpen
-                    ? controller.labels.hideMessage
-                    : controller.labels.addMessage}
-                </ActionButton>
-              ) : null}
-            </div>
-          ) : null}
-          {controller.invite.showNotifyPeople &&
-          controller.invite.notifyPeople &&
-          controller.invite.messageOpen ? (
-            <TextArea
-              aria-label={controller.labels.addMessage}
-              placeholder={controller.labels.messagePlaceholder}
-              value={controller.invite.message}
-              onChange={(value) => controller.invite.setMessage(value)}
-              maxLength={500}
-              rows={3}
-              className="min-h-20 resize-y text-sm"
-            />
-          ) : null}
-        </div>
-      ) : null}
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="border-t border-border px-3 py-3">
+          <div className="space-y-4">
+            {controller.canManage ? (
+              <div className="space-y-2">
+                <div className="flex items-stretch gap-2">
+                  <input
+                    type="email"
+                    placeholder={controller.labels.addPeopleByEmail}
+                    value={controller.invite.email}
+                    onChange={(event) =>
+                      controller.invite.setEmail(event.currentTarget.value)
+                    }
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") controller.invite.submit();
+                    }}
+                    autoComplete="off"
+                    className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+                  />
+                  <RoleSelect controller={controller} />
+                </div>
+                {controller.invite.showNotifyPeople ? (
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-muted-foreground">
+                    <label className="inline-flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={controller.invite.notifyPeople}
+                        onChange={(event) =>
+                          controller.invite.setNotifyPeople(
+                            event.currentTarget.checked,
+                          )
+                        }
+                        className="h-4 w-4 rounded border-input accent-primary"
+                      />
+                      {controller.labels.notifyPeople}
+                    </label>
+                    {controller.invite.notifyPeople ? (
+                      <ActionButton
+                        type="button"
+                        emphasis="ghost"
+                        aria-expanded={controller.invite.messageOpen}
+                        onPress={() =>
+                          controller.invite.setMessageOpen(
+                            !controller.invite.messageOpen,
+                          )
+                        }
+                        className="!h-auto !rounded-sm !px-1 !py-0.5 text-xs font-medium !text-foreground underline decoration-border underline-offset-2 hover:!bg-accent hover:!text-accent-foreground active:!scale-100"
+                      >
+                        {controller.invite.messageOpen
+                          ? controller.labels.hideMessage
+                          : controller.labels.addMessage}
+                      </ActionButton>
+                    ) : null}
+                  </div>
+                ) : null}
+                {controller.invite.showNotifyPeople &&
+                controller.invite.notifyPeople &&
+                controller.invite.messageOpen ? (
+                  <TextArea
+                    aria-label={controller.labels.addMessage}
+                    placeholder={controller.labels.messagePlaceholder}
+                    value={controller.invite.message}
+                    onChange={(value) => controller.invite.setMessage(value)}
+                    maxLength={500}
+                    rows={3}
+                    className="min-h-20 resize-y text-sm"
+                  />
+                ) : null}
+              </div>
+            ) : null}
 
-      <div>
-        <div className="mb-2 text-sm font-semibold">
-          {controller.labels.peopleWithAccess}
-        </div>
-        <ul className="flex flex-col gap-1 list-none p-0 m-0">
-          {controller.people.map((person) => (
-            <PersonRow
-              key={person.key}
-              person={person}
-              canManage={controller.canManage}
-              removeLabel={controller.labels.remove}
-              onRemove={controller.removeShare}
-            />
-          ))}
-          {!controller.people.length ? (
-            <li className="px-1 py-1.5 text-sm text-muted-foreground">
-              {controller.labels.noAccess}
-            </li>
-          ) : null}
-        </ul>
-      </div>
+            <div>
+              <div className="mb-2 text-sm font-semibold">
+                {controller.labels.peopleWithAccess}
+              </div>
+              <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                {controller.people.map((person) => (
+                  <PersonRow
+                    key={person.key}
+                    person={person}
+                    canManage={controller.canManage}
+                    removeLabel={controller.labels.remove}
+                    onRemove={controller.removeShare}
+                  />
+                ))}
+                {!controller.people.length ? (
+                  <li className="px-1 py-1.5 text-sm text-muted-foreground">
+                    {controller.labels.noAccess}
+                  </li>
+                ) : null}
+              </ul>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
 
       {showVisibility ? (
         <div>
@@ -355,7 +391,7 @@ function InviteTab({
             </span>
             <div className="min-w-0 flex-1">
               <VisibilitySelect controller={controller} />
-              <div className="mt-0.5 text-xs text-muted-foreground">
+              <div className="sr-only text-xs text-muted-foreground">
                 {controller.visibility.description}
               </div>
             </div>

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -217,6 +217,77 @@ describe("server/auth", () => {
       );
     });
 
+    it("carries signup attribution into the delayed verification request", async () => {
+      vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("RESEND_API_KEY", "resend-example-key");
+      const secret = "test-magic-link-attribution-secret";
+      const signInMagicLink = vi.fn(async () => ({ status: true }));
+      vi.doMock("./better-auth-instance.js", () => ({
+        getAuthSecret: vi.fn(() => secret),
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signInMagicLink,
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: vi.fn(async () => ({ rows: [] })) }),
+        isLocalDatabase: () => true,
+        isPostgres: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+        describeDbError: (error: unknown) => String(error),
+      }));
+      const { autoMountAuth } = await import("./auth.js");
+      const { readMagicLinkSignupAttribution } =
+        await import("./magic-link-attribution.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const handler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/magic-link",
+      )?.[1];
+      const firstTouch = encodeURIComponent(
+        JSON.stringify({ ref: "external", utm_campaign: "launch" }),
+      );
+      await expect(
+        handler(
+          createJsonPostEvent(
+            "/_agent-native/auth/magic-link",
+            { email: "new@example.com", callbackURL: "/welcome" },
+            { cookie: `an_aid=anon_123; an_ft=${firstTouch}` },
+          ),
+        ),
+      ).resolves.toEqual({ ok: true });
+
+      const request = signInMagicLink.mock.calls[0]?.[0];
+      const callback = new URL(request.body.newUserCallbackURL);
+      expect(callback.searchParams.get("return")).toBe("/welcome");
+      const token = callback.searchParams.get("signup_attribution");
+      expect(token).toBeTruthy();
+
+      const verification = new URL(
+        "http://localhost/_agent-native/auth/ba/magic-link/verify?token=mail-token",
+      );
+      verification.searchParams.set("newUserCallbackURL", callback.toString());
+      expect(
+        readMagicLinkSignupAttribution(verification.toString(), secret),
+      ).toEqual({
+        attribution: {
+          referral_source: "external",
+          referral_campaign: "launch",
+          utm_campaign: "launch",
+        },
+        anonymousId: "anon_123",
+      });
+    });
+
     it("promotes tracking callbacks that Better Auth cannot accept relatively", async () => {
       vi.stubEnv("NODE_ENV", "development");
       vi.stubEnv("RESEND_API_KEY", "resend-example-key");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -127,12 +127,14 @@ import { getConfiguredAppBasePath } from "./app-base-path.js";
 import { getAppProductionUrl } from "./app-url.js";
 import {
   readAnalyticsAnonymousId,
+  readFirstTouchAttribution,
   signupAttributionFromCookieHeader,
 } from "./attribution.js";
 import { getAuthLoginMode } from "./auth-login-mode.js";
 import {
   createBetterAuthSessionForEmail,
   ensureGoogleAuthIdentity,
+  getAuthSecret,
   getBetterAuth,
   getBetterAuthSync,
   isDeployPreview,
@@ -180,6 +182,10 @@ import {
   isIdentitySsoEnabled,
 } from "./identity-sso-store.js";
 import { ensureCanonicalUserForLegacySession } from "./legacy-auth-migration.js";
+import {
+  encodeMagicLinkSignupAttribution,
+  MAGIC_LINK_ATTRIBUTION_PARAM,
+} from "./magic-link-attribution.js";
 import { safeOAuthReturnUrl } from "./oauth-return-url.js";
 import {
   getOnboardingHtml,
@@ -4245,13 +4251,37 @@ async function mountBetterAuthRoutes(
           callbackPath = withDesktopMagicLinkFlow(callbackPath, desktopFlow);
         }
         const callbackURL = betterAuthCallbackURL(callbackPath, true, event);
-        const newUserCallbackPath = `${getAppBasePath()}/_agent-native/auth/magic-link/new-user?return=${encodeURIComponent(callbackPath)}`;
+        const cookieHeader = getHeader(event, "cookie") ?? null;
+        const signupAttribution =
+          signupAttributionFromCookieHeader(cookieHeader);
+        const signupAnonymousId = readAnalyticsAnonymousId(cookieHeader);
+        const hasSignupAttribution =
+          !!readFirstTouchAttribution(cookieHeader) || !!signupAnonymousId;
+        const attributionToken = hasSignupAttribution
+          ? encodeMagicLinkSignupAttribution(
+              {
+                attribution: signupAttribution,
+                anonymousId: signupAnonymousId,
+              },
+              getAuthSecret(),
+            )
+          : undefined;
+        const newUserCallbackUrl = new URL(
+          `${getAppBasePath()}/_agent-native/auth/magic-link/new-user?return=${encodeURIComponent(callbackPath)}`,
+          getOrigin(event),
+        );
+        if (attributionToken) {
+          newUserCallbackUrl.searchParams.set(
+            MAGIC_LINK_ATTRIBUTION_PARAM,
+            attributionToken,
+          );
+        }
         await auth.api.signInMagicLink({
           body: {
             email,
             callbackURL,
             newUserCallbackURL: betterAuthCallbackURL(
-              newUserCallbackPath,
+              `${newUserCallbackUrl.pathname}${newUserCallbackUrl.search}`,
               true,
               event,
             ),

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -78,6 +78,7 @@ import {
 } from "./email-templates.js";
 import { getEmailReadiness, sendEmail } from "./email.js";
 import { resolveGoogleSignInCredentials } from "./google-oauth-credentials.js";
+import { readMagicLinkSignupAttribution } from "./magic-link-attribution.js";
 
 export {
   getAuthLoginMode,
@@ -1349,7 +1350,7 @@ async function createBetterAuthInstance(
             // browser's `an_ft` first-touch cookie rides in.
             context?: {
               headers?: Headers | null;
-              request?: { headers?: Headers | null } | null;
+              request?: { headers?: Headers | null; url?: string } | null;
             } | null,
           ) => {
             // When a newly-created user's email has pending org invitations
@@ -1368,8 +1369,19 @@ async function createBetterAuthInstance(
                 context?.headers?.get("cookie") ??
                 context?.request?.headers?.get("cookie") ??
                 null;
+              const magicLinkAttribution = context?.request?.url?.includes(
+                "newUserCallbackURL",
+              )
+                ? readMagicLinkSignupAttribution(
+                    context.request.url,
+                    getAuthSecret(),
+                  )
+                : undefined;
               attribution = signupAttributionFromCookieHeader(cookieHeader);
-              anonymousId = readAnalyticsAnonymousId(cookieHeader);
+              attribution = magicLinkAttribution?.attribution ?? attribution;
+              anonymousId =
+                magicLinkAttribution?.anonymousId ??
+                readAnalyticsAnonymousId(cookieHeader);
             } catch (err) {
               console.error("[auth] failed to derive signup attribution", err);
               attribution = undefined;

--- a/packages/core/src/server/magic-link-attribution.spec.ts
+++ b/packages/core/src/server/magic-link-attribution.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeMagicLinkSignupAttribution,
+  encodeMagicLinkSignupAttribution,
+  MAGIC_LINK_ATTRIBUTION_PARAM,
+  readMagicLinkSignupAttribution,
+} from "./magic-link-attribution.js";
+
+const SECRET = "test-magic-link-attribution-secret";
+const NOW = Date.parse("2026-08-12T16:00:00.000Z");
+
+describe("magic-link attribution handoff", () => {
+  it("round-trips attribution through Better Auth's verification URL", () => {
+    const token = encodeMagicLinkSignupAttribution(
+      {
+        attribution: {
+          referral_source: "external",
+          utm_campaign: "launch + % & 日本語",
+        },
+        anonymousId: "anon_123",
+      },
+      SECRET,
+      NOW,
+    );
+    expect(token).toBeTruthy();
+
+    const callback = new URL(
+      "https://app.example.com/_agent-native/auth/magic-link/new-user?return=%2F",
+    );
+    callback.searchParams.set(MAGIC_LINK_ATTRIBUTION_PARAM, token!);
+    const verification = new URL(
+      "https://app.example.com/_agent-native/auth/ba/magic-link/verify?token=mail-token",
+    );
+    verification.searchParams.set("newUserCallbackURL", callback.toString());
+
+    expect(
+      readMagicLinkSignupAttribution(verification.toString(), SECRET, NOW),
+    ).toEqual({
+      attribution: {
+        referral_source: "external",
+        utm_campaign: "launch + % & 日本語",
+      },
+      anonymousId: "anon_123",
+    });
+  });
+
+  it("rejects a tampered or expired handoff", () => {
+    const token = encodeMagicLinkSignupAttribution(
+      { anonymousId: "anon_123" },
+      SECRET,
+      NOW,
+    )!;
+    const [payload, signature] = token.split(".");
+
+    expect(
+      decodeMagicLinkSignupAttribution(`${payload}x.${signature}`, SECRET, NOW),
+    ).toBeNull();
+    expect(
+      decodeMagicLinkSignupAttribution(token, SECRET, NOW + 11 * 60 * 1000),
+    ).toBeNull();
+  });
+
+  it("does not mint a token without attribution context", () => {
+    expect(encodeMagicLinkSignupAttribution({}, SECRET, NOW)).toBeUndefined();
+  });
+
+  it("only extracts from Better Auth's magic-link verification route", () => {
+    const token = encodeMagicLinkSignupAttribution(
+      { anonymousId: "anon_123" },
+      SECRET,
+      NOW,
+    )!;
+    const callback = new URL("https://app.example.com/_agent-native/new-user");
+    callback.searchParams.set(MAGIC_LINK_ATTRIBUTION_PARAM, token);
+    const nonVerificationUrl = new URL(
+      "https://app.example.com/_agent-native/auth/register",
+    );
+    nonVerificationUrl.searchParams.set(
+      "newUserCallbackURL",
+      callback.toString(),
+    );
+
+    expect(
+      readMagicLinkSignupAttribution(
+        nonVerificationUrl.toString(),
+        SECRET,
+        NOW,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/server/magic-link-attribution.ts
+++ b/packages/core/src/server/magic-link-attribution.ts
@@ -1,0 +1,158 @@
+import crypto from "node:crypto";
+
+import { normalizeAnalyticsAnonymousId } from "../shared/analytics-anonymous-id.js";
+
+/** Query parameter carried by Better Auth's new-user callback URL. */
+export const MAGIC_LINK_ATTRIBUTION_PARAM = "signup_attribution";
+
+/** Better Auth's magic-link token is valid for five minutes; keep this handoff
+ * slightly longer so clock skew does not discard a still-valid link. */
+const MAGIC_LINK_ATTRIBUTION_TTL_SECONDS = 10 * 60;
+const MAX_ATTRIBUTION_FIELDS = 32;
+const MAX_ATTRIBUTION_VALUE_LENGTH = 200;
+
+export interface MagicLinkSignupAttribution {
+  attribution?: Record<string, string>;
+  anonymousId?: string;
+}
+
+interface MagicLinkAttributionPayload extends MagicLinkSignupAttribution {
+  exp: number;
+}
+
+function sanitizeAttribution(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value).slice(
+    0,
+    MAX_ATTRIBUTION_FIELDS,
+  )) {
+    if (
+      !/^[a-z][a-z0-9_]{0,63}$/.test(key) ||
+      typeof raw !== "string" ||
+      raw.length === 0
+    ) {
+      continue;
+    }
+    out[key] = raw.slice(0, MAX_ATTRIBUTION_VALUE_LENGTH);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function encodePayload(payload: MagicLinkAttributionPayload): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+/**
+ * Sign the attribution captured when a magic link is requested. The token is
+ * analytics context only; it never authorizes the user or changes the return
+ * URL. The Better Auth secret keeps the callback from accepting forged data.
+ */
+export function encodeMagicLinkSignupAttribution(
+  value: MagicLinkSignupAttribution,
+  secret: string,
+  now = Date.now(),
+): string | undefined {
+  if (!secret) return undefined;
+
+  const attribution = sanitizeAttribution(value.attribution);
+  const anonymousId = normalizeAnalyticsAnonymousId(value.anonymousId);
+  if (!attribution && !anonymousId) return undefined;
+
+  const payload: MagicLinkAttributionPayload = {
+    exp: Math.floor(now / 1000) + MAGIC_LINK_ATTRIBUTION_TTL_SECONDS,
+    ...(attribution ? { attribution } : {}),
+    ...(anonymousId ? { anonymousId } : {}),
+  };
+  const data = encodePayload(payload);
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(data)
+    .digest("base64url");
+  return `${data}.${signature}`;
+}
+
+/** Verify and decode a token previously produced by
+ * {@link encodeMagicLinkSignupAttribution}. */
+export function decodeMagicLinkSignupAttribution(
+  token: string | null | undefined,
+  secret: string,
+  now = Date.now(),
+): MagicLinkSignupAttribution | null | undefined {
+  if (token === null || token === undefined) return undefined;
+  if (!token || !secret) return null;
+
+  try {
+    const dotIndex = token.lastIndexOf(".");
+    if (dotIndex <= 0 || dotIndex === token.length - 1) return null;
+
+    const data = token.slice(0, dotIndex);
+    const signature = token.slice(dotIndex + 1);
+    const expected = crypto
+      .createHmac("sha256", secret)
+      .update(data)
+      .digest("base64url");
+    if (
+      signature.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))
+    ) {
+      return null;
+    }
+
+    const payload = JSON.parse(
+      Buffer.from(data, "base64url").toString("utf8"),
+    ) as Partial<MagicLinkAttributionPayload>;
+    if (
+      typeof payload.exp !== "number" ||
+      payload.exp < Math.floor(now / 1000)
+    ) {
+      return null;
+    }
+
+    const attribution = sanitizeAttribution(payload.attribution);
+    const anonymousId = normalizeAnalyticsAnonymousId(payload.anonymousId);
+    if (!attribution && !anonymousId) return undefined;
+    return {
+      ...(attribution ? { attribution } : {}),
+      ...(anonymousId ? { anonymousId } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the signed handoff from Better Auth's magic-link verification request.
+ * Better Auth copies `newUserCallbackURL` into the verification URL, so this
+ * remains available even when the link is opened on another device.
+ */
+export function readMagicLinkSignupAttribution(
+  requestUrl: string | undefined,
+  secret: string,
+  now = Date.now(),
+): MagicLinkSignupAttribution | null | undefined {
+  if (!requestUrl) return undefined;
+
+  try {
+    const verificationUrl = new URL(requestUrl, "http://localhost");
+    if (!verificationUrl.pathname.endsWith("/magic-link/verify")) {
+      return undefined;
+    }
+    const callback = verificationUrl.searchParams.get("newUserCallbackURL");
+    if (!callback) return undefined;
+
+    const callbackUrl = new URL(callback, verificationUrl.origin);
+    return decodeMagicLinkSignupAttribution(
+      callbackUrl.searchParams.get(MAGIC_LINK_ATTRIBUTION_PARAM),
+      secret,
+      now,
+    );
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/server/magic-link-attribution.ts
+++ b/packages/core/src/server/magic-link-attribution.ts
@@ -122,6 +122,7 @@ export function decodeMagicLinkSignupAttribution(
       ...(anonymousId ? { anonymousId } : {}),
     };
   } catch {
+    // coercion-ok: malformed signed input is distinct from absent context.
     return null;
   }
 }
@@ -153,6 +154,7 @@ export function readMagicLinkSignupAttribution(
       now,
     );
   } catch {
+    // coercion-ok: malformed request input is distinct from absent context.
     return null;
   }
 }

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  APP_WEBVIEW_PREFERENCES,
   resolveAppWebviewPartition,
   resolveAppWebviewUrl,
 } from "./AppWebview.js";
@@ -77,5 +78,12 @@ describe("AppWebview URL resolution", () => {
         mode: "dev",
       }),
     ).toBe("http://localhost:3003");
+  });
+});
+
+describe("AppWebview runtime preferences", () => {
+  it("keeps guest pages eligible for Chromium background throttling", () => {
+    expect(APP_WEBVIEW_PREFERENCES).toContain("backgroundThrottling=true");
+    expect(APP_WEBVIEW_PREFERENCES).not.toContain("backgroundThrottling=false");
   });
 });

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -22,6 +22,8 @@ import {
 import { buildContentDirectoryPickerBridgeScript } from "../lib/content-directory-picker-bridge.js";
 
 const IS_DEV = window.location.protocol !== "file:";
+export const APP_WEBVIEW_PREFERENCES =
+  "contextIsolation=true,nodeIntegration=false,sandbox=true,backgroundThrottling=true";
 
 type WebviewTitleUpdatedEvent = Event & { title?: string };
 type WebviewLoadFailedEvent = Event & {
@@ -678,10 +680,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
                   window.electronAPI.webviewPreloadPath,
                 );
               }
-              wv.setAttribute(
-                "webpreferences",
-                "contextIsolation=true,nodeIntegration=false,sandbox=true,backgroundThrottling=false",
-              );
+              wv.setAttribute("webpreferences", APP_WEBVIEW_PREFERENCES);
               wv.setAttribute(
                 "partition",
                 resolveAppWebviewPartition({

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -232,6 +232,7 @@ const DayEventCard = memo(function DayEventCard({
   const li = layout.get(event.id) ?? {
     left: 0,
     width: 100,
+    indent: 0,
     col: 0,
     totalCols: 1,
     stackOrder: 0,
@@ -304,8 +305,8 @@ const DayEventCard = memo(function DayEventCard({
       }
       style={{
         ...posStyle,
-        left: `calc(${li.left}% + ${li.col > 0 ? 2 : 0}px)`,
-        width: `calc(${li.width}% - ${li.col > 0 ? 4 : 2}px)`,
+        left: `calc(${li.left}% + ${li.indent}px)`,
+        width: `calc(${li.width}% - ${li.indent * 2 + 2}px)`,
         zIndex:
           isBeingDragged && isDragging
             ? 100

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -274,6 +274,7 @@ const WeekEventCard = memo(function WeekEventCard({
   const li = layout.get(event.id) ?? {
     left: 0,
     width: 100,
+    indent: 0,
     col: 0,
     totalCols: 1,
     stackOrder: 0,
@@ -372,8 +373,8 @@ const WeekEventCard = memo(function WeekEventCard({
       }
       style={{
         ...style,
-        left: `calc(${li.left}% + ${li.col > 0 ? 2 : 0}px)`,
-        width: `calc(${li.width}% - ${li.col > 0 ? 4 : 2}px)`,
+        left: `calc(${li.left}% + ${li.indent}px)`,
+        width: `calc(${li.width}% - ${li.indent * 2 + 2}px)`,
         zIndex:
           isBeingDragged && isDragging
             ? 100

--- a/templates/calendar/app/lib/event-layout.test.ts
+++ b/templates/calendar/app/lib/event-layout.test.ts
@@ -37,34 +37,55 @@ describe("computeTimedEventLayout", () => {
     });
   });
 
-  it("keeps overlapping cards full width when their labels are separated", () => {
+  it("indents the later event while keeping both cards wide", () => {
     const layout = computeTimedEventLayout(
-      [event("long", "08:00", "18:00"), event("short", "09:00", "10:00")],
+      [event("gym", "16:00", "18:00"), event("friyay", "17:00", "18:00")],
       DAY,
     );
 
-    expect(layout.get("long")).toMatchObject({ left: 0, width: 100 });
-    expect(layout.get("short")).toMatchObject({ left: 0, width: 100 });
+    expect(layout.get("gym")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 0,
+      col: 0,
+    });
+    expect(layout.get("friyay")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 16,
+      col: 1,
+      totalCols: 2,
+    });
   });
 
-  it("places colliding labels in half-width columns", () => {
+  it("adds another inset layer for simultaneous events", () => {
     const layout = computeTimedEventLayout(
       [event("a", "09:00", "11:00"), event("b", "09:20", "10:00")],
       DAY,
     );
 
-    expect(layout.get("a")).toMatchObject({ left: 0, width: 50, col: 0 });
-    expect(layout.get("b")).toMatchObject({ left: 50, width: 50, col: 1 });
+    expect(layout.get("a")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 0,
+      col: 0,
+    });
+    expect(layout.get("b")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 16,
+      col: 1,
+    });
   });
 
-  it("keeps labels at the text boundary in the same column", () => {
+  it("keeps adjacent events in the same layer", () => {
     const layout = computeTimedEventLayout(
-      [event("a", "08:00", "10:00"), event("b", "08:45", "09:45")],
+      [event("a", "08:00", "08:45"), event("b", "08:45", "09:45")],
       DAY,
     );
 
-    expect(layout.get("a")).toMatchObject({ left: 0, width: 100 });
-    expect(layout.get("b")).toMatchObject({ left: 0, width: 100 });
+    expect(layout.get("a")).toMatchObject({ left: 0, width: 100, indent: 0 });
+    expect(layout.get("b")).toMatchObject({ left: 0, width: 100, indent: 0 });
   });
 
   it("accounts for the minimum rendered height of short events", () => {
@@ -73,11 +94,11 @@ describe("computeTimedEventLayout", () => {
       DAY,
     );
 
-    expect(layout.get("a")).toMatchObject({ left: 0, width: 50 });
-    expect(layout.get("b")).toMatchObject({ left: 50, width: 50 });
+    expect(layout.get("a")).toMatchObject({ left: 0, width: 100, indent: 0 });
+    expect(layout.get("b")).toMatchObject({ left: 0, width: 100, indent: 16 });
   });
 
-  it("expands a later event across a free column", () => {
+  it("reuses a free overlap layer after an earlier event ends", () => {
     const layout = computeTimedEventLayout(
       [
         event("background", "08:00", "12:00"),
@@ -87,12 +108,8 @@ describe("computeTimedEventLayout", () => {
       DAY,
     );
 
-    expect(layout.get("later")).toMatchObject({
-      left: 0,
-      width: 100,
-      col: 0,
-      totalCols: 2,
-    });
+    expect(layout.get("early")).toMatchObject({ col: 1, indent: 16 });
+    expect(layout.get("later")).toMatchObject({ col: 1, indent: 16 });
   });
 
   it("does not create a third column for a chained overlap", () => {
@@ -105,9 +122,21 @@ describe("computeTimedEventLayout", () => {
       DAY,
     );
 
-    expect(layout.get("first")).toMatchObject({ col: 0, totalCols: 2 });
-    expect(layout.get("middle")).toMatchObject({ col: 1, totalCols: 2 });
-    expect(layout.get("last")).toMatchObject({ col: 0, totalCols: 2 });
+    expect(layout.get("first")).toMatchObject({
+      col: 0,
+      indent: 0,
+      totalCols: 2,
+    });
+    expect(layout.get("middle")).toMatchObject({
+      col: 1,
+      indent: 16,
+      totalCols: 2,
+    });
+    expect(layout.get("last")).toMatchObject({
+      col: 0,
+      indent: 0,
+      totalCols: 2,
+    });
   });
 
   it("uses the visible day segment when laying out overnight events", () => {
@@ -117,7 +146,15 @@ describe("computeTimedEventLayout", () => {
 
     const layout = computeTimedEventLayout([overnight, later], DAY);
 
-    expect(layout.get("overnight")).toMatchObject({ left: 0, width: 100 });
-    expect(layout.get("later")).toMatchObject({ left: 0, width: 100 });
+    expect(layout.get("overnight")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 0,
+    });
+    expect(layout.get("later")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 16,
+    });
   });
 });

--- a/templates/calendar/app/lib/event-layout.ts
+++ b/templates/calendar/app/lib/event-layout.ts
@@ -4,6 +4,7 @@ import { addDays, parseISO, startOfDay } from "date-fns";
 export interface TimedEventLayout {
   left: number;
   width: number;
+  indent: number;
   col: number;
   totalCols: number;
   stackOrder: number;
@@ -20,18 +21,16 @@ interface EventEntry {
   inputOrder: number;
 }
 
-const TEXT_REGION_MINUTES = 45;
 const MIN_VISIBLE_EVENT_MINUTES = 15;
+const OVERLAP_INDENT_PX = 16;
 
 function overlaps(a: EventBounds, b: EventBounds): boolean {
   return a.start < b.end && b.start < a.end;
 }
 
 /**
- * Pack timed events into columns while reserving horizontal space only when
- * the event labels can collide. An event may span unused columns when another
- * event is present there at a different time, which keeps long events readable
- * without wasting the column width needed for genuinely simultaneous labels.
+ * Pack timed events into shallow overlap layers. Later events stay wide enough
+ * to read while their inset exposes the boundary of the event underneath.
  */
 export function computeTimedEventLayout(
   dayEvents: readonly CalendarEvent[],
@@ -66,52 +65,34 @@ export function computeTimedEventLayout(
     return a.inputOrder - b.inputOrder;
   });
 
-  const textOverlaps = (a: EventBounds, b: EventBounds): boolean => {
-    const aTextEnd = Math.min(a.start + TEXT_REGION_MINUTES * 60 * 1000, a.end);
-    const bTextEnd = Math.min(b.start + TEXT_REGION_MINUTES * 60 * 1000, b.end);
-    return a.start < bTextEnd && b.start < aTextEnd;
-  };
-
-  // Place labels side by side only when their visible text regions overlap.
-  const columns: EventEntry[][] = [];
+  // Put overlapping events into the first layer that is free at their start.
+  // Reusing finished layers keeps chained overlaps from creating empty gaps.
+  const overlapLayers: EventEntry[][] = [];
   const eventColumns = new Map<CalendarEvent, number>();
 
   for (const entry of sorted) {
-    let column = columns.findIndex((columnEntries) =>
-      columnEntries.every(
-        (placed) => !textOverlaps(placed.bounds, entry.bounds),
-      ),
+    let column = overlapLayers.findIndex((layerEntries) =>
+      layerEntries.every((placed) => !overlaps(placed.bounds, entry.bounds)),
     );
 
     if (column === -1) {
-      column = columns.length;
-      columns.push([]);
+      column = overlapLayers.length;
+      overlapLayers.push([]);
     }
 
-    columns[column].push(entry);
+    overlapLayers[column].push(entry);
     eventColumns.set(entry.event, column);
   }
 
-  const totalCols = columns.length;
+  const totalCols = overlapLayers.length;
 
   for (const [stackOrder, entry] of sorted.entries()) {
     const col = eventColumns.get(entry.event)!;
-    let span = 1;
-
-    // A column to the right is available when it has no event that overlaps
-    // this card in time. Label-only collisions do not need to block expansion.
-    for (let candidate = col + 1; candidate < totalCols; candidate++) {
-      if (
-        columns[candidate].some((other) => overlaps(other.bounds, entry.bounds))
-      ) {
-        break;
-      }
-      span++;
-    }
 
     result.set(entry.event.id, {
-      left: (col / totalCols) * 100,
-      width: (span / totalCols) * 100,
+      left: 0,
+      width: 100,
+      indent: col * OVERLAP_INDENT_PX,
       col,
       totalCols,
       stackOrder,

--- a/templates/clips/app/components/meetings/share-meeting-dialog.test.ts
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.test.ts
@@ -10,8 +10,6 @@ const source = readFileSync(
 
 describe("meeting share popover", () => {
   it("makes transcript sharing an explicit admin-managed opt-in", () => {
-    expect(source).toContain('t("shareMeeting.sharedContent")');
-    expect(source).toContain('t("shareMeeting.summaryIncluded")');
     expect(source).toContain('t("shareMeeting.includeTranscript")');
     expect(source).toContain("checked={includeTranscript}");
     expect(source).toContain("!canManage || !transcriptReady");

--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -4,7 +4,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconCheck, IconLink, IconMail } from "@tabler/icons-react";
+import { IconLink, IconMail } from "@tabler/icons-react";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
@@ -192,57 +192,40 @@ function LinkTab({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <GeneralAccessSelect
         visibility={visibility}
         canManage={canManage}
         isPending={isPending}
         onChange={(next) => setResourceVisibility(next)}
+        showDescription={false}
       />
 
-      <div>
-        <div className="mb-2 text-xs font-semibold">
-          {t("shareMeeting.sharedContent")}
+      <div className="flex items-center justify-between gap-4 rounded-md border border-border px-3 py-2.5">
+        <div className="min-w-0">
+          <label
+            htmlFor={`meeting-share-transcript-${meetingId}`}
+            className="text-sm font-medium"
+          >
+            {t("shareMeeting.includeTranscript")}
+          </label>
+          <p
+            id={`meeting-share-transcript-description-${meetingId}`}
+            className="sr-only"
+          >
+            {transcriptReady
+              ? t("shareMeeting.includeTranscriptDescription")
+              : t("shareMeeting.transcriptUnavailable")}
+          </p>
         </div>
-        <div className="rounded-md border border-border">
-          <div className="flex items-center gap-3 border-b border-border px-3 py-2.5">
-            <span
-              aria-hidden
-              className="inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground"
-            >
-              <IconCheck size={12} strokeWidth={2.5} />
-            </span>
-            <span className="text-sm">{t("shareMeeting.summaryIncluded")}</span>
-          </div>
-          <div className="flex items-start justify-between gap-4 px-3 py-2.5">
-            <div className="min-w-0">
-              <label
-                htmlFor={`meeting-share-transcript-${meetingId}`}
-                className="text-sm font-medium"
-              >
-                {t("shareMeeting.includeTranscript")}
-              </label>
-              <p
-                id={`meeting-share-transcript-description-${meetingId}`}
-                className="mt-0.5 text-xs text-muted-foreground"
-              >
-                {transcriptReady
-                  ? t("shareMeeting.includeTranscriptDescription")
-                  : t("shareMeeting.transcriptUnavailable")}
-              </p>
-            </div>
-            <Switch
-              id={`meeting-share-transcript-${meetingId}`}
-              checked={includeTranscript}
-              onCheckedChange={handleTranscriptSharingChange}
-              disabled={
-                !canManage || !transcriptReady || updateMeeting.isPending
-              }
-              aria-describedby={`meeting-share-transcript-description-${meetingId}`}
-              className="mt-0.5 shrink-0"
-            />
-          </div>
-        </div>
+        <Switch
+          id={`meeting-share-transcript-${meetingId}`}
+          checked={includeTranscript}
+          onCheckedChange={handleTranscriptSharingChange}
+          disabled={!canManage || !transcriptReady || updateMeeting.isPending}
+          aria-describedby={`meeting-share-transcript-description-${meetingId}`}
+          className="shrink-0"
+        />
       </div>
 
       <CopyField label={t("clipsFinalRaw.shareLink")} value={shareUrl} />

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -27,7 +27,8 @@ describe("recording share popover", () => {
     );
     expect(shareDialogSource).toContain("{!isPublic ? (");
     expect(shareDialogSource).toContain("if (!isPublic)");
-    expect(shareDialogSource).not.toContain("Collapsible");
+    expect(shareDialogSource).toContain("<Collapsible");
+    expect(shareDialogSource).toContain("agentDetailsOpen");
   });
 
   it("uses known recording access while share details load", () => {

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
+  IconChevronDown,
   IconCode,
   IconExternalLink,
   IconLink,
@@ -35,6 +36,11 @@ import {
   type Visibility,
 } from "@/components/sharing/share-ui";
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -434,6 +440,11 @@ function LinkTab({
   const agentPrompt = agentLink
     ? t("shareDialog.agentPrompt", { agentContextUrl: agentLink })
     : "";
+  const [agentDetailsOpen, setAgentDetailsOpen] = useState(false);
+
+  useEffect(() => {
+    if (isPublic) setAgentDetailsOpen(false);
+  }, [isPublic]);
 
   return (
     <div className="space-y-4">
@@ -444,6 +455,7 @@ function LinkTab({
           isPending={visibilityPending}
           onChange={(next) => setResourceVisibility(next)}
           publicDescription={t("shareDialog.publicDescription")}
+          showDescription={false}
         />
       ) : (
         <div className="space-y-2" aria-hidden>
@@ -463,42 +475,69 @@ function LinkTab({
       />
 
       {!isPublic ? (
-        <div className="space-y-2">
-          <CopyField
-            label={t("shareDialog.shareWithAgents")}
-            value={agentLink}
-            disabled={agentShareDisabled}
-          />
-          {sharesLoaded ? (
-            <>
-              <p className="text-xs text-muted-foreground">
-                {t("shareDialog.agentTokenDescription")}
-              </p>
-              {agentLinkError ? (
-                <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
-                  <p className="text-xs text-muted-foreground">
-                    {t("shareDialog.agentLinkUnavailable")}
-                  </p>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-7"
-                    onClick={() => void loadAgentContextUrl()}
-                    disabled={createAgentLink.isPending}
-                  >
-                    {t("shareDialog.retryAgentLink")}
-                  </Button>
-                </div>
-              ) : null}
+        <Collapsible
+          open={agentDetailsOpen}
+          onOpenChange={setAgentDetailsOpen}
+          className="overflow-hidden rounded-md border border-border"
+        >
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex min-h-10 w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm font-medium transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+            >
+              <span className="flex min-w-0 items-center gap-2 truncate">
+                <IconLink
+                  aria-hidden="true"
+                  className="size-3.5 shrink-0 text-muted-foreground"
+                  strokeWidth={1.8}
+                />
+                {t("shareDialog.shareWithAgents")}
+              </span>
+              <IconChevronDown
+                aria-hidden="true"
+                className={`size-4 shrink-0 text-muted-foreground transition-transform ${agentDetailsOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="clips-collapsible-content border-t border-border px-3 py-3">
+            <div className="space-y-2">
               <CopyField
-                label={t("shareDialog.copyAgentPrompt")}
-                value={agentPrompt}
+                label={t("shareDialog.shareWithAgents")}
+                value={agentLink}
                 disabled={agentShareDisabled}
               />
-            </>
-          ) : null}
-        </div>
+              {sharesLoaded ? (
+                <>
+                  <p className="text-xs text-muted-foreground">
+                    {t("shareDialog.agentTokenDescription")}
+                  </p>
+                  {agentLinkError ? (
+                    <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+                      <p className="text-xs text-muted-foreground">
+                        {t("shareDialog.agentLinkUnavailable")}
+                      </p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7"
+                        onClick={() => void loadAgentContextUrl()}
+                        disabled={createAgentLink.isPending}
+                      >
+                        {t("shareDialog.retryAgentLink")}
+                      </Button>
+                    </div>
+                  ) : null}
+                  <CopyField
+                    label={t("shareDialog.copyAgentPrompt")}
+                    value={agentPrompt}
+                    disabled={agentShareDisabled}
+                  />
+                </>
+              ) : null}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       ) : null}
 
       {sharesLoaded && !isPublic && canManage ? (

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -178,6 +178,7 @@ export function GeneralAccessSelect({
   isPending,
   onChange,
   publicDescription,
+  showDescription = true,
 }: {
   visibility: Visibility;
   canManage: boolean;
@@ -185,6 +186,7 @@ export function GeneralAccessSelect({
   onChange: (next: Visibility) => void;
   /** Override for the "public" visibility description (e.g. Clips comment hint). */
   publicDescription?: string;
+  showDescription?: boolean;
 }) {
   const t = useT();
   const meta = VIS_META[visibility];
@@ -222,7 +224,12 @@ export function GeneralAccessSelect({
               ))}
             </SelectContent>
           </Select>
-          <div className="mt-0.5 text-xs text-muted-foreground">
+          <div
+            className={cn(
+              "mt-0.5 text-xs text-muted-foreground",
+              !showDescription && "sr-only",
+            )}
+          >
             {description}
           </div>
         </div>
@@ -244,14 +251,13 @@ export function MakePublicCard({
 }) {
   const t = useT();
   return (
-    <div className="rounded-md border border-border bg-muted/40 px-3 py-2.5">
-      <p className="text-xs text-muted-foreground">
-        {t("shareUi.restrictedLinkDescription")}
-      </p>
+    <div className="flex items-center justify-end gap-2 rounded-md bg-muted/40 px-3 py-2">
+      <p className="sr-only">{t("shareUi.restrictedLinkDescription")}</p>
       <Button
         type="button"
+        variant="outline"
         size="sm"
-        className="mt-2 h-7"
+        className="h-7"
         onClick={onMakePublic}
         disabled={isPending}
       >

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -251,8 +251,14 @@ export function MakePublicCard({
 }) {
   const t = useT();
   return (
-    <div className="flex items-center justify-end gap-2 rounded-md bg-muted/40 px-3 py-2">
+    <div className="flex items-center justify-between gap-2 rounded-md bg-muted/40 px-3 py-2">
       <p className="sr-only">{t("shareUi.restrictedLinkDescription")}</p>
+      <IconLock
+        aria-hidden
+        size={14}
+        strokeWidth={1.8}
+        className="text-muted-foreground"
+      />
       <Button
         type="button"
         variant="outline"

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -70,7 +70,7 @@ const ONBOARDING_HEIGHT_LOGICAL: f64 = 640.0;
 const BUBBLE_SIZE_SMALL: u32 = 360;
 const BUBBLE_SIZE_MEDIUM: u32 = 504;
 const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 24.0;
-const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 360.0;
+const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 320.0;
 const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
 const OVERLAY_SHADOW_GUTTER_LOGICAL: f64 = 18.0;
 
@@ -1342,7 +1342,7 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
             })
             .unwrap_or(820.0);
         let clamped = height.clamp(200.0, max_logical_height);
-        let width = width.unwrap_or(360.0).clamp(320.0, 960.0);
+        let width = width.unwrap_or(320.0).clamp(320.0, 960.0);
         let (window_width, window_height) = popover_window_size_logical(width, clamped);
         let _ = w.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
             window_width,

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -7,7 +7,7 @@ use crate::state::{
 };
 
 const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 24.0;
-const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 360.0;
+const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 320.0;
 const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
 
 // ---------------------------------------------------------------------------

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2629,7 +2629,7 @@ export function App() {
       isRecording ||
       recordingFlowActive,
     width:
-      popoverView === "settings" ? 920 : popoverView === "memory" ? 440 : 360,
+      popoverView === "settings" ? 920 : popoverView === "memory" ? 440 : 320,
   });
 
   const loadPendingUploads = useCallback(async () => {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -13,6 +13,7 @@
   --surface: #f7f7f7;
   --surface-hover: #f0f0f0;
   --surface-strong: #ebebeb;
+  --settings-nav-active: #ffffff;
   --fg: #171717;
   --fg-muted: #737373;
   --fg-subtle: #a3a3a3;
@@ -48,6 +49,7 @@
     --surface: #262626;
     --surface-hover: #2e2e2e;
     --surface-strong: #3d3d3d;
+    --settings-nav-active: var(--surface-hover);
     --fg: #f5f5f5;
     --fg-muted: #a3a3a3;
     --fg-subtle: #737373;
@@ -237,9 +239,9 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 .settings-nav-button.is-active {
-  background: var(--bg);
+  background: var(--settings-nav-active);
   color: var(--fg);
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
 }
 
 .settings-nav-button:focus-visible {
@@ -2575,6 +2577,12 @@ body[data-clips-route="recording-pill"] #root {
   max-height: none;
   overflow: visible;
   overscroll-behavior: contain;
+}
+
+.setup.settings-page {
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
 }
 
 /* Meetings / dictation drill-ins: a touch more room under the last row so

--- a/templates/factory/app/factory-i18n.spec.ts
+++ b/templates/factory/app/factory-i18n.spec.ts
@@ -45,7 +45,10 @@ describe("Factory i18n catalog", () => {
   it("keeps the Factory route keys aligned across shipped locales", async () => {
     for (const [locale, messages] of Object.entries(localeMessages)) {
       for (const key of requiredKeys) {
-        expect(readKey(messages, key), `${locale} missing ${key}`).toBeDefined();
+        expect(
+          readKey(messages, key),
+          `${locale} missing ${key}`,
+        ).toBeDefined();
       }
     }
 

--- a/templates/factory/app/routes/factory.tsx
+++ b/templates/factory/app/routes/factory.tsx
@@ -1516,9 +1516,6 @@ function RulesView({ t }: { t: ReturnType<typeof useT> }) {
           <CardTitle className="text-base">
             {t("factoryRoute.rulesTitle")}
           </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            {t("factoryRoute.rulesDescription")}
-          </p>
         </CardHeader>
         <CardContent className="space-y-2">
           <Button

--- a/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
+++ b/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
@@ -30,6 +30,12 @@ describe("EditorToolbar layout contract", () => {
     );
   });
 
+  it("pushes the top-right actions to the row edge when the style toolbar moves below", () => {
+    expect(editorToolbarSource).toContain(
+      '<div className="ml-auto flex-shrink-0">',
+    );
+  });
+
   it("lets the wide contextual toolbar scroll instead of clipping rare overflow", () => {
     expect(globalCssSource).toContain(
       ".deck-editor-context-toolbar-host {\n  min-width: 0;\n  overflow: auto;\n}",

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -636,7 +636,7 @@ export default function EditorToolbar({
       />
 
       {/* Consolidated editor menu */}
-      <div className="flex-shrink-0">
+      <div className="ml-auto flex-shrink-0">
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/templates/slides/app/components/editor/ShareDialog.tsx
+++ b/templates/slides/app/components/editor/ShareDialog.tsx
@@ -6,6 +6,7 @@ import {
   IconCheck,
   IconLoader2,
   IconExternalLink,
+  IconChevronDown,
 } from "@tabler/icons-react";
 import { useState, type ReactNode } from "react";
 
@@ -86,7 +87,7 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-[420px] bg-card border-border p-4"
+        className="w-[min(420px,calc(100vw-2rem))] bg-card border-border p-4"
       >
         {showCloudUpgrade || isLocal ? (
           <CloudUpgrade
@@ -104,35 +105,37 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
                 <IconShare2 className="w-4 h-4 text-[#609FF8]" />
                 {t("share.title")}
               </div>
-              <div className="text-muted-foreground text-xs mt-0.5">
-                {t("share.description", { title: deck.title })}
-              </div>
             </div>
 
             <div className="space-y-4">
               {!shareUrl ? (
                 <>
-                  <div className="bg-muted/50 rounded-lg p-3 border border-border">
-                    <h4 className="text-sm font-medium text-foreground/90 mb-2">
+                  <details className="group rounded-md border border-border bg-muted/30">
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2.5 text-sm font-medium [&::-webkit-details-marker]:hidden">
                       {t("share.whatGetsShared")}
-                    </h4>
-                    <ul className="text-xs text-muted-foreground space-y-1">
-                      <li>
-                        {t("share.slideContent", {
-                          count: deck.slides.length,
-                        })}
-                      </li>
-                      <li>{t("share.presentationView")}</li>
-                    </ul>
-                    <h4 className="text-sm font-medium text-foreground/90 mt-3 mb-2">
-                      {t("share.whatStaysPrivate")}
-                    </h4>
-                    <ul className="text-xs text-muted-foreground space-y-1">
-                      <li>{t("share.speakerNotes")}</li>
-                      <li>{t("share.otherPresentations")}</li>
-                      <li>{t("share.editingAccess")}</li>
-                    </ul>
-                  </div>
+                      <IconChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+                    </summary>
+                    <div className="space-y-3 border-t border-border px-3 py-3 text-xs text-muted-foreground">
+                      <ul className="space-y-1">
+                        <li>
+                          {t("share.slideContent", {
+                            count: deck.slides.length,
+                          })}
+                        </li>
+                        <li>{t("share.presentationView")}</li>
+                      </ul>
+                      <div>
+                        <h4 className="mb-1 font-medium text-foreground/90">
+                          {t("share.whatStaysPrivate")}
+                        </h4>
+                        <ul className="space-y-1">
+                          <li>{t("share.speakerNotes")}</li>
+                          <li>{t("share.otherPresentations")}</li>
+                          <li>{t("share.editingAccess")}</li>
+                        </ul>
+                      </div>
+                    </div>
+                  </details>
 
                   {error && (
                     <p className="text-xs text-red-400 bg-red-400/10 px-3 py-2 rounded-lg">
@@ -194,7 +197,7 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
                     {t("share.openSharedLink")}
                   </a>
 
-                  <p className="text-[11px] text-muted-foreground/70 text-center">
+                  <p className="sr-only text-[11px] text-muted-foreground/70 text-center">
                     {t("share.anyoneWithLink")}
                   </p>
                 </>

--- a/templates/slides/app/components/editor/SlideContextToolbar.layout.test.tsx
+++ b/templates/slides/app/components/editor/SlideContextToolbar.layout.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -70,5 +76,39 @@ describe("contextual toolbar object layout", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Vertical" }));
 
     expect(onDistributeObjects).toHaveBeenCalledWith("vertical");
+  });
+
+  it("keeps zoom controls inside the style toolbar", () => {
+    const onZoomOut = vi.fn();
+    const onZoomIn = vi.fn();
+
+    render(
+      <TooltipProvider>
+        <SlideContextToolbar
+          snapshot={null}
+          background="#000000"
+          onChange={vi.fn()}
+          onBackgroundChange={vi.fn()}
+          zoomControls={{
+            value: 100,
+            onZoomOut,
+            onZoomIn,
+            canZoomOut: true,
+            canZoomIn: true,
+          }}
+        />
+      </TooltipProvider>,
+    );
+
+    const toolbar = screen.getByRole("toolbar");
+    expect(within(toolbar).getByText("100%")).toBeTruthy();
+    fireEvent.click(within(toolbar).getByRole("button", { name: "Zoom out" }));
+    fireEvent.click(within(toolbar).getByRole("button", { name: "Zoom in" }));
+
+    expect(onZoomOut).toHaveBeenCalledOnce();
+    expect(onZoomIn).toHaveBeenCalledOnce();
+    expect(
+      within(toolbar).queryByRole("button", { name: "Fit slide to screen" }),
+    ).toBeNull();
   });
 });

--- a/templates/slides/app/components/editor/SlideContextToolbar.tsx
+++ b/templates/slides/app/components/editor/SlideContextToolbar.tsx
@@ -36,6 +36,8 @@ import {
   IconStackBack,
   IconStackFront,
   IconUnderline,
+  IconZoomIn,
+  IconZoomOut,
 } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 
@@ -150,6 +152,7 @@ export function SlideContextToolbar({
   objectSelectionCount = 0,
   onAlignObjects,
   onDistributeObjects,
+  zoomControls,
 }: {
   snapshot: SlideStyleSnapshot | null;
   background: string | undefined;
@@ -164,6 +167,13 @@ export function SlideContextToolbar({
   objectSelectionCount?: number;
   onAlignObjects?: (alignment: SlideObjectAlignment) => void;
   onDistributeObjects?: (distribution: SlideObjectDistribution) => void;
+  zoomControls?: {
+    value: number;
+    onZoomOut: () => void;
+    onZoomIn: () => void;
+    canZoomOut: boolean;
+    canZoomIn: boolean;
+  };
 }) {
   const t = useT();
   const documentColors = tokenPalette(designSystem, t).map(
@@ -912,6 +922,46 @@ export function SlideContextToolbar({
               )}
             </PopoverContent>
           </Popover>
+        </>
+      )}
+      {zoomControls && (
+        <>
+          <div className={TOOLBAR_DIVIDER} />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={MENU_BUTTON_CLASS}
+                onClick={zoomControls.onZoomOut}
+                disabled={!zoomControls.canZoomOut}
+                aria-label={t("raw.zoomOut")}
+              >
+                <IconZoomOut className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("raw.zoomOut")}</TooltipContent>
+          </Tooltip>
+          <span className="w-11 shrink-0 text-center text-xs tabular-nums text-muted-foreground">
+            {zoomControls.value}%
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={MENU_BUTTON_CLASS}
+                onClick={zoomControls.onZoomIn}
+                disabled={!zoomControls.canZoomIn}
+                aria-label={t("raw.zoomIn")}
+              >
+                <IconZoomIn className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("raw.zoomIn")}</TooltipContent>
+          </Tooltip>
         </>
       )}
     </div>

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -21,13 +21,10 @@ import {
   IconBrush,
   IconClipboard,
   IconCopy,
-  IconMaximize,
   IconStackBack,
   IconStackFront,
   IconTrash,
   IconX,
-  IconZoomIn,
-  IconZoomOut,
 } from "@tabler/icons-react";
 import {
   useState,
@@ -1252,10 +1249,6 @@ export default function SlideEditor({
       .find((preset) => preset < canvasZoom);
     setManualCanvasZoom(previous ?? CANVAS_ZOOM_PRESETS[0]);
   }, [canvasZoom, setManualCanvasZoom]);
-  const fitCanvasToScreen = useCallback(() => {
-    userSetCanvasZoomRef.current = false;
-    setCanvasZoom(fitCanvasZoom);
-  }, [fitCanvasZoom]);
 
   usePinchZoom({
     containerRef: scrollContainerRef,
@@ -5010,6 +5003,16 @@ export default function SlideEditor({
   const objectOperationSelection = getObjectOperationSelection();
   const hasObjectSelection = objectOperationSelection !== null;
   const objectSelectionCount = objectOperationSelection?.elements.length ?? 0;
+  const zoomControls = slide.excalidrawData
+    ? undefined
+    : {
+        value: canvasZoom,
+        onZoomOut: canvasZoomOut,
+        onZoomIn: canvasZoomIn,
+        canZoomOut: canvasZoom > MIN_CANVAS_ZOOM,
+        canZoomIn:
+          canvasZoom < CANVAS_ZOOM_PRESETS[CANVAS_ZOOM_PRESETS.length - 1],
+      };
 
   // Excalidraw slides have no selectable slide content, so the row collapses
   // to its slide-level state — but that state owns the background picker, and
@@ -5038,6 +5041,7 @@ export default function SlideEditor({
         objectSelectionCount={objectSelectionCount}
         onAlignObjects={handleAlignSelectedObjects}
         onDistributeObjects={handleDistributeSelectedObjects}
+        zoomControls={zoomControls}
       />
     </div>
   ) : null;
@@ -5061,6 +5065,7 @@ export default function SlideEditor({
         objectSelectionCount={objectSelectionCount}
         onAlignObjects={handleAlignSelectedObjects}
         onDistributeObjects={handleDistributeSelectedObjects}
+        zoomControls={zoomControls}
         className="slide-context-toolbar--top-row"
       />
     </div>
@@ -5102,59 +5107,6 @@ export default function SlideEditor({
             </div>
           ) : (
             <div className="relative h-full bg-[var(--slides-editor-surface)]">
-              <div className="absolute right-3 top-3 z-20 flex h-8 items-center gap-0.5 rounded-md bg-popover/95 px-1">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 cursor-pointer"
-                      onClick={canvasZoomOut}
-                      disabled={canvasZoom <= MIN_CANVAS_ZOOM}
-                      aria-label={t("raw.zoomOut")}
-                    >
-                      <IconZoomOut className="h-3.5 w-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t("raw.zoomOut")}</TooltipContent>
-                </Tooltip>
-                <span className="w-11 text-center text-xs tabular-nums text-muted-foreground">
-                  {canvasZoom}%
-                </span>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 cursor-pointer"
-                      onClick={canvasZoomIn}
-                      disabled={
-                        canvasZoom >=
-                        CANVAS_ZOOM_PRESETS[CANVAS_ZOOM_PRESETS.length - 1]
-                      }
-                      aria-label={t("raw.zoomIn")}
-                    >
-                      <IconZoomIn className="h-3.5 w-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t("raw.zoomIn")}</TooltipContent>
-                </Tooltip>
-                <div className="mx-0.5 h-4 w-px bg-border" />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 cursor-pointer"
-                      onClick={fitCanvasToScreen}
-                      aria-label={t("raw.fitSlideToScreen")}
-                    >
-                      <IconMaximize className="h-3.5 w-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{t("raw.fitToScreen")}</TooltipContent>
-                </Tooltip>
-              </div>
               <div
                 ref={scrollContainerRef}
                 className={`h-full overflow-auto ${


### PR DESCRIPTION
## Summary
- Preserve chat completion handoff across transient database failures.
- Harden sharing, auth attribution, workspace, desktop, calendar, Clips, Factory, and Slides surfaces.
- Include focused regression coverage and changesets for publishable Core fixes.

## Validation
- Focused Core tests: 596 passed.
- Clips focused tests: 6 passed.
- Slides focused tests: 8 passed.
- Core, Clips, and Slides typechecks completed.
- `guard:no-default-chrome` and `guard:no-silent-coercion` passed.
- Formatting and diff checks passed.

This is a ready follow-up to the already merged framework update.