### PR TITLE
ci: run targeted checks for changed workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
           while IFS= read -r filter; do
             filters+=(--filter "$filter")
           done < <(node -e 'for (const filter of JSON.parse(process.env.CI_WORKSPACE_FILTERS)) console.log(filter)')
-          pnpm -r --no-bail --if-present --workspace-concurrency=1 "${filters[@]}" run test -- \
+          pnpm -r --no-bail --if-present --workspace-concurrency=1 "${filters[@]}" run test \
             --exclude "**/*.db.test.ts" \
             --exclude "**/*.integration.spec.ts" \
             --exclude "**/*.integration.test.ts" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
     timeout-minutes: 5
     outputs:
       docs_only: ${{ steps.scope.outputs.docs_only }}
+      full: ${{ steps.scope.outputs.full }}
+      lint: ${{ steps.scope.outputs.lint }}
+      typecheck: ${{ steps.scope.outputs.typecheck }}
+      workspace_filters: ${{ steps.scope.outputs.workspace_filters }}
+      fast_tests: ${{ steps.scope.outputs.fast_tests }}
+      content: ${{ steps.scope.outputs.content }}
+      core_integration: ${{ steps.scope.outputs.core_integration }}
+      plan_e2e: ${{ steps.scope.outputs.plan_e2e }}
+      brain_evals: ${{ steps.scope.outputs.brain_evals }}
+      brain_privacy: ${{ steps.scope.outputs.brain_privacy }}
+      build: ${{ steps.scope.outputs.build }}
+      trusted_acceptance: ${{ steps.scope.outputs.trusted_acceptance }}
+      scaffold: ${{ steps.scope.outputs.scaffold }}
+      ssr_boot: ${{ steps.scope.outputs.ssr_boot }}
+      guards: ${{ steps.scope.outputs.guards }}
+      drizzle: ${{ steps.scope.outputs.drizzle }}
+      qa_static: ${{ steps.scope.outputs.qa_static }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -44,10 +61,14 @@ jobs:
 
   lint:
     name: Lint & format
+    needs: change-scope
+    if: needs.change-scope.outputs.lint == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -60,14 +81,45 @@ jobs:
       # builds are required, so skip the postinstall build chain entirely.
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Oxfmt check
-        run: pnpm fmt:check
+      - name: Check the full tree
+        if: needs.change-scope.outputs.full == 'true'
+        run: pnpm fmt:check && pnpm oxlint
 
-      - name: Oxlint
-        run: pnpm oxlint
+      - name: Check changed source files
+        if: needs.change-scope.outputs.full != 'true'
+        env:
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          format_files=()
+          lint_files=()
+          while IFS= read -r -d '' file; do
+            [ -f "$file" ] || continue
+            case "$file" in
+              *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.mts|*.cts|*.json|*.jsonc|*.css)
+                format_files+=("$file")
+                ;;
+            esac
+            case "$file" in
+              *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.mts|*.cts)
+                lint_files+=("$file")
+                ;;
+            esac
+          done < <(git diff --name-only -z "$CI_BASE_SHA...$CI_HEAD_SHA")
+
+          if ((${#format_files[@]} > 0)); then
+            pnpm exec oxfmt --check "${format_files[@]}"
+          fi
+          if ((${#lint_files[@]} > 0)); then
+            pnpm exec oxlint --config .oxlintrc.json "${lint_files[@]}"
+          fi
 
   typecheck:
     name: Typecheck
+    needs: change-scope
+    if: needs.change-scope.outputs.typecheck == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -85,21 +137,33 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
-        run: pnpm typecheck
+      - name: Typecheck affected workspaces
+        env:
+          CI_FULL: ${{ needs.change-scope.outputs.full }}
+          CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
+        run: |
+          if [ "$CI_FULL" = "true" ]; then
+            pnpm typecheck
+          else
+            filters=()
+            while IFS= read -r filter; do
+              filters+=(--filter "$filter")
+            done < <(node -e 'for (const filter of JSON.parse(process.env.CI_WORKSPACE_FILTERS)) console.log(filter)')
+            pnpm -r --no-bail --if-present "${filters[@]}" run typecheck
+          fi
 
-  # Non-docs PRs run the full fast-test suite — nothing is change-selected, so a
-  # test can never be silently skipped. Docs-only PRs use the focused docs job
-  # below and the stable Fast tests gate records the intentional skip. The full
-  # suite is split into parallel lanes purely for wall-clock: @agent-native/core
-  # runs isolated and uncapped (test-core), and every other test package is
-  # partitioned across balanced lanes (test-rest) by scripts/ci-test-lanes.ts,
-  # which asserts every package lands in exactly one lane. Adding a package
-  # auto-assigns it; dropping one fails the discover job.
+  # Full-fallback PRs run the complete fast-test suite — nothing is
+  # change-selected, so a test can never be silently skipped. Workspace-scoped
+  # PRs use test-targeted below, and docs-only PRs use the focused docs job.
+  # The full suite is split into parallel lanes purely for wall-clock:
+  # @agent-native/core runs isolated and uncapped (test-core), and every other
+  # test package is partitioned across balanced lanes (test-rest) by
+  # scripts/ci-test-lanes.ts, which asserts every package lands in exactly one
+  # lane. Adding a package auto-assigns it; dropping one fails discover-lanes.
   discover-lanes:
     name: Plan test lanes
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -118,7 +182,7 @@ jobs:
   test-core:
     name: Fast tests core
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.full == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -171,7 +235,7 @@ jobs:
   test-rest:
     name: Fast tests ${{ matrix.lane }}
     needs: [change-scope, discover-lanes]
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.full == 'true'
     runs-on: ubuntu-latest
     # Cap the run so a hung test fails fast instead of pinning a runner for
     # GitHub's 6h default. Slow DB/integration/e2e specs run in separate jobs
@@ -225,11 +289,64 @@ jobs:
           --exclude "**/*.perf.test.ts"
           --exclude "**/create-e2e.spec.ts"
 
+  test-targeted:
+    name: Fast tests targeted workspaces
+    needs: change-scope
+    if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Restore dist + tsBuildInfo cache
+        uses: ./.github/actions/restore-dist-cache
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore Playwright browser cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium for browser-backed unit tests
+        run: pnpm exec playwright install --only-shell chromium
+
+      - name: Run fast tests for affected workspaces
+        env:
+          CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
+        run: |
+          filters=()
+          while IFS= read -r filter; do
+            filters+=(--filter "$filter")
+          done < <(node -e 'for (const filter of JSON.parse(process.env.CI_WORKSPACE_FILTERS)) console.log(filter)')
+          pnpm -r --no-bail --if-present --workspace-concurrency=1 "${filters[@]}" run test -- \
+            --exclude "**/*.db.test.ts" \
+            --exclude "**/*.integration.spec.ts" \
+            --exclude "**/*.integration.test.ts" \
+            --exclude "**/*.e2e.spec.ts" \
+            --exclude "**/*.e2e.test.ts" \
+            --exclude "**/e2e/**" \
+            --exclude "**/*.live.spec.ts" \
+            --exclude "**/*.live.test.ts" \
+            --exclude "**/*.perf.spec.ts" \
+            --exclude "**/*.perf.test.ts" \
+            --exclude "**/create-e2e.spec.ts"
+
   # Stable required status check. Point branch protection at "Fast tests" (this
-  # gate), not the per-lane jobs whose names vary with the matrix.
+  # gate), not the per-lane or targeted jobs whose names may vary.
   fast-tests:
     name: Fast tests
-    needs: [change-scope, docs, discover-lanes, test-core, test-rest]
+    needs:
+      [change-scope, docs, discover-lanes, test-core, test-rest, test-targeted]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -242,6 +359,7 @@ jobs:
           DISCOVER_LANES_RESULT: ${{ needs.discover-lanes.result }}
           TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_REST_RESULT: ${{ needs.test-rest.result }}
+          TEST_TARGETED_RESULT: ${{ needs.test-targeted.result }}
         run: |
           if [ "$CHANGE_SCOPE_RESULT" != "success" ]; then
             echo "::error::change-scope did not succeed ($CHANGE_SCOPE_RESULT)"
@@ -253,6 +371,10 @@ jobs:
               exit 1
             fi
             echo "Docs-only change: full fast-test lanes are not required."
+            exit 0
+          fi
+          if [ "$TEST_TARGETED_RESULT" = "success" ]; then
+            echo "Targeted workspace fast tests passed."
             exit 0
           fi
           for dep in "discover-lanes:$DISCOVER_LANES_RESULT" \
@@ -296,7 +418,7 @@ jobs:
   content-parity:
     name: Content parity
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.content == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -320,7 +442,7 @@ jobs:
   content-db-tests:
     name: Content DB tests
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.content == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -355,7 +477,7 @@ jobs:
   content-db-postgres-tests:
     name: Content DB PostgreSQL locking
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.content == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -397,7 +519,7 @@ jobs:
   core-integration-tests:
     name: Core integration tests
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.core_integration == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -431,7 +553,7 @@ jobs:
   plan-e2e-tests:
     name: Plan E2E tests
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.plan_e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -455,7 +577,7 @@ jobs:
   brain-evals:
     name: Brain evals
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.brain_evals == 'true'
     runs-on: ubuntu-latest
     # Brain evals are offline action/fixture retrieval checks; live LLM evals
     # belong in the gated eval workflow.
@@ -481,7 +603,7 @@ jobs:
   brain-privacy-evals:
     name: Brain privacy leakage evals
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.brain_privacy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -505,7 +627,7 @@ jobs:
   build:
     name: Build
     needs: change-scope
-    if: needs.change-scope.result == 'success'
+    if: needs.change-scope.result == 'success' && (needs.change-scope.outputs.docs_only == 'true' || needs.change-scope.outputs.build == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -524,8 +646,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build all packages
-        if: needs.change-scope.outputs.docs_only != 'true'
+        if: needs.change-scope.outputs.full == 'true'
         run: pnpm build
+
+      - name: Build affected workspaces
+        if: needs.change-scope.outputs.build == 'true' && needs.change-scope.outputs.full != 'true'
+        env:
+          CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
+        run: |
+          filters=()
+          while IFS= read -r filter; do
+            filters+=(--filter "$filter")
+          done < <(node -e 'for (const filter of JSON.parse(process.env.CI_WORKSPACE_FILTERS)) console.log(filter)')
+          pnpm -r --no-bail --if-present "${filters[@]}" run build
 
       - name: Build docs site
         if: needs.change-scope.outputs.docs_only == 'true'
@@ -534,7 +667,7 @@ jobs:
   trusted-acceptance:
     name: Trusted acceptance substrate
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.trusted_acceptance == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -567,7 +700,7 @@ jobs:
   scaffold-e2e:
     name: Scaffold E2E — create + pnpm install
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.scaffold == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -697,7 +830,7 @@ jobs:
   ssr-boot-smoke:
     name: SSR cold-start smoke
     needs: change-scope
-    if: needs.change-scope.outputs.docs_only != 'true'
+    if: needs.change-scope.outputs.ssr_boot == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -755,6 +888,8 @@ jobs:
 
   guards:
     name: Security guards
+    needs: change-scope
+    if: needs.change-scope.outputs.guards == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -788,6 +923,8 @@ jobs:
 
   guard-no-drizzle-push:
     name: Guard — no drizzle-kit push in build paths
+    needs: change-scope
+    if: needs.change-scope.outputs.drizzle == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -803,6 +940,8 @@ jobs:
 
   qa-static:
     name: QA — static template checks
+    needs: change-scope
+    if: needs.change-scope.outputs.qa_static == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -244,6 +244,8 @@ production deployment:
 | `POSTGRES_DB`                 | Database name for the ephemeral Postgres service container used by the Content DB test lane. |
 | `POSTGRES_HOST_AUTH_METHOD`   | Auth method for that same throwaway container; `trust` keeps the lane password-free.         |
 | `S2573_PGLITE_INSTALL_PREFIX` | Install prefix for the PGlite build used by the Content database row-migration lock test.    |
+| `CI_FULL`                     | Change-scope classifier output selecting the full CI suite instead of targeted jobs.         |
+| `CI_WORKSPACE_FILTERS`        | JSON-encoded pnpm workspace selectors emitted by the change-scope classifier.                |
 
 GitHub Actions also creates short-lived step handoff variables such as
 `HEAD_SHA`, `MATRIX`, `PLAN_JSON`, `PLAN_URL`, `PR_NUMBER`, `RUN_URL`,

--- a/scripts/ci-change-scope.test.ts
+++ b/scripts/ci-change-scope.test.ts
@@ -4,14 +4,17 @@ import test from "node:test";
 import {
   classifyChangedPaths,
   isDocsPath,
+  isWorkspacePath,
   normalizeChangedPath,
+  workspaceFiltersForPaths,
 } from "./ci-change-scope.ts";
 
-test("recognizes the docs surfaces", () => {
+test("recognizes documentation surfaces and package metadata", () => {
   assert.equal(isDocsPath("packages/core/docs/content/actions.mdx"), true);
   assert.equal(isDocsPath("packages/docs/app/routes/docs.$slug.tsx"), true);
   assert.equal(isDocsPath("docs/environment-variables.md"), true);
-  assert.equal(isDocsPath("README.md"), true);
+  assert.equal(isDocsPath("templates/chat/README.md"), true);
+  assert.equal(isDocsPath("packages/core/CHANGELOG.md"), true);
   assert.equal(isDocsPath(".changeset/docs-refresh.md"), true);
   assert.equal(isDocsPath("scripts/i18n-raw-literal-baseline.txt"), true);
 });
@@ -22,6 +25,7 @@ test("does not treat implementation and instruction paths as docs-only", () => {
   assert.equal(isDocsPath(".agents/skills/qa/SKILL.md"), false);
   assert.equal(isDocsPath(".github/workflows/ci.yml"), false);
   assert.equal(isDocsPath("scripts/ci-test-lanes.ts"), false);
+  assert.equal(isWorkspacePath("examples/demo/src/index.ts"), true);
 });
 
 test("normalizes paths from git output", () => {
@@ -35,32 +39,92 @@ test("normalizes paths from git output", () => {
   );
 });
 
-test("fails closed for empty and mixed change sets", () => {
-  assert.equal(classifyChangedPaths([]).docsOnly, false);
-  assert.equal(
-    classifyChangedPaths([
-      "packages/core/docs/content/actions.mdx",
-      "packages/core/src/index.ts",
-    ]).docsOnly,
-    false,
+test("fails closed for empty and unknown root change sets", () => {
+  const empty = classifyChangedPaths([]);
+  assert.equal(empty.docsOnly, false);
+  assert.equal(empty.full, true);
+  assert.equal(empty.checks.build, true);
+
+  const unknown = classifyChangedPaths(["scripts/new-ci-tool.ts"]);
+  assert.equal(unknown.docsOnly, false);
+  assert.equal(unknown.full, true);
+  for (const enabled of Object.values(unknown.checks)) {
+    assert.equal(enabled, true);
+  }
+});
+
+test("selects only docs checks for an all-docs change set", () => {
+  const scope = classifyChangedPaths([
+    "packages/core/docs/content/actions.mdx",
+    "packages/docs/app/components/MarkdownRenderer.tsx",
+    "README.md",
+  ]);
+
+  assert.equal(scope.docsOnly, true);
+  assert.equal(scope.full, false);
+  assert.deepEqual(Object.values(scope.checks).filter(Boolean), []);
+});
+
+test("selects dependency-aware checks for a template change", () => {
+  const scope = classifyChangedPaths([
+    "templates/calendar/app/components/EventCard.tsx",
+  ]);
+
+  assert.equal(scope.docsOnly, false);
+  assert.equal(scope.full, false);
+  assert.deepEqual(scope.workspaceFilters, ["...{templates/calendar}..."]);
+  assert.equal(scope.checks.lint, true);
+  assert.equal(scope.checks.typecheck, true);
+  assert.equal(scope.checks.fast_tests, true);
+  assert.equal(scope.checks.build, true);
+  assert.equal(scope.checks.scaffold, true);
+  assert.equal(scope.checks.trusted_acceptance, true);
+  assert.equal(scope.checks.qa_static, true);
+  assert.equal(scope.checks.core_integration, false);
+  assert.equal(scope.checks.brain_evals, false);
+});
+
+test("runs shared coverage when core changes", () => {
+  const scope = classifyChangedPaths(["packages/core/src/agent/engine/run.ts"]);
+
+  assert.equal(scope.full, false);
+  assert.deepEqual(scope.workspaceFilters, ["...{packages/core}..."]);
+  assert.equal(scope.checks.content, true);
+  assert.equal(scope.checks.core_integration, true);
+  assert.equal(scope.checks.plan_e2e, true);
+  assert.equal(scope.checks.brain_evals, true);
+  assert.equal(scope.checks.brain_privacy, true);
+  assert.equal(scope.checks.scaffold, true);
+  assert.equal(scope.checks.ssr_boot, true);
+  assert.equal(scope.checks.trusted_acceptance, true);
+});
+
+test("keeps package metadata targeted but runs the drizzle guard", () => {
+  const scope = classifyChangedPaths(["templates/calendar/package.json"]);
+
+  assert.equal(scope.full, false);
+  assert.equal(scope.checks.build, true);
+  assert.equal(scope.checks.fast_tests, true);
+  assert.equal(scope.checks.drizzle, true);
+});
+
+test("includes nested and example workspaces in selectors", () => {
+  assert.deepEqual(
+    workspaceFiltersForPaths([
+      "templates/clips/desktop/src/main.ts",
+      "examples/demo/src/index.ts",
+    ]),
+    ["...{examples/demo}...", "...{templates/clips/desktop}..."],
   );
 });
 
-test("classifies an all-docs change set", () => {
-  assert.deepEqual(
-    classifyChangedPaths([
-      "packages/core/docs/content/actions.mdx",
-      "packages/docs/app/components/MarkdownRenderer.tsx",
-      "README.md",
-    ]),
-    {
-      changedPaths: [
-        "packages/core/docs/content/actions.mdx",
-        "packages/docs/app/components/MarkdownRenderer.tsx",
-        "README.md",
-      ],
-      docsOnly: true,
-      nonDocsPaths: [],
-    },
-  );
+test("does not run code checks for a mixed docs-only package change", () => {
+  const scope = classifyChangedPaths([
+    "packages/core/CHANGELOG.md",
+    "templates/chat/README.md",
+  ]);
+
+  assert.equal(scope.docsOnly, true);
+  assert.equal(scope.full, false);
+  assert.deepEqual(Object.values(scope.checks).filter(Boolean), []);
 });

--- a/scripts/ci-change-scope.ts
+++ b/scripts/ci-change-scope.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { appendFileSync, existsSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const DOCS_PATH_PREFIXES = [
@@ -9,8 +9,6 @@ const DOCS_PATH_PREFIXES = [
   "packages/docs/",
 ] as const;
 
-const DOCS_ROOT_FILES = new Set(["CONTRIBUTING.md", "README.md"]);
-
 const DOCS_SUPPORT_PATHS = new Set([
   "scripts/i18n-catalog-english-value-baseline.txt",
   "scripts/i18n-localized-docs-baseline.txt",
@@ -18,28 +16,223 @@ const DOCS_SUPPORT_PATHS = new Set([
   "scripts/i18n-raw-literal-baseline.txt",
 ]);
 
+const FULL_CHECK_FILES = new Set([
+  ".github/workflows/ci.yml",
+  ".oxlintrc.json",
+  ".oxfmtrc.json",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "tsconfig.json",
+  "vitest.shared.ts",
+]);
+
+const CHECK_NAMES = [
+  "lint",
+  "typecheck",
+  "fast_tests",
+  "content",
+  "core_integration",
+  "plan_e2e",
+  "brain_evals",
+  "brain_privacy",
+  "build",
+  "trusted_acceptance",
+  "scaffold",
+  "ssr_boot",
+  "guards",
+  "drizzle",
+  "qa_static",
+] as const;
+
+type CheckName = (typeof CHECK_NAMES)[number];
+
+export type CheckSelection = Record<CheckName, boolean>;
+
+export type ChangeScope = {
+  changedPaths: string[];
+  docsOnly: boolean;
+  full: boolean;
+  nonDocsPaths: string[];
+  checks: CheckSelection;
+  workspaceFilters: string[];
+};
+
 export function normalizeChangedPath(path: string): string {
   return path.replaceAll("\\", "/").replace(/^\.\/+/, "");
 }
 
 export function isDocsPath(path: string): boolean {
   const normalized = normalizeChangedPath(path);
+
+  if (normalized.startsWith(".changeset/")) return true;
+  if (DOCS_SUPPORT_PATHS.has(normalized)) return true;
+  if (DOCS_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return true;
+  }
+
+  const fileName = basename(normalized);
+  return /^(?:CHANGELOG|CONTRIBUTING|README)\.md$/u.test(fileName);
+}
+
+export function isWorkspacePath(path: string): boolean {
+  const normalized = normalizeChangedPath(path);
   return (
-    DOCS_ROOT_FILES.has(normalized) ||
-    normalized.startsWith(".changeset/") ||
-    DOCS_SUPPORT_PATHS.has(normalized) ||
-    DOCS_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+    normalized.startsWith("examples/") ||
+    normalized.startsWith("packages/") ||
+    normalized.startsWith("templates/")
   );
 }
 
-export function classifyChangedPaths(paths: readonly string[]) {
+function workspaceRootForPath(path: string): string | undefined {
+  const segments = normalizeChangedPath(path).split("/");
+  const parent = segments[0];
+
+  if ((parent === "examples" || parent === "packages") && segments[1]) {
+    return `${parent}/${segments[1]}`;
+  }
+
+  if (parent !== "templates" || !segments[1]) return undefined;
+  if (segments[1] === ".retired" && segments[2]) {
+    return `templates/.retired/${segments[2]}`;
+  }
+
+  const nested = segments[2];
+  if (
+    nested &&
+    (nested === "chrome-extension" || nested === "desktop") &&
+    existsSync(
+      join(process.cwd(), "templates", segments[1], nested, "package.json"),
+    )
+  ) {
+    return `templates/${segments[1]}/${nested}`;
+  }
+
+  return `templates/${segments[1]}`;
+}
+
+export function workspaceFiltersForPaths(paths: readonly string[]): string[] {
+  const roots = new Set<string>();
+  for (const path of paths) {
+    const root = workspaceRootForPath(path);
+    if (root) roots.add(root);
+  }
+
+  // Include the changed workspace and both its dependency/dependent closure.
+  // Explicit path selectors work in detached PR checkouts and do not rely on
+  // pnpm discovering a Git base revision.
+  return [...roots].sort().map((root) => `...{${root}}...`);
+}
+
+function isFullPath(path: string): boolean {
+  const normalized = normalizeChangedPath(path);
+
+  if (FULL_CHECK_FILES.has(normalized)) return true;
+  if (normalized.startsWith(".github/")) return true;
+  if (normalized.startsWith("scripts/") && !isDocsPath(normalized)) {
+    return true;
+  }
+
+  // Unknown repository-level files are dependencies of the whole CI graph.
+  // Run everything when they change so a new root tool cannot bypass checks.
+  return !isWorkspacePath(normalized) && !isDocsPath(normalized);
+}
+
+function hasPath(paths: readonly string[], prefix: string): boolean {
+  return paths.some((path) => path.startsWith(prefix));
+}
+
+function buildChecks(
+  changedPaths: readonly string[],
+  full: boolean,
+): CheckSelection {
+  if (full) {
+    return Object.fromEntries(
+      CHECK_NAMES.map((name) => [name, true]),
+    ) as CheckSelection;
+  }
+
+  const workspaceChanged = changedPaths.some(isWorkspacePath);
+  const coreChanged = hasPath(changedPaths, "packages/core/");
+  const toolkitChanged = hasPath(changedPaths, "packages/toolkit/");
+  const schedulingChanged = hasPath(changedPaths, "packages/scheduling/");
+  const dispatchChanged = hasPath(changedPaths, "packages/dispatch/");
+  const contentChanged = hasPath(changedPaths, "templates/content/");
+  const calendarChanged = hasPath(changedPaths, "templates/calendar/");
+  const templateChanged = hasPath(changedPaths, "templates/");
+  const planChanged = hasPath(changedPaths, "templates/plan/");
+  const brainChanged = hasPath(changedPaths, "templates/brain/");
+  const clipsChanged = hasPath(changedPaths, "templates/clips/");
+  const assetsChanged = hasPath(changedPaths, "templates/assets/");
+  const recapCliChanged = hasPath(changedPaths, "packages/recap-cli/");
+  const creativeContextChanged = hasPath(
+    changedPaths,
+    "packages/creative-context/",
+  );
+
+  return {
+    lint: workspaceChanged,
+    typecheck: workspaceChanged,
+    fast_tests: workspaceChanged,
+    content: contentChanged || coreChanged || schedulingChanged,
+    core_integration: coreChanged || toolkitChanged,
+    plan_e2e: coreChanged || planChanged,
+    brain_evals: coreChanged || brainChanged,
+    brain_privacy: coreChanged || brainChanged,
+    build: workspaceChanged,
+    trusted_acceptance:
+      coreChanged || contentChanged || calendarChanged || dispatchChanged,
+    scaffold:
+      coreChanged ||
+      dispatchChanged ||
+      schedulingChanged ||
+      hasPath(changedPaths, "templates/chat/") ||
+      calendarChanged ||
+      hasPath(changedPaths, "templates/dispatch/"),
+    ssr_boot:
+      coreChanged ||
+      toolkitChanged ||
+      recapCliChanged ||
+      creativeContextChanged ||
+      contentChanged ||
+      planChanged ||
+      clipsChanged ||
+      assetsChanged,
+    guards: workspaceChanged,
+    drizzle: changedPaths.some((path) => {
+      const normalized = normalizeChangedPath(path);
+      return (
+        normalized === "netlify.toml" ||
+        normalized.endsWith("/netlify.toml") ||
+        normalized === "package.json" ||
+        normalized.endsWith("/package.json")
+      );
+    }),
+    qa_static: templateChanged,
+  };
+}
+
+export function classifyChangedPaths(paths: readonly string[]): ChangeScope {
   const changedPaths = paths.map(normalizeChangedPath);
   const nonDocsPaths = changedPaths.filter((path) => !isDocsPath(path));
+  const docsOnly = changedPaths.length > 0 && nonDocsPaths.length === 0;
+  const workspaceFilters = workspaceFiltersForPaths(changedPaths);
+  const full =
+    changedPaths.length === 0 ||
+    changedPaths.some(isFullPath) ||
+    (changedPaths.some(isWorkspacePath) && workspaceFilters.length === 0);
 
   return {
     changedPaths,
-    docsOnly: changedPaths.length > 0 && nonDocsPaths.length === 0,
+    docsOnly,
+    full,
     nonDocsPaths,
+    checks: docsOnly
+      ? (Object.fromEntries(
+          CHECK_NAMES.map((name) => [name, false]),
+        ) as CheckSelection)
+      : buildChecks(changedPaths, full),
+    workspaceFilters,
   };
 }
 
@@ -52,24 +245,45 @@ export function readChangedPaths(baseSha: string, headSha: string): string[] {
   return output.split("\0").filter(Boolean);
 }
 
-function writeOutputs(docsOnly: boolean, changedCount: number): void {
+function writeOutputs(scope: ChangeScope): void {
   const outputPath = process.env.GITHUB_OUTPUT;
   if (outputPath) {
-    appendFileSync(
-      outputPath,
-      `docs_only=${docsOnly ? "true" : "false"}\nchanged_count=${changedCount}\n`,
-    );
+    const lines = [
+      `docs_only=${scope.docsOnly ? "true" : "false"}`,
+      `full=${scope.full ? "true" : "false"}`,
+      `changed_count=${scope.changedPaths.length}`,
+      `workspace_filters=${JSON.stringify(scope.workspaceFilters)}`,
+      ...Object.entries(scope.checks).map(
+        ([name, enabled]) => `${name}=${enabled ? "true" : "false"}`,
+      ),
+    ];
+    appendFileSync(outputPath, `${lines.join("\n")}\n`);
   }
 
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (summaryPath) {
+    const selectedChecks = CHECK_NAMES.filter((name) => scope.checks[name]);
+    const preview = scope.changedPaths.slice(0, 20);
     appendFileSync(
       summaryPath,
       [
         "## CI change scope",
         "",
-        `- Docs-only change: **${docsOnly ? "yes" : "no"}**`,
-        `- Changed paths: **${changedCount}**`,
+        `- Changed paths: **${scope.changedPaths.length}**`,
+        `- Docs-only change: **${scope.docsOnly ? "yes" : "no"}**`,
+        `- Full fallback: **${scope.full ? "yes" : "no"}**`,
+        `- Workspace selectors: **${scope.workspaceFilters.join(", ") || "none"}**`,
+        `- Selected checks: **${selectedChecks.join(", ") || "docs"}**`,
+        ...(preview.length > 0
+          ? [
+              "",
+              "Changed path preview:",
+              ...preview.map((path) => `- \`${path}\``),
+            ]
+          : []),
+        ...(scope.changedPaths.length > preview.length
+          ? ["", `_(showing first ${preview.length} paths)_`]
+          : []),
         "",
       ].join("\n"),
     );
@@ -83,9 +297,9 @@ function main(): void {
     throw new Error("CI_BASE_SHA and CI_HEAD_SHA are required");
   }
 
-  const result = classifyChangedPaths(readChangedPaths(baseSha, headSha));
-  console.log(JSON.stringify(result, null, 2));
-  writeOutputs(result.docsOnly, result.changedPaths.length);
+  const scope = classifyChangedPaths(readChangedPaths(baseSha, headSha));
+  console.log(JSON.stringify(scope, null, 2));
+  writeOutputs(scope);
 }
 
 if (


### PR DESCRIPTION
## Summary

- classify pull requests as docs-only, full-fallback, or workspace-scoped changes
- run lint, typecheck, build, and fast tests only for affected workspace dependency closures
- keep the existing full sharded test lanes for fail-closed root/config changes and gate specialized jobs by ownership
- preserve stable Fast tests status behavior for docs-only, targeted, and full paths

## Validation

- `pnpm test:ci-change-scope`
- `actionlint .github/workflows/ci.yml`
- `pnpm exec oxfmt --check scripts/ci-change-scope.ts scripts/ci-change-scope.test.ts`
- `pnpm exec prettier --check .github/workflows/ci.yml`
- focused TypeScript check and explicit pnpm workspace selector probes

The targeted selectors use pnpm dependency/dependent closure path filters; unknown root/config changes continue to use the full suite.