### PR TITLE
feat: show transient computer-use cursor

### DIFF
--- a/packages/agent-chrome-extension/README.md
+++ b/packages/agent-chrome-extension/README.md
@@ -6,7 +6,10 @@ grant access to one exact extension origin instead of a wildcard.
 
 This private Manifest V3 extension is the Chrome-side capability adapter for the
 Agent-Native desktop app. It does not accept messages from web pages and it has
-no arbitrary JavaScript evaluation command.
+no agent-supplied JavaScript evaluation command. The shared control service may
+evaluate one fixed, extension-owned phantom-cursor expression with bounded
+coordinates so users can see the current action; that expression removes its
+own marker after a short fade and is also cleared during teardown.
 
 ## Native host contract
 
@@ -48,8 +51,9 @@ triggers an emergency detach of every controlled tab.
 
 ## Security boundaries
 
-- No content script, externally connectable page, `eval`, or CDP
-  `Runtime.evaluate` surface exists.
+- No content script, externally connectable page, `eval`, or agent-controlled
+  CDP expression surface exists. The only CDP `Runtime.evaluate` call is the
+  fixed cursor marker described above; action payloads never become code.
 - Every mutation revalidates the task, tab, and current origin immediately
   before input is dispatched.
 - Main-frame and tab URL changes are monitored and fail closed by detaching.

