### PR TITLE
ci: accept unchanged beta deploys

### DIFF
--- a/.github/workflows/deploy-beta-sites.yml
+++ b/.github/workflows/deploy-beta-sites.yml
@@ -153,6 +153,17 @@ jobs:
             );
           }
 
+          async function reuseMatchingDeploy(site, betaSha) {
+            const matchingDeploy = await findMatchingDeploy(site, betaSha);
+            if (!matchingDeploy) return false;
+            if (matchingDeploy.state === "ready") {
+              console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
+            } else {
+              console.log(`[${site.id}] sibling deploy had no content change; reusing the existing beta deploy.`);
+            }
+            return true;
+          }
+
           async function waitForReady(site, betaSha) {
             const deadline = Date.now() + 30 * 60 * 1000;
             while (Date.now() < deadline) {
@@ -161,21 +172,11 @@ jobs:
                 readJson(await request(`${api}/deploys/${site.deployId}`, { headers }), `[${site.id}] deploy status`),
               ]);
               const noContentChange = [build.error, deploy.error_message].some(isNoContentChange);
-              if (noContentChange) {
-                console.log(`[${site.id}] no content change; reusing the existing beta deploy.`);
-                return;
-              }
               const skipped = [build.error, deploy.error_message].some(
                 (value) => value === "Skipped",
               );
-              if (skipped) {
-                const matchingDeploy = await findMatchingDeploy(site, betaSha);
-                if (matchingDeploy) {
-                  if (matchingDeploy.state === "ready") {
-                    console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
-                  } else {
-                    console.log(`[${site.id}] sibling deploy had no content change; reusing the existing beta deploy.`);
-                  }
+              if (noContentChange || skipped) {
+                if (await reuseMatchingDeploy(site, betaSha)) {
                   return;
                 }
                 await new Promise((resolve) => setTimeout(resolve, 15_000));

--- a/.github/workflows/deploy-beta-sites.yml
+++ b/.github/workflows/deploy-beta-sites.yml
@@ -130,6 +130,29 @@ jobs:
             return { ...site, buildId: build.id, deployId: build.deploy_id };
           }
 
+          function isNoContentChange(value) {
+            return (
+              typeof value === "string" &&
+              value.includes("Canceled build due to no content change")
+            );
+          }
+
+          async function findMatchingDeploy(site, betaSha) {
+            const deploys = await readJson(
+              await request(`${api}/sites/${site.siteId}/deploys?per_page=20`, { headers }),
+              `[${site.id}] recent deploys`,
+            );
+            if (!Array.isArray(deploys)) {
+              throw new Error(`[${site.id}] Netlify returned an invalid deploy list.`);
+            }
+            return deploys.find(
+              (candidate) =>
+                candidate.branch === "beta" &&
+                candidate.commit_ref === betaSha &&
+                (candidate.state === "ready" || isNoContentChange(candidate.error_message)),
+            );
+          }
+
           async function waitForReady(site, betaSha) {
             const deadline = Date.now() + 30 * 60 * 1000;
             while (Date.now() < deadline) {
@@ -137,14 +160,26 @@ jobs:
                 readJson(await request(`${api}/builds/${site.buildId}`, { headers }), `[${site.id}] build status`),
                 readJson(await request(`${api}/deploys/${site.deployId}`, { headers }), `[${site.id}] deploy status`),
               ]);
-              const noContentChange = [build.error, deploy.error_message].some(
-                (value) =>
-                  typeof value === "string" &&
-                  value.includes("Canceled build due to no content change"),
-              );
+              const noContentChange = [build.error, deploy.error_message].some(isNoContentChange);
               if (noContentChange) {
                 console.log(`[${site.id}] no content change; reusing the existing beta deploy.`);
                 return;
+              }
+              const skipped = [build.error, deploy.error_message].some(
+                (value) => value === "Skipped",
+              );
+              if (skipped) {
+                const matchingDeploy = await findMatchingDeploy(site, betaSha);
+                if (matchingDeploy) {
+                  if (matchingDeploy.state === "ready") {
+                    console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
+                  } else {
+                    console.log(`[${site.id}] sibling deploy had no content change; reusing the existing beta deploy.`);
+                  }
+                  return;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 15_000));
+                continue;
               }
               if (build.error || deploy.state === "error") {
                 throw new Error(`[${site.id}] deploy failed: ${build.error || deploy.error_message || deploy.state}`);

--- a/.github/workflows/deploy-beta-sites.yml
+++ b/.github/workflows/deploy-beta-sites.yml
@@ -149,18 +149,14 @@ jobs:
               (candidate) =>
                 candidate.branch === "beta" &&
                 candidate.commit_ref === betaSha &&
-                (candidate.state === "ready" || isNoContentChange(candidate.error_message)),
+                candidate.state === "ready",
             );
           }
 
           async function reuseMatchingDeploy(site, betaSha) {
             const matchingDeploy = await findMatchingDeploy(site, betaSha);
             if (!matchingDeploy) return false;
-            if (matchingDeploy.state === "ready") {
-              console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
-            } else {
-              console.log(`[${site.id}] sibling deploy had no content change; reusing the existing beta deploy.`);
-            }
+            console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
             return true;
           }
 

