### PR TITLE
fix: address post-merge review findings

### DIFF
--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn() },
+  net: { request: vi.fn() },
+  session: { fromPartition: vi.fn() },
+}));
+
+vi.mock("../app-store", () => ({
+  loadApps: vi.fn(() => []),
+}));
+
+import { resolveTargetUrl } from "./desktop-chat.js";
+
+describe("desktop chat relay target URLs", () => {
+  it("rejects dot-segment traversal after URL normalization", () => {
+    expect(
+      resolveTargetUrl(
+        "https://mail.example.com",
+        "/_agent-native/../settings",
+      ),
+    ).toBeNull();
+    expect(
+      resolveTargetUrl(
+        "https://mail.example.com",
+        "/_agent-native/%2e%2e/settings",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps allowed agent-native routes on the app origin", () => {
+    expect(
+      resolveTargetUrl(
+        "https://mail.example.com/app",
+        "/_agent-native/agent-chat?surface=desktop",
+      )?.toString(),
+    ).toBe(
+      "https://mail.example.com/app/_agent-native/agent-chat?surface=desktop",
+    );
+  });
+});

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -97,9 +97,16 @@ function parseRelayPath(pathname: string, secret: string): RelayPath | null {
   return { appId, targetPath };
 }
 
-function resolveTargetUrl(baseUrl: string, targetPath: string): URL | null {
+export function resolveTargetUrl(
+  baseUrl: string,
+  targetPath: string,
+): URL | null {
   try {
     const target = new URL(targetPath, "http://desktop-chat.invalid");
+    // Check the normalized URL, not the raw path. Otherwise
+    // /_agent-native/../ can pass the prefix check before escaping the
+    // relay's route boundary.
+    if (!target.pathname.startsWith(RELAY_ALLOWED_PREFIX)) return null;
     const base = new URL(baseUrl);
     const basePath = base.pathname.replace(/\/+$/, "");
     base.pathname = `${basePath}${target.pathname}` || "/";

--- a/packages/desktop-app/src/main/ipc/updates.spec.ts
+++ b/packages/desktop-app/src/main/ipc/updates.spec.ts
@@ -206,6 +206,31 @@ describe("desktop updates", () => {
     expect(updaterState.quitAndInstall).toHaveBeenCalledWith(false, true);
   });
 
+  it("keeps a downloaded update retryable after an asynchronous install error", async () => {
+    registerUpdatesIpc({
+      refreshApplicationMenu: vi.fn(),
+      focusMainWindow: vi.fn(),
+    });
+    updaterState.handlers.get("update-downloaded")?.({
+      version: "1.1.0",
+    });
+
+    const installHandler = electronState.ipcMain.handlers.get(
+      IPC.UPDATE_INSTALL,
+    );
+    await installHandler?.();
+    expect(updaterState.quitAndInstall).toHaveBeenCalledTimes(1);
+
+    updaterState.handlers.get("error")?.(new Error("installer failed"));
+
+    expect(getCurrentUpdateStatus()).toEqual({
+      state: "downloaded",
+      version: "1.1.0",
+    });
+    await installHandler?.();
+    expect(updaterState.quitAndInstall).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps development updates explicitly unsupported", async () => {
     vi.stubGlobal("__AGENT_NATIVE_DESKTOP_BUILD_CHANNEL__", "dev");
     vi.resetModules();

--- a/packages/desktop-app/src/main/ipc/updates.ts
+++ b/packages/desktop-app/src/main/ipc/updates.ts
@@ -46,6 +46,10 @@ let updateCheckInFlight: Promise<unknown> | null = null;
 let lastUpdateCheckStartedAt = 0;
 let notifiedUpdateVersion: string | null = null;
 let updateInstallInFlight = false;
+let installingUpdateForRetry: Extract<
+  UpdateStatus,
+  { state: "downloaded" }
+> | null = null;
 let pendingDownloadedUpdate: Extract<
   UpdateStatus,
   { state: "downloaded" }
@@ -86,6 +90,9 @@ export async function installDownloadedUpdate(): Promise<void> {
   ) {
     return;
   }
+  installingUpdateForRetry =
+    pendingDownloadedUpdate ||
+    (currentUpdateStatus.state === "downloaded" ? currentUpdateStatus : null);
   updateInstallInFlight = true;
   try {
     // Native helpers can outlive the Electron window. Close them before
@@ -96,6 +103,17 @@ export async function installDownloadedUpdate(): Promise<void> {
     autoUpdater.quitAndInstall(false, true);
   } catch (err) {
     updateInstallInFlight = false;
+    const retryUpdate = installingUpdateForRetry;
+    installingUpdateForRetry = null;
+    if (retryUpdate) {
+      pendingDownloadedUpdate = retryUpdate;
+      console.warn(
+        "[updates] update installation failed; keeping the downloaded update ready for retry:",
+        err,
+      );
+      broadcastUpdateStatus(retryUpdate);
+      return;
+    }
     broadcastUpdateStatus({
       state: "error",
       message: err instanceof Error ? err.message : String(err),
@@ -293,6 +311,20 @@ export function registerUpdatesIpc(ipcDeps: UpdatesIpcDeps): void {
     });
 
     autoUpdater.on("error", (err) => {
+      const retryUpdate = updateInstallInFlight
+        ? installingUpdateForRetry
+        : null;
+      updateInstallInFlight = false;
+      installingUpdateForRetry = null;
+      if (retryUpdate) {
+        pendingDownloadedUpdate = retryUpdate;
+        console.warn(
+          "[updates] update installation failed; keeping the downloaded update ready for retry:",
+          err,
+        );
+        broadcastUpdateStatus(retryUpdate);
+        return;
+      }
       pendingDownloadedUpdate = null;
       broadcastUpdateStatus({
         state: "error",

--- a/packages/desktop-app/src/renderer/App.spec.ts
+++ b/packages/desktop-app/src/renderer/App.spec.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("desktop app webview mounting", () => {
+  it("keeps warmed webviews mounted while switching the active app", () => {
+    const appSource = readFileSync(
+      new URL("./App.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(appSource).toContain("key={tab.id}");
+    expect(appSource).not.toContain("key={activeApp.id}");
+  });
+});

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -1220,11 +1220,7 @@ export default function App() {
             </div>
           )}
           {!isCodeAgentsActive && activeApp ? (
-            <DesktopAppChatShell
-              key={activeApp.id}
-              appId={activeApp.id}
-              appName={activeApp.name}
-            >
+            <DesktopAppChatShell appId={activeApp.id} appName={activeApp.name}>
               {webviewContent}
             </DesktopAppChatShell>
           ) : (

--- a/templates/calendar/server/handlers/bookings-preview.spec.ts
+++ b/templates/calendar/server/handlers/bookings-preview.spec.ts
@@ -160,6 +160,11 @@ describe("draft booking availability previews", () => {
     expect(mocks.getFreeBusy.mock.calls[0]?.[2]).not.toContain(
       "old-host@example.com",
     );
-    expect(mocks.accessFilter).toHaveBeenCalled();
+    expect(mocks.accessFilter).toHaveBeenCalledWith(
+      schema.bookingLinks,
+      schema.bookingLinkShares,
+      undefined,
+      "editor",
+    );
   });
 });

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -483,7 +483,12 @@ async function resolveAvailabilityContext({
             draft
               ? and(
                   eq(schema.bookingLinks.slug, slug),
-                  accessFilter(schema.bookingLinks, schema.bookingLinkShares),
+                  accessFilter(
+                    schema.bookingLinks,
+                    schema.bookingLinkShares,
+                    undefined,
+                    "editor",
+                  ),
                 )
               : eq(schema.bookingLinks.slug, slug),
           )

--- a/templates/clips/actions/request-recording-access.test.ts
+++ b/templates/clips/actions/request-recording-access.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => ({
   getRequestUserName: vi.fn(),
   resolveAccess: vi.fn(),
   getDb: vi.fn(),
-  nanoid: vi.fn(() => "event-1"),
   notify: vi.fn(),
   isEmailConfigured: vi.fn(),
   sendEmail: vi.fn(),
@@ -67,6 +66,7 @@ vi.mock("../server/db/index.js", () => ({
       trashedAt: "recordings.trashedAt",
     },
     recordingEvents: {
+      id: "recording_events.id",
       recordingId: "recording_events.recording_id",
       kind: "recording_events.kind",
       createdAt: "recording_events.created_at",
@@ -76,7 +76,6 @@ vi.mock("../server/db/index.js", () => ({
 }));
 
 vi.mock("../server/lib/recordings.js", () => ({
-  nanoid: (...args: unknown[]) => mocks.nanoid(...args),
   normalizeOwnerEmail: (value: string) => value.trim().toLowerCase(),
 }));
 
@@ -84,7 +83,11 @@ import requestRecordingAccess, {
   renderRecordingAccessRequestEmail,
 } from "./request-recording-access.js";
 
-function createDb(recordingRows: unknown[], requestRows: unknown[] = []) {
+function createDb(
+  recordingRows: unknown[],
+  requestRows: unknown[] = [],
+  insertedRows: unknown[] = [{ id: "event-1" }],
+) {
   let selectIndex = 0;
   const db = {
     select: vi.fn(() => {
@@ -101,7 +104,13 @@ function createDb(recordingRows: unknown[], requestRows: unknown[] = []) {
       };
       return builder;
     }),
-    insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(async () => insertedRows),
+        })),
+      })),
+    })),
   };
   return db;
 }
@@ -127,7 +136,6 @@ describe("request-recording-access", () => {
     mocks.notify.mockResolvedValue(undefined);
     mocks.sendEmail.mockResolvedValue(undefined);
     mocks.verifyScopedAgentAccessToken.mockReturnValue({ ok: true });
-    mocks.nanoid.mockReturnValue("event-1");
   });
 
   it("requires a signed-in requester", async () => {
@@ -227,6 +235,26 @@ describe("request-recording-access", () => {
         resourceId: "rec-1",
       },
     );
+  });
+
+  it("does not notify when the database claim is won by another request", async () => {
+    const db = createDb([privateRecording()], [], []);
+    mocks.getDb.mockReturnValue(db);
+
+    await expect(
+      (requestRecordingAccess as any).run({
+        recordingId: "rec-1",
+        accessRequestToken: "request-token",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      alreadyHasAccess: false,
+      alreadyRequested: true,
+      notifiedOwner: false,
+    });
+
+    expect(mocks.notify).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
   });
 
   it("does not send duplicate requests from the same viewer", async () => {

--- a/templates/clips/actions/request-recording-access.ts
+++ b/templates/clips/actions/request-recording-access.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { defineAction } from "@agent-native/core";
 import { notify } from "@agent-native/core/notifications";
 import {
@@ -19,13 +21,27 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { nanoid, normalizeOwnerEmail } from "../server/lib/recordings.js";
+import { normalizeOwnerEmail } from "../server/lib/recordings.js";
 import {
   CLIPS_ACCESS_REQUEST_TOKEN_PREFIX,
   recordingSharePath,
 } from "../shared/recording-link.js";
 
 export const CLIPS_ACCESS_REQUEST_EMAIL_ID = "clips.access-request";
+
+function accessRequestEventId(
+  recordingId: string,
+  requesterEmail: string,
+): string {
+  return (
+    "access-request-" +
+    createHash("sha256")
+      .update(recordingId)
+      .update("\0")
+      .update(requesterEmail)
+      .digest("hex")
+  );
+}
 
 function httpError(message: string, statusCode: number): Error {
   return Object.assign(new Error(message), { statusCode });
@@ -211,19 +227,36 @@ export default defineAction({
       getRequestUserName()?.trim() ||
       displayNameForEmail(normalizedRequesterEmail);
     const requestedAt = new Date().toISOString();
-    await db.insert(schema.recordingEvents).values({
-      id: nanoid(),
-      recordingId,
-      viewerId: null,
-      kind: "access-request",
-      timestampMs: 0,
-      payload: JSON.stringify({
-        requesterEmail: normalizedRequesterEmail,
-        requesterName,
-        requestedAt,
-      }),
-      createdAt: requestedAt,
-    });
+    const [insertedRequest] = await db
+      .insert(schema.recordingEvents)
+      .values({
+        id: accessRequestEventId(recordingId, normalizedRequesterEmail),
+        recordingId,
+        viewerId: null,
+        kind: "access-request",
+        timestampMs: 0,
+        payload: JSON.stringify({
+          requesterEmail: normalizedRequesterEmail,
+          requesterName,
+          requestedAt,
+        }),
+        createdAt: requestedAt,
+      })
+      .onConflictDoNothing()
+      .returning({ id: schema.recordingEvents.id });
+
+    // Historical requests use random IDs, so the read above still handles
+    // them. New requests use a deterministic primary key so concurrent
+    // callers have one database-backed winner before notifications are sent.
+    if (!insertedRequest) {
+      return {
+        ok: true as const,
+        alreadyHasAccess: false,
+        alreadyRequested: true,
+        notifiedOwner: false,
+        message: "Your access request is already with the clip owner.",
+      };
+    }
 
     const ownerEmail = recording.ownerEmail
       ? normalizeOwnerEmail(recording.ownerEmail)

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWriteAppState = vi.hoisted(() => vi.fn());
 const mockReadAppState = vi.hoisted(() => vi.fn());
+const mockDeleteAppState = vi.hoisted(() => vi.fn());
 const mockCompareAndSetAppState = vi.hoisted(() => vi.fn());
+const mockPendingCleanup = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+}));
 const mockDeleteRecordingChunks = vi.hoisted(() => vi.fn());
 const mockGetActiveFileUploadProviderForRequest = vi.hoisted(() => vi.fn());
 const mockGetRouterParam = vi.hoisted(() => vi.fn());
@@ -54,6 +58,7 @@ const mockDb = vi.hoisted(() => ({
 vi.mock("@agent-native/core/application-state", () => ({
   compareAndSetAppState: (...args: unknown[]) =>
     mockCompareAndSetAppState(...args),
+  deleteAppState: (...args: unknown[]) => mockDeleteAppState(...args),
   readAppState: (...args: unknown[]) => mockReadAppState(...args),
   writeAppState: (...args: unknown[]) => mockWriteAppState(...args),
 }));
@@ -156,10 +161,27 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
     mockDeleteResumableSession.mockResolvedValue(undefined);
     mockGetResumableSession.mockResolvedValue(null);
     mockSetResumableSession.mockResolvedValue(undefined);
-    mockWriteAppState.mockResolvedValue(undefined);
-    mockReadAppState.mockResolvedValue({
-      recordingId: "rec-1",
-      status: "uploading",
+    mockPendingCleanup.current = null;
+    mockReadAppState.mockImplementation(async (key: string) =>
+      key === "recording-resumable-cleanup-rec-1"
+        ? mockPendingCleanup.current
+        : {
+            recordingId: "rec-1",
+            status: "uploading",
+          },
+    );
+    mockWriteAppState.mockImplementation(
+      async (key: string, value: Record<string, unknown>) => {
+        if (key === "recording-resumable-cleanup-rec-1") {
+          mockPendingCleanup.current = value;
+        }
+      },
+    );
+    mockDeleteAppState.mockImplementation(async (key: string) => {
+      if (key === "recording-resumable-cleanup-rec-1") {
+        mockPendingCleanup.current = null;
+      }
+      return true;
     });
     mockCompareAndSetAppState.mockResolvedValue(true);
     mockRenewUploadLease.mockResolvedValue({ held: true });
@@ -276,6 +298,52 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
       meta: { objectKey: "clips/rec-1.webm" },
     });
     expect(mockDeleteResumableSession).toHaveBeenCalledWith(
+      "rec-1",
+      "generation-old",
+    );
+  });
+
+  it("retains a cleanup claim when provider abort fails so a retry can finish it", async () => {
+    mockExistingRecording.current.uploadGenerationId = "generation-old";
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-old",
+      useGenerationFence: true,
+    });
+    mockGetResumableSession.mockResolvedValue({
+      providerId: "test-provider",
+      sessionId: "old-session",
+      meta: { objectKey: "clips/rec-1.webm" },
+      bytesUploaded: 12,
+    });
+    mockAbortSession
+      .mockRejectedValueOnce(new Error("provider cleanup failed"))
+      .mockResolvedValue(true);
+
+    await expect(handler({} as any)).resolves.toEqual({
+      error:
+        "The previous recording upload could not be cleaned up. Retry the upload restart.",
+    });
+    expect(mockPendingCleanup.current).toEqual(
+      expect.objectContaining({
+        recordingId: "rec-1",
+        generationId: "generation-old",
+      }),
+    );
+    expect(mockDeleteAppState).not.toHaveBeenCalled();
+
+    mockExistingRecording.current.uploadGenerationId = "generation-new";
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-new",
+      useGenerationFence: true,
+    });
+    await expect(handler({} as any)).resolves.toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(mockAbortSession).toHaveBeenCalledTimes(2);
+    expect(mockDeleteAppState).toHaveBeenCalledWith(
+      "recording-resumable-cleanup-rec-1",
+    );
+    expect(mockDeleteResumableSession).toHaveBeenLastCalledWith(
       "rec-1",
       "generation-old",
     );

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
@@ -25,6 +25,8 @@ const mockShouldEnableStreamingUpload = vi.hoisted(() => vi.fn());
 const mockAllowsSqlRecordingChunkScratch = vi.hoisted(() => vi.fn());
 const mockIsMediaVerificationPending = vi.hoisted(() => vi.fn());
 const mockUpdateSets = vi.hoisted(() => [] as Record<string, unknown>[]);
+const mockResetWins = vi.hoisted(() => ({ current: true }));
+const mockReplaceCleanupOnRelease = vi.hoisted(() => ({ current: false }));
 const mockExistingRecording = vi.hoisted(() => ({
   current: {
     id: "rec-1",
@@ -49,7 +51,9 @@ const mockDb = vi.hoisted(() => ({
         return builder;
       }),
       where: vi.fn(() => builder),
-      returning: vi.fn(async () => [{ id: "rec-1" }]),
+      returning: vi.fn(async () =>
+        mockResetWins.current ? [{ id: "rec-1" }] : [],
+      ),
     };
     return builder;
   }),
@@ -151,6 +155,8 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUpdateSets.length = 0;
+    mockResetWins.current = true;
+    mockReplaceCleanupOnRelease.current = false;
     mockGetRouterParam.mockReturnValue("rec-1");
     mockGetEventOwnerContext.mockResolvedValue({
       userEmail: "owner@example.com",
@@ -183,7 +189,37 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
       }
       return true;
     });
-    mockCompareAndSetAppState.mockResolvedValue(true);
+    mockCompareAndSetAppState.mockImplementation(
+      async (
+        key: string,
+        expected: Record<string, unknown> | null,
+        next: Record<string, unknown> | null,
+      ) => {
+        if (key === "recording-resumable-cleanup-rec-1") {
+          const current = mockPendingCleanup.current;
+          if (JSON.stringify(current) !== JSON.stringify(expected)) {
+            return false;
+          }
+          if (next === null && mockReplaceCleanupOnRelease.current) {
+            mockPendingCleanup.current = {
+              recordingId: "rec-1",
+              generationId: "generation-old",
+              ownerGenerationId: "generation-newer",
+              claimId: "newer-claim",
+              session: {
+                providerId: "test-provider",
+                sessionId: "newer-session",
+                meta: { objectKey: "clips/rec-1-newer.webm" },
+                bytesUploaded: 0,
+              },
+            };
+            return false;
+          }
+          mockPendingCleanup.current = next;
+        }
+        return true;
+      },
+    );
     mockRenewUploadLease.mockResolvedValue({ held: true });
     mockAbortSession.mockResolvedValue(undefined);
     mockAllowsSqlRecordingChunkScratch.mockReturnValue(false);
@@ -303,6 +339,50 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
     );
   });
 
+  it("does not leave a cleanup claim when it loses the generation fence", async () => {
+    mockResetWins.current = false;
+    mockExistingRecording.current.uploadGenerationId = "generation-old";
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-old",
+      useGenerationFence: true,
+    });
+    mockGetResumableSession.mockResolvedValue({
+      providerId: "test-provider",
+      sessionId: "old-session",
+      meta: { objectKey: "clips/rec-1.webm" },
+      bytesUploaded: 12,
+    });
+
+    await expect(handler({} as any)).resolves.toEqual(
+      expect.objectContaining({ staleAttempt: true }),
+    );
+    expect(mockPendingCleanup.current).toBeNull();
+    expect(mockCompareAndSetAppState).not.toHaveBeenCalled();
+    expect(mockAbortSession).not.toHaveBeenCalled();
+  });
+
+  it("does not release a cleanup claim replaced by a newer reset", async () => {
+    mockReplaceCleanupOnRelease.current = true;
+    mockExistingRecording.current.uploadGenerationId = "generation-old";
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-old",
+      useGenerationFence: true,
+    });
+    mockGetResumableSession.mockResolvedValue({
+      providerId: "test-provider",
+      sessionId: "old-session",
+      meta: { objectKey: "clips/rec-1.webm" },
+      bytesUploaded: 12,
+    });
+
+    await expect(handler({} as any)).resolves.toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(mockPendingCleanup.current).toEqual(
+      expect.objectContaining({ claimId: "newer-claim" }),
+    );
+  });
+
   it("retains a cleanup claim when provider abort fails so a retry can finish it", async () => {
     mockExistingRecording.current.uploadGenerationId = "generation-old";
     mockReadBody.mockResolvedValue({
@@ -329,20 +409,21 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
         generationId: "generation-old",
       }),
     );
-    expect(mockDeleteAppState).not.toHaveBeenCalled();
+    const pendingOwnerGenerationId = (
+      mockPendingCleanup.current as { ownerGenerationId: string }
+    ).ownerGenerationId;
+    expect(pendingOwnerGenerationId).toEqual(expect.any(String));
 
-    mockExistingRecording.current.uploadGenerationId = "generation-new";
+    mockExistingRecording.current.uploadGenerationId = pendingOwnerGenerationId;
     mockReadBody.mockResolvedValue({
-      uploadGenerationId: "generation-new",
+      uploadGenerationId: pendingOwnerGenerationId,
       useGenerationFence: true,
     });
     await expect(handler({} as any)).resolves.toEqual(
       expect.objectContaining({ ok: true }),
     );
     expect(mockAbortSession).toHaveBeenCalledTimes(2);
-    expect(mockDeleteAppState).toHaveBeenCalledWith(
-      "recording-resumable-cleanup-rec-1",
-    );
+    expect(mockPendingCleanup.current).toBeNull();
     expect(mockDeleteResumableSession).toHaveBeenLastCalledWith(
       "rec-1",
       "generation-old",

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.test.ts
@@ -361,6 +361,78 @@ describe("/api/uploads/:recordingId/reset-chunks route", () => {
     expect(mockAbortSession).not.toHaveBeenCalled();
   });
 
+  it("does not let a stale cleanup claim hide the current generation session", async () => {
+    mockExistingRecording.current.uploadGenerationId = "generation-current";
+    mockPendingCleanup.current = {
+      recordingId: "rec-1",
+      generationId: "generation-old",
+      ownerGenerationId: "generation-old",
+      claimId: "stale-claim",
+      session: {
+        providerId: "test-provider",
+        sessionId: "stale-session",
+        meta: { objectKey: "clips/rec-1-stale.webm" },
+        bytesUploaded: 12,
+      },
+    };
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-current",
+      useGenerationFence: true,
+    });
+    mockGetResumableSession.mockResolvedValue({
+      providerId: "test-provider",
+      sessionId: "active-session",
+      meta: { objectKey: "clips/rec-1-active.webm" },
+      bytesUploaded: 24,
+    });
+
+    await expect(handler({} as any)).resolves.toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(mockAbortSession).toHaveBeenCalledWith({
+      sessionId: "active-session",
+      meta: { objectKey: "clips/rec-1-active.webm" },
+    });
+    expect(mockDeleteResumableSession).toHaveBeenCalledWith(
+      "rec-1",
+      "generation-current",
+    );
+  });
+
+  it("ignores an unowned cleanup claim during a fenced reset", async () => {
+    mockExistingRecording.current.uploadGenerationId = "generation-current";
+    mockPendingCleanup.current = {
+      recordingId: "rec-1",
+      generationId: "generation-old",
+      ownerGenerationId: null,
+      claimId: null,
+      session: {
+        providerId: "test-provider",
+        sessionId: "legacy-session",
+        meta: { objectKey: "clips/rec-1-legacy.webm" },
+        bytesUploaded: 12,
+      },
+    };
+    mockReadBody.mockResolvedValue({
+      uploadGenerationId: "generation-current",
+      useGenerationFence: true,
+    });
+    mockGetResumableSession.mockResolvedValue({
+      providerId: "test-provider",
+      sessionId: "active-session",
+      meta: { objectKey: "clips/rec-1-active.webm" },
+      bytesUploaded: 24,
+    });
+
+    await expect(handler({} as any)).resolves.toEqual(
+      expect.objectContaining({ ok: true }),
+    );
+    expect(mockAbortSession).toHaveBeenCalledWith({
+      sessionId: "active-session",
+      meta: { objectKey: "clips/rec-1-active.webm" },
+    });
+  });
+
   it("does not release a cleanup claim replaced by a newer reset", async () => {
     mockReplaceCleanupOnRelease.current = true;
     mockExistingRecording.current.uploadGenerationId = "generation-old";

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -28,6 +28,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   compareAndSetAppState,
+  deleteAppState,
   readAppState,
   writeAppState,
 } from "@agent-native/core/application-state";
@@ -57,6 +58,7 @@ import {
   deleteResumableSession,
   getResumableSession,
   setResumableSession,
+  type StoredResumableSession,
 } from "../../../../lib/resumable-session.js";
 import { abortResumableUploadSession } from "../../../../lib/resumable-upload-cleanup.js";
 import { shouldEnableStreamingUpload } from "../../../../lib/streaming-upload-mode.js";
@@ -72,6 +74,53 @@ interface CompressionMeta {
   ratio?: number;
   elapsedMs?: number;
   outputMimeType?: string;
+}
+
+interface PendingResumableCleanup {
+  generationId: string | null;
+  session: StoredResumableSession;
+}
+
+function parsePendingResumableCleanup(
+  raw: Record<string, unknown> | null,
+  recordingId: string,
+): PendingResumableCleanup | null {
+  if (!raw) return null;
+  const session = raw.session;
+  const generationId = raw.generationId;
+  if (
+    raw.recordingId !== recordingId ||
+    !session ||
+    typeof session !== "object" ||
+    Array.isArray(session) ||
+    !(generationId === null || typeof generationId === "string")
+  ) {
+    throw new Error(
+      `Invalid resumable cleanup state for recording ${recordingId}`,
+    );
+  }
+
+  const candidate = session as Record<string, unknown>;
+  if (
+    typeof candidate.providerId !== "string" ||
+    typeof candidate.sessionId !== "string" ||
+    !candidate.meta ||
+    typeof candidate.meta !== "object" ||
+    Array.isArray(candidate.meta) ||
+    typeof candidate.bytesUploaded !== "number" ||
+    !Number.isFinite(candidate.bytesUploaded) ||
+    (candidate.lastCommittedIndex !== undefined &&
+      typeof candidate.lastCommittedIndex !== "number")
+  ) {
+    throw new Error(
+      `Invalid resumable session in cleanup state for recording ${recordingId}`,
+    );
+  }
+
+  return {
+    generationId,
+    session: candidate as unknown as StoredResumableSession,
+  };
 }
 
 function normalizeVideoMimeType(value: unknown): string | null {
@@ -219,10 +268,26 @@ export default defineEventHandler(async (event: H3Event) => {
     const nextGenerationId = useGenerationFence ? randomUUID() : null;
     const uploadStateKey = `recording-upload-${recordingId}`;
     const uploadStateSnapshot = await readAppState(uploadStateKey);
-    const discardedResumableSession = await getResumableSession(
+    const cleanupStateKey = `recording-resumable-cleanup-${recordingId}`;
+    const pendingCleanup = parsePendingResumableCleanup(
+      await readAppState(cleanupStateKey),
       recordingId,
-      existingGenerationId,
     );
+    const discardedGenerationId = pendingCleanup
+      ? pendingCleanup.generationId
+      : existingGenerationId;
+    const discardedResumableSession =
+      pendingCleanup?.session ??
+      (await getResumableSession(recordingId, existingGenerationId));
+    if (discardedResumableSession) {
+      // Persist the old handle before changing the generation. If provider
+      // cleanup fails after the fence, the next retry can still find it.
+      await writeAppState(cleanupStateKey, {
+        recordingId,
+        generationId: discardedGenerationId,
+        session: discardedResumableSession,
+      });
+    }
     const reset = await db
       .update(schema.recordings)
       .set({
@@ -269,15 +334,16 @@ export default defineEventHandler(async (event: H3Event) => {
             "The previous recording upload could not be cleaned up. Retry the upload restart.",
         };
       }
+      await deleteAppState(cleanupStateKey);
     }
     const cleared = await deleteRecordingChunks(
       ownerEmail,
       recordingId,
-      existingGenerationId,
+      discardedGenerationId,
     );
     // Clear any stale resumable session so a buffered retry does not
     // accidentally route through handleResumableChunk with stale offsets.
-    await deleteResumableSession(recordingId, existingGenerationId).catch(
+    await deleteResumableSession(recordingId, discardedGenerationId).catch(
       () => {},
     );
 

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -28,7 +28,6 @@ import { randomUUID } from "node:crypto";
 
 import {
   compareAndSetAppState,
-  deleteAppState,
   readAppState,
   writeAppState,
 } from "@agent-native/core/application-state";
@@ -77,7 +76,10 @@ interface CompressionMeta {
 }
 
 interface PendingResumableCleanup {
+  recordingId: string;
   generationId: string | null;
+  ownerGenerationId: string | null;
+  claimId: string | null;
   session: StoredResumableSession;
 }
 
@@ -88,12 +90,18 @@ function parsePendingResumableCleanup(
   if (!raw) return null;
   const session = raw.session;
   const generationId = raw.generationId;
+  const ownerGenerationId = raw.ownerGenerationId;
+  const claimId = raw.claimId;
   if (
     raw.recordingId !== recordingId ||
     !session ||
     typeof session !== "object" ||
     Array.isArray(session) ||
-    !(generationId === null || typeof generationId === "string")
+    !(generationId === null || typeof generationId === "string") ||
+    (ownerGenerationId !== undefined &&
+      ownerGenerationId !== null &&
+      typeof ownerGenerationId !== "string") ||
+    (claimId !== undefined && claimId !== null && typeof claimId !== "string")
   ) {
     throw new Error(
       `Invalid resumable cleanup state for recording ${recordingId}`,
@@ -118,7 +126,11 @@ function parsePendingResumableCleanup(
   }
 
   return {
+    recordingId,
     generationId,
+    ownerGenerationId:
+      ownerGenerationId === undefined ? null : ownerGenerationId,
+    claimId: claimId === undefined ? null : claimId,
     session: candidate as unknown as StoredResumableSession,
   };
 }
@@ -269,25 +281,23 @@ export default defineEventHandler(async (event: H3Event) => {
     const uploadStateKey = `recording-upload-${recordingId}`;
     const uploadStateSnapshot = await readAppState(uploadStateKey);
     const cleanupStateKey = `recording-resumable-cleanup-${recordingId}`;
-    const pendingCleanup = parsePendingResumableCleanup(
-      await readAppState(cleanupStateKey),
+    const cleanupStateSnapshot = await readAppState(cleanupStateKey);
+    const parsedCleanup = parsePendingResumableCleanup(
+      cleanupStateSnapshot,
       recordingId,
     );
+    const pendingCleanup =
+      parsedCleanup &&
+      (parsedCleanup.ownerGenerationId === null ||
+        parsedCleanup.ownerGenerationId === existingGenerationId)
+        ? parsedCleanup
+        : null;
     const discardedGenerationId = pendingCleanup
       ? pendingCleanup.generationId
       : existingGenerationId;
     const discardedResumableSession =
       pendingCleanup?.session ??
       (await getResumableSession(recordingId, existingGenerationId));
-    if (discardedResumableSession) {
-      // Persist the old handle before changing the generation. If provider
-      // cleanup fails after the fence, the next retry can still find it.
-      await writeAppState(cleanupStateKey, {
-        recordingId,
-        generationId: discardedGenerationId,
-        session: discardedResumableSession,
-      });
-    }
     const reset = await db
       .update(schema.recordings)
       .set({
@@ -322,19 +332,50 @@ export default defineEventHandler(async (event: H3Event) => {
       };
     }
 
+    let cleanupClaim: PendingResumableCleanup | null = null;
     if (discardedResumableSession) {
-      const cleaned = await abortResumableUploadSession(
-        discardedResumableSession,
-        { label: `reset-${recordingId}` },
+      // A cleanup claim belongs to the generation that won this fence. A
+      // losing reset must never resurrect a claim after the winner releases
+      // it, and a later winner must be able to transfer an unfinished claim.
+      const candidate: PendingResumableCleanup = {
+        recordingId,
+        generationId: discardedGenerationId,
+        ownerGenerationId: nextGenerationId,
+        claimId: randomUUID(),
+        session: discardedResumableSession,
+      };
+      const claimed = await compareAndSetAppState(
+        cleanupStateKey,
+        cleanupStateSnapshot,
+        candidate as unknown as Record<string, unknown>,
       );
-      if (!cleaned) {
-        setResponseStatus(event, 502);
-        return {
-          error:
-            "The previous recording upload could not be cleaned up. Retry the upload restart.",
-        };
+      if (claimed) cleanupClaim = candidate;
+    }
+
+    if (discardedResumableSession) {
+      if (cleanupClaim) {
+        const cleaned = await abortResumableUploadSession(
+          discardedResumableSession,
+          { label: `reset-${recordingId}` },
+        );
+        if (!cleaned) {
+          setResponseStatus(event, 502);
+          return {
+            error:
+              "The previous recording upload could not be cleaned up. Retry the upload restart.",
+          };
+        }
+        const released = await compareAndSetAppState(
+          cleanupStateKey,
+          cleanupClaim as unknown as Record<string, unknown>,
+          null,
+        );
+        if (!released) {
+          console.warn(
+            `[reset-chunks-${recordingId}] cleanup claim changed while releasing it`,
+          );
+        }
       }
-      await deleteAppState(cleanupStateKey);
     }
     const cleared = await deleteRecordingChunks(
       ownerEmail,
@@ -343,9 +384,11 @@ export default defineEventHandler(async (event: H3Event) => {
     );
     // Clear any stale resumable session so a buffered retry does not
     // accidentally route through handleResumableChunk with stale offsets.
-    await deleteResumableSession(recordingId, discardedGenerationId).catch(
-      () => {},
-    );
+    if (!discardedResumableSession || cleanupClaim) {
+      await deleteResumableSession(recordingId, discardedGenerationId).catch(
+        () => {},
+      );
+    }
 
     let uploadMode: UploadMode = "buffered";
     let compensateStartedSession: (() => Promise<void>) | null = null;

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -288,8 +288,9 @@ export default defineEventHandler(async (event: H3Event) => {
     );
     const pendingCleanup =
       parsedCleanup &&
-      (parsedCleanup.ownerGenerationId === null ||
-        parsedCleanup.ownerGenerationId === existingGenerationId)
+      (parsedCleanup.ownerGenerationId === null
+        ? !useGenerationFence
+        : parsedCleanup.ownerGenerationId === existingGenerationId)
         ? parsedCleanup
         : null;
     const discardedGenerationId = pendingCleanup


### PR DESCRIPTION
## Summary

- harden desktop relay URL validation against encoded and literal dot-segment traversal
- keep desktop update installs retryable after synchronous or asynchronous failures
- preserve warmed desktop app webviews across app switching
- require editor access for calendar draft booking-link previews
- make Clips recording-access requests idempotent under concurrent retries
- fence and retry resumable upload cleanup across chunk-generation resets

## Validation

- focused Vitest suites: 84 tests passed
- desktop TypeScript check passed
- formatting check passed
- targeted oxlint passed
- repository guards passed except the existing isolated-worktree i18n catalog baseline failure

Ready for review.