### PR TITLE
Prevent tiny camera bubble crashes in Clips recording

### DIFF
--- a/templates/clips/app/lib/camera-composite.test.ts
+++ b/templates/clips/app/lib/camera-composite.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { clampToMaxDimension } from "./camera-composite";
+import {
+  cameraBubbleStrokeRadius,
+  clampToMaxDimension,
+} from "./camera-composite";
 
 describe("clampToMaxDimension", () => {
   it("preserves dimensions that are already within the composite ceiling", () => {
@@ -22,5 +25,15 @@ describe("clampToMaxDimension", () => {
       width: 1080,
       height: 1920,
     });
+  });
+});
+
+describe("cameraBubbleStrokeRadius", () => {
+  it("never returns a negative radius for a small startup bubble", () => {
+    expect(cameraBubbleStrokeRadius(1, 4)).toBe(0);
+  });
+
+  it("keeps the normal inset for a full-size bubble", () => {
+    expect(cameraBubbleStrokeRadius(200, 5)).toBe(97.5);
   });
 });

--- a/templates/clips/app/lib/camera-composite.ts
+++ b/templates/clips/app/lib/camera-composite.ts
@@ -149,6 +149,13 @@ export function clampToMaxDimension(
   };
 }
 
+export function cameraBubbleStrokeRadius(
+  size: number,
+  lineWidth: number,
+): number {
+  return Math.max(0, size / 2 - lineWidth / 2);
+}
+
 function resizeCanvasToDisplay(
   canvas: HTMLCanvasElement,
   displayVideo: HTMLVideoElement,
@@ -225,6 +232,7 @@ function drawCameraBubble(
       maxSize,
     ),
   );
+  if (size <= 0) return;
   const margin = Math.round(
     clamp(minDimension * options.bubbleMarginRatio, 24, 80),
   );
@@ -255,7 +263,13 @@ function drawCameraBubble(
   ctx.strokeStyle = "rgba(255, 255, 255, 0.86)";
   ctx.lineWidth = Math.max(4, Math.round(size * 0.025));
   ctx.beginPath();
-  ctx.arc(centerX, centerY, radius - ctx.lineWidth / 2, 0, Math.PI * 2);
+  ctx.arc(
+    centerX,
+    centerY,
+    cameraBubbleStrokeRadius(size, ctx.lineWidth),
+    0,
+    Math.PI * 2,
+  );
   ctx.stroke();
   ctx.restore();
 }

--- a/templates/clips/changelog/2026-08-18-clips-no-longer-crashes-when-a-camera-bubble-starts-at-a-tin.md
+++ b/templates/clips/changelog/2026-08-18-clips-no-longer-crashes-when-a-camera-bubble-starts-at-a-tin.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-18
+---
+
+Clips no longer crashes when a camera bubble starts at a tiny size.


### PR DESCRIPTION
## Summary

- Prevent Clips camera compositing from drawing a negative canvas arc radius while recording starts or the canvas is temporarily tiny.
- Add a regression test for the Sentry-reported geometry and a user-facing Clips changelog entry.

## Feedback and Sentry sweep

- Fixed: Sentry `erriss_6ef3c48fb083453be6398c74` (`IndexSizeError`, `arc` radius `-1.5`) owns this change; the source seam is `templates/clips/app/lib/camera-composite.ts`.
- Awaiting reporter clarification: Clips black camera circle report at TS `1787086285.722919` - eyes reaction added and targeted preview-vs-recorded-composite repro request sent: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787097886494709?thread_ts=1787086285.722919&cid=C0ATH3CCZT4.
- Awaiting reporter clarification: new Slides copy/paste and duplicate-blank-slide report at TS `1787098602.584339` - eyes reaction added and Slides URL/browser/OS/repro request sent: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787098876183009?thread_ts=1787098602.584339&cid=C0ATH3CCZT4.
- Already owned or duplicate: the Clips Better Auth recursion group `erriss_5e5bd222b8ee078d9f2672e2` already has the `experimental.joins: false` guard on `origin/main`; no duplicate patch.
- Deferred or informational: OpenRouter missing optional provider package, Plan optimistic revision conflicts, and Dispatch custom-app registry errors need deployment/config or product evidence rather than a speculative source change.
- External or non-repo-owned: database connection/cooldown groups, gateway timeouts, browser extensions, Amplitude/Vector failures, and stale build-only groups have no repo-owned root cause in the captured evidence.
- Awaiting reporter clarification: [CSM dashboard login loop](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787096991789599?thread_ts=1787092368.834509&cid=C0ATH3CCZT4), [Dispatch settings base-path links](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787096992624499?thread_ts=1787086216.855909&cid=C0ATH3CCZT4). Both received the required eyes reaction and a targeted request for repro evidence.
- GitHub follow-up pending reporter evidence: [#2752](https://github.com/BuilderIO/agent-native/issues/2752) and [#1652](https://github.com/BuilderIO/agent-native/issues/1652). [#3095](https://github.com/BuilderIO/agent-native/issues/3095) is a production health incident/status issue, not a source fix.

## Validation

- `pnpm --filter clips test -- app/lib/camera-composite.test.ts --config vitest.config.ts` - 223 files, 1,338 tests passed.
- `pnpm exec vitest --run --config vitest.config.ts app/lib/camera-composite.test.ts` - 1 file, 5 tests passed.
- `pnpm --filter clips typecheck` - passed; emits the expected local missing production secret/database warnings.
- `git diff --check` - passed.
- GitHub Actions passed Build, Lint & format, Typecheck, Security guards, QA, SSR cold-start smoke, targeted Fast tests, stable Fast tests, Visual Recap, and the retried standalone Chat plus cross-surface sign-in matrix.

The Sentry and feedback sweep was read-only apart from the required Slack eyes reactions and clarification replies; no GitHub or Sentry comments/labels were changed.