### PR TITLE
Disable cron job polling by default

### DIFF
--- a/packages/core/docs/content/recurring-jobs.mdx
+++ b/packages/core/docs/content/recurring-jobs.mdx
@@ -233,6 +233,19 @@ The scheduler is a framework plugin (the internal `processRecurringJobs()` routi
 
 </Callout>
 
+<Callout id="doc-block-rj3" tone="warning">
+
+**Opt-in on hosted Netlify deploys.** The build emits a Netlify scheduled function that wakes a background sweep once a minute for the life of the deploy — whether or not the app defines a single job. Because that cost is paid even by apps with no recurring work, it ships only when you ask for it: set **`AGENT_NATIVE_ENABLE_RECURRING_JOBS=true`**. Without it, no cron is registered and scheduled jobs never fire on Netlify. `AGENT_NATIVE_DISABLE_RECURRING_JOBS=1` remains a kill switch and wins if both are set.
+
+This flag is read **while the build runs**, not at runtime — it decides whether the scheduled function is emitted at all. Set it wherever your build environment lives:
+
+- **Builder-hosted (Fusion) projects** — Project Settings → Hosting → **Build environment variables**, or `hosting.environment.build` in `builder.config.json`. The build runs in Builder's deploy pod and Netlify only receives finished artifacts, so a **Production** environment variable arrives too late to have any effect.
+- **Git-connected Netlify sites** (Netlify runs the build itself) — a site environment variable scoped to builds, or `[build.environment]` in `netlify.toml`.
+
+The function's runtime still needs `A2A_SECRET` to sign the sweep handoff; that one belongs in the production/runtime environment.
+
+</Callout>
+
 ## Debugging a job {#debugging}
 
 - Open the automation's details in **Automations**, or inspect

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -52,6 +52,7 @@ import {
   isIntegrationDurableDispatchDeployEnabled,
   isKeepWarmBackgroundDeployEnabled,
   isKeepWarmDeployEnabled,
+  isRecurringJobsDeployEnabled,
   resolveKeepWarmSchedule,
   NETLIFY_RECURRING_JOBS_FUNCTION_NAME,
   NITRO_RUNTIME_IGNORE_PATTERNS,
@@ -1954,6 +1955,7 @@ describe("durable-background Netlify function emit (single-template, default-on)
   let previousWorkspaceFlag: string | undefined;
   let previousViteWorkspaceFlag: string | undefined;
   let previousDisableRecurringJobs: string | undefined;
+  let previousEnableRecurringJobs: string | undefined;
   let previousEnableKeepWarm: string | undefined;
   let previousAppBasePath: string | undefined;
   let previousViteAppBasePath: string | undefined;
@@ -1964,6 +1966,8 @@ describe("durable-background Netlify function emit (single-template, default-on)
     previousViteWorkspaceFlag = process.env.VITE_AGENT_NATIVE_WORKSPACE;
     previousDisableRecurringJobs =
       process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS;
+    previousEnableRecurringJobs =
+      process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS;
     previousEnableKeepWarm = process.env.AGENT_NATIVE_ENABLE_KEEP_WARM;
     previousAppBasePath = process.env.APP_BASE_PATH;
     previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
@@ -1971,6 +1975,7 @@ describe("durable-background Netlify function emit (single-template, default-on)
     delete process.env.AGENT_NATIVE_WORKSPACE;
     delete process.env.VITE_AGENT_NATIVE_WORKSPACE;
     delete process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS;
+    delete process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS;
     delete process.env.AGENT_NATIVE_ENABLE_KEEP_WARM;
     delete process.env.APP_BASE_PATH;
     delete process.env.VITE_APP_BASE_PATH;
@@ -1987,6 +1992,10 @@ describe("durable-background Netlify function emit (single-template, default-on)
     restoreEnv(
       "AGENT_NATIVE_DISABLE_RECURRING_JOBS",
       previousDisableRecurringJobs,
+    );
+    restoreEnv(
+      "AGENT_NATIVE_ENABLE_RECURRING_JOBS",
+      previousEnableRecurringJobs,
     );
     restoreEnv("AGENT_NATIVE_ENABLE_KEEP_WARM", previousEnableKeepWarm);
     restoreEnv("APP_BASE_PATH", previousAppBasePath);
@@ -2145,6 +2154,7 @@ describe("durable-background Netlify function emit (single-template, default-on)
   });
 
   it("emits a durable recurring-job handoff beside the background worker", () => {
+    process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS = "1";
     const cwd = setupNetlifyOutput();
 
     emitSingleTemplateNetlifyBackgroundFunction(cwd);
@@ -2173,6 +2183,53 @@ describe("durable-background Netlify function emit (single-template, default-on)
     // includedFiles is declared.
     expect(entry).toContain('import { createHmac } from "node:crypto"');
     expect(entry).toContain('includedFiles: ["**"]');
+  });
+
+  describe("recurring-jobs opt-in", () => {
+    function recurringJobsDir(cwd: string): string {
+      return path.join(
+        cwd,
+        ".netlify",
+        "functions-internal",
+        NETLIFY_RECURRING_JOBS_FUNCTION_NAME,
+      );
+    }
+
+    it("is OFF BY DEFAULT so a deploy with no jobs gets no once-a-minute cron", () => {
+      expect(isRecurringJobsDeployEnabled()).toBe(false);
+    });
+
+    it("requires a truthy explicit opt-in flag", () => {
+      for (const value of ["", "0", "false", "no", "off", "maybe"]) {
+        process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS = value;
+        expect(isRecurringJobsDeployEnabled()).toBe(false);
+      }
+      for (const value of ["1", "true", "TRUE", " yes ", "on"]) {
+        process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS = value;
+        expect(isRecurringJobsDeployEnabled()).toBe(true);
+      }
+    });
+
+    it("emits nothing until recurring jobs are explicitly enabled", () => {
+      const cwd = setupNetlifyOutput();
+
+      emitSingleTemplateNetlifyBackgroundFunction(cwd);
+      emitSingleTemplateNetlifyRecurringJobsFunction(cwd);
+
+      expect(fs.existsSync(recurringJobsDir(cwd))).toBe(false);
+    });
+
+    it("keeps the compatibility disable flag winning over the opt-in", () => {
+      process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS = "1";
+      process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS = "1";
+      expect(isRecurringJobsDeployEnabled()).toBe(false);
+
+      const cwd = setupNetlifyOutput();
+      emitSingleTemplateNetlifyBackgroundFunction(cwd);
+      emitSingleTemplateNetlifyRecurringJobsFunction(cwd);
+
+      expect(fs.existsSync(recurringJobsDir(cwd))).toBe(false);
+    });
   });
 
   describe("keep-warm opt-in and cadence", () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -2857,8 +2857,25 @@ function isDisabledByEnv(name: string): boolean {
   return isTruthyEnv(name);
 }
 
+/**
+ * Recurring jobs are opt-in because the emitted Netlify scheduled function
+ * fires once a minute for the lifetime of the deploy whether or not the app has
+ * a single job defined. A deploy with no recurring jobs was paying ~1,440
+ * wake-ups a day — each one a background-function invocation — for a sweep that
+ * had nothing to scan. `AGENT_NATIVE_DISABLE_RECURRING_JOBS` remains a
+ * compatibility kill switch and wins when both flags are set.
+ *
+ * This gate is read while the BUILD runs, not at runtime. On Builder-hosted
+ * (Fusion) projects the build happens in the deploy pod and Netlify only
+ * receives finished artifacts, so the flag belongs in the project's *build*
+ * environment variables — a production/runtime env var arrives too late to
+ * affect whether the scheduled function was emitted.
+ */
 export function isRecurringJobsDeployEnabled(): boolean {
-  return !isDisabledByEnv("AGENT_NATIVE_DISABLE_RECURRING_JOBS");
+  return (
+    isTruthyEnv("AGENT_NATIVE_ENABLE_RECURRING_JOBS") &&
+    !isDisabledByEnv("AGENT_NATIVE_DISABLE_RECURRING_JOBS")
+  );
 }
 
 /**

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -25,6 +25,7 @@ let previousNetlify: string | undefined;
 let previousNetlifyLocal: string | undefined;
 let previousIntegrationDurableDispatch: string | undefined;
 let previousDisableRecurringJobs: string | undefined;
+let previousEnableRecurringJobs: string | undefined;
 let previousNitroPreset: string | undefined;
 let previousVercel: string | undefined;
 let previousViteWorkspaceAppsJson: string | undefined;
@@ -69,6 +70,7 @@ beforeEach(() => {
     process.env.AGENT_INTEGRATION_DURABLE_DISPATCH;
   previousDisableRecurringJobs =
     process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS;
+  previousEnableRecurringJobs = process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS;
   previousNitroPreset = process.env.NITRO_PRESET;
   previousVercel = process.env.VERCEL;
   previousViteWorkspaceAppsJson =
@@ -102,6 +104,7 @@ beforeEach(() => {
   delete process.env.NETLIFY_LOCAL;
   delete process.env.AGENT_INTEGRATION_DURABLE_DISPATCH;
   delete process.env.AGENT_NATIVE_DISABLE_RECURRING_JOBS;
+  delete process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS;
   delete process.env.NITRO_PRESET;
   delete process.env.VERCEL;
   delete process.env.VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON;
@@ -136,6 +139,10 @@ afterEach(() => {
   restoreEnv(
     "AGENT_NATIVE_DISABLE_RECURRING_JOBS",
     previousDisableRecurringJobs,
+  );
+  restoreEnv(
+    "AGENT_NATIVE_ENABLE_RECURRING_JOBS",
+    previousEnableRecurringJobs,
   );
   restoreEnv("NITRO_PRESET", previousNitroPreset);
   restoreEnv("VERCEL", previousVercel);
@@ -1314,6 +1321,12 @@ describe("durable-background Netlify function emit (workspace, flag-gated)", () 
     // Default-on: the flag is unset (deleted in beforeEach) and the 15-min
     // `-background` function MUST still be emitted so the worker gets the real
     // long budget instead of overshooting the ~60s synchronous wall.
+    //
+    // Recurring jobs are opted IN explicitly here only so this test can also
+    // assert the shape of the emitted sweep entry. The `-background` default-on
+    // claim above does not depend on it — durable background is default-on on
+    // its own flag (see the recurring-jobs-off-by-default test below).
+    process.env.AGENT_NATIVE_ENABLE_RECURRING_JOBS = "1";
     makeWorkspaceApp(tmpDir, "dispatch");
     makeWorkspaceApp(tmpDir, "starter");
 
@@ -1418,6 +1431,26 @@ describe("durable-background Netlify function emit (workspace, flag-gated)", () 
         ),
       ),
     ).toBe(true);
+  });
+
+  it("emits NO recurring-jobs cron BY DEFAULT (opt-in), for any app", async () => {
+    // The emitted sweep fires once a minute for the life of the deploy whether
+    // or not the app has a job defined, so it must not ship unasked.
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "starter");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      args: ["--preset=netlify", "--build-only"],
+      execFile: execFile as typeof execFileSync,
+    });
+
+    for (const app of ["dispatch", "starter"]) {
+      expect(fs.existsSync(recurringFuncDir(app))).toBe(false);
+    }
+    // ...while the durable background function is untouched by the change: it is
+    // default-on under its own flag.
+    expect(fs.existsSync(backgroundFuncDir("starter"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
This PR makes it so the cron job polling is disabled by default in agent native. It can be enabled via a per-project environment variable.

To enable it, go to Project Settings → Hosting → Build environment variables, and set AGENT_NATIVE_ENABLE_RECURRING_JOBS=true.