### PR TITLE
Use the Agent-Native bot for feedback Slack interactions

### DIFF
--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -70,16 +70,16 @@ reference from Slack, fetch them through the artifact's owning connector or
 public URL; never send the Slack bearer token to an external service.
 
 - Load the value from `.env` without printing it, then call Slack `auth.test`
-  before the first request. Require `ok: true`, `team_id`, and `user_id`, and
-  verify the returned user resolves to `agent-native` (using `users.info` with
-  the returned `user_id` when the human-readable `user` field is insufficient).
-  Keep the stable identity tuple `{ team_id, user_id, bot_id }`, with
-  `bot_id` included when Slack returns it, for all read-back checks.
+  before the first request. Require `ok: true`, `team_id`, `user_id`, and
+  `bot_id`; verify `users.info(user_id)` returns a bot user (`is_bot: true`)
+  whose canonical name or display name is `agent-native`. Keep the stable
+  identity tuple `{ team_id, user_id, bot_id }` for all read-back checks.
 - Use that same bearer token for channel history, thread replies, reactions,
   and Slack metadata. Use Slack cursors until the requested history or thread
-  is complete. A message read-back must match the `team_id` and `user_id`, and
-  must match `bot_id` when the message includes it; a reaction read-back must
-  include the same `user_id` in its users list.
+  is complete. A bot-message read-back must match the `team_id` and `bot_id`;
+  if Slack also includes a `user` author, it must match `user_id`, but a missing
+  `user` field is valid for bot messages. A reaction read-back must include the
+  same `user_id` in its users list.
 - After every reaction or reply, re-read through the same token and verify the
   reaction or reply exists and matches that identity tuple.
 - If the token is absent, invalid, or resolves to any identity other than

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -127,12 +127,12 @@ needed to fix it, do not post it. These are ledger states, not mandatory
 headings: keep the reporter-facing wording natural instead of opening with the
 robotic phrase “Clarification needed”.
 
-**Clarification needed** is an open state, not a finished one. Asking the
-question creates a standing obligation to come back for the answer: the thread
-now looks owned to any cursor that scans for unhandled reports, so nothing will
-resurface it on its own. `review-latest-feedback` owns that re-check and runs
-it before it scans for new messages; when this workflow runs on its own, re-read
-every thread it previously asked in and act on the replies first.
+**Clarification needed** is an open state, not a completed product fix. Asking
+the question creates a standing obligation to come back for the answer. It is
+the bot's terminal disposition for the current cursor, but the next
+`review-latest-feedback` run must re-read every thread it previously asked in
+before scanning newer messages; when this workflow runs on its own, do the same
+and act on the replies first.
 
 Treat a clarification reply as new evidence, not as a fresh blank report.
 Re-read the whole thread after the reply, update the ledger, and try the fix

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Complete the Slack feedback cycle: read every thread and linked evidence,
   fix verified repo-owned issues, and reply in-thread with honest status,
   clarification questions, and release follow-up. Use when the user asks to
-  address feedback and respond as themselves.
+  address feedback and respond in the requested voice through the @agent-native
+  Slack bot.
 scope: dev
 metadata:
   internal: true
@@ -23,9 +24,10 @@ status.
 Every actionable Slack parent that receives `👀` is in scope for the reply
 ledger. The reaction is only the first external action - it never counts as a
 reply, ownership marker, or completion. Before finishing, re-read every
-eye-marked parent and confirm that Steve posted either **Fixed** or
-**Clarification needed** in that thread. A bot forward, another person's
-reply, or a generic acknowledgement does not satisfy the ledger.
+eye-marked parent and confirm that the `@agent-native` bot posted either
+**Fixed** or **Clarification needed** in that thread. A generic bot forward or
+acknowledgement, another person's reply, or the `👀` reaction alone does not
+satisfy the ledger.
 
 ## Prerequisites
 
