### PR TITLE
chore(core): add stale-run test changeset

### DIFF
--- a/.changeset/stale-run-recovery-test-contract.md
+++ b/.changeset/stale-run-recovery-test-contract.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Align stale-run recovery persistence tests with the normalized terminal reason written by the reaper.

--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -86,6 +86,7 @@ const {
   reapIfStale,
   reapAllStaleRuns,
   BACKGROUND_PROCESSING_RUN_STALE_MS,
+  STALE_RUN_TERMINAL_REASON,
   __resetNoRunningRunsProbeForTests,
 } = await import("./run-store.js");
 
@@ -213,7 +214,7 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapIfStale)", () =>
 
     const oldRow = readRow(runId);
     expect(oldRow?.status).toBe("errored");
-    expect(oldRow?.terminal_reason).toBe("stale_run");
+    expect(oldRow?.terminal_reason).toBe(STALE_RUN_TERMINAL_REASON);
     // Terminal writes elsewhere NULL dispatch_payload, but reapIfStale's own
     // UPDATE never touches it directly — the important invariant is that the
     // payload was captured into the successor before the row went terminal.


### PR DESCRIPTION
Add the required @agent-native/core patch changeset for the stale-run recovery test contract correction.\n\nTargeted validation:\n- node scripts/check-changeset.mjs\n- oxfmt check\n- git diff --check\n- focused stale-run and run-store suites: 130 passed