### PR TITLE
fix: earlier changes on dispatch nuked factory

### DIFF
--- a/.agents/skills/feature-flags/SKILL.md
+++ b/.agents/skills/feature-flags/SKILL.md
@@ -46,6 +46,12 @@ export const FULL_APP_BUILDING = defineFeatureFlag({
 });
 ```
 
+Never import `defineFeatureFlag` from `@agent-native/core/feature-flags`.
+That barrel is server evaluation (`isFeatureFlagEnabled`) plus store code;
+Vite will follow it into the browser and crash the page. Plugin and A2A auth
+helpers live on `@agent-native/core/server` (or
+`@agent-native/core/feature-flags/server`).
+
 Keys are immutable, never reused, and contain only letters, numbers, dots,
 underscores, or hyphens. Prefer a concise app-owned name. Do not create flag
 definitions or rollout rows from Analytics.

--- a/.changeset/keep-feature-flag-registry-browser-safe.md
+++ b/.changeset/keep-feature-flag-registry-browser-safe.md
@@ -4,4 +4,3 @@
 ---
 
 Keep feature-flag definitions off the server HMAC barrel so Vite client graphs do not crash.
-

--- a/.changeset/keep-feature-flag-registry-browser-safe.md
+++ b/.changeset/keep-feature-flag-registry-browser-safe.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Keep feature-flag definitions off the server HMAC barrel so Vite client graphs do not crash.
+

--- a/packages/core/docs/content/actions-advanced.mdx
+++ b/packages/core/docs/content/actions-advanced.mdx
@@ -17,7 +17,7 @@ Declare the flag in a module both the server and the client can import, since th
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/ar-SA/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/ar-SA/actions-advanced.mdx
@@ -17,7 +17,7 @@ description: "التحكم بأعلام الميزات لـ actions ما زال�
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/de-DE/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/de-DE/actions-advanced.mdx
@@ -17,7 +17,7 @@ Deklarieren Sie das Flag in einem Modul, das sowohl der Server als auch der Clie
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/es-ES/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/es-ES/actions-advanced.mdx
@@ -17,7 +17,7 @@ Declara el flag en un módulo que tanto el servidor como el cliente puedan impor
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/fr-FR/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/fr-FR/actions-advanced.mdx
@@ -17,7 +17,7 @@ Déclarez le flag dans un module que le serveur et le client peuvent tous deux i
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/hi-IN/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/hi-IN/actions-advanced.mdx
@@ -17,7 +17,7 @@ flag को एक ऐसे मॉड्यूल में घोषित क
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/ja-JP/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/ja-JP/actions-advanced.mdx
@@ -17,7 +17,7 @@ description: "段階的に展開中のアクションに対するフィーチャ
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/ko-KR/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/ko-KR/actions-advanced.mdx
@@ -21,7 +21,7 @@ description: "아직 단계적으로 배포 중인 action을 위한 기능 플�
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/pt-BR/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/pt-BR/actions-advanced.mdx
@@ -17,7 +17,7 @@ Declare a flag em um módulo que tanto o servidor quanto o cliente possam import
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/zh-CN/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/zh-CN/actions-advanced.mdx
@@ -17,7 +17,7 @@ Feature flag 只针对一种特定情形:一个 action 已经可以安全部署,
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/docs/content/locales/zh-TW/actions-advanced.mdx
+++ b/packages/core/docs/content/locales/zh-TW/actions-advanced.mdx
@@ -17,7 +17,7 @@ description: "用於仍在推出中的 action 的功能旗標閘控，以及為�
 
 ```ts
 // shared/feature-flags.ts
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 export const FULL_APP_BUILDING = defineFeatureFlag({
   key: "full-app-building",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -182,6 +182,7 @@
     "./user-profile/server": "./dist/user-profile/store.js",
     "./feature-flags": "./dist/feature-flags/index.js",
     "./feature-flags/registry": "./dist/feature-flags/registry.js",
+    "./feature-flags/server": "./dist/feature-flags/server.js",
     "./feature-flags/actions/get-feature-flags": "./dist/feature-flags/actions/get-feature-flags.js",
     "./feature-flags/actions/list-feature-flags": "./dist/feature-flags/actions/list-feature-flags.js",
     "./feature-flags/actions/set-feature-flag": "./dist/feature-flags/actions/set-feature-flag.js",

--- a/packages/core/src/feature-flags/browser-safe.guard.spec.ts
+++ b/packages/core/src/feature-flags/browser-safe.guard.spec.ts
@@ -175,6 +175,24 @@ describe("feature-flags/registry is a browser-safe leaf", () => {
   });
 });
 
