### PR TITLE
fix: recover interrupted Clips recordings safely

### DIFF
--- a/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
+++ b/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
@@ -101,25 +101,27 @@ Don't just dump raw data. Synthesize findings:
 
 ### Step 4: Generate Charts (when useful)
 
-When the analysis benefits from a visual — trends over time, distributions, comparisons between categories — call `generate-chart` before formatting the report. The action returns a `url` you embed directly in the markdown.
+When the analysis benefits from a visual — trends over time, distributions, or
+comparisons between categories — query the data first, then use the live
+`/chart` embed described in `data-querying` for an in-chat answer. Do not call
+`generate-chart` for a one-off chat result: it produces a static image for
+saved artifacts, requires pre-stringified JSON, and does not count as a real
+data query for the final response guard.
 
-```
-generate-chart
-  --title "Closed-lost deals by month"
-  --type bar
-  --labels '["Jan","Feb","Mar"]'
-  --data '[18, 22, 14]'
-```
+For a stacked multi-series bar chart, keep the query in long form and emit a
+panel with `chartType: "bar"`, `config.pivot` containing `xKey`, `seriesKey`,
+and `valueKey`, plus `config.stacked: true`. The live chart route pivots the
+rows and renders one stack per x-axis category. See `data-querying`'s
+"Inline Charts In Chat" section for the exact `embed` fence and encoding.
 
-Embed the returned URL in `resultMarkdown` using standard markdown image syntax:
+Only use `generate-chart` when a saved analysis artifact explicitly needs a
+static image. If it returns an error while answering in chat, switch to the
+live embed instead of retrying reformatted `labels` or `data` parameters.
 
-```markdown
-![Closed-lost deals by month](/api/media/closed-lost-deals-by-month-1234567890.png?v=1234567890)
-```
-
-You can include multiple charts in one analysis. Reach for a chart when it communicates the finding faster than a table — don't force visuals on every analysis.
-
-Include the re-generation step in your saved `instructions` so re-runs produce fresh charts.
+You can include multiple live charts in one analysis. Reach for a chart when it
+communicates the finding faster than a table - don't force visuals on every
+analysis. Include the query and embed configuration in saved `instructions` so
+re-runs produce fresh charts.
 
 ### Step 5: Format Results as Markdown
 

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -1,5 +1,12 @@
+import { readFileSync } from "node:fs";
+
 import type { AgentLoopFinalResponseGuardContext } from "@agent-native/core/server";
 import { describe, expect, it, vi } from "vitest";
