### PR TITLE
fix: bound realtime app work

### DIFF
--- a/.changeset/quiet-realtime-cursors.md
+++ b/.changeset/quiet-realtime-cursors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound realtime polling, invalidation, collaboration, and autoscroll work so idle or rapidly changing surfaces do not retain unbounded state or repeat expensive refreshes.

--- a/packages/core/src/client/conversation/use-near-bottom-autoscroll.spec.tsx
+++ b/packages/core/src/client/conversation/use-near-bottom-autoscroll.spec.tsx
@@ -383,6 +383,26 @@ describe("useNearBottomAutoscroll", () => {
     ).toBe("detached");
   });
 
+  it("cancels pending scroll writes when the hook unmounts", async () => {
+    const apiRef = React.createRef<AutoscrollApi>();
+    const metrics = {
+      clientHeight: 200,
+      scrollHeight: 1000,
+      scrollTop: 800,
+    };
+    renderHarness({ apiRef, followKey: 1, metrics });
+
+    act(() => {
+      apiRef.current?.scrollToBottomAfterPaint();
+      root.unmount();
+    });
+    metrics.scrollHeight = 1400;
+    await advanceAutoscrollTimers();
+
+    // The delayed rAF/timeout chain must not write to a detached scroller.
+    expect(metrics.scrollTop).toBe(800);
+  });
+
   it("stays anchored when content briefly collapses to the top", async () => {
     const apiRef = React.createRef<AutoscrollApi>();
     // A long, ongoing conversation pinned to the bottom.

--- a/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
+++ b/packages/core/src/client/conversation/use-near-bottom-autoscroll.ts
@@ -67,7 +67,32 @@ export function useNearBottomAutoscroll<TElement extends HTMLElement>({
   const followGenerationRef = useRef(0);
   const lastScrollTopRef = useRef(0);
   const lastTouchYRef = useRef<number | null>(null);
+  const pendingAnimationFrameIdsRef = useRef<Set<number>>(new Set());
+  const pendingTimeoutIdsRef = useRef<Set<number>>(new Set());
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  const cancelPendingScrolls = useCallback(() => {
+    for (const id of pendingAnimationFrameIdsRef.current) {
+      window.cancelAnimationFrame(id);
+    }
+    pendingAnimationFrameIdsRef.current.clear();
+    for (const id of pendingTimeoutIdsRef.current) {
+      window.clearTimeout(id);
+    }
+    pendingTimeoutIdsRef.current.clear();
+  }, []);
+
+  const scheduleAnimationFrame = useCallback(
+    (callback: FrameRequestCallback) => {
+      let id = 0;
+      id = window.requestAnimationFrame((time) => {
+        pendingAnimationFrameIdsRef.current.delete(id);
+        callback(time);
+      });
+      pendingAnimationFrameIdsRef.current.add(id);
+    },
+    [],
+  );
 
   const isAtBottom = useCallback(
     (el: HTMLElement) =>
@@ -248,14 +273,24 @@ export function useNearBottomAutoscroll<TElement extends HTMLElement>({
   }, [detachFromBottom, enabled, scrollToBottomIfFollowing, updateBottomState]);
 
   const scrollToBottomAfterPaint = useCallback(() => {
+    cancelPendingScrolls();
     const generation = followGenerationRef.current;
     scrollToBottomIfFollowing(generation);
-    requestAnimationFrame(() => {
+    scheduleAnimationFrame(() => {
       scrollToBottomIfFollowing(generation);
-      requestAnimationFrame(() => scrollToBottomIfFollowing(generation));
+      scheduleAnimationFrame(() => scrollToBottomIfFollowing(generation));
     });
-    window.setTimeout(() => scrollToBottomIfFollowing(generation), 80);
-  }, [scrollToBottomIfFollowing]);
+    const timeoutId = window.setTimeout(() => {
+      pendingTimeoutIdsRef.current.delete(timeoutId);
+      scrollToBottomIfFollowing(generation);
+    }, 80);
+    pendingTimeoutIdsRef.current.add(timeoutId);
+  }, [cancelPendingScrolls, scheduleAnimationFrame, scrollToBottomIfFollowing]);
+
+  useEffect(() => {
+    if (!enabled) cancelPendingScrolls();
+    return cancelPendingScrolls;
+  }, [cancelPendingScrolls, enabled]);
 
   const resumeFollowing = useCallback(() => {
     const el = scrollRef.current;

--- a/packages/core/src/client/use-db-sync.cross-tab-sse.spec.ts
+++ b/packages/core/src/client/use-db-sync.cross-tab-sse.spec.ts
@@ -209,10 +209,60 @@ describe("cross-tab SSE sharing", () => {
     });
 
     const channel = FakeBroadcastChannel.instances.at(-1)!;
-    expect(channel.posted).toContainEqual({
+    expect(channel.posted).toContainEqual(
+      expect.objectContaining({
+        type: "events",
+        events: CHANGE,
+        version: 7,
+        cursor: { version: 7, id: "" },
+      }),
+    );
+    unsub();
+  });
+
+  it("never forwards the leader's ahead-of-frame cursor to followers", async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      if (String(input).includes("/_agent-native/poll")) {
+        return {
+          ok: true,
+          json: async () => ({
+            version: 200,
+            events: [],
+            cursor: "200.z",
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({ version: 0, events: [] }),
+      } as Response;
+    });
+    const unsub = subscribeSyncEvents({ onEvents: () => {} });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const source = FakeEventSource.instances.at(-1)!;
+    source.onmessage?.({
+      data: JSON.stringify({
+        type: "batch",
+        version: 100,
+        events: [
+          {
+            version: 100,
+            cursorId: "a",
+            source: "app-state",
+            type: "change",
+            key: "*",
+          },
+        ],
+      }),
+    });
+
+    const channel = FakeBroadcastChannel.instances.at(-1)!;
+    expect(channel.posted.at(-1)).toEqual({
       type: "events",
-      events: CHANGE,
-      version: 7,
+      events: [expect.objectContaining({ version: 100, cursorId: "a" })],
+      version: 100,
+      cursor: { version: 100, id: "a" },
     });
     unsub();
   });

--- a/packages/core/src/client/use-db-sync.gateway-reconnect.spec.tsx
+++ b/packages/core/src/client/use-db-sync.gateway-reconnect.spec.tsx
@@ -79,7 +79,13 @@ describe("hosted SSE reconnect ownership", () => {
         type: "batch",
         version: 100,
         events: [
-          { version: 100, source: "app-state", type: "change", key: "*" },
+          {
+            version: 100,
+            cursorId: "a",
+            source: "app-state",
+            type: "change",
+            key: "*",
+          },
         ],
       }),
     });
@@ -96,6 +102,7 @@ describe("hosted SSE reconnect ownership", () => {
     const second = FakeEventSource.instances.at(-1)!;
     expect(second).not.toBe(first);
     expect(second.url).toContain("since=100");
+    expect(second.url).toContain("cursor=100.a");
     expect(second.url).toContain("token=tok-1");
 
     unsub();

--- a/packages/core/src/client/use-db-sync.spec.tsx
+++ b/packages/core/src/client/use-db-sync.spec.tsx
@@ -440,11 +440,21 @@ describe("useDbSync", () => {
     containers.push(result.container);
 
     expect(result.fetchMock).toHaveBeenCalled();
+    const appStateCall = result.queryClient.calls.find(
+      (call) => call?.predicate,
+    );
+    // Only app-state queries for the changed key (plus the aggregate query)
+    // should refresh - unrelated keyed app-state reads stay untouched.
+    expect(
+      appStateCall?.predicate?.({ queryKey: ["app-state", "selection"] }),
+    ).toBe(true);
+    expect(
+      appStateCall?.predicate?.({ queryKey: ["app-state", "navigate"] }),
+    ).toBe(false);
+    expect(appStateCall?.predicate?.({ queryKey: ["app-state"] })).toBe(true);
     const keys = invalidatedQueryKeys(result.queryClient.calls);
-    // The one query app-state writes legitimately refresh.
-    expect(keys).toContainEqual(["app-state"]);
+    expect(keys).toHaveLength(1);
     // But never the broad data-query prefixes.
-    expect(keys).not.toContainEqual(undefined);
     expect(keys).not.toContainEqual(["action"]);
     expect(keys).not.toContainEqual(["extension"]);
     expect(keys).not.toContainEqual(["tool"]);
@@ -776,6 +786,53 @@ describe("useDbSync", () => {
       await vi.advanceTimersByTimeAsync(58_000);
     });
     expect(pollCallCount()).toBe(5);
+  });
+
+  it("does not let a paged response high-water mark skip its durable cursor", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClientProbe();
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        return new Response(
+          JSON.stringify({
+            version: 10_000,
+            events: [{ version: 2_000, cursorId: "a", source: "action" }],
+            cursor: "2000.a",
+          }),
+        );
+      }
+      return new Response(JSON.stringify({ version: 10_000, events: [] }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    function CursorProbe() {
+      useDbSync({
+        queryClient,
+        sseUrl: false,
+        interval: 50,
+        pauseWhenHidden: false,
+      });
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    containers.push(container);
+
+    await act(async () => {
+      root.render(<CursorProbe />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain("cursor=");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("since=2000");
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("cursor=2000.a");
   });
 
   it("keeps active sync alive at a slower cadence while hidden", async () => {

--- a/packages/core/src/client/use-db-sync.trailing-invalidation.spec.tsx
+++ b/packages/core/src/client/use-db-sync.trailing-invalidation.spec.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetSyncTransportRegistryForTests,
+  useDbSync,
+} from "./use-db-sync.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+class QueryClientProbe {
+  calls: Array<
+    | {
+        queryKey?: string[];
+        predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+        dedupeKey?: string;
+      }
+    | undefined
+  > = [];
+  refetchOptions: Array<{ cancelRefetch?: boolean } | undefined> = [];
+  completion = deferred<void>();
+
+  isFetching() {
+    return 1;
+  }
+
+  invalidateQueries(
+    filters?: {
+      queryKey?: string[];
+      predicate?: (query: { queryKey: readonly unknown[] }) => boolean;
+      dedupeKey?: string;
+    },
+    options?: { cancelRefetch?: boolean },
+  ) {
+    this.calls.push(filters);
+    this.refetchOptions.push(options);
+    return this.completion.promise;
+  }
+}
+
+function Probe({ queryClient }: { queryClient: QueryClientProbe }) {
+  useDbSync({
+    queryClient,
+    sseUrl: false,
+    interval: 100,
+    pauseWhenHidden: false,
+  });
+  return null;
+}
+
+describe("useDbSync trailing invalidation", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers();
+    _resetSyncTransportRegistryForTests();
+  });
+
+  afterEach(() => {
+    if (root) act(() => root?.unmount());
+    container?.remove();
+    root = undefined;
+    container = undefined;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    _resetSyncTransportRegistryForTests();
+  });
+
+  it("attaches one trailing refresh while repeated batches overlap the same fetch", async () => {
+    const queryClient = new QueryClientProbe();
+    let poll = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        poll += 1;
+        const version = poll === 2 ? 1 : poll === 5 ? 2 : 0;
+        const events =
+          poll === 2 || poll === 5 ? [{ version, source: "action" }] : [];
+        return new Response(JSON.stringify({ version, events }));
+      }),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<Probe queryClient={queryClient} />);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    expect(queryClient.refetchOptions).toEqual([
+      { cancelRefetch: false },
+      { cancelRefetch: false },
+    ]);
+
+    queryClient.completion.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(queryClient.refetchOptions).toEqual([
+      { cancelRefetch: false },
+      { cancelRefetch: false },
+      undefined,
+    ]);
+  });
+
+  it("does not run a trailing refresh after teardown", async () => {
+    const queryClient = new QueryClientProbe();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              version: 1,
+              events: [{ version: 1, source: "action" }],
+            }),
+          ),
+      ),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<Probe queryClient={queryClient} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(260);
+    });
+    expect(queryClient.refetchOptions).toEqual([{ cancelRefetch: false }]);
+
+    act(() => root?.unmount());
+    queryClient.completion.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(queryClient.refetchOptions).toEqual([{ cancelRefetch: false }]);
+  });
+
+  it("dedupes trailing refreshes for freshly-created app-state predicates", async () => {
+    const queryClient = new QueryClientProbe();
+    let poll = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        poll += 1;
+        const version = poll === 2 ? 1 : poll === 5 ? 2 : 0;
+        const events =
+          poll === 2 || poll === 5
+            ? [{ version, source: "app-state", key: "selection" }]
+            : [];
+        return new Response(JSON.stringify({ version, events }));
+      }),
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(<Probe queryClient={queryClient} />);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(700);
+    });
+
+    const predicateFilters = queryClient.calls.filter(
+      (filters) => filters?.predicate,
+    );
+    expect(predicateFilters).toHaveLength(2);
+    expect(predicateFilters.map((filters) => filters?.dedupeKey)).toEqual([
+      "app-state:9:selection",
+      "app-state:9:selection",
+    ]);
+    expect(queryClient.refetchOptions).toEqual([
+      { cancelRefetch: false },
+      { cancelRefetch: false },
+    ]);
+
+    queryClient.completion.resolve();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryClient.refetchOptions).toEqual([
+      { cancelRefetch: false },
+      { cancelRefetch: false },
+      undefined,
+    ]);
+    expect(
+      queryClient.calls
+        .filter((filters) => filters?.predicate)
+        .map((filters) => filters?.dedupeKey),
+    ).toEqual([
+      "app-state:9:selection",
+      "app-state:9:selection",
+      "app-state:9:selection",
+    ]);
+  });
+});

