### PR TITLE
fix: keep imported rules axis-aligned

### DIFF
--- a/.changeset/portal-proxy-auth.md
+++ b/.changeset/portal-proxy-auth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Portal device authentication working when a proxy supplies or strips the Authorization header.

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -1008,12 +1008,17 @@ export function createIntegrationsPlugin(
       // sees the request. Keep the device secret in a dedicated TLS-only
       // header as a transport fallback; the value is still hashed and looked
       // up by authenticateRemoteDeviceToken, never persisted raw.
-      const token =
-        extractBearerToken(getRequestHeader(event, "authorization")) ??
-        (getRequestHeader(event, "x-agent-native-device-token")?.trim() ||
-          null);
-      const device = await authenticateRemoteDeviceToken(token);
-      if (device) return device;
+      const candidates = [
+        getRequestHeader(event, "x-agent-native-device-token")?.trim() || null,
+        extractBearerToken(getRequestHeader(event, "authorization")),
+      ].filter(
+        (token, index, all): token is string =>
+          Boolean(token) && all.indexOf(token) === index,
+      );
+      for (const token of candidates) {
+        const device = await authenticateRemoteDeviceToken(token);
+        if (device) return device;
+      }
       setResponseStatus(event, 401);
       return null;
     }

--- a/packages/core/src/integrations/remote-plugin.spec.ts
+++ b/packages/core/src/integrations/remote-plugin.spec.ts
@@ -325,6 +325,43 @@ describe("remote integration plugin routes", () => {
     );
   });
 
