### PR TITLE
Cache Clips root redirect at the edge

### DIFF
--- a/templates/clips/app/routes/_index.test.ts
+++ b/templates/clips/app/routes/_index.test.ts
@@ -17,9 +17,7 @@ function expectLibraryRedirect(
   const response = thrown as Response;
   expect(response.status).toBe(302);
   expect(response.headers.get("location")).toBe("/library?from=home");
-  expect(response.headers.get("content-type")).toBe(
-    "text/html; charset=utf-8",
-  );
+  expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
 }
 
 describe("Clips root route", () => {

--- a/templates/clips/app/routes/_index.test.ts
+++ b/templates/clips/app/routes/_index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { clientLoader, loader } from "./_index";
+
+function expectLibraryRedirect(
+  routeLoader: typeof loader | typeof clientLoader,
+  url = "https://clips.agent-native.com/?from=home",
+) {
+  let thrown: unknown;
+  try {
+    routeLoader({ url: new URL(url) } as never);
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(Response);
+  const response = thrown as Response;
+  expect(response.status).toBe(302);
+  expect(response.headers.get("location")).toBe("/library?from=home");
+  expect(response.headers.get("content-type")).toBe(
+    "text/html; charset=utf-8",
+  );
+}
+
+describe("Clips root route", () => {
+  it("marks the SSR redirect as cacheable HTML", () => {
+    expectLibraryRedirect(loader);
+  });
+
+  it("keeps client navigations on the same redirect contract", () => {
+    expectLibraryRedirect(clientLoader);
+  });
+});

--- a/templates/clips/app/routes/_index.tsx
+++ b/templates/clips/app/routes/_index.tsx
@@ -4,12 +4,7 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 const SEO_TITLE = "Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
-const SSR_REDIRECT_HEADERS = {
-  // The deploy adapter uses the HTML content type to apply Clips' public SSR
-  // cache policy. Without it, the root redirect reaches origin on every visit
-  // even though the /library shell is already cached at the edge.
-  "content-type": "text/html; charset=utf-8",
-};
+const SSR_REDIRECT_CONTENT_TYPE = "text/html; charset=utf-8";
 
 export function meta() {
   return [
@@ -44,11 +39,18 @@ function buildTarget(url: URL): string {
 }
 
 export function loader({ url }: LoaderFunctionArgs) {
-  throw redirect(buildTarget(url), { headers: SSR_REDIRECT_HEADERS });
+  const response = redirect(buildTarget(url));
+  // The deploy adapter uses the HTML content type to apply Clips' public SSR
+  // cache policy. Without it, the root redirect reaches origin on every visit
+  // even though the /library shell is already cached at the edge.
+  response.headers.set("content-type", SSR_REDIRECT_CONTENT_TYPE);
+  throw response;
 }
 
 export function clientLoader({ url }: LoaderFunctionArgs) {
-  throw redirect(buildTarget(url), { headers: SSR_REDIRECT_HEADERS });
+  const response = redirect(buildTarget(url));
+  response.headers.set("content-type", SSR_REDIRECT_CONTENT_TYPE);
+  throw response;
 }
 
 export function HydrateFallback() {

--- a/templates/clips/app/routes/_index.tsx
+++ b/templates/clips/app/routes/_index.tsx
@@ -4,6 +4,12 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 const SEO_TITLE = "Clips - Open Source screen recorder";
 const SEO_DESCRIPTION =
   "Open Source screen recorder and meeting-notes app with AI transcripts, summaries, search, dictation, and agent-readable share links.";
+const SSR_REDIRECT_HEADERS = {
+  // The deploy adapter uses the HTML content type to apply Clips' public SSR
+  // cache policy. Without it, the root redirect reaches origin on every visit
+  // even though the /library shell is already cached at the edge.
+  "content-type": "text/html; charset=utf-8",
+};
 
 export function meta() {
   return [
@@ -38,11 +44,11 @@ function buildTarget(url: URL): string {
 }
 
 export function loader({ url }: LoaderFunctionArgs) {
-  throw redirect(buildTarget(url));
+  throw redirect(buildTarget(url), { headers: SSR_REDIRECT_HEADERS });
 }
 
 export function clientLoader({ url }: LoaderFunctionArgs) {
-  throw redirect(buildTarget(url));
+  throw redirect(buildTarget(url), { headers: SSR_REDIRECT_HEADERS });
 }
 
 export function HydrateFallback() {

--- a/templates/clips/server/routes/[...page].head.test.ts
+++ b/templates/clips/server/routes/[...page].head.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetRequestURL = vi.hoisted(() => vi.fn());
+const mockSetResponseHeader = vi.hoisted(() => vi.fn());
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getRequestURL: (...args: unknown[]) => mockGetRequestURL(...args),
+  setResponseHeader: (...args: unknown[]) => mockSetResponseHeader(...args),
+}));
+
+import handler from "./[...page].head";
+
+function makeEvent(pathname: string) {
+  const event = { pathname };
+  mockGetRequestURL.mockReturnValue(
+    new URL(`https://clips.example.test${pathname}`),
+  );
+  return event;
+}
+
+describe("Clips page HEAD route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the root redirect as HTML so the SSR cache policy can apply", async () => {
+    const response = await handler(makeEvent("/") as never);
+
+    expect(response).toMatchObject({ status: 302 });
+    expect(response.headers.get("location")).toBe("/library");
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+  });
+
+  it("keeps non-root HEAD responses as HTML", async () => {
+    const response = await handler(makeEvent("/library") as never);
+
+    expect(response).toMatchObject({ status: 200 });
+    expect(response.headers.get("content-type")).toBe("text/html");
+    expect(response.headers.get("location")).toBeNull();
+  });
+});

--- a/templates/clips/server/routes/[...page].head.test.ts
+++ b/templates/clips/server/routes/[...page].head.test.ts
@@ -24,8 +24,8 @@ describe("Clips page HEAD route", () => {
     vi.clearAllMocks();
   });
 
-  it("marks the root redirect as HTML so the SSR cache policy can apply", async () => {
-    const response = await handler(makeEvent("/") as never);
+  it("marks the root redirect as HTML so the SSR cache policy can apply", () => {
+    const response = handler(makeEvent("/") as never);
 
     expect(response).toMatchObject({ status: 302 });
     expect(response.headers.get("location")).toBe("/library");
@@ -34,8 +34,8 @@ describe("Clips page HEAD route", () => {
     );
   });
 
-  it("keeps non-root HEAD responses as HTML", async () => {
-    const response = await handler(makeEvent("/library") as never);
+  it("keeps non-root HEAD responses as HTML", () => {
+    const response = handler(makeEvent("/library") as never);
 
     expect(response).toMatchObject({ status: 200 });
     expect(response.headers.get("content-type")).toBe("text/html");

--- a/templates/clips/server/routes/[...page].head.ts
+++ b/templates/clips/server/routes/[...page].head.ts
@@ -16,6 +16,11 @@ export default defineEventHandler((event) => {
     return new Response(null, {
       status: 302,
       headers: {
+        // Keep this redirect on the same public SSR-cache path as the shell.
+        // Without a content type the deploy adapter cannot apply the canonical
+        // cache policy, so every visit to `/` reaches the origin before the
+        // already-cached `/library` shell can load.
+        "content-type": "text/html; charset=utf-8",
         location: "/library",
         "Permissions-Policy": MEDIA_CAPTURE_PERMISSIONS_POLICY,
       },


### PR DESCRIPTION
## Why
The hosted-app health audit found Clips root-shell latency around 3.1-3.4s while /library was already edge-cached. The root GET response was a 302 without content-type or SSR cache headers, so every visit reached the origin before redirecting to the cached shell.

## What changed
- Mark the Clips React Router loader and client-loader redirects as HTML.
- Keep the dedicated HEAD redirect on the same cacheability contract.
- Add focused regression tests for both GET loader paths and the HEAD route.

The existing deploy adapter applies the deployment-wide public SSR cache policy when the redirect identifies itself as HTML; no new cache duration or per-user behavior is introduced.

## Validation
- Focused Clips Vitest: 4/4 passed.
- Clips typecheck: passed; existing local production-config diagnostics remain because this checkout has no production auth/database env.
- Clips build: passed; existing doctor findings and bundler warnings remain non-fatal.
- Rebuilt local server GET /: 302 with public cache headers and shared_cacheable=true.

Plan and Slides were rechecked separately: their prior slow readings were transient health cold starts and recovered on repeat probes, so no source change was justified there.