### PR TITLE
fix: serialize durable sync-event pruning

### DIFF
--- a/.changeset/serialize-sync-event-prunes.md
+++ b/.changeset/serialize-sync-event-prunes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Serialize durable sync-event retention prunes across Postgres workers.

--- a/packages/core/src/server/db-assigned-versions.spec.ts
+++ b/packages/core/src/server/db-assigned-versions.spec.ts
@@ -63,7 +63,12 @@ function makeAllocatorDb(shared?: { v: number; ids: Map<string, number> }) {
       return { rows: [], rowsAffected: 0 };
     },
   };
-  return db;
+  return {
+    ...db,
+    transaction: async (
+      fn: (tx: typeof db) => Promise<unknown>,
+    ): Promise<unknown> => fn(db),
+  };
 }
 
 function baseEvent(extra: Record<string, unknown> = {}) {

--- a/packages/core/src/server/db-assigned-versions.spec.ts
+++ b/packages/core/src/server/db-assigned-versions.spec.ts
@@ -63,12 +63,11 @@ function makeAllocatorDb(shared?: { v: number; ids: Map<string, number> }) {
       return { rows: [], rowsAffected: 0 };
     },
   };
-  return {
-    ...db,
-    transaction: async (
-      fn: (tx: typeof db) => Promise<unknown>,
-    ): Promise<unknown> => fn(db),
+  const transactionalDb = db as typeof db & {
+    transaction: (fn: (tx: typeof db) => Promise<unknown>) => Promise<unknown>;
   };
+  transactionalDb.transaction = async (fn) => fn(db);
+  return transactionalDb;
 }
 
 function baseEvent(extra: Record<string, unknown> = {}) {

--- a/packages/core/src/server/poll-prune.spec.ts
+++ b/packages/core/src/server/poll-prune.spec.ts
@@ -10,36 +10,60 @@ function makeDb(
   options: {
     deletedPerBatch?: number[];
     failDeletes?: boolean;
+    postgres?: boolean;
+    advisoryLock?: boolean;
   } = {},
 ) {
   const deletes: Array<{ sql: string; args: unknown[] }> = [];
+  const locks: Array<{ sql: string; args: unknown[] }> = [];
   let batch = 0;
+  const execute = async (query: string | { sql: string; args?: unknown[] }) => {
+    const sql = typeof query === "string" ? query : query.sql;
+    const args = typeof query === "string" ? [] : (query.args ?? []);
+    if (sql.includes("pg_try_advisory_xact_lock")) {
+      locks.push({ sql, args });
+      return {
+        rows: [{ acquired: options.advisoryLock ?? true }],
+        rowsAffected: 0,
+      };
+    }
+    if (sql.includes("DELETE") && sql.includes("sync_events")) {
+      if (options.failDeletes) throw new Error("deadlock detected");
+      deletes.push({ sql, args });
+      const n = options.deletedPerBatch?.[batch] ?? 0;
+      batch++;
+      return { rows: [] as any[], rowsAffected: n };
+    }
+    return { rows: [] as any[], rowsAffected: 0 };
+  };
+  const transaction = options.postgres
+    ? vi.fn(async (fn: (tx: { execute: typeof execute }) => Promise<unknown>) =>
+        fn({ execute }),
+      )
+    : undefined;
   return {
     deletes,
+    locks,
     exec: {
-      execute: vi.fn(
-        async (query: string | { sql: string; args?: unknown[] }) => {
-          const sql = typeof query === "string" ? query : query.sql;
-          const args = typeof query === "string" ? [] : (query.args ?? []);
-          if (sql.includes("DELETE") && sql.includes("sync_events")) {
-            if (options.failDeletes) throw new Error("deadlock detected");
-            deletes.push({ sql, args });
-            const n = options.deletedPerBatch?.[batch] ?? 0;
-            batch++;
-            return { rows: [] as any[], rowsAffected: n };
-          }
-          return { rows: [] as any[], rowsAffected: 0 };
-        },
-      ),
+      execute: vi.fn(execute),
+      transaction,
     },
   };
 }
 
-function stateWith(db: { exec: { execute: unknown } }) {
+function stateWith(db: { exec: { execute: unknown } }, postgres = false) {
   return new AppSyncState({
     getDb: () => db.exec as never,
-    isPostgres: () => false,
+    isPostgres: () => postgres,
   });
+}
+
+async function prune(state: AppSyncState, db: { exec: unknown }) {
+  await (
+    state as unknown as {
+      pruneDurableEvents: (client: unknown) => Promise<void>;
+    }
+  ).pruneDurableEvents(db.exec);
 }
 
 describe("sync_events prune", () => {
@@ -145,5 +169,27 @@ describe("sync_events prune", () => {
     vi.setSystemTime(1_800_000_000_000 + 5 * 60 * 1000 + 1);
     await state.persistSyncEvent(event);
     expect(db.deletes).toHaveLength(2);
+  });
+
+  it("serializes Postgres batches with a transaction-scoped advisory lease", async () => {
+    const db = makeDb({
+      postgres: true,
+      deletedPerBatch: [10_000, 3],
+    });
+    await prune(stateWith(db, true), db);
+
+    expect(db.locks).toHaveLength(2);
+    expect(db.locks[0].sql).toContain("pg_try_advisory_xact_lock");
+    expect(db.locks[0].args).toEqual(["agent-native:sync-events-prune"]);
+    expect(db.exec.transaction).toHaveBeenCalledTimes(2);
+    expect(db.deletes).toHaveLength(2);
+  });
+
+  it("skips a Postgres prune when another worker owns the lease", async () => {
+    const db = makeDb({ postgres: true, advisoryLock: false });
+    await prune(stateWith(db, true), db);
+
+    expect(db.locks).toHaveLength(1);
+    expect(db.deletes).toHaveLength(0);
   });
 });

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -90,6 +90,12 @@ const DURABLE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const DURABLE_PRUNE_BATCH = 10_000;
 const DURABLE_PRUNE_MAX_BATCHES = 40;
 /**
+ * Postgres advisory-lock key for the per-database retention worker. The lock
+ * is transaction-scoped so a serverless worker that is killed cannot leave a
+ * lease behind for another worker to clear.
+ */
+const DURABLE_PRUNE_LOCK_KEY = "agent-native:sync-events-prune";
+/**
  * How far back a cold-started process replays durable action markers.
  * Covers the gap between a separate action process writing its marker and this
  * process's first poll — seconds in practice. Anything older is history, and
@@ -679,10 +685,10 @@ export class AppSyncState {
    *     bounded index range scan.
    *
    * The `lastDurablePrune` throttle below is per-process, so every serverless
-   * worker prunes on its first poll. That was survivable only once the work
-   * itself became bounded and indexed; if concurrency is still a problem,
-   * the next step is a `pg_try_advisory_xact_lock` so one worker prunes at a
-   * time. Deliberately not done yet — measure before adding a lock.
+   * worker prunes on its first poll. Postgres workers also take a
+   * transaction-scoped advisory lease for each batch: only one worker deletes
+   * at a time, but each batch still commits independently so a killed worker
+   * cannot hold a long transaction open.
    */
   private async pruneDurableEvents(client: DbExec): Promise<void> {
     const now = Date.now();
@@ -692,17 +698,44 @@ export class AppSyncState {
     let deleted = 0;
     try {
       for (let batch = 0; batch < DURABLE_PRUNE_MAX_BATCHES; batch++) {
-        const result = await client.execute({
+        const runBatch = async (tx: DbExec): Promise<number | null> => {
+          if (this.isPg()) {
+            const lockResult = await tx.execute({
+              sql: "SELECT pg_try_advisory_xact_lock(hashtextextended(?, 0::bigint)) AS acquired",
+              args: [DURABLE_PRUNE_LOCK_KEY],
+            });
+            const acquired = lockResult.rows[0]?.acquired;
+            if (acquired !== true && acquired !== "t") return null;
+          }
+
           // `id IN (...)` rather than ctid/rowid: both are dialect-specific,
           // and the primary key is indexed on every dialect we ship.
-          sql: `DELETE FROM sync_events WHERE id IN (
-                  SELECT id FROM sync_events WHERE created_at < ?
-                  ORDER BY created_at, id LIMIT ?
-                )`,
-          args: [cutoff, DURABLE_PRUNE_BATCH],
-        });
-        deleted += result.rowsAffected;
-        if (result.rowsAffected < DURABLE_PRUNE_BATCH) break;
+          const result = await tx.execute({
+            sql: `DELETE FROM sync_events WHERE id IN (
+                    SELECT id FROM sync_events WHERE created_at < ?
+                    ORDER BY created_at, id LIMIT ?
+                  )`,
+            args: [cutoff, DURABLE_PRUNE_BATCH],
+          });
+          return result.rowsAffected;
+        };
+
+        // A Postgres advisory transaction lock is only useful when the lock
+        // and delete share a connection and transaction. Never fall back to
+        // an uncoordinated delete on a transactionless client.
+        const rowsAffected = this.isPg()
+          ? client.transaction
+            ? await client.transaction(runBatch)
+            : null
+          : await runBatch(client);
+        if (rowsAffected == null) {
+          if (this.isPg() && !client.transaction) {
+            throw new Error("Postgres prune requires a database transaction");
+          }
+          break;
+        }
+        deleted += rowsAffected;
+        if (rowsAffected < DURABLE_PRUNE_BATCH) break;
       }
       this.durablePruneFailures = 0;
     } catch (err) {


### PR DESCRIPTION
## Summary
- serialize `sync_events` retention batches with a Postgres transaction-scoped advisory lease
- keep each batch independently committed so killed serverless workers cannot hold long transactions
- skip rather than issue an uncoordinated prune when a Postgres transaction is unavailable
- add focused coverage and a core patch changeset

## Production signal
Plan's live database was running dozens of concurrent copies of the retention DELETE. The per-process throttle did not coordinate cold-started workers, so the cleanup itself became the hot query reported by the fleet health audit.

## Verification
Focused tests and the strict hosted health audit will be run against the merged release.
