### PR TITLE
fix: match computer-use cursor to Figma style

### DIFF
--- a/packages/browser-control-extension-core/src/cursor-overlay.test.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.test.ts
@@ -25,6 +25,9 @@ describe("cursor overlay expression", () => {
     expect(expression).toContain("#7b61ff");
     expect(expression).toContain("pointer-outline");
     expect(expression).toContain("drop-shadow");
+    expect(expression).toContain("--agent-native-pointer-x");
+    expect(expression).toContain("labelOnLeft");
+    expect(expression).toContain("labelAbove");
     expect(expression).not.toContain("click-ring");
     expect(expression).not.toContain("royalblue");
     expect(expression).not.toContain("Runtime.evaluate");

--- a/packages/browser-control-extension-core/src/cursor-overlay.test.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.test.ts
@@ -20,6 +20,13 @@ describe("cursor overlay expression", () => {
     expect(expression).toContain('"x":120.5');
     expect(expression).toContain('"y":48');
     expect(expression).toContain('"click":true');
+    expect(expression).toContain('label.textContent = "Agent"');
+    expect(expression).toContain("border-radius: 2px");
+    expect(expression).toContain("#7b61ff");
+    expect(expression).toContain("pointer-outline");
+    expect(expression).toContain("drop-shadow");
+    expect(expression).not.toContain("click-ring");
+    expect(expression).not.toContain("royalblue");
     expect(expression).not.toContain("Runtime.evaluate");
     expect(expression).not.toContain("candidate.remove");
   });

--- a/packages/browser-control-extension-core/src/cursor-overlay.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.ts
@@ -58,12 +58,16 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
       "  position: fixed;",
       "  left: 0;",
       "  top: 0;",
-      "  width: 68px;",
+      "  width: 70px;",
       "  height: 44px;",
       "  z-index: 2147483647;",
       "  pointer-events: none;",
       "  contain: layout style;",
       "  opacity: 0;",
+      "  --agent-native-pointer-x: 0px;",
+      "  --agent-native-pointer-y: 0px;",
+      "  --agent-native-label-x: 16px;",
+      "  --agent-native-label-y: 20px;",
       "  transform: translate3d(var(--agent-native-x), var(--agent-native-y), 0);",
       "  transition: opacity 140ms ease-out;",
       "}",
@@ -71,8 +75,8 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
       ":host([data-state=fading]) { opacity: 0; transition-duration: 420ms; }",
       ".pointer-outline {",
       "  position: absolute;",
-      "  left: -1px;",
-      "  top: -1px;",
+      "  left: var(--agent-native-pointer-x);",
+      "  top: var(--agent-native-pointer-y);",
       "  width: 19px;",
       "  height: 23px;",
       "  background: white;",
@@ -82,8 +86,8 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
       "}",
       ".pointer {",
       "  position: absolute;",
-      "  left: 0;",
-      "  top: 0;",
+      "  left: var(--agent-native-pointer-x);",
+      "  top: var(--agent-native-pointer-y);",
       "  width: 17px;",
       "  height: 21px;",
       // guard:allow-raw-color — the isolated overlay has no app theme tokens.
@@ -97,8 +101,8 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
       "}",
       ".label {",
       "  position: absolute;",
-      "  left: 16px;",
-      "  top: 20px;",
+      "  left: var(--agent-native-label-x);",
+      "  top: var(--agent-native-label-y);",
       "  box-sizing: border-box;",
       "  min-height: 20px;",
       "  padding: 2px 6px;",
@@ -128,8 +132,44 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
   }
 
   clearTimers(host);
-  host.style.setProperty("--agent-native-x", x + "px");
-  host.style.setProperty("--agent-native-y", y + "px");
+  const overlayWidth = 70;
+  const overlayHeight = 44;
+  const pointerWidth = 17;
+  const pointerHeight = 21;
+  const pointerOutlineWidth = 19;
+  const pointerOutlineHeight = 23;
+  const labelWidth = 48;
+  const labelHeight = 20;
+  const labelGap = 2;
+  const labelOnLeft = x + pointerWidth + labelGap + labelWidth > window.innerWidth;
+  const labelAbove =
+    y + pointerHeight + labelGap + labelHeight > window.innerHeight;
+  const desiredOriginX = labelOnLeft ? x - 52 : x;
+  const desiredOriginY = labelAbove ? y - 22 : y;
+  const originX = Math.max(
+    0,
+    Math.min(desiredOriginX, window.innerWidth - overlayWidth),
+  );
+  const originY = Math.max(
+    0,
+    Math.min(desiredOriginY, window.innerHeight - overlayHeight),
+  );
+  const pointerX = Math.max(
+    0,
+    Math.min(x - originX, overlayWidth - pointerOutlineWidth),
+  );
+  const pointerY = Math.max(
+    0,
+    Math.min(y - originY, overlayHeight - pointerOutlineHeight),
+  );
+  const labelX = labelOnLeft ? Math.max(0, pointerX - labelWidth - labelGap) : 16;
+  const labelY = labelAbove ? Math.max(0, pointerY - labelHeight - labelGap) : 20;
+  host.style.setProperty("--agent-native-x", originX + "px");
+  host.style.setProperty("--agent-native-y", originY + "px");
+  host.style.setProperty("--agent-native-pointer-x", pointerX + "px");
+  host.style.setProperty("--agent-native-pointer-y", pointerY + "px");
+  host.style.setProperty("--agent-native-label-x", labelX + "px");
+  host.style.setProperty("--agent-native-label-y", labelY + "px");
   host.dataset.action = action.click ? "click" : "move";
   host.dataset.state = "visible";
   void host.offsetWidth;

--- a/packages/browser-control-extension-core/src/cursor-overlay.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.ts
@@ -136,8 +136,6 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
   const overlayHeight = 44;
   const pointerWidth = 17;
   const pointerHeight = 21;
-  const pointerOutlineWidth = 19;
-  const pointerOutlineHeight = 23;
   const labelWidth = 48;
   const labelHeight = 20;
   const labelGap = 2;
@@ -154,14 +152,10 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
     0,
     Math.min(desiredOriginY, window.innerHeight - overlayHeight),
   );