@@ -56,25 +58,34 @@ reply, or a generic acknowledgement does not satisfy the ledger.
 
 ## Slack bot identity
 
-Every Slack interaction in this workflow - reads, reactions, replies, thread
-re-reads, and linked-file lookups - must use the Slack Web API with the local,
-untracked `.env` value `SLACK_BOT_TOKEN`. That value must authenticate the
-`@agent-native` Slack bot. Do not use the connected Slack MCP user's OAuth
-identity, a Steve/ChatGPT identity, or a different bot token for any Slack
-operation in this workflow.
+Every Slack API interaction in this workflow - channel history, reactions,
+thread replies and read-backs, permalinks, and Slack message/user/file
+metadata - must use the Slack Web API with the local, untracked `.env` value
+`SLACK_BOT_TOKEN`. That value must authenticate the `@agent-native` Slack bot.
+Do not use the connected Slack MCP user's OAuth identity, a Steve/ChatGPT
+identity, or a different bot token for any Slack operation in this workflow.
+
+Linked external artifacts are not Slack interactions. After extracting their
+reference from Slack, fetch them through the artifact's owning connector or
+public URL; never send the Slack bearer token to an external service.
 
 - Load the value from `.env` without printing it, then call Slack `auth.test`
-  before the first request. Keep the returned bot identity for read-back
-  checks; do not infer it from a display name in a message.
+  before the first request. Require `ok: true`, `team_id`, and `user_id`, and
+  verify the returned user resolves to `agent-native` (using `users.info` with
+  the returned `user_id` when the human-readable `user` field is insufficient).
+  Keep the stable identity tuple `{ team_id, user_id, bot_id }`, with
+  `bot_id` included when Slack returns it, for all read-back checks.
 - Use that same bearer token for channel history, thread replies, reactions,
-  user/file metadata, and `chat.postMessage` replies with `thread_ts`. Use
-  Slack cursors until the requested history or thread is complete.
+  and Slack metadata. Use Slack cursors until the requested history or thread
+  is complete. A message read-back must match the `team_id` and `user_id`, and
+  must match `bot_id` when the message includes it; a reaction read-back must
+  include the same `user_id` in its users list.
 - After every reaction or reply, re-read through the same token and verify the
-  reaction or reply exists and was authored by the `auth.test` bot identity.
+  reaction or reply exists and matches that identity tuple.
 - If the token is absent, invalid, or resolves to any identity other than
-  `@agent-native`, do not fall back to a user connector for Slack writes.
-  Record Slack as unavailable, preserve the exact gap, and continue only with
-  non-Slack evidence.
+  `@agent-native`, do not fall back to a user connector for Slack reads or
+  writes. Record Slack as unavailable, preserve the exact gap, and continue
+  only with non-Slack evidence.
 
 ## Decision Gate
 
@@ -188,14 +199,15 @@ missing value. A `Clarification needed` reply is invalid when the requested
    the reporter to solve an internal tooling or deployment gap; keep working
    until the check is available. The run is incomplete while that parent has
    only `👀`.
-6. When the user explicitly asks to reply, post directly in each requested
-   thread with `slack_send_message` and `thread_ts`. Do not silently turn an
-   authorized write into a draft. Re-read each thread afterward to confirm the
-   reply landed. Before ending the run, mechanically audit the reply ledger:
-   for every `👀` parent, record the Steve-authored reply timestamp and whether
-   it is **Fixed** or **Clarification needed**. If any parent has only `👀`, a
-   bot forward, or another person's reply, keep working and post the missing
-   reply before finishing.
+6. When the user explicitly asks to reply, call Slack Web API
+   `chat.postMessage` directly in each requested thread with `thread_ts` and
+   the same `SLACK_BOT_TOKEN`. Do not silently turn an authorized write into a
+   draft. Re-read each thread afterward to confirm the reply landed. Before
+   ending the run, mechanically audit the reply ledger: for every `👀` parent,
+   record the `@agent-native` reply timestamp and whether it is **Fixed** or
+   **Clarification needed**. If any parent has only `👀`, a generic bot
+   forward, or another person's reply, keep working and post the missing reply
+   before finishing.
    If a reporter replies after the post, re-read the entire thread again before
    deciding whether to fix, close, or ask anything else.
 7. If a reporter answers a clarification question, re-read the full thread and
