### PR TITLE
fix(core): restore formatter compliance

### DIFF
--- a/.changeset/format-core-files.md
+++ b/.changeset/format-core-files.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore formatter compliance in core schema sanitization code.

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -1282,7 +1282,10 @@ export function stripUnsupportedSchemaKeywords<T>(node: T): T {
   const obj = node as Record<string, unknown>;
 
   for (const keyword of PROVIDER_REJECTED_KEYWORDS) delete obj[keyword];
-  if (typeof obj.format === "string" && !PROVIDER_SUPPORTED_FORMATS.has(obj.format)) {
+  if (
+    typeof obj.format === "string" &&
+    !PROVIDER_SUPPORTED_FORMATS.has(obj.format)
+  ) {
     delete obj.format;
   }
 

--- a/packages/core/src/agent/tool-schema-seam.spec.ts
+++ b/packages/core/src/agent/tool-schema-seam.spec.ts
@@ -91,7 +91,13 @@ describe("provider-rejected format and constraint keywords", () => {
     const safe = stripUnsupportedSchemaKeywords(
       JSON.parse(JSON.stringify(schema)),
     ) as any;
-    for (const k of ["patternProperties","not","if","then","dependentRequired"]) {
+    for (const k of [
+      "patternProperties",
+      "not",
+      "if",
+      "then",
+      "dependentRequired",
+    ]) {
       expect(safe[k]).toBeUndefined();
     }
     // The real shape survives.


### PR DESCRIPTION
## Summary
- restore Oxfmt compliance in core schema sanitization code
- add the required core patch changeset

## Validation
- pnpm fmt:check
- pnpm oxlint
- pnpm --filter @agent-native/core exec vitest --run src/agent/tool-schema-seam.spec.ts --config vitest.config.ts

The full local typecheck was attempted but could not run cleanly in the fresh --ignore-scripts checkout because generated package dist exports were unavailable; CI build/cache setup is the authoritative check.