--- a/packages/browser-control-extension-core/src/browser-control.test.ts
+++ b/packages/browser-control-extension-core/src/browser-control.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BrowserControlService } from "./browser-control";
+import { cursorOverlayExpression } from "./cursor-overlay";
 
 describe("BrowserControlService", () => {
   const debuggerMethods: string[] = [];
+  const runtimeExpressions: string[] = [];
   const attach = vi.fn();
   const detach = vi.fn();
   const createTab = vi.fn();
@@ -16,6 +18,7 @@ describe("BrowserControlService", () => {
 
   beforeEach(() => {
     debuggerMethods.length = 0;
+    runtimeExpressions.length = 0;
     attach.mockReset();
     attach.mockImplementation(
       (
@@ -58,10 +61,19 @@ describe("BrowserControlService", () => {
       (
         _source: chrome.debugger.Debuggee,
         method: string,
-        _params: object | undefined,
+        params: object | undefined,
         callback?: (result: unknown) => void,
       ) => {
         debuggerMethods.push(method);
+        if (
+          method === "Runtime.evaluate" &&
+          typeof (params as { expression?: unknown } | undefined)
+            ?.expression === "string"
+        ) {
+          runtimeExpressions.push(
+            (params as { expression: string }).expression,
+          );
+        }
         callback?.({});
       },
     );
@@ -123,7 +135,7 @@ describe("BrowserControlService", () => {
     expect(detach).toHaveBeenCalledWith({ tabId: 42 }, expect.any(Function));
   });
 
-  it("never uses unrestricted runtime evaluation", async () => {
+  it("uses only the fixed cursor expression for visual cleanup", async () => {
     const service = new BrowserControlService();
 
     await service.execute({
@@ -137,7 +149,106 @@ describe("BrowserControlService", () => {
     });
     await service.emergencyStopAll();
 
-    expect(debuggerMethods).not.toContain("Runtime.evaluate");
+    expect(debuggerMethods).toContain("Runtime.evaluate");
+    expect(runtimeExpressions).toEqual([
+      cursorOverlayExpression({ type: "hide" }),
+    ]);
+  });
+
+  it("shows the phantom cursor at a click target and clears it on stop", async () => {
+    sendCommand.mockImplementation(
+      (
+        _source: chrome.debugger.Debuggee,
+        method: string,
+        params: object | undefined,
+        callback?: (result: unknown) => void,
+      ) => {
+        debuggerMethods.push(method);
+        if (
+          method === "Runtime.evaluate" &&
+          typeof (params as { expression?: unknown } | undefined)
+            ?.expression === "string"
+        ) {
+          runtimeExpressions.push(
+            (params as { expression: string }).expression,
+          );
+        }
+        if (method === "Accessibility.getFullAXTree") {
+          callback?.({
+            nodes: [
+              {
+                backendDOMNodeId: 7,
+                role: { value: "button" },
+                name: { value: "Open" },
+              },
+            ],
+          });
+          return;
+        }
+        if (method === "Accessibility.getPartialAXTree") {
+          callback?.({
+            nodes: [
+              {
+                backendDOMNodeId: 7,
+                role: { value: "button" },
+                name: { value: "Open" },
+              },
+            ],
+          });
+          return;
+        }
+        if (method === "DOM.getBoxModel") {
+          callback?.({
+            model: { border: [100, 200, 120, 200, 120, 220, 100, 220] },
+          });
+          return;
+        }
+        callback?.({});
+      },
+    );
+    const service = new BrowserControlService();
+
+    await service.execute({
+      id: "attach-request",
+      taskId: "task-1",
+      command: {
+        type: "attach",
+        tabId: 42,
+        allowedOrigins: ["https://example.com"],
+      },
+    });
+    const observation = (await service.execute({
+      id: "observe-request",
+      taskId: "task-1",
+      command: { type: "observe", includeScreenshot: false },
+    })) as { observationId: string };
+
+    await service.execute({
+      id: "click-request",
+      taskId: "task-1",
+      command: {
+        type: "click",
+        target: { observationId: observation.observationId, backendNodeId: 7 },
+      },
+    });
+
+    expect(runtimeExpressions[0]).toBe(
+      cursorOverlayExpression({ type: "show", x: 110, y: 210, click: true }),
+    );
+    expect(debuggerMethods.indexOf("Runtime.evaluate")).toBeLessThan(
+      debuggerMethods.indexOf("Input.dispatchMouseEvent"),
+    );
+
+    await service.execute({
+      id: "stop-request",
+      taskId: "task-1",
+      command: { type: "stop" },
+    });
+    await vi.waitFor(() =>
+      expect(runtimeExpressions).toContain(
+        cursorOverlayExpression({ type: "hide" }),
+      ),
+    );
   });
 
   it("rechecks ownership before committing concurrent attaches", async () => {

--- a/packages/browser-control-extension-core/src/browser-control.test.ts
+++ b/packages/browser-control-extension-core/src/browser-control.test.ts
@@ -606,6 +606,7 @@ describe("BrowserControlService", () => {
       }),
     ).rejects.toMatchObject({ code: "BROWSER_STOPPING" });
 
+    await vi.waitFor(() => expect(releaseDetach).toBeDefined());
     releaseDetach?.();
     await expect(emergencyStop).resolves.toBeUndefined();
   });

--- a/packages/browser-control-extension-core/src/browser-control.ts
+++ b/packages/browser-control-extension-core/src/browser-control.ts
@@ -1323,9 +1323,10 @@ export class BrowserControlService {
   ): Promise<Error | undefined> {
     let releaseError: Error | undefined;
     await this.drainPendingInputOperations(tabId);
-    // Cursor cleanup must never hold the input-release or debugger-detach gate.
-    // The page marker also owns a hard removal timer for the crash/stall case.
-    void this.hideCursor(tabId, taskId);
+    // Complete the owned cleanup before detach so it cannot outlive teardown
+    // and remove a later owner's cursor after this tab is reused. The page
+    // marker still owns a hard removal timer if the renderer is unavailable.
+    await this.hideCursor(tabId, taskId);
     const pressedKeys = this.pressedKeys.get(tabId)?.values() ?? [];
     try {
       await releaseInjectedInput(tabId, pressedKeys);

--- a/packages/browser-control-extension-core/src/browser-control.ts
+++ b/packages/browser-control-extension-core/src/browser-control.ts
@@ -9,6 +9,7 @@ import {
   sendDebuggerCommand,
   type DebuggerSource,
 } from "./chrome-debugger";
+import { cursorOverlayExpression, hideCursorOverlay } from "./cursor-overlay";
 import { assertUrlAllowed, ProtocolValidationError } from "./policy";
 import type {
   BrowserCommand,
@@ -25,6 +26,7 @@ type TaskSession = {
   tabId: number;
   allowedOrigins: Set<string>;
   observation?: BrowserObservation;
+  lastCursor?: { x: number; y: number };
 };
 
 type StoredTaskSession = Omit<TaskSession, "allowedOrigins"> & {
@@ -1207,6 +1209,57 @@ export class BrowserControlService {
     });
   }
 
+  private async showCursor(
+    session: TaskSession,
+    point: { x: number; y: number },
+    click: boolean,
+    expectedGeneration?: number,
+  ): Promise<void> {
+    try {
+      await this.sendCommand(
+        session.taskId,
+        expectedGeneration,
+        session.tabId,
+        "Runtime.evaluate",
+        {
+          expression: cursorOverlayExpression({
+            type: "show",
+            x: point.x,
+            y: point.y,
+            ...(click ? { click: true } : {}),
+          }),
+          awaitPromise: false,
+          returnByValue: true,
+        },
+      );
+    } catch (error) {
+      if (
+        this.isTaskCancellation(error) ||
+        (error instanceof Error && isDebuggerNotAttachedError(error.message))
+      ) {
+        return;
+      }
+      console.warn("[browser-control] phantom cursor could not be shown", {
+        tabId: session.tabId,
+        error,
+      });
+    }
+  }
+
+  private async hideCursor(tabId: number): Promise<void> {
+    try {
+      await hideCursorOverlay(source(tabId));
+    } catch (error) {
+      if (error instanceof Error && isDebuggerNotAttachedError(error.message)) {
+        return;
+      }
+      console.warn("[browser-control] phantom cursor cleanup failed", {
+        tabId,
+        error,
+      });
+    }
+  }
+
   private scheduleLateAttachTeardown(
     pending: PendingAttach,
   ): Promise<Error | undefined> | undefined {
@@ -1263,6 +1316,9 @@ export class BrowserControlService {
   ): Promise<Error | undefined> {
     let releaseError: Error | undefined;
     await this.drainPendingInputOperations(tabId);
+    // Cursor cleanup must never hold the input-release or debugger-detach gate.
+    // The page marker also owns a hard removal timer for the crash/stall case.
+    void this.hideCursor(tabId);
     const pressedKeys = this.pressedKeys.get(tabId)?.values() ?? [];
     try {
       await releaseInjectedInput(tabId, pressedKeys);
@@ -1476,6 +1532,8 @@ export class BrowserControlService {
       );
       const point = centerOfBox(box);
       await this.revalidate(taskId, expectedGeneration);
+      await this.showCursor(session, point, true, expectedGeneration);
+      session.lastCursor = point;
       await this.sendCommand(
         taskId,
         expectedGeneration,
@@ -1506,6 +1564,33 @@ export class BrowserControlService {
     }
   }
 
+  private async targetPoint(
+    taskId: string,
+    expectedGeneration: number | undefined,
+    session: TaskSession,
+    backendNodeId: number,
+  ): Promise<{ x: number; y: number } | undefined> {
+    try {
+      const box = await this.sendCommand<BoxModelResult>(
+        taskId,
+        expectedGeneration,
+        session.tabId,
+        "DOM.getBoxModel",
+        { backendNodeId },
+      );
+      return centerOfBox(box);
+    } catch (error) {
+      if (!this.isTaskCancellation(error)) {
+        console.warn("[browser-control] phantom cursor target unavailable", {
+          tabId: session.tabId,
+          backendNodeId,
+          error,
+        });
+      }
+      return undefined;
+    }
+  }
+
   private async type(
     taskId: string,
     target: { observationId: string; backendNodeId: number },
@@ -1516,6 +1601,16 @@ export class BrowserControlService {
     const session = await this.revalidate(taskId, expectedGeneration);
     await this.assertFreshTarget(session, target, taskId, expectedGeneration);
     try {
+      const point = await this.targetPoint(
+        taskId,
+        expectedGeneration,
+        session,
+        target.backendNodeId,
+      );
+      if (point) {
+        await this.showCursor(session, point, false, expectedGeneration);
+        session.lastCursor = point;
+      }
       await this.sendCommand(
         taskId,
         expectedGeneration,
@@ -1614,6 +1709,14 @@ export class BrowserControlService {
   ): Promise<unknown> {
     const session = await this.revalidate(taskId, expectedGeneration);
     try {
+      if (session.lastCursor) {
+        await this.showCursor(
+          session,
+          session.lastCursor,
+          false,
+          expectedGeneration,
+        );
+      }
       const data = KEY_DATA[key];
       const params = {
         key: data.key,
@@ -1650,6 +1753,8 @@ export class BrowserControlService {
     const session = await this.revalidate(taskId, expectedGeneration);
     try {
       const url = assertUrlAllowed(rawUrl, session.allowedOrigins);
+      await this.hideCursor(session.tabId);
+      session.lastCursor = undefined;
       const result = await this.sendCommand<Record<string, unknown>>(
         taskId,
         expectedGeneration,
@@ -1764,6 +1869,9 @@ export class BrowserControlService {
   ): Promise<unknown> {
     const session = await this.revalidate(taskId, expectedGeneration);
     try {
+      const point = { x, y };
+      await this.showCursor(session, point, false, expectedGeneration);
+      session.lastCursor = point;
       await this.sendCommand(
         taskId,
         expectedGeneration,

--- a/packages/browser-control-extension-core/src/browser-control.ts
+++ b/packages/browser-control-extension-core/src/browser-control.ts
@@ -1766,6 +1766,7 @@ export class BrowserControlService {
       const url = assertUrlAllowed(rawUrl, session.allowedOrigins);
       await this.hideCursor(session.tabId, session.taskId);
       session.lastCursor = undefined;
+      await this.revalidate(taskId, expectedGeneration);
       const result = await this.sendCommand<Record<string, unknown>>(
         taskId,
         expectedGeneration,

--- a/packages/browser-control-extension-core/src/browser-control.ts
+++ b/packages/browser-control-extension-core/src/browser-control.ts
@@ -1246,7 +1246,14 @@ export class BrowserControlService {
     }
   }
 
-  private async hideCursor(tabId: number): Promise<void> {
+  private async hideCursor(tabId: number, ownerTaskId?: string): Promise<void> {
+    if (
+      ownerTaskId &&
+      this.teardownOwners.get(tabId) !== ownerTaskId &&
+      this.tabOwners.get(tabId) !== ownerTaskId
+    ) {
+      return;
+    }
     try {
       await hideCursorOverlay(source(tabId));
     } catch (error) {
@@ -1318,7 +1325,7 @@ export class BrowserControlService {
     await this.drainPendingInputOperations(tabId);
     // Cursor cleanup must never hold the input-release or debugger-detach gate.
     // The page marker also owns a hard removal timer for the crash/stall case.
-    void this.hideCursor(tabId);
+    void this.hideCursor(tabId, taskId);
     const pressedKeys = this.pressedKeys.get(tabId)?.values() ?? [];
     try {
       await releaseInjectedInput(tabId, pressedKeys);
@@ -1753,7 +1760,7 @@ export class BrowserControlService {
     const session = await this.revalidate(taskId, expectedGeneration);
     try {
       const url = assertUrlAllowed(rawUrl, session.allowedOrigins);
-      await this.hideCursor(session.tabId);
+      await this.hideCursor(session.tabId, session.taskId);
       session.lastCursor = undefined;
       const result = await this.sendCommand<Record<string, unknown>>(
         taskId,

--- a/packages/browser-control-extension-core/src/browser-control.ts
+++ b/packages/browser-control-extension-core/src/browser-control.ts
@@ -1541,6 +1541,7 @@ export class BrowserControlService {
       const point = centerOfBox(box);
       await this.revalidate(taskId, expectedGeneration);
       await this.showCursor(session, point, true, expectedGeneration);
+      await this.revalidate(taskId, expectedGeneration);
       session.lastCursor = point;
       await this.sendCommand(
         taskId,
@@ -1617,6 +1618,7 @@ export class BrowserControlService {
       );
       if (point) {
         await this.showCursor(session, point, false, expectedGeneration);
+        await this.revalidate(taskId, expectedGeneration);
         session.lastCursor = point;
       }
       await this.sendCommand(
@@ -1724,6 +1726,7 @@ export class BrowserControlService {
           false,
           expectedGeneration,
         );
+        await this.revalidate(taskId, expectedGeneration);
       }
       const data = KEY_DATA[key];
       const params = {
@@ -1879,6 +1882,7 @@ export class BrowserControlService {
     try {
       const point = { x, y };
       await this.showCursor(session, point, false, expectedGeneration);
+      await this.revalidate(taskId, expectedGeneration);
       session.lastCursor = point;
       await this.sendCommand(
         taskId,

--- a/packages/browser-control-extension-core/src/cursor-overlay.test.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CURSOR_OVERLAY_FADE_MS,
+  CURSOR_OVERLAY_MAX_LIFETIME_MS,
+  CURSOR_OVERLAY_VISIBLE_MS,
+  cursorOverlayExpression,
+} from "./cursor-overlay";
+
+describe("cursor overlay expression", () => {
+  it("encodes only bounded coordinates into the fixed overlay script", () => {
+    const expression = cursorOverlayExpression({
+      type: "show",
+      x: 120.5,
+      y: 48,
+      click: true,
+    });
+
+    expect(expression).toContain("agent-native-phantom-cursor");
+    expect(expression).toContain('"x":120.5');
+    expect(expression).toContain('"y":48');
+    expect(expression).toContain('"click":true');
+    expect(expression).not.toContain("Runtime.evaluate");
+  });
+
+  it("rejects coordinates that could escape the page viewport contract", () => {
+    expect(() =>
+      cursorOverlayExpression({ type: "show", x: Number.NaN, y: 10 }),
+    ).toThrow("finite coordinate");
+    expect(() =>
+      cursorOverlayExpression({ type: "show", x: 10, y: 100_001 }),
+    ).toThrow("finite coordinate");
+  });
+
+  it("contains a bounded fade and removal deadline", () => {
+    const expression = cursorOverlayExpression({ type: "show", x: 0, y: 0 });
+
+    expect(CURSOR_OVERLAY_VISIBLE_MS).toBe(1_800);
+    expect(CURSOR_OVERLAY_FADE_MS).toBe(420);
+    expect(CURSOR_OVERLAY_MAX_LIFETIME_MS).toBe(2_220);
+    expect(expression).toContain("data-state=fading");
+    expect(expression).toContain("node.remove()");
+    expect(expression).toContain("1800");
+    expect(expression).toContain("420");
+  });
+
+  it("has an explicit hide expression for teardown and app shutdown", () => {
+    const expression = cursorOverlayExpression({ type: "hide" });
+
+    expect(expression).toContain('"type":"hide"');
+    expect(expression).toContain("remove(existing)");
+  });
+});

--- a/packages/browser-control-extension-core/src/cursor-overlay.test.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.test.ts
@@ -21,6 +21,7 @@ describe("cursor overlay expression", () => {
     expect(expression).toContain('"y":48');
     expect(expression).toContain('"click":true');
     expect(expression).not.toContain("Runtime.evaluate");
+    expect(expression).not.toContain("candidate.remove");
   });
 
   it("rejects coordinates that could escape the page viewport contract", () => {

--- a/packages/browser-control-extension-core/src/cursor-overlay.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.ts
@@ -1,0 +1,162 @@
+import { sendDebuggerCommand, type DebuggerSource } from "./chrome-debugger";
+
+export type CursorOverlayAction =
+  | { type: "show"; x: number; y: number; click?: boolean }
+  | { type: "hide" };
+
+export const CURSOR_OVERLAY_VISIBLE_MS = 1_800;
+export const CURSOR_OVERLAY_FADE_MS = 420;
+export const CURSOR_OVERLAY_MAX_LIFETIME_MS =
+  CURSOR_OVERLAY_VISIBLE_MS + CURSOR_OVERLAY_FADE_MS;
+
+const CURSOR_OVERLAY_ID = "agent-native-phantom-cursor";
+
+// This is a fixed extension-owned expression. Coordinates are the only values
+// interpolated into it; the browser-control protocol never accepts page code.
+const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
+  const id = "${CURSOR_OVERLAY_ID}";
+  const candidate = document.getElementById(id);
+  const existing = candidate?.getAttribute("data-agent-native-owned") === "true" ? candidate : null;
+  if (candidate && !existing) candidate.remove();
+  const clearTimers = node => {
+    if (!node) return;
+    if (node.__agentNativeCursorTimer) {
+      clearTimeout(node.__agentNativeCursorTimer);
+      node.__agentNativeCursorTimer = undefined;
+    }
+    if (node.__agentNativeCursorRemoveTimer) {
+      clearTimeout(node.__agentNativeCursorRemoveTimer);
+      node.__agentNativeCursorRemoveTimer = undefined;
+    }
+  };
+  const remove = node => {
+    if (!node) return;
+    clearTimers(node);
+    node.remove();
+  };
+
+  if (action.type === "hide") {
+    remove(existing);
+    return;
+  }
+
+  if (!document.documentElement) return;
+  const x = Math.max(0, Math.min(action.x, Math.max(0, window.innerWidth - 1)));
+  const y = Math.max(0, Math.min(action.y, Math.max(0, window.innerHeight - 1)));
+  let host = existing;
+  if (!host) {
+    host = document.createElement("div");
+    host.id = id;
+    host.setAttribute("data-agent-native-owned", "true");
+    host.setAttribute("aria-hidden", "true");
+    host.attachShadow({ mode: "open" });
+    const shadow = host.shadowRoot;
+    if (!shadow) return;
+    const style = document.createElement("style");
+    style.textContent = [
+      ":host {",
+      "  position: fixed;",
+      "  left: 0;",
+      "  top: 0;",
+      "  width: 30px;",
+      "  height: 36px;",
+      "  z-index: 2147483647;",
+      "  pointer-events: none;",
+      "  contain: layout style paint;",
+      "  opacity: 0;",
+      "  transform: translate3d(var(--agent-native-x), var(--agent-native-y), 0);",
+      "  transition: opacity 180ms ease-out;",
+      "}",
+      ":host([data-state=visible]) { opacity: 1; }",
+      ":host([data-state=fading]) { opacity: 0; transition-duration: 420ms; }",
+      ".pointer {",
+      "  position: absolute;",
+      "  inset: 0 auto auto 0;",
+      "  width: 26px;",
+      "  height: 34px;",
+      "  background: white;",
+      "  clip-path: polygon(1px 1px, 1px 30px, 9px 22px, 15px 34px, 19px 32px, 13px 20px, 26px 20px);",
+      "  filter: drop-shadow(0 1px 2px black);",
+      "}",
+      ".hotspot {",
+      "  position: absolute;",
+      "  left: -2px;",
+      "  top: -2px;",
+      "  width: 12px;",
+      "  height: 12px;",
+      "  border: 2px solid royalblue;",
+      "  border-radius: 999px;",
+      "  box-sizing: border-box;",
+      "  opacity: .6;",
+      "  transform: scale(.9);",
+      "}",
+      ":host([data-action=click]) .hotspot {",
+      "  animation: agent-native-cursor-click 520ms ease-out both;",
+      "}",
+      "@keyframes agent-native-cursor-click {",
+      "  0% { opacity: .85; transform: scale(.75); }",
+      "  100% { opacity: 0; transform: scale(2.4); }",
+      "}",
+      "@media (prefers-reduced-motion: reduce) {",
+      "  :host { transition: none; }",
+      "  :host([data-action=click]) .hotspot { animation: none; opacity: .5; }",
+      "}",
+    ].join("");
+    const pointer = document.createElement("span");
+    pointer.className = "pointer";
+    const hotspot = document.createElement("span");
+    hotspot.className = "hotspot";
+    shadow.append(style, pointer, hotspot);
+    document.documentElement.append(host);
+  }
+
+  clearTimers(host);
+  host.style.setProperty("--agent-native-x", x + "px");
+  host.style.setProperty("--agent-native-y", y + "px");
+  host.dataset.action = action.click ? "click" : "move";
+  host.dataset.state = "visible";
+  void host.offsetWidth;
+  host.__agentNativeCursorTimer = setTimeout(() => {
+    host.dataset.state = "fading";
+    host.__agentNativeCursorRemoveTimer = setTimeout(() => remove(host), ${CURSOR_OVERLAY_FADE_MS});
+  }, ${CURSOR_OVERLAY_VISIBLE_MS});
+})`;
+
+function finiteCoordinate(value: number, label: "x" | "y"): number {
+  if (!Number.isFinite(value) || value < 0 || value > 100_000) {
+    throw new Error(`Cursor overlay ${label} must be a finite coordinate.`);
+  }
+  return value;
+}
+
+export function cursorOverlayExpression(action: CursorOverlayAction): string {
+  const normalized =
+    action.type === "hide"
+      ? action
+      : {
+          type: "show" as const,
+          x: finiteCoordinate(action.x, "x"),
+          y: finiteCoordinate(action.y, "y"),
+          ...(action.click ? { click: true } : {}),
+        };
+  return `(${CURSOR_OVERLAY_SOURCE})(${JSON.stringify(normalized)})`;
+}
+
+export async function showCursorOverlay(
+  source: DebuggerSource,
+  action: Exclude<CursorOverlayAction, { type: "hide" }>,
+): Promise<void> {
+  await sendDebuggerCommand(source, "Runtime.evaluate", {
+    expression: cursorOverlayExpression(action),
+    awaitPromise: false,
+    returnByValue: true,
+  });
+}
+
+export async function hideCursorOverlay(source: DebuggerSource): Promise<void> {
+  await sendDebuggerCommand(source, "Runtime.evaluate", {
+    expression: cursorOverlayExpression({ type: "hide" }),
+    awaitPromise: false,
+    returnByValue: true,
+  });
+}

--- a/packages/browser-control-extension-core/src/cursor-overlay.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.ts
@@ -17,7 +17,7 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
   const id = "${CURSOR_OVERLAY_ID}";
   const candidate = document.getElementById(id);
   const existing = candidate?.getAttribute("data-agent-native-owned") === "true" ? candidate : null;
-  if (candidate && !existing) candidate.remove();
+  if (candidate && !existing) return;
   const clearTimers = node => {
     if (!node) return;
     if (node.__agentNativeCursorTimer) {

--- a/packages/browser-control-extension-core/src/index.ts
+++ b/packages/browser-control-extension-core/src/index.ts
@@ -1,5 +1,14 @@
 export { BrowserControlError, BrowserControlService } from "./browser-control";
 export {
+  CURSOR_OVERLAY_FADE_MS,
+  CURSOR_OVERLAY_MAX_LIFETIME_MS,
+  CURSOR_OVERLAY_VISIBLE_MS,
+  cursorOverlayExpression,
+  hideCursorOverlay,
+  showCursorOverlay,
+  type CursorOverlayAction,
+} from "./cursor-overlay";
+export {
   attachDebugger,
   detachDebugger,
   getTab,

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -522,7 +522,12 @@ DispatchQueue.global(qos: .userInitiated).async {
                     throw HelperFailure(description: "Invalid request envelope.")
                 }
                 response["id"] = id
-                let result = try helper.handle(request)
+                // Accessibility and AppKit must stay on the main thread. The
+                // stdin worker remains serialized while the main run loop
+                // owns every helper operation.
+                let result = try DispatchQueue.main.sync {
+                    try helper.handle(request)
+                }
                 response["ok"] = true
                 if let result { response["result"] = result }
             } catch {

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -6,7 +6,148 @@ private struct HelperFailure: Error, CustomStringConvertible {
     let description: String
 }
 
+private final class PhantomCursorView: NSView {
+    var showsClickPulse = false {
+        didSet { needsDisplay = true }
+    }
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.clear.setFill()
+        dirtyRect.fill()
+
+        let hotspot = NSBezierPath(ovalIn: NSRect(x: 0, y: 24, width: 13, height: 13))
+        NSColor(calibratedRed: 0.35, green: 0.42, blue: 1.0, alpha: 0.2).setFill()
+        hotspot.fill()
+
+        if showsClickPulse {
+            let pulse = NSBezierPath(ovalIn: NSRect(x: -2, y: 22, width: 17, height: 17))
+            NSColor(calibratedRed: 0.35, green: 0.42, blue: 1.0, alpha: 0.7).setStroke()
+            pulse.lineWidth = 1.5
+            pulse.stroke()
+        }
+
+        let pointer = NSBezierPath()
+        pointer.move(to: NSPoint(x: 3, y: 35))
+        pointer.line(to: NSPoint(x: 3, y: 7))
+        pointer.line(to: NSPoint(x: 11, y: 15))
+        pointer.line(to: NSPoint(x: 16, y: 4))
+        pointer.line(to: NSPoint(x: 20, y: 6))
+        pointer.line(to: NSPoint(x: 14, y: 17))
+        pointer.line(to: NSPoint(x: 27, y: 17))
+        pointer.close()
+
+        NSColor.white.setFill()
+        pointer.fill()
+        NSColor(calibratedWhite: 0.05, alpha: 0.82).setStroke()
+        pointer.lineWidth = 1.3
+        pointer.stroke()
+    }
+}
+
+private final class PhantomCursorOverlay {
+    private let visibleDuration: TimeInterval = 1.8
+    private let fadeDuration: TimeInterval = 0.42
+    private var panel: NSPanel?
+    private var fadeTimer: Timer?
+    private var removeTimer: Timer?
+
+    func show(at quartzPoint: CGPoint, click: Bool) {
+        onMain { [self] in
+            guard let origin = appKitOrigin(for: quartzPoint) else { return }
+            removeTimers()
+
+            let view: PhantomCursorView
+            if let existingView = panel?.contentView as? PhantomCursorView {
+                view = existingView
+            } else {
+                view = PhantomCursorView(frame: NSRect(x: 0, y: 0, width: 32, height: 40))
+                let nextPanel = NSPanel(
+                    contentRect: view.frame,
+                    styleMask: [.borderless, .nonactivatingPanel],
+                    backing: .buffered,
+                    defer: false
+                )
+                nextPanel.isOpaque = false
+                nextPanel.backgroundColor = .clear
+                nextPanel.hasShadow = false
+                nextPanel.ignoresMouseEvents = true
+                nextPanel.hidesOnDeactivate = false
+                nextPanel.level = .floating
+                nextPanel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+                nextPanel.contentView = view
+                panel = nextPanel
+            }
+
+            view.showsClickPulse = click
+            panel?.alphaValue = 1
+            panel?.setFrameOrigin(origin)
+            panel?.orderFrontRegardless()
+
+            fadeTimer = Timer.scheduledTimer(withTimeInterval: visibleDuration, repeats: false) { [weak self] _ in
+                self?.fade()
+            }
+        }
+    }
+
+    func hide() {
+        onMain { [self] in
+            removeTimers()
+            panel?.orderOut(nil)
+            panel = nil
+        }
+    }
+
+    private func fade() {
+        guard let panel else { return }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = fadeDuration
+            panel.animator().alphaValue = 0
+        }
+        removeTimer = Timer.scheduledTimer(withTimeInterval: fadeDuration, repeats: false) { [weak self] _ in
+            self?.hide()
+        }
+    }
+
+    private func removeTimers() {
+        fadeTimer?.invalidate()
+        fadeTimer = nil
+        removeTimer?.invalidate()
+        removeTimer = nil
+    }
+
+    private func onMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
+        }
+    }
+
+    private func appKitOrigin(for quartzPoint: CGPoint) -> NSPoint? {
+        for screen in NSScreen.screens {
+            guard
+                let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
+            else { continue }
+            let displayFrame = CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value))
+            guard displayFrame.contains(quartzPoint) else { continue }
+            return NSPoint(
+                x: screen.frame.minX + quartzPoint.x - displayFrame.minX - 3,
+                y: screen.frame.maxY - (quartzPoint.y - displayFrame.minY) - 35
+            )
+        }
+
+        guard let screen = NSScreen.main else { return nil }
+        return NSPoint(
+            x: screen.frame.minX + quartzPoint.x - 3,
+            y: screen.frame.maxY - quartzPoint.y - 35
+        )
+    }
+}
+
 private final class ComputerHelper {
+    private let cursorOverlay = PhantomCursorOverlay()
     private var snapshotId: String?
     private var targets: [String: AXUIElement] = [:]
     private var snapshotBundleId: String?
@@ -14,6 +155,10 @@ private final class ComputerHelper {
     private var nodeCount = 0
     private let maxNodes = 500
     private let maxDepth = 8
+
+    func close() {
+        cursorOverlay.hide()
+    }
 
     func handle(_ request: [String: Any]) throws -> Any? {
         guard let command = request["command"] as? String else {
@@ -33,6 +178,7 @@ private final class ComputerHelper {
             return nil
         case "releaseAll":
             releaseAllInputs()
+            cursorOverlay.hide()
             return nil
         default:
             throw HelperFailure(description: "Unsupported command.")
@@ -131,6 +277,13 @@ private final class ComputerHelper {
         }
         guard isElementEnabled(element) else {
             throw HelperFailure(description: "Semantic target is no longer enabled.")
+        }
+
+        if let rect = rect(of: element) {
+            cursorOverlay.show(
+                at: CGPoint(x: rect.midX, y: rect.midY),
+                click: kind == "input.click"
+            )
         }
 
         switch kind {
@@ -359,26 +512,35 @@ private func keyCode(_ name: String) -> CGKeyCode? {
 }
 
 private let helper = ComputerHelper()
-while let line = readLine() {
-    autoreleasepool {
-        var response: [String: Any] = ["ok": false]
-        do {
-            guard let data = line.data(using: .utf8),
-                  let request = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let id = request["id"] as? NSNumber else {
-                throw HelperFailure(description: "Invalid request envelope.")
+let application = NSApplication.shared
+application.setActivationPolicy(.prohibited)
+DispatchQueue.global(qos: .userInitiated).async {
+    while let line = readLine() {
+        autoreleasepool {
+            var response: [String: Any] = ["ok": false]
+            do {
+                guard let data = line.data(using: .utf8),
+                      let request = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let id = request["id"] as? NSNumber else {
+                    throw HelperFailure(description: "Invalid request envelope.")
+                }
+                response["id"] = id
+                let result = try helper.handle(request)
+                response["ok"] = true
+                if let result { response["result"] = result }
+            } catch {
+                response["error"] = String(describing: error)
             }
-            response["id"] = id
-            let result = try helper.handle(request)
-            response["ok"] = true
-            if let result { response["result"] = result }
-        } catch {
-            response["error"] = String(describing: error)
-        }
-        if let data = try? JSONSerialization.data(withJSONObject: response),
-           let output = String(data: data, encoding: .utf8) {
-            print(output)
-            fflush(stdout)
+            if let data = try? JSONSerialization.data(withJSONObject: response),
+               let output = String(data: data, encoding: .utf8) {
+                print(output)
+                fflush(stdout)
+            }
         }
     }
+    DispatchQueue.main.async {
+        helper.close()
+        application.terminate(nil)
+    }
 }
+application.run()

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -510,7 +510,7 @@ private func keyCode(_ name: String) -> CGKeyCode? {
 
 private let helper = ComputerHelper()
 let application = NSApplication.shared
-application.setActivationPolicy(.prohibited)
+application.setActivationPolicy(.accessory)
 DispatchQueue.global(qos: .userInitiated).async {
     while let line = readLine() {
         autoreleasepool {

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -126,22 +126,19 @@ private final class PhantomCursorOverlay {
     }
 
     private func appKitOrigin(for quartzPoint: CGPoint) -> NSPoint? {
-        for screen in NSScreen.screens {
-            guard
-                let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
-            else { continue }
-            let displayFrame = CGDisplayBounds(CGDirectDisplayID(screenNumber.uint32Value))
-            guard displayFrame.contains(quartzPoint) else { continue }
-            return NSPoint(
-                x: screen.frame.minX + quartzPoint.x - displayFrame.minX - 3,
-                y: screen.frame.maxY - (quartzPoint.y - displayFrame.minY) - 35
-            )
-        }
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else { return nil }
 
-        guard let screen = NSScreen.main else { return nil }
+        // Accessibility and NSScreen frames are both logical points. Derive a
+        // shared top-left space instead of mixing them with display pixels.
+        let globalTop = screens.map(\.frame.maxY).max() ?? 0
+        let appKitPoint = NSPoint(x: quartzPoint.x, y: globalTop - quartzPoint.y)
+        guard screens.contains(where: { $0.frame.insetBy(dx: -0.5, dy: -0.5).contains(appKitPoint) }) else {
+            return nil
+        }
         return NSPoint(
-            x: screen.frame.minX + quartzPoint.x - 3,
-            y: screen.frame.maxY - quartzPoint.y - 35
+            x: appKitPoint.x - 3,
+            y: appKitPoint.y - 35
         )
     }
 }


### PR DESCRIPTION
## What changed
- Show a quiet phantom cursor at the target of native macOS computer-use actions and Chrome extension actions.
- Use a fixed, extension-owned Chrome expression with bounded coordinates; no agent-supplied page JavaScript is accepted.
- Fade and remove the cursor after 2.22s, clear it on stop/detach/navigation/app shutdown, and keep cleanup off the input-release safety gate.
- Add click pulse treatment and multi-display-aware native cursor placement.

## Verification
- Browser-control extension core: 64 tests, typecheck
- Chrome extension: test, typecheck, production build
- Desktop computer-control suite: 54 tests
- macOS native helper: universal build
- Repository guards: all 53 pass
- Live Chrome smoke: cursor rendered from the shared expression; marker present immediately and absent after 2.5s

Known unrelated baseline: desktop app typecheck currently fails in CodeAgentsHub because the installed code-agents-ui package does not export ChatFirstKeyboardNavigation/renderChatFirstChatSurface.