### PR TITLE
fix: recover Rewind clips after interrupted export

### DIFF
--- a/templates/clips/desktop/src-tauri/src/native_screen.rs
+++ b/templates/clips/desktop/src-tauri/src/native_screen.rs
@@ -4486,8 +4486,8 @@ pub(crate) fn persist_shared_clip_recording(
     server_url: &str,
     recording_id: &str,
     duration_ms: u128,
-    width: u32,
-    height: u32,
+    width: Option<u32>,
+    height: Option<u32>,
     include_mic: bool,
     include_system_audio: bool,
     has_camera: bool,
@@ -4506,8 +4506,8 @@ pub(crate) fn persist_shared_clip_recording(
         segment_paths: Vec::new(),
         mime_type: MP4_RECORDING_MIME_TYPE.to_string(),
         duration_ms,
-        width: Some(width),
-        height: Some(height),
+        width,
+        height,
         bytes,
         has_audio: include_mic || include_system_audio,
         mic_captured: include_mic,
@@ -4532,8 +4532,11 @@ pub(crate) fn clear_shared_clip_recording(app: &AppHandle, recording_id: &str, p
     let saved = read_saved_recording_metadata(app, recording_id).ok();
     if let Some(saved) = saved {
         clear_saved_recording_after_success(app, &saved);
-    } else if let Err(error) = remove_saved_file(path, "shared Clip temporary artifact") {
-        eprintln!("[clips-tray] shared Clip cleanup failed: {error}");
+    } else {
+        remove_recording_intent(path);
+        if let Err(error) = remove_saved_file(path, "shared Clip temporary artifact") {
+            eprintln!("[clips-tray] shared Clip cleanup failed: {error}");
+        }
     }
     let _ = app.emit("clips:pending-uploads-changed", ());
 }

--- a/templates/clips/desktop/src-tauri/src/rewind_clip.rs
+++ b/templates/clips/desktop/src-tauri/src/rewind_clip.rs
@@ -1215,8 +1215,8 @@ pub(crate) async fn rewind_clip_stop_and_upload(
                         &server_url,
                         &recording_id,
                         logical_duration_ms as u128,
-                        sink_width,
-                        sink_height,
+                        Some(sink_width),
+                        Some(sink_height),
                         include_mic,
                         include_system_audio,
                         has_camera,
@@ -1246,8 +1246,8 @@ pub(crate) async fn rewind_clip_stop_and_upload(
                 &server_url,
                 &recording_id,
                 result.duration_ms as u128,
-                result.width,
-                result.height,
+                Some(result.width),
+                Some(result.height),
                 include_mic,
                 include_system_audio,
                 has_camera,
@@ -1273,8 +1273,8 @@ pub(crate) async fn rewind_clip_stop_and_upload(
                         &server_url,
                         &recording_id,
                         result.duration_ms as u128,
-                        result.width,
-                        result.height,
+                        Some(result.width),
+                        Some(result.height),
                         include_mic,
                         include_system_audio,
                         has_camera,
@@ -1332,18 +1332,60 @@ pub(crate) async fn rewind_clip_stop_and_upload(
         include_system_audio,
         Some((&server_url, &recording_id, has_camera)),
     )?;
-    native_screen::upload_finalized_native_artifact(
+    native_screen::persist_shared_clip_recording(
+        &app,
+        &artifact.path,
+        &server_url,
+        &recording_id,
+        artifact.duration_ms,
+        artifact.width,
+        artifact.height,
+        include_mic,
+        include_system_audio,
+        has_camera,
+        None,
+    )?;
+    let recovery_server_url = server_url.clone();
+    let recovery_recording_id = recording_id.clone();
+    let artifact_path = artifact.path.clone();
+    let result = native_screen::upload_finalized_native_artifact(
         &app,
         &artifact,
         server_url,
-        recording_id,
+        recording_id.clone(),
         auth_token.unwrap_or_default(),
         cookie.unwrap_or_default(),
         NativeUploadMode::from_option(upload_mode),
         include_mic || include_system_audio,
         has_camera,
     )
-    .await
+    .await;
+    match &result {
+        Ok(upload) if !upload.verification_pending => {
+            native_screen::clear_shared_clip_recording(
+                &app,
+                &recovery_recording_id,
+                &artifact_path,
+            );
+        }
+        Err(error) => {
+            let _ = native_screen::persist_shared_clip_recording(
+                &app,
+                &artifact_path,
+                &recovery_server_url,
+                &recovery_recording_id,
+                artifact.duration_ms,
+                artifact.width,
+                artifact.height,
+                include_mic,
+                include_system_audio,
+                has_camera,
+                Some(error),
+            );
+        }
+        _ => {}
+    }
+    result
 }
 
 #[tauri::command]

--- a/templates/clips/desktop/src-tauri/src/rewind_clip.rs
+++ b/templates/clips/desktop/src-tauri/src/rewind_clip.rs
@@ -1038,6 +1038,7 @@ fn materialize(
     label: &str,
     include_mic: bool,
     include_system_audio: bool,
+    recovery: Option<(&str, &str, bool)>,
 ) -> Result<FinalizedNativeArtifact, String> {
     let active = take_active(state)?;
     let mut intervals = active.intervals.clone();
@@ -1112,10 +1113,25 @@ fn materialize(
         }
         let output = artifact_path(app, label)?;
         let audio = select_audio(&active.sources, include_mic, include_system_audio)?;
-        native_screen::materialize_mp4_slices_exact(&slices, &output, audio)?;
         let first = first_segment
             .as_ref()
             .ok_or_else(|| "no Rewind media selected".to_string())?;
+        if let Some((server_url, recording_id, has_camera)) = recovery {
+            native_screen::persist_recording_intent(
+                &output,
+                recording_id,
+                server_url,
+                native_screen::MP4_RECORDING_MIME_TYPE,
+                first.width,
+                first.height,
+                include_mic || include_system_audio,
+                include_mic,
+                include_system_audio,
+                has_camera,
+                true,
+            )?;
+        }
+        native_screen::materialize_mp4_slices_exact(&slices, &output, audio)?;
         Ok(FinalizedNativeArtifact::rewind_mp4(
             output,
             duration_ms,
@@ -1314,6 +1330,7 @@ pub(crate) async fn rewind_clip_stop_and_upload(
         &recording_id,
         include_mic,
         include_system_audio,
+        Some((&server_url, &recording_id, has_camera)),
     )?;
     native_screen::upload_finalized_native_artifact(
         &app,
@@ -1390,6 +1407,7 @@ pub(crate) async fn rewind_clip_stop_and_save(
         &folder_name,
         include_mic,
         include_system_audio,
+        None,
     )?;
     native_screen::save_finalized_native_artifact_to_local_export(
         &app,


### PR DESCRIPTION
## Summary
- persist recovery intent after Rewind media is materialized for remote upload
- preserve local-only Rewind exports without creating upload recovery metadata

## Validation
- cargo fmt --manifest-path templates/clips/desktop/src-tauri/Cargo.toml -- --check
- cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml --lib native_screen (44 passed)
- cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml --lib rewind_clip (9 passed)
- pnpm --dir templates/clips/desktop typecheck

This is a targeted post-merge follow-up for the native recording recovery path.