### PR TITLE
Fix Cloudflare Pages PDF.js template builds

### DIFF
--- a/.changeset/repair-cloudflare-pdf-stub.md
+++ b/.changeset/repair-cloudflare-pdf-stub.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Cloudflare Pages builds for templates that import the PDF.js legacy entrypoint.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -207,6 +207,9 @@ describe("cloudflareWorkerStubAliasArgs", () => {
     const workerAlias = aliases.find((alias) =>
       alias.startsWith("--alias:pdf-parse/worker="),
     );
+    const pdfJsAlias = aliases.find((alias) =>
+      alias.startsWith("--alias:pdfjs-dist/legacy/build/pdf.mjs="),
+    );
     const packageAlias = aliases.find((alias) =>
       alias.startsWith("--alias:pdf-parse="),
     );
@@ -217,8 +220,17 @@ describe("cloudflareWorkerStubAliasArgs", () => {
     expect(CLOUDFLARE_WORKER_STUB_SUBPATH_MODULES).toHaveProperty(
       "pdf-parse/worker",
     );
+    expect(CLOUDFLARE_WORKER_STUB_SUBPATH_MODULES).toHaveProperty(
+      "pdfjs-dist/legacy/build/pdf.mjs",
+    );
     expect(workerAlias).toBe(
       `--alias:pdf-parse/worker=${path.join(stubDir, "pdf-parse__worker.js")}`,
+    );
+    expect(pdfJsAlias).toBe(
+      `--alias:pdfjs-dist/legacy/build/pdf.mjs=${path.join(
+        stubDir,
+        "pdfjs-dist__legacy__build__pdf.mjs.js",
+      )}`,
     );
     expect(packageAlias).toBe(
       `--alias:pdf-parse=${path.join(stubDir, "pdf-parse", "index.js")}`,

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -1215,6 +1215,12 @@ describe("CLOUDFLARE_WORKER_ESBUILD_EXTERNALS", () => {
     expect(CLOUDFLARE_WORKER_STUB_MODULES["playwright-core"]).toContain(
       "chromium",
     );
+
+    const pdfJsStub =
+      CLOUDFLARE_WORKER_STUB_SUBPATH_MODULES["pdfjs-dist/legacy/build/pdf.mjs"];
+    expect(pdfJsStub).toContain("export const OPS = new Proxy");
+    expect(pdfJsStub).toContain("export const Util = new Proxy");
+    expect(pdfJsStub).toContain("export const getDocument = unavailable");
   });
 
   it("stubs node builtins that Cloudflare Pages rejects at upload time", () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -387,6 +387,14 @@ export const CLOUDFLARE_WORKER_STUB_SUBPATH_MODULES: Record<string, string> = {
     "export default { CanvasFactory, getData };",
     "",
   ].join("\n"),
+  "pdfjs-dist/legacy/build/pdf.mjs": [
+    "const unavailable = () => { throw new Error('pdfjs-dist unavailable in Cloudflare Pages worker'); };",
+    "export const OPS = {};",
+    "export const Util = new Proxy({}, { get: unavailable });",
+    "export const getDocument = unavailable;",
+    "export default { OPS, Util, getDocument };",
+    "",
+  ].join("\n"),
 };
 
 export function cloudflareWorkerStubAliasArgs(stubDir: string): string[] {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -389,7 +389,7 @@ export const CLOUDFLARE_WORKER_STUB_SUBPATH_MODULES: Record<string, string> = {
   ].join("\n"),
   "pdfjs-dist/legacy/build/pdf.mjs": [
     "const unavailable = () => { throw new Error('pdfjs-dist unavailable in Cloudflare Pages worker'); };",
-    "export const OPS = {};",
+    "export const OPS = new Proxy({}, { get: unavailable });",
     "export const Util = new Proxy({}, { get: unavailable });",
     "export const getDocument = unavailable;",
     "export default { OPS, Util, getDocument };",


### PR DESCRIPTION
## Summary
- add an exact Cloudflare worker stub alias for `pdfjs-dist/legacy/build/pdf.mjs`
- keep PDF.js fail-closed on the edge while allowing the worker bundle to resolve
- add regression coverage for the subpath alias

## Verification
- `pnpm --filter @agent-native/core exec vitest --run src/deploy/build.spec.ts`
- `pnpm --filter @agent-native/core build`
- `NITRO_PRESET=cloudflare_pages pnpm --filter slides build`

This follow-up is based on the current `main` tree, including the already-merged database-pressure and Portal changes.