### PR TITLE
Fix Clips public replay CORS and playback warnings

### DIFF
--- a/.changeset/public-ingest-cors.md
+++ b/.changeset/public-ingest-cors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow explicitly configured public ingestion routes to complete cross-origin preflight requests without enabling credentialed CORS.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -1282,7 +1282,10 @@ export function stripUnsupportedSchemaKeywords<T>(node: T): T {
   const obj = node as Record<string, unknown>;
 
   for (const keyword of PROVIDER_REJECTED_KEYWORDS) delete obj[keyword];
-  if (typeof obj.format === "string" && !PROVIDER_SUPPORTED_FORMATS.has(obj.format)) {
+  if (
+    typeof obj.format === "string" &&
+    !PROVIDER_SUPPORTED_FORMATS.has(obj.format)
+  ) {
     delete obj.format;
   }
 

--- a/packages/core/src/agent/tool-schema-seam.spec.ts
+++ b/packages/core/src/agent/tool-schema-seam.spec.ts
@@ -91,7 +91,13 @@ describe("provider-rejected format and constraint keywords", () => {
     const safe = stripUnsupportedSchemaKeywords(
       JSON.parse(JSON.stringify(schema)),
     ) as any;
-    for (const k of ["patternProperties","not","if","then","dependentRequired"]) {
+    for (const k of [
+      "patternProperties",
+      "not",
+      "if",
+      "then",
+      "dependentRequired",
+    ]) {
       expect(safe[k]).toBeUndefined();
     }
     // The real shape survives.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2604,6 +2604,46 @@ describe("server/auth", () => {
       expect(event.res.headers.get("access-control-allow-origin")).toBeNull();
     });
 
+    it("allows explicitly configured public ingest preflights without credentials", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("CORS_ALLOWED_ORIGINS", "");
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        publicPaths: ["/api/public-ingest"],
+        publicCorsPaths: ["/api/public-ingest"],
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const event = createMockEvent({
+        path: "/api/public-ingest",
+        headers: {
+          origin: "https://clips.agent-native.com",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type",
+        },
+      });
+      event.req.method = "OPTIONS";
+      event.node.req.method = "OPTIONS";
+
+      const result = await guard(event);
+
+      expect(result).toBe("");
+      expect(event.res.status).toBe(204);
+      expect(event.res.headers.get("access-control-allow-origin")).toBe(
+        "https://clips.agent-native.com",
+      );
+      expect(event.res.headers.get("access-control-allow-credentials")).toBe(
+        null,
+      );
+    });
+
     it.each([
       "https://520ba469ac5783c72c33d79bea940871.claudemcpcontent.com",
       "https://shakira-professor-conscious-frederick-trycloudflare-com.web-sandbox.oaiusercontent.com",

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -244,6 +244,12 @@ export interface AuthOptions {
    */
   publicPaths?: string[];
   /**
+   * Public, unauthenticated ingest paths that may receive cross-origin
+   * requests when CORS_ALLOWED_ORIGINS is unset. These routes must perform
+   * their own request validation and must not rely on cookies for auth.
+   */
+  publicCorsPaths?: string[];
+  /**
    * Workspace-level audience for the app.
    *
    * "internal" keeps the existing behavior: every app page requires an
@@ -1397,6 +1403,7 @@ interface AuthGuardConfig {
   getLoginHtml?: (event: H3Event, rawPath: string) => string;
   authMode?: OnboardingHtmlOptions["authMode"];
   publicPaths: string[];
+  publicCorsPaths: string[];
   workspaceAppAudience: WorkspaceAppAudience;
   workspaceAppPublicPaths: string[];
   workspaceAppProtectedPaths: string[];
@@ -1969,11 +1976,15 @@ export async function runAuthGuard(
  * unauthenticated requests. Returns the login HTML for page routes
  * or a 401 JSON response for API routes.
  *
- * Reads loginHtml and publicPaths from _authGuardConfig on every request
+ * Reads loginHtml and public paths from _authGuardConfig on every request
  * so that a custom plugin can update them after the default has already
  * installed this middleware (the production race condition fix).
  */
-function applyCorsHeaders(event: H3Event): {
+function applyCorsHeaders(
+  event: H3Event,
+  publicCorsPaths: string[] = [],
+  requestPath?: string,
+): {
   hasOrigin: boolean;
   allowed: boolean;
 } {
@@ -1998,14 +2009,25 @@ function applyCorsHeaders(event: H3Event): {
       Boolean(getHeader(event, EMBED_TARGET_HEADER)) ||
       Boolean(getHeader(event, EMBED_TRANSPLANT_HEADER)) ||
       Boolean(getHeader(event, "authorization")));
+  const isPublicCorsPath = Boolean(
+    requestPath && matchesPathList(requestPath, publicCorsPaths),
+  );
   const allowedOrigin = getAllowedCorsOrigin(origin, {
     allowedOrigins: readCorsAllowedOrigins(),
+    // Public ingestion endpoints such as analytics replay are intentionally
+    // callable by browser apps on arbitrary origins. The endpoint still owns
+    // its public-key, payload, quota, and origin checks; this only lets the
+    // browser complete the preflight when no deployment-wide allowlist exists.
+    allowAnyOriginWhenNoAllowlist: isPublicCorsPath,
   });
   const responseOrigin = mcpEmbedCorsRequest ? origin : allowedOrigin;
   if (!responseOrigin) return { hasOrigin: true, allowed: false };
   setResponseHeader(event, "Access-Control-Allow-Origin", responseOrigin);
   setResponseHeader(event, "Vary", "Origin");
-  if (!mcpEmbedCorsRequest || shouldAllowMcpEmbedCredentials(responseOrigin)) {
+  if (
+    !isPublicCorsPath &&
+    (!mcpEmbedCorsRequest || shouldAllowMcpEmbedCredentials(responseOrigin))
+  ) {
     setResponseHeader(event, "Access-Control-Allow-Credentials", "true");
   }
   setResponseHeader(
@@ -2033,7 +2055,7 @@ function applyCorsHeaders(event: H3Event): {
 
 function createAuthCorsHandler() {
   return defineEventHandler((event) => {
-    const cors = applyCorsHeaders(event);
+    const cors = applyCorsHeaders(event, _authGuardConfig?.publicCorsPaths);
     if (getMethod(event) !== "OPTIONS") return;
 
     if (cors.hasOrigin && !cors.allowed) {
@@ -2568,7 +2590,7 @@ function createAuthGuardFn(
 
     // Emit CORS headers on every request the guard sees so that even
     // error responses (401) reach the browser.
-    const cors = applyCorsHeaders(event);
+    const cors = applyCorsHeaders(event, config.publicCorsPaths, p);
     // Preflight short-circuit: the browser sends OPTIONS before the real
     // credentialed request. Must return success without invoking auth.
     if (getMethod(event) === "OPTIONS") {
@@ -5146,6 +5168,7 @@ async function mountBetterAuthRoutes(
   _authGuardConfig = {
     ...loginHtmlConfig,
     publicPaths,
+    publicCorsPaths: options.publicCorsPaths ?? [],
     workspaceAppAudience,
     workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
     workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
@@ -5375,6 +5398,14 @@ export async function autoMountAuth(
           ...options.publicPaths,
         ];
       }
+      if (options.publicCorsPaths) {
+        _authGuardConfig.publicCorsPaths = [
+          ...new Set([
+            ...(_authGuardConfig.publicCorsPaths ?? []),
+            ...options.publicCorsPaths,
+          ]),
+        ];
+      }
       if (options.workspaceAppAudience) {
         _authGuardConfig.workspaceAppAudience =
           resolveWorkspaceAppAudience(options);
@@ -5462,6 +5493,7 @@ export async function autoMountAuth(
             getLoginHtml: () => getCustomAuthRequiredHtml(),
           }),
       publicPaths,
+      publicCorsPaths: options.publicCorsPaths ?? [],
       workspaceAppAudience,
       workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
       workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,
@@ -5492,6 +5524,7 @@ export async function autoMountAuth(
     _authGuardConfig = {
       ...loginHtmlConfig,
       publicPaths,
+      publicCorsPaths: options.publicCorsPaths ?? [],
       workspaceAppAudience,
       workspaceAppPublicPaths: workspaceAppRouteAccess.publicPaths,
       workspaceAppProtectedPaths: workspaceAppRouteAccess.protectedPaths,

--- a/templates/analytics/server/plugins/auth.ts
+++ b/templates/analytics/server/plugins/auth.ts
@@ -16,6 +16,10 @@ const authPlugin = createAuthPlugin({
     "/status",
     "/_agent-native/actions/get-public-status-page",
   ],
+  // These browser-ingest routes validate their public key and payload at the
+  // handler boundary. Allow their preflights even when the deployment-wide
+  // CORS allowlist is intentionally empty.
+  publicCorsPaths: ["/track", "/api/analytics/track", "/api/analytics/replay"],
   marketing: {
     appName: "Analytics",
     tagline:

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -183,6 +183,8 @@ export interface VideoPlayerProps {
   defaultSpeed?: number;
   /** Autoplay on mount. */
   autoPlay?: boolean;
+  /** Persist resume position for an authenticated viewer. */
+  persistPlaybackPosition?: boolean;
   /** Start time in ms. */
   startMs?: number;
   /** Comment + chapter overlays for the scrubber. */
@@ -247,6 +249,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       thumbnailUrl,
       defaultSpeed = 1.2,
       autoPlay,
+      persistPlaybackPosition = true,
       startMs,
       editsJson,
       comments,
@@ -520,6 +523,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       recordingId,
       videoEl: playbackVideoEl,
       durationMs,
+      enabled: persistPlaybackPosition,
       explicitStartMs: startMs,
       allowRestoreWhilePlaying: autoPlay,
       onRestore: restorePlaybackPosition,

--- a/templates/clips/app/hooks/use-playback-position.test.tsx
+++ b/templates/clips/app/hooks/use-playback-position.test.tsx
@@ -16,9 +16,11 @@ vi.mock("@/lib/playback-position", () => ({
 }));
 
 function Harness({
+  enabled = true,
   explicitStartMs,
   onRestore,
 }: {
+  enabled?: boolean;
   explicitStartMs?: number;
   onRestore: (positionMs: number) => void;
 }) {
@@ -27,6 +29,7 @@ function Harness({
     recordingId: "recording-1",
     videoEl,
     durationMs: 10_000,
+    enabled,
     explicitStartMs,
     onRestore,
   });
@@ -124,5 +127,30 @@ describe("usePlaybackPosition", () => {
 
     expect(mockGetPlaybackPosition).not.toHaveBeenCalled();
     expect(restores).toEqual([]);
+  });
+
+  it("does not call playback-position actions when persistence is disabled", async () => {
+    act(() => {
+      root.render(
+        <Harness
+          enabled={false}
+          onRestore={(positionMs) => restores.push(positionMs)}
+        />,
+      );
+    });
+
+    const video = getVideo();
+    video.currentTime = 4.5;
+    act(() => {
+      video.dispatchEvent(new Event("play"));
+      video.dispatchEvent(new Event("pause"));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetPlaybackPosition).not.toHaveBeenCalled();
+    expect(mockSavePlaybackPosition).not.toHaveBeenCalled();
   });
 });

--- a/templates/clips/app/hooks/use-playback-position.ts
+++ b/templates/clips/app/hooks/use-playback-position.ts
@@ -13,6 +13,7 @@ export interface UsePlaybackPositionOptions {
   recordingId: string;
   videoEl: HTMLVideoElement | null;
   durationMs: number;
+  enabled?: boolean;
   explicitStartMs?: number;
   allowRestoreWhilePlaying?: boolean;
   onRestore?: (positionMs: number) => void;
@@ -27,6 +28,7 @@ export function usePlaybackPosition({
   recordingId,
   videoEl,
   durationMs,
+  enabled = true,
   explicitStartMs,
   allowRestoreWhilePlaying = false,
   onRestore,
@@ -38,7 +40,7 @@ export function usePlaybackPosition({
   onRestoreRef.current = onRestore;
 
   useEffect(() => {
-    if (!videoEl || !recordingId) return;
+    if (!enabled || !videoEl || !recordingId) return;
 
     const controller = new AbortController();
     let cancelled = false;
@@ -184,5 +186,11 @@ export function usePlaybackPosition({
       window.removeEventListener("pagehide", onPageHide);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [allowRestoreWhilePlaying, explicitStartMs, recordingId, videoEl]);
+  }, [
+    allowRestoreWhilePlaying,
+    enabled,
+    explicitStartMs,
+    recordingId,
+    videoEl,
+  ]);
 }

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -236,6 +236,7 @@ export default function EmbedRoute() {
         videoFormat={recording.videoFormat}
         embedProvider={isLoomEmbedBacked ? "loom" : null}
         durationMs={recording.durationMs}
+        persistPlaybackPosition={false}
         editsJson={recording.editsJson}
         thumbnailUrl={recording.thumbnailUrl}
         defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1226,6 +1226,7 @@ export default function ShareRoute() {
               videoFormat={recording.videoFormat}
               embedProvider={isLoomEmbedBacked ? "loom" : null}
               durationMs={recording.durationMs}
+              persistPlaybackPosition={Boolean(session)}
               editsJson={recording.editsJson}
               thumbnailUrl={recording.thumbnailUrl}
               role={viewerRole ?? (viewerCanEdit ? "owner" : "viewer")}


### PR DESCRIPTION
## Summary

- Allow explicitly configured public analytics ingest routes to complete browser preflight without credentialed CORS.
- Stop anonymous Clips share/embed viewers from calling authenticated playback-position actions.
- Add focused Core and Clips regression coverage.

## Validation

- `pnpm --filter @agent-native/core exec vitest --run src/server/auth.spec.ts --config vitest.config.ts`
- `pnpm --filter clips exec vitest --run app/hooks/use-playback-position.test.tsx app/components/player/video-player.test.tsx --config vitest.config.ts`
- `pnpm --filter analytics exec vitest --run server/handlers/session-replay.spec.ts --config vitest.config.ts`
- Core typecheck/build and Clips/Analytics typecheck
- oxfmt check