### PR TITLE
fix(core): bound realtime client state retention

### DIFF
--- a/.changeset/steady-realtime-state.md
+++ b/.changeset/steady-realtime-state.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound core client state retention and avoid repeating semantic route-state serialization on unrelated renders.

--- a/packages/core/src/client/embed-auth.spec.ts
+++ b/packages/core/src/client/embed-auth.spec.ts
@@ -11,15 +11,21 @@ import {
 
 const STORAGE_KEY = "agent-native:embed-auth-token";
 const BRIDGE_STORAGE_KEY = "agent-native:mcp-chat-bridge";
+type EmbedAuthModule = typeof import("./embed-auth.js");
+let lastEmbedAuthModule: EmbedAuthModule | undefined;
 
 async function loadEmbedAuth() {
+  lastEmbedAuthModule?._resetEmbedAuthForTests();
   vi.resetModules();
-  return import("./embed-auth.js");
+  lastEmbedAuthModule = await import("./embed-auth.js");
+  return lastEmbedAuthModule;
 }
 
 describe("embed auth client", () => {
   beforeEach(() => {
+    lastEmbedAuthModule?._resetEmbedAuthForTests();
     vi.resetModules();
+    vi.useRealTimers();
     sessionStorage.clear();
     window.history.replaceState(null, "", "/");
     Object.defineProperty(window, "fetch", {
@@ -241,6 +247,47 @@ describe("embed auth client", () => {
     expect(style?.textContent).toContain("height: 560px !important");
     expect(style?.textContent).toContain("overflow: hidden !important");
     expect(notifyIntrinsicHeight).toHaveBeenCalledWith({ height: 560 });
+  });
+
+  it("dedupes delayed viewport notifications across repeated bridge setup", async () => {
+    vi.useFakeTimers();
+    const notifyIntrinsicHeight = vi.fn();
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(performance.now()), 0),
+    );
+    Object.defineProperty(window, "openai", {
+      configurable: true,
+      writable: true,
+      value: { notifyIntrinsicHeight },
+    });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      writable: true,
+      value: requestAnimationFrame,
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      writable: true,
+      value: (id: number) => window.clearTimeout(id),
+    });
+    window.history.replaceState(
+      null,
+      "",
+      `/inbox?embedded=1&${MCP_APP_CHAT_BRIDGE_QUERY_PARAM}=1&${EMBED_TOKEN_QUERY_PARAM}=signed-token`,
+    );
+
+    try {
+      const first = await loadEmbedAuth();
+      first.ensureEmbedAuthFetchInterceptor();
+      first.ensureEmbedAuthFetchInterceptor();
+
+      expect(notifyIntrinsicHeight).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(notifyIntrinsicHeight).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("does not leak a stored MCP chat bridge flag to a different embed token", async () => {

--- a/packages/core/src/client/embed-auth.ts
+++ b/packages/core/src/client/embed-auth.ts
@@ -24,6 +24,11 @@ const AUTH_FAILURE_HEADER = "x-agent-native-auth-circuit-breaker";
 const MCP_CHAT_BRIDGE_VIEWPORT_STYLE_ID =
   "agent-native-mcp-chat-bridge-viewport";
 const MCP_CHAT_BRIDGE_VIEWPORT_HEIGHT = 560;
+let pendingMcpChatBridgeViewportNotification: {
+  win: Window;
+  animationFrameId: number | null;
+  timeoutIds: number[];
+} | null = null;
 
 type AuthFailureRecord = {
   status: number;
@@ -247,11 +252,37 @@ function notifyMcpChatBridgeViewportHeight(win: Window): void {
     }
   };
 
+  const pending = pendingMcpChatBridgeViewportNotification;
+  pendingMcpChatBridgeViewportNotification = null;
+  if (pending) {
+    if (pending.animationFrameId !== null) {
+      pending.win.cancelAnimationFrame?.(pending.animationFrameId);
+    }
+    for (const id of pending.timeoutIds) pending.win.clearTimeout(id);
+  }
+
   notify();
+  const nextPending = {
+    win,
+    animationFrameId: null as number | null,
+    timeoutIds: [] as number[],
+  };
+  pendingMcpChatBridgeViewportNotification = nextPending;
+  const notifyIfCurrent = () => {
+    // Some hosts expose requestAnimationFrame/timers from a different clock
+    // than the one used by clearTimeout. The identity guard keeps a superseded
+    // setup from notifying even when cancellation cannot reach that clock.
+    if (pendingMcpChatBridgeViewportNotification !== nextPending) return;
+    notify();
+  };
   try {
-    win.requestAnimationFrame?.(() => notify());
-    win.setTimeout?.(notify, 250);
-    win.setTimeout?.(notify, 1000);
+    if (win.requestAnimationFrame) {
+      nextPending.animationFrameId = win.requestAnimationFrame(notifyIfCurrent);
+    }
+    if (win.setTimeout) {
+      nextPending.timeoutIds.push(win.setTimeout(notifyIfCurrent, 250));
+      nextPending.timeoutIds.push(win.setTimeout(notifyIfCurrent, 1000));
+    }
   } catch {
     // Timers are a progressive enhancement for late host bridge initialization.
   }
@@ -259,6 +290,14 @@ function notifyMcpChatBridgeViewportHeight(win: Window): void {
 
 /** Internal test helper. Do not use in app code. */
 export function _resetEmbedAuthForTests(): void {
+  if (pendingMcpChatBridgeViewportNotification) {
+    const pending = pendingMcpChatBridgeViewportNotification;
+    pendingMcpChatBridgeViewportNotification = null;
+    if (pending.animationFrameId !== null) {
+      pending.win.cancelAnimationFrame?.(pending.animationFrameId);
+    }
+    for (const id of pending.timeoutIds) pending.win.clearTimeout(id);
+  }
   installed = false;
   memoryToken = null;
   mcpChatBridgeActive = false;

--- a/packages/core/src/client/route-state.spec.tsx
+++ b/packages/core/src/client/route-state.spec.tsx
@@ -146,6 +146,134 @@ describe("route-state client helpers", () => {
     });
   });
 
+  it("does not stringify unchanged route state on unrelated rerenders", async () => {
+    const { fetchMock } = makeAppStateFetch({});
+    vi.stubGlobal("fetch", fetchMock);
+    const stringify = vi.spyOn(JSON, "stringify");
+
+    let bump: (() => void) | undefined;
+
+    function Harness() {
+      const [, setTick] = React.useState(0);
+      bump = () => setTick((tick) => tick + 1);
+      useAgentRouteState({
+        refetchInterval: false,
+        getNavigationState: ({ pathname }) => ({
+          view: pathname === "/" ? "home" : pathname.slice(1),
+        }),
+        getCommandPath: () => null,
+      });
+      return null;
+    }
+
+    const rendered = renderWithQueryClient(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="*" element={<Harness />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    roots.push(rendered.root);
+    containers.push(rendered.container);
+    await act(flush);
+    const navigationDedupCallCount = () =>
+      stringify.mock.calls.filter(([value]) => {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          return false;
+        }
+        return "keys" in value && "state" in value;
+      }).length;
+    const afterInitialRender = navigationDedupCallCount();
+
+    await act(async () => {
+      bump?.();
+      await Promise.resolve();
+    });
+
+    expect(navigationDedupCallCount()).toBe(afterInitialRender);
+  });
+
+  it("updates semantic route state when its callback captures app state", async () => {
+    const { fetchMock, writes } = makeAppStateFetch({});
+    vi.stubGlobal("fetch", fetchMock);
+    let setView: React.Dispatch<React.SetStateAction<string>> | undefined;
+
+    function Harness() {
+      const [view, updateView] = React.useState("home");
+      setView = updateView;
+      useAgentRouteState({
+        refetchInterval: false,
+        getNavigationState: () => ({ view }),
+        getCommandPath: () => null,
+      });
+      return null;
+    }
+
+    const rendered = renderWithQueryClient(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="*" element={<Harness />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    roots.push(rendered.root);
+    containers.push(rendered.container);
+    await act(flush);
+    expect(writes.map((write) => write.body)).toEqual([{ view: "home" }]);
+
+    await act(async () => {
+      setView?.("details");
+      await Promise.resolve();
+    });
+    await act(flush);
+
+    expect(writes.map((write) => write.body)).toEqual([
+      { view: "home" },
+      { view: "details" },
+    ]);
+  });
+
+  it("does not permanently deduplicate unserializable navigation states", async () => {
+    const { fetchMock } = makeAppStateFetch({});
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+    const firstState: { self?: unknown } = {};
+    firstState.self = firstState;
+    const secondState: { self?: unknown } = {};
+    secondState.self = secondState;
+    let setState:
+      | React.Dispatch<React.SetStateAction<{ self?: unknown }>>
+      | undefined;
+
+    function Harness() {
+      const [state, updateState] = React.useState(firstState);
+      setState = updateState;
+      useSemanticNavigationState({
+        state,
+        navigationKeys: ["navigation"],
+        commandKeys: ["navigate"],
+        commandRefetchInterval: false,
+        onCommand: () => {},
+        onError,
+      });
+      return null;
+    }
+
+    const rendered = renderWithQueryClient(<Harness />);
+    roots.push(rendered.root);
+    containers.push(rendered.container);
+    await act(flush);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      setState?.(secondState);
+      await Promise.resolve();
+    });
+    await act(flush);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
   it("reads the first available command key and deletes the consumed command", async () => {
     const { deletes, fetchMock } = makeAppStateFetch({
       "navigate:tab-1": { view: "thread", threadId: "thread-2", _writeId: "a" },

--- a/packages/core/src/client/route-state.ts
+++ b/packages/core/src/client/route-state.ts
@@ -199,11 +199,47 @@ function currentRouterPath(location: Location): string {
   return `${location.pathname}${location.search}${location.hash}`;
 }
 
-function stringifyForWriteDedup(value: unknown): string {
+function shallowEqualNavigationState(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (
+    !left ||
+    !right ||
+    typeof left !== "object" ||
+    typeof right !== "object"
+  ) {
+    return false;
+  }
+
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  for (const key of leftKeys) {
+    if (
+      !Object.prototype.hasOwnProperty.call(right, key) ||
+      !Object.is(
+        (left as Record<string, unknown>)[key],
+        (right as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function stringifyForWriteDedup(value: unknown): string | symbol {
   try {
-    return JSON.stringify(value);
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string"
+      ? serialized
+      : Symbol("unserializable navigation state");
   } catch {
-    return "";
+    // Do not turn a serialization failure into a reusable string key. A
+    // distinct token lets a changed unserializable state reach the write path
+    // and surface its real error instead of being silently deduplicated.
+    return Symbol("unserializable navigation state");
   }
 }
 
@@ -255,10 +291,14 @@ export function useSemanticNavigationState<
     [options.commandQueryKey],
   );
   const navigationState = options.state ?? null;
-  const navigationWriteDedup = stringifyForWriteDedup({
-    keys: navigationKeys,
-    state: navigationState,
-  });
+  const navigationWriteDedup = useMemo(
+    () =>
+      stringifyForWriteDedup({
+        keys: navigationKeys,
+        state: navigationState,
+      }),
+    [navigationKeys, navigationState],
+  );
 
   const getCommandDedupKeyRef = useRef(options.getCommandDedupKey);
   const onCommandRef = useRef(options.onCommand);
@@ -267,7 +307,7 @@ export function useSemanticNavigationState<
   onCommandRef.current = options.onCommand;
   onErrorRef.current = options.onError;
 
-  const lastNavigationWriteRef = useRef<string | null>(null);
+  const lastNavigationWriteRef = useRef<string | symbol | null>(null);
 
   useEffect(() => {
     if (!enabled) return;
@@ -415,7 +455,25 @@ export function useAgentRouteState<
     () => routeLocationFromReactRouter(location),
     [location],
   );
-  const navigationState = options.getNavigationState(routeLocation) ?? null;
+  // Callers may include app-local state in this callback in addition to the
+  // router location. Derive on every render so those values are not frozen at
+  // the last route change, then retain the previous object when its shallow
+  // values are unchanged. This keeps the write-dedup serialization off the
+  // unrelated-render path without hiding captured state updates.
+  const derivedNavigationState =
+    options.getNavigationState(routeLocation) ?? null;
+  const navigationStateRef = useRef<NavigationState | null>(
+    derivedNavigationState,
+  );
+  if (
+    !shallowEqualNavigationState(
+      navigationStateRef.current,
+      derivedNavigationState,
+    )
+  ) {
+    navigationStateRef.current = derivedNavigationState;
+  }
+  const navigationState = navigationStateRef.current;
 
   return useSemanticNavigationState<NavigationState, NavigateCommand>({
     state: navigationState,

--- a/packages/core/src/client/use-change-version.spec.tsx
+++ b/packages/core/src/client/use-change-version.spec.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _resetChangeVersionStoreForTests,
+  bumpChangeVersion,
+  getChangeVersion,
+  useChangeVersion,
+  useChangeVersions,
+} from "./use-change-version.js";
+
+const MAX_TRACKED_SOURCES = 1_000;
+
+describe("use-change-version", () => {
+  let roots: Root[] = [];
+  let containers: HTMLDivElement[] = [];
+
+  beforeEach(() => {
+    _resetChangeVersionStoreForTests();
+    roots = [];
+    containers = [];
+  });
+
+  afterEach(() => {
+    for (const root of roots) act(() => root.unmount());
+    for (const container of containers) container.remove();
+    _resetChangeVersionStoreForTests();
+  });
+
+  it("bounds retention of dynamic source keys", () => {
+    bumpChangeVersion("dynamic-0", 1);
+    for (let index = 1; index <= MAX_TRACKED_SOURCES; index++) {
+      bumpChangeVersion(`dynamic-${index}`, 1);
+    }
+
+    expect(getChangeVersion("dynamic-0")).toBe(0);
+    expect(getChangeVersion(`dynamic-${MAX_TRACKED_SOURCES}`)).toBe(1);
+  });
+
+  it("does not evict a source while a component is subscribed", async () => {
+    function Probe() {
+      useChangeVersion("active");
+      return null;
+    }
+
+    const container = document.createElement("div");
+    containers.push(container);
+    const root = createRoot(container);
+    roots.push(root);
+
+    await act(async () => root.render(<Probe />));
+    bumpChangeVersion("active", 7);
+    for (let index = 0; index <= MAX_TRACKED_SOURCES; index++) {
+      bumpChangeVersion(`other-${index}`, 1);
+    }
+
+    expect(getChangeVersion("active")).toBe(7);
+  });
+
+  it("advances single and multi-source hook snapshots", async () => {
+    const values: Array<[number, number]> = [];
+    function Probe() {
+      values.push([
+        useChangeVersion("projects"),
+        useChangeVersions(["projects", "action"]),
+      ]);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    containers.push(container);
+    const root = createRoot(container);
+    roots.push(root);
+
+    await act(async () => root.render(<Probe />));
+    expect(values.at(-1)).toEqual([0, 0]);
+
+    await act(async () => {
+      bumpChangeVersion("projects", 3);
+      bumpChangeVersion("action", 2);
+    });
+    expect(values.at(-1)).toEqual([3, 5]);
+  });
+
+  it("keeps subscriptions and snapshots stable across no-op rerenders", async () => {
+    let renders = 0;
+    function Probe({ tick }: { tick: number }) {
+      renders++;
+      useChangeVersion("projects");
+      return <span>{tick}</span>;
+    }
+
+    const container = document.createElement("div");
+    containers.push(container);
+    const root = createRoot(container);
+    roots.push(root);
+
+    await act(async () => root.render(<Probe tick={0} />));
+    await act(async () => root.render(<Probe tick={1} />));
+    expect(renders).toBe(2);
+
+    await act(async () => bumpChangeVersion("projects", 1));
+    expect(renders).toBe(3);
+  });
+
+  it("uses the preserved zero snapshot during SSR", () => {
+    bumpChangeVersion("projects", 4);
+
+    function Probe() {
+      return <>{useChangeVersion("projects")}</>;
+    }
+
+    expect(renderToString(<Probe />)).toContain("0");
+  });
+});

--- a/packages/core/src/client/use-change-version.ts
+++ b/packages/core/src/client/use-change-version.ts
@@ -31,12 +31,15 @@
  * refetch when that source fires. A poll heartbeat with no event does
  * nothing.
  */
-import { useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+const MAX_TRACKED_SOURCES = 1_000;
+const ZERO_SNAPSHOT = () => 0;
 
 class ChangeVersionStore {
   private versions = new Map<string, number>();
-  private listeners = new Set<() => void>();
-  private cachedSnapshots = new Map<string, number>();
+  private listeners = new Map<string, Set<() => void>>();
+  private activeSources = new Map<string, number>();
 
   /**
    * Advance the counter for `source` to at least `version`. Returns true if
@@ -47,32 +50,58 @@ class ChangeVersionStore {
     const current = this.versions.get(source) ?? 0;
     if (version > current) {
       this.versions.set(source, version);
-      this.cachedSnapshots.set(source, version);
-      this.notify();
+      this.evictUnobservedSources();
+      for (const listener of this.listeners.get(source) ?? []) listener();
       return true;
     }
     return false;
   }
 
   get(source: string): number {
-    // useSyncExternalStore requires reference-stable snapshots for unchanged
-    // values, so we serve from a cached map that we only update inside
-    // `bump`.
-    const cached = this.cachedSnapshots.get(source);
-    if (cached !== undefined) return cached;
-    this.cachedSnapshots.set(source, 0);
-    return 0;
+    return this.versions.get(source) ?? 0;
   }
 
-  subscribe(listener: () => void): () => void {
-    this.listeners.add(listener);
+  subscribe(sources: readonly string[], listener: () => void): () => void {
+    const uniqueSources = new Set(sources.filter(Boolean));
+    for (const source of uniqueSources) {
+      this.activeSources.set(source, (this.activeSources.get(source) ?? 0) + 1);
+      let listeners = this.listeners.get(source);
+      if (!listeners) {
+        listeners = new Set();
+        this.listeners.set(source, listeners);
+      }
+      listeners.add(listener);
+    }
     return () => {
-      this.listeners.delete(listener);
+      for (const source of uniqueSources) {
+        const listeners = this.listeners.get(source);
+        listeners?.delete(listener);
+        if (listeners?.size === 0) this.listeners.delete(source);
+        const count = (this.activeSources.get(source) ?? 1) - 1;
+        if (count > 0) this.activeSources.set(source, count);
+        else this.activeSources.delete(source);
+      }
+      this.evictUnobservedSources();
     };
   }
 
-  private notify() {
-    for (const listener of this.listeners) listener();
+  reset(): void {
+    this.versions.clear();
+    this.listeners.clear();
+    this.activeSources.clear();
+  }
+
+  private evictUnobservedSources(): void {
+    while (this.versions.size > MAX_TRACKED_SOURCES) {
+      let evicted = false;
+      for (const source of this.versions.keys()) {
+        if (this.activeSources.has(source)) continue;
+        this.versions.delete(source);
+        evicted = true;
+        break;
+      }
+      if (!evicted) return;
+    }
   }
 }
 
@@ -116,11 +145,13 @@ export function getChangeVersion(source: string): number {
  * ```
  */
 export function useChangeVersion(source: string): number {
-  return useSyncExternalStore(
-    (cb) => store.subscribe(cb),
-    () => store.get(source),
-    () => 0,
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribe([source], listener),
+    [source],
   );
+  const getSnapshot = useCallback(() => store.get(source), [source]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, ZERO_SNAPSHOT);
 }
 
 /**
@@ -134,17 +165,32 @@ export function useChangeVersion(source: string): number {
  * ```
  */
 export function useChangeVersions(sources: readonly string[]): number {
-  return useSyncExternalStore(
-    (cb) => store.subscribe(cb),
-    () => sources.reduce((sum, src) => sum + store.get(src), 0),
-    () => 0,
+  const sourceKey = sources
+    .map((source) => `${source.length}:${source}`)
+    .join("\u0001");
+  const stableSources = useMemo(() => {
+    const uniqueSources: string[] = [];
+    const seen = new Set<string>();
+    for (const source of sources) {
+      if (seen.has(source)) continue;
+      seen.add(source);
+      uniqueSources.push(source);
+    }
+    return uniqueSources;
+  }, [sourceKey]);
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribe(stableSources, listener),
+    [stableSources],
   );
+  const getSnapshot = useCallback(
+    () => stableSources.reduce((sum, src) => sum + store.get(src), 0),
+    [stableSources],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, ZERO_SNAPSHOT);
 }
 
 /** Internal test helper — reset all counters. Do not use in app code. */
 export function _resetChangeVersionStoreForTests(): void {
-  // @ts-expect-error reaching past private to clear state in tests
-  store.versions.clear();
-  // @ts-expect-error reaching past private to clear state in tests
-  store.cachedSnapshots.clear();
+  store.reset();
 }

--- a/packages/core/src/collab/awareness.spec.ts
+++ b/packages/core/src/collab/awareness.spec.ts
@@ -16,6 +16,8 @@ vi.mock("../server/h3-helpers.js", () => ({
 }));
 
 import {
+  emitAwarenessChange,
+  getAwarenessEmitter,
   getDocAwareness,
   cleanExpired,
   postAwareness,
@@ -69,6 +71,58 @@ describe("cleanExpired", () => {
     vi.setSystemTime(30_000); // exactly 30s — boundary is not expired
     cleanExpired(map);
     expect(map.has(1)).toBe(true);
+  });
+});
+
+describe("awareness scope retention", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("expires scopes that stop receiving awareness activity", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const docId = "scope-expiry";
+    const received: Array<{ owner?: string }> = [];
+    const onChange = (event: { owner?: string }) =>
+      received.push({ owner: event.owner });
+    getAwarenessEmitter().on("awareness-change", onChange);
+
+    try {
+      emitAwarenessChange(docId, [], { owner: "owner@example.com" });
+      vi.setSystemTime(35_001);
+      emitAwarenessChange(docId, []);
+    } finally {
+      getAwarenessEmitter().off("awareness-change", onChange);
+    }
+
+    expect(received).toEqual([{ owner: "owner@example.com" }, {}]);
+  });
+
+  it("keeps a scope alive for scope-less presence heartbeats", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const docId = "scope-heartbeat";
+    const received: Array<{ owner?: string }> = [];
+    const onChange = (event: { owner?: string }) =>
+      received.push({ owner: event.owner });
+    getAwarenessEmitter().on("awareness-change", onChange);
+
+    try {
+      emitAwarenessChange(docId, [], { owner: "owner@example.com" });
+      vi.setSystemTime(10_000);
+      emitAwarenessChange(docId, []);
+      vi.setSystemTime(35_001);
+      emitAwarenessChange(docId, []);
+    } finally {
+      getAwarenessEmitter().off("awareness-change", onChange);
+    }
+
+    expect(received).toEqual([
+      { owner: "owner@example.com" },
+      { owner: "owner@example.com" },
+      { owner: "owner@example.com" },
+    ]);
   });
 });
 

--- a/packages/core/src/collab/awareness.ts
+++ b/packages/core/src/collab/awareness.ts
@@ -25,6 +25,8 @@ import {
 
 const AWARENESS_TIMEOUT = 30_000; // 30 seconds
 const CLEAR_TOMBSTONE_TTL = AWARENESS_TIMEOUT + 5_000;
+const AWARENESS_SCOPE_TIMEOUT = AWARENESS_TIMEOUT + 5_000;
+const MAX_AWARENESS_SCOPES = 10_000;
 
 export interface AwarenessEntry {
   clientId: number;
@@ -65,7 +67,26 @@ export interface AwarenessScope {
 const _awarenessEmitter = new EventEmitter();
 _awarenessEmitter.setMaxListeners(0);
 
-const _awarenessScopes = new Map<string, AwarenessScope>();
+interface AwarenessScopeEntry {
+  scope: AwarenessScope;
+  lastSeen: number;
+}
+
+const _awarenessScopes = new Map<string, AwarenessScopeEntry>();
+
+function pruneAwarenessScopes(now: number): void {
+  for (const [docId, entry] of _awarenessScopes) {
+    if (now - entry.lastSeen > AWARENESS_SCOPE_TIMEOUT) {
+      _awarenessScopes.delete(docId);
+    }
+  }
+
+  while (_awarenessScopes.size > MAX_AWARENESS_SCOPES) {
+    const oldest = _awarenessScopes.keys().next().value as string | undefined;
+    if (!oldest) break;
+    _awarenessScopes.delete(oldest);
+  }
+}
 
 export function getAwarenessEmitter(): EventEmitter {
   return _awarenessEmitter;
@@ -75,12 +96,30 @@ export function rememberAwarenessScope(
   docId: string,
   scope: AwarenessScope | undefined,
 ): void {
-  if (!scope) return;
-  const next = { ...(_awarenessScopes.get(docId) ?? {}), ...scope };
+  const now = Date.now();
+  pruneAwarenessScopes(now);
+  const existing = _awarenessScopes.get(docId);
+  if (!scope) {
+    // Agent-presence heartbeats emit scope-less awareness changes. They still
+    // prove the document is active and must keep the access scope alive.
+    if (existing) {
+      _awarenessScopes.delete(docId);
+      _awarenessScopes.set(docId, { ...existing, lastSeen: now });
+    }
+    return;
+  }
+  const next = {
+    ...(existing?.scope ?? {}),
+    ...scope,
+  };
   if (!next.owner && !next.orgId && !next.resourceType && !next.resourceId) {
     return;
   }
-  _awarenessScopes.set(docId, next);
+  _awarenessScopes.delete(docId);
+  _awarenessScopes.set(docId, { scope: next, lastSeen: now });
+  // Enforce the cap after insertion too. Pruning only before insertion lets
+  // the map temporarily exceed its advertised bound on every new document.
+  pruneAwarenessScopes(now);
 }
 
 export function emitAwarenessChange(
@@ -89,7 +128,8 @@ export function emitAwarenessChange(
   scope?: AwarenessScope,
 ): void {
   rememberAwarenessScope(docId, scope);
-  const resolvedScope = _awarenessScopes.get(docId) ?? {};
+  pruneAwarenessScopes(Date.now());
+  const resolvedScope = _awarenessScopes.get(docId)?.scope ?? {};
   const event: AwarenessChangeEvent = {
     source: "awareness",
     type: "awareness-change",


### PR DESCRIPTION
## Summary
- bound change-version and awareness scope retention so dynamic sources and stale scopes cannot grow without limit
- cancel delayed embed viewport notifications and keep route-state serialization stable across unrelated renders
- preserve meaningful serialization failures and add focused regression coverage

## Validation
- `packages/core`: 4 focused Vitest files, 40 tests passing