### PR TITLE
fix: clear stale Analytics context on new chat

### DIFF
--- a/templates/analytics/app/hooks/use-dashboard-chat-context.spec.tsx
+++ b/templates/analytics/app/hooks/use-dashboard-chat-context.spec.tsx
@@ -157,6 +157,54 @@ describe("useDashboardChatContext", () => {
     );
   });
 
+  it("clears dashboard context when a fresh chat starts", async () => {
+    await act(async () => {
+      root.render(<Harness id="dash-1" />);
+    });
+    await settleContextPublish();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("agent-chat:new-chat"));
+    });
+
+    expect(clientMocks.removeAgentChatContextItem).toHaveBeenCalledWith({
+      key: "analytics-selected-dashboard",
+      openSidebar: false,
+    });
+    expect(clientMocks.removeAgentChatContextItem).toHaveBeenCalledWith({
+      key: "analytics-selected-dashboard-panel",
+      openSidebar: false,
+    });
+    expect(clientMocks.callAction).toHaveBeenCalledWith(
+      "clear-selected-dashboard-object",
+      {
+        browserTabId: TAB_ID,
+        expectedSelection: expect.objectContaining({
+          id: "dash-1",
+          __agentNativeSelectedObjectSource: TAB_ID,
+        }),
+        source: TAB_ID,
+      },
+    );
+  });
+
+  it("does not let a pending dashboard publish resurrect context after new chat", async () => {
+    await act(async () => {
+      root.render(<Harness id="dash-1" />);
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event("agent-chat:new-chat"));
+    });
+    await settleContextPublish();
+
+    expect(clientMocks.setAgentChatContextItem).not.toHaveBeenCalled();
+    expect(clientMocks.setClientAppState).not.toHaveBeenCalledWith(
+      "selected-object",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("stages a selected panel for chat and app state", async () => {
     await act(async () => {
       root.render(<PanelHarness />);

--- a/templates/analytics/app/hooks/use-dashboard-chat-context.ts
+++ b/templates/analytics/app/hooks/use-dashboard-chat-context.ts
@@ -132,6 +132,7 @@ export function useDashboardChatContext(
       : null;
   const hasSelectedPanel = selectedPanelId !== null;
   const publishedSelectionRef = useRef<SelectedDashboardObject | null>(null);
+  const suppressDashboardContextRef = useRef(false);
 
   const selectPanelForChat = useCallback(
     (
@@ -140,6 +141,7 @@ export function useDashboardChatContext(
     ) => {
       if (!id) return;
       if (options.openSidebar !== true && !isAgentSidebarOpen) return;
+      suppressDashboardContextRef.current = false;
       const displayDashboardTitle = title?.trim() || id;
       const displayPanelTitle = panel.panelTitle.trim() || panel.panelId;
       const contextLines = [
@@ -211,13 +213,38 @@ export function useDashboardChatContext(
       );
   }, []);
 
+  useEffect(() => {
+    const handleNewChat = () => {
+      removeAgentChatContextItem({
+        key: DASHBOARD_CONTEXT_KEY,
+        openSidebar: false,
+      });
+      removeAgentChatContextItem({
+        key: DASHBOARD_PANEL_CONTEXT_KEY,
+        openSidebar: false,
+      });
+      const publishedSelection = publishedSelectionRef.current;
+      publishedSelectionRef.current = null;
+      suppressDashboardContextRef.current = true;
+      if (publishedSelection) {
+        void clearSelectedDashboardObjectIfOwned(publishedSelection);
+      }
+    };
+
+    window.addEventListener("agent-chat:new-chat", handleNewChat);
+    return () =>
+      window.removeEventListener("agent-chat:new-chat", handleNewChat);
+  }, []);
+
   // Dashboard metadata lands in pieces — title first, then panel count, then
   // the access role. Publishing each piece costs a round-trip and a sync event
   // that invalidates every mounted query, so only the settled value is sent.
   useEffect(() => {
     if (!id) return;
+    suppressDashboardContextRef.current = false;
     const displayTitle = title?.trim() || id;
     const timer = setTimeout(() => {
+      if (suppressDashboardContextRef.current) return;
       setAgentChatContextItem({
         key: DASHBOARD_CONTEXT_KEY,
         title: `Dashboard: ${displayTitle}`,
@@ -237,6 +264,7 @@ export function useDashboardChatContext(
 
   useEffect(() => {
     if (!id || hasSelectedPanel) return;
+    if (suppressDashboardContextRef.current) return;
     const displayTitle = title?.trim() || id;
     const selection: SelectedDashboardObject = {
       type: "dashboard",
@@ -248,6 +276,7 @@ export function useDashboardChatContext(
       [SELECTED_OBJECT_SOURCE_FIELD]: TAB_ID,
     };
     const timer = setTimeout(() => {
+      if (suppressDashboardContextRef.current) return;
       setClientAppState(SELECTED_OBJECT_STATE_KEY, selection, {
         keepalive: true,
         requestSource: TAB_ID,


### PR DESCRIPTION
## Summary\n\n- clear Analytics dashboard and panel context when a fresh chat starts\n- cancel delayed republish paths so stale context cannot return after cleanup\n- add regressions for normal cleanup and the timer race\n\n## Validation\n\n- corepack pnpm --dir templates/analytics exec vitest run app/hooks/use-dashboard-chat-context.spec.tsx app/pages/Ask.spec.tsx actions/clear-selected-dashboard-object.spec.ts\n- corepack pnpm guards\n- corepack pnpm exec oxfmt --check templates/analytics/app/hooks/use-dashboard-chat-context.ts templates/analytics/app/hooks/use-dashboard-chat-context.spec.tsx\n- git diff --check