### PR TITLE
Fix MCP app iframe error recovery

### DIFF
--- a/.changeset/mcp-app-error-overlay.md
+++ b/.changeset/mcp-app-error-overlay.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep failed MCP app iframes visible under a compact error overlay with a clear open-in-new-tab escape hatch.

--- a/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
+++ b/packages/core/src/client/mcp-apps/McpAppRenderer.spec.ts
@@ -144,6 +144,8 @@ describe("McpAppRenderer security helpers", () => {
     expect(container.textContent).toContain(
       "MCP App did not finish initializing.",
     );
+    expect(container.querySelector(".agent-mcp-app__error-box")).toBeTruthy();
+    expect(container.querySelector("iframe")).toBe(iframe);
     const button = Array.from(container.querySelectorAll("button")).find(
       (candidate) => candidate.textContent === "Open in new tab",
     );

--- a/packages/core/src/client/mcp-apps/McpAppRenderer.tsx
+++ b/packages/core/src/client/mcp-apps/McpAppRenderer.tsx
@@ -116,6 +116,12 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
     setError(null);
   }, []);
 
+  const handleIframeError = useCallback(() => {
+    readyRef.current = false;
+    setReady(false);
+    setError("MCP App iframe failed to load.");
+  }, []);
+
   const applyHeight = useCallback((desiredHeight?: number) => {
     if (
       typeof desiredHeight === "number" &&
@@ -318,6 +324,17 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
       <div className={cn("agent-mcp-app agent-mcp-app--error", className)}>
         <IconAlertTriangle size={15} />
         <span>MCP App resource was not available.</span>
+        {externalOpenUrl && (
+          <button
+            type="button"
+            className="agent-mcp-app__open"
+            onClick={() =>
+              window.open(externalOpenUrl, "_blank", "noopener,noreferrer")
+            }
+          >
+            Open in new tab
+          </button>
+        )}
       </div>
     );
   }
@@ -337,20 +354,22 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
         </div>
       )}
       {error && (
-        <div className="agent-mcp-app__error">
-          <IconAlertTriangle size={15} />
-          <span>{error}</span>
-          {externalOpenUrl && (
-            <button
-              type="button"
-              className="agent-mcp-app__open"
-              onClick={() =>
-                window.open(externalOpenUrl, "_blank", "noopener,noreferrer")
-              }
-            >
-              Open in new tab
-            </button>
-          )}
+        <div className="agent-mcp-app__error" role="alert">
+          <div className="agent-mcp-app__error-box">
+            <IconAlertTriangle size={15} />
+            <span>{error}</span>
+            {externalOpenUrl && (
+              <button
+                type="button"
+                className="agent-mcp-app__open"
+                onClick={() =>
+                  window.open(externalOpenUrl, "_blank", "noopener,noreferrer")
+                }
+              >
+                Open in new tab
+              </button>
+            )}
+          </div>
         </div>
       )}
       <iframe
