### PR TITLE
Fix public docs agent tools in production

### DIFF
--- a/packages/docs/actions/docs-actions.test.ts
+++ b/packages/docs/actions/docs-actions.test.ts
@@ -8,7 +8,13 @@ import searchSource from "./search-source";
 
 describe("docs actions", () => {
   it("marks documentation reads and searches as read-only", () => {
-    const actions = [listDocs, readDoc, readSourceFile, searchDocs, searchSource];
+    const actions = [
+      listDocs,
+      readDoc,
+      readSourceFile,
+      searchDocs,
+      searchSource,
+    ];
 
     expect(actions.map((action) => action.readOnly)).toEqual([
       true,

--- a/packages/docs/actions/docs-actions.test.ts
+++ b/packages/docs/actions/docs-actions.test.ts
@@ -8,11 +8,22 @@ import searchSource from "./search-source";
 
 describe("docs actions", () => {
   it("marks documentation reads and searches as read-only", () => {
-    expect(
-      [listDocs, readDoc, readSourceFile, searchDocs, searchSource].map(
-        (action) => action.readOnly,
-      ),
-    ).toEqual([true, true, true, true, true]);
+    const actions = [listDocs, readDoc, readSourceFile, searchDocs, searchSource];
+
+    expect(actions.map((action) => action.readOnly)).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(actions.map((action) => action.publicAgent)).toEqual([
+      { expose: true, readOnly: true },
+      { expose: true, readOnly: true },
+      { expose: true, readOnly: true },
+      { expose: true, readOnly: true },
+      { expose: true, readOnly: true },
+    ]);
   });
 
   it("lists the current core docs content", async () => {

--- a/packages/docs/actions/docs-files.ts
+++ b/packages/docs/actions/docs-files.ts
@@ -1,34 +1,17 @@
-import { existsSync } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import {
-  docSourceFilenamesForSlug,
-  preferMdxDocSourceFiles,
-} from "../lib/docs-source";
-
-export const docsContentDir = fileURLToPath(
-  new URL("../../core/docs/content/", import.meta.url),
-);
+import { listDocSourceFiles, readDocSource } from "../lib/docs-content-source";
 
 export function sanitizeDocSlug(slug: string): string {
   return slug.replace(/[^a-z0-9-]/gi, "");
 }
 
-export function docPath(slug: string): string {
-  const sanitizedSlug = sanitizeDocSlug(slug);
-  for (const filename of docSourceFilenamesForSlug(sanitizedSlug)) {
-    const candidate = join(docsContentDir, filename);
-    if (existsSync(candidate)) return candidate;
-  }
-  return join(docsContentDir, `${sanitizedSlug}.mdx`);
-}
-
-export async function listDocFiles(): Promise<string[]> {
-  return preferMdxDocSourceFiles(await readdir(docsContentDir));
+export function listDocFiles(): string[] {
+  return listDocSourceFiles();
 }
 
 export async function readDocFile(slug: string): Promise<string> {
-  return readFile(docPath(slug), "utf-8");
+  const raw = await readDocSource(sanitizeDocSlug(slug));
+  if (raw === undefined) {
+    throw new Error(`Documentation page "${slug}" not found`);
+  }
+  return raw;
 }

--- a/packages/docs/actions/list-docs.ts
+++ b/packages/docs/actions/list-docs.ts
@@ -30,6 +30,7 @@ export default defineAction({
   schema: z.object({}),
   http: false,
   readOnly: true,
+  publicAgent: { expose: true, readOnly: true },
   run: async () => {
     const docs = await loadDocsIndex();
     return docs

--- a/packages/docs/actions/public-assets.ts
+++ b/packages/docs/actions/public-assets.ts
@@ -1,0 +1,67 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getRequestContext } from "@agent-native/core/server/request-context";
+
+const cachedAssets = new Map<string, Promise<unknown | undefined>>();
+
+function localAssetPaths(filename: string): string[] {
+  const roots = [
+    join(import.meta.dirname, "../public"),
+    join(process.cwd(), "public"),
+    join(process.cwd(), "dist"),
+    join(process.cwd(), "dist/client"),
+    join(process.cwd(), "dist/server/public"),
+    join(process.cwd(), "build/client"),
+    join(process.cwd(), ".output/public"),
+  ];
+  return roots.map((root) => join(root, filename));
+}
+
+function publicAssetUrl(filename: string): string | undefined {
+  const origin = getRequestContext()?.requestOrigin;
+  if (!origin) return undefined;
+
+  const configuredBasePath =
+    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
+  const basePath = configuredBasePath
+    .trim()
+    .replace(/^\/+|\/+$/g, "");
+  const pathname = `/${basePath ? `${basePath}/` : ""}${filename}`;
+  return new URL(pathname, origin).toString();
+}
+
+async function loadPublicJsonAsset<T>(filename: string): Promise<T | undefined> {
+  for (const filePath of localAssetPaths(filename)) {
+    try {
+      return JSON.parse(await readFile(filePath, "utf-8")) as T;
+    } catch {
+      // Try the next known build output location.
+    }
+  }
+
+  const url = publicAssetUrl(filename);
+  if (!url) return undefined;
+
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) return undefined;
+    return (await response.json()) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readPublicJsonAsset<T>(filename: string): Promise<T | undefined> {
+  const cached = cachedAssets.get(filename);
+  if (cached) return cached as Promise<T | undefined>;
+
+  const promise = loadPublicJsonAsset<T>(filename).then((asset) => {
+    if (asset === undefined) cachedAssets.delete(filename);
+    return asset;
+  });
+  cachedAssets.set(filename, promise);
+  return promise;
+}

--- a/packages/docs/actions/public-assets.ts
+++ b/packages/docs/actions/public-assets.ts
@@ -36,6 +36,7 @@ async function loadPublicJsonAsset<T>(
     try {
       return JSON.parse(await readFile(filePath, "utf-8")) as T;
     } catch {
+      // coercion-ok: a missing local build location should try the next location.
       // Try the next known build output location.
     }
   }
@@ -50,6 +51,7 @@ async function loadPublicJsonAsset<T>(
     if (!response.ok) return undefined;
     return (await response.json()) as T;
   } catch {
+    // coercion-ok: a failed same-origin asset fetch is an unavailable asset.
     return undefined;
   }
 }

--- a/packages/docs/actions/public-assets.ts
+++ b/packages/docs/actions/public-assets.ts
@@ -24,14 +24,14 @@ function publicAssetUrl(filename: string): string | undefined {
 
   const configuredBasePath =
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
-  const basePath = configuredBasePath
-    .trim()
-    .replace(/^\/+|\/+$/g, "");
+  const basePath = configuredBasePath.trim().replace(/^\/+|\/+$/g, "");
   const pathname = `/${basePath ? `${basePath}/` : ""}${filename}`;
   return new URL(pathname, origin).toString();
 }
 
-async function loadPublicJsonAsset<T>(filename: string): Promise<T | undefined> {
+async function loadPublicJsonAsset<T>(
+  filename: string,
+): Promise<T | undefined> {
   for (const filePath of localAssetPaths(filename)) {
     try {
       return JSON.parse(await readFile(filePath, "utf-8")) as T;
@@ -54,7 +54,9 @@ async function loadPublicJsonAsset<T>(filename: string): Promise<T | undefined> 
   }
 }
 
-export function readPublicJsonAsset<T>(filename: string): Promise<T | undefined> {
+export function readPublicJsonAsset<T>(
+  filename: string,
+): Promise<T | undefined> {
   const cached = cachedAssets.get(filename);
   if (cached) return cached as Promise<T | undefined>;
 

--- a/packages/docs/actions/public-assets.ts
+++ b/packages/docs/actions/public-assets.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { getAppBasePath } from "@agent-native/core/server";
 import { getRequestContext } from "@agent-native/core/server/request-context";
 
 const cachedAssets = new Map<string, Promise<unknown | undefined>>();
@@ -22,10 +23,8 @@ function publicAssetUrl(filename: string): string | undefined {
   const origin = getRequestContext()?.requestOrigin;
   if (!origin) return undefined;
 
-  const configuredBasePath =
-    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "";
-  const basePath = configuredBasePath.trim().replace(/^\/+|\/+$/g, "");
-  const pathname = `/${basePath ? `${basePath}/` : ""}${filename}`;
+  const basePath = getAppBasePath();
+  const pathname = `${basePath ? `${basePath}/` : "/"}${filename}`;
   return new URL(pathname, origin).toString();
 }
 

--- a/packages/docs/actions/read-doc.ts
+++ b/packages/docs/actions/read-doc.ts
@@ -11,6 +11,7 @@ export default defineAction({
   }),
   http: false,
   readOnly: true,
+  publicAgent: { expose: true, readOnly: true },
   run: async ({ slug }) => {
     const matter = (await import("gray-matter")).default;
     const sanitized = sanitizeDocSlug(slug);

--- a/packages/docs/actions/read-source-file.ts
+++ b/packages/docs/actions/read-source-file.ts
@@ -22,9 +22,10 @@ export default defineAction({
   readOnly: true,
   publicAgent: { expose: true, readOnly: true },
   run: async ({ path, startLine, endLine }) => {
-    const index = await readPublicJsonAsset<
-      Array<{ path: string; content: string }>
-    >("source-index.json");
+    const index =
+      await readPublicJsonAsset<Array<{ path: string; content: string }>>(
+        "source-index.json",
+      );
     if (!index) {
       return "Source index not available. The source-index.json may not have been generated yet.";
     }

--- a/packages/docs/actions/read-source-file.ts
+++ b/packages/docs/actions/read-source-file.ts
@@ -1,6 +1,8 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 
+import { readPublicJsonAsset } from "./public-assets";
+
 export default defineAction({
   description:
     "Read a specific framework source file to understand implementation details",
@@ -18,47 +20,41 @@ export default defineAction({
   }),
   http: false,
   readOnly: true,
+  publicAgent: { expose: true, readOnly: true },
   run: async ({ path, startLine, endLine }) => {
-    const { readFile } = await import("node:fs/promises");
-    const { join } = await import("node:path");
-
-    try {
-      const indexPath = join(
-        import.meta.dirname,
-        "../public/source-index.json",
-      );
-      const raw = await readFile(indexPath, "utf-8");
-      const index: Array<{ path: string; content: string }> = JSON.parse(raw);
-
-      const entry = index.find(
-        (e) => e.path === path || e.path.endsWith("/" + path),
-      );
-      if (!entry) {
-        const similar = index
-          .filter((e) => e.path.includes(path.split("/").pop() || ""))
-          .slice(0, 5)
-          .map((e) => e.path);
-
-        return similar.length
-          ? `File "${path}" not found. Did you mean:\n${similar.map((s) => `- ${s}`).join("\n")}`
-          : `File "${path}" not found in the source index.`;
-      }
-
-      let lines = entry.content.split("\n");
-      if (startLine || endLine) {
-        const start = Math.max(0, (startLine || 1) - 1);
-        const end = endLine || lines.length;
-        lines = lines.slice(start, end);
-      }
-
-      const maxLines = 200;
-      if (lines.length > maxLines) {
-        return `**${entry.path}** (showing first ${maxLines} of ${lines.length} lines)\n\n\`\`\`typescript\n${lines.slice(0, maxLines).join("\n")}\n\`\`\`\n\nUse startLine/endLine to read specific sections.`;
-      }
-
-      return `**${entry.path}**\n\n\`\`\`typescript\n${lines.join("\n")}\n\`\`\``;
-    } catch {
+    const index = await readPublicJsonAsset<
+      Array<{ path: string; content: string }>
+    >("source-index.json");
+    if (!index) {
       return "Source index not available. The source-index.json may not have been generated yet.";
     }
+
+    const entry = index.find(
+      (e) => e.path === path || e.path.endsWith("/" + path),
+    );
+    if (!entry) {
+      const similar = index
+        .filter((e) => e.path.includes(path.split("/").pop() || ""))
+        .slice(0, 5)
+        .map((e) => e.path);
+
+      return similar.length
+        ? `File "${path}" not found. Did you mean:\n${similar.map((s) => `- ${s}`).join("\n")}`
+        : `File "${path}" not found in the source index.`;
+    }
+
+    let lines = entry.content.split("\n");
+    if (startLine || endLine) {
+      const start = Math.max(0, (startLine || 1) - 1);
+      const end = endLine || lines.length;
+      lines = lines.slice(start, end);
+    }
+
+    const maxLines = 200;
+    if (lines.length > maxLines) {
+      return `**${entry.path}** (showing first ${maxLines} of ${lines.length} lines)\n\n\`\`\`typescript\n${lines.slice(0, maxLines).join("\n")}\n\`\`\`\n\nUse startLine/endLine to read specific sections.`;
+    }
+
+    return `**${entry.path}**\n\n\`\`\`typescript\n${lines.join("\n")}\n\`\`\``;
   },
 });

--- a/packages/docs/actions/search-docs.ts
+++ b/packages/docs/actions/search-docs.ts
@@ -71,6 +71,7 @@ export default defineAction({
   }),
   http: false,
   readOnly: true,
+  publicAgent: { expose: true, readOnly: true },
   run: async ({ query }) => {
     const sections = await loadDocSections();
     const lower = query.toLowerCase();

--- a/packages/docs/actions/search-source.ts
+++ b/packages/docs/actions/search-source.ts
@@ -1,6 +1,8 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 
+import { readPublicJsonAsset } from "./public-assets";
+
 interface SourceEntry {
   path: string;
   content: string;
@@ -10,18 +12,10 @@ let cachedIndex: SourceEntry[] | null = null;
 
 async function loadSourceIndex(): Promise<SourceEntry[]> {
   if (cachedIndex) return cachedIndex;
-
-  const { readFile } = await import("node:fs/promises");
-  const { join } = await import("node:path");
-
-  try {
-    const indexPath = join(import.meta.dirname, "../public/source-index.json");
-    const raw = await readFile(indexPath, "utf-8");
-    cachedIndex = JSON.parse(raw);
-    return cachedIndex!;
-  } catch {
-    return [];
-  }
+  const index = await readPublicJsonAsset<SourceEntry[]>("source-index.json");
+  if (!Array.isArray(index)) return [];
+  cachedIndex = index;
+  return index;
 }
 
 export default defineAction({
@@ -40,6 +34,7 @@ export default defineAction({
   }),
   http: false,
   readOnly: true,
+  publicAgent: { expose: true, readOnly: true },
   run: async ({ query, directory }) => {
     const index = await loadSourceIndex();
     if (index.length === 0) {

--- a/packages/docs/lib/docs-content-source.ts
+++ b/packages/docs/lib/docs-content-source.ts
@@ -1,0 +1,53 @@
+import {
+  docSourceSlugFromFilename,
+  preferMdxDocSourceFiles,
+} from "./docs-source";
+
+type DocSourceLoader = () => Promise<string>;
+
+const docSourceLoaders = {
+  ...import.meta.glob("../core/docs/content/*.md", {
+    query: "?raw",
+    import: "default",
+  }),
+  ...import.meta.glob("../core/docs/content/*.mdx", {
+    query: "?raw",
+    import: "default",
+  }),
+} as Record<string, DocSourceLoader>;
+
+interface DocSource {
+  filename: string;
+  slug: string;
+  load: DocSourceLoader;
+}
+
+const docSources: DocSource[] = preferMdxDocSourceFiles(
+  Object.keys(docSourceLoaders),
+).flatMap((path) => {
+  const load = docSourceLoaders[path];
+  if (!load) return [];
+
+  return [
+    {
+      filename: path.split("/").pop() ?? path,
+      slug: docSourceSlugFromFilename(path),
+      load,
+    },
+  ];
+});
+
+const docSourcesBySlug = new Map(
+  docSources.map((source) => [source.slug, source]),
+);
+
+export function listDocSourceFiles(): string[] {
+  return docSources.map((source) => source.filename);
+}
+
+export async function readDocSource(
+  slug: string,
+): Promise<string | undefined> {
+  const source = docSourcesBySlug.get(slug);
+  return source ? source.load() : undefined;
+}

--- a/packages/docs/lib/docs-content-source.ts
+++ b/packages/docs/lib/docs-content-source.ts
@@ -6,11 +6,11 @@ import {
 type DocSourceLoader = () => Promise<string>;
 
 const docSourceLoaders = {
-  ...import.meta.glob("../core/docs/content/*.md", {
+  ...import.meta.glob("../../core/docs/content/*.md", {
     query: "?raw",
     import: "default",
   }),
-  ...import.meta.glob("../core/docs/content/*.mdx", {
+  ...import.meta.glob("../../core/docs/content/*.mdx", {
     query: "?raw",
     import: "default",
   }),
@@ -45,9 +45,7 @@ export function listDocSourceFiles(): string[] {
   return docSources.map((source) => source.filename);
 }
 
-export async function readDocSource(
-  slug: string,
-): Promise<string | undefined> {
+export async function readDocSource(slug: string): Promise<string | undefined> {
   const source = docSourcesBySlug.get(slug);
   return source ? source.load() : undefined;
 }


### PR DESCRIPTION
## Summary
- load docs actions from the bundled core docs source instead of the package filesystem
- make the docs read/search actions explicitly public-safe for public Agent Card discovery
- load the generated source index from local build output or the same-origin public asset

## Verification
- git diff --check
- docs action regression coverage updated for public-safe metadata

Fixes the Agent Native feedback report about docs search and Ask AI tools returning empty results.