### PR TITLE
test(core): align stale-run recovery expectation

### DIFF
--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -86,6 +86,7 @@ const {
   reapIfStale,
   reapAllStaleRuns,
   BACKGROUND_PROCESSING_RUN_STALE_MS,
+  STALE_RUN_TERMINAL_REASON,
   __resetNoRunningRunsProbeForTests,
 } = await import("./run-store.js");
 
@@ -213,7 +214,7 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapIfStale)", () =>
 
     const oldRow = readRow(runId);
     expect(oldRow?.status).toBe("errored");
-    expect(oldRow?.terminal_reason).toBe("stale_run");
+    expect(oldRow?.terminal_reason).toBe(STALE_RUN_TERMINAL_REASON);
     // Terminal writes elsewhere NULL dispatch_payload, but reapIfStale's own
     // UPDATE never touches it directly — the important invariant is that the
     // payload was captured into the successor before the row went terminal.


### PR DESCRIPTION
Align the stale-run recovery regression expectation with the normalized terminal reason written by the reaper ().\n\nTargeted validation:\n- run-store stale/recovery/outcome/reconcile/durable suites: 130 passed\n- Core typecheck\n- oxfmt and diff check