-  const pointerX = Math.max(
-    0,
-    Math.min(x - originX, overlayWidth - pointerOutlineWidth),
-  );
-  const pointerY = Math.max(
-    0,
-    Math.min(y - originY, overlayHeight - pointerOutlineHeight),
-  );
+  // Keep the arrow tip anchored to the action point. The viewport clips only
+  // the artwork that naturally extends beyond a physical page edge.
+  const pointerX = x - originX;
+  const pointerY = y - originY;
   const labelX = labelOnLeft ? Math.max(0, pointerX - labelWidth - labelGap) : 16;
   const labelY = labelAbove ? Math.max(0, pointerY - labelHeight - labelGap) : 20;
   host.style.setProperty("--agent-native-x", originX + "px");

--- a/packages/browser-control-extension-core/src/cursor-overlay.ts
+++ b/packages/browser-control-extension-core/src/cursor-overlay.ts
@@ -58,55 +58,72 @@ const CURSOR_OVERLAY_SOURCE = String.raw`(action => {
       "  position: fixed;",
       "  left: 0;",
       "  top: 0;",
-      "  width: 30px;",
-      "  height: 36px;",
+      "  width: 68px;",
+      "  height: 44px;",
       "  z-index: 2147483647;",
       "  pointer-events: none;",
-      "  contain: layout style paint;",
+      "  contain: layout style;",
       "  opacity: 0;",
       "  transform: translate3d(var(--agent-native-x), var(--agent-native-y), 0);",
-      "  transition: opacity 180ms ease-out;",
+      "  transition: opacity 140ms ease-out;",
       "}",
       ":host([data-state=visible]) { opacity: 1; }",
       ":host([data-state=fading]) { opacity: 0; transition-duration: 420ms; }",
+      ".pointer-outline {",
+      "  position: absolute;",
+      "  left: -1px;",
+      "  top: -1px;",
+      "  width: 19px;",
+      "  height: 23px;",
+      "  background: white;",
+      "  clip-path: polygon(0 0, 0 19px, 5px 15px, 9.5px 23px, 13.5px 20.5px, 9px 14px, 18.5px 14px);",
+      // guard:allow-raw-color — the isolated overlay has no app theme tokens.
+      "  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, .22));",
+      "}",
       ".pointer {",
       "  position: absolute;",
-      "  inset: 0 auto auto 0;",
-      "  width: 26px;",
-      "  height: 34px;",
-      "  background: white;",
-      "  clip-path: polygon(1px 1px, 1px 30px, 9px 22px, 15px 34px, 19px 32px, 13px 20px, 26px 20px);",
-      "  filter: drop-shadow(0 1px 2px black);",
+      "  left: 0;",
+      "  top: 0;",
+      "  width: 17px;",
+      "  height: 21px;",
+      // guard:allow-raw-color — the isolated overlay has no app theme tokens.
+      "  background: #7b61ff;",
+      "  clip-path: polygon(0 0, 0 17px, 5px 13px, 9px 20px, 12px 18px, 8px 12px, 16px 12px);",
+      // guard:allow-raw-color — the isolated overlay has no app theme tokens.
+      "  filter: drop-shadow(0 1px 1px rgba(0, 0, 0, .26));",
       "}",
-      ".hotspot {",
+      ".pointer {",
+      "  z-index: 1;",
+      "}",
+      ".label {",
       "  position: absolute;",
-      "  left: -2px;",
-      "  top: -2px;",
-      "  width: 12px;",
-      "  height: 12px;",
-      "  border: 2px solid royalblue;",
-      "  border-radius: 999px;",
+      "  left: 16px;",
+      "  top: 20px;",
       "  box-sizing: border-box;",
-      "  opacity: .6;",
-      "  transform: scale(.9);",
-      "}",
-      ":host([data-action=click]) .hotspot {",
-      "  animation: agent-native-cursor-click 520ms ease-out both;",
-      "}",
-      "@keyframes agent-native-cursor-click {",
-      "  0% { opacity: .85; transform: scale(.75); }",
-      "  100% { opacity: 0; transform: scale(2.4); }",
+      "  min-height: 20px;",
+      "  padding: 2px 6px;",
+      // guard:allow-raw-color — the isolated overlay has no app theme tokens.
+      "  background: #7b61ff;",
+      "  color: white;",
+      "  border-radius: 2px;",
+      // guard:allow-raw-color — the isolated overlay has no app theme tokens.
+      "  box-shadow: 0 1px 2px rgba(0, 0, 0, .22);",
+      "  font: 12px/16px -apple-system, BlinkMacSystemFont, \"Inter\", \"Helvetica Neue\", sans-serif;",
+      "  white-space: nowrap;",
+      "  z-index: 2;",
       "}",
       "@media (prefers-reduced-motion: reduce) {",
       "  :host { transition: none; }",
-      "  :host([data-action=click]) .hotspot { animation: none; opacity: .5; }",
       "}",
     ].join("");
+    const pointerOutline = document.createElement("span");
+    pointerOutline.className = "pointer-outline";
     const pointer = document.createElement("span");
     pointer.className = "pointer";
-    const hotspot = document.createElement("span");
-    hotspot.className = "hotspot";
-    shadow.append(style, pointer, hotspot);
+    const label = document.createElement("span");
+    label.className = "label";
+    label.textContent = "Agent";
+    shadow.append(style, pointerOutline, pointer, label);
     document.documentElement.append(host);
   }
 

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -73,7 +73,9 @@ private final class PhantomCursorView: NSView {
         let labelSize = label.size(withAttributes: labelAttributes)
         let labelRect = NSRect(
             x: labelOnLeft ? max(0, pointerOriginX - labelSize.width - 14) : 17,
-            y: labelAbove ? 24 : 5,
+            y: labelAbove
+                ? min(max(pointerTipY + 2, 0), PhantomCursorView.panelHeight - 20)
+                : 5,
             width: labelSize.width + 12,
             height: 20
         )
@@ -137,7 +139,6 @@ private final class PhantomCursorOverlay {
 
             let labelGap: CGFloat = 2
             let pointerWidth: CGFloat = 17
-            let pointerMaxX = PhantomCursorView.panelWidth - 19
             view.labelOnLeft = placement.appKitPoint.x + pointerWidth + labelGap + view.preferredLabelWidth > placement.screen.frame.maxX
             view.labelAbove = placement.appKitPoint.y - 44 < placement.screen.frame.minY
             _ = click
@@ -148,10 +149,9 @@ private final class PhantomCursorOverlay {
                 max(desiredOriginX, placement.screen.frame.minX),
                 placement.screen.frame.maxX - PhantomCursorView.panelWidth
             )
-            view.pointerOriginX = min(
-                max(placement.appKitPoint.x - originX, 1),
-                pointerMaxX
-            )
+            // Keep the arrow tip on the action point. The display clips only
+            // the artwork that naturally extends past a physical edge.
+            view.pointerOriginX = max(placement.appKitPoint.x - originX, 1)
 
             let desiredOriginY = view.labelAbove
                 ? placement.appKitPoint.y - 22
@@ -160,9 +160,7 @@ private final class PhantomCursorOverlay {
                 max(desiredOriginY, placement.screen.frame.minY),
                 placement.screen.frame.maxY - PhantomCursorView.panelHeight
             )
-            view.pointerTipY = view.labelAbove
-                ? 22
-                : min(max(placement.appKitPoint.y - originY, 0), 44)
+            view.pointerTipY = min(max(placement.appKitPoint.y - originY, 0), 44)
             panel?.alphaValue = 1
             panel?.setFrameOrigin(NSPoint(
                 x: originX,
@@ -221,8 +219,11 @@ private final class PhantomCursorOverlay {
 
         // Accessibility and NSScreen frames are both logical points. Derive a
         // shared top-left space instead of mixing them with display pixels.
-        let globalTop = screens.map(\.frame.maxY).max() ?? 0
-        let appKitPoint = NSPoint(x: quartzPoint.x, y: globalTop - quartzPoint.y)
+        let referenceScreen = screens.first(where: {
+            $0.frame.minX == 0 && $0.frame.minY == 0
+        }) ?? screens[0]
+        let referenceTop = referenceScreen.frame.maxY
+        let appKitPoint = NSPoint(x: quartzPoint.x, y: referenceTop - quartzPoint.y)
         guard let screen = screens.first(where: {
             $0.frame.insetBy(dx: -0.5, dy: -0.5).contains(appKitPoint)
         }) else { return nil }

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -9,6 +9,7 @@ private struct HelperFailure: Error, CustomStringConvertible {
 private final class PhantomCursorView: NSView {
     static let panelWidth: CGFloat = 70
     static let panelHeight: CGFloat = 45
+    static let labelGap: CGFloat = 2
 
     var labelOnLeft = false {
         didSet { needsDisplay = true }
@@ -71,12 +72,15 @@ private final class PhantomCursorView: NSView {
             .foregroundColor: NSColor.white,
         ]
         let labelSize = label.size(withAttributes: labelAttributes)
+        let labelWidth = labelSize.width + 12
         let labelRect = NSRect(
-            x: labelOnLeft ? max(0, pointerOriginX - labelSize.width - 14) : 17,
+            x: labelOnLeft
+                ? max(0, pointerOriginX - labelWidth - PhantomCursorView.labelGap)
+                : 17,
             y: labelAbove
                 ? min(max(pointerTipY + 2, 0), PhantomCursorView.panelHeight - 20)
                 : 5,
-            width: labelSize.width + 12,
+            width: labelWidth,
             height: 20
         )
         let labelPath = NSBezierPath(roundedRect: labelRect, xRadius: 2, yRadius: 2)
@@ -137,13 +141,18 @@ private final class PhantomCursorOverlay {
                 panel = nextPanel
             }
 
-            let labelGap: CGFloat = 2
             let pointerWidth: CGFloat = 17
-            view.labelOnLeft = placement.appKitPoint.x + pointerWidth + labelGap + view.preferredLabelWidth > placement.screen.frame.maxX
+            view.labelOnLeft = placement.appKitPoint.x
+                + pointerWidth
+                + PhantomCursorView.labelGap
+                + view.preferredLabelWidth
+                > placement.screen.frame.maxX
             view.labelAbove = placement.appKitPoint.y - 44 < placement.screen.frame.minY
             _ = click
             let desiredOriginX = view.labelOnLeft
-                ? placement.appKitPoint.x - 52
+                ? placement.appKitPoint.x
+                    - view.preferredLabelWidth
+                    - PhantomCursorView.labelGap
                 : placement.appKitPoint.x - 1
             let originX = min(
                 max(desiredOriginX, placement.screen.frame.minX),

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -7,42 +7,62 @@ private struct HelperFailure: Error, CustomStringConvertible {
 }
 
 private final class PhantomCursorView: NSView {
-    var showsClickPulse = false {
-        didSet { needsDisplay = true }
-    }
-
     override var isOpaque: Bool { false }
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.clear.setFill()
         dirtyRect.fill()
 
-        let hotspot = NSBezierPath(ovalIn: NSRect(x: 0, y: 24, width: 13, height: 13))
-        NSColor(calibratedRed: 0.35, green: 0.42, blue: 1.0, alpha: 0.2).setFill()
-        hotspot.fill()
-
-        if showsClickPulse {
-            let pulse = NSBezierPath(ovalIn: NSRect(x: -2, y: 22, width: 17, height: 17))
-            NSColor(calibratedRed: 0.35, green: 0.42, blue: 1.0, alpha: 0.7).setStroke()
-            pulse.lineWidth = 1.5
-            pulse.stroke()
-        }
-
         let pointer = NSBezierPath()
-        pointer.move(to: NSPoint(x: 3, y: 35))
-        pointer.line(to: NSPoint(x: 3, y: 7))
-        pointer.line(to: NSPoint(x: 11, y: 15))
-        pointer.line(to: NSPoint(x: 16, y: 4))
-        pointer.line(to: NSPoint(x: 20, y: 6))
-        pointer.line(to: NSPoint(x: 14, y: 17))
-        pointer.line(to: NSPoint(x: 27, y: 17))
+        pointer.move(to: NSPoint(x: 0, y: 44))
+        pointer.line(to: NSPoint(x: 0, y: 27))
+        pointer.line(to: NSPoint(x: 5, y: 31))
+        pointer.line(to: NSPoint(x: 9, y: 24))
+        pointer.line(to: NSPoint(x: 12, y: 26))
+        pointer.line(to: NSPoint(x: 8, y: 32))
+        pointer.line(to: NSPoint(x: 16, y: 32))
         pointer.close()
 
-        NSColor.white.setFill()
+        let shadow = NSShadow()
+        shadow.shadowColor = NSColor(calibratedWhite: 0, alpha: 0.26)
+        shadow.shadowBlurRadius = 1
+        shadow.shadowOffset = NSSize(width: 0, height: -1)
+        NSGraphicsContext.saveGraphicsState()
+        shadow.set()
+        NSColor(calibratedRed: 0.482, green: 0.380, blue: 1, alpha: 1).setFill()
         pointer.fill()
-        NSColor(calibratedWhite: 0.05, alpha: 0.82).setStroke()
-        pointer.lineWidth = 1.3
+        NSGraphicsContext.restoreGraphicsState()
+        NSColor.white.setStroke()
+        pointer.lineWidth = 1.1
         pointer.stroke()
+
+        let label = "Agent" as NSString
+        let labelFont = NSFont.systemFont(ofSize: 12, weight: .regular)
+        let labelAttributes: [NSAttributedString.Key: Any] = [
+            .font: labelFont,
+            .foregroundColor: NSColor.white,
+        ]
+        let labelSize = label.size(withAttributes: labelAttributes)
+        let labelRect = NSRect(
+            x: 16,
+            y: 5,
+            width: labelSize.width + 12,
+            height: 20
+        )
+        let labelPath = NSBezierPath(roundedRect: labelRect, xRadius: 2, yRadius: 2)
+        NSGraphicsContext.saveGraphicsState()
+        let labelShadow = NSShadow()
+        labelShadow.shadowColor = NSColor(calibratedWhite: 0, alpha: 0.22)
+        labelShadow.shadowBlurRadius = 2
+        labelShadow.shadowOffset = NSSize(width: 0, height: -1)
+        labelShadow.set()
+        NSColor(calibratedRed: 0.482, green: 0.380, blue: 1, alpha: 1).setFill()
+        labelPath.fill()
+        NSGraphicsContext.restoreGraphicsState()
+        label.draw(
+            at: NSPoint(x: labelRect.minX + 6, y: labelRect.minY + 3),
+            withAttributes: labelAttributes
+        )
     }
 }
 
@@ -62,7 +82,7 @@ private final class PhantomCursorOverlay {
             if let existingView = panel?.contentView as? PhantomCursorView {
                 view = existingView
             } else {
-                view = PhantomCursorView(frame: NSRect(x: 0, y: 0, width: 32, height: 40))
+                view = PhantomCursorView(frame: NSRect(x: 0, y: 0, width: 68, height: 45))
                 let nextPanel = NSPanel(
                     contentRect: view.frame,
                     styleMask: [.borderless, .nonactivatingPanel],
@@ -80,7 +100,7 @@ private final class PhantomCursorOverlay {
                 panel = nextPanel
             }
 
-            view.showsClickPulse = click
+            _ = click
             panel?.alphaValue = 1
             panel?.setFrameOrigin(origin)
             panel?.orderFrontRegardless()
@@ -137,8 +157,8 @@ private final class PhantomCursorOverlay {
             return nil
         }
         return NSPoint(
-            x: appKitPoint.x - 3,
-            y: appKitPoint.y - 35
+            x: appKitPoint.x,
+            y: appKitPoint.y - 44
         )
     }
 }

--- a/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
+++ b/packages/desktop-app/native/macos/AgentNativeComputerHelper.swift
@@ -7,20 +7,48 @@ private struct HelperFailure: Error, CustomStringConvertible {
 }
 
 private final class PhantomCursorView: NSView {
+    static let panelWidth: CGFloat = 70
+    static let panelHeight: CGFloat = 45
+
+    var labelOnLeft = false {
+        didSet { needsDisplay = true }
+    }
+
+    var labelAbove = false {
+        didSet { needsDisplay = true }
+    }
+
+    var pointerOriginX: CGFloat = 1 {
+        didSet { needsDisplay = true }
+    }
+
+    var pointerTipY: CGFloat = 44 {
+        didSet { needsDisplay = true }
+    }
+
+    var preferredLabelWidth: CGFloat {
+        let label = "Agent" as NSString
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .regular),
+        ]
+        return label.size(withAttributes: attributes).width + 12
+    }
+
     override var isOpaque: Bool { false }
 
     override func draw(_ dirtyRect: NSRect) {
         NSColor.clear.setFill()
         dirtyRect.fill()
 
+        let pointerOriginY = pointerTipY - 44
         let pointer = NSBezierPath()
-        pointer.move(to: NSPoint(x: 0, y: 44))
-        pointer.line(to: NSPoint(x: 0, y: 27))
-        pointer.line(to: NSPoint(x: 5, y: 31))
-        pointer.line(to: NSPoint(x: 9, y: 24))
-        pointer.line(to: NSPoint(x: 12, y: 26))
-        pointer.line(to: NSPoint(x: 8, y: 32))
-        pointer.line(to: NSPoint(x: 16, y: 32))
+        pointer.move(to: NSPoint(x: pointerOriginX, y: pointerOriginY + 44))
+        pointer.line(to: NSPoint(x: pointerOriginX, y: pointerOriginY + 27))
+        pointer.line(to: NSPoint(x: pointerOriginX + 5, y: pointerOriginY + 31))
+        pointer.line(to: NSPoint(x: pointerOriginX + 9, y: pointerOriginY + 24))
+        pointer.line(to: NSPoint(x: pointerOriginX + 12, y: pointerOriginY + 26))
+        pointer.line(to: NSPoint(x: pointerOriginX + 8, y: pointerOriginY + 32))
+        pointer.line(to: NSPoint(x: pointerOriginX + 16, y: pointerOriginY + 32))
         pointer.close()
 
         let shadow = NSShadow()
@@ -44,8 +72,8 @@ private final class PhantomCursorView: NSView {
         ]
         let labelSize = label.size(withAttributes: labelAttributes)
         let labelRect = NSRect(
-            x: 16,
-            y: 5,
+            x: labelOnLeft ? max(0, pointerOriginX - labelSize.width - 14) : 17,
+            y: labelAbove ? 24 : 5,
             width: labelSize.width + 12,
             height: 20
         )
@@ -75,14 +103,21 @@ private final class PhantomCursorOverlay {
 
     func show(at quartzPoint: CGPoint, click: Bool) {
         onMain { [self] in
-            guard let origin = appKitOrigin(for: quartzPoint) else { return }
+            guard let placement = placement(for: quartzPoint) else { return }
             removeTimers()
 
             let view: PhantomCursorView
             if let existingView = panel?.contentView as? PhantomCursorView {
                 view = existingView
             } else {
-                view = PhantomCursorView(frame: NSRect(x: 0, y: 0, width: 68, height: 45))
+                view = PhantomCursorView(
+                    frame: NSRect(
+                        x: 0,
+                        y: 0,
+                        width: PhantomCursorView.panelWidth,
+                        height: PhantomCursorView.panelHeight
+                    )
+                )
                 let nextPanel = NSPanel(
                     contentRect: view.frame,
                     styleMask: [.borderless, .nonactivatingPanel],
@@ -100,9 +135,39 @@ private final class PhantomCursorOverlay {
                 panel = nextPanel
             }
 
+            let labelGap: CGFloat = 2
+            let pointerWidth: CGFloat = 17
+            let pointerMaxX = PhantomCursorView.panelWidth - 19
+            view.labelOnLeft = placement.appKitPoint.x + pointerWidth + labelGap + view.preferredLabelWidth > placement.screen.frame.maxX
+            view.labelAbove = placement.appKitPoint.y - 44 < placement.screen.frame.minY
             _ = click
+            let desiredOriginX = view.labelOnLeft
+                ? placement.appKitPoint.x - 52
+                : placement.appKitPoint.x - 1
+            let originX = min(
+                max(desiredOriginX, placement.screen.frame.minX),
+                placement.screen.frame.maxX - PhantomCursorView.panelWidth
+            )
+            view.pointerOriginX = min(
+                max(placement.appKitPoint.x - originX, 1),
+                pointerMaxX
+            )
+
+            let desiredOriginY = view.labelAbove
+                ? placement.appKitPoint.y - 22
+                : placement.appKitPoint.y - 44
+            let originY = min(
+                max(desiredOriginY, placement.screen.frame.minY),
+                placement.screen.frame.maxY - PhantomCursorView.panelHeight
+            )
+            view.pointerTipY = view.labelAbove
+                ? 22
+                : min(max(placement.appKitPoint.y - originY, 0), 44)
             panel?.alphaValue = 1
-            panel?.setFrameOrigin(origin)
+            panel?.setFrameOrigin(NSPoint(
+                x: originX,
+                y: originY
+            ))
             panel?.orderFrontRegardless()
 
             fadeTimer = Timer.scheduledTimer(withTimeInterval: visibleDuration, repeats: false) { [weak self] _ in
@@ -145,7 +210,12 @@ private final class PhantomCursorOverlay {
         }
     }
 
-    private func appKitOrigin(for quartzPoint: CGPoint) -> NSPoint? {
+    private struct CursorPlacement {
+        let appKitPoint: NSPoint
+        let screen: NSScreen
+    }
+
+    private func placement(for quartzPoint: CGPoint) -> CursorPlacement? {
         let screens = NSScreen.screens
         guard !screens.isEmpty else { return nil }
 
@@ -153,13 +223,10 @@ private final class PhantomCursorOverlay {
         // shared top-left space instead of mixing them with display pixels.
         let globalTop = screens.map(\.frame.maxY).max() ?? 0
         let appKitPoint = NSPoint(x: quartzPoint.x, y: globalTop - quartzPoint.y)
-        guard screens.contains(where: { $0.frame.insetBy(dx: -0.5, dy: -0.5).contains(appKitPoint) }) else {
-            return nil
-        }
-        return NSPoint(
-            x: appKitPoint.x,
-            y: appKitPoint.y - 44
-        )
+        guard let screen = screens.first(where: {
+            $0.frame.insetBy(dx: -0.5, dy: -0.5).contains(appKitPoint)
+        }) else { return nil }
+        return CursorPlacement(appKitPoint: appKitPoint, screen: screen)
     }
 }
 


### PR DESCRIPTION
Match Chrome and macOS computer-use cursors to Figma multiplayer cursors: same-color purple arrow, white keyline, Agent label attached below/right, bounded coordinates, explicit teardown, and automatic fade/removal. Verified with core tests, Chrome extension tests/typecheck/build, desktop computer-control tests, macOS native helper build, pnpm guards (55 checks), and live Chrome render plus 2.3s expiry check.