### PR TITLE
fix: contain Clips desktop settings popovers

### DIFF
--- a/.changeset/bright-clips-share.md
+++ b/.changeset/bright-clips-share.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Polish sharing dialogs and controls across the core and Clips surfaces.

--- a/packages/core/src/client/sharing/ShareDialog.tsx
+++ b/packages/core/src/client/sharing/ShareDialog.tsx
@@ -119,7 +119,11 @@ export function ShareDialog({
       onOpenChange={controller.onOpenChange}
       title={
         <span
-          className="truncate !text-base !leading-normal !tracking-normal !text-inherit"
+          className={cn(
+            controller.tabsEnabled
+              ? "sr-only"
+              : "truncate !text-base !leading-normal !tracking-normal !text-inherit",
+          )}
           title={controller.title}
         >
           {controller.title}
@@ -130,13 +134,13 @@ export function ShareDialog({
       className="!top-4 !z-[2010] !block !max-h-none !w-[calc(100vw-2rem)] !max-w-lg !translate-y-0 !gap-0 !overflow-visible !rounded-xl !border-border !bg-popover !p-0 !text-popover-foreground !shadow-2xl sm:!top-1/2 sm:!-translate-y-1/2"
       aria-label={controller.title}
     >
-      <div className="px-5 pt-0 pb-3">
-        {controller.ownerLabel ? (
+      {!controller.tabsEnabled && controller.ownerLabel ? (
+        <div className="px-5 pt-0 pb-3">
           <div className="truncate text-xs text-muted-foreground">
             {controller.ownerLabel}
           </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       {controller.tabsEnabled ? (
         <div
@@ -224,7 +228,7 @@ function LinkTab({
         controller={controller}
       />
       <div>
-        <div className="mb-2 text-sm font-semibold">
+        <div className="mb-2 text-xs font-medium text-muted-foreground">
           {controller.labels.generalAccess}
         </div>
         <div className="flex items-center gap-3">

--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -12,7 +12,6 @@ import {
   CopyField,
   GeneralAccessSelect,
   MakePublicCard,
-  ShareCardHeader,
   SharePeopleTab,
   copyToClipboard,
   useResourceVisibilityMutation,
@@ -30,7 +29,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 export interface ShareMeetingPopoverProps {
   meetingId: string;
-  meetingTitle?: string;
   shareTranscript: boolean;
   transcriptReady: boolean;
   children: ReactNode;
@@ -38,7 +36,6 @@ export interface ShareMeetingPopoverProps {
 
 export function ShareMeetingPopover({
   meetingId,
-  meetingTitle,
   shareTranscript,
   transcriptReady,
   children,
@@ -52,7 +49,6 @@ export function ShareMeetingPopover({
       >
         <ShareMeetingContent
           meetingId={meetingId}
-          meetingTitle={meetingTitle}
           shareTranscript={shareTranscript}
           transcriptReady={transcriptReady}
         />
@@ -63,12 +59,10 @@ export function ShareMeetingPopover({
 
 function ShareMeetingContent({
   meetingId,
-  meetingTitle,
   shareTranscript,
   transcriptReady,
 }: {
   meetingId: string;
-  meetingTitle?: string;
   shareTranscript: boolean;
   transcriptReady: boolean;
 }) {
@@ -85,14 +79,9 @@ function ShareMeetingContent({
 
   const data = sharesQuery.data;
   const canManage = data?.role === "owner" || data?.role === "admin";
-  const titleText = meetingTitle
-    ? t("clipsFinalRaw.shareNamedMeeting", { title: meetingTitle })
-    : t("clipsFinalRaw.shareMeeting");
 
   return (
     <>
-      <ShareCardHeader title={titleText} ownerEmail={data?.ownerEmail} />
-
       <Tabs defaultValue="link" className="min-w-0 px-4 py-3">
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="link" className="gap-1.5">

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -125,7 +125,6 @@ export function ShareRecordingPopover({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
-          reserveCloseButton
         />
       </PopoverContent>
     </Popover>
@@ -169,6 +168,7 @@ export function ShareRecordingDialog({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
+          reserveCloseButton
         />
       </DialogContent>
     </Dialog>

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -27,7 +27,6 @@ import {
   CopyField,
   GeneralAccessSelect,
   MakePublicCard,
-  ShareCardHeader,
   SharePeopleTab,
   copyToClipboard,
   useResourceVisibilityMutation,
@@ -51,6 +50,7 @@ import {
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 
 import { buildEmailPreviewMarkup } from "../../../shared/email-preview";
 import { isLoomEmbedUrl } from "../../../shared/loom";
@@ -168,7 +168,6 @@ export function ShareRecordingDialog({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
-          reserveCloseButton
         />
       </DialogContent>
     </Dialog>
@@ -184,7 +183,6 @@ function ShareRecordingContent({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording = false,
-  reserveCloseButton = false,
   hasPassword,
 }: {
   recordingId: string;
@@ -195,7 +193,6 @@ function ShareRecordingContent({
   thumbnailUrl?: string | null;
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
-  reserveCloseButton?: boolean;
   hasPassword?: boolean;
 }) {
   const t = useT();
@@ -228,19 +225,12 @@ function ShareRecordingContent({
           absoluteAppUrl(`/share/${recordingId}`),
           ownerViaId,
         );
-  const titleText = recordingTitle
-    ? t("shareDialog.shareTitle", { title: recordingTitle })
-    : t("shareDialog.shareRecording");
-
   return (
     <>
-      <ShareCardHeader
-        title={titleText}
-        ownerEmail={data?.ownerEmail}
-        reserveCloseButton={reserveCloseButton}
-      />
-
-      <Tabs defaultValue="link" className="min-w-0 px-4 py-3">
+      <Tabs
+        defaultValue="link"
+        className={cn("min-w-0 px-4 py-3", reserveCloseButton && "pe-12")}
+      >
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="link" className="gap-1.5">
             <IconLink size={14} />
@@ -441,6 +431,25 @@ function LinkTab({
     ? t("shareDialog.agentPrompt", { agentContextUrl: agentLink })
     : "";
   const [agentDetailsOpen, setAgentDetailsOpen] = useState(false);
+  const showMakePublic = sharesLoaded && !isPublic && canManage;
+  const downloadButton = videoUrl ? (
+    <Button
+      variant="outline"
+      size="sm"
+      className={isLoomRecording ? "gap-1.5" : undefined}
+      onClick={() => window.open(videoUrl, "_blank", "noopener,noreferrer")}
+    >
+      {isLoomRecording ? (
+        <>
+          <IconExternalLink className="h-4 w-4" />
+          {t("shareDialog.openPlayer")}
+        </>
+      ) : (
+        t("recordRoute.downloadRecording")
+      )}
+    </Button>
+  ) : null;
+  const moveDownloadIntoMakePublicRow = showMakePublic && Boolean(videoUrl);
 
   useEffect(() => {
     if (isPublic) setAgentDetailsOpen(false);
@@ -540,9 +549,12 @@ function LinkTab({
         </Collapsible>
       ) : null}
 
-      {sharesLoaded && !isPublic && canManage ? (
+      {showMakePublic ? (
         <MakePublicCard
           isPending={isPending}
+          secondaryAction={
+            moveDownloadIntoMakePublicRow ? downloadButton : undefined
+          }
           onMakePublic={() =>
             setResourceVisibility("public", {
               onSuccess: () => copyToClipboard(shareUrl),
@@ -551,7 +563,9 @@ function LinkTab({
         />
       ) : null}
 
-      {emailPreviewThumbnailUrl || videoUrl || animatedThumbnailUrl ? (
+      {emailPreviewThumbnailUrl ||
+      animatedThumbnailUrl ||
+      (videoUrl && !moveDownloadIntoMakePublicRow) ? (
         <div className="flex flex-wrap gap-2">
           {emailPreviewThumbnailUrl ? (
             <Button
@@ -571,25 +585,7 @@ function LinkTab({
               {t("shareDialog.gifPreview")}
             </Button>
           ) : null}
-          {videoUrl ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className={isLoomRecording ? "gap-1.5" : undefined}
-              onClick={() =>
-                window.open(videoUrl, "_blank", "noopener,noreferrer")
-              }
-            >
-              {isLoomRecording ? (
-                <>
-                  <IconExternalLink className="h-4 w-4" />
-                  {t("shareDialog.openPlayer")}
-                </>
-              ) : (
-                t("recordRoute.downloadRecording")
-              )}
-            </Button>
-          ) : null}
+          {!moveDownloadIntoMakePublicRow ? downloadButton : null}
         </div>
       ) : null}
     </div>

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -125,6 +125,7 @@ export function ShareRecordingPopover({
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
           hasPassword={hasPassword}
+          reserveCloseButton
         />
       </PopoverContent>
     </Popover>
@@ -183,6 +184,7 @@ function ShareRecordingContent({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording = false,
+  reserveCloseButton = false,
   hasPassword,
 }: {
   recordingId: string;
@@ -193,6 +195,7 @@ function ShareRecordingContent({
   thumbnailUrl?: string | null;
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
+  reserveCloseButton?: boolean;
   hasPassword?: boolean;
 }) {
   const t = useT();

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -14,7 +14,7 @@ import {
   IconWorld,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 
 import {
   Avatar as UserAvatar,
@@ -136,34 +136,19 @@ export function useResourceVisibilityMutation(
 }
 
 // ---------------------------------------------------------------------------
-// Header (title + owner)
+// Compact section labels
 // ---------------------------------------------------------------------------
 
-export function ShareCardHeader({
-  title,
-  ownerEmail,
-  reserveCloseButton = false,
+export function ShareSectionLabel({
+  children,
+  className,
 }: {
-  title: string;
-  ownerEmail?: string | null;
-  reserveCloseButton?: boolean;
+  children: ReactNode;
+  className?: string;
 }) {
-  const t = useT();
   return (
-    <div
-      className={cn(
-        "min-w-0 border-b border-border px-4 pb-3 pt-3",
-        reserveCloseButton && "pe-12",
-      )}
-    >
-      <div className="min-w-0 truncate text-sm font-semibold" title={title}>
-        {title}
-      </div>
-      {ownerEmail ? (
-        <div className="mt-0.5 truncate text-xs text-muted-foreground">
-          {t("shareUi.owner", { email: ownerEmail })}
-        </div>
-      ) : null}
+    <div className={cn("text-xs font-medium text-muted-foreground", className)}>
+      {children}
     </div>
   );
 }
@@ -197,9 +182,9 @@ export function GeneralAccessSelect({
 
   return (
     <div>
-      <div className="mb-2 text-xs font-semibold">
+      <ShareSectionLabel className="mb-2">
         {t("shareUi.generalAccess")}
-      </div>
+      </ShareSectionLabel>
       <div className="flex items-center gap-3">
         <span
           aria-hidden
@@ -245,9 +230,11 @@ export function GeneralAccessSelect({
 export function MakePublicCard({
   isPending,
   onMakePublic,
+  secondaryAction,
 }: {
   isPending: boolean;
   onMakePublic: () => void;
+  secondaryAction?: ReactNode;
 }) {
   const t = useT();
   return (
@@ -259,16 +246,21 @@ export function MakePublicCard({
         strokeWidth={1.8}
         className="text-muted-foreground"
       />
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-7"
-        onClick={onMakePublic}
-        disabled={isPending}
-      >
-        {isPending ? t("shareUi.makingPublic") : t("shareUi.makePublicAndCopy")}
-      </Button>
+      <div className="flex items-center gap-2">
+        {secondaryAction}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7"
+          onClick={onMakePublic}
+          disabled={isPending}
+        >
+          {isPending
+            ? t("shareUi.makingPublic")
+            : t("shareUi.makePublicAndCopy")}
+        </Button>
+      </div>
     </div>
   );
 }
@@ -297,9 +289,9 @@ export function CopyField({
   return (
     <div>
       {label ? (
-        <div className="mb-1 text-xs font-medium text-muted-foreground">
+        <ShareSectionLabel className="mb-1">
           {label}
-        </div>
+        </ShareSectionLabel>
       ) : null}
       <div className="flex items-stretch gap-2">
         <Input

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -289,9 +289,7 @@ export function CopyField({
   return (
     <div>
       {label ? (
-        <ShareSectionLabel className="mb-1">
-          {label}
-        </ShareSectionLabel>
+        <ShareSectionLabel className="mb-1">{label}</ShareSectionLabel>
       ) : null}
       <div className="flex items-stretch gap-2">
         <Input

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -704,7 +704,6 @@ export default function MeetingDetailRoute() {
           ) : null}
           <ShareMeetingPopover
             meetingId={meeting.id}
-            meetingTitle={meeting.title}
             shareTranscript={meeting.shareTranscript === true}
             transcriptReady={
               meeting.transcriptStatus === "ready" &&

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1,7 +1,10 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import {
   IconAlertTriangle,
   IconArrowLeft,
   IconCalendarEvent,
+  IconCheck,
+  IconChevronDown,
   IconCircleCheck,
   IconCopy,
   IconDownload,
@@ -24,6 +27,7 @@ import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import {
+  type ReactElement,
   type ReactNode,
   type RefObject,
   useCallback,
@@ -796,6 +800,10 @@ function measurePopoverHeight(el: HTMLElement): number {
   // by the current viewport height.
   let lowestBottom = rect.bottom;
   for (const child of Array.from(el.querySelectorAll<HTMLElement>("*"))) {
+    // Floating settings layers are intentionally independent of the native
+    // window size. Their content can scroll inside the layer without changing
+    // the tray popover underneath it.
+    if (child.closest('[data-popover-overlay="true"]')) continue;
     const childStyle = window.getComputedStyle(child);
     if (childStyle.display === "none") continue;
     const childRect = child.getBoundingClientRect();
@@ -2625,6 +2633,7 @@ export function App() {
   const appRef = useRef<HTMLDivElement | null>(null);
   usePopoverAutoSize(appRef, {
     disabled:
+      popoverView === "rewind-settings" ||
       (popoverView !== "settings" && !popoverVisible) ||
       isRecording ||
       recordingFlowActive,
@@ -5322,6 +5331,12 @@ function Setup({
   const [url, setUrl] = useState(initial ?? DEFAULT_URL);
   const [readinessOpen, setReadinessOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTabId>("general");
+  const [rewindSettingsOpen, setRewindSettingsOpen] = useState(false);
+  const [rewindActivityOpen, setRewindActivityOpen] = useState(false);
+  const [rewindMemoryOpen, setRewindMemoryOpen] = useState(false);
+  const [rewindPrivacyOpen, setRewindPrivacyOpen] = useState(false);
+  const [rewindAgentSetupOpen, setRewindAgentSetupOpen] = useState(false);
+  const [rewindHandoffOpen, setRewindHandoffOpen] = useState(false);
   const featureConfig = useFeatureConfig();
   const updateStatus = useUpdateStatus();
   const voiceEnabled = featureConfig?.voiceEnabled !== false;
@@ -7597,6 +7612,113 @@ function Setup({
         </main>
       </div>
     </div>
+  );
+}
+
+function DesktopSettingsPopover({
+  title,
+  trigger,
+  children,
+  open,
+  onOpenChange,
+  side = "left",
+  contentClassName,
+}: {
+  title: string;
+  trigger: ReactElement;
+  children: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  side?: "bottom" | "left" | "right" | "top";
+  contentClassName?: string;
+}) {
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <PopoverPrimitive.Trigger asChild>{trigger}</PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Content
+        side={side}
+        align="start"
+        sideOffset={10}
+        collisionPadding={12}
+        className={`desktop-settings-popover ${contentClassName ?? ""}`}
+        data-popover-overlay="true"
+      >
+        <div className="desktop-settings-popover-header">
+          <PopoverPrimitive.Title className="desktop-settings-popover-title">
+            {title}
+          </PopoverPrimitive.Title>
+          <PopoverPrimitive.Close
+            type="button"
+            className="desktop-settings-popover-close"
+            aria-label={`Close ${title}`}
+          >
+            <IconX size={15} stroke={1.9} />
+          </PopoverPrimitive.Close>
+        </div>
+        {children}
+      </PopoverPrimitive.Content>
+    </PopoverPrimitive.Root>
+  );
+}
+
+function RewindChoicePopover({
+  title,
+  value,
+  options,
+  onChange,
+  disabled = false,
+}: {
+  title: string;
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const selectedOption =
+    options.find((option) => option.value === value)?.label ?? value;
+
+  return (
+    <DesktopSettingsPopover
+      title={title}
+      open={open}
+      onOpenChange={setOpen}
+      side="bottom"
+      trigger={
+        <button
+          type="button"
+          className="rewind-setting-trigger"
+          disabled={disabled}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+        >
+          <span>{selectedOption}</span>
+          <IconChevronDown size={15} stroke={1.8} aria-hidden="true" />
+        </button>
+      }
+    >
+      <div className="rewind-choice-list" role="listbox" aria-label={title}>
+        {options.map((option) => {
+          const selected = option.value === value;
+          return (
+            <button
+              type="button"
+              role="option"
+              aria-selected={selected}
+              className={`rewind-choice-option ${selected ? "is-selected" : ""}`}
+              key={option.value}
+              onClick={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+            >
+              <span>{option.label}</span>
+              {selected ? <IconCheck size={15} stroke={2.1} /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </DesktopSettingsPopover>
   );
 }
 

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3750,8 +3750,6 @@ export function App() {
           rewindAgentPromptCopied={rewindAgentPromptCopied}
           onCopyRewindAgentPrompt={copyRewindAgentPrompt}
           onOpenRewindDocs={openRewindDocs}
-          onOpenRewind={() => setPopoverView("rewind-settings")}
-          onOpenMemory={() => setPopoverView("memory")}
           onCancel={() => {
             setPromptRewindEnable(false);
             setPopoverView(
@@ -3799,11 +3797,6 @@ export function App() {
           rewindAgentPromptCopied={rewindAgentPromptCopied}
           onCopyRewindAgentPrompt={copyRewindAgentPrompt}
           onOpenRewindDocs={openRewindDocs}
-          onOpenRewind={() => {
-            setPromptRewindEnable(false);
-            setRewindSettingsReturnView("settings");
-            setPopoverView("rewind-settings");
-          }}
           onCancel={() => setPopoverView("recorder")}
         />
       </div>
@@ -5294,8 +5287,6 @@ function Setup({
   rewindAgentPromptCopied,
   onCopyRewindAgentPrompt,
   onOpenRewindDocs,
-  onOpenRewind,
-  onOpenMemory,
   onCancel,
   onSignOut,
 }: {
@@ -5324,8 +5315,6 @@ function Setup({
   rewindAgentPromptCopied: boolean;
   onCopyRewindAgentPrompt: () => void;
   onOpenRewindDocs: () => void;
-  onOpenRewind?: () => void;
-  onOpenMemory?: () => void;
   onCancel?: () => void;
   onSignOut?: () => void;
 }) {
@@ -5407,7 +5396,6 @@ function Setup({
   const [rewindEgressEvents, setRewindEgressEvents] = useState<
     RewindEgressEvent[]
   >([]);
-  const [rewindEgressOpen, setRewindEgressOpen] = useState(false);
   const [rewindLocalQuery, setRewindLocalQuery] = useState("");
   const [rewindLocalResult, setRewindLocalResult] =
     useState<RewindLocalAskResult | null>(null);
@@ -6336,17 +6324,7 @@ function Setup({
       excludedAppGroups.length === 0
         ? "No apps excluded"
         : `${excludedAppGroups.length} app${excludedAppGroups.length === 1 ? "" : "s"} excluded`;
-    const retentionLabel =
-      screenMemory.retentionHours === 24 ? "24 hours" : "8 hours";
     const storageLabel = formatStorageBytes(screenMemory.maxBytes);
-    const agentRetentionLabel =
-      screenMemory.agentClipRetention === "24-hours"
-        ? "Delete after 24 hours"
-        : screenMemory.agentClipRetention === "7-days"
-          ? "Delete after 7 days"
-          : screenMemory.agentClipRetention === "30-days"
-            ? "Delete after 30 days"
-            : "Keep forever";
 
     return (
       <div className="setup popover-view rewind-settings-surface">
@@ -6833,6 +6811,61 @@ function Setup({
                       ))
                     )}
                   </div>
+                </DesktopSettingsPopover>
+              </div>
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Manual search"
+                    hint="Search retained local evidence without asking an agent."
+                  />
+                  <span>Find and replay a source moment</span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Manual search"
+                  open={rewindSearchOpen}
+                  onOpenChange={setRewindSearchOpen}
+                  side="bottom"
+                  contentClassName="rewind-memory-launcher"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                    >
+                      Search
+                    </button>
+                  }
+                >
+                  <Setup
+                    surface="memory"
+                    recordingActive={recordingActive}
+                    promptRewindEnable={false}
+                    initial={initial}
+                    serverUrl={serverUrl}
+                    signedInAs={signedInAs}
+                    voiceShortcut={voiceShortcut}
+                    voiceCustomShortcut={voiceCustomShortcut}
+                    popoverCustomShortcut={popoverCustomShortcut}
+                    recordCustomShortcut={recordCustomShortcut}
+                    voiceMode={voiceMode}
+                    voiceProvider={voiceProvider}
+                    voiceInstructions={voiceInstructions}
+                    shortcutRegistrationError={shortcutRegistrationError}
+                    onVoiceShortcutChange={onVoiceShortcutChange}
+                    onVoiceCustomShortcutChange={onVoiceCustomShortcutChange}
+                    onPopoverCustomShortcutChange={
+                      onPopoverCustomShortcutChange
+                    }
+                    onRecordCustomShortcutChange={onRecordCustomShortcutChange}
+                    onVoiceModeChange={onVoiceModeChange}
+                    onVoiceProviderChange={onVoiceProviderChange}
+                    onVoiceInstructionsChange={onVoiceInstructionsChange}
+                    onConnect={onConnect}
+                    rewindAgentPromptCopied={rewindAgentPromptCopied}
+                    onCopyRewindAgentPrompt={onCopyRewindAgentPrompt}
+                    onOpenRewindDocs={onOpenRewindDocs}
+                    onCancel={() => setRewindSearchOpen(false)}
+                  />
                 </DesktopSettingsPopover>
               </div>
               <div className="rewind-setting-row rewind-setting-row--action">

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -5335,6 +5335,7 @@ function Setup({
   const [rewindSettingsOpen, setRewindSettingsOpen] = useState(false);
   const [rewindActivityOpen, setRewindActivityOpen] = useState(false);
   const [rewindMemoryOpen, setRewindMemoryOpen] = useState(false);
+  const [rewindSearchOpen, setRewindSearchOpen] = useState(false);
   const [rewindPrivacyOpen, setRewindPrivacyOpen] = useState(false);
   const [rewindAgentSetupOpen, setRewindAgentSetupOpen] = useState(false);
   const [rewindHandoffOpen, setRewindHandoffOpen] = useState(false);
@@ -7168,13 +7169,47 @@ function Setup({
             label="Rewind"
             description={rewindStatusPresentation.title}
             control={
-              <button
-                type="button"
-                className="secondary"
-                onClick={() => onOpenRewind?.()}
+              <DesktopSettingsPopover
+                title="Rewind settings"
+                open={rewindSettingsOpen}
+                onOpenChange={setRewindSettingsOpen}
+                side="left"
+                contentClassName="rewind-settings-launcher"
+                trigger={
+                  <button type="button" className="secondary">
+                    Manage
+                  </button>
+                }
               >
-                Open Rewind settings
-              </button>
+                <Setup
+                  surface="rewind"
+                  recordingActive={recordingActive}
+                  promptRewindEnable={false}
+                  initial={initial}
+                  serverUrl={serverUrl}
+                  signedInAs={signedInAs}
+                  voiceShortcut={voiceShortcut}
+                  voiceCustomShortcut={voiceCustomShortcut}
+                  popoverCustomShortcut={popoverCustomShortcut}
+                  recordCustomShortcut={recordCustomShortcut}
+                  voiceMode={voiceMode}
+                  voiceProvider={voiceProvider}
+                  voiceInstructions={voiceInstructions}
+                  shortcutRegistrationError={shortcutRegistrationError}
+                  onVoiceShortcutChange={onVoiceShortcutChange}
+                  onVoiceCustomShortcutChange={onVoiceCustomShortcutChange}
+                  onPopoverCustomShortcutChange={onPopoverCustomShortcutChange}
+                  onRecordCustomShortcutChange={onRecordCustomShortcutChange}
+                  onVoiceModeChange={onVoiceModeChange}
+                  onVoiceProviderChange={onVoiceProviderChange}
+                  onVoiceInstructionsChange={onVoiceInstructionsChange}
+                  onConnect={onConnect}
+                  rewindAgentPromptCopied={rewindAgentPromptCopied}
+                  onCopyRewindAgentPrompt={onCopyRewindAgentPrompt}
+                  onOpenRewindDocs={onOpenRewindDocs}
+                  onCancel={() => setRewindSettingsOpen(false)}
+                />
+              </DesktopSettingsPopover>
             }
           />
           <DesktopSettingsRow

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -4395,9 +4395,10 @@ function PendingUploadBanner({
             ) : null}
             <button
               type="button"
-              className="pending-upload-retry"
+              className={`pending-upload-retry${retrying ? " pending-upload-retry-spinning" : ""}`}
               disabled={actionsDisabled}
               onClick={() => onRetry(latest)}
+              aria-busy={retrying}
             >
               <IconRefresh size={14} stroke={2} />
               {retrying ? (retryingUploadStatus ?? "Retrying") : "Retry"}
@@ -6329,6 +6330,23 @@ function Setup({
   }
 
   if (surface === "rewind") {
+    const captureDisabled = screenMemoryConfigBusy || captureControlsLocked;
+    const excludedAppsSummary =
+      excludedAppGroups.length === 0
+        ? "No apps excluded"
+        : `${excludedAppGroups.length} app${excludedAppGroups.length === 1 ? "" : "s"} excluded`;
+    const retentionLabel =
+      screenMemory.retentionHours === 24 ? "24 hours" : "8 hours";
+    const storageLabel = formatStorageBytes(screenMemory.maxBytes);
+    const agentRetentionLabel =
+      screenMemory.agentClipRetention === "24-hours"
+        ? "Delete after 24 hours"
+        : screenMemory.agentClipRetention === "7-days"
+          ? "Delete after 7 days"
+          : screenMemory.agentClipRetention === "30-days"
+            ? "Delete after 30 days"
+            : "Keep forever";
+
     return (
       <div className="setup popover-view rewind-settings-surface">
         <div className="setup-header">
@@ -6342,465 +6360,595 @@ function Setup({
           </button>
           <h2>Rewind settings</h2>
         </div>
-        <div className="rewind-setting-row">
-          <SettingLabel
-            label="Rewind"
-            hint={
-              !screenMemory.enabled
-                ? "Off"
-                : screenMemory.paused
-                  ? "Paused · existing local memory is still available"
-                  : "Remembering locally"
-            }
-          />
-          <Switch
-            on={screenMemory.enabled}
-            disabled={screenMemoryConfigBusy || captureControlsLocked}
-            onChange={(enabled) => {
-              if (enabled) setRewindConsentOpen(true);
-              else
-                void setScreenMemoryConfig({ enabled: false, paused: false });
-            }}
-            label="Enable Rewind"
-          />
+        <div className="rewind-settings-section">
+          <div className="rewind-setting-row">
+            <SettingLabel
+              label="Rewind"
+              hint={
+                !screenMemory.enabled
+                  ? "Off"
+                  : screenMemory.paused
+                    ? "Paused · existing local memory is still available"
+                    : "Remembering locally"
+              }
+            />
+            <Switch
+              on={screenMemory.enabled}
+              disabled={captureDisabled}
+              onChange={(enabled) => {
+                if (enabled) setRewindConsentOpen(true);
+                else
+                  void setScreenMemoryConfig({ enabled: false, paused: false });
+              }}
+              label="Enable Rewind"
+            />
+          </div>
+          {captureControlsLocked ? (
+            <p className="rewind-capture-lock-note" role="status">
+              Capture settings unlock when this Clip ends.
+            </p>
+          ) : null}
+          {screenMemory.enabled ? (
+            <>
+              <div className="rewind-setting-row">
+                <SettingLabel
+                  label="Remember"
+                  hint="Choose whether audio joins the local screen memory."
+                />
+                <RewindChoicePopover
+                  title="Remember"
+                  value={screenMemory.captureMode}
+                  options={[
+                    { value: "visuals", label: "Visuals" },
+                    { value: "visuals-audio", label: "Visuals + audio" },
+                  ]}
+                  disabled={captureDisabled}
+                  onChange={(value) =>
+                    void setScreenMemoryConfig({
+                      captureMode: value as "visuals" | "visuals-audio",
+                    })
+                  }
+                />
+              </div>
+              <div className="rewind-setting-row">
+                <SettingLabel
+                  label="Remember the last…"
+                  hint="How long Rewind keeps recent moments available."
+                />
+                <RewindChoicePopover
+                  title="Remember the last"
+                  value={String(screenMemory.retentionHours)}
+                  options={[
+                    { value: "8", label: "8 hours" },
+                    { value: "24", label: "24 hours" },
+                  ]}
+                  disabled={screenMemoryConfigBusy}
+                  onChange={(value) =>
+                    void setScreenMemoryConfig({
+                      retentionHours: Number(value),
+                    })
+                  }
+                />
+              </div>
+              <div className="rewind-setting-row">
+                <SettingLabel
+                  label="Keep up to"
+                  hint="Older moments are removed when this local limit is reached."
+                />
+                <RewindChoicePopover
+                  title="Keep up to"
+                  value={String(screenMemory.maxBytes)}
+                  options={[
+                    {
+                      value: String(5 * 1024 * 1024 * 1024),
+                      label: "5 GB",
+                    },
+                    {
+                      value: String(20 * 1024 * 1024 * 1024),
+                      label: "20 GB",
+                    },
+                    {
+                      value: String(50 * 1024 * 1024 * 1024),
+                      label: "50 GB",
+                    },
+                  ]}
+                  disabled={screenMemoryConfigBusy}
+                  onChange={(value) =>
+                    void setScreenMemoryConfig({ maxBytes: Number(value) })
+                  }
+                />
+              </div>
+              <div className="rewind-settings-status">
+                <span
+                  className={`rewind-home-dot ${rewindStatusPresentation.isLive ? "is-live" : ""}`}
+                />
+                <span className="rewind-settings-status-copy">
+                  <strong>{rewindStatusPresentation.title}</strong>
+                  <span>
+                    {rewindStatusPresentation.kind === "recording" &&
+                    !rewindStatusPresentation.hasError
+                      ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
+                      : rewindStatusPresentation.detail}
+                  </span>
+                </span>
+              </div>
+            </>
+          ) : null}
         </div>
-        {captureControlsLocked ? (
-          <p className="rewind-capture-lock-note" role="status">
-            Rewind capture settings unlock when this Clip ends. This keeps one
-            screen and audio recorder running at a time.
-          </p>
-        ) : null}
         {screenMemory.enabled ? (
           <>
-            <div className="rewind-setting-row">
-              <SettingLabel
-                label="Remember"
-                hint="Choose whether audio joins the local screen memory."
-                htmlFor="rewind-capture-mode"
-              />
-              <select
-                id="rewind-capture-mode"
-                className="setup-select rewind-setting-control"
-                disabled={screenMemoryConfigBusy || captureControlsLocked}
-                value={screenMemory.captureMode}
-                onChange={(event) =>
-                  void setScreenMemoryConfig({
-                    captureMode: event.target.value as
-                      | "visuals"
-                      | "visuals-audio",
-                  })
-                }
-              >
-                <option value="visuals">Visuals</option>
-                <option value="visuals-audio">Visuals + audio</option>
-              </select>
-            </div>
-            <div className="rewind-setting-row">
-              <SettingLabel
-                label="Remember the last…"
-                hint={`${formatStorageBytes(screenMemory.maxBytes)} maximum on disk`}
-                htmlFor="rewind-retention"
-              />
-              <select
-                id="rewind-retention"
-                className="setup-select rewind-setting-control"
-                disabled={screenMemoryConfigBusy}
-                value={screenMemory.retentionHours}
-                onChange={(event) =>
-                  void setScreenMemoryConfig({
-                    retentionHours: Number(event.target.value),
-                  })
-                }
-              >
-                <option value={8}>8 hours</option>
-                <option value={24}>24 hours</option>
-              </select>
-            </div>
-            <div className="rewind-setting-row">
-              <SettingLabel
-                label="Keep up to"
-                hint="Older moments are removed automatically when this limit is reached."
-                htmlFor="rewind-disk-cap"
-              />
-              <select
-                id="rewind-disk-cap"
-                className="setup-select rewind-setting-control"
-                disabled={screenMemoryConfigBusy}
-                value={screenMemory.maxBytes}
-                onChange={(event) =>
-                  void setScreenMemoryConfig({
-                    maxBytes: Number(event.target.value),
-                  })
-                }
-              >
-                <option value={5 * 1024 * 1024 * 1024}>5 GB</option>
-                <option value={20 * 1024 * 1024 * 1024}>20 GB</option>
-                <option value={50 * 1024 * 1024 * 1024}>50 GB</option>
-              </select>
-            </div>
-            <div className="rewind-settings-status">
-              <span
-                className={`rewind-home-dot ${rewindStatusPresentation.isLive ? "is-live" : ""}`}
-              />
-              <span className="rewind-settings-status-copy">
-                <strong>{rewindStatusPresentation.title}</strong>
-                <span>
-                  {rewindStatusPresentation.kind === "recording" &&
-                  !rewindStatusPresentation.hasError
-                    ? `${screenMemorySegments.length} retained segment${screenMemorySegments.length === 1 ? "" : "s"} · ${formatStorageBytes(screenMemoryTotalBytes)}`
-                    : rewindStatusPresentation.detail}
-                </span>
-              </span>
-            </div>
             <div className="setup-section-heading">Privacy</div>
-            <div className="rewind-excluded-apps">
-              <div className="rewind-excluded-apps-header">
-                <SettingLabel
-                  label="Excluded apps"
-                  hint="Rewind never remembers these applications."
-                />
-                <button
-                  type="button"
-                  className="secondary rewind-choose-apps"
-                  disabled={excludedAppsBusy || screenMemoryConfigBusy}
-                  onClick={() => void chooseExcludedApplications()}
-                >
-                  <IconFolderOpen size={14} stroke={1.9} />
-                  {excludedAppsBusy ? "Choosing…" : "Choose applications…"}
-                </button>
-              </div>
-              {excludedAppGroups.length > 0 ? (
-                <div className="rewind-excluded-app-list">
-                  {excludedAppGroups.map((app) => (
-                    <div
-                      className={`rewind-excluded-app ${app.installed ? "" : "is-missing"}`}
-                      key={app.bundleId}
+            <div className="rewind-settings-section">
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Excluded apps"
+                    hint="Rewind never remembers these applications."
+                  />
+                  <span>{excludedAppsSummary}</span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Excluded apps"
+                  open={rewindPrivacyOpen}
+                  onOpenChange={setRewindPrivacyOpen}
+                  side="bottom"
+                  contentClassName="rewind-popover-content"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                      disabled={screenMemoryConfigBusy}
                     >
-                      <div
-                        className="rewind-excluded-app-mark"
-                        aria-hidden="true"
-                      >
-                        {app.name.slice(0, 1).toUpperCase()}
+                      Manage
+                    </button>
+                  }
+                >
+                  <div className="rewind-popover-stack">
+                    <p className="rewind-popover-hint">
+                      These applications are always excluded from local Rewind
+                      memory.
+                    </p>
+                    <button
+                      type="button"
+                      className="secondary"
+                      disabled={excludedAppsBusy || screenMemoryConfigBusy}
+                      onClick={() => void chooseExcludedApplications()}
+                    >
+                      <IconFolderOpen size={14} stroke={1.9} />
+                      {excludedAppsBusy ? "Choosing…" : "Add applications…"}
+                    </button>
+                    {excludedAppGroups.length > 0 ? (
+                      <div className="rewind-excluded-app-list">
+                        {excludedAppGroups.map((app) => (
+                          <div
+                            className={`rewind-excluded-app ${app.installed ? "" : "is-missing"}`}
+                            key={app.bundleId}
+                          >
+                            <div
+                              className="rewind-excluded-app-mark"
+                              aria-hidden="true"
+                            >
+                              {app.name.slice(0, 1).toUpperCase()}
+                            </div>
+                            <div className="rewind-excluded-app-copy">
+                              <strong>{app.name}</strong>
+                              <span>
+                                {app.installed
+                                  ? "Excluded"
+                                  : "Not currently installed · still excluded"}
+                              </span>
+                            </div>
+                            <button
+                              type="button"
+                              className="rewind-excluded-app-remove"
+                              aria-label={`Remove ${app.name}`}
+                              disabled={screenMemoryConfigBusy}
+                              onClick={() =>
+                                removeExcludedApplications(app.bundleIds)
+                              }
+                            >
+                              <IconX size={14} stroke={2} />
+                            </button>
+                          </div>
+                        ))}
                       </div>
-                      <div className="rewind-excluded-app-copy">
-                        <strong>{app.name}</strong>
-                        <span>
-                          {app.installed
-                            ? "Excluded"
-                            : "Not currently installed · still excluded"}
-                        </span>
+                    ) : (
+                      <p className="setup-hint">No apps are excluded.</p>
+                    )}
+                  </div>
+                </DesktopSettingsPopover>
+              </div>
+            </div>
+            <div className="setup-section-heading">Agent</div>
+            <div className="rewind-settings-section">
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Agent setup"
+                    hint="Install the reusable Rewind instructions for a local agent."
+                  />
+                  <span>Prompt and local connection</span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Agent setup"
+                  open={rewindAgentSetupOpen}
+                  onOpenChange={setRewindAgentSetupOpen}
+                  side="bottom"
+                  contentClassName="rewind-popover-content"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                    >
+                      Manage
+                    </button>
+                  }
+                >
+                  <div className="rewind-popover-stack">
+                    <div className="rewind-agent-guide">
+                      <div className="rewind-agent-guide-icon">
+                        <IconHistory size={17} stroke={1.8} />
                       </div>
+                      <div>
+                        <strong>Set up your agent once</strong>
+                        <p>
+                          Copy the setup prompt into a compatible agent. It
+                          installs Rewind's instructions and repairs the local
+                          connection.
+                        </p>
+                      </div>
+                    </div>
+                    <div className="setup-button-row">
                       <button
                         type="button"
-                        className="rewind-excluded-app-remove"
-                        aria-label={`Remove ${app.name}`}
-                        disabled={screenMemoryConfigBusy}
-                        onClick={() =>
-                          removeExcludedApplications(app.bundleIds)
-                        }
+                        className="secondary"
+                        onClick={onCopyRewindAgentPrompt}
                       >
-                        <IconX size={14} stroke={2} />
+                        <IconCopy size={14} stroke={1.9} />
+                        {rewindAgentPromptCopied
+                          ? "Setup prompt copied"
+                          : "Copy setup prompt"}
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary"
+                        onClick={onOpenRewindDocs}
+                      >
+                        <IconExternalLink size={14} stroke={1.9} />
+                        Learn about Rewind
                       </button>
                     </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="setup-hint">No additional apps are excluded.</p>
-              )}
-            </div>
-            <div className="setup-section-heading">Agent handoff</div>
-            <div className="rewind-agent-guide">
-              <div className="rewind-agent-guide-icon">
-                <IconHistory size={17} stroke={1.8} />
-              </div>
-              <div>
-                <strong>Set up your agent once</strong>
-                <p>
-                  Copy the setup prompt into any compatible agent. It installs
-                  Rewind's reusable instructions and repairs the local
-                  connection, so later you can simply say “Look at Rewind.”
-                </p>
-                <div className="setup-button-row">
-                  <button
-                    type="button"
-                    className="secondary"
-                    onClick={onCopyRewindAgentPrompt}
-                  >
-                    <IconCopy size={14} stroke={1.9} />
-                    {rewindAgentPromptCopied
-                      ? "Setup prompt copied"
-                      : "Copy setup prompt"}
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary"
-                    onClick={onOpenRewindDocs}
-                  >
-                    <IconExternalLink size={14} stroke={1.9} />
-                    Learn about Rewind
-                  </button>
-                </div>
-              </div>
-            </div>
-            <details className="setup-advanced rewind-agent-repair">
-              <summary className="setup-advanced-summary">
-                Repair an agent connection
-              </summary>
-              <div className="setup-advanced-body">
-                <p className="setup-hint">
-                  Usually your agent can install Rewind from the copied prompt.
-                  These buttons are a manual repair for known clients.
-                </p>
-                <div className="rewind-memory-actions">
-                  <button
-                    type="button"
-                    className="secondary"
-                    disabled={agentConnectionBusy !== null}
-                    onClick={() => void installRewindAgentConnection("codex")}
-                  >
-                    {agentConnectionBusy === "codex"
-                      ? "Repairing…"
-                      : "Repair Codex connection"}
-                  </button>
-                  <button
-                    type="button"
-                    className="secondary"
-                    disabled={agentConnectionBusy !== null}
-                    onClick={() =>
-                      void installRewindAgentConnection("claude-code")
-                    }
-                  >
-                    {agentConnectionBusy === "claude-code"
-                      ? "Repairing…"
-                      : "Repair Claude Code connection"}
-                  </button>
-                </div>
-                {agentConnectionMessage ? (
-                  <p
-                    className={
-                      agentConnectionMessage.kind === "error"
-                        ? "setup-error"
-                        : "setup-hint"
-                    }
-                    role="status"
-                  >
-                    {agentConnectionMessage.text}
-                  </p>
-                ) : null}
-              </div>
-            </details>
-            <div className="rewind-setting-row rewind-agent-row">
-              <SettingLabel
-                label="Review before sending"
-                hint="Preview and trim any visual or audio range before it becomes a private Clip."
-              />
-              <Switch
-                on={screenMemory.reviewBeforeSending}
-                disabled={screenMemoryConfigBusy}
-                onChange={(enabled) =>
-                  void setScreenMemoryConfig({
-                    reviewBeforeSending: enabled,
-                  })
-                }
-                label="Review visual and audio ranges before sending"
-              />
-            </div>
-            <div className="rewind-setting-row rewind-agent-row">
-              <SettingLabel
-                label="Open local preview automatically"
-                hint="When review is on, prepare the selected range in QuickTime when an agent asks for it."
-              />
-              <Switch
-                on={screenMemory.autoPreviewBeforeSending}
-                disabled={
-                  screenMemoryConfigBusy || !screenMemory.reviewBeforeSending
-                }
-                onChange={(enabled) =>
-                  void setScreenMemoryConfig({
-                    autoPreviewBeforeSending: enabled,
-                  })
-                }
-                label="Open a local preview automatically before sending"
-              />
-            </div>
-            <p className="rewind-boundary-note">
-              Asking your agent authorizes bounded matching text. Raw Rewind
-              files stay local. If this review is off, an agent-requested media
-              range becomes a private Clip immediately and leaves a receipt.
-            </p>
-            <div className="rewind-setting-row">
-              <SettingLabel
-                label="Agent-created Clip retention"
-                hint="Applies to future private Clips created for an agent."
-                htmlFor="rewind-agent-clip-retention"
-              />
-              <select
-                id="rewind-agent-clip-retention"
-                className="setup-select rewind-setting-control"
-                disabled={screenMemoryConfigBusy}
-                value={screenMemory.agentClipRetention}
-                onChange={(event) =>
-                  void setScreenMemoryConfig({
-                    agentClipRetention: event.target.value as
-                      | "forever"
-                      | "24-hours"
-                      | "7-days"
-                      | "30-days",
-                  })
-                }
-              >
-                <option value="forever">Keep forever</option>
-                <option value="24-hours">Delete after 24 hours</option>
-                <option value="7-days">Delete after 7 days</option>
-                <option value="30-days">Delete after 30 days</option>
-              </select>
-            </div>
-            <div className="rewind-agent-guide">
-              <div className="rewind-agent-guide-icon">
-                <IconHistory size={17} stroke={1.8} />
-              </div>
-              <div>
-                <strong>Ask your agent</strong>
-                <p>
-                  Try “What was the Terminal error?” or “Replay Tuesday’s design
-                  review.”
-                </p>
-                <button
-                  type="button"
-                  className="rewind-text-button"
-                  onClick={onOpenMemory}
-                >
-                  Search manually
-                </button>
-              </div>
-            </div>
-            <details
-              className="setup-advanced"
-              open={rewindEgressOpen}
-              onToggle={(event) => {
-                const open = event.currentTarget.open;
-                setRewindEgressOpen(open);
-                if (open) refreshRewindEgressLog();
-              }}
-            >
-              <summary className="setup-advanced-summary">
-                Agent activity
-              </summary>
-              <div className="setup-advanced-body">
-                <p className="setup-hint">
-                  See when an agent searched bounded local evidence. Raw Rewind
-                  media remains on this Mac unless you explicitly create a
-                  private Clip.
-                </p>
-                {rewindEgressEvents.length === 0 ? (
-                  <p className="setup-hint">No matching-text requests yet.</p>
-                ) : (
-                  rewindEgressEvents.slice(0, 10).map((event) => (
-                    <p
-                      className="setup-hint"
-                      key={`${event.requestId}-${event.state}`}
-                    >
-                      <strong>
-                        {new Date(event.occurredAt).toLocaleString()}
-                      </strong>
-                      {` · ${event.state} · ${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
-                    </p>
-                  ))
-                )}
-              </div>
-            </details>
-            <details className="setup-advanced">
-              <summary className="setup-advanced-summary">
-                Manage local memory
-              </summary>
-              <div className="setup-advanced-body">
-                <div className="rewind-memory-actions">
-                  <div className="rewind-memory-action">
-                    <div className="rewind-memory-action-copy">
-                      <strong>Save a local Clip</strong>
-                      <p>
-                        Export the previous five minutes as a video on this Mac.
-                        Nothing is uploaded.
-                      </p>
-                      {screenMemoryExportResult ? (
-                        <div className="rewind-inline-receipt" role="status">
-                          <span>Saved locally</span>
+                    <details className="setup-advanced rewind-agent-repair">
+                      <summary className="setup-advanced-summary">
+                        Repair an agent connection
+                      </summary>
+                      <div className="setup-advanced-body">
+                        <p className="setup-hint">
+                          Use this only when the copied setup prompt cannot
+                          repair a known client.
+                        </p>
+                        <div className="rewind-memory-actions">
                           <button
                             type="button"
-                            className="rewind-text-button"
+                            className="secondary"
+                            disabled={agentConnectionBusy !== null}
                             onClick={() =>
-                              void invoke("open_local_recording_folder", {
-                                path: screenMemoryExportResult.folderPath,
-                              })
+                              void installRewindAgentConnection("codex")
                             }
                           >
-                            Show in Finder
+                            {agentConnectionBusy === "codex"
+                              ? "Repairing…"
+                              : "Repair Codex connection"}
+                          </button>
+                          <button
+                            type="button"
+                            className="secondary"
+                            disabled={agentConnectionBusy !== null}
+                            onClick={() =>
+                              void installRewindAgentConnection("claude-code")
+                            }
+                          >
+                            {agentConnectionBusy === "claude-code"
+                              ? "Repairing…"
+                              : "Repair Claude Code connection"}
                           </button>
                         </div>
-                      ) : null}
-                    </div>
-                    <button
-                      type="button"
-                      className="secondary"
-                      disabled={
-                        screenMemoryBusy || screenMemorySegments.length === 0
-                      }
-                      onClick={exportScreenMemoryRecent}
-                    >
-                      <IconDownload size={15} stroke={1.9} /> Save previous 5
-                      minutes
-                    </button>
+                        {agentConnectionMessage ? (
+                          <p
+                            className={
+                              agentConnectionMessage.kind === "error"
+                                ? "setup-error"
+                                : "setup-hint"
+                            }
+                            role="status"
+                          >
+                            {agentConnectionMessage.text}
+                          </p>
+                        ) : null}
+                      </div>
+                    </details>
                   </div>
-                  <div className="rewind-memory-action">
-                    <div>
-                      <strong>View Rewind files</strong>
-                      <p>
-                        Open the private folder where Rewind keeps its temporary
-                        local memory.
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      className="secondary"
-                      onClick={openScreenMemoryFolder}
-                    >
-                      <IconFolderOpen size={15} stroke={1.9} /> Open Rewind
-                      folder
-                    </button>
-                  </div>
-                  <div className="rewind-memory-action is-danger">
-                    <div>
-                      <strong>Erase Rewind memory</strong>
-                      <p>
-                        Permanently delete all retained media and indexes from
-                        this Mac.
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      className="secondary rewind-danger-button"
-                      disabled={
-                        screenMemoryBusy || screenMemorySegments.length === 0
-                      }
-                      onClick={clearScreenMemory}
-                    >
-                      <IconTrash size={15} stroke={1.9} /> Erase all memory…
-                    </button>
-                  </div>
-                </div>
+                </DesktopSettingsPopover>
               </div>
-            </details>
-            {screenMemoryMessage ? (
-              <p
-                className={
-                  screenMemoryMessage.kind === "ok"
-                    ? "setup-success"
-                    : "setup-warning"
-                }
-              >
-                {screenMemoryMessage.text}
-              </p>
-            ) : null}
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Before sending"
+                    hint="Control how an agent-created private Clip is prepared."
+                  />
+                  <span>
+                    {screenMemory.reviewBeforeSending
+                      ? "Review media before sending"
+                      : "Send private Clips immediately"}
+                  </span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Before sending"
+                  open={rewindHandoffOpen}
+                  onOpenChange={setRewindHandoffOpen}
+                  side="bottom"
+                  contentClassName="rewind-popover-content"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                    >
+                      Manage
+                    </button>
+                  }
+                >
+                  <div className="rewind-popover-stack">
+                    <div className="rewind-popover-setting-row">
+                      <div className="rewind-setting-copy">
+                        <strong>Review before sending</strong>
+                        <span>
+                          Preview and trim a visual or audio range before it
+                          becomes a private Clip.
+                        </span>
+                      </div>
+                      <Switch
+                        on={screenMemory.reviewBeforeSending}
+                        disabled={screenMemoryConfigBusy}
+                        onChange={(enabled) =>
+                          void setScreenMemoryConfig({
+                            reviewBeforeSending: enabled,
+                          })
+                        }
+                        label="Review visual and audio ranges before sending"
+                      />
+                    </div>
+                    <div className="rewind-popover-setting-row">
+                      <div className="rewind-setting-copy">
+                        <strong>Open local preview automatically</strong>
+                        <span>
+                          Prepare the selected range in QuickTime when an agent
+                          asks for it.
+                        </span>
+                      </div>
+                      <Switch
+                        on={screenMemory.autoPreviewBeforeSending}
+                        disabled={
+                          screenMemoryConfigBusy ||
+                          !screenMemory.reviewBeforeSending
+                        }
+                        onChange={(enabled) =>
+                          void setScreenMemoryConfig({
+                            autoPreviewBeforeSending: enabled,
+                          })
+                        }
+                        label="Open a local preview automatically before sending"
+                      />
+                    </div>
+                    <div className="rewind-popover-setting-row">
+                      <div className="rewind-setting-copy">
+                        <strong>Agent-created Clip retention</strong>
+                        <span>Applies to future private Clips.</span>
+                      </div>
+                      <RewindChoicePopover
+                        title="Agent-created Clip retention"
+                        value={screenMemory.agentClipRetention}
+                        options={[
+                          { value: "forever", label: "Keep forever" },
+                          {
+                            value: "24-hours",
+                            label: "Delete after 24 hours",
+                          },
+                          { value: "7-days", label: "Delete after 7 days" },
+                          {
+                            value: "30-days",
+                            label: "Delete after 30 days",
+                          },
+                        ]}
+                        disabled={screenMemoryConfigBusy}
+                        onChange={(value) =>
+                          void setScreenMemoryConfig({
+                            agentClipRetention: value as
+                              | "forever"
+                              | "24-hours"
+                              | "7-days"
+                              | "30-days",
+                          })
+                        }
+                      />
+                    </div>
+                    <p className="rewind-boundary-note">
+                      Raw Rewind files stay local. If review is off, an
+                      agent-requested media range becomes a private Clip
+                      immediately.
+                    </p>
+                  </div>
+                </DesktopSettingsPopover>
+              </div>
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Agent activity"
+                    hint="Review when an agent searched bounded local evidence."
+                  />
+                  <span>
+                    {rewindEgressEvents.length === 0
+                      ? "No matching-text requests yet"
+                      : `${rewindEgressEvents.length} recent request${rewindEgressEvents.length === 1 ? "" : "s"}`}
+                  </span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Agent activity"
+                  open={rewindActivityOpen}
+                  onOpenChange={(open) => {
+                    setRewindActivityOpen(open);
+                    if (open) refreshRewindEgressLog();
+                  }}
+                  side="bottom"
+                  contentClassName="rewind-popover-content"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                    >
+                      View
+                    </button>
+                  }
+                >
+                  <div className="rewind-popover-stack">
+                    <p className="rewind-popover-hint">
+                      Raw Rewind media remains on this Mac unless you explicitly
+                      create a private Clip.
+                    </p>
+                    {rewindEgressEvents.length === 0 ? (
+                      <p className="setup-hint">
+                        No matching-text requests yet.
+                      </p>
+                    ) : (
+                      rewindEgressEvents.slice(0, 10).map((event) => (
+                        <p
+                          className="setup-hint"
+                          key={`${event.requestId}-${event.state}`}
+                        >
+                          <strong>
+                            {new Date(event.occurredAt).toLocaleString()}
+                          </strong>
+                          {` · ${event.state} · ${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
+                        </p>
+                      ))
+                    )}
+                  </div>
+                </DesktopSettingsPopover>
+              </div>
+              <div className="rewind-setting-row rewind-setting-row--action">
+                <div className="rewind-setting-copy">
+                  <SettingLabel
+                    label="Local memory"
+                    hint="Save, open, or erase the private Rewind archive on this Mac."
+                  />
+                  <span>
+                    {screenMemorySegments.length} retained segment
+                    {screenMemorySegments.length === 1 ? "" : "s"} ·{" "}
+                    {storageLabel}
+                  </span>
+                </div>
+                <DesktopSettingsPopover
+                  title="Local memory"
+                  open={rewindMemoryOpen}
+                  onOpenChange={setRewindMemoryOpen}
+                  side="bottom"
+                  contentClassName="rewind-popover-content"
+                  trigger={
+                    <button
+                      type="button"
+                      className="secondary rewind-manage-button"
+                    >
+                      Manage
+                    </button>
+                  }
+                >
+                  <div className="rewind-popover-stack">
+                    <div className="rewind-memory-actions">
+                      <div className="rewind-memory-action">
+                        <div className="rewind-memory-action-copy">
+                          <strong>Save a local Clip</strong>
+                          <p>
+                            Export the previous five minutes as a video on this
+                            Mac. Nothing is uploaded.
+                          </p>
+                          {screenMemoryExportResult ? (
+                            <div
+                              className="rewind-inline-receipt"
+                              role="status"
+                            >
+                              <span>Saved locally</span>
+                              <button
+                                type="button"
+                                className="rewind-text-button"
+                                onClick={() =>
+                                  void invoke("open_local_recording_folder", {
+                                    path: screenMemoryExportResult.folderPath,
+                                  })
+                                }
+                              >
+                                Show in Finder
+                              </button>
+                            </div>
+                          ) : null}
+                        </div>
+                        <button
+                          type="button"
+                          className="secondary"
+                          disabled={
+                            screenMemoryBusy ||
+                            screenMemorySegments.length === 0
+                          }
+                          onClick={exportScreenMemoryRecent}
+                        >
+                          <IconDownload size={15} stroke={1.9} /> Save previous
+                          5 minutes
+                        </button>
+                      </div>
+                      <div className="rewind-memory-action">
+                        <div>
+                          <strong>View Rewind files</strong>
+                          <p>Open the private folder for local memory.</p>
+                        </div>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={openScreenMemoryFolder}
+                        >
+                          <IconFolderOpen size={15} stroke={1.9} /> Open folder
+                        </button>
+                      </div>
+                      <div className="rewind-memory-action is-danger">
+                        <div>
+                          <strong>Erase Rewind memory</strong>
+                          <p>Permanently delete retained media and indexes.</p>
+                        </div>
+                        <button
+                          type="button"
+                          className="secondary rewind-danger-button"
+                          disabled={
+                            screenMemoryBusy ||
+                            screenMemorySegments.length === 0
+                          }
+                          onClick={clearScreenMemory}
+                        >
+                          <IconTrash size={15} stroke={1.9} /> Erase all memory…
+                        </button>
+                      </div>
+                    </div>
+                    {screenMemoryMessage ? (
+                      <p
+                        className={
+                          screenMemoryMessage.kind === "ok"
+                            ? "setup-success"
+                            : "setup-warning"
+                        }
+                      >
+                        {screenMemoryMessage.text}
+                      </p>
+                    ) : null}
+                  </div>
+                </DesktopSettingsPopover>
+              </div>
+            </div>
           </>
         ) : (
           <div className="popover-empty-card rewind-memory-empty">
@@ -6819,6 +6967,17 @@ function Setup({
             </button>
           </div>
         )}
+        {screenMemoryMessage && screenMemory.enabled ? (
+          <p
+            className={
+              screenMemoryMessage.kind === "ok"
+                ? "setup-success"
+                : "setup-warning"
+            }
+          >
+            {screenMemoryMessage.text}
+          </p>
+        ) : null}
       </div>
     );
   }
@@ -7644,9 +7803,13 @@ function DesktopSettingsPopover({
         data-popover-overlay="true"
       >
         <div className="desktop-settings-popover-header">
-          <PopoverPrimitive.Title className="desktop-settings-popover-title">
+          <div
+            className="desktop-settings-popover-title"
+            role="heading"
+            aria-level={2}
+          >
             {title}
-          </PopoverPrimitive.Title>
+          </div>
           <PopoverPrimitive.Close
             type="button"
             className="desktop-settings-popover-close"

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1910,6 +1910,230 @@ body[data-clips-route="recording-pill"] #root {
   padding-bottom: 18px;
 }
 
+/* Settings detail stays inside the existing tray window. The content is a
+   floating layer, so changing a choice never becomes a native window resize. */
+.desktop-settings-popover {
+  z-index: 80;
+  width: min(360px, calc(100vw - 24px));
+  max-height: min(680px, calc(100vh - 24px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+  box-shadow: var(--shadow-md);
+  outline: none;
+  transform-origin: var(--radix-popover-content-transform-origin);
+}
+
+.desktop-settings-popover[data-state="open"] {
+  animation: feedback-popover-in 120ms ease-out;
+}
+
+.desktop-settings-popover[data-state="closed"] {
+  animation: feedback-popover-out 90ms ease-out;
+}
+
+.desktop-settings-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.desktop-settings-popover-title {
+  min-width: 0;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.desktop-settings-popover-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.desktop-settings-popover-close:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.desktop-settings-popover-close:focus-visible,
+.rewind-setting-trigger:focus-visible,
+.rewind-choice-option:focus-visible,
+.rewind-manage-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.desktop-settings-popover > .setup {
+  width: auto;
+  max-height: none;
+  padding: 0;
+  overflow: visible;
+  border-radius: 0;
+  background: transparent;
+}
+
+.desktop-settings-popover > .setup > .setup-header {
+  display: none;
+}
+
+.desktop-settings-popover > .rewind-settings-surface,
+.desktop-settings-popover > .rewind-memory-surface {
+  gap: 12px;
+  padding-bottom: 2px;
+}
+
+.rewind-settings-launcher {
+  width: min(430px, calc(100vw - 24px));
+}
+
+.rewind-memory-launcher {
+  width: min(430px, calc(100vw - 24px));
+}
+
+.rewind-popover-content {
+  width: min(380px, calc(100vw - 24px));
+}
+
+.rewind-setting-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 142px;
+  min-height: 34px;
+  padding: 7px 9px 7px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.rewind-setting-trigger:hover:not(:disabled) {
+  border-color: var(--fg-muted);
+  background: var(--surface-hover);
+}
+
+.rewind-setting-trigger:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.rewind-choice-list {
+  display: grid;
+  gap: 3px;
+}
+
+.rewind-choice-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  min-height: 34px;
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+}
+
+.rewind-choice-option:hover,
+.rewind-choice-option.is-selected {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.rewind-choice-option.is-selected {
+  border-color: var(--border);
+}
+
+.rewind-settings-section {
+  display: grid;
+  min-width: 0;
+}
+
+.rewind-setting-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.rewind-setting-copy > span {
+  overflow: hidden;
+  color: var(--fg-muted);
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rewind-setting-row--action {
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 58px;
+}
+
+.rewind-manage-button {
+  width: auto;
+  min-width: 72px;
+  padding: 7px 10px;
+  font-size: 11px;
+}
+
+.rewind-popover-stack {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.rewind-popover-hint {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.rewind-popover-setting-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.rewind-popover-setting-row:last-child {
+  border-bottom: none;
+}
+
+.rewind-popover-setting-row .rewind-setting-trigger {
+  width: 150px;
+}
+
 .rewind-search-row {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -3358,6 +3358,10 @@ body[data-clips-route="recording-pill"] #root {
   border-color: #93c5fd;
 }
 
+.pending-upload-retry-spinning svg {
+  animation: readiness-spin 0.8s linear infinite;
+}
+
 .pending-upload-connect:hover {
   background: #dbeafe;
   border-color: #93c5fd;
@@ -3378,6 +3382,12 @@ body[data-clips-route="recording-pill"] #root {
 .pending-upload-dismiss:disabled {
   cursor: default;
   opacity: 0.6;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pending-upload-retry-spinning svg {
+    animation: none;
+  }
 }
 
 .local-recording-banner,


### PR DESCRIPTION
## Summary
- Keep nested Rewind settings popovers independent from tray auto-sizing.
- Allow the nested settings content to scroll without changing the underlying tray height.

## Validation
- Clips desktop formatting and diff checks pass.
- Desktop typecheck/build and focused tests are being run against this branch.