### PR TITLE
fix: share auth public paths across core instances

### DIFF
--- a/.changeset/share-auth-public-path-registry.md
+++ b/.changeset/share-auth-public-path-registry.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep framework-managed bearer routes reachable when authentication and action modules are loaded from separate server bundle instances.

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -390,6 +390,7 @@ export function mountActionRoutes(
   options?: MountActionRoutesOptions,
 ) {
   const mounted: string[] = [];
+  const app = getH3App(nitroApp);
 
   for (const [name, entry] of Object.entries(actions)) {
     // Skip agent-only actions
@@ -404,10 +405,10 @@ export function mountActionRoutes(
     // auth guard rejects it; the action route still fails closed on invalid
     // or missing credentials.
     if (name === "list-feature-flags" || name === "set-feature-flag") {
-      registerAuthPublicPaths([routePath]);
+      registerAuthPublicPaths([routePath], app);
     }
 
-    getH3App(nitroApp).use(
+    app.use(
       routePath,
       defineEventHandler(async (event) => {
         const reqMethod = getMethod(event);

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -39,8 +39,7 @@ function clearAuthPublicPathRegistry(): void {
   const globalState = globalThis as unknown as {
     [key: symbol]: unknown;
   };
-  const registry = globalState[AUTH_PUBLIC_PATHS_REGISTRY_KEY];
-  if (registry instanceof Set) registry.clear();
+  delete globalState[AUTH_PUBLIC_PATHS_REGISTRY_KEY];
 }
 
 describe("server/auth", () => {
@@ -1351,12 +1350,15 @@ describe("server/auth", () => {
       vi.stubEnv("ACCESS_TOKEN", "my-secret");
       const { autoMountAuth, registerAuthPublicPaths } =
         await import("./auth.js");
-
-      registerAuthPublicPaths([
-        "/_agent-native/actions/list-feature-flags",
-        "/_agent-native/actions/set-feature-flag",
-      ]);
       const app = createMockApp();
+
+      registerAuthPublicPaths(
+        [
+          "/_agent-native/actions/list-feature-flags",
+          "/_agent-native/actions/set-feature-flag",
+        ],
+        app,
+      );
       await autoMountAuth(app);
 
       const guard = app.use.mock.calls
@@ -1396,9 +1398,10 @@ describe("server/auth", () => {
       // route registration must still reach the already-mounted guard.
       vi.resetModules();
       const secondCore = await import("./auth.js");
-      secondCore.registerAuthPublicPaths([
-        "/_agent-native/actions/cross-module-registry-test",
-      ]);
+      secondCore.registerAuthPublicPaths(
+        ["/_agent-native/actions/cross-module-registry-test"],
+        app,
+      );
 
       await expect(
         guard(
@@ -1407,6 +1410,35 @@ describe("server/auth", () => {
           }),
         ),
       ).resolves.toBeUndefined();
+    });
+
+    it("does not share public-path registrations across H3 app scopes", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      const firstCore = await import("./auth.js");
+      const app = createMockApp();
+      await firstCore.autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      vi.resetModules();
+      const secondCore = await import("./auth.js");
+      const otherApp = createMockApp();
+      secondCore.registerAuthPublicPaths(
+        ["/_agent-native/actions/other-app-only"],
+        otherApp,
+      );
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/_agent-native/actions/other-app-only",
+          }),
+        ),
+      ).resolves.toEqual({ error: "Unauthorized" });
     });
 
     it("allows selected public workspace page paths in an internal app", async () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1366,6 +1366,35 @@ describe("server/auth", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("shares late public-path registrations across Core module instances", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      const firstCore = await import("./auth.js");
+      const app = createMockApp();
+      await firstCore.autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      // A second SSR bundle can evaluate the same package independently. The
+      // route registration must still reach the already-mounted guard.
+      vi.resetModules();
+      const secondCore = await import("./auth.js");
+      secondCore.registerAuthPublicPaths([
+        "/_agent-native/actions/cross-module-registry-test",
+      ]);
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/_agent-native/actions/cross-module-registry-test",
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
     it("allows selected public workspace page paths in an internal app", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -31,14 +31,28 @@ function expectLoginHtmlCacheHeaders(response: Response) {
   );
 }
 
+const AUTH_PUBLIC_PATHS_REGISTRY_KEY = Symbol.for(
+  "@agent-native/core/auth.publicPaths",
+);
+
+function clearAuthPublicPathRegistry(): void {
+  const globalState = globalThis as unknown as {
+    [key: symbol]: unknown;
+  };
+  const registry = globalState[AUTH_PUBLIC_PATHS_REGISTRY_KEY];
+  if (registry instanceof Set) registry.clear();
+}
+
 describe("server/auth", () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     originalEnv = { ...process.env };
+    clearAuthPublicPathRegistry();
   });
 
   afterEach(() => {
+    clearAuthPublicPathRegistry();
     process.env = originalEnv;
     vi.doUnmock("./better-auth-instance.js");
     vi.doUnmock("../db/client.js");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1385,7 +1385,22 @@ interface AuthGuardConfig {
   workspaceAppProtectedPaths: string[];
 }
 let _authGuardConfig: AuthGuardConfig | null = null;
-const _registeredAuthPublicPaths = new Set<string>();
+// Pin the registry to globalThis so template plugins and framework routes that
+// load Core through different SSR bundle or pnpm peer graphs still share it.
+// A module-local Set lets the auth guard miss paths registered by a second
+// Core instance, which turns its own non-cookie-authenticated routes into 401s.
+const AUTH_PUBLIC_PATHS_REGISTRY_KEY = Symbol.for(
+  "@agent-native/core/auth.publicPaths",
+);
+interface GlobalWithAuthPublicPaths {
+  [AUTH_PUBLIC_PATHS_REGISTRY_KEY]?: Set<string>;
+}
+
+function getRegisteredAuthPublicPaths(): Set<string> {
+  const globals = globalThis as unknown as GlobalWithAuthPublicPaths;
+  return (globals[AUTH_PUBLIC_PATHS_REGISTRY_KEY] ??= new Set());
+}
+
 const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
 
 /**
@@ -1397,10 +1412,11 @@ const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
  * workspace deployments that do not own a template auth file.
  */
 export function registerAuthPublicPaths(paths: readonly string[]): void {
+  const registeredPaths = getRegisteredAuthPublicPaths();
   for (const path of paths) {
     const normalized = typeof path === "string" ? path.trim() : "";
     if (!normalized.startsWith("/")) continue;
-    _registeredAuthPublicPaths.add(normalized);
+    registeredPaths.add(normalized);
     if (
       _authGuardConfig &&
       !_authGuardConfig.publicPaths.includes(normalized)
@@ -1413,7 +1429,7 @@ export function registerAuthPublicPaths(paths: readonly string[]): void {
 function resolveAuthPublicPaths(
   paths: readonly string[] | undefined,
 ): string[] {
-  return [...new Set([...(paths ?? []), ..._registeredAuthPublicPaths])];
+  return [...new Set([...(paths ?? []), ...getRegisteredAuthPublicPaths()])];
 }
 
 function getRequestHost(event: H3Event): string | undefined {
@@ -2219,7 +2235,9 @@ function createAuthGuardFn(): (
   return async (event: H3Event) => {
     const config = _authGuardConfig;
     if (!config) return;
-    const { publicPaths } = config;
+    // Resolve on every request because a framework route can be mounted by a
+    // different Core module instance after this auth guard is initialized.
+    const publicPaths = resolveAuthPublicPaths(config.publicPaths);
 
     const url = event.node?.req?.url ?? event.path ?? "/";
     const queryStart = url.indexOf("?");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1387,18 +1387,36 @@ interface AuthGuardConfig {
 let _authGuardConfig: AuthGuardConfig | null = null;
 // Pin the registry to globalThis so template plugins and framework routes that
 // load Core through different SSR bundle or pnpm peer graphs still share it.
-// A module-local Set lets the auth guard miss paths registered by a second
-// Core instance, which turns its own non-cookie-authenticated routes into 401s.
+// Scope entries by H3 app so a route registered by one app cannot become public
+// in another app that happens to share the same Node realm.
 const AUTH_PUBLIC_PATHS_REGISTRY_KEY = Symbol.for(
   "@agent-native/core/auth.publicPaths",
 );
+interface AuthPublicPathRegistry {
+  pathsByApp: WeakMap<object, Set<string>>;
+}
 interface GlobalWithAuthPublicPaths {
-  [AUTH_PUBLIC_PATHS_REGISTRY_KEY]?: Set<string>;
+  [AUTH_PUBLIC_PATHS_REGISTRY_KEY]?: AuthPublicPathRegistry;
 }
 
-function getRegisteredAuthPublicPaths(): Set<string> {
+const _registeredAuthPublicPaths = new Set<string>();
+
+function getAuthPublicPathRegistry(): AuthPublicPathRegistry {
   const globals = globalThis as unknown as GlobalWithAuthPublicPaths;
-  return (globals[AUTH_PUBLIC_PATHS_REGISTRY_KEY] ??= new Set());
+  return (globals[AUTH_PUBLIC_PATHS_REGISTRY_KEY] ??= {
+    pathsByApp: new WeakMap(),
+  });
+}
+
+function getRegisteredAuthPublicPaths(app?: object): Set<string> {
+  if (!app) return _registeredAuthPublicPaths;
+  const registry = getAuthPublicPathRegistry();
+  let paths = registry.pathsByApp.get(app);
+  if (!paths) {
+    paths = new Set();
+    registry.pathsByApp.set(app, paths);
+  }
+  return paths;
 }
 
 const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
@@ -1411,25 +1429,29 @@ const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
  * routes can be mounted after the auth plugin and must also work in custom
  * workspace deployments that do not own a template auth file.
  */
-export function registerAuthPublicPaths(paths: readonly string[]): void {
-  const registeredPaths = getRegisteredAuthPublicPaths();
+export function registerAuthPublicPaths(
+  paths: readonly string[],
+  app?: object,
+): void {
+  const registeredPaths = getRegisteredAuthPublicPaths(app);
   for (const path of paths) {
     const normalized = typeof path === "string" ? path.trim() : "";
     if (!normalized.startsWith("/")) continue;
     registeredPaths.add(normalized);
-    if (
-      _authGuardConfig &&
-      !_authGuardConfig.publicPaths.includes(normalized)
-    ) {
-      _authGuardConfig.publicPaths.push(normalized);
-    }
   }
 }
 
 function resolveAuthPublicPaths(
   paths: readonly string[] | undefined,
+  app?: object,
 ): string[] {
-  return [...new Set([...(paths ?? []), ...getRegisteredAuthPublicPaths()])];
+  return [
+    ...new Set([
+      ...(paths ?? []),
+      ..._registeredAuthPublicPaths,
+      ...(app ? getRegisteredAuthPublicPaths(app) : []),
+    ]),
+  ];
 }
 
 function getRequestHost(event: H3Event): string | undefined {
@@ -2229,15 +2251,15 @@ function isHtmlDocumentRequest(event: H3Event, pathname: string): boolean {
   return !accept || accept.includes("text/html") || accept.includes("*/*");
 }
 
-function createAuthGuardFn(): (
-  event: H3Event,
-) => Promise<Response | object | string | void> {
+function createAuthGuardFn(
+  app?: object,
+): (event: H3Event) => Promise<Response | object | string | void> {
   return async (event: H3Event) => {
     const config = _authGuardConfig;
     if (!config) return;
     // Resolve on every request because a framework route can be mounted by a
     // different Core module instance after this auth guard is initialized.
-    const publicPaths = resolveAuthPublicPaths(config.publicPaths);
+    const publicPaths = resolveAuthPublicPaths(config.publicPaths, app);
 
     const url = event.node?.req?.url ?? event.path ?? "/";
     const queryStart = url.indexOf("?");
@@ -3419,7 +3441,7 @@ async function mountBetterAuthRoutes(
   app: H3App,
   options: AuthOptions,
 ): Promise<void> {
-  const publicPaths = resolveAuthPublicPaths(options.publicPaths);
+  const publicPaths = resolveAuthPublicPaths(options.publicPaths, app);
   const workspaceAppAudience = resolveWorkspaceAppAudience(options);
   const workspaceAppRouteAccess = resolveWorkspaceAppRouteAccess(options);
 
@@ -4603,7 +4625,7 @@ async function mountBetterAuthRoutes(
     workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
     workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
   };
-  const guardFn = createAuthGuardFn();
+  const guardFn = createAuthGuardFn(app);
   _authGuardFn = guardFn;
   app.use(defineEventHandler(guardFn));
 }
@@ -4863,7 +4885,7 @@ export async function autoMountAuth(
   // Reset globals
   customGetSession = null;
   sessionMaxAge = options.maxAge ?? DEFAULT_MAX_AGE;
-  const publicPaths = resolveAuthPublicPaths(options.publicPaths);
+  const publicPaths = resolveAuthPublicPaths(options.publicPaths, app);
   const workspaceAppAudience = resolveWorkspaceAppAudience(options);
   const workspaceAppRouteAccess = resolveWorkspaceAppRouteAccess(options);
 
@@ -4919,7 +4941,7 @@ export async function autoMountAuth(
       workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
       workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
     };
-    const guardFn = createAuthGuardFn();
+    const guardFn = createAuthGuardFn(app);
     _authGuardFn = guardFn;
     app.use(defineEventHandler(guardFn));
 
@@ -4949,7 +4971,7 @@ export async function autoMountAuth(
       workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
       workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
     };
-    const guardFn = createAuthGuardFn();
+    const guardFn = createAuthGuardFn(app);
     _authGuardFn = guardFn;
     app.use(defineEventHandler(guardFn));
     console.log(

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -11,6 +11,7 @@ import {
   isDesktopIdentityCompletion,
   isDesktopIdentityConfiguredAppEligible,
   isDesktopWorkspaceLogoutRequest,
+  shouldStartDesktopIdentitySignIn,
   type DesktopIdentityApp,
 } from "./desktop-identity";
 
@@ -245,6 +246,21 @@ describe("Desktop identity navigation boundaries", () => {
       false,
     );
     expect(isDesktopIdentityOriginEligible("https://custom.example/path")).toBe(
+      false,
+    );
+  });
+
+  it("only starts the automatic ceremony for a signed-out authority", () => {
+    const authority = authorityFixture();
+
+    expect(
+      shouldStartDesktopIdentitySignIn("sign-in-required", authority),
+    ).toBe(true);
+    expect(shouldStartDesktopIdentitySignIn("signed-in", authority)).toBe(
+      false,
+    );
+    expect(shouldStartDesktopIdentitySignIn("failed", authority)).toBe(false);
+    expect(shouldStartDesktopIdentitySignIn("sign-in-required", null)).toBe(
       false,
     );
   });

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -34,6 +34,13 @@ export type DesktopIdentityStatus =
   | "sign-in-required"
   | "failed";
 
+export function shouldStartDesktopIdentitySignIn(
+  status: DesktopIdentityStatus,
+  authorityApp: Pick<DesktopIdentityApp, "origin"> | null,
+): boolean {
+  return status === "sign-in-required" && authorityApp !== null;
+}
+
 export interface DesktopIdentityApp {
   id: string;
   origin: string;

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -209,6 +209,7 @@ import {
   fetchDesktopIdentityAvailability,
   isDesktopIdentityAppConfigEligible,
   isDesktopIdentityOriginEligible,
+  shouldStartDesktopIdentitySignIn,
   type DesktopIdentityApp,
 } from "./desktop-identity";
 import {
@@ -353,6 +354,7 @@ let desktopDesignPreviewManager: DesktopDesignPreviewManager | null = null;
 let desktopComputerMcpBridge: DesktopComputerMcpBridge | null = null;
 let desktopBrowserControlBridge: BrowserControlLoopbackBridge | null = null;
 let desktopIdentityBroker: DesktopIdentityBroker | null = null;
+let desktopIdentityAutoSignInStarted = false;
 const desktopWebviewAppIds = new WeakMap<Electron.WebContents, string>();
 let browserNativeHostManifestPath: string | null = null;
 const pendingOpenRequests: DesktopOpenRequest[] = [];
@@ -1265,6 +1267,31 @@ ipcMain.handle(IPC.IDENTITY_SIGN_OUT, async (event) => {
   await desktopIdentityBroker.signOut(listDesktopIdentityCleanupApps());
   return true;
 });
+
+function maybeStartDesktopIdentitySignIn(win: BrowserWindow): void {
+  if (desktopIdentityAutoSignInStarted || !desktopIdentityBroker) return;
+  const authorityApp = resolveDesktopIdentityApp("dispatch");
+  if (
+    !shouldStartDesktopIdentitySignIn(
+      desktopIdentityBroker.getStatus(),
+      authorityApp,
+    )
+  ) {
+    return;
+  }
+  desktopIdentityAutoSignInStarted = true;
+
+  const start = () => {
+    const identityApp = resolveDesktopIdentityApp(activeAppId) ?? authorityApp;
+    if (!identityApp) return;
+    void desktopIdentityBroker?.signIn(identityApp.id).catch(() => undefined);
+  };
+  if (win.webContents.isLoading()) {
+    win.webContents.once("did-finish-load", start);
+  } else {
+    start();
+  }
+}
 
 function createWindow(): BrowserWindow {
   if (mainWindow && !mainWindow.isDestroyed()) {
@@ -11369,6 +11396,7 @@ app.whenReady().then(async () => {
   registerDesktopShortcutBindings();
 
   const win = createWindow();
+  if (IS_DESKTOP_SSO_CANARY) maybeStartDesktopIdentitySignIn(win);
   registerQuickPromptShortcut();
   // Pairing details persist, but background access is opt-in per launch.
   // A read-only status check must never spawn a process or unlock Keychain.


### PR DESCRIPTION
## Summary
- make framework-managed auth public paths process-shared across duplicated Core SSR module instances
- resolve registered paths at guard request time so late route mounts are visible
- add a regression test for registration from a second Core module graph

## Verification
- Core auth tests: 172 passed
- Core action and feature-flag tests: 73 passed
- Core typecheck and build passed
- `pnpm guards`: all 53 checks passed
- packed Core artifact contains the global auth registry and guard-time resolution

## Live failure this fixes
The deployed Workspace could verify the signed Steve/org A2A token for `/_agent-native/org/apps` but returned 401 for framework-managed feature-flag actions. Workspace uses separate pnpm peer-resolution paths for the app auth module and `@builder-workspace/shared`, so a module-local registry was invisible across those copies.