--- a/.github/workflows/deploy-beta-sites.yml
+++ b/.github/workflows/deploy-beta-sites.yml
@@ -137,6 +137,15 @@ jobs:
                 readJson(await request(`${api}/builds/${site.buildId}`, { headers }), `[${site.id}] build status`),
                 readJson(await request(`${api}/deploys/${site.deployId}`, { headers }), `[${site.id}] deploy status`),
               ]);
+              const noContentChange = [build.error, deploy.error_message].some(
+                (value) =>
+                  typeof value === "string" &&
+                  value.includes("Canceled build due to no content change"),
+              );
+              if (noContentChange) {
+                console.log(`[${site.id}] no content change; reusing the existing beta deploy.`);
+                return;
+              }
               if (build.error || deploy.state === "error") {
                 throw new Error(`[${site.id}] deploy failed: ${build.error || deploy.error_message || deploy.state}`);
               }

--- a/.github/workflows/deploy-beta-sites.yml
+++ b/.github/workflows/deploy-beta-sites.yml
@@ -137,26 +137,43 @@ jobs:
             );
           }
 
-          async function findMatchingDeploy(site, betaSha) {
-            const deploys = await readJson(
-              await request(`${api}/sites/${site.siteId}/deploys?per_page=20`, { headers }),
-              `[${site.id}] recent deploys`,
-            );
-            if (!Array.isArray(deploys)) {
-              throw new Error(`[${site.id}] Netlify returned an invalid deploy list.`);
+          async function listBetaDeploys(site) {
+            const deploys = [];
+            for (let page = 1; page <= 100; page += 1) {
+              const pageDeploys = await readJson(
+                await request(`${api}/sites/${site.siteId}/deploys?per_page=100&page=${page}`, { headers }),
+                `[${site.id}] recent deploys page ${page}`,
+              );
+              if (!Array.isArray(pageDeploys)) {
+                throw new Error(`[${site.id}] Netlify returned an invalid deploy list.`);
+              }
+              deploys.push(...pageDeploys);
+              if (pageDeploys.length < 100) return deploys;
             }
+            throw new Error(`[${site.id}] Netlify deploy pagination exceeded 100 pages.`);
+          }
+
+          async function findReadyDeploy(site, betaSha) {
+            const deploys = await listBetaDeploys(site);
             return deploys.find(
               (candidate) =>
                 candidate.branch === "beta" &&
-                candidate.commit_ref === betaSha &&
-                candidate.state === "ready",
+                candidate.state === "ready" &&
+                (!betaSha || candidate.commit_ref === betaSha),
             );
           }
 
-          async function reuseMatchingDeploy(site, betaSha) {
-            const matchingDeploy = await findMatchingDeploy(site, betaSha);
+          async function reuseMatchingDeploy(site, betaSha, requireExactSha) {
+            const matchingDeploy = await findReadyDeploy(
+              site,
+              requireExactSha ? betaSha : undefined,
+            );
             if (!matchingDeploy) return false;
-            console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
+            if (requireExactSha) {
+              console.log(`[${site.id}] sibling deploy ready at ${matchingDeploy.commit_ref}.`);
+            } else {
+              console.log(`[${site.id}] no content change; reusing ready beta deploy at ${matchingDeploy.commit_ref}.`);
+            }
             return true;
           }
 
@@ -172,7 +189,7 @@ jobs:
                 (value) => value === "Skipped",
               );
               if (noContentChange || skipped) {
-                if (await reuseMatchingDeploy(site, betaSha)) {
+                if (await reuseMatchingDeploy(site, betaSha, skipped)) {
                   return;
                 }
                 await new Promise((resolve) => setTimeout(resolve, 15_000));


### PR DESCRIPTION
## Summary
- treat Netlify no-content-change cancellations as a successful beta reuse
- continue smoke testing every host after reuse so unchanged apps remain covered

## Verification
- actionlint .github/workflows/deploy-beta-sites.yml
- pnpm exec prettier --check .github/workflows/deploy-beta-sites.yml
- git diff --check