### PR TITLE
docs: update internal PR review policy

### DIFF
--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: review-prs
 description: >-
-  Review recent BuilderIO/agent-native pull requests, auto-approve only safe
-  clear fixes from verified BuilderIO members, and recap every disposition.
+  Review recent BuilderIO/agent-native pull requests, approve safe internal
+  fixes under the internal-author exception, and recap every disposition.
   Use for scheduled or manual PR review sweeps.
 user-invocable: true
 scope: dev
@@ -13,9 +13,9 @@ metadata:
 # Review Pull Requests
 
 Review the newest relevant pull requests in `BuilderIO/agent-native`. Approve
-only a clear, safe fix from a verified BuilderIO organization member. Treat
-approval as a narrow trust decision, not as a signal to approve everything
-recent or everything authored by a collaborator. Never auto-merge.
+safe fixes from verified BuilderIO organization members under the internal
+author policy below. Treat approval as a trust decision, never auto-merge, and
+never approve an external or unverified author.
 
 ## Selection and evidence
 
@@ -41,29 +41,60 @@ company claim, branch name, `authorAssociation`, or a familiar-looking bot.
 If membership cannot be verified, do not approve. External authors are never
 auto-approved, even when the patch looks safe or the issue is obviously valid.
 
-## Approval gate
+## Internal-author approval policy
 
-Approve only when every condition below is true:
+The user has explicitly authorized a practical internal-author exception for
+this skill:
 
-1. The PR is in `BuilderIO/agent-native` and the author is verified as a
-   current BuilderIO organization member.
+ - For a verified current BuilderIO member, failed, pending, skipped, or
+   unknown CI/check evidence does not by itself block approval. Record the
+   exact state in the recap and assume the author will resolve it before merge.
+ - For a verified current BuilderIO member, ordinary unresolved review
+   feedback, including bot findings, does not by itself block approval. Record
+   the unresolved feedback and assume it will be handled before merge.
+ - These exceptions do not waive the ultra-scary safety gate below. Do not
+   approve when the current diff or review evidence indicates a credible auth
+   bypass, permission or tenant-isolation failure, secret or credential leak,
+   destructive data loss or migration, remote code execution, SSRF, payment
+   compromise, deployment compromise, or similarly severe production risk.
+ - Do not claim that ignored checks are green or that ignored feedback is
+   resolved. The recap must distinguish approval under the internal exception
+   from a clean merge state.
+
+The verified Design owner is:
+
+ - Sid (`sidmohanty11`) - Design
+
+For a verified PR authored by `sidmohanty11`, auto-approve by default,
+including Design UX changes, refactors, failed or pending checks, and ordinary
+unresolved human or bot feedback. Sid's owner exception overrides the normal
+UX-owner, narrow-refactor, check, and review-resolution gates. The ultra-scary
+safety gate, repository membership check, and external-author prohibition
+still apply. A PR involving preview execution, credential routing, tenant
+isolation, or another potentially severe security boundary needs an explicit
+ultra-scary assessment before approval.
+
+## Standard approval gate
+
+For verified internal authors other than the Sid owner exception, approve only
+when all of the following are true after applying the internal-author policy:
+
+1. The PR is in `BuilderIO/agent-native` and the author is a verified current
+   BuilderIO organization member.
 2. It fixes a clear, repo-owned issue with a narrow root-cause change. The
    evidence supports the changed boundary, and the PR does not encode one
    chat report as a brittle global prompt or situation-specific rule.
-3. The relevant focused tests and required checks are conclusively green.
-   Do not approve with pending, skipped, unknown, or failed required evidence.
-4. All actionable review comments are addressed or a clear resolution is
-   visible in the current diff. Do not approve a PR with unresolved concerns.
-5. There is no unresolved concern involving security, auth, permissions,
-   secrets, data loss, destructive migrations, payments, deployment safety,
-   generated artifacts, or an unexplained dependency or infrastructure change.
-6. The scope and ownership are unambiguous. A PR with a material concern is
-   flagged for Steve, not approved.
+3. There is no ultra-scary concern involving security, auth, permissions,
+   secrets, data loss, destructive migrations, remote code execution, SSRF,
+   payments, deployment safety, or an unexplained dependency/infrastructure
+   change.
+4. The scope and ownership are unambiguous. UX implications still require the
+   verified owner of every affected named app unless the Sid owner exception
+   applies. Cross-app, framework-wide, or ambiguous UX changes remain flagged.
 
-Do not approve refactors, speculative features, ambiguous behavior changes,
-unverified fixes, or a patch whose main evidence is a single subjective
-request. A clean-looking diff is not enough when the owner, runtime behavior,
-or release state is uncertain.
+Do not approve external authors, unverified authors, or internal PRs whose
+remaining concern is ultra-scary. A clean-looking diff is not enough when the
+owner, runtime behavior, or release state is uncertain.
 
 ## UX exception and app owners
 
@@ -71,30 +102,29 @@ Detect UX implications from the actual diff, not only filenames. UX includes
 visible copy, layout, density, navigation, controls, settings, interaction,
 loading states, accessibility behavior, and user-facing defaults.
 
-If a PR has UX implications, do not auto-approve it unless its author is the
-verified owner of every affected named app and the change is otherwise fully
-safe. The current app-owner map is:
+The current app-owner map is:
 
  - Alice - Content
  - Milos - Clips
  - Nicholas - Slides and Analytics
+ - Sid (`sidmohanty11`) - Design
 
 Verify the author's GitHub identity and the affected app. A cross-app,
-framework-wide, or ambiguous UX change has no app-owner exception and must be
-flagged for Steve. If the author is not the owner of an affected app, flag it.
-An app owner's status does not waive the safety, evidence, check, or review
-gates above.
+framework-wide, or ambiguous UX change has no standard app-owner exception and
+must be flagged unless the verified Sid owner exception applies. An app
+owner's status does not waive the ultra-scary safety gate.
 
 ## Review actions
 
-For a PR that passes the complete gate, submit one GitHub approval review and
+For a PR that passes the applicable gate, submit one GitHub approval review and
 record the approval URL in the recap. Do not add a tag, assignment, mention,
 or explanatory comment unless the invocation explicitly asks for it.
 
-For a PR that fails any gate, do not submit an approval. Flag the exact concern
-and the evidence needed to resolve it. External PRs may be inspected and
-recapped, but never approved. If GitHub or organization membership is
-unavailable, preserve the no-approval outcome and name the missing check.
+For a PR that fails any applicable gate, do not submit an approval. Flag the
+exact concern and the evidence needed to resolve it. External PRs may be
+inspected and recapped, but never approved. If GitHub or organization
+membership is unavailable, preserve the no-approval outcome and name the
+missing check.
 
 ## Worktrees and PR provenance
 


### PR DESCRIPTION
## Summary

- Allow verified BuilderIO members to be approved despite ordinary CI/check and review-feedback state, while recording those states honestly.
- Add Sid (sidmohanty11) as Design owner with an auto-approve exception.
- Preserve the ultra-scary safety gate and external-author prohibition.

## Validation

- git diff --check

No source or runtime behavior changed.