### PR TITLE
fix(core): cap inline attachment bytes instead of sending unbounded base64

### DIFF
--- a/.changeset/cors-allowlist-origin-normalization.md
+++ b/.changeset/cors-allowlist-origin-normalization.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `CORS_ALLOWED_ORIGINS` exact-match comparison to tolerate operator formatting differences (scheme/host casing, a trailing slash, or a bare domain with no scheme) instead of silently rejecting an otherwise-legitimate configured origin.

--- a/.changeset/inline-attachment-cap.md
+++ b/.changeset/inline-attachment-cap.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Stop sending unbounded inline base64 attachments to the model. Text attachments
+were capped; binary ones were not, so a large screenshot or PDF went out as a
+multi-megabyte `file_url` and OpenAI rejected the entire request ("string too
+long", 4,149,128 against a 1,048,576 limit), killing the turn. The upload to
+blob storage already happened — the hosted URL is now used in place of the bytes
+when they exceed the cap, instead of being discarded.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -469,6 +469,62 @@ describe("buildUserContentWithAttachments", () => {
     ]);
   });
 
+  // Binary attachments were never capped, so a large screenshot or PDF went out
+  // as unbounded inline base64. OpenAI rejects the whole request over 1,048,576
+  // chars in one file_url ("string too long", measured at 4,149,128) and the
+  // turn dies -- 64 events in 7 days, all on the gateway path.
+  it("does not inline an oversized image, and points at the uploaded URL instead", () => {
+    const att: any = {
+      type: "image",
+      name: "huge.png",
+      contentType: "image/png",
+      data: `data:image/png;base64,${"A".repeat(1_000_001)}`,
+      url: "https://cdn.example.com/huge.png",
+    };
+    const parts = buildUserContentWithAttachments({
+      text: "Describe this",
+      attachments: [att],
+    });
+    expect(parts.some((p: any) => p.type === "image")).toBe(false);
+    const text = parts.map((p: any) => p.text ?? "").join("\n");
+    expect(text).toContain("https://cdn.example.com/huge.png");
+    expect(text).toContain("too large to send inline");
+  });
+
+  it("still inlines an image that fits", () => {
+    const parts = buildUserContentWithAttachments({
+      text: "Describe this",
+      attachments: [
+        {
+          type: "image",
+          name: "small.png",
+          contentType: "image/png",
+          data: "data:image/png;base64,aW1hZ2U=",
+        } as any,
+      ],
+    });
+    expect(parts.some((p: any) => p.type === "image")).toBe(true);
+  });
+
+  // Without a URL the bytes are unreachable, so say so rather than dropping the
+  // attachment and leaving the model to answer as if nothing was sent.
+  it("says an oversized file is unavailable when there is no upload URL", () => {
+    const att: any = {
+      type: "file",
+      name: "huge.pdf",
+      contentType: "application/pdf",
+      data: `data:application/pdf;base64,${"A".repeat(1_000_001)}`,
+    };
+    const parts = buildUserContentWithAttachments({
+      text: "Summarize",
+      attachments: [att],
+    });
+    expect(parts.some((p: any) => p.type === "file")).toBe(false);
+    const text = parts.map((p: any) => p.text ?? "").join("\n");
+    expect(text).toContain("huge.pdf");
+    expect(text).toContain("no upload URL");
+  });
+
   it("keeps hosted image URLs in text context instead of sending malformed URL image parts", () => {
     const att = {
       type: "image",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1420,6 +1420,15 @@ const RUN_BUDGET_EXHAUSTED_MESSAGE =
   "I ran out of time before finishing this step. " +
   "I stopped rather than keep retrying silently. " +
   "Check any completed tool cards above before retrying, ideally as one smaller follow-up.";
+/**
+ * Text attachments have been capped since forever; binary ones never were, so
+ * a large PDF or screenshot went to the provider as unbounded inline base64.
+ * OpenAI rejects the whole request over 1,048,576 chars in one `file_url`
+ * ("string too long", measured at 4,149,128), which kills the turn — the cap is
+ * on the encoded string, so that is what this counts rather than decoded bytes.
+ * Held under the limit to leave room for the `data:<mediaType>;base64,` prefix.
+ */
+const MAX_INLINE_ATTACHMENT_BASE64_CHARS = 1_000_000;
 const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 const MAX_TEXT_ATTACHMENTS_TOTAL_CHARS = 80_000;
 const MAX_SELECTION_CONTEXT_CHARS = 8_000;
@@ -1801,6 +1810,21 @@ export function buildUserContentWithAttachments(opts: {
         continue;
       }
       const match = att.data.match(/^data:(image\/[^;]+);base64,(.+)$/);
+      if (
+        match &&
+        isSupportedImageMediaType(match[1]) &&
+        match[2].length > MAX_INLINE_ATTACHMENT_BASE64_CHARS
+      ) {
+        // The upload already happened and `uploadedUrl` is the whole point of
+        // it. Inlining the bytes anyway is what made the request unsendable.
+        const label = att.name ? `"${att.name}"` : "An image";
+        textAttachments.push(
+          uploadedUrl
+            ? `[${label} was uploaded to ${uploadedUrl}. It was too large to send inline for vision analysis, so use the URL for embedding/reference.]`
+            : `[${label} was too large to send inline for vision analysis and no upload URL is available. Ask the user to attach a smaller image.]`,
+        );
+        continue;
+      }
       if (match && isSupportedImageMediaType(match[1])) {
         userContent.push({
           type: "image",
@@ -1837,6 +1861,15 @@ export function buildUserContentWithAttachments(opts: {
 
     const filePart = dataUrlToFilePart(att);
     if (filePart) {
+      if (filePart.data.length > MAX_INLINE_ATTACHMENT_BASE64_CHARS) {
+        const label = att.name ? `"${att.name}"` : "A file";
+        textAttachments.push(
+          uploadedUrl
+            ? `[${label} was uploaded to ${uploadedUrl}. It was too large to send inline, so read it from the URL if its contents are needed.]`
+            : `[${label} was too large to send inline and no upload URL is available. Ask the user for a smaller file.]`,
+        );
+        continue;
+      }
       userContent.push(filePart);
       continue;
     }
@@ -9460,7 +9493,9 @@ export function createProductionAgentHandler(
           await import("./thread-data-builder.js");
         const priorThreadData = (await getThread(effectiveThreadId))
           ?.threadData;
-        const resumed = threadDataToEngineMessages(priorThreadData);
+        const resumed = threadDataToEngineMessages(priorThreadData, {
+          includeToolCalls: true,
+        });
         if (resumed.length > 0) {
           const actionPreparationTool =
             typeof backgroundRunMarker?.actionPreparationTool === "string" &&

--- a/packages/core/src/server/cors-origins.spec.ts
+++ b/packages/core/src/server/cors-origins.spec.ts
@@ -43,6 +43,52 @@ describe("getAllowedCorsOrigin", () => {
     ).toBe("https://preview.example.com");
   });
 
+  it("still rejects an origin that is genuinely absent from the allowlist", () => {
+    expect(
+      getAllowedCorsOrigin("https://evil.example.com", {
+        allowedOrigins: ["https://app.example.com"],
+      }),
+    ).toBeNull();
+  });
+
+  it("admits a real Origin header when the allowlist entry has different casing", () => {
+    // A legitimate origin, e.g. copy-pasted from a UI that preserves entered
+    // case, must still resolve — the browser's Origin header is always
+    // lowercase, but the allowlist config is operator-entered text.
+    expect(
+      getAllowedCorsOrigin("https://app.example.com", {
+        allowedOrigins: ["HTTPS://App.Example.com"],
+      }),
+    ).toBe("https://app.example.com");
+  });
+
+  it("admits a real Origin header when the allowlist entry has a trailing slash", () => {
+    expect(
+      getAllowedCorsOrigin("https://app.example.com", {
+        allowedOrigins: ["https://app.example.com/"],
+      }),
+    ).toBe("https://app.example.com");
+  });
+
+  it("admits a real Origin header when the allowlist entry is a bare domain with no scheme", () => {
+    // CORS_ALLOWED_ORIGINS is operationally a "domain allowlist" — an
+    // operator entering "app.example.com" (no scheme) is a legitimate
+    // first-party origin, not a different one.
+    expect(
+      getAllowedCorsOrigin("https://app.example.com", {
+        allowedOrigins: ["app.example.com"],
+      }),
+    ).toBe("https://app.example.com");
+  });
+
+  it("does not admit a different host just because the scheme was implied", () => {
+    expect(
+      getAllowedCorsOrigin("https://evil.example.com", {
+        allowedOrigins: ["app.example.com"],
+      }),
+    ).toBeNull();
+  });
+
   describe("production localhost gate (no allowlist, no explicit override)", () => {
     const savedEnv = process.env.NODE_ENV;
 

--- a/packages/core/src/server/cors-origins.ts
+++ b/packages/core/src/server/cors-origins.ts
@@ -28,6 +28,27 @@ export function isLocalhostOrigin(origin: string): boolean {
   return LOCALHOST_ORIGIN_RE.test(origin);
 }
 
+/**
+ * Normalize an allowlist entry or an incoming `Origin` header for exact-match
+ * comparison. This does not widen what is admitted — it is still an exact
+ * scheme+host+port match — it only tolerates formatting slop that carries no
+ * security meaning:
+ *  - scheme/host casing (RFC 6454 origins are case-insensitive; an operator
+ *    pasting a domain from a UI that preserves entered case can end up with
+ *    e.g. "HTTPS://App.Example.com")
+ *  - a trailing slash (browsers never send one in `Origin`, but it's an easy
+ *    copy/paste mistake when configuring the allowlist)
+ *  - a bare domain with no scheme (`CORS_ALLOWED_ORIGINS` is operationally a
+ *    "domain allowlist" — operators reasonably enter "app.example.com"
+ *    instead of "https://app.example.com", which then never matches a real
+ *    Origin header and silently locks out that legitimate origin)
+ */
+function normalizeCorsOrigin(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed);
+  return (hasScheme ? trimmed : `https://${trimmed}`).toLowerCase();
+}
+
 export function getAllowedCorsOrigin(
   origin: string | undefined,
   options: CorsOriginOptions = {},
@@ -41,7 +62,12 @@ export function getAllowedCorsOrigin(
 
   const allowedOrigins = options.allowedOrigins ?? readCorsAllowedOrigins();
   if (allowedOrigins.length > 0) {
-    return allowedOrigins.includes(origin) ? origin : null;
+    const normalizedOrigin = normalizeCorsOrigin(origin);
+    return allowedOrigins.some(
+      (allowed) => normalizeCorsOrigin(allowed) === normalizedOrigin,
+    )
+      ? origin
+      : null;
   }
 
   if (options.allowAnyOriginWhenNoAllowlist) return origin;

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -1376,6 +1376,127 @@ describe("DesktopIdentityBroker", () => {
     );
   });
 
+  it("retries a transient 502 from the exchange gateway instead of failing the ceremony", async () => {
+    const authority = authorityFixture();
+    const identityCookies = cookieStore();
+    const identityFetch = vi
+      .fn<() => Promise<Response>>()
+      // The gateway/runtime in front of the exchange route, not the route
+      // itself, returns this — a bare gateway error page, not JSON.
+      .mockResolvedValueOnce(new Response("Bad Gateway", { status: 502 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "desktop-session",
+            email: "steve@example.com",
+          }),
+          { status: 200 },
+        ),
+      );
+    const webContents = { on: vi.fn(), setWindowOpenHandler: vi.fn() };
+    let closedListener: (() => void) | undefined;
+    const identityWindow = {
+      webContents,
+      loadURL: vi.fn(async () => {}),
+      isDestroyed: vi.fn(() => false),
+      close: vi.fn(),
+      on: vi.fn((event: string, listener: () => void) => {
+        if (event === "closed") closedListener = listener;
+      }),
+    };
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: identityCookies,
+        fetch: identityFetch,
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      isAvailable: vi.fn(async () => true),
+      resolveApp: (id) => (id === authority.id ? authority : null),
+      listApps: () => [authority],
+      createWindow: () => identityWindow as never,
+      handleOAuthNavigation: vi.fn(() => true),
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+
+    const signIn = broker.signIn(authority.id);
+    await vi.waitFor(() => expect(identityWindow.loadURL).toHaveBeenCalled());
+    const navigationHandler = webContents.on.mock.calls.find(
+      ([event]) => event === "will-navigate",
+    )?.[1] as (event: { preventDefault: () => void }, url: string) => void;
+    const state = `${Buffer.from(JSON.stringify({ f: "desktop-flow" })).toString("base64url")}.signature`;
+    navigationHandler(
+      { preventDefault: vi.fn() },
+      `https://accounts.google.com/o/oauth2/v2/auth?state=${state}&verifier=magic-link-verifier`,
+    );
+
+    await vi.waitFor(() => expect(identityFetch).toHaveBeenCalledTimes(2));
+    closedListener?.();
+
+    await expect(signIn).resolves.toBe(true);
+    expect(identityCookies.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "an_session_dispatch",
+        value: "desktop-session",
+      }),
+    );
+  });
+
+  it("still fails the ceremony on a real application error from the exchange route", async () => {
+    const authority = authorityFixture();
+    const identityCookies = cookieStore();
+    const identityFetch = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ error: "Invalid desktop exchange verifier." }),
+          { status: 403 },
+        ),
+      );
+    const webContents = { on: vi.fn(), setWindowOpenHandler: vi.fn() };
+    let closedListener: (() => void) | undefined;
+    const identityWindow = {
+      webContents,
+      loadURL: vi.fn(async () => {}),
+      isDestroyed: vi.fn(() => false),
+      close: vi.fn(),
+      on: vi.fn((event: string, listener: () => void) => {
+        if (event === "closed") closedListener = listener;
+      }),
+    };
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: identityCookies,
+        fetch: identityFetch,
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      isAvailable: vi.fn(async () => true),
+      resolveApp: (id) => (id === authority.id ? authority : null),
+      listApps: () => [authority],
+      createWindow: () => identityWindow as never,
+      handleOAuthNavigation: vi.fn(() => true),
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+
+    const signIn = broker.signIn(authority.id);
+    await vi.waitFor(() => expect(identityWindow.loadURL).toHaveBeenCalled());
+    const navigationHandler = webContents.on.mock.calls.find(
+      ([event]) => event === "will-navigate",
+    )?.[1] as (event: { preventDefault: () => void }, url: string) => void;
+    const state = `${Buffer.from(JSON.stringify({ f: "desktop-flow" })).toString("base64url")}.signature`;
+    navigationHandler(
+      { preventDefault: vi.fn() },
+      `https://accounts.google.com/o/oauth2/v2/auth?state=${state}&verifier=magic-link-verifier`,
+    );
+
+    await vi.waitFor(() => expect(identityFetch).toHaveBeenCalledTimes(1));
+    closedListener?.();
+
+    await expect(signIn).resolves.toBe(false);
+    expect(identityFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the system browser and one-time embed sessions for modern fan-out", async () => {
     const authority = authorityFixture();
     const mail = appFixture();

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -2371,6 +2371,22 @@ export class DesktopIdentityBroker {
         );
       }
 
+      // A 5xx here is the gateway/runtime in front of our own route failing
+      // (cold start, transient Lambda/DB blip) — the exchange handler itself
+      // only ever answers 200/400/403. Treat it like "pending" and keep
+      // polling instead of aborting the whole sign-in ceremony on one
+      // transient hiccup during the multi-minute polling window.
+      if (response.status >= 500) {
+        await this.waitForCookiePoll(
+          Math.min(
+            DESKTOP_EXCHANGE_POLL_INTERVAL_MS,
+            Math.max(0, deadline - Date.now()),
+          ),
+          signal,
+        );
+        continue;
+      }
+
       let payload: {
         code?: unknown;
         email?: unknown;

--- a/packages/docs/app/entry.client.spec.ts
+++ b/packages/docs/app/entry.client.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Guard: the docs client entry must wire up stale-chunk recovery the same
+ * way the default app scaffold does (see
+ * packages/core/src/templates/default/app/entry.client.tsx). Without this,
+ * a visitor holding a cached JS chunk from before a deploy hits a hard
+ * "Something went wrong" error instead of an automatic reload — see the
+ * incident this guard was added for.
+ *
+ * This only checks that the wiring is present in source, not the recovery
+ * behavior itself (that's covered by
+ * packages/core/src/client/route-chunk-recovery.spec.ts and
+ * client-bootstrap.spec.ts). `appBasePath()` also installs recovery
+ * transitively via `initializeAgentNativeClient()`, so this call is
+ * belt-and-suspenders — but it must stay explicit so the wiring doesn't
+ * silently depend on that side effect.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("docs client entry", () => {
+  it("installs route chunk recovery", () => {
+    const source = fs.readFileSync(
+      path.join(import.meta.dirname, "entry.client.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      'import { installRouteChunkRecovery } from "@agent-native/core/client/route-chunk-recovery";',
+    );
+    expect(source).toMatch(/^installRouteChunkRecovery\(\);$/m);
+  });
+});

--- a/packages/docs/app/entry.client.tsx
+++ b/packages/docs/app/entry.client.tsx
@@ -1,8 +1,11 @@
 import { appBasePath } from "@agent-native/core/client/api-path";
+import { installRouteChunkRecovery } from "@agent-native/core/client/route-chunk-recovery";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
 import { preloadDocBlocksContent } from "./components/doc-block-renderer";
+
+installRouteChunkRecovery();
 
 const basePath = appBasePath();
 if (basePath) {

--- a/templates/clips/app/hooks/use-recording-leave-guard.test.tsx
+++ b/templates/clips/app/hooks/use-recording-leave-guard.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import React, { act, useCallback, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useRecordingLeaveGuard } from "./use-recording-leave-guard";
+
+function RecordProbe({ atRisk }: { atRisk: boolean }) {
+  // Mirrors record.tsx: hasRecordingAtRisk() reads live engine state, not a
+  // prop the hook re-subscribes to, so the guard consults it through a ref.
+  const atRiskRef = useRef(atRisk);
+  atRiskRef.current = atRisk;
+  const {
+    leavePromptOpen,
+    onDialogOpenChange,
+    onCloseAutoFocus,
+    confirmLeave,
+  } = useRecordingLeaveGuard(useCallback(() => atRiskRef.current, []));
+
+  return (
+    <div>
+      <output
+        data-testid="record-probe"
+        data-prompt-open={String(leavePromptOpen)}
+      />
+      <button
+        type="button"
+        id="cancel-leave"
+        onClick={() => onDialogOpenChange(false)}
+      >
+        cancel
+      </button>
+      <button
+        type="button"
+        id="confirm-leave"
+        onClick={() => {
+          confirmLeave();
+          // Radix defers this to `onCloseAutoFocus` once its own close
+          // transition finishes; the probe stands in for Radix here.
+          onCloseAutoFocus({ preventDefault() {} });
+        }}
+      >
+        confirm
+      </button>
+    </div>
+  );
+}
+
+function OtherProbe() {
+  return <output data-testid="other-probe" />;
+}
+
+function renderProbe(container: HTMLDivElement, atRisk: boolean) {
+  const router = createMemoryRouter(
+    [
+      { path: "/record", Component: () => <RecordProbe atRisk={atRisk} /> },
+      { path: "/other", Component: OtherProbe },
+    ],
+    { initialEntries: ["/record"] },
+  );
+  const root = createRoot(container);
+  act(() => {
+    root.render(<RouterProvider router={router} />);
+  });
+  return { router, root };
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("useRecordingLeaveGuard", () => {
+  let container: HTMLDivElement;
+  let root: Root | undefined;
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container?.remove();
+    root = undefined;
+  });
+
+  it("lets in-app navigation through when nothing is at risk", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const rendered = renderProbe(container, false);
+    root = rendered.root;
+
+    act(() => {
+      void rendered.router.navigate("/other");
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="other-probe"]'),
+    ).not.toBeNull();
+  });
+
+  // Regression: before the fix, RecordRoute had no route-change protection at
+  // all, so clicking into Library (an ordinary in-app navigation) unmounted
+  // the recorder and its cleanup effect cancelled the in-progress recording
+  // with no warning — the exact bug reported by Elaine Mao.
+  it("blocks in-app navigation away from an at-risk recording instead of silently discarding it", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const rendered = renderProbe(container, true);
+    root = rendered.root;
+
+    act(() => {
+      void rendered.router.navigate("/other");
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="other-probe"]')).toBeNull();
+    const probe = container.querySelector('[data-testid="record-probe"]');
+    expect(probe?.getAttribute("data-prompt-open")).toBe("true");
+  });
+
+  it("resumes the blocked navigation once the user confirms leaving", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const rendered = renderProbe(container, true);
+    root = rendered.root;
+
+    act(() => {
+      void rendered.router.navigate("/other");
+    });
+    await flush();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>("#confirm-leave")?.click();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="other-probe"]'),
+    ).not.toBeNull();
+  });
+
+  it("stays put and clears the prompt when the user cancels leaving", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    const rendered = renderProbe(container, true);
+    root = rendered.root;
+
+    act(() => {
+      void rendered.router.navigate("/other");
+    });
+    await flush();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>("#cancel-leave")?.click();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="other-probe"]')).toBeNull();
+    const probe = container.querySelector('[data-testid="record-probe"]');
+    expect(probe?.getAttribute("data-prompt-open")).toBe("false");
+  });
+});

--- a/templates/clips/app/hooks/use-recording-leave-guard.ts
+++ b/templates/clips/app/hooks/use-recording-leave-guard.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useBlocker } from "react-router";
+
+/**
+ * Blocks in-app route navigation while `hasRecordingAtRisk()` is true, using
+ * React Router's `useBlocker` — the same check the recorder's `beforeunload`
+ * handler already uses for tab close/reload. Without this, an in-app link
+ * (e.g. Library) unmounts the recorder route with no warning at all, since
+ * the browser never fires `beforeunload` for client-side navigation.
+ *
+ * Exposes a tiny state machine for a confirm dialog rather than a boolean,
+ * because confirming has to navigate away only after the dialog has actually
+ * finished closing — see the `onCloseAutoFocus` deferral below.
+ */
+export function useRecordingLeaveGuard(hasRecordingAtRisk: () => boolean) {
+  const blocker = useBlocker(
+    useCallback(
+      ({ currentLocation, nextLocation }) =>
+        currentLocation.pathname !== nextLocation.pathname &&
+        hasRecordingAtRisk(),
+      [hasRecordingAtRisk],
+    ),
+  );
+
+  const [leavePromptOpen, setLeavePromptOpen] = useState(false);
+  // See delete-recording-menu.tsx's `deletedWhileOpenRef`: navigating away
+  // while Radix is still tearing down the AlertDialog portal can leave its
+  // body pointer-events lock behind. Close the dialog first and defer
+  // `blocker.proceed()` to `onCloseAutoFocus`, once Radix has actually
+  // finished closing it, instead of calling it straight from the click
+  // handler.
+  const proceedBlockerRef = useRef<() => void>(() => {});
+  proceedBlockerRef.current =
+    blocker.state === "blocked" ? blocker.proceed : () => {};
+  const leaveConfirmedRef = useRef(false);
+
+  useEffect(() => {
+    if (blocker.state === "blocked") setLeavePromptOpen(true);
+  }, [blocker.state]);
+
+  const confirmLeave = useCallback(() => {
+    leaveConfirmedRef.current = true;
+    setLeavePromptOpen(false);
+  }, []);
+
+  const onDialogOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) return;
+      setLeavePromptOpen(false);
+      if (!leaveConfirmedRef.current && blocker.state === "blocked") {
+        blocker.reset();
+      }
+    },
+    [blocker],
+  );
+
+  const onCloseAutoFocus = useCallback((event: { preventDefault(): void }) => {
+    if (!leaveConfirmedRef.current) return;
+    leaveConfirmedRef.current = false;
+    event.preventDefault();
+    setTimeout(() => proceedBlockerRef.current(), 0);
+  }, []);
+
+  return {
+    leavePromptOpen,
+    onDialogOpenChange,
+    onCloseAutoFocus,
+    confirmLeave,
+  };
+}

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1431,6 +1431,10 @@ const messages = {
       "صِل التخزين في الشاشة التالية: Builder.io (تخزين + ذكاء اصطناعي في الخطة المجانية) أو تخزين متوافق مع S3. سيكمل Clips الحفظ.",
     connectStorageToRetryLoom:
       "صِل التخزين في الشاشة التالية: Builder.io (تخزين + ذكاء اصطناعي في الخطة المجانية) أو تخزين متوافق مع S3. سيعيد Clips محاولة الاستيراد.",
+    leaveConfirmTitle: "مغادرة هذه الصفحة وحذف التسجيل؟",
+    leaveConfirmDescription:
+      "لم يكتمل حفظ التسجيل الجاري بعد. مغادرة هذه الصفحة الآن ستؤدي إلى حذفه.",
+    leaveAndDiscard: "مغادرة وحذف",
   },
   importRoute: {
     pageTitle: "استيراد Loom — Clips",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1459,6 +1459,10 @@ Alle sichtbaren Änderungen für Clips-Nutzer werden hier dokumentiert. Du kanns
       "Verbinde Speicher im nächsten Bildschirm: Builder.io (Speicher + KI im kostenlosen Tarif) oder S3-kompatibler Speicher. Clips schließt das Speichern ab.",
     connectStorageToRetryLoom:
       "Verbinde Speicher im nächsten Bildschirm: Builder.io (Speicher + KI im kostenlosen Tarif) oder S3-kompatibler Speicher. Clips versucht den Import erneut.",
+    leaveConfirmTitle: "Diese Aufnahme verlassen und verwerfen?",
+    leaveConfirmDescription:
+      "Deine laufende Aufnahme wurde noch nicht vollständig gespeichert. Wenn du diese Seite jetzt verlässt, wird sie verworfen.",
+    leaveAndDiscard: "Verlassen und verwerfen",
   },
   importRoute: {
     pageTitle: "Loom importieren — Clips",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -1413,6 +1413,10 @@ All notable user-facing changes to Clips are documented here. Open it any time f
       "Connect storage on the next screen: Builder.io (free tier storage + AI) or S3-compatible storage. Clips will finish saving it.",
     connectStorageToRetryLoom:
       "Connect storage on the next screen: Builder.io (free tier storage + AI) or S3-compatible storage. Clips will retry the import.",
+    leaveConfirmTitle: "Leave and discard this recording?",
+    leaveConfirmDescription:
+      "Your in-progress recording hasn't finished saving. Leaving this page now will discard it.",
+    leaveAndDiscard: "Leave and discard",
   },
   importRoute: {
     pageTitle: "Import Loom — Clips",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1444,6 +1444,10 @@ Todos los cambios visibles para los usuarios de Clips se documentan aquí. Puede
       "Conecta almacenamiento en la siguiente pantalla: Builder.io (almacenamiento + IA en el plan gratuito) o almacenamiento compatible con S3. Clips terminará de guardarlo.",
     connectStorageToRetryLoom:
       "Conecta almacenamiento en la siguiente pantalla: Builder.io (almacenamiento + IA en el plan gratuito) o almacenamiento compatible con S3. Clips reintentará la importación.",
+    leaveConfirmTitle: "¿Salir y descartar esta grabación?",
+    leaveConfirmDescription:
+      "Tu grabación en curso aún no ha terminado de guardarse. Si sales de esta página ahora, se descartará.",
+    leaveAndDiscard: "Salir y descartar",
   },
   importRoute: {
     pageTitle: "Importar Loom — Clips",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1450,6 +1450,10 @@ Tous les changements visibles par les utilisateurs de Clips sont documentés ici
       "Connectez le stockage sur l’écran suivant : Builder.io (stockage + IA sur l’offre gratuite) ou stockage compatible S3. Clips terminera l’enregistrement.",
     connectStorageToRetryLoom:
       "Connectez le stockage sur l’écran suivant : Builder.io (stockage + IA sur l’offre gratuite) ou stockage compatible S3. Clips relancera l’import.",
+    leaveConfirmTitle: "Quitter et abandonner cet enregistrement ?",
+    leaveConfirmDescription:
+      "Votre enregistrement en cours n’a pas fini d’être sauvegardé. Si vous quittez cette page maintenant, il sera abandonné.",
+    leaveAndDiscard: "Quitter et abandonner",
   },
   importRoute: {
     pageTitle: "Importer Loom — Clips",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -1410,6 +1410,10 @@ Clips में उपयोगकर्ताओं को दिखने व�
       "अगली स्क्रीन पर स्टोरेज कनेक्ट करें: Builder.io (free tier storage + AI) या S3-संगत स्टोरेज. Clips सेव पूरा करेगा.",
     connectStorageToRetryLoom:
       "अगली स्क्रीन पर स्टोरेज कनेक्ट करें: Builder.io (free tier storage + AI) या S3-संगत स्टोरेज. Clips इंपोर्ट फिर से करेगा.",
+    leaveConfirmTitle: "इस रिकॉर्डिंग को छोड़कर हटाएं?",
+    leaveConfirmDescription:
+      "आपकी चल रही रिकॉर्डिंग अभी पूरी तरह सेव नहीं हुई है. अभी इस पेज से बाहर जाने पर यह हट जाएगी.",
+    leaveAndDiscard: "बाहर जाएं और हटाएं",
   },
   importRoute: {
     pageTitle: "Loom आयात करें — Clips",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1439,6 +1439,10 @@ Clips のユーザー向けの主な変更はここに記録されます。コ�
       "次の画面でストレージを接続してください: Builder.io (無料プランのストレージ + AI) または S3 互換ストレージ。Clips が保存を完了します。",
     connectStorageToRetryLoom:
       "次の画面でストレージを接続してください: Builder.io (無料プランのストレージ + AI) または S3 互換ストレージ。Clips がインポートを再試行します。",
+    leaveConfirmTitle: "このページを離れて録画を破棄しますか?",
+    leaveConfirmDescription:
+      "録画中のデータはまだ保存が完了していません。今このページを離れると破棄されます。",
+    leaveAndDiscard: "離れて破棄する",
   },
   importRoute: {
     pageTitle: "Loom をインポート — Clips",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -1422,6 +1422,10 @@ Clips의 모든 사용자 대상 변경 사항은 여기에 기록됩니다. 명
       "다음 화면에서 스토리지를 연결하세요: Builder.io(무료 티어 스토리지 + AI) 또는 S3 호환 스토리지. Clips가 저장을 완료합니다.",
     connectStorageToRetryLoom:
       "다음 화면에서 스토리지를 연결하세요: Builder.io(무료 티어 스토리지 + AI) 또는 S3 호환 스토리지. Clips가 가져오기를 다시 시도합니다.",
+    leaveConfirmTitle: "나가서 이 녹화를 삭제하시겠습니까?",
+    leaveConfirmDescription:
+      "진행 중인 녹화가 아직 저장되지 않았습니다. 지금 이 페이지를 나가면 삭제됩니다.",
+    leaveAndDiscard: "나가서 삭제",
   },
   importRoute: {
     pageTitle: "Loom 가져오기 — Clips",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1439,6 +1439,10 @@ Todas as mudanças visíveis para usuários do Clips são documentadas aqui. Voc
       "Conecte armazenamento na próxima tela: Builder.io (armazenamento + IA no plano gratuito) ou armazenamento compatível com S3. Clips terminará de salvar.",
     connectStorageToRetryLoom:
       "Conecte armazenamento na próxima tela: Builder.io (armazenamento + IA no plano gratuito) ou armazenamento compatível com S3. Clips tentará importar novamente.",
+    leaveConfirmTitle: "Sair e descartar esta gravação?",
+    leaveConfirmDescription:
+      "Sua gravação em andamento ainda não terminou de ser salva. Se você sair desta página agora, ela será descartada.",
+    leaveAndDiscard: "Sair e descartar",
   },
   importRoute: {
     pageTitle: "Importar Loom — Clips",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -1374,6 +1374,10 @@ Clips 中所有面向用户的重要更改都会记录在这里。你可以随�
       "在下一屏连接存储：Builder.io（免费套餐存储 + AI）或 S3 兼容存储。Clips 将完成保存。",
     connectStorageToRetryLoom:
       "在下一屏连接存储：Builder.io（免费套餐存储 + AI）或 S3 兼容存储。Clips 将重试导入。",
+    leaveConfirmTitle: "离开并丢弃此录制？",
+    leaveConfirmDescription:
+      "正在进行的录制尚未保存完成。现在离开此页面将丢弃它。",
+    leaveAndDiscard: "离开并丢弃",
   },
   importRoute: {
     pageTitle: "导入 Loom — Clips",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -1352,6 +1352,10 @@ const messages = {
       "在下一個畫面連線儲存：Builder.io（免費方案儲存 + AI）或 S3 相容儲存。Clips 將完成儲存。",
     connectStorageToRetryLoom:
       "在下一個畫面連線儲存：Builder.io（免費方案儲存 + AI）或 S3 相容儲存。Clips 將重試匯入。",
+    leaveConfirmTitle: "離開並捨棄此錄製？",
+    leaveConfirmDescription:
+      "進行中的錄製尚未儲存完成。現在離開此頁面將會捨棄它。",
+    leaveAndDiscard: "離開並捨棄",
   },
   importRoute: {
     pageTitle: "匯入 Loom — Clips",

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -35,6 +35,7 @@ import { Link, useLocation, useNavigate } from "react-router";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDesktopPromo } from "@/hooks/use-desktop-promo";
+import { useRecordingLeaveGuard } from "@/hooks/use-recording-leave-guard";
 import {
   fetchVideoStorageStatus,
   useVideoStorageStatus,
@@ -2518,6 +2519,22 @@ export default function RecordRoute() {
     };
   }, [extensionCapture, stopLiveTranscription]);
 
