### PR TITLE
fix: stop repeated agent failures and ground analytics responses

### DIFF
--- a/.changeset/action-grounding-declaration.md
+++ b/.changeset/action-grounding-declaration.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional `grounding` declaration to `defineAction` so an action can state that a successful call returns real evidence from a data source, instead of apps maintaining separate name lists that drift.

--- a/.changeset/bound-non-advancing-chat-continuations.md
+++ b/.changeset/bound-non-advancing-chat-continuations.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop runaway chat turns: one "did this continuation advance?" budget now covers every reason code including `loop_limit`, failed prior-turn tool calls replay as failures instead of successes, and a retry `clear` no longer deletes narration from earlier steps of the turn.

--- a/.changeset/gate-connected-agent-settings.md
+++ b/.changeset/gate-connected-agent-settings.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Gate connected-agent mutations to workspace owners and admins instead of issuing failed shared-resource writes for organization members.

--- a/.changeset/per-turn-repeat-ledger-and-loud-guard-stops.md
+++ b/.changeset/per-turn-repeat-ledger-and-loud-guard-stops.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make agent repetition guards hold across continuation chunks, record guard stops as failed runs, and stop retrying a precondition the turn cannot satisfy.

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -20,6 +20,27 @@ describe("defineAction", () => {
     expect(action.readOnly).toBe(true);
   });
 