+
+const adhocAnalysisSkill = readFileSync(
+  new URL("../../.agents/skills/adhoc-analysis/SKILL.md", import.meta.url),
+  "utf8",
+);
 
 const { agentChatPluginOptions, representativeAnalyticsActions } = vi.hoisted(
   () => ({
@@ -70,6 +77,17 @@ import {
 } from "./agent-chat";
 
 describe("Analytics agent Plan mode policy", () => {
+  it("routes one-off stacked charts through the live embed path", () => {
+    expect(adhocAnalysisSkill).toMatch(/use the live\s+`\/chart` embed/);
+    expect(adhocAnalysisSkill).toMatch(
+      /Do not call\s+`generate-chart` for a one-off chat result/,
+    );
+    expect(adhocAnalysisSkill).toContain("config.stacked: true");
+    expect(adhocAnalysisSkill).not.toContain(
+      "call `generate-chart` before formatting the report",
+    );
+  });
+
   it("recovers a silent background dashboard run before the long chunk timeout", () => {
     expect(ANALYTICS_BACKGROUND_RUN_NO_PROGRESS_TIMEOUT_MS).toBe(3 * 60_000);
   });

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run() {
             native_screen::native_fullscreen_recording_resume,
             native_screen::native_fullscreen_recording_rotate_segment,
             native_screen::native_fullscreen_pending_uploads,
+            native_screen::native_fullscreen_recover_orphaned_uploads,
             native_screen::native_fullscreen_recording_retry_upload,
             native_screen::native_fullscreen_recording_mark_upload_error,
             native_screen::native_fullscreen_recording_clear_upload,

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -1,5 +1,6 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{ErrorKind, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -567,6 +568,7 @@ impl SharedClipSink {
             cancel_clip_live_upload(&live);
         }
         self.sink.cancel();
+        remove_recording_intent(&self.path);
     }
 
     /// Use when Add previous 30s/5m switches to Rewind's exact local
@@ -578,6 +580,7 @@ impl SharedClipSink {
             cancel_clip_live_upload(&live);
         }
         self.sink.cancel();
+        remove_recording_intent(&self.path);
         if let Some(config) = self.upload_reset.take() {
             let Some((server_url, recording_id, auth_token, cookie)) = config.validated()? else {
                 return Ok(());
@@ -1035,6 +1038,26 @@ struct SavedNativeRecording {
     corrupt: bool,
 }
 
+/// Written as soon as a remote recording starts. If the process dies before
+/// the normal stop path can write SavedNativeRecording, this small sidecar is
+/// enough for the next startup to promote the media file into the same retry
+/// queue instead of leaving an invisible orphan on disk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NativeRecordingIntent {
+    recording_id: String,
+    server_url: String,
+    mime_type: String,
+    width: Option<u32>,
+    height: Option<u32>,
+    has_audio: bool,
+    mic_captured: bool,
+    system_audio_captured: bool,
+    has_camera: bool,
+    custom_pipeline: bool,
+    saved_at: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PendingNativeRecording {
@@ -1052,6 +1075,13 @@ pub struct PendingNativeRecording {
     last_error: Option<String>,
     retry_count: u32,
     corrupt: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeOrphanedRecordingRecoveryResult {
+    recovered: u32,
+    skipped: u32,
 }
 
 #[derive(Serialize)]
@@ -1360,6 +1390,33 @@ fn start_native_session_locked(
     })
 }
 
+#[cfg(target_os = "macos")]
+fn persist_active_recording_intent(
+    session: &NativeFullscreenSession,
+    recording_id: &str,
+    server_url: Option<&str>,
+    has_camera: bool,
+) {
+    let Some(server_url) = server_url.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    if let Err(error) = persist_recording_intent(
+        &session.path,
+        recording_id,
+        server_url,
+        session.mime_type,
+        session.width,
+        session.height,
+        session.restart.include_audio || session.restart.capture_system_audio,
+        session.restart.mic_captured_in_file,
+        session.restart.capture_system_audio,
+        has_camera,
+        session.custom_pipeline,
+    ) {
+        eprintln!("[clips-tray] native recording recovery intent unavailable: {error}");
+    }
+}
+
 /// Phase 1 of the warm/begin start. Starts ScreenCaptureKit capture with the
 /// recording output DEFERRED so the microphone pipeline warms up (its first
 /// sample lands ~1s after capture begins) without that silent second being
@@ -1554,6 +1611,12 @@ pub async fn native_fullscreen_recording_begin(
                         include_audio,
                         has_camera.unwrap_or(false),
                     );
+                    persist_active_recording_intent(
+                        session,
+                        &recording_id,
+                        server_url.as_deref(),
+                        has_camera.unwrap_or(false),
+                    );
                 }
             }
             return Ok(info);
@@ -1643,6 +1706,12 @@ pub async fn native_fullscreen_recording_begin(
             auth_token.as_deref(),
             cookie.as_deref(),
             include_audio,
+            has_camera.unwrap_or(false),
+        );
+        persist_active_recording_intent(
+            session,
+            &recording_id,
+            server_url.as_deref(),
             has_camera.unwrap_or(false),
         );
 
@@ -2659,8 +2728,10 @@ fn discard_session(session: &mut NativeFullscreenSession) {
     }
     let _ = finalize_active_backend(session, false);
     for segment in &session.segments {
+        remove_recording_intent(segment);
         let _ = std::fs::remove_file(segment);
     }
+    remove_recording_intent(&session.path);
     let _ = std::fs::remove_file(&session.path);
 }
 
@@ -3424,6 +3495,108 @@ fn now_iso() -> String {
     Utc::now().to_rfc3339()
 }
 
+fn recording_intent_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("recording");
+    path.with_file_name(format!("{file_name}.intent.json"))
+}
+
+fn recording_path_from_intent(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_str()?;
+    let recording_name = file_name.strip_suffix(".intent.json")?;
+    Some(path.with_file_name(recording_name))
+}
+
+/// Persist only non-secret recording facts. The auth token and cookie remain
+/// in the normal session state, so a crash cannot turn this recovery marker
+/// into a credentials file.
+pub(crate) fn persist_recording_intent(
+    path: &Path,
+    recording_id: &str,
+    server_url: &str,
+    mime_type: &str,
+    width: Option<u32>,
+    height: Option<u32>,
+    has_audio: bool,
+    mic_captured: bool,
+    system_audio_captured: bool,
+    has_camera: bool,
+    custom_pipeline: bool,
+) -> Result<(), String> {
+    if recording_id.trim().is_empty() || server_url.trim().is_empty() {
+        return Err("recording recovery intent requires a recording ID and server URL".into());
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("recording path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("recording recovery directory unavailable: {error}"))?;
+    let intent = NativeRecordingIntent {
+        recording_id: recording_id.to_string(),
+        server_url: server_url.trim_end_matches('/').to_string(),
+        mime_type: mime_type.to_string(),
+        width,
+        height,
+        has_audio,
+        mic_captured,
+        system_audio_captured,
+        has_camera,
+        custom_pipeline,
+        saved_at: now_iso(),
+    };
+    let data = serde_json::to_vec_pretty(&intent)
+        .map_err(|error| format!("recording recovery intent encode failed: {error}"))?;
+    let destination = recording_intent_path(path);
+    let temporary = destination.with_file_name(format!(
+        ".{}.tmp",
+        destination
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("recording.intent.json")
+    ));
+    std::fs::write(&temporary, data)
+        .map_err(|error| format!("recording recovery intent write failed: {error}"))?;
+    if let Err(error) = std::fs::rename(&temporary, &destination) {
+        let _ = std::fs::remove_file(&temporary);
+        return Err(format!("recording recovery intent finalize failed: {error}"));
+    }
+    Ok(())
+}
+
+pub(crate) fn remove_recording_intent(path: &Path) {
+    let intent_path = recording_intent_path(path);
+    if let Err(error) = std::fs::remove_file(&intent_path) {
+        if error.kind() != ErrorKind::NotFound {
+            eprintln!(
+                "[clips-tray] recording recovery intent cleanup failed for {}: {error}",
+                intent_path.display()
+            );
+        }
+    }
+}
+
+fn read_recording_intent(path: &Path) -> Result<Option<NativeRecordingIntent>, String> {
+    let intent_path = recording_intent_path(path);
+    let data = match std::fs::read(&intent_path) {
+        Ok(data) => data,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "recording recovery intent read failed for {}: {error}",
+                intent_path.display()
+            ));
+        }
+    };
+    serde_json::from_slice(&data).map(Some).map_err(|error| {
+        format!(
+            "recording recovery intent decode failed for {}: {error}",
+            intent_path.display()
+        )
+    })
+}
+
 fn describe_recording_path(path: &Path) -> String {
     let exists = path.exists();
     let size = std::fs::metadata(path).map(|m| m.len()).ok();
@@ -3840,7 +4013,13 @@ fn write_saved_recording_metadata(
     let path = saved_recording_metadata_path(app, &saved.recording_id)?;
     let data = serde_json::to_vec_pretty(saved)
         .map_err(|e| format!("pending recording metadata encode failed: {e}"))?;
-    std::fs::write(path, data).map_err(|e| format!("pending recording metadata write failed: {e}"))
+    std::fs::write(path, data)
+        .map_err(|e| format!("pending recording metadata write failed: {e}"))?;
+    remove_recording_intent(&saved.file_path);
+    for segment_path in &saved.segment_paths {
+        remove_recording_intent(segment_path);
+    }
+    Ok(())
 }
 
 fn read_saved_recording_metadata_path(path: &Path) -> Result<SavedNativeRecording, String> {
@@ -3872,6 +4051,10 @@ fn clear_saved_recording(app: &AppHandle, saved: &SavedNativeRecording) -> Resul
         if segment_path != &saved.file_path {
             remove_saved_file(segment_path, "pending recording segment")?;
         }
+    }
+    remove_recording_intent(&saved.file_path);
+    for segment_path in &saved.segment_paths {
+        remove_recording_intent(segment_path);
     }
     let path = saved_recording_metadata_path(app, &saved.recording_id)?;
     remove_saved_file(&path, "pending recording metadata")

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -3165,11 +3165,14 @@ fn is_recording_segment_path(path: &Path) -> bool {
 }
 
 fn orphan_recording_id(path: &Path) -> Option<String> {
+    if is_recording_segment_path(path) {
+        return None;
+    }
     let stem = path.file_stem().and_then(|value| value.to_str())?;
-    let (prefix, value) = if let Some(value) = stem.strip_prefix("rewind-") {
-        ("rewind", value)
+    let value = if let Some(value) = stem.strip_prefix("rewind-") {
+        value
     } else if let Some(value) = stem.strip_prefix("clips-fullscreen-") {
-        ("fullscreen", value)
+        value
     } else {
         return None;
     };
@@ -3177,7 +3180,6 @@ fn orphan_recording_id(path: &Path) -> Option<String> {
     if recording_id.is_empty() || suffix.is_empty() || !suffix.chars().all(|v| v.is_ascii_digit()) {
         return None;
     }
-    let _ = prefix;
     Some(recording_id.to_string())
 }
 
@@ -3446,6 +3448,21 @@ pub async fn native_fullscreen_recover_orphaned_uploads(
     app: AppHandle,
     server_url: String,
 ) -> Result<NativeOrphanedRecordingRecoveryResult, String> {
+    let native_recording_active = app
+        .try_state::<NativeFullscreenRecordingState>()
+        .is_some_and(|state| {
+            state
+                .inner
+                .lock()
+                .map(|recording| recording.is_some())
+                .unwrap_or(false)
+        });
+    if native_recording_active || crate::rewind_clip::is_active(&app) {
+        return Ok(NativeOrphanedRecordingRecoveryResult {
+            recovered: 0,
+            skipped: 0,
+        });
+    }
     let fallback_server_url = server_url.trim_end_matches('/').to_string();
     let worker_app = app.clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
@@ -3457,6 +3474,70 @@ pub async fn native_fullscreen_recover_orphaned_uploads(
         let _ = app.emit("clips:pending-uploads-changed", ());
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod orphan_recovery_tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_recording_ids_without_treating_segments_as_new_clips() {
+        assert_eq!(
+            orphan_recording_id(Path::new("rewind-dvDBh5T8t4FU-1723456789012.mp4")),
+            Some("dvDBh5T8t4FU".into())
+        );
+        assert_eq!(
+            orphan_recording_id(Path::new("clips-fullscreen-e4esSx9NZCZa-1234.mov")),
+            Some("e4esSx9NZCZa".into())
+        );
+        assert!(is_recording_segment_path(Path::new(
+            "clips-fullscreen-e4esSx9NZCZa-1234-seg2.mp4"
+        )));
+        assert!(
+            orphan_recording_id(Path::new("clips-fullscreen-e4esSx9NZCZa-1234-seg2.mp4")).is_none()
+        );
+        assert!(orphan_recording_id(Path::new("unrelated.mp4")).is_none());
+    }
+
+    #[test]
+    fn intent_sidecars_round_trip_and_map_back_to_media() {
+        let root = std::env::temp_dir().join(format!(
+            "clips-recovery-intent-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let media = root.join("rewind-recording-123.mp4");
+        persist_recording_intent(
+            &media,
+            "recording-123",
+            "https://clips.example.test",
+            MP4_RECORDING_MIME_TYPE,
+            Some(1280),
+            Some(720),
+            true,
+            true,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        let intent_path = recording_intent_path(&media);
+        assert!(intent_path.exists());
+        assert_eq!(
+            recording_path_from_intent(&intent_path),
+            Some(media.clone())
+        );
+        let intent = read_recording_intent(&media).unwrap().unwrap();
+        assert_eq!(intent.recording_id, "recording-123");
+        assert_eq!(intent.server_url, "https://clips.example.test");
+        assert!(intent.custom_pipeline);
+        remove_recording_intent(&media);
+        assert!(!intent_path.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
 }
 
 #[tauri::command]

--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -3147,6 +3147,318 @@ pub async fn native_fullscreen_pending_uploads(
     Ok(pending)
 }
 
+fn is_recording_media_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("mp4" | "mov")
+    )
+}
+
+fn is_recording_segment_path(path: &Path) -> bool {
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    let Some((_, suffix)) = stem.rsplit_once("-seg") else {
+        return false;
+    };
+    !suffix.is_empty() && suffix.chars().all(|value| value.is_ascii_digit())
+}
+
+fn orphan_recording_id(path: &Path) -> Option<String> {
+    let stem = path.file_stem().and_then(|value| value.to_str())?;
+    let (prefix, value) = if let Some(value) = stem.strip_prefix("rewind-") {
+        ("rewind", value)
+    } else if let Some(value) = stem.strip_prefix("clips-fullscreen-") {
+        ("fullscreen", value)
+    } else {
+        return None;
+    };
+    let (recording_id, suffix) = value.rsplit_once('-')?;
+    if recording_id.is_empty() || suffix.is_empty() || !suffix.chars().all(|v| v.is_ascii_digit()) {
+        return None;
+    }
+    let _ = prefix;
+    Some(recording_id.to_string())
+}
+
+fn orphan_recording_mime_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|value| value.to_str()) {
+        Some("mov") => QUICKTIME_RECORDING_MIME_TYPE,
+        _ => MP4_RECORDING_MIME_TYPE,
+    }
+}
+
+fn orphan_recording_candidates(app: &AppHandle) -> Result<Vec<PathBuf>, String> {
+    let local_dir = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("local data directory unavailable: {error}"))?
+        .join("pending-recordings");
+    let native_dir = pending_uploads_dir(app)?;
+    let mut candidates = BTreeSet::new();
+
+    for directory in [local_dir, native_dir] {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "orphaned recording lookup failed for {}: {error}",
+                    directory.display()
+                ));
+            }
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if is_recording_media_path(&path) {
+                if !is_recording_segment_path(&path) {
+                    candidates.insert(path);
+                }
+            } else if path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.ends_with(".intent.json"))
+            {
+                if let Some(recording_path) = recording_path_from_intent(&path) {
+                    candidates.insert(recording_path);
+                }
+            }
+        }
+    }
+    Ok(candidates.into_iter().collect())
+}
+
+fn orphan_recording_paths(path: &Path) -> Vec<PathBuf> {
+    let mut paths = if path.is_file() {
+        vec![path.to_path_buf()]
+    } else {
+        Vec::new()
+    };
+    let Some(parent) = path.parent() else {
+        return paths;
+    };
+    let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+        return paths;
+    };
+    let Some(extension) = path.extension().and_then(|value| value.to_str()) else {
+        return paths;
+    };
+    let prefix = format!("{stem}-seg");
+    let mut segments = Vec::new();
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return paths;
+    };
+    for entry in entries.flatten() {
+        let candidate = entry.path();
+        if candidate.extension().and_then(|value| value.to_str()) != Some(extension) {
+            continue;
+        }
+        let Some(candidate_stem) = candidate.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let Some(suffix) = candidate_stem.strip_prefix(&prefix) else {
+            continue;
+        };
+        let Ok(index) = suffix.parse::<u32>() else {
+            continue;
+        };
+        if candidate.is_file() {
+            segments.push((index, candidate));
+        }
+    }
+    segments.sort_by_key(|(index, _)| *index);
+    paths.extend(segments.into_iter().map(|(_, path)| path));
+    paths
+}
+
+fn orphan_recording_intent(
+    path: &Path,
+    fallback_server_url: &str,
+) -> Result<Option<NativeRecordingIntent>, String> {
+    let mut intent = match read_recording_intent(path)? {
+        Some(intent) => intent,
+        None => {
+            let Some(recording_id) = orphan_recording_id(path) else {
+                return Ok(None);
+            };
+            if fallback_server_url.trim().is_empty() {
+                return Ok(None);
+            }
+            let is_rewind = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.starts_with("rewind-"));
+            NativeRecordingIntent {
+                recording_id,
+                server_url: fallback_server_url.trim_end_matches('/').to_string(),
+                mime_type: orphan_recording_mime_type(path).to_string(),
+                width: None,
+                height: None,
+                has_audio: false,
+                mic_captured: false,
+                system_audio_captured: false,
+                has_camera: false,
+                custom_pipeline: is_rewind,
+                saved_at: now_iso(),
+            }
+        }
+    };
+    if intent.server_url.trim().is_empty() {
+        intent.server_url = fallback_server_url.trim_end_matches('/').to_string();
+    }
+    if intent.recording_id.trim().is_empty() || intent.server_url.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(intent))
+}
+
+fn recover_orphaned_recording(
+    app: &AppHandle,
+    path: &Path,
+    fallback_server_url: &str,
+) -> Result<bool, String> {
+    let Some(intent) = orphan_recording_intent(path, fallback_server_url)? else {
+        return Ok(false);
+    };
+    let metadata_path = saved_recording_metadata_path(app, &intent.recording_id)?;
+    if metadata_path.exists() {
+        if let Ok(saved) = read_saved_recording_metadata_path(&metadata_path) {
+            if saved_recording_has_local_artifact(&saved) {
+                remove_recording_intent(path);
+                return Ok(false);
+            }
+        }
+        return Err(format!(
+            "pending metadata already exists for {}",
+            intent.recording_id
+        ));
+    }
+
+    let paths = orphan_recording_paths(path);
+    if paths.is_empty() {
+        return Ok(false);
+    }
+    for recording_path in &paths {
+        let bytes = std::fs::metadata(recording_path)
+            .map_err(|error| format!("orphaned recording metadata unavailable: {error}"))?
+            .len();
+        if bytes == 0 {
+            return Err(format!(
+                "orphaned recording is empty: {}",
+                recording_path.display()
+            ));
+        }
+        if !playable_recording_file(recording_path, &intent.mime_type) {
+            return Err(format!(
+                "orphaned recording is not playable yet: {}",
+                recording_path.display()
+            ));
+        }
+    }
+    let duration_ms = paths.iter().try_fold(0u128, |total, recording_path| {
+        let duration = probe_local_media_duration_ms(recording_path)?;
+        total
+            .checked_add(duration)
+            .ok_or_else(|| "orphaned recording duration overflowed".to_string())
+    })?;
+    if duration_ms == 0 {
+        return Err("orphaned recording has no measurable duration".into());
+    }
+    let bytes = paths.iter().try_fold(0u64, |total, recording_path| {
+        let size = std::fs::metadata(recording_path)
+            .map_err(|error| format!("orphaned recording metadata unavailable: {error}"))?
+            .len();
+        total
+            .checked_add(size)
+            .ok_or_else(|| "orphaned recording size overflowed".to_string())
+    })?;
+    let file_path = paths
+        .first()
+        .cloned()
+        .ok_or_else(|| "orphaned recording has no file path".to_string())?;
+    let segment_paths = if paths.len() > 1 {
+        paths.clone()
+    } else {
+        Vec::new()
+    };
+    let saved = SavedNativeRecording {
+        recording_id: intent.recording_id,
+        server_url: intent.server_url.trim_end_matches('/').to_string(),
+        file_path,
+        segment_paths,
+        mime_type: intent.mime_type,
+        duration_ms,
+        width: intent.width,
+        height: intent.height,
+        bytes,
+        has_audio: intent.has_audio,
+        mic_captured: intent.mic_captured,
+        system_audio_captured: intent.system_audio_captured,
+        has_camera: intent.has_camera,
+        saved_at: intent.saved_at,
+        last_attempt_at: None,
+        last_error: None,
+        retry_count: 0,
+        retry_attempt_id: None,
+        custom_pipeline: intent.custom_pipeline,
+        corrupt: false,
+    };
+    write_saved_recording_metadata(app, &saved)?;
+    Ok(true)
+}
+
+fn recover_orphaned_recordings(
+    app: &AppHandle,
+    fallback_server_url: &str,
+) -> Result<NativeOrphanedRecordingRecoveryResult, String> {
+    let candidates = orphan_recording_candidates(app)?;
+    let mut result = NativeOrphanedRecordingRecoveryResult {
+        recovered: 0,
+        skipped: 0,
+    };
+    for candidate in candidates {
+        match recover_orphaned_recording(app, &candidate, fallback_server_url) {
+            Ok(true) => {
+                result.recovered = result.recovered.saturating_add(1);
+                eprintln!(
+                    "[clips-tray] recovered orphaned recording for retry: {}",
+                    candidate.display()
+                );
+            }
+            Ok(false) => {}
+            Err(error) => {
+                result.skipped = result.skipped.saturating_add(1);
+                eprintln!(
+                    "[clips-tray] skipped orphaned recording {}: {error}",
+                    candidate.display()
+                );
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Run after the renderer starts so media inspection cannot delay tray startup.
+/// The command is idempotent: once metadata exists, the intent sidecar is
+/// removed and later startup checks leave the ordinary retry record alone.
+#[tauri::command]
+pub async fn native_fullscreen_recover_orphaned_uploads(
+    app: AppHandle,
+    server_url: String,
+) -> Result<NativeOrphanedRecordingRecoveryResult, String> {
+    let fallback_server_url = server_url.trim_end_matches('/').to_string();
+    let worker_app = app.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        recover_orphaned_recordings(&worker_app, &fallback_server_url)
+    })
+    .await
+    .map_err(|error| format!("orphaned recording recovery task failed: {error}"))??;
+    if result.recovered > 0 {
+        let _ = app.emit("clips:pending-uploads-changed", ());
+    }
+    Ok(result)
+}
+
 #[tauri::command]
 pub async fn native_fullscreen_recording_retry_upload(
     app: AppHandle,
@@ -3560,7 +3872,9 @@ pub(crate) fn persist_recording_intent(
         .map_err(|error| format!("recording recovery intent write failed: {error}"))?;
     if let Err(error) = std::fs::rename(&temporary, &destination) {
         let _ = std::fs::remove_file(&temporary);
-        return Err(format!("recording recovery intent finalize failed: {error}"));
+        return Err(format!(
+            "recording recovery intent finalize failed: {error}"
+        ));
     }
     Ok(())
 }
@@ -4912,6 +5226,11 @@ fn probe_local_media_duration_ms(path: &Path) -> Result<u128, String> {
             })?;
         Ok(duration_ms)
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn probe_local_media_duration_ms(_path: &Path) -> Result<u128, String> {
+    Err("local media duration probing is only available on macOS".into())
 }
 
 async fn upload_prepared_recording_file(

--- a/templates/clips/desktop/src-tauri/src/rewind_clip.rs
+++ b/templates/clips/desktop/src-tauri/src/rewind_clip.rs
@@ -136,6 +136,8 @@ pub(crate) fn rewind_clip_prepare(
     let sources = screen_memory::rewind_clip_sources(&app);
     let output = artifact_path(&app, &artifact_label)?;
     #[cfg(target_os = "macos")]
+    let recovery_intent = (server_url.clone(), recording_id.clone());
+    #[cfg(target_os = "macos")]
     let shared_sink = match screen_memory::prepare_shared_clip_sink(
         &app,
         output,
@@ -167,6 +169,29 @@ pub(crate) fn rewind_clip_prepare(
         );
         release_temporary_audio(&app, temporary_audio);
         return Err(not_compatible("shared Rewind Clip sinks require macOS"));
+    }
+    #[cfg(target_os = "macos")]
+    if let (Some(server_url), Some(recording_id)) = recovery_intent {
+        if !server_url.trim().is_empty() && !recording_id.trim().is_empty() {
+            let (width, height) = shared_sink.dimensions();
+            if let Err(error) = native_screen::persist_recording_intent(
+                shared_sink.path(),
+                &recording_id,
+                &server_url,
+                native_screen::MP4_RECORDING_MIME_TYPE,
+                Some(width),
+                Some(height),
+                include_mic || include_system_audio,
+                include_mic,
+                include_system_audio,
+                has_camera,
+                true,
+            ) {
+                shared_sink.cancel();
+                release_temporary_audio(&app, temporary_audio);
+                return Err(error);
+            }
+        }
     }
     let response_sources = sources.clone();
     let mut active = state.0.lock().map_err(|error| error.to_string())?;

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2703,6 +2703,29 @@ export function App() {
     loadPendingUploads();
   }, [loadPendingUploads, popoverVisible]);
 
+  useEffect(() => {
+    let cancelled = false;
+    void invoke<{ recovered: number }>(
+      "native_fullscreen_recover_orphaned_uploads",
+      { serverUrl },
+    )
+      .then((result) => {
+        if (!cancelled && result.recovered > 0) {
+          return loadPendingUploads();
+        }
+        return undefined;
+      })
+      .catch((error) => {
+        console.warn(
+          "[clips-tray] orphaned recording recovery lookup failed:",
+          error,
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPendingUploads, serverUrl]);
+
   // ---- persist selections -------------------------------------------------
 
   useEffect(() => saveString(MODE_KEY, mode), [mode]);


### PR DESCRIPTION
## Summary
- persist non-secret recording recovery intent for interrupted native Clips recordings
- avoid treating segmented media as duplicate orphan recordings and skip recovery during active capture
- add Analytics regression coverage for stacked live chart embeds

## Validation
- cargo fmt --manifest-path templates/clips/desktop/src-tauri/Cargo.toml -- --check
- cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml --lib native_screen (44 passed)
- pnpm --dir templates/analytics exec vitest run server/plugins/agent-chat.spec.ts (41 passed)
- pnpm --dir templates/clips/desktop typecheck

Merging per the explicit ship instruction without waiting on external CI/install queue or soak.