### PR TITLE
fix(auth): recover Better Auth JWKS after secret rotation

### DIFF
--- a/.changeset/rotate-better-auth-jwks-after-secret-change.md
+++ b/.changeset/rotate-better-auth-jwks-after-secret-change.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Rotate persisted Better Auth JWKS keys safely after an auth-secret change.

--- a/packages/core/src/server/better-auth-migrations.spec.ts
+++ b/packages/core/src/server/better-auth-migrations.spec.ts
@@ -88,4 +88,14 @@ describe("Better Auth migrations", () => {
       sqlite: expect.stringContaining("created_at INTEGER NOT NULL"),
     });
   });
+
+  it("rotates persisted JWKS keys after an auth-secret change", () => {
+    const rotation = BETTER_AUTH_MIGRATIONS.find(
+      (migration) =>
+        migration.name === "better-auth-jwks-key-rotation-recovery",
+    );
+    expect(rotation?.version).toBe(4);
+    expect(rotation?.sql).toEqual({});
+    expect(rotation?.run).toEqual(expect.any(Function));
+  });
 });

--- a/packages/core/src/server/better-auth-migrations.ts
+++ b/packages/core/src/server/better-auth-migrations.ts
@@ -41,6 +41,30 @@ async function assertBetterAuthUserIdentityColumns(): Promise<void> {
 }
 
 /**
+ * Better Auth encrypts persisted JWT private keys with the current auth
+ * secret. If that secret is rotated, the old row remains the newest key and
+ * every token-producing request fails before it can mint a replacement. Mark
+ * active rows expired during the release so Better Auth rotates the signing
+ * key without touching users or sessions. The JWKS endpoint keeps expired
+ * keys during its grace period, so already-issued short-lived tokens remain
+ * verifiable while the new key propagates.
+ */
+async function expireJwksKeysAfterAuthSecretRotation(): Promise<void> {
+  const { getDbExec, isPostgres } = await import("../db/client.js");
+  const now = isPostgres() ? new Date().toISOString() : Date.now();
+  const table = isPostgres() ? '"jwks"' : "jwks";
+  const result = await getDbExec().execute({
+    sql: `UPDATE ${table} SET expires_at = ? WHERE expires_at IS NULL OR expires_at > ?`,
+    args: [now, now],
+  });
+  if (result.rowsAffected > 0) {
+    console.info(
+      `[auth] Expired ${result.rowsAffected} Better Auth JWKS key(s) after auth-secret rotation; public keys remain in the verification grace period.`,
+    );
+  }
+}
+
+/**
  * Better Auth's framework-owned schema. This is deliberately a release
  * migration, not a fallback inside `getBetterAuth()`: request functions must
  * be able to construct the auth adapter without probing or creating tables.
@@ -259,6 +283,12 @@ export const BETTER_AUTH_MIGRATIONS: MigrationEntry[] = [
         )
       `,
     },
+  },
+  {
+    version: 4,
+    name: "better-auth-jwks-key-rotation-recovery",
+    sql: {},
+    run: expireJwksKeysAfterAuthSecretRotation,
   },
 ];
 


### PR DESCRIPTION
## Root cause

A fresh production magic link was verified and consumed successfully. The callback then failed before desktop adoption because Better Auth could not decrypt the persisted JWKS private key with the current BETTER_AUTH_SECRET, which had been rotated after the JWKS row was created. The browser surfaced this as INVALID_TOKEN.

## Fix

Add release migration 4 to expire active persisted Better Auth JWKS rows. Better Auth then mints a new encrypted signing key with the current secret. Existing public keys remain available during the verification grace period, and user, account, and session rows are untouched.

## Validation

- pnpm exec vitest run packages/core/src/server/better-auth-migrations.spec.ts packages/core/src/server/release-migrations.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm guards
- production DB repair was limited to expiring the single stale JWKS row; no user/session data was changed
