### PR TITLE
fix(analytics): generate action registry in grounding test

### DIFF
--- a/templates/analytics/server/lib/grounding-derivation.spec.ts
+++ b/templates/analytics/server/lib/grounding-derivation.spec.ts
@@ -1,12 +1,25 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { generateActionRegistryForProject } from "@agent-native/core/vite";
 import { describe, expect, it } from "vitest";
 
-import actionsRegistry from "../../.generated/actions-registry";
 import getDataProgram from "../../actions/get-data-program";
 import {
   deriveGroundingActionNames,
   hasDataQueryAttempt,
   registerGroundingActions,
 } from "./real-data-actions";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+generateActionRegistryForProject(projectRoot);
+const { default: actionsRegistry } = await import(
+  `${pathToFileURL(path.join(projectRoot, ".generated/actions-registry.ts")).href}?cacheBust=${Date.now()}`
+);
 
 // The hand-maintained DATA_QUERY_ACTIONS allowlist is gone, so no file in this
 // template names these actions any more. They are defined in


### PR DESCRIPTION
Fixes the clean-checkout CI failure in the Analytics grounding derivation test.

The test now generates and dynamically imports the ignored .generated/actions-registry.ts, matching the established agent-card test pattern.

Validation:
- Analytics targeted lane: 175 test files, 1368 tests passed
- Analytics typecheck: completed with existing local production-config warnings only
- oxfmt check and git diff --check passed
- changeset check passed

The CI failure was: Cannot find module ../../.generated/actions-registry from the new test.