### PR TITLE
Fix repeated agent failures and production stale runs

### DIFF
--- a/.changeset/continuation-guard-false-stops.md
+++ b/.changeset/continuation-guard-false-stops.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop the chat continuation guards from ending turns that were still working: an explicit `recoverable: false` on an error event now outranks the transient message sniff (a repeat-guard stop naming a `*connection*` tool auto-continued the loop it was meant to break), `loop_limit` work boundaries are bounded by their own ceiling instead of the transient-failure one, and the stall signal is read from each round's delta so an unresolved "Preparing" card cannot make later rounds look stuck. History trimming also prices object tool results by what the request actually sends instead of `[object Object]`.

--- a/.changeset/durable-stale-run-reaping.md
+++ b/.changeset/durable-stale-run-reaping.md
@@ -1,0 +1,19 @@
+---
+"@agent-native/core": patch
+---
+
+Fix stale agent runs never being reaped in production. The periodic stale reaper
+lived on an in-process timer that `shouldDisableInProcessSweeps()` turns off for
+every production serverless function, and nothing durable replaced it, so a run
+whose producer died stayed "running" until an unrelated request path happened to
+notice. Stale reaping now rides the signed, platform-scheduled recurring-job
+sweep — one site-wide reap per tick instead of one per warm container.
+
+Also corrects what the reapers record: `completed_at` is now the run's last
+liveness basis rather than the time a reaper noticed, so a reaped run reports its
+real duration instead of detection latency; and `terminal_reason` is the
+normalized `error:stale_run` that the event reconciler already writes for the
+same outcome, so one failure no longer splits across two permanent
+`agent_run_outcome_daily` buckets. Heartbeat writes are bounded to one attempt
+inside a third of the stale window, so a live run can no longer be reaped while
+its own heartbeat is still in flight holding a pooler connection.

--- a/.changeset/loading-page-indicator.md
+++ b/.changeset/loading-page-indicator.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use a clear loading message for the route transition indicator instead of exposing the destination URL.

--- a/.changeset/lucky-buttons-melt.md
+++ b/.changeset/lucky-buttons-melt.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep agent runs alive when the SQL abort state is briefly unreadable. A few consecutive failed abort-state reads (roughly 9s of database unreadability) used to self-abort the run with `aborted_abort_check_unavailable`, killing in-flight work the user was waiting on. The check now fails open and reports the outage to Sentry instead; the run stays bounded by the soft timeout, no-progress backstop, and iteration limits.

--- a/.changeset/no-false-stops-in-repeat-guards.md
+++ b/.changeset/no-false-stops-in-repeat-guards.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop the new repeat-loop guards from killing turns that would have succeeded: network "connect … before/first" failures and retention-window "only available in …" errors no longer read as permanent preconditions, per-item errors that differ only by id (`Record 41 not found`) are counted separately again, the permanent-precondition stop keeps the raw tool error in `details` like every other terminal stop, an explicit `recoverable: false` outranks the message sniff, a single ledger-read blip is retried before the turn stops, and the persisted-thread rebuild scopes retry clears exactly like the live client so narration no longer vanishes on reload.

--- a/packages/core/src/agent/engine/tool-call-journal-seed.ts
+++ b/packages/core/src/agent/engine/tool-call-journal-seed.ts
@@ -47,6 +47,31 @@ export type PriorTurnToolCallJournalRead =
     }
   | { status: "unreadable"; error: string };
 