+  it("carries the grounding declaration through to the entry", () => {
+    const action = defineAction({
+      description: "query a provider",
+      parameters: { q: { type: "string" } },
+      http: false,
+      grounding: true,
+      run: async () => "ok",
+    });
+    expect(action.grounding).toBe(true);
+  });
+
+  it("leaves grounding undefined when the action does not declare it", () => {
+    const action = defineAction({
+      description: "list saved config",
+      parameters: { id: { type: "string" } },
+      http: { method: "GET" },
+      run: async () => "ok",
+    });
+    expect(action.grounding).toBeUndefined();
+  });
+
   it("leaves readOnly undefined for default POST actions", () => {
     const action = defineAction({
       description: "write things",

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -473,6 +473,15 @@ interface DefineActionWithSchema<
    *  Only set this manually when you need to override the inference — e.g. a
    *  POST action that only reads data but can't use GET for a protocol reason. */
   readOnly?: boolean;
+  /** Declares that a successful call returns real evidence retrieved from a data
+   *  source at call time — a provider API, a warehouse, a connected repo, or the
+   *  app's own event/observability store. Apps that police fabricated answers
+   *  (see the Analytics final-response guard) read this instead of keeping a
+   *  hand-maintained list of action names, which drifts the moment a new source
+   *  action ships. Orthogonal to `readOnly`: a write that probes a live endpoint
+   *  and returns the outcome is still grounding. Metadata-only reads (schema,
+   *  catalogs, saved config) are not. */
+  grounding?: boolean;
   /** Set false for read-only tools that should stay available in Act mode but
    *  must not run during Plan mode because they perform substantive work
    *  rather than lightweight inspection. Defaults to allowed when read-only. */
@@ -631,6 +640,9 @@ interface DefineActionWithParams<
   /** If true, the framework will NOT emit a screen-refresh change event after a
    *  successful call. Auto-inferred as `true` when `http.method === "GET"`. */
   readOnly?: boolean;
+  /** Declares that a successful call returns real evidence retrieved from a data
+   *  source at call time. See the schema overload above. */
+  grounding?: boolean;
   /** Set false for read-only tools that should stay available in Act mode but
    *  must not run during Plan mode. See the schema overload above. */
   allowInPlanMode?: boolean;
@@ -708,6 +720,7 @@ export interface ActionDefinition<TInput, TReturn> {
   readonly maxBodyBytes?: number;
   readonly agentTool?: boolean;
   readonly readOnly?: boolean;
+  readonly grounding?: boolean;
   readonly allowInPlanMode?: boolean;
   readonly planMode?: ActionPlanModeConfig<TInput>;
   readonly parallelSafe?: boolean;
@@ -968,6 +981,9 @@ export function defineAction(options: any) {
       : {}),
     ...(typeof agentTool === "boolean" ? { agentTool } : {}),
     ...(typeof readOnly === "boolean" ? { readOnly } : {}),
+    ...(typeof options.grounding === "boolean"
+      ? { grounding: options.grounding }
+      : {}),
     ...(typeof options.allowInPlanMode === "boolean"
       ? { allowInPlanMode: options.allowInPlanMode }
       : {}),

--- a/packages/core/src/agent/engine/tool-call-journal-seed.ts
+++ b/packages/core/src/agent/engine/tool-call-journal-seed.ts
@@ -3,6 +3,7 @@ import {
   classifyToolCallJournal,
   type ToolCallJournal,
 } from "../tool-call-journal.js";
+import type { AgentChatEvent } from "../types.js";
 
 /**
  * Minimal shape `runAgentLoop` needs from a prior tool call — kept local
@@ -18,9 +19,33 @@ export interface PriorTurnToolCallSummary {
  * `PriorTurnToolCallSummary` for why this is a local shape, not an import. */
 export interface PriorTurnToolResultSummary {
   name: string;
+  /**
+   * Input of the `tool_start` this result was matched to, so the caller can
+   * rebuild the same `(tool, arguments)` breaker key its live counters use.
+   * Legacy `tool_done` events carry no input; those keep the positional
+   * FIFO-per-tool pairing documented in `tool-call-journal.ts`, so this is
+   * absent only when neither event carried one.
+   */
+  input?: unknown;
   content: string;
   isError: boolean;
 }
+
+/**
+ * Outcome of reading the per-turn ledger. `unreadable` is deliberately NOT the
+ * same value as a turn with no history: the repetition ledger, the read-only
+ * result cache and the write-replay hard block are all seeded from this read,
+ * so a swallowed ledger failure silently restores the per-chunk ceilings those
+ * mechanisms exist to remove.
+ */
+export type PriorTurnToolCallJournalRead =
+  | {
+      status: "read";
+      toolCallJournal: ToolCallJournal | null;
+      priorToolCalls: PriorTurnToolCallSummary[];
+      priorToolResults: PriorTurnToolResultSummary[];
+    }
+  | { status: "unreadable"; error: string };
 
 /**
  * Tool-call journal hard-block (resume safety). Snapshot the per-turn journal
@@ -32,9 +57,8 @@ export interface PriorTurnToolResultSummary {
  *
  * Loaded eagerly (not lazily mid-loop) so the current chunk's own
  * asynchronously-persisted tool_done events can never leak in and make a
- * same-chunk call wrongly short-circuit. Best-effort: any ledger failure
- * leaves the journal empty and all calls run normally. Fresh first-turn calls
- * see an empty journal and are unaffected.
+ * same-chunk call wrongly short-circuit. Fresh first-turn calls see an empty
+ * journal and are unaffected.
  *
  * Also returns the prior chunks' tool calls/results so the caller can seed
  * its own `toolCallHistory` / `toolResultHistory` accumulators — final
@@ -42,45 +66,57 @@ export interface PriorTurnToolResultSummary {
  * tools executed after the latest handoff. Otherwise a guard can reject a
  * grounded answer (or a successfully-created artifact) after the
  * evidence-producing query completed in a predecessor run.
- *
- * Moved verbatim out of `runAgentLoop`'s per-turn setup — behavior unchanged.
  */
 export async function loadPriorTurnToolCallJournal(
   threadId: string | undefined,
   turnId?: string,
-): Promise<{
-  toolCallJournal: ToolCallJournal | null;
-  priorToolCalls: PriorTurnToolCallSummary[];
-  priorToolResults: PriorTurnToolResultSummary[];
-}> {
+): Promise<PriorTurnToolCallJournalRead> {
+  if (!threadId) {
+    // No thread means no durable ledger exists for this turn at all — a true
+    // "no prior history", not a read that failed.
+    return {
+      status: "read",
+      toolCallJournal: null,
+      priorToolCalls: [],
+      priorToolResults: [],
+    };
+  }
+  let priorEvents: AgentChatEvent[];
+  try {
+    priorEvents = await getCurrentTurnEventsForThread(threadId, turnId);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[tool-call-journal] per-turn ledger read failed for thread ${threadId}: ${error}`,
+    );
+    return { status: "unreadable", error };
+  }
   const priorToolCalls: PriorTurnToolCallSummary[] = [];
   const priorToolResults: PriorTurnToolResultSummary[] = [];
-  let toolCallJournal: ToolCallJournal | null = null;
-  if (!threadId) {
-    return { toolCallJournal, priorToolCalls, priorToolResults };
-  }
-  try {
-    const priorEvents = await getCurrentTurnEventsForThread(threadId, turnId);
-    if (priorEvents.length > 0) {
-      for (const event of priorEvents) {
-        if (event.type === "tool_start") {
-          priorToolCalls.push({
-            name: event.tool,
-            input: event.input,
-          });
-        } else if (event.type === "tool_done") {
-          priorToolResults.push({
-            name: event.tool,
-            content: event.result,
-            isError: event.isError === true,
-          });
-        }
-      }
-      toolCallJournal = classifyToolCallJournal(priorEvents);
+  // Open `tool_start` inputs per tool, so a legacy `tool_done` with no input of
+  // its own can still be attributed to the arguments it ran with.
+  const openInputsByTool = new Map<string, unknown[]>();
+  for (const event of priorEvents) {
+    if (event.type === "tool_start") {
+      priorToolCalls.push({ name: event.tool, input: event.input });
+      const queue = openInputsByTool.get(event.tool);
+      if (queue) queue.push(event.input);
+      else openInputsByTool.set(event.tool, [event.input]);
+    } else if (event.type === "tool_done") {
+      const fifoInput = openInputsByTool.get(event.tool)?.shift();
+      priorToolResults.push({
+        name: event.tool,
+        input: event.input ?? fifoInput,
+        content: event.result,
+        isError: event.isError === true,
+      });
     }
-  } catch {
-    // Journal is a hardening layer, never a gate — a failed ledger read just
-    // means no hard-block this turn.
   }
-  return { toolCallJournal, priorToolCalls, priorToolResults };
+  return {
+    status: "read",
+    toolCallJournal:
+      priorEvents.length > 0 ? classifyToolCallJournal(priorEvents) : null,
+    priorToolCalls,
+    priorToolResults,
+  };
 }

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -50,7 +50,11 @@ vi.mock("./observational-memory/index.js", () => ({
   serializeObservationalMemoryBlock: () => "",
 }));
 
-const { runAgentLoop } = await import("./production-agent.js");
+const {
+  runAgentLoop,
+  MAX_IDENTICAL_TOOL_CALLS,
+  AGENT_INTERNAL_CONTINUE_PROMPT,
+} = await import("./production-agent.js");
 import type { AgentEngine, EngineEvent } from "./engine/types.js";
 import type { ActionEntry } from "./production-agent.js";
 
@@ -185,6 +189,7 @@ describe("tool-call journal hard-block", () => {
     expect(guard.mock.calls[0]?.[0].toolResults).toEqual([
       {
         name: "bigquery",
+        input: { sql: "select count(*)" },
         content: '{"rows":[{"count":3}]}',
         isError: false,
       },
@@ -398,5 +403,152 @@ describe("tool-call journal hard-block", () => {
     });
 
     expect(readAction.run).toHaveBeenCalledOnce();
+  });
+
+  it("counts identical tool calls from earlier chunks of the same turn", async () => {
+    // Seven identical calls already in this turn's ledger, none of them
+    // completed. Unseeded, this chunk starts from zero and the model gets
+    // another full MAX_IDENTICAL_TOOL_CALLS budget at every chunk boundary.
+    currentTurnEventsMock.mockResolvedValue(
+      Array.from({ length: MAX_IDENTICAL_TOOL_CALLS - 1 }, () => ({
+        type: "tool_start",
+        tool: "flaky-write",
+        input: { id: "row-1" },
+      })),
+    );
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("flaky-write", { id: "row-1" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: { "flaky-write": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-repeat-across-chunks",
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "repeated_tool_call",
+        recoverable: false,
+      }),
+    );
+    // A guard stop is a failed run, not a clean one.
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "done" }),
+    );
+  });
+
+  it("counts identical tool errors from earlier chunks of the same turn", async () => {
+    currentTurnEventsMock.mockResolvedValue([
+      { type: "tool_start", tool: "flaky-write", input: { id: "row-1" } },
+      {
+        type: "tool_done",
+        tool: "flaky-write",
+        input: { id: "row-1" },
+        result: "Error running flaky-write: DB exploded",
+        isError: true,
+      },
+      { type: "tool_start", tool: "flaky-write", input: { id: "row-1" } },
+      {
+        type: "tool_done",
+        tool: "flaky-write",
+        result: "Error running flaky-write: DB exploded",
+        isError: true,
+      },
+    ]);
+    const action: ActionEntry = {
+      tool: {
+        description: "A write action",
+        parameters: { type: "object", properties: {} },
+      },
+      readOnly: false,
+      run: vi.fn(async () => {
+        throw new Error("DB exploded");
+      }),
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("flaky-write", { id: "row-1" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: { "flaky-write": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-repeat-error-across-chunks",
+    });
+
+    // Two prior failures are already on the ledger, so this chunk's first
+    // failure is the third and last.
+    expect(action.run).toHaveBeenCalledOnce();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "repeated_identical_tool_error",
+        details: expect.stringContaining("DB exploded"),
+      }),
+    );
+  });
+
+  it("stops a continuation whose per-turn ledger cannot be read", async () => {
+    currentTurnEventsMock.mockRejectedValue(new Error("neon: connection lost"));
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+        },
+      ],
+      actions: { "send-email": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-unreadable",
+    });
+
+    // Without the ledger we cannot tell a completed side effect from a fresh
+    // one, so nothing runs.
+    expect(action.run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "tool_call_journal_unreadable",
+        recoverable: false,
+        details: expect.stringContaining("neon: connection lost"),
+      }),
+    );
+  });
+
+  it("runs a FRESH turn normally when the ledger read fails", async () => {
+    currentTurnEventsMock.mockRejectedValue(new Error("neon: connection lost"));
+    const action = makeWriteAction();
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "send" }] }],
+      actions: { "send-email": action },
+      send: () => {},
+      signal: new AbortController().signal,
+      threadId: "thread-unreadable-fresh",
+    });
+
+    expect(action.run).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -49,6 +49,7 @@ import {
   resolveFinalResponseGuardRequestText,
   resolveAgentRequestReasoningEffort,
   resolveSkillReferenceContent,
+  permanentPreconditionRemedy,
   runAgentLoop,
   runAgentLoopWithMainChatInternalContinuations,
   runCompletionCallbackWithDatabaseRetry,
@@ -4473,8 +4474,11 @@ describe("runAgentLoop", () => {
     expect(readAction).toHaveBeenCalledTimes(1);
     expect(streamCalls).toBe(4);
     expect(events).toContainEqual({
-      type: "text",
-      text: "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+      type: "error",
+      error:
+        "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+      errorCode: "duplicate_read_only_tool",
+      recoverable: false,
     });
   });
 
@@ -4590,8 +4594,11 @@ describe("runAgentLoop", () => {
     expect(second.streamCalls).toBe(2);
     expect(third.streamCalls).toBe(1);
     expect(third.events).toContainEqual({
-      type: "text",
-      text: "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+      type: "error",
+      error:
+        "I stopped because the agent kept asking for the same read-only context it already had. Please send the request again if you want me to retry from a fresh turn.",
+      errorCode: "duplicate_read_only_tool",
+      recoverable: false,
     });
   });
 
@@ -5189,8 +5196,10 @@ describe("runAgentLoop", () => {
       }),
     );
     expect(events).toContainEqual({
-      type: "text",
-      text: "Stop: password=[REDACTED]",
+      type: "error",
+      error: "Stop: password=[REDACTED]",
+      errorCode: "tool_failed",
+      recoverable: false,
     });
   });
 
@@ -5806,7 +5815,7 @@ describe("runAgentLoop", () => {
     // detail — that it stops quickly is the contract.
     expect(streamCalls).toBeLessThanOrEqual(MAX_IDENTICAL_TOOL_CALLS);
     expect(run.mock.calls.length).toBeLessThanOrEqual(MAX_IDENTICAL_TOOL_CALLS);
-    expect(events).toContainEqual(expect.objectContaining({ type: "text" }));
+    expect(events).toContainEqual(expect.objectContaining({ type: "error" }));
   });
 
   it("stops a turn whose tool keeps failing the same way under different arguments", async () => {
@@ -5998,16 +6007,16 @@ describe("runAgentLoop", () => {
         result: expect.stringContaining("Stopped after 3 identical errors"),
       }),
     );
+    // The raw provider error rides in `details`, never in `error`: the client
+    // and the resume loop both sniff `error` for transport words and would
+    // auto-continue the very spiral this stop ends.
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining("failed 3 times"),
-      }),
-    );
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining("DB failed"),
+        type: "error",
+        errorCode: "repeated_identical_tool_error",
+        recoverable: false,
+        error: expect.stringContaining("failed 3 times"),
+        details: expect.stringContaining("DB failed"),
       }),
     );
   });
@@ -6065,9 +6074,167 @@ describe("runAgentLoop", () => {
     );
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining("failed 3 times"),
+        type: "error",
+        errorCode: "repeated_identical_tool_error",
+        error: expect.stringContaining("failed 3 times"),
       }),
+    );
+  });
+
+  it("classifies permanent preconditions and leaves recoverable failures alone", () => {
+    // Verbatim production strings that were retried until a breaker or the
+    // iteration cap fired.
+    for (const permanent of [
+      "Error running add-slide: Requires editor role on deck ZJshjrXhjx (have viewer)",
+      "Error running generate-slides-ai: Gemini API key not configured. Save GEMINI_API_KEY in settings.",
+      "Error running index-design-system-with-builder: Connect Builder.io before indexing a design system from Figma or code.",
+      "Error running get-local-plan-folder: Local plan folder preview is only available in local Plan runtime.",
+      "Plan mode blocked `update-extension`. Switch to Act mode after the user approves the plan, then retry the action.",
+      "no authenticated user",
+      "Error running call-agent: Error: The Analytics agent call failed. (SSRF blocked: refusing to fetch private/internal address (http://localhost:8088/a2a))",
+    ]) {
+      expect(permanentPreconditionRemedy(permanent)).not.toBeNull();
+    }
+
+    // Every one of these the model can act on. A false positive here kills a
+    // turn that would have succeeded, so they matter more than the list above.
+    for (const recoverable of [
+      "Error running query-agent-native-analytics: canceling statement due to statement timeout",
+      "Error running update-slide: Slide content changed since it was read. Call get-deck with this slideId again and rebase the patch.",
+      "Error running mutate-dashboard: mutation script does not support template literals",
+      "Invalid action parameters for update-extension: input must have required property 'id'. Received: {}. Expected: object",
+      "Error running provider-api-request: Staged dataset byte cap exceeded: this app already stores 49.9 MB (limit 50 MB). Delete older datasets before staging more data.",
+      "Error running bigquery: Not found: Dataset builder-3b0a2 was not found in location US",
+      'Error running run-sql: syntax error at or near "slect"',
+      "Error running run-sql: column deals.stage does not exist",
+    ]) {
+      expect(permanentPreconditionRemedy(recoverable)).toBeNull();
+    }
+  });
+
+  it("stops on the FIRST permanently-failing precondition instead of retrying it", async () => {
+    let streamCalls = 0;
+    const run = vi.fn(async () => {
+      throw new Error(
+        "Gemini API key not configured. Save GEMINI_API_KEY in settings.",
+      );
+    });
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `gen-${streamCalls}`,
+              name: "generate-slides-ai",
+              // New arguments every attempt: the argument-keyed breaker never
+              // counts past one, which is why only content classification can
+              // stop this.
+              input: { prompt: `attempt ${streamCalls}` },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "generate-slides-ai": { ...actionEntry({}), run },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    const stop = events.find((e) => e.type === "error");
+    expect(stop).toMatchObject({
+      errorCode: "permanent_precondition",
+      recoverable: false,
+    });
+    // The remedy is the last thing the user reads.
+    expect((stop as { error: string }).error).toContain(
+      "Save GEMINI_API_KEY in settings",
+    );
+  });
+
+  it("terminates a source-sweep guard that keeps declining new arguments", async () => {
+    let streamCalls = 0;
+    const run = vi.fn(async () => "call data");
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `sweep-${streamCalls}`,
+              name: "gong-calls",
+              // A fresh account every time: `noteRepeatedToolCall` mints a new
+              // key per call, so nothing but an error breaker can end this.
+              input: { company: `Account ${streamCalls}` },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "sweep" }] }],
+      actions: { "gong-calls": { ...actionEntry({ readOnly: true }), run } },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    // 12 real calls exhaust the convergence budget; the declines that follow
+    // are bounded by the existing error breaker instead of running to
+    // maxIterations.
+    expect(streamCalls).toBeLessThan(25);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "repeated_tool_error_across_arguments",
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "loop_limit" }),
     );
   });
 
@@ -6661,8 +6828,8 @@ describe("runAgentLoop", () => {
     // The agent should stop with a helpful message.
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining("interrupted 2 time(s)"),
+        type: "error",
+        error: expect.stringContaining("interrupted 2 time(s)"),
       }),
     );
   });
@@ -7622,7 +7789,12 @@ describe("runAgentLoop", () => {
         isError: true,
         completedSideEffect: false,
       },
-      { type: "text", text: "BigQuery returned: nope" },
+      {
+        type: "error",
+        error: "BigQuery returned: nope",
+        errorCode: "bigquery_query_failed",
+        recoverable: false,
+      },
     ]);
     expect(outcomes).toEqual([
       {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -682,6 +682,8 @@ export interface ActionEntry {
   /** If true, completion does NOT trigger a screen-refresh change event.
    *  Set automatically by `defineAction` when `http.method === "GET"`. */
   readOnly?: boolean;
+  /** If true, a successful call returns evidence retrieved from a live source. */
+  grounding?: boolean;
   /** False keeps a read-only tool available in Act mode but hides/blocks it in
    *  Plan mode. Use for tools that perform substantive work even without
    *  mutating state. */
@@ -2924,6 +2926,22 @@ export const MAX_SAME_ERROR_ACROSS_ARGUMENTS = 6;
  */
 export const MAX_IDENTICAL_TOOL_CALLS = 8;
 
+/**
+ * A stop that ends the turn from inside the tool loop.
+ *
+ * `message` is the last thing the user reads, so it must name the remedy and
+ * must NOT quote a raw provider/tool error: both `isAutoRecoverableError`
+ * (client) and `isRecoverableContinuationError` (below) sniff this string for
+ * "timeout"/"connection"/"network", and a stop whose text happens to contain
+ * one is auto-continued into the very spiral it was raised to end. The raw
+ * error belongs in `details`, which nothing retries on.
+ */
+export interface TerminalActionStop {
+  message: string;
+  errorCode?: string;
+  details?: string;
+}
+
 function seedWriteToolInterruptionsFromHistory(
   messages: EngineMessage[],
   actions: Record<string, ActionEntry>,
@@ -3481,6 +3499,11 @@ async function waitForInterruptedToolLedgerEntry(opts: {
  * Dropping the echoed input costs nothing: the fault is already named by the
  * sentence before it, and two failures that differ ONLY in the arguments they
  * echo are the same failure.
+ *
+ * Numbers go the same way, for the same reason. A guard that reports its own
+ * running tally ("this turn already made 13 call(s)") hands the breaker a new
+ * key on every single decline, so the decline that exists to stop a spiral is
+ * itself uncountable.
  */
 function normalizeToolErrorForBreaker(error: string): string {
   return (
@@ -3492,6 +3515,7 @@ function normalizeToolErrorForBreaker(error: string): string {
       )
       // Bare JSON payloads some providers inline instead of a Received: span.
       .replace(/\{[\s\S]{0,2000}?\}/g, "{}")
+      .replace(/\d+/g, "#")
       .replace(/\s+/g, " ")
       .trim()
   );
@@ -3507,6 +3531,51 @@ function rateLimitRecoveryHint(message: string): string {
   }
   return "\n\nProvider rate-limit guidance: stop retrying this provider in this turn. Report the rate limit as a coverage gap, include any evidence already gathered, and ask the user to retry after the provider quota resets if full coverage is required.";
 }
+
+/**
+ * Tool errors the model has no way to clear: the missing thing lives outside
+ * the turn (a credential, a role grant, a connected account, a runtime, the
+ * user's own approval). Every retry costs a full round-trip carrying the whole
+ * transcript and lands on the identical error, so these stop on the FIRST
+ * occurrence rather than after `MAX_SAME_ERROR_ACROSS_ARGUMENTS` of them.
+ *
+ * The distinction is the one `stopForBigQueryNotConfigured` draws in
+ * templates/analytics: a *configuration* gap is permanent for this turn, a
+ * *query* failure is not. Anything the model can act on — a stale read to
+ * rebase, a bad argument, a full quota it can free, a wrong dataset name, a
+ * statement timeout — must stay out of this list and keep its retries.
+ * Precision over recall: a wrong match kills a turn that would have succeeded,
+ * which is worse than one more retry.
+ */
+export function permanentPreconditionRemedy(message: string): string | null {
+  const trimmed = message.replace(/\s+/g, " ").trim();
+  for (const pattern of PERMANENT_PRECONDITION_PATTERNS) {
+    if (pattern.test(trimmed)) return trimmed;
+  }
+  return null;
+}
+
+const PERMANENT_PRECONDITION_PATTERNS: readonly RegExp[] = [
+  // "Requires editor role on deck ZJshjrXhjx (have viewer)". The trailing space
+  // is load-bearing: it keeps "must have required property" out.
+  /\brequires? (?:an? |the )?[\w-]+ role\b/i,
+  // "Gemini API key not configured. Save GEMINI_API_KEY in settings." Only the
+  // not-configured/not-set wordings — "not found" is how providers report a
+  // missing dataset or record, which the model can and should correct.
+  /\b(?:api[ -]?keys?|access tokens?|credentials?|secrets?)\b[^.]{0,60}\bnot (?:configured|set|connected|available)\b/i,
+  /\bsave [A-Z][A-Z0-9_]{3,} in (?:the )?settings\b/i,
+  // "Connect Builder.io before indexing a design system from Figma or code."
+  /\bconnect\b[^;]{1,40}?\b(?:before|first|in settings)\b/i,
+  // "…is only available in local Plan runtime." Excludes "only available after
+  // …", which names a condition that clears on its own.
+  /\bonly available (?:in|on|from|to)\b/i,
+  // "Plan mode blocked `update-extension`. Switch to Act mode …" — cleared by
+  // the user approving the plan, never by the model trying again.
+  /\bplan mode blocked\b/i,
+  /\bno authenticated user\b/i,
+  // "SSRF blocked: refusing to fetch private/internal address (…)"
+  /\bssrf blocked\b/i,
+];
 
 const SOURCE_SWEEP_TOOL_NAME =
   /\b(?:api|calls?|deals?|docs?|events?|issues?|messages?|metrics?|provider|query|records?|request|search|source|tickets?|transcripts?)\b/i;
@@ -4398,13 +4467,32 @@ export async function runAgentLoop(opts: {
   // calls/results are folded into `toolCallHistory` / `toolResultHistory` so
   // final response guards see evidence from earlier chunks of this turn.
   const consumedJournalKeys = new Set<string>();
-  const {
-    toolCallJournal,
-    priorToolCalls: journaledPriorToolCalls,
-    priorToolResults: journaledPriorToolResults,
-  } = await loadPriorTurnToolCallJournal(opts.threadId, opts.turnId);
+  const journalRead = await loadPriorTurnToolCallJournal(
+    opts.threadId,
+    opts.turnId,
+  );
+  const toolCallJournal =
+    journalRead.status === "read" ? journalRead.toolCallJournal : null;
+  const journaledPriorToolCalls =
+    journalRead.status === "read" ? journalRead.priorToolCalls : [];
+  const journaledPriorToolResults =
+    journalRead.status === "read" ? journalRead.priorToolResults : [];
   toolCallHistory.push(...journaledPriorToolCalls);
   toolResultHistory.push(...journaledPriorToolResults);
+  // Every per-turn ceiling below is seeded from that read, and the write-replay
+  // hard block is enforced from it. On a continuation we cannot tell an
+  // already-completed side effect from a fresh one without it, so a failed read
+  // stops the turn instead of quietly resuming with a blank ledger.
+  const unreadableJournalStop: TerminalActionStop | null =
+    journalRead.status === "unreadable" && isInternalContinuationTurn(messages)
+      ? {
+          message:
+            "I stopped because I could not read this turn's run ledger, so I could not tell which steps had already finished. " +
+            "Retrying would risk repeating a step that already completed. Please send the request again.",
+          errorCode: "tool_call_journal_unreadable",
+          details: journalRead.error,
+        }
+      : null;
 
   const readOnlyToolResultCache = seedReadOnlyToolResultsFromHistory(
     messages,
@@ -4419,25 +4507,34 @@ export async function runAgentLoop(opts: {
     messages,
     actions,
   );
+  // All three repetition ledgers are SEEDED from earlier chunks of this turn,
+  // like `toolCallHistory` and `toolResultHistory` above. A fresh Map makes the
+  // limit per-CHUNK rather than per-turn, and a turn may chain up to
+  // MAX_RUN_LOOP_CONTINUATIONS (6) or MAX_BACKGROUND_RUN_LOOP_CONTINUATIONS
+  // (20) of them — so the real ceiling becomes 20x the constant, and a spiral
+  // resumes with a clean slate at every chunk boundary.
   const repeatedToolErrors = new Map<string, number>();
-  // Keyed WITHOUT the arguments — see MAX_SAME_ERROR_ACROSS_ARGUMENTS.
-  //
-  // SEEDED from earlier chunks of this turn, like `toolCallHistory` and
-  // `toolResultHistory` above. A fresh Map here would make the limit per-CHUNK
-  // rather than per-turn, and a turn may chain up to MAX_RUN_LOOP_CONTINUATIONS
-  // (6) or MAX_BACKGROUND_RUN_LOOP_CONTINUATIONS (20) of them — so the real
-  // ceiling would be 36 or 120 identical failures, not 6, and a spiral would
-  // resume with a clean slate at every chunk boundary.
+  /** Keyed WITHOUT the arguments — see MAX_SAME_ERROR_ACROSS_ARGUMENTS. */
   const repeatedToolErrorsAnyArgs = new Map<string, number>();
-  for (const prior of toolResultHistory) {
+  const repeatedToolCalls = new Map<string, number>();
+  for (const prior of journaledPriorToolCalls) {
+    const key = toolCallCacheKey(prior.name, prior.input);
+    repeatedToolCalls.set(key, (repeatedToolCalls.get(key) ?? 0) + 1);
+  }
+  for (const prior of journaledPriorToolResults) {
     if (!prior.isError) continue;
-    const key = `${prior.name}:${normalizeToolErrorForBreaker(prior.content)}`;
+    const normalized = normalizeToolErrorForBreaker(prior.content);
+    const anyArgsKey = `${prior.name}:${normalized}`;
     repeatedToolErrorsAnyArgs.set(
-      key,
-      (repeatedToolErrorsAnyArgs.get(key) ?? 0) + 1,
+      anyArgsKey,
+      (repeatedToolErrorsAnyArgs.get(anyArgsKey) ?? 0) + 1,
+    );
+    const errorKey = `${toolCallCacheKey(prior.name, prior.input)}:${normalized}`;
+    repeatedToolErrors.set(
+      errorKey,
+      (repeatedToolErrors.get(errorKey) ?? 0) + 1,
     );
   }
-  const repeatedToolCalls = new Map<string, number>();
 
   let finalGuardRetries = 0;
   let emptyFinalResponseRetries = 0;
@@ -4445,7 +4542,34 @@ export async function runAgentLoop(opts: {
   // `loop_limit` and `done` share one terminal-event slot in run-manager, so a
   // trailing `done` would overwrite the boundary the continuation logic reads.
   let endedAtLoopLimit = false;
-  let terminalActionStop: { message: string; errorCode?: string } | null = null;
+  let terminalActionStop: TerminalActionStop | null = null;
+  /**
+   * A stop is either a hand-off to the user (the two `input_required` codes) or
+   * a failed run. Failed runs MUST leave a terminal `error` event behind: the
+   * run row's status, `error_code`, `listErroredRuns`, the outcome counters and
+   * the client's retry affordance all key off that event, and a stop that only
+   * streams text is recorded as `status='completed', terminal_reason='done'` —
+   * a guard trip counted as a success.
+   */
+  const sendTerminalActionStop = (stop: TerminalActionStop) => {
+    if (
+      stop.errorCode === "needs-approval" ||
+      stop.errorCode === "awaiting-user-input"
+    ) {
+      send({ type: "text", text: stop.message });
+      return;
+    }
+    // Sent ONLY as an error: both the live client and the thread rebuild render
+    // an error event's message as assistant text themselves, so also sending it
+    // as `text` prints the same sentence twice.
+    send({
+      type: "error",
+      error: stop.message,
+      errorCode: stop.errorCode ?? "tool_failed",
+      ...(stop.details ? { details: stop.details } : {}),
+      recoverable: false,
+    });
+  };
   // Overridden (raised tokens, lowered effort) only after an empty-final-
   // response retry below — kept separate from `opts.maxOutputTokens`/
   // `opts.reasoningEffort` so the very first attempt is unaffected and later
@@ -4473,6 +4597,11 @@ export async function runAgentLoop(opts: {
 
   while (true) {
     if (signal.aborted) break;
+    if (unreadableJournalStop) {
+      terminalActionStop = unreadableJournalStop;
+      sendTerminalActionStop(unreadableJournalStop);
+      break;
+    }
     const turnInputTokens = priorTurnInputTokens + usage.inputTokens;
     if (turnInputTokens > maxRunInputTokens) {
       // Terminal for the whole TURN, not a chunk boundary: emitting
@@ -5264,8 +5393,7 @@ export async function runAgentLoop(opts: {
 
     flushUnstreamedAssistantText();
 
-    let requestedActionStop: { message: string; errorCode?: string } | null =
-      null;
+    let requestedActionStop: TerminalActionStop | null = null;
     // An `endsTurn` action ran and handed control to the user. Distinct from
     // `requestedActionStop`, which also covers failure stops that must not
     // suppress the remaining tool calls.
@@ -5368,6 +5496,22 @@ export async function runAgentLoop(opts: {
       };
       const finalizeToolErrorResult = (rawResult: string): string => {
         const sanitizedResult = sanitizeToolErrorText(rawResult);
+        // Counting is the wrong instrument for a precondition the turn cannot
+        // satisfy: six identical round-trips through a missing API key cost the
+        // user minutes and end where the first one did. Classified first so the
+        // remedy reaches them on attempt one.
+        const permanentRemedy = permanentPreconditionRemedy(sanitizedResult);
+        if (permanentRemedy) {
+          requestedActionStop ??= {
+            message: `I stopped because ${toolCall.name} cannot run until this is fixed: ${permanentRemedy} Retrying would not have changed it, and anything completed before this is saved.`,
+            errorCode: "permanent_precondition",
+            details: sanitizedResult,
+          };
+          return (
+            `Stopped: ${toolCall.name} cannot run until a setup step outside this turn is fixed. ` +
+            `Do not retry it with different arguments. ${sanitizedResult}`
+          );
+        }
         const errorKey = `${toolCallCacheKey(
           toolCall.name,
           toolCall.input,
@@ -5394,9 +5538,9 @@ export async function runAgentLoop(opts: {
           requestedActionStop ??= {
             message:
               `I stopped because the ${toolCall.name} action rejected ${anyArgsCount} different attempts the same way, ` +
-              "so changing the arguments again would not have worked. Anything completed before this is saved. " +
-              `Error: ${sanitizedResult}`,
+              "so changing the arguments again would not have worked. Anything completed before this is saved.",
             errorCode: "repeated_tool_error_across_arguments",
+            details: sanitizedResult,
           };
           return result;
         }
@@ -5411,15 +5555,23 @@ export async function runAgentLoop(opts: {
         requestedActionStop ??= {
           message:
             `I stopped because the ${toolCall.name} action failed ${count} times in a row the same way, ` +
-            "so retrying it again would not have worked. Anything completed before this is saved. " +
-            `Error: ${sanitizedResult}`,
+            "so retrying it again would not have worked. Anything completed before this is saved.",
           errorCode: "repeated_identical_tool_error",
+          details: sanitizedResult,
         };
         return result;
       };
-      if (sourceSweepGuard) {
-        sourceSweepDelegationGuardActive = true;
-        const result = sourceSweepGuard.message;
+      /**
+       * A guard refused to run the tool. Recorded as an ERROR, not as a plain
+       * result: a decline costs a full model round-trip carrying the whole
+       * transcript, and `noteRepeatedToolCall` keys on name+args, so a model
+       * iterating ids mints a fresh key every time and declines forever until
+       * `maxIterations`. Routing through `finalizeToolErrorResult` gives the
+       * existing breakers something to count — no new counter — while the text
+       * the model reads is still the guard's own guidance.
+       */
+      const declineToolCall = (guidance: string): EngineContentPart => {
+        const result = finalizeToolErrorResult(guidance);
         send({
           type: "tool_start",
           id: toolCall.id,
@@ -5432,9 +5584,10 @@ export async function runAgentLoop(opts: {
           tool: toolCall.name,
           input: toolCall.input as Record<string, unknown>,
           result,
+          isError: true,
           completedSideEffect: false,
         });
-        recordToolResult(result, false);
+        recordToolResult(result, true);
         return {
           type: "tool-result" as const,
           toolCallId: toolCall.id,
@@ -5442,32 +5595,15 @@ export async function runAgentLoop(opts: {
           toolInput: wireToolInput,
           content: result,
         };
+      };
+
+      if (sourceSweepGuard) {
+        sourceSweepDelegationGuardActive = true;
+        return declineToolCall(sourceSweepGuard.message);
       }
 
       if (sourceSweepDelegationGuard) {
-        const result = sourceSweepDelegationGuard;
-        send({
-          type: "tool_start",
-          id: toolCall.id,
-          tool: toolCall.name,
-          input: toolCall.input as Record<string, string>,
-        });
-        send({
-          type: "tool_done",
-          id: toolCall.id,
-          tool: toolCall.name,
-          input: toolCall.input as Record<string, unknown>,
-          result,
-          completedSideEffect: false,
-        });
-        recordToolResult(result, false);
-        return {
-          type: "tool-result" as const,
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-          toolInput: wireToolInput,
-          content: result,
-        };
+        return declineToolCall(sourceSweepDelegationGuard);
       }
 
       if (!actionEntry) {
@@ -6376,12 +6512,9 @@ export async function runAgentLoop(opts: {
     messages.push({ role: "user", content: toolResultParts });
     if (requestedActionStop) {
       // TypeScript can't track ??= through async closures; cast to known type.
-      const stop = requestedActionStop as {
-        message: string;
-        errorCode?: string;
-      };
+      const stop = requestedActionStop as TerminalActionStop;
       terminalActionStop = stop;
-      send({ type: "text", text: stop.message });
+      sendTerminalActionStop(stop);
       break;
     }
   }
@@ -6469,6 +6602,11 @@ export async function runAgentLoop(opts: {
     }
   }
 
+  // Assignments happen inside async tool-loop closures, which TypeScript cannot
+  // use for narrowing at this point. Snapshot the runtime value before the
+  // outcome branches so a stop is still represented as a possible value.
+  const finalTerminalActionStop =
+    terminalActionStop as TerminalActionStop | null;
   if (signal.aborted) {
     reportOutcome({ state: "canceled", message: "Agent run was aborted." });
   } else if (endedAtLoopLimit) {
@@ -6478,24 +6616,24 @@ export async function runAgentLoop(opts: {
       retryable: false,
       message: `Agent stopped after ${maxIterations} iterations.`,
     });
-  } else if (terminalActionStop?.errorCode === "needs-approval") {
+  } else if (finalTerminalActionStop?.errorCode === "needs-approval") {
     reportOutcome({
       state: "input_required",
       code: "needs_approval",
-      message: terminalActionStop.message,
+      message: finalTerminalActionStop.message,
     });
-  } else if (terminalActionStop?.errorCode === "awaiting-user-input") {
+  } else if (finalTerminalActionStop?.errorCode === "awaiting-user-input") {
     reportOutcome({
       state: "input_required",
       code: "awaiting_user_input",
-      message: terminalActionStop.message,
+      message: finalTerminalActionStop.message,
     });
-  } else if (terminalActionStop) {
+  } else if (finalTerminalActionStop) {
     reportOutcome({
       state: "failed",
-      code: terminalActionStop.errorCode ?? "tool_failed",
+      code: finalTerminalActionStop.errorCode ?? "tool_failed",
       retryable: false,
-      message: terminalActionStop.message,
+      message: finalTerminalActionStop.message,
     });
   } else {
     reportOutcome({ state: "completed" });
@@ -7175,11 +7313,11 @@ async function describeTurnProgress(
   threadId: string,
   turnId?: string,
 ): Promise<string> {
-  const { toolCallJournal } = await loadPriorTurnToolCallJournal(
-    threadId,
-    turnId,
-  );
-  const completed = toolCallJournal?.completed ?? [];
+  const journalRead = await loadPriorTurnToolCallJournal(threadId, turnId);
+  if (journalRead.status === "unreadable") {
+    return "I could not read the run ledger, so I cannot say which steps completed.";
+  }
+  const completed = journalRead.toolCallJournal?.completed ?? [];
   if (completed.length === 0) return "No steps had completed yet.";
   const names = [...new Set(completed.map((entry) => entry.tool))];
   const shown = names.slice(0, 8).join(", ");

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -1243,6 +1243,44 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     expect(sentEvents.filter((e) => e.type === "clear")).toHaveLength(0);
   });
 
+  it("keeps user-visible output when the ledger read fails mid-recovery", async () => {
+    // `clear` WIPES what the user already sees. A ledger blip must not be read
+    // as "no completed side effect", which is what made it wipe tool cards.
+    mockGetCurrentTurnEventsForThread.mockRejectedValue(
+      new Error("neon: connection lost"),
+    );
+    const sentEvents: import("./types.js").AgentChatEvent[] = [];
+    let attempts = 0;
+    mockRunAgentLoop.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new EngineError("Builder gateway timed out", {
+          errorCode: "builder_gateway_timeout",
+        });
+      }
+      return {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      };
+    });
+
+    await runAgentLoopDirectWithSoftTimeout(
+      makeOpts(
+        [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        new AbortController().signal,
+        (event) => sentEvents.push(event),
+        "thread-1",
+      ),
+      60_000,
+    );
+
+    expect(attempts).toBe(2);
+    expect(sentEvents.filter((e) => e.type === "clear")).toHaveLength(0);
+  });
+
   // ─── Per-turn tool-call journal on resume ─────────────────────────────────
 
   it("injects a structured journal note on resume listing completed and interrupted tool calls", async () => {
@@ -1280,7 +1318,10 @@ describe("runAgentLoopDirectWithSoftTimeout", () => {
     );
 
     expect(attempts).toBe(2);
-    expect(mockGetCurrentTurnEventsForThread).toHaveBeenCalledWith("thread-1");
+    expect(mockGetCurrentTurnEventsForThread).toHaveBeenCalledWith(
+      "thread-1",
+      undefined,
+    );
 
     const journalNote = messages
       .map((m) => (m.content[0]?.type === "text" ? m.content[0].text : ""))

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -43,24 +43,40 @@ import {
 } from "./tool-call-journal.js";
 import type { AgentChatEvent } from "./types.js";
 
+/**
+ * `persisted: false` means the durable half of the turn could not be read, so
+ * `events` holds only what this invocation saw. Callers that decide whether to
+ * DISCARD user-visible output must not read that as "nothing else happened".
+ */
 async function readCurrentTurnEventsForResume(
   threadId: string | undefined,
+  turnId: string | undefined,
   localEvents: readonly AgentChatEvent[] = [],
-): Promise<AgentChatEvent[]> {
+): Promise<{ events: AgentChatEvent[]; persisted: boolean }> {
   let persistedEvents: AgentChatEvent[] = [];
+  let persisted = true;
   try {
+    // Without the turnId this can return the PREVIOUS turn's events — see
+    // `getCurrentTurnEventsForThread`, whose run row is written without await.
     persistedEvents = threadId
-      ? await getCurrentTurnEventsForThread(threadId)
+      ? await getCurrentTurnEventsForThread(threadId, turnId)
       : [];
-  } catch {
-    persistedEvents = [];
+  } catch (err) {
+    persisted = false;
+    console.warn(
+      "[run-loop] current-turn ledger read failed:",
+      err instanceof Error ? err.message : String(err),
+    );
   }
-  if (localEvents.length === 0) return persistedEvents;
+  if (localEvents.length === 0) return { events: persistedEvents, persisted };
   const seen = new Set(persistedEvents.map((event) => JSON.stringify(event)));
-  return [
-    ...persistedEvents,
-    ...localEvents.filter((event) => !seen.has(JSON.stringify(event))),
-  ];
+  return {
+    events: [
+      ...persistedEvents,
+      ...localEvents.filter((event) => !seen.has(JSON.stringify(event))),
+    ],
+    persisted,
+  };
 }
 
 function actionPreparationContinuationOptions(
@@ -116,9 +132,14 @@ async function appendContinuationAndJournal(
   messages: EngineMessage[],
   reason: AgentLoopContinuationReason | "rate_limited",
   threadId: string | undefined,
+  turnId: string | undefined,
   localEvents: readonly AgentChatEvent[] = [],
 ): Promise<void> {
-  const events = await readCurrentTurnEventsForResume(threadId, localEvents);
+  const { events } = await readCurrentTurnEventsForResume(
+    threadId,
+    turnId,
+    localEvents,
+  );
   appendAgentLoopContinuation(
     messages,
     reason,
@@ -135,26 +156,35 @@ export async function appendDurableContinuationContext(
   messages: EngineMessage[],
   reason: AgentLoopContinuationReason,
   threadId: string,
+  turnId?: string,
 ): Promise<void> {
-  await appendContinuationAndJournal(messages, reason, threadId);
+  await appendContinuationAndJournal(messages, reason, threadId, turnId);
 }
 
-async function hasCompletedSideEffectToolCallInCurrentTurn(
+/**
+ * `"unknown"` is not `"none"`: the only caller uses this to decide whether to
+ * emit `clear`, and `clear` WIPES user-visible output. A transient ledger error
+ * must not delete the tool cards that are the user's only proof a side effect
+ * landed.
+ */
+async function completedSideEffectInCurrentTurn(
   threadId: string | undefined,
+  turnId: string | undefined,
   localEvents: readonly AgentChatEvent[] = [],
-): Promise<boolean> {
-  try {
-    const events = await readCurrentTurnEventsForResume(threadId, localEvents);
-    if (events.length === 0) return false;
-    return events.some(
-      (event) =>
-        event.type === "tool_done" &&
-        event.completedSideEffect === true &&
-        event.isError !== true,
-    );
-  } catch {
-    return false;
-  }
+): Promise<"some" | "none" | "unknown"> {
+  const { events, persisted } = await readCurrentTurnEventsForResume(
+    threadId,
+    turnId,
+    localEvents,
+  );
+  const found = events.some(
+    (event) =>
+      event.type === "tool_done" &&
+      event.completedSideEffect === true &&
+      event.isError !== true,
+  );
+  if (found) return "some";
+  return persisted ? "none" : "unknown";
 }
 
 function internalContinuationReasonForAttempt(
@@ -438,10 +468,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         lastAttemptWasUnfinishedContinuation = true;
         const continuationEvents = [...localTurnEvents];
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+          (await completedSideEffectInCurrentTurn(
             opts.threadId,
+            opts.turnId,
             continuationEvents,
-          ))
+          )) === "none"
         ) {
           opts.send({ type: "clear" });
         }
@@ -449,6 +480,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           internalContinuationReason,
           opts.threadId,
+          opts.turnId,
           continuationEvents,
         );
         continue;
@@ -459,6 +491,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           "run_timeout",
           opts.threadId,
+          opts.turnId,
           localTurnEvents,
         );
         continue;
@@ -475,10 +508,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         // resumed model doesn't re-emit it and produce duplicated output.
         lastAttemptWasUnfinishedContinuation = true;
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+          (await completedSideEffectInCurrentTurn(
             opts.threadId,
+            opts.turnId,
             localTurnEvents,
-          ))
+          )) === "none"
         ) {
           opts.send({ type: "clear" });
         }
@@ -486,6 +520,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           "run_timeout",
           opts.threadId,
+          opts.turnId,
           localTurnEvents,
         );
         continue;
@@ -507,10 +542,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
         lastAttemptWasUnfinishedContinuation = true;
         backgroundRateLimitContinuations++;
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+          (await completedSideEffectInCurrentTurn(
             opts.threadId,
+            opts.turnId,
             localTurnEvents,
-          ))
+          )) === "none"
         ) {
           opts.send({ type: "clear" });
         }
@@ -518,6 +554,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           "rate_limited",
           opts.threadId,
+          opts.turnId,
           localTurnEvents,
         );
         await waitForBackgroundRateLimitCooldown(upstreamSignal);
@@ -539,10 +576,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
       if (!upstreamSignal.aborted && isResumableEngineError(err)) {
         lastAttemptWasUnfinishedContinuation = true;
         if (
-          !(await hasCompletedSideEffectToolCallInCurrentTurn(
+          (await completedSideEffectInCurrentTurn(
             opts.threadId,
+            opts.turnId,
             localTurnEvents,
-          ))
+          )) === "none"
         ) {
           opts.send({ type: "clear" });
         }
@@ -550,6 +588,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
           opts.messages,
           continuationReasonForResumableError(err),
           opts.threadId,
+          opts.turnId,
           localTurnEvents,
         );
         continue;
@@ -594,10 +633,11 @@ export async function runAgentLoopDirectWithSoftTimeout(
     // Preserve completed tool cards: they are the user's only durable proof
     // that a side effect landed before the final assistant note timed out.
     if (
-      !(await hasCompletedSideEffectToolCallInCurrentTurn(
+      (await completedSideEffectInCurrentTurn(
         opts.threadId,
+        opts.turnId,
         localTurnEvents,
-      ))
+      )) === "none"
     ) {
       opts.send({ type: "clear" });
     }

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1822,6 +1822,240 @@ describe("createAgentChatAdapter", () => {
     ]);
   });
 
+  it("stops a loop_limit chain that keeps producing the same tool calls", async () => {
+    // The "it worked for 20 minutes" bug. `loop_limit` used to skip every
+    // client continuation budget AND reset two of them, and the durable
+    // per-turn ledger lives inside one server run, so a model that degenerated
+    // into a tool loop re-POSTed the same turnId forever (production: 186m,
+    // 113m, 77m turns that never answered).
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      postCount += 1;
+      return sseResponse([
+        { type: "tool_start", tool: "list-rows", input: { table: "users" } },
+        { type: "tool_done", tool: "list-rows", result: "0 rows" },
+        { type: "tool_start", tool: "list-rows", input: { table: "users" } },
+        { type: "tool_done", tool: "list-rows", result: "0 rows" },
+        { type: "loop_limit", maxIterations: 400 },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-loop-limit-runaway",
+      threadId: "thread-loop-limit-runaway",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "count users" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    const results = await promise;
+
+    // Identical work every round collapses to one advance signature, so the
+    // chain stops within MAX_NON_ADVANCING_CONTINUATIONS instead of running
+    // until the user closes the tab.
+    expect(postCount).toBeLessThanOrEqual(5);
+    const last = results.at(-1) as any;
+    expect(last.status).toEqual({ type: "incomplete", reason: "error" });
+  });
+
+  it("keeps continuing a loop_limit chain that completes new work each round", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      postCount += 1;
+      if (postCount <= 8) {
+        return sseResponse([
+          {
+            type: "tool_start",
+            tool: "read-file",
+            input: { path: `src/${postCount}.ts` },
+          },
+          {
+            type: "tool_done",
+            tool: "read-file",
+            result: `contents of ${postCount}`,
+          },
+          { type: "loop_limit", maxIterations: 400 },
+        ]);
+      }
+      return sseResponse([
+        { type: "text", text: "analysis complete" },
+        { type: "done" },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-loop-limit-progress",
+      threadId: "thread-loop-limit-progress",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "audit the repo" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    const results = await promise;
+
+    // A genuinely long, PROGRESSING turn must still finish: eight loop_limit
+    // rounds that each read a different file, then the answer.
+    expect(postCount).toBe(9);
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("analysis complete");
+  });
+
+  it("replays a failed prior-turn tool call as a failure, not a success", async () => {
+    // "I tried something repeatedly and it repeatedly failed": without
+    // `isError` the next turn sees the failed call as an ordinary result whose
+    // body happens to read like an error, so the model retries a permanently
+    // failing precondition. The server's repeat-error breaker keys on the flag.
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-failed-tool-history",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "send the email" }] },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "call-send",
+                toolName: "send-email",
+                args: { to: "a@example.com" },
+                result: "Missing RESEND_API_KEY.",
+                isError: true,
+              },
+              {
+                type: "tool-call",
+                toolCallId: "call-save",
+                toolName: "save-draft",
+                args: { id: "1" },
+                result: "Interrupted before this tool returned a result.",
+                outcome: "unknown",
+              },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "try again" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    const results = body.structuredHistory.flatMap((message: any) =>
+      message.content.filter((part: any) => part.type === "tool-result"),
+    );
+    const failed = results.find((part: any) => part.toolName === "send-email");
+    expect(failed.isError).toBe(true);
+    const interrupted = results.find(
+      (part: any) => part.toolName === "save-draft",
+    );
+    // Unknown is neither success nor failure: it keeps the interrupted marker
+    // the server matches on and must never claim the call errored.
+    expect(interrupted.isError).toBeUndefined();
+    expect(interrupted.content).toContain(
+      "Interrupted before this tool returned a result.",
+    );
+  });
+
+  it("prices tool-heavy assistant turns against the history budget", async () => {
+    // Counting only text parts made a turn of large tool calls cost ~0, so it
+    // survived every trim while the user's own prose was evicted around it.
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-history-cost",
+    });
+
+    const bulkyAssistantTurn = (index: number) => ({
+      role: "assistant",
+      content: Array.from({ length: 6 }, (_, i) => ({
+        type: "tool-call",
+        toolCallId: `call-${index}-${i}`,
+        toolName: "query-rows",
+        args: { sql: "x".repeat(7_000) },
+        result: "y".repeat(11_000),
+      })),
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "the original ask" }],
+          },
+          bulkyAssistantTurn(1),
+          { role: "user", content: [{ type: "text", text: "second ask" }] },
+          bulkyAssistantTurn(2),
+          { role: "user", content: [{ type: "text", text: "third ask" }] },
+          bulkyAssistantTurn(3),
+          { role: "user", content: [{ type: "text", text: "now do it" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(JSON.stringify(body.structuredHistory).length).toBeLessThan(400_000);
+  });
+
   it("preserves structured tool history when auto-continuing after a transient error", async () => {
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });
     vi.stubGlobal(
@@ -2892,10 +3126,10 @@ describe("createAgentChatAdapter", () => {
 
     // A run that produces nothing visible no longer gives up on the first
     // soft-timeout (that made heavier prompts feel like they "stop midway").
-    // It retries through the empty-continuation budget
-    // (MAX_EMPTY_TRANSIENT_CONTINUATIONS = 3) — 1 initial + 3 retries = 4
-    // POSTs — then surfaces the "no visible progress" error.
-    expect(postCount).toBe(4);
+    // It retries through the non-advancing budget
+    // (MAX_NON_ADVANCING_CONTINUATIONS = 3) — 1 initial + 2 retries, and the
+    // third non-advancing round stops it — then surfaces the error.
+    expect(postCount).toBe(3);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
@@ -3556,7 +3790,10 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const results = await promise;
 
-    expect(postCount).toBe(5);
+    // The narration differs every round, which is exactly why text alone
+    // cannot be the progress signal: the unstarted action card is what the
+    // advance signature keys on.
+    expect(postCount).toBe(4);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
@@ -3565,9 +3802,7 @@ describe("createAgentChatAdapter", () => {
           message: expect.stringContaining(
             "got stuck preparing the present design variants action input",
           ),
-          details: expect.stringContaining(
-            "repeated_action_preparation_stalls: 4",
-          ),
+          details: expect.stringContaining("non_advancing_continuations: 3"),
         }),
       }),
     );
@@ -3588,12 +3823,12 @@ describe("createAgentChatAdapter", () => {
       "attempted_runs: run-qa",
     );
     expect(dispatchedRunError?.detail.details).toContain(
-      "last_preparing_tool: present-design-variants",
+      "stalled_on_tool: present-design-variants",
     );
     const last = results.at(-1) as any;
     expect(last.status).toEqual({ type: "incomplete", reason: "error" });
     expect(last.metadata.custom.runError.details).toContain(
-      "last_preparing_tool: present-design-variants",
+      "stalled_on_tool: present-design-variants",
     );
     expect(last.content.at(-1).text).toContain(
       "got stuck preparing the present design variants action input",
@@ -4232,7 +4467,7 @@ describe("createAgentChatAdapter", () => {
         type: "agent-chat:run-error",
         detail: expect.objectContaining({
           errorCode: "stale_run",
-          details: expect.stringContaining("stale_run_continuations: 4"),
+          details: expect.stringContaining("non_advancing_continuations: 3"),
         }),
       }),
     );
@@ -5043,7 +5278,7 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const results = await promise;
 
-    expect(chatPostCount).toBe(4);
+    expect(chatPostCount).toBe(5);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
@@ -5396,9 +5631,9 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const results = await promise;
 
-    // 1 initial + 3 empty retries, then the empty cap (3) is exceeded — no
-    // 10-POST runaway up to the stalled cap.
-    expect(postCount).toBe(4);
+    // 1 initial + 2 retries; the third non-advancing round stops it — no
+    // 10-POST runaway.
+    expect(postCount).toBe(3);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
@@ -7748,17 +7983,15 @@ describe("createAgentChatAdapter", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     const results = await promise;
 
-    // 1 initial + 4 repeated continuations, then the repetition cap (3) is
-    // exceeded — far short of MAX_TOTAL_TRANSIENT_CONTINUATIONS (12).
-    expect(postCount).toBe(5);
+    // 1 initial + 3 repeated continuations, then MAX_NON_ADVANCING_CONTINUATIONS
+    // (3) stops it — far short of MAX_TOTAL_TRANSIENT_CONTINUATIONS (12).
+    expect(postCount).toBe(4);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:run-error",
         detail: expect.objectContaining({
           errorCode: "connection_error",
-          details: expect.stringContaining(
-            "repeated_transient_continuations: 4",
-          ),
+          details: expect.stringContaining("non_advancing_continuations: 3"),
         }),
       }),
     );
@@ -7768,8 +8001,8 @@ describe("createAgentChatAdapter", () => {
   });
 
   it("gives a budget message, not a connection-failure message, when a progressing turn exhausts the total continuation cap", async () => {
-    // A turn that keeps completing a DIFFERENT tool every round never trips
-    // the empty/stalled/repeat/action-prep guards — it is "making real
+    // A turn that keeps completing a DIFFERENT tool every round advances on
+    // every continuation — it is "making real
     // progress" the whole time, exactly what MAX_TOTAL_TRANSIENT_CONTINUATIONS
     // (12) exists to bound. Reported bug: hitting that whole-turn ceiling was
     // told to the user as "the agent connection kept failing", which is not

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -26,6 +26,7 @@ import { agentNativePath } from "./api-path.js";
 import { formatChatErrorText, normalizeChatError } from "./error-format.js";
 import {
   AgentAutoContinueSignal,
+  INTERRUPTED_TOOL_RESULT,
   appendMissingFinalResponseWarning,
   type AgentActivityTrailEntry,
   type AgentAutoContinueErrorInfo,
@@ -92,37 +93,20 @@ const AUTO_CONTINUE_COMPLETION_GUARD =
 const MAX_RECONNECT_ATTEMPTS = 5;
 const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
 const MAX_QUEUED_CONFLICT_RETRIES = 120;
-const MAX_STALE_RUN_CONTINUATIONS = 3;
-const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
+// How many consecutive continuations that did not advance the turn (see
+// `describeContinuationAdvance`) we tolerate before giving up. This replaced
+// five separate budgets — stale-run, stalled, empty, repeated-narration and
+// repeated-action-preparation — each of which existed because the rung above
+// it had a hole the next one patched. One question answers all five: a round
+// that produced nothing, or produced exactly what the round before it
+// produced, did not advance.
+const MAX_NON_ADVANCING_CONTINUATIONS = 3;
 // Ceiling across the whole turn. Every attempt re-POSTs the full history plus
-// attachments, so a high ceiling only burns tokens and wall time. Unproductive
-// turns are already stopped far earlier by the empty/stalled/repeat budgets;
-// this one only ever binds turns that keep making real progress, so it stays
-// just above the longest recovery we deliberately support.
+// attachments, so a high ceiling only burns tokens and wall time. Non-advancing
+// turns are already stopped far earlier by the budget above; this one only ever
+// binds turns that keep making real progress, so it stays just above the
+// longest recovery we deliberately support.
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 12;
-// How many consecutive continuations that produce NO progress (no streamed
-// text, no completed/in-flight tool) we tolerate before giving up. A complex
-// first turn can spend the whole soft-timeout window (~40s) "thinking" with no
-// visible output; giving up after a single such window made the agent feel like
-// it "craps out / stops midway" on heavier prompts (Analytics). Retrying a few
-// times lets a transient slow start recover, while the cap still terminates a
-// genuinely stuck turn with a clear message instead of looping forever.
-const MAX_EMPTY_TRANSIENT_CONTINUATIONS = 3;
-// How many consecutive continuations that re-stream the SAME narration without
-// advancing (no in-flight tool, no completed tool) we tolerate before giving
-// up. A model that degenerates into repeating one phrase ("I have the full
-// HTML. Creating the extension now!") emits "new" text every continuation,
-// which keeps resetting the stalled/empty budgets — so without this guard the
-// stuck turn burns the entire MAX_TOTAL_TRANSIENT_CONTINUATIONS budget (each
-// round re-sending any large pasted payload) before bailing. Catching the
-// repeat ends it in a few rounds with a clear, actionable message instead.
-const MAX_REPEATED_TRANSIENT_CONTINUATIONS = 3;
-// How many consecutive continuations that only reach the SAME "preparing
-// action" activity card we tolerate before giving up. This catches runs that
-// keep timing out while assembling a large tool payload: they are not empty,
-// and the narration may vary enough to bypass the text-repeat guard, but the
-// real tool never starts.
-const MAX_REPEATED_ACTION_PREPARATION_CONTINUATIONS = 3;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
 const MAX_HISTORY_ATTACHMENT_CHARS = 60_000;
@@ -811,18 +795,30 @@ function contentToStructuredMessages(
           : (part.args ?? {}),
       });
       if (part.result !== undefined) {
+        const body = truncate
+          ? truncateForHistory(
+              toolResultContent(part.result, part.toolName),
+              MAX_HISTORY_TOOL_RESULT_CHARS,
+              "Tool result",
+            )
+          : toolResultContent(part.result, part.toolName);
         pendingToolResults.push({
           type: "tool-result",
           toolCallId,
           toolName: part.toolName,
           toolInput: JSON.stringify(part.args ?? {}),
-          content: truncate
-            ? truncateForHistory(
-                toolResultContent(part.result, part.toolName),
-                MAX_HISTORY_TOOL_RESULT_CHARS,
-                "Tool result",
-              )
-            : toolResultContent(part.result, part.toolName),
+          // A settled-interrupted tool has a result whose outcome is UNKNOWN.
+          // It is neither a success nor a failure, so it carries the marker the
+          // server's write-interruption breaker matches on instead of claiming
+          // either.
+          content:
+            part.outcome === "unknown" &&
+            !body.includes(INTERRUPTED_TOOL_RESULT)
+              ? `${INTERRUPTED_TOOL_RESULT} ${body}`
+              : body,
+          ...(part.isError === true && part.outcome !== "unknown"
+            ? { isError: true }
+            : {}),
         });
       } else {
         pendingToolResults.push({
@@ -830,7 +826,7 @@ function contentToStructuredMessages(
           toolCallId,
           toolName: part.toolName,
           toolInput: JSON.stringify(part.args ?? {}),
-          content: "Interrupted before this tool returned a result.",
+          content: INTERRUPTED_TOOL_RESULT,
         });
       }
     }
@@ -901,6 +897,14 @@ function assistantUiMessagesToStructuredHistory(
           ...(part.result !== undefined
             ? { result: toolResultContent(part.result, toolName) }
             : {}),
+          // A failed call replayed without `isError` reads to the next turn as
+          // an ordinary success whose body happens to contain error prose, so
+          // the model cannot tell it already tried this and failed. The
+          // server's repeat-error breaker keys on exactly this flag.
+          ...(part.isError === true ? { isError: true } : {}),
+          ...(part.outcome === "unknown"
+            ? { outcome: "unknown" as const }
+            : {}),
         });
       }
     }
@@ -914,11 +918,39 @@ function assistantUiMessagesToStructuredHistory(
   return structured;
 }
 
+/**
+ * Size this message will actually contribute to the request, AFTER the
+ * per-part truncation `assistantUiMessagesToStructuredHistory` applies. Tool
+ * calls are most of a tool-heavy turn, so counting only text parts priced a
+ * turn of 40 tool calls at ~0: it survived every trim against
+ * MAX_HISTORY_TOTAL_CHARS while the user's own prose was evicted around it.
+ */
 function estimateHistoryMessageCost(message: {
   content: readonly { type: string; text?: string }[];
   attachments?: readonly AssistantUiAttachment[];
 }): number {
-  return Math.max(1, messageTextForHistory(message).length);
+  let cost = messageTextForHistory(message).length;
+  for (const part of message.content) {
+    if (part.type !== "tool-call") continue;
+    const tool = part as {
+      toolName?: string;
+      argsText?: string;
+      args?: unknown;
+      result?: unknown;
+    };
+    const argsCap = LARGE_INPUT_TOOL_NAMES.has(tool.toolName ?? "")
+      ? MAX_HISTORY_LARGE_TOOL_ARGS_CHARS
+      : MAX_HISTORY_TOOL_ARGS_CHARS;
+    const argsText = tool.argsText ?? stableJson(tool.args ?? {});
+    cost += Math.min(argsText.length, argsCap);
+    if (tool.result !== undefined) {
+      cost += Math.min(
+        String(tool.result).length,
+        MAX_HISTORY_TOOL_RESULT_CHARS,
+      );
+    }
+  }
+  return Math.max(1, cost);
 }
 
 function limitPriorMessagesForRequest<
@@ -1044,6 +1076,74 @@ function continuationRepeatSignature(content: ContentPart[]): string {
     .filter((segment) => segment.length > 0);
   if (segments.length === 0) return "";
   return Array.from(new Set(segments)).sort().join("\u0000");
+}
+
+type ContinuationAdvance = {
+  signature: string;
+  /**
+   * What the round was left sitting on. Only the give-up wording reads this;
+   * the control flow is the signature comparison alone.
+   */
+  stall: {
+    kind: "in-flight" | "preparing" | "repeat" | "empty";
+    toolName?: string;
+  };
+};
+
+/**
+ * Everything a continuation could have advanced, as one signature over the
+ * work it produced: the distinct tool results it completed, the tool it left
+ * in flight, and the action card it left unstarted. Two consecutive
+ * continuations with the same signature moved the turn nowhere, whatever the
+ * server's reason code called it.
+ *
+ * DISTINCT, not per-occurrence: a round that degenerates into four hundred
+ * copies of one tool call collapses to the same signature as the round before
+ * it, which is exactly the shape production shows (up to 28 identical calls in
+ * one turn).
+ *
+ * Narration counts only when the round left NO unfinished work. A model stuck
+ * re-wording "I have the file, creating it now!" while the same action never
+ * starts emits new prose every round, and prose alone is why that used to look
+ * like progress.
+ */
+function describeContinuationAdvance(
+  content: ContentPart[],
+  preparingToolName: string | undefined,
+): ContinuationAdvance {
+  const work = new Set<string>();
+  let stall: ContinuationAdvance["stall"] | null = null;
+  for (const part of content) {
+    if (part.type !== "tool-call") continue;
+    if (part.result !== undefined) {
+      if (part.activity !== true) {
+        work.add(
+          `done ${part.toolName} ${inFlightToolInputSignature(part)} ${part.result.length} ${part.result.slice(0, 256)}`,
+        );
+      }
+      continue;
+    }
+    if (part.activity === true) {
+      work.add(`preparing ${part.toolName}`);
+      stall ??= { kind: "preparing", toolName: part.toolName };
+    } else {
+      work.add(`pending ${part.toolName} ${inFlightToolInputSignature(part)}`);
+      stall = { kind: "in-flight", toolName: part.toolName };
+    }
+  }
+  // A "Preparing X action" card is an activity-trail entry, not a content
+  // part, so a round can sit on an unstarted action while its content holds
+  // nothing but narration.
+  if (preparingToolName && !stall) {
+    work.add(`preparing ${preparingToolName}`);
+    stall = { kind: "preparing", toolName: preparingToolName };
+  }
+  if (!stall) {
+    const text = continuationRepeatSignature(content);
+    if (text) work.add(`text ${text}`);
+    stall = text ? { kind: "repeat" } : { kind: "empty" };
+  }
+  return { signature: Array.from(work).sort().join(""), stall };
 }
 
 /**
@@ -1953,30 +2053,20 @@ export function createAgentChatAdapter(
       let internalContinuationRequest = latestUserIsRecovery;
       let startupRecoveryAttempts = 0;
       let queuedConflictRetries = 0;
-      let staleRunContinuationAttempts = 0;
-      let stalledTransientContinuationAttempts = 0;
-      let emptyTransientContinuationAttempts = 0;
       let totalTransientContinuationAttempts = 0;
-      let repeatedTransientContinuationAttempts = 0;
-      let lastContinuationRepeatSignature: string | null = null;
-      let recoveryGaveUpOnRepetition = false;
-      // Track when the same write tool is stuck in-flight across consecutive
-      // continuations (connection keeps dropping mid-execution). This is
-      // orthogonal to the text-repeat guard — in-flight tools reset
-      // madeProgress=true so the stalled/empty budgets never fire, but the tool
-      // never actually completes. After MAX_REPEATED_INFLIGHT_TOOL_STALLS
-      // consecutive interruptions of the same tool, bail with a clear message.
-      let lastInFlightToolName: string | undefined;
-      // Signature of the stuck tool's input. A retry with a changed payload
-      // (different signature) resets the stall count so the new attempt gets
-      // its own budget rather than inheriting the prior payload's.
-      let lastInFlightToolSignature: string | undefined;
-      let repeatedInFlightToolCount = 0;
-      let recoveryGaveUpOnInFlightTool = false;
-      const MAX_REPEATED_INFLIGHT_TOOL_STALLS = 3;
-      let lastPreparingToolName: string | undefined;
-      let repeatedActionPreparationCount = 0;
-      let recoveryGaveUpOnActionPreparation = false;
+      // Consecutive continuations whose advance signature matched the previous
+      // round's (or was empty). Reset by any real advance.
+      let nonAdvancingContinuations = 0;
+      let lastAdvanceSignature: string | null = null;
+      // Set at the moment we give up, so the user-facing message can name what
+      // the turn was stuck on without a counter per shape of stuck.
+      let recoveryStall: ContinuationAdvance["stall"] | null = null;
+      // Content already accounted for by a previous advance check. Tracked
+      // separately from `visibleContinuationPrefix`, which deliberately does
+      // NOT advance on a `loop_limit` boundary so that round's output stays in
+      // continuation history; the advance check needs the per-round delta for
+      // every reason code, `loop_limit` included.
+      let advanceCheckPrefix: ContentPart[] = [];
       // Set when the turn is stopped by MAX_TOTAL_TRANSIENT_CONTINUATIONS —
       // the whole-turn continuation ceiling, not a dropped connection. This
       // can trip on a turn that was making real progress the entire time, so
@@ -2033,17 +2123,10 @@ export function createAgentChatAdapter(
           lastRecoverableRunError?.message
             ? `last_recoverable_error: ${lastRecoverableRunError.message}`
             : "",
-          `stale_run_continuations: ${staleRunContinuationAttempts}`,
-          `stalled_transient_continuations: ${stalledTransientContinuationAttempts}`,
-          `empty_transient_continuations: ${emptyTransientContinuationAttempts}`,
-          `repeated_transient_continuations: ${repeatedTransientContinuationAttempts}`,
-          `repeated_inflight_tool_stalls: ${repeatedInFlightToolCount}`,
-          lastInFlightToolName
-            ? `last_inflight_tool: ${lastInFlightToolName}`
-            : "",
-          `repeated_action_preparation_stalls: ${repeatedActionPreparationCount}`,
-          lastPreparingToolName
-            ? `last_preparing_tool: ${lastPreparingToolName}`
+          `non_advancing_continuations: ${nonAdvancingContinuations}`,
+          recoveryStall ? `stalled_on: ${recoveryStall.kind}` : "",
+          recoveryStall?.toolName
+            ? `stalled_on_tool: ${recoveryStall.toolName}`
             : "",
           formatActivityTrail(lastActivityTrail)
             ? `activity_trail: ${formatActivityTrail(lastActivityTrail)}`
@@ -2070,15 +2153,15 @@ export function createAgentChatAdapter(
       };
 
       const exhaustedRecoveryMessage = (reason?: string): string => {
-        if (recoveryGaveUpOnInFlightTool) {
+        if (recoveryStall?.kind === "in-flight") {
           return "The agent got stuck waiting for the same tool to finish, so I stopped the automatic retries. The tool did not report a completed result.";
         }
-        if (recoveryGaveUpOnRepetition) {
+        if (recoveryStall?.kind === "repeat") {
           return "The agent got stuck repeating the same response without finishing, so I stopped the automatic retries. This often happens when it tries to re-type a large pasted file into one action — starting a new chat, or asking for a smaller first step, usually gets it unstuck.";
         }
-        if (recoveryGaveUpOnActionPreparation) {
-          const tool = lastPreparingToolName
-            ? ` the ${humanizeActionName(lastPreparingToolName)} action`
+        if (recoveryStall?.kind === "preparing") {
+          const tool = recoveryStall.toolName
+            ? ` the ${humanizeActionName(recoveryStall.toolName)} action`
             : " the same action";
           return `The agent got stuck preparing${tool} input and never started the tool, so I stopped the automatic retries. Try a smaller first step or a more compact version of the request.`;
         }
@@ -2092,6 +2175,9 @@ export function createAgentChatAdapter(
             reason === "stream_ended")
         ) {
           return "The agent request started but did not produce any visible progress before timing out. I stopped the automatic retries so this chat would not stay stuck on Thinking.";
+        }
+        if (recoveryStall?.kind === "empty") {
+          return "The agent stopped producing new output across several automatic retries, so I stopped it here rather than leaving the chat stuck on Thinking.";
         }
         return "The agent connection kept failing after several automatic recovery attempts.";
       };
@@ -2254,14 +2340,9 @@ export function createAgentChatAdapter(
             attemptedRunIds: [...attemptedRunIds],
             activityTrail: [...lastActivityTrail],
             startupRecoveryAttempts,
-            staleRunContinuationAttempts,
-            stalledTransientContinuationAttempts,
-            emptyTransientContinuationAttempts,
-            repeatedTransientContinuationAttempts,
-            repeatedInFlightToolCount,
-            lastInFlightToolName,
-            repeatedActionPreparationCount,
-            lastPreparingToolName,
+            nonAdvancingContinuations,
+            stalledOn: recoveryStall?.kind,
+            stalledOnTool: recoveryStall?.toolName,
             totalTransientContinuationAttempts,
             ...extra,
           },
@@ -2273,14 +2354,9 @@ export function createAgentChatAdapter(
               lastSeq,
               contentParts: content.length,
               startupRecoveryAttempts,
-              staleRunContinuationAttempts,
-              stalledTransientContinuationAttempts,
-              emptyTransientContinuationAttempts,
-              repeatedTransientContinuationAttempts,
-              repeatedInFlightToolCount,
-              lastInFlightToolName,
-              repeatedActionPreparationCount,
-              lastPreparingToolName,
+              nonAdvancingContinuations,
+              stalledOn: recoveryStall?.kind,
+              stalledOnTool: recoveryStall?.toolName,
               totalTransientContinuationAttempts,
             },
           },
@@ -3372,7 +3448,7 @@ export function createAgentChatAdapter(
           ok: boolean;
           resetVisibleContent: boolean;
           completedToolName?: string;
-          emptyRun?: boolean;
+          nonAdvancing?: boolean;
         } => {
           lastAutoContinueReason = signal.reason;
           lastActivityTrail = [...signal.activityTrail];
@@ -3383,216 +3459,77 @@ export function createAgentChatAdapter(
           const visibleContent = visibleContentForContinuation();
           let currentPartialHistory =
             contentToContinuationHistory(visibleContent);
-          // Real, content-weight progress: streamed text or a completed tool
-          // result. Used to reset the stalled/empty counters so trivial
-          // whitespace-only output cannot keep the run alive indefinitely.
           const madeContentProgress = hasContinuationProgress(visibleContent);
           // An action was streamed but has not returned yet (a tool_start with
-          // no tool_done). This is durable enough to survive continuation: the
-          // server already emitted a real tool call. A tool-scoped activity
-          // card ("Preparing generate-design") is useful UI, but it happens
-          // before tool_start; treating it as progress caused silent retry
-          // loops when the LLM timed out while assembling a large tool input.
+          // no tool_done). Only a run_timeout in that window means the SERVER
+          // is still executing it and a reconnect can still deliver the result;
+          // every other reason means the stream is dead and nothing will
+          // complete the tool.
           const hasInFlightTool = hasInFlightToolCall(visibleContent);
           const completedTool = lastCompletedTimeoutCandidateTool(content);
-          // Either real output or an actively-running tool counts as progress
-          // for the stalled/empty caps.
-          const madeProgress = madeContentProgress || hasInFlightTool;
-          const emptyRun = !madeProgress && signal.reason !== "loop_limit";
-          const madeDurableToolProgress = visibleContent.some(
-            (part) =>
-              part.type === "tool-call" &&
-              part.activity !== true &&
-              part.result !== undefined,
-          );
           const currentPreparingToolName =
             lastUnresolvedToolActivity(visibleContent) ??
             lastPreparingActionTool(signal.activityTrail);
-          // In-flight tool stall guard. When the same write tool is stuck
-          // in-flight because the connection keeps dropping (stream_ended),
-          // hasInFlightTool=true keeps madeProgress=true and completely
-          // bypasses the stalled/empty budgets. Track the last in-flight tool
-          // name; when the same tool is still unresolved after
-          // MAX_REPEATED_INFLIGHT_TOOL_STALLS consecutive stream_ended events,
-          // bail with a clear message.
-          //
-          // Count broken streams (connection drop / reconnect failed) and
-          // no_progress stalls (the client aborts a stream that stayed open but
-          // stopped producing events). Do NOT count run_timeout: with an
-          // in-flight tool that means the server is still actively executing a
-          // slow action and reconnection may recover the result.
-          const currentInFlightToolPart = visibleContent.find(
-            (p): p is Extract<ContentPart, { type: "tool-call" }> =>
-              p.type === "tool-call" &&
-              p.result === undefined &&
-              p.activity !== true,
+
+          // THE boundary. One question — did this continuation advance the
+          // turn? — decides every reason code, `loop_limit` included. It used
+          // to skip this block entirely AND reset two of the budgets, so a
+          // model that degenerated into a tool loop re-POSTed the same turnId
+          // until the user gave up (measured in production at 186 minutes with
+          // no answer). The durable per-turn ledger lives server-side inside
+          // one run and never sees a client re-POST, so nothing else bounds it.
+          const advanceDelta = contentAfterContinuationPrefix(
+            content,
+            advanceCheckPrefix,
           );
-          const currentInFlightToolName = currentInFlightToolPart?.toolName;
-          const currentInFlightToolSignature = currentInFlightToolPart
-            ? inFlightToolInputSignature(currentInFlightToolPart)
-            : undefined;
-          const isBrokenInFlightTool =
-            signal.reason === "stream_ended" || signal.reason === "no_progress";
-          if (currentInFlightToolName && isBrokenInFlightTool) {
-            if (
-              currentInFlightToolName === lastInFlightToolName &&
-              currentInFlightToolSignature === lastInFlightToolSignature
-            ) {
-              repeatedInFlightToolCount += 1;
-            } else {
-              // New tool, or the same tool retried with a CHANGED (e.g.
-              // smaller) payload — give the changed input a fresh stall budget
-              // instead of aborting it as a repeat of the prior payload.
-              repeatedInFlightToolCount = 0;
-              lastInFlightToolName = currentInFlightToolName;
-              lastInFlightToolSignature = currentInFlightToolSignature;
-            }
-          } else if (!currentInFlightToolName) {
-            repeatedInFlightToolCount = 0;
-          }
+          const advance = describeContinuationAdvance(
+            advanceDelta,
+            currentPreparingToolName,
+          );
+          const serverStillRunningTool =
+            signal.reason === "run_timeout" && hasInFlightTool;
+          const advanced =
+            serverStillRunningTool ||
+            (advance.signature !== "" &&
+              advance.signature !== lastAdvanceSignature);
+          // Only remember a non-empty signature, so an empty round between two
+          // identical rounds cannot launder the second one into "new work".
+          if (advance.signature) lastAdvanceSignature = advance.signature;
+          nonAdvancingContinuations = advanced
+            ? 0
+            : nonAdvancingContinuations + 1;
+          totalTransientContinuationAttempts += 1;
+          advanceCheckPrefix = snapshotContent(content);
 
-          const isRepeatedActionPreparationCandidate =
-            signal.reason !== "loop_limit" &&
-            currentPreparingToolName !== undefined &&
-            !hasInFlightTool &&
-            !madeDurableToolProgress;
-          if (isRepeatedActionPreparationCandidate) {
-            if (currentPreparingToolName === lastPreparingToolName) {
-              repeatedActionPreparationCount += 1;
-            } else {
-              repeatedActionPreparationCount = 0;
-              lastPreparingToolName = currentPreparingToolName;
-            }
-          } else if (
-            !currentPreparingToolName ||
-            hasInFlightTool ||
-            madeDurableToolProgress
+          // If a tool already completed, do not turn a missing closing
+          // sentence into a scary connection failure. Give the model one
+          // continuation opportunity (the completed tool itself counts as an
+          // advance on the first timeout); if the follow-up produces no new
+          // content, stop locally with a clear completed-tool warning.
+          if (
+            signal.reason === "run_timeout" &&
+            completedTool &&
+            !hasInFlightToolCall(content) &&
+            !currentPreparingToolName &&
+            !madeContentProgress &&
+            !hasInFlightTool
           ) {
-            repeatedActionPreparationCount = 0;
-            lastPreparingToolName = undefined;
+            return {
+              ok: false,
+              resetVisibleContent: false,
+              completedToolName: completedTool.toolName,
+            };
           }
-
-          // Degenerate repetition guard. When the model gets stuck re-streaming
-          // the SAME narration every continuation without ever starting or
-          // finishing a tool, each round is "new" text — so madeProgress stays
-          // true and the stalled/empty budgets never trip. Compare this round's
-          // unique-sentence signature to the previous round's; a match with no
-          // tool progress is a non-advancing loop. Tracked by its own counter
-          // so it bails after a few rounds instead of the full transient budget,
-          // without perturbing the stalled/empty/stale accounting.
-          const repeatSignature = continuationRepeatSignature(visibleContent);
-          const isNonAdvancingRepeat =
-            signal.reason !== "loop_limit" &&
-            repeatSignature !== "" &&
-            repeatSignature === lastContinuationRepeatSignature &&
-            !hasInFlightTool &&
-            !madeDurableToolProgress;
-
-          if (signal.reason === "loop_limit") {
-            stalledTransientContinuationAttempts = 0;
-            emptyTransientContinuationAttempts = 0;
-          } else {
-            totalTransientContinuationAttempts += 1;
-            // If a tool already completed, do not turn a missing closing
-            // sentence into a scary connection failure. Give the model one
-            // continuation opportunity (the completed tool itself counts as
-            // progress on the first timeout); if the follow-up produces no new
-            // content, stop locally with a clear completed-tool warning.
-            if (
-              signal.reason === "run_timeout" &&
-              completedTool &&
-              !hasInFlightToolCall(content) &&
-              !currentPreparingToolName &&
-              !madeContentProgress &&
-              !hasInFlightTool
-            ) {
-              return {
-                ok: false,
-                resetVisibleContent: false,
-                completedToolName: completedTool.toolName,
-              };
-            }
-            // Bail when the same write tool is stuck in-flight across too many
-            // consecutive continuations. Checked before the text-repeat guard
-            // because hasInFlightTool=true would mask the repeat as progress.
-            if (
-              repeatedInFlightToolCount >= MAX_REPEATED_INFLIGHT_TOOL_STALLS
-            ) {
-              recoveryGaveUpOnInFlightTool = true;
-              return { ok: false, resetVisibleContent: false };
-            }
-            if (
-              repeatedActionPreparationCount >
-              MAX_REPEATED_ACTION_PREPARATION_CONTINUATIONS
-            ) {
-              recoveryGaveUpOnActionPreparation = true;
-              return { ok: false, resetVisibleContent: false };
-            }
-            // Bail fast on a non-advancing repetition loop, well before the
-            // stalled/empty/total budgets would (each round otherwise re-sends
-            // the whole pasted payload). Tracked separately so it never trips
-            // on legitimately-progressing runs that happen to be slow.
-            if (isNonAdvancingRepeat) {
-              repeatedTransientContinuationAttempts += 1;
-              if (
-                repeatedTransientContinuationAttempts >
-                MAX_REPEATED_TRANSIENT_CONTINUATIONS
-              ) {
-                recoveryGaveUpOnRepetition = true;
-                return { ok: false, resetVisibleContent: false };
-              }
-            } else {
-              repeatedTransientContinuationAttempts = 0;
-            }
-            if (repeatSignature) {
-              lastContinuationRepeatSignature = repeatSignature;
-            }
-            // A run_timeout that produced nothing visible and no activity (the
-            // model spent the whole soft-timeout window thinking before its
-            // first output) is NOT an immediate give-up: a transient slow start
-            // routinely recovers on the next continuation. Let it fall through
-            // to the empty-continuation budget below so it retries a bounded
-            // number of times before surfacing the "no visible progress" error.
-            // Reset the empty-continuation counter on real progress — streamed
-            // text/completed tool OR an in-flight tool the server is running —
-            // not merely on a non-zero part count, which whitespace-only or
-            // unresolved-only output would falsely satisfy.
-            if (!madeProgress) {
-              emptyTransientContinuationAttempts += 1;
-              if (
-                emptyTransientContinuationAttempts >
-                MAX_EMPTY_TRANSIENT_CONTINUATIONS
-              ) {
-                return { ok: false, resetVisibleContent: false };
-              }
-            } else {
-              emptyTransientContinuationAttempts = 0;
-            }
-            if (signal.reason === "stale_run") {
-              staleRunContinuationAttempts = madeDurableToolProgress
-                ? 0
-                : staleRunContinuationAttempts + 1;
-              if (staleRunContinuationAttempts > MAX_STALE_RUN_CONTINUATIONS) {
-                return { ok: false, resetVisibleContent: false };
-              }
-            }
-            stalledTransientContinuationAttempts = madeProgress
-              ? 0
-              : stalledTransientContinuationAttempts + 1;
-            if (
-              totalTransientContinuationAttempts >
-              MAX_TOTAL_TRANSIENT_CONTINUATIONS
-            ) {
-              recoveryGaveUpOnTransientBudget = true;
-            }
-            if (
-              stalledTransientContinuationAttempts >
-                MAX_STALLED_TRANSIENT_CONTINUATIONS ||
-              totalTransientContinuationAttempts >
-                MAX_TOTAL_TRANSIENT_CONTINUATIONS
-            ) {
-              return { ok: false, resetVisibleContent: false };
-            }
+          if (nonAdvancingContinuations >= MAX_NON_ADVANCING_CONTINUATIONS) {
+            recoveryStall = advance.stall;
+            return { ok: false, resetVisibleContent: false };
+          }
+          if (
+            totalTransientContinuationAttempts >
+            MAX_TOTAL_TRANSIENT_CONTINUATIONS
+          ) {
+            recoveryGaveUpOnTransientBudget = true;
+            return { ok: false, resetVisibleContent: false };
           }
 
           if (isTransient) {
@@ -3653,14 +3590,22 @@ export function createAgentChatAdapter(
           startupRecoveryAttempts = 0;
           clearActiveRun();
           if (!isTransient) {
-            return { ok: true, resetVisibleContent: false, emptyRun };
+            return {
+              ok: true,
+              resetVisibleContent: false,
+              nonAdvancing: !advanced,
+            };
           }
 
           // Keep everything visible during transient recovery. The continuation
           // prefix diff tracks what the next request has already seen, so
           // preserving text no longer causes duplicate continuation history.
           visibleContinuationPrefix = snapshotContent(content);
-          return { ok: true, resetVisibleContent: false, emptyRun };
+          return {
+            ok: true,
+            resetVisibleContent: false,
+            nonAdvancing: !advanced,
+          };
         };
 
         while (true) {
@@ -4106,12 +4051,12 @@ export function createAgentChatAdapter(
                   }),
                 );
               }
-              // A run that produced nothing visible never got past
+              // A run that advanced nothing usually never got past
               // startup/gateway; re-POSTing the identical payload immediately
               // just hits the identical wall. Back that case off instead.
-              if (continuation.emptyRun) {
+              if (continuation.nonAdvancing) {
                 await retryDelay(
-                  Math.max(0, emptyTransientContinuationAttempts - 1),
+                  Math.max(0, nonAdvancingContinuations - 1),
                   abortSignal,
                 );
               } else {

--- a/packages/core/src/client/settings/AgentsSection.spec.tsx
+++ b/packages/core/src/client/settings/AgentsSection.spec.tsx
@@ -128,4 +128,44 @@ describe("AgentsSection", () => {
     expect(text.toLowerCase()).not.toContain("not set");
     expect(text.toLowerCase()).toContain("workspace owner");
   });
+
+  it("does not expose shared-agent mutations to organization members", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/_agent-native/org/me")) {
+          return Response.json({
+            email: "member@acme.com",
+            orgId: "org-1",
+            orgName: "Acme",
+            role: "member",
+            orgs: [],
+            pendingInvitations: [],
+            domainMatches: [],
+            allowedDomain: "acme.com",
+          });
+        }
+        if (url.includes("/_agent-native/agents/probe")) {
+          return Response.json({ results: [] });
+        }
+        const detail = url.match(/\/resources\/([^?]+)$/);
+        if (detail) return Response.json({ content: contentById[detail[1]] });
+        return Response.json({ resources });
+      }),
+    );
+
+    await renderSection(root);
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    expect(buttons.map((button) => button.textContent?.trim())).not.toContain(
+      "Connect agent",
+    );
+    expect(buttons.map((button) => button.textContent?.trim())).not.toContain(
+      "Manage",
+    );
+    expect(container.textContent).toContain(
+      "Only workspace owners and admins can connect agents.",
+    );
+  });
 });

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -313,12 +313,19 @@ function AgentAddPopover({
     const trimmedUrl = url.trim();
     if (!trimmedName || !trimmedUrl) return;
     const trimmedDescription = description.trim();
-    const ok = await onAdd(trimmedName, trimmedUrl, trimmedDescription);
-    if (ok) {
-      setAdded({
-        name: trimmedName,
-        url: trimmedUrl,
-        description: trimmedDescription,
+    try {
+      const ok = await onAdd(trimmedName, trimmedUrl, trimmedDescription);
+      if (ok) {
+        setAdded({
+          name: trimmedName,
+          url: trimmedUrl,
+          description: trimmedDescription,
+        });
+      }
+    } catch (error) {
+      setCheck({
+        status: "error",
+        message: error instanceof Error ? error.message : "Could not add agent",
       });
     }
   };
@@ -613,8 +620,13 @@ export function AgentsSection() {
     AgentProbeResult
   > | null>(null);
 
-  const { data: org } = useOrg();
+  const orgQuery = useOrg();
+  const { data: org } = orgQuery;
   const syncSecret = useSyncA2ASecret();
+  const canManageSharedAgents =
+    !orgQuery.isLoading &&
+    !orgQuery.isError &&
+    (!org?.orgId || org.role === "owner" || org.role === "admin");
 
   // Landing from a peer's "register back" deep link (see
   // buildPeerRegisterBackLink): the open route only echoes `f_*` params onto
@@ -735,24 +747,34 @@ export function AgentsSection() {
       2,
     );
 
-    try {
-      const res = await fetch(agentNativePath("/_agent-native/resources"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          path: remoteAgentResourcePath(id),
-          content: agentJson,
-          shared: true,
-        }),
-      });
-      // Deliberately don't close the popover here — a successful add shows a
-      // follow-up state (registration is one-way; the peer doesn't know
-      // about us yet) that the user dismisses explicitly.
-      if (res.ok) fetchAgents();
-      return res.ok;
-    } catch {
-      return false;
+    const res = await fetch(agentNativePath("/_agent-native/resources"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: remoteAgentResourcePath(id),
+        content: agentJson,
+        shared: true,
+      }),
+    });
+    if (!res.ok) {
+      let body: { error?: string; message?: string } | null;
+      try {
+        body = (await res.json()) as {
+          error?: string;
+          message?: string;
+        };
+      } catch {
+        throw new Error(`Add failed (${res.status})`);
+      }
+      throw new Error(
+        body?.error ?? body?.message ?? `Add failed (${res.status})`,
+      );
     }
+    // Deliberately don't close the popover here — a successful add shows a
+    // follow-up state (registration is one-way; the peer doesn't know
+    // about us yet) that the user dismisses explicitly.
+    fetchAgents();
+    return true;
   };
 
   const handleSave = async (agent: AgentInfo) => {
@@ -803,32 +825,38 @@ export function AgentsSection() {
   return (
     <div>
       <div className="mb-3 flex flex-wrap items-center justify-end gap-3">
-        <div className="relative">
-          <button
-            onClick={() => {
-              setShowAdd(!showAdd);
-              setEditingAgent(null);
-            }}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-          >
-            {showAdd ? <IconX size={13} /> : <IconPlus size={13} />}
-            {showAdd ? "Cancel" : "Connect agent"}
-          </button>
-          {showAdd && (
-            <AgentAddPopover
-              initialName={prefill?.name}
-              initialUrl={prefill?.url}
-              initialDescription={prefill?.description}
-              secretSet={org?.a2aSecretSet}
-              syncSecret={syncSecret}
-              onAdd={handleAdd}
-              onClose={() => {
-                setShowAdd(false);
-                setPrefill(null);
+        {canManageSharedAgents ? (
+          <div className="relative">
+            <button
+              onClick={() => {
+                setShowAdd(!showAdd);
+                setEditingAgent(null);
               }}
-            />
-          )}
-        </div>
+              className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+            >
+              {showAdd ? <IconX size={13} /> : <IconPlus size={13} />}
+              {showAdd ? "Cancel" : "Connect agent"}
+            </button>
+            {showAdd && (
+              <AgentAddPopover
+                initialName={prefill?.name}
+                initialUrl={prefill?.url}
+                initialDescription={prefill?.description}
+                secretSet={org?.a2aSecretSet}
+                syncSecret={syncSecret}
+                onAdd={handleAdd}
+                onClose={() => {
+                  setShowAdd(false);
+                  setPrefill(null);
+                }}
+              />
+            )}
+          </div>
+        ) : !orgQuery.isLoading ? (
+          <span className="text-[10px] text-muted-foreground">
+            Only workspace owners and admins can connect agents.
+          </span>
+        ) : null}
       </div>
 
       <A2ASecretStatusRow org={org} syncSecret={syncSecret} />
@@ -855,13 +883,19 @@ export function AgentsSection() {
           <p className="mt-1 max-w-sm text-xs leading-5 text-muted-foreground">
             Connect an A2A agent to delegate work from chat.
           </p>
-          <button
-            onClick={() => setShowAdd(true)}
-            className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-          >
-            <IconPlus size={13} />
-            Connect agent
-          </button>
+          {canManageSharedAgents ? (
+            <button
+              onClick={() => setShowAdd(true)}
+              className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+            >
+              <IconPlus size={13} />
+              Connect agent
+            </button>
+          ) : !orgQuery.isLoading ? (
+            <p className="mt-4 text-xs text-muted-foreground">
+              Ask a workspace owner or admin to connect an agent.
+            </p>
+          ) : null}
         </div>
       ) : (
         <div className="overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground">
@@ -907,19 +941,21 @@ export function AgentsSection() {
                         {agent.url}
                       </span>
                     </div>
-                    <button
-                      onClick={() => {
-                        setEditingAgent(
-                          editingAgent === agent.id ? null : agent.id,
-                        );
-                        setShowAdd(false);
-                      }}
-                      className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
-                    >
-                      Manage
-                    </button>
+                    {canManageSharedAgents ? (
+                      <button
+                        onClick={() => {
+                          setEditingAgent(
+                            editingAgent === agent.id ? null : agent.id,
+                          );
+                          setShowAdd(false);
+                        }}
+                        className="shrink-0 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
+                      >
+                        Manage
+                      </button>
+                    ) : null}
                   </div>
-                  {editingAgent === agent.id && (
+                  {canManageSharedAgents && editingAgent === agent.id && (
                     <AgentEditPopover
                       agent={agent}
                       onSave={handleSave}

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -3374,6 +3374,40 @@ describe("SSE event processor error classification", () => {
     });
   });
 
+  it("keeps narration from earlier steps when a later draft is cleared", async () => {
+    // A `clear` is the server retrying the CURRENT draft, which always resumes
+    // after the last completed tool. Splicing every text part wiped multi-step
+    // narration from the whole turn, which users reported as "it deleted its
+    // reply and started over".
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          { type: "text", text: "Step 1: reading the schema." },
+          { type: "tool_start", tool: "query", input: { sql: "select 1" } },
+          { type: "tool_done", tool: "query", result: "1" },
+          { type: "text", text: "Step 2: rejected draft." },
+          { type: "clear" },
+          { type: "text", text: "Step 2: corrected answer." },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+      ),
+    );
+
+    expect(results.at(-1)).toEqual({
+      content: [
+        { type: "text", text: "Step 1: reading the schema." },
+        expect.objectContaining({
+          type: "tool-call",
+          toolName: "query",
+          result: "1",
+        }),
+        { type: "text", text: "Step 2: corrected answer." },
+      ],
+    });
+  });
+
   it("keeps materialized pending tool calls across clear events", async () => {
     const results = await drain(
       readSSEStream(

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -131,7 +131,13 @@ export interface AgentAutoContinueErrorInfo {
   upgradeUrl?: string;
 }
 
-const INTERRUPTED_TOOL_RESULT =
+/**
+ * Kept verbatim in sync with `INTERRUPTED_TOOL_RESULT_MARKER`
+ * (agent/production-agent.ts): the server matches this substring in replayed
+ * history to count how many times a write tool was interrupted, which is the
+ * only thing that tells "we do not know if it landed" apart from "it failed".
+ */
+export const INTERRUPTED_TOOL_RESULT =
   "Interrupted before this tool returned a result.";
 const INTERRUPTED_ACTIVITY_RESULT = "Stopped before this action started.";
 
@@ -2025,10 +2031,26 @@ export function processEvent(
   return { action: "continue" };
 }
 
+/**
+ * Drop the draft the server is about to re-emit — the narration since the last
+ * completed tool, not the whole turn. A `clear` arrives on a final-answer-guard
+ * retry or a continuation, both of which resume AFTER the last completed tool
+ * call, so anything before that boundary is settled multi-step narration the
+ * retry will never re-send. Wiping it read to users as "it deleted its reply
+ * and started over", and `thread-data-builder` replays this same scoping on
+ * rebuild, so the loss survived a reload.
+ */
 function clearAssistantDraftContent(content: ContentPart[]): void {
   for (let index = content.length - 1; index >= 0; index--) {
     const part = content[index];
     if (!part) continue;
+    if (
+      part.type === "tool-call" &&
+      part.activity !== true &&
+      part.result !== undefined
+    ) {
+      return;
+    }
     if (part.type === "text" || part.type === "reasoning") {
       content.splice(index, 1);
       continue;

--- a/packages/core/src/provider-api/actions/github-repo-files.ts
+++ b/packages/core/src/provider-api/actions/github-repo-files.ts
@@ -183,6 +183,7 @@ export function createGitHubRepoFilesAction(
       ? (args: GitHubRepoFilesActionArgs) =>
           args.operation === "write" || args.operation === "delete"
       : false,
+    grounding: true,
     run: async (args) => {
       if (args.operation === "list") {
         return runtime.listGitHubRepositoryFiles({

--- a/packages/core/src/provider-api/actions/provider-api.ts
+++ b/packages/core/src/provider-api/actions/provider-api.ts
@@ -364,6 +364,7 @@ export function createProviderApiRequestAction<
       summary: (args) =>
         buildProviderApiAuditSummary(args as ProviderRequestActionArgs),
     },
+    grounding: true,
     run: async (rawArgs) => {
       const args = rawArgs as ProviderRequestActionArgs;
       if (args.stageAs) {

--- a/packages/core/src/provider-api/actions/staged-datasets.ts
+++ b/packages/core/src/provider-api/actions/staged-datasets.ts
@@ -219,6 +219,7 @@ export function createQueryStagedDatasetAction<
     schema,
     http: options.http ?? false,
     readOnly: true,
+    grounding: true,
     run: async (rawArgs) => {
       const args = rawArgs as StagedActionArgs;
       const scope = resolveScope("query-staged-dataset", args, options);

--- a/packages/core/src/provider-api/corpus-jobs.ts
+++ b/packages/core/src/provider-api/corpus-jobs.ts
@@ -287,6 +287,7 @@ export function createProviderCorpusJobAction(
       "When status is paused or quota_wait, call operation=continue with the jobId after the indicated time/budget. Report coverage counts, paginationComplete, and any remaining gaps; a max-pages stop is not exhaustive.",
     schema: ProviderCorpusJobSchema,
     http: false,
+    grounding: true,
     run: async (args) => runProviderCorpusJobAction(args, options),
   });
 }

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -67,6 +67,26 @@ describe("action discovery", () => {
     expect(registry["mutating-read"].readOnly).toBe(false);
   });
 
+  it("preserves grounding metadata from static action entries", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "grounded-query": {
+        default: {
+          tool: { description: "Grounded query", parameters: {} },
+          grounding: true,
+          run: async () => ({ ok: true }),
+        },
+      },
+      "metadata-read": {
+        tool: { description: "Metadata read", parameters: {} },
+        grounding: false,
+        run: async () => ({ ok: true }),
+      },
+    });
+
+    expect(registry["grounded-query"].grounding).toBe(true);
+    expect(registry["metadata-read"].grounding).toBe(false);
+  });
+
   it("preserves explicit readOnly false from named action entries", () => {
     const registry = loadActionsFromStaticRegistry({
       "named-mutating-read": {

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -215,6 +215,7 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
     out.requiresAuth = entry.requiresAuth;
   }
   if (typeof entry.readOnly === "boolean") out.readOnly = entry.readOnly;
+  if (typeof entry.grounding === "boolean") out.grounding = entry.grounding;
   if (typeof entry.allowInPlanMode === "boolean") {
     out.allowInPlanMode = entry.allowInPlanMode;
   }

--- a/packages/dispatch/src/components/agents-panel.tsx
+++ b/packages/dispatch/src/components/agents-panel.tsx
@@ -1,4 +1,5 @@
 import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useOrgRole } from "@agent-native/core/client/org";
 import { IconExternalLink, IconTrash } from "@tabler/icons-react";
 import { useRef, useState, type FormEvent } from "react";
 
@@ -77,6 +78,11 @@ export function AgentsPanel({
   agents: ConnectedAgent[];
   onRefresh: () => void;
 }) {
+  const { org, isLoading: orgLoading, error: orgError } = useOrgRole();
+  const canManageSharedAgents =
+    !orgLoading &&
+    !orgError &&
+    (!org?.orgId || org.role === "owner" || org.role === "admin");
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [description, setDescription] = useState("");
@@ -249,30 +255,35 @@ export function AgentsPanel({
                       <span>{agent.scope || "shared"}</span>
                     </div>
                   </div>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="ghost" size="icon">
-                        <IconTrash className="h-4 w-4" />
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Remove this agent?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          “{agent.name}” will be removed from the workspace. Any
-                          jobs or chats that delegate to it will stop working.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={() => handleDelete(agent.resourceId)}
-                        >
-                          Remove
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
+                  {canManageSharedAgents && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <IconTrash className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            Remove this agent?
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            “{agent.name}” will be removed from the workspace.
+                            Any jobs or chats that delegate to it will stop
+                            working.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleDelete(agent.resourceId)}
+                          >
+                            Remove
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
                 </div>
               ))}
               {workspaceAgents.length === 0 && customAgents.length === 0 && (
@@ -288,10 +299,20 @@ export function AgentsPanel({
           <div className="text-sm font-medium text-foreground">
             Add external agent
           </div>
-          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-            Add another A2A-compatible app by saving its agent endpoint here.
-          </p>
-          <form className="mt-4 space-y-3" onSubmit={handleAdd} noValidate>
+          {canManageSharedAgents ? (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Add another A2A-compatible app by saving its agent endpoint here.
+            </p>
+          ) : !orgLoading ? (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Only workspace owners and admins can add shared agents.
+            </p>
+          ) : null}
+          <form
+            className={`mt-4 space-y-3 ${canManageSharedAgents ? "" : "hidden"}`}
+            onSubmit={handleAdd}
+            noValidate
+          >
             <div className="space-y-1.5">
               <Input
                 ref={nameRef}
@@ -347,7 +368,11 @@ export function AgentsPanel({
                 {errors.form}
               </p>
             ) : null}
-            <Button type="submit" className="w-full" disabled={saving}>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={saving || !canManageSharedAgents}
+            >
               {saving ? "Saving..." : "Add agent"}
             </Button>
           </form>

--- a/scripts/chat-health.mjs
+++ b/scripts/chat-health.mjs
@@ -66,6 +66,18 @@ const postgres = loadPostgres();
 const BAD_TURN_BUDGET = 0.1;
 /** Share of received A2A tasks that may fail or hang before --strict fails. */
 const A2A_FAIL_BUDGET = 0.1;
+// A turn that made the user wait this long and then ended with no answer is
+// the "it worked for 20 minutes on this thing" complaint, measured. Outcome
+// rate alone cannot see it: a stall and an instant failure are both one bad
+// turn, so the metric that was supposed to catch this scored them the same.
+//
+// 10 minutes because it is already past every per-run ceiling the runtime
+// documents — a turn there is not slow, it is chaining. Measured over 21 days
+// across 13 production apps: 164 turns crossed it and 131 of those ended with
+// nothing to show, so this is a live number, not a guess.
+const STALL_TURN_S = 600;
+/** Share of scored turns that may stall before --strict fails. */
+const STALL_BUDGET = 0.02;
 const CONNECT_TIMEOUT_S = 20;
 // Thresholds set from a real outage, not intuition. Healthy analytics right now
 // reads 0 / 128ms / 1; at the point it went down it read 20 / 6000ms / 56.
@@ -134,8 +146,22 @@ function discoverApps() {
 // Scores the LAST run of every interactive turn in the window. `job-%` ids are
 // scheduled automations, which fail in completely different ways and would
 // swamp the number people actually experience.
+//
+// `turn_span` measures the whole turn, not the final run: a turn spans every
+// run it chained through, and the wait the user actually sat through is from
+// the FIRST run's start to the LAST one's end. Scoring the final run alone —
+// which is right for the outcome — reports a 30-minute turn that chained five
+// times as however long its last 40-second chunk took.
 const TURN_OUTCOME_SQL = `
-WITH final_run AS (
+WITH turn_span AS (
+  SELECT turn_id,
+    (max(coalesce(completed_at, heartbeat_at, started_at)) - min(started_at)) / 1000.0 AS span_s
+  FROM agent_runs
+  WHERE id NOT LIKE 'job-%'
+    AND turn_id IS NOT NULL
+    AND started_at > $1
+  GROUP BY turn_id
+), final_run AS (
   SELECT DISTINCT ON (turn_id)
     turn_id, status, error_code, terminal_reason
   FROM agent_runs
@@ -146,13 +172,21 @@ WITH final_run AS (
 )
 SELECT
   count(*)::int AS turns,
-  count(*) FILTER (WHERE status = 'completed')::int AS ok,
-  count(*) FILTER (WHERE terminal_reason LIKE 'aborted:user%')::int AS user_stopped,
+  count(*) FILTER (WHERE f.status = 'completed')::int AS ok,
+  count(*) FILTER (WHERE f.terminal_reason LIKE 'aborted:user%')::int AS user_stopped,
   count(*) FILTER (
-    WHERE status <> 'completed'
-      AND coalesce(terminal_reason, '') NOT LIKE 'aborted:user%'
-  )::int AS bad
-FROM final_run`;
+    WHERE f.status <> 'completed'
+      AND coalesce(f.terminal_reason, '') NOT LIKE 'aborted:user%'
+  )::int AS bad,
+  coalesce(round(percentile_cont(0.5) WITHIN GROUP (ORDER BY s.span_s))::int, 0) AS p50_wait_s,
+  coalesce(round(percentile_cont(0.9) WITHIN GROUP (ORDER BY s.span_s))::int, 0) AS p90_wait_s,
+  coalesce(round(max(s.span_s))::int, 0) AS max_wait_s,
+  count(*) FILTER (
+    WHERE s.span_s > ${STALL_TURN_S}
+      AND f.status <> 'completed'
+      AND coalesce(f.terminal_reason, '') NOT LIKE 'aborted:user%'
+  )::int AS stalled
+FROM final_run f JOIN turn_span s USING (turn_id)`;
 
 const TURN_REASONS_SQL = `
 WITH final_run AS (
@@ -310,7 +344,12 @@ settled.forEach((outcome, i) => {
 const scored = results
   .map((r) => {
     const scored = r.turns - r.user_stopped;
-    return { ...r, badRate: scored > 0 ? r.bad / scored : 0, scored };
+    return {
+      ...r,
+      badRate: scored > 0 ? r.bad / scored : 0,
+      stallRate: scored > 0 ? r.stalled / scored : 0,
+      scored,
+    };
   })
   .sort((a, b) => b.badRate - a.badRate);
 
@@ -318,9 +357,10 @@ const fleet = scored.reduce(
   (acc, r) => ({
     turns: acc.turns + r.turns,
     bad: acc.bad + r.bad,
+    stalled: acc.stalled + r.stalled,
     scored: acc.scored + r.scored,
   }),
-  { turns: 0, bad: 0, scored: 0 },
+  { turns: 0, bad: 0, stalled: 0, scored: 0 },
 );
 const fleetRate = fleet.scored > 0 ? fleet.bad / fleet.scored : 0;
 
@@ -343,7 +383,7 @@ if (asJson) {
     `Agent chat turns, last ${hours}h (excludes user-stopped turns)\n`,
   );
   console.log(
-    `  ${"app".padEnd(11)}${"turns".padStart(6)}${"ok".padStart(6)}${"bad".padStart(6)}${"bad%".padStart(7)}  top reasons`,
+    `  ${"app".padEnd(11)}${"turns".padStart(6)}${"ok".padStart(6)}${"bad".padStart(6)}${"bad%".padStart(7)}${"p50s".padStart(6)}${"p90s".padStart(6)}${"maxs".padStart(6)}${"stall".padStart(6)}  top reasons`,
   );
   for (const r of scored) {
     const pct = `${(r.badRate * 100).toFixed(0)}%`;
@@ -351,13 +391,20 @@ if (asJson) {
       .slice(0, 3)
       .map((x) => `${x.reason}(${x.turns})`)
       .join(" ");
-    const mark = r.badRate > BAD_TURN_BUDGET ? "!" : " ";
+    const mark =
+      r.badRate > BAD_TURN_BUDGET || r.stallRate > STALL_BUDGET ? "!" : " ";
     console.log(
-      `${mark} ${r.name.padEnd(11)}${String(r.turns).padStart(6)}${String(r.ok).padStart(6)}${String(r.bad).padStart(6)}${pct.padStart(7)}  ${top}`,
+      `${mark} ${r.name.padEnd(11)}${String(r.turns).padStart(6)}${String(r.ok).padStart(6)}${String(r.bad).padStart(6)}${pct.padStart(7)}${String(r.p50_wait_s).padStart(6)}${String(r.p90_wait_s).padStart(6)}${String(r.max_wait_s).padStart(6)}${String(r.stalled).padStart(6)}  ${top}`,
     );
   }
   console.log(
     `\n  fleet: ${fleet.bad}/${fleet.scored} turns ended without an answer (${(fleetRate * 100).toFixed(1)}%)`,
+  );
+  console.log(
+    `  fleet: ${fleet.stalled}/${fleet.scored} turns ran over ${STALL_TURN_S / 60}m and still ended without one`,
+  );
+  console.log(
+    "  p50s/p90s/maxs are seconds the user waited for one message, first run start to last run end.",
   );
 
   const withA2a = scored.filter((r) => r.a2a && r.a2a.tasks > 0);
@@ -419,6 +466,7 @@ if (strict && scored.some((r) => dbPressureWarnings(r.dbPressure).length > 0)) {
 }
 if (unreachable.length > 0 && strict) process.exit(1);
 if (strict && scored.some((r) => r.badRate > BAD_TURN_BUDGET)) process.exit(1);
+if (strict && scored.some((r) => r.stallRate > STALL_BUDGET)) process.exit(1);
 if (
   strict &&
   scored.some(

--- a/templates/analytics/actions/account-deep-dive.ts
+++ b/templates/analytics/actions/account-deep-dive.ts
@@ -414,6 +414,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     const trimmedQuery = args.query.trim();
     const gaps: string[] = [];

--- a/templates/analytics/actions/bigquery-query.ts
+++ b/templates/analytics/actions/bigquery-query.ts
@@ -17,5 +17,6 @@ export default defineAction({
   http: { method: "POST" },
   readOnly: true,
   toolCallable: true,
+  grounding: true,
   run: bigquery.run,
 });

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -75,6 +75,7 @@ export default defineAction({
   }),
   readOnly: true,
   toolCallable: true,
+  grounding: true,
   run: async (args, context?: ActionRunContext) => {
     try {
       return await runQuery(args.sql, { signal: context?.signal });

--- a/templates/analytics/actions/content-calendar-schema.ts
+++ b/templates/analytics/actions/content-calendar-schema.ts
@@ -11,6 +11,7 @@ export default defineAction({
   }),
   http: { method: "GET" },
   readOnly: true,
+  grounding: true,
   run: async ({ databaseId }) => {
     return await getContentCalendarSchema(databaseId);
   },

--- a/templates/analytics/actions/content-calendar.ts
+++ b/templates/analytics/actions/content-calendar.ts
@@ -18,6 +18,7 @@ export default defineAction({
       ),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async ({ databaseId }) => {
     const entries = await getContentCalendar(databaseId);
     return { entries, total: Array.isArray(entries) ? entries.length : 0 };

--- a/templates/analytics/actions/gcloud.ts
+++ b/templates/analytics/actions/gcloud.ts
@@ -56,6 +56,7 @@ export default defineAction({
       .describe("Additional Cloud Monitoring filter expression"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["BIGQUERY_PROJECT_ID", "GOOGLE_APPLICATION_CREDENTIALS_JSON"],

--- a/templates/analytics/actions/get-data-program.ts
+++ b/templates/analytics/actions/get-data-program.ts
@@ -22,6 +22,7 @@ export default defineAction({
   }),
   http: { method: "GET" },
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     const ctx = getCredentialContext();
     if (!ctx) throw new Error("No authenticated context for get-data-program.");

--- a/templates/analytics/actions/get-error-issue.ts
+++ b/templates/analytics/actions/get-error-issue.ts
@@ -29,6 +29,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     return getErrorIssue(resolveScope(), args.id, {
       eventsLimit: args.eventsLimit,

--- a/templates/analytics/actions/get-monitor-stats.ts
+++ b/templates/analytics/actions/get-monitor-stats.ts
@@ -37,6 +37,7 @@ export default defineAction({
       ),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async ({ monitorIds, timelineDays, responseWindowHours }) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");

--- a/templates/analytics/actions/get-monitor.ts
+++ b/templates/analytics/actions/get-monitor.ts
@@ -14,6 +14,7 @@ export default defineAction({
     id: z.string().describe("Monitor id."),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async ({ id }) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");

--- a/templates/analytics/actions/get-session-replay-events.ts
+++ b/templates/analytics/actions/get-session-replay-events.ts
@@ -40,6 +40,7 @@ export default defineAction({
   }),
   http: { method: "GET" },
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     return getSessionReplayEvents(args.recordingId, resolveScope(), {
       startSeq: args.startSeq,

--- a/templates/analytics/actions/get-session-replay-summary.ts
+++ b/templates/analytics/actions/get-session-replay-summary.ts
@@ -22,6 +22,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     return getSessionReplaySummary(args.recordingId, resolveScope());
   },

--- a/templates/analytics/actions/get-session-replay-timeline.ts
+++ b/templates/analytics/actions/get-session-replay-timeline.ts
@@ -32,6 +32,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     return getSessionReplayTimeline(args.recordingId, resolveScope(), {
       eventLimit: args.eventLimit,

--- a/templates/analytics/actions/gong-calls.ts
+++ b/templates/analytics/actions/gong-calls.ts
@@ -583,6 +583,7 @@ export default defineAction({
       ),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args, ctx) => {
     const requestOptions = ctx?.signal ? { signal: ctx.signal } : undefined;
     if (args.users) {

--- a/templates/analytics/actions/gong-native-insights.ts
+++ b/templates/analytics/actions/gong-native-insights.ts
@@ -66,6 +66,7 @@ export default defineAction({
     Boolean(operation && allowCreditRequest),
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
   http: false,
+  grounding: true,
   run: async ({ operation, allowCreditRequest, arguments: args }) => {
     const tools = gongNativeTools(await listVisibleMcpTools());
     if (!operation) {

--- a/templates/analytics/actions/grafana.ts
+++ b/templates/analytics/actions/grafana.ts
@@ -36,6 +36,7 @@ export default defineAction({
     to: z.string().optional().describe("Query end time in epoch ms"),
   }),
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["GRAFANA_URL", "GRAFANA_API_TOKEN"],

--- a/templates/analytics/actions/grounding-flags.spec.ts
+++ b/templates/analytics/actions/grounding-flags.spec.ts
@@ -1,0 +1,42 @@
+import { readdirSync, readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import prometheus from "./prometheus";
+
+const actionsDir = new URL(".", import.meta.url);
+
+function declaresGrounding(name: string): boolean {
+  const source = readFileSync(new URL(`${name}.ts`, actionsDir), "utf8");
+  return /^\s{2}grounding: true,$/m.test(source);
+}
+
+describe("grounding declarations", () => {
+  it("declares Prometheus as a grounding source action", () => {
+    expect(declaresGrounding("prometheus")).toBe(true);
+    expect(prometheus.grounding).toBe(true);
+  });
+
+  // Every provider action reaches its source through requireActionCredentials.
+  // The response guard used to consult a separate name list, so a provider
+  // action could ship fully working and still have its grounded answer replaced
+  // with "connect data sources". Keeping the two in step is now one flag.
+  it("declares every credentialed provider action as grounding", () => {
+    const missing = readdirSync(actionsDir)
+      .filter(
+        (file) =>
+          file.endsWith(".ts") &&
+          !file.endsWith(".spec.ts") &&
+          !file.startsWith("_"),
+      )
+      .map((file) => file.replace(/\.ts$/, ""))
+      .filter(
+        (name) =>
+          readFileSync(new URL(`${name}.ts`, actionsDir), "utf8").includes(
+            "requireActionCredentials(",
+          ) && !declaresGrounding(name),
+      );
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/templates/analytics/actions/hubspot-deals.ts
+++ b/templates/analytics/actions/hubspot-deals.ts
@@ -494,6 +494,7 @@ export default defineAction({
   }),
   http: { method: "GET" },
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async ({
     properties,
     owner,

--- a/templates/analytics/actions/hubspot-metrics.ts
+++ b/templates/analytics/actions/hubspot-metrics.ts
@@ -15,6 +15,7 @@ export default defineAction({
     "Get computed HubSpot sales metrics: win rate, ACV, pipeline value, etc.",
   schema: z.object({}),
   http: { method: "GET" },
+  grounding: true,
   run: async () => {
     const [deals, pipelines] = await Promise.all([
       getAllDeals(),

--- a/templates/analytics/actions/hubspot-pipelines.ts
+++ b/templates/analytics/actions/hubspot-pipelines.ts
@@ -10,6 +10,7 @@ export default defineAction({
   description: "Get HubSpot deal pipelines and their stages.",
   schema: z.object({}),
   http: { method: "GET" },
+  grounding: true,
   run: async () => {
     const allPipelines = await getDealPipelines();
     const pipelines = getVisiblePipelines(allPipelines);

--- a/templates/analytics/actions/hubspot-records.ts
+++ b/templates/analytics/actions/hubspot-records.ts
@@ -49,6 +49,7 @@ export default defineAction({
   }),
   http: { method: "GET" },
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async ({ objectType, query, properties, limit, after }) => {
     const result = await searchHubSpotObjects({
       objectType,

--- a/templates/analytics/actions/jira-search.ts
+++ b/templates/analytics/actions/jira-search.ts
@@ -25,6 +25,7 @@ export default defineAction({
       .describe("Comma-separated field names to include"),
   }),
   http: false,
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["JIRA_BASE_URL", "JIRA_USER_EMAIL", "JIRA_API_TOKEN"],

--- a/templates/analytics/actions/jira.ts
+++ b/templates/analytics/actions/jira.ts
@@ -66,6 +66,7 @@ export default defineAction({
       .describe("Lookback days for mode=analytics"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["JIRA_BASE_URL", "JIRA_USER_EMAIL", "JIRA_API_TOKEN"],

--- a/templates/analytics/actions/list-error-issues.ts
+++ b/templates/analytics/actions/list-error-issues.ts
@@ -47,6 +47,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     return listErrorIssues(resolveScope(), args);
   },

--- a/templates/analytics/actions/list-monitors.ts
+++ b/templates/analytics/actions/list-monitors.ts
@@ -12,6 +12,7 @@ export default defineAction({
     "List the current user's uptime monitors with their latest status, latency, and 24h/7d uptime percentage.",
   schema: z.object({}),
   http: { method: "GET" },
+  grounding: true,
   run: async () => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");

--- a/templates/analytics/actions/list-session-recordings.ts
+++ b/templates/analytics/actions/list-session-recordings.ts
@@ -59,6 +59,7 @@ export default defineAction({
   http: { method: "GET" },
   readOnly: true,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     return listSessionRecordings(resolveScope(), args);
   },

--- a/templates/analytics/actions/match-error-issues.ts
+++ b/templates/analytics/actions/match-error-issues.ts
@@ -45,6 +45,7 @@ export default defineAction({
   }),
   http: { method: "POST" },
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     return matchErrorIssuesBySignatures(resolveScope(), args.signatures);
   },

--- a/templates/analytics/actions/prometheus.ts
+++ b/templates/analytics/actions/prometheus.ts
@@ -52,6 +52,7 @@ export default defineAction({
     metric: z.string().optional().describe("Metric name for mode=metadata"),
   }),
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     const creds = await requireActionCredentials(
       ["PROMETHEUS_URL"],

--- a/templates/analytics/actions/pylon-issues.ts
+++ b/templates/analytics/actions/pylon-issues.ts
@@ -27,6 +27,7 @@ export default defineAction({
   agentTool: false,
   toolCallable: true,
   http: { method: "POST" },
+  grounding: true,
   run: async ({ account, accounts, query, days, pageSize, maxPages }) => {
     if (accounts) {
       const response = (await executeProviderApiRequest({

--- a/templates/analytics/actions/query-agent-native-analytics.ts
+++ b/templates/analytics/actions/query-agent-native-analytics.ts
@@ -69,6 +69,7 @@ export default defineAction({
   // natural-language question and Analytics forms the query.
   http: false,
   publicAgent: { expose: true, readOnly: true, requiresAuth: true },
+  grounding: true,
   run: async (args) => {
     const result = await queryFirstPartyAnalytics(args.sql, resolveScope(), {
       cache: true,

--- a/templates/analytics/actions/query-dashboard-panel.ts
+++ b/templates/analytics/actions/query-dashboard-panel.ts
@@ -18,6 +18,7 @@ export default defineAction({
   http: { method: "POST" },
   readOnly: true,
   agentTool: false,
+  grounding: true,
   run: async (args) => {
     const context = getCredentialContext();
     if (!context) {

--- a/templates/analytics/actions/query-inbound-forms.ts
+++ b/templates/analytics/actions/query-inbound-forms.ts
@@ -8,6 +8,7 @@ export default defineAction({
     "Query inbound sales/demo form submissions from a configured warehouse form-submissions table.",
   schema: z.object({}),
   http: false,
+  grounding: true,
   run: async () => {
     const sql = `
 SELECT

--- a/templates/analytics/actions/run-monitor-check.ts
+++ b/templates/analytics/actions/run-monitor-check.ts
@@ -14,6 +14,7 @@ export default defineAction({
     id: z.string().describe("Monitor id to check now."),
   }),
   http: { method: "POST" },
+  grounding: true,
   run: async ({ id }) => {
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");

--- a/templates/analytics/actions/sentry.ts
+++ b/templates/analytics/actions/sentry.ts
@@ -44,6 +44,7 @@ export default defineAction({
       .describe("Sentry stats category for mode=stats; defaults to error"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["SENTRY_SERVER_TOKEN", "SENTRY_AUTH_TOKEN"],

--- a/templates/analytics/actions/seo-blog-pages.ts
+++ b/templates/analytics/actions/seo-blog-pages.ts
@@ -10,6 +10,7 @@ export default defineAction({
   description: "Get SEO metrics for all blog pages.",
   schema: z.object({}),
   http: { method: "GET" },
+  grounding: true,
   run: async () => {
     const pages = await getAllBlogPagesSeo();
     return { pages, total: Object.keys(pages).length };

--- a/templates/analytics/actions/seo-page-keywords.ts
+++ b/templates/analytics/actions/seo-page-keywords.ts
@@ -15,6 +15,7 @@ export default defineAction({
       .describe("Blog page slug (e.g. micro-frontends)"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     if (!args.slug) return { error: "slug is required" };
     const keywords = await getRankedKeywordsForPage(args.slug, 20);

--- a/templates/analytics/actions/seo-top-keywords.ts
+++ b/templates/analytics/actions/seo-top-keywords.ts
@@ -16,6 +16,7 @@ export default defineAction({
       .describe("Max keywords to return (default 500)"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     const limit = Math.min(args.limit ?? 500, 1000);
     const keywords = await getAllTopBlogKeywords(limit);

--- a/templates/analytics/actions/slack-messages.ts
+++ b/templates/analytics/actions/slack-messages.ts
@@ -77,6 +77,7 @@ export default defineAction({
       .describe("Per-channel cursors for mode=multi-history"),
   }),
   readOnly: true,
+  grounding: true,
   run: async (args) => {
     const workspace = parseWorkspace(args.workspace);
     const key =

--- a/templates/analytics/actions/stripe.ts
+++ b/templates/analytics/actions/stripe.ts
@@ -74,6 +74,7 @@ export default defineAction({
       .describe("Months of billing history"),
   }),
   http: { method: "GET" },
+  grounding: true,
   run: async (args) => {
     const credentials = await requireActionCredentials(
       ["STRIPE_SECRET_KEY"],

--- a/templates/analytics/actions/test-custom-api-connection.ts
+++ b/templates/analytics/actions/test-custom-api-connection.ts
@@ -30,6 +30,7 @@ export default defineAction({
   agentTool: false,
   http: { method: "POST" },
   readOnly: true,
+  grounding: true,
   run: async ({ provider, path, query, itemsPath }) => {
     try {
       const result = (await getAnalyticsProviderApiRuntime().executeRequest({

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -20,8 +20,31 @@ import {
   looksLikeAnalyticsDataRequest,
   needsCorpusWorkflowForCoverageSensitiveRequest,
   needsSourceRecordBodyWorkflowForCoverageSensitiveRequest,
+  registerGroundingActions,
   stripInjectedAnalyticsGuardContext,
 } from "./real-data-actions";
+
+// These tests exercise the predicates, not the derivation: the agent-chat
+// plugin is what reads `grounding: true` off the shipped action definitions.
+registerGroundingActions([
+  "account-deep-dive",
+  "bigquery",
+  "get-session-replay-summary",
+  "get-session-replay-timeline",
+  "gong-calls",
+  "gong-native-insights",
+  "hubspot-deals",
+  "hubspot-records",
+  "jira-search",
+  "list-error-issues",
+  "list-session-recordings",
+  "prometheus",
+  "provider-api-request",
+  "provider-corpus-job",
+  "query-agent-native-analytics",
+  "query-staged-dataset",
+  "slack-messages",
+]);
 
 describe("real data action classification", () => {
   it("treats unstructured source records as real analytics evidence", () => {

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -13,45 +13,6 @@ const INJECTED_CONTEXT_BLOCKS = [
   "response-guard",
 ];
 
-export const DATA_QUERY_ACTIONS = new Set([
-  "account-deep-dive",
-  "bigquery",
-  "content-calendar",
-  "content-calendar-schema",
-  // First-party observability reads are grounded data for incident triage,
-  // even though they are not provider queries. Keep the final-response guard
-  // from replacing valid session/error/replay evidence with the generic
-  // "connect a source" fallback.
-  "get-error-issue",
-  "get-session-replay-events",
-  "get-session-replay-summary",
-  "get-session-replay-timeline",
-  "list-error-issues",
-  "list-session-recordings",
-  "match-error-issues",
-  "gcloud",
-  "gong-calls",
-  "gong-native-insights",
-  "grafana",
-  "hubspot-deals",
-  "hubspot-metrics",
-  "hubspot-pipelines",
-  "hubspot-records",
-  "jira",
-  "jira-search",
-  "provider-api-request",
-  "provider-corpus-job",
-  "query-staged-dataset",
-  "query-agent-native-analytics",
-  "query-inbound-forms",
-  "sentry",
-  "seo-blog-pages",
-  "seo-page-keywords",
-  "seo-top-keywords",
-  "slack-messages",
-  "stripe",
-]);
-
 export const CORPUS_SOURCE_ACTIONS = new Set([
   "provider-api-request",
   "provider-corpus-job",
@@ -127,8 +88,39 @@ function isToolName(name: string, expected: string): boolean {
   return normalizeActionToolName(name) === expected;
 }
 
-function isDataQueryActionName(name: string): boolean {
-  return DATA_QUERY_ACTIONS.has(normalizeActionToolName(name));
+let groundingActionNames: ReadonlySet<string> | null = null;
+
+/**
+ * Publish the action names whose definitions declare `grounding: true`.
+ *
+ * The set is pushed in rather than read from `.generated/actions-registry`
+ * because that registry imports every action, and `save-analysis` imports this
+ * module — importing it back here would close an evaluation cycle. The
+ * agent-chat plugin derives the set once at module load; nothing else may.
+ */
+export function registerGroundingActions(names: Iterable<string>): void {
+  const normalized = new Set(
+    [...names].map((name) => normalizeActionToolName(name)),
+  );
+  // An empty set is never a real deployment: it means the installed core build
+  // predates `grounding` and dropped it from every definition. Left unchecked,
+  // the guard would replace every correct grounded answer with "connect data
+  // sources" — the exact silent failure this flag replaced.
+  if (normalized.size === 0) {
+    throw new Error(
+      "no action declares grounding: true; the installed @agent-native/core cannot carry the flag",
+    );
+  }
+  groundingActionNames = normalized;
+}
+
+function isGroundingActionName(name: string): boolean {
+  if (!groundingActionNames) {
+    throw new Error(
+      "grounding actions were never registered: the analytics response guard cannot tell a grounded turn from an ungrounded one",
+    );
+  }
+  return groundingActionNames.has(normalizeActionToolName(name));
 }
 
 function isDashboardConstructionActionName(name: string): boolean {
@@ -214,7 +206,7 @@ function getRunCodeBridgeToolNames(content: string | undefined): string[] {
 
 function hasRunCodeDataQueryAttempt(content: string | undefined): boolean {
   return getRunCodeBridgeToolNames(content).some(
-    (name) => isDataQueryActionName(name) || isMcpDataSourceTool(name),
+    (name) => isGroundingActionName(name) || isMcpDataSourceTool(name),
   );
 }
 
@@ -530,10 +522,9 @@ export function hasIncompleteDataEvidence(
     const name = String(result.name ?? "");
     if (
       name &&
-      !isDataQueryActionName(name) &&
+      !isGroundingActionName(name) &&
       !isMcpDataSourceTool(name) &&
-      !isToolName(name, "run-code") &&
-      !isToolName(name, "provider-api-request")
+      !isToolName(name, "run-code")
     ) {
       return false;
     }
@@ -594,7 +585,7 @@ export function hasDataQueryAttempt(
     if (isToolName(name, "run-code")) {
       return hasRunCodeDataQueryAttempt(result.content);
     }
-    return isDataQueryActionName(name) || isMcpDataSourceTool(name);
+    return isGroundingActionName(name) || isMcpDataSourceTool(name);
   });
 }
 
@@ -605,7 +596,7 @@ function isFailedDataQueryAttempt(result: {
 }): boolean {
   const name = String(result.name ?? "");
   const isDataQuery =
-    isDataQueryActionName(name) ||
+    isGroundingActionName(name) ||
     isMcpDataSourceTool(name) ||
     (isToolName(name, "run-code") &&
       hasRunCodeDataQueryAttempt(result.content));

--- a/templates/analytics/server/plugins/agent-chat.dashboard-edit.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.dashboard-edit.spec.ts
@@ -1,7 +1,19 @@
 import type { AgentLoopFinalResponseGuardContext } from "@agent-native/core/server";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../../.generated/actions-registry.js", () => ({ default: {} }));
+vi.mock("../../.generated/actions-registry.js", () => ({
+  default: {
+    bigquery: {
+      readOnly: true,
+      grounding: true,
+      tool: {
+        description: "Query BigQuery",
+        parameters: { type: "object", properties: {} },
+      },
+      run: async () => "ok",
+    },
+  },
+}));
 
 import { realDataFinalGuard } from "./agent-chat";
 

--- a/templates/analytics/server/plugins/agent-chat.spec.ts
+++ b/templates/analytics/server/plugins/agent-chat.spec.ts
@@ -14,6 +14,7 @@ const { agentChatPluginOptions, representativeAnalyticsActions } = vi.hoisted(
     representativeAnalyticsActions: {
       "query-agent-native-analytics": {
         readOnly: true,
+        grounding: true,
         tool: {
           description: "Query first-party analytics",
           parameters: { type: "object", properties: {} },
@@ -22,6 +23,7 @@ const { agentChatPluginOptions, representativeAnalyticsActions } = vi.hoisted(
       },
       bigquery: {
         readOnly: true,
+        grounding: true,
         tool: {
           description: "Query BigQuery",
           parameters: { type: "object", properties: {} },
@@ -30,8 +32,27 @@ const { agentChatPluginOptions, representativeAnalyticsActions } = vi.hoisted(
       },
       "hubspot-records": {
         readOnly: true,
+        grounding: true,
         tool: {
           description: "Read HubSpot records",
+          parameters: { type: "object", properties: {} },
+        },
+        run: async () => "ok",
+      },
+      // A shipped source action the guard's retired name list never named.
+      prometheus: {
+        readOnly: true,
+        grounding: true,
+        tool: {
+          description: "Query Prometheus",
+          parameters: { type: "object", properties: {} },
+        },
+        run: async () => "ok",
+      },
+      "list-data-dictionary": {
+        readOnly: true,
+        tool: {
+          description: "Browse metric definitions",
           parameters: { type: "object", properties: {} },
         },
         run: async () => "ok",
@@ -355,6 +376,44 @@ function guardContext(params: {
 }
 
 describe("realDataFinalGuard", () => {
+  it("accepts a grounded answer from a source action no name list ever enumerated", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "How many sessions did we record in the last 24 hours?",
+        draftText:
+          "We recorded 41,208 sessions in the last 24 hours, from Prometheus (24h range, 1m step).",
+        toolResults: [
+          {
+            name: "prometheus",
+            isError: false,
+            content:
+              '{"resultType":"matrix","data":{"result":[{"values":[]}]}}',
+          },
+        ],
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("still rejects a metric answer whose only tool call was a metadata read", () => {
+    const result = realDataFinalGuard(
+      guardContext({
+        userText: "How many sessions did we record in the last 24 hours?",
+        draftText: "We recorded 41,208 sessions in the last 24 hours.",
+        toolResults: [
+          {
+            name: "list-data-dictionary",
+            isError: false,
+            content: '{"entries":[{"name":"p95_latency"}]}',
+          },
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
   it("retries a dashboard build that pauses after creating an extension shell", () => {
     const result = realDataFinalGuard(
       guardContext({

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -29,7 +29,27 @@ import {
   looksLikeAnalyticsDataRequest,
   needsCorpusWorkflowForCoverageSensitiveRequest,
   needsSourceRecordBodyWorkflowForCoverageSensitiveRequest,
+  registerGroundingActions,
 } from "../lib/real-data-actions";
+
+// Which actions return real data-source evidence is a fact each action states
+// on itself (`grounding: true`). Reading it off the definitions here is what
+// keeps the response guard from drifting behind a newly shipped source action.
+registerGroundingActions(
+  Object.entries(actionsRegistry)
+    .filter(([, module]) => {
+      // Action modules reach the registry either as the module namespace or as
+      // an already-unwrapped definition, the same two shapes
+      // `loadActionsFromStaticRegistry` normalizes.
+      const candidate = module as
+        | { grounding?: boolean; default?: { grounding?: boolean } }
+        | undefined;
+      return (
+        candidate?.grounding === true || candidate?.default?.grounding === true
+      );
+    })
+    .map(([name]) => name),
+);
 
 const ANALYTICS_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
 // A background job may legitimately spend minutes inside a provider/tool call,
@@ -764,17 +784,23 @@ export function realDataFinalGuard(
   }
 
   if (dataQueryAttempted) return null;
+  const failedQueryMessage = failedDataQueryAttemptMessage(context.toolResults);
+  // Whether the built-in source is worth trying is decided by tool evidence,
+  // not by how the draft is worded, so it is asked once for every draft shape.
+  // A source that already failed this turn is not an untried source: steering
+  // the model back into it is how a permanently failing precondition turns
+  // into a retry loop.
+  if (firstPartySourceShouldBeTried && !failedQueryMessage) {
+    return {
+      retryMessage:
+        "The user asked for live analytics, and the built-in first-party Analytics source is available even though no external provider is connected. Call `query-agent-native-analytics` for first-party product, usage, conversion, or observability data and answer from that result. If the request specifically names an external provider, explain what is missing and include the real Connect data sources link.",
+      fallbackMessage:
+        "I couldn't complete a grounded first-party Analytics query yet. Please retry and I'll use the built-in Analytics source before asking you to connect an external provider.",
+      maxRetries: 2,
+      expandToolSurface: true,
+    };
+  }
   if (isSafeNoDataAnalyticsResponse(context.text)) {
-    if (firstPartySourceShouldBeTried) {
-      return {
-        retryMessage:
-          "The built-in first-party Analytics source is available even though no external provider is connected. Use `query-agent-native-analytics` for the user's first-party product, usage, conversion, or observability question before explaining that data is unavailable. Only guide the user to connect a source if the request specifically needs an external provider.",
-        fallbackMessage:
-          "I couldn't complete a grounded first-party Analytics query yet. Please retry and I'll use the built-in Analytics source before asking you to connect an external provider.",
-        maxRetries: 2,
-        expandToolSurface: true,
-      };
-    }
     if (
       needsDataSourceLink &&
       !includesDataSourcesLink(context.text, setupLink)
@@ -787,7 +813,6 @@ export function realDataFinalGuard(
     }
     return null;
   }
-  const failedQueryMessage = failedDataQueryAttemptMessage(context.toolResults);
   if (failedQueryMessage) {
     if (
       needsDataSourceLink &&
@@ -805,11 +830,10 @@ export function realDataFinalGuard(
     };
   }
 
-  if (
-    needsDataSourceLink &&
-    (missingRequestedExternalSource ||
-      (noConnectedExternalSources && externalSourceRequest))
-  ) {
+  // `needsDataSourceLink` already carries "status was checked, the user named an
+  // external source, and it is missing or nothing is connected". Restating those
+  // clauses here is what made the next branch look reachable.
+  if (needsDataSourceLink) {
     return {
       retryMessage: `The requested external source is not connected. Explain what is missing in the context of the user's question and include this exact markdown link: ${setupMarkdown}. Do not use the generic no-grounded-data fallback.`,
       fallbackMessage: `I can help with that once the relevant source is connected. ${setupMarkdown}`,
@@ -819,24 +843,6 @@ export function realDataFinalGuard(
   }
 
   const configuredSources = configuredDataSourceLabels(context.toolResults);
-  if (firstPartySourceShouldBeTried) {
-    return {
-      retryMessage:
-        "The user asked for live analytics, and the built-in first-party Analytics source is available even though no external provider is connected. Call `query-agent-native-analytics` for first-party product, usage, conversion, or observability data and answer from that result. If the request specifically names an external provider, explain what is missing and include the real Connect data sources link.",
-      fallbackMessage:
-        "I couldn't complete a grounded first-party Analytics query yet. Please retry and I'll use the built-in Analytics source before asking you to connect an external provider.",
-      maxRetries: 2,
-      expandToolSurface: true,
-    };
-  }
-  if (noConnectedExternalSources) {
-    return {
-      retryMessage: `The user asked for live analytics, but data-source-status found no connected external providers. The built-in first-party source is still available for first-party Analytics data. If this request needs an external source, respond naturally in the context of the user's question, explain what is missing, and include ${setupMarkdown}. Do not use a generic canned no-data response.`,
-      fallbackMessage: `I can help with that once the relevant source is connected. ${setupMarkdown}`,
-      maxRetries: 2,
-      expandToolSurface: true,
-    };
-  }
   const configuredSourceGuidance = configuredSources.length
     ? ` \`data-source-status\` already confirmed these connected sources: ${configuredSources.join(", ")}. Do not claim that no sources are connected and do not ask the user to reconnect them. Immediately call the relevant query action for one of those sources.`
     : "";


### PR DESCRIPTION
## Summary
- persist repeat/error ledgers across agent continuation chunks and report guard stops as failed terminal outcomes
- bound non-advancing client continuations and preserve failed/unknown tool outcomes in replayed history
- declare grounding on live-data actions and derive Analytics response guards from action metadata

## Validation
- Core targeted Vitest: 11 files, 628 tests
- Analytics targeted Vitest: 4 files, 102 tests
- Core TypeScript typecheck
- oxfmt check, diff check, changeset check

Ready for review.