### PR TITLE
debug(auth): trace desktop magic-link cookie handoff

### DIFF
--- a/.changeset/trace-desktop-magic-link-cookies.md
+++ b/.changeset/trace-desktop-magic-link-cookies.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add redacted diagnostics for desktop magic-link session-cookie handoff failures.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -729,6 +729,19 @@ function getSetCookieHeaders(headers: Headers): string[] {
         .filter(Boolean);
 }
 
+function cookieNames(header: string | null | undefined): string[] {
+  return (header ?? "")
+    .split(";")
+    .map((part) => part.split("=", 1)[0]?.trim() ?? "")
+    .filter(Boolean);
+}
+
+function setCookieNames(headers: Headers): string[] {
+  return getSetCookieHeaders(headers)
+    .map((cookie) => cookie.split("=", 1)[0]?.trim() ?? "")
+    .filter(Boolean);
+}
+
 function extractSessionTokenFromSetCookies(
   response: Response,
 ): string | undefined {
@@ -2373,6 +2386,9 @@ function logMagicLinkVerificationResponse(
     ),
     producer: invalidToken ? "better-auth.magic-link.verify" : undefined,
     reason: invalidToken ? "consumeVerificationValue returned null" : undefined,
+    requestCookieNames: cookieNames(getHeader(event, "cookie")),
+    responseSetCookieCount: getSetCookieHeaders(response.headers).length,
+    responseSetCookieNames: setCookieNames(response.headers),
     preConsume,
     classification: invalidToken
       ? preConsume?.lookup === "present" && preConsume.expiryState === "valid"
@@ -4325,6 +4341,11 @@ async function mountBetterAuthRoutes(
         return oauthErrorPage(AUTH_MAGIC_LINK_FALLBACK);
       }
 
+      logMagicLinkDebug(event, "callback-session-lookup", {
+        source: "desktop-callback",
+        flow: oauthDebugFlowId(flowId),
+        requestCookieNames: cookieNames(getHeader(event, "cookie")),
+      });
       const session = await getSession(event);
       if (!session?.email || !session.token) {
         setDesktopExchangeError(flowId, {


### PR DESCRIPTION
## Summary
- record redacted request cookie names and response Set-Cookie names/counts around desktop magic-link verification
- record redacted callback cookie names before session lookup
- preserve token values and cookie values out of logs

## Verification
- pnpm --filter @agent-native/core exec vitest run --config vitest.config.ts src/server/auth.spec.ts
- pnpm --filter @agent-native/core typecheck
- git diff --check

This is diagnostic-only and is intended to identify whether the hosted verification response cookie reaches the desktop callback before changing behavior.