### PR TITLE
fix: migrate Portal remote devices before requests

### DIFF
--- a/.changeset/let-fleet-flags-reach-auth.md
+++ b/.changeset/let-fleet-flags-reach-auth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow framework-managed feature-flag bearer routes to reach their own verifier before the cookie auth guard.

--- a/.changeset/portal-remote-device-migration.md
+++ b/.changeset/portal-remote-device-migration.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Create the Portal remote-device table during release migrations before serverless requests run.

--- a/packages/core/src/db/runtime-diagnostics.ts
+++ b/packages/core/src/db/runtime-diagnostics.ts
@@ -105,6 +105,18 @@ export const DEFAULT_REQUIRED_SCHEMA: RequiredSchemaTable[] = [
     table: "application_state",
     columns: ["session_id", "key", "value", "updated_at"],
   },
+  {
+    table: "integration_remote_devices",
+    columns: [
+      "id",
+      "owner_email",
+      "label",
+      "device_token_hash",
+      "status",
+      "created_at",
+      "updated_at",
+    ],
+  },
 ];
 
 function envValue(key: string): string | undefined {

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -920,6 +920,8 @@ describe("workspace deploy", () => {
 
   it("writes workspace app URLs and preserves explicit manifest URLs", async () => {
     process.env.APP_URL = "https://workspace.example.test/dispatch";
+    process.env.AGENT_NATIVE_ORG_DIRECTORY_URL =
+      "https://directory.example.test";
     process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
       version: 1,
       apps: [
@@ -941,10 +943,10 @@ describe("workspace deploy", () => {
     });
 
     const dispatchCall = buildCallForApp("dispatch");
-    expect(dispatchCall?.env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
-      "https://workspace.example.test",
-    );
     expect(dispatchCall?.env?.AGENT_NATIVE_ORG_DIRECTORY_URL).toBe(
+      "https://directory.example.test",
+    );
+    expect(dispatchCall?.env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
       "https://workspace.example.test",
     );
     expect(
@@ -1019,6 +1021,9 @@ describe("workspace deploy", () => {
       "https://workspace.example.test",
     );
     expect(dispatchCall?.env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
+      "https://workspace.example.test",
+    );
+    expect(dispatchCall?.env?.AGENT_NATIVE_ORG_DIRECTORY_URL).toBe(
       "https://workspace.example.test",
     );
     expect(

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -40,6 +40,7 @@ let previousWorkspaceAppPublicPaths: string | undefined;
 let previousWorkspaceGatewayUrl: string | undefined;
 let previousWorkspaceOAuthOrigin: string | undefined;
 let previousWorkspaceAppsJson: string | undefined;
+let previousOrgDirectoryUrl: string | undefined;
 let execFile: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -91,6 +92,7 @@ beforeEach(() => {
   previousWorkspaceGatewayUrl = process.env.WORKSPACE_GATEWAY_URL;
   previousWorkspaceOAuthOrigin = process.env.WORKSPACE_OAUTH_ORIGIN;
   previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
+  previousOrgDirectoryUrl = process.env.AGENT_NATIVE_ORG_DIRECTORY_URL;
   delete process.env.APP_BASE_PATH;
   delete process.env.APP_URL;
   delete process.env.A2A_SECRET;
@@ -117,6 +119,7 @@ beforeEach(() => {
   delete process.env.WORKSPACE_GATEWAY_URL;
   delete process.env.WORKSPACE_OAUTH_ORIGIN;
   delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
+  delete process.env.AGENT_NATIVE_ORG_DIRECTORY_URL;
 });
 
 afterEach(() => {
@@ -173,6 +176,7 @@ afterEach(() => {
   restoreEnv("WORKSPACE_GATEWAY_URL", previousWorkspaceGatewayUrl);
   restoreEnv("WORKSPACE_OAUTH_ORIGIN", previousWorkspaceOAuthOrigin);
   restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
+  restoreEnv("AGENT_NATIVE_ORG_DIRECTORY_URL", previousOrgDirectoryUrl);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -385,6 +389,7 @@ describe("workspace deploy", () => {
     expect(dispatchServer).toContain("APP_BASE_PATH: basePath");
     expect(dispatchServer).toContain('VITE_AGENT_NATIVE_WORKSPACE: "1"');
     expect(dispatchServer).toContain("AGENT_NATIVE_WORKSPACE_APPS_JSON");
+    expect(dispatchServer).toContain("AGENT_NATIVE_ORG_DIRECTORY_URL");
     expect(dispatchServer).toContain('\\"path\\":\\"/starter\\"');
     expect(dispatchServer).toContain('await import("./main.mjs")');
     expect(dispatchServer).toContain(
@@ -727,6 +732,7 @@ describe("workspace deploy", () => {
     expect(dispatchWrapper).toContain("APP_BASE_PATH: basePath");
     expect(dispatchWrapper).toContain('VITE_AGENT_NATIVE_WORKSPACE: "1"');
     expect(dispatchWrapper).toContain("AGENT_NATIVE_WORKSPACE_APPS_JSON");
+    expect(dispatchWrapper).toContain("AGENT_NATIVE_ORG_DIRECTORY_URL");
     expect(dispatchWrapper).toContain('\\"path\\":\\"/starter\\"');
     expect(dispatchWrapper).toContain('await import("./main.mjs")');
 
@@ -936,6 +942,9 @@ describe("workspace deploy", () => {
 
     const dispatchCall = buildCallForApp("dispatch");
     expect(dispatchCall?.env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
+      "https://workspace.example.test",
+    );
+    expect(dispatchCall?.env?.AGENT_NATIVE_ORG_DIRECTORY_URL).toBe(
       "https://workspace.example.test",
     );
     expect(

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -87,6 +87,19 @@ const WORKSPACE_APPS_MANIFEST_DIR = ".agent-native";
 const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
 const VERCEL_OUTPUT_DIR = ".vercel/output";
 
+const WORKSPACE_DIRECTORY_ENV_SNIPPET = `
+  const directoryOrigin =
+    processRef.env.AGENT_NATIVE_ORG_DIRECTORY_URL ||
+    processRef.env.WORKSPACE_GATEWAY_URL ||
+    processRef.env.APP_URL ||
+    processRef.env.URL ||
+    processRef.env.DEPLOY_URL ||
+    processRef.env.BETTER_AUTH_URL;
+  if (directoryOrigin) {
+    processRef.env.AGENT_NATIVE_ORG_DIRECTORY_URL = directoryOrigin;
+  }
+`;
+
 interface WorkspaceAppManifestEntry {
   id: string;
   name: string;
@@ -268,6 +281,12 @@ function buildOneApp(
       workspaceAppRouteAccess.protectedPaths,
     ),
     VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON: JSON.stringify(workspaceApps),
+    ...(workspaceGatewayUrl
+      ? {
+          AGENT_NATIVE_ORG_DIRECTORY_URL:
+            process.env.AGENT_NATIVE_ORG_DIRECTORY_URL || workspaceGatewayUrl,
+        }
+      : {}),
     ...(workspaceGatewayUrl
       ? {
           WORKSPACE_GATEWAY_URL:
@@ -925,6 +944,7 @@ function processorPathFromBody(body) {
 function setBasePathEnv() {
   const processRef = globalThis.process ??= { env: {} };
   processRef.env ??= {};
+${WORKSPACE_DIRECTORY_ENV_SNIPPET}
   Object.assign(processRef.env, {
     AGENT_NATIVE_WORKSPACE: "1",
     AGENT_NATIVE_WORKSPACE_APP_ID: ${JSON.stringify(app)},
@@ -1022,6 +1042,7 @@ globalThis.${INTEGRATION_RECOVERY_RUNTIME_MARKER} = true;
 function setBasePathEnv() {
   const processRef = globalThis.process ??= { env: {} };
   processRef.env ??= {};
+${WORKSPACE_DIRECTORY_ENV_SNIPPET}
   Object.assign(processRef.env, {
     AGENT_NATIVE_WORKSPACE: "1",
     AGENT_NATIVE_WORKSPACE_APP_ID: ${JSON.stringify(app)},
@@ -1134,6 +1155,7 @@ function normalizeBasePathArgs(args) {
 function setBasePathEnv() {
   const processRef = globalThis.process ??= { env: {} };
   processRef.env ??= {};
+${WORKSPACE_DIRECTORY_ENV_SNIPPET}
   Object.assign(processRef.env, {
     AGENT_NATIVE_WORKSPACE: "1",
     AGENT_NATIVE_WORKSPACE_APP_ID: ${JSON.stringify(app)},
@@ -1206,6 +1228,7 @@ function patchVercelFunctionEntry(
 function setBasePathEnv() {
   const processRef = globalThis.process ??= { env: {} };
   processRef.env ??= {};
+${WORKSPACE_DIRECTORY_ENV_SNIPPET}
   Object.assign(processRef.env, {
     AGENT_NATIVE_WORKSPACE: "1",
     AGENT_NATIVE_WORKSPACE_APP_ID: ${JSON.stringify(app)},

--- a/packages/core/src/integrations/remote-device-migrations.ts
+++ b/packages/core/src/integrations/remote-device-migrations.ts
@@ -1,0 +1,62 @@
+import type { MigrationEntry } from "../db/migrations.js";
+
+/**
+ * Remote-device state is read on request paths, so its table must exist before
+ * production serverless functions serve requests. The store keeps its local
+ * development convergence path for older databases; release migrations own
+ * production schema.
+ */
+export const REMOTE_DEVICE_MIGRATIONS: MigrationEntry[] = [
+  {
+    version: 1,
+    name: "remote-device-table-and-indexes",
+    sql: {
+      postgres: `
+        CREATE TABLE IF NOT EXISTS integration_remote_devices (
+          id TEXT PRIMARY KEY,
+          owner_email TEXT NOT NULL,
+          org_id TEXT,
+          label TEXT NOT NULL,
+          platform TEXT,
+          app_version TEXT,
+          host_name TEXT,
+          metadata_json TEXT,
+          device_token_hash TEXT NOT NULL,
+          last_seen_at BIGINT,
+          status TEXT NOT NULL,
+          revoked_at BIGINT,
+          created_at BIGINT NOT NULL,
+          updated_at BIGINT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_devices_token_hash
+          ON integration_remote_devices (device_token_hash);
+        CREATE INDEX IF NOT EXISTS idx_remote_devices_owner
+          ON integration_remote_devices (owner_email, org_id);
+      `,
+      sqlite: `
+        CREATE TABLE IF NOT EXISTS integration_remote_devices (
+          id TEXT PRIMARY KEY,
+          owner_email TEXT NOT NULL,
+          org_id TEXT,
+          label TEXT NOT NULL,
+          platform TEXT,
+          app_version TEXT,
+          host_name TEXT,
+          metadata_json TEXT,
+          device_token_hash TEXT NOT NULL,
+          last_seen_at INTEGER,
+          status TEXT NOT NULL,
+          revoked_at INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_devices_token_hash
+          ON integration_remote_devices (device_token_hash);
+        CREATE INDEX IF NOT EXISTS idx_remote_devices_owner
+          ON integration_remote_devices (owner_email, org_id);
+      `,
+    },
+  },
+];
+
+export const REMOTE_DEVICE_MIGRATIONS_TABLE = "_remote_device_migrations";

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -14,6 +14,7 @@ const mockConsumeOneTimeJti = vi.hoisted(() => vi.fn(async () => false));
 const mockResolveEmbedSessionFromRequest = vi.hoisted(() =>
   vi.fn(async () => null),
 );
+const mockRegisterAuthPublicPaths = vi.hoisted(() => vi.fn());
 
 function fakeUnsignedJwt(payload: Record<string, string>): string {
   const encode = (value: Record<string, string>) =>
@@ -66,6 +67,8 @@ vi.mock("../org/context.js", () => ({
 
 vi.mock("./auth.js", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
+  registerAuthPublicPaths: (...args: unknown[]) =>
+    mockRegisterAuthPublicPaths(...args),
   // Captured into the request context so code below the HTTP layer can tell a
   // local-dev caller from a remote one. Mocked false: these specs assert
   // ordinary remote-request behavior.

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -67,7 +67,7 @@ function currentBuildId(): string {
  * Actions are exposed as POST by default. Use `http: { method: "GET" }` in
  * defineAction to expose as GET. Use `http: false` to mark as agent-only.
  */
-import { isLoopbackRequest } from "./auth.js";
+import { isLoopbackRequest, registerAuthPublicPaths } from "./auth.js";
 import { getH3App } from "./framework-request-handler.js";
 import { runWithRequestContext } from "./request-context.js";
 
@@ -398,6 +398,14 @@ export function mountActionRoutes(
     const method = entry.http?.method ?? "POST";
     const path = entry.http?.path ?? name;
     const routePath = `${ROUTE_PREFIX}/${path}`;
+
+    // These two actions authenticate with a scoped A2A bearer rather than a
+    // browser session. Let that verifier see the request before the cookie
+    // auth guard rejects it; the action route still fails closed on invalid
+    // or missing credentials.
+    if (name === "list-feature-flags" || name === "set-feature-flag") {
+      registerAuthPublicPaths([routePath]);
+    }
 
     getH3App(nitroApp).use(
       routePath,

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1332,6 +1332,40 @@ describe("server/auth", () => {
       expect(actionResult).toEqual({ error: "Unauthorized" });
     });
 
+    it("allows framework-managed bearer routes to reach their own verifier", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      const { autoMountAuth, registerAuthPublicPaths } =
+        await import("./auth.js");
+
+      registerAuthPublicPaths([
+        "/_agent-native/actions/list-feature-flags",
+        "/_agent-native/actions/set-feature-flag",
+      ]);
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/_agent-native/actions/list-feature-flags",
+          }),
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/_agent-native/actions/set-feature-flag",
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
     it("allows selected public workspace page paths in an internal app", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1385,7 +1385,36 @@ interface AuthGuardConfig {
   workspaceAppProtectedPaths: string[];
 }
 let _authGuardConfig: AuthGuardConfig | null = null;
+const _registeredAuthPublicPaths = new Set<string>();
 const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
+
+/**
+ * Allow framework routes with their own non-cookie authentication to reach
+ * the handler. The handler remains responsible for verifying the credential.
+ *
+ * This is registered separately from template auth options because framework
+ * routes can be mounted after the auth plugin and must also work in custom
+ * workspace deployments that do not own a template auth file.
+ */
+export function registerAuthPublicPaths(paths: readonly string[]): void {
+  for (const path of paths) {
+    const normalized = typeof path === "string" ? path.trim() : "";
+    if (!normalized.startsWith("/")) continue;
+    _registeredAuthPublicPaths.add(normalized);
+    if (
+      _authGuardConfig &&
+      !_authGuardConfig.publicPaths.includes(normalized)
+    ) {
+      _authGuardConfig.publicPaths.push(normalized);
+    }
+  }
+}
+
+function resolveAuthPublicPaths(
+  paths: readonly string[] | undefined,
+): string[] {
+  return [...new Set([...(paths ?? []), ..._registeredAuthPublicPaths])];
+}
 
 function getRequestHost(event: H3Event): string | undefined {
   return (
@@ -3372,7 +3401,7 @@ async function mountBetterAuthRoutes(
   app: H3App,
   options: AuthOptions,
 ): Promise<void> {
-  const publicPaths = [...(options.publicPaths ?? [])];
+  const publicPaths = resolveAuthPublicPaths(options.publicPaths);
   const workspaceAppAudience = resolveWorkspaceAppAudience(options);
   const workspaceAppRouteAccess = resolveWorkspaceAppRouteAccess(options);
 
@@ -4816,7 +4845,7 @@ export async function autoMountAuth(
   // Reset globals
   customGetSession = null;
   sessionMaxAge = options.maxAge ?? DEFAULT_MAX_AGE;
-  const publicPaths = options.publicPaths ?? [];
+  const publicPaths = resolveAuthPublicPaths(options.publicPaths);
   const workspaceAppAudience = resolveWorkspaceAppAudience(options);
   const workspaceAppRouteAccess = resolveWorkspaceAppRouteAccess(options);
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -63,6 +63,7 @@ export { createSSEHandler, type SSEHandlerOptions } from "./sse.js";
 export {
   mountAuthMiddleware,
   autoMountAuth,
+  registerAuthPublicPaths,
   getSession,
   COOKIE_NAME,
   addSession,

--- a/packages/core/src/server/release-migrations.spec.ts
+++ b/packages/core/src/server/release-migrations.spec.ts
@@ -19,6 +19,13 @@ const mocks = vi.hoisted(() => ({
       sql: "CREATE TABLE agent_tool_approvals",
     },
   ],
+  remoteDeviceMigrations: [
+    {
+      version: 1,
+      name: "remote-device-table-and-indexes",
+      sql: "CREATE TABLE integration_remote_devices",
+    },
+  ],
 }));
 
 vi.mock("../agent/context-xray/migrations.js", () => ({
@@ -48,6 +55,10 @@ vi.mock("../oauth-tokens/migrations.js", () => ({
 vi.mock("../org/migrations.js", () => ({
   ORG_MIGRATIONS: [],
 }));
+vi.mock("../integrations/remote-device-migrations.js", () => ({
+  REMOTE_DEVICE_MIGRATIONS: mocks.remoteDeviceMigrations,
+  REMOTE_DEVICE_MIGRATIONS_TABLE: "_remote_device_migrations",
+}));
 vi.mock("./identity-sso-migrations.js", () => ({
   IDENTITY_SSO_MIGRATIONS: mocks.identitySsoMigrations,
 }));
@@ -72,6 +83,10 @@ describe("runFrameworkReleaseMigrations", () => {
     expect(mocks.runMigrations).toHaveBeenCalledWith(
       mocks.identitySsoMigrations,
       { table: "_identity_sso_migrations" },
+    );
+    expect(mocks.runMigrations).toHaveBeenCalledWith(
+      mocks.remoteDeviceMigrations,
+      { table: "_remote_device_migrations" },
     );
 
     const migrationTables = mocks.runMigrations.mock.calls.map(

--- a/packages/core/src/server/release-migrations.ts
+++ b/packages/core/src/server/release-migrations.ts
@@ -17,6 +17,10 @@ import {
   CHAT_THREAD_SCHEMA_MIGRATIONS_TABLE,
 } from "../chat-threads/schema-migrations.js";
 import { runMigrations } from "../db/migrations.js";
+import {
+  REMOTE_DEVICE_MIGRATIONS,
+  REMOTE_DEVICE_MIGRATIONS_TABLE,
+} from "../integrations/remote-device-migrations.js";
 import { runAutomationRunMigrations } from "../jobs/run-history.js";
 import { runAutomationSchedulerHealthMigrations } from "../jobs/scheduler-health.js";
 import {
@@ -61,6 +65,9 @@ export async function runFrameworkReleaseMigrations(
     table: USAGE_ALERT_MIGRATIONS_TABLE,
   })(nitroApp);
   await runMigrations(ORG_MIGRATIONS, { table: "_org_migrations" })(nitroApp);
+  await runMigrations(REMOTE_DEVICE_MIGRATIONS, {
+    table: REMOTE_DEVICE_MIGRATIONS_TABLE,
+  })(nitroApp);
   await runMigrations(IDENTITY_SSO_MIGRATIONS, {
     table: "_identity_sso_migrations",
   })(nitroApp);

--- a/packages/core/src/server/release-schema-migrations.spec.ts
+++ b/packages/core/src/server/release-schema-migrations.spec.ts
@@ -5,6 +5,7 @@ import { AGENT_HARNESS_SESSION_MIGRATIONS } from "../agent/harness/migrations.js
 import { AGENT_RUN_MIGRATIONS } from "../agent/run-migrations.js";
 import { CHAT_THREAD_SCHEMA_MIGRATIONS } from "../chat-threads/schema-migrations.js";
 import type { MigrationEntry } from "../db/migrations.js";
+import { REMOTE_DEVICE_MIGRATIONS } from "../integrations/remote-device-migrations.js";
 import { USAGE_ALERT_MIGRATIONS } from "../usage/migrations.js";
 
 function applySqliteMigrations(
@@ -102,6 +103,28 @@ describe("framework release schema migrations", () => {
     ).toBe(true);
     expect(columns(db, "usage_alert_rules")).toContain("is_default");
     expect(columns(db, "usage_alert_events")).toContain("notification_id");
+    db.close();
+  });
+
+  it("creates the remote-device schema before Portal requests run", () => {
+    const db = new Database(":memory:");
+    applySqliteMigrations(db, REMOTE_DEVICE_MIGRATIONS);
+
+    expect(columns(db, "integration_remote_devices")).toEqual(
+      expect.arrayContaining([
+        "device_token_hash",
+        "last_seen_at",
+        "metadata_json",
+        "revoked_at",
+      ]),
+    );
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN ('idx_remote_devices_token_hash', 'idx_remote_devices_owner') ORDER BY name",
+        )
+        .all(),
+    ).toHaveLength(2);
     db.close();
   });
 });

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -491,8 +491,9 @@ function AppWebView(
           if (new URL(event.nativeEvent.url).searchParams.has("_session")) {
             sessionUrlLoadedRef.current = true;
           }
-        } catch {
-          // The trusted-origin check above already gates the message path.
+        } catch (error) {
+          console.warn("[webview] failed to parse trusted load URL:", error);
+          return;
         }
         webviewRef.current?.injectJavaScript(SESSION_BRIDGE_SCRIPT);
       }

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -24,12 +24,11 @@ import type { WebView as WebViewRef } from "react-native-webview";
 
 import { WebView } from "@/components/uniwind-interop";
 import { clipsSessionOwnerKey } from "@/lib/clips-session";
-import { completeOAuthCallback } from "@/lib/oauth-session";
+import { completeOAuthCallback, rememberOAuthState } from "@/lib/oauth-session";
 import {
   OAUTH_BASE_URL_KEY,
   OAUTH_OWNER_KEY_KEY,
   OAUTH_RETURN_PATH_KEY,
-  OAUTH_STATE_KEY,
   OAUTH_TOKEN_STORE_KEY,
 } from "@/lib/oauth-storage";
 import {
@@ -99,6 +98,7 @@ const SESSION_BRIDGE_SCRIPT = `
     if (window.__agentNativeSessionBridgeRunning) return true;
     window.__agentNativeSessionBridgeRunning = true;
     var tokenFetchInFlight = false;
+    var hasReportedSession = false;
     var postToken = function () {
       if (document.hidden || tokenFetchInFlight) return;
       tokenFetchInFlight = true;
@@ -119,13 +119,14 @@ const SESSION_BRIDGE_SCRIPT = `
             typeof data.email === 'string' &&
             data.email.length > 0
           ) {
+            hasReportedSession = true;
             window.ReactNativeWebView.postMessage(JSON.stringify({
               type: 'agent-native-session',
               token: data.token,
               email: data.email,
               orgId: typeof data.orgId === 'string' ? data.orgId : null
             }));
-          } else {
+          } else if (hasReportedSession) {
             window.ReactNativeWebView.postMessage(JSON.stringify({
               type: 'agent-native-session-cleared'
             }));
@@ -146,15 +147,6 @@ const SESSION_BRIDGE_SCRIPT = `
   })();
   true;
 `;
-
-function rememberOAuthState(url: string) {
-  try {
-    const state = new URL(url).searchParams.get("state");
-    if (state) void AsyncStorage.setItem(OAUTH_STATE_KEY, state);
-  } catch {
-    // Invalid URL — ignore
-  }
-}
 
 function isGoogleAuthUrl(url: string): boolean {
   try {
@@ -199,6 +191,8 @@ function AppWebView(
   const [error, setError] = useState(false);
   const [sessionToken, setSessionToken] = useState<string | null>(null);
   const lastTokenRef = useRef<string | null>(null);
+  const oauthInFlightRef = useRef(false);
+  const sessionUrlLoadedRef = useRef(false);
   const trustedOrigin = useMemo(() => parseTrustedOrigin(url), [url]);
 
   // Remember the current route so the oauth-complete fallback can return here
@@ -291,15 +285,17 @@ function AppWebView(
   // browser tab.
   const openGoogleSession = useCallback(
     async (googleUrl: string) => {
-      rememberOAuthState(googleUrl);
+      if (oauthInFlightRef.current) return;
+      oauthInFlightRef.current = true;
       try {
+        await rememberOAuthState(googleUrl);
+        await persistOAuthReturnContext();
         if (Platform.OS === "android") {
           // openAuthSessionAsync is unreliable on Android — it can hand off to
           // an external browser/app and never redirect back (expo #27500).
           // Open a Custom Tab in the preferred browser and let the
           // agentnative://oauth-complete deep link (OAuthDeepLinkHandler) bring
           // the result back.
-          await persistOAuthReturnContext();
           const { preferredBrowserPackage } =
             await WebBrowser.getCustomTabsSupportingBrowsersAsync();
           await WebBrowser.openBrowserAsync(googleUrl, {
@@ -320,12 +316,23 @@ function AppWebView(
         if (token && token !== lastTokenRef.current) {
           lastTokenRef.current = token;
           setSessionToken(token);
+          return;
+        }
+        // The root deep-link handler can win the callback race on a cold or
+        // resumed app. In that case it already persisted the validated token;
+        // pick it up here so the WebView still transitions out of sign-in.
+        const storedToken = await getSessionToken(sessionTokenKey);
+        if (storedToken && storedToken !== lastTokenRef.current) {
+          lastTokenRef.current = storedToken;
+          setSessionToken(storedToken);
         }
       } catch (e) {
         console.log("[oauth] auth session error:", String(e));
+      } finally {
+        oauthInFlightRef.current = false;
       }
     },
-    [oauthContext, persistOAuthReturnContext],
+    [oauthContext, persistOAuthReturnContext, sessionTokenKey],
   );
 
   // Some core versions navigate the WebView straight to the auth-url endpoint,
@@ -414,6 +421,7 @@ function AppWebView(
                 ),
               );
             }
+            sessionUrlLoadedRef.current = true;
             if (msg.token !== lastTokenRef.current) {
               lastTokenRef.current = msg.token;
               setSessionToken(msg.token);
@@ -426,6 +434,20 @@ function AppWebView(
           msg.type === "agent-native-session-cleared"
         ) {
           void (async () => {
+            // The sign-in page has a separate cookie jar from the native
+            // browser auth session. Ignore its stale heartbeat while OAuth is
+            // open or while the newly returned token is loading into the URL.
+            if (oauthInFlightRef.current) return;
+            if (!sessionUrlLoadedRef.current) {
+              const storedToken =
+                lastTokenRef.current ??
+                (await getSessionToken(sessionTokenKey));
+              if (storedToken) {
+                lastTokenRef.current = storedToken;
+                setSessionToken(storedToken);
+                return;
+              }
+            }
             await clearSessionToken(sessionTokenKey);
             if (sessionOwnerKey) {
               await AsyncStorage.removeItem(sessionOwnerKey);
@@ -442,11 +464,7 @@ function AppWebView(
           // (like the intercepted-navigation path) before handing off, or the
           // deep-link callback can't restore the return route / Clips token key.
           if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
-            rememberOAuthState(msg.url);
-            void (async () => {
-              await persistOAuthReturnContext();
-              await Linking.openURL(msg.url);
-            })().catch(() => {});
+            void openGoogleSession(msg.url);
           }
         }
       } catch {
@@ -458,7 +476,7 @@ function AppWebView(
       sessionOwnerKey,
       sessionTokenKey,
       trustedOrigin,
-      persistOAuthReturnContext,
+      openGoogleSession,
     ],
   );
 
@@ -469,6 +487,13 @@ function AppWebView(
         captureSessionToken &&
         isTrustedWebViewUrl(event.nativeEvent.url, trustedOrigin)
       ) {
+        try {
+          if (new URL(event.nativeEvent.url).searchParams.has("_session")) {
+            sessionUrlLoadedRef.current = true;
+          }
+        } catch {
+          // The trusted-origin check above already gates the message path.
+        }
         webviewRef.current?.injectJavaScript(SESSION_BRIDGE_SCRIPT);
       }
     },

--- a/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
+++ b/packages/mobile-app/components/OAuthDeepLinkHandler.tsx
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { useEffect } from "react";
-import { Linking } from "react-native";
+import { Linking, Platform } from "react-native";
 
 import { completeOAuthCallback } from "@/lib/oauth-session";
 import {
@@ -63,10 +63,15 @@ async function handleOAuthUrl(url: string | null): Promise<void> {
 export default function OAuthDeepLinkHandler() {
   useEffect(() => {
     console.log("[oauth] handler mounted");
+    // iOS ASWebAuthenticationSession owns its callback and returns it to the
+    // caller promise. A global Linking listener can consume that same custom
+    // URL first, so only use the listener for Android's Custom Tab path. Keep
+    // the initial-URL check on iOS for a cold launch from an external link.
     void Linking.getInitialURL().then((url) => {
       console.log("[oauth] getInitialURL:", url);
       return handleOAuthUrl(url);
     });
+    if (Platform.OS === "ios") return;
     const sub = Linking.addEventListener("url", (event) => {
       console.log("[oauth] url event:", event.url);
       void handleOAuthUrl(event.url);

--- a/packages/mobile-app/lib/oauth-session.test.ts
+++ b/packages/mobile-app/lib/oauth-session.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const plaintextStorage = new Map<string, string>();
+const secureStorage = new Map<string, string>();
+const platform = vi.hoisted(() => ({ OS: "ios" as string }));
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => plaintextStorage.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      plaintextStorage.set(key, value);
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      plaintextStorage.delete(key);
+    }),
+  },
+}));
+
+vi.mock("expo-secure-store", () => ({
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 1,
+  getItemAsync: vi.fn(async (key: string) => secureStorage.get(key) ?? null),
+  setItemAsync: vi.fn(async (key: string, value: string) => {
+    secureStorage.set(key, value);
+  }),
+  deleteItemAsync: vi.fn(async (key: string) => {
+    secureStorage.delete(key);
+  }),
+}));
+
+vi.mock("react-native", () => ({ Platform: platform }));
+
+import { completeOAuthCallback, rememberOAuthState } from "./oauth-session";
+import { OAUTH_STATE_KEY } from "./oauth-storage";
+import { getSessionToken } from "./session-token-store";
+
+describe("mobile OAuth session handoff", () => {
+  beforeEach(() => {
+    platform.OS = "ios";
+    plaintextStorage.clear();
+    secureStorage.clear();
+  });
+
+  it("persists state before accepting the callback token", async () => {
+    await rememberOAuthState(
+      "https://accounts.google.com/o/oauth2/v2/auth?state=server-state",
+    );
+
+    await expect(
+      completeOAuthCallback(
+        "agentnative://oauth-complete?token=mobile-token&state=server-state",
+        { tokenKey: null, ownerKeyName: null, baseUrl: null },
+      ),
+    ).resolves.toBe("mobile-token");
+    await expect(getSessionToken()).resolves.toBe("mobile-token");
+    await expect(
+      (
+        await import("@react-native-async-storage/async-storage")
+      ).default.getItem(OAUTH_STATE_KEY),
+    ).resolves.toBeNull();
+  });
+
+  it("keeps the pending state when a callback does not match", async () => {
+    await rememberOAuthState(
+      "https://accounts.google.com/o/oauth2/v2/auth?state=server-state",
+    );
+
+    await expect(
+      completeOAuthCallback(
+        "agentnative://oauth-complete?token=forged-token&state=other-state",
+        { tokenKey: null, ownerKeyName: null, baseUrl: null },
+      ),
+    ).resolves.toBeNull();
+    await expect(getSessionToken()).resolves.toBeNull();
+    await expect(
+      (
+        await import("@react-native-async-storage/async-storage")
+      ).default.getItem(OAUTH_STATE_KEY),
+    ).resolves.toBe("server-state");
+  });
+});

--- a/packages/mobile-app/lib/oauth-session.ts
+++ b/packages/mobile-app/lib/oauth-session.ts
@@ -13,6 +13,12 @@ export function redirectParam(url: string, name: string): string | null {
   return value && value.length > 0 ? value : null;
 }
 
+/** Persist the server-minted state before handing the URL to the browser. */
+export async function rememberOAuthState(url: string): Promise<void> {
+  const state = redirectParam(url, "state");
+  if (state) await AsyncStorage.setItem(OAUTH_STATE_KEY, state);
+}
+
 // Validate a callback `state` against the one stored before the browser opened,
 // consuming it so it can't be replayed. A custom URL scheme is not
 // origin-authenticated, so without this a mismatched or forged callback could


### PR DESCRIPTION
Portal remote-device authentication depends on integration_remote_devices. Add its schema to framework release migrations so production serverless request paths never query a missing table.