### PR TITLE
fix: align Changesets action with CLI v2

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create Release PR or publish to npm
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           # When changesets/action finds no pending changesets, it runs
           # `publish`. @changesets/cli publishes packages concurrently, which


### PR DESCRIPTION
The post-merge package release failed before publishing because changesets/action v2.1.0 rejects this repository's @changesets/cli v2.31.0.

This pins the latest compatible v1.9.0 action. The existing publish/title/commit inputs are supported by v1.9.0.