@@ -208,9 +220,10 @@ missing value. A `Clarification needed` reply is invalid when the requested
    place. Do not fix only the newest example or leave the other addressed
    threads with the old wording.
 
-## Steve's Slack voice
+## Slack reply voice
 
-Write as Steve, not as a formal support bot:
+Write in Steve's voice, but let `@agent-native` be the sender - do not switch
+to a user-authored Slack identity:
 
 - Use lowercase, short conversational paragraphs, and clear, conversational
   wording. Keep the tone casual and collaborative - warm without being corny,

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -76,10 +76,13 @@ public URL; never send the Slack bearer token to an external service.
   identity tuple `{ team_id, user_id, bot_id }` for all read-back checks.
 - Use that same bearer token for channel history, thread replies, reactions,
   and Slack metadata. Use Slack cursors until the requested history or thread
-  is complete. A bot-message read-back must match the `team_id` and `bot_id`;
-  if Slack also includes a `user` author, it must match `user_id`, but a missing
-  `user` field is valid for bot messages. A reaction read-back must include the
-  same `user_id` in its users list.
+  is complete. The authenticated `team_id` scopes the request; do not require
+  individual message objects to repeat it. A message read-back must match the
+  target channel, timestamp, and thread parent, compare `team` or `team_id`
+  when Slack returns either field, and match the `bot_id`; if Slack also
+  includes a `user` author, it must match `user_id`, but a missing `user` field
+  is valid for bot messages. A reaction read-back must target the same message
+  and include the same `user_id` in its users list.
 - After every reaction or reply, re-read through the same token and verify the
   reaction or reply exists and matches that identity tuple.
 - If the token is absent, invalid, or resolves to any identity other than

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -54,6 +54,28 @@ reply, or a generic acknowledgement does not satisfy the ledger.
 - Re-read dirty files before changing them. Preserve the shared checkout and
   never move branches, reset, stash, or overwrite peer work.
 
+## Slack bot identity
+
+Every Slack interaction in this workflow - reads, reactions, replies, thread
+re-reads, and linked-file lookups - must use the Slack Web API with the local,
+untracked `.env` value `SLACK_BOT_TOKEN`. That value must authenticate the
+`@agent-native` Slack bot. Do not use the connected Slack MCP user's OAuth
+identity, a Steve/ChatGPT identity, or a different bot token for any Slack
+operation in this workflow.
+
+- Load the value from `.env` without printing it, then call Slack `auth.test`
+  before the first request. Keep the returned bot identity for read-back
+  checks; do not infer it from a display name in a message.
+- Use that same bearer token for channel history, thread replies, reactions,
+  user/file metadata, and `chat.postMessage` replies with `thread_ts`. Use
+  Slack cursors until the requested history or thread is complete.
+- After every reaction or reply, re-read through the same token and verify the
+  reaction or reply exists and was authored by the `auth.test` bot identity.
+- If the token is absent, invalid, or resolves to any identity other than
+  `@agent-native`, do not fall back to a user connector for Slack writes.
+  Record Slack as unavailable, preserve the exact gap, and continue only with
+  non-Slack evidence.
+
 ## Decision Gate
 
 Apply the shared `address-feedback` **Choose the fix altitude** gate before

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -38,6 +38,9 @@ the right abstraction, not the most general one.
 - If no link or feedback text is provided, ask for it.
 - Read the repo `AGENTS.md` before touching code.
 - Use the relevant connector/plugin/skill for the source when available, instead of scraping authenticated pages.
