### PR TITLE
chore: version packages [skip netlify]

### DIFF
--- a/.changeset/bind-embed-sessions-to-owner.md
+++ b/.changeset/bind-embed-sessions-to-owner.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Bind workspace embed-session adoption to the existing target identity while allowing app-local organization ids.

--- a/.changeset/desktop-magic-link-landing.md
+++ b/.changeset/desktop-magic-link-landing.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Prevent email security scanners from consuming Electron magic-link sign-ins before the user confirms them.

--- a/.changeset/desktop-magic-link-post-confirmation.md
+++ b/.changeset/desktop-magic-link-post-confirmation.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Keep Electron magic-link verification behind an explicit POST confirmation so link scanners cannot consume the sign-in token.

--- a/.changeset/desktop-magic-link-same-request.md
+++ b/.changeset/desktop-magic-link-same-request.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Verify confirmed desktop magic links in the confirmation request so the one-time session cookie reaches the native callback reliably.

--- a/.changeset/diagnose-desktop-magic-link.md
+++ b/.changeset/diagnose-desktop-magic-link.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Add no-secret diagnostics around desktop magic-link issuance and verification so invalid-token failures can be isolated without logging the token.

--- a/.changeset/portal-docs-format.md
+++ b/.changeset/portal-docs-format.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Format the Portal reference table in the shared core documentation.

--- a/.changeset/redact-nested-magic-link-diagnostics.md
+++ b/.changeset/redact-nested-magic-link-diagnostics.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Redact nested callback parameters in desktop magic-link diagnostics.

--- a/.changeset/trace-desktop-magic-link-cookies.md
+++ b/.changeset/trace-desktop-magic-link-cookies.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-Add redacted diagnostics for desktop magic-link session-cookie handoff failures.

--- a/packages/agent-browser-extension/CHANGELOG.md
+++ b/packages/agent-browser-extension/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @agent-native/agent-browser-extension
 
+## 0.1.152
+
+### Patch Changes
+
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+  - @agent-native/core@0.159.2
+
 ## 0.1.151
 
 ### Patch Changes

--- a/packages/agent-browser-extension/package.json
+++ b/packages/agent-browser-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/agent-browser-extension",
-  "version": "0.1.151",
+  "version": "0.1.152",
   "private": true,
   "description": "Public Agent Native browser context and chat extension.",
   "type": "module",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @agent-native/core
 
+## 0.159.2
+
+### Patch Changes
+
+- 7acc86e: Bind workspace embed-session adoption to the existing target identity while allowing app-local organization ids.
+- 7acc86e: Prevent email security scanners from consuming Electron magic-link sign-ins before the user confirms them.
+- 7acc86e: Keep Electron magic-link verification behind an explicit POST confirmation so link scanners cannot consume the sign-in token.
+- 7acc86e: Verify confirmed desktop magic links in the confirmation request so the one-time session cookie reaches the native callback reliably.
+- 7acc86e: Add no-secret diagnostics around desktop magic-link issuance and verification so invalid-token failures can be isolated without logging the token.
+- 7acc86e: Format the Portal reference table in the shared core documentation.
+- 7acc86e: Redact nested callback parameters in desktop magic-link diagnostics.
+- 7acc86e: Add redacted diagnostics for desktop magic-link session-cookie handoff failures.
+
 ## 0.159.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.159.1",
+  "version": "0.159.2",
   "description": "Framework for agent-native application development — where AI agents and UI share SQL state, actions, and context",
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
   "bugs": {

--- a/packages/skills/CHANGELOG.md
+++ b/packages/skills/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @agent-native/skills
 
+## 0.2.592
+
+### Patch Changes
+
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+- Updated dependencies [7acc86e]
+  - @agent-native/core@0.159.2
+
 ## 0.2.591
 
 ### Patch Changes

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/skills",
-  "version": "0.2.591",
+  "version": "0.2.592",
   "description": "Install BuilderIO skills for coding agents.",
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
   "bugs": {


### PR DESCRIPTION
Generated by the Changesets release workflow for the merged shared-auth fix. This PR only applies the generated package version/changelog updates so the published package and downstream workspace update can run.