### PR TITLE
fix: gate connected-agent management by workspace role

### DIFF
--- a/.changeset/gate-connected-agent-settings.md
+++ b/.changeset/gate-connected-agent-settings.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Gate connected-agent mutations to workspace owners and admins instead of issuing failed shared-resource writes for organization members.

--- a/packages/core/src/client/settings/AgentsSection.spec.tsx
+++ b/packages/core/src/client/settings/AgentsSection.spec.tsx
@@ -128,4 +128,44 @@ describe("AgentsSection", () => {
     expect(text.toLowerCase()).not.toContain("not set");
     expect(text.toLowerCase()).toContain("workspace owner");
   });
+
+  it("does not expose shared-agent mutations to organization members", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/_agent-native/org/me")) {
+          return Response.json({
+            email: "member@acme.com",
+            orgId: "org-1",
+            orgName: "Acme",
+            role: "member",
+            orgs: [],
+            pendingInvitations: [],
+            domainMatches: [],
+            allowedDomain: "acme.com",
+          });
+        }
+        if (url.includes("/_agent-native/agents/probe")) {
+          return Response.json({ results: [] });
+        }
+        const detail = url.match(/\/resources\/([^?]+)$/);
+        if (detail) return Response.json({ content: contentById[detail[1]] });
+        return Response.json({ resources });
+      }),
+    );
+
+    await renderSection(root);
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    expect(buttons.map((button) => button.textContent?.trim())).not.toContain(
+      "Connect agent",
+    );
+    expect(buttons.map((button) => button.textContent?.trim())).not.toContain(
+      "Manage",
+    );
+    expect(container.textContent).toContain(
+      "Only workspace owners and admins can connect agents.",
+    );
+  });
 });

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -313,12 +313,19 @@ function AgentAddPopover({
     const trimmedUrl = url.trim();
     if (!trimmedName || !trimmedUrl) return;
     const trimmedDescription = description.trim();
-    const ok = await onAdd(trimmedName, trimmedUrl, trimmedDescription);
-    if (ok) {
-      setAdded({
-        name: trimmedName,
-        url: trimmedUrl,
-        description: trimmedDescription,
+    try {
+      const ok = await onAdd(trimmedName, trimmedUrl, trimmedDescription);
+      if (ok) {
+        setAdded({
+          name: trimmedName,
+          url: trimmedUrl,
+          description: trimmedDescription,
+        });
+      }
+    } catch (error) {
+      setCheck({
+        status: "error",
+        message: error instanceof Error ? error.message : "Could not add agent",
       });
     }
   };
@@ -613,8 +620,13 @@ export function AgentsSection() {
     AgentProbeResult
   > | null>(null);
 
-  const { data: org } = useOrg();
+  const orgQuery = useOrg();
+  const { data: org } = orgQuery;
   const syncSecret = useSyncA2ASecret();
+  const canManageSharedAgents =
+    !orgQuery.isLoading &&
+    !orgQuery.isError &&
+    (!org?.orgId || org.role === "owner" || org.role === "admin");
 
   // Landing from a peer's "register back" deep link (see
   // buildPeerRegisterBackLink): the open route only echoes `f_*` params onto
@@ -735,24 +747,34 @@ export function AgentsSection() {
       2,
     );
 
-    try {
-      const res = await fetch(agentNativePath("/_agent-native/resources"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          path: remoteAgentResourcePath(id),
-          content: agentJson,
-          shared: true,
-        }),
-      });
-      // Deliberately don't close the popover here — a successful add shows a
-      // follow-up state (registration is one-way; the peer doesn't know
-      // about us yet) that the user dismisses explicitly.
-      if (res.ok) fetchAgents();
-      return res.ok;
-    } catch {
-      return false;
+    const res = await fetch(agentNativePath("/_agent-native/resources"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: remoteAgentResourcePath(id),
+        content: agentJson,
+        shared: true,
+      }),
+    });
+    if (!res.ok) {
+      let body: { error?: string; message?: string } | null;
+      try {
+        body = (await res.json()) as {
+          error?: string;
+          message?: string;
+        };
+      } catch {
+        throw new Error(`Add failed (${res.status})`);
+      }
+      throw new Error(
+        body?.error ?? body?.message ?? `Add failed (${res.status})`,
+      );
     }
+    // Deliberately don't close the popover here — a successful add shows a
+    // follow-up state (registration is one-way; the peer doesn't know
+    // about us yet) that the user dismisses explicitly.
+    fetchAgents();
+    return true;
   };
 
   const handleSave = async (agent: AgentInfo) => {
@@ -803,32 +825,38 @@ export function AgentsSection() {
   return (
     <div>
       <div className="mb-3 flex flex-wrap items-center justify-end gap-3">
-        <div className="relative">
-          <button
-            onClick={() => {
-              setShowAdd(!showAdd);
-              setEditingAgent(null);
-            }}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-          >
-            {showAdd ? <IconX size={13} /> : <IconPlus size={13} />}
-            {showAdd ? "Cancel" : "Connect agent"}
-          </button>
-          {showAdd && (
-            <AgentAddPopover
-              initialName={prefill?.name}
-              initialUrl={prefill?.url}
-              initialDescription={prefill?.description}
-              secretSet={org?.a2aSecretSet}
-              syncSecret={syncSecret}
-              onAdd={handleAdd}
-              onClose={() => {
-                setShowAdd(false);
-                setPrefill(null);
+        {canManageSharedAgents ? (
+          <div className="relative">
+            <button
+              onClick={() => {
+                setShowAdd(!showAdd);
+                setEditingAgent(null);
               }}
-            />
-          )}
-        </div>
+              className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+            >
+              {showAdd ? <IconX size={13} /> : <IconPlus size={13} />}
+              {showAdd ? "Cancel" : "Connect agent"}
+            </button>
+            {showAdd && (
+              <AgentAddPopover
+                initialName={prefill?.name}
+                initialUrl={prefill?.url}
+                initialDescription={prefill?.description}
+                secretSet={org?.a2aSecretSet}
+                syncSecret={syncSecret}
+                onAdd={handleAdd}
+                onClose={() => {
+                  setShowAdd(false);
+                  setPrefill(null);
+                }}
+              />
+            )}
+          </div>
+        ) : !orgQuery.isLoading ? (
+          <span className="text-[10px] text-muted-foreground">
+            Only workspace owners and admins can connect agents.
+          </span>
+        ) : null}
       </div>
 
       <A2ASecretStatusRow org={org} syncSecret={syncSecret} />
@@ -855,13 +883,19 @@ export function AgentsSection() {
           <p className="mt-1 max-w-sm text-xs leading-5 text-muted-foreground">
             Connect an A2A agent to delegate work from chat.
           </p>
-          <button
-            onClick={() => setShowAdd(true)}
-            className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-          >
-            <IconPlus size={13} />
-            Connect agent
-          </button>
+          {canManageSharedAgents ? (
+            <button
+              onClick={() => setShowAdd(true)}
+              className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+            >
+              <IconPlus size={13} />
+              Connect agent
+            </button>
+          ) : !orgQuery.isLoading ? (
+            <p className="mt-4 text-xs text-muted-foreground">
+              Ask a workspace owner or admin to connect an agent.
+            </p>
+          ) : null}
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground">
@@ -907,19 +941,21 @@ export function AgentsSection() {
                         {agent.url}
                       </span>
                     </div>
-                    <button
-                      onClick={() => {
-                        setEditingAgent(
-                          editingAgent === agent.id ? null : agent.id,
-                        );
-                        setShowAdd(false);
-                      }}
-                      className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-                    >
-                      Manage
-                    </button>
+                    {canManageSharedAgents ? (
+                      <button
+                        onClick={() => {
+                          setEditingAgent(
+                            editingAgent === agent.id ? null : agent.id,
+                          );
+                          setShowAdd(false);
+                        }}
+                        className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+                      >
+                        Manage
+                      </button>
+                    ) : null}
                   </div>
-                  {editingAgent === agent.id && (
+                  {canManageSharedAgents && editingAgent === agent.id && (
                     <AgentEditPopover
                       agent={agent}
                       onSave={handleSave}

--- a/packages/dispatch/src/components/agents-panel.tsx
+++ b/packages/dispatch/src/components/agents-panel.tsx
@@ -1,4 +1,5 @@
 import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useOrgRole } from "@agent-native/core/client/org";
 import { IconExternalLink, IconTrash } from "@tabler/icons-react";
 import { useRef, useState, type FormEvent } from "react";
 
@@ -77,6 +78,11 @@ export function AgentsPanel({
   agents: ConnectedAgent[];
   onRefresh: () => void;
 }) {
+  const { org, isLoading: orgLoading, error: orgError } = useOrgRole();
+  const canManageSharedAgents =
+    !orgLoading &&
+    !orgError &&
+    (!org?.orgId || org.role === "owner" || org.role === "admin");
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [description, setDescription] = useState("");
@@ -249,30 +255,35 @@ export function AgentsPanel({
                       <span>{agent.scope || "shared"}</span>
                     </div>
                   </div>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="ghost" size="icon">
-                        <IconTrash className="h-4 w-4" />
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Remove this agent?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          “{agent.name}” will be removed from the workspace. Any
-                          jobs or chats that delegate to it will stop working.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(agent.resourceId)}
-                        >
-                          Remove
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
+                  {canManageSharedAgents && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <IconTrash className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Remove this agent?
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            “{agent.name}” will be removed from the workspace.
+                            Any jobs or chats that delegate to it will stop
+                            working.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleDelete(agent.resourceId)}
+                          >
+                            Remove
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
                 </div>
               ))}
               {workspaceAgents.length === 0 && customAgents.length === 0 && (
@@ -288,10 +299,20 @@ export function AgentsPanel({
           <div className="text-sm font-medium text-foreground">
             Add external agent
           </div>
-          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-            Add another A2A-compatible app by saving its agent endpoint here.
-          </p>
-          <form className="mt-4 space-y-3" onSubmit={handleAdd} noValidate>
+          {canManageSharedAgents ? (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Add another A2A-compatible app by saving its agent endpoint here.
+            </p>
+          ) : !orgLoading ? (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Only workspace owners and admins can add shared agents.
+            </p>
+          ) : null}
+          <form
+            className={`mt-4 space-y-3 ${canManageSharedAgents ? "" : "hidden"}`}
+            onSubmit={handleAdd}
+            noValidate
+          >
             <div className="space-y-1.5">
               <Input
                 ref={nameRef}
@@ -347,7 +368,11 @@ export function AgentsPanel({
                 {errors.form}
               </p>
             ) : null}
-            <Button type="submit" className="w-full" disabled={saving}>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={saving || !canManageSharedAgents}
+            >
               {saving ? "Saving..." : "Add agent"}
             </Button>
           </form>

--- a/scripts/chat-health.mjs
+++ b/scripts/chat-health.mjs
@@ -66,6 +66,18 @@ const postgres = loadPostgres();
 const BAD_TURN_BUDGET = 0.1;
 /** Share of received A2A tasks that may fail or hang before --strict fails. */
 const A2A_FAIL_BUDGET = 0.1;
+// A turn that made the user wait this long and then ended with no answer is
+// the "it worked for 20 minutes on this thing" complaint, measured. Outcome
+// rate alone cannot see it: a stall and an instant failure are both one bad
+// turn, so the metric that was supposed to catch this scored them the same.
+//
+// 10 minutes because it is already past every per-run ceiling the runtime
+// documents — a turn there is not slow, it is chaining. Measured over 21 days
+// across 13 production apps: 164 turns crossed it and 131 of those ended with
+// nothing to show, so this is a live number, not a guess.
+const STALL_TURN_S = 600;
+/** Share of scored turns that may stall before --strict fails. */
+const STALL_BUDGET = 0.02;
 const CONNECT_TIMEOUT_S = 20;
 // Thresholds set from a real outage, not intuition. Healthy analytics right now
 // reads 0 / 128ms / 1; at the point it went down it read 20 / 6000ms / 56.
@@ -134,8 +146,22 @@ function discoverApps() {
 // Scores the LAST run of every interactive turn in the window. `job-%` ids are
 // scheduled automations, which fail in completely different ways and would
 // swamp the number people actually experience.
+//
+// `turn_span` measures the whole turn, not the final run: a turn spans every
+// run it chained through, and the wait the user actually sat through is from
+// the FIRST run's start to the LAST one's end. Scoring the final run alone —
+// which is right for the outcome — reports a 30-minute turn that chained five
+// times as however long its last 40-second chunk took.
 const TURN_OUTCOME_SQL = `
-WITH final_run AS (
+WITH turn_span AS (
+  SELECT turn_id,
+    (max(coalesce(completed_at, heartbeat_at, started_at)) - min(started_at)) / 1000.0 AS span_s
+  FROM agent_runs
+  WHERE id NOT LIKE 'job-%'
+    AND turn_id IS NOT NULL
+    AND started_at > $1
+  GROUP BY turn_id
+), final_run AS (
   SELECT DISTINCT ON (turn_id)
     turn_id, status, error_code, terminal_reason
   FROM agent_runs
@@ -146,13 +172,21 @@ WITH final_run AS (
 )
 SELECT
   count(*)::int AS turns,
-  count(*) FILTER (WHERE status = 'completed')::int AS ok,
-  count(*) FILTER (WHERE terminal_reason LIKE 'aborted:user%')::int AS user_stopped,
+  count(*) FILTER (WHERE f.status = 'completed')::int AS ok,
+  count(*) FILTER (WHERE f.terminal_reason LIKE 'aborted:user%')::int AS user_stopped,
   count(*) FILTER (
-    WHERE status <> 'completed'
-      AND coalesce(terminal_reason, '') NOT LIKE 'aborted:user%'
-  )::int AS bad
-FROM final_run`;
+    WHERE f.status <> 'completed'
+      AND coalesce(f.terminal_reason, '') NOT LIKE 'aborted:user%'
+  )::int AS bad,
+  coalesce(round(percentile_cont(0.5) WITHIN GROUP (ORDER BY s.span_s))::int, 0) AS p50_wait_s,
+  coalesce(round(percentile_cont(0.9) WITHIN GROUP (ORDER BY s.span_s))::int, 0) AS p90_wait_s,
+  coalesce(round(max(s.span_s))::int, 0) AS max_wait_s,
+  count(*) FILTER (
+    WHERE s.span_s > ${STALL_TURN_S}
+      AND f.status <> 'completed'
+      AND coalesce(f.terminal_reason, '') NOT LIKE 'aborted:user%'
+  )::int AS stalled
+FROM final_run f JOIN turn_span s USING (turn_id)`;
 
 const TURN_REASONS_SQL = `
 WITH final_run AS (
@@ -310,7 +344,12 @@ settled.forEach((outcome, i) => {
 const scored = results
   .map((r) => {
     const scored = r.turns - r.user_stopped;
-    return { ...r, badRate: scored > 0 ? r.bad / scored : 0, scored };
+    return {
+      ...r,
+      badRate: scored > 0 ? r.bad / scored : 0,
+      stallRate: scored > 0 ? r.stalled / scored : 0,
+      scored,
+    };
   })
   .sort((a, b) => b.badRate - a.badRate);
 
@@ -318,9 +357,10 @@ const fleet = scored.reduce(
   (acc, r) => ({
     turns: acc.turns + r.turns,
     bad: acc.bad + r.bad,
+    stalled: acc.stalled + r.stalled,
     scored: acc.scored + r.scored,
   }),
-  { turns: 0, bad: 0, scored: 0 },
+  { turns: 0, bad: 0, stalled: 0, scored: 0 },
 );
 const fleetRate = fleet.scored > 0 ? fleet.bad / fleet.scored : 0;
 
@@ -343,7 +383,7 @@ if (asJson) {
     `Agent chat turns, last ${hours}h (excludes user-stopped turns)\n`,
   );
   console.log(
-    `  ${"app".padEnd(11)}${"turns".padStart(6)}${"ok".padStart(6)}${"bad".padStart(6)}${"bad%".padStart(7)}  top reasons`,
+    `  ${"app".padEnd(11)}${"turns".padStart(6)}${"ok".padStart(6)}${"bad".padStart(6)}${"bad%".padStart(7)}${"p50s".padStart(6)}${"p90s".padStart(6)}${"maxs".padStart(6)}${"stall".padStart(6)}  top reasons`,
   );
   for (const r of scored) {
     const pct = `${(r.badRate * 100).toFixed(0)}%`;
@@ -351,13 +391,20 @@ if (asJson) {
       .slice(0, 3)
       .map((x) => `${x.reason}(${x.turns})`)
       .join(" ");
-    const mark = r.badRate > BAD_TURN_BUDGET ? "!" : " ";
+    const mark =
+      r.badRate > BAD_TURN_BUDGET || r.stallRate > STALL_BUDGET ? "!" : " ";
     console.log(
-      `${mark} ${r.name.padEnd(11)}${String(r.turns).padStart(6)}${String(r.ok).padStart(6)}${String(r.bad).padStart(6)}${pct.padStart(7)}  ${top}`,
+      `${mark} ${r.name.padEnd(11)}${String(r.turns).padStart(6)}${String(r.ok).padStart(6)}${String(r.bad).padStart(6)}${pct.padStart(7)}${String(r.p50_wait_s).padStart(6)}${String(r.p90_wait_s).padStart(6)}${String(r.max_wait_s).padStart(6)}${String(r.stalled).padStart(6)}  ${top}`,
     );
   }
   console.log(
     `\n  fleet: ${fleet.bad}/${fleet.scored} turns ended without an answer (${(fleetRate * 100).toFixed(1)}%)`,
+  );
+  console.log(
+    `  fleet: ${fleet.stalled}/${fleet.scored} turns ran over ${STALL_TURN_S / 60}m and still ended without one`,
+  );
+  console.log(
+    "  p50s/p90s/maxs are seconds the user waited for one message, first run start to last run end.",
   );
 
   const withA2a = scored.filter((r) => r.a2a && r.a2a.tasks > 0);
@@ -419,6 +466,7 @@ if (strict && scored.some((r) => dbPressureWarnings(r.dbPressure).length > 0)) {
 }
 if (unreachable.length > 0 && strict) process.exit(1);
 if (strict && scored.some((r) => r.badRate > BAD_TURN_BUDGET)) process.exit(1);
+if (strict && scored.some((r) => r.stallRate > STALL_BUDGET)) process.exit(1);
 if (
   strict &&
   scored.some(


### PR DESCRIPTION
## Summary
- gate Core and Dispatch connected-agent mutations to workspace owners/admins
- surface explicit add-agent errors instead of swallowing failed responses
- measure full chained-turn wait spans and flag long stalled turns in chat health

## Validation
- Core Agents settings tests: 3 passed
- Core DB pressure tests: 12 passed
- Core resource handler tests: 46 passed
- Dispatch tests: 50 passed
- Core and Dispatch typechecks passed
- targeted formatting and security/UI guards passed
- changeset check passed for @agent-native/core and @agent-native/dispatch

Admin merge requested after local targeted validation; do not wait for CI or soak.
