### PR TITLE
fix: restore the concurrent-edit file-lease hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,29 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/file-lease.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/file-lease.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,16 @@ editing them, and use `corepack pnpm ship:push` when the user authorizes a
 branch-wide checkpoint. Read `concurrent-agents` before working in a shared
 checkout.
 
+**One hook** (`scripts/hooks/file-lease.mjs`, registered in the tracked
+`.claude/settings.json`): denies a write when another live session holds the
+file, or when it changed on disk under you. It exists because this is the only
+rule you cannot follow by reading instructions — no amount of guidance tells you
+that a peer session is mid-edit in the same file right now. Re-read and build on
+their change; never force past it. It is a Claude Code mechanism only: it gives
+Codex sessions and plain human edits nothing, so it is a backstop, not a
+guarantee. Read `concurrent-agents` before working in a shared checkout.
+`guard:hooks-registered` keeps this section and that file from drifting apart.
+
 Everything else is guidance — but guidance nobody measures is guidance nobody
 can tell is working. `node scripts/agent-friction-report.mjs --weeks 2` counts
 how often the user has had to repeat each correction, and names the skill that

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lint": "pnpm fmt:check && pnpm oxlint && pnpm typecheck",
     "oxlint": "oxlint --config .oxlintrc.json .",
     "dev:cli": "tsx packages/core/src/cli/index.ts",
+    "guard:hooks-registered": "node scripts/guard-hooks-registered.mjs",
     "guard:no-drizzle-push": "node scripts/guard-no-drizzle-push.mjs",
     "guard:no-pnpm-patches": "tsx scripts/guard-no-pnpm-patches.ts",
     "guard:chat-first-shared-ui": "tsx scripts/guard-chat-first-shared-ui.ts",

--- a/scripts/guard-hooks-registered.mjs
+++ b/scripts/guard-hooks-registered.mjs
@@ -1,4 +1,25 @@
 #!/usr/bin/env node
+/**
+ * guard-hooks-registered.mjs
+ *
+ * CLAUDE.md documents exactly one behavioral mechanism — the file-lease hook —
+ * and describes it as "registered in .claude/settings.json". For most of this
+ * repo's life that file was gitignored, so the claim could not be checked by
+ * anyone: a fresh checkout got no hook, a removed hook left no diff, and an
+ * instruction-surface audit on 2026-08-11 found a documented-but-unregistered
+ * hook exactly once this had become possible.
+ *
+ * This guard closes the loop in both directions:
+ *   - every `scripts/hooks/*.mjs` that CLAUDE.md names must be wired into
+ *     .claude/settings.json
+ *   - every hook command wired into settings.json must point at a script that
+ *     exists on disk
+ *
+ * It deliberately does not check *which* event a hook is registered on. That
+ * is a design choice a reviewer should make; this only stops the two failures
+ * that are invisible without it — documented-but-absent, and wired-but-gone.
+ */
+
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/guard-hooks-registered.mjs
+++ b/scripts/guard-hooks-registered.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const SETTINGS_PATH = path.join(REPO_ROOT, ".claude", "settings.json");
+const HOOKS_DIR = path.join(REPO_ROOT, "scripts", "hooks");
+const CLAUDE_MD = path.join(REPO_ROOT, "CLAUDE.md");
+
+function fail(lines) {
+  console.error(`guard-hooks-registered: ${lines.length} problem(s).\n`);
+  for (const line of lines) console.error(`  ${line}`);
+  console.error(
+    "\nCLAUDE.md's Checks section is the source of truth for which hooks exist.\n" +
+      "Either wire the hook into .claude/settings.json, or stop documenting it.\n",
+  );
+  process.exit(1);
+}
+
+if (!existsSync(SETTINGS_PATH)) {
+  fail([
+    ".claude/settings.json is missing — the hooks CLAUDE.md documents are not registered anywhere.",
+  ]);
+}
+
+let settings;
+try {
+  settings = JSON.parse(readFileSync(SETTINGS_PATH, "utf8"));
+} catch (error) {
+  fail([`.claude/settings.json is not valid JSON: ${error.message}`]);
+}
+
+const registeredCommands = Object.values(settings.hooks ?? {})
+  .flat()
+  .flatMap((group) => group?.hooks ?? [])
+  .map((hook) => hook?.command)
+  .filter((command) => typeof command === "string");
+
+const claudeMd = readFileSync(CLAUDE_MD, "utf8");
+const hookScripts = existsSync(HOOKS_DIR)
+  ? readdirSync(HOOKS_DIR).filter((name) => /\.(mjs|js|ts)$/.test(name))
+  : [];
+
+const problems = [];
+
+const claudeMdHookRefs = [
+  ...claudeMd.matchAll(/scripts\/hooks\/([\w.-]+\.(?:mjs|js|ts))/g),
+].map((match) => match[1]);
+
+for (const name of new Set(claudeMdHookRefs)) {
+  const wired = registeredCommands.some((command) => command.includes(name));
+  if (!wired) {
+    problems.push(
+      `CLAUDE.md documents \`scripts/hooks/${name}\` but no hook command in .claude/settings.json references it.`,
+    );
+  }
+}
+
+for (const command of registeredCommands) {
+  const match = command.match(/scripts\/hooks\/([\w.-]+\.(?:mjs|js|ts))/);
+  if (!match) continue;
+  const name = match[1];
+  if (!hookScripts.includes(name)) {
+    problems.push(
+      `.claude/settings.json registers \`scripts/hooks/${name}\` but that file does not exist.`,
+    );
+  }
+}
+
+if (problems.length > 0) fail(problems);
+
+console.log(
+  `guard-hooks-registered: OK (${registeredCommands.length} hook command(s) registered, ${hookScripts.length} hook script(s) on disk).`,
+);

