### PR TITLE
fix(core): bound stale-run reaper batches

### DIFF
--- a/.changeset/bounded-stale-reap-batches.md
+++ b/.changeset/bounded-stale-reap-batches.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound one stale-run reap pass and stop swallowing per-row reap failures. `reapAllStaleRuns` now returns `{ reaped, failed, truncated }` instead of a bare count, so a pass where every row threw is no longer indistinguishable from "nothing was stale", and a pass that hit the batch cap is no longer reported as a clean sweep.

--- a/.changeset/stale-run-recovery-test-contract.md
+++ b/.changeset/stale-run-recovery-test-contract.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Align stale-run recovery persistence tests with the normalized terminal reason written by the reaper.

--- a/packages/core/src/agent/run-store.stale-reap-batching.spec.ts
+++ b/packages/core/src/agent/run-store.stale-reap-batching.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * `reapAllStaleRuns` returned a bare count, and every per-row failure inside it
+ * was coerced to "not reaped" by a `.catch(() => false)`. So a pass in which
+ * every single row failed to reap returned `0` — the same value as "nothing was
+ * stale". The route above it had just been given a `null`-vs-`0` distinction for
+ * exactly this reason, which that coercion made worthless one level down.
+ *
+ * The sweep is also now the first thing on the shared durable tick, ahead of
+ * `processRecurringJobs`. Production carried 1,216 stale rows while nothing
+ * periodic reaped them, so the first tick after that fix meets a backlog; an
+ * unbounded pass at ~5-10 serial round trips per row would spend the whole
+ * platform wall before any recurring job ran.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let staleSelectRows: Array<{ id: string }> = [];
+const updatedRunIds: string[] = [];
+
+const mockDb = {
+  execute: vi.fn(
+    async (statement: string | { sql: string; args?: unknown[] }) => {
+      const sql = typeof statement === "string" ? statement : statement.sql;
+      const args = typeof statement === "string" ? [] : (statement.args ?? []);
+
+      if (
+        /SELECT id FROM agent_runs WHERE status = 'running' LIMIT 1/i.test(sql)
+      ) {
+        return { rows: staleSelectRows.slice(0, 1), rowsAffected: 0 };
+      }
+      if (/SELECT id FROM agent_runs[\s\S]*status = 'running'/i.test(sql)) {
+        // Honour the LIMIT the sweep asks for, so a test can prove the cap is
+        // real rather than that the fixture happened to be small.
+        const limit = /LIMIT (\d+)/i.exec(sql)?.[1];
+        return {
+          rows: limit
+            ? staleSelectRows.slice(0, Number(limit))
+            : staleSelectRows,
+          rowsAffected: 0,
+        };
+      }
+      if (
+        /UPDATE agent_runs/i.test(sql) &&
+        /SET status = 'errored'/i.test(sql)
+      ) {
+        const id = args.find(
+          (arg): arg is string =>
+            typeof arg === "string" && arg.startsWith("run-"),
+        );
+        if (id === "run-boom") throw new Error("pooler exhausted");
+        if (id) updatedRunIds.push(id);
+      }
+      return {
+        rows: [],
+        rowsAffected: /^\s*(UPDATE|INSERT|DELETE)\b/i.test(sql) ? 1 : 0,
+      };
+    },
+  ),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  intType: () => "INTEGER",
+  isPostgres: () => false,
+}));
+
+vi.mock("../server/capture-error.js", () => ({
+  captureError: vi.fn(),
+}));
+
+const { reapAllStaleRuns, __resetNoRunningRunsProbeForTests } =
+  await import("./run-store.js");
+
+beforeEach(() => {
+  staleSelectRows = [];
+  updatedRunIds.length = 0;
+  __resetNoRunningRunsProbeForTests();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("reapAllStaleRuns accounting", () => {
+  it("counts a row whose reap threw as failed, not as nothing-to-reap", async () => {
+    staleSelectRows = [{ id: "run-boom" }];
+
+    const result = await reapAllStaleRuns();
+
+    expect(result.failed).toBe(1);
+    expect(result.reaped).toBe(0);
+    // The distinction the caller depends on: a pass where everything failed
+    // must not be reportable as a clean sweep of an empty table.
+    const nothingStale = { reaped: 0, failed: 0, truncated: false };
+    expect(result).not.toEqual(nothingStale);
+  });
+
+  it("keeps reaping the rest of the batch after one row fails", async () => {
+    staleSelectRows = [{ id: "run-a" }, { id: "run-boom" }, { id: "run-b" }];
+
+    const result = await reapAllStaleRuns();
+
+    expect(result).toEqual({ reaped: 2, failed: 1, truncated: false });
+    expect(updatedRunIds).toEqual(["run-a", "run-b"]);
+  });
+
+  it("bounds one pass and reports that more remain", async () => {
+    staleSelectRows = Array.from({ length: 250 }, (_, i) => ({
+      id: `run-${i}`,
+    }));
+
+    const result = await reapAllStaleRuns();
+
+    expect(result.truncated).toBe(true);
+    expect(result.reaped).toBe(200);
+    expect(updatedRunIds.length).toBe(200);
+  });
+
+  it("does not claim truncation when the batch fits", async () => {
+    staleSelectRows = Array.from({ length: 5 }, (_, i) => ({ id: `run-${i}` }));
+
+    const result = await reapAllStaleRuns();
+
+    expect(result).toEqual({ reaped: 5, failed: 0, truncated: false });
+  });
+});

--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -86,6 +86,7 @@ const {
   reapIfStale,
   reapAllStaleRuns,
   BACKGROUND_PROCESSING_RUN_STALE_MS,
+  STALE_RUN_TERMINAL_REASON,
   __resetNoRunningRunsProbeForTests,
 } = await import("./run-store.js");
 
@@ -213,7 +214,7 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapIfStale)", () =>
 
     const oldRow = readRow(runId);
     expect(oldRow?.status).toBe("errored");
-    expect(oldRow?.terminal_reason).toBe("stale_run");
+    expect(oldRow?.terminal_reason).toBe(STALE_RUN_TERMINAL_REASON);
     // Terminal writes elsewhere NULL dispatch_payload, but reapIfStale's own
     // UPDATE never touches it directly — the important invariant is that the
     // payload was captured into the successor before the row went terminal.

--- a/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
+++ b/packages/core/src/agent/run-store.stale-run-recovery.spec.ts
@@ -431,8 +431,9 @@ describe("FIX 3 — stale-run reaper server-owned recovery (reapAllStaleRuns)", 
     await claimBackgroundRun(runId);
     setStaleLiveness(runId, Date.now() - STALE_PAST_MS);
 
-    const reapedCount = await reapAllStaleRuns();
-    expect(reapedCount).toBeGreaterThanOrEqual(1);
+    const swept = await reapAllStaleRuns();
+    expect(swept.reaped).toBeGreaterThanOrEqual(1);
+    expect(swept.failed).toBe(0);
     expect(readRow(runId)?.status).toBe("errored");
     expect(rowsForTurn(turn)).toHaveLength(2);
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -2693,14 +2693,46 @@ export async function getCurrentTurnEventsForThread(
 }
 
 /**
+ * Rows one pass will reap. Each costs ~5-10 serial round trips (reconcile,
+ * transactional reap plus recovery, terminal-event append), and this sweep now
+ * runs ahead of `processRecurringJobs` on the shared durable tick — so an
+ * unbounded first pass against a backlog spends the platform wall before jobs
+ * get any. Production carried 1,216 stale rows while nothing periodic reaped
+ * them, so the first tick after that fix lands on exactly such a backlog.
+ * A truncated pass is drained by the next tick (60s durable, 20s in-process),
+ * never dropped — `truncated` is what stops a partial sweep being reported as
+ * a clean one.
+ */
+const REAP_ALL_STALE_BATCH_LIMIT = 200;
+
+export interface StaleRunReapResult {
+  /** Rows this pass reaped. */
+  reaped: number;
+  /**
+   * Rows whose reap threw. Separate from `reaped` because a pass where every
+   * row failed must not read as "nothing was stale" — those were the same
+   * number before, and the caller's own `null`-vs-`0` distinction is worthless
+   * while the per-row failures underneath it are coerced away.
+   */
+  failed: number;
+  /** More stale rows remain than the batch cap; the next tick continues. */
+  truncated: boolean;
+}
+
+/**
  * Expire any "running" rows whose heartbeat is stale — producer died.
  * Safe to call at server startup on multi-isolate deployments: only rows
  * without a fresh heartbeat get reaped, so runs owned by OTHER live
  * isolates (which keep heartbeating) are left alone.
  */
-export async function reapAllStaleRuns(): Promise<number> {
+export async function reapAllStaleRuns(): Promise<StaleRunReapResult> {
+  const nothingStale: StaleRunReapResult = {
+    reaped: 0,
+    failed: 0,
+    truncated: false,
+  };
   await ensureRunTables();
-  if (!(await hasRunningRuns())) return 0;
+  if (!(await hasRunningRuns())) return nothingStale;
   const client = getDbExec();
   const now = Date.now();
   // Background-dispatched runs use the wider window; everything else 15s. The
@@ -2712,13 +2744,23 @@ export async function reapAllStaleRuns(): Promise<number> {
   // server startup across possibly-multiple isolates, so a sibling isolate's
   // still-alive, in-flight run must not be reaped just because THIS isolate
   // just booted and has no heartbeat history for it.
-  const stale = await client.execute({
+  // One row over the cap is how a truncated pass is detected without a second
+  // COUNT query against the same predicate.
+  const scanned = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
             AND ${livenessBasisSql()} < ${backgroundAwareStaleCutoffSql()}
-            AND ${inFlightGraceSql()}`,
+            AND ${inFlightGraceSql()}
+          ORDER BY started_at ASC
+          LIMIT ${REAP_ALL_STALE_BATCH_LIMIT + 1}`,
     args: [now, now, now],
   });
+  const truncated = scanned.rows.length > REAP_ALL_STALE_BATCH_LIMIT;
+  const stale = {
+    rows: truncated
+      ? scanned.rows.slice(0, REAP_ALL_STALE_BATCH_LIMIT)
+      : scanned.rows,
+  };
   for (const row of stale.rows) {
     const id = (row as { id?: unknown }).id;
     if (typeof id === "string") {
@@ -2737,11 +2779,16 @@ export async function reapAllStaleRuns(): Promise<number> {
   // already found stale; on an idle app `hasRunningRuns` returns before any of
   // this, so the 20s fast sweep (agent-chat-plugin.ts) costs one probe.
   let reapedCount = 0;
+  let failedCount = 0;
   for (const row of stale.rows) {
     const id = (row as { id?: unknown }).id;
     if (typeof id !== "string") continue;
-    const reaped = await reapSingleStaleRun(id).catch(() => false);
-    if (reaped) reapedCount += 1;
+    try {
+      if (await reapSingleStaleRun(id)) reapedCount += 1;
+    } catch (error) {
+      failedCount += 1;
+      console.error(`[run-store] stale reap failed for run ${id}:`, error);
+    }
   }
   for (const row of stale.rows) {
     const id = (row as { id?: unknown }).id;
@@ -2753,7 +2800,7 @@ export async function reapAllStaleRuns(): Promise<number> {
       );
     }
   }
-  return reapedCount;
+  return { reaped: reapedCount, failed: failedCount, truncated };
 }
 
 const RUN_OUTCOME_DAY_MS = 86_400_000;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -6146,7 +6146,10 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             //
             // Reported, never swallowed, and never fatal to the job sweep: a
             // reap failure must not take recurring jobs down with it, and
-            // `null` must stay distinguishable from "reaped nothing".
+            // `null` must stay distinguishable from "reaped nothing". The
+            // result carries `failed` and `truncated` for the same reason one
+            // level down — a pass where every row threw, and a pass that hit
+            // the batch cap, both used to be reportable as a clean sweep.
             const { reapAllStaleRuns } = await import("../agent/run-store.js");
             const staleRunsReaped = await reapAllStaleRuns().catch(
               (error: unknown) => {


### PR DESCRIPTION
Bound the site-wide stale-run reaper to 200 rows per pass, preserve per-row failure accounting, and return structured sweep state so durable and in-process callers do not mistake a failed or truncated pass for an empty sweep. Added regression coverage for failure continuation and backlog truncation.\n\nValidation:\n- focused stale-run/recovery/accounting/startup suites: 140 passed\n- Core typecheck\n- oxfmt and diff check\n- changeset check\n- 52/53 guards passed; the sole failure is pre-existing Slides i18n debt at SlideEditor.tsx:5012