+const LEDGER_READ_RETRY_MS = 250;
+
+/**
+ * `unreadable` ends the turn with a stop the user sees, so a single pool
+ * timeout or connection blip must not produce one. One retry, because the
+ * failures worth surviving are transient and the caller is holding the whole
+ * turn open while we wait.
+ */
+async function readCurrentTurnEventsWithRetry(
+  threadId: string,
+  turnId?: string,
+): Promise<AgentChatEvent[]> {
+  try {
+    return await getCurrentTurnEventsForThread(threadId, turnId);
+  } catch (err) {
+    console.warn(
+      `[tool-call-journal] per-turn ledger read failed for thread ${threadId}, retrying once: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, LEDGER_READ_RETRY_MS));
+    return await getCurrentTurnEventsForThread(threadId, turnId);
+  }
+}
+
 /**
  * Tool-call journal hard-block (resume safety). Snapshot the per-turn journal
  * ONCE here, before any tool runs in this chunk, so it reflects only PRIOR
@@ -83,7 +108,7 @@ export async function loadPriorTurnToolCallJournal(
   }
   let priorEvents: AgentChatEvent[];
   try {
-    priorEvents = await getCurrentTurnEventsForThread(threadId, turnId);
+    priorEvents = await readCurrentTurnEventsWithRetry(threadId, turnId);
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     console.warn(

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -580,6 +580,39 @@ describe("tool-call journal hard-block", () => {
     );
   });
 
+  // One pool timeout is not an unreadable ledger. Without the retry, a single
+  // blip ended the turn before its first iteration with a stop the user sees
+  // and the client will not auto-continue.
+  it("survives a single ledger read blip on a continuation", async () => {
+    currentTurnEventsMock
+      .mockRejectedValueOnce(new Error("neon: connection lost"))
+      .mockResolvedValue([]);
+    const action = makeWriteAction();
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("send-email", { to: "a@b.com" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: AGENT_INTERNAL_CONTINUE_PROMPT }],
+        },
+      ],
+      actions: { "send-email": action },
+      send: (e) => events.push(e),
+      signal: new AbortController().signal,
+      threadId: "thread-ledger-blip",
+    });
+
+    expect(action.run).toHaveBeenCalledOnce();
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ errorCode: "tool_call_journal_unreadable" }),
+    );
+  });
+
   it("runs a FRESH turn normally when the ledger read fails", async () => {
     currentTurnEventsMock.mockRejectedValue(new Error("neon: connection lost"));
     const action = makeWriteAction();

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -6088,7 +6088,7 @@ describe("runAgentLoop", () => {
       "Error running add-slide: Requires editor role on deck ZJshjrXhjx (have viewer)",
       "Error running generate-slides-ai: Gemini API key not configured. Save GEMINI_API_KEY in settings.",
       "Error running index-design-system-with-builder: Connect Builder.io before indexing a design system from Figma or code.",
-      "Error running get-local-plan-folder: Local plan folder preview is only available in local Plan runtime.",
+      "Error running connect-google-calendar: Connect Google Calendar in settings first.",
       "Plan mode blocked `update-extension`. Switch to Act mode after the user approves the plan, then retry the action.",
       "no authenticated user",
       "Error running call-agent: Error: The Analytics agent call failed. (SSRF blocked: refusing to fetch private/internal address (http://localhost:8088/a2a))",
@@ -6107,6 +6107,14 @@ describe("runAgentLoop", () => {
       "Error running bigquery: Not found: Dataset builder-3b0a2 was not found in location US",
       'Error running run-sql: syntax error at or near "slect"',
       "Error running run-sql: column deals.stage does not exist",
+      // Network failures. The canonical retryable error must never read as a
+      // "connect X first" setup instruction.
+      "Error running warehouse-query: failed to connect to the warehouse before the deadline",
+      "Error running warehouse-query: could not connect to host db-1 before timeout",
+      "Error running warehouse-query: Connect timed out, retry first",
+      // Retention windows, fixed by narrowing the range and asking again.
+      "Error running list-session-recordings: Data is only available from the last 90 days",
+      "Error running gong-calls: transcripts are only available in the last 12 months",
     ]) {
       expect(permanentPreconditionRemedy(recoverable)).toBeNull();
     }
@@ -6171,9 +6179,78 @@ describe("runAgentLoop", () => {
       errorCode: "permanent_precondition",
       recoverable: false,
     });
-    // The remedy is the last thing the user reads.
-    expect((stop as { error: string }).error).toContain(
+    // Raw tool error in `details`, remedy in `message` — the shape every other
+    // terminal stop uses, and the one `TerminalActionStop` documents.
+    expect((stop as { details: string }).details).toContain(
       "Save GEMINI_API_KEY in settings",
+    );
+    expect((stop as { error: string }).error).not.toContain("GEMINI_API_KEY");
+    expect((stop as { error: string }).error).toContain(
+      "needs a setup step outside this turn",
+    );
+  });
+
+  // A model iterating ids that each genuinely 404 is not repeating a failure —
+  // it is making progress. Normalizing digits out of the breaker key merged
+  // them into one and ended the sweep at item six.
+  it("counts per-item not-found errors as distinct failures", async () => {
+    const ITEMS = 7;
+    let streamCalls = 0;
+    const run = vi.fn(async (input: { id: number }) => {
+      throw new Error(`Record ${input.id} not found`);
+    });
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls > ITEMS) {
+          yield {
+            type: "assistant-content",
+            parts: [{ type: "text" as const, text: "None of them exist." }],
+          };
+          yield { type: "stop", reason: "end_turn" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [
+            {
+              type: "tool-call" as const,
+              id: `fetch-${streamCalls}`,
+              name: "fetch-record",
+              input: { id: 40 + streamCalls },
+            },
+          ],
+        };
+        yield { type: "stop", reason: "tool_use" };
+      },
+    };
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "sweep" }] }],
+      actions: { "fetch-record": { ...actionEntry({ readOnly: true }), run } },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).toHaveBeenCalledTimes(ITEMS);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "error" }),
     );
   });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2929,12 +2929,12 @@ export const MAX_IDENTICAL_TOOL_CALLS = 8;
 /**
  * A stop that ends the turn from inside the tool loop.
  *
- * `message` is the last thing the user reads, so it must name the remedy and
- * must NOT quote a raw provider/tool error: both `isAutoRecoverableError`
- * (client) and `isRecoverableContinuationError` (below) sniff this string for
- * "timeout"/"connection"/"network", and a stop whose text happens to contain
- * one is auto-continued into the very spiral it was raised to end. The raw
- * error belongs in `details`, which nothing retries on.
+ * `message` is the last thing the user reads, so it names the remedy in plain
+ * words and does not quote a raw provider/tool error; the raw error goes in
+ * `details`. Both retry sniffers now honour the `recoverable: false` these
+ * stops are sent with, so a stop that happens to say "timeout" is no longer
+ * auto-continued — but the prose still has one reader who cannot ignore it,
+ * and a pasted stack trace is not a remedy.
  */
 export interface TerminalActionStop {
   message: string;
@@ -3500,10 +3500,12 @@ async function waitForInterruptedToolLedgerEntry(opts: {
  * sentence before it, and two failures that differ ONLY in the arguments they
  * echo are the same failure.
  *
- * Numbers go the same way, for the same reason. A guard that reports its own
- * running tally ("this turn already made 13 call(s)") hands the breaker a new
- * key on every single decline, so the decline that exists to stop a spiral is
- * itself uncountable.
+ * Digits stay. Collapsing them merges failures that are genuinely different:
+ * "Record 41 not found" and "Record 42 not found" are two missing records, so a
+ * seven-item sweep where every item legitimately 404s would trip the
+ * across-arguments breaker at item six. A guard message that varies its own
+ * running tally is fixed where that message is written, not by blinding every
+ * breaker to numbers.
  */
 function normalizeToolErrorForBreaker(error: string): string {
   return (
@@ -3515,7 +3517,6 @@ function normalizeToolErrorForBreaker(error: string): string {
       )
       // Bare JSON payloads some providers inline instead of a Received: span.
       .replace(/\{[\s\S]{0,2000}?\}/g, "{}")
-      .replace(/\d+/g, "#")
       .replace(/\s+/g, " ")
       .trim()
   );
@@ -3565,16 +3566,27 @@ const PERMANENT_PRECONDITION_PATTERNS: readonly RegExp[] = [
   /\b(?:api[ -]?keys?|access tokens?|credentials?|secrets?)\b[^.]{0,60}\bnot (?:configured|set|connected|available)\b/i,
   /\bsave [A-Z][A-Z0-9_]{3,} in (?:the )?settings\b/i,
   // "Connect Builder.io before indexing a design system from Figma or code."
-  /\bconnect\b[^;]{1,40}?\b(?:before|first|in settings)\b/i,
-  // "…is only available in local Plan runtime." Excludes "only available after
-  // …", which names a condition that clears on its own.
-  /\bonly available (?:in|on|from|to)\b/i,
+  // Case-sensitive, sentence-initial, and followed by a capitalized service
+  // name, because that is the only shape that separates the imperative remedy
+  // from the retryable network failure: "failed to connect to the warehouse
+  // before the deadline" and "Connect timed out, retry first" both satisfy
+  // every looser reading of the same words.
+  /(?:^|[.:!?]\s+)Connect [A-Z][\w.-]*[^;]{0,40}?\b(?:before|first|in settings)\b/,
   // "Plan mode blocked `update-extension`. Switch to Act mode …" — cleared by
   // the user approving the plan, never by the model trying again.
   /\bplan mode blocked\b/i,
+  // The templates' most-copied throw, and always `if (!getRequestUserEmail())`:
+  // one synchronous AsyncLocalStorage read of a value fixed when the request
+  // context was established. It cannot appear and disappear between tool calls
+  // of the same chunk, so retrying inside this turn lands on it again.
   /\bno authenticated user\b/i,
   // "SSRF blocked: refusing to fetch private/internal address (…)"
   /\bssrf blocked\b/i,
+  // Deliberately absent: "only available in …". Retention windows ("only
+  // available from the last 90 days") share its wording and are fixed by
+  // narrowing the range, so it stopped turns that were one argument away from
+  // succeeding. The count-based breaker still ends a genuine runtime gate
+  // after six.
 ];
 
 const SOURCE_SWEEP_TOOL_NAME =
@@ -3718,9 +3730,15 @@ function restrictAgentTeamsAfterSourceSweep(tools: EngineTool[]): EngineTool[] {
   });
 }
 
+/**
+ * Deliberately carries no running call count. This decline is recorded as a
+ * tool error, and the breakers key on that text: a message that reports its own
+ * tally ("already made 13 call(s)") mints a fresh key on every decline, so the
+ * decline that exists to stop a spiral becomes the one thing nothing can count.
+ * The fixed threshold below says the same thing without varying.
+ */
 export function repeatedSourceSweepGuardMessage(opts: {
   toolName: string;
-  priorCalls: number;
   threshold?: number;
   scope?: "tool" | "aggregate";
 }): string {
@@ -3730,9 +3748,8 @@ export function repeatedSourceSweepGuardMessage(opts: {
       ? "read-only source/search tools"
       : "the same read-only source/search tool";
   return (
-    `Skipped ${opts.toolName}: this turn already made ${opts.priorCalls} ` +
-    `call(s) to ${target}, which exceeds the ` +
-    `${threshold}-call convergence budget. Stop calling ${opts.toolName} ` +
+    `Skipped ${opts.toolName}: this turn already exhausted its ` +
+    `${threshold}-call convergence budget for ${target}. Stop calling ${opts.toolName} ` +
     `one item at a time and change strategy before answering. If a broader ` +
     `read-only bulk/source mechanism is available, use it now: provider API ` +
     `catalog/docs/request tools with pagination or staging, code execution ` +
@@ -3776,7 +3793,6 @@ export function shouldGuardRepeatedSourceSweep(opts: {
       priorCalls: priorSourceSweepCalls,
       message: repeatedSourceSweepGuardMessage({
         toolName: opts.toolName,
-        priorCalls: priorSourceSweepCalls,
         threshold,
         scope: "aggregate",
       }),
@@ -3788,7 +3804,6 @@ export function shouldGuardRepeatedSourceSweep(opts: {
     priorCalls,
     message: repeatedSourceSweepGuardMessage({
       toolName: opts.toolName,
-      priorCalls,
       threshold,
       scope: "tool",
     }),
@@ -5505,7 +5520,9 @@ export async function runAgentLoop(opts: {
         const permanentRemedy = permanentPreconditionRemedy(sanitizedResult);
         if (permanentRemedy) {
           requestedActionStop ??= {
-            message: `I stopped because ${toolCall.name} cannot run until this is fixed: ${permanentRemedy} Retrying would not have changed it, and anything completed before this is saved.`,
+            message:
+              `I stopped because ${toolCall.name} needs a setup step outside this turn — a credential, a role, a connected account, or an approval — before it can run. ` +
+              "Retrying would not have changed it, and anything completed before this is saved.",
             errorCode: "permanent_precondition",
             details: sanitizedResult,
           };
@@ -6661,6 +6678,12 @@ function isRecoverableContinuationError(event: {
   const code = String(event.errorCode ?? "").toLowerCase();
   const message = event.error.toLowerCase();
   if (code === "builder_gateway_error") return false;
+  // An explicit flag outranks the message sniff below, which exists for events
+  // that carry no flag at all. Every guard stop sets `recoverable: false`, and
+  // sniffing its prose is how a stop that merely NAMES a connection or a
+  // timeout gets continued into the spiral it was raised to end. The client
+  // applies the same precedence in `isAutoRecoverableError`.
+  if (event.recoverable === false) return false;
   return (
     event.recoverable === true ||
     code === "builder_gateway_timeout" ||

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -3531,38 +3531,39 @@ describe("run manager soft timeout", () => {
     );
   });
 
-  // checkSqlAbort must fail closed: a rejected getRunAbortState read used to
-  // be swallowed as "not aborted", so a real cross-isolate Stop could go
-  // unseen for the rest of the run. Sustained read failures must self-abort
-  // instead of retrying silently forever.
-  it("fails closed and self-aborts after sustained getRunAbortState read failures", async () => {
+  // checkSqlAbort is a cross-isolate backstop, so an unreadable abort state
+  // must fail OPEN: the outage hides a Stop from every other reader too, and
+  // killing the run only guarantees destroyed work in the common case where
+  // nobody pressed Stop. Sustained read failures used to self-abort with
+  // `abort_check_unavailable` after ~9s.
+  it("keeps running to completion when every abort-state read fails", async () => {
     vi.mocked(getRunAbortState).mockRejectedValue(new Error("read timeout"));
+    vi.mocked(getRunStatus).mockRejectedValue(new Error("read timeout"));
 
     let abortFired = false;
     const run = startRun(
       "run-abort-check-unreadable",
       "thread-abort-check-unreadable",
-      async (_send, signal) => {
-        await new Promise<void>((resolve) => {
-          signal.addEventListener("abort", () => {
-            abortFired = true;
-            resolve();
-          });
+      async (send, signal) => {
+        signal.addEventListener("abort", () => {
+          abortFired = true;
         });
+        // Far longer than the old 3-failure (~9s) kill threshold.
+        await new Promise<void>((resolve) => setTimeout(resolve, 120_000));
+        send({ type: "done" });
       },
       undefined,
       { softTimeoutMs: 0 },
     );
 
-    // First two failed checks (at the 3s poll interval) stay below the
-    // heartbeat handler's own escalation threshold — no self-abort yet.
-    await vi.advanceTimersByTimeAsync(4500);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(abortFired).toBe(false);
+    expect(run.status).toBe("running");
 
-    // Third consecutive failure crosses the threshold: fail closed.
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(abortFired).toBe(true);
-    expect(run.abortReason).toBe("abort_check_unavailable");
+    await vi.advanceTimersByTimeAsync(61_000);
+    expect(abortFired).toBe(false);
+    expect(run.status).toBe("completed");
+    expect(run.abortReason).toBeUndefined();
   });
 
   // Fix 3: ordered event persistence

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -1245,12 +1245,15 @@ export function startRun(
   // false-stale-reap zombie scenario where the reaper flipped the row while
   // this isolate was briefly unable to heartbeat (DB latency / GC pause).
   let lastAbortCheck = Date.now() - 3000;
-  // A read failure here used to be indistinguishable from "not aborted" —
-  // exactly the coerced-to-false pattern that lets a real Stop go unseen for
-  // the rest of the run. Count consecutive failures like the heartbeat-write
-  // handler above; past the same threshold, fail closed (self-abort with a
-  // reason outside TURN_ENDING_ABORT_REASONS/RECOVERABLE_ABORT_REASONS, so it
-  // surfaces as a typed error) instead of silently retrying forever.
+  // A read failure here is not "not aborted" — but it is not grounds to kill
+  // the run either. This check is only a cross-isolate backstop: the outage
+  // that hides a Stop from us hides it from every other reader too, so
+  // self-aborting delivers nobody's Stop any sooner while destroying in-flight
+  // work in the far more common case where nobody pressed Stop at all. Fail
+  // open and stay bounded by the soft timeout, no-progress backstop, and
+  // iteration/token limits — none of which touch the DB. Report the outage to
+  // Sentry (once at the threshold, then ~once a minute) so a long unreadable
+  // window is visible and its duration is queryable instead of silent.
   let consecutiveAbortCheckFailures = 0;
   const checkSqlAbort = () => {
     const now = Date.now();
@@ -1277,7 +1280,11 @@ export function startRun(
       })
       .catch((error) => {
         consecutiveAbortCheckFailures += 1;
-        if (consecutiveAbortCheckFailures >= 3) {
+        // 3 ticks ≈ 9s of unreadability, then every 20 ticks ≈ 60s.
+        if (
+          consecutiveAbortCheckFailures === 3 ||
+          consecutiveAbortCheckFailures % 20 === 0
+        ) {
           captureError(error, {
             route: "/_agent-native/agent-chat",
             tags: {
@@ -1286,11 +1293,12 @@ export function startRun(
               consecutiveFailures: String(consecutiveAbortCheckFailures),
             },
             aiTraceId: runId,
-            extra: { runId, threadId },
+            extra: {
+              runId,
+              threadId,
+              unreadableForMs: consecutiveAbortCheckFailures * 3000,
+            },
           });
-          if (!abort.signal.aborted) {
-            abortInMemoryRun(run, "abort_check_unavailable");
-          }
         }
       });
   };

--- a/packages/core/src/agent/run-store.durable-background.spec.ts
+++ b/packages/core/src/agent/run-store.durable-background.spec.ts
@@ -171,9 +171,8 @@ const mockDb = {
       /UPDATE agent_runs SET status = 'errored'/i.test(sql) &&
       /WHERE id = \?/i.test(sql)
     ) {
-      const completedAt = args[0] as number;
-      const id = args[4] as string;
-      const lastBound = args[5] as number;
+      const id = args[3] as string;
+      const lastBound = args[4] as number;
       // Default path inlines the background-aware CASE and binds `now`; the
       // explicit-maxStaleMs path inlines a plain `?` and binds a pre-computed
       // cutoff. Distinguish by the SQL fragment, not the arg type.
@@ -186,10 +185,12 @@ const mockDb = {
         : lastBound; // already (now - maxStaleMs)
       if (liveness(row) < cutoff) {
         row.status = "errored";
-        row.completed_at = completedAt;
-        row.error_code = args[1] as string;
-        row.error_detail = args[2] as string;
-        row.terminal_reason = args[3] as string;
+        // `completed_at = COALESCE(completed_at, <livenessBasis>)` — the reaper
+        // records when the run DIED, not when it was noticed.
+        row.completed_at = row.completed_at ?? liveness(row);
+        row.error_code = args[0] as string;
+        row.error_detail = args[1] as string;
+        row.terminal_reason = args[2] as string;
         return { rows: [], rowsAffected: 1 };
       }
       return { rows: [], rowsAffected: 0 };

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -192,6 +192,7 @@ vi.mock("../server/capture-error.js", () => ({
 
 const {
   STALE_RUN_ERROR_EVENT,
+  STALE_RUN_TERMINAL_REASON,
   markRunAborted,
   reapAllStaleRuns,
   reapIfStale,
@@ -522,10 +523,12 @@ describe("run store", () => {
     expect(update?.sql).toContain("error_code = ?");
     expect(update?.sql).toContain("error_detail = ?");
     expect(update?.sql).toContain("terminal_reason = ?");
-    expect(update?.args[1]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
-    expect(update?.args[2]).toBe(STALE_RUN_ERROR_EVENT.details);
-    expect(update?.args[3]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
-    expect(update?.args[4]).toBe("run-stale");
+    // `completed_at` is no longer bound — it comes from the row's liveness
+    // basis, so the SET list binds exactly these three.
+    expect(update?.args[0]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
+    expect(update?.args[1]).toBe(STALE_RUN_ERROR_EVENT.details);
+    expect(update?.args[2]).toBe(STALE_RUN_TERMINAL_REASON);
+    expect(update?.args[3]).toBe("run-stale");
 
     const insert = execCalls.find((call) =>
       /INSERT INTO agent_run_events/i.test(call.sql),
@@ -895,9 +898,9 @@ describe("run store", () => {
     );
     expect(staleUpdates.length).toBeGreaterThanOrEqual(3);
     for (const update of staleUpdates) {
-      expect(update.args[1]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
-      expect(update.args[2]).toBe(STALE_RUN_ERROR_EVENT.details);
-      expect(update.args[3]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
+      expect(update.args[0]).toBe(STALE_RUN_ERROR_EVENT.errorCode);
+      expect(update.args[1]).toBe(STALE_RUN_ERROR_EVENT.details);
+      expect(update.args[2]).toBe(STALE_RUN_TERMINAL_REASON);
     }
   });
 

--- a/packages/core/src/agent/run-store.stale-reap-accounting.spec.ts
+++ b/packages/core/src/agent/run-store.stale-reap-accounting.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * The stale reapers used to lie twice about the same failure.
+ *
+ * 1. `completed_at` was stamped at REAP time, so a run that died at T+15s but
+ *    was not noticed until T+30m recorded a 30-minute duration. That is
+ *    detection latency filed as run duration — and it is the exact measurement
+ *    used to judge whether reaping is timely, so the corruption hid itself.
+ * 2. `terminal_reason` was written as the bare `stale_run` while
+ *    `reconcileTerminalRunFromEvents` wrote `error:stale_run` for the very same
+ *    outcome, splitting one failure across two permanent
+ *    `agent_run_outcome_daily` buckets (prod: 612 + 604).
+ *
+ * A third lie was in the heartbeat that feeds them: its write inherited the
+ * default DbExec budget (8s x 3 attempts on serverless = 24s) against a 15s
+ * `RUN_STALE_MS`, so a live run could be reaped while its own heartbeat was
+ * still in flight.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ExecCall {
+  sql: string;
+  args: unknown[];
+  timeoutMs?: number;
+  maxAttempts?: number;
+}
+
+const execCalls: ExecCall[] = [];
+let staleSelectRows: Array<{ id: string }> = [];
+
+const mockDb = {
+  execute: vi.fn(
+    async (
+      statement:
+        | string
+        | {
+            sql: string;
+            args?: unknown[];
+            timeoutMs?: number;
+            maxAttempts?: number;
+          },
+    ) => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+      execCalls.push({
+        sql,
+        args: typeof statement === "string" ? [] : (statement.args ?? []),
+        timeoutMs:
+          typeof statement === "string" ? undefined : statement.timeoutMs,
+        maxAttempts:
+          typeof statement === "string" ? undefined : statement.maxAttempts,
+      });
+
+      // hasRunningRuns short-circuits every sweep, so it must agree with the
+      // stale fixture or the test would assert on a sweep that never ran.
+      if (
+        /SELECT id FROM agent_runs WHERE status = 'running' LIMIT 1/i.test(sql)
+      ) {
+        return { rows: staleSelectRows.slice(0, 1), rowsAffected: 0 };
+      }
+      if (/SELECT id FROM agent_runs[\s\S]*status = 'running'/i.test(sql)) {
+        return { rows: staleSelectRows, rowsAffected: 0 };
+      }
+      return {
+        rows: [],
+        rowsAffected: /^\s*(UPDATE|INSERT|DELETE)\b/i.test(sql) ? 1 : 0,
+      };
+    },
+  ),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  intType: () => "INTEGER",
+  isPostgres: () => false,
+}));
+
+vi.mock("../server/capture-error.js", () => ({
+  captureError: vi.fn(),
+}));
+
+const {
+  RUN_STALE_MS,
+  STALE_RUN_TERMINAL_REASON,
+  cleanupOldRuns,
+  reapAllStaleRuns,
+  updateRunHeartbeat,
+  __resetNoRunningRunsProbeForTests,
+} = await import("./run-store.js");
+
+/** The reap-to-errored UPDATEs, in call order. */
+function staleReapUpdates(): ExecCall[] {
+  return execCalls.filter(
+    (call) =>
+      /UPDATE agent_runs/i.test(call.sql) &&
+      /SET status = 'errored'/i.test(call.sql) &&
+      call.args.includes("stale_run"),
+  );
+}
+
+beforeEach(() => {
+  execCalls.length = 0;
+  staleSelectRows = [];
+  __resetNoRunningRunsProbeForTests();
+});
+
+describe("stale reap accounting", () => {
+  it("records completed_at from the liveness basis, never the reap time", async () => {
+    staleSelectRows = [{ id: "run-dead" }];
+    await reapAllStaleRuns();
+    await cleanupOldRuns(24 * 60 * 60 * 1000);
+
+    const updates = staleReapUpdates();
+    expect(updates.length).toBe(3);
+    for (const update of updates) {
+      // The liveness basis is the last proof the producer was alive; COALESCE
+      // keeps an already-written completed_at authoritative.
+      expect(update.sql).toMatch(
+        /completed_at = COALESCE\(completed_at, \(CASE WHEN COALESCE\(last_progress_at/,
+      );
+      expect(update.sql).not.toMatch(/completed_at = \?/);
+      // No clock value may be BOUND into the SET list at all: three
+      // placeholders, for error_code, error_detail and terminal_reason.
+      const setPlaceholders =
+        update.sql.slice(0, update.sql.indexOf("WHERE")).split("?").length - 1;
+      expect(setPlaceholders).toBe(3);
+      expect(
+        update.args.slice(0, 3).every((arg) => typeof arg === "string"),
+      ).toBe(true);
+    }
+  });
+
+  it("writes one terminal_reason for one outcome, matching the reconciler's error:<code>", async () => {
+    staleSelectRows = [{ id: "run-dead" }];
+    await reapAllStaleRuns();
+    await cleanupOldRuns(24 * 60 * 60 * 1000);
+
+    const updates = staleReapUpdates();
+    // reapAllStaleRuns' per-row UPDATE plus cleanupOldRuns' absolute-age and
+    // heartbeat-stale UPDATEs — every writer of this outcome.
+    expect(updates.length).toBe(3);
+    expect(STALE_RUN_TERMINAL_REASON).toBe("error:stale_run");
+    for (const update of updates) {
+      expect(update.args).toContain(STALE_RUN_TERMINAL_REASON);
+      // The bare code stays the error_code; only terminal_reason is normalized,
+      // so `reconcileTerminalRunFromEvents`' repair WHERE still matches the row.
+      expect(update.args).toContain("stale_run");
+    }
+  });
+
+  it("bounds the heartbeat write well inside the stale window it defends", async () => {
+    await updateRunHeartbeat("run-live");
+
+    const heartbeat = execCalls.find((call) =>
+      /UPDATE agent_runs\s*SET heartbeat_at/i.test(call.sql),
+    );
+    expect(heartbeat).toBeDefined();
+    expect(heartbeat?.maxAttempts).toBe(1);
+    expect(heartbeat?.timeoutMs).toBeGreaterThan(0);
+    // Worst-case occupancy is maxAttempts * timeoutMs. It must leave room for a
+    // later tick to land before the reap cutoff, or the single-flight guard lets
+    // a live run go stale behind its own in-flight write.
+    const worstCaseMs =
+      (heartbeat?.maxAttempts ?? 0) * (heartbeat?.timeoutMs ?? 0);
+    expect(worstCaseMs).toBeLessThan(RUN_STALE_MS / 2);
+  });
+});

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -69,6 +69,23 @@ export const STALE_RUN_ERROR_EVENT = {
 } as const;
 
 /**
+ * `agent_runs.terminal_reason` recorded by the stale reapers.
+ *
+ * Every other error path records `error:<code>` (`terminalReasonForEvent`), and
+ * `reconcileTerminalRunFromEvents` writes that form for THIS failure too when it
+ * replays the terminal event a reaper itself appended. The reapers used to write
+ * the bare code, which split one outcome across two permanent
+ * `agent_run_outcome_daily` buckets (prod: 612 `stale_run` + 604
+ * `error:stale_run`) purely by whether anything happened to read the row after
+ * the reap — and made the reconciliation convergence guard, which compares
+ * `terminal_reason` for equality, rewrite the row on every read forever.
+ *
+ * Rows reaped before this change keep the bare `stale_run`, so anything matching
+ * on the value must accept both forms for one retention window.
+ */
+export const STALE_RUN_TERMINAL_REASON = `error:${STALE_RUN_ERROR_EVENT.errorCode}`;
+
+/**
  * Terminal error for a background-dispatched run whose worker NEVER claimed it
  * (the foreground fired the self-dispatch, Netlify acked it async with a 202,
  * but the `_process-run` worker never ran far enough to flip
@@ -1467,6 +1484,23 @@ export async function recordRunDiagnostic(
   }
 }
 
+/**
+ * Wall-clock budget for ONE heartbeat write.
+ *
+ * The default `DbExec` budget is `dbOpTimeoutMs()` (8s on serverless) across 3
+ * connection attempts, so a single heartbeat can occupy up to 24s — against a
+ * 15s `RUN_STALE_MS`. The run-manager single-flights the write, so that one
+ * attempt suppresses every 1.5s tick behind it: a live foreground run in a quiet
+ * phase becomes reapable while its own heartbeat is still in flight. The same
+ * attempt also pins a pooler connection for those 24s, feeding the saturation
+ * that starves heartbeats in the first place.
+ *
+ * A heartbeat that cannot land promptly has no value — the 1.5s tick IS the
+ * retry — so it gets ONE attempt inside a third of the stale window, leaving
+ * room for two more to land before the reap cutoff.
+ */
+const HEARTBEAT_WRITE_TIMEOUT_MS = Math.floor(RUN_STALE_MS / 3);
+
 /** Update the run's liveness heartbeat. Called periodically by run-manager. */
 export async function updateRunHeartbeat(runId: string): Promise<void> {
   await ensureRunTables();
@@ -1485,6 +1519,8 @@ export async function updateRunHeartbeat(runId: string): Promise<void> {
               END
           WHERE id = ? AND status = 'running'`,
     args: [Date.now(), currentRssMb(), currentRssMb(), runId],
+    timeoutMs: HEARTBEAT_WRITE_TIMEOUT_MS,
+    maxAttempts: 1,
   });
 }
 