+- For Slack, use the `SLACK_BOT_TOKEN` / `@agent-native` identity contract in
+  `address-feedback-with-replies`; never mix user OAuth reads or writes into a
+  bot-authenticated feedback workflow.
 - Before starting work, search available task history and local Git/PR metadata for the exact feedback link or issue identifiers. Reuse existing work instead of creating a duplicate fix.
 
 ## Steps

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -53,11 +53,11 @@ the right abstraction, not the most general one.
    | Google Docs/Drive link | Google Drive connector or Google Docs skill |
    | Linear link | Linear connector if installed; otherwise ask for pasted content |
    | GitHub issue or PR | GitHub connector or `gh issue view` / `gh pr view` |
-   | Slack thread | Slack connector |
+   | Slack thread | Slack Web API with `SLACK_BOT_TOKEN` / `@agent-native` identity |
    | Public URL | Web browsing |
    | Pasted text | Read directly |
 
-   Use web browsing only for public URLs. Auth-gated docs usually need their matching connector. For threads, read the parent and all replies; note when there are no replies, and inspect linked files or newer follow-ups when the source refers to them.
+   Use web browsing only for public URLs. Auth-gated docs usually need their matching connector. For Slack threads, use the bot-authenticated Web API for the parent, replies, reactions, and Slack metadata; fetch linked external artifacts through their owning connector or public URL.
 
 2. Check whether this defect has already been reported.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -130,6 +130,12 @@ Use the configured Slack, GitHub, and Sentry connectors when available:
  - Sentry: newest unresolved errors for the repository's projects, stack
    traces, route or component, frequency, affected release, and event links.
 
+For every Slack read or write, follow the `## Slack bot identity` contract in
+`address-feedback-with-replies`: load the local untracked `.env`'s
+`SLACK_BOT_TOKEN`, verify it with `auth.test` as `@agent-native`, and use that
+same bot identity for history, reactions, replies, and read-backs. Never fall
+back to a user/OAuth Slack connector or another bot token for this sweep.
+
 If a connector or permission is missing, continue with the other sources and
 name the exact gap in the final recap. Treat that as unavailable evidence, not
 as “nothing matched.” If the unavailable source is required to identify or

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -24,11 +24,11 @@ This is a reply-producing workflow, not a reaction-only workflow. Apply the
 reply rules in `address-feedback-with-replies` to every actionable Slack item.
 The moment this skill adds `👀` to a Slack parent, that parent enters a
 mandatory reply ledger. Before the run ends, re-read every ledger item and
-confirm that Steve has posted either a concise **Fixed** reply or a concise
-**Clarification needed** question. A bot acknowledgement, another person's
-reply, or the `👀` reaction alone never satisfies the ledger. Do not finish the
-sweep or report success while an actionable parent that this run marked has
-only `👀` or an unrelated reply.
+confirm that the `@agent-native` bot has posted either a concise **Fixed**
+reply or a concise **Clarification needed** question. A generic bot
+acknowledgement or forward, another person's reply, or the `👀` reaction alone
+never satisfies the ledger. Do not finish the sweep or report success while an
+actionable parent that this run marked has only `👀` or an unrelated reply.
 
 ## Start cursor
 
@@ -121,10 +121,12 @@ Before changing code, read `address-feedback`,
 `address-feedback-with-replies`, `concurrent-agents`, and
 `verifying-changes`. Read `ship` when a verified fix is ready to publish.
 
-Use the configured Slack, GitHub, and Sentry connectors when available:
+Use the Slack Web API under the bot-identity contract above. Use the configured
+GitHub and Sentry connectors when available:
 
  - Slack: channel history, reactions, full thread replies, permalinks, and
-   linked evidence.
+   Slack message/user/file metadata. Fetch linked external evidence through
+   its owning connector or public URL, not with the Slack bearer token.
  - GitHub: the newest relevant open issues in `BuilderIO/agent-native`, all
    comments and linked PRs, labels, current state, and duplicate searches.
  - Sentry: newest unresolved errors for the repository's projects, stack