+describe("feature-flags public barrel stays off the HMAC path", () => {
+  const entry = join(SRC_DIR, "feature-flags", "index.ts");
+
+  it("does not re-export plugin or A2A auth", () => {
+    const specs = staticSpecifiers(readFileSync(entry, "utf8"));
+    expect(specs).not.toContain("./plugin.js");
+    expect(specs).not.toContain("./a2a-action-route.js");
+  });
+
+  it("does not statically reach integrations/internal-token", () => {
+    const { visited } = walkGraph(entry);
+    expect(
+      [...visited].map(rel),
+      "the public barrel must not pull Node HMAC into Vite client graphs",
+    ).not.toContain("integrations/internal-token.ts");
+  });
+});
+
 describe("possibly-browser modules access Node builtins lazily", () => {
   const VALUE_IMPORT_RE =
     /(?:^|\n)[ \t]*import[ \t]+(?!type\b)[^;]*from[ \t\n]*["'](?:node:)?(?:async_hooks|events)["']/;

--- a/packages/core/src/feature-flags/index.ts
+++ b/packages/core/src/feature-flags/index.ts
@@ -18,5 +18,6 @@ export {
   type FeatureFlagRules,
   type FeatureFlagScope,
 } from "./store.js";
-export { createFeatureFlagsPlugin } from "./plugin.js";
-export { createFeatureFlagA2AActionRouteAuth } from "./a2a-action-route.js";
+// Plugin and A2A auth stay on `./server` and `@agent-native/core/server`.
+// Re-exporting them here pulls HMAC Node builtins into any Vite client that
+// imports this barrel for `defineFeatureFlag` / `isFeatureFlagEnabled`.

--- a/packages/core/src/feature-flags/server.ts
+++ b/packages/core/src/feature-flags/server.ts
@@ -1,0 +1,2 @@
+export { createFeatureFlagsPlugin } from "./plugin.js";
+export { createFeatureFlagA2AActionRouteAuth } from "./a2a-action-route.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,7 +152,6 @@ export {
   type JsonSchema,
 } from "./automation/index.js";
 export {
-  createFeatureFlagsPlugin,
   defineFeatureFlag,
   defineFeatureFlags,
   evaluateFeatureFlag,
@@ -167,6 +166,10 @@ export {
   type FeatureFlagRules,
   type FeatureFlagScope,
 } from "./feature-flags/index.js";
+export {
+  createFeatureFlagA2AActionRouteAuth,
+  createFeatureFlagsPlugin,
+} from "./feature-flags/server.js";
 
 // Server
 export {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -207,7 +207,10 @@ export { createSentryPlugin, defaultSentryPlugin } from "./sentry-plugin.js";
 // (which references "defaultOrgPlugin" from @agent-native/core/server) can
 // resolve it during the deploy build worker-entry generation.
 export { createOrgPlugin, defaultOrgPlugin } from "../org/plugin.js";
-export { createFeatureFlagsPlugin } from "../feature-flags/plugin.js";
+export {
+  createFeatureFlagA2AActionRouteAuth,
+  createFeatureFlagsPlugin,
+} from "../feature-flags/server.js";
 export {
   createContextXrayPlugin,
   defaultContextXrayPlugin,

--- a/packages/dispatch/src/shared/feature-flags.ts
+++ b/packages/dispatch/src/shared/feature-flags.ts
@@ -1,4 +1,4 @@
-import { defineFeatureFlag } from "@agent-native/core/feature-flags";
+import { defineFeatureFlag } from "@agent-native/core/feature-flags/registry";
 
 /**
  * Browser-only rollout for app-scoped sessions in Dispatch panes. The server


### PR DESCRIPTION
## TLDR
changes on this [PR](https://github.com/BuilderIO/agent-native/pull/2872) made factory go on an infinite loop. Seems to have only affected local development 💀 

<img width="720" height="368" alt="Screenshot 2026-08-14 at 1 28 31 PM" src="https://github.com/user-attachments/assets/0b9b7744-af84-425a-9a3e-2ecc824ad27e" />


## Summary
- Stop importing `defineFeatureFlag` from `@agent-native/core/feature-flags` in Dispatch (and the Dispatch template). That barrel pulled A2A HMAC / `node:crypto` into Vite client graphs and looped Factory's home page (`GET /` 503 + route-module reload).
- Move plugin and A2A auth helpers off the public feature-flag barrel onto `@agent-native/core/feature-flags/server` (still re-exported from `@agent-native/core/server`).
- Guard the public barrel so it cannot re-export those server modules, and point docs/skill examples at `/registry`.

## Test plan
- [ ] Restart `pnpm --filter factory dev` and hard-refresh `http://localhost:8081/` — page should stay on `/factory` without a reload loop
- [ ] Confirm the console does **not** show `Module "node:crypto" has been externalized` / `createHmac` / `internal-token`
- [ ] Confirm network does **not** keep returning `GET /` 503
- [ ] Optional: open Factory Agents (Dispatch components) and confirm it still loads
- [ ] `pnpm --filter @agent-native/core exec vitest --run src/feature-flags/browser-safe.guard.spec.ts` (and related feature-flag specs) should pass


Made with [Cursor](https://cursor.com)