### PR TITLE
fix(core): sanitize every tool schema at the engine boundary

### DIFF
--- a/.changeset/tool-schema-seam.md
+++ b/.changeset/tool-schema-seam.md
@@ -1,0 +1,9 @@
+---
+"@agent-native/core": patch
+---
+
+Sanitize every tool schema at the engine boundary, not just `defineAction` ones.
+Hand-written tools (extensions, MCP, context tools) and third-party MCP server
+schemas bypassed the sanitizer entirely, so `extension-data-set` shipped a `data`
+property with no `type` and OpenAI 400'd the whole request — every tool in the
+payload, not just that one.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -1238,7 +1238,7 @@ const TYPE_SUBSTITUTE_KEYS = [
   "not",
 ] as const;
 
-function stripUnsupportedSchemaKeywords<T>(node: T): T {
+export function stripUnsupportedSchemaKeywords<T>(node: T): T {
   if (!node || typeof node !== "object" || Array.isArray(node)) return node;
   const obj = node as Record<string, unknown>;
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -17,6 +17,7 @@ import {
   isAgentActionStopError,
   type ActionAutomationContext,
   type ActionCaller,
+  stripUnsupportedSchemaKeywords,
 } from "../action.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import { isReadOnlyShellCommand } from "../coding-tools/index.js";
@@ -3501,19 +3502,42 @@ function extractToolSearchResultNamesFromMessages(
   return names;
 }
 
+/**
+ * Every tool the model is offered passes through here -- `defineAction`
+ * schemas, the hand-written ones in extensions/mcp/context tools, and whatever
+ * a third-party MCP server advertises. `defineAction` sanitizes at
+ * construction; nothing else did, so `extension-data-set` shipped a `data`
+ * property carrying a description and no `type`, and OpenAI 400'd the whole
+ * request -- every tool in the payload, not just that one. Sanitizing here is
+ * what makes that unrepresentable rather than a thing each definition site has
+ * to remember.
+ *
+ * Cloned first: the hand-written schemas are module constants, so rewriting in
+ * place would mutate shared state on first use.
+ */
 function normalizeToolInputSchema(
   schema: ActionTool["parameters"] | undefined,
 ): EngineTool["inputSchema"] | null {
   if (!schema) return { type: "object", properties: {} };
   if (schema.type !== "object") return null;
+  type ToolParams = NonNullable<ActionTool["parameters"]>;
+  let cloned: ToolParams;
+  try {
+    cloned = JSON.parse(JSON.stringify(schema)) as ToolParams;
+  } catch {
+    // A schema that will not round-trip cannot be safely rewritten, and
+    // shipping it unsanitized is how this class of 400 reaches the provider.
+    return null;
+  }
+  const safe = stripUnsupportedSchemaKeywords(cloned);
   return {
-    ...schema,
+    ...safe,
     type: "object",
     properties:
-      schema.properties && typeof schema.properties === "object"
-        ? schema.properties
+      safe.properties && typeof safe.properties === "object"
+        ? safe.properties
         : {},
-    required: Array.isArray(schema.required) ? schema.required : [],
+    required: Array.isArray(safe.required) ? safe.required : [],
   };
 }
 

--- a/packages/core/src/agent/tool-schema-seam.spec.ts
+++ b/packages/core/src/agent/tool-schema-seam.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { stripUnsupportedSchemaKeywords } from "../action.js";
+
+// `extension-data-set` shipped this exact shape: a hand-written tool schema
+// whose `data` property carried a description and no `type`. OpenAI answers
+// that with "schema must have a 'type' key" and 400s the WHOLE request -- every
+// tool in the payload -- so one such property breaks all chat in the app.
+// defineAction sanitized at construction; hand-written tools never did.
+describe("hand-written tool schemas", () => {
+  it("gives a description-only property a concrete type union", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        extensionId: { type: "string" },
+        data: { description: "The data value to store." },
+      },
+      required: ["extensionId", "data"],
+    };
+    const safe = stripUnsupportedSchemaKeywords(
+      JSON.parse(JSON.stringify(schema)),
+    ) as any;
+    expect(Array.isArray(safe.properties.data.anyOf)).toBe(true);
+    expect(safe.properties.data.anyOf.map((b: any) => b.type)).toContain(
+      "string",
+    );
+    // An already-typed sibling is untouched.
+    expect(safe.properties.extensionId).toEqual({ type: "string" });
+  });
+
+  it("leaves every subschema position typed or composed", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        anything: {},
+        nested: { type: "object", properties: { inner: {} } },
+        listed: { type: "array", items: {} },
+      },
+    };
+    const safe = stripUnsupportedSchemaKeywords(
+      JSON.parse(JSON.stringify(schema)),
+    ) as any;
+    const TYPED = ["type", "anyOf", "oneOf", "allOf", "enum", "const", "$ref"];
+    const bad: string[] = [];
+    const walk = (n: any, path: string) => {
+      if (!n || typeof n !== "object" || Array.isArray(n)) return;
+      if (!TYPED.some((k) => n[k] !== undefined)) bad.push(path);
+      if (n.items && typeof n.items === "object") walk(n.items, `${path}.items`);
+      if (n.properties)
+        for (const [k, v] of Object.entries(n.properties))
+          walk(v, `${path}.${k}`);
+      if (Array.isArray(n.anyOf))
+        n.anyOf.forEach((b: any, i: number) => walk(b, `${path}.anyOf[${i}]`));
+    };
+    walk(safe, "$");
+    expect(bad).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Observed in production **after** the earlier fixes deployed

```
[18:28:01, deploy 8cab23692 live at 18:26:25]
400 Invalid schema for function 'extension-data-set':
In context=('properties','data'), schema must have a 'type' key
```

Analytics chat was still failing with all three schema fixes live. This is why.

## What the earlier fixes missed

`defineAction` sanitizes its schema at construction (`schemaToJsonSchema` → `stripUnsupportedSchemaKeywords`). **Nothing else does.**

- hand-written tools in `extensions/actions.ts`, `mcp/builtin-tools.ts`, `server/agent-chat/context-tools.ts`
- anything a third-party MCP server advertises

`extension-data-set` declares:

```ts
data: {
  description: "The data value to store. Objects are JSON-serialized automatically.",
},
```

No `type`. OpenAI rejects the **entire request** for that — every tool in the payload, not just this one — so one unsanitized property in one hand-written tool breaks all chat in the app. That is exactly the blast radius `oneOf` had.

## Fix

`normalizeToolInputSchema` (`production-agent.ts:3504`) is the single seam every offered tool passes through on its way to `EngineTool.inputSchema` — `defineAction`, hand-written, and MCP alike. Sanitizing there makes this class unrepresentable instead of something each definition site has to remember.

Cloned before rewriting: those hand-written schemas are module constants, so in-place mutation would alter shared state on first use. A schema that will not round-trip returns `null` rather than shipping unsanitized — the failure that reaches the provider is the one worth being loud about.

## My mistake

I found this gap in the earlier sweep and wrote that `context-tools.ts` "bypasses the stripper… clean today". I checked whether *those particular* tools had bad schemas and never asked which *other* hand-written tools bypass the same boundary. `extension-data-set` did, and it was live the whole time.

## Tests

Two cases: a description-only property gets a concrete type union (and a typed sibling is untouched), and a full walk of every subschema position asserts none is left bare.

`tsc --noEmit` clean against `origin/main` in an isolated worktree — the shared checkout has a peer's in-flight merge, so this was built and verified away from it.
