### PR TITLE
fix: send resolved model to Builder gateway

### DIFF
--- a/.changeset/explicit-agent-model-selection.md
+++ b/.changeset/explicit-agent-model-selection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resolve Agent Native model selections through request, org/user defaults, and the global catalog before sending a concrete model to the Builder gateway.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -310,6 +310,24 @@ describe("createBuilderEngine", () => {
     ]);
   });
 
+  it("resolves auto to the Agent Native default before posting to the gateway", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        jsonlResponse([
+          { type: "stop", reason: "end_turn", requestId: "req_1" },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    await collectEvents(engine.stream({ ...BASE_OPTS, model: "auto" }));
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.model).toBe(BUILDER_DEFAULT_MODEL);
+    expect(body.model).not.toBe("auto");
+  });
+
   it("splits the system prompt at the cache sentinel, keeping the breakpoint on the stable prefix", async () => {
     const fetchSpy = vi
       .fn()

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -215,12 +215,20 @@ class BuilderEngine implements AgentEngine {
       return;
     }
 
+    // The Builder gateway has an "auto" fallback mode, but Agent Native owns
+    // model selection. Always send a concrete model so the gateway cannot
+    // select an organization-level override or another fallback model.
+    const requestedModel = opts.model.trim();
+    const model =
+      requestedModel.length === 0 || requestedModel === "auto"
+        ? BUILDER_DEFAULT_MODEL
+        : requestedModel;
     const messages = engineMessagesToBuilderGatewayAnthropic(opts.messages);
     const tools = engineToolsToAnthropic(opts.tools);
     const thinkingBudget =
       opts.providerOptions?.anthropic?.thinking?.budgetTokens;
     const reasoningEffort = normalizeReasoningEffortForModel(
-      opts.model,
+      model,
       opts.reasoningEffort ??
         (typeof thinkingBudget === "number"
           ? mapReasoningEffort(thinkingBudget)
@@ -290,16 +298,16 @@ class BuilderEngine implements AgentEngine {
     }
 
     const gptToolsRequireExplicitNoReasoning =
-      cachedTools.length > 0 && isGPTReasoningModel(opts.model);
+      cachedTools.length > 0 && isGPTReasoningModel(model);
     const body: Record<string, unknown> = {
-      model: opts.model,
+      model,
       messages: cachedMessages,
       ...(systemValue !== undefined ? { system: systemValue } : {}),
       ...(cachedTools.length > 0 ? { tools: cachedTools } : {}),
       max_tokens: resolveMaxOutputTokensForEngine(
         this.name,
         opts.maxOutputTokens,
-        opts.model,
+        model,
       ),
       ...(typeof opts.temperature === "number"
         ? { temperature: opts.temperature }
@@ -327,7 +335,7 @@ class BuilderEngine implements AgentEngine {
     // gateway outage are the same capture.
     const payload = JSON.stringify(body);
     const requestShape: EngineRequestShape = {
-      model: opts.model,
+      model,
       payloadBytes: new TextEncoder().encode(payload).length,
       toolCount: cachedTools.length,
       messageCount: cachedMessages.length,
@@ -342,7 +350,7 @@ class BuilderEngine implements AgentEngine {
     const orgLabel = creds.orgName || "unknown-org";
     const tStart = Date.now();
     console.log(
-      `[builder-engine] → POST ${gatewayUrl.origin}${gatewayUrl.pathname} model=${opts.model} tools=${tools.length} org=${orgLabel}`,
+      `[builder-engine] → POST ${gatewayUrl.origin}${gatewayUrl.pathname} model=${model} tools=${tools.length} org=${orgLabel}`,
     );
 
     const gatewayTimeoutMs = getBuilderGatewayTimeoutMs();
@@ -375,7 +383,7 @@ class BuilderEngine implements AgentEngine {
         if (timedOut || isBuilderGatewayNetworkError(err)) {
           captureBuilderGatewayTransportError(err, {
             phase: "request",
-            model: opts.model,
+            model,
             gatewayUrl,
             timeoutMs: gatewayAbort.effectiveTimeoutMs(),
             timedOut,
@@ -453,7 +461,7 @@ class BuilderEngine implements AgentEngine {
         return;
       }
 
-      yield* parseJsonlStream(reader, opts.model, {
+      yield* parseJsonlStream(reader, model, {
         creditsLane,
         abortSignal: gatewayAbort.signal,
         didGatewayTimeout: gatewayAbort.didTimeout,

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -51,6 +51,7 @@ import {
   resolveBackgroundNoProgressRepeat,
   lastUnfinishedPreparingActionToolFromEvents,
   markBackgroundContinuationChunkTerminal,
+  resolveAgentModelSelection,
   resolveAgentOwnerEmail,
   resolveBackgroundDispatchOutcome,
   resolveFinalResponseGuardRequestText,
@@ -166,6 +167,40 @@ describe("resolveAgentRequestReasoningEffort", () => {
         configuredEffort: "high",
       }),
     ).toBe("none");
+  });
+});
+
+describe("resolveAgentModelSelection", () => {
+  const defaultModel = "gpt-5-6-luna";
+
+  it("uses a manually selected request model first", () => {
+    expect(
+      resolveAgentModelSelection({
+        requestModel: "gpt-5-6-terra",
+        storedModel: "gpt-5-6-sol",
+        defaultModel,
+      }),
+    ).toEqual({ model: "gpt-5-6-terra", source: "request" });
+  });
+
+  it("treats auto as a sentinel and uses the stored AN default", () => {
+    expect(
+      resolveAgentModelSelection({
+        requestModel: "auto",
+        storedModel: "gpt-5-6-terra",
+        defaultModel,
+      }),
+    ).toEqual({ model: "gpt-5-6-terra", source: "stored" });
+  });
+
+  it("uses the single configured global default when no override exists", () => {
+    expect(
+      resolveAgentModelSelection({
+        requestModel: "auto",
+        storedModel: "auto",
+        defaultModel,
+      }),
+    ).toEqual({ model: defaultModel, source: "default" });
   });
 });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -8363,6 +8363,42 @@ export function resolveAgentRequestReasoningEffort({
   );
 }
 
+export type AgentModelSelectionSource =
+  | "request"
+  | "configured"
+  | "stored"
+  | "default";
+
+function isConcreteModelSelection(
+  model: string | null | undefined,
+): model is string {
+  const normalized = typeof model === "string" ? model.trim() : "";
+  return normalized.length > 0 && normalized !== "auto";
+}
+
+/**
+ * Resolve the model before the engine boundary. `auto` is a UI sentinel, not
+ * a model to forward to the gateway, so it gives way to an AN org/user
+ * default, then the configured global engine default.
+ */
+export function resolveAgentModelSelection(options: {
+  requestModel?: string | null;
+  configuredModel?: string | null;
+  storedModel?: string | null;
+  defaultModel: string;
+}): { model: string; source: AgentModelSelectionSource } {
+  if (isConcreteModelSelection(options.requestModel)) {
+    return { model: options.requestModel, source: "request" };
+  }
+  if (isConcreteModelSelection(options.configuredModel)) {
+    return { model: options.configuredModel, source: "configured" };
+  }
+  if (isConcreteModelSelection(options.storedModel)) {
+    return { model: options.storedModel, source: "stored" };
+  }
+  return { model: options.defaultModel, source: "default" };
+}
+
 export function createProductionAgentHandler(
   options: ProductionAgentOptions,
 ): H3EventHandler {
@@ -8806,29 +8842,25 @@ export function createProductionAgentHandler(
     // DIAGNOSTIC-ONLY: bracket stored-model resolution (getStoredModelForEngine
     // settings read).
     workerStep("model_start");
+    const requestModelIsExplicit = isConcreteModelSelection(requestModel);
+    const configuredModelIsExplicit = isConcreteModelSelection(configuredModel);
     const storedModel =
-      requestModel == null && configuredModel == null
+      !requestModelIsExplicit && !configuredModelIsExplicit
         ? await getStoredModelForEngine(engine, { appId: options.appId })
         : undefined;
-    const modelCandidate =
-      requestModel ?? configuredModel ?? storedModel ?? engine.defaultModel;
+    const modelSelection = resolveAgentModelSelection({
+      requestModel,
+      configuredModel,
+      storedModel,
+      defaultModel: engine.defaultModel,
+    });
+    const modelCandidate = modelSelection.model;
     // DIAGNOSTIC-ONLY: stored-model resolution finished.
     workerStep("model_done");
     const model = normalizeModelForEngine(engine, modelCandidate);
     let effectiveModel = model;
-    let modelSelectionSource:
-      | "request"
-      | "configured"
-      | "stored"
-      | "default"
-      | "experiment" =
-      requestModel != null
-        ? "request"
-        : configuredModel != null
-          ? "configured"
-          : storedModel != null
-            ? "stored"
-            : "default";
+    let modelSelectionSource: AgentModelSelectionSource | "experiment" =
+      modelSelection.source;
     let experimentAssignments: Array<{
       experimentId: string;
       variantId: string;


### PR DESCRIPTION
## Summary
- resolve manual, org/user, and global Agent Native model precedence before engine execution
- send a concrete model to the Builder gateway so its organization fallback is never used
- make Luna the single configured managed OpenAI/Builder default

## Validation
- focused Vitest: 304 tests passed
- @agent-native/core typecheck
- oxfmt check
- git diff --check