@@ -1844,9 +1880,15 @@ async function reapSingleStaleRun(
       : // First `?` is backgroundAwareStaleCutoffSql's CAST param, the next two
         // are inFlightGraceSql's — all bound to the same "now".
         [completedAt, completedAt, completedAt];
+  // `completed_at` is when the run DIED, not when a reaper noticed. Stamping
+  // reap time made every stale row report its own detection latency as run
+  // duration (prod: 30-59 minute "runs" against a 15s window), which is the
+  // measurement used to judge whether reaping is timely at all. The liveness
+  // basis is the last proof the producer was alive, and it is what
+  // `reconcileTerminalRunFromEvents` already records for the same failure.
   const updateSql = `UPDATE agent_runs
           SET status = 'errored',
-              completed_at = ?,
+              completed_at = COALESCE(completed_at, ${livenessBasisSql()}),
               error_code = ?,
               error_detail = ?,
               terminal_reason = ?
@@ -1855,10 +1897,9 @@ async function reapSingleStaleRun(
             AND ${terminalRunEventExclusionSql()}
             AND ${staleClause}`;
   const updateArgs = [
-    completedAt,
     STALE_RUN_ERROR_EVENT.errorCode,
     STALE_RUN_ERROR_EVENT.details,
-    STALE_RUN_ERROR_EVENT.errorCode,
+    STALE_RUN_TERMINAL_REASON,
     runId,
     ...staleArgs,
   ];
@@ -2907,11 +2948,16 @@ export async function cleanupOldRuns(
       await reconcileTerminalRunFromEvents(id);
     }
   }
