### PR TITLE
fix: normalize repeat guard inputs

### DIFF
--- a/.changeset/normalize-repeat-guard-input.md
+++ b/.changeset/normalize-repeat-guard-input.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use normalized tool inputs when enforcing per-turn repeat-call guards.

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -444,6 +444,53 @@ describe("tool-call journal hard-block", () => {
     );
   });
 
+  it("uses the persisted normalized input for repeat counts", async () => {
+    currentTurnEventsMock.mockResolvedValue(
+      Array.from({ length: MAX_IDENTICAL_TOOL_CALLS - 1 }, () => ({
+        type: "tool_start",
+        tool: "write-config",
+        input: { config: { a: 1 } },
+      })),
+    );
+    const action: ActionEntry = {
+      tool: {
+        description: "A config write action",
+        parameters: {
+          type: "object",
+          properties: { config: { type: "object" } },
+        },
+      },
+      readOnly: false,
+      run: vi.fn(async () => "fresh-execution-result"),
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      // The model sends the same object as a JSON string; action execution and
+      // the journal normalize it to the object form before recording the call.
+      engine: singleToolEngine("write-config", { config: '{"a":1}' }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: { "write-config": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-repeat-normalized-input",
+    });
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "repeated_tool_call",
+        recoverable: false,
+      }),
+    );
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "done" }),
+    );
+  });
+
   it("counts identical tool errors from earlier chunks of the same turn", async () => {
     currentTurnEventsMock.mockResolvedValue([
       { type: "tool_start", tool: "flaky-write", input: { id: "row-1" } },

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -5435,9 +5435,6 @@ export async function runAgentLoop(opts: {
     const runToolCall = async (
       toolCall: import("./engine/types.js").EngineToolCallPart,
     ): Promise<EngineContentPart> => {
-      // Counted before any journal/cache short-circuit: serving a repeat from
-      // cache still means the model is asking the same question again.
-      noteRepeatedToolCall(toolCall.name, toolCall.input);
       const actionEntry = actions[toolCall.name];
       const placeholderNormalization = actionEntry
         ? normalizeOptionalToolPlaceholders(
@@ -5457,6 +5454,11 @@ export async function runAgentLoop(opts: {
       if (jsonStringCoercion.changed) {
         toolCall = { ...toolCall, input: jsonStringCoercion.input };
       }
+      // Count after the same normalization that is persisted in the journal:
+      // a model can send a JSON-encoded object/array, while the action and
+      // ledger both see the coerced value. Serving a repeat from cache still
+      // counts as asking the same question again.
+      noteRepeatedToolCall(toolCall.name, toolCall.input);
       const toolInputNormalized =
         placeholderNormalization.changed || jsonStringCoercion.changed;
       const wireToolInput = JSON.stringify(toolCall.input ?? {});


### PR DESCRIPTION
## Summary
- count repeat calls after the same placeholder/JSON normalization persisted in the tool ledger
- add a regression for a JSON-string object input replayed across continuation chunks

## Validation
- Core targeted Vitest: 2 files, 248 tests
- Core TypeScript typecheck
- oxfmt, diff, and changeset checks

This follows the merged PR #2839 and fixes a concrete adversarial regression found immediately after merge.