### PR TITLE
fix(docs): make server docs sources deploy-safe

### DIFF
--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -22,3 +22,4 @@ todos.json
 
 # Generated at build time
 public/source-index.json
+public/docs-source-index.json

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -8,7 +8,9 @@ This package builds the public docs site for Agent-Native.
 - MDX docs are loaded from `../core/docs/content/` by `app/components/docs-content.ts`.
 - The left nav is `app/components/docsNavItems.ts`.
 - Template landing-page metadata comes from `app/components/TemplateCard.tsx`.
-- `scripts/generate-source-index.ts` builds `public/source-index.json` before production builds.
+- `scripts/generate-source-index.ts` builds `public/source-index.json` and the
+  raw `public/docs-source-index.json` used by server-side documentation actions
+  before production builds.
 - `app/vite-sitemap-plugin.ts` generates `public/sitemap.xml` during `pnpm build`.
 
 Search is built at runtime from the loaded docs. Public `.md` mirrors are generated from the MDX source for crawlers, agents, and copy-as-markdown. There is no generated `searchIndex.ts` source file.

--- a/packages/docs/actions/docs-files.ts
+++ b/packages/docs/actions/docs-files.ts
@@ -4,7 +4,7 @@ export function sanitizeDocSlug(slug: string): string {
   return slug.replace(/[^a-z0-9-]/gi, "");
 }
 
