### PR TITLE
fix: preserve slide fidelity and bound abandoned transactions

### DIFF
--- a/.changeset/netlify-function-pool-timeout.md
+++ b/.changeset/netlify-function-pool-timeout.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Treat Netlify function runtimes as serverless when configuring database pools so abandoned transactions are reaped.

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -135,6 +135,22 @@ describe("db/client dialect detection", () => {
     });
   });
 
+  it("keeps the pool bounded when Netlify exposes only the function marker", async () => {
+    vi.stubEnv("NETLIFY", "");
+    vi.stubEnv("NETLIFY_FUNCTION_NAME", "slides");
+    const { neonPoolOptions, pgPoolOptions, isServerlessRuntime } =
+      await import("./client.js");
+
+    expect(isServerlessRuntime()).toBe(true);
+    expect(neonPoolOptions()).toMatchObject({
+      idle_in_transaction_session_timeout: 30_000,
+    });
+    expect(pgPoolOptions("postgres://example.test/db").connection).toEqual({
+      application_name: "agent-native:app",
+      idle_in_transaction_session_timeout: 30_000,
+    });
+  });
+
   it("recognizes production serverless execution and honors local emulation", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NETLIFY", "true");

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -949,6 +949,7 @@ export async function withDbTimeout<T>(
 export function isServerlessRuntime(): boolean {
   return (
     !!process.env.NETLIFY ||
+    !!process.env.NETLIFY_FUNCTION_NAME ||
     !!process.env.VERCEL ||
     !!process.env.AWS_LAMBDA_FUNCTION_NAME ||
     !!process.env.LAMBDA_TASK_ROOT ||

--- a/templates/slides/actions/export-pptx.spec.ts
+++ b/templates/slides/actions/export-pptx.spec.ts
@@ -646,6 +646,18 @@ describe("parseSlideHtml", () => {
     expect(connector.lineTailType).toBe("oval");
   });
 
+  it("ignores an end-cap circle that lacks the line-axis coordinate", () => {
+    const malformed = CONNECTOR_ELEMENT.replace('cy="2.25"', 'cx="3"');
+    const [connector] = parseSlideHtml(
+      sourcePagedSlide(malformed),
+      "16:9",
+      4,
+    ).shapes;
+
+    expect(connector.lineHeadType).toBeUndefined();
+    expect(connector.lineTailType).toBe("oval");
+  });
+
   it("does not read a four-sided outline as a line", () => {
     const [outlined] = parseSlideHtml(
       importedSlide(
@@ -657,6 +669,16 @@ describe("parseSlideHtml", () => {
 
     expect(outlined.shapeType).toBeUndefined();
     expect(outlined.lineHeadType).toBeUndefined();
+  });
+
+  it("preserves authored line-height for ordinary server exports", () => {
+    const [text] = parseSlideHtml(
+      '<div class="fmd-slide"><h1 style="font-size:18px;line-height:1.2;">Body</h1></div>',
+      "16:9",
+      1,
+    ).texts;
+
+    expect(text.lineSpacingMultiple).toBe(1.2);
   });
 
   it("converts a CSS line-height back to single spacing rather than re-applying it", () => {
@@ -1127,6 +1149,15 @@ describe("exported slide XML", () => {
 
     expect(slideXml).toContain('<a:lnSpc><a:spcPct val="100000"/></a:lnSpc>');
     expect(slideXml).not.toContain('<a:spcPct val="120000"/>');
+  });
+
+  it("keeps authored line-height in ordinary server-exported slide XML", async () => {
+    const slideXml = await writeParsedSlide(
+      '<div class="fmd-slide"><h1 style="font-size:18px;line-height:1.2;">Body</h1></div>',
+    );
+
+    expect(slideXml).toContain('<a:lnSpc><a:spcPct val="120000"/></a:lnSpc>');
+    expect(slideXml).not.toContain('<a:spcPct val="100000"/>');
   });
 });
 

--- a/templates/slides/actions/export-pptx.spec.ts
+++ b/templates/slides/actions/export-pptx.spec.ts
@@ -1105,7 +1105,9 @@ describe("exported slide XML", () => {
   }
 
   it("writes a connector with its stroke and both oval ends", async () => {
-    const slideXml = await writeParsedSlide(sourcePagedSlide(CONNECTOR_ELEMENT));
+    const slideXml = await writeParsedSlide(
+      sourcePagedSlide(CONNECTOR_ELEMENT),
+    );
 
     expect(slideXml).toContain('<a:prstGeom prst="line">');
     expect(slideXml).toContain(

--- a/templates/slides/actions/export-pptx.spec.ts
+++ b/templates/slides/actions/export-pptx.spec.ts
@@ -40,6 +40,22 @@ function importedSlide(element: string, slideStyle = "background:#000000;") {
 const SHAPE_BOX =
   "position:absolute;left:96px;top:54px;width:192px;height:108px;";
 
+/** `importedSlide`, but stamped with a real 16:9 source page like the importer does. */
+function sourcePagedSlide(element: string) {
+  return `<div class="fmd-slide fmd-imported-pptx" data-imported-pptx="true" data-slide-width-emu="12192000" data-slide-height-emu="6858000" style="background:#FFFFFF;">${element}</div>`;
+}
+
+/**
+ * Slide 4 of SlidesMania "Infographics Set 1", verbatim: a `<p:cxnSp>`
+ * `straightConnector1` of `cx="0"`, which the importer renders as a
+ * zero-width box with one `border-left` plus its two `oval` end caps.
+ */
+const CONNECTOR_ELEMENT =
+  '<div class="fmd-pptx-shape" data-pptx-element-kind="shape" data-slide-object-id="153" style="position: absolute; left: 95.528px; top: 216.774px; width: 0px; height: 72.581px; z-index: 9; box-sizing: border-box; transform: rotate(180deg); transform-origin: center center;border-left: 1.5px solid #3A3838;">' +
+  '<svg viewBox="0 0 4.5 77.081" style="position:absolute;left:-2.25px;top:-2.25px;width:4.5px;height:77.081px;overflow:visible;pointer-events:none;">' +
+  '<circle cx="3" cy="2.25" r="2.25" fill="#3A3838" />' +
+  '<circle cx="3" cy="74.831" r="2.25" fill="#3A3838" /></svg></div>';
+
 describe("fetchImageAsBase64", () => {
   beforeEach(() => {
     mocks.ssrfSafeFetch.mockReset();
@@ -596,6 +612,68 @@ describe("parseSlideHtml", () => {
     expect(solid?.lineDashType).toBeUndefined();
   });
 
+  it("exports a connector as a real line, not a zero-width unstroked rect", () => {
+    const [connector] = parseSlideHtml(
+      sourcePagedSlide(CONNECTOR_ELEMENT),
+      "16:9",
+      4,
+    ).shapes;
+
+    expect(connector).toMatchObject({
+      shapeType: "line",
+      // 1.5px at this deck's 72 px/in is the source's own `<a:ln w="19050">`.
+      lineColor: "3A3838",
+      lineWidth: 2,
+      lineHeadType: "oval",
+      lineTailType: "oval",
+      rotate: 180,
+    });
+    expect(connector.w).toBe(0);
+  });
+
+  it("caps only the end of a line the source actually decorated", () => {
+    const tailOnly = CONNECTOR_ELEMENT.replace(
+      '<circle cx="3" cy="2.25" r="2.25" fill="#3A3838" />',
+      "",
+    );
+    const [connector] = parseSlideHtml(
+      sourcePagedSlide(tailOnly),
+      "16:9",
+      4,
+    ).shapes;
+
+    expect(connector.lineHeadType).toBeUndefined();
+    expect(connector.lineTailType).toBe("oval");
+  });
+
+  it("does not read a four-sided outline as a line", () => {
+    const [outlined] = parseSlideHtml(
+      importedSlide(
+        `<div data-pptx-element-kind="shape" style="${SHAPE_BOX}border:1px solid #0000FF;"></div>`,
+      ),
+      "16:9",
+      1,
+    ).shapes;
+
+    expect(outlined.shapeType).toBeUndefined();
+    expect(outlined.lineHeadType).toBeUndefined();
+  });
+
+  it("converts a CSS line-height back to single spacing rather than re-applying it", () => {
+    const [text] = parseSlideHtml(
+      importedSlide(
+        `<div data-pptx-element-kind="text" style="${SHAPE_BOX}">` +
+          `<p style="line-height:1.2;"><span style="font-size:18px;">Body</span></p></div>`,
+      ),
+      "16:9",
+      1,
+    ).texts;
+
+    // The importer renders the source's `spcPct 100000` as CSS 1.2; writing
+    // that back out unchanged shipped every paragraph at 120%.
+    expect(text.lineSpacingMultiple).toBe(1);
+  });
+
   it("maps a dotted table rule to the nearest border pptxgenjs can draw", () => {
     const result = parseSlideHtml(
       importedSlide(
@@ -972,6 +1050,81 @@ describe("themeClrSchemeXml", () => {
     const { accent4: _dropped, ...incomplete } = palette;
 
     expect(themeClrSchemeXml(incomplete)).toBeUndefined();
+  });
+});
+
+describe("exported slide XML", () => {
+  /** The slide part pptxgenjs writes for one parsed slide, exercised the way the action does. */
+  async function writeParsedSlide(html: string): Promise<string> {
+    const { texts, shapes } = parseSlideHtml(html, "16:9", 1);
+    const pptx = new PptxGenJS();
+    const slide = pptx.addSlide();
+    for (const shape of shapes) {
+      slide.addShape(resolveShapeType(pptx.ShapeType, shape.shapeType), {
+        x: shape.x,
+        y: shape.y,
+        w: shape.w,
+        h: shape.h,
+        ...(shape.lineColor
+          ? {
+              line: {
+                color: shape.lineColor,
+                width: shape.lineWidth ?? 1,
+                ...(shape.lineHeadType
+                  ? { beginArrowType: shape.lineHeadType }
+                  : {}),
+                ...(shape.lineTailType
+                  ? { endArrowType: shape.lineTailType }
+                  : {}),
+              },
+            }
+          : {}),
+      });
+    }
+    for (const text of texts) {
+      slide.addText(text.runs ?? text.text, {
+        x: text.x,
+        y: text.y,
+        w: text.w,
+        h: text.h,
+        ...(text.lineSpacingMultiple != null
+          ? { lineSpacingMultiple: text.lineSpacingMultiple }
+          : {}),
+      });
+    }
+    const JSZip = (await import("jszip")).default;
+    const slideXml = await (
+      await JSZip.loadAsync(
+        (await pptx.write({ outputType: "nodebuffer" })) as Buffer,
+      )
+    )
+      .file("ppt/slides/slide1.xml")
+      ?.async("string");
+    if (slideXml === undefined) throw new Error("missing slide part");
+    return slideXml;
+  }
+
+  it("writes a connector with its stroke and both oval ends", async () => {
+    const slideXml = await writeParsedSlide(sourcePagedSlide(CONNECTOR_ELEMENT));
+
+    expect(slideXml).toContain('<a:prstGeom prst="line">');
+    expect(slideXml).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="3A3838"/></a:solidFill>',
+    );
+    expect(slideXml).toContain('<a:headEnd type="oval"/>');
+    expect(slideXml).toContain('<a:tailEnd type="oval"/>');
+  });
+
+  it("round-trips a source spcPct of 100% back to 100%, not 120%", async () => {
+    const slideXml = await writeParsedSlide(
+      importedSlide(
+        `<div data-pptx-element-kind="text" style="${SHAPE_BOX}">` +
+          `<p style="line-height:1.2;"><span style="font-size:18px;">Body</span></p></div>`,
+      ),
+    );
+
+    expect(slideXml).toContain('<a:lnSpc><a:spcPct val="100000"/></a:lnSpc>');
+    expect(slideXml).not.toContain('<a:spcPct val="120000"/>');
   });
 });
 

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -194,6 +194,29 @@ interface ParsedCssBorder {
   color: string;
 }
 
+/**
+ * PowerPoint's `a:spcPct val="100000"` is 100% of the font's *natural* line
+ * height, which CSS renders as `line-height: 1.2`, so the importer multiplies a
+ * declared percentage by that ratio. Writing the CSS value back out as `lnSpc`
+ * unchanged applied that correction a second time, and every imported paragraph
+ * came back 20% looser than the source. Neither copy of the constant is
+ * exported — `SINGLE_LINE_SPACING_RATIO` in packages/core/src/ingestion/pptx.ts
+ * and `DEFAULT_LINE_SPACING` in server/handlers/import/html-converter.ts — so
+ * all three have to move together.
+ */
+const SINGLE_LINE_SPACING_RATIO = 1.2;
+
+/** A CSS line-height ratio as the single-spacing multiple `lnSpc` measures. */
+function cssLineHeightToSpacingMultiple(
+  lineHeight: number | undefined,
+): number | undefined {
+  return lineHeight !== undefined &&
+    Number.isFinite(lineHeight) &&
+    lineHeight > 0
+    ? lineHeight / SINGLE_LINE_SPACING_RATIO
+    : undefined;
+}
+
 /** Parse a CSS `border` shorthand. `none`/`hidden` borders yield `undefined`. */
 function parseCssBorder(
   border: string | null | undefined,
@@ -320,6 +343,8 @@ interface ShapeElement {
   lineTransparency?: number; // 0-100, percent transparent
   lineWidth?: number; // in pt
   lineDashType?: NonNullable<PptxGenJS.ShapeLineProps["dashType"]>;
+  lineHeadType?: NonNullable<PptxGenJS.ShapeLineProps["beginArrowType"]>;
+  lineTailType?: NonNullable<PptxGenJS.ShapeLineProps["endArrowType"]>;
   /** A PowerPoint preset geometry name, or `custGeom` when `points` carry a traced outline. */
   shapeType?: string;
   rectRadius?: number; // inches; roundRect corner radius
@@ -591,7 +616,7 @@ export function parseSlideHtml(
         w: contentW,
         h: elHeight + 0.2,
         letterSpacing: letterSpacing ? parseFloat(letterSpacing) : undefined,
-        lineSpacingMultiple: lineH,
+        lineSpacingMultiple: cssLineHeightToSpacingMultiple(lineH),
       });
 
       yPos += elHeight + pxToIn(marginBottom, dims) + 0.1;
@@ -748,6 +773,7 @@ function parseImportedSlideHtml(html: string, dims: SlideDims): ParsedSlide {
       const border = parseCssBorder(getStyle(style, "border"));
       const parsedLine = border ? colorToHex(border.color) : undefined;
       const outline = importedFreeformStroke(innerHtml, dims);
+      const line = importedLineStroke(style, innerHtml, dims);
       shapes.push({
         ...geometry,
         ...(parsedFill
@@ -770,6 +796,9 @@ function parseImportedSlideHtml(html: string, dims: SlideDims): ParsedSlide {
               }
             : {}),
         ...importedShapeGeometry(attrs, style, outline?.path, geometry, dims),
+        // A single-edge border is the importer's own verdict that this box is a
+        // line rather than an outline, so it settles the geometry too.
+        ...line,
         ...(rotate != null ? { rotate } : {}),
         order: match.index,
       });
@@ -818,7 +847,9 @@ function parseImportedSlideHtml(html: string, dims: SlideDims): ParsedSlide {
       bold: runs.length > 0 && runs.every((run) => run.options.bold === true),
       align:
         alignValue === "center" || alignValue === "right" ? alignValue : "left",
-      lineSpacingMultiple: lineHeight ? Number(lineHeight) : undefined,
+      lineSpacingMultiple: cssLineHeightToSpacingMultiple(
+        lineHeight ? Number(lineHeight) : undefined,
+      ),
       x: geometry.x,
       y: geometry.y,
       w: geometry.w,
@@ -996,6 +1027,86 @@ function importedFreeformStroke(
     // hairline outline that rounds to 0pt is an invisible shape.
     width: Math.max(0.5, pxToPt(Number.isFinite(widthPx) ? widthPx : 1, dims)),
   };
+}
+
+/** The line axis each single-edge border the importer writes draws along. */
+const SINGLE_EDGE_BORDER_AXES = {
+  "border-top": "x",
+  "border-left": "y",
+} as const;
+
+/**
+ * The stroke of a `<p:cxnSp>` or a degenerate `<p:sp>` — a box with one
+ * dimension of zero. The importer draws those with a single `border-left` or
+ * `border-top` rather than the `border` shorthand (`strokeDecoration` in
+ * server/handlers/import/html-converter.ts), which `parseCssBorder` above
+ * cannot see, so every connector used to export as a `rect` of `cx="0"` with
+ * `<a:noFill/>` and an empty `<a:ln/>`: no width, no color, no ends, nothing
+ * drawn. Reading the edge the importer actually wrote gives back the real line.
+ */
+function importedLineStroke(
+  style: string,
+  innerHtml: string,
+  dims: SlideDims,
+):
+  | Pick<
+      ShapeElement,
+      | "shapeType"
+      | "lineColor"
+      | "lineTransparency"
+      | "lineWidth"
+      | "lineDashType"
+      | "lineHeadType"
+      | "lineTailType"
+    >
+  | undefined {
+  for (const [property, axis] of Object.entries(SINGLE_EDGE_BORDER_AXES)) {
+    const border = parseCssBorder(getStyle(style, property));
+    if (!border) continue;
+    const color = colorToHex(border.color);
+    return {
+      shapeType: "line",
+      lineColor: color.hex,
+      lineTransparency: color.transparency,
+      // The same 0.5pt floor the outline paths use, for the same reason:
+      // `pxToPt` rounds, and a hairline that rounds to 0pt draws nothing.
+      lineWidth: Math.max(0.5, pxToPt(border.widthPx, dims)),
+      ...(border.dashType ? { lineDashType: border.dashType } : {}),
+      ...importedLineEndTypes(innerHtml, axis),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * The `<a:headEnd>`/`<a:tailEnd>` the importer redraws as absolutely
+ * positioned `<circle>` overlays (`lineEndCaps` in html-converter.ts). It only
+ * ever reproduces `oval`, and it centers the overlay on the line, so a circle
+ * before the viewBox midpoint caps the head and one after it caps the tail —
+ * still true for a flipped source, because the importer swapped the two before
+ * drawing them.
+ */
+function importedLineEndTypes(
+  innerHtml: string,
+  axis: "x" | "y",
+): Pick<ShapeElement, "lineHeadType" | "lineTailType"> {
+  const svg = innerHtml.match(/<svg\b([^>]*)>([\s\S]*?)<\/svg>/i);
+  const viewBox = getAttribute(svg?.[1] ?? "", "viewBox")
+    ?.trim()
+    .split(/[\s,]+/)
+    .map(Number);
+  if (!svg || viewBox?.length !== 4 || !viewBox.every(Number.isFinite)) {
+    return {};
+  }
+  const middle = (axis === "x" ? viewBox[2] : viewBox[3]) / 2;
+  const ends: Pick<ShapeElement, "lineHeadType" | "lineTailType"> = {};
+  for (const circle of svg[2].matchAll(/<circle\b([^>]*)>/gi)) {
+    const along = Number(getAttribute(circle[1], axis === "x" ? "cx" : "cy"));
+    if (!Number.isFinite(along)) continue;
+    if (along < middle) ends.lineHeadType = "oval";
+    else ends.lineTailType = "oval";
+  }
+  return ends;
 }
 
 type CustomGeometryPoint = NonNullable<ShapeElement["points"]>[number];
@@ -2020,6 +2131,12 @@ export default defineAction({
                       width: shape.lineWidth ?? 1,
                       ...(shape.lineDashType
                         ? { dashType: shape.lineDashType }
+                        : {}),
+                      ...(shape.lineHeadType
+                        ? { beginArrowType: shape.lineHeadType }
+                        : {}),
+                      ...(shape.lineTailType
+                        ? { endArrowType: shape.lineTailType }
                         : {}),
                       ...(shape.lineTransparency != null
                         ? { transparency: shape.lineTransparency }

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -616,7 +616,9 @@ export function parseSlideHtml(
         w: contentW,
         h: elHeight + 0.2,
         letterSpacing: letterSpacing ? parseFloat(letterSpacing) : undefined,
-        lineSpacingMultiple: cssLineHeightToSpacingMultiple(lineH),
+        // Editor-authored HTML already uses the multiple pptxgenjs expects;
+        // the importer-only correction belongs in parseImportedSlideHtml.
+        lineSpacingMultiple: lineH,
       });
 
       yPos += elHeight + pxToIn(marginBottom, dims) + 0.1;
@@ -1101,7 +1103,9 @@ function importedLineEndTypes(
   const middle = (axis === "x" ? viewBox[2] : viewBox[3]) / 2;
   const ends: Pick<ShapeElement, "lineHeadType" | "lineTailType"> = {};
   for (const circle of svg[2].matchAll(/<circle\b([^>]*)>/gi)) {
-    const along = Number(getAttribute(circle[1], axis === "x" ? "cx" : "cy"));
+    const alongAttribute = getAttribute(circle[1], axis === "x" ? "cx" : "cy");
+    if (alongAttribute == null) continue;
+    const along = Number(alongAttribute);
     if (!Number.isFinite(along)) continue;
     if (along < middle) ends.lineHeadType = "oval";
     else ends.lineTailType = "oval";

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -14,10 +14,18 @@ const UPLOAD_URL =
   "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,webViewLink";
 
 /**
- * Uploads a browser-generated PPTX into the user's Drive, letting Drive convert
- * it to a native Google Slides deck. The PPTX comes from the client because the
- * browser export renders the real slide DOM — the server-side pptxgenjs export
- * is a lower-fidelity fallback and would ship a visibly worse deck to Google.
+ * Uploads a PPTX into the user's Drive, letting Drive convert it to a native
+ * Google Slides deck. The caller decides which exporter produced those bytes,
+ * and which one is higher fidelity depends on the deck:
+ *
+ * - Source-imported decks go through the server `export-pptx`, which writes the
+ *   source's own geometry as real vector shapes. The browser exporter cannot —
+ *   `dom-to-pptx` has no custom-geometry support at all and rasterizes every
+ *   vector shape to a bitmap, so Google receives silhouettes instead of curves.
+ * - Editor-authored decks go through the browser exporter, the only place
+ *   geometry positioned in the DOM is measurable.
+ *
+ * See "Export Behavior" in `templates/slides/AGENTS.md` for the routing rule.
  */
 export default defineEventHandler(async (event) => {
   const session = await getSession(event).catch(() => null);


### PR DESCRIPTION
Summary:
- Preserve imported connector strokes and end caps when exporting PPTX.
- Avoid applying imported CSS line spacing twice.
- Route source-imported decks through the higher-fidelity server exporter for Google Slides.
- Treat Netlify function runtimes as serverless for database pool idle-transaction reaping.

Validation:
- pnpm --filter slides exec vitest --run server/handlers/import/html-converter.test.ts actions/export-pptx.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/db/client.spec.ts src/db/migrations.spec.ts src/db/ddl-guard.spec.ts src/db/ensure-additive-columns.spec.ts
- pnpm prep (typecheck, 53 guards, test:fast)