@@ -360,6 +379,7 @@ export function McpAppRenderer({ app, className }: McpAppRendererProps) {
         sandbox={SANDBOX_FLAGS}
         allow={buildAllowAttribute(supportedPermissions)}
         style={{ height }}
+        onError={handleIframeError}
       />
     </div>
   );

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -248,6 +248,7 @@ describe("embedApp", () => {
 
     expect(html).toContain('document.createElement("iframe")');
     expect(html).toContain("renderFrameFallback");
+    expect(html).toContain("function clearFallbackOverlay");
     expect(html).toContain("function renderFallbackOverlay");
     expect(html).toContain(".fallback-overlay");
     expect(html).toContain("data-fallback-overlay");

--- a/packages/core/src/mcp/embed-app.spec.ts
+++ b/packages/core/src/mcp/embed-app.spec.ts
@@ -248,6 +248,10 @@ describe("embedApp", () => {
 
     expect(html).toContain('document.createElement("iframe")');
     expect(html).toContain("renderFrameFallback");
+    expect(html).toContain("function renderFallbackOverlay");
+    expect(html).toContain(".fallback-overlay");
+    expect(html).toContain("data-fallback-overlay");
+    expect(html).toContain('frame.addEventListener("error"');
     expect(html).toContain("openFallbackExternal");
     expect(html).toContain("let url = withChatBridgeParam(openUrl)");
     expect(html).toContain("const buttonUrl = openUrl");

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -74,6 +74,8 @@ export function embedApp(
     iframe { display: block; width: 100%; height: var(--agent-native-viewport-height); border: 0; background: Canvas; }
     .message { display: grid; place-items: center; min-height: var(--agent-native-viewport-height); padding: 18px; color: color-mix(in srgb, CanvasText 62%, Canvas); font-size: 13px; line-height: 1.45; text-align: center; }
     .fallback { display: grid; align-content: center; justify-items: center; gap: 12px; min-height: var(--agent-native-viewport-height); padding: 24px; background: Canvas; color: CanvasText; text-align: center; }
+    .fallback-overlay { position: absolute; inset: 0; z-index: 2; display: grid; align-items: start; justify-items: end; padding: 12px; pointer-events: none; }
+    .fallback-overlay .fallback { width: min(100%, 560px); min-height: 0; border: 1px solid color-mix(in srgb, CanvasText 18%, Canvas); border-radius: 9px; background: color-mix(in srgb, Canvas 96%, transparent); box-shadow: 0 8px 24px color-mix(in srgb, CanvasText 16%, transparent); pointer-events: auto; }
     .fallback-title { max-width: 440px; font-size: 14px; font-weight: 700; }
     .fallback-copy { max-width: 520px; color: color-mix(in srgb, CanvasText 64%, Canvas); font-size: 13px; line-height: 1.45; }
     .fallback-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 8px; }
@@ -1100,14 +1102,60 @@ export function embedApp(
       } catch {}
     }
 
+    function renderFallbackOverlay({ title, copyHtml, retryLabel, onRetry }) {
+      if (!appFrame || appFrame.parentElement !== stage) return false;
+      stage.querySelector("[data-fallback-overlay]")?.remove();
+      const overlay = document.createElement("div");
+      overlay.className = "fallback-overlay";
+      overlay.dataset.fallbackOverlay = "1";
+      overlay.innerHTML =
+        '<div class="fallback">' +
+          '<div class="fallback-title">' + esc(title) + '</div>' +
+          '<div class="fallback-copy">' + copyHtml + '</div>' +
+          '<div class="fallback-actions">' +
+            '<button type="button" class="primary" data-fallback-open>Open in new tab</button>' +
+            '<button type="button" data-fallback-retry>' + esc(retryLabel) + '</button>' +
+          '</div>' +
+          (openUrl ? '<a class="fallback-url" href="' + esc(openUrl) + '" target="_blank" rel="noreferrer">' + esc(openUrl) + '</a>' : '') +
+        '</div>';
+      stage.appendChild(overlay);
+
+      const fallbackOpen = overlay.querySelector("[data-fallback-open]");
+      const fallbackRetry = overlay.querySelector("[data-fallback-retry]");
+      if (fallbackOpen) {
+        fallbackOpen.disabled = !openUrl;
+        fallbackOpen.onclick = () => {
+          if (openUrl) void openFallbackExternal();
+        };
+      }
+      if (fallbackRetry) {
+        fallbackRetry.disabled = typeof onRetry !== "function";
+        fallbackRetry.onclick = () => {
+          if (typeof onRetry === "function") void onRetry();
+        };
+      }
+      return true;
+    }
+
     function renderFrameFallback() {
       clearFrameReadyTimer();
       clearFrameLoadTimer();
-      appFrame = null;
+      appFrameReady = false;
       const fallbackCopy = openUrl
         ? "This chat host did not allow the embedded app frame to load inline. You can still open the same app route through the host or use the URL below."
         : "This chat host did not allow the embedded app frame to load inline.";
       reportEmbedError("frame-fallback", fallbackCopy);
+      if (renderFallbackOverlay({
+        title: "Open this app in its own tab",
+        copyHtml: esc(fallbackCopy),
+        retryLabel: "Try inline again",
+        onRetry: lastFrameSrc
+          ? () => renderFrame(lastFrameSrc)
+          : undefined
+      })) {
+        return;
+      }
+      appFrame = null;
       stage.innerHTML =
         '<div class="fallback">' +
           '<div class="fallback-title">Open this app in its own tab</div>' +
@@ -1137,7 +1185,7 @@ export function embedApp(
     function renderAppLaunchError(message) {
       clearFrameReadyTimer();
       clearFrameLoadTimer();
-      appFrame = null;
+      appFrameReady = false;
       const fallbackCopy = openUrl
         ? "The inline MCP app could not load in this chat host. You can open the same app route in a new tab or retry the inline load."
         : "The inline MCP app could not load in this chat host.";
@@ -1145,6 +1193,18 @@ export function embedApp(
       const copyHtml = message
         ? '<div>' + esc(message) + '</div><div>' + esc(fallbackCopy) + '</div>'
         : esc(fallbackCopy);
+      if (renderFallbackOverlay({
+        title: "App did not load",
+        copyHtml,
+        retryLabel: "Retry",
+        onRetry: () => {
+          startedFor = "";
+          void launchEmbed();
+        }
+      })) {
+        return;
+      }
+      appFrame = null;
       stage.innerHTML =
         '<div class="fallback">' +
           '<div class="fallback-title">App did not load</div>' +
@@ -1204,6 +1264,10 @@ export function embedApp(
         notifyOuterMcpAppReady();
         sendFrameReadyMessages(frame);
         startFrameReadyTimer(frame);
+      });
+      frame.addEventListener("error", () => {
+        if (appFrame !== frame) return;
+        renderFrameFallback();
       });
       stage.replaceChildren(frame);
       notifyHostHeight();

--- a/packages/core/src/mcp/embed-app.ts
+++ b/packages/core/src/mcp/embed-app.ts
@@ -1102,9 +1102,13 @@ export function embedApp(
       } catch {}
     }
 
+    function clearFallbackOverlay() {
+      stage.querySelector("[data-fallback-overlay]")?.remove();
+    }
+
     function renderFallbackOverlay({ title, copyHtml, retryLabel, onRetry }) {
       if (!appFrame || appFrame.parentElement !== stage) return false;
-      stage.querySelector("[data-fallback-overlay]")?.remove();
+      clearFallbackOverlay();
       const overlay = document.createElement("div");
       overlay.className = "fallback-overlay";
       overlay.dataset.fallbackOverlay = "1";
@@ -1555,6 +1559,7 @@ export function embedApp(
       const data = event.data.data || {};
       if (event.data.type === "agentNative.embeddedAppReady") {
         appFrameReady = true;
+        clearFallbackOverlay();
         embedSessionRefreshAttempts = 0;
         clearFrameLoadTimer();
         clearFrameReadyTimer();

--- a/packages/core/src/styles/agent-conversation.css
+++ b/packages/core/src/styles/agent-conversation.css
@@ -326,16 +326,37 @@
 }
 
 .agent-mcp-app__error {
+  pointer-events: none;
+  background: transparent;
+}
+
+.agent-mcp-app__error-box {
+  display: flex;
+  max-width: min(100%, 540px);
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid hsl(var(--destructive) / 0.35);
+  border-radius: calc(var(--radius) - 2px);
+  background: hsl(var(--background) / 0.96);
+  box-shadow: 0 8px 24px hsl(var(--foreground) / 0.12);
+  color: hsl(var(--destructive));
+  text-align: center;
+  pointer-events: auto;
+}
+
+.agent-mcp-app__error {
   flex-direction: column;
   text-align: center;
 }
 
 .agent-mcp-app__open {
   min-height: 28px;
-  border: 1px solid hsl(var(--destructive) / 0.35);
+  border: 1px solid hsl(var(--foreground));
   border-radius: calc(var(--radius) - 2px);
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
+  background: hsl(var(--foreground));
+  color: hsl(var(--background));
   cursor: pointer;
   font: inherit;
   font-weight: 600;
@@ -343,7 +364,7 @@
 }
 
 .agent-mcp-app__open:hover {
-  background: hsl(var(--muted));
+  opacity: 0.86;
 }
 
 .agent-mcp-app__error,


### PR DESCRIPTION
## Summary
- keep failed MCP app iframes visible beneath a compact error overlay
- make opening the app in a new tab the primary recovery CTA
- retain retry behavior and cover the generated MCP embed shell

## Validation
- focused MCP renderer and embed tests
- @agent-native/core typecheck and build
- full core suite: 7,774 passed, 1 skipped; one unrelated existing template tsconfig failure