### PR TITLE
Pin calendar timezone and add working locations from days

### DIFF
--- a/templates/calendar/.agents/skills/event-management/SKILL.md
+++ b/templates/calendar/.agents/skills/event-management/SKILL.md
@@ -165,11 +165,14 @@ Creating from a calendar day uses the selected Home, Office, or Other type —
 do not leave the draft as Home and create that instead. Office does not need a
 custom building name; Other does. The Other name is `workingLocationLabel`
 (drafts keep `location` empty), so create must send that label — not an empty
-`location`. If that day already has a working location
+`location`. Create and update reject a blank Other name instead of storing
+`Working`. If that day already has a working location
 on the same account, update that day's occurrence (`scope: "single"`) instead
 of creating a second event. Timed (not all-day) working locations need a
-summary of Home, Office, or the custom label; all-day ones omit it so Google
-can derive the title.
+summary of Home, Office, or the custom label — never the generated
+`Working location` placeholder. All-day ones omit summary so Google can derive
+the title. Converting a timed location that ends at local midnight back to
+all-day keeps that single day; do not add another exclusive day.
 
 `--fullDay true` is semantic only for out-of-office creation. It does not send
 Google an all-day `date` event, which Google rejects for this event type.

--- a/templates/calendar/.agents/skills/event-management/SKILL.md
+++ b/templates/calendar/.agents/skills/event-management/SKILL.md
@@ -91,7 +91,8 @@ pnpm action create-event \
 ```
 
 Required for ordinary events: `--title`, `--start`, `--end` (ISO datetime
-format). Out-of-office events default the title to `Out of office` when it is
+format). Out-of-office events default the title to `Out of office`, and
+working-location events use Google's generated display title when `--title` is
 omitted.
 Optional: `--description`, `--location`, `--attendees`, `--addGoogleMeet`, `--addZoom`, `--sendUpdates`, `--accountEmail`.
 
@@ -156,9 +157,17 @@ pnpm action create-event \
 
 Working-location events sync from Google with `workingLocationProperties` and
 render as native working locations in the UI instead of generic all-day events.
-They are transparent/non-blocking for availability. Google allows timed working
-locations or single-day all-day working locations; multi-day all-day ranges must
-be represented as separate daily working-location events.
+They are transparent/non-blocking for availability. All-day working locations
+use an exclusive `--end` date and can span multiple days; timed working
+locations use ISO datetime start and end values.
+
+Creating from a calendar day uses the selected Home, Office, or Other type —
+do not leave the draft as Home and create that instead. Office does not need a
+custom building name; Other does. If that day already has a working location
+on the same account, update that day's occurrence (`scope: "single"`) instead
+of creating a second event. Timed (not all-day) working locations need a
+summary of Home, Office, or the custom label; all-day ones omit it so Google
+can derive the title.
 
 `--fullDay true` is semantic only for out-of-office creation. It does not send
 Google an all-day `date` event, which Google rejects for this event type.

--- a/templates/calendar/.agents/skills/event-management/SKILL.md
+++ b/templates/calendar/.agents/skills/event-management/SKILL.md
@@ -163,7 +163,9 @@ locations use ISO datetime start and end values.
 
 Creating from a calendar day uses the selected Home, Office, or Other type —
 do not leave the draft as Home and create that instead. Office does not need a
-custom building name; Other does. If that day already has a working location
+custom building name; Other does. The Other name is `workingLocationLabel`
+(drafts keep `location` empty), so create must send that label — not an empty
+`location`. If that day already has a working location
 on the same account, update that day's occurrence (`scope: "single"`) instead
 of creating a second event. Timed (not all-day) working locations need a
 summary of Home, Office, or the custom label; all-day ones omit it so Google

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -37,7 +37,9 @@ export default defineAction({
     title: z
       .string()
       .optional()
-      .describe("Event title. Defaults to 'Out of office' for OOO events."),
+      .describe(
+        "Event title. Defaults to 'Out of office' for OOO events. Working-location events use Google's generated display title and do not require one.",
+      ),
     start: z
       .string()
       .describe(
@@ -46,7 +48,7 @@ export default defineAction({
     end: z
       .string()
       .describe(
-        "End time in ISO format, or the last inclusive YYYY-MM-DD date for a full-day OOO event.",
+        "End time in ISO format, the last inclusive YYYY-MM-DD date for a full-day OOO event, or the exclusive YYYY-MM-DD date for an all-day working-location event.",
       ),
     startTimeZone: z
       .string()

--- a/templates/calendar/actions/event-action-helpers.test.ts
+++ b/templates/calendar/actions/event-action-helpers.test.ts
@@ -214,6 +214,17 @@ describe("buildStatusEventFields", () => {
       },
     });
   });
+
+  it("rejects Other working locations without a name", () => {
+    expect(() =>
+      buildStatusEventFields({
+        eventType: "workingLocation",
+        workingLocationType: "customLocation",
+        location: "",
+        title: "",
+      }),
+    ).toThrow("Other working locations require a name");
+  });
 });
 
 describe("normalizeCreateEventInput", () => {

--- a/templates/calendar/actions/event-action-helpers.test.ts
+++ b/templates/calendar/actions/event-action-helpers.test.ts
@@ -183,6 +183,20 @@ describe("buildStatusEventFields", () => {
       },
     });
   });
+
+  it("creates unlabeled office working-location fields without a placeholder name", () => {
+    expect(
+      buildStatusEventFields({
+        eventType: "workingLocation",
+        workingLocationType: "officeLocation",
+      }),
+    ).toMatchObject({
+      workingLocationProperties: {
+        type: "officeLocation",
+        officeLocation: {},
+      },
+    });
+  });
 });
 
 describe("normalizeCreateEventInput", () => {
@@ -313,6 +327,24 @@ describe("normalizeCreateEventInput", () => {
       }),
     ).toThrow("Event title is required");
   });
+
+  it("allows titleless all-day working locations with exclusive date bounds", () => {
+    expect(
+      normalizeCreateEventInput({
+        eventType: "workingLocation",
+        start: "2026-08-10",
+        end: "2026-08-15",
+        allDay: true,
+      }),
+    ).toEqual({
+      title: "",
+      start: "2026-08-10",
+      end: "2026-08-15",
+      startTimeZone: undefined,
+      endTimeZone: undefined,
+      allDay: true,
+    });
+  });
 });
 
 describe("validateStatusEventTiming", () => {
@@ -353,7 +385,7 @@ describe("validateStatusEventTiming", () => {
     ).not.toThrow();
   });
 
-  it("rejects multi-day all-day working locations", () => {
+  it("allows multi-day all-day working locations", () => {
     expect(() =>
       validateStatusEventTiming({
         eventType: "workingLocation",
@@ -361,6 +393,17 @@ describe("validateStatusEventTiming", () => {
         start: "2026-07-06",
         end: "2026-07-11",
       }),
-    ).toThrow("All-day working location events must be a single day.");
+    ).not.toThrow();
+  });
+
+  it("rejects empty all-day working-location ranges", () => {
+    expect(() =>
+      validateStatusEventTiming({
+        eventType: "workingLocation",
+        allDay: true,
+        start: "2026-07-06",
+        end: "2026-07-06",
+      }),
+    ).toThrow("end date must be after");
   });
 });

--- a/templates/calendar/actions/event-action-helpers.test.ts
+++ b/templates/calendar/actions/event-action-helpers.test.ts
@@ -197,6 +197,23 @@ describe("buildStatusEventFields", () => {
       },
     });
   });
+
+  it("creates Other working-location fields from workingLocationLabel", () => {
+    expect(
+      buildStatusEventFields({
+        eventType: "workingLocation",
+        workingLocationType: "customLocation",
+        workingLocationLabel: "Church",
+        location: "",
+        title: "",
+      }),
+    ).toMatchObject({
+      workingLocationProperties: {
+        type: "customLocation",
+        customLocation: { label: "Church" },
+      },
+    });
+  });
 });
 
 describe("normalizeCreateEventInput", () => {

--- a/templates/calendar/actions/event-action-helpers.ts
+++ b/templates/calendar/actions/event-action-helpers.ts
@@ -311,8 +311,7 @@ export function buildStatusEventFields(args: {
   }
 
   const type = args.workingLocationType ?? "customLocation";
-  const label =
-    args.workingLocationLabel || args.location || args.title || "Working";
+  const label = args.workingLocationLabel || args.location || args.title || "";
   return {
     eventType: args.eventType,
     transparency: "transparent" as const,
@@ -321,8 +320,8 @@ export function buildStatusEventFields(args: {
       type === "homeOffice"
         ? { type, homeOffice: {} }
         : type === "officeLocation"
-          ? { type, officeLocation: { label } }
-          : { type, customLocation: { label } },
+          ? { type, officeLocation: label ? { label } : {} }
+          : { type, customLocation: { label: label || "Working" } },
   };
 }
 
@@ -359,6 +358,16 @@ function normalizedIso(value: string, label: "start" | "end"): string {
   return date.toISOString();
 }
 
+function normalizeWorkingLocationAllDayDate(value: string): string {
+  const date = allDayDatePart(value);
+  if (!isValidDateOnly(date)) {
+    throw new Error(
+      "All-day working location events require valid YYYY-MM-DD dates.",
+    );
+  }
+  return date;
+}
+
 export function normalizeCreateEventInput(args: {
   title?: string;
   eventType?: "default" | "outOfOffice" | "focusTime" | "workingLocation";
@@ -376,7 +385,27 @@ export function normalizeCreateEventInput(args: {
   const title =
     args.title?.trim() ||
     (args.eventType === "outOfOffice" ? "Out of office" : "");
-  if (!title) throw new Error("Event title is required.");
+  if (!title && args.eventType !== "workingLocation") {
+    throw new Error("Event title is required.");
+  }
+
+  if (args.eventType === "workingLocation" && args.allDay === true) {
+    const start = normalizeWorkingLocationAllDayDate(args.start);
+    const end = normalizeWorkingLocationAllDayDate(args.end);
+    if (end <= start) {
+      throw new Error(
+        "All-day working location end date must be after its start date.",
+      );
+    }
+    return {
+      title,
+      start,
+      end,
+      startTimeZone: undefined,
+      endTimeZone: undefined,
+      allDay: true,
+    };
+  }
 
   if (args.eventType === "outOfOffice" && args.fullDay === true) {
     const timezone = requireIanaTimezone(
@@ -435,15 +464,21 @@ export function normalizeCreateEventInput(args: {
 }
 
 function allDayDatePart(value: string): string {
-  const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
-  if (dateOnlyPattern.test(value)) return value;
+  if (DATE_ONLY_PATTERN.test(value)) {
+    if (isValidDateOnly(value)) return value;
+    throw new Error("All-day status events must use valid YYYY-MM-DD dates.");
+  }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
     throw new Error(
       "All-day status events must use valid date or datetime start and end values.",
     );
   }
-  return date.toISOString().slice(0, 10);
+  const datePart = date.toISOString().slice(0, 10);
+  if (!isValidDateOnly(datePart)) {
+    throw new Error("All-day status events must use valid YYYY-MM-DD dates.");
+  }
+  return datePart;
 }
 
 function allDaySpanDays(start: string, end: string): number {
@@ -477,8 +512,10 @@ export function validateStatusEventTiming(args: {
 
   if (args.eventType === "workingLocation" && args.allDay === true) {
     const days = allDaySpanDays(args.start, args.end);
-    if (days !== 1) {
-      throw new Error("All-day working location events must be a single day.");
+    if (days < 1) {
+      throw new Error(
+        "All-day working location end date must be after its start date.",
+      );
     }
   }
 }

--- a/templates/calendar/actions/event-action-helpers.ts
+++ b/templates/calendar/actions/event-action-helpers.ts
@@ -311,7 +311,17 @@ export function buildStatusEventFields(args: {
   }
 
   const type = args.workingLocationType ?? "customLocation";
-  const label = args.workingLocationLabel || args.location || args.title || "";
+  const label = (
+    args.workingLocationLabel ||
+    args.location ||
+    args.title ||
+    ""
+  ).trim();
+  if (type === "customLocation" && !label) {
+    throw new Error(
+      "Other working locations require a name. Pass workingLocationLabel.",
+    );
+  }
   return {
     eventType: args.eventType,
     transparency: "transparent" as const,
@@ -321,7 +331,7 @@ export function buildStatusEventFields(args: {
         ? { type, homeOffice: {} }
         : type === "officeLocation"
           ? { type, officeLocation: label ? { label } : {} }
-          : { type, customLocation: { label: label || "Working" } },
+          : { type, customLocation: { label } },
   };
 }
 

--- a/templates/calendar/actions/update-event.test.ts
+++ b/templates/calendar/actions/update-event.test.ts
@@ -512,7 +512,7 @@ describe("update-event working locations", () => {
     expect(updateEventMock).not.toHaveBeenCalled();
   });
 
-  it("rejects multi-day all-day updates for working-location events before patching Google", async () => {
+  it("allows multi-day all-day updates for working-location events", async () => {
     getEventMock.mockResolvedValue({
       id: "google-working-location-1",
       title: "Home",
@@ -532,14 +532,23 @@ describe("update-event working locations", () => {
       updatedAt: "2026-07-06T00:00:00.000Z",
     });
 
-    await expect(
-      runWithRequestContext({ userEmail: "owner@example.com" }, () =>
-        action.run({
-          id: "google-working-location-1",
-          end: "2026-07-11",
-        }),
-      ),
-    ).rejects.toThrow("All-day working location events must be a single day.");
-    expect(updateEventMock).not.toHaveBeenCalled();
+    await runWithRequestContext({ userEmail: "owner@example.com" }, () =>
+      action.run({
+        id: "google-working-location-1",
+        end: "2026-07-11",
+      }),
+    );
+
+    expect(updateEventMock).toHaveBeenCalledWith(
+      "working-location-1",
+      expect.objectContaining({
+        allDay: true,
+        end: "2026-07-11",
+        eventType: "workingLocation",
+        transparency: "transparent",
+        visibility: "public",
+      }),
+      expect.any(Object),
+    );
   });
 });

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -412,6 +412,7 @@ export default defineAction({
         start: args.start ?? existingEvent.start,
         end: args.end ?? existingEvent.end,
       });
+      updates.allDay = args.allDay ?? existingEvent.allDay;
       if (
         existingEvent.eventType === "workingLocation" &&
         existingEvent.workingLocationProperties

--- a/templates/calendar/agent-native.config.ts
+++ b/templates/calendar/agent-native.config.ts
@@ -1,5 +1,6 @@
 import { defineAgentNativeConfig } from "@agent-native/core/config";
 
 export default defineAgentNativeConfig({
+  changelog: { enabled: true },
   harness: true,
 });

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -180,6 +180,10 @@ function dateTimePartsInTimezone(value: string, timezone: string) {
 
 function allDayEndDate(end: string | undefined, fallback: string) {
   if (!end) return fallback;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(end)) {
+    const previous = addDaysToDateString(end, -1);
+    return previous < fallback ? fallback : previous;
+  }
   const parsed = new Date(end);
   if (Number.isNaN(parsed.getTime())) return fallback;
   parsed.setDate(parsed.getDate() - 1);
@@ -323,12 +327,14 @@ export function CreateEventPopover({
 
     if (draft) {
       const startParts = draft.start
-        ? draft.fullDay && /^\d{4}-\d{2}-\d{2}$/.test(draft.start)
+        ? (draft.fullDay || draft.allDay) &&
+          /^\d{4}-\d{2}-\d{2}$/.test(draft.start)
           ? { date: draft.start, time: "00:00" }
           : dateTimePartsInTimezone(draft.start, draftTimezone)
         : null;
       const endParts = draft.end
-        ? draft.fullDay && /^\d{4}-\d{2}-\d{2}$/.test(draft.end)
+        ? (draft.fullDay || draft.allDay) &&
+          /^\d{4}-\d{2}-\d{2}$/.test(draft.end)
           ? { date: draft.end, time: "00:00" }
           : dateTimePartsInTimezone(
               draft.end,

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -1,19 +1,11 @@
 import { useT } from "@agent-native/core/client/i18n";
 import type { CalendarEvent } from "@shared/api";
-import { IconAlertTriangleFilled, IconMapPin } from "@tabler/icons-react";
 import {
-  eachHourOfInterval,
-  format,
-  parseISO,
-  differenceInMinutes,
-  startOfDay,
-  isSameDay,
-  set,
-  isToday,
-  addMinutes,
-  addDays,
-  min,
-} from "date-fns";
+  IconAlertTriangleFilled,
+  IconMapPin,
+  IconPlus,
+} from "@tabler/icons-react";
+import { eachHourOfInterval, format, set, addMinutes } from "date-fns";
 import { useState, useEffect, useRef, useMemo, useCallback, memo } from "react";
 
 import { useCalendarSetters } from "@/components/layout/AppLayout";
@@ -29,6 +21,13 @@ import {
   type ViewPreferences,
 } from "@/hooks/use-view-preferences";
 import { partitionAllDayEvents } from "@/lib/all-day-layout";
+import {
+  dateToCalendarDateKey,
+  getBrowserTimezone,
+  getDateKeyInTimezone,
+  getEventDateKey,
+  getEventSegmentForCalendarDay,
+} from "@/lib/calendar-timezone";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import {
   computeTimedEventLayout,
@@ -58,6 +57,7 @@ import { OutOfOfficeEvent } from "./OutOfOfficeEvent";
 interface DayViewProps {
   events: CalendarEvent[];
   date: Date;
+  timezone?: string;
   onDeleteEvent: (eventId: string) => void;
   onEventTimeChange?: (eventId: string, newStart: Date, newEnd: Date) => void;
   onClickTimeSlot?: (
@@ -66,6 +66,7 @@ interface DayViewProps {
     endTime: string,
     options?: { explicitDuration?: boolean },
   ) => void;
+  onCreateWorkingLocation?: (date: Date) => void;
   quickEditEventId?: string | null;
   onQuickEditSave?: (
     eventId: string,
@@ -118,7 +119,7 @@ function minutesToTimeString(totalMinutes: number): string {
 /** Convert minutes-from-START_HOUR on a given day into a Date, for ghost label formatting */
 function minutesToDate(date: Date, totalMinutes: number): Date {
   return addMinutes(
-    set(startOfDay(date), { hours: START_HOUR, minutes: 0, seconds: 0 }),
+    set(date, { hours: START_HOUR, minutes: 0, seconds: 0 }),
     totalMinutes,
   );
 }
@@ -142,18 +143,14 @@ function formatEventTime(start: Date, end: Date): string {
   return `${startWithAmPm}–${endStr}`;
 }
 
-function getEventStyleForDate(event: CalendarEvent, date: Date) {
-  const start = parseISO(event.start);
-  const end = parseISO(event.end);
-  const dayStart = set(startOfDay(date), { hours: START_HOUR });
-  const dayEnd = addDays(startOfDay(date), 1);
-  const cappedEnd = min([end, dayEnd]);
-  const segStart = start > dayStart ? start : dayStart;
-  const topMinutes = Math.max(0, differenceInMinutes(segStart, dayStart));
-  const durationMinutes = Math.max(
-    15,
-    differenceInMinutes(cappedEnd, segStart),
-  );
+function getEventStyleForDate(
+  event: CalendarEvent,
+  date: Date,
+  timezone: string,
+) {
+  const segment = getEventSegmentForCalendarDay(event, date, timezone);
+  const topMinutes = segment?.topMinutes ?? 0;
+  const durationMinutes = Math.max(15, segment?.durationMinutes ?? 15);
   return {
     top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
     height: `${(durationMinutes / 60) * HOUR_HEIGHT}px`,
@@ -163,6 +160,7 @@ function getEventStyleForDate(event: CalendarEvent, date: Date) {
 interface DayEventCardProps {
   event: CalendarEvent;
   date: Date;
+  timezone: string;
   layout: Map<string, TimedEventLayout>;
   now: Date;
   prefs: ViewPreferences;
@@ -204,6 +202,7 @@ interface DayEventCardProps {
 const DayEventCard = memo(function DayEventCard({
   event,
   date,
+  timezone,
   layout,
   now,
   prefs,
@@ -246,32 +245,24 @@ const DayEventCard = memo(function DayEventCard({
         top: `${overrides.top}px`,
         height: `${overrides.height}px`,
       }
-    : getEventStyleForDate(event, date);
+    : getEventStyleForDate(event, date, timezone);
   const color = getEventDisplayColor(event, prefs);
-  const evStart = parseISO(event.start);
-  const rawEnd = parseISO(event.end);
-  const midnight = addDays(startOfDay(date), 1);
-  const evEnd = min([rawEnd, midnight]);
-  const isOvernightCapped = rawEnd > midnight;
-  const isStart = isSameDay(evStart, date);
-  const isEnd = rawEnd <= midnight;
-  const dayGridStart = set(startOfDay(date), { hours: START_HOUR });
-  // For continuation segments (started a prior day), measure visible
-  // duration from the grid start, not from the event's true start.
-  const visibleSegStart = isStart ? evStart : dayGridStart;
+  const segment = getEventSegmentForCalendarDay(event, date, timezone);
+  const isStart =
+    getEventDateKey(event, timezone) === dateToCalendarDateKey(date);
+  const isOvernightCapped = !(segment?.endsOnDay ?? true);
+  const isEnd = segment?.endsOnDay ?? true;
   const durationMin = overrides
     ? (overrides.height / HOUR_HEIGHT) * 60
-    : differenceInMinutes(evEnd, visibleSegStart);
+    : (segment?.durationMinutes ?? 15);
   // Compute display times (use drag overrides if active)
   const displayStart = overrides
-    ? addMinutes(dayGridStart, (overrides.top / HOUR_HEIGHT) * 60)
-    : visibleSegStart;
+    ? minutesToDate(date, START_HOUR * 60 + (overrides.top / HOUR_HEIGHT) * 60)
+    : minutesToDate(date, segment?.startMinutes ?? 0);
   const displayEnd = overrides
     ? addMinutes(displayStart, durationMin)
-    : isEnd
-      ? evEnd
-      : midnight;
-  const isPast = parseISO(event.end) < now;
+    : minutesToDate(date, segment?.endMinutes ?? durationMin);
+  const isPast = new Date(event.end) < now;
   const isDeclined = event.responseStatus === "declined";
   const allOthersOut = allOtherDeclined(event);
 
@@ -446,6 +437,7 @@ const DayEventCard = memo(function DayEventCard({
   return (
     <EventDetailPopover
       event={event}
+      timezone={timezone}
       onDelete={onDeleteEvent}
       isDraft={isDraft}
       defaultOpen={defaultOpen}
@@ -492,9 +484,11 @@ const DayCreateGhost = memo(function DayCreateGhost({
 export const DayView = memo(function DayView({
   events,
   date,
+  timezone = getBrowserTimezone(),
   onDeleteEvent,
   onEventTimeChange,
   onClickTimeSlot,
+  onCreateWorkingLocation,
   quickEditEventId,
   onQuickEditSave,
   onQuickEditCancel,
@@ -584,8 +578,8 @@ export const DayView = memo(function DayView({
     [events],
   );
   const layout = useMemo(
-    () => computeTimedEventLayout(timedEvents, date),
-    [date, timedEvents],
+    () => computeTimedEventLayout(timedEvents, date, timezone),
+    [date, timedEvents, timezone],
   );
 
   // Timezone label: prefer the short generic name (e.g. "PT", "ET")
@@ -595,7 +589,10 @@ export const DayView = memo(function DayView({
     function nameForToken(token: "shortGeneric" | "longGeneric" | "short") {
       try {
         return (
-          new Intl.DateTimeFormat("en-US", { timeZoneName: token })
+          new Intl.DateTimeFormat("en-US", {
+            timeZone: timezone,
+            timeZoneName: token,
+          })
             .formatToParts(now)
             .find((p) => p.type === "timeZoneName")?.value ?? ""
         );
@@ -604,10 +601,7 @@ export const DayView = memo(function DayView({
       }
     }
 
-    let iana = "";
-    try {
-      iana = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
-    } catch {}
+    const iana = timezone;
 
     const longGeneric = nameForToken("longGeneric");
     let shortGeneric = nameForToken("shortGeneric");
@@ -625,10 +619,26 @@ export const DayView = memo(function DayView({
       tzLong: longGeneric || iana,
       tzIana: iana,
     };
-  }, []);
+  }, [now, timezone]);
 
-  const today = isToday(date);
-  const nowMinutes = (now.getHours() - START_HOUR) * 60 + now.getMinutes();
+  const today =
+    dateToCalendarDateKey(date) === getDateKeyInTimezone(now, timezone);
+  const nowParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+    .formatToParts(now)
+    .reduce(
+      (parts, part) => {
+        if (part.type === "hour") parts.hour = Number(part.value);
+        if (part.type === "minute") parts.minute = Number(part.value);
+        return parts;
+      },
+      { hour: 0, minute: 0 },
+    );
+  const nowMinutes = (nowParts.hour - START_HOUR) * 60 + nowParts.minute;
   const nowTop = (nowMinutes / 60) * HOUR_HEIGHT;
   const showNowIndicator =
     today && nowMinutes >= 0 && nowMinutes <= (END_HOUR - START_HOUR) * 60;
@@ -653,6 +663,7 @@ export const DayView = memo(function DayView({
     scrollContainerRef,
     onEventTimeChange: handleEventTimeChange,
     events,
+    timezone,
   });
 
   const canDrag = !!onEventTimeChange;
@@ -745,19 +756,38 @@ export const DayView = memo(function DayView({
             {format(date, "MMMM d, yyyy")}
           </div>
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="cursor-default truncate px-1 pt-1 text-[11px] font-medium text-muted-foreground">
-              {tzShort}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p className="text-xs">{tzLong}</p>
-            {tzIana && tzIana !== tzLong ? (
-              <p className="text-[10px] text-muted-foreground">{tzIana}</p>
-            ) : null}
-          </TooltipContent>
-        </Tooltip>
+        <div className="flex items-start gap-1">
+          {onCreateWorkingLocation && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("calendarView.addWorkingLocation")}
+                  className="flex size-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={() => onCreateWorkingLocation(date)}
+                >
+                  <IconPlus aria-hidden="true" className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {t("calendarView.addWorkingLocation")}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-default truncate px-1 pt-1 text-[11px] font-medium text-muted-foreground">
+                {tzShort}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">{tzLong}</p>
+              {tzIana && tzIana !== tzLong ? (
+                <p className="text-[10px] text-muted-foreground">{tzIana}</p>
+              ) : null}
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
       {/* Working locations and ordinary all-day events */}
@@ -776,6 +806,7 @@ export const DayView = memo(function DayView({
                     <EventDetailPopover
                       key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
                       event={event}
+                      timezone={timezone}
                       onDelete={onDeleteEvent}
                       isDraft={draftEventIds.includes(event.id)}
                       defaultOpen={quickEditEventId === event.id}
@@ -852,6 +883,7 @@ export const DayView = memo(function DayView({
                     <EventDetailPopover
                       key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
                       event={event}
+                      timezone={timezone}
                       onDelete={onDeleteEvent}
                       isDraft={draftEventIds.includes(event.id)}
                       defaultOpen={quickEditEventId === event.id}
@@ -1017,6 +1049,7 @@ export const DayView = memo(function DayView({
                   key={event._tempId ?? event.id}
                   event={event}
                   day={date}
+                  timezone={timezone}
                   hourHeight={HOUR_HEIGHT}
                   color={
                     getEventDisplayColor(event, prefs) ?? "hsl(var(--primary))"
@@ -1087,6 +1120,7 @@ export const DayView = memo(function DayView({
                   key={event._tempId ?? event.id}
                   event={event}
                   date={date}
+                  timezone={timezone}
                   layout={layout}
                   now={now}
                   prefs={prefs}

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -113,10 +113,16 @@ vi.mock("@/components/ui/popover", () => ({
   PopoverContent: ({
     children,
     className,
+    side,
   }: {
     children?: ReactNode;
     className?: string;
-  }) => <div className={className}>{children}</div>,
+    side?: string;
+  }) => (
+    <div className={className} data-popover-side={side}>
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/ui/select", () => ({
@@ -807,5 +813,150 @@ describe("EventDetailPopover characterization", () => {
     });
 
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps working-location drafts all-day by default and converts them to timed bounds in the calendar timezone", () => {
+    const onDraftUpdate = vi.fn();
+    const event = baseEvent({
+      id: "working-location-draft",
+      title: "",
+      source: "local",
+      start: "2026-08-14",
+      end: "2026-08-15",
+      allDay: true,
+      eventType: "workingLocation",
+      workingLocationProperties: {
+        type: "homeOffice",
+        homeOffice: {},
+      },
+    });
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          timezone="America/Los_Angeles"
+          isDraft
+          defaultOpen
+          onDelete={() => undefined}
+          onDraftUpdate={onDraftUpdate}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    expect(findByExactText("span", "→")).toBeTruthy();
+
+    const allDaySwitch =
+      document.querySelector<HTMLButtonElement>('[role="switch"]');
+    expect(allDaySwitch?.getAttribute("aria-checked")).toBe("true");
+
+    act(() => {
+      allDaySwitch?.click();
+    });
+
+    expect(onDraftUpdate).toHaveBeenCalledWith(
+      "working-location-draft",
+      expect.objectContaining({
+        allDay: false,
+        start: "2026-08-14T16:00:00.000Z",
+        end: "2026-08-15T00:00:00.000Z",
+        startTimeZone: "America/Los_Angeles",
+        endTimeZone: "America/Los_Angeles",
+      }),
+    );
+  });
+
+  it("applies Home/Office/Other on a draft immediately and hides Save", () => {
+    const onDraftUpdate = vi.fn();
+    const event = baseEvent({
+      id: "working-location-draft",
+      title: "",
+      source: "local",
+      start: "2026-08-14",
+      end: "2026-08-15",
+      allDay: true,
+      eventType: "workingLocation",
+      workingLocationProperties: {
+        type: "homeOffice",
+        homeOffice: {},
+      },
+    });
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          timezone="America/Chicago"
+          isDraft
+          defaultOpen
+          onDelete={() => undefined}
+          onDraftUpdate={onDraftUpdate}
+          onDraftCreate={() => undefined}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    expect(findByExactText("button", "eventForm.save")).toBeUndefined();
+
+    const office = document.querySelector<HTMLInputElement>(
+      "#working-location-working-location-draft-officeLocation",
+    );
+    expect(office).toBeTruthy();
+    act(() => {
+      office?.click();
+    });
+
+    expect(onDraftUpdate).toHaveBeenCalledWith(
+      "working-location-draft",
+      expect.objectContaining({
+        workingLocationType: "officeLocation",
+      }),
+    );
+  });
+
+  it("blocks creating an Other working location until it has a name", () => {
+    const onDraftCreate = vi.fn();
+    const event = baseEvent({
+      id: "working-location-draft",
+      title: "",
+      location: "",
+      source: "local",
+      start: "2026-08-14",
+      end: "2026-08-15",
+      allDay: true,
+      eventType: "workingLocation",
+      workingLocationProperties: {
+        type: "customLocation",
+        customLocation: {},
+      },
+    });
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          timezone="America/Chicago"
+          isDraft
+          defaultOpen
+          onDelete={() => undefined}
+          onDraftCreate={onDraftCreate}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    const createButton = findByExactText("button", "eventForm.createEvent");
+    expect(createButton).toBeTruthy();
+    expect((createButton as HTMLButtonElement).disabled).toBe(true);
+
+    act(() => {
+      (createButton as HTMLButtonElement).click();
+    });
+    expect(onDraftCreate).not.toHaveBeenCalled();
   });
 });

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -868,6 +868,57 @@ describe("EventDetailPopover characterization", () => {
     );
   });
 
+  it("does not add an extra day when converting a midnight-ending timed location to all-day", () => {
+    const onDraftUpdate = vi.fn();
+    const event = baseEvent({
+      id: "working-location-draft",
+      title: "",
+      source: "local",
+      start: "2026-08-14T16:00:00.000Z",
+      end: "2026-08-15T00:00:00.000Z",
+      startTimeZone: "America/Los_Angeles",
+      endTimeZone: "America/Los_Angeles",
+      allDay: false,
+      eventType: "workingLocation",
+      workingLocationProperties: {
+        type: "homeOffice",
+        homeOffice: {},
+      },
+    });
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          timezone="America/Los_Angeles"
+          isDraft
+          defaultOpen
+          onDelete={() => undefined}
+          onDraftUpdate={onDraftUpdate}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    const allDaySwitch =
+      document.querySelector<HTMLButtonElement>('[role="switch"]');
+    expect(allDaySwitch?.getAttribute("aria-checked")).toBe("false");
+
+    act(() => {
+      allDaySwitch?.click();
+    });
+
+    expect(onDraftUpdate).toHaveBeenCalledWith(
+      "working-location-draft",
+      expect.objectContaining({
+        allDay: true,
+        start: "2026-08-14",
+        end: "2026-08-15",
+      }),
+    );
+  });
+
   it("applies Home/Office/Other on a draft immediately and hides Save", () => {
     const onDraftUpdate = vi.fn();
     const event = baseEvent({

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -419,6 +419,19 @@ function toAllDayEndDateInputValue(iso: string, timezone?: string): string {
   return format(new Date(d.getTime() - 1), "yyyy-MM-dd");
 }
 
+/** Timed events ending at 00:00 already store the next date; don't add another day. */
+function inclusiveEndDateForAllDayConversion(
+  startDate: string,
+  endDate: string,
+  endTime: string,
+): string {
+  const bounded = endDate < startDate ? startDate : endDate;
+  if (endTime === "00:00" && bounded > startDate) {
+    return addCalendarDays(bounded, -1);
+  }
+  return bounded;
+}
+
 /** Convert an event time to the calendar's time input value. */
 function toTimeInputValue(iso: string, timezone?: string): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return "00:00";
@@ -1093,7 +1106,15 @@ export function EventDetailPopover({
         !nextAllDay && editStartTime === "00:00" && editEndTime === "00:00"
           ? "17:00"
           : editEndTime;
-      const nextEndDate = editEndDate < editDate ? editDate : editEndDate;
+      const nextEndDate = nextAllDay
+        ? inclusiveEndDateForAllDayConversion(
+            editDate,
+            editEndDate,
+            editEndTime,
+          )
+        : editEndDate < editDate
+          ? editDate
+          : editEndDate;
       setEditEndDate(nextEndDate);
       setEditStartTime(nextStartTime);
       setEditEndTime(nextEndTime);

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -51,6 +51,7 @@ import {
 import { WorkingLocationEditor } from "@/components/calendar/WorkingLocationEditor";
 import { useCalendarContext } from "@/components/layout/AppLayout";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverTrigger,
@@ -64,6 +65,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipContent,
@@ -73,6 +75,11 @@ import {
 import { useEvent, useUpdateEvent } from "@/hooks/use-events";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useConnectZoom, useZoomStatus } from "@/hooks/use-zoom-auth";
+import { addCalendarDays } from "@/lib/calendar-timezone";
+import {
+  getDateKeyInTimezone,
+  getDateTimePartsInTimezone,
+} from "@/lib/calendar-timezone";
 import {
   attachmentsToDrafts,
   buildRecurrenceRules,
@@ -83,7 +90,6 @@ import {
   getEventEndValidationMessage,
   getLocalTimezone,
   getRecurrencePreset,
-  normalizeAllDayEditEndDate,
   remindersToDraftState,
   resolveTimeEditScope,
   type AttachmentDraft,
@@ -103,6 +109,7 @@ import {
   buildWorkingLocationUpdate,
   createWorkingLocationDisplayLabels,
   getWorkingLocationTitle,
+  isWorkingLocationDraftReadyToCreate,
   isWorkingLocationEvent,
   type WorkingLocationSelection,
 } from "@/lib/working-location";
@@ -395,19 +402,32 @@ function isUrl(str: string): boolean {
   return /^https?:\/\//i.test(str.trim());
 }
 
-/** Convert ISO date string to local date input value (YYYY-MM-DD) */
-function toDateInputValue(iso: string): string {
+/** Convert an event date to the calendar's date input value. */
+function toDateInputValue(iso: string, timezone?: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
+  const zonedDate = timezone ? getDateKeyInTimezone(iso, timezone) : null;
+  if (zonedDate) return zonedDate;
   const d = parseISO(iso);
   return format(d, "yyyy-MM-dd");
 }
 
-function toAllDayEndDateInputValue(iso: string): string {
+function toAllDayEndDateInputValue(iso: string, timezone?: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return addCalendarDays(iso, -1);
+  const zonedDate = timezone ? getDateKeyInTimezone(iso, timezone) : null;
+  if (zonedDate) return addCalendarDays(zonedDate, -1);
   const d = parseISO(iso);
   return format(new Date(d.getTime() - 1), "yyyy-MM-dd");
 }
 
-/** Convert ISO date string to local time input value (HH:mm) */
-function toTimeInputValue(iso: string): string {
+/** Convert an event time to the calendar's time input value. */
+function toTimeInputValue(iso: string, timezone?: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return "00:00";
+  const zonedTime = timezone ? getDateTimePartsInTimezone(iso, timezone) : null;
+  if (zonedTime) {
+    return `${String(zonedTime.hour).padStart(2, "0")}:${String(
+      zonedTime.minute,
+    ).padStart(2, "0")}`;
+  }
   const d = parseISO(iso);
   return format(d, "HH:mm");
 }
@@ -426,6 +446,7 @@ interface EventDetailPopoverProps {
   children: React.ReactNode;
   onDelete: (eventId: string) => void;
   isDraft?: boolean;
+  timezone?: string;
   /** When true, the popover opens immediately and title is focused for editing */
   defaultOpen?: boolean;
   /** Called when the title is changed and should be persisted */
@@ -458,6 +479,7 @@ export function EventDetailPopover({
   children,
   onDelete,
   isDraft = false,
+  timezone,
   defaultOpen = false,
   onTitleSave,
   onDismissNew,
@@ -469,6 +491,7 @@ export function EventDetailPopover({
   const t = useT();
   const workingLocationLabels = createWorkingLocationDisplayLabels(t);
   const isMobile = useIsMobile();
+  const eventTimezone = event.startTimeZone || timezone || getLocalTimezone();
   const [open, setOpen] = useState(defaultOpen);
   const [editingTitle, setEditingTitle] = useState(
     defaultOpen ? getEditableEventTitle(event) : "",
@@ -489,7 +512,6 @@ export function EventDetailPopover({
   } = useCalendarContext();
   const isWorkingLocation = isWorkingLocationEvent(event);
   const isOutOfOffice = isOutOfOfficeEvent(event);
-  const isSingleDayWorkingLocation = isWorkingLocation && event.allDay;
   const editableLocationValue = event.location || "";
 
   // Inline editing state
@@ -499,21 +521,23 @@ export function EventDetailPopover({
     event.description || "",
   );
   const [editLocation, setEditLocation] = useState(editableLocationValue);
-  const [editDate, setEditDate] = useState(() => toDateInputValue(event.start));
+  const [editDate, setEditDate] = useState(() =>
+    toDateInputValue(event.start, eventTimezone),
+  );
   const [editEndDate, setEditEndDate] = useState(() =>
     event.allDay
-      ? toAllDayEndDateInputValue(event.end)
-      : toDateInputValue(event.end),
+      ? toAllDayEndDateInputValue(event.end, eventTimezone)
+      : toDateInputValue(event.end, eventTimezone),
   );
   const [editStartTime, setEditStartTime] = useState(() =>
-    toTimeInputValue(event.start),
+    toTimeInputValue(event.start, eventTimezone),
   );
   const [editEndTime, setEditEndTime] = useState(() =>
-    toTimeInputValue(event.end),
+    toTimeInputValue(event.end, eventTimezone),
   );
-  const [editTimezone, setEditTimezone] = useState(
-    event.startTimeZone || getLocalTimezone(),
-  );
+  const [editTimezone, setEditTimezone] = useState(eventTimezone);
+  const isSingleDayWorkingLocation =
+    isWorkingLocation && event.allDay && editDate === editEndDate;
   const [editReminderMode, setEditReminderMode] = useState<ReminderMode>(
     () => remindersToDraftState(event).mode,
   );
@@ -615,15 +639,15 @@ export function EventDetailPopover({
       setEditDescription(event.description || "");
     if (editingField !== "location") setEditLocation(editableLocationValue);
     if (editingField !== "time") {
-      setEditDate(toDateInputValue(event.start));
+      setEditDate(toDateInputValue(event.start, eventTimezone));
       setEditEndDate(
         event.allDay
-          ? toAllDayEndDateInputValue(event.end)
-          : toDateInputValue(event.end),
+          ? toAllDayEndDateInputValue(event.end, eventTimezone)
+          : toDateInputValue(event.end, eventTimezone),
       );
-      setEditStartTime(toTimeInputValue(event.start));
-      setEditEndTime(toTimeInputValue(event.end));
-      setEditTimezone(event.startTimeZone || getLocalTimezone());
+      setEditStartTime(toTimeInputValue(event.start, eventTimezone));
+      setEditEndTime(toTimeInputValue(event.end, eventTimezone));
+      setEditTimezone(eventTimezone);
       setEditTimeScope("single");
     }
     if (editingField !== "reminders") {
@@ -652,6 +676,7 @@ export function EventDetailPopover({
     event.remindersUseDefault,
     event.attachments,
     editableLocationValue,
+    eventTimezone,
   ]);
 
   // When defaultOpen changes to true (new event created), open the popover
@@ -659,14 +684,14 @@ export function EventDetailPopover({
     if (defaultOpen) {
       setOpen(true);
       setIsEditingTitle(true);
-      isNewEventRef.current = true;
+      isNewEventRef.current = isDraft;
       setEditingTitle((current) => {
         const eventTitle = getEditableEventTitle(event);
         if (current.trim() && current !== eventTitle) return current;
         return eventTitle;
       });
     }
-  }, [defaultOpen, event.title, event.titleIsGenerated]);
+  }, [defaultOpen, event.title, event.titleIsGenerated, isDraft]);
 
   // Focus title input when editing starts
   useEffect(() => {
@@ -998,32 +1023,29 @@ export function EventDetailPopover({
   );
 
   const saveTimeValues = useCallback(
-    (values: TimeEditValues) => {
-      const normalizedEndDate = normalizeAllDayEditEndDate(
-        isSingleDayWorkingLocation,
-        values.date,
-        values.endDate,
-      );
-      const allDayEnd = new Date(`${normalizedEndDate}T00:00:00`);
-      allDayEnd.setDate(allDayEnd.getDate() + 1);
-      const newStart = event.allDay
-        ? new Date(`${values.date}T00:00:00`).toISOString()
+    (values: TimeEditValues, nextAllDay = event.allDay) => {
+      const newStart = nextAllDay
+        ? values.date
         : dateTimeInTimezoneToIso(
             values.date,
             values.startTime,
             values.timezone,
           );
-      const newEnd = event.allDay
-        ? allDayEnd.toISOString()
+      const newEnd = nextAllDay
+        ? addCalendarDays(values.endDate, 1)
         : dateTimeInTimezoneToIso(
             values.endDate,
             values.endTime,
             values.timezone,
           );
-      if (new Date(newEnd).getTime() <= new Date(newStart).getTime()) {
+      if (
+        nextAllDay
+          ? values.endDate < values.date
+          : new Date(newEnd).getTime() <= new Date(newStart).getTime()
+      ) {
         toast.error(
           getEventEndValidationMessage({
-            allDay: event.allDay ?? false,
+            allDay: nextAllDay,
             startDate: values.date,
             endDate: values.endDate,
             startTime: values.startTime,
@@ -1037,9 +1059,9 @@ export function EventDetailPopover({
         saved = saveField({
           start: newStart,
           end: newEnd,
-          allDay: event.allDay,
-          startTimeZone: event.allDay ? undefined : values.timezone,
-          endTimeZone: event.allDay ? undefined : values.timezone,
+          allDay: nextAllDay,
+          startTimeZone: nextAllDay ? undefined : values.timezone,
+          endTimeZone: nextAllDay ? undefined : values.timezone,
           scope: resolveTimeEditScope(
             isRecurringEvent,
             isSingleDayWorkingLocation,
@@ -1058,6 +1080,41 @@ export function EventDetailPopover({
       isRecurringEvent,
       editTimeScope,
       saveField,
+    ],
+  );
+
+  const handleWorkingLocationAllDayChange = useCallback(
+    (nextAllDay: boolean) => {
+      const nextStartTime =
+        !nextAllDay && editStartTime === "00:00" && editEndTime === "00:00"
+          ? "09:00"
+          : editStartTime;
+      const nextEndTime =
+        !nextAllDay && editStartTime === "00:00" && editEndTime === "00:00"
+          ? "17:00"
+          : editEndTime;
+      const nextEndDate = editEndDate < editDate ? editDate : editEndDate;
+      setEditEndDate(nextEndDate);
+      setEditStartTime(nextStartTime);
+      setEditEndTime(nextEndTime);
+      saveTimeValues(
+        {
+          date: editDate,
+          endDate: nextEndDate,
+          startTime: nextStartTime,
+          endTime: nextEndTime,
+          timezone: editTimezone,
+        },
+        nextAllDay,
+      );
+    },
+    [
+      editDate,
+      editEndDate,
+      editEndTime,
+      editStartTime,
+      editTimezone,
+      saveTimeValues,
     ],
   );
 
@@ -1182,10 +1239,10 @@ export function EventDetailPopover({
 
   const handleSelectFindTimeSlot = useCallback(
     (slot: FindTimeSlot) => {
-      setEditDate(toDateInputValue(slot.start));
-      setEditEndDate(toDateInputValue(slot.end));
-      setEditStartTime(toTimeInputValue(slot.start));
-      setEditEndTime(toTimeInputValue(slot.end));
+      setEditDate(toDateInputValue(slot.start, findTimeTimezone));
+      setEditEndDate(toDateInputValue(slot.end, findTimeTimezone));
+      setEditStartTime(toTimeInputValue(slot.start, findTimeTimezone));
+      setEditEndTime(toTimeInputValue(slot.end, findTimeTimezone));
       setEditTimezone(findTimeTimezone);
       setEditingField(null);
       setFindTimeOpen(false);
@@ -1312,6 +1369,7 @@ export function EventDetailPopover({
 
   const handleCreateDraft = useCallback(() => {
     if (!onDraftCreate) return;
+    if (!isWorkingLocationDraftReadyToCreate(event)) return;
     const title = editingTitle.trim();
     const updates = isEditingTitle && title ? { title } : undefined;
     if (updates) {
@@ -1586,11 +1644,29 @@ export function EventDetailPopover({
               <div className="flex items-start gap-3 rounded-md py-1.5">
                 <IconClock className="mt-1 h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
+                  {isWorkingLocation && (
+                    <div className="mb-1 flex items-center gap-2">
+                      <Switch
+                        id={`working-location-all-day-${event.id}`}
+                        checked={event.allDay}
+                        onCheckedChange={handleWorkingLocationAllDayChange}
+                        disabled={updateEvent.isPending}
+                      />
+                      <Label
+                        htmlFor={`working-location-all-day-${event.id}`}
+                        className="text-xs"
+                      >
+                        {t("eventForm.allDay")}
+                      </Label>
+                    </div>
+                  )}
                   {event.allDay ? (
                     <div className="flex flex-wrap items-center gap-1 text-sm">
-                      <span className="text-muted-foreground">
-                        {t("eventForm.allDay")}
-                      </span>
+                      {!isWorkingLocation && (
+                        <span className="text-muted-foreground">
+                          {t("eventForm.allDay")}
+                        </span>
+                      )}
                       <DatePickerPopover
                         value={editDate}
                         label={t("eventForm.startDate")}
@@ -1598,7 +1674,7 @@ export function EventDetailPopover({
                           handleInlineDateChange("date", value)
                         }
                       />
-                      {editEndDate !== editDate && (
+                      {(isWorkingLocation || editEndDate !== editDate) && (
                         <>
                           <span className="text-muted-foreground/50">→</span>
                           <DatePickerPopover
@@ -1715,7 +1791,9 @@ export function EventDetailPopover({
                   onOpenChange={setFindTimeOpen}
                   title={t("eventForm.findTime")}
                   subtitle={event.title}
-                  date={editDate || toDateInputValue(event.start)}
+                  date={
+                    editDate || toDateInputValue(event.start, findTimeTimezone)
+                  }
                   timezone={findTimeTimezone}
                   durationMinutes={findTimeDurationMinutes}
                   attendees={schedulingAttendees}
@@ -1733,6 +1811,7 @@ export function EventDetailPopover({
                 <WorkingLocationEditor
                   event={event}
                   isRecurring={isRecurringEvent}
+                  isDraft={isDraft}
                   readOnly={isOverlay}
                   disabled={updateEvent.isPending}
                   onSave={handleSaveWorkingLocation}
@@ -2422,6 +2501,7 @@ export function EventDetailPopover({
                 <Button
                   size="sm"
                   className="ml-auto text-xs"
+                  disabled={!isWorkingLocationDraftReadyToCreate(event)}
                   onClick={handleCreateDraft}
                 >
                   {event.attendees?.length

--- a/templates/calendar/app/components/calendar/MonthView.tsx
+++ b/templates/calendar/app/components/calendar/MonthView.tsx
@@ -1,23 +1,35 @@
+import { useT } from "@agent-native/core/client/i18n";
 import type { CalendarEvent } from "@shared/api";
 import { getWeekdayOrder } from "@shared/calendar-week";
+import { IconPlus } from "@tabler/icons-react";
 import {
   startOfMonth,
   endOfMonth,
   startOfWeek,
   endOfWeek,
   eachDayOfInterval,
-  startOfDay,
-  addDays,
   isSameMonth,
   isSameDay,
-  isToday,
   format,
-  parseISO,
 } from "date-fns";
 import { memo, useState, useMemo } from "react";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
+import {
+  dateToCalendarDateKey,
+  addCalendarDays,
+  dateKeyToDate,
+  eventOverlapsCalendarDay,
+  getBrowserTimezone,
+  getDateKeyInTimezone,
+  getEventDateKey,
+} from "@/lib/calendar-timezone";
 import { getFullDayOutOfOfficeDateRange } from "@/lib/out-of-office";
 import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
 import { cn } from "@/lib/utils";
@@ -28,7 +40,9 @@ import { EventDetailPopover } from "./EventDetailPopover";
 interface MonthViewProps {
   events: CalendarEvent[];
   selectedDate: Date;
+  timezone?: string;
   onDateSelect: (date: Date) => void;
+  onCreateWorkingLocation?: (date: Date) => void;
   onDeleteEvent?: (eventId: string) => void;
   onEventDrop?: (eventId: string, newDate: Date) => void;
   draftEventIds?: string[];
@@ -79,7 +93,9 @@ interface DayOccurrence {
 export const MonthView = memo(function MonthView({
   events,
   selectedDate,
+  timezone = getBrowserTimezone(),
   onDateSelect,
+  onCreateWorkingLocation,
   onDeleteEvent,
   onEventDrop,
   draftEventIds = [],
@@ -89,6 +105,7 @@ export const MonthView = memo(function MonthView({
   isLoading = false,
   weekStartsOn = 0,
 }: MonthViewProps) {
+  const t = useT();
   const isMobile = useIsMobile();
   const { prefs } = useViewPreferences();
   const [dragOverDay, setDragOverDay] = useState<string | null>(null);
@@ -119,7 +136,7 @@ export const MonthView = memo(function MonthView({
       const fullDayOutOfOfficeRange = getFullDayOutOfOfficeDateRange(e);
       if (fullDayOutOfOfficeRange) {
         for (const day of days) {
-          const key = format(day, "yyyy-MM-dd");
+          const key = dateToCalendarDateKey(day);
           if (
             key < fullDayOutOfOfficeRange.startDate ||
             key >= fullDayOutOfOfficeRange.endDateExclusive
@@ -130,7 +147,7 @@ export const MonthView = memo(function MonthView({
             event: e,
             isStart: key === fullDayOutOfOfficeRange.startDate,
             continuesNext:
-              format(addDays(day, 1), "yyyy-MM-dd") <
+              addCalendarDays(key, 1) <
               fullDayOutOfOfficeRange.endDateExclusive,
           };
           const list = map.get(key);
@@ -139,17 +156,17 @@ export const MonthView = memo(function MonthView({
         }
         continue;
       }
-      const evStart = parseISO(e.start);
-      const evEnd = e.end ? parseISO(e.end) : addDays(evStart, 1);
       for (const day of days) {
-        const dayStart = startOfDay(day);
-        const dayEnd = addDays(dayStart, 1);
-        if (evStart < dayEnd && evEnd > dayStart) {
-          const key = format(day, "yyyy-MM-dd");
+        if (eventOverlapsCalendarDay(e, day, timezone)) {
+          const key = dateToCalendarDateKey(day);
           const occurrence: DayOccurrence = {
             event: e,
-            isStart: evStart >= dayStart && evStart < dayEnd,
-            continuesNext: evEnd > dayEnd,
+            isStart: getEventDateKey(e, timezone) === key,
+            continuesNext: eventOverlapsCalendarDay(
+              e,
+              dateKeyToDate(addCalendarDays(key, 1)),
+              timezone,
+            ),
           };
           const list = map.get(key);
           if (list) list.push(occurrence);
@@ -158,7 +175,7 @@ export const MonthView = memo(function MonthView({
       }
     }
     return map;
-  }, [events, days]);
+  }, [days, events, timezone]);
 
   function handleDragOver(e: React.DragEvent, dayKey: string) {
     e.preventDefault();
@@ -200,11 +217,13 @@ export const MonthView = memo(function MonthView({
       >
         {days.map((day) => {
           const dayOccurrences =
-            eventsByDay.get(format(day, "yyyy-MM-dd")) ?? [];
+            eventsByDay.get(dateToCalendarDateKey(day)) ?? [];
           const inMonth = isSameMonth(day, selectedDate);
-          const today = isToday(day);
+          const today =
+            dateToCalendarDateKey(day) ===
+            getDateKeyInTimezone(new Date(), timezone);
           const selected = isSameDay(day, selectedDate);
-          const dayKey = day.toISOString();
+          const dayKey = dateToCalendarDateKey(day);
           const isDragTarget = dragOverDay === dayKey;
 
           return (
@@ -249,11 +268,25 @@ export const MonthView = memo(function MonthView({
                   {format(day, "d")}
                 </span>
 
-                {/* Subtle "+" on hover */}
-                {inMonth && (
-                  <span className="mr-0.5 text-xs text-muted-foreground opacity-0 transition-opacity group-hover:opacity-60">
-                    +
-                  </span>
+                {inMonth && onCreateWorkingLocation && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={t("calendarView.addWorkingLocation")}
+                        className="mr-0.5 flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover:opacity-100"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onCreateWorkingLocation(day);
+                        }}
+                      >
+                        <IconPlus aria-hidden="true" className="size-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {t("calendarView.addWorkingLocation")}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
               </div>
 
@@ -274,6 +307,7 @@ export const MonthView = memo(function MonthView({
                       <EventDetailPopover
                         key={event.id}
                         event={event}
+                        timezone={timezone}
                         onDelete={onDeleteEvent ?? (() => {})}
                         isDraft={draftEventIds.includes(event.id)}
                         onDraftUpdate={onDraftUpdate}

--- a/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
+++ b/templates/calendar/app/components/calendar/OutOfOfficeEvent.tsx
@@ -8,6 +8,7 @@ import { EventDetailPopover } from "./EventDetailPopover";
 interface OutOfOfficeEventProps {
   event: CalendarEvent;
   day: Date;
+  timezone?: string;
   hourHeight: number;
   color: string;
   label: string;
@@ -51,6 +52,7 @@ interface OutOfOfficeEventProps {
 export function OutOfOfficeEvent({
   event,
   day,
+  timezone,
   hourHeight,
   color,
   label,
@@ -76,7 +78,7 @@ export function OutOfOfficeEvent({
   onDraftDiscard,
   onOpenChange,
 }: OutOfOfficeEventProps) {
-  const segment = getOutOfOfficeSegment(event, day);
+  const segment = getOutOfOfficeSegment(event, day, timezone);
   const hasDragOverride =
     isBeingDragged &&
     isDragTargetDay &&
@@ -114,6 +116,7 @@ export function OutOfOfficeEvent({
       </div>
       <EventDetailPopover
         event={event}
+        timezone={timezone}
         onDelete={onDelete}
         isDraft={isDraft}
         defaultOpen={defaultOpen}

--- a/templates/calendar/app/components/calendar/TimezoneSwitchDialog.tsx
+++ b/templates/calendar/app/components/calendar/TimezoneSwitchDialog.tsx
@@ -1,0 +1,70 @@
+import { useT } from "@agent-native/core/client/i18n";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface TimezoneSwitchDialogProps {
+  open: boolean;
+  savedTimezone: string;
+  browserTimezone: string;
+  isSwitching?: boolean;
+  onKeep: () => void;
+  onSwitch: () => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TimezoneSwitchDialog({
+  open,
+  savedTimezone,
+  browserTimezone,
+  isSwitching = false,
+  onKeep,
+  onSwitch,
+  onOpenChange,
+}: TimezoneSwitchDialogProps) {
+  const t = useT();
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("calendarView.timezoneSwitchTitle")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("calendarView.timezoneSwitchDescription", {
+              savedTimezone,
+              browserTimezone,
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onKeep}>
+            {t("calendarView.timezoneSwitchKeep", {
+              timezone: savedTimezone,
+            })}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isSwitching}
+            onClick={(event) => {
+              event.preventDefault();
+              onSwitch();
+            }}
+          >
+            {t("calendarView.timezoneSwitchSwitch", {
+              timezone: browserTimezone,
+            })}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -5,22 +5,16 @@ import {
   IconBuilding,
   IconHome,
   IconMapPin,
+  IconPlus,
 } from "@tabler/icons-react";
 import {
   startOfWeek,
   endOfWeek,
   eachDayOfInterval,
   eachHourOfInterval,
-  isSameDay,
-  isToday,
   format,
-  parseISO,
-  differenceInMinutes,
-  startOfDay,
   set,
-  addDays,
   addMinutes,
-  min,
 } from "date-fns";
 import { useState, useEffect, useRef, useMemo, useCallback, memo } from "react";
 
@@ -42,6 +36,13 @@ import {
   layoutAllDayEvents,
   partitionAllDayEvents,
 } from "@/lib/all-day-layout";
+import {
+  dateToCalendarDateKey,
+  getBrowserTimezone,
+  getDateKeyInTimezone,
+  getEventDateKey,
+  getEventSegmentForCalendarDay,
+} from "@/lib/calendar-timezone";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import {
   computeTimedEventLayout,
@@ -72,6 +73,7 @@ import { shouldRenderWeekDragSegment } from "./week-drag-segment";
 interface WeekViewProps {
   events: CalendarEvent[];
   selectedDate: Date;
+  timezone?: string;
   onDateSelect: (date: Date) => void;
   onDeleteEvent: (eventId: string) => void;
   onEventTimeChange?: (eventId: string, newStart: Date, newEnd: Date) => void;
@@ -81,6 +83,7 @@ interface WeekViewProps {
     endTime: string,
     options?: { explicitDuration?: boolean },
   ) => void;
+  onCreateWorkingLocation?: (date: Date) => void;
   quickEditEventId?: string | null;
   onQuickEditSave?: (
     eventId: string,
@@ -148,7 +151,7 @@ function minutesToTimeString(totalMinutes: number): string {
 /** Convert minutes-from-START_HOUR on a given day into a Date, for ghost label formatting */
 function minutesToDate(day: Date, totalMinutes: number): Date {
   return addMinutes(
-    set(startOfDay(day), { hours: START_HOUR, minutes: 0, seconds: 0 }),
+    set(day, { hours: START_HOUR, minutes: 0, seconds: 0 }),
     totalMinutes,
   );
 }
@@ -173,15 +176,10 @@ function formatEventTime(start: Date, end: Date): string {
   return `${startWithAmPm}\u2013${endStr}`;
 }
 
-function getSegmentStyle(event: CalendarEvent, day: Date) {
-  const evStart = parseISO(event.start);
-  const evEnd = parseISO(event.end);
-  const dayBase = set(startOfDay(day), { hours: START_HOUR });
-  const dayEnd = addDays(dayBase, 1);
-  const segStart = evStart > dayBase ? evStart : dayBase;
-  const segEnd = min([evEnd, dayEnd]);
-  const topMinutes = Math.max(0, differenceInMinutes(segStart, dayBase));
-  const durationMinutes = Math.max(15, differenceInMinutes(segEnd, segStart));
+function getSegmentStyle(event: CalendarEvent, day: Date, timezone: string) {
+  const segment = getEventSegmentForCalendarDay(event, day, timezone);
+  const topMinutes = segment?.topMinutes ?? 0;
+  const durationMinutes = Math.max(15, segment?.durationMinutes ?? 15);
   return {
     top: `${(topMinutes / 60) * HOUR_HEIGHT}px`,
     height: `${(durationMinutes / 60) * HOUR_HEIGHT}px`,
@@ -192,6 +190,7 @@ interface WeekEventCardProps {
   event: CalendarEvent;
   day: Date;
   dayIndex: number;
+  timezone: string;
   layout: Map<string, TimedEventLayout>;
   now: Date;
   prefs: ViewPreferences;
@@ -246,6 +245,7 @@ const WeekEventCard = memo(function WeekEventCard({
   event,
   day,
   dayIndex,
+  timezone,
   layout,
   now,
   prefs,
@@ -272,6 +272,9 @@ const WeekEventCard = memo(function WeekEventCard({
   onPopoverOpenChange,
 }: WeekEventCardProps) {
   const t = useT();
+  const workingLocationLabels = createWorkingLocationDisplayLabels(t);
+  const title = getWorkingLocationChipLabel(event, workingLocationLabels);
+  const ariaTitle = getWorkingLocationTitle(event, workingLocationLabels);
   const li = layout.get(event.id) ?? {
     left: 0,
     width: 100,
@@ -284,12 +287,10 @@ const WeekEventCard = memo(function WeekEventCard({
     overrideTop !== null && overrideHeight !== null && overrideDayIndex !== null
       ? { top: overrideTop, height: overrideHeight, dayIndex: overrideDayIndex }
       : null;
-  const start = parseISO(event.start);
-  const end = parseISO(event.end);
-  const dayBase = startOfDay(day);
-  const segDayEnd = addDays(dayBase, 1);
-  const isStart = isSameDay(start, day);
-  const isEnd = end <= segDayEnd;
+  const segment = getEventSegmentForCalendarDay(event, day, timezone);
+  const isStart =
+    getEventDateKey(event, timezone) === dateToCalendarDateKey(day);
+  const isEnd = segment?.endsOnDay ?? true;
   const isDragPreviewSegment =
     isBeingDragged && overrides?.dayIndex === dayIndex;
   const segmentStartsHere = isStart || isDragPreviewSegment;
@@ -321,26 +322,19 @@ const WeekEventCard = memo(function WeekEventCard({
         top: `${overrides.top}px`,
         height: `${overrides.height}px`,
       }
-    : getSegmentStyle(event, day);
+    : getSegmentStyle(event, day, timezone);
   const color = getEventDisplayColor(event, prefs);
-  const segStart = isStart ? start : dayBase;
-  const segEnd = min([end, segDayEnd]);
   const durationMin = overrides
     ? (overrides.height / HOUR_HEIGHT) * 60
-    : differenceInMinutes(segEnd, segStart);
+    : (segment?.durationMinutes ?? 15);
   // Compute display times (use drag overrides if active)
   const displayStart = overrides
-    ? addMinutes(
-        set(startOfDay(day), {
-          hours: START_HOUR,
-          minutes: 0,
-          seconds: 0,
-        }),
-        (overrides.top / HOUR_HEIGHT) * 60,
-      )
-    : start;
-  const displayEnd = overrides ? addMinutes(displayStart, durationMin) : end;
-  const isPast = end < now;
+    ? minutesToDate(day, START_HOUR * 60 + (overrides.top / HOUR_HEIGHT) * 60)
+    : minutesToDate(day, segment?.startMinutes ?? 0);
+  const displayEnd = overrides
+    ? addMinutes(displayStart, durationMin)
+    : minutesToDate(day, segment?.endMinutes ?? durationMin);
+  const isPast = new Date(event.end) < now;
   const isDeclined = event.responseStatus === "declined";
   const allOthersOut = allOtherDeclined(event);
 
@@ -367,10 +361,8 @@ const WeekEventCard = memo(function WeekEventCard({
       )}
       aria-label={
         event.ownerName || event.overlayEmail
-          ? `${event.title}, ${
-              event.ownerName || event.overlayEmail
-            }'s calendar`
-          : event.title
+          ? `${ariaTitle}, ${event.ownerName || event.overlayEmail}'s calendar`
+          : ariaTitle
       }
       style={{
         ...style,
@@ -429,7 +421,7 @@ const WeekEventCard = memo(function WeekEventCard({
               !isPast && !isDeclined && "font-semibold",
             )}
           >
-            {event.title}
+            {title}
           </span>
         </div>
       ) : (
@@ -451,7 +443,7 @@ const WeekEventCard = memo(function WeekEventCard({
               />
             )}
             <EventStatusIcon event={event} className="shrink-0" />
-            <span className="truncate">{event.title}</span>
+            <span className="truncate">{title}</span>
           </div>
           {segmentStartsHere && (
             <div
@@ -502,6 +494,7 @@ const WeekEventCard = memo(function WeekEventCard({
   return (
     <EventDetailPopover
       event={event}
+      timezone={timezone}
       onDelete={onDeleteEvent}
       isDraft={isDraft}
       defaultOpen={defaultOpen}
@@ -548,10 +541,12 @@ const WeekCreateGhost = memo(function WeekCreateGhost({
 export const WeekView = memo(function WeekView({
   events,
   selectedDate,
+  timezone = getBrowserTimezone(),
   onDateSelect,
   onDeleteEvent,
   onEventTimeChange,
   onClickTimeSlot,
+  onCreateWorkingLocation,
   quickEditEventId,
   onQuickEditSave,
   onQuickEditCancel,
@@ -664,8 +659,8 @@ export const WeekView = memo(function WeekView({
     [allDayEvents],
   );
   const workingLocationLayout = useMemo(
-    () => layoutAllDayEvents(workingLocations, days),
-    [days, workingLocations],
+    () => layoutAllDayEvents(workingLocations, days, timezone),
+    [days, timezone, workingLocations],
   );
   const workingLocationGroups = useMemo(
     () =>
@@ -684,29 +679,45 @@ export const WeekView = memo(function WeekView({
     [prefs, workingLocationLabels, workingLocationLayout.placements],
   );
   const regularAllDayLayout = useMemo(() => {
-    return layoutAllDayEvents(regularEvents, days);
-  }, [days, regularEvents]);
+    return layoutAllDayEvents(regularEvents, days, timezone);
+  }, [days, regularEvents, timezone]);
 
   // Pre-compute timed events per day with layout — include events spanning into this day
   const dayData = useMemo(() => {
     return days.map((day) => {
-      const dayStart = startOfDay(day);
-      const dayEnd = addDays(dayStart, 1);
-      const dayEvents = timedEvents.filter((e) => {
-        const evStart = parseISO(e.start);
-        const evEnd = parseISO(e.end);
-        return evStart < dayEnd && evEnd > dayStart;
-      });
-      const layout = computeTimedEventLayout(dayEvents, day);
+      const dayEvents = timedEvents.filter((event) =>
+        getEventSegmentForCalendarDay(event, day, timezone),
+      );
+      const layout = computeTimedEventLayout(dayEvents, day, timezone);
       return { day, events: dayEvents, layout };
     });
-  }, [days, timedEvents]);
+  }, [days, timedEvents, timezone]);
 
   // Current time indicator
-  const nowMinutes = (now.getHours() - START_HOUR) * 60 + now.getMinutes();
+  const nowParts = getDateKeyInTimezone(now, timezone)
+    ? new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        hourCycle: "h23",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+        .formatToParts(now)
+        .reduce(
+          (parts, part) => {
+            if (part.type === "hour") parts.hour = Number(part.value);
+            if (part.type === "minute") parts.minute = Number(part.value);
+            return parts;
+          },
+          { hour: 0, minute: 0 },
+        )
+    : null;
+  const nowMinutes = nowParts
+    ? (nowParts.hour - START_HOUR) * 60 + nowParts.minute
+    : -1;
   const nowTop = (nowMinutes / 60) * HOUR_HEIGHT;
   const showNowIndicator =
     nowMinutes >= 0 && nowMinutes <= (END_HOUR - START_HOUR) * 60;
+  const currentDateKey = getDateKeyInTimezone(now, timezone);
 
   const hasWorkingLocations = workingLocationLayout.rowCount > 0;
   const hasRegularAllDayEvents = regularAllDayLayout.rowCount > 0;
@@ -774,7 +785,10 @@ export const WeekView = memo(function WeekView({
     function nameForToken(token: "shortGeneric" | "longGeneric" | "short") {
       try {
         return (
-          new Intl.DateTimeFormat("en-US", { timeZoneName: token })
+          new Intl.DateTimeFormat("en-US", {
+            timeZone: timezone,
+            timeZoneName: token,
+          })
             .formatToParts(now)
             .find((p) => p.type === "timeZoneName")?.value ?? ""
         );
@@ -783,10 +797,7 @@ export const WeekView = memo(function WeekView({
       }
     }
 
-    let iana = "";
-    try {
-      iana = Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
-    } catch {}
+    const iana = timezone;
 
     const longGeneric = nameForToken("longGeneric");
     let shortGeneric = nameForToken("shortGeneric");
@@ -804,7 +815,7 @@ export const WeekView = memo(function WeekView({
       tzLong: longGeneric || iana,
       tzIana: iana,
     };
-  }, []);
+  }, [now, timezone]);
 
   // Drag-to-move and drag-to-resize
   const handleEventTimeChange = useCallback(
@@ -827,6 +838,7 @@ export const WeekView = memo(function WeekView({
     days,
     onEventTimeChange: handleEventTimeChange,
     events,
+    timezone,
   });
 
   const canDrag = !!onEventTimeChange;
@@ -934,30 +946,53 @@ export const WeekView = memo(function WeekView({
           </div>
 
           {/* Day columns */}
-          {days.map((day) => (
-            <div
-              key={day.toISOString()}
-              onClick={() => onDateSelect(day)}
-              className={cn(
-                "flex flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 border-r border-border py-1.5 sm:flex-row sm:gap-1.5 sm:py-2.5 last:border-r-0",
-                isToday(day) ? "bg-primary/5" : "hover:bg-accent/40",
-              )}
-            >
-              <span className="text-[10px] font-medium text-muted-foreground sm:text-xs">
-                {isMobile ? format(day, "EEEEE") : format(day, "EEE")}
-              </span>
-              <span
+          {days.map((day) => {
+            const isCurrentDay = dateToCalendarDateKey(day) === currentDateKey;
+            return (
+              <div
+                key={day.toISOString()}
+                onClick={() => onDateSelect(day)}
                 className={cn(
-                  "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold sm:h-7 sm:w-7 sm:text-sm",
-                  isToday(day)
-                    ? "bg-foreground text-background"
-                    : "text-foreground",
+                  "group/day relative flex flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 border-r border-border py-1.5 sm:flex-row sm:gap-1.5 sm:py-2.5 last:border-r-0",
+                  isCurrentDay ? "bg-primary/5" : "hover:bg-accent/40",
                 )}
               >
-                {format(day, "d")}
-              </span>
-            </div>
-          ))}
+                <span className="text-[10px] font-medium text-muted-foreground sm:text-xs">
+                  {isMobile ? format(day, "EEEEE") : format(day, "EEE")}
+                </span>
+                <span
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold sm:h-7 sm:w-7 sm:text-sm",
+                    isCurrentDay
+                      ? "bg-foreground text-background"
+                      : "text-foreground",
+                  )}
+                >
+                  {format(day, "d")}
+                </span>
+                {onCreateWorkingLocation && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={t("calendarView.addWorkingLocation")}
+                        className="absolute right-1 top-1 flex size-5 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring group-hover/day:opacity-100"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onCreateWorkingLocation(day);
+                        }}
+                      >
+                        <IconPlus aria-hidden="true" className="size-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {t("calendarView.addWorkingLocation")}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            );
+          })}
           {timeGridScrollbarWidth > 0 && (
             <div
               aria-hidden="true"
@@ -1065,6 +1100,7 @@ export const WeekView = memo(function WeekView({
                           <EventDetailPopover
                             key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
                             event={event}
+                            timezone={timezone}
                             onDelete={onDeleteEvent}
                             isDraft={draftEventIds.includes(event.id)}
                             defaultOpen={quickEditEventId === event.id}
@@ -1145,6 +1181,7 @@ export const WeekView = memo(function WeekView({
                       <EventDetailPopover
                         key={`${event.overlayEmail ?? event.accountEmail ?? "primary"}:${event.id}`}
                         event={event}
+                        timezone={timezone}
                         onDelete={onDeleteEvent}
                         isDraft={draftEventIds.includes(event.id)}
                         defaultOpen={quickEditEventId === event.id}
@@ -1245,7 +1282,7 @@ export const WeekView = memo(function WeekView({
 
           {/* Day columns */}
           {dayData.map(({ day, events: dayEvents, layout }, dayIndex) => {
-            const isCurrentDay = isToday(day);
+            const isCurrentDay = dateToCalendarDateKey(day) === currentDateKey;
 
             // Collect events that were dragged into this column from another day
             const draggedInEvents: CalendarEvent[] = [];
@@ -1265,7 +1302,7 @@ export const WeekView = memo(function WeekView({
               (event) => {
                 const overrides = getDragOverrides(event.id);
                 return (
-                  getOutOfOfficeSegment(event, day) !== null ||
+                  getOutOfOfficeSegment(event, day, timezone) !== null ||
                   (dragEventId === event.id && overrides?.dayIndex === dayIndex)
                 );
               },
@@ -1353,12 +1390,13 @@ export const WeekView = memo(function WeekView({
                     const isBeingDragged = dragEventId === event.id;
                     const overrides = getDragOverrides(event.id);
                     const canonicalDayIndex =
-                      getFirstVisibleOutOfOfficeDayIndex(event, days);
+                      getFirstVisibleOutOfOfficeDayIndex(event, days, timezone);
                     return (
                       <OutOfOfficeEvent
                         key={`${event._tempId ?? event.id}:${day.toISOString()}`}
                         event={event}
                         day={day}
+                        timezone={timezone}
                         hourHeight={HOUR_HEIGHT}
                         color={
                           getEventDisplayColor(event, prefs) ??
@@ -1451,6 +1489,7 @@ export const WeekView = memo(function WeekView({
                         event={event}
                         day={day}
                         dayIndex={dayIndex}
+                        timezone={timezone}
                         layout={layout}
                         now={now}
                         prefs={prefs}

--- a/templates/calendar/app/components/calendar/WorkingLocationEditor.test.tsx
+++ b/templates/calendar/app/components/calendar/WorkingLocationEditor.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+
+import type { CalendarEvent } from "@shared/api";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WorkingLocationEditor } from "./WorkingLocationEditor";
+
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT:
+    () =>
+    (key: string, _values?: Record<string, unknown>): string =>
+      key,
+}));
+
+function event(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "google-home",
+    title: "Home",
+    description: "",
+    start: "2026-08-13",
+    end: "2026-08-14",
+    location: "",
+    allDay: true,
+    source: "google",
+    eventType: "workingLocation",
+    workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+    createdAt: "2026-08-13T00:00:00.000Z",
+    updatedAt: "2026-08-13T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("WorkingLocationEditor", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("keeps Save on existing events and allows an unlabeled office", () => {
+    const onSave = vi.fn();
+
+    act(() => {
+      root.render(
+        <WorkingLocationEditor
+          event={event()}
+          isRecurring={false}
+          onSave={onSave}
+        />,
+      );
+    });
+
+    const save = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "eventForm.save",
+    );
+    expect(save).toBeTruthy();
+    expect(save?.disabled).toBe(true);
+
+    act(() => {
+      container
+        .querySelector<HTMLInputElement>(
+          "#working-location-google-home-officeLocation",
+        )
+        ?.click();
+    });
+
+    const saveAfterOffice = Array.from(
+      container.querySelectorAll("button"),
+    ).find((button) => button.textContent === "eventForm.save");
+    expect(saveAfterOffice?.disabled).toBe(false);
+
+    act(() => {
+      saveAfterOffice?.click();
+    });
+
+    expect(onSave).toHaveBeenCalledWith({
+      type: "officeLocation",
+      label: "",
+      scope: undefined,
+    });
+  });
+
+  it("does not show Save on drafts and commits the selected type immediately", () => {
+    const onSave = vi.fn();
+
+    act(() => {
+      root.render(
+        <WorkingLocationEditor
+          event={event({
+            id: "working-location-draft",
+            source: "local",
+          })}
+          isRecurring={false}
+          isDraft
+          onSave={onSave}
+        />,
+      );
+    });
+
+    expect(
+      Array.from(container.querySelectorAll("button")).some(
+        (button) => button.textContent === "eventForm.save",
+      ),
+    ).toBe(false);
+
+    act(() => {
+      container
+        .querySelector<HTMLInputElement>(
+          "#working-location-working-location-draft-officeLocation",
+        )
+        ?.click();
+    });
+
+    expect(onSave).toHaveBeenCalledWith({
+      type: "officeLocation",
+      label: "",
+    });
+  });
+});

--- a/templates/calendar/app/components/calendar/WorkingLocationEditor.tsx
+++ b/templates/calendar/app/components/calendar/WorkingLocationEditor.tsx
@@ -21,6 +21,7 @@ import {
 interface WorkingLocationEditorProps {
   event: CalendarEvent;
   isRecurring: boolean;
+  isDraft?: boolean;
   readOnly?: boolean;
   disabled?: boolean;
   onSave: (selection: WorkingLocationSelection) => void;
@@ -40,6 +41,7 @@ function initialLabels(event: CalendarEvent) {
 export function WorkingLocationEditor({
   event,
   isRecurring,
+  isDraft = false,
   readOnly = false,
   disabled = false,
   onSave,
@@ -54,17 +56,41 @@ export function WorkingLocationEditor({
   const detail = getWorkingLocationDetail(event, workingLocationLabels);
 
   useEffect(() => {
-    setType(getWorkingLocationType(event));
-    setLabels(initialLabels(event));
-    setScope("single");
-  }, [currentLabel, currentType, event.id]);
+    setType(currentType);
+    setLabels((current) => {
+      const incoming = initialLabels(event);
+      if (!isDraft) return incoming;
+      return {
+        officeLocation:
+          currentType === "officeLocation"
+            ? incoming.officeLocation
+            : current.officeLocation,
+        customLocation:
+          currentType === "customLocation"
+            ? incoming.customLocation
+            : current.customLocation,
+      };
+    });
+    if (!isDraft) setScope("single");
+  }, [currentLabel, currentType, event.id, isDraft]);
 
   const label = type === "homeOffice" ? "" : labels[type];
-  const isValid = type === "homeOffice" || label.trim().length > 0;
+  const isValid = type !== "customLocation" || label.trim().length > 0;
   const isDirty = useMemo(
     () => type !== currentType || label.trim() !== currentLabel.trim(),
     [currentLabel, currentType, label, type],
   );
+
+  const commitDraft = (
+    nextType: WorkingLocationKind,
+    nextLabels: Record<LabeledWorkingLocation, string>,
+  ) => {
+    if (!isDraft) return;
+    onSave({
+      type: nextType,
+      label: nextType === "homeOffice" ? "" : nextLabels[nextType],
+    });
+  };
 
   if (readOnly) {
     return (
@@ -108,7 +134,11 @@ export function WorkingLocationEditor({
       </div>
       <RadioGroup
         value={type}
-        onValueChange={(value) => setType(value as WorkingLocationKind)}
+        onValueChange={(value) => {
+          const nextType = value as WorkingLocationKind;
+          setType(nextType);
+          commitDraft(nextType, labels);
+        }}
         className="grid grid-cols-3 gap-1.5"
         aria-label={t("eventForm.workingLocation")}
         disabled={disabled}
@@ -143,12 +173,14 @@ export function WorkingLocationEditor({
         <div className="mt-2">
           <Input
             value={labels[type]}
-            onChange={(event) =>
-              setLabels((current) => ({
-                ...current,
-                [type]: event.target.value,
-              }))
-            }
+            onChange={(inputEvent) => {
+              const nextLabels = {
+                ...labels,
+                [type]: inputEvent.target.value,
+              };
+              setLabels(nextLabels);
+              commitDraft(type, nextLabels);
+            }}
             aria-label={
               type === "officeLocation"
                 ? t("eventForm.office")
@@ -166,7 +198,7 @@ export function WorkingLocationEditor({
         </div>
       )}
 
-      {isRecurring && (
+      {isRecurring && !isDraft && (
         <div className="mt-2">
           <p className="mb-1 text-[10px] font-medium text-muted-foreground">
             {t("eventForm.applyTo")}
@@ -205,18 +237,20 @@ export function WorkingLocationEditor({
         </div>
       )}
 
-      <div className="mt-2 flex justify-end">
-        <Button
-          size="sm"
-          className="h-7 text-xs"
-          disabled={disabled || !isValid || !isDirty}
-          onClick={() =>
-            onSave({ type, label, scope: isRecurring ? scope : undefined })
-          }
-        >
-          {t("eventForm.save")}
-        </Button>
-      </div>
+      {!isDraft && (
+        <div className="mt-2 flex justify-end">
+          <Button
+            size="sm"
+            className="h-7 text-xs"
+            disabled={disabled || !isValid || !isDirty}
+            onClick={() =>
+              onSave({ type, label, scope: isRecurring ? scope : undefined })
+            }
+          >
+            {t("eventForm.save")}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/templates/calendar/app/hooks/use-event-drag.ts
+++ b/templates/calendar/app/hooks/use-event-drag.ts
@@ -1,6 +1,16 @@
 import type { CalendarEvent } from "@shared/api";
-import { parseISO, startOfDay, set, addMinutes } from "date-fns";
+import { parseISO, startOfDay } from "date-fns";
 import { useState, useRef, useCallback, useEffect } from "react";
+
+import {
+  addCalendarDays,
+  dateKeyToDate,
+  dateKeyToTimezoneIso,
+  dateToCalendarDateKey,
+  getBrowserTimezone,
+  getEventDateKey,
+  getEventSegmentForCalendarDay,
+} from "@/lib/calendar-timezone";
 
 const SNAP_MINUTES = 15;
 
@@ -48,6 +58,8 @@ export interface UseEventDragOptions {
   onEventTimeChange: (eventId: string, newStart: Date, newEnd: Date) => void;
   /** All events (to find the event being dragged) */
   events: CalendarEvent[];
+  /** IANA timezone used by the visible calendar grid */
+  timezone?: string;
 }
 
 export function useEventDrag({
@@ -57,6 +69,7 @@ export function useEventDrag({
   days,
   onEventTimeChange,
   events,
+  timezone = getBrowserTimezone(),
 }: UseEventDragOptions) {
   const [dragState, setDragState] = useState<DragState | null>(null);
   const dragStateRef = useRef<DragState | null>(null);
@@ -127,10 +140,13 @@ export function useEventDrag({
       // Compute current event position
       const evStart = parseISO(event.start);
       const evEnd = parseISO(event.end);
-      const dayStart = set(startOfDay(evStart), {
-        hours: startHour,
-      });
-      const startMinutes = (evStart.getTime() - dayStart.getTime()) / 60000;
+      const eventDateKey =
+        getEventDateKey(event, timezone) ?? dateToCalendarDateKey(evStart);
+      const eventDay = days?.[dayIndex] ?? dateKeyToDate(eventDateKey);
+      const segment = getEventSegmentForCalendarDay(event, eventDay, timezone);
+      const startMinutes =
+        segment?.startMinutes ??
+        (evStart.getTime() - startOfDay(evStart).getTime()) / 60000;
       const durationMinutes = (evEnd.getTime() - evStart.getTime()) / 60000;
 
       const originalTop = Math.max(0, (startMinutes / 60) * hourHeight);
@@ -172,6 +188,7 @@ export function useEventDrag({
       getScrollTop,
       startHour,
       hourHeight,
+      timezone,
     ],
   );
 
@@ -288,20 +305,39 @@ export function useEventDrag({
         pxToMinutes(state.currentHeight),
       );
 
-      // Determine the base day
+      // Determine the base day in the visible calendar timezone.
       const originalStart = parseISO(state.event.start);
-      let baseDay: Date;
-      if (days && state.currentDayIndex !== state.startDayIndex) {
-        baseDay = days[state.currentDayIndex];
-      } else {
-        baseDay = startOfDay(originalStart);
-      }
-
-      const newStart = addMinutes(
-        set(baseDay, { hours: startHour, minutes: 0, seconds: 0 }),
-        topMinutes,
-      );
-      const newEnd = addMinutes(newStart, heightMinutes);
+      const baseDay =
+        days && state.currentDayIndex !== state.startDayIndex
+          ? days[state.currentDayIndex]
+          : dateKeyToDate(
+              getEventDateKey(state.event, timezone) ??
+                dateToCalendarDateKey(originalStart),
+            );
+      const baseDate = dateToCalendarDateKey(baseDay);
+      const startTotalMinutes = startHour * 60 + topMinutes;
+      const endTotalMinutes = startTotalMinutes + heightMinutes;
+      const toZonedIso = (totalMinutes: number) => {
+        const dayOffset = Math.floor(totalMinutes / (24 * 60));
+        const minuteOfDay = totalMinutes - dayOffset * 24 * 60;
+        const hour = Math.floor(minuteOfDay / 60);
+        const minute = Math.round(minuteOfDay % 60);
+        const normalizedMinute = minute === 60 ? 0 : minute;
+        const normalizedHour = minute === 60 ? hour + 1 : hour;
+        const time =
+          normalizedHour >= 24
+            ? "00:00"
+            : `${String(normalizedHour).padStart(2, "0")}:${String(
+                normalizedMinute,
+              ).padStart(2, "0")}`;
+        return dateKeyToTimezoneIso(
+          addCalendarDays(baseDate, dayOffset),
+          time,
+          timezone,
+        );
+      };
+      const newStart = new Date(toZonedIso(startTotalMinutes));
+      const newEnd = new Date(toZonedIso(endTotalMinutes));
 
       onEventTimeChange(state.eventId, newStart, newEnd);
     }
@@ -314,6 +350,7 @@ export function useEventDrag({
     days,
     startHour,
     onEventTimeChange,
+    timezone,
   ]);
 
   const cancelDrag = useCallback(() => {

--- a/templates/calendar/app/i18n-data.ts
+++ b/templates/calendar/app/i18n-data.ts
@@ -664,6 +664,7 @@ const enUS = {
     },
   },
   calendarView: {
+    addWorkingLocation: "Add working location",
     addTitleBeforeCreate: "Add a title before creating the event",
     calendarSettingsLoading:
       "Calendar settings are still loading. Try again in a moment.",
@@ -692,6 +693,11 @@ const enUS = {
     updatingEvent: "Updating event...",
     updatingRecurringEvent: "Updating recurring event...",
     week: "Week",
+    timezoneSwitchTitle: "Use your browser timezone?",
+    timezoneSwitchDescription:
+      "Calendar is pinned to {{savedTimezone}}, but your browser is in {{browserTimezone}}. Switch the calendar timezone?",
+    timezoneSwitchKeep: "Keep {{timezone}}",
+    timezoneSwitchSwitch: "Switch to {{timezone}}",
   },
   eventForm: {
     addAttachment: "Add attachment",
@@ -8014,6 +8020,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "你的信息",
     },
     calendarView: {
+      addWorkingLocation: "添加工作地点",
       addTitleBeforeCreate: "创建事件前请添加标题",
       calendarSettingsLoading: "日历设置仍在加载。请稍后再试。",
       day: "日",
@@ -8041,6 +8048,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "正在更新事件...",
       updatingRecurringEvent: "正在更新重复事件...",
       week: "周",
+      timezoneSwitchTitle: "使用浏览器时区？",
+      timezoneSwitchDescription:
+        "日历固定为 {{savedTimezone}}，但浏览器使用 {{browserTimezone}}。要切换日历时区吗？",
+      timezoneSwitchKeep: "保留 {{timezone}}",
+      timezoneSwitchSwitch: "切换到 {{timezone}}",
     },
     routeTitles: {
       bookingLinks: "预约链接 — Calendar",
@@ -8183,6 +8195,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "Tu información",
     },
     calendarView: {
+      addWorkingLocation: "Añadir ubicación de trabajo",
       addTitleBeforeCreate: "Añade un título antes de crear el evento",
       calendarSettingsLoading:
         "La configuración del calendario aún se está cargando. Inténtalo de nuevo en un momento.",
@@ -8213,6 +8226,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "Actualizando evento...",
       updatingRecurringEvent: "Actualizando evento recurrente...",
       week: "Semana",
+      timezoneSwitchTitle: "¿Usar la zona horaria del navegador?",
+      timezoneSwitchDescription:
+        "El calendario está fijado en {{savedTimezone}}, pero tu navegador usa {{browserTimezone}}. ¿Cambiar la zona horaria del calendario?",
+      timezoneSwitchKeep: "Mantener {{timezone}}",
+      timezoneSwitchSwitch: "Cambiar a {{timezone}}",
     },
     routeTitles: {
       bookingLinks: "Enlaces de reserva — Calendar",
@@ -8361,6 +8379,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "Vos informations",
     },
     calendarView: {
+      addWorkingLocation: "Ajouter un lieu de travail",
       addTitleBeforeCreate: "Ajoutez un titre avant de créer l'événement",
       calendarSettingsLoading:
         "Les paramètres du calendrier sont encore en cours de chargement. Réessayez dans un instant.",
@@ -8389,6 +8408,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "Mise à jour de l'événement...",
       updatingRecurringEvent: "Mise à jour de l'événement récurrent...",
       week: "Semaine",
+      timezoneSwitchTitle: "Utiliser le fuseau horaire du navigateur ?",
+      timezoneSwitchDescription:
+        "Le calendrier est fixé sur {{savedTimezone}}, mais votre navigateur utilise {{browserTimezone}}. Changer le fuseau horaire du calendrier ?",
+      timezoneSwitchKeep: "Conserver {{timezone}}",
+      timezoneSwitchSwitch: "Passer à {{timezone}}",
     },
     routeTitles: {
       bookingLinks: "Liens de réservation — Calendar",
@@ -8539,6 +8563,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "Deine Informationen",
     },
     calendarView: {
+      addWorkingLocation: "Arbeitsort hinzufügen",
       addTitleBeforeCreate:
         "Fügen Sie einen Titel hinzu, bevor Sie das Ereignis erstellen",
       calendarSettingsLoading:
@@ -8569,6 +8594,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "Ereignis wird aktualisiert...",
       updatingRecurringEvent: "Wiederkehrendes Ereignis wird aktualisiert...",
       week: "Woche",
+      timezoneSwitchTitle: "Browser-Zeitzone verwenden?",
+      timezoneSwitchDescription:
+        "Der Kalender ist auf {{savedTimezone}} festgelegt, aber Ihr Browser verwendet {{browserTimezone}}. Kalenderzeitzone wechseln?",
+      timezoneSwitchKeep: "{{timezone}} beibehalten",
+      timezoneSwitchSwitch: "Zu {{timezone}} wechseln",
     },
     routeTitles: {
       bookingLinks: "Buchungslinks — Calendar",
@@ -8718,6 +8748,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "あなたの情報",
     },
     calendarView: {
+      addWorkingLocation: "勤務場所を追加",
       addTitleBeforeCreate: "イベントを作成する前にタイトルを追加してください",
       calendarSettingsLoading:
         "カレンダー設定を読み込み中です。少し待ってからもう一度お試しください。",
@@ -8746,6 +8777,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "イベントを更新中...",
       updatingRecurringEvent: "繰り返しイベントを更新中...",
       week: "週",
+      timezoneSwitchTitle: "ブラウザのタイムゾーンを使用しますか？",
+      timezoneSwitchDescription:
+        "カレンダーは {{savedTimezone}} に固定されていますが、ブラウザは {{browserTimezone}} を使用しています。カレンダーのタイムゾーンを切り替えますか？",
+      timezoneSwitchKeep: "{{timezone}} を維持",
+      timezoneSwitchSwitch: "{{timezone}} に切り替え",
     },
     routeTitles: {
       bookingLinks: "予約リンク — Calendar",
@@ -8890,6 +8926,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "내 정보",
     },
     calendarView: {
+      addWorkingLocation: "근무 위치 추가",
       addTitleBeforeCreate: "이벤트를 만들기 전에 제목을 추가하세요",
       calendarSettingsLoading:
         "캘린더 설정을 아직 불러오는 중입니다. 잠시 후 다시 시도하세요.",
@@ -8919,6 +8956,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "이벤트 업데이트 중...",
       updatingRecurringEvent: "반복 이벤트 업데이트 중...",
       week: "주",
+      timezoneSwitchTitle: "브라우저 시간대를 사용할까요?",
+      timezoneSwitchDescription:
+        "캘린더는 {{savedTimezone}}에 고정되어 있지만 브라우저는 {{browserTimezone}}을(를) 사용합니다. 캘린더 시간대를 전환할까요?",
+      timezoneSwitchKeep: "{{timezone}} 유지",
+      timezoneSwitchSwitch: "{{timezone}}(으)로 전환",
     },
     routeTitles: {
       bookingLinks: "예약 링크 — Calendar",
@@ -9065,6 +9107,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "Suas informações",
     },
     calendarView: {
+      addWorkingLocation: "Adicionar local de trabalho",
       addTitleBeforeCreate: "Adicione um título antes de criar o evento",
       calendarSettingsLoading:
         "As configurações do calendário ainda estão carregando. Tente novamente em instantes.",
@@ -9094,6 +9137,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "Atualizando evento...",
       updatingRecurringEvent: "Atualizando evento recorrente...",
       week: "Semana",
+      timezoneSwitchTitle: "Usar o fuso horário do navegador?",
+      timezoneSwitchDescription:
+        "O calendário está fixado em {{savedTimezone}}, mas o navegador usa {{browserTimezone}}. Mudar o fuso horário do calendário?",
+      timezoneSwitchKeep: "Manter {{timezone}}",
+      timezoneSwitchSwitch: "Mudar para {{timezone}}",
     },
     routeTitles: {
       bookingLinks: "Links de reserva — Calendar",
@@ -9240,6 +9288,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "आपकी जानकारी",
     },
     calendarView: {
+      addWorkingLocation: "कार्य स्थान जोड़ें",
       addTitleBeforeCreate: "इवेंट बनाने से पहले शीर्षक जोड़ें",
       calendarSettingsLoading:
         "कैलेंडर सेटिंग अभी लोड हो रही हैं। कृपया थोड़ी देर में फिर कोशिश करें।",
@@ -9268,6 +9317,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "इवेंट अपडेट हो रहा है...",
       updatingRecurringEvent: "दोहराया जाने वाला इवेंट अपडेट हो रहा है...",
       week: "सप्ताह",
+      timezoneSwitchTitle: "ब्राउज़र का टाइमज़ोन इस्तेमाल करें?",
+      timezoneSwitchDescription:
+        "कैलेंडर {{savedTimezone}} पर पिन है, लेकिन आपका ब्राउज़र {{browserTimezone}} पर है। कैलेंडर टाइमज़ोन बदलें?",
+      timezoneSwitchKeep: "{{timezone}} रखें",
+      timezoneSwitchSwitch: "{{timezone}} पर बदलें",
     },
     routeTitles: {
       bookingLinks: "बुकिंग लिंक — Calendar",
@@ -9413,6 +9467,7 @@ const translatedCalendarRawBurnDown = {
       yourInformation: "معلوماتك",
     },
     calendarView: {
+      addWorkingLocation: "إضافة موقع العمل",
       addTitleBeforeCreate: "أضف عنوانًا قبل إنشاء الحدث",
       calendarSettingsLoading:
         "لا تزال إعدادات التقويم قيد التحميل. حاول مرة أخرى بعد قليل.",
@@ -9441,6 +9496,11 @@ const translatedCalendarRawBurnDown = {
       updatingEvent: "جارٍ تحديث الحدث...",
       updatingRecurringEvent: "جارٍ تحديث الحدث المتكرر...",
       week: "الأسبوع",
+      timezoneSwitchTitle: "استخدام المنطقة الزمنية للمتصفح؟",
+      timezoneSwitchDescription:
+        "التقويم مثبت على {{savedTimezone}}، لكن متصفحك يستخدم {{browserTimezone}}. هل تريد تبديل المنطقة الزمنية للتقويم؟",
+      timezoneSwitchKeep: "الاحتفاظ بـ {{timezone}}",
+      timezoneSwitchSwitch: "التبديل إلى {{timezone}}",
     },
     routeTitles: {
       bookingLinks: "روابط الحجز — Calendar",

--- a/templates/calendar/app/i18n/zh-TW.ts
+++ b/templates/calendar/app/i18n/zh-TW.ts
@@ -624,6 +624,7 @@ const messages = {
     },
   },
   calendarView: {
+    addWorkingLocation: "新增工作地點",
     addTitleBeforeCreate: "建立事件前請新增標題",
     calendarSettingsLoading: "行事曆設定仍在載入。請稍後再試。",
     day: "日",
@@ -651,6 +652,11 @@ const messages = {
     updatingEvent: "正在更新事件...",
     updatingRecurringEvent: "正在更新重複事件...",
     week: "週",
+    timezoneSwitchTitle: "使用瀏覽器時區？",
+    timezoneSwitchDescription:
+      "行事曆固定使用 {{savedTimezone}}，但瀏覽器使用 {{browserTimezone}}。要切換行事曆時區嗎？",
+    timezoneSwitchKeep: "保留 {{timezone}}",
+    timezoneSwitchSwitch: "切換到 {{timezone}}",
   },
   eventForm: {
     addAttachment: "新增附件",

--- a/templates/calendar/app/lib/all-day-layout.test.ts
+++ b/templates/calendar/app/lib/all-day-layout.test.ts
@@ -70,6 +70,25 @@ describe("all-day layout", () => {
     });
   });
 
+  it("places a timed event on the day defined by the pinned timezone", () => {
+    const timedEvent: CalendarEvent = {
+      ...event(
+        "tokyo-evening",
+        "2026-07-10T23:00:00.000Z",
+        "2026-07-11T02:00:00.000Z",
+      ),
+      allDay: false,
+    };
+
+    expect(
+      getAllDaySpan(
+        timedEvent,
+        [new Date(2026, 6, 10), new Date(2026, 6, 11)],
+        "Asia/Tokyo",
+      ),
+    ).toEqual({ startCol: 1, endCol: 1 });
+  });
+
   it("assigns overlapping spans to deterministic non-overlapping rows", () => {
     const layout = layoutAllDayEvents(
       [
@@ -104,6 +123,23 @@ describe("all-day layout", () => {
       workingLocations: [workingLocation],
       regularEvents: [ordinaryEvent],
     });
+  });
+
+  it("keeps same-day working locations in separate all-day rows", () => {
+    const layout = layoutAllDayEvents(
+      [
+        event("home", "2026-07-07", "2026-07-08", "workingLocation"),
+        event("office", "2026-07-07", "2026-07-08", "workingLocation"),
+      ],
+      days,
+      "America/Los_Angeles",
+    );
+
+    expect(layout.rowCount).toBe(2);
+    expect(layout.placements.map((placement) => placement.event.id)).toEqual([
+      "home",
+      "office",
+    ]);
   });
 
   it("groups adjacent placements with the same visual identity", () => {

--- a/templates/calendar/app/lib/all-day-layout.ts
+++ b/templates/calendar/app/lib/all-day-layout.ts
@@ -1,6 +1,11 @@
 import type { CalendarEvent } from "@shared/api";
-import { addDays, format, parseISO, startOfDay } from "date-fns";
 
+import {
+  addCalendarDays,
+  dateToCalendarDateKey,
+  eventOverlapsCalendarDay,
+  getBrowserTimezone,
+} from "@/lib/calendar-timezone";
 import { getFullDayOutOfOfficeDateRange } from "@/lib/out-of-office";
 import { isWorkingLocationEvent } from "@/lib/working-location";
 
@@ -37,22 +42,24 @@ export function partitionAllDayEvents(events: CalendarEvent[]) {
 export function getAllDaySpan(
   event: CalendarEvent,
   days: Date[],
+  timezone: string = getBrowserTimezone(),
 ): Omit<AllDaySpan, "event"> | null {
-  const eventStart = parseISO(event.start);
-  const eventEnd = event.end ? parseISO(event.end) : addDays(eventStart, 1);
   const outOfOfficeRange = getFullDayOutOfOfficeDateRange(event);
+  const eventStartDate = event.start.slice(0, 10);
+  const eventEndDate =
+    event.end?.slice(0, 10) ?? addCalendarDays(eventStartDate, 1);
 
   let startCol = -1;
   let endCol = -1;
 
   for (let index = 0; index < days.length; index++) {
-    const dayStart = startOfDay(days[index]);
-    const dayEnd = addDays(dayStart, 1);
-    const dayDate = format(days[index], "yyyy-MM-dd");
+    const dayDate = dateToCalendarDateKey(days[index]);
     const overlaps = outOfOfficeRange
       ? dayDate >= outOfOfficeRange.startDate &&
         dayDate < outOfOfficeRange.endDateExclusive
-      : eventStart < dayEnd && eventEnd > dayStart;
+      : event.allDay
+        ? eventStartDate <= dayDate && eventEndDate > dayDate
+        : eventOverlapsCalendarDay(event, days[index], timezone);
     if (overlaps) {
       if (startCol === -1) startCol = index;
       endCol = index;
@@ -71,10 +78,11 @@ function compareSpans(a: AllDaySpan, b: AllDaySpan): number {
 export function layoutAllDayEvents(
   events: CalendarEvent[],
   days: Date[],
+  timezone: string = getBrowserTimezone(),
 ): AllDayLayout {
   const spans = events
     .map((event) => {
-      const span = getAllDaySpan(event, days);
+      const span = getAllDaySpan(event, days, timezone);
       return span ? { event, ...span } : null;
     })
     .filter((span): span is AllDaySpan => span !== null)

--- a/templates/calendar/app/lib/calendar-drafts.test.ts
+++ b/templates/calendar/app/lib/calendar-drafts.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorkingLocationDraft } from "./calendar-drafts";
+import {
+  buildWorkingLocationDraft,
+  resolveDraftWorkingLocation,
+} from "./calendar-drafts";
 import { dateKeyToDate } from "./calendar-timezone";
 
 describe("working location drafts", () => {
@@ -33,6 +36,32 @@ describe("working location drafts", () => {
       start: "2026-08-31",
       end: "2026-09-01",
       allDay: true,
+    });
+  });
+
+  it("keeps an Other name when location is the empty draft default", () => {
+    expect(
+      resolveDraftWorkingLocation({
+        workingLocationType: "customLocation",
+        workingLocationLabel: "Church",
+        location: "",
+      }),
+    ).toEqual({
+      workingLocationType: "customLocation",
+      workingLocationLabel: "Church",
+    });
+  });
+
+  it("falls back to location when the Other name was stored there", () => {
+    expect(
+      resolveDraftWorkingLocation({
+        workingLocationType: "customLocation",
+        workingLocationLabel: "",
+        location: "Library",
+      }),
+    ).toEqual({
+      workingLocationType: "customLocation",
+      workingLocationLabel: "Library",
     });
   });
 });

--- a/templates/calendar/app/lib/calendar-drafts.test.ts
+++ b/templates/calendar/app/lib/calendar-drafts.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkingLocationDraft } from "./calendar-drafts";
+import { dateKeyToDate } from "./calendar-timezone";
+
+describe("working location drafts", () => {
+  it("creates a single-day all-day event by default", () => {
+    expect(
+      buildWorkingLocationDraft({
+        id: "slot-first",
+        date: dateKeyToDate("2026-08-14"),
+        now: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      start: "2026-08-14",
+      end: "2026-08-15",
+      allDay: true,
+      eventType: "workingLocation",
+      workingLocationType: "homeOffice",
+      startTimeZone: undefined,
+      endTimeZone: undefined,
+    });
+  });
+
+  it("keeps a date range in exclusive all-day format", () => {
+    expect(
+      buildWorkingLocationDraft({
+        id: "slot-range",
+        date: dateKeyToDate("2026-08-31"),
+        now: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toMatchObject({
+      start: "2026-08-31",
+      end: "2026-09-01",
+      allDay: true,
+    });
+  });
+});

--- a/templates/calendar/app/lib/calendar-drafts.ts
+++ b/templates/calendar/app/lib/calendar-drafts.ts
@@ -2,6 +2,26 @@ import type { CalendarEventDraft } from "@shared/api";
 
 import { addCalendarDays, dateToCalendarDateKey } from "./calendar-timezone";
 
+export function resolveDraftWorkingLocation(
+  draft: Pick<
+    CalendarEventDraft,
+    "workingLocationType" | "workingLocationLabel" | "location"
+  >,
+): {
+  workingLocationType: "homeOffice" | "officeLocation" | "customLocation";
+  workingLocationLabel: string;
+} {
+  return {
+    workingLocationType: draft.workingLocationType ?? "homeOffice",
+    // Drafts initialize `location` to "", so `??` would drop the Other name.
+    workingLocationLabel: (
+      draft.workingLocationLabel ||
+      draft.location ||
+      ""
+    ).trim(),
+  };
+}
+
 export function buildWorkingLocationDraft({
   id,
   date,

--- a/templates/calendar/app/lib/calendar-drafts.ts
+++ b/templates/calendar/app/lib/calendar-drafts.ts
@@ -1,0 +1,36 @@
+import type { CalendarEventDraft } from "@shared/api";
+
+import { addCalendarDays, dateToCalendarDateKey } from "./calendar-timezone";
+
+export function buildWorkingLocationDraft({
+  id,
+  date,
+  accountEmail,
+  now = new Date().toISOString(),
+}: {
+  id: string;
+  date: Date;
+  accountEmail?: string;
+  now?: string;
+}): CalendarEventDraft {
+  const dateKey = dateToCalendarDateKey(date);
+  return {
+    id,
+    title: "",
+    description: "",
+    location: "",
+    start: dateKey,
+    end: addCalendarDays(dateKey, 1),
+    startTimeZone: undefined,
+    endTimeZone: undefined,
+    allDay: true,
+    eventType: "workingLocation",
+    workingLocationType: "homeOffice",
+    workingLocationLabel: "",
+    transparency: "transparent",
+    visibility: "public",
+    accountEmail,
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/templates/calendar/app/lib/calendar-timezone.test.ts
+++ b/templates/calendar/app/lib/calendar-timezone.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dateKeyToDate,
+  eventOverlapsCalendarDay,
+  getCalendarDayBounds,
+  getDateKeyInTimezone,
+  getEventSegmentForCalendarDay,
+  getViewDateRange,
+  moveEventToCalendarDate,
+} from "./calendar-timezone";
+import { dateTimeInTimezoneToIso } from "./event-form-utils";
+
+describe("calendar timezone helpers", () => {
+  it("keeps selected date keys in the pinned timezone across travel", () => {
+    const instant = "2026-08-14T23:30:00.000Z";
+
+    expect(getDateKeyInTimezone(instant, "America/Los_Angeles")).toBe(
+      "2026-08-14",
+    );
+    expect(getDateKeyInTimezone(instant, "Asia/Tokyo")).toBe("2026-08-15");
+  });
+
+  it("uses zoned midnight bounds across a DST transition", () => {
+    const bounds = getCalendarDayBounds(
+      dateKeyToDate("2026-03-08"),
+      "America/New_York",
+    );
+
+    expect(bounds.start.toISOString()).toBe("2026-03-08T05:00:00.000Z");
+    expect(bounds.end.toISOString()).toBe("2026-03-09T04:00:00.000Z");
+  });
+
+  it("lays out a cross-midnight instant using pinned wall-clock time", () => {
+    const event = {
+      start: "2026-08-14T23:30:00.000Z",
+      end: "2026-08-15T01:00:00.000Z",
+      allDay: false as const,
+    };
+    const day = dateKeyToDate("2026-08-14");
+
+    expect(eventOverlapsCalendarDay(event, day, "America/Los_Angeles")).toBe(
+      true,
+    );
+    expect(
+      getEventSegmentForCalendarDay(event, day, "America/Los_Angeles"),
+    ).toMatchObject({
+      topMinutes: 16 * 60 + 30,
+      durationMinutes: 90,
+      startsOnDay: true,
+      endsOnDay: true,
+    });
+  });
+
+  it("keeps a same-day timed draft on a date-carrier selected day", () => {
+    const timezone = "America/Chicago";
+    const day = dateKeyToDate("2026-08-13");
+    const event = {
+      start: dateTimeInTimezoneToIso("2026-08-13", "16:00", timezone),
+      end: dateTimeInTimezoneToIso("2026-08-13", "16:30", timezone),
+      allDay: false as const,
+    };
+
+    expect(eventOverlapsCalendarDay(event, day, timezone)).toBe(true);
+    expect(getEventSegmentForCalendarDay(event, day, timezone)).toMatchObject({
+      topMinutes: 16 * 60,
+      durationMinutes: 30,
+      startsOnDay: true,
+      endsOnDay: true,
+    });
+  });
+
+  it("moves an event by display date without changing its wall-clock time", () => {
+    expect(
+      moveEventToCalendarDate(
+        {
+          start: "2026-08-14T23:30:00.000Z",
+          end: "2026-08-15T01:00:00.000Z",
+          allDay: false,
+        },
+        dateKeyToDate("2026-08-17"),
+        "America/Los_Angeles",
+      ),
+    ).toEqual({
+      start: "2026-08-17T23:30:00.000Z",
+      end: "2026-08-18T01:00:00.000Z",
+    });
+  });
+
+  it("honors weekStartsOn when computing week bounds in the pinned timezone", () => {
+    const selectedDate = dateKeyToDate("2026-08-13");
+
+    expect(
+      getViewDateRange("week", selectedDate, "America/Los_Angeles", 0),
+    ).toEqual({
+      from: "2026-08-09T07:00:00.000Z",
+      to: "2026-08-16T07:00:00.000Z",
+    });
+    expect(
+      getViewDateRange("week", selectedDate, "America/Los_Angeles", 1),
+    ).toEqual({
+      from: "2026-08-10T07:00:00.000Z",
+      to: "2026-08-17T07:00:00.000Z",
+    });
+  });
+});

--- a/templates/calendar/app/lib/calendar-timezone.test.ts
+++ b/templates/calendar/app/lib/calendar-timezone.test.ts
@@ -8,6 +8,7 @@ import {
   getEventSegmentForCalendarDay,
   getViewDateRange,
   moveEventToCalendarDate,
+  normalizeTimezone,
 } from "./calendar-timezone";
 import { dateTimeInTimezoneToIso } from "./event-form-utils";
 
@@ -102,5 +103,11 @@ describe("calendar timezone helpers", () => {
       from: "2026-08-10T07:00:00.000Z",
       to: "2026-08-17T07:00:00.000Z",
     });
+  });
+
+  it("falls back to the browser timezone when a saved zone is invalid", () => {
+    expect(normalizeTimezone("Not/AZone")).toBe(
+      Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    );
   });
 });

--- a/templates/calendar/app/lib/calendar-timezone.ts
+++ b/templates/calendar/app/lib/calendar-timezone.ts
@@ -1,0 +1,349 @@
+import type { CalendarEvent } from "@shared/api";
+import {
+  addDays,
+  endOfMonth,
+  endOfWeek,
+  format,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+
+import { dateTimeInTimezoneToIso } from "./event-form-utils";
+
+export const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface CalendarDateTimeParts {
+  date: string;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+export interface CalendarDayBounds {
+  date: string;
+  start: Date;
+  end: Date;
+}
+
+export interface CalendarEventSegment {
+  topMinutes: number;
+  durationMinutes: number;
+  startsOnDay: boolean;
+  endsOnDay: boolean;
+  startMinutes: number;
+  endMinutes: number;
+}
+
+export function getBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+export function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeTimezone(timezone?: string): string {
+  return timezone && isValidTimezone(timezone)
+    ? timezone
+    : getBrowserTimezone();
+}
+
+/** Date carriers are kept at local noon so browser DST never changes their date. */
+export function dateKeyToDate(date: string): Date {
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(year, month - 1, day, 12, 0, 0, 0);
+}
+
+export function dateToCalendarDateKey(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+export function addCalendarDays(date: string, amount: number): string {
+  const [year, month, day] = date.split("-").map(Number);
+  const next = new Date(Date.UTC(year, month - 1, day + amount));
+  return next.toISOString().slice(0, 10);
+}
+
+function dateTimeParts(value: Date | string, timezone: string) {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(parsed);
+    const valueFor = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((part) => part.type === type)?.value;
+    const year = valueFor("year");
+    const month = valueFor("month");
+    const day = valueFor("day");
+    const hour = valueFor("hour");
+    const minute = valueFor("minute");
+    const second = valueFor("second");
+    if (!year || !month || !day || !hour || !minute || !second) return null;
+
+    return {
+      date: `${year}-${month}-${day}`,
+      hour: Number(hour),
+      minute: Number(minute),
+      second: Number(second),
+    } satisfies CalendarDateTimeParts;
+  } catch {
+    return null;
+  }
+}
+
+export function getDateTimePartsInTimezone(
+  value: Date | string,
+  timezone: string,
+): CalendarDateTimeParts | null {
+  return dateTimeParts(value, normalizeTimezone(timezone));
+}
+
+export function getDateKeyInTimezone(
+  value: Date | string,
+  timezone: string,
+): string | null {
+  return dateTimeParts(value, normalizeTimezone(timezone))?.date ?? null;
+}
+
+export function dateKeyToTimezoneIso(
+  date: string,
+  time: string,
+  timezone: string,
+): string {
+  return dateTimeInTimezoneToIso(date, time, normalizeTimezone(timezone));
+}
+
+export function getCalendarDayBounds(
+  day: Date,
+  timezone: string,
+): CalendarDayBounds {
+  const normalizedTimezone = normalizeTimezone(timezone);
+  const date = dateToCalendarDateKey(day);
+  return {
+    date,
+    start: new Date(dateKeyToTimezoneIso(date, "00:00", normalizedTimezone)),
+    end: new Date(
+      dateKeyToTimezoneIso(
+        addCalendarDays(date, 1),
+        "00:00",
+        normalizedTimezone,
+      ),
+    ),
+  };
+}
+
+export function getViewDateRange(
+  viewMode: "month" | "week" | "day",
+  selectedDate: Date,
+  timezone: string,
+  weekStartsOn: 0 | 1 = 0,
+): { from: string; to: string } {
+  const normalizedTimezone = normalizeTimezone(timezone);
+  const weekOptions = { weekStartsOn };
+  let rangeStart: Date;
+  let rangeEndExclusive: Date;
+
+  if (viewMode === "month") {
+    rangeStart = startOfWeek(startOfMonth(selectedDate), weekOptions);
+    rangeEndExclusive = addDays(
+      endOfWeek(endOfMonth(selectedDate), weekOptions),
+      1,
+    );
+  } else if (viewMode === "week") {
+    rangeStart = startOfWeek(selectedDate, weekOptions);
+    rangeEndExclusive = addDays(endOfWeek(selectedDate, weekOptions), 1);
+  } else {
+    rangeStart = selectedDate;
+    rangeEndExclusive = addDays(selectedDate, 1);
+  }
+
+  return {
+    from: dateKeyToTimezoneIso(
+      dateToCalendarDateKey(rangeStart),
+      "00:00",
+      normalizedTimezone,
+    ),
+    to: dateKeyToTimezoneIso(
+      dateToCalendarDateKey(rangeEndExclusive),
+      "00:00",
+      normalizedTimezone,
+    ),
+  };
+}
+
+function dateOnlyPart(value: string | undefined): string | null {
+  if (!value) return null;
+  if (DATE_ONLY_PATTERN.test(value)) return value;
+  return value.slice(0, 10);
+}
+
+function eventDateRange(
+  event: Pick<CalendarEvent, "start" | "end" | "allDay">,
+  timezone: string,
+) {
+  if (event.allDay) {
+    const startDate = dateOnlyPart(event.start);
+    const endDate =
+      dateOnlyPart(event.end) ??
+      (startDate ? addCalendarDays(startDate, 1) : null);
+    return startDate && endDate ? { startDate, endDate } : null;
+  }
+
+  const start = getDateTimePartsInTimezone(event.start, timezone);
+  const end = getDateTimePartsInTimezone(event.end, timezone);
+  return start && end ? { startDate: start.date, endDate: end.date } : null;
+}
+
+export function getEventDateKey(
+  event: Pick<CalendarEvent, "start" | "end" | "allDay">,
+  timezone: string,
+): string | null {
+  return eventDateRange(event, timezone)?.startDate ?? null;
+}
+
+export function moveEventToCalendarDate(
+  event: Pick<CalendarEvent, "start" | "end" | "allDay">,
+  targetDate: Date,
+  timezone: string,
+): { start: string; end: string } | null {
+  const targetDateKey = dateToCalendarDateKey(targetDate);
+  const sourceStartDate = getEventDateKey(event, timezone);
+  if (!sourceStartDate) return null;
+
+  if (event.allDay) {
+    const sourceEndDate =
+      dateOnlyPart(event.end) ?? addCalendarDays(sourceStartDate, 1);
+    const spanDays = Math.max(
+      1,
+      Math.round(
+        (dateKeyToDate(sourceEndDate).getTime() -
+          dateKeyToDate(sourceStartDate).getTime()) /
+          (24 * 60 * 60 * 1000),
+      ),
+    );
+    return {
+      start: targetDateKey,
+      end: addCalendarDays(targetDateKey, spanDays),
+    };
+  }
+
+  const start = getDateTimePartsInTimezone(event.start, timezone);
+  const end = getDateTimePartsInTimezone(event.end, timezone);
+  if (!start || !end) return null;
+  const spanDays = Math.max(
+    0,
+    Math.round(
+      (dateKeyToDate(end.date).getTime() -
+        dateKeyToDate(start.date).getTime()) /
+        (24 * 60 * 60 * 1000),
+    ),
+  );
+  const startTime = `${String(start.hour).padStart(2, "0")}:${String(
+    start.minute,
+  ).padStart(2, "0")}`;
+  const endTime = `${String(end.hour).padStart(2, "0")}:${String(
+    end.minute,
+  ).padStart(2, "0")}`;
+  return {
+    start: dateKeyToTimezoneIso(targetDateKey, startTime, timezone),
+    end: dateKeyToTimezoneIso(
+      addCalendarDays(targetDateKey, spanDays),
+      endTime,
+      timezone,
+    ),
+  };
+}
+
+export function eventOverlapsCalendarDay(
+  event: Pick<CalendarEvent, "start" | "end" | "allDay">,
+  day: Date,
+  timezone: string,
+): boolean {
+  const normalizedTimezone = normalizeTimezone(timezone);
+  const dayBounds = getCalendarDayBounds(day, normalizedTimezone);
+  if (event.allDay) {
+    const range = eventDateRange(event, normalizedTimezone);
+    const dayDate = dayBounds.date;
+    return Boolean(
+      range && range.startDate <= dayDate && range.endDate > dayDate,
+    );
+  }
+
+  const start = new Date(event.start);
+  const end = new Date(event.end);
+  return (
+    !Number.isNaN(start.getTime()) &&
+    !Number.isNaN(end.getTime()) &&
+    start < dayBounds.end &&
+    end > dayBounds.start
+  );
+}
+
+function clockMinutes(parts: CalendarDateTimeParts): number {
+  return parts.hour * 60 + parts.minute + parts.second / 60;
+}
+
+export function getEventSegmentForCalendarDay(
+  event: Pick<CalendarEvent, "start" | "end">,
+  day: Date,
+  timezone: string,
+): CalendarEventSegment | null {
+  const normalizedTimezone = normalizeTimezone(timezone);
+  const dayBounds = getCalendarDayBounds(day, normalizedTimezone);
+  const rawStart = new Date(event.start);
+  const rawEnd = new Date(event.end);
+  if (
+    Number.isNaN(rawStart.getTime()) ||
+    Number.isNaN(rawEnd.getTime()) ||
+    rawStart >= dayBounds.end ||
+    rawEnd <= dayBounds.start
+  ) {
+    return null;
+  }
+
+  const start = getDateTimePartsInTimezone(rawStart, normalizedTimezone);
+  const end = getDateTimePartsInTimezone(rawEnd, normalizedTimezone);
+  if (!start || !end) return null;
+
+  const startMinutes =
+    start.date < dayBounds.date
+      ? 0
+      : start.date > dayBounds.date
+        ? 24 * 60
+        : clockMinutes(start);
+  const endMinutes =
+    end.date > dayBounds.date
+      ? 24 * 60
+      : end.date < dayBounds.date
+        ? 0
+        : clockMinutes(end);
+  const visibleStart = Math.max(0, Math.min(24 * 60, startMinutes));
+  const visibleEnd = Math.max(visibleStart, Math.min(24 * 60, endMinutes));
+
+  return {
+    topMinutes: visibleStart,
+    durationMinutes: Math.max(1, visibleEnd - visibleStart),
+    startsOnDay: start.date === dayBounds.date,
+    endsOnDay: end.date === dayBounds.date,
+    startMinutes: visibleStart,
+    endMinutes: visibleEnd,
+  };
+}

--- a/templates/calendar/app/lib/calendar-timezone.ts
+++ b/templates/calendar/app/lib/calendar-timezone.ts
@@ -46,8 +46,9 @@ export function isValidTimezone(timezone: string): boolean {
   try {
     new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof RangeError) return false;
+    throw error;
   }
 }
 
@@ -104,8 +105,9 @@ function dateTimeParts(value: Date | string, timezone: string) {
       minute: Number(minute),
       second: Number(second),
     } satisfies CalendarDateTimeParts;
-  } catch {
-    return null;
+  } catch (error) {
+    if (error instanceof RangeError) return null;
+    throw error;
   }
 }
 

--- a/templates/calendar/app/lib/event-layout.test.ts
+++ b/templates/calendar/app/lib/event-layout.test.ts
@@ -157,4 +157,28 @@ describe("computeTimedEventLayout", () => {
       indent: 16,
     });
   });
+
+  it("uses the pinned timezone across a DST boundary", () => {
+    const overnight = event("overnight-dst", "00:00", "10:00");
+    overnight.start = "2026-03-08T06:30:00.000Z";
+    overnight.end = "2026-03-08T08:30:00.000Z";
+    const later = event("later-dst", "00:00", "01:00");
+    later.start = "2026-03-08T07:00:00.000Z";
+    later.end = "2026-03-08T07:30:00.000Z";
+
+    const layout = computeTimedEventLayout(
+      [overnight, later],
+      new Date(2026, 2, 8, 12),
+      "America/New_York",
+    );
+
+    expect(layout.get("overnight-dst")).toMatchObject({
+      col: 0,
+      totalCols: 2,
+    });
+    expect(layout.get("later-dst")).toMatchObject({
+      col: 1,
+      totalCols: 2,
+    });
+  });
 });

--- a/templates/calendar/app/lib/event-layout.ts
+++ b/templates/calendar/app/lib/event-layout.ts
@@ -1,5 +1,9 @@
 import type { CalendarEvent } from "@shared/api";
-import { addDays, parseISO, startOfDay } from "date-fns";
+
+import {
+  getBrowserTimezone,
+  getEventSegmentForCalendarDay,
+} from "@/lib/calendar-timezone";
 
 export interface TimedEventLayout {
   left: number;
@@ -35,21 +39,23 @@ function overlaps(a: EventBounds, b: EventBounds): boolean {
 export function computeTimedEventLayout(
   dayEvents: readonly CalendarEvent[],
   day: Date,
+  timezone: string = getBrowserTimezone(),
 ): Map<string, TimedEventLayout> {
   const result = new Map<string, TimedEventLayout>();
   if (dayEvents.length === 0) return result;
 
-  const dayStartMs = startOfDay(day).getTime();
-  const dayEndMs = addDays(startOfDay(day), 1).getTime();
   const entries = dayEvents.map<EventEntry>((event, inputOrder) => {
-    const rawStart = parseISO(event.start).getTime();
-    const rawEnd = parseISO(event.end).getTime();
-    const start = Math.min(dayEndMs, Math.max(dayStartMs, rawStart));
+    const segment = getEventSegmentForCalendarDay(event, day, timezone);
+    const start = segment?.startMinutes ?? 0;
     // Match the card renderer's minimum height so tiny adjacent events get
     // collision-aware placement even when their raw times barely overlap.
     const end = Math.min(
-      dayEndMs,
-      Math.max(start, rawEnd, start + MIN_VISIBLE_EVENT_MINUTES * 60 * 1000),
+      24 * 60,
+      Math.max(
+        start,
+        segment?.endMinutes ?? start,
+        start + MIN_VISIBLE_EVENT_MINUTES,
+      ),
     );
 
     return { event, bounds: { start, end }, inputOrder };

--- a/templates/calendar/app/lib/out-of-office.test.ts
+++ b/templates/calendar/app/lib/out-of-office.test.ts
@@ -63,6 +63,24 @@ describe("out-of-office display", () => {
     );
   });
 
+  it("uses the pinned timezone for a DST-crossing visible segment", () => {
+    expect(
+      getOutOfOfficeSegment(
+        {
+          start: "2026-03-08T06:30:00.000Z",
+          end: "2026-03-08T08:30:00.000Z",
+        },
+        new Date(2026, 2, 8, 12),
+        "America/New_York",
+      ),
+    ).toEqual({
+      topMinutes: 90,
+      durationMinutes: 180,
+      startsOnDay: true,
+      endsOnDay: true,
+    });
+  });
+
   it("keeps partial-day and ordinary midnight events out of the all-day lane", () => {
     expect(
       isFullDayOutOfOfficeEvent({

--- a/templates/calendar/app/lib/out-of-office.ts
+++ b/templates/calendar/app/lib/out-of-office.ts
@@ -1,13 +1,12 @@
 import type { CalendarEvent } from "@shared/api";
-import {
-  addDays,
-  differenceInMinutes,
-  format,
-  parseISO,
-  startOfDay,
-} from "date-fns";
 
-import { dateTimeInTimezoneToIso } from "@/lib/event-form-utils";
+import {
+  dateKeyToTimezoneIso,
+  dateToCalendarDateKey,
+  getBrowserTimezone,
+  getDateTimePartsInTimezone,
+  getEventSegmentForCalendarDay,
+} from "@/lib/calendar-timezone";
 
 export interface OutOfOfficeSegment {
   topMinutes: number;
@@ -20,34 +19,6 @@ export function isOutOfOfficeEvent(
   event: Pick<CalendarEvent, "eventType">,
 ): boolean {
   return event.eventType === "outOfOffice";
-}
-
-function localDateTimeParts(value: string, timeZone: string) {
-  const date = parseISO(value);
-  if (Number.isNaN(date.getTime())) return null;
-
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-    }).formatToParts(date);
-    const valueFor = (type: Intl.DateTimeFormatPartTypes) =>
-      parts.find((part) => part.type === type)?.value;
-    const year = valueFor("year");
-    const month = valueFor("month");
-    const day = valueFor("day");
-    const hour = valueFor("hour");
-    const minute = valueFor("minute");
-    if (!year || !month || !day || !hour || !minute) return null;
-    return { date: `${year}-${month}-${day}`, hour, minute };
-  } catch {
-    return null;
-  }
 }
 
 export function isFullDayOutOfOfficeEvent(
@@ -68,19 +39,15 @@ export function getFullDayOutOfOfficeDateRange(
   if (!isOutOfOfficeEvent(event) || event.allDay) return null;
   const timeZone = event.startTimeZone ?? event.endTimeZone;
   if (!timeZone) return null;
-  const start = localDateTimeParts(event.start, timeZone);
-  const end = localDateTimeParts(event.end, timeZone);
+  const start = getDateTimePartsInTimezone(event.start, timeZone);
+  const end = getDateTimePartsInTimezone(event.end, timeZone);
   const isFullDay =
     start !== null &&
     end !== null &&
     new Date(event.start).getTime() ===
-      new Date(
-        dateTimeInTimezoneToIso(start.date, "00:00", timeZone),
-      ).getTime() &&
+      new Date(dateKeyToTimezoneIso(start.date, "00:00", timeZone)).getTime() &&
     new Date(event.end).getTime() ===
-      new Date(
-        dateTimeInTimezoneToIso(end.date, "00:00", timeZone),
-      ).getTime() &&
+      new Date(dateKeyToTimezoneIso(end.date, "00:00", timeZone)).getTime() &&
     end.date > start.date;
   return isFullDay
     ? { startDate: start.date, endDateExclusive: end.date }
@@ -96,36 +63,37 @@ export function fullDayOutOfOfficeCoversDate(
 ): boolean {
   const range = getFullDayOutOfOfficeDateRange(event);
   if (!range) return false;
-  const dateString = format(date, "yyyy-MM-dd");
+  const dateString = dateToCalendarDateKey(date);
   return dateString >= range.startDate && dateString < range.endDateExclusive;
 }
 
 /** Return the portion of a timed out-of-office event visible on one day. */
 export function getOutOfOfficeSegment(
-  event: Pick<CalendarEvent, "start" | "end">,
+  event: Pick<CalendarEvent, "start" | "end" | "startTimeZone" | "endTimeZone">,
   day: Date,
+  timezone: string = event.startTimeZone ??
+    event.endTimeZone ??
+    getBrowserTimezone(),
 ): OutOfOfficeSegment | null {
-  const eventStart = parseISO(event.start);
-  const eventEnd = parseISO(event.end);
-  const dayStart = startOfDay(day);
-  const dayEnd = addDays(dayStart, 1);
-
-  if (eventStart >= dayEnd || eventEnd <= dayStart) return null;
-
-  const segmentStart = eventStart > dayStart ? eventStart : dayStart;
-  const segmentEnd = eventEnd < dayEnd ? eventEnd : dayEnd;
+  const segment = getEventSegmentForCalendarDay(event, day, timezone);
+  if (!segment) return null;
 
   return {
-    topMinutes: Math.max(0, differenceInMinutes(segmentStart, dayStart)),
-    durationMinutes: Math.max(1, differenceInMinutes(segmentEnd, segmentStart)),
-    startsOnDay: eventStart >= dayStart && eventStart < dayEnd,
-    endsOnDay: eventEnd > dayStart && eventEnd <= dayEnd,
+    topMinutes: segment.topMinutes,
+    durationMinutes: segment.durationMinutes,
+    startsOnDay: segment.startsOnDay,
+    endsOnDay: segment.endsOnDay,
   };
 }
 
 export function getFirstVisibleOutOfOfficeDayIndex(
-  event: Pick<CalendarEvent, "start" | "end">,
+  event: Pick<CalendarEvent, "start" | "end" | "startTimeZone" | "endTimeZone">,
   days: Date[],
+  timezone: string = event.startTimeZone ??
+    event.endTimeZone ??
+    getBrowserTimezone(),
 ): number {
-  return days.findIndex((day) => getOutOfOfficeSegment(event, day) !== null);
+  return days.findIndex(
+    (day) => getOutOfOfficeSegment(event, day, timezone) !== null,
+  );
 }

--- a/templates/calendar/app/lib/working-location.test.ts
+++ b/templates/calendar/app/lib/working-location.test.ts
@@ -1,14 +1,17 @@
 import type { CalendarEvent } from "@shared/api";
 import { describe, expect, it } from "vitest";
 
+import { dateKeyToDate } from "./calendar-timezone";
 import {
   buildWorkingLocationProperties,
   buildWorkingLocationUpdate,
   createWorkingLocationDisplayLabels,
+  findOwnedWorkingLocationForDay,
   getWorkingLocationChipLabel,
   getWorkingLocationDetail,
   getWorkingLocationEditableLabel,
   getWorkingLocationTitle,
+  isWorkingLocationDraftReadyToCreate,
 } from "./working-location";
 
 const translatedLabels = createWorkingLocationDisplayLabels((key, values) => {
@@ -123,6 +126,21 @@ describe("working location display helpers", () => {
     );
   });
 
+  it("does not let a generated summary hide an unlabeled office", () => {
+    const office = event({
+      title: "Working location",
+      eventType: "workingLocation",
+      workingLocationProperties: {
+        type: "officeLocation",
+        officeLocation: {},
+      },
+    });
+
+    expect(getWorkingLocationChipLabel(office, translatedLabels)).toBe(
+      "Oficina",
+    );
+  });
+
   it("uses native labels as editable values without summary fallbacks", () => {
     expect(
       getWorkingLocationEditableLabel({
@@ -213,5 +231,118 @@ describe("working location display helpers", () => {
       type: "customLocation",
       customLocation: { label: "Neighborhood cafe" },
     });
+  });
+});
+
+describe("working location create readiness", () => {
+  it("allows unlabeled office drafts and requires a name for Other", () => {
+    expect(
+      isWorkingLocationDraftReadyToCreate(
+        event({
+          eventType: "workingLocation",
+          workingLocationProperties: {
+            type: "officeLocation",
+            officeLocation: {},
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isWorkingLocationDraftReadyToCreate(
+        event({
+          eventType: "workingLocation",
+          workingLocationProperties: {
+            type: "customLocation",
+            customLocation: {},
+          },
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isWorkingLocationDraftReadyToCreate(
+        event({
+          eventType: "workingLocation",
+          workingLocationProperties: {
+            type: "customLocation",
+            customLocation: { label: "Cafe" },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("findOwnedWorkingLocationForDay", () => {
+  it("returns the owned Google location on that day, not overlays or adjacent days", () => {
+    const home = event({
+      id: "home-thu",
+      start: "2026-08-13",
+      end: "2026-08-14",
+      eventType: "workingLocation",
+      workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+      accountEmail: "owner@example.com",
+    });
+    const overlay = event({
+      id: "overlay-thu",
+      start: "2026-08-13",
+      end: "2026-08-14",
+      eventType: "workingLocation",
+      overlayEmail: "teammate@example.com",
+      workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+    });
+    const friday = event({
+      id: "home-fri",
+      start: "2026-08-14",
+      end: "2026-08-15",
+      eventType: "workingLocation",
+      workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+      accountEmail: "owner@example.com",
+    });
+
+    expect(
+      findOwnedWorkingLocationForDay(
+        [overlay, friday, home],
+        dateKeyToDate("2026-08-13"),
+        "America/Chicago",
+        "owner@example.com",
+      )?.id,
+    ).toBe("home-thu");
+    expect(
+      findOwnedWorkingLocationForDay(
+        [overlay, friday, home],
+        dateKeyToDate("2026-08-15"),
+        "America/Chicago",
+        "owner@example.com",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("prefers a Google event over a local draft on the same day", () => {
+    const draft = event({
+      id: "calendar-draft-event:slot-working-location-1",
+      source: "local",
+      start: "2026-08-13",
+      end: "2026-08-14",
+      eventType: "workingLocation",
+      workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+      accountEmail: "owner@example.com",
+    });
+    const google = event({
+      id: "google-home",
+      start: "2026-08-13",
+      end: "2026-08-14",
+      eventType: "workingLocation",
+      workingLocationProperties: { type: "homeOffice", homeOffice: {} },
+      accountEmail: "owner@example.com",
+    });
+
+    expect(
+      findOwnedWorkingLocationForDay(
+        [draft, google],
+        dateKeyToDate("2026-08-13"),
+        "America/Chicago",
+        "owner@example.com",
+      )?.id,
+    ).toBe("google-home");
   });
 });

--- a/templates/calendar/app/lib/working-location.ts
+++ b/templates/calendar/app/lib/working-location.ts
@@ -1,5 +1,7 @@
 import type { CalendarEvent, UpdateEventScope } from "@shared/api";
 
+import { eventOverlapsCalendarDay } from "@/lib/calendar-timezone";
+
 export type WorkingLocationKind =
   | "homeOffice"
   | "officeLocation"
@@ -64,14 +66,12 @@ export function getWorkingLocationLabel(
       properties.officeLocation?.label ||
       properties.officeLocation?.buildingId ||
       event.location ||
-      event.title ||
       labels.office
     );
   }
   return (
     properties?.customLocation?.label ||
     event.location ||
-    event.title ||
     labels.workingLocation
   );
 }
@@ -145,6 +145,38 @@ export function getWorkingLocationTitle(
   return isWorkingLocationEvent(event)
     ? labels.title(getWorkingLocationLabel(event, labels))
     : event.title;
+}
+
+export function isWorkingLocationDraftReadyToCreate(
+  event: Pick<
+    CalendarEvent,
+    "eventType" | "location" | "workingLocationProperties"
+  >,
+): boolean {
+  if (!isWorkingLocationEvent(event)) return true;
+  if (getWorkingLocationType(event) !== "customLocation") return true;
+  return getWorkingLocationEditableLabel(event).trim().length > 0;
+}
+
+export function findOwnedWorkingLocationForDay(
+  events: readonly CalendarEvent[],
+  day: Date,
+  timezone: string,
+  accountEmail?: string,
+): CalendarEvent | undefined {
+  const matches = events.filter((event) => {
+    if (!isWorkingLocationEvent(event)) return false;
+    if (event.overlayEmail) return false;
+    if (
+      accountEmail &&
+      event.accountEmail &&
+      event.accountEmail !== accountEmail
+    ) {
+      return false;
+    }
+    return eventOverlapsCalendarDay(event, day, timezone);
+  });
+  return matches.find((event) => event.source === "google") ?? matches[0];
 }
 
 export function getWorkingLocationDetail(

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -18,8 +18,6 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import {
   format,
-  startOfMonth,
-  endOfMonth,
   startOfWeek,
   endOfWeek,
   addMonths,
@@ -28,8 +26,6 @@ import {
   subWeeks,
   addDays,
   subDays,
-  parseISO,
-  startOfDay,
 } from "date-fns";
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router";
@@ -48,6 +44,7 @@ import {
 } from "@/components/calendar/GuestNotificationDialog";
 import { MonthView } from "@/components/calendar/MonthView";
 import { PeopleSearchDialog } from "@/components/calendar/PeopleSearchDialog";
+import { TimezoneSwitchDialog } from "@/components/calendar/TimezoneSwitchDialog";
 import { WeekView } from "@/components/calendar/WeekView";
 import { useCalendarContext } from "@/components/layout/AppLayout";
 import type { ViewMode } from "@/components/layout/AppLayout";
@@ -81,9 +78,22 @@ import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useMeetingStartNotifications } from "@/hooks/use-meeting-start-notifications";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
-import { useSettings } from "@/hooks/use-settings";
+import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
 import { setUndoAction, runUndo } from "@/hooks/use-undo";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
+import { buildWorkingLocationDraft } from "@/lib/calendar-drafts";
+import {
+  addCalendarDays,
+  dateKeyToDate,
+  dateKeyToTimezoneIso,
+  dateToCalendarDateKey,
+  eventOverlapsCalendarDay,
+  getBrowserTimezone,
+  getDateKeyInTimezone,
+  getEventDateKey,
+  getViewDateRange,
+  moveEventToCalendarDate,
+} from "@/lib/calendar-timezone";
 import { resolveEventAccountEmail } from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
 import {
@@ -97,8 +107,19 @@ import { buildDeleteEventMutationInput } from "@/lib/event-mutation-inputs";
 import { getLocationSuggestions } from "@/lib/location-suggestions";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { cn } from "@/lib/utils";
+import {
+  buildWorkingLocationProperties,
+  findOwnedWorkingLocationForDay,
+} from "@/lib/working-location";
 
 const CALENDAR_DRAFT_EVENT_PREFIX = "calendar-draft-event:";
+const TIMEZONE_DISMISSAL_PREFIX = "calendar.timezone.dismissed.";
+
+function timezoneDismissalKey(savedTimezone: string, browserTimezone: string) {
+  return `${TIMEZONE_DISMISSAL_PREFIX}${encodeURIComponent(
+    savedTimezone,
+  )}:${encodeURIComponent(browserTimezone)}`;
+}
 
 type DraftEventPatch = Partial<CalendarEvent> & {
   fullDay?: boolean;
@@ -176,6 +197,14 @@ function draftRange(draft: CalendarEventDraft, fallbackDate: Date) {
   const fallback = fallbackDraftRange(fallbackDate);
   const fullDayTimezone = draft.startTimeZone ?? draft.endTimeZone;
   const fullDayDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+  const dateOnlyAllDay =
+    draft.allDay === true &&
+    Boolean(
+      draft.start &&
+      draft.end &&
+      fullDayDatePattern.test(draft.start) &&
+      fullDayDatePattern.test(draft.end),
+    );
   const semanticFullDay =
     draft.eventType === "outOfOffice" &&
     draft.fullDay &&
@@ -184,18 +213,24 @@ function draftRange(draft: CalendarEventDraft, fallbackDate: Date) {
     draft.end &&
     fullDayDatePattern.test(draft.start) &&
     fullDayDatePattern.test(draft.end);
-  const start = semanticFullDay
-    ? new Date(dateTimeInTimezoneToIso(draft.start!, "00:00", fullDayTimezone!))
-    : (parseValidDate(draft.start) ?? fallback.start);
-  const parsedEnd = semanticFullDay
-    ? new Date(
-        dateTimeInTimezoneToIso(
-          format(addDays(parseISO(draft.end!), 1), "yyyy-MM-dd"),
-          "00:00",
-          fullDayTimezone!,
-        ),
-      )
-    : parseValidDate(draft.end);
+  const start = dateOnlyAllDay
+    ? dateKeyToDate(draft.start!)
+    : semanticFullDay
+      ? new Date(
+          dateTimeInTimezoneToIso(draft.start!, "00:00", fullDayTimezone!),
+        )
+      : (parseValidDate(draft.start) ?? fallback.start);
+  const parsedEnd = dateOnlyAllDay
+    ? dateKeyToDate(draft.end!)
+    : semanticFullDay
+      ? new Date(
+          dateTimeInTimezoneToIso(
+            addCalendarDays(draft.end!, 1),
+            "00:00",
+            fullDayTimezone!,
+          ),
+        )
+      : parseValidDate(draft.end);
   const end =
     parsedEnd && parsedEnd.getTime() > start.getTime()
       ? parsedEnd
@@ -209,24 +244,36 @@ function draftToCalendarEvent(
 ): CalendarEvent {
   const { start, end } = draftRange(draft, fallbackDate);
   const editableTitle = draft.title?.trim() ?? "";
+  const allDay =
+    draft.eventType === "outOfOffice" && draft.fullDay
+      ? false
+      : (draft.allDay ?? false);
+  const dateOnlyAllDay =
+    allDay &&
+    Boolean(
+      draft.start &&
+      draft.end &&
+      /^\d{4}-\d{2}-\d{2}$/.test(draft.start) &&
+      /^\d{4}-\d{2}-\d{2}$/.test(draft.end),
+    );
+  const workingLocationType = draft.workingLocationType ?? "homeOffice";
   return {
     id: calendarDraftEventId(draft.id),
     title:
       editableTitle ||
       (draft.eventType === "outOfOffice"
         ? "Out of office"
-        : UNNAMED_EVENT_TITLE),
+        : draft.eventType === "workingLocation"
+          ? "Working location"
+          : UNNAMED_EVENT_TITLE),
     titleIsGenerated: !editableTitle,
     description: draft.description ?? "",
-    start: start.toISOString(),
-    end: end.toISOString(),
+    start: dateOnlyAllDay ? draft.start! : start.toISOString(),
+    end: dateOnlyAllDay ? draft.end! : end.toISOString(),
     startTimeZone: draft.startTimeZone,
     endTimeZone: draft.endTimeZone ?? draft.startTimeZone,
     location: draft.location ?? draft.workingLocationLabel ?? "",
-    allDay:
-      draft.eventType === "outOfOffice" && draft.fullDay
-        ? false
-        : (draft.allDay ?? false),
+    allDay,
     source: "local",
     accountEmail: draft.accountEmail,
     colorId: draft.colorId,
@@ -234,6 +281,16 @@ function draftToCalendarEvent(
     transparency: draft.transparency,
     visibility: draft.visibility,
     eventType: draft.eventType ?? "default",
+    workingLocationProperties:
+      draft.eventType === "workingLocation"
+        ? buildWorkingLocationProperties(
+            { workingLocationProperties: undefined },
+            {
+              type: workingLocationType,
+              label: draft.workingLocationLabel ?? draft.location ?? "",
+            },
+          )
+        : undefined,
     outOfOfficeProperties: draft.outOfOfficeProperties,
     recurrence: draft.recurrence,
     attendees: draft.attendees,
@@ -273,6 +330,10 @@ function applyDraftPatch(
   copy("location");
   copy("allDay");
   copy("fullDay");
+  if (patch.allDay === true) {
+    delete next.startTimeZone;
+    delete next.endTimeZone;
+  }
   copy("eventType");
   copy("outOfOfficeProperties");
   copy("transparency");
@@ -361,6 +422,7 @@ export default function CalendarView() {
     Record<string, string>
   >({});
   const openedDraftIdRef = useRef<string | null>(null);
+  const preserveDraftViewRef = useRef(false);
   const committingDraftIdsRef = useRef<Set<string>>(new Set());
   const discardedCommittingDraftsRef = useRef<Map<string, CalendarEventDraft>>(
     new Map(),
@@ -375,6 +437,12 @@ export default function CalendarView() {
   const settingsQuery = useSettings();
   const { data: settings } = settingsQuery;
   const weekStartsOn = getWeekStartsOn(settings?.weekStart);
+  const updateSettings = useUpdateSettings();
+  const displayTimezone = settings?.timezone ?? getBrowserTimezone();
+  const [timezonePrompt, setTimezonePrompt] = useState<{
+    savedTimezone: string;
+    browserTimezone: string;
+  } | null>(null);
   const { data: rawOverlayPeople } = useOverlayPeople();
   const overlayPeople = Array.isArray(rawOverlayPeople) ? rawOverlayPeople : [];
   const overlayEmails = useMemo(
@@ -393,32 +461,83 @@ export default function CalendarView() {
     day: t("calendarView.day"),
   };
 
-  // Compute date range for query based on view
-  const { from, to } = useMemo(() => {
-    switch (viewMode) {
-      case "month": {
-        const ms = startOfMonth(selectedDate);
-        const me = endOfMonth(selectedDate);
-        return {
-          from: startOfWeek(ms, { weekStartsOn }).toISOString(),
-          to: endOfWeek(me, { weekStartsOn }).toISOString(),
-        };
+  useEffect(() => {
+    if (!settings?.timezone || typeof window === "undefined") return;
+
+    const checkBrowserTimezone = () => {
+      const browserTimezone = getBrowserTimezone();
+      if (browserTimezone === settings.timezone) {
+        setTimezonePrompt(null);
+        return;
       }
-      case "week": {
-        return {
-          from: startOfWeek(selectedDate, { weekStartsOn }).toISOString(),
-          to: endOfWeek(selectedDate, { weekStartsOn }).toISOString(),
-        };
+
+      const dismissalKey = timezoneDismissalKey(
+        settings.timezone,
+        browserTimezone,
+      );
+      try {
+        if (window.localStorage.getItem(dismissalKey) === "1") {
+          setTimezonePrompt(null);
+          return;
+        }
+      } catch (error) {
+        console.warn(
+          "Calendar timezone dismissal could not be read from local storage.",
+          error,
+        );
       }
-      case "day": {
-        const dayStart = new Date(selectedDate);
-        dayStart.setHours(0, 0, 0, 0);
-        const dayEnd = new Date(selectedDate);
-        dayEnd.setHours(23, 59, 59, 999);
-        return { from: dayStart.toISOString(), to: dayEnd.toISOString() };
-      }
+      setTimezonePrompt({
+        savedTimezone: settings.timezone,
+        browserTimezone,
+      });
+    };
+
+    checkBrowserTimezone();
+    window.addEventListener("focus", checkBrowserTimezone);
+    document.addEventListener("visibilitychange", checkBrowserTimezone);
+    return () => {
+      window.removeEventListener("focus", checkBrowserTimezone);
+      document.removeEventListener("visibilitychange", checkBrowserTimezone);
+    };
+  }, [settings?.timezone]);
+
+  const keepSavedTimezone = useCallback(() => {
+    if (!timezonePrompt) return;
+    try {
+      window.localStorage.setItem(
+        timezoneDismissalKey(
+          timezonePrompt.savedTimezone,
+          timezonePrompt.browserTimezone,
+        ),
+        "1",
+      );
+    } catch (error) {
+      console.warn(
+        "Calendar timezone dismissal could not be saved to local storage.",
+        error,
+      );
     }
-  }, [viewMode, selectedDate, weekStartsOn]);
+    setTimezonePrompt(null);
+  }, [timezonePrompt]);
+
+  const switchToBrowserTimezone = useCallback(() => {
+    if (!timezonePrompt || !settings) return;
+    updateSettings.mutate(
+      { ...settings, timezone: timezonePrompt.browserTimezone },
+      {
+        onSuccess: () => setTimezonePrompt(null),
+        onError: () => toast.error(t("settings.saveFailed")),
+      },
+    );
+  }, [settings, t, timezonePrompt, updateSettings]);
+
+  // The saved Calendar Settings timezone owns the range boundary. The browser
+  // timezone is only a temporary fallback while settings are loading.
+  const { from, to } = useMemo(
+    () =>
+      getViewDateRange(viewMode, selectedDate, displayTimezone, weekStartsOn),
+    [displayTimezone, selectedDate, viewMode, weekStartsOn],
+  );
 
   const {
     data: rawEventsData,
@@ -471,31 +590,25 @@ export default function CalendarView() {
         case "month": {
           const next = addMonths(selectedDate, 1);
           const prev = subMonths(selectedDate, 1);
-          return [next, prev].map((d) => ({
-            from: startOfWeek(startOfMonth(d), { weekStartsOn }).toISOString(),
-            to: endOfWeek(endOfMonth(d), { weekStartsOn }).toISOString(),
-          }));
+          return [next, prev].map((date) =>
+            getViewDateRange("month", date, displayTimezone, weekStartsOn),
+          );
         }
         case "week": {
           // Two weeks forward so rapid `j j` stays instant, plus one back.
           const next = addWeeks(selectedDate, 1);
           const next2 = addWeeks(selectedDate, 2);
           const prev = subWeeks(selectedDate, 1);
-          return [next, next2, prev].map((d) => ({
-            from: startOfWeek(d, { weekStartsOn }).toISOString(),
-            to: endOfWeek(d, { weekStartsOn }).toISOString(),
-          }));
+          return [next, next2, prev].map((date) =>
+            getViewDateRange("week", date, displayTimezone, weekStartsOn),
+          );
         }
         case "day": {
           const next = addDays(selectedDate, 1);
           const prev = subDays(selectedDate, 1);
-          return [next, prev].map((d) => {
-            const start = new Date(d);
-            start.setHours(0, 0, 0, 0);
-            const end = new Date(d);
-            end.setHours(23, 59, 59, 999);
-            return { from: start.toISOString(), to: end.toISOString() };
-          });
+          return [next, prev].map((date) =>
+            getViewDateRange("day", date, displayTimezone, weekStartsOn),
+          );
         }
       }
     })();
@@ -503,11 +616,12 @@ export default function CalendarView() {
       void prefetchEvents(queryClient, range.from, range.to, overlayEmails);
     }
   }, [
+    displayTimezone,
     isLoading,
-    viewMode,
-    selectedDate,
     overlayEmails,
     queryClient,
+    selectedDate,
+    viewMode,
     weekStartsOn,
   ]);
 
@@ -581,31 +695,31 @@ export default function CalendarView() {
 
   // Filter events for day view — use overlap check so multi-day continuation
   // events (started on a prior day) still appear on the selected day.
-  const dayEvents = useMemo(
-    () =>
-      viewMode === "day"
-        ? events.filter((e) => {
-            const evStart = parseISO(e.start);
-            const evEnd = parseISO(e.end);
-            const dayStart = startOfDay(selectedDate);
-            const dayEnd = addDays(dayStart, 1);
-            return evStart < dayEnd && evEnd > dayStart;
-          })
-        : events,
-    [events, viewMode, selectedDate],
-  );
+  const dayEvents = useMemo(() => {
+    if (viewMode !== "day") return events;
+    return events.filter((event) =>
+      eventOverlapsCalendarDay(event, selectedDate, displayTimezone),
+    );
+  }, [displayTimezone, events, selectedDate, viewMode]);
   const locationSuggestions = useMemo(
     () => getLocationSuggestions(events),
     [events],
   );
   const openNotificationEvent = useCallback(
     (event: CalendarEvent) => {
-      setSelectedDate(parseISO(event.start));
+      const eventDate = getEventDateKey(event, displayTimezone);
+      if (eventDate) setSelectedDate(dateKeyToDate(eventDate));
       setViewMode("day");
       setSidebarEvent(event);
       setFocusedEvent(event);
     },
-    [setFocusedEvent, setSelectedDate, setSidebarEvent, setViewMode],
+    [
+      displayTimezone,
+      setFocusedEvent,
+      setSelectedDate,
+      setSidebarEvent,
+      setViewMode,
+    ],
   );
   useMeetingStartNotifications(events, openNotificationEvent);
 
@@ -616,10 +730,17 @@ export default function CalendarView() {
     }
     if (openedDraftIdRef.current === eventDraft.id) return;
     openedDraftIdRef.current = eventDraft.id;
+    const preserveView = preserveDraftViewRef.current;
+    preserveDraftViewRef.current = false;
 
-    const { start } = draftRange(eventDraft, selectedDate);
-    setSelectedDate(start);
-    if (isMobile || viewMode === "month") {
+    const draftDate = getEventDateKey(
+      draftToCalendarEvent(eventDraft, selectedDate),
+      displayTimezone,
+    );
+    if (!preserveView && draftDate) {
+      setSelectedDate(dateKeyToDate(draftDate));
+    }
+    if (!preserveView && (isMobile || viewMode === "month")) {
       setViewMode("day");
     }
     setCreateDefaultStart(undefined);
@@ -630,6 +751,7 @@ export default function CalendarView() {
     setQuickEditEventId(calendarDraftEventId(eventDraft.id));
   }, [
     eventDraft,
+    displayTimezone,
     isMobile,
     selectedDate,
     setEventDetailSidebar,
@@ -670,7 +792,11 @@ export default function CalendarView() {
       const eventType = draft.eventType ?? "default";
       const title =
         editableTitle || (eventType === "outOfOffice" ? "Out of office" : "");
-      if (!title && !isSlotDraftId(draftId)) {
+      if (
+        !title &&
+        eventType !== "workingLocation" &&
+        !isSlotDraftId(draftId)
+      ) {
         committingDraftIdsRef.current.delete(draftId);
         toast.error(t("calendarView.addTitleBeforeCreate"));
         return;
@@ -685,11 +811,15 @@ export default function CalendarView() {
 
       const location = draft.location ?? draft.workingLocationLabel ?? "";
       const timezone = resolveEventTimezone(
-        draft.startTimeZone ?? draft.endTimeZone,
+        draft.startTimeZone ?? draft.endTimeZone ?? displayTimezone,
       );
       const semanticFullDay =
         eventType === "outOfOffice" &&
         draft.fullDay === true &&
+        /^\d{4}-\d{2}-\d{2}$/.test(draft.start ?? "") &&
+        /^\d{4}-\d{2}-\d{2}$/.test(draft.end ?? "");
+      const dateOnlyAllDay =
+        draft.allDay === true &&
         /^\d{4}-\d{2}-\d{2}$/.test(draft.start ?? "") &&
         /^\d{4}-\d{2}-\d{2}$/.test(draft.end ?? "");
       const statusPatch =
@@ -698,10 +828,15 @@ export default function CalendarView() {
           : {
               eventType,
               workingLocationType:
-                draft.workingLocationType ?? "customLocation",
+                draft.workingLocationType ??
+                (eventType === "workingLocation"
+                  ? "homeOffice"
+                  : "customLocation"),
               workingLocationLabel:
-                (draft.workingLocationType ?? "customLocation") ===
-                "customLocation"
+                (draft.workingLocationType ??
+                  (eventType === "workingLocation"
+                    ? "homeOffice"
+                    : "customLocation")) === "customLocation"
                   ? location
                   : draft.workingLocationLabel,
               autoDeclineMode:
@@ -720,8 +855,11 @@ export default function CalendarView() {
         titleIsGenerated: !editableTitle,
         description:
           eventType === "outOfOffice" ? "" : (draft.description ?? ""),
-        start: semanticFullDay ? draft.start! : start.toISOString(),
-        end: semanticFullDay ? draft.end! : end.toISOString(),
+        start:
+          semanticFullDay || dateOnlyAllDay
+            ? draft.start!
+            : start.toISOString(),
+        end: semanticFullDay || dateOnlyAllDay ? draft.end! : end.toISOString(),
         startTimeZone: draft.allDay ? undefined : timezone,
         endTimeZone: draft.allDay
           ? undefined
@@ -803,6 +941,7 @@ export default function CalendarView() {
       defaultAccountEmail,
       deleteEvent,
       eventDraft,
+      displayTimezone,
       googleStatus.data?.accounts,
       selectedDate,
       setEventDraft,
@@ -882,7 +1021,8 @@ export default function CalendarView() {
   }
 
   function handleToday() {
-    setSelectedDate(new Date());
+    const today = getDateKeyInTimezone(new Date(), displayTimezone);
+    if (today) setSelectedDate(dateKeyToDate(today));
   }
 
   const handleDateSelect = useCallback(
@@ -1047,54 +1187,24 @@ export default function CalendarView() {
     const event = events.find((e) => e.id === eventId);
     if (!event) return;
 
+    const moved = moveEventToCalendarDate(event, newDate, displayTimezone);
+    if (!moved) return;
+
     if (calendarDraftIdFromEventId(eventId)) {
-      const originalStart = parseISO(event.start);
-      const originalEnd = parseISO(event.end);
-      const newStart = new Date(originalStart);
-      const newEnd = new Date(originalEnd);
-      newStart.setFullYear(
-        newDate.getFullYear(),
-        newDate.getMonth(),
-        newDate.getDate(),
-      );
-      newEnd.setFullYear(
-        newDate.getFullYear(),
-        newDate.getMonth(),
-        newDate.getDate(),
-      );
-      updateDraftEvent(eventId, {
-        start: newStart.toISOString(),
-        end: newEnd.toISOString(),
-      });
+      updateDraftEvent(eventId, moved);
       return;
     }
 
     const oldStartISO = event.start;
     const oldEndISO = event.end;
-    const originalStart = parseISO(event.start);
-    const originalEnd = parseISO(event.end);
-    const newStart = new Date(originalStart);
-    const newEnd = new Date(originalEnd);
-
-    newStart.setFullYear(
-      newDate.getFullYear(),
-      newDate.getMonth(),
-      newDate.getDate(),
-    );
-    newEnd.setFullYear(
-      newDate.getFullYear(),
-      newDate.getMonth(),
-      newDate.getDate(),
-    );
+    const newStart = new Date(moved.start);
+    const newEnd = new Date(moved.end);
 
     // Guard against a zero/negative duration reaching the server (e.g. a
     // DST transition collapsing a short event's start/end onto each other).
     if (newEnd.getTime() <= newStart.getTime()) return;
 
-    const updates = {
-      start: newStart.toISOString(),
-      end: newEnd.toISOString(),
-    };
+    const updates = moved;
     const isRecurring = isRecurringCalendarEvent(event);
     const guestNotification = await promptGuestNotification({
       event,
@@ -1155,7 +1265,7 @@ export default function CalendarView() {
 
       if (calendarDraftIdFromEventId(eventId)) {
         const timezone = resolveEventTimezone(
-          event.startTimeZone ?? event.endTimeZone,
+          event.startTimeZone ?? event.endTimeZone ?? displayTimezone,
         );
         updateDraftEvent(eventId, {
           start: newStart.toISOString(),
@@ -1167,8 +1277,8 @@ export default function CalendarView() {
         return;
       }
 
-      const oldStart = parseISO(event.start).getTime();
-      const oldEnd = parseISO(event.end).getTime();
+      const oldStart = new Date(event.start).getTime();
+      const oldEnd = new Date(event.end).getTime();
       if (oldStart === newStart.getTime() && oldEnd === newEnd.getTime()) {
         return;
       }
@@ -1226,8 +1336,9 @@ export default function CalendarView() {
       );
     },
     [
+      displayTimezone,
       events,
-      settings,
+      displayTimezone,
       updateDraftEvent,
       promptGuestNotification,
       updateEvent,
@@ -1261,7 +1372,7 @@ export default function CalendarView() {
       setCreateDefaultStart(startTime);
       setCreateDialogOpen(false);
 
-      const dateStr = format(clickedDate, "yyyy-MM-dd");
+      const dateStr = dateToCalendarDateKey(clickedDate);
       // A drag-to-create gesture already computed the exact dragged range;
       // a plain click falls back to the user's configured default duration.
       const end = options?.explicitDuration
@@ -1298,6 +1409,53 @@ export default function CalendarView() {
       settingsQuery,
       t,
       setSelectedDate,
+      setEventDraft,
+    ],
+  );
+
+  const handleCreateWorkingLocation = useCallback(
+    (date: Date) => {
+      const existing = findOwnedWorkingLocationForDay(
+        events,
+        date,
+        displayTimezone,
+        defaultAccountEmail,
+      );
+
+      preserveDraftViewRef.current = true;
+      setCreateDefaultStart(undefined);
+      setCreateDefaultEnd(undefined);
+
+      if (existing) {
+        const existingDraftId = calendarDraftIdFromEventId(existing.id);
+        if (!existingDraftId && eventDraft) {
+          discardDraftEvent(calendarDraftEventId(eventDraft.id));
+        }
+        setQuickEditEventId(existing.id);
+        return;
+      }
+
+      if (eventDraft) {
+        discardDraftEvent(calendarDraftEventId(eventDraft.id));
+      }
+
+      const draftId = `slot-working-location-${Date.now()}`;
+      const draft = buildWorkingLocationDraft({
+        id: draftId,
+        date,
+        accountEmail: defaultAccountEmail,
+      });
+
+      persistCalendarDraft(draft);
+      setEventDraft(draft);
+      setQuickEditEventId(calendarDraftEventId(draftId));
+    },
+    [
+      defaultAccountEmail,
+      discardDraftEvent,
+      displayTimezone,
+      eventDraft,
+      events,
       setEventDraft,
     ],
   );
@@ -1806,7 +1964,9 @@ export default function CalendarView() {
               <MonthView
                 events={events}
                 selectedDate={selectedDate}
+                timezone={displayTimezone}
                 onDateSelect={handleDateSelect}
+                onCreateWorkingLocation={handleCreateWorkingLocation}
                 onDeleteEvent={handleDeleteEvent}
                 onEventDrop={handleEventDrop}
                 draftEventIds={draftEventIds}
@@ -1821,10 +1981,12 @@ export default function CalendarView() {
               <WeekView
                 events={events}
                 selectedDate={selectedDate}
+                timezone={displayTimezone}
                 onDateSelect={handleDateSelect}
                 onDeleteEvent={handleDeleteEvent}
                 onEventTimeChange={handleEventTimeChange}
                 onClickTimeSlot={handleClickTimeSlot}
+                onCreateWorkingLocation={handleCreateWorkingLocation}
                 quickEditEventId={quickEditEventId}
                 onQuickEditSave={handleQuickEditSave}
                 onQuickEditCancel={handleQuickEditCancel}
@@ -1840,9 +2002,11 @@ export default function CalendarView() {
               <DayView
                 events={dayEvents}
                 date={selectedDate}
+                timezone={displayTimezone}
                 onDeleteEvent={handleDeleteEvent}
                 onEventTimeChange={handleEventTimeChange}
                 onClickTimeSlot={handleClickTimeSlot}
+                onCreateWorkingLocation={handleCreateWorkingLocation}
                 quickEditEventId={quickEditEventId}
                 onQuickEditSave={handleQuickEditSave}
                 onQuickEditCancel={handleQuickEditCancel}
@@ -1867,6 +2031,19 @@ export default function CalendarView() {
         )}
 
         {/* Dialogs */}
+        {timezonePrompt && (
+          <TimezoneSwitchDialog
+            open
+            savedTimezone={timezonePrompt.savedTimezone}
+            browserTimezone={timezonePrompt.browserTimezone}
+            isSwitching={updateSettings.isPending}
+            onKeep={keepSavedTimezone}
+            onSwitch={switchToBrowserTimezone}
+            onOpenChange={(open) => {
+              if (!open) keepSavedTimezone();
+            }}
+          />
+        )}
         <CommandPalette
           open={commandPaletteOpen}
           onClose={() => setCommandPaletteOpen(false)}
@@ -1874,7 +2051,8 @@ export default function CalendarView() {
           onGoToDate={handleGoToDate}
           onEventClick={(event) => {
             setCommandPaletteOpen(false);
-            handleGoToDate(parseISO(event.start));
+            const eventDate = getEventDateKey(event, displayTimezone);
+            if (eventDate) handleGoToDate(dateKeyToDate(eventDate));
           }}
           onCreateEvent={() => {
             setCommandPaletteOpen(false);

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -96,6 +96,7 @@ import {
   getEventDateKey,
   getViewDateRange,
   moveEventToCalendarDate,
+  normalizeTimezone,
 } from "@/lib/calendar-timezone";
 import { resolveEventAccountEmail } from "@/lib/event-account-selection";
 import { getGoogleEventColorHex } from "@/lib/event-colors";
@@ -442,7 +443,7 @@ export default function CalendarView() {
   const { data: settings } = settingsQuery;
   const weekStartsOn = getWeekStartsOn(settings?.weekStart);
   const updateSettings = useUpdateSettings();
-  const displayTimezone = settings?.timezone ?? getBrowserTimezone();
+  const displayTimezone = normalizeTimezone(settings?.timezone);
   const [timezonePrompt, setTimezonePrompt] = useState<{
     savedTimezone: string;
     browserTimezone: string;

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -81,7 +81,10 @@ import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
 import { setUndoAction, runUndo } from "@/hooks/use-undo";
 import { useViewPreferences } from "@/hooks/use-view-preferences";
-import { buildWorkingLocationDraft } from "@/lib/calendar-drafts";
+import {
+  buildWorkingLocationDraft,
+  resolveDraftWorkingLocation,
+} from "@/lib/calendar-drafts";
 import {
   addCalendarDays,
   dateKeyToDate,
@@ -256,7 +259,8 @@ function draftToCalendarEvent(
       /^\d{4}-\d{2}-\d{2}$/.test(draft.start) &&
       /^\d{4}-\d{2}-\d{2}$/.test(draft.end),
     );
-  const workingLocationType = draft.workingLocationType ?? "homeOffice";
+  const { workingLocationType, workingLocationLabel } =
+    resolveDraftWorkingLocation(draft);
   return {
     id: calendarDraftEventId(draft.id),
     title:
@@ -272,7 +276,7 @@ function draftToCalendarEvent(
     end: dateOnlyAllDay ? draft.end! : end.toISOString(),
     startTimeZone: draft.startTimeZone,
     endTimeZone: draft.endTimeZone ?? draft.startTimeZone,
-    location: draft.location ?? draft.workingLocationLabel ?? "",
+    location: draft.location || workingLocationLabel,
     allDay,
     source: "local",
     accountEmail: draft.accountEmail,
@@ -287,7 +291,7 @@ function draftToCalendarEvent(
             { workingLocationProperties: undefined },
             {
               type: workingLocationType,
-              label: draft.workingLocationLabel ?? draft.location ?? "",
+              label: workingLocationLabel,
             },
           )
         : undefined,
@@ -809,7 +813,12 @@ export default function CalendarView() {
         return;
       }
 
-      const location = draft.location ?? draft.workingLocationLabel ?? "";
+      const { workingLocationType, workingLocationLabel } =
+        resolveDraftWorkingLocation(draft);
+      const location =
+        eventType === "workingLocation"
+          ? workingLocationLabel
+          : (draft.location ?? "");
       const timezone = resolveEventTimezone(
         draft.startTimeZone ?? draft.endTimeZone ?? displayTimezone,
       );
@@ -827,18 +836,8 @@ export default function CalendarView() {
           ? {}
           : {
               eventType,
-              workingLocationType:
-                draft.workingLocationType ??
-                (eventType === "workingLocation"
-                  ? "homeOffice"
-                  : "customLocation"),
-              workingLocationLabel:
-                (draft.workingLocationType ??
-                  (eventType === "workingLocation"
-                    ? "homeOffice"
-                    : "customLocation")) === "customLocation"
-                  ? location
-                  : draft.workingLocationLabel,
+              workingLocationType,
+              workingLocationLabel,
               autoDeclineMode:
                 eventType === "outOfOffice"
                   ? draft.outOfOfficeProperties?.autoDeclineMode

--- a/templates/calendar/changelog/2026-08-13-calendar-stays-pinned-to-the-saved-timezone-and-asks-before-.md
+++ b/templates/calendar/changelog/2026-08-13-calendar-stays-pinned-to-the-saved-timezone-and-asks-before-.md
@@ -1,0 +1,6 @@
+---
+type: changed
+date: 2026-08-13
+---
+
+Calendar stays pinned to the saved timezone and asks before adopting a changed browser timezone

--- a/templates/calendar/changelog/2026-08-13-working-locations-can-be-added-from-calendar-days-with-a-ful.md
+++ b/templates/calendar/changelog/2026-08-13-working-locations-can-be-added-from-calendar-days-with-a-ful.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-08-13
+---
+
+Working locations can be added from calendar days, with a full-day first entry and timed same-day additions

--- a/templates/calendar/changelog/2026-08-14-choosing-office-or-other-when-adding-a-working-location-creates.md
+++ b/templates/calendar/changelog/2026-08-14-choosing-office-or-other-when-adding-a-working-location-creates.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-14
+---
+
+Choosing Office or Other when adding a working location creates that type, and adding one on a day that already has a location updates that day instead of extending Home.

--- a/templates/calendar/changelog/2026-08-14-creating-an-other-working-location-now-keeps-the-custom-name.md
+++ b/templates/calendar/changelog/2026-08-14-creating-an-other-working-location-now-keeps-the-custom-name.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-14
+---
+
+Creating an Other working location now keeps the custom name instead of saving it as Working.

--- a/templates/calendar/changelog/2026-08-14-timed-working-locations-keep-home-office-or-custom-titles.md
+++ b/templates/calendar/changelog/2026-08-14-timed-working-locations-keep-home-office-or-custom-titles.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-14
+---
+
+Timed working locations keep a Home, Office, or custom title instead of the generated Working location label.

--- a/templates/calendar/changelog/2026-08-14-timed-working-locations-now-keep-a-home-office-or-custom-title.md
+++ b/templates/calendar/changelog/2026-08-14-timed-working-locations-now-keep-a-home-office-or-custom-title.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-14
+---
+
+Timed working locations now keep a Home, Office, or custom title instead of showing as Untitled.

--- a/templates/calendar/changelog/2026-08-14-turning-a-midnight-ending-working-location-back-to-all-day.md
+++ b/templates/calendar/changelog/2026-08-14-turning-a-midnight-ending-working-location-back-to-all-day.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-14
+---
+
+Turning a timed working location that ends at midnight back to all-day no longer adds an extra day.

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -858,15 +858,15 @@ describe("calendar event creation", () => {
     );
   });
 
-  it("lets Google derive the summary for working-location events", async () => {
+  it("lets Google derive the summary for titleless multi-day working locations", async () => {
     await createEvent(
       {
         id: "",
-        title: "Neighborhood cafe",
+        title: "",
         description: "",
         location: "",
         start: "2026-07-08",
-        end: "2026-07-09",
+        end: "2026-07-11",
         allDay: true,
         source: "google",
         accountEmail: "steve@example.com",
@@ -893,7 +893,7 @@ describe("calendar event creation", () => {
       "primary",
       expect.objectContaining({
         start: { date: "2026-07-08" },
-        end: { date: "2026-07-09" },
+        end: { date: "2026-07-11" },
         workingLocationProperties: {
           type: "customLocation",
           customLocation: { label: "Neighborhood cafe" },
@@ -905,6 +905,56 @@ describe("calendar event creation", () => {
     expect(body).not.toHaveProperty("summary");
     expect(body).not.toHaveProperty("description");
     expect(body).not.toHaveProperty("location");
+  });
+
+  it("sends a Home/Office summary for timed working locations so they are not Untitled", async () => {
+    await createEvent(
+      {
+        id: "",
+        title: "",
+        description: "",
+        location: "",
+        start: "2026-08-14T16:00:00.000Z",
+        end: "2026-08-15T00:00:00.000Z",
+        startTimeZone: "America/Los_Angeles",
+        endTimeZone: "America/Los_Angeles",
+        allDay: false,
+        source: "google",
+        accountEmail: "steve@example.com",
+        transparency: "transparent",
+        visibility: "public",
+        eventType: "workingLocation",
+        workingLocationProperties: {
+          type: "officeLocation",
+          officeLocation: {},
+        },
+        createdAt: "2026-08-14T00:00:00.000Z",
+        updatedAt: "2026-08-14T00:00:00.000Z",
+      },
+      {
+        account: {
+          ownerEmail: "steve@example.com",
+          accountEmail: "steve@example.com",
+        },
+      },
+    );
+
+    expect(calendarInsertEventMock).toHaveBeenCalledWith(
+      "access-token",
+      "primary",
+      expect.objectContaining({
+        summary: "Office",
+        start: {
+          dateTime: "2026-08-14T16:00:00.000Z",
+          timeZone: "America/Los_Angeles",
+        },
+        workingLocationProperties: {
+          type: "officeLocation",
+          officeLocation: {},
+        },
+      }),
+      undefined,
+    );
   });
 
   it("serializes full-day OOO semantics as timed Google event bounds", async () => {

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -957,6 +957,49 @@ describe("calendar event creation", () => {
     );
   });
 
+  it("ignores a generated Working location title for timed Home/Office summaries", async () => {
+    await createEvent(
+      {
+        id: "",
+        title: "Working location",
+        titleIsGenerated: true,
+        description: "",
+        location: "",
+        start: "2026-08-14T16:00:00.000Z",
+        end: "2026-08-15T00:00:00.000Z",
+        startTimeZone: "America/Los_Angeles",
+        endTimeZone: "America/Los_Angeles",
+        allDay: false,
+        source: "google",
+        accountEmail: "steve@example.com",
+        transparency: "transparent",
+        visibility: "public",
+        eventType: "workingLocation",
+        workingLocationProperties: {
+          type: "homeOffice",
+          homeOffice: {},
+        },
+        createdAt: "2026-08-14T00:00:00.000Z",
+        updatedAt: "2026-08-14T00:00:00.000Z",
+      },
+      {
+        account: {
+          ownerEmail: "steve@example.com",
+          accountEmail: "steve@example.com",
+        },
+      },
+    );
+
+    expect(calendarInsertEventMock).toHaveBeenCalledWith(
+      "access-token",
+      "primary",
+      expect.objectContaining({
+        summary: "Home",
+      }),
+      undefined,
+    );
+  });
+
   it("serializes full-day OOO semantics as timed Google event bounds", async () => {
     await createEvent(
       {

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1211,8 +1211,6 @@ export async function getEvent(
 
 function timedWorkingLocationSummary(event: CalendarEvent): string | undefined {
   if (event.eventType !== "workingLocation" || event.allDay) return undefined;
-  const trimmed = event.title?.trim();
-  if (trimmed) return trimmed;
   const properties = event.workingLocationProperties;
   if (properties?.type === "officeLocation") {
     return properties.officeLocation?.label || "Office";
@@ -1220,6 +1218,9 @@ function timedWorkingLocationSummary(event: CalendarEvent): string | undefined {
   if (properties?.type === "customLocation") {
     return properties.customLocation?.label || "Working location";
   }
+  if (properties?.type === "homeOffice") return "Home";
+  const trimmed = event.title?.trim();
+  if (trimmed && !event.titleIsGenerated) return trimmed;
   return "Home";
 }
 

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1209,6 +1209,20 @@ export async function getEvent(
   };
 }
 
+function timedWorkingLocationSummary(event: CalendarEvent): string | undefined {
+  if (event.eventType !== "workingLocation" || event.allDay) return undefined;
+  const trimmed = event.title?.trim();
+  if (trimmed) return trimmed;
+  const properties = event.workingLocationProperties;
+  if (properties?.type === "officeLocation") {
+    return properties.officeLocation?.label || "Office";
+  }
+  if (properties?.type === "customLocation") {
+    return properties.customLocation?.label || "Working location";
+  }
+  return "Home";
+}
+
 export async function createEvent(
   event: CalendarEvent,
   opts: {
@@ -1230,9 +1244,15 @@ export async function createEvent(
     throw new Error("Out of office and focus time events must be timed.");
   }
 
+  const workingLocationSummary = timedWorkingLocationSummary(event);
   const body: any =
     event.eventType === "workingLocation"
-      ? buildDateRange(event)
+      ? {
+          ...buildDateRange(event),
+          ...(workingLocationSummary
+            ? { summary: workingLocationSummary }
+            : {}),
+        }
       : {
           summary: event.title,
           description: event.description,


### PR DESCRIPTION
## Summary
- Calendar stays on the saved timezone and asks before switching if the browser differs.
- Working locations can be added from Week, Month, and Day via `+` (all-day by default, optional timed 9–5, multi-day exclusive end, stay in the current view).
- Home, Office, and Other apply on the draft immediately; Create Event writes that type. Unlabeled Office is allowed; Other needs a name. `+` on a day that already has a location updates that day.
- Creating an Other working location keeps the custom name instead of saving it as Working.
- Timed working locations get a Home, Office, or custom title in Google (not the generated Working location placeholder).
- Turning a timed working location that ends at midnight back to all-day keeps that single day.
- Invalid saved timezones fall back instead of crashing the grid. Nameless Other is rejected on create instead of stored as Working.
## Test plan
- [ ] Timezone prompt Switch/Keep when the browser timezone differs from Calendar Settings
- [ ] Add Home, Office, and Other from a day's `+` control
- [ ] `+` on a day that already has a location updates that day instead of creating a second one
- [ ] Other named Pool still shows Pool in Google after Create Event
- [ ] Timed Office keeps a title in Google instead of Untitled
- [ ] Timed location ending at midnight, switched to all-day, stays one day
- [ ] Creating from Week or Month stays in that view


Made with [Cursor](https://cursor.com)