+  // In-app navigation (e.g. a Library link) unmounts this route the same way
+  // a tab close does, but the browser never fires `beforeunload` for it — so
+  // without this, the cleanup effect above ran `releaseCapture()`
+  // unconditionally and silently killed an at-risk recording. Route every
+  // in-app navigation attempt through the same `hasRecordingAtRisk()` check
+  // `warnBeforeDiscard` uses, so both exits are gated by one check instead of
+  // two divergent ones.
+  const {
+    leavePromptOpen,
+    onDialogOpenChange,
+    onCloseAutoFocus,
+    confirmLeave,
+  } = useRecordingLeaveGuard(
+    useCallback(() => !!engineRef.current?.hasRecordingAtRisk(), []),
+  );
+
   // -------------------------------------------------------------------------
   // Render.
   // -------------------------------------------------------------------------
@@ -2735,6 +2752,31 @@ export default function RecordRoute() {
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {t("recordingToolbar.discardRecording")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={leavePromptOpen} onOpenChange={onDialogOpenChange}>
+        <AlertDialogContent onCloseAutoFocus={onCloseAutoFocus}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("recordRoute.leaveConfirmTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("recordRoute.leaveConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                confirmLeave();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("recordRoute.leaveAndDiscard")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## The bug

```
400 Invalid 'input[40].content[0].file_url': string too long.
Expected a string with maximum length 1048576, but got a string with length 4149128
```

**64 events in 7 days**, every one on `POST /agent-native/gateway/v1/messages`, split across `openai-gpt-5.6-luna` and `openai-gpt5-2-20251211`. Each one kills the user's turn — OpenAI rejects the *entire* request, not just the attachment.

## Cause

Text attachments have been capped at 60k/80k chars for a long time (`MAX_TEXT_ATTACHMENT_CHARS`). **Binary attachments were never capped.** `dataUrlToFilePart` and the image branch push the client's whole base64 payload straight into the engine call:

```ts
return { type: "file", data: match[2], mediaType: …, filename: … };  // unbounded
```

The part worth noting: **the upload already succeeded.** `pre-upload-attachments` sets a hosted `url` on the attachment for exactly this reason — and the code then inlines the raw bytes anyway and discards that URL. That inverts the repo's own rule that large payloads live in blob storage and only URLs travel onward.

## Fix

Cap the encoded length at `buildUserContentWithAttachments`, the single boundary every engine routes through — so Anthropic's base64 `document`/`image` path is covered by the same change rather than needing a second patch in `translate-anthropic.ts`.

Over the cap, the attachment becomes the URL-reference text hint the unsupported-format branch already uses. The model is told what happened and where the file is, instead of being handed a turn where the attachment silently vanished. With no URL available, it says that explicitly rather than dropping it.

Counting encoded chars rather than decoded bytes because OpenAI's limit is on the `file_url` string itself; the cap sits under it to leave room for the `data:<mediaType>;base64,` prefix.

## Tests

Three cases: an oversized image is not inlined and its URL is surfaced, a normal image still inlines, and an oversized file with no URL says so. Verified they fail with the cap disabled (`2 failed | 29 passed`) and pass with it (`31 passed`).

`pnpm guards` 55/55, `tsc --noEmit` clean.

## Context

Third fix today in the same class — the provider rejects the request outright and the gateway folds it into an opaque 500, so it reads as "chat is broken" with no usable signal. The other two were `oneOf` (#3045) and type-less schema positions (#3047).