--- a/scripts/hooks/file-lease.mjs
+++ b/scripts/hooks/file-lease.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * file-lease.mjs — PreToolUse(Edit|Write|MultiEdit|NotebookEdit)
+ *
+ * Many agents share one checkout by design. Today they discover collisions
+ * only after a diff quietly vanishes: "another agent landed its OWN complete
+ * fix for the exact same bug in the exact same file, overwriting my in-progress
+ * edits on disk". The inverse is just as costly — a false "you reverted my
+ * work" accusation burns a whole investigation round.
+ *
+ * Two checks, both cheap:
+ *   1. Another live session (lease newer than LEASE_TTL_MS) holds this file →
+ *      deny and name the holder, so the agents coordinate instead of racing.
+ *   2. The file changed on disk since THIS session last wrote it → deny, so a
+ *      peer's landed edit is never silently overwritten by a stale buffer.
+ *
+ * Leases live in .claude/leases/ (gitignored) and are just a timestamp plus
+ * the session id; a crashed session's lease expires on its own.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const LEASE_TTL_MS = 15 * 60 * 1000;
+const SWEEP_AFTER_MS = 60 * 60 * 1000;
+
+const input = readStdin();
+const session = String(input.session_id ?? "");
+const file = String(
+  input?.tool_input?.file_path ?? input?.tool_input?.notebook_path ?? "",
+);
+if (!session || !file) allow();
+
+const root = process.env.CLAUDE_PROJECT_DIR ?? input.cwd ?? process.cwd();
+const leaseDir = path.join(root, ".claude", "leases");
+const leasePath = path.join(
+  leaseDir,
+  `${createHash("sha1").update(path.resolve(file)).digest("hex")}.json`,
+);
+
+const now = Date.now();
+const diskMtime = mtimeOf(file);
+
+if (input.hook_event_name === "PostToolUse") {
+  writeLease();
+  allow();
+}
+
+const previous = readLease(leasePath);
+
+if (
+  previous &&
+  previous.session !== session &&
+  now - previous.at < LEASE_TTL_MS
+) {
+  deny(
+    `Another agent session (\`${previous.session.slice(0, 8)}\`) claimed ` +
+      `${show(file)} ${Math.round((now - previous.at) / 1000)}s ago ` +
+      `and may have unsaved reasoning about it.\n\n` +
+      `Do not overwrite it. Either work on a different file, or — if this edit ` +
+      `genuinely belongs to you — re-read the file first so you are editing its ` +
+      `current contents, and say in your response that you are taking over a ` +
+      `file another session was holding.\n\n` +
+      `The lease expires on its own after 15 minutes of inactivity.`,
+  );
+}
+
+if (
+  previous &&
+  previous.session === session &&
+  previous.mtime !== null &&
+  (diskMtime === null || diskMtime > previous.mtime)
+) {
+  writeLease();
+  deny(
+    `${show(file)} changed on disk since you last wrote it — ` +
+      `another agent edited or deleted it while you were working.\n\n` +
+      `Re-read the file before editing so you build on their change instead of ` +
+      `reverting it. Losing a peer's landed work this way is the exact failure ` +
+      `this check exists to prevent. Re-running this edit after re-reading will ` +
+      `proceed.`,
+  );
+}
+
+if (!previous || previous.session === session) {
+  writeLease();
+  allow();
+}
+
+if (!writeLease(/* exclusive */ true)) {
+  const winner = readLease(leasePath);
+  if (winner && winner.session !== session && now - winner.at < LEASE_TTL_MS) {
+    deny(
+      `Another agent session (\`${winner.session.slice(0, 8)}\`) claimed ` +
+        `${show(file)} moments ago, winning a race to acquire it.\n\n` +
+        `Do not overwrite it. Work on a different file, or retry shortly.`,
+    );
+  }
+  writeLease();
+}
+allow();
+
+function writeLease(exclusive = false) {
+  try {
+    mkdirSync(leaseDir, { recursive: true });
+    sweep();
+    writeFileSync(
+      leasePath,
+      JSON.stringify({ session, at: now, mtime: diskMtime, file }),
+      exclusive ? { flag: "wx" } : undefined,
+    );
+    return true;
+  } catch (err) {
+    if (exclusive && err?.code === "EEXIST") return false;
+    process.stderr.write("file-lease: could not record lease\n");
+    return true;
+  }
+}
+
+function sweep() {
+  try {
+    for (const name of readdirSync(leaseDir)) {
+      const full = path.join(leaseDir, name);
+      if (now - statSync(full).mtimeMs > SWEEP_AFTER_MS) unlinkSync(full);
+    }
+  } catch {
+    /* best effort */
+  }
+}
+
+function show(target) {
+  const rel = path.relative(root, target);
+  return rel.startsWith("..") ? target : rel;
+}
+
+function readLease(target) {
+  try {
+    const parsed = JSON.parse(readFileSync(target, "utf8"));
+    return typeof parsed?.session === "string" && typeof parsed?.at === "number"
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function mtimeOf(target) {
+  try {
+    return statSync(target).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function readStdin() {
+  try {
+    return JSON.parse(readFileSync(0, "utf8"));
+  } catch {
+    process.stderr.write("file-lease: unreadable hook input\n");
+    process.exit(0);
+  }
+}
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+function allow() {
+  process.exit(0);
+}

--- a/scripts/hooks/file-lease.test.ts
+++ b/scripts/hooks/file-lease.test.ts
@@ -9,8 +9,8 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 
 const HOOK = fileURLToPath(new URL("./file-lease.mjs", import.meta.url));
 

--- a/scripts/hooks/file-lease.test.ts
+++ b/scripts/hooks/file-lease.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const HOOK = fileURLToPath(new URL("./file-lease.mjs", import.meta.url));
+
+function runHook(root: string, session: string, event: string) {
+  const target = path.join(root, "target.txt");
+  const input = JSON.stringify({
+    session_id: session,
+    hook_event_name: event,
+    tool_input: { file_path: target },
+  });
+  const result = spawnSync(process.execPath, [HOOK], {
+    input,
+    encoding: "utf8",
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root },
+  });
+  const decision = result.stdout
+    ? JSON.parse(result.stdout)?.hookSpecificOutput?.permissionDecision
+    : "allow";
+  return { decision, target };
+}
+
+describe("file-lease hook", () => {
+  it("allows a session's own first write and re-write", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "file-lease-basic-"));
+    try {
+      writeFileSync(path.join(root, "target.txt"), "v1");
+      assert.equal(runHook(root, "session-a", "PreToolUse").decision, "allow");
+      runHook(root, "session-a", "PostToolUse");
+      assert.equal(runHook(root, "session-a", "PreToolUse").decision, "allow");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("denies a different live session editing a leased file", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "file-lease-collide-"));
+    try {
+      writeFileSync(path.join(root, "target.txt"), "v1");
+      runHook(root, "session-a", "PreToolUse");
+      runHook(root, "session-a", "PostToolUse");
+      assert.equal(runHook(root, "session-b", "PreToolUse").decision, "deny");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("denies a stale write that would resurrect a peer-deleted file", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "file-lease-delete-"));
+    try {
+      const target = path.join(root, "target.txt");
+      writeFileSync(target, "v1");
+      runHook(root, "session-a", "PreToolUse");
+      runHook(root, "session-a", "PostToolUse");
+
+      unlinkSync(target);
+
+      const first = runHook(root, "session-a", "PreToolUse");
+      assert.equal(first.decision, "deny");
+
+      writeFileSync(target, "v2");
+      assert.equal(runHook(root, "session-a", "PreToolUse").decision, "allow");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("creates the lease directory on first use", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "file-lease-mkdir-"));
+    try {
+      writeFileSync(path.join(root, "target.txt"), "v1");
+      assert.equal(runHook(root, "session-a", "PreToolUse").decision, "allow");
+      mkdirSync(path.join(root, ".claude", "leases"), { recursive: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/run-guards.ts
+++ b/scripts/run-guards.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import { resultStatus, summarizeGuardRun } from "./lib/guard-run-summary";
 
 const guards = [
+  "guard:hooks-registered",
   "guard:no-drizzle-push",
   "guard:no-pnpm-patches",
   "guard:chat-first-shared-ui",

--- a/scripts/trusted-acceptance/controller.ts
+++ b/scripts/trusted-acceptance/controller.ts
@@ -593,7 +593,7 @@ export async function updateTrustedAcceptanceDirectoryScenario(
   profile: TrustedAuthorityProfile,
   lease: RuntimeLease,
   providers: RuntimeProviders,
-  now?: () => Date,
+  now: (() => Date) | undefined,
   journalStore: LeaseJournalStore,
 ): Promise<RuntimeLease> {
   const issues = validateTrustedAuthorityProfile(profile);


### PR DESCRIPTION
Restores the file-lease hook that #3076's squash removed from `main`, plus two hardening fixes found in review.

## Why this is a PR to main from an isolated worktree

The hook was restored and re-deleted **seven times** today. The mechanism:

1. #3076's squash (`0b572934d9`) removed the files from `main`.
2. The shared checkout rotated onto a branch cut from post-#3076 `main`, so its working tree had no such files.
3. The commit sweeper publishes whatever that working tree holds, so every sweep re-published their absence as a deletion.

Restoring in a *commit on a branch* never fixed it — the files still weren't on the shared checkout's disk. One restore was undone 91 seconds after being pushed:

```
16:25:03  308fbc8a28  fix: restore the concurrent-edit hook
16:26:34  74e4a5694e  chore: publish branch work ...  -> D on all three files
```

Landing on `main` is what breaks the cycle: branches cut from `main` will carry the files again. This PR is built in a separate worktree so the sweeper can't reach it before merge.

## Contents

- `scripts/hooks/file-lease.mjs` — denies a write when another live session holds the file, or when it changed on disk under you. AGENTS.md calls it the one rule an agent cannot follow by reading instructions.
- Two hardening fixes from review: **peer-deletion detection**, so a stale write can't resurrect a file a peer deleted; and **atomic first-lease acquisition** via exclusive create, closing a two-session race.
- `scripts/hooks/file-lease.test.ts` — 4 tests, passing.
- `scripts/guard-hooks-registered.mjs`, wired into `package.json` and `run-guards.ts` so `pnpm guards` actually runs it. It had been dropped from the runner even in earlier restores, which is why the drift went unnoticed.
- The AGENTS.md section the guard checks against. This matters mechanically: the guard parses CLAUDE.md (a symlink to AGENTS.md) for `scripts/hooks/*` references, so without the section its documented-hook check iterates nothing and passes while toothless.

## Why it matters

With the hook off, one session today produced two WIP edits swept into pushes: a disabled raw-SQL-error sanitizer in `publicAuthError()`, and a disabled password-too-short message that reproduced a bug a user had actually reported.

Verified: `guard-hooks-registered` OK (2 hook commands registered, 2 hook scripts on disk); `node --test scripts/hooks/file-lease.test.ts` → 4 pass, 0 fail.