### PR TITLE
Include database pages in Content exports

### DIFF
--- a/templates/content/actions/export-document.db.test.ts
+++ b/templates/content/actions/export-document.db.test.ts
@@ -1,0 +1,319 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runWithRequestContext } from "@agent-native/core/server";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const TEST_DB_PATH = join(
+  tmpdir(),
+  `content-export-document-${process.pid}-${Date.now()}.sqlite`,
+);
+
+type Schema = typeof import("../server/db/schema.js");
+let getDb: () => any;
+let schema: Schema;
+let exportDocumentAction: typeof import("./export-document.js").default;
+
+const OWNER = "owner@example.com";
+
+beforeAll(async () => {
+  process.env.DATABASE_URL = `file:${TEST_DB_PATH}`;
+  const dbModule = await import("../server/db/index.js");
+  getDb = dbModule.getDb;
+  schema = dbModule.schema;
+  exportDocumentAction = (await import("./export-document.js")).default;
+  const plugin = (await import("../server/plugins/db.js")).default;
+  await plugin(undefined as any);
+}, 60000);
+
+afterAll(() => {
+  for (const suffix of ["", "-shm", "-wal"]) {
+    rmSync(`${TEST_DB_PATH}${suffix}`, { force: true });
+  }
+});
+
+let nextPosition = 0;
+
+async function createDocument(args: {
+  id: string;
+  title: string;
+  content?: string;
+  ownerEmail?: string;
+  trashedAt?: string;
+}) {
+  const now = new Date().toISOString();
+  await getDb()
+    .insert(schema.documents)
+    .values({
+      id: args.id,
+      ownerEmail: args.ownerEmail ?? OWNER,
+      parentId: null,
+      title: args.title,
+      content: args.content ?? "",
+      position: nextPosition++,
+      visibility: "private",
+      trashedAt: args.trashedAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+}
+
+async function createDatabase(args: {
+  id: string;
+  documentId: string;
+  title: string;
+  viewType?: "table" | "list";
+}) {
+  await createDocument({
+    id: args.documentId,
+    title: args.title,
+  });
+  await getDb()
+    .insert(schema.contentDatabases)
+    .values({
+      id: args.id,
+      ownerEmail: OWNER,
+      documentId: args.documentId,
+      title: args.title,
+      viewConfigJson: JSON.stringify({
+        activeViewId: "primary",
+        views: [
+          {
+            id: "primary",
+            name: args.viewType === "list" ? "List" : "Table",
+            type: args.viewType ?? "table",
+          },
+        ],
+      }),
+    });
+}
+
+async function addDatabaseItem(args: {
+  id: string;
+  databaseId: string;
+  documentId: string;
+  position: number;
+  bodyHydrationStatus?: "pending" | "hydrated";
+}) {
+  const now = new Date().toISOString();
+  await getDb()
+    .insert(schema.contentDatabaseItems)
+    .values({
+      id: args.id,
+      ownerEmail: OWNER,
+      databaseId: args.databaseId,
+      documentId: args.documentId,
+      position: args.position,
+      bodyHydrationStatus: args.bodyHydrationStatus ?? "hydrated",
+      createdAt: now,
+      updatedAt: now,
+    });
+}
+
+async function shareDocumentWithOwner(documentId: string, id: string) {
+  await getDb().insert(schema.documentShares).values({
+    id,
+    resourceId: documentId,
+    principalType: "user",
+    principalId: OWNER,
+    role: "viewer",
+    createdBy: "someone-else@example.com",
+    createdAt: new Date().toISOString(),
+  });
+}
+
+describe("export-document database collections", () => {
+  it.each(["table", "list"] as const)(
+    "exports immediate authorized members from a %s view in membership order for every format",
+    async (viewType) => {
+      const databaseId = `launch-library-${viewType}`;
+      const databaseDocumentId = `launch-library-document-${viewType}`;
+      const faqId = `faq-${viewType}`;
+      const announcementId = `announcement-${viewType}`;
+      const sharedRecordId = `shared-record-${viewType}`;
+      const privateRecordId = `private-record-${viewType}`;
+
+      await createDatabase({
+        id: databaseId,
+        documentId: databaseDocumentId,
+        title: "Launch Library",
+        viewType,
+      });
+      await createDocument({
+        id: faqId,
+        title: "FAQ",
+        content: "Answers",
+      });
+      await createDocument({
+        id: announcementId,
+        title: "Announcement",
+        content: "Launch copy",
+      });
+      await createDocument({
+        id: sharedRecordId,
+        title: "Shared record",
+        content: "Shared body",
+        ownerEmail: "someone-else@example.com",
+      });
+      await shareDocumentWithOwner(
+        sharedRecordId,
+        `shared-record-share-${viewType}`,
+      );
+      await createDocument({
+        id: privateRecordId,
+        title: "Private record",
+        content: "Do not export",
+        ownerEmail: "someone-else@example.com",
+      });
+      await addDatabaseItem({
+        id: `faq-item-${viewType}`,
+        databaseId,
+        documentId: faqId,
+        position: 2,
+      });
+      await addDatabaseItem({
+        id: `announcement-item-${viewType}`,
+        databaseId,
+        documentId: announcementId,
+        position: 1,
+      });
+      await addDatabaseItem({
+        id: `shared-item-${viewType}`,
+        databaseId,
+        documentId: sharedRecordId,
+        position: 3,
+      });
+      await addDatabaseItem({
+        id: `private-item-${viewType}`,
+        databaseId,
+        documentId: privateRecordId,
+        position: 0,
+      });
+
+      const [markdown, html, pdf] = await runWithRequestContext(
+        { userEmail: OWNER },
+        () =>
+          Promise.all(
+            (["markdown", "html", "pdf"] as const).map((format) =>
+              exportDocumentAction.run({
+                id: databaseDocumentId,
+                format,
+              }),
+            ),
+          ),
+      );
+
+      expect(markdown.content).toBe(
+        "# Launch Library\n\n## Announcement\n\nLaunch copy\n\n## FAQ\n\nAnswers\n\n## Shared record\n\nShared body\n",
+      );
+      expect(markdown.content).not.toContain("Private record");
+      for (const result of [html, pdf]) {
+        expect(result.content).toContain("<h1>Launch Library</h1>");
+        expect(result.content).toContain("<h2>Announcement</h2>");
+        expect(result.content).toContain("<p>Launch copy</p>");
+        expect(result.content).toContain("<h2>FAQ</h2>");
+        expect(result.content).toContain("<p>Answers</p>");
+        expect(result.content).toContain("<h2>Shared record</h2>");
+        expect(result.content).toContain("<p>Shared body</p>");
+        expect(result.content).not.toContain("Private record");
+        expect(result.content.indexOf("<h2>Announcement</h2>")).toBeLessThan(
+          result.content.indexOf("<h2>FAQ</h2>"),
+        );
+      }
+    },
+  );
+
+  it("makes an empty database export explicit", async () => {
+    await createDatabase({
+      id: "empty-database",
+      documentId: "empty-database-document",
+      title: "Empty Database",
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      exportDocumentAction.run({
+        id: "empty-database-document",
+        format: "markdown",
+      }),
+    );
+
+    expect(result.content).toBe("# Empty Database\n\n_No accessible items._\n");
+  });
+
+  it("treats a database with only trashed members as having no accessible items", async () => {
+    await createDatabase({
+      id: "trashed-database",
+      documentId: "trashed-database-document",
+      title: "Trashed Database",
+    });
+    await createDocument({
+      id: "trashed-page",
+      title: "Trashed Page",
+      content: "Do not export",
+      trashedAt: new Date().toISOString(),
+    });
+    await addDatabaseItem({
+      id: "trashed-item",
+      databaseId: "trashed-database",
+      documentId: "trashed-page",
+      position: 0,
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      exportDocumentAction.run({
+        id: "trashed-database-document",
+        format: "markdown",
+      }),
+    );
+
+    expect(result.content).toBe(
+      "# Trashed Database\n\n_No accessible items._\n",
+    );
+  });
+
+  it("fails instead of silently omitting a member whose body is not ready", async () => {
+    await createDatabase({
+      id: "pending-database",
+      documentId: "pending-database-document",
+      title: "Pending Database",
+    });
+    await createDocument({
+      id: "pending-page",
+      title: "Pending Page",
+    });
+    await addDatabaseItem({
+      id: "pending-item",
+      databaseId: "pending-database",
+      documentId: "pending-page",
+      position: 0,
+      bodyHydrationStatus: "pending",
+    });
+
+    await expect(
+      runWithRequestContext({ userEmail: OWNER }, () =>
+        exportDocumentAction.run({
+          id: "pending-database-document",
+          format: "markdown",
+        }),
+      ),
+    ).rejects.toThrow('Database item "pending-page" is not ready for export');
+  });
+
+  it("keeps ordinary page exports unchanged", async () => {
+    await createDocument({
+      id: "ordinary-page",
+      title: "Ordinary Page",
+      content: "Page body",
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      exportDocumentAction.run({
+        id: "ordinary-page",
+        format: "markdown",
+      }),
+    );
+
+    expect(result.content).toBe("# Ordinary Page\n\nPage body\n");
+  });
+});

--- a/templates/content/actions/export-document.db.test.ts
+++ b/templates/content/actions/export-document.db.test.ts
@@ -94,7 +94,7 @@ async function addDatabaseItem(args: {
   databaseId: string;
   documentId: string;
   position: number;
-  bodyHydrationStatus?: "pending" | "hydrated";
+  bodyHydrationStatus?: "pending" | "hydrated" | "unavailable";
 }) {
   const now = new Date().toISOString();
   await getDb()
@@ -298,6 +298,36 @@ describe("export-document database collections", () => {
         }),
       ),
     ).rejects.toThrow('Database item "pending-page" is not ready for export');
+  });
+
+  it("exports a member whose provider body is terminally unavailable", async () => {
+    await createDatabase({
+      id: "unavailable-database",
+      documentId: "unavailable-database-document",
+      title: "Unavailable Database",
+    });
+    await createDocument({
+      id: "unavailable-page",
+      title: "Unavailable Page",
+    });
+    await addDatabaseItem({
+      id: "unavailable-item",
+      databaseId: "unavailable-database",
+      documentId: "unavailable-page",
+      position: 0,
+      bodyHydrationStatus: "unavailable",
+    });
+
+    const result = await runWithRequestContext({ userEmail: OWNER }, () =>
+      exportDocumentAction.run({
+        id: "unavailable-database-document",
+        format: "markdown",
+      }),
+    );
+
+    expect(result.content).toBe(
+      "# Unavailable Database\n\n## Unavailable Page\n",
+    );
   });
 
   it("keeps ordinary page exports unchanged", async () => {

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -1,16 +1,58 @@
 import { defineAction } from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { asc, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { getDb, schema } from "../server/db/index.js";
 import { blocksContentHash } from "../shared/blocks-field-identity.js";
-import { buildDocumentExport } from "../shared/document-export.js";
+import {
+  buildDocumentExport,
+  collectionItemsMarkdown,
+  type CollectionExportItem,
+} from "../shared/document-export.js";
 import {
   isBlocksPropertyType,
   isPrimaryBlocksField,
 } from "../shared/properties.js";
-import "../server/db/index.js";
+import { getDatabaseByDocumentId } from "./_database-utils.js";
 import { listPropertiesForAllDocumentDatabases } from "./_property-utils.js";
+
+async function databaseExportContent(documentId: string) {
+  const database = await getDatabaseByDocumentId(documentId);
+  if (!database) return null;
+
+  const members = await getDb()
+    .select({
+      documentId: schema.contentDatabaseItems.documentId,
+      bodyHydrationStatus: schema.contentDatabaseItems.bodyHydrationStatus,
+    })
+    .from(schema.contentDatabaseItems)
+    .where(eq(schema.contentDatabaseItems.databaseId, database.id))
+    .orderBy(
+      asc(schema.contentDatabaseItems.position),
+      asc(schema.contentDatabaseItems.createdAt),
+      asc(schema.contentDatabaseItems.id),
+    );
+  const items: CollectionExportItem[] = [];
+
+  for (const member of members) {
+    const access = await resolveAccess("document", member.documentId);
+    if (!access || access.resource.trashedAt) continue;
+    if (member.bodyHydrationStatus !== "hydrated") {
+      throw new Error(
+        `Database item "${member.documentId}" is not ready for export`,
+      );
+    }
+
+    items.push({
+      title: access.resource.title,
+      content: access.resource.content,
+    });
+  }
+
+  return collectionItemsMarkdown(items);
+}
 
 export default defineAction({
   description:
@@ -73,10 +115,11 @@ export default defineAction({
           identity,
         };
       });
+    const collectionContent = await databaseExportContent(doc.id);
     const payload = buildDocumentExport({
       id: doc.id,
       title: title ?? doc.title,
-      content: content ?? doc.content,
+      content: collectionContent ?? content ?? doc.content,
       updatedAt: doc.updatedAt,
       format,
       blocksFields,

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -15,8 +15,11 @@ import {
   isBlocksPropertyType,
   isPrimaryBlocksField,
 } from "../shared/properties.js";
+import { resolveContentDocumentAccess } from "./_content-document-access.js";
 import { getDatabaseByDocumentId } from "./_database-utils.js";
 import { listPropertiesForAllDocumentDatabases } from "./_property-utils.js";
+
+const COLLECTION_EXPORT_ACCESS_CONCURRENCY = 8;
 
 async function databaseExportContent(documentId: string) {
   const database = await getDatabaseByDocumentId(documentId);
@@ -36,19 +39,35 @@ async function databaseExportContent(documentId: string) {
     );
   const items: CollectionExportItem[] = [];
 
-  for (const member of members) {
-    const access = await resolveAccess("document", member.documentId);
-    if (!access || access.resource.trashedAt) continue;
-    if (member.bodyHydrationStatus !== "hydrated") {
-      throw new Error(
-        `Database item "${member.documentId}" is not ready for export`,
-      );
-    }
+  for (
+    let offset = 0;
+    offset < members.length;
+    offset += COLLECTION_EXPORT_ACCESS_CONCURRENCY
+  ) {
+    const batch = members.slice(
+      offset,
+      offset + COLLECTION_EXPORT_ACCESS_CONCURRENCY,
+    );
+    const resolved = await Promise.all(
+      batch.map(async (member) => ({
+        member,
+        access: await resolveContentDocumentAccess(member.documentId),
+      })),
+    );
 
-    items.push({
-      title: access.resource.title,
-      content: access.resource.content,
-    });
+    for (const { member, access } of resolved) {
+      if (!access || access.resource.trashedAt) continue;
+      if (member.bodyHydrationStatus !== "hydrated") {
+        throw new Error(
+          `Database item "${member.documentId}" is not ready for export`,
+        );
+      }
+
+      items.push({
+        title: access.resource.title,
+        content: access.resource.content,
+      });
+    }
   }
 
   return collectionItemsMarkdown(items);

--- a/templates/content/actions/export-document.ts
+++ b/templates/content/actions/export-document.ts
@@ -57,7 +57,10 @@ async function databaseExportContent(documentId: string) {
 
     for (const { member, access } of resolved) {
       if (!access || access.resource.trashedAt) continue;
-      if (member.bodyHydrationStatus !== "hydrated") {
+      if (
+        member.bodyHydrationStatus !== "hydrated" &&
+        member.bodyHydrationStatus !== "unavailable"
+      ) {
         throw new Error(
           `Database item "${member.documentId}" is not ready for export`,
         );

--- a/templates/content/changelog/2026-08-06-database-exports-now-include-their-pages.md
+++ b/templates/content/changelog/2026-08-06-database-exports-now-include-their-pages.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-06
+---
+
+Database exports now include their pages instead of downloading an empty collection.

--- a/templates/content/shared/document-export.spec.ts
+++ b/templates/content/shared/document-export.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { legacyBlocksFieldIdentity } from "./blocks-field-identity";
 import {
   buildDocumentExport,
+  collectionItemsMarkdown,
   exportFilename,
   markdownWithTitle,
 } from "./document-export";
@@ -75,6 +76,22 @@ describe("document export", () => {
     expect(markdownWithTitle("Roadmap", "# Roadmap\n\nFirst paragraph")).toBe(
       "# Roadmap\n\nFirst paragraph\n",
     );
+  });
+
+  it("composes collection items as readable document sections", () => {
+    expect(
+      collectionItemsMarkdown([
+        { title: "Announcement", content: "Launch copy" },
+        { title: "FAQ", content: "# FAQ\n\nAnswers" },
+        { title: "Empty record", content: "" },
+      ]),
+    ).toBe(
+      "## Announcement\n\nLaunch copy\n\n## FAQ\n\nAnswers\n\n## Empty record\n",
+    );
+  });
+
+  it("makes an empty authorized collection explicit", () => {
+    expect(collectionItemsMarkdown([])).toBe("_No accessible items._\n");
   });
 
   it("escapes user-authored HTML in portable HTML exports", () => {

--- a/templates/content/shared/document-export.ts
+++ b/templates/content/shared/document-export.ts
@@ -41,6 +41,11 @@ function serializeBlocksFieldsManifest(fields: BlocksFieldExport[]): string {
     .replace(/--/g, "\\u002d\\u002d");
 }
 
+export interface CollectionExportItem {
+  title?: string | null;
+  content?: string | null;
+}
+
 const EXTENSION_BY_FORMAT: Record<DocumentExportFormat, string> = {
   pdf: "pdf",
   markdown: "md",
@@ -121,6 +126,26 @@ export function markdownWithTitle(
   }
 
   return `${`# ${safeTitle}`}${body ? `\n\n${body}` : ""}\n`;
+}
+
+export function collectionItemsMarkdown(
+  items: readonly CollectionExportItem[],
+): string {
+  if (items.length === 0) return "_No accessible items._\n";
+
+  return `${items
+    .map((item) => {
+      const title = normalizeTitle(item.title);
+      const body = (item.content ?? "").trim();
+      const firstHeading = body.match(/^#\s+(.+?)(?:\n|$)/);
+      const content =
+        firstHeading?.[1]?.trim().toLowerCase() === title.toLowerCase()
+          ? body.slice(firstHeading[0].length).trimStart()
+          : body;
+
+      return `## ${title}${content ? `\n\n${content}` : ""}`;
+    })
+    .join("\n\n")}\n`;
 }
 
 interface InlineExportToken {


### PR DESCRIPTION
## Problem

Exporting a Content database or List currently produces a file containing only the collection title. People expect a human-readable export of the collection, but every Page row and its body is omitted.

## Approach

Treat a database document as a collection at the existing `export-document` action boundary. The action resolves immediate database membership in canonical order, checks each Page through the existing access resolver, and passes one composed Markdown body through the existing Markdown, HTML, and PDF formatters.

This is intentionally a small contract repair. It does not add active-view fidelity, recursive hierarchy, CSV or ZIP packaging, schema export, or another action surface.

## What changed

- Export authorized, non-trashed immediate Page members in membership order.
- Include each Page title and body as a readable section.
- Use the same base membership for Table and List layouts and all three export formats.
- Make empty accessible membership explicit instead of returning a title-only file.
- Fail loudly when an authorized member body is not hydrated, while accepting the terminal `unavailable` state and preserving ordinary Page exports and Blocks-field export metadata.
- Bound concurrent access resolution to eight members at a time.
- Add focused database-action and formatter coverage plus a user-facing changelog entry.

## Safety and operations

Every member is independently checked with the existing Content document access resolver, so inaccessible and trashed rows are omitted. The change is read-only, adds no schema or migration, and needs no feature flag. Rolling back the commit restores the previous export behavior without data changes.

This bounded repair still resolves access per member and accumulates one human-readable export in memory. Large resumable or whole-vault exports remain separate portability work rather than being introduced through this bug fix.

## Verification

- Focused export verification: 2 files and 31 tests passed on exact head `09ecc5e9`, covering Table/List membership, all formats, ordering, access, trash, empty collections, hydration states, and ordinary Page behavior.
- Same-context real-browser acceptance on the exact head created a two-record database, verified both Page bodies in downloaded Markdown and HTML, opened the PDF print handoff, switched to a List view, and verified the same two bodies in its Markdown export. All disposable files and local database state were removed afterward.
- Content product-impact policy: all 30 checks passed.
- Exact-head CI is green, including Typecheck, Content DB tests, Content parity, security guards, formatting, builds, and deploy-preview checks.
- Independent review repaired the original Content-space authorization, serial access, and terminal hydration findings; the PR is approved.

## Review focus

- Confirm per-member Content access checks and hydration failure semantics match export expectations.
- Confirm the current Blocks-field export metadata remains intact when collection content replaces the database document body.
- Confirm canonical immediate membership is the right bounded base contract for both Table and List exports.
- Confirm large/resumable collection export remains correctly deferred from this repair.

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.publish-with-confidence
  capabilities:
    - content.object.database
    - content.portability.pdf-export
  record_change: none
  proof:
    - pnpm --dir templates/content test actions/export-document.db.test.ts shared/document-export.spec.ts
  rationale: The change restores immediate database and list members in the existing human-readable export formats without changing the broader portability contract.
```
