### PR TITLE
Fix intermittent Neon database pressure

### DIFF
--- a/.changeset/bound-durable-event-pruning.md
+++ b/.changeset/bound-durable-event-pruning.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound durable-event pruning to one atomic Postgres statement so interrupted serverless workers cannot leave idle transactions behind.

--- a/.changeset/rearm-neon-transaction-reaper.md
+++ b/.changeset/rearm-neon-transaction-reaper.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Re-arm Neon idle-transaction cleanup and bound concurrent agent-run pruning.

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -35,6 +35,8 @@ let unclaimedBackgroundRunRowsWithStartedAt: Array<{
   has_dispatch_payload?: boolean | number;
 }> = [];
 let runCountRows: Array<{ run_count: number }> = [];
+let prunedRunRows: Array<Record<string, unknown>> = [];
+let postgres = false;
 // claimBackgroundRun CAS simulation: the real DB row only has `dispatch_mode
 // = 'background'` ONCE, so only the FIRST `claimBackgroundRun` UPDATE for a
 // given runId can match the WHERE clause; every subsequent attempt (a
@@ -48,6 +50,10 @@ const mockDb = {
     const rawSql = typeof sql === "string" ? sql : sql.sql;
     const args = typeof sql === "string" ? [] : (sql.args ?? []);
     execCalls.push({ sql: rawSql, args });
+
+    if (/pg_try_advisory_xact_lock/i.test(rawSql)) {
+      return { rows: [{ acquired: true }], rowsAffected: 0 };
+    }
 
     if (
       /SELECT seq,\s*event_data(?:,\s*event_at)?\s+FROM agent_run_events/i.test(
@@ -150,6 +156,9 @@ const mockDb = {
     if (/SELECT dispatch_payload FROM agent_runs WHERE id/i.test(rawSql)) {
       return { rows: dispatchPayloadRows, rowsAffected: 0 };
     }
+    if (/DELETE FROM agent_runs[\s\S]*RETURNING/i.test(rawSql)) {
+      return { rows: prunedRunRows, rowsAffected: prunedRunRows.length };
+    }
     // countRunsForTurn: SELECT COUNT(*) AS run_count FROM agent_runs WHERE thread_id = ? AND turn_id = ?
     if (/SELECT COUNT\(\*\) AS run_count FROM agent_runs/i.test(rawSql)) {
       return { rows: runCountRows, rowsAffected: 0 };
@@ -183,7 +192,7 @@ const mockCaptureError = vi.fn();
 vi.mock("../db/client.js", () => ({
   getDbExec: () => mockDb,
   intType: () => "INTEGER",
-  isPostgres: () => false,
+  isPostgres: () => postgres,
 }));
 
 vi.mock("../server/capture-error.js", () => ({
@@ -251,6 +260,8 @@ describe("run store", () => {
     unclaimedBackgroundRunRows = [];
     unclaimedBackgroundRunRowsWithStartedAt = [];
     runCountRows = [];
+    prunedRunRows = [];
+    postgres = false;
     insertEventBehavior = () => {};
     abortRowsAffected = 1;
     __resetNoRunningRunsProbeForTests();
@@ -905,18 +916,26 @@ describe("run store", () => {
   });
 
   it("keeps errored runs longer than completed runs during cleanup", async () => {
+    prunedRunRows = [
+      {
+        id: "run-completed",
+        status: "completed",
+        completed_at: Date.now() - 2 * 24 * 60 * 60 * 1000,
+        terminal_reason: "done",
+      },
+      {
+        id: "run-errored",
+        status: "errored",
+        completed_at: Date.now() - 8 * 24 * 60 * 60 * 1000,
+        terminal_reason: "error:provider",
+      },
+    ];
     await cleanupOldRuns(24 * 60 * 60 * 1000, 7 * 24 * 60 * 60 * 1000);
 
     const deleteEvents = execCalls.find((call) =>
       /DELETE FROM agent_run_events/i.test(call.sql),
     );
-    expect(deleteEvents?.sql).toContain("status = 'completed'");
-    expect(deleteEvents?.sql).toContain(
-      "status IN ('errored', 'aborted', 'truncated')",
-    );
-    expect(Number(deleteEvents?.args[1])).toBeLessThan(
-      Number(deleteEvents?.args[0]),
-    );
+    expect(deleteEvents?.args).toEqual(["run-completed", "run-errored"]);
 
     const deleteRuns = execCalls.find((call) =>
       /DELETE FROM agent_runs/i.test(call.sql),
@@ -928,6 +947,18 @@ describe("run store", () => {
     expect(Number(deleteRuns?.args[1])).toBeLessThan(
       Number(deleteRuns?.args[0]),
     );
+    expect(deleteRuns?.sql).toContain("LIMIT 200");
+  });
+
+  it("uses a transaction-scoped lease for Postgres cleanup", async () => {
+    postgres = true;
+
+    await cleanupOldRuns(24 * 60 * 60 * 1000);
+
+    const lock = execCalls.find((call) =>
+      /pg_try_advisory_xact_lock/i.test(call.sql),
+    );
+    expect(lock?.args).toEqual(["agent-native:run-outcome-prune"]);
   });
 
   // Fix 2: atomic run lease

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -2813,6 +2813,8 @@ const RUN_OUTCOME_DAY_MS = 86_400_000;
  * every run id a user pasted into a bug report was gone before anyone looked.
  */
 const UNSUCCESSFUL_STATUS_SQL_LIST = `('errored', 'aborted', 'truncated')`;
+const RUN_OUTCOME_PRUNE_BATCH_LIMIT = 200;
+const RUN_OUTCOME_PRUNE_LOCK_KEY = "agent-native:run-outcome-prune";
 
 /**
  * Fold the terminal outcomes of the rows `cleanupOldRuns` is about to delete
@@ -2821,9 +2823,10 @@ const UNSUCCESSFUL_STATUS_SQL_LIST = `('errored', 'aborted', 'truncated')`;
  * covers exactly the unpruned ones, so a rate over any window is
  * `getRunOutcomeCounters()` plus the live rows — no gap, no double count.
  *
- * The DELETE ... RETURNING is the claim: concurrent cleanup calls can both
- * observe a row, but only the caller that deletes it receives it to roll up.
- * Grouping the returned rows in TypeScript avoids dialect-specific date SQL.
+ * Postgres callers take a transaction-scoped advisory lease before the claim.
+ * The bounded DELETE ... RETURNING is still the source of truth for which rows
+ * this invocation owns. Grouping the returned rows in TypeScript avoids
+ * dialect-specific date SQL.
  * Counter upserts run in the same transaction as the delete; a failed upsert
  * rolls back the claim so the source rows remain available for a retry.
  */
@@ -2833,22 +2836,38 @@ async function pruneAndRollUpPrunedRunOutcomes(
   erroredCutoff: number,
 ): Promise<void> {
   const prune = async (tx: ReturnType<typeof getDbExec>): Promise<void> => {
-    await tx.execute({
-      sql: `DELETE FROM agent_run_events WHERE run_id IN (
-        SELECT id FROM agent_runs
-        WHERE (status = 'completed' AND completed_at < ?)
-           OR (status IN ${UNSUCCESSFUL_STATUS_SQL_LIST} AND completed_at < ?)
-      )`,
-      args: [cutoff, erroredCutoff],
-    });
+    if (isPostgres()) {
+      const lockResult = await tx.execute({
+        sql: "SELECT pg_try_advisory_xact_lock(hashtextextended(?, 0::bigint)) AS acquired",
+        args: [RUN_OUTCOME_PRUNE_LOCK_KEY],
+      });
+      const acquired = lockResult.rows[0]?.acquired;
+      if (acquired !== true && acquired !== "t") return;
+    }
 
     const { rows } = await tx.execute({
       sql: `DELETE FROM agent_runs
-            WHERE (status = 'completed' AND completed_at < ?)
-               OR (status IN ${UNSUCCESSFUL_STATUS_SQL_LIST} AND completed_at < ?)
-            RETURNING status, completed_at, terminal_reason`,
+            WHERE id IN (
+              SELECT id FROM agent_runs
+              WHERE (status = 'completed' AND completed_at < ?)
+                 OR (status IN ${UNSUCCESSFUL_STATUS_SQL_LIST} AND completed_at < ?)
+              ORDER BY completed_at ASC, id ASC
+              LIMIT ${RUN_OUTCOME_PRUNE_BATCH_LIMIT}
+            )
+            RETURNING id, status, completed_at, terminal_reason`,
       args: [cutoff, erroredCutoff],
     });
+
+    const runIds = rows
+      .map((row) => (row as { id?: unknown }).id)
+      .filter((id): id is string => typeof id === "string");
+    if (runIds.length > 0) {
+      const placeholders = runIds.map(() => "?").join(", ");
+      await tx.execute({
+        sql: `DELETE FROM agent_run_events WHERE run_id IN (${placeholders})`,
+        args: runIds,
+      });
+    }
 
     const groups = new Map<
       string,
@@ -2956,7 +2975,9 @@ export async function getRunOutcomeCounters(options?: {
  *  pruned at `olderThanMs`; errored/aborted/truncated runs are kept until
  *  `erroredOlderThanMs` (a longer window, falling back to `olderThanMs`) so
  *  their event log survives for cut-off pattern analysis via listErroredRuns. */
-export async function cleanupOldRuns(
+let cleanupOldRunsInFlight: Promise<void> | undefined;
+
+async function cleanupOldRunsInternal(
   olderThanMs: number,
   erroredOlderThanMs?: number,
 ): Promise<void> {
@@ -3060,6 +3081,26 @@ export async function cleanupOldRuns(
   // deleted. The transaction prevents concurrent cleanup calls from both
   // counting the same source rows.
   await pruneAndRollUpPrunedRunOutcomes(client, cutoff, erroredCutoff);
+}
+
+/**
+ * Run cleanup is scheduled after every completed run, including completions
+ * from several concurrent requests in one isolate. Share one sweep locally;
+ * Postgres additionally serializes the durable prune across isolates.
+ */
+export function cleanupOldRuns(
+  olderThanMs: number,
+  erroredOlderThanMs?: number,
+): Promise<void> {
+  if (cleanupOldRunsInFlight) return cleanupOldRunsInFlight;
+
+  const current = cleanupOldRunsInternal(olderThanMs, erroredOlderThanMs);
+  let settled: Promise<void>;
+  settled = current.finally(() => {
+    if (cleanupOldRunsInFlight === settled) cleanupOldRunsInFlight = undefined;
+  });
+  cleanupOldRunsInFlight = settled;
+  return settled;
 }
 
 /**

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -1194,7 +1194,7 @@ describe("Neon foreground statement budgets", () => {
     ).resolves.toEqual({ rows: [{ value: 1 }], rowsAffected: 1 });
 
     expect(query.mock.calls.map(([sql]) => sql)).toEqual([
-      "BEGIN",
+      "BEGIN; SET LOCAL idle_in_transaction_session_timeout = 30000",
       "SET LOCAL statement_timeout = 900",
       "SELECT 1",
       "COMMIT",
@@ -1241,7 +1241,10 @@ describe("Neon foreground statement budgets", () => {
       }),
     ).rejects.toBe(transactionError);
 
-    expect(query.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
+    expect(query.mock.calls.map(([sql]) => sql)).toEqual([
+      "BEGIN; SET LOCAL idle_in_transaction_session_timeout = 30000",
+      "ROLLBACK",
+    ]);
     expect(client.release).toHaveBeenCalledWith(true);
   });
 });

--- a/packages/core/src/db/client.spec.ts
+++ b/packages/core/src/db/client.spec.ts
@@ -1155,11 +1155,14 @@ describe("Neon foreground statement budgets", () => {
 
   it("uses a transaction-local timeout for explicitly budgeted transaction work", async () => {
     vi.stubEnv("NETLIFY", "true");
-    const query = vi.fn(async (sql: string) =>
-      sql === "SELECT 1"
+    const query = vi.fn(async (sql: string, args?: unknown[]) => {
+      if (sql.includes(";") && args !== undefined) {
+        throw new Error("multi-command queries require the simple protocol");
+      }
+      return sql === "SELECT 1"
         ? { rows: [{ value: 1 }], rowCount: 1 }
-        : { rows: [], rowCount: 0 },
-    );
+        : { rows: [], rowCount: 0 };
+    });
     const client = {
       query,
       release: vi.fn(),

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1777,7 +1777,13 @@ async function createDbExecInternal(
               },
             };
             try {
-              await queryNeonClient(client, "BEGIN");
+              // Send the transaction start and idle reaper together. Neon
+              // transaction pooling can ignore startup parameters, and a
+              // worker can die between separate BEGIN and SET LOCAL calls.
+              await queryNeonClient(
+                client,
+                "BEGIN; SET LOCAL idle_in_transaction_session_timeout = 30000",
+              );
               const result = await fn(tx);
               await queryNeonClient(client, "COMMIT");
               releaseClient();

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1572,13 +1572,15 @@ async function createDbExecInternal(
         const { rawSql, args } = sqlAndArgs(sql);
         const { timeoutMs } = dbExecQueryBudget(sql);
         const pgSql = sqliteToPostgresParams(rawSql);
+        // Neon only accepts multiple SQL commands through its simple protocol;
+        // the transaction start has no parameters, so use that overload.
+        const runQuery = () =>
+          args.length === 0 && rawSql.includes(";")
+            ? client.query(pgSql)
+            : client.query(pgSql, args as any[]);
         const result = await withDbTimeout(
           "query",
-          () =>
-            client.query(pgSql, args as any[]) as Promise<{
-              rows: unknown[];
-              rowCount?: number;
-            }>,
+          () => runQuery() as Promise<{ rows: unknown[]; rowCount?: number }>,
           timeoutOverrideMs ?? timeoutMs,
         );
         return {

--- a/packages/core/src/db/create-get-db.spec.ts
+++ b/packages/core/src/db/create-get-db.spec.ts
@@ -286,6 +286,33 @@ describe("buildResilientNeonPool", () => {
     // Called with no error argument on clean release (undefined = return slot to pool)
     expect(releasesMock).toHaveBeenCalledWith(undefined);
   });
+
+  it("arms Neon idle transaction cleanup when Drizzle starts a transaction", async () => {
+    const { buildResilientNeonPool } = await import("./create-get-db.js");
+
+    const client = {
+      query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      release: vi.fn(),
+    };
+    const pool = {
+      connect: vi.fn(async () => client),
+      query: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn(),
+    };
+
+    const resilient = buildResilientNeonPool(pool as any);
+    const transactionClient = await resilient.connect();
+
+    await transactionClient.query({ text: "begin", rowMode: "array" }, []);
+    await transactionClient.query("SELECT 1");
+
+    expect(client.query).toHaveBeenNthCalledWith(
+      1,
+      "begin; SET LOCAL idle_in_transaction_session_timeout = 30000",
+    );
+    expect(client.query).toHaveBeenNthCalledWith(2, "SELECT 1");
+  });
 });
 
 describe("isSqlRead", () => {

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -68,6 +68,50 @@ export function isSqlRead(sql: string): boolean {
   return /^\s*(SELECT|WITH\s)/i.test(sql);
 }
 
+const NEON_IDLE_IN_TRANSACTION_TIMEOUT_SQL =
+  "SET LOCAL idle_in_transaction_session_timeout = 30000";
+
+function queryText(sql: unknown): string {
+  if (typeof sql === "string") return sql;
+  if (sql && typeof sql === "object" && "text" in sql) {
+    const text = (sql as { text?: unknown }).text;
+    return typeof text === "string" ? text : "";
+  }
+  return "";
+}
+
+function isBeginQuery(sql: unknown): boolean {
+  return /^\s*BEGIN(?:\s|$)/i.test(queryText(sql));
+}
+
+/**
+ * Drizzle sends BEGIN through the client returned by pool.connect(), so a
+ * pool startup parameter alone is not enough protection when Neon routes the
+ * connection through a transaction pooler. Put the idle timeout in the same
+ * simple-protocol message as BEGIN; a worker killed before its next query
+ * still leaves a backend that will reap itself.
+ */
+function guardNeonTransactionClient<
+  T extends { query: (...args: any[]) => any },
+>(client: T): T {
+  return new Proxy(client, {
+    get(target, prop) {
+      if (prop !== "query") {
+        const value = (target as any)[prop];
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+
+      return (...args: any[]) => {
+        const sql = args[0];
+        if (!isBeginQuery(sql)) return target.query(...args);
+
+        const text = queryText(sql).replace(/;\s*$/, "");
+        return target.query(`${text}; ${NEON_IDLE_IN_TRANSACTION_TIMEOUT_SQL}`);
+      };
+    },
+  });
+}
+
 /**
  * Wraps a @neondatabase/serverless Pool so every query goes through
  * the same withDbTimeout + retryOnConnectionError resilience that the
@@ -187,6 +231,12 @@ export function buildResilientNeonPool<
   return new Proxy(pool, {
     get(target, prop) {
       if (prop === "query") return resilientQuery;
+      if (prop === "connect") {
+        return (...args: any[]) =>
+          (target as any)
+            .connect(...args)
+            .then((client: any) => guardNeonTransactionClient(client));
+      }
       const val = (target as any)[prop];
       return typeof val === "function" ? val.bind(target) : val;
     },

--- a/packages/core/src/server/poll-prune.spec.ts
+++ b/packages/core/src/server/poll-prune.spec.ts
@@ -22,6 +22,18 @@ function makeDb(
     const args = typeof query === "string" ? [] : (query.args ?? []);
     if (sql.includes("pg_try_advisory_xact_lock")) {
       locks.push({ sql, args });
+      if (sql.includes("DELETE")) {
+        if (options.failDeletes) throw new Error("deadlock detected");
+        const n =
+          options.advisoryLock === false
+            ? 0
+            : (options.deletedPerBatch?.[batch] ?? 0);
+        if (options.advisoryLock !== false) {
+          deletes.push({ sql, args });
+          batch++;
+        }
+        return { rows: [] as any[], rowsAffected: n };
+      }
       return {
         rows: [{ acquired: options.advisoryLock ?? true }],
         rowsAffected: 0,
@@ -171,7 +183,7 @@ describe("sync_events prune", () => {
     expect(db.deletes).toHaveLength(2);
   });
 
-  it("serializes Postgres batches with a transaction-scoped advisory lease", async () => {
+  it("serializes Postgres batches with a transaction-scoped advisory lease in autocommit statements", async () => {
     const db = makeDb({
       postgres: true,
       deletedPerBatch: [10_000, 3],
@@ -180,9 +192,18 @@ describe("sync_events prune", () => {
 
     expect(db.locks).toHaveLength(2);
     expect(db.locks[0].sql).toContain("pg_try_advisory_xact_lock");
-    expect(db.locks[0].args).toEqual(["agent-native:sync-events-prune"]);
-    expect(db.exec.transaction).toHaveBeenCalledTimes(2);
+    expect(db.locks[0].args).toEqual([
+      "agent-native:sync-events-prune",
+      1_800_000_000_000 - 86_400_000,
+      10_000,
+    ]);
+    expect(db.exec.transaction).not.toHaveBeenCalled();
     expect(db.deletes).toHaveLength(2);
+    expect(db.deletes[0].args).toEqual([
+      "agent-native:sync-events-prune",
+      1_800_000_000_000 - 86_400_000,
+      10_000,
+    ]);
   });
 
   it("skips a Postgres prune when another worker owns the lease", async () => {

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -679,16 +679,16 @@ export class AppSyncState {
    *     transaction, and a long transaction killed mid-flight by a serverless
    *     worker shutdown is what leaves connections `idle in transaction`
    *     holding locks — the shape of the 2026-08-06 outage.
-   *   - `ORDER BY version` inside the subquery. Without it the planner
+   *   - `ORDER BY created_at, id` inside the subquery. Without it the planner
    *     prefers a sequential scan even with a LIMIT; with it, the existing
-   *     `sync_events_version_idx` drives the batch and the delete is a
+   *     `sync_events_created_at_id_idx` drives the batch and the delete is a
    *     bounded index range scan.
    *
    * The `lastDurablePrune` throttle below is per-process, so every serverless
    * worker prunes on its first poll. Postgres workers also take a
-   * transaction-scoped advisory lease for each batch: only one worker deletes
-   * at a time, but each batch still commits independently so a killed worker
-   * cannot hold a long transaction open.
+   * transaction-scoped advisory lease for each batch. The lease and delete
+   * are one bounded statement, so a serverless worker killed after the
+   * statement starts cannot leave an open transaction.
    */
   private async pruneDurableEvents(client: DbExec): Promise<void> {
     const now = Date.now();
@@ -698,16 +698,7 @@ export class AppSyncState {
     let deleted = 0;
     try {
       for (let batch = 0; batch < DURABLE_PRUNE_MAX_BATCHES; batch++) {
-        const runBatch = async (tx: DbExec): Promise<number | null> => {
-          if (this.isPg()) {
-            const lockResult = await tx.execute({
-              sql: "SELECT pg_try_advisory_xact_lock(hashtextextended(?, 0::bigint)) AS acquired",
-              args: [DURABLE_PRUNE_LOCK_KEY],
-            });
-            const acquired = lockResult.rows[0]?.acquired;
-            if (acquired !== true && acquired !== "t") return null;
-          }
-
+        const runBatch = async (tx: DbExec): Promise<number> => {
           // `id IN (...)` rather than ctid/rowid: both are dialect-specific,
           // and the primary key is indexed on every dialect we ship.
           const result = await tx.execute({
@@ -720,20 +711,24 @@ export class AppSyncState {
           return result.rowsAffected;
         };
 
-        // A Postgres advisory transaction lock is only useful when the lock
-        // and delete share a connection and transaction. Never fall back to
-        // an uncoordinated delete on a transactionless client.
         const rowsAffected = this.isPg()
-          ? client.transaction
-            ? await client.transaction(runBatch)
-            : null
+          ? (
+              await client.execute({
+                sql: `WITH prune_lease AS MATERIALIZED (
+                       SELECT pg_try_advisory_xact_lock(hashtextextended(?, 0::bigint)) AS acquired
+                     ), prune_batch AS MATERIALIZED (
+                       SELECT sync_events.id
+                       FROM sync_events CROSS JOIN prune_lease
+                       WHERE prune_lease.acquired AND sync_events.created_at < ?
+                       ORDER BY sync_events.created_at, sync_events.id LIMIT ?
+                     )
+                     DELETE FROM sync_events WHERE id IN (
+                       SELECT id FROM prune_batch
+                     )`,
+                args: [DURABLE_PRUNE_LOCK_KEY, cutoff, DURABLE_PRUNE_BATCH],
+              })
+            ).rowsAffected
           : await runBatch(client);
-        if (rowsAffected == null) {
-          if (this.isPg() && !client.transaction) {
-            throw new Error("Postgres prune requires a database transaction");
-          }
-          break;
-        }
         deleted += rowsAffected;
         if (rowsAffected < DURABLE_PRUNE_BATCH) break;
       }

--- a/templates/slides/actions/list-decks.test.ts
+++ b/templates/slides/actions/list-decks.test.ts
@@ -26,6 +26,8 @@ vi.mock("../server/db/index.js", () => ({
       id: "id_col",
       title: "title_col",
       ownerEmail: "owner_email_col",
+      designSystemId: "design_system_id_col",
+      createdAt: "created_at_col",
       updatedAt: "updated_at_col",
       visibility: "visibility_col",
     },
@@ -63,16 +65,36 @@ describe("list-decks", () => {
       id: "deck_123",
       title: "Roadmap",
       url: "https://slides.agent.test/deck/deck_123",
-      slideCount: 1,
     });
+    expect(selectFn).toHaveBeenCalledWith({
+      id: "id_col",
+      title: "title_col",
+      ownerEmail: "owner_email_col",
+      designSystemId: "design_system_id_col",
+      createdAt: "created_at_col",
+      updatedAt: "updated_at_col",
+      visibility: "visibility_col",
+    });
+    expect(result.decks[0]).not.toHaveProperty("slideCount");
   });
 
-  it("includes URLs in compact output too", async () => {
+  it("keeps compact output metadata-only", async () => {
     const result = await action.run({ compact: "true" });
 
     expect(result.decks[0]).toMatchObject({
       id: "deck_123",
       url: "https://slides.agent.test/deck/deck_123",
+    });
+    expect(result.decks[0]).not.toHaveProperty("slideCount");
+  });
+
+  it("only reads deck bodies when full slides are explicitly requested", async () => {
+    const result = await action.run({ includeSlides: "true" });
+
+    expect(selectFn).toHaveBeenCalledWith();
+    expect(result.decks[0]).toMatchObject({
+      id: "deck_123",
+      slides: [{ id: "slide-1" }],
     });
   });
 

--- a/templates/slides/actions/list-decks.ts
+++ b/templates/slides/actions/list-decks.ts
@@ -22,7 +22,9 @@ export default defineAction({
     includeSlides: z
       .enum(["true", "false"])
       .optional()
-      .describe("Set to 'true' for full frontend deck payloads"),
+      .describe(
+        "Set to 'true' for full frontend deck payloads; omitted returns metadata only",
+      ),
     light: z
       .enum(["true", "false"])
       .optional()
@@ -82,6 +84,39 @@ export default defineAction({
         .where(where)
         .orderBy(desc(schema.decks.updatedAt));
       return { count: rows.length, decks: rows };
+    }
+
+    if (args.includeSlides !== "true") {
+      // The deck body is an opaque JSON blob containing every slide's HTML.
+      // Metadata callers must opt into it explicitly; the frontend opens one
+      // deck at a time through get-deck instead of downloading every body.
+      const rows = await db
+        .select({
+          id: schema.decks.id,
+          title: schema.decks.title,
+          ownerEmail: schema.decks.ownerEmail,
+          designSystemId: schema.decks.designSystemId,
+          createdAt: schema.decks.createdAt,
+          updatedAt: schema.decks.updatedAt,
+          visibility: schema.decks.visibility,
+        })
+        .from(schema.decks)
+        .where(where)
+        .orderBy(desc(schema.decks.updatedAt));
+
+      return {
+        count: rows.length,
+        decks: rows.map((row) => ({
+          id: row.id,
+          title: row.title,
+          url: getDeckUrl(row.id),
+          visibility: row.visibility,
+          designSystemId: row.designSystemId ?? null,
+          createdByMe: ownerEmail ? row.ownerEmail === ownerEmail : false,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        })),
+      };
     }
 
     const rows = await db

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -940,7 +940,7 @@ export function deriveInverseOp(
 }
 
 /**
- * Fetch the deck list. Returns `null` on any failure (network error, non-2xx
+ * Fetch the deck metadata list. Returns `null` on any failure (network error, non-2xx
  * response) so callers can distinguish "authoritative empty list" from
  * "couldn't reach the server" — wiping local state on a transient failure
  * kicks the user out of the editor and shows the "Create your first deck"
@@ -951,7 +951,7 @@ async function fetchDecksFromAPI(): Promise<Deck[] | null> {
   try {
     const result = await callAction<DeckListActionResult>(
       "list-decks",
-      { includeSlides: "true" },
+      { light: "true" },
       { method: "GET" },
     );
     if (!Array.isArray(result?.decks)) {
@@ -1076,12 +1076,23 @@ export async function includeOpenDeckIfMissing(
 async function fetchDecksForCurrentRoute(): Promise<Deck[] | null> {
   const currentOpenDeckId = currentOpenDeckIdFromWindow();
   const loaded = await fetchDecksFromAPI();
-  if (loaded !== null) {
-    return includeOpenDeckIfMissing(loaded, currentOpenDeckId);
+  if (loaded === null) {
+    if (!currentOpenDeckId) return null;
+    const directDeck = await fetchDeckFromAPI(currentOpenDeckId);
+    return directDeck ? [directDeck] : null;
   }
-  if (!currentOpenDeckId) return null;
+  if (!currentOpenDeckId) return loaded;
+
+  // The list is intentionally metadata-only. Hydrate just the deck the user
+  // opened so the editor gets full slide content without making the home page
+  // download every deck body.
   const directDeck = await fetchDeckFromAPI(currentOpenDeckId);
-  return directDeck ? [directDeck] : null;
+  if (!directDeck) return loaded;
+  const index = loaded.findIndex((deck) => deck.id === currentOpenDeckId);
+  if (index < 0) return [...loaded, directDeck];
+  const next = [...loaded];
+  next[index] = directDeck;
+  return next;
 }
 
 async function deleteDeckFromAPI(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Re-arm Neon `idle_in_transaction_session_timeout` on every raw and Drizzle transaction start.
- Bound and single-flight agent-run outcome pruning, with a transaction-scoped Postgres lease and event deletion limited to rows actually pruned.
- Add regression coverage and a Core patch changeset.

## Verification

- Core DB/health focused suite: 156 tests passed.
- Run-store and run-manager suites: 229 tests passed.
- `oxfmt --check` and `git diff --check` passed.

The full local guard/typecheck commands also surfaced unrelated fresh-worktree/generated-package baseline failures; no errors were reported in the changed DB paths.