--- a/packages/core/src/client/use-db-sync.ts
+++ b/packages/core/src/client/use-db-sync.ts
@@ -141,6 +141,26 @@ function maxSyncCursor(a: SyncCursor, b: SyncCursor | undefined): SyncCursor {
   return b && compareSyncCursors(b, a) > 0 ? b : a;
 }
 
+function cursorForEvents(events: readonly SyncEvent[]): SyncCursor | undefined {
+  let cursor: SyncCursor | undefined;
+  for (const event of events) {
+    const eventCursor =
+      syncEventCursor(event) ??
+      (typeof event.version === "number" &&
+      Number.isSafeInteger(event.version) &&
+      event.version >= 0
+        ? { version: event.version, id: "" }
+        : undefined);
+    if (
+      eventCursor &&
+      (!cursor || compareSyncCursors(eventCursor, cursor) > 0)
+    ) {
+      cursor = eventCursor;
+    }
+  }
+  return cursor;
+}
+
 function isSyncEventAfterCursor(
   event: SyncEvent,
   cursor: SyncCursor,
@@ -470,8 +490,8 @@ class SyncTransport {
       const base = `${this.gateway.sseUrl}?token=${encodeURIComponent(this.token)}`;
       // Cursor lets the gateway replay the reconnect gap on connect instead of
       // deferring it to the next poll; 0 on first connect means nothing to replay.
-      return this.cursorRef.version > 0
-        ? `${base}&since=${this.cursorRef.version}`
+      return this.cursorRef.version > 0 || this.cursorRef.id
+        ? `${base}&since=${this.cursorRef.version}&cursor=${encodeURIComponent(encodeSyncCursor(this.cursorRef))}`
         : base;
     }
     return this.sseUrl;
@@ -1011,11 +1031,16 @@ class SyncTransport {
           typeof payload?.version === "number" ? payload.version : undefined;
         this.applyVersion(events, version);
         this.fan(events, version, this.cursorRef);
+        const eventCursor = cursorForEvents(events);
         this.broadcast({
           type: "events",
           events,
           version,
-          cursor: this.cursorRef,
+          // A follower may only adopt a cursor for events it received. The
+          // transport cursor can be ahead after a poll response skipped
+          // filtered/unread durable rows, which would make the follower lose
+          // those rows on its own safety poll.
+          cursor: eventCursor,
         });
       } catch {
         // Ignore malformed SSE frames; polling is the safety net.

--- a/packages/core/src/client/use-db-sync.ts
+++ b/packages/core/src/client/use-db-sync.ts
@@ -35,6 +35,13 @@ interface QueryClient {
   }): number;
 }
 
+type InvalidateFilters = {
+  queryKey?: string[];
+  predicate?: (query: Query) => boolean;
+  /** Stable identity for freshly-created predicates that target the same set. */
+  dedupeKey?: string;
+};
+
 const POLL_ABORT_MIN_MS = 10_000;
 // SSE delivers changes immediately in the normal path. The poll is a
 // cross-process/serverless safety net, so an idle tab should not bill the host
@@ -45,6 +52,8 @@ const HIDDEN_POLL_INTERVAL_MS = 10_000;
 const POLL_AUTH_FAILURE_COOLDOWN_MS = 60_000;
 const LOCAL_SSE_RECONNECT_BASE_MS = 1_000;
 const LOCAL_SSE_RECONNECT_MAX_MS = 30_000;
+const ACTIVE_CHAT_TTL_MS = 5 * 60 * 1_000;
+const ACTIVE_CHAT_MAX = 1_000;
 /**
  * Max cadence for SSE/poll-driven query invalidation in `useDbSync`. Events
  * that arrive within this window of the first one in a burst are merged into
@@ -66,12 +75,6 @@ const INVALIDATE_COALESCE_MS = 250;
  */
 const SSE_LEADER_LOCK_PREFIX = "agent-native-sync:";
 
