### PR TITLE
Keep the Vite restart page polling through first boot

### DIFF
--- a/.changeset/nitro-startup-retry-until-ready.md
+++ b/.changeset/nitro-startup-retry-until-ready.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the Vite "dev server is restarting" page polling until Nitro answers instead of stopping after five 1-second reloads during a multi-minute first boot.

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -128,9 +128,12 @@ describe("Nitro dev startup recovery", () => {
     expect(res.statusCode).toBe(503);
     expect(res.setHeader).toHaveBeenCalledWith("retry-after", "1");
     const html = res.end.mock.calls[0]?.[0] as string;
-    expect(html).toContain("__agent_native_nitro_startup_retry");
-    expect(html).toContain("Retrying in one second");
-    expect(html).toContain("Refresh when it is ready");
+    expect(html).toContain("Waiting for the dev server");
+    expect(html).toContain("first boot can take a couple of minutes");
+    expect(html).toContain("res.status !== 503");
+    expect(html).toContain("fetch(location.href");
+    expect(html).not.toContain("sessionStorage");
+    expect(html).not.toContain("Refresh when it is ready");
     expect(html).not.toContain('http-equiv="refresh"');
   });
 

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -2780,10 +2780,9 @@ type NitroModuleGraph = {
 
 const NITRO_STARTUP_SETTLE_MS = 1_000;
 const NITRO_STARTUP_TIMEOUT_MS = 30_000;
-const NITRO_STARTUP_RETRY_KEY = "__agent_native_nitro_startup_retry";
-const NITRO_STARTUP_RETRY_MAX = 5;
 const NITRO_STARTUP_RETRY_DELAY_MS = 1_000;
-const NITRO_STARTUP_RETRY_RESET_MS = 15_000;
+const NITRO_STARTUP_RETRY_MAX_DELAY_MS = 3_000;
+const NITRO_STARTUP_SLOW_HINT_MS = 8_000;
 
 function nitroModuleGraphSignature(environment: unknown): string | null {
   const graph = (environment as { moduleGraph?: NitroModuleGraph } | undefined)
@@ -2818,6 +2817,9 @@ function sendNitroStartingResponse(
   req: IncomingMessage,
   res: ServerResponse,
 ): void {
+  // Fetch-poll this URL instead of location.reload(). Reloading after the
+  // startup gate opens stacks Nitro SSR compiles, and a 5-reload cap left
+  // the tab stuck on this page for the rest of a multi-minute first boot.
   res.statusCode = 503;
   res.setHeader("cache-control", "no-store");
   res.setHeader("content-type", "text/html; charset=utf-8");
@@ -2846,42 +2848,38 @@ function sendNitroStartingResponse(
     </main>
     <script>
       (() => {
-        const key = ${JSON.stringify(NITRO_STARTUP_RETRY_KEY)};
-        const maxRetries = ${NITRO_STARTUP_RETRY_MAX};
-        const resetAfterMs = ${NITRO_STARTUP_RETRY_RESET_MS};
-        const retryDelayMs = ${NITRO_STARTUP_RETRY_DELAY_MS};
         const status = document.getElementById("agent-native-nitro-retry-status");
-        const now = Date.now();
-        let count = 0;
-        let lastAttemptAt = 0;
-
-        try {
-          const stored = JSON.parse(sessionStorage.getItem(key) || "null");
-          if (stored && typeof stored === "object") {
-            count = Number.isFinite(stored.count) ? stored.count : 0;
-            lastAttemptAt = Number.isFinite(stored.at) ? stored.at : 0;
+        const startedAt = Date.now();
+        let delayMs = ${NITRO_STARTUP_RETRY_DELAY_MS};
+        const maxDelayMs = ${NITRO_STARTUP_RETRY_MAX_DELAY_MS};
+        const slowHintMs = ${NITRO_STARTUP_SLOW_HINT_MS};
+        const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+        const setStatus = (text) => {
+          if (status) status.textContent = text;
+        };
+        const poll = async () => {
+          setStatus("Waiting for the dev server…");
+          while (true) {
+            if (Date.now() - startedAt >= slowHintMs) {
+              setStatus("Still starting… first boot can take a couple of minutes.");
+            }
+            try {
+              const res = await fetch(location.href, {
+                cache: "no-store",
+                headers: { Accept: "text/html" },
+              });
+              if (res.status !== 503) {
+                location.reload();
+                return;
+              }
+            } catch {
+              // Connection reset mid-boot; keep polling.
+            }
+            await wait(delayMs);
+            delayMs = Math.min(delayMs + 500, maxDelayMs);
           }
-        } catch (error) {
-          // A blocked session store is handled below by showing a manual retry.
-        }
-
-        if (now - lastAttemptAt > resetAfterMs) count = 0;
-        if (count >= maxRetries) {
-          if (status) status.textContent = "The server is still unavailable. Refresh when it is ready.";
-          return;
-        }
-
-        const nextState = JSON.stringify({ count: count + 1, at: now });
-        try {
-          sessionStorage.setItem(key, nextState);
-          if (sessionStorage.getItem(key) !== nextState) throw new Error("unavailable");
-        } catch (error) {
-          if (status) status.textContent = "Refresh manually when the server is ready.";
-          return;
-        }
-
-        if (status) status.textContent = "Retrying in one second…";
-        setTimeout(() => window.location.reload(), retryDelayMs);
+        };
+        void poll();
       })();
     </script>
   </body>


### PR DESCRIPTION
## Problem
Local pnpm dev looked hung on “Dev server is restarting…” with a pile of /slides 503s. It wasn’t a crash.

Lazy gateway only boots the app you open. Dispatch and Slides each do a cold first boot (migrations + Nitro SSR compile) with almost no “ready” log after [db] Applied migration…. Measured init on the first HTML request: Dispatch ~176s, Slides ~103s.

Vite’s Nitro startup gate serves a 503 HTML placeholder while that happens. That page auto-reloaded 5 times at 1s, then stopped on “The server is still unavailable. Refresh when it is ready.” DevTools keeps those old 503s, so it looks broken even after the app is returning 200.

Fix: the placeholder now fetch-polls until status ≠ 503, then reloads once. After ~8s it says first boot can take a couple of minutes. We poll with fetch instead of location.reload() so we don’t stack SSR compiles. Restart pnpm dev to pick it up.

## Summary
- Local `pnpm dev` first boot (Dispatch ~176s, Slides ~103s) made the Nitro 503 restart page look hung: it stopped after five 1-second reloads and sat on “Refresh when it is ready.”
- The placeholder now fetch-polls until the response is not 503, then reloads once, so a multi-minute cold start does not leave the tab stuck.
- Polling uses `fetch` instead of `location.reload()` on every 503 so we do not stack Nitro SSR compiles after the startup gate opens.

## Test plan
- [ ] Restart `pnpm dev` so core is rebuilt, then open `/dispatch` on a cold DB and leave the restart page alone until the app loads (no manual refresh).
- [ ] Open `/slides` (or `/dispatch/apps/slides`) the same way; after ~8s the copy should mention first boot can take a couple of minutes, then the app should appear.
- [ ] Confirm DevTools no longer ends on a stuck 503 document; the latest HTML request should be 200.
- [ ] `pnpm --filter @agent-native/core exec vitest --run src/vite/client.spec.ts`


Made with [Cursor](https://cursor.com)