### PR TITLE
fix: close post-merge import and scaffolding gaps

### DIFF
--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -5667,13 +5667,12 @@ async function createDesktopAppFromPrompt(
     port,
   });
   // The target is intentionally empty until the coding agent runs the
-  // scaffold command. Start the runner from the framework workspace so the
-  // local Codex/Claude CLIs can initialize before they write into the target.
-  const appCreationCwd = resolveRepositoryRoot(appsRoot);
+  // scaffold command. Run from appsRoot so the relative scaffold command
+  // creates the app exactly where the Desktop registry points.
   const runResult = await createCodeAgentRun({
     goalId: "task",
     prompt: agentPrompt,
-    cwd: appCreationCwd,
+    cwd: appsRoot,
     permissionMode: "full-auto",
     metadata: {
       kind: "desktop-create-app",

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -190,7 +190,7 @@ describe("desktop passive-access regressions", () => {
     expect(runner).toContain('phase: "missing-credentials"');
   });
 
-  it("starts empty desktop app creation from the framework workspace", () => {
+  it("starts empty desktop app creation from the selected apps folder", () => {
     const main = source("./index.ts");
     const repository = between(
       main,
@@ -202,14 +202,18 @@ describe("desktop passive-access regressions", () => {
       "async function createDesktopAppFromPrompt(",
       "const lastDesktopAppRuntimeStatus",
     );
+    const prompt = between(
+      main,
+      "function buildDesktopCreateAppAgentPrompt(",
+      "async function createDesktopAppFromPrompt(",
+    );
 
     expect(repository).toContain(
       'IS_DEV ? path.resolve(__dirname, "../../../..") : undefined',
     );
-    expect(creation).toContain(
-      "const appCreationCwd = resolveRepositoryRoot(appsRoot);",
-    );
-    expect(creation).toContain("cwd: appCreationCwd");
+    expect(creation).toContain("cwd: appsRoot");
+    expect(creation).not.toContain("resolveRepositoryRoot(appsRoot)");
+    expect(prompt).toContain("create ${input.folderName} --template chat");
   });
 
   it("only marks the local Codex provider configured after authentication", () => {

--- a/templates/analytics/scripts/first-party-analytics-postgres-retention-dry-run.sql
+++ b/templates/analytics/scripts/first-party-analytics-postgres-retention-dry-run.sql
@@ -10,11 +10,14 @@
 -- never included in the candidate count. Session replay, exception issues,
 -- public-key metadata, rollups, alerts, and pressure data are reported as
 -- preserved SQL rows; they are not deletion candidates.
+-- The organization and owner values below are intentionally fake safe
+-- defaults. Supply scoped values in a local copy or SQL-client parameters;
+-- never commit real organization IDs or employee addresses here.
 
 WITH params AS (
   SELECT
-    'PlRt3bfcpJNnOyF_Wfgsh'::text AS org_id,
-    'steve@builder.io'::text AS owner_email,
+    'org-example'::text AS org_id,
+    'owner@example.com'::text AS owner_email,
     '2026-06-10T18:50:43.370Z'::text AS lookback_start,
     '2026-08-09T19:11:44.834Z'::text AS cutoff,
     'http.response'::text AS excluded_event_name

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -14,7 +14,10 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
-import { uploadPptxSlideImages } from "../server/handlers/import/pptx-assets.js";
+import {
+  assertPptxImagesRenderable,
+  uploadPptxSlideImages,
+} from "../server/handlers/import/pptx-assets.js";
 import { upsertBuilderProxyDesignSystem } from "../server/lib/builder-design-system-proxy.js";
 import { setupPdfParse } from "../server/lib/pdf-parse-setup.js";
 import {
@@ -148,6 +151,7 @@ export default defineAction({
         await assertAccess("deck", deckId, "editor");
         const pptxOwnerEmail = getRequestUserEmail();
         if (!pptxOwnerEmail) throw new Error("no authenticated user");
+        assertPptxImagesRenderable(presentation.slides);
         const pptxThemeFont = presentation.theme?.fonts?.[0];
         const uploadLimit = pLimit(4);
         const pptxResults = await Promise.all(

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -30,6 +30,7 @@ import {
 } from "../shared/aspect-ratios.js";
 import { getDeckUrl } from "./_app-url.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
+import { withDeckLock } from "./patch-deck.js";
 
 export interface ImportedImageFallback {
   slideIndex: number;
@@ -125,7 +126,6 @@ export async function importPptxBufferToDeck(args: {
   // a side effect with real storage cost, so an unauthorized caller must
   // be rejected before that side effect happens, not after.
   const db = getDb();
-  let existingDeck: typeof schema.decks.$inferSelect | undefined;
   if (deckId) {
     await assertAccess("deck", deckId, "editor");
     const [deck] = await db
@@ -135,7 +135,6 @@ export async function importPptxBufferToDeck(args: {
     if (!deck) {
       throw new Error(`Deck ${deckId} not found`);
     }
-    existingDeck = deck;
   }
   assertPptxImagesRenderable(presentation.slides);
 
@@ -210,47 +209,56 @@ export async function importPptxBufferToDeck(args: {
   const now = new Date().toISOString();
 
   if (deckId) {
-    if (!existingDeck) {
-      throw new Error(`Deck ${deckId} not found`);
-    }
+    return withDeckLock(deckId, async () => {
+      // Image uploads happen before this lock because they are independent of
+      // the deck row. Re-read inside the lock so the replacement is based on
+      // the latest deck data rather than the preflight snapshot.
+      const [latestDeck] = await db
+        .select()
+        .from(schema.decks)
+        .where(eq(schema.decks.id, deckId));
+      if (!latestDeck) {
+        throw new Error(`Deck ${deckId} not found`);
+      }
 
-    const previousData = safeParseDeckData(existingDeck.data);
-    const data = {
-      ...previousData,
-      title: deckTitle,
-      slides,
-      ...(aspectRatio ? { aspectRatio } : {}),
-      sourceImport,
-      updatedAt: now,
-    };
-    await db
-      .update(schema.decks)
-      .set({
+      const previousData = safeParseDeckData(latestDeck.data);
+      const data = {
+        ...previousData,
         title: deckTitle,
-        data: JSON.stringify(data),
-        ...(designSystemId !== undefined
-          ? { designSystemId }
-          : { designSystemId: existingDeck.designSystemId }),
+        slides,
+        ...(aspectRatio ? { aspectRatio } : {}),
+        sourceImport,
         updatedAt: now,
-      })
-      .where(eq(schema.decks.id, deckId));
+      };
+      await db
+        .update(schema.decks)
+        .set({
+          title: deckTitle,
+          data: JSON.stringify(data),
+          ...(designSystemId !== undefined
+            ? { designSystemId }
+            : { designSystemId: latestDeck.designSystemId }),
+          updatedAt: now,
+        })
+        .where(eq(schema.decks.id, deckId));
 
-    notifyClients(deckId);
-    await writeAppState("refresh-signal", {
-      ts: now,
-      source,
+      notifyClients(deckId);
+      await writeAppState("refresh-signal", {
+        ts: now,
+        source,
+      });
+
+      return {
+        id: deckId,
+        title: deckTitle,
+        slideCount: slides.length,
+        theme: presentation.theme,
+        imported: true,
+        url: getDeckUrl(deckId),
+        ...(imagesSkipped > 0 ? { imagesSkipped } : {}),
+        ...(tablesDegraded > 0 ? { tablesDegraded } : {}),
+      };
     });
-
-    return {
-      id: deckId,
-      title: deckTitle,
-      slideCount: slides.length,
-      theme: presentation.theme,
-      imported: true,
-      url: getDeckUrl(deckId),
-      ...(imagesSkipped > 0 ? { imagesSkipped } : {}),
-      ...(tablesDegraded > 0 ? { tablesDegraded } : {}),
-    };
   }
 
   // Create new deck

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -12,7 +12,10 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { convertToSlideHtml } from "../server/handlers/import/html-converter.js";
-import { uploadPptxSlideImages } from "../server/handlers/import/pptx-assets.js";
+import {
+  assertPptxImagesRenderable,
+  uploadPptxSlideImages,
+} from "../server/handlers/import/pptx-assets.js";
 import {
   parsePptx,
   type ParsedElement,
@@ -121,9 +124,20 @@ export async function importPptxBufferToDeck(args: {
   // Check edit access before uploading any embedded images — uploads are
   // a side effect with real storage cost, so an unauthorized caller must
   // be rejected before that side effect happens, not after.
+  const db = getDb();
+  let existingDeck: typeof schema.decks.$inferSelect | undefined;
   if (deckId) {
     await assertAccess("deck", deckId, "editor");
+    const [deck] = await db
+      .select()
+      .from(schema.decks)
+      .where(eq(schema.decks.id, deckId));
+    if (!deck) {
+      throw new Error(`Deck ${deckId} not found`);
+    }
+    existingDeck = deck;
   }
+  assertPptxImagesRenderable(presentation.slides);
 
   // Convert each parsed slide to its positioned scene graph, uploading every
   // browser-renderable image so the imported deck keeps the source layering
@@ -193,20 +207,14 @@ export async function importPptxBufferToDeck(args: {
     presentation.slides[0]?.heightEmu,
   );
 
-  const db = getDb();
   const now = new Date().toISOString();
 
   if (deckId) {
-    const existing = await db
-      .select()
-      .from(schema.decks)
-      .where(eq(schema.decks.id, deckId));
-
-    if (!existing.length) {
+    if (!existingDeck) {
       throw new Error(`Deck ${deckId} not found`);
     }
 
-    const previousData = safeParseDeckData(existing[0].data);
+    const previousData = safeParseDeckData(existingDeck.data);
     const data = {
       ...previousData,
       title: deckTitle,
@@ -222,7 +230,7 @@ export async function importPptxBufferToDeck(args: {
         data: JSON.stringify(data),
         ...(designSystemId !== undefined
           ? { designSystemId }
-          : { designSystemId: existing[0].designSystemId }),
+          : { designSystemId: existingDeck.designSystemId }),
         updatedAt: now,
       })
       .where(eq(schema.decks.id, deckId));

--- a/templates/slides/server/handlers/import/pdf-fidelity-parser.spec.ts
+++ b/templates/slides/server/handlers/import/pdf-fidelity-parser.spec.ts
@@ -547,6 +547,11 @@ describe("detectBlockAlignment", () => {
     expect(detectBlockAlignment(lines, 10, 90)).toBe("center");
   });
 
+  it("keeps equal-width left-aligned lines left when their midpoint is ambiguous", () => {
+    const lines = [box({ left: 10, right: 90 }), box({ left: 10, right: 90 })];
+    expect(detectBlockAlignment(lines, 10, 90)).toBe("left");
+  });
+
   it("detects right-aligned lines from their shared right edge", () => {
     const lines = [
       box({ left: 50, right: 200 }),

--- a/templates/slides/server/handlers/import/pdf-fidelity-parser.spec.ts
+++ b/templates/slides/server/handlers/import/pdf-fidelity-parser.spec.ts
@@ -552,6 +552,11 @@ describe("detectBlockAlignment", () => {
     expect(detectBlockAlignment(lines, 10, 90)).toBe("left");
   });
 
+  it("keeps near-equal widths eligible for midpoint alignment when bounds shift", () => {
+    const lines = [box({ left: 10, right: 90 }), box({ left: 11, right: 89 })];
+    expect(detectBlockAlignment(lines, 10, 90)).toBe("center");
+  });
+
   it("detects right-aligned lines from their shared right edge", () => {
     const lines = [
       box({ left: 50, right: 200 }),

--- a/templates/slides/server/handlers/import/pdf-fidelity-parser.ts
+++ b/templates/slides/server/handlers/import/pdf-fidelity-parser.ts
@@ -621,6 +621,14 @@ export function detectBlockAlignment(
   blockRight: number,
 ): "left" | "center" | "right" {
   if (blockLines.length < 2) return "left";
+  // The block bounds come from these same lines. Equal-width lines therefore
+  // have identical left edges, right edges, and midpoints whether they were
+  // left-aligned or centered; keep that ambiguous case left-aligned rather
+  // than moving ordinary paragraphs to the center.
+  const widths = blockLines.map((line) => line.right - line.left);
+  const minWidth = Math.min(...widths);
+  const maxWidth = Math.max(...widths);
+  if (maxWidth - minWidth <= TEXT_ALIGNMENT_TOLERANCE_PT) return "left";
   const midpoint = (blockLeft + blockRight) / 2;
   const centered = blockLines.every(
     (line) =>

--- a/templates/slides/server/handlers/import/pdf-fidelity-parser.ts
+++ b/templates/slides/server/handlers/import/pdf-fidelity-parser.ts
@@ -628,7 +628,12 @@ export function detectBlockAlignment(
   const widths = blockLines.map((line) => line.right - line.left);
   const minWidth = Math.min(...widths);
   const maxWidth = Math.max(...widths);
-  if (maxWidth - minWidth <= TEXT_ALIGNMENT_TOLERANCE_PT) return "left";
+  const sameBounds = blockLines.every(
+    (line) => line.left === blockLeft && line.right === blockRight,
+  );
+  if (maxWidth - minWidth <= TEXT_ALIGNMENT_TOLERANCE_PT && sameBounds) {
+    return "left";
+  }
   const midpoint = (blockLeft + blockRight) / 2;
   const centered = blockLines.every(
     (line) =>

--- a/templates/slides/server/handlers/import/pptx-assets.spec.ts
+++ b/templates/slides/server/handlers/import/pptx-assets.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertPptxImagesRenderable,
+  uploadPptxSlideImages,
+} from "./pptx-assets.js";
+import type { ParsedSlide } from "./pptx-parser.js";
+
+const uploadFileMock = vi.hoisted(() => vi.fn());
+const storeLocalImportedAssetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/file-upload", () => ({
+  uploadFile: uploadFileMock,
+}));
+vi.mock("../../lib/import-asset-storage.js", () => ({
+  storeLocalImportedAsset: storeLocalImportedAssetMock,
+}));
+
+function slideWithImage(mimeType: string): ParsedSlide {
+  return {
+    texts: [],
+    images: [],
+    elements: [
+      {
+        id: "image-1",
+        kind: "image",
+        name: "image",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        image: {
+          name: "image.bin",
+          mimeType,
+          data: new Uint8Array([1, 2, 3]),
+        },
+      },
+    ],
+  } as ParsedSlide;
+}
+
+describe("PPTX image uploads", () => {
+  it("rejects unsupported image types before the upload phase", () => {
+    expect(() =>
+      assertPptxImagesRenderable([slideWithImage("image/tiff")]),
+    ).toThrow("No images were uploaded");
+  });
+
+  it("uploads browser-renderable images", async () => {
+    uploadFileMock.mockResolvedValue({
+      url: "https://files.example/image.png",
+      provider: "test",
+    });
+
+    const slide = slideWithImage("image/png");
+    assertPptxImagesRenderable([slide]);
+    await expect(
+      uploadPptxSlideImages({
+        slide,
+        slideIndex: 0,
+        ownerEmail: "owner@example.com",
+      }),
+    ).resolves.toMatchObject({
+      urls: { "image-1": "https://files.example/image.png" },
+      imageSkippedCount: 0,
+    });
+  });
+});

--- a/templates/slides/server/handlers/import/pptx-assets.ts
+++ b/templates/slides/server/handlers/import/pptx-assets.ts
@@ -12,6 +12,30 @@ const BROWSER_RENDERABLE_IMAGE_MIME_TYPES = new Set([
   "image/bmp",
 ]);
 
+/**
+ * Validate every image before any upload starts. PPTX imports reject partial
+ * fidelity, so an unsupported image must not leave earlier slide uploads
+ * orphaned when the action eventually throws.
+ */
+export function assertPptxImagesRenderable(
+  slides: readonly ParsedSlide[],
+): void {
+  const unsupported = new Set<string>();
+  for (const slide of slides) {
+    for (const element of slide.elements ?? []) {
+      if (element.kind !== "image" || !element.image) continue;
+      if (!BROWSER_RENDERABLE_IMAGE_MIME_TYPES.has(element.image.mimeType)) {
+        unsupported.add(element.image.mimeType || "unknown");
+      }
+    }
+  }
+  if (unsupported.size > 0) {
+    throw new Error(
+      `Source-faithful PPTX import cannot preserve unsupported image type(s): ${[...unsupported].join(", ")}. No images were uploaded. Re-export the deck with browser-renderable images or use a PDF export for page-faithful preservation.`,
+    );
+  }
+}
+
 export async function uploadPptxSlideImages(args: {
   slide: ParsedSlide;
   slideIndex: number;


### PR DESCRIPTION
Follow-up fixes from the post-merge review of #2896.

- Preflight PPTX image MIME types and existing deck state before any upload, preventing orphaned imports.
- Keep equal-width PDF text blocks left-aligned when geometry cannot distinguish left from centered text.
- Scaffold Desktop apps from the selected apps directory.
- Replace real-looking analytics organization and owner identifiers with safe example values.

Validation: Slides focused tests (70 passed), Desktop regression tests (14 passed), Desktop typecheck, and all 53 repository guards passed.