+  // Both UPDATEs below backdate `completed_at` to the liveness basis for the
+  // reason given on `reapSingleStaleRun`'s UPDATE: this pass can fire a DAY
+  // after the producer died, and stamping now would file that whole gap as run
+  // duration. On the absolute-age branch the basis degrades to `started_at`,
+  // which is still the truest thing known about a row that never heartbeat.
   const completedAt = Date.now();
   await client.execute({
     sql: `UPDATE agent_runs
           SET status = 'errored',
-              completed_at = ?,
+              completed_at = COALESCE(completed_at, ${livenessBasisSql()}),
               error_code = ?,
               error_detail = ?,
               terminal_reason = ?
@@ -2919,10 +2965,9 @@ export async function cleanupOldRuns(
             AND ${terminalRunEventExclusionSql()}
             AND started_at < ?`,
     args: [
-      completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
-      STALE_RUN_ERROR_EVENT.errorCode,
+      STALE_RUN_TERMINAL_REASON,
       cutoff,
     ],
   });
@@ -2937,7 +2982,7 @@ export async function cleanupOldRuns(
   await client.execute({
     sql: `UPDATE agent_runs
           SET status = 'errored',
-              completed_at = ?,
+              completed_at = COALESCE(completed_at, ${livenessBasisSql()}),
               error_code = ?,
               error_detail = ?,
               terminal_reason = ?
@@ -2946,10 +2991,9 @@ export async function cleanupOldRuns(
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}
             AND ${inFlightGraceSql()}`,
     args: [
-      completedAt,
       STALE_RUN_ERROR_EVENT.errorCode,
       STALE_RUN_ERROR_EVENT.details,
-      STALE_RUN_ERROR_EVENT.errorCode,
+      STALE_RUN_TERMINAL_REASON,
       completedAt,
       completedAt,
       completedAt,

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -54,6 +56,39 @@ describe("buildAssistantMessage", () => {
     const message = buildAssistantMessage(events, "run-clear");
 
     expect(message?.content).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "query",
+        result: "1",
+      }),
+      { type: "text", text: "Corrected answer" },
+    ]);
+  });
+
+  // The live client stops clearing at the last completed tool call, so this
+  // narration survives the retry on screen. A rebuild that splices it anyway
+  // makes it vanish on reload — visible loss, and only after the user leaves.
+  it("keeps narration from before the last completed tool call", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "Checked the schema." } },
+      {
+        seq: 1,
+        event: {
+          type: "tool_start",
+          tool: "query",
+          input: { sql: "select 1" },
+        },
+      },
+      { seq: 2, event: { type: "tool_done", tool: "query", result: "1" } },
+      { seq: 3, event: { type: "text", text: "Rejected draft" } },
+      { seq: 4, event: { type: "clear" } },
+      { seq: 5, event: { type: "text", text: "Corrected answer" } },
+    ];
+
+    const message = buildAssistantMessage(events, "run-clear-scoped");
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "Checked the schema." },
       expect.objectContaining({
         type: "tool-call",
         toolName: "query",
@@ -1914,5 +1949,77 @@ describe("upsertUserMessage", () => {
       text: expect.stringContaining("Important notes"),
     });
     expect(storedAtt.metadata).toBeUndefined();
+  });
+});
+
+/**
+ * The rebuild path re-implements two pieces of the live SSE client because the
+ * dependency cannot go the other way. A comment asking the next author to keep
+ * them in sync is what already failed: the client copy was rescoped and this
+ * one was not, so narration survived live and vanished on reload. These read
+ * both sources and fail on the drift itself.
+ */
+describe("live-client twins", () => {
+  const sourceOf = (relativePath: string): string =>
+    readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+  const functionBody = (source: string, name: string): string => {
+    const start = source.indexOf(`function ${name}(`);
+    expect(start, `${name} not found`).toBeGreaterThan(-1);
+    const open = source.indexOf("{", start);
+    let depth = 0;
+    for (let i = open; i < source.length; i++) {
+      if (source[i] === "{") depth++;
+      else if (source[i] === "}" && --depth === 0) {
+        return source
+          .slice(open + 1, i)
+          .replace(/\/\/[^\n]*/g, "")
+          .replace(/\s+/g, " ")
+          .trim();
+      }
+    }
+    throw new Error(`unterminated body for ${name}`);
+  };
+
+  const stringConst = (source: string, name: string): string => {
+    const match = new RegExp(`\\b${name}\\s*=\\s*\n?\\s*"([^"]*)"`).exec(
+      source,
+    );
+    expect(match, `${name} not found`).not.toBeNull();
+    return match![1]!;
+  };
+
+  it("keeps clearAssistantDraftContent identical to the live client copy", () => {
+    expect(
+      functionBody(
+        sourceOf("./thread-data-builder.ts"),
+        "clearAssistantDraftContent",
+      ),
+    ).toBe(
+      functionBody(
+        sourceOf("../client/sse-event-processor.ts"),
+        "clearAssistantDraftContent",
+      ),
+    );
+  });
+
+  it("keeps the interrupted-tool-result marker identical across all three copies", () => {
+    const client = stringConst(
+      sourceOf("../client/sse-event-processor.ts"),
+      "INTERRUPTED_TOOL_RESULT",
+    );
+
+    expect(
+      stringConst(
+        sourceOf("./thread-data-builder.ts"),
+        "INTERRUPTED_TOOL_RESULT",
+      ),
+    ).toBe(client);
+    expect(
+      stringConst(
+        sourceOf("./production-agent.ts"),
+        "INTERRUPTED_TOOL_RESULT_MARKER",
+      ),
+    ).toBe(client);
   });
 });

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -30,6 +30,7 @@ interface ContentPart {
   completedSideEffect?: boolean;
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
+  activity?: boolean;
   approval?: { approvalKey: string; dismissed?: boolean };
 }
 
