### PR TITLE
fix: make Chrome page capture injectable

### DIFF
--- a/packages/agent-browser-extension/package.json
+++ b/packages/agent-browser-extension/package.json
@@ -5,7 +5,7 @@
   "description": "Public Agent Native browser context and chat extension.",
   "type": "module",
   "scripts": {
-    "build": "pnpm icons && vite build",
+    "build": "pnpm icons && vite build && vite build --config vite.capture-page.config.ts && tsx scripts/verify-capture-bundle.ts",
     "icons": "tsx scripts/generate-icons.ts",
     "package": "pnpm build && tsx scripts/package.ts",
     "test": "pnpm icons && vitest run",

--- a/packages/agent-browser-extension/scripts/verify-capture-bundle.ts
+++ b/packages/agent-browser-extension/scripts/verify-capture-bundle.ts
@@ -1,0 +1,17 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const bundlePath = resolve("dist/assets/capture-page.js");
+const bundle = await readFile(bundlePath, "utf8");
+
+if (/^\s*(?:import|export)\b/m.test(bundle)) {
+  throw new Error(
+    `${bundlePath} still contains module syntax and cannot be injected by chrome.scripting.executeScript.`,
+  );
+}
+
+if (!bundle.includes("agent-native.capture-result.v1")) {
+  throw new Error(
+    `${bundlePath} is missing the capture result message contract.`,
+  );
+}

--- a/packages/agent-browser-extension/vite.capture-page.config.ts
+++ b/packages/agent-browser-extension/vite.capture-page.config.ts
@@ -1,0 +1,44 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root,
+  base: "./",
+  publicDir: false,
+  resolve: {
+    alias: {
+      "@agent-native/browser-control-extension-core": resolve(
+        root,
+        "../browser-control-extension-core/src/index.ts",
+      ),
+      "@agent-native/core/browser-context": resolve(
+        root,
+        "../core/src/browser-context/index.ts",
+      ),
+      "@agent-native/core/integrations/computer-supervision": resolve(
+        root,
+        "../core/src/integrations/computer-supervision.ts",
+      ),
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: false,
+    sourcemap: false,
+    rollupOptions: {
+      input: resolve(root, "src/capture-page.ts"),
+      output: {
+        // chrome.scripting.executeScript injects a classic script, not an ES module.
+        format: "iife",
+        name: "AgentNativeCapturePage",
+        entryFileNames: "assets/capture-page.js",
+        chunkFileNames: "assets/[name].js",
+        assetFileNames: "assets/[name][extname]",
+      },
+    },
+  },
+});

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
@@ -36,8 +36,12 @@ describe("DesktopIdentityGate", () => {
       );
     });
 
-    expect(container.textContent).toContain("Sign in once to open your workspace");
-    expect(container.textContent).toContain("Continue with Google or magic link");
+    expect(container.textContent).toContain(
+      "Sign in once to open your workspace",
+    );
+    expect(container.textContent).toContain(
+      "Continue with Google or magic link",
+    );
     container
       .querySelector(".desktop-identity-gate__provider")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));


### PR DESCRIPTION
## Summary
- build the public Chrome extension capture entry as a standalone IIFE for `chrome.scripting.executeScript`
- add a build-time check that rejects module syntax in the injected artifact

## Verification
- loaded both unpacked extensions in Chrome
- verified the private browser-control extension reports connected in the desktop app
- verified the public side panel captures `example.com` and reports “Shared with this chat”
- `pnpm --filter @agent-native/agent-browser-extension build`
- `pnpm --filter @agent-native/agent-browser-extension test`
- `pnpm --filter @agent-native/agent-browser-extension typecheck`
- `pnpm --filter @agent-native/agent-chrome-extension test`
- `pnpm --filter @agent-native/agent-chrome-extension typecheck`
- `pnpm --filter @agent-native/desktop-app test:computer-control`
- `pnpm guards`