@@ -217,8 +219,9 @@ failure modes, surfaces, or owners.
    running surface. For Sentry reports, confirm the affected release and
    distinguish a source fix from deployed and observed-live recovery.
 6. This skill is authorized to react to actionable Slack threads and must post
-   one concise in-thread update for every actionable parent it marked `👀`, not
-   only for items whose code it changed. Post only after the fix or
+   one concise in-thread update through the `@agent-native` bot for every
+   actionable parent it marked `👀`, not only for items whose code it changed.
+   Post only after the fix or
    clarification is ready. A **Fixed** reply says that the fix is complete and
    when it should be live. A **Clarification needed** reply asks one concrete
    question about missing reporter or product input. Thank the reporter by name
@@ -283,9 +286,9 @@ skipped, duplicated, already owned, blocked by missing evidence, or blocked by
 an unavailable connector. Include direct links to the Slack message or thread,
 GitHub issue, Sentry event, PR, commit, and verification result when present.
 For Slack, include the reply-ledger result for every parent this run marked
-`👀`: Steve reply timestamp and disposition, or the exact reason the item was
-not marked. Never call a sweep complete while an actionable Slack parent in the
-ledger has no Steve reply.
+`👀`: `@agent-native` reply timestamp and disposition, or the exact reason the
+item was not marked. Never call a sweep complete while an actionable Slack
+parent in the ledger has no bot-authored reply.
 
 Use this shape:
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -37,13 +37,13 @@ repository that is currently `#product-agent-native-feedback` (`C0ATH3CCZT4`);
 if the invocation names another channel, use that channel instead.
 
 Scan the channel newest to oldest and choose the most recent parent message
-without a final disposition reply from Steve, `agent-native`, or another person
-clearly investigating or owning the report. An `👀` reaction is only an
-investigation marker and never suppresses the scan. A thread with only that
-reaction, including a fix waiting for internal verification, remains the next
-work item until it receives a final **Fixed** reply or an open
-**Clarification needed** question. Do not treat a generic acknowledgement, bot
-reply, or vague status update as a terminal ownership marker.
+without a verified `@agent-native` bot-authored final disposition - either a
+**Fixed** reply or an open **Clarification needed** question - from the same
+token contract. An `👀` reaction is only an investigation marker and never
+suppresses the scan. A thread with only that reaction, including a fix waiting
+for internal verification, remains the next work item until it receives the
+verified bot disposition. Do not treat a Steve or another person's reply,
+generic bot acknowledgement or forward, or vague status update as terminal.
 
 That message is the start cursor. Classify it, record it if it is not
 actionable, then continue toward older messages, processing each actionable
@@ -110,10 +110,9 @@ post a new **Fixed** reply when the fix is verified. Ask another question only
 for the one remaining missing detail. An answered clarification is never a
 reason to skip the thread or continue scanning newer messages.
 
-Our own question is what makes a thread look owned to the cursor rule above,
-which is why this pass runs first. Without it every thread we asked about
-becomes permanently invisible on later runs and the reporter's answer is never
-read.
+Our own question is what makes a thread eligible for the first work item,
+which is why this pass runs first. Without it every thread we asked about can
+become invisible on later runs and the reporter's answer is never read.
 
 ## Required reading and tools
 


### PR DESCRIPTION
## Summary
- require feedback Slack reads and writes to use the local `SLACK_BOT_TOKEN`
- verify the token with `auth.test` and require the `@agent-native` bot identity
- use the same bot for history, reactions, replies, linked metadata, and read-backs; do not fall back to user OAuth

## Verification
- `corepack pnpm guard:workspace-skills`
- `git diff --check`

This is a skill-only change, so no runtime or deployment verification applies. The local token value is not committed and remains pending because it was not available in this checkout.