@@ -347,19 +348,34 @@ export function buildAssistantMessage(
   };
 }
 
+/**
+ * The rebuild half of the live client's `clearAssistantDraftContent`
+ * (client/sse-event-processor.ts). The two bodies are asserted identical by
+ * `keeps clearAssistantDraftContent identical to the live client copy` in
+ * thread-data-builder.spec.ts — a rebuild that clears more than the live stream
+ * did makes narration vanish on reload, which is worse than clearing nothing.
+ */
 function clearAssistantDraftContent(content: ContentPart[]): void {
   for (let index = content.length - 1; index >= 0; index--) {
     const part = content[index];
     if (!part) continue;
+    if (
+      part.type === "tool-call" &&
+      part.activity !== true &&
+      part.result !== undefined
+    ) {
+      return;
+    }
     if (part.type === "text" || part.type === "reasoning") {
       content.splice(index, 1);
       continue;
     }
     if (part.type === "tool-call" && part.result === undefined) {
-      // Keep materialized in-flight tool cards across retry clears so persisted
-      // thread rebuilds match the live SSE processor and avoid hide→show flicker.
+      // Only drop ephemeral placeholders. Materialized in-flight tool cards
+      // (real args from tool_start) stay mounted so a retry/auto-continue clear
+      // does not hide→show the same call when the next chunk re-emits it.
       const isEphemeral =
-        (part as { activity?: boolean }).activity === true ||
+        part.activity === true ||
         part.argsText === "" ||
         Object.keys(part.args ?? {}).length === 0;
       if (isEphemeral) content.splice(index, 1);

--- a/packages/core/src/client/RouteTransitionIndicator.spec.tsx
+++ b/packages/core/src/client/RouteTransitionIndicator.spec.tsx
@@ -84,9 +84,9 @@ describe("RouteTransitionIndicator", () => {
     expect(indicator?.getAttribute("data-route-transition-target")).toBe(
       "/slow",
     );
-    // The pathname stays a test/debug attribute. Rendering it as visible chrome
-    // read as a bug ("a spinner in the corner ... the spinner shows the new
-    // route"), so the user-facing surface is a top progress bar with no text.
+    expect(indicator?.getAttribute("aria-label")).toBe("Loading page...");
+    // The pathname stays a test/debug attribute. The user-facing surface is a
+    // top progress bar with an accessible loading message, not routing chrome.
     expect(indicator?.textContent).toBe("");
     expect(indicator?.className).toContain("top-0");
 

--- a/packages/core/src/client/RouteTransitionIndicator.tsx
+++ b/packages/core/src/client/RouteTransitionIndicator.tsx
@@ -47,7 +47,7 @@ export function RouteTransitionIndicator() {
 
   return (
     <div
-      aria-label="Loading the next page"
+      aria-label="Loading page..."
       aria-live="polite"
       className="pointer-events-none fixed inset-x-0 top-0 z-50 h-0.5 overflow-hidden bg-primary/15"
       data-route-transition-indicator="true"

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1951,6 +1951,146 @@ describe("createAgentChatAdapter", () => {
     expect(last.content.at(-1).text).toBe("analysis complete");
   });
 
+  it("bounds a progressing loop_limit chain at the work-boundary ceiling, not the transient one", async () => {
+    // Every round completes a DIFFERENT tool at a server work boundary —
+    // nothing failed, so the transient ceiling (12) is the wrong unit and used
+    // to kill this turn at round 13. MAX_LOOP_LIMIT_CONTINUATIONS (25) is the
+    // boundary that binds instead.
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      postCount += 1;
+      const tool = `read-file-${postCount}`;
+      return sseResponse([
+        { type: "tool_start", tool, input: { path: `src/${postCount}.ts` } },
+        { type: "tool_done", tool, result: `contents of ${postCount}` },
+        { type: "loop_limit", maxIterations: 400 },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-loop-limit-ceiling",
+      threadId: "thread-loop-limit-ceiling",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "audit the repo" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    const results = await promise;
+
+    expect(postCount).toBe(26);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          details: expect.stringContaining("loop_limit_continuations: 26"),
+        }),
+      }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toContain(
+      "reached the limit on how many times it can be automatically continued",
+    );
+  });
+
+  it("keeps a loop_limit chain going when an earlier round left an unresolved Preparing card", async () => {
+    // `visibleContent` accumulates across a loop_limit chain, so an activity
+    // card left unresolved in round 1 used to make every later text-only round
+    // produce the same `preparing X` signature and die as "stuck preparing the
+    // X action" while the model was streaming genuinely new prose.
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      postCount += 1;
+      if (postCount === 1) {
+        return sseResponse([
+          {
+            type: "activity",
+            label: "Preparing create-extension action",
+            tool: "create-extension",
+          },
+          { type: "text", text: "Starting the review." },
+          { type: "loop_limit", maxIterations: 400 },
+        ]);
+      }
+      if (postCount <= 5) {
+        return sseResponse([
+          { type: "text", text: `Section ${postCount} of the review.` },
+          { type: "loop_limit", maxIterations: 400 },
+        ]);
+      }
+      return sseResponse([
+        { type: "text", text: "Review done." },
+        { type: "done" },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-loop-limit-preparing",
+      threadId: "thread-loop-limit-preparing",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          { role: "user", content: [{ type: "text", text: "review this" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    const results = await promise;
+
+    expect(postCount).toBe(6);
+    const last = results.at(-1) as any;
+    const text = JSON.stringify(last.content);
+    expect(text).toContain("Review done.");
+    expect(text).not.toContain("stuck preparing");
+  });
+
   it("replays a failed prior-turn tool call as a failure, not a success", async () => {
     // "I tried something repeatedly and it repeatedly failed": without
     // `isError` the next turn sees the failed call as an ordinary result whose
@@ -2054,6 +2194,46 @@ describe("createAgentChatAdapter", () => {
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(JSON.stringify(body.structuredHistory).length).toBeLessThan(400_000);
+  });
+
+  it("prices object tool results by what the request actually carries", async () => {
+    // Action results are objects, not strings. `String(result)` prices every
+    // one of them at 15 chars ("[object Object]"), so a turn of large object
+    // results again survived the trim while older prose was evicted for it.
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-object-result-cost",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "the original ask" }],
+          },
+          {
+            role: "assistant",
+            content: Array.from({ length: 6 }, (_, i) => ({
+              type: "tool-call",
+              toolCallId: `call-${i}`,
+              toolName: "query-rows",
+              args: { sql: "select 1" },
+              result: { rows: [{ col: "y".repeat(13_000) }] },
+            })),
+          },
+          { role: "user", content: [{ type: "text", text: "now do it" }] },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = fetchSpy.mock.calls[0][1].body as string;
+    expect(body).toContain("now do it");
+    expect(body).not.toContain("the original ask");
   });
 
   it("preserves structured tool history when auto-continuing after a transient error", async () => {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -93,20 +93,29 @@ const AUTO_CONTINUE_COMPLETION_GUARD =
 const MAX_RECONNECT_ATTEMPTS = 5;
 const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
 const MAX_QUEUED_CONFLICT_RETRIES = 120;
-// How many consecutive continuations that did not advance the turn (see
-// `describeContinuationAdvance`) we tolerate before giving up. This replaced
-// five separate budgets — stale-run, stalled, empty, repeated-narration and
-// repeated-action-preparation — each of which existed because the rung above
+// The consecutive non-advancing continuation (see `describeContinuationAdvance`)
+// that ends the turn: the third one stops it, so two are tolerated. This
+// replaced five separate budgets — stale-run, stalled, empty, repeated-narration
+// and repeated-action-preparation — each of which existed because the rung above
 // it had a hole the next one patched. One question answers all five: a round
 // that produced nothing, or produced exactly what the round before it
 // produced, did not advance.
 const MAX_NON_ADVANCING_CONTINUATIONS = 3;
-// Ceiling across the whole turn. Every attempt re-POSTs the full history plus
-// attachments, so a high ceiling only burns tokens and wall time. Non-advancing
-// turns are already stopped far earlier by the budget above; this one only ever
-// binds turns that keep making real progress, so it stays just above the
-// longest recovery we deliberately support.
+// Ceiling across the whole turn for TRANSIENT continuations — rounds that
+// followed a failure (timeout, dropped stream, stale run). Every attempt
+// re-POSTs the full history plus attachments, so a high ceiling only burns
+// tokens and wall time on a connection that keeps breaking.
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 12;
+// Ceiling across the whole turn for WORK-boundary continuations. A `loop_limit`
+// round is not a failure — the server spent a full iteration budget on real
+// tool work and handed the turn back — so counting it against the transient
+// ceiling killed progressing turns at round 13 that had never failed once.
+// Sized against the server's own limits: at its default budget of 400
+// iterations per run this is ~10,000 tool calls, two orders past the deepest
+// legitimate production turn (117 tool calls) that sized that budget. It still
+// has to exist, because the server's per-turn token backstop rides the request
+// body between server-chained chunks and resets on every client re-POST.
+const MAX_LOOP_LIMIT_CONTINUATIONS = 25;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
 const MAX_HISTORY_ATTACHMENT_CHARS = 60_000;
@@ -945,7 +954,10 @@ function estimateHistoryMessageCost(message: {
     cost += Math.min(argsText.length, argsCap);
     if (tool.result !== undefined) {
       cost += Math.min(
-        String(tool.result).length,
+        // Price the string the request actually carries. `String(result)` is
+        // 15 chars ("[object Object]") for every object result, which is most
+        // of them.
+        toolResultContent(tool.result, tool.toolName).length,
         MAX_HISTORY_TOOL_RESULT_CHARS,
       );
     }
@@ -2054,6 +2066,9 @@ export function createAgentChatAdapter(
       let startupRecoveryAttempts = 0;
       let queuedConflictRetries = 0;
       let totalTransientContinuationAttempts = 0;
+      // Work-boundary continuations (`loop_limit`), counted apart from the
+      // transient ones — see MAX_LOOP_LIMIT_CONTINUATIONS.
+      let loopLimitContinuations = 0;
       // Consecutive continuations whose advance signature matched the previous
       // round's (or was empty). Reset by any real advance.
       let nonAdvancingContinuations = 0;
@@ -2067,12 +2082,13 @@ export function createAgentChatAdapter(
       // continuation history; the advance check needs the per-round delta for
       // every reason code, `loop_limit` included.
       let advanceCheckPrefix: ContentPart[] = [];
-      // Set when the turn is stopped by MAX_TOTAL_TRANSIENT_CONTINUATIONS —
-      // the whole-turn continuation ceiling, not a dropped connection. This
-      // can trip on a turn that was making real progress the entire time, so
-      // it needs its own honest message instead of falling through to the
-      // generic "connection kept failing" copy below.
-      let recoveryGaveUpOnTransientBudget = false;
+      // Set when the turn is stopped by a whole-turn continuation ceiling
+      // (MAX_TOTAL_TRANSIENT_CONTINUATIONS or MAX_LOOP_LIMIT_CONTINUATIONS)
+      // rather than by a dropped connection. Either can trip on a turn that was
+      // making real progress the entire time, so it needs its own honest
+      // message instead of falling through to the generic "connection kept
+      // failing" copy below.
+      let recoveryGaveUpOnContinuationBudget = false;
       const continuationHistoryFragments: string[] = [];
       const structuredContinuationFragments: AgentChatStructuredMessage[] = [];
       let visibleContinuationPrefix: ContentPart[] = [];
@@ -2132,6 +2148,7 @@ export function createAgentChatAdapter(
             ? `activity_trail: ${formatActivityTrail(lastActivityTrail)}`
             : "",
           `total_transient_continuations: ${totalTransientContinuationAttempts}`,
+          `loop_limit_continuations: ${loopLimitContinuations}`,
           `background_follow_no_progress_detaches: ${backgroundFollowNoProgressDetaches}`,
           `background_follow_consecutive_no_progress_detaches: ${backgroundFollowConsecutiveNoProgressDetaches}`,
           backgroundFollowLastDetachReason
@@ -2165,7 +2182,7 @@ export function createAgentChatAdapter(
             : " the same action";
           return `The agent got stuck preparing${tool} input and never started the tool, so I stopped the automatic retries. Try a smaller first step or a more compact version of the request.`;
         }
-        if (recoveryGaveUpOnTransientBudget) {
+        if (recoveryGaveUpOnContinuationBudget) {
           return "This turn reached the limit on how many times it can be automatically continued, so I stopped it here. It may have still been making progress — retry as a single, narrower request so it can finish within fewer continuations.";
         }
         if (
@@ -3460,17 +3477,6 @@ export function createAgentChatAdapter(
           let currentPartialHistory =
             contentToContinuationHistory(visibleContent);
           const madeContentProgress = hasContinuationProgress(visibleContent);
-          // An action was streamed but has not returned yet (a tool_start with
-          // no tool_done). Only a run_timeout in that window means the SERVER
-          // is still executing it and a reconnect can still deliver the result;
-          // every other reason means the stream is dead and nothing will
-          // complete the tool.
-          const hasInFlightTool = hasInFlightToolCall(visibleContent);
-          const completedTool = lastCompletedTimeoutCandidateTool(content);
-          const currentPreparingToolName =
-            lastUnresolvedToolActivity(visibleContent) ??
-            lastPreparingActionTool(signal.activityTrail);
-
           // THE boundary. One question — did this continuation advance the
           // turn? — decides every reason code, `loop_limit` included. It used
           // to skip this block entirely AND reset two of the budgets, so a
@@ -3482,6 +3488,22 @@ export function createAgentChatAdapter(
             content,
             advanceCheckPrefix,
           );
+          // Everything that asks "what did THIS round do" reads the delta.
+          // `visibleContent` accumulates across a `loop_limit` chain — its
+          // prefix deliberately does not advance there — so one unresolved
+          // "Preparing X" card from an earlier round would otherwise stall
+          // every later round on the same name and kill a turn that was
+          // streaming new prose the whole time.
+          // An action streamed but not returned yet (a tool_start with no
+          // tool_done) means the SERVER is still executing it, so a run_timeout
+          // in that window can still deliver the result on reconnect; every
+          // other reason means the stream is dead and nothing will complete it.
+          const hasInFlightTool = hasInFlightToolCall(advanceDelta);
+          const completedTool = lastCompletedTimeoutCandidateTool(content);
+          const currentPreparingToolName =
+            lastUnresolvedToolActivity(advanceDelta) ??
+            lastPreparingActionTool(signal.activityTrail);
+
           const advance = describeContinuationAdvance(
             advanceDelta,
             currentPreparingToolName,
@@ -3498,7 +3520,11 @@ export function createAgentChatAdapter(
           nonAdvancingContinuations = advanced
             ? 0
             : nonAdvancingContinuations + 1;
-          totalTransientContinuationAttempts += 1;
+          if (isTransient) {
+            totalTransientContinuationAttempts += 1;
+          } else {
+            loopLimitContinuations += 1;
+          }
           advanceCheckPrefix = snapshotContent(content);
 
           // If a tool already completed, do not turn a missing closing
@@ -3526,9 +3552,10 @@ export function createAgentChatAdapter(
           }
           if (
             totalTransientContinuationAttempts >
-            MAX_TOTAL_TRANSIENT_CONTINUATIONS
+              MAX_TOTAL_TRANSIENT_CONTINUATIONS ||
+            loopLimitContinuations > MAX_LOOP_LIMIT_CONTINUATIONS
           ) {
-            recoveryGaveUpOnTransientBudget = true;
+            recoveryGaveUpOnContinuationBudget = true;
             return { ok: false, resetVisibleContent: false };
           }
 

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -3779,6 +3779,53 @@ describe("SSE event processor error classification", () => {
     expect(terminal?.status).toEqual({ type: "incomplete", reason: "error" });
     expect(terminal?.metadata?.custom?.runError?.recoverable).toBe(true);
   });
+
+  it("does not auto-continue a repeat-guard stop whose message names a tool that matches the transient message sniff", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    // The guard interpolates the looping tool's name, and 17 shipped actions
+    // are named `*connection*` — enough to match the "connection" sniff and
+    // auto-continue the exact loop this event exists to break.
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "error",
+            error:
+              "Stopped because `list-workspace-connections` was called 8 times with identical arguments without making progress.",
+            errorCode: "repeated_tool_call",
+            recoverable: false,
+          },
+        ]),
+        [],
+        { value: 0 },
+        "tab-repeat-guard",
+      ),
+    );
+
+    const terminal = results.at(-1) as
+      | {
+          status?: { type: string; reason: string };
+          metadata?: { custom?: { runError?: { errorCode?: string } } };
+        }
+      | undefined;
+    expect(terminal?.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(terminal?.metadata?.custom?.runError?.errorCode).toBe(
+      "repeated_tool_call",
+    );
+  });
 });
 
 describe("SSE event processor tool id matching", () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -838,6 +838,12 @@ function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
   }
 
   if (ev.recoverable === true) return true;
+  // An explicit flag outranks the message sniff below, which exists only for
+  // events that carry no flag at all. The repeat guards stop a turn with
+  // `recoverable: false` and a message that names the looping tool, so a stop
+  // on `list-workspace-connections` matched the "connection" sniff and
+  // auto-continued the very loop it was emitted to break.
+  if (ev.recoverable === false) return false;
 
   if (msg.includes("daily gateway request cap")) return false;
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1361,7 +1361,7 @@ export function sharedDbPool<T extends ClosablePool>(
   url: string,
   create: () => T,
 ): T {
-  const key = `${driver} ${url}`;
+  const key = `${driver}\u0000${url}`;
   const existing = _sharedDbPools.get(key);
   if (existing) return existing as T;
   const created = create();
@@ -1380,7 +1380,7 @@ export function replaceSharedDbPool<T extends ClosablePool>(
   previous: T,
   next: T,
 ): void {
-  const key = `${driver} ${url}`;
+  const key = `${driver}\u0000${url}`;
   if (_sharedDbPools.get(key) !== previous) return;
   _sharedDbPools.set(key, next);
   for (const hook of _sharedDbPoolReplacementHooks.get(key) ?? []) {

--- a/packages/core/src/server/agent-chat-plugin-startup.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin-startup.spec.ts
@@ -68,4 +68,45 @@ describe("agent chat startup", () => {
     expect(triggerSetup).toContain("await initTriggerDispatcher");
     expect(triggerSetup).not.toContain("void (async () =>");
   });
+
+  /**
+   * The in-process fast sweep is gated on `shouldDisableInProcessSweeps()`,
+   * which is ON for every production serverless function — so for 21 days
+   * production had NO periodic stale reaper at all (1,216 stranded runs, 12% of
+   * all runs, up to 59 minutes each). The durable, signed, platform-scheduled
+   * recurring-job sweep is the only per-site tick that exists; stale reaping
+   * rides it rather than getting a second scheduled function or a second
+   * kill-switch exemption.
+   */
+  it("drives stale reaping from the durable scheduled sweep", () => {
+    const source = readFileSync(
+      new URL("./agent-chat-plugin.ts", import.meta.url),
+      "utf8",
+    );
+    const sweepRoute = source.slice(
+      source.indexOf("          RECURRING_JOBS_SWEEP_PATH,\n"),
+      source.indexOf("        if (disableRecurringJobsRuntime) {"),
+    );
+
+    expect(sweepRoute).toContain("reapAllStaleRuns()");
+    // Ahead of the open-ended job sweep, which can spend the platform wall.
+    expect(sweepRoute.indexOf("reapAllStaleRuns()")).toBeLessThan(
+      sweepRoute.indexOf("processRecurringJobs(schedulerDeps)"),
+    );
+    // A reap failure is reported and stays distinguishable from "reaped
+    // nothing", but must never take recurring jobs down with it.
+    expect(sweepRoute).toContain("durable stale-run reap failed");
+    expect(sweepRoute).toContain("staleRunsReaped");
+    expect(sweepRoute).not.toContain(".catch(() => {})");
+  });
+
+  it("does not swallow the in-process stale reap either", () => {
+    const source = readFileSync(
+      new URL("./agent-chat-plugin.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("await reapAllStaleRuns().catch(() => {});");
+    expect(source).toContain("in-process stale-run reap failed");
+  });
 });

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -6129,17 +6129,45 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                   "Recurring-job sweep reached the synchronous server instead of the durable background worker.",
               };
             }
+            // Stale reaping runs FIRST and site-wide, before the open-ended job
+            // sweep can spend the platform wall. It is the durable driver the
+            // in-process fast sweep below cannot be on serverless: that timer is
+            // off wherever `shouldDisableInProcessSweeps` is on — i.e. every
+            // production Lambda — and nothing replaced it, so a claimed run
+            // whose producer died was only reaped when an unrelated request path
+            // happened to look (prod: 1,216 runs, 12% of all runs, sitting
+            // "running" for up to 59 minutes against a 15s window).
+            //
+            // One reap per site-tick instead of one per warm container is also
+            // the point: the per-container timers are what issued 237k queries
+            // in two minutes and earned that kill switch. `reapAllStaleRuns`
+            // short-circuits on `hasRunningRuns()` (negative-cached), so an idle
+            // app pays one probe.
+            //
+            // Reported, never swallowed, and never fatal to the job sweep: a
+            // reap failure must not take recurring jobs down with it, and
+            // `null` must stay distinguishable from "reaped nothing".
+            const { reapAllStaleRuns } = await import("../agent/run-store.js");
+            const staleRunsReaped = await reapAllStaleRuns().catch(
+              (error: unknown) => {
+                console.error(
+                  "[agent-chat] durable stale-run reap failed:",
+                  error,
+                );
+                return null;
+              },
+            );
             try {
               // Jobs may request MCP tools, and `getActions` is synchronous —
               // hydrate before the sweep so a serverless container that never
               // eagerly initialized still resolves them.
               await ensureMcpInitialized();
               await processRecurringJobs(schedulerDeps);
-              return { ok: true };
+              return { ok: true, staleRunsReaped };
             } catch (error) {
               console.error("[recurring-jobs] Sweep route failed:", error);
               setResponseStatus(event, 500);
-              return { error: "Recurring-job sweep failed" };
+              return { error: "Recurring-job sweep failed", staleRunsReaped };
             }
           }),
         );
@@ -6411,7 +6439,19 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 // against a 45s window). `reapAllStaleRuns` is per-row,
                 // idempotent, re-checks staleness at UPDATE time and honours
                 // the in-flight grace, so it is safe on this cadence.
-                await reapAllStaleRuns().catch(() => {});
+                //
+                // This timer is the driver only where it actually runs — a
+                // long-lived Node host. Wherever `sweepsDisabled` turns it off
+                // (every production serverless function) the signed
+                // RECURRING_JOBS_SWEEP_PATH route above owns the same reap,
+                // driven by the platform scheduler. The two never both fire on
+                // one host, which is why neither needs to coordinate.
+                await reapAllStaleRuns().catch((error: unknown) => {
+                  console.error(
+                    "[agent-chat] in-process stale-run reap failed:",
+                    error,
+                  );
+                });
                 let rows: UnclaimedBackgroundRunRow[];
                 try {
                   rows = await listUnclaimedBackgroundRunRows();

--- a/templates/analytics/actions/get-data-program.ts
+++ b/templates/analytics/actions/get-data-program.ts
@@ -22,7 +22,10 @@ export default defineAction({
   }),
   http: { method: "GET" },
   readOnly: true,
-  grounding: true,
+  // Not `grounding`: this reads the stored program plus its last-run summary,
+  // and even `includeRows` replays rows cached by an earlier run rather than
+  // querying the source. The flag means evidence retrieved at call time, which
+  // is why `get-analysis` is excluded too.
   run: async (args) => {
     const ctx = getCredentialContext();
     if (!ctx) throw new Error("No authenticated context for get-data-program.");

--- a/templates/analytics/server/lib/grounding-derivation.spec.ts
+++ b/templates/analytics/server/lib/grounding-derivation.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import actionsRegistry from "../../.generated/actions-registry";
+import getDataProgram from "../../actions/get-data-program";
+import {
+  deriveGroundingActionNames,
+  hasDataQueryAttempt,
+  registerGroundingActions,
+} from "./real-data-actions";
+
+// The hand-maintained DATA_QUERY_ACTIONS allowlist is gone, so no file in this
+// template names these actions any more. They are defined in
+// @agent-native/core and re-exported here, which means a core build that drops
+// `grounding: true` sends every grounded provider answer to the "connect data
+// sources" fallback with nothing failing. This is the only check between that
+// regression and production; provider-api-request is the recommended path for
+// every provider integration, so it is also the most-used one.
+const CORE_GROUNDING_ACTIONS = [
+  "provider-api-request",
+  "provider-corpus-job",
+  "query-staged-dataset",
+  "github-repo-files",
+];
+
+describe("grounding derivation", () => {
+  it("derives the core provider-api actions from the shipped registry", () => {
+    const derived = deriveGroundingActionNames(actionsRegistry);
+    expect(
+      CORE_GROUNDING_ACTIONS.filter((name) => !derived.includes(name)),
+    ).toEqual([]);
+  });
+
+  it("leaves cached-result reads out of the derived set", () => {
+    expect(getDataProgram.grounding).toBeUndefined();
+    expect(deriveGroundingActionNames(actionsRegistry)).not.toContain(
+      "get-data-program",
+    );
+  });
+
+  // Runs last on purpose: "never registered" is a state this module cannot be
+  // returned to once anything registers.
+  it("fails at first use rather than at registration when the flag is missing", () => {
+    expect(() => hasDataQueryAttempt([{ name: "gong-calls" }])).toThrow(
+      /never registered/,
+    );
+    expect(() => registerGroundingActions([])).not.toThrow();
+    expect(() => hasDataQueryAttempt([{ name: "gong-calls" }])).toThrow(
+      /cannot carry the flag/,
+    );
+  });
+});

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -91,33 +91,57 @@ function isToolName(name: string, expected: string): boolean {
 let groundingActionNames: ReadonlySet<string> | null = null;
 
 /**
- * Publish the action names whose definitions declare `grounding: true`.
+ * Read the action names whose definitions declare `grounding: true`.
  *
- * The set is pushed in rather than read from `.generated/actions-registry`
- * because that registry imports every action, and `save-analysis` imports this
- * module — importing it back here would close an evaluation cycle. The
- * agent-chat plugin derives the set once at module load; nothing else may.
+ * Takes the registry as an argument rather than importing
+ * `.generated/actions-registry` because that registry imports every action, and
+ * `save-analysis` imports this module — importing it back here would close an
+ * evaluation cycle. The agent-chat plugin passes it in once at module load.
  */
+export function deriveGroundingActionNames(
+  registry: Record<string, unknown>,
+): string[] {
+  return Object.entries(registry)
+    .filter(([, module]) => {
+      // Action modules reach the registry either as the module namespace or as
+      // an already-unwrapped definition, the same two shapes
+      // `loadActionsFromStaticRegistry` normalizes.
+      const candidate = module as
+        | { grounding?: boolean; default?: { grounding?: boolean } }
+        | undefined;
+      return (
+        candidate?.grounding === true || candidate?.default?.grounding === true
+      );
+    })
+    .map(([name]) => name);
+}
+
+/** Publish the derived set for the response guard to consult. */
 export function registerGroundingActions(names: Iterable<string>): void {
-  const normalized = new Set(
+  groundingActionNames = new Set(
     [...names].map((name) => normalizeActionToolName(name)),
   );
   // An empty set is never a real deployment: it means the installed core build
-  // predates `grounding` and dropped it from every definition. Left unchecked,
-  // the guard would replace every correct grounded answer with "connect data
-  // sources" — the exact silent failure this flag replaced.
-  if (normalized.size === 0) {
-    throw new Error(
-      "no action declares grounding: true; the installed @agent-native/core cannot carry the flag",
+  // predates `grounding` and dropped it from every definition. Registration
+  // runs at plugin module scope, so throwing here would take the whole server
+  // down for a response-guard heuristic; the failure is raised at first use
+  // instead, where it costs one turn.
+  if (groundingActionNames.size === 0) {
+    console.error(
+      "[analytics] no action declares grounding: true; the installed @agent-native/core cannot carry the flag, so the response guard is unusable",
     );
   }
-  groundingActionNames = normalized;
 }
 
 function isGroundingActionName(name: string): boolean {
   if (!groundingActionNames) {
     throw new Error(
       "grounding actions were never registered: the analytics response guard cannot tell a grounded turn from an ungrounded one",
+    );
+  }
+  if (groundingActionNames.size === 0) {
+    throw new Error(
+      "no action declares grounding: true; the installed @agent-native/core cannot carry the flag",
     );
   }
   return groundingActionNames.has(normalizeActionToolName(name));

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -12,6 +12,7 @@ import { ANALYTICS_CONNECTOR_CATALOG } from "../lib/analytics-connector-catalog"
 import { credentialProviderConfigs } from "../lib/credential-keys";
 import { isProductionServerlessRuntime } from "../lib/production-serverless-runtime.js";
 import {
+  deriveGroundingActionNames,
   draftClaimsAnalyticsMetrics,
   failedDataQueryAttemptMessage,
   hasDashboardConstructionAttempt,
@@ -35,21 +36,7 @@ import {
 // Which actions return real data-source evidence is a fact each action states
 // on itself (`grounding: true`). Reading it off the definitions here is what
 // keeps the response guard from drifting behind a newly shipped source action.
-registerGroundingActions(
-  Object.entries(actionsRegistry)
-    .filter(([, module]) => {
-      // Action modules reach the registry either as the module namespace or as
-      // an already-unwrapped definition, the same two shapes
-      // `loadActionsFromStaticRegistry` normalizes.
-      const candidate = module as
-        | { grounding?: boolean; default?: { grounding?: boolean } }
-        | undefined;
-      return (
-        candidate?.grounding === true || candidate?.default?.grounding === true
-      );
-    })
-    .map(([name]) => name),
-);
+registerGroundingActions(deriveGroundingActionNames(actionsRegistry));
 
 const ANALYTICS_BACKGROUND_RUN_SOFT_TIMEOUT_MS = 13 * 60_000;
 // A background job may legitimately spend minutes inside a provider/tool call,


### PR DESCRIPTION
Fixes the remaining production failure paths from the Repeated failures in production apps investigation.

Included:
- bound continuation and repeat-loop guards without false stops
- preserve failure state and persisted thread rebuild parity
- durable stale-run reaping and corrected stale-run accounting
- fail-open abort-state reads with telemetry
- Analytics grounding derivation and route loading accessibility label

Local validation:
- Core targeted suites: 11 files, 786 tests passed
- Analytics targeted suites: 5 files, 105 tests passed
- Core TypeScript passed
- formatting and diff checks passed
- repository guards: all scoped checks passed; one pre-existing Slides i18n raw-literal baseline failure remains at templates/slides/app/components/editor/SlideEditor.tsx:5012