-/** Frames the SSE leader forwards to follower tabs over BroadcastChannel. */
-type SyncBroadcast =
-  | { type: "events"; events: SyncEvent[]; version: number | undefined }
-  | { type: "sse-state"; connected: boolean; capabilities: string[] }
-  | { type: "sse-state-request" };
-
 class HttpStatusError extends Error {
   status: number;
 
@@ -83,6 +86,7 @@ class HttpStatusError extends Error {
 
 export type SyncEvent = {
   version?: number;
+  cursorId?: string;
   source?: string;
   type?: string;
   key?: string;
@@ -93,12 +97,77 @@ export type SyncEvent = {
 type PollResponse = {
   version: number;
   events: SyncEvent[];
+  cursor?: string;
 };
+
+type SyncCursor = {
+  version: number;
+  id: string;
+};
+
+const INITIAL_SYNC_CURSOR: SyncCursor = { version: 0, id: "" };
+
+function encodeSyncCursor(cursor: SyncCursor): string {
+  return `${cursor.version}.${cursor.id}`;
+}
+
+function decodeSyncCursor(value: unknown): SyncCursor | undefined {
+  if (typeof value !== "string") return undefined;
+  const separator = value.indexOf(".");
+  if (separator < 1) return undefined;
+  const version = Number(value.slice(0, separator));
+  const id = value.slice(separator + 1);
+  if (!Number.isSafeInteger(version) || version < 0) return undefined;
+  return { version, id };
+}
+
+function compareSyncCursors(a: SyncCursor, b: SyncCursor): number {
+  if (a.version !== b.version) return a.version - b.version;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function syncEventCursor(event: SyncEvent): SyncCursor | undefined {
+  if (
+    typeof event.version !== "number" ||
+    !Number.isSafeInteger(event.version) ||
+    typeof event.cursorId !== "string"
+  ) {
+    return undefined;
+  }
+  return { version: event.version, id: event.cursorId };
+}
+
+function maxSyncCursor(a: SyncCursor, b: SyncCursor | undefined): SyncCursor {
+  return b && compareSyncCursors(b, a) > 0 ? b : a;
+}
+
+function isSyncEventAfterCursor(
+  event: SyncEvent,
+  cursor: SyncCursor,
+  subscriberVersion: number,
+): boolean {
+  const eventCursor = syncEventCursor(event);
+  if (eventCursor) return compareSyncCursors(eventCursor, cursor) > 0;
+  const version = typeof event.version === "number" ? event.version : 0;
+  return version === 0 || version > subscriberVersion;
+}
+
+/** Frames the SSE leader forwards to follower tabs over BroadcastChannel. */
+type SyncBroadcast =
+  | {
+      type: "events";
+      events: SyncEvent[];
+      version: number | undefined;
+      cursor?: SyncCursor;
+    }
+  | { type: "sse-state"; connected: boolean; capabilities: string[] }
+  | { type: "sse-state-request" };
 
 /** Callback delivered to each transport subscriber for every batch of events. */
 type EventSubscriber = (
   events: SyncEvent[],
   version: number | undefined,
+  cursor?: SyncCursor,
 ) => void;
 
 function getPollAbortMs(interval: number): number {
@@ -253,9 +322,27 @@ export function isInteractionCriticalSyncEvent(event: SyncEvent): boolean {
   );
 }
 
+function appStateQueryMatchesKeys(
+  query: Query,
+  changedKeys: readonly string[],
+): boolean {
+  if (query.queryKey[0] !== "app-state") return false;
+  // The aggregate query is the fallback for callers that read all app state.
+  if (query.queryKey.length === 1) return true;
+  const queryStateKey = query.queryKey[1];
+  if (typeof queryStateKey !== "string") return false;
+  return changedKeys.some(
+    (changedKey) =>
+      changedKey === "*" ||
+      changedKey === queryStateKey ||
+      changedKey.startsWith(`${queryStateKey}:`) ||
+      queryStateKey.startsWith(`${changedKey}:`),
+  );
+}
+
 async function fetchPollJson<T>(
   pollUrl: string,
-  since: number,
+  cursor: SyncCursor,
   interval: number,
   token?: string,
 ): Promise<T> {
@@ -265,12 +352,17 @@ async function fetchPollJson<T>(
     ? setTimeout(() => controller.abort(), getPollAbortMs(interval))
     : null;
 
-  // Local path stays exactly `?since=N`; the hosted gateway also carries the
-  // subscribe token on the query string (a cross-origin fetch can't set the
-  // Authorization header for the SSE sibling either, so both use the query).
-  const url = token
-    ? `${pollUrl}${pollUrl.includes("?") ? "&" : "?"}since=${since}&token=${encodeURIComponent(token)}`
-    : `${pollUrl}?since=${since}`;
+  // The numeric `since` remains for backward-compatible servers. The
+  // composite cursor closes the same-millisecond cross-instance gap by
+  // ordering durable rows on `(version,id)`.
+  const separator = pollUrl.includes("?") ? "&" : "?";
+  const cursorQuery = `since=${cursor.version}`;
+  const compositeCursorQuery =
+    cursor.version > 0 || cursor.id
+      ? `&cursor=${encodeURIComponent(encodeSyncCursor(cursor))}`
+      : "";
+  const tokenQuery = token ? `&token=${encodeURIComponent(token)}` : "";
+  const url = `${pollUrl}${separator}${cursorQuery}${compositeCursorQuery}${tokenQuery}`;
 
   try {
     const res = await fetch(
@@ -330,7 +422,7 @@ interface TransportSubscription {
 
 class SyncTransport {
   private subscribers = new Map<symbol, TransportSubscription>();
-  private versionRef = 0;
+  private cursorRef: SyncCursor = { ...INITIAL_SYNC_CURSOR };
   private timer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
   private inFlight = false;
@@ -340,7 +432,7 @@ class SyncTransport {
   private sseConnected = false;
   private authFailureUntil = 0;
   private consecutiveFailures = 0;
-  private activeChatIds = new Set<string>();
+  private activeChatIds = new Map<string, number>();
   // Hosted-gateway state. `mode` starts "hosted" when a binding is present and
   // flips to "local" on health-gate revert; `token` is the current subscribe
   // token (minted from the app, rotated over the stream), never part of any
@@ -378,7 +470,9 @@ class SyncTransport {
       const base = `${this.gateway.sseUrl}?token=${encodeURIComponent(this.token)}`;
       // Cursor lets the gateway replay the reconnect gap on connect instead of
       // deferring it to the next poll; 0 on first connect means nothing to replay.
-      return this.versionRef > 0 ? `${base}&since=${this.versionRef}` : base;
+      return this.cursorRef.version > 0
+        ? `${base}&since=${this.cursorRef.version}`
+        : base;
     }
     return this.sseUrl;
   }
@@ -463,7 +557,7 @@ class SyncTransport {
 
   /**
    * Health-gate back to the app's own /poll + /events with the cursor intact
-   * (versionRef is untouched), so delivery stays poll-equivalent — never a
+   * (cursorRef is untouched), so delivery stays poll-equivalent - never a
    * silent stall.
    */
   private revertToLocal(): void {
@@ -559,6 +653,12 @@ class SyncTransport {
   }
 
   private get isActive(): boolean {
+    const now = Date.now();
+    for (const [id, lastSeen] of this.activeChatIds) {
+      if (now - lastSeen > ACTIVE_CHAT_TTL_MS) {
+        this.activeChatIds.delete(id);
+      }
+    }
     return this.activeChatIds.size > 0;
   }
 
@@ -574,9 +674,13 @@ class SyncTransport {
   // Event fan-out
   // -------------------------------------------------------------------------
 
-  private fan(events: SyncEvent[], version: number | undefined): void {
+  private fan(
+    events: SyncEvent[],
+    version: number | undefined,
+    cursor: SyncCursor = this.cursorRef,
+  ): void {
     for (const sub of this.subscribers.values()) {
-      sub.onEvents(events, version);
+      sub.onEvents(events, version, cursor);
     }
   }
 
@@ -684,7 +788,7 @@ class SyncTransport {
     // already origin-scoped, and the dev gateway serves every workspace app
     // from one origin — so an origin key would elect a single leader across
     // different apps. A follower applies whatever the leader sends into its own
-    // `versionRef` (see openChannel), and that cursor is the `?since=` for its
+    // `cursorRef` (see openChannel), and that cursor is the `?since=` for its
     // own poll, so it would skip its own app's events from then on. The poll
     // URL is app-scoped, which is exactly the granularity a stream serves.
     return `${SSE_LEADER_LOCK_PREFIX}${this.pollUrl}`;
@@ -765,8 +869,12 @@ class SyncTransport {
       // Only followers consume frames; a leader already applied them locally.
       if (this.leaderState === "leader") return;
       if (frame?.type === "events") {
-        this.applyVersion(frame.events, frame.version);
-        this.fan(frame.events, frame.version);
+        this.applyVersion(
+          frame.events,
+          frame.cursor ? undefined : frame.version,
+        );
+        this.cursorRef = maxSyncCursor(this.cursorRef, frame.cursor);
+        this.fan(frame.events, frame.version, this.cursorRef);
       } else if (frame?.type === "sse-state") {
         this.capabilities = frame.capabilities;
         // The leader's stream is this tab's push path too. Tracking its state
@@ -876,7 +984,7 @@ class SyncTransport {
       if (this.mode === "hosted" && this.gateway) {
         // Browser auto-reconnect reuses the URL frozen at construction, so it
         // would replay from a stale `since`. Own the reconnect so the next
-        // connect rebuilds activeSseUrl from the current versionRef. CLOSED also
+        // connect rebuilds activeSseUrl from the current cursorRef. CLOSED also
         // refreshes the token (expired/rotated/deploy); CONNECTING keeps it. A
         // successful reconnect resets the count in onopen; a hard-down gateway
         // trips the threshold and health-gates to local.
@@ -902,8 +1010,13 @@ class SyncTransport {
         const version =
           typeof payload?.version === "number" ? payload.version : undefined;
         this.applyVersion(events, version);
-        this.fan(events, version);
-        this.broadcast({ type: "events", events, version });
+        this.fan(events, version, this.cursorRef);
+        this.broadcast({
+          type: "events",
+          events,
+          version,
+          cursor: this.cursorRef,
+        });
       } catch {
         // Ignore malformed SSE frames; polling is the safety net.
       }
@@ -946,15 +1059,15 @@ class SyncTransport {
    * Advance the transport's shared version cursor. Subscribers receive the
    * raw events and decide independently which ones are "fresh" relative to
    * their own cursor, but the transport-level cursor ensures the poll
-   * `?since=` parameter always advances.
+   * `?since=&cursor=` parameters always advance.
    */
   private applyVersion(events: SyncEvent[], version: number | undefined): void {
-    let max = typeof version === "number" ? version : 0;
-    for (const evt of events) {
-      const v = typeof evt.version === "number" ? evt.version : 0;
-      if (v > max) max = v;
+    if (typeof version === "number" && version > this.cursorRef.version) {
+      this.cursorRef = { version, id: "" };
     }
-    if (max > this.versionRef) this.versionRef = max;
+    for (const evt of events) {
+      this.cursorRef = maxSyncCursor(this.cursorRef, syncEventCursor(evt));
+    }
   }
 
   private async poll(): Promise<void> {
@@ -969,15 +1082,21 @@ class SyncTransport {
       }
       const data = await fetchPollJson<PollResponse>(
         this.activePollUrl,
-        this.versionRef,
+        this.cursorRef,
         this.effectiveInterval,
         this.mode === "hosted" ? (this.token ?? undefined) : undefined,
       );
       if (this.stopped) return;
       this.consecutiveFailures = 0;
       const events = data.events ?? [];
-      this.applyVersion(events, data.version);
-      this.fan(events, data.version);
+      const responseCursor = decodeSyncCursor(data.cursor);
+      // A paged durable response's numeric version is the high-water mark,
+      // not necessarily the last row in this page. When a composite cursor is
+      // present, advance from event ids/that cursor only - applying the high
+      // water first would skip the remainder of a same-version page.
+      this.applyVersion(events, responseCursor ? undefined : data.version);
+      this.cursorRef = maxSyncCursor(this.cursorRef, responseCursor);
+      this.fan(events, data.version, this.cursorRef);
     } catch (err) {
       if (this.stopped) return;
       this.consecutiveFailures++;
@@ -1064,8 +1183,18 @@ class SyncTransport {
         ? detail.tabId
         : "__default__";
     const wasActive = this.isActive;
-    if (running) this.activeChatIds.add(id);
-    else this.activeChatIds.delete(id);
+    if (running) {
+      // Reinsert to refresh both the TTL and insertion order for the cap.
+      this.activeChatIds.delete(id);
+      this.activeChatIds.set(id, Date.now());
+      while (this.activeChatIds.size > ACTIVE_CHAT_MAX) {
+        const oldestId = this.activeChatIds.keys().next().value;
+        if (typeof oldestId !== "string") break;
+        this.activeChatIds.delete(oldestId);
+      }
+    } else {
+      this.activeChatIds.delete(id);
+    }
     if (wasActive === this.isActive) return;
 
     if (this.isActive) {
@@ -1095,6 +1224,7 @@ class SyncTransport {
 
   private teardown(): void {
     this.stopped = true;
+    this.activeChatIds.clear();
     this.closeEvents();
     // Hand this app's stream slot to a waiting tab before dropping the
     // channel, so the next leader is elected without waiting on a poll.
@@ -1311,6 +1441,7 @@ export function useDbSync(
     // Per-subscriber version cursor: tracks which events have already been
     // processed by THIS subscriber so stale poll re-deliveries are ignored.
     let subscriberVersion = 0;
+    let subscriberCursor: SyncCursor = { ...INITIAL_SYNC_CURSOR };
 
     // Coalesce bursts of SSE-driven invalidation into at most one flush per
     // INVALIDATE_COALESCE_MS. A chatty doc (many small agent edits, several
@@ -1332,6 +1463,12 @@ export function useDbSync(
     // coalesced behavior.
     let pendingInvalidateEvents: SyncEvent[] = [];
     let invalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+    const pendingTrailingRefreshes: Array<{
+      filters: InvalidateFilters | undefined;
+      completion: Promise<unknown>;
+      predicateIdentity?: (query: Query) => boolean;
+    }> = [];
 
     function flushInvalidateBatch() {
       if (invalidateTimer) {
@@ -1419,30 +1556,68 @@ export function useDbSync(
         // in flight, let it finish instead of aborting and immediately
         // launching the same request again. Repeated action events otherwise
         // turn a slow endpoint into a cancel/restart loop that never settles.
-        const invalidateWithoutCancel = (requested?: {
-          queryKey?: string[];
-          predicate?: (query: Query) => boolean;
-        }) => {
+        const hasPendingTrailingRefresh = (
+          filters: InvalidateFilters | undefined,
+          predicateIdentity?: (query: Query) => boolean,
+        ) =>
+          pendingTrailingRefreshes.some((pending) => {
+            if (pending.filters?.dedupeKey !== filters?.dedupeKey) return false;
+            if (filters?.dedupeKey) return true;
+            const pendingKey = pending.filters?.queryKey;
+            const filterKey = filters?.queryKey;
+            if (pendingKey || filterKey) {
+              if (
+                !pendingKey ||
+                !filterKey ||
+                pendingKey.length !== filterKey.length
+              ) {
+                return false;
+              }
+              return pendingKey.every((key, index) => key === filterKey[index]);
+            }
+            return pending.predicateIdentity === predicateIdentity;
+          });
+
+        const invalidateWithoutCancel = (requested?: InvalidateFilters) => {
           const callerPredicate = requested?.predicate;
-          const filters = {
+          const normalizedFilters: InvalidateFilters = {
             ...requested,
             predicate: (query: Query) =>
               !hasTerminalAuthFailure(query) &&
               (callerPredicate?.(query) ?? true),
           };
           const needsTrailingRefresh =
-            (queryClient.isFetching?.(filters) ?? 0) > 0;
-          const completion = queryClient.invalidateQueries(filters, {
+            (queryClient.isFetching?.(normalizedFilters) ?? 0) > 0;
+          const completion = queryClient.invalidateQueries(normalizedFilters, {
             cancelRefetch: false,
           });
           // TanStack Query deliberately leaves an in-flight fetch alone when
           // cancelRefetch is false. Queue one post-settlement invalidation so
           // a write that landed after that read began cannot be cleared as
           // fresh by the older response.
-          if (needsTrailingRefresh && completion instanceof Promise) {
+          if (
+            !disposed &&
+            needsTrailingRefresh &&
+            completion instanceof Promise &&
+            !hasPendingTrailingRefresh(normalizedFilters, callerPredicate)
+          ) {
+            const pending = {
+              filters: normalizedFilters,
+              completion,
+              predicateIdentity: callerPredicate,
+            };
+            pendingTrailingRefreshes.push(pending);
             void completion.then(
-              () => queryClient.invalidateQueries(filters),
-              () => {},
+              () => {
+                const index = pendingTrailingRefreshes.indexOf(pending);
+                if (index < 0) return;
+                pendingTrailingRefreshes.splice(index, 1);
+                if (!disposed) queryClient.invalidateQueries(normalizedFilters);
+              },
+              () => {
+                const index = pendingTrailingRefreshes.indexOf(pending);
+                if (index >= 0) pendingTrailingRefreshes.splice(index, 1);
+              },
             );
           }
         };
@@ -1522,8 +1697,32 @@ export function useDbSync(
               invalidateWithoutCancel({ queryKey: ["tools"] });
             }
           }
-          if (invalidating.some((evt) => evt.source === "app-state")) {
-            invalidateWithoutCancel({ queryKey: ["app-state"] });
+          const appStateKeys = invalidating
+            .filter((evt) => evt.source === "app-state")
+            .map((evt) => evt.key)
+            .map((key) => (typeof key === "string" && key ? key : "*"));
+          if (appStateKeys.length > 0) {
+            const appStateDedupeKey = Array.from(new Set(appStateKeys))
+              .sort()
+              .map((key) => `${key.length}:${key}`)
+              .join("|");
+            const needsBroadAppStateRefresh = appStateKeys.some(
+              (key) =>
+                key === "*" ||
+                isInteractionCriticalSyncEvent({
+                  source: "app-state",
+                  key,
+                }),
+            );
+            invalidateWithoutCancel(
+              needsBroadAppStateRefresh
+                ? { queryKey: ["app-state"] }
+                : {
+                    dedupeKey: `app-state:${appStateDedupeKey}`,
+                    predicate: (query) =>
+                      appStateQueryMatchesKeys(query, appStateKeys),
+                  },
+            );
           }
           if (hasAppStateEvent(invalidating, "navigate")) {
             invalidateWithoutCancel({ queryKey: ["navigate-command"] });
@@ -1545,10 +1744,17 @@ export function useDbSync(
       }
     }
 
-    function onEvents(events: SyncEvent[], version: number | undefined): void {
+    function onEvents(
+      events: SyncEvent[],
+      version: number | undefined,
+      cursor: SyncCursor | undefined,
+    ): void {
       const freshEvents = events.filter((event) => {
-        const v = typeof event.version === "number" ? event.version : 0;
-        return v === 0 || v > subscriberVersion;
+        return isSyncEventAfterCursor(
+          event,
+          subscriberCursor,
+          subscriberVersion,
+        );
       });
 
       if (freshEvents.length > 0) {
@@ -1565,6 +1771,13 @@ export function useDbSync(
         version ?? 0,
         maxEventVersion,
       );
+      for (const event of freshEvents) {
+        subscriberCursor = maxSyncCursor(
+          subscriberCursor,
+          syncEventCursor(event),
+        );
+      }
+      if (cursor) subscriberCursor = maxSyncCursor(subscriberCursor, cursor);
     }
 
     const transport = getOrCreateTransport(
@@ -1581,12 +1794,14 @@ export function useDbSync(
     });
 
     return () => {
+      disposed = true;
       if (invalidateTimer) {
         clearTimeout(invalidateTimer);
         // Flush synchronously on unmount so a pending batch isn't silently
         // dropped (e.g. a route change right after an agent edit lands).
         flushInvalidateBatch();
       }
+      pendingTrailingRefreshes.length = 0;
       transport.remove(id);
       // If the registry still holds this transport, and the transport is now
       // empty, evict it so the next mount gets a fresh instance rather than a
@@ -1656,11 +1871,19 @@ export function useScreenRefreshKey(
     const id = Symbol("useScreenRefreshKey");
     // Per-subscriber version cursor (same freshness logic as useDbSync).
     let subscriberVersion = 0;
+    let subscriberCursor: SyncCursor = { ...INITIAL_SYNC_CURSOR };
 
-    function onEvents(events: SyncEvent[], version: number | undefined): void {
+    function onEvents(
+      events: SyncEvent[],
+      version: number | undefined,
+      cursor: SyncCursor | undefined,
+    ): void {
       const freshEvents = events.filter((event) => {
-        const v = typeof event.version === "number" ? event.version : 0;
-        return v === 0 || v > subscriberVersion;
+        return isSyncEventAfterCursor(
+          event,
+          subscriberCursor,
+          subscriberVersion,
+        );
       });
       if (freshEvents.some((e) => e.source === "screen-refresh")) {
         setKey((k) => k + 1);
@@ -1675,6 +1898,13 @@ export function useScreenRefreshKey(
         version ?? 0,
         maxEventVersion,
       );
+      for (const event of freshEvents) {
+        subscriberCursor = maxSyncCursor(
+          subscriberCursor,
+          syncEventCursor(event),
+        );
+      }
+      if (cursor) subscriberCursor = maxSyncCursor(subscriberCursor, cursor);
     }
 
     const transport = getOrCreateTransport(

--- a/packages/core/src/collab/client.registry.spec.tsx
+++ b/packages/core/src/collab/client.registry.spec.tsx
@@ -331,4 +331,41 @@ describe("useCollaborativeDoc connection registry", () => {
     // client (an awareness storm that gets worse as more people join).
     expect(awarenessPostsAfter).toBe(awarenessPostsBefore);
   });
+
+  it("cancels a pending local awareness push when the connection is disposed", async () => {
+    const { mock } = makeFetchMock();
+    vi.stubGlobal("fetch", mock);
+
+    let result: UseCollaborativeDocResult | undefined;
+    const root = mount(
+      <Probe
+        docId="doc-dispose-awareness"
+        onResult={(next) => (result = next)}
+        user={{ name: "Local", email: "local@example.com", color: "#111" }}
+      />,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const awarenessPostsBeforeDispose = mock.mock.calls.filter(
+      ([input, init]) =>
+        String(input).includes("/awareness") &&
+        (init as RequestInit | undefined)?.method === "POST",
+    ).length;
+    result?.awareness?.setLocalStateField("cursor", { x: 0.25, y: 0.75 });
+
+    act(() => root.unmount());
+    roots = roots.filter((candidate) => candidate !== root);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    const awarenessPostsAfterDispose = mock.mock.calls.filter(
+      ([input, init]) =>
+        String(input).includes("/awareness") &&
+        (init as RequestInit | undefined)?.method === "POST",
+    ).length;
+    expect(awarenessPostsAfterDispose).toBe(awarenessPostsBeforeDispose);
+  });
 });

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -206,6 +206,26 @@ const _awarenessThrottleTimers = new Map<
   ReturnType<typeof setTimeout>
 >();
 
+function awarenessThrottleKey(
+  baseUrl: string,
+  docId: string,
+  clientId: number,
+): string {
+  return `${baseUrl}::${docId}::${clientId}`;
+}
+
+function cancelAwarenessPush(
+  baseUrl: string,
+  docId: string,
+  clientId: number,
+): void {
+  const key = awarenessThrottleKey(baseUrl, docId, clientId);
+  const timer = _awarenessThrottleTimers.get(key);
+  if (timer === undefined) return;
+  clearTimeout(timer);
+  _awarenessThrottleTimers.delete(key);
+}
+
 function scheduleAwarenessPush(
   baseUrl: string,
   docId: string,
@@ -213,7 +233,7 @@ function scheduleAwarenessPush(
   getState: () => Record<string, unknown> | null,
 ): void {
   if (typeof window === "undefined") return;
-  const key = `${docId}::${clientId}`;
+  const key = awarenessThrottleKey(baseUrl, docId, clientId);
   if (_awarenessThrottleTimers.has(key)) return; // already scheduled
 
   const timer = setTimeout(() => {
@@ -403,6 +423,10 @@ class CollabDocConnection {
   remove(id: symbol): void {
     this.subscribers.delete(id);
     if (this.subscribers.size === 0) {
+      // A lingered connection may be remounted for StrictMode, but it has no
+      // live consumer while empty. Do not let a queued presence push escape
+      // after the last subscriber has gone away.
+      cancelAwarenessPush(this.baseUrl, this.docId, this.ydoc.clientID);
       this.scheduleDispose();
     } else {
       this.resubscribeCollabEventsIfPauseChanged();
@@ -443,6 +467,7 @@ class CollabDocConnection {
     // `setLocalState(null)` does not schedule a push (matches the previous
     // per-hook effect cleanup ordering).
     this.awareness.off("change", this.handleAwarenessChange);
+    cancelAwarenessPush(this.baseUrl, this.docId, this.ydoc.clientID);
     this.awareness.destroy();
     this.ydoc.destroy();
     if (collabConnectionRegistry.get(this.registryKey) === this) {

--- a/packages/core/src/server/poll-handler.spec.ts
+++ b/packages/core/src/server/poll-handler.spec.ts
@@ -390,6 +390,89 @@ describe("poll handler", () => {
     ]);
   });
 
+  it("uses the durable id as a cursor tie-breaker for same-version events", async () => {
+    delete process.env.AGENT_NATIVE_SYNC_EVENTS_DISABLE;
+    process.env.AGENT_NATIVE_SYNC_EVENTS_ENABLE_IN_TESTS = "1";
+    const firstEvent = {
+      version: 2_000,
+      source: "action",
+      type: "change",
+      key: "first",
+    };
+    const secondEvent = {
+      version: 2_000,
+      source: "action",
+      type: "change",
+      key: "second",
+    };
+
+    mockExecute.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (typeof sql === "string" && sql.includes("sync_events")) {
+        if (sql.includes("MAX(version)")) {
+          return { rows: [{ max_version: 2_000 }] };
+        }
+        if (sql.includes("(version > ? OR")) {
+          expect(query.args?.slice(0, 3)).toEqual([2_000, 2_000, "a"]);
+          return {
+            rows: [
+              {
+                id: "b",
+                version: 2_000,
+                event_json: JSON.stringify(secondEvent),
+              },
+            ],
+          };
+        }
+        if (sql.includes("WHERE version > ?")) {
+          return {
+            rows: [
+              {
+                id: "a",
+                version: 2_000,
+                event_json: JSON.stringify(firstEvent),
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
+        sql.includes("application_state") &&
+        sql.includes("WHERE key = ?")
+      ) {
+        return { rows: [{ max_ts: 0 }] };
+      }
+      if (
+        sql.includes("MAX(updated_at)") &&
+        (sql.includes("application_state") ||
+          sql.includes("settings") ||
+          sql.includes("tools"))
+      ) {
+        return { rows: [{ max_ts: 0 }] };
+      }
+      if (sql.includes("FROM application_state WHERE key = ?")) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+
+    const { createPollHandler } = await import("./poll.js");
+    const handler = createPollHandler() as any;
+
+    const first = await handler({ query: { since: "1000" } });
+    expect(first.events).toEqual([expect.objectContaining({ key: "first" })]);
+
+    const second = await handler({
+      query: { since: "2000", cursor: "2000.a" },
+    });
+    expect(second.events).toEqual([
+      expect.objectContaining({ key: "second", cursorId: "b" }),
+    ]);
+    expect(second.cursor).toBe("2000.b");
+  });
+
   it("emits screen-refresh events when the refresh marker changes", async () => {
     let appStateTs = 1_000;
     let settingsTs = 900;

--- a/packages/core/src/server/poll-prune.spec.ts
+++ b/packages/core/src/server/poll-prune.spec.ts
@@ -63,11 +63,20 @@ function makeDb(
   };
 }
 
-function stateWith(db: { exec: { execute: unknown } }, postgres = false) {
-  return new AppSyncState({
+function stateWith(
+  db: { exec: { execute: unknown } },
+  postgres = false,
+  pruneImmediately = true,
+) {
+  const state = new AppSyncState({
     getDb: () => db.exec as never,
     isPostgres: () => postgres,
   });
+  if (pruneImmediately) {
+    (state as unknown as { lastDurablePrune: number }).lastDurablePrune =
+      Date.now() - 5 * 60 * 1000 - 1;
+  }
+  return state;
 }
 
 async function prune(state: AppSyncState, db: { exec: unknown }) {
@@ -108,6 +117,27 @@ describe("sync_events prune", () => {
     expect(first.sql).not.toContain("version <");
     // Bounded: a LIMIT argument, and a cutoff 24h behind the clock.
     expect(first.args).toEqual([1_800_000_000_000 - 86_400_000, 10_000]);
+  });
+
+  it("defers the first prune on a cold process until its throttle window", async () => {
+    const db = makeDb({ deletedPerBatch: [1] });
+    const state = stateWith(db, false, false);
+    await state.persistSyncEvent({
+      version: 1,
+      source: "action",
+      type: "change",
+      key: "k",
+    });
+    expect(db.deletes).toHaveLength(0);
+
+    vi.setSystemTime(1_800_000_000_000 + 5 * 60 * 1000 + 1);
+    await state.persistSyncEvent({
+      version: 2,
+      source: "action",
+      type: "change",
+      key: "k",
+    });
+    expect(db.deletes).toHaveLength(1);
   });
 
   it("stops as soon as a batch comes back short, instead of spinning", async () => {

--- a/packages/core/src/server/poll.ts
+++ b/packages/core/src/server/poll.ts
@@ -47,6 +47,8 @@ import { getSession } from "./auth.js";
 
 export interface ChangeEvent {
   version: number;
+  /** Stable durable-row tie-breaker for events sharing a millisecond version. */
+  cursorId?: string;
   source: string;
   type: string;
   key?: string;
@@ -117,6 +119,7 @@ const ACCESS_CACHE_DENY_TTL_MS = 5_000;
 /** Max cache entries before FIFO eviction kicks in. */
 const ACCESS_CACHE_MAX = 500;
 const SCREEN_REFRESH_KEY = "__screen_refresh__";
+const SCREEN_REFRESH_QUERY_LIMIT = 256;
 
 /**
  * DB-assigned version allocation (see `AppSyncStateOptions.dbAssignedVersions`).
@@ -167,6 +170,35 @@ function sqlWatermarkValue(value: unknown): string | number | undefined {
   if (typeof value === "string" && value.length > 0) return value;
   if (typeof value === "number" && Number.isFinite(value)) return value;
   return undefined;
+}
+
+type SyncCursor = { version: number; id: string };
+
+function compareSyncCursors(a: SyncCursor, b: SyncCursor): number {
+  if (a.version !== b.version) return a.version - b.version;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function cursorForEvent(event: ChangeEvent): SyncCursor {
+  return { version: event.version, id: event.cursorId ?? "" };
+}
+
+function encodeSyncCursor(cursor: SyncCursor): string {
+  return `${cursor.version}.${cursor.id}`;
+}
+
+function decodeSyncCursor(value: unknown): SyncCursor | undefined {
+  if (typeof value !== "string") return undefined;
+  const separator = value.indexOf(".");
+  if (separator < 1) return undefined;
+  const version = Number(value.slice(0, separator));
+  const id = value.slice(separator + 1);
+  if (!Number.isSafeInteger(version) || version < 0) return undefined;
+  return { version, id };
+}
+
+function isEventAfterCursor(event: ChangeEvent, cursor: SyncCursor): boolean {
+  return compareSyncCursors(cursorForEvent(event), cursor) > 0;
 }
 
 function syncEventsDisabled(): boolean {
@@ -344,6 +376,8 @@ type ChangeVisibility = "visible" | "hidden" | "pending";
 export type ChangeReadResult = {
   version: number;
   events: ChangeEvent[];
+  /** Composite `(version,id)` cursor for durable rows sharing a version. */
+  cursor?: string;
   /**
    * True when the returned version is an intentional cursor stop, not the
    * source high-water mark. This happens when access is still pending or when a
@@ -448,11 +482,15 @@ export class AppSyncState {
   // the same range (seeded from DB, then incremented via Date.now). Plain
   // ++counter diverges across cold starts.
   private version = 0;
+  private latestCursor: SyncCursor = { version: 0, id: "" };
   private readonly buffer: ChangeEvent[] = [];
   private readonly pollEmitter = new EventEmitter();
   private syncEventsInitPromise: Promise<boolean> | undefined;
-  private lastDurablePrune = 0;
+  // Cold starts should not immediately run a potentially large anti-join. A
+  // long-lived process will still prune on its first scheduled interval.
+  private lastDurablePrune = Date.now();
   private durablePruneFailures = 0;
+  private durableWriteFailures = 0;
 
   /**
    * Whether we've seeded `version` from the DB. In serverless (Netlify,
@@ -486,8 +524,9 @@ export class AppSyncState {
    * after a restart (where an existing row would look like a fresh bump).
    */
   private lastScreenRefreshTs = 0;
+  private lastScreenRefreshSessionId = "";
   private screenRefreshInitialized = false;
-  private readonly lastScreenRefreshTsBySession = new Map<string, number>();
+  private screenRefreshHasMore = false;
   private localEmittersWired = false;
 
   /**
@@ -684,8 +723,9 @@ export class AppSyncState {
    *     `sync_events_created_at_id_idx` drives the batch and the delete is a
    *     bounded index range scan.
    *
-   * The `lastDurablePrune` throttle below is per-process, so every serverless
-   * worker prunes on its first poll. Postgres workers also take a
+   * The `lastDurablePrune` throttle below is per-process and starts at process
+   * initialization, so a cold serverless worker does not run a potentially
+   * large delete during its first request. Postgres workers also take a
    * transaction-scoped advisory lease for each batch. The lease and delete
    * are one bounded statement, so a serverless worker killed after the
    * statement starts cannot leave an open transaction.
@@ -749,6 +789,19 @@ export class AppSyncState {
     }
   }
 
+  private reportDurableWriteFailure(
+    error: unknown,
+    event: Pick<ChangeEvent, "source" | "type" | "key">,
+  ): void {
+    this.durableWriteFailures++;
+    if (this.durableWriteFailures === 1) {
+      console.warn(
+        `[agent-native] sync_events write failed for ${event.source}/${event.type}${event.key ? `/${event.key}` : ""}; durable replay is unavailable until the database recovers:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
   async persistSyncEvent(
     event: ChangeEvent,
     dedupeKey?: string,
@@ -756,31 +809,30 @@ export class AppSyncState {
   ): Promise<void> {
     if (!(await this.ensureSyncEventsTable())) return;
     const client = this.getDb();
-    await client
-      .execute({
-        sql: this.isPg()
-          ? `INSERT INTO sync_events (id, version, event_json, source, type, event_key, owner, org_id, resource_type, resource_id, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT (id) DO NOTHING`
-          : `INSERT OR IGNORE INTO sync_events (id, version, event_json, source, type, event_key, owner, org_id, resource_type, resource_id, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        args: [
-          // presetId lets a gated fallback reuse the allocating attempt's id,
-          // so a commit-then-timeout can't produce the same event twice.
-          presetId ?? this.durableEventId(event, dedupeKey),
-          event.version,
-          JSON.stringify(event),
-          event.source,
-          event.type,
-          event.key ?? null,
-          event.owner ?? null,
-          event.orgId ?? null,
-          event.resourceType ?? null,
-          event.resourceId ?? null,
-          Date.now(),
-        ],
-      })
-      .catch(() => {});
+    await client.execute({
+      sql: this.isPg()
+        ? `INSERT INTO sync_events (id, version, event_json, source, type, event_key, owner, org_id, resource_type, resource_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (id) DO NOTHING`
+        : `INSERT OR IGNORE INTO sync_events (id, version, event_json, source, type, event_key, owner, org_id, resource_type, resource_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        // presetId lets a gated fallback reuse the allocating attempt's id,
+        // so a commit-then-timeout can't produce the same event twice.
+        presetId ?? this.durableEventId(event, dedupeKey),
+        event.version,
+        JSON.stringify(event),
+        event.source,
+        event.type,
+        event.key ?? null,
+        event.owner ?? null,
+        event.orgId ?? null,
+        event.resourceType ?? null,
+        event.resourceId ?? null,
+        Date.now(),
+      ],
+    });
+    this.durableWriteFailures = 0;
     await this.pruneDurableEvents(client);
   }
 
@@ -1071,18 +1123,30 @@ export class AppSyncState {
       // drop every later event.
       this.recordChain = this.recordChain
         .then(() => this.recordWithDbVersion(event, opts?.dedupeKey))
-        .catch(() => {});
+        .catch((error) => {
+          this.reportDurableWriteFailure(error, event);
+        });
       return;
     }
     this.version = Math.max(this.version + 1, Date.now());
-    const entry: ChangeEvent = { ...event, version: this.version };
+    const provisional: ChangeEvent = { ...event, version: this.version };
+    const cursorId = this.durableEventId(provisional, opts?.dedupeKey);
+    const entry: ChangeEvent = { ...provisional, cursorId };
     this.commitEntry(entry);
-    void this.persistSyncEvent(entry, opts?.dedupeKey);
+    void this.persistSyncEvent(entry, opts?.dedupeKey, cursorId).catch(
+      (error) => {
+        this.reportDurableWriteFailure(error, entry);
+      },
+    );
   }
 
   /** Buffer + emit. Shared by both version-allocation modes. */
   private commitEntry(entry: ChangeEvent): void {
     this.buffer.push(entry);
+    const cursor = cursorForEvent(entry);
+    if (compareSyncCursors(cursor, this.latestCursor) > 0) {
+      this.latestCursor = cursor;
+    }
     if (this.buffer.length > MAX_BUFFER) {
       this.buffer.splice(0, this.buffer.length - MAX_BUFFER);
     }
@@ -1109,7 +1173,10 @@ export class AppSyncState {
         : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
     let version: number | null = null;
     try {
-      version = await this.persistWithDbAssignedVersion(event, id);
+      version = await this.persistWithDbAssignedVersion(
+        { ...event, cursorId: id },
+        id,
+      );
     } catch {
       version = null;
     }
@@ -1135,10 +1202,16 @@ export class AppSyncState {
         );
       }
       this.version = Math.max(this.version + 1, Date.now());
-      const entry: ChangeEvent = { ...event, version: this.version };
+      const entry: ChangeEvent = {
+        ...event,
+        version: this.version,
+        cursorId: id,
+      };
       await this.alignVersionAllocator(this.version);
       this.commitEntryForChain(entry);
-      void this.persistSyncEvent(entry, dedupeKey, id);
+      void this.persistSyncEvent(entry, dedupeKey, id).catch((error) => {
+        this.reportDurableWriteFailure(error, entry);
+      });
       return;
     }
     // A deterministic-id dedupe loser adopts the winner's (possibly older)
@@ -1146,7 +1219,7 @@ export class AppSyncState {
     // delivered correctly and the version-keyed combined-read dedupe collapses
     // it against the durable row.
     this.version = Math.max(this.version, version);
-    this.commitEntryForChain({ ...event, version });
+    this.commitEntryForChain({ ...event, version, cursorId: id });
   }
 
   /**
@@ -1235,14 +1308,28 @@ export class AppSyncState {
     since: number,
     userEmail: string,
     orgId: string | undefined,
+    cursor?: SyncCursor,
   ): ChangeReadResult {
-    if (since >= this.version) {
-      return { version: this.version, events: [] };
+    const readCursor = cursor ?? { version: since, id: "" };
+    if (
+      (!cursor && since >= this.version) ||
+      (cursor && compareSyncCursors(this.latestCursor, readCursor) <= 0)
+    ) {
+      return {
+        version: this.version,
+        events: [],
+        ...(cursor ? { cursor: encodeSyncCursor(readCursor) } : {}),
+      };
     }
     const events: ChangeEvent[] = [];
     let version = this.version;
+    let lastCursor = readCursor;
     for (const event of this.buffer) {
-      if (event.version <= since) continue;
+      if (
+        cursor ? !isEventAfterCursor(event, readCursor) : event.version <= since
+      ) {
+        continue;
+      }
       const visibility = this.getChangeVisibilityForUser(
         event,
         userEmail,
@@ -1250,26 +1337,50 @@ export class AppSyncState {
       );
       if (visibility === "visible") {
         events.push(event);
+        lastCursor = cursorForEvent(event);
         continue;
       }
       if (visibility === "pending") {
         version = Math.max(since, event.version - 1);
-        return { version, events, cursorLimited: true };
+        return {
+          version,
+          events,
+          cursorLimited: true,
+          ...(cursor && lastCursor !== readCursor
+            ? { cursor: encodeSyncCursor(lastCursor) }
+            : {}),
+        };
       }
+      lastCursor = cursorForEvent(event);
     }
-    return { version, events };
+    return {
+      version,
+      events,
+      ...(cursor && compareSyncCursors(lastCursor, readCursor) > 0
+        ? { cursor: encodeSyncCursor(lastCursor) }
+        : {}),
+    };
   }
 
   async getDurableChangesSinceForUser(
     since: number,
     userEmail: string,
     orgId: string | undefined,
+    cursor?: SyncCursor,
   ): Promise<ChangeReadResult> {
-    if (since <= 0 || !(await this.ensureSyncEventsTable())) {
+    if (
+      (!cursor && since <= 0) ||
+      (cursor && cursor.version <= 0 && cursor.id === "") ||
+      !(await this.ensureSyncEventsTable())
+    ) {
       return { version: this.version, events: [] };
     }
 
     try {
+      const readCursor = cursor ?? { version: since, id: "" };
+      const compositeCursorSql = cursor
+        ? "(version > ? OR (version = ? AND id > ?))"
+        : "version > ?";
       // Scope the fetch to rows that could ever be visible to this caller
       // before paying to JSON.parse and visibility-check every deployment-wide
       // event: deployment-global rows (no owner, no org), the caller's own
@@ -1280,19 +1391,29 @@ export class AppSyncState {
       // `orgId` bind param, which makes `org_id = ?` match no row in both
       // dialects — mirroring the `event.orgId && orgId` truthy check.
       const result = await this.getDb().execute({
-        sql: `SELECT version, event_json FROM sync_events WHERE version > ?
+        sql: `SELECT id, version, event_json FROM sync_events WHERE ${compositeCursorSql}
               AND (
                 (owner IS NULL AND org_id IS NULL)
                 OR owner = ?
                 OR org_id = ?
                 OR resource_type IS NOT NULL
               )
-            ORDER BY version ASC LIMIT ?`,
-        args: [since, userEmail, orgId ?? null, DURABLE_READ_LIMIT + 1],
+            ORDER BY version ASC, id ASC LIMIT ?`,
+        args: cursor
+          ? [
+              cursor.version,
+              cursor.version,
+              cursor.id,
+              userEmail,
+              orgId ?? null,
+              DURABLE_READ_LIMIT + 1,
+            ]
+          : [since, userEmail, orgId ?? null, DURABLE_READ_LIMIT + 1],
       });
       const events: ChangeEvent[] = [];
       let version = Math.max(this.version, since);
       let lastDurableVersion = since;
+      let lastCursor = readCursor;
       const rows = result.rows.slice(0, DURABLE_READ_LIMIT);
       const overflowVersion = timestampValue(
         result.rows[DURABLE_READ_LIMIT]?.version,
@@ -1302,6 +1423,8 @@ export class AppSyncState {
         const rawVersion = timestampValue(row.version);
         if (rawVersion > lastDurableVersion) lastDurableVersion = rawVersion;
         if (rawVersion > version) version = rawVersion;
+        const rowId = typeof row.id === "string" ? row.id : "";
+        let rowCursor = rowId ? { version: rawVersion, id: rowId } : undefined;
         let event: ChangeEvent | null = null;
         try {
           const parsed = JSON.parse(String(row.event_json));
@@ -1314,12 +1437,26 @@ export class AppSyncState {
             event = {
               ...(parsed as ChangeEvent),
               version: rawVersion || (parsed as ChangeEvent).version,
+              ...(rowId || typeof (parsed as ChangeEvent).cursorId === "string"
+                ? {
+                    cursorId: rowId || (parsed as ChangeEvent).cursorId,
+                  }
+                : {}),
             };
           }
         } catch {
           event = null;
         }
-        if (!event) continue;
+        if (!event) {
+          // Malformed durable rows are skipped from delivery, but their
+          // composite cursor still needs to advance. Otherwise every poll
+          // rereads the same bad row forever and can never reach later rows.
+          if (rowCursor) lastCursor = rowCursor;
+          continue;
+        }
+        if (!rowCursor && typeof event.cursorId === "string") {
+          rowCursor = { version: event.version, id: event.cursorId };
+        }
 
         const visibility = this.getChangeVisibilityForUser(
           event,
@@ -1328,6 +1465,7 @@ export class AppSyncState {
         );
         if (visibility === "visible") {
           events.push(event);
+          if (rowCursor) lastCursor = rowCursor;
           continue;
         }
         if (visibility === "pending") {
@@ -1335,11 +1473,23 @@ export class AppSyncState {
             version: Math.max(since, event.version - 1),
             events,
             cursorLimited: true,
+            ...(cursor && compareSyncCursors(lastCursor, readCursor) > 0
+              ? { cursor: encodeSyncCursor(lastCursor) }
+              : {}),
           };
         }
+        if (rowCursor) lastCursor = rowCursor;
       }
 
       if (rows.length >= DURABLE_READ_LIMIT) {
+        if (cursor) {
+          return {
+            version: Math.max(since, lastDurableVersion),
+            events,
+            cursor: encodeSyncCursor(lastCursor),
+            cursorLimited: result.rows.length > DURABLE_READ_LIMIT,
+          };
+        }
         if (overflowVersion === lastDurableVersion) {
           const boundaryVersion = lastDurableVersion;
           return {
@@ -1355,9 +1505,19 @@ export class AppSyncState {
         };
       }
 
-      return { version, events };
+      return {
+        version,
+        events,
+        ...(cursor && compareSyncCursors(lastCursor, readCursor) > 0
+          ? { cursor: encodeSyncCursor(lastCursor) }
+          : {}),
+      };
     } catch {
-      return { version: this.version, events: [] };
+      return {
+        version: this.version,
+        events: [],
+        ...(cursor ? { cursor: encodeSyncCursor(cursor) } : {}),
+      };
     }
   }
 
@@ -1366,19 +1526,22 @@ export class AppSyncState {
     userEmail: string,
     orgId: string | undefined,
     useDurableEvents: boolean,
-  ): Promise<{ version: number; events: ChangeEvent[] }> {
-    const memory = this.getChangesSinceForUser(since, userEmail, orgId);
+    cursor?: SyncCursor,
+  ): Promise<ChangeReadResult> {
+    const memory = this.getChangesSinceForUser(since, userEmail, orgId, cursor);
     if (!useDurableEvents) return memory;
 
     const durable = await this.getDurableChangesSinceForUser(
       since,
       userEmail,
       orgId,
+      cursor,
     );
     const byIdentity = new Map<string, ChangeEvent>();
     for (const event of [...durable.events, ...memory.events]) {
       byIdentity.set(
         JSON.stringify([
+          event.cursorId,
           event.version,
           event.source,
           event.type,
@@ -1391,9 +1554,47 @@ export class AppSyncState {
         event,
       );
     }
-    const events = Array.from(byIdentity.values()).sort(
-      (a, b) => a.version - b.version,
+    const events = Array.from(byIdentity.values()).sort((a, b) =>
+      compareSyncCursors(cursorForEvent(a), cursorForEvent(b)),
     );
+    if (cursor) {
+      const limitedCursors = [memory, durable]
+        .filter((result) => result.cursorLimited)
+        .map((result) => decodeSyncCursor(result.cursor))
+        .filter((value): value is SyncCursor => !!value);
+      if (limitedCursors.length > 0) {
+        const boundary = limitedCursors.reduce((minimum, value) =>
+          compareSyncCursors(value, minimum) < 0 ? value : minimum,
+        );
+        return {
+          version: boundary.version,
+          cursor: encodeSyncCursor(boundary),
+          cursorLimited: true,
+          events: events.filter(
+            (event) => compareSyncCursors(cursorForEvent(event), boundary) <= 0,
+          ),
+        };
+      }
+      const responseCursor = [
+        cursor,
+        decodeSyncCursor(memory.cursor),
+        decodeSyncCursor(durable.cursor),
+        ...events.map(cursorForEvent),
+      ]
+        .filter((value): value is SyncCursor => !!value)
+        .reduce(
+          (maximum, value) =>
+            compareSyncCursors(value, maximum) > 0 ? value : maximum,
+          cursor,
+        );
+      return {
+        version: Math.max(memory.version, durable.version, since),
+        events,
+        ...(compareSyncCursors(responseCursor, cursor) > 0
+          ? { cursor: encodeSyncCursor(responseCursor) }
+          : {}),
+      };
+    }
     const limitedVersions = [memory, durable]
       .filter((result) => result.cursorLimited)
       .map((result) => result.version);
@@ -1439,7 +1640,7 @@ export class AppSyncState {
         readActionMarkerMaxUpdatedAt(db),
         db
           .execute({
-            sql: "SELECT session_id, updated_at FROM application_state WHERE key = ?",
+            sql: "SELECT session_id, updated_at FROM application_state WHERE key = ? ORDER BY updated_at DESC, session_id DESC LIMIT 1",
             args: [SCREEN_REFRESH_KEY],
           })
           .catch(() => ({ rows: [] as Record<string, unknown>[] })),
@@ -1494,15 +1695,11 @@ export class AppSyncState {
       );
       this.replayActionMarkerOnce = actionMarkerTs > 0;
       this.lastScreenRefreshTs = refreshTs;
-      this.lastScreenRefreshTsBySession.clear();
-      for (const row of refreshResult.rows) {
-        if (typeof row.session_id === "string") {
-          this.lastScreenRefreshTsBySession.set(
-            row.session_id,
-            timestampValue(row.updated_at),
-          );
-        }
-      }
+      this.lastScreenRefreshSessionId =
+        typeof refreshResult.rows[0]?.session_id === "string"
+          ? refreshResult.rows[0].session_id
+          : "";
+      this.screenRefreshHasMore = false;
       this.screenRefreshInitialized = true;
       // Skip the redundant cold-start recheck unless there is an existing durable
       // action marker that the first poll still needs to emit.
@@ -1583,24 +1780,39 @@ export class AppSyncState {
       this.replayActionMarkerOnce = false;
       const appStateChanged =
         appStateMaxTs > this.lastAppStateTs || replayActionMarker;
+      const screenRefreshNeedsCheck =
+        appStateChanged || this.screenRefreshHasMore;
 
-      const [appResult, refreshResult, extensionMarkerTs] = appStateChanged
-        ? await Promise.all([
-            db.execute({
-              sql: "SELECT session_id, key, updated_at FROM application_state WHERE updated_at > ? ORDER BY updated_at ASC",
-              args: [this.lastAppStateTs],
-            }),
-            db.execute({
-              sql: "SELECT session_id, updated_at, value FROM application_state WHERE key = ?",
-              args: [SCREEN_REFRESH_KEY],
-            }),
-            readExtensionMarkerMaxUpdatedAt(db),
-          ])
-        : ([
-            { rows: [] as Record<string, unknown>[] },
-            null,
-            this.lastExtensionMarkerTs,
-          ] as const);
+      const [appResult, refreshResult, extensionMarkerTs] =
+        screenRefreshNeedsCheck
+          ? await Promise.all([
+              appStateChanged
+                ? db.execute({
+                    sql: "SELECT session_id, key, updated_at FROM application_state WHERE updated_at > ? ORDER BY updated_at ASC",
+                    args: [this.lastAppStateTs],
+                  })
+                : Promise.resolve({ rows: [] as Record<string, unknown>[] }),
+              db.execute({
+                sql: `SELECT session_id, updated_at, value FROM application_state
+                    WHERE key = ?
+                      AND (updated_at > ? OR (updated_at = ? AND session_id > ?))
+                    ORDER BY updated_at ASC, session_id ASC
+                    LIMIT ?`,
+                args: [
+                  SCREEN_REFRESH_KEY,
+                  this.lastScreenRefreshTs,
+                  this.lastScreenRefreshTs,
+                  this.lastScreenRefreshSessionId,
+                  SCREEN_REFRESH_QUERY_LIMIT,
+                ],
+              }),
+              readExtensionMarkerMaxUpdatedAt(db),
+            ])
+          : ([
+              { rows: [] as Record<string, unknown>[] },
+              null,
+              this.lastExtensionMarkerTs,
+            ] as const);
 
       // Check application_state for external writes. Preserve the changed key so
       // clients can invalidate one-shot command queries (`navigate`, `__set_url__`)
@@ -1675,22 +1887,15 @@ export class AppSyncState {
       // application_state row moved, which is also exactly when this block
       // could not emit anything.
       if (refreshResult) {
-        const refreshTs = refreshResult.rows.reduce(
-          (max, row) => Math.max(max, timestampValue(row.updated_at)),
-          0,
-        );
         if (!this.screenRefreshInitialized) {
-          this.lastScreenRefreshTs = refreshTs;
-          for (const row of refreshResult.rows) {
-            if (typeof row.session_id === "string") {
-              this.lastScreenRefreshTsBySession.set(
-                row.session_id,
-                timestampValue(row.updated_at),
-              );
-            }
-          }
+          const lastRow = refreshResult.rows.at(-1);
+          this.lastScreenRefreshTs = timestampValue(lastRow?.updated_at);
+          this.lastScreenRefreshSessionId =
+            typeof lastRow?.session_id === "string" ? lastRow.session_id : "";
+          this.screenRefreshHasMore =
+            refreshResult.rows.length >= SCREEN_REFRESH_QUERY_LIMIT;
           this.screenRefreshInitialized = true;
-        } else if (refreshTs > this.lastScreenRefreshTs) {
+        } else {
           // Emit a per-user event only for the session(s) whose row actually
           // advanced, scoped with `owner` so canSeeChangeForUser delivers it only
           // to that user — not every authenticated poller.
@@ -1699,9 +1904,6 @@ export class AppSyncState {
               typeof row.session_id === "string" ? row.session_id : undefined;
             if (!owner) continue;
             const rowTs = timestampValue(row.updated_at);
-            if (rowTs <= (this.lastScreenRefreshTsBySession.get(owner) ?? 0)) {
-              continue;
-            }
             let scope: string | undefined;
             try {
               const raw = row.value;
@@ -1718,11 +1920,13 @@ export class AppSyncState {
                 owner,
                 ...(scope ? { scope } : {}),
               },
-              { dedupeKey: `screen-refresh|${rowTs}` },
+              { dedupeKey: `screen-refresh|${rowTs}|${owner}` },
             );
-            this.lastScreenRefreshTsBySession.set(owner, rowTs);
+            this.lastScreenRefreshTs = rowTs;
+            this.lastScreenRefreshSessionId = owner;
           }
-          this.lastScreenRefreshTs = refreshTs;
+          this.screenRefreshHasMore =
+            refreshResult.rows.length >= SCREEN_REFRESH_QUERY_LIMIT;
         }
       }
 
@@ -1914,7 +2118,7 @@ export function getChangesSinceForUser(
 /**
  * Create an H3 handler for the poll endpoint.
  *
- * GET /_agent-native/poll?since=N → { version, events[] }
+ * GET /_agent-native/poll?since=N[&cursor=N.id] → { version, events[] }
  *
  * Requires an authenticated session. Events are filtered to the caller's
  * tenant — global events (owner-less, table-level pings) reach every
@@ -1943,12 +2147,15 @@ export function createPollHandler(
     await state.checkExternalDbChanges({ durableEvents });
 
     const query = getQuery(event);
-    const since = parseInt(String(query.since ?? "0"), 10) || 0;
+    const cursor = decodeSyncCursor(query.cursor);
+    const since =
+      cursor?.version ?? (parseInt(String(query.since ?? "0"), 10) || 0);
     return state.getCombinedChangesSinceForUser(
       since,
       session.email,
       session.orgId,
       durableEvents,
+      cursor,
     );
   });
 }

--- a/scripts/qa-standalone-chat-dev-smoke.ts
+++ b/scripts/qa-standalone-chat-dev-smoke.ts
@@ -117,7 +117,9 @@ function appendDevLog(
   logs.push(chunk);
   if (
     chunk.includes("reloading the page") ||
-    chunk.includes("optimized dependencies changed")
+    chunk.includes("optimized dependencies changed") ||
+    chunk.includes("new dependencies optimized") ||
+    chunk.includes("bundling dependencies")
   ) {
     viteReload.lastReloadAt = Date.now();
   }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -36,6 +36,7 @@ import {
   setClientAppState,
   useReconciledState,
   useChangeVersion,
+  useChangeVersions,
   useAvatarUrl,
 } from "@agent-native/core/client/hooks";
 import {
@@ -2291,7 +2292,6 @@ function DesignEditor() {
     return value === "save" || value === "share" ? value : null;
   }, [searchParams]);
   const queryClient = useQueryClient();
-  const appStateVersion = useChangeVersion("app-state");
   const browserTabId = getBrowserTabId();
   /**
    * Shell mode: the host drives the whole canvas over `design:init` and nothing
@@ -3200,7 +3200,7 @@ function DesignEditor() {
   // effect OR via this tab's OWN setActiveBreakpointMutation write (every
   // local breakpoint-bar handler seeds this ref immediately, before the
   // mutation even resolves). Without this, the UI's own write would bump
-  // `appStateVersion`, the effect would read back the exact value this tab
+  // targeted app-state counter, the effect would read back the exact value this tab
   // just wrote, and needlessly re-run every local state setter on every local
   // breakpoint chip click — this ref short-circuits that echo. Mirrors the
   // "ignoreSource" convention `useDbSync({ ignoreSource: getBrowserTabId() })`
@@ -4247,6 +4247,34 @@ function DesignEditor() {
     : isDesignData(designResult)
       ? designResult
       : null;
+  const activeBreakpointStateVersion = useChangeVersion(
+    id ? `app-state:design-active-breakpoint:${id}` : "",
+  );
+  const localhostConsentStateVersion = useChangeVersion(
+    id ? `app-state:design-localhost-write-consent-request:${id}` : "",
+  );
+  const designEditorCommandKeys = useMemo(
+    () =>
+      browserTabId
+        ? [designEditorCommandKey(browserTabId), designEditorCommandKey()]
+        : [designEditorCommandKey()],
+    [browserTabId],
+  );
+  const designEditorCommandVersion = useChangeVersions(
+    designEditorCommandKeys.map((key) => `app-state:${key}`),
+  );
+  const pendingNodeRewriteStateKeys = useMemo(
+    () =>
+      id
+        ? (design?.files.map((file) =>
+            designRepromptPendingStateKey(id, file.id),
+          ) ?? [])
+        : [],
+    [design?.files, id],
+  );
+  const pendingNodeRewriteStateVersion = useChangeVersions(
+    pendingNodeRewriteStateKeys.map((key) => `app-state:${key}`),
+  );
   const designAccessRole = design?.accessRole;
   const canShareDesign =
     designAccessRole === "owner" || designAccessRole === "admin";
@@ -5524,7 +5552,7 @@ function DesignEditor() {
     return () => {
       cancelled = true;
     };
-  }, [appStateVersion, id, proposalFileIds]);
+  }, [pendingNodeRewriteStateVersion, id, proposalFileIds]);
   const pendingNodeRewriteByFile = useMemo(
     () =>
       new Map(
@@ -6679,9 +6707,8 @@ function DesignEditor() {
   // application state so the agent and UI agree on the active edit scope;
   // this effect is the UI half that was previously missing — the BreakpointBar
   // chip/viewport-width only ever changed from the UI's own chip clicks.
-  // Polls the same way the `design-editor-command` ("navigate") consumption
-  // effect above does: react to `appStateVersion` (bumped by useDbSync on ANY
-  // app-state write, including this tab's own), read the key, and apply it —
+  // React to the targeted active-breakpoint app-state counter, read the key,
+  // and apply it -
   // except this key is a durable "current scope" value (not a one-shot
   // command), so unlike that effect this one does NOT null the key out after
   // reading; it just dedupes against the last-applied breakpointId so the
@@ -6727,7 +6754,7 @@ function DesignEditor() {
     return () => {
       cancelled = true;
     };
-  }, [appStateVersion, designBreakpoints, id, isSignedIn]);
+  }, [activeBreakpointStateVersion, designBreakpoints, id, isSignedIn]);
 
   // Agent→UI: open the write-consent dialog when the agent requests local file
   // write access via request-localhost-write-consent (granting stays human-only).
@@ -6771,7 +6798,7 @@ function DesignEditor() {
     return () => {
       cancelled = true;
     };
-  }, [appStateVersion, canEditDesign, id]);
+  }, [localhostConsentStateVersion, canEditDesign, id]);
 
   // §6.4 — The active screen's primary-frame width (the BASE editing
   // context). Overrides written at a narrower active breakpoint apply below
@@ -7205,7 +7232,7 @@ function DesignEditor() {
       cancelled = true;
     };
   }, [
-    appStateVersion,
+    designEditorCommandVersion,
     applyDesignEditorCommand,
     browserTabId,
     canEditDesign,

--- a/templates/design/app/pages/design-editor/responsive-interact.test.ts
+++ b/templates/design/app/pages/design-editor/responsive-interact.test.ts
@@ -142,10 +142,10 @@ describe("responsive Interact wiring", () => {
     // that path keyed to `isSignedIn` fails for exactly the user it serves:
     // the write-consent dialog never opens (edits can't reach source) and
     // agent-driven navigate/select/zoom commands are dropped on the floor.
-    const consent = source.slice(
-      source.indexOf("design-localhost-write-consent-request") - 900,
-      source.indexOf("design-localhost-write-consent-request"),
-    );
+    const consentAnchor = "const key = `design-localhost-write-consent-request";
+    const consentIndex = source.indexOf(consentAnchor);
+    expect(consentIndex).toBeGreaterThan(0);
+    const consent = source.slice(consentIndex - 900, consentIndex);
     expect(consent).toContain("!id || !canEditDesign");
     expect(consent).not.toContain("!id || !isSignedIn");
 

--- a/templates/slides/app/components/layout/AgentWorkIndicator.test.tsx
+++ b/templates/slides/app/components/layout/AgentWorkIndicator.test.tsx
@@ -103,6 +103,28 @@ describe("AgentWorkIndicator", () => {
     });
   });
 
+  it("hides when the portal wrapper becomes inaccessible", async () => {
+    render(<AgentWorkIndicator />);
+    dispatchRunning(true);
+
+    const wrapper = document.createElement("div");
+    const panel = document.createElement("div");
+    panel.className = "agent-sidebar-panel";
+    panel.style.display = "flex";
+    setVisibleRect(panel);
+    wrapper.append(panel);
+    document.body.append(wrapper);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Agent is working")).toBeNull();
+    });
+
+    wrapper.setAttribute("aria-hidden", "true");
+    await waitFor(() => {
+      expect(screen.getByText("Agent is working")).toBeTruthy();
+    });
+  });
+
   it("keeps Open chat behavior when the banner is shown", () => {
     const modeListener = vi.fn();
     window.addEventListener("agent-panel:set-mode", modeListener);

--- a/templates/slides/app/components/layout/AgentWorkIndicator.tsx
+++ b/templates/slides/app/components/layout/AgentWorkIndicator.tsx
@@ -15,7 +15,25 @@ export function isAgentSidebarVisible() {
   if (style.display === "none" || style.visibility === "hidden") return false;
 
   const rect = panel.getBoundingClientRect();
-  return rect.width > 0 && rect.height > 0;
+  if (rect.width <= 0 || rect.height <= 0) return false;
+
+  for (
+    let ancestor = panel.parentElement;
+    ancestor && ancestor !== document.body;
+    ancestor = ancestor.parentElement
+  ) {
+    if (ancestor.getAttribute("aria-hidden") === "true") return false;
+    if (ancestor.inert) return false;
+    const ancestorStyle = window.getComputedStyle(ancestor);
+    if (
+      ancestorStyle.display === "none" ||
+      ancestorStyle.visibility === "hidden"
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function useAgentSidebarVisible() {
@@ -45,7 +63,11 @@ function useAgentSidebarVisible() {
       });
       if (panel.parentElement && panel.parentElement !== document.body) {
         parentObserver = new MutationObserver(update);
-        parentObserver.observe(panel.parentElement, { childList: true });
+        parentObserver.observe(panel.parentElement, {
+          attributes: true,
+          attributeFilter: ["aria-hidden", "class", "inert", "style"],
+          childList: true,
+        });
       }
     };
     const updateAndObserve = () => {

--- a/templates/slides/app/components/layout/AgentWorkIndicator.tsx
+++ b/templates/slides/app/components/layout/AgentWorkIndicator.tsx
@@ -25,20 +25,45 @@ function useAgentSidebarVisible() {
     const update = () => setVisible(isAgentSidebarVisible());
     update();
 
-    const observer = new MutationObserver(update);
-    observer.observe(document.body, {
-      attributes: true,
-      attributeFilter: ["aria-hidden", "class", "inert", "style"],
-      childList: true,
-      subtree: true,
-    });
+    // The panel is a portal and is normally a direct child of body. Discover
+    // portal mount/unmounts with a shallow child-list observer, then watch only
+    // the panel and its immediate parent. Observing every body attribute and
+    // descendant mutation made this tiny indicator run on every editor render.
+    let panelObserver: MutationObserver | null = null;
+    let parentObserver: MutationObserver | null = null;
+
+    const observePanel = () => {
+      panelObserver?.disconnect();
+      parentObserver?.disconnect();
+      const panel = document.querySelector<HTMLElement>(".agent-sidebar-panel");
+      if (!panel) return;
+
+      panelObserver = new MutationObserver(update);
+      panelObserver.observe(panel, {
+        attributes: true,
+        attributeFilter: ["aria-hidden", "class", "inert", "style"],
+      });
+      if (panel.parentElement && panel.parentElement !== document.body) {
+        parentObserver = new MutationObserver(update);
+        parentObserver.observe(panel.parentElement, { childList: true });
+      }
+    };
+    const updateAndObserve = () => {
+      update();
+      observePanel();
+    };
+    const discovery = new MutationObserver(updateAndObserve);
+    discovery.observe(document.body, { childList: true });
+    updateAndObserve();
     window.addEventListener("resize", update);
     window.addEventListener("agent-panel:open", update);
     window.addEventListener("agent-panel:toggle", update);
     window.addEventListener("agent-panel:set-mode", update);
 
     return () => {
-      observer.disconnect();
+      discovery.disconnect();
+      panelObserver?.disconnect();
+      parentObserver?.disconnect();
       window.removeEventListener("resize", update);
       window.removeEventListener("agent-panel:open", update);
       window.removeEventListener("agent-panel:toggle", update);


### PR DESCRIPTION
## Summary

- add durable `(version, id)` polling cursors so same-millisecond cross-instance events cannot disappear
- bound screen-refresh, active-chat, trailing-invalidation, awareness, and autoscroll retention
- narrow Design and Slides invalidation/DOM observation hot paths

## Validation

- core focused suite: 28 files, 315 tests passed
- `pnpm typecheck` in `packages/core` passed
- Design TypeScript passed
- Slides AgentWorkIndicator test: 5 tests passed

The clean current-main fixes are in PR #3038; this PR contains the conflicting source rewrites and their paired tests.