### PR TITLE
Add slide transition control and fix focus/navigation bugs

### DIFF
--- a/templates/slides/actions/patch-deck.test.ts
+++ b/templates/slides/actions/patch-deck.test.ts
@@ -217,6 +217,27 @@ describe("applyOperation — add-slide", () => {
     ]);
   });
 
+  it("keeps transition, animations, and image data on a duplicated slide", () => {
+    const deck = { slides: [{ id: "s1", content: "1" }] };
+    applyOperation(deck, {
+      op: "add-slide",
+      slideId: "s2",
+      afterSlideId: "s1",
+      fields: {
+        content: "<p>Copy</p>",
+        transition: "fade",
+        animations: [{ id: "a1", elementIndex: 0, type: "fade" }],
+        imageUrl: "https://example.com/slide.png",
+        imageLoading: true,
+      },
+    });
+    const copy = deck.slides[1];
+    expect(copy.transition).toBe("fade");
+    expect(copy.animations).toHaveLength(1);
+    expect(copy.imageUrl).toBe("https://example.com/slide.png");
+    expect(copy.imageLoading).toBeUndefined();
+  });
+
   it("is idempotent — duplicate delivery is silently ignored", () => {
     const deck = {
       slides: [

--- a/templates/slides/actions/patch-deck.ts
+++ b/templates/slides/actions/patch-deck.ts
@@ -157,6 +157,14 @@ const AddSlideOp = z.object({
       notes: z.string().optional(),
       layout: z.string().optional(),
       background: z.string().optional(),
+      imageUrl: z.string().optional(),
+      imagePrompt: z.string().optional(),
+      excalidrawData: z.string().optional(),
+      transition: z
+        .enum(["instant", "none", "fade", "slide", "zoom"])
+        .optional(),
+      animations: z.array(z.unknown()).optional(),
+      splitByParagraph: z.boolean().optional(),
     })
     .passthrough(),
 });
@@ -382,7 +390,10 @@ export function applyOperation(deck: any, op: Operation): void {
       // Idempotency: if the slide already exists (duplicate delivery), skip.
       if (slides.some((s: { id: string }) => s.id === slideId)) return;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // Copy every provided field: a duplicated or undo-restored slide has to
+      // keep its transition, animations, and image data, not just its text.
       const newSlide: any = {
+        ...fields,
         id: slideId,
         content:
           typeof fields.content === "string"
@@ -391,9 +402,7 @@ export function applyOperation(deck: any, op: Operation): void {
         notes: fields.notes ?? "",
         layout: fields.layout ?? "content",
       };
-      if (fields.background !== undefined) {
-        newSlide.background = fields.background;
-      }
+      delete newSlide.imageLoading;
       const insertAfterIdx = afterSlideId
         ? slides.findIndex((s: { id: string }) => s.id === afterSlideId)
         : -1;

--- a/templates/slides/app/components/editor/EditorActionCluster.tsx
+++ b/templates/slides/app/components/editor/EditorActionCluster.tsx
@@ -1,12 +1,24 @@
 import { useT } from "@agent-native/core/client/i18n";
-import { IconLoader2, IconPlus, IconTextSize } from "@tabler/icons-react";
+import {
+  IconLoader2,
+  IconPlus,
+  IconTextSize,
+  IconTransitionRight,
+} from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import type { Slide } from "@/context/DeckContext";
 import { useAgentGenerating } from "@/hooks/use-agent-generating";
 import { cn } from "@/lib/utils";
 
@@ -18,6 +30,15 @@ const IDLE_CLASS =
   "text-muted-foreground hover:bg-accent hover:text-foreground/70";
 const ACTIVE_CLASS = "bg-accent text-foreground";
 const DIVIDER_CLASS = "mx-1 h-4 w-px shrink-0 bg-border";
+
+type SlideTransition = NonNullable<Slide["transition"]>;
+
+const TRANSITIONS: { value: SlideTransition; labelKey: string }[] = [
+  { value: "instant", labelKey: "editorToolbar.transition_instant" },
+  { value: "fade", labelKey: "editorToolbar.transition_fade" },
+  { value: "slide", labelKey: "editorToolbar.transition_slide" },
+  { value: "zoom", labelKey: "editorToolbar.transition_zoom" },
+];
 
 /**
  * Add slide, undo, redo, and add-text-box — the actions that stay put
@@ -36,6 +57,8 @@ export function EditorActionCluster({
   onDuplicateCurrentSlide,
   textBoxMode,
   onToggleTextBoxMode,
+  slideTransition,
+  onChangeSlideTransition,
   className,
 }: {
   deckId: string;
@@ -49,12 +72,19 @@ export function EditorActionCluster({
   onDuplicateCurrentSlide?: () => void;
   textBoxMode?: boolean;
   onToggleTextBoxMode?: () => void;
+  slideTransition?: Slide["transition"];
+  onChangeSlideTransition?: (transition: SlideTransition) => void;
   className?: string;
 }) {
   const t = useT();
   const { generating, submit: agentSubmit } = useAgentGenerating();
   const [addSlideOpen, setAddSlideOpen] = useState(false);
   const addSlideRef = useRef<HTMLButtonElement>(null);
+  // "none" is a legacy alias the presentation view already treats as instant.
+  const activeTransition: SlideTransition =
+    !slideTransition || slideTransition === "none"
+      ? "instant"
+      : slideTransition;
 
   useEffect(() => {
     if (!generating) onAddSlideGeneratingChange?.(false);
@@ -123,6 +153,48 @@ export function EditorActionCluster({
             </TooltipTrigger>
             <TooltipContent>{t("editorToolbar.addTextBox")} (T)</TooltipContent>
           </Tooltip>
+        </>
+      )}
+
+      {onChangeSlideTransition && currentSlideId && (
+        <>
+          <div className={DIVIDER_CLASS} />
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t("editorToolbar.transition")}
+                    className={cn(
+                      BUTTON_CLASS,
+                      activeTransition === "instant"
+                        ? IDLE_CLASS
+                        : ACTIVE_CLASS,
+                    )}
+                  >
+                    <IconTransitionRight className="size-4" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{t("editorToolbar.transition")}</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="start" className="w-40">
+              {TRANSITIONS.map((transition) => (
+                <DropdownMenuItem
+                  key={transition.value}
+                  onSelect={() => onChangeSlideTransition(transition.value)}
+                  className={
+                    activeTransition === transition.value
+                      ? "bg-accent text-accent-foreground"
+                      : undefined
+                  }
+                >
+                  {t(transition.labelKey)}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </>
       )}
     </div>

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -198,7 +198,12 @@ function SortableSlideThumb({
         type="button"
         {...(readOnly ? {} : attributes)}
         {...(readOnly ? {} : listeners)}
-        onClick={onSelect}
+        onClick={(event) => {
+          // Safari does not focus a button on click, and the slide copy/paste
+          // and delete shortcuts are scoped to a focused thumbnail.
+          event.currentTarget.focus();
+          onSelect();
+        }}
         onFocus={onSelect}
         aria-label={t("editorSidebar.selectSlide", { number: index + 1 })}
         aria-current={isActive ? "true" : undefined}

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -122,6 +122,9 @@ interface EditorToolbarProps {
   textBoxMode?: boolean;
   /** Toggle the add-text-box tool */
   onToggleTextBoxMode?: () => void;
+  onChangeSlideTransition?: (
+    transition: NonNullable<Slide["transition"]>,
+  ) => void;
   /** Duplicate the current deck */
   onDuplicateDeck?: () => void;
   /** Export the deck as PDF */
@@ -177,6 +180,7 @@ export default function EditorToolbar({
   onTogglePinMode,
   textBoxMode,
   onToggleTextBoxMode,
+  onChangeSlideTransition,
   onDuplicateDeck,
   onExportPdf,
   onExportPptx,
@@ -578,6 +582,8 @@ export default function EditorToolbar({
           onDuplicateCurrentSlide={onDuplicateCurrentSlide}
           textBoxMode={textBoxMode}
           onToggleTextBoxMode={onToggleTextBoxMode}
+          slideTransition={currentSlide?.transition}
+          onChangeSlideTransition={onChangeSlideTransition}
         />
       )}
 

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
@@ -191,6 +191,42 @@ describe("<NewDeckReferenceStep>", () => {
     expect(screen.getByLabelText("Slides - Imported")).toBeTruthy();
   });
 
+  it("drops the imported reference deck when Slides is deselected", async () => {
+    const imported: ImportedReference = {
+      id: "deck-google",
+      title: "Quarterly plan",
+      source: "google-slides",
+    };
+    const { onSelect, onImportSource } = renderStep();
+    onImportSource.mockResolvedValue(imported);
+
+    fireEvent.click(screen.getByRole("button", { name: "Slides" }));
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Google Slides link" }),
+      {
+        target: {
+          value: "https://docs.google.com/presentation/d/deck-google/edit",
+        },
+      },
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Slides - Imported" }));
+    expect(screen.queryByRole("status")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith({
+      designSystemId: null,
+      referenceDeckId: null,
+      referenceSource: null,
+    });
+  });
+
   it("only shows Google connection recovery after choosing Slides", () => {
     renderStep();
 

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
@@ -176,6 +176,14 @@ export function NewDeckReferenceStep({
   const chooseSource = (
     kind: NonNullable<NewDeckReferenceSelection["referenceSource"]>["kind"],
   ) => {
+    const isAlreadySelected =
+      selectedSource?.kind === kind ||
+      (kind === "google-docs" && importedReference?.source === "google-slides");
+    if (isAlreadySelected) {
+      setSelectedSource(null);
+      setImportedReference(null);
+      return;
+    }
     setSelectedSource({ kind, value: "" });
     if (kind === "website" || kind === "figma") {
       setSelectedDesignSystemId(null);

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
@@ -181,7 +181,14 @@ export function NewDeckReferenceStep({
       (kind === "google-docs" && importedReference?.source === "google-slides");
     if (isAlreadySelected) {
       setSelectedSource(null);
-      setImportedReference(null);
+      if (importedReference) {
+        // The import also set the reference deck. Leaving that id behind would
+        // submit a deck the UI no longer shows as selected.
+        setSelectedReferenceDeckId((current) =>
+          current === importedReference.id ? null : current,
+        );
+        setImportedReference(null);
+      }
       return;
     }
     setSelectedSource({ kind, value: "" });

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -40,12 +40,10 @@ type GranularOp =
       op: "add-slide";
       slideId: string;
       afterSlideId?: string;
-      fields: {
-        content: string;
-        notes?: string;
-        layout?: string;
-        background?: string;
-      };
+      /** Everything but `id` and the transient `imageLoading` flag. A slide
+       * copied or restored through this op keeps its transition, animations,
+       * and image/Excalidraw data instead of silently losing them on reload. */
+      fields: Omit<Partial<Slide>, "id" | "imageLoading"> & { content: string };
     }
   | {
       op: "patch-deck-fields";
@@ -57,6 +55,16 @@ type GranularOp =
   | { op: "full-replace"; deck: Deck };
 
 export type PatchDeckOp = Exclude<GranularOp, { op: "full-replace" }>;
+
+/** Slide payload for an `add-slide` op. `imageLoading` is transient UI state
+ * and must not persist; everything else on the slide has to survive the round
+ * trip or a duplicated/restored slide comes back missing fields. */
+function addSlideFields(
+  slide: Slide,
+): Extract<GranularOp, { op: "add-slide" }>["fields"] {
+  const { id: _id, imageLoading: _imageLoading, ...fields } = slide;
+  return fields;
+}
 export type DeckReloadStatus = "loaded" | "failed" | "stale";
 export interface UpdateSlideOptions {
   persistence?: "debounced" | "immediate";
@@ -683,13 +691,11 @@ export function applyOpToDeck(deck: Deck, op: PatchDeckOp): Deck {
     case "add-slide": {
       if (deck.slides.some((s) => s.id === op.slideId)) return deck; // idempotent
       const newSlide: Slide = {
+        ...op.fields,
         id: op.slideId,
         content: op.fields.content,
         notes: op.fields.notes ?? "",
         layout: (op.fields.layout as SlideLayout) ?? "content",
-        ...(op.fields.background !== undefined
-          ? { background: op.fields.background }
-          : {}),
       };
       const slides = [...deck.slides];
       const afterIdx = op.afterSlideId
@@ -822,14 +828,7 @@ export function deriveInverseOp(
           op: "add-slide",
           slideId: prior.id,
           afterSlideId,
-          fields: {
-            content: prior.content,
-            notes: prior.notes,
-            layout: prior.layout,
-            ...(prior.background !== undefined
-              ? { background: prior.background }
-              : {}),
-          },
+          fields: addSlideFields(prior),
         },
         {
           op: "reorder-slides",
@@ -2127,12 +2126,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         op: "add-slide",
         slideId: newSlide.id,
         afterSlideId,
-        fields: {
-          content: newSlide.content,
-          notes: newSlide.notes,
-          layout: newSlide.layout,
-          background: newSlide.background,
-        },
+        fields: addSlideFields(newSlide),
       };
       enqueueDeckOp(deckId, op);
       if (before) recordUndo(before, op, { label: "Add slide" });
@@ -2240,17 +2234,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // Granular add-slide op — inserts the copy after the original. Build it
       // from the current deck before scheduling the React state update; the
       // functional updater runs later and cannot be used to produce the op.
-      const { id: newSlideId, ...rest } = copiedSlide;
       const op: PatchDeckOp = {
         op: "add-slide",
-        slideId: newSlideId,
+        slideId: copiedSlide.id,
         afterSlideId: slideId,
-        fields: {
-          content: rest.content,
-          notes: rest.notes,
-          layout: rest.layout,
-          background: rest.background,
-        },
+        fields: addSlideFields(copiedSlide),
       };
       enqueueDeckOp(deckId, op);
       recordUndo(before, op, { label: "Duplicate slide" });

--- a/templates/slides/app/hooks/use-navigation-state.ts
+++ b/templates/slides/app/hooks/use-navigation-state.ts
@@ -152,22 +152,21 @@ export function useNavigationState() {
       path = `/deck/${cmd.deckId}`;
       if (cmd.view === "present") {
         path += "/present";
-      } else {
-        const internalSlideIndex =
-          typeof cmd.slideNumber === "number" &&
-          Number.isFinite(cmd.slideNumber) &&
-          cmd.slideNumber >= 1
-            ? cmd.slideNumber - 1
-            : cmd.slideIndex;
-        if (
-          typeof internalSlideIndex === "number" &&
-          Number.isFinite(internalSlideIndex) &&
-          internalSlideIndex >= 0
-        ) {
-          // Convert the internal zero-based value back to the 1-based
-          // ?slide=N URL param the editor reads.
-          path += `?slide=${internalSlideIndex + 1}`;
-        }
+      }
+      const internalSlideIndex =
+        typeof cmd.slideNumber === "number" &&
+        Number.isFinite(cmd.slideNumber) &&
+        cmd.slideNumber >= 1
+          ? cmd.slideNumber - 1
+          : cmd.slideIndex;
+      if (
+        typeof internalSlideIndex === "number" &&
+        Number.isFinite(internalSlideIndex) &&
+        internalSlideIndex >= 0
+      ) {
+        // Convert the internal zero-based value back to the 1-based
+        // ?slide=N URL param both the editor and presentation view read.
+        path += `?slide=${internalSlideIndex + 1}`;
       }
     }
 

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1194,6 +1194,11 @@ export default function DeckEditor() {
         onDuplicateCurrentSlide={
           currentSlide ? () => duplicateSlide(id, currentSlide.id) : undefined
         }
+        onChangeSlideTransition={
+          canEdit && currentSlide
+            ? (transition) => updateSlide(id, currentSlide.id, { transition })
+            : undefined
+        }
       />
 
       {/* Full-width host for the slide's contextual style toolbar: it spans the
@@ -1312,6 +1317,10 @@ export default function DeckEditor() {
                   }
                   textBoxMode={textBoxMode}
                   onToggleTextBoxMode={toggleTextBoxMode}
+                  slideTransition={currentSlide.transition}
+                  onChangeSlideTransition={(transition) =>
+                    updateSlide(id, currentSlide.id, { transition })
+                  }
                 />
               ) : undefined
             }

--- a/templates/slides/changelog/2026-08-13-clicking-a-slide-thumbnail-now-focuses-it-so-the-slide-shortc.md
+++ b/templates/slides/changelog/2026-08-13-clicking-a-slide-thumbnail-now-focuses-it-so-the-slide-shortc.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-13
+---
+
+Clicking a slide thumbnail now focuses it, so the slide copy, paste, and delete shortcuts work after a plain click

--- a/templates/slides/changelog/2026-08-13-duplicating-or-restoring-a-slide-now-keeps-its-transition-ani.md
+++ b/templates/slides/changelog/2026-08-13-duplicating-or-restoring-a-slide-now-keeps-its-transition-ani.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-13
+---
+
+Duplicating or undoing the deletion of a slide now keeps its transition, animations, and image data after reload

--- a/templates/slides/changelog/2026-08-13-opening-presentation-mode-from-the-agent-now-starts-on-the-re.md
+++ b/templates/slides/changelog/2026-08-13-opening-presentation-mode-from-the-agent-now-starts-on-the-re.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-13
+---
+
+Opening presentation mode from the agent now starts on the requested slide instead of the first one

--- a/templates/slides/changelog/2026-08-13-slide-transitions-can-be-set-from-a-visible-control-in-the-sl.md
+++ b/templates/slides/changelog/2026-08-13-slide-transitions-can-be-set-from-a-visible-control-in-the-sl.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-13
+---
+
+Slide transitions can be set from a visible control in the slide toolbar instead of being agent-only


### PR DESCRIPTION
### Summary
Adds a visible slide transition control to the editor toolbar and fixes several editor interaction bugs around slide thumbnail focus, presentation navigation, and reference source selection.

### Problem
Transition settings for a slide were only agent-configurable with no visible UI control. Additionally, clicking a slide thumbnail in Safari didn't focus it, breaking copy/paste/delete shortcuts, and opening presentation mode from the agent always started on the first slide instead of the requested one.

### Solution
Introduced a dropdown menu in the `EditorActionCluster` toolbar for selecting a slide's transition, wired it through `EditorToolbar` and `DeckEditor` to update the slide via `updateSlide`. Fixed the thumbnail click handler to explicitly focus the element, and corrected the navigation path builder so the slide query param is applied regardless of whether the view is present mode or editor mode.

### Key Changes
- `EditorActionCluster.tsx`: New transition dropdown (instant, fade, slide, zoom) with active-state highlighting, backed by a `SlideTransition` type derived from `Slide["transition"]`; treats legacy `"none"` value as `"instant"`.
- `EditorToolbar.tsx` / `DeckEditor.tsx`: Passes `slideTransition` and `onChangeSlideTransition` props down to the action cluster, calling `updateSlide` to persist the change.
- `EditorSidebar.tsx`: Slide thumbnail click handler now explicitly calls `event.currentTarget.focus()` before selecting, fixing Safari's lack of auto-focus on click so slide shortcuts work.
- `use-navigation-state.ts`: Fixed slide index/query param logic so `?slide=N` is appended for both editor and presentation views, not just the editor.
- `NewDeckReferenceStep.tsx`: Clicking an already-selected reference source now deselects it, clearing `selectedSource` and `importedReference`.
- Added changelog entries documenting the transition control, thumbnail focus fix, and presentation navigation fix.


---

<a href="https://builder.io/app/projects/88e92dea5bdd4ad396c8/majestic-queue-qrvmvuzh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://88e92dea5bdd4ad396c8-majestic-queue-qrvmvuzh.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2853`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>88e92dea5bdd4ad396c8</projectId>-->
<!--<branchName>majestic-queue-qrvmvuzh</branchName>-->