+  it("tries the proxy-safe token when Authorization is also present", async () => {
+    const device = {
+      id: "device-1",
+      ownerEmail: "alice@example.com",
+      orgId: null,
+      label: "Studio Mac",
+      deviceTokenHash: "hashed",
+      lastSeenAt: 1,
+      status: "active",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    authenticateRemoteDeviceTokenMock.mockImplementation(async (token) =>
+      token === "anr_raw-token" ? device : null,
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/remote/poll?waitMs=0",
+      "POST",
+      { waitMs: 0 },
+      {
+        authorization: "Bearer proxy-supplied-token",
+        "x-agent-native-device-token": "anr_raw-token",
+      },
+    );
+
+    expect(result.status).toBe(200);
+    expect(authenticateRemoteDeviceTokenMock).toHaveBeenNthCalledWith(
+      1,
+      "anr_raw-token",
+    );
+    expect(claimNextRemoteCommandMock).toHaveBeenCalledWith("device-1");
+  });
+
   it("claims only computer operations matching advertised device capabilities", async () => {
     const device = {
       id: "device-1",

--- a/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
@@ -82,17 +82,15 @@ describe("countFirstPartyAnalyticsPostgresRows", () => {
 });
 
 describe("purgeFirstPartyAnalyticsPostgresRows", () => {
-  it("deletes each scoped table in bounded returning batches", async () => {
+  it("deletes each scoped table in bounded batches", async () => {
     execute
       .mockResolvedValueOnce({ rows: [{ row_count: "5" }] })
       .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
       .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
-      .mockResolvedValueOnce({
-        rows: Array.from({ length: 5_000 }, () => ({ id: "id" })),
-      })
-      .mockResolvedValueOnce({ rows: [{ id: "last" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "rollup" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "user-day" }] });
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 50_000 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 });
 
     await expect(
       purgeFirstPartyAnalyticsPostgresRows(scope, false, window),
@@ -103,10 +101,10 @@ describe("purgeFirstPartyAnalyticsPostgresRows", () => {
       4,
       expect.objectContaining({
         sql: expect.stringMatching(
-          /WITH candidates[\s\S]*LIMIT \?[\s\S]*DELETE FROM analytics_events[\s\S]*RETURNING id/,
+          /WITH candidates[\s\S]*LIMIT \?[\s\S]*DELETE FROM analytics_events/,
         ),
-        args: ["org-1", "2026-07-01T00:00:00.000Z", 5_000],
-        timeoutMs: 30_000,
+        args: ["org-1", "2026-07-01T00:00:00.000Z", 50_000],
+        timeoutMs: 60_000,
         maxAttempts: 1,
       }),
     );

--- a/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
@@ -10,7 +10,10 @@ vi.mock("../db/index.js", () => ({
   schema: {},
 }));
 
-import { countFirstPartyAnalyticsPostgresRows } from "./first-party-analytics-purge.js";
+import {
+  countFirstPartyAnalyticsPostgresRows,
+  purgeFirstPartyAnalyticsPostgresRows,
+} from "./first-party-analytics-purge.js";
 
 const scope = { orgId: "org-1", userEmail: "admin@example.com" };
 const window = {
@@ -75,5 +78,37 @@ describe("countFirstPartyAnalyticsPostgresRows", () => {
     await expect(
       countFirstPartyAnalyticsPostgresRows(scope, false, window),
     ).rejects.toThrow("invalid value");
+  });
+});
+
+describe("purgeFirstPartyAnalyticsPostgresRows", () => {
+  it("deletes each scoped table in bounded returning batches", async () => {
+    execute
+      .mockResolvedValueOnce({ rows: [{ row_count: "5" }] })
+      .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
+      .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
+      .mockResolvedValueOnce({
+        rows: Array.from({ length: 5_000 }, () => ({ id: "id" })),
+      })
+      .mockResolvedValueOnce({ rows: [{ id: "last" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "rollup" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "user-day" }] });
+
+    await expect(
+      purgeFirstPartyAnalyticsPostgresRows(scope, false, window),
+    ).resolves.toEqual({ eventRows: 5, dailyRollupRows: 1, userDayRows: 1 });
+
+    expect(execute).toHaveBeenCalledTimes(7);
+    expect(execute).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        sql: expect.stringMatching(
+          /WITH candidates[\s\S]*LIMIT \?[\s\S]*DELETE FROM analytics_events[\s\S]*RETURNING id/,
+        ),
+        args: ["org-1", "2026-07-01T00:00:00.000Z", 5_000],
+        timeoutMs: 30_000,
+        maxAttempts: 1,
+      }),
+    );
   });
 });

--- a/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.spec.ts
@@ -39,7 +39,7 @@ describe("countFirstPartyAnalyticsPostgresRows", () => {
           /FROM analytics_events[\s\S]*event_name IS DISTINCT FROM 'http\.response'/,
         ),
         args: ["org-1", "2026-07-01T00:00:00.000Z"],
-        timeoutMs: 5_000,
+        timeoutMs: 60_000,
         maxAttempts: 1,
       }),
     );
@@ -87,7 +87,7 @@ describe("purgeFirstPartyAnalyticsPostgresRows", () => {
       .mockResolvedValueOnce({ rows: [{ row_count: "5" }] })
       .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
       .mockResolvedValueOnce({ rows: [{ row_count: "1" }] })
-      .mockResolvedValueOnce({ rows: [], rowsAffected: 50_000 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 10_000 })
       .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
       .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
       .mockResolvedValueOnce({ rows: [], rowsAffected: 1 });
@@ -103,7 +103,7 @@ describe("purgeFirstPartyAnalyticsPostgresRows", () => {
         sql: expect.stringMatching(
           /WITH candidates[\s\S]*LIMIT \?[\s\S]*DELETE FROM analytics_events/,
         ),
-        args: ["org-1", "2026-07-01T00:00:00.000Z", 50_000],
+        args: ["org-1", "2026-07-01T00:00:00.000Z", 10_000],
         timeoutMs: 60_000,
         maxAttempts: 1,
       }),

--- a/templates/analytics/server/lib/first-party-analytics-purge.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.ts
@@ -23,8 +23,8 @@ type CountTable =
 
 type CountTimeColumn = "received_at" | "event_date";
 
-const PURGE_BATCH_SIZE = 5_000;
-const PURGE_BATCH_TIMEOUT_MS = 30_000;
+const PURGE_BATCH_SIZE = 50_000;
+const PURGE_BATCH_TIMEOUT_MS = 60_000;
 
 function purgeWhereSql(
   table: CountTable,
@@ -159,13 +159,12 @@ export async function purgeFirstPartyAnalyticsPostgresRows(
           LIMIT ?
         )
         DELETE FROM ${table}
-        WHERE id IN (SELECT id FROM candidates)
-        RETURNING id`,
+        WHERE id IN (SELECT id FROM candidates)`,
         args: [...args, PURGE_BATCH_SIZE],
         timeoutMs: PURGE_BATCH_TIMEOUT_MS,
         maxAttempts: 1,
       });
-      if (result.rows.length < PURGE_BATCH_SIZE) break;
+      if (Number(result.rowsAffected ?? 0) < PURGE_BATCH_SIZE) break;
     }
   }
   return counts;

--- a/templates/analytics/server/lib/first-party-analytics-purge.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.ts
@@ -23,8 +23,9 @@ type CountTable =
 
 type CountTimeColumn = "received_at" | "event_date";
 
-const PURGE_BATCH_SIZE = 50_000;
+const PURGE_BATCH_SIZE = 10_000;
 const PURGE_BATCH_TIMEOUT_MS = 60_000;
+const PURGE_COUNT_TIMEOUT_MS = 60_000;
 
 function purgeWhereSql(
   table: CountTable,
@@ -86,7 +87,7 @@ async function countScopedRows(
              ${eventFilter}
              AND ${timeColumn} >= ?`,
     args,
-    timeoutMs: 5_000,
+    timeoutMs: PURGE_COUNT_TIMEOUT_MS,
     maxAttempts: 1,
   });
   const rawCount = (rows[0] as { row_count?: unknown } | undefined)?.row_count;

--- a/templates/analytics/server/lib/first-party-analytics-purge.ts
+++ b/templates/analytics/server/lib/first-party-analytics-purge.ts
@@ -1,7 +1,4 @@
 import { getDbExec } from "@agent-native/core/db";
-import { and, eq, gte, isNull, ne, or } from "drizzle-orm";
-
-import { getDb, schema } from "../db/index.js";
 
 export interface FirstPartyAnalyticsPurgeScope {
   userEmail: string;
@@ -19,40 +16,45 @@ export interface FirstPartyAnalyticsPurgeWindow {
   startEventDate: string;
 }
 
-function scopePredicate(
-  table: {
-    orgId: any;
-    ownerEmail: any;
-  },
-  scope: FirstPartyAnalyticsPurgeScope,
-  includeLegacyOwnerRows: boolean,
-) {
-  if (!includeLegacyOwnerRows) return eq(table.orgId, scope.orgId);
-  return or(
-    eq(table.orgId, scope.orgId),
-    and(isNull(table.orgId), eq(table.ownerEmail, scope.userEmail)),
-  );
-}
-
-function windowPredicate(
-  table: {
-    eventDate: any;
-    receivedAt?: any;
-  },
-  predicate: any,
-  window: FirstPartyAnalyticsPurgeWindow,
-) {
-  return table.receivedAt
-    ? and(predicate, gte(table.receivedAt, window.startReceivedAt))
-    : and(predicate, gte(table.eventDate, window.startEventDate));
-}
-
 type CountTable =
   | "analytics_events"
   | "analytics_event_daily_rollups"
   | "analytics_user_days";
 
 type CountTimeColumn = "received_at" | "event_date";
+
+const PURGE_BATCH_SIZE = 5_000;
+const PURGE_BATCH_TIMEOUT_MS = 30_000;
+
+function purgeWhereSql(
+  table: CountTable,
+  scope: FirstPartyAnalyticsPurgeScope,
+  includeLegacyOwnerRows: boolean,
+  window: FirstPartyAnalyticsPurgeWindow,
+): { sql: string; args: unknown[]; timeColumn: CountTimeColumn } {
+  const scopeSql = includeLegacyOwnerRows
+    ? "(org_id = ? OR (org_id IS NULL AND owner_email = ?))"
+    : "org_id = ?";
+  const args: unknown[] = includeLegacyOwnerRows
+    ? [scope.orgId, scope.userEmail]
+    : [scope.orgId];
+  const timeColumn =
+    table === "analytics_events" ? "received_at" : "event_date";
+  args.push(
+    timeColumn === "received_at"
+      ? window.startReceivedAt
+      : window.startEventDate,
+  );
+  const eventFilter =
+    table === "analytics_events"
+      ? " AND event_name IS DISTINCT FROM 'http.response'"
+      : "";
+  return {
+    sql: `${scopeSql}${eventFilter} AND ${timeColumn} >= ?`,
+    args,
+    timeColumn,
+  };
+}
 
 async function countScopedRows(
   table: CountTable,
@@ -136,49 +138,35 @@ export async function purgeFirstPartyAnalyticsPostgresRows(
     includeLegacyOwnerRows,
     window,
   );
-  await (getDb() as any).transaction(async (tx: any) => {
-    await tx
-      .delete(schema.analyticsEvents)
-      .where(
-        and(
-          windowPredicate(
-            schema.analyticsEvents,
-            scopePredicate(
-              schema.analyticsEvents,
-              scope,
-              includeLegacyOwnerRows,
-            ),
-            window,
-          ),
-          ne(schema.analyticsEvents.eventName, "http.response"),
-        ),
-      );
-    await tx
-      .delete(schema.analyticsEventDailyRollups)
-      .where(
-        windowPredicate(
-          schema.analyticsEventDailyRollups,
-          scopePredicate(
-            schema.analyticsEventDailyRollups,
-            scope,
-            includeLegacyOwnerRows,
-          ),
-          window,
-        ),
-      );
-    await tx
-      .delete(schema.analyticsUserDays)
-      .where(
-        windowPredicate(
-          schema.analyticsUserDays,
-          scopePredicate(
-            schema.analyticsUserDays,
-            scope,
-            includeLegacyOwnerRows,
-          ),
-          window,
-        ),
-      );
-  });
+
+  for (const table of [
+    "analytics_events",
+    "analytics_event_daily_rollups",
+    "analytics_user_days",
+  ] as const) {
+    const {
+      sql: whereSql,
+      args,
+      timeColumn,
+    } = purgeWhereSql(table, scope, includeLegacyOwnerRows, window);
+    while (true) {
+      const result = await getDbExec().execute({
+        sql: `WITH candidates AS (
+          SELECT id
+          FROM ${table}
+          WHERE ${whereSql}
+          ORDER BY ${timeColumn}, id
+          LIMIT ?
+        )
+        DELETE FROM ${table}
+        WHERE id IN (SELECT id FROM candidates)
+        RETURNING id`,
+        args: [...args, PURGE_BATCH_SIZE],
+        timeoutMs: PURGE_BATCH_TIMEOUT_MS,
+        maxAttempts: 1,
+      });
+      if (result.rows.length < PURGE_BATCH_SIZE) break;
+    }
+  }
   return counts;
 }

--- a/templates/slides/actions/export-pptx.spec.ts
+++ b/templates/slides/actions/export-pptx.spec.ts
@@ -631,6 +631,20 @@ describe("parseSlideHtml", () => {
     expect(connector.w).toBe(0);
   });
 
+  it("collapses a thin imported rule onto its line axis", () => {
+    const [connector] = parseSlideHtml(
+      sourcePagedSlide(CONNECTOR_ELEMENT.replace("width: 0px;", "width: 2px;")),
+      "16:9",
+      4,
+    ).shapes;
+
+    expect(connector).toMatchObject({
+      shapeType: "line",
+      w: 0,
+    });
+    expect(connector.h).toBeGreaterThan(0);
+  });
+
   it("caps only the end of a line the source actually decorated", () => {
     const tailOnly = CONNECTOR_ELEMENT.replace(
       '<circle cx="3" cy="2.25" r="2.25" fill="#3A3838" />',
@@ -1137,6 +1151,14 @@ describe("exported slide XML", () => {
     );
     expect(slideXml).toContain('<a:headEnd type="oval"/>');
     expect(slideXml).toContain('<a:tailEnd type="oval"/>');
+  });
+
+  it("round-trips a thin imported rule without making it diagonal", async () => {
+    const thinRule = CONNECTOR_ELEMENT.replace("width: 0px;", "width: 2px;");
+    const slideXml = await writeParsedSlide(sourcePagedSlide(thinRule));
+
+    expect(slideXml).toContain('<a:prstGeom prst="line">');
+    expect(slideXml).toContain('cx="0"');
   });
 
   it("round-trips a source spcPct of 100% back to 100%, not 120%", async () => {

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -1060,9 +1060,8 @@ function importedLineStroke(
       | "lineDashType"
       | "lineHeadType"
       | "lineTailType"
-      | "w"
-      | "h"
     >
+      & Partial<Pick<ShapeElement, "w" | "h">>>
   | undefined {
   for (const [property, axis] of Object.entries(SINGLE_EDGE_BORDER_AXES)) {
     const border = parseCssBorder(getStyle(style, property));

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -1060,6 +1060,8 @@ function importedLineStroke(
       | "lineDashType"
       | "lineHeadType"
       | "lineTailType"
+      | "w"
+      | "h"
     >
   | undefined {
   for (const [property, axis] of Object.entries(SINGLE_EDGE_BORDER_AXES)) {
@@ -1068,6 +1070,10 @@ function importedLineStroke(
     const color = colorToHex(border.color);
     return {
       shapeType: "line",
+      // A single-edge border is a line in the element's local coordinate
+      // system. Keep its perpendicular dimension collapsed after the box
+      // geometry has been parsed, or a thin rule becomes a diagonal line.
+      ...(axis === "x" ? { h: 0 } : { w: 0 }),
       lineColor: color.hex,
       lineTransparency: color.transparency,
       // The same 0.5pt floor the outline paths use, for the same reason:

--- a/templates/slides/actions/export-pptx.ts
+++ b/templates/slides/actions/export-pptx.ts
@@ -1051,7 +1051,7 @@ function importedLineStroke(
   innerHtml: string,
   dims: SlideDims,
 ):
-  | Pick<
+  | (Pick<
       ShapeElement,
       | "shapeType"
       | "lineColor"
@@ -1060,8 +1060,8 @@ function importedLineStroke(
       | "lineDashType"
       | "lineHeadType"
       | "lineTailType"
-    >
-      & Partial<Pick<ShapeElement, "w" | "h">>>
+    > &
+      Partial<Pick<ShapeElement, "w" | "h">>)
   | undefined {
   for (const [property, axis] of Object.entries(SINGLE_EDGE_BORDER_AXES)) {
     const border = parseCssBorder(getStyle(style, property));


### PR DESCRIPTION
## Summary

- Collapse the perpendicular dimension when imported single-edge borders are converted to PPTX lines.
- Add parser and XML round-trip coverage for thin imported rules.

## Validation

- `pnpm exec vitest run actions/export-pptx.spec.ts` (72 passed)
- `pnpm prep` run after publishing this follow-up