-export function listDocFiles(): string[] {
+export async function listDocFiles(): Promise<string[]> {
   return listDocSourceFiles();
 }
 

--- a/packages/docs/lib/docs-content-source.ts
+++ b/packages/docs/lib/docs-content-source.ts
@@ -67,6 +67,10 @@ async function loadLocalDocSources(): Promise<DocSource[]> {
 let docSourcesPromise: Promise<DocSource[]> | undefined;
 
 async function loadDocSources(): Promise<DocSource[]> {
+  // A source checkout may retain the ignored generated asset after a build.
+  // Keep local actions aligned with edits to core docs until the next build.
+  if (process.env.NODE_ENV !== "production") return loadLocalDocSources();
+
   const generated =
     await readPublicJsonAsset<DocSourceAsset[]>(GENERATED_DOCS_ASSET);
   if (Array.isArray(generated)) return buildDocSources(generated);

--- a/packages/docs/lib/docs-content-source.ts
+++ b/packages/docs/lib/docs-content-source.ts
@@ -1,51 +1,93 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { readPublicJsonAsset } from "../actions/public-assets";
 import {
   docSourceSlugFromFilename,
+  isDocSourceFile,
   preferMdxDocSourceFiles,
 } from "./docs-source";
 
-type DocSourceLoader = () => Promise<string>;
+const LOCAL_DOCS_ROOT = join(import.meta.dirname, "../../core/docs/content");
+const GENERATED_DOCS_ASSET = "docs-source-index.json";
 
-const docSourceLoaders = {
-  ...import.meta.glob("../../core/docs/content/*.md", {
-    query: "?raw",
-    import: "default",
-  }),
-  ...import.meta.glob("../../core/docs/content/*.mdx", {
-    query: "?raw",
-    import: "default",
-  }),
-} as Record<string, DocSourceLoader>;
+interface DocSourceAsset {
+  filename: string;
+  content: string;
+}
 
 interface DocSource {
   filename: string;
   slug: string;
-  load: DocSourceLoader;
+  content: string;
 }
 
-const docSources: DocSource[] = preferMdxDocSourceFiles(
-  Object.keys(docSourceLoaders),
-).flatMap((path) => {
-  const load = docSourceLoaders[path];
-  if (!load) return [];
+function buildDocSources(entries: DocSourceAsset[]): DocSource[] {
+  const entriesByFilename = new Map(
+    entries
+      .filter(
+        (entry) =>
+          typeof entry?.filename === "string" &&
+          typeof entry?.content === "string" &&
+          isDocSourceFile(entry.filename),
+      )
+      .map((entry) => [entry.filename, entry]),
+  );
 
-  return [
-    {
-      filename: path.split("/").pop() ?? path,
-      slug: docSourceSlugFromFilename(path),
-      load,
+  return preferMdxDocSourceFiles(Array.from(entriesByFilename.keys())).flatMap(
+    (filename) => {
+      const entry = entriesByFilename.get(filename);
+      if (!entry) return [];
+
+      return [
+        {
+          filename,
+          slug: docSourceSlugFromFilename(filename),
+          content: entry.content,
+        },
+      ];
     },
-  ];
-});
+  );
+}
 
-const docSourcesBySlug = new Map(
-  docSources.map((source) => [source.slug, source]),
-);
+async function loadLocalDocSources(): Promise<DocSource[]> {
+  const entries = await readdir(LOCAL_DOCS_ROOT, { withFileTypes: true });
+  const files = entries
+    .filter((entry) => entry.isFile() && isDocSourceFile(entry.name))
+    .map((entry) => entry.name);
+  const sources = await Promise.all(
+    files.map(async (filename) => ({
+      filename,
+      content: await readFile(join(LOCAL_DOCS_ROOT, filename), "utf-8"),
+    })),
+  );
+  return buildDocSources(sources);
+}
 
-export function listDocSourceFiles(): string[] {
-  return docSources.map((source) => source.filename);
+let docSourcesPromise: Promise<DocSource[]> | undefined;
+
+async function loadDocSources(): Promise<DocSource[]> {
+  const generated =
+    await readPublicJsonAsset<DocSourceAsset[]>(GENERATED_DOCS_ASSET);
+  if (Array.isArray(generated)) return buildDocSources(generated);
+  return loadLocalDocSources();
+}
+
+function cachedDocSources(): Promise<DocSource[]> {
+  docSourcesPromise ??= loadDocSources().catch((error) => {
+    docSourcesPromise = undefined;
+    throw error;
+  });
+  return docSourcesPromise;
+}
+
+export async function listDocSourceFiles(): Promise<string[]> {
+  return (await cachedDocSources()).map((source) => source.filename);
 }
 
 export async function readDocSource(slug: string): Promise<string | undefined> {
-  const source = docSourcesBySlug.get(slug);
-  return source ? source.load() : undefined;
+  const source = (await cachedDocSources()).find(
+    (candidate) => candidate.slug === slug,
+  );
+  return source?.content;
 }

--- a/packages/docs/scripts/generate-source-index.ts
+++ b/packages/docs/scripts/generate-source-index.ts
@@ -4,6 +4,11 @@ import { join, relative } from "node:path";
 
 const CORE_SRC = join(import.meta.dirname, "../../core/src");
 const OUTPUT = join(import.meta.dirname, "../public/source-index.json");
+const CORE_DOCS = join(import.meta.dirname, "../../core/docs/content");
+const DOCS_OUTPUT = join(
+  import.meta.dirname,
+  "../public/docs-source-index.json",
+);
 
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "__tests__"]);
 const EXTENSIONS = new Set([".ts", ".tsx"]);
@@ -11,6 +16,11 @@ const MAX_FILE_SIZE = 50_000;
 
 interface SourceEntry {
   path: string;
+  content: string;
+}
+
+interface DocSourceEntry {
+  filename: string;
   content: string;
 }
 
@@ -39,6 +49,25 @@ async function walkDir(dir: string, base: string): Promise<SourceEntry[]> {
   return entries;
 }
 
+async function readDocSources(): Promise<DocSourceEntry[]> {
+  const entries = await readdir(CORE_DOCS, { withFileTypes: true });
+  const files = entries
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        [".md", ".mdx"].includes(entry.name.slice(entry.name.lastIndexOf("."))),
+    )
+    .map((entry) => entry.name)
+    .sort();
+
+  return Promise.all(
+    files.map(async (filename) => ({
+      filename,
+      content: await readFile(join(CORE_DOCS, filename), "utf-8"),
+    })),
+  );
+}
+
 async function main() {
   console.log(`Indexing source files from ${CORE_SRC}...`);
   const entries = await walkDir(CORE_SRC, CORE_SRC);
@@ -46,6 +75,11 @@ async function main() {
 
   writeFileSync(OUTPUT, JSON.stringify(entries));
   console.log(`Written to ${OUTPUT}`);
+
+  const docSources = await readDocSources();
+  console.log(`Indexed ${docSources.length} documentation source files`);
+  writeFileSync(DOCS_OUTPUT, JSON.stringify(docSources));
+  console.log(`Written to ${DOCS_OUTPUT}`);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary
- generate a raw docs source asset during the docs prebuild
- load server-side documentation actions from that asset, with a local source fallback
- remove the untransformed `import.meta.glob` from the Netlify server entry

## Verification
- `pnpm --filter @agent-native/docs test`
- `pnpm --filter @agent-native/docs typecheck`
- `NITRO_PRESET=netlify pnpm --filter @agent-native/docs build`
- emitted Netlify `server/main.mjs` contains no `import.meta.glob`

This follows the production 502 observed on the desktop update endpoint after the first feed fix.