### PR TITLE
fix(core): prevent large template archives from exceeding tar buffer

### DIFF
--- a/.changeset/fix-create-tar-listing-buffer.md
+++ b/.changeset/fix-create-tar-listing-buffer.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Increase the buffer available when listing downloaded template archives.

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -92,6 +92,7 @@ const FIRST_PARTY_TARBALL_SYMLINK_EXCLUDES = [
   "*/CLAUDE.md",
   "*/.claude/skills",
 ];
+const TAR_LISTING_MAX_BUFFER = 100 * 1024 * 1024;
 const localPackageTarballs = new Map<string, string>();
 /** VCS/editor files that don't count as "not empty" for an in-place scaffold. */
 const IN_PLACE_ALLOWLIST = new Set([
@@ -2303,6 +2304,7 @@ function archiveSymlinksForExtraction(tarPath: string): ArchiveSymlink[] {
   const listing = execFileSync("tar", ["tvzf", tarPath], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: TAR_LISTING_MAX_BUFFER,
   });
 
   return listing.split(/\r?\n/).flatMap((line) => {
@@ -2491,6 +2493,7 @@ function validateCommunityArchive(tarPath: string): void {
   const listing = execFileSync("tar", ["tvzf", tarPath], {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: TAR_LISTING_MAX_BUFFER,
   });
   assertSafeCommunityArchiveListing(listing);
 }


### PR DESCRIPTION
## Summary
- Increase the tar listing buffer used during template archive extraction and community archive validation.
- Add a patch changeset for `@agent-native/core`.

## Test plan
- [x] Focused `create.spec.ts` suite: 38 tests passed.
- [x] `oxfmt --check packages/core/src/cli/create.ts`.
- [x] Packed-package smoke test: install the local tarball and run `npx agent-native create` successfully.

## Smoke Test

```
tmpdir="$(mktemp -d)"
pnpm --filter @agent-native/core pack --pack-destination "$tmpdir" || exit 1
ls -lh "$tmpdir"

cd "$tmpdir"
npm init -y
npm install ./agent-native-core-*.tgz
npx agent-native create smoke-workspace
```

Made with [Cursor](https://cursor.com)