### PR TITLE
docs: revamp Agent-Native overview and Getting Started

### DIFF
--- a/packages/core/docs/content/drop-in-agent.mdx
+++ b/packages/core/docs/content/drop-in-agent.mdx
@@ -11,7 +11,7 @@ description: "Mount the agent chat + resources into any React app with <AgentPan
 
 </Callout>
 
-You don't need to build agent-native from scratch. The agent chat, resources tab, CLI terminal, voice input, and all the related infrastructure ship as a handful of React components you drop into any app.
+You don't need to build Agent-Native from scratch. The agent chat, resources tab, CLI terminal, voice input, and all the related infrastructure ship as a handful of React components you drop into any app.
 
 <Callout tone="info">
 

--- a/packages/core/docs/content/drop-in-agent.mdx
+++ b/packages/core/docs/content/drop-in-agent.mdx
@@ -184,7 +184,7 @@ Full props: `AgentPanelProps` in `@agent-native/core/client`.
 
 ## Programmatic messages: `sendToAgentChat()` {#send}
 
-A button that hands work off to the agent (instead of running an inline `llm()` call — the anti-pattern from the [ladder](/docs/what-is-agent-native#the-ladder)). For visible, user-initiated AI work, open the sidebar explicitly so the user can see, steer, and continue the same thread:
+A button that hands work off to the agent instead of creating a separate AI path with an inline `llm()` call. See [Why build apps this way](/docs/what-is-agent-native#why-build-apps-this-way) for why that distinction matters. For visible, user-initiated AI work, open the sidebar explicitly so the user can see, steer, and continue the same thread:
 
 ```tsx
 import { sendToAgentChat } from "@agent-native/core/client/agent-chat";
@@ -283,7 +283,7 @@ AI-shaped workflow inside one opaque action.
 
 ## Typesafe actions from the UI: `useActionMutation()` {#use-action-mutation}
 
-When the UI needs to run the same operation an agent tool would run — rung 3 of the [ladder](/docs/what-is-agent-native#rung-three) — use `useActionMutation`:
+When the UI needs to run the same operation an agent tool would run, use [`useActionMutation`](/docs/client-data#use-action-mutation):
 
 ```tsx
 import { useActionMutation } from "@agent-native/core/client/hooks";
@@ -298,7 +298,7 @@ Type-safe arguments come from the zod schema in your `defineAction()`. See [Acti
 
 <Callout id="doc-block-1757zi5" tone="decision">
 
-**`useActionMutation` vs `sendToAgentChat`.** Run the operation directly with `useActionMutation` when the user clicked a deterministic button ("Send reply"). Hand it to `sendToAgentChat` when the work needs the agent's reasoning, tools, or multi-step planning. Never call an inline `llm()` from UI — that is rung 1 of the [ladder](/docs/what-is-agent-native#the-ladder).
+**`useActionMutation` vs `sendToAgentChat`.** Run the operation directly with `useActionMutation` when the user clicked a deterministic button ("Send reply"). Hand it to `sendToAgentChat` when the work needs the agent's reasoning, tools, or multi-step planning. Never call an inline `llm()` from UI; that creates a separate AI path instead of using the shared agent loop.
 
 </Callout>
 

--- a/packages/core/docs/content/faq.mdx
+++ b/packages/core/docs/content/faq.mdx
@@ -9,9 +9,9 @@ Common questions about agent-native, organized from "I'm just looking" to "I'm w
 
 ## The basics {#general}
 
-### What is agent-native? {#what-is-agent-native}
+### What is Agent-Native? {#what-is-agent-native}
 
-Agent-native is a framework for building apps where the AI agent and the product surface around it are equal partners. The usual path starts with chat, adds typed actions, renders structured results inline, and grows into durable pages around the same SQL state. The invariant is that agents and humans share the same actions, database, and state. See [What Is Agent-Native?](/docs/what-is-agent-native) for the full explanation.
+Agent-Native is a framework for building apps where the AI agent and the product surface around it are equal partners. The usual path starts with chat, adds typed actions, renders structured results inline, and grows into durable pages around the same SQL state. The invariant is that agents and humans share the same actions, database, and state. See [What is Agent-Native?](/docs/what-is-agent-native) for the full explanation.
 
 ### Who is this for? {#who-is-this-for}
 
@@ -26,7 +26,7 @@ Agent-native is for people who want a real app and an AI agent to work from the 
 
 ### How is this different from adding AI to an existing app? {#how-is-this-different}
 
-Most apps bolt AI on as an afterthought that can't actually _do_ things in the app. In an agent-native app the agent is a first-class citizen that shares the same actions, database, and state as the UI, so it can do anything the buttons can. See [What Is Agent-Native?](/docs/what-is-agent-native#the-ladder).
+Most apps bolt AI on as an afterthought that can't actually _do_ things in the app. In an agent-native app the agent is a first-class citizen that shares the same actions, database, and state as the UI, so it can do anything the buttons can. See [Why build apps this way](/docs/what-is-agent-native#why-build-apps-this-way).
 
 <Diagram id="doc-block-1s6b04" title="Bolted-on AI vs. agent-native" summary="A bolted-on chat sidebar lives in its own world. An agent-native agent shares the same actions, database, and state as the UI.">
 
@@ -227,7 +227,7 @@ SSE gives same-process writes an immediate path to the browser, and a lightweigh
 
 AI is non-deterministic, so you need conversation flow to give feedback and iterate — not one-shot buttons — and the agent already has your codebase, instructions, skills, and history that an inline call lacks. Routing everything through the agent is also what lets the app be driven from Slack, Telegram, or another agent. See [Key Concepts — Agent chat bridge](/docs/key-concepts#agent-chat-bridge).
 
-### How do I upgrade an older Agent Native app? {#upgrade-older-app}
+### How do I upgrade an older agent-native app? {#upgrade-older-app}
 
 Run the supported upgrade path from the app or workspace root:
 
@@ -251,7 +251,7 @@ The shared database, live sync, actions system, and application state only work 
 ## What's next
 
 - [**Getting Started**](/docs/getting-started) — build your first action and render it inline in chat
-- [**What Is Agent-Native?**](/docs/what-is-agent-native) — the full explanation behind the answers above
+- [**What is Agent-Native?**](/docs/what-is-agent-native) — the full explanation behind the answers above
 - [**Templates**](/docs/cloneable-saas) — start from a complete SaaS product instead of starting from scratch
 - [**Key Concepts**](/docs/key-concepts) — the architecture: SQL, actions, polling sync, and portability
 - [**Deployment**](/docs/deployment) — host on your own domain or any Nitro-compatible provider

--- a/packages/core/docs/content/faq.mdx
+++ b/packages/core/docs/content/faq.mdx
@@ -1,11 +1,11 @@
 ---
 title: "FAQ"
-description: "Common questions about agent-native — what it is, who it's for, what you can build, and how it works."
+description: "Common questions about Agent-Native — what it is, who it's for, what you can build, and how it works."
 ---
 
 # FAQ
 
-Common questions about agent-native, organized from "I'm just looking" to "I'm wiring up auth right now."
+Common questions about Agent-Native, organized from "I'm just looking" to "I'm wiring up auth right now."
 
 ## The basics {#general}
 
@@ -15,20 +15,20 @@ Agent-Native is a framework for building apps where the AI agent and the product
 
 ### Who is this for? {#who-is-this-for}
 
-Agent-native is for people who want a real app and an AI agent to work from the same data and actions. The common paths are:
+Agent-Native is for people who want a real app and an AI agent to work from the same data and actions. The common paths are:
 
 - **Use a hosted app** if you want Mail, Calendar, Forms, Plan, or another finished template with no setup — start at the [template gallery](/templates).
 - **Start with Chat** if you want the default from-scratch path: users can talk to the agent immediately, then you extend with actions, native results, and screens — start with [Getting Started](/docs/getting-started) or [Chat](/docs/template-chat).
 - **Start automation-first** if you are building scheduled jobs, queues, scripts, integration workers, or external-agent workflows with no browser UI yet — start with [Automation-First Apps](/docs/pure-agent-apps).
 - **Start from a template and customize it** if you want your own SaaS product with auth, database, UI, and agent actions already wired — see [Templates](/docs/cloneable-saas).
 - **Build from scratch** if you want the framework primitives for a new agent-driven product — start with [Getting Started](/docs/getting-started).
-- **Connect another agent or code tool** if you want Claude, ChatGPT, Codex, Cursor, or GitHub Copilot / VS Code to use an agent-native app — see [External Agents](/docs/external-agents) and [Skills Guide](/docs/skills-guide).
+- **Connect another agent or code tool** if you want Claude, ChatGPT, Codex, Cursor, or GitHub Copilot / VS Code to use an Agent-Native app — see [External Agents](/docs/external-agents) and [Skills Guide](/docs/skills-guide).
 
 ### How is this different from adding AI to an existing app? {#how-is-this-different}
 
-Most apps bolt AI on as an afterthought that can't actually _do_ things in the app. In an agent-native app the agent is a first-class citizen that shares the same actions, database, and state as the UI, so it can do anything the buttons can. See [Why build apps this way](/docs/what-is-agent-native#why-build-apps-this-way).
+Most apps bolt AI on as an afterthought that can't actually _do_ things in the app. In an Agent-Native app the agent is a first-class citizen that shares the same actions, database, and state as the UI, so it can do anything the buttons can. See [Why build apps this way](/docs/what-is-agent-native#why-build-apps-this-way).
 
-<Diagram id="doc-block-1s6b04" title="Bolted-on AI vs. agent-native" summary="A bolted-on chat sidebar lives in its own world. An agent-native agent shares the same actions, database, and state as the UI.">
+<Diagram id="doc-block-1s6b04" title="Bolted-on AI vs. Agent-Native" summary="A bolted-on chat sidebar lives in its own world. An Agent-Native agent shares the same actions, database, and state as the UI.">
 
 ```html
 <div class="diagram-vs">
@@ -45,7 +45,7 @@ Most apps bolt AI on as an afterthought that can't actually _do_ things in the a
   </div>
   <div class="diagram-divider" aria-hidden="true"></div>
   <div class="diagram-col">
-    <span class="diagram-pill ok">Agent-native</span>
+    <span class="diagram-pill ok">Agent-Native</span>
     <div class="diagram-row2">
       <div class="diagram-node">UI</div>
       <div class="diagram-node">Agent</div>
@@ -114,9 +114,9 @@ Anthropic Claude, OpenAI (GPT-5 family), Google Gemini, and any provider that sp
 
 No. You don't train models, fine-tune, or deal with embeddings. You build a regular web app — and on the hosted version, you barely build anything at all. The framework handles the agent integration: routing messages, running actions, syncing state.
 
-### Can I migrate an existing app to agent-native? {#can-i-use-existing-code}
+### Can I migrate an existing app to Agent-Native? {#can-i-use-existing-code}
 
-You can, but agent-native works best when built from the ground up. The architecture — shared database, polling sync, actions, application state — needs to be integrated throughout. Starting from an app and customizing it is the recommended path. Think of it like the shift from desktop-first to mobile-first: you _can_ retrofit, but building native is better.
+You can, but Agent-Native works best when built from the ground up. The architecture — shared database, polling sync, actions, application state — needs to be integrated throughout. Starting from an app and customizing it is the recommended path. Think of it like the shift from desktop-first to mobile-first: you _can_ retrofit, but building native is better.
 
 ## Templates and what you can build {#templates}
 
@@ -148,7 +148,7 @@ Yes. The same agent runs in your web UI, in Slack, in Telegram, over email, and 
 
 ### Can agents talk to each other? {#can-agents-talk-to-each-other}
 
-Yes, via the [A2A (Agent-to-Agent) protocol](/docs/a2a-protocol). Every agent-native app automatically gets an A2A endpoint. From the mail app, you can tag the analytics agent to query data. An agent discovers what other agents are available, calls them over the protocol, and shows results in the UI. No configuration needed — the agent card is auto-generated from your template's actions.
+Yes, via the [A2A (Agent-to-Agent) protocol](/docs/a2a-protocol). Every Agent-Native app automatically gets an A2A endpoint. From the mail app, you can tag the analytics agent to query data. An agent discovers what other agents are available, calls them over the protocol, and shows results in the UI. No configuration needed — the agent card is auto-generated from your template's actions.
 
 ### What can the agent see in the app? {#what-can-the-agent-see}
 
@@ -156,7 +156,7 @@ The agent always knows what the user is currently viewing. The UI writes navigat
 
 ## Development questions {#development}
 
-### Which AI coding tools work with agent-native? {#which-ai-tools-work}
+### Which AI coding tools work with Agent-Native? {#which-ai-tools-work}
 
 Any AI coding tool that reads project instructions. The framework uses AGENTS.md as the universal standard:
 
@@ -227,7 +227,7 @@ SSE gives same-process writes an immediate path to the browser, and a lightweigh
 
 AI is non-deterministic, so you need conversation flow to give feedback and iterate — not one-shot buttons — and the agent already has your codebase, instructions, skills, and history that an inline call lacks. Routing everything through the agent is also what lets the app be driven from Slack, Telegram, or another agent. See [Key Concepts — Agent chat bridge](/docs/key-concepts#agent-chat-bridge).
 
-### How do I upgrade an older agent-native app? {#upgrade-older-app}
+### How do I upgrade an older Agent-Native app? {#upgrade-older-app}
 
 Run the supported upgrade path from the app or workspace root:
 

--- a/packages/core/docs/content/getting-started.mdx
+++ b/packages/core/docs/content/getting-started.mdx
@@ -5,9 +5,10 @@ description: "Create an Agent-Native app and call the same action from the agent
 
 # Getting Started
 
-Agent-Native is a framework for building apps for both people and AI agents. It
-defines app functionality through [actions](/docs/actions-overview): typed
-functions that the UI calls from code and the agent uses as tools.
+Agent-Native is an open-source TypeScript framework for building apps that
+serve both people and AI agents. You define your app's functionality once as
+[actions](/docs/actions-overview)—typed functions that your React UI calls
+from code and agents use as tools.
 
 In this guide, you'll create a Chat app and call its included `hello` action
 from the agent and the UI.
@@ -147,20 +148,20 @@ return { message: `Welcome, ${name}.` };
 Refresh `/hello`, then ask the agent to call `hello` again. Both return the
 updated greeting because they call the same action.
 
-## Call actions from other interfaces
+## Call actions in other ways
 
-The agent and UI are the two interfaces you used in this guide. The same action
-definition can support other ways of calling your app:
+You called the same action from the agent and UI. The same action can also be
+called from:
 
-| Interface                               | Use it to                                                     |
+| Call from                               | Use it to                                                     |
 | --------------------------------------- | ------------------------------------------------------------- |
 | [HTTP API](/docs/http-api)              | Call an action from a script, backend, or integration.        |
 | [CLI](/docs/actions-other-surfaces#cli) | Run or test an action from a terminal.                        |
 | [MCP](/docs/actions-other-surfaces#mcp) | Let an external AI client discover and call actions as tools. |
 | [A2A](/docs/actions-other-surfaces#a2a) | Let another Agent-Native app ask this app to do work.         |
 
-Each interface uses the same action definition. You do not need to rebuild the
-operation for every place it can be called.
+Every caller uses the same action definition. You do not need a separate
+implementation for each one.
 
 ## What you built
 
@@ -186,6 +187,7 @@ together.
 
 ### [Actions](/docs/actions-overview)
 
-Define actions for reads, writes, approvals, and other interfaces.
+Define actions for reads, writes, and approvals, then call them from the UI,
+agents, and external clients.
 
 </Cards>

--- a/packages/core/docs/content/getting-started.mdx
+++ b/packages/core/docs/content/getting-started.mdx
@@ -1,69 +1,191 @@
 ---
 title: "Getting Started"
-description: "Create a Chat app and configure an agent, then extend it with an action and a page."
+description: "Create an Agent-Native app and call the same action from the agent and the UI."
 ---
 
 # Getting Started
 
-Agent-Native apps give the agent and the UI the same [actions](/docs/actions-overview),
-SQL data, and application state. This path starts with Chat, which already
-creates the framework tables it needs and stores chat history in local SQLite by
-default. Add your own tables only when your app needs to persist domain data.
+Agent-Native is a framework for building apps that people and AI agents can both
+operate. It defines app operations as [actions](/docs/actions-overview): typed
+functions that the agent can call as tools and the UI can call from code.
 
-<Steps>
+In this guide, you'll create a Chat app and call its included `hello` action
+from the agent and the UI.
 
-### Create a chat app and configure an agent
+## Prerequisites
 
-Scaffold the Chat template, install dependencies, start the dev server, and
-configure an agent. You'll have a working chat app to extend.
-**You are here.**
+- [Node.js](https://nodejs.org) 22 or later
+- [pnpm](https://pnpm.io)
+- An LLM connection for the agent: Builder.io, an Anthropic or OpenAI API key,
+  or a local Ollama model
 
-### Add an action
+## Create an app
 
-Define a typed text analyzer and render its result as a chart in the chat.
-
-### Add a page
-
-Build a React route that calls the same action outside the transcript.
-
-</Steps>
-
-## 1. Create a chat app {#create-your-app}
-
-You'll need [Node.js 22+](https://nodejs.org) and [pnpm](https://pnpm.io).
-
-Open a terminal, go to the directory where you want your Agent Native app, and run:
+In a new directory, create a Chat app:
 
 ```bash
-npx @agent-native/core@latest create my-app --template chat
+npx @agent-native/core@latest create my-app --standalone --template chat
 cd my-app
 pnpm install
+```
+
+The template includes a browser app, authentication, durable conversations,
+live sync, application context, and an `actions/` directory. It also includes a
+small `hello` action that you'll use throughout this guide.
+
+## Start the development server
+
+Start the app:
+
+```bash
 pnpm dev
 ```
 
-The app opens at `http://localhost:8080`. If you see the login screen, sign up
-with a made-up login. Local development does not require email verification.
+The app opens at `http://localhost:8080`. If it doesn't open automatically,
+visit that URL in your browser.
 
-The Chat template includes durable chat threads, auth, live sync, an
-`actions/` directory, and the standard `view-screen` and `navigate` actions.
+<Callout tone="info">
 
-### Choose a different starting point
+Create a local account if you're asked to sign in. You can use any email
+address; local development doesn't require email verification.
 
-If Chat is not the right starting point, run `create` without `--template` and
-choose another option in the CLI. See [Creating Templates](/docs/creating-templates)
-for the other paths.
+</Callout>
 
-## 2. Configure an agent {#connect-ai}
+To configure the LLM connection, open **Settings > Manage agent** or use
+**Cmd/Ctrl+K > Manage agent**, then select an option.
 
-The Chat template opens directly to the chat surface. If the agent is not ready
-to respond, open **Settings > Manage agent** or use **Cmd/Ctrl+K > Manage agent**
-to configure a model and provider.
+## Run the action from the agent
 
-Once the agent responds, continue with [Add an Action](/docs/getting-started-actions).
+In the app, ask:
 
-## Related docs
+> Call the hello action for Alex.
 
-- [What Is Agent-Native?](/docs/what-is-agent-native): the architecture behind this path.
-- [Chat Template](/docs/template-chat): what the starter app includes.
-- [Database](/docs/database): add app-owned tables when your app needs domain data.
-- [FAQ](/docs/faq): answers about models, hosting, and templates.
+The agent discovers the action from its description and input schema, calls it,
+and returns the same greeting.
+
+## Inspect the action
+
+Open `actions/hello.ts`:
+
+```ts filename="actions/hello.ts"
+import { defineAction } from "@agent-native/core/action";
+import { z } from "zod";
+
+export default defineAction({
+  description: "Return a friendly greeting.",
+  schema: z.object({
+    name: z.string().default("world").describe("Name to greet"),
+  }),
+  http: { method: "GET" },
+  run: async ({ name }) => {
+    return { message: `Hello, ${name}!` };
+  },
+});
+```
+
+For now, focus on four parts:
+
+- `description` tells the agent when to use the action.
+- `schema` validates the input and gives the agent a typed tool definition.
+- `http` exposes this read-only action through `GET`, which lets
+  `useActionQuery` call it from React.
+- `run` contains the application logic shared by the agent and the UI.
+
+Read [Defining Actions](/docs/actions-defining) for the complete API.
+
+## Call the action from React
+
+Add a route at `app/routes/hello.tsx`:
+
+```tsx filename="app/routes/hello.tsx"
+import { useActionQuery } from "@agent-native/core/client/hooks";
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export default function HelloRoute() {
+  const [name, setName] = useState("Alex");
+  const { data } = useActionQuery("hello", { name });
+
+  return (
+    <main className="mx-auto grid w-full max-w-xl gap-6 p-6">
+      <h1 className="text-2xl font-semibold">Hello action</h1>
+      <div className="grid gap-2">
+        <Label htmlFor="name">Name</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+      <p className="text-xl font-medium">{data?.message}</p>
+    </main>
+  );
+}
+```
+
+<Callout tone="warning">
+
+Restart the development server so it discovers the new route, then open
+`http://localhost:8080/hello`.
+
+</Callout>
+
+As you type a name, `useActionQuery` calls `hello` and renders the result. It
+infers the action's input and result types, so the page doesn't need a custom
+API route or a second implementation of the greeting.
+
+## Change the action
+
+In `actions/hello.ts`, change the return value:
+
+```ts
+return { message: `Welcome, ${name}.` };
+```
+
+Refresh `/hello`, then ask the agent to call `hello` again. Both return the
+updated greeting because they call the same action.
+
+## Call actions from other interfaces
+
+The agent and UI are the two interfaces you used in this guide. The same action
+definition can support other ways of calling your app:
+
+| Interface                               | Use it to                                                     |
+| --------------------------------------- | ------------------------------------------------------------- |
+| [HTTP API](/docs/http-api)              | Call an action from a script, backend, or integration.        |
+| [CLI](/docs/actions-other-surfaces#cli) | Run or test an action from a terminal.                        |
+| [MCP](/docs/actions-other-surfaces#mcp) | Let an external AI client discover and call actions as tools. |
+| [A2A](/docs/actions-other-surfaces#a2a) | Let another Agent-Native app ask this app to do work.         |
+
+Each interface uses the same action definition. You do not need to rebuild the
+operation for every place it can be called.
+
+## What you built
+
+You created a Chat app, called its `hello` action from the agent, and rendered
+the same result in the UI. When you changed the action, both picked up the new
+behavior.
+
+That is the core Agent-Native pattern: define a product operation once, then
+let people use it through the UI and agents use it as a tool.
+
+## Next steps
+
+<Cards>
+
+### [Why Agent-Native?](/docs/why-agent-native)
+
+Understand why the UI and agent share actions, data, and context.
+
+### [Key Concepts](/docs/key-concepts)
+
+Learn how actions, SQL data, application context, access, and live sync fit
+together.
+
+### [Actions](/docs/actions-overview)
+
+Define actions for reads, writes, approvals, and other interfaces.
+
+</Cards>

--- a/packages/core/docs/content/getting-started.mdx
+++ b/packages/core/docs/content/getting-started.mdx
@@ -5,9 +5,9 @@ description: "Create an Agent-Native app and call the same action from the agent
 
 # Getting Started
 
-Agent-Native is a framework for building apps that people and AI agents can both
-operate. It defines app operations as [actions](/docs/actions-overview): typed
-functions that the agent can call as tools and the UI can call from code.
+Agent-Native is a framework for building apps for both people and AI agents. It
+defines app functionality through [actions](/docs/actions-overview): typed
+functions that the UI calls from code and the agent uses as tools.
 
 In this guide, you'll create a Chat app and call its included `hello` action
 from the agent and the UI.
@@ -168,14 +168,14 @@ You created a Chat app, called its `hello` action from the agent, and rendered
 the same result in the UI. When you changed the action, both picked up the new
 behavior.
 
-That is the core Agent-Native pattern: define a product operation once, then
-let people use it through the UI and agents use it as a tool.
+That is the core Agent-Native pattern: define app functionality once, then make
+it available through the UI and as tools for agents.
 
 ## Next steps
 
 <Cards>
 
-### [Why Agent-Native?](/docs/why-agent-native)
+### [What is Agent-Native?](/docs/what-is-agent-native)
 
 Understand why the UI and agent share actions, data, and context.
 

--- a/packages/core/docs/content/getting-started.mdx
+++ b/packages/core/docs/content/getting-started.mdx
@@ -47,22 +47,31 @@ visit that URL in your browser.
 
 <Callout tone="info">
 
-Create a local account if you're asked to sign in. You can use any email
-address; local development doesn't require email verification.
+On the Welcome screen, select **Continue as local dev**. You don't need to
+enter an email or password for local development.
 
 </Callout>
 
-To configure the LLM connection, open **Settings > Manage agent** or use
-**Cmd/Ctrl+K > Manage agent**, then select an option.
+Next, connect an LLM. Select **Connect Builder.io** to use free credits, or
+select **Custom keys**, choose a provider, and enter the requested connection
+details.
 
 ## Run the action from the agent
+
+An action is a typed function that your React UI can call from code and agents
+can use as a tool. The Chat template includes a simple `hello` action so you
+can try the pattern before writing one yourself.
 
 In the app, ask:
 
 > Call the hello action for Alex.
 
-The agent discovers the action from its description and input schema, calls it,
-and returns the same greeting.
+The agent finds `hello` from its description and input schema, passes `Alex` as
+the `name` input, and responds:
+
+```text
+Hello, Alex!
+```
 
 ## Inspect the action
 
@@ -161,16 +170,15 @@ called from:
 | [A2A](/docs/actions-other-surfaces#a2a) | Let another Agent-Native app ask this app to do work.         |
 
 Every caller uses the same action definition. You do not need a separate
-implementation for each one.
+implementation for each one. This shared action model is central to
+Agent-Native: behavior, validation, and permissions stay aligned across the
+UI, agents, and integrations as the app changes.
 
 ## What you built
 
-You created a Chat app, called its `hello` action from the agent, and rendered
-the same result in the UI. When you changed the action, both picked up the new
-behavior.
-
-That is the core Agent-Native pattern: define app functionality once, then make
-it available through the UI and as tools for agents.
+You created an Agent-Native app, called its `hello` action from the agent and a
+React UI, then changed the greeting once and watched both update. Every action
+you write from here follows that same pattern.
 
 ## Next steps
 

--- a/packages/core/docs/content/key-concepts.mdx
+++ b/packages/core/docs/content/key-concepts.mdx
@@ -5,11 +5,11 @@ description: "How agent-native apps work across three layers: the Core framework
 
 # Key Concepts
 
-How agent-native apps work under the hood: the principles and the architecture. This page is the contract: the fixed rules an app has to follow to count as agent-native. For the vision and the case for building this way, see [What Is Agent-Native?](/docs/what-is-agent-native).
+How agent-native apps work under the hood: the principles and the architecture. This page is the contract: the fixed rules an app has to follow to count as agent-native. For the vision and the case for building this way, see [What is Agent-Native?](/docs/what-is-agent-native).
 
 ## The three layers {#three-layers}
 
-Agent Native is a framework with three layers:
+Agent-Native is a framework with three layers:
 
 | Layer                                      | What it is                                                                                                                                                                                            |
 | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -150,7 +150,7 @@ Every user-facing feature should update all applicable areas. Skipping an applic
 
 A feature with only UI is invisible to the agent. A full UI feature with only actions is invisible to the user. A feature without app-state means the agent is blind to what the user is doing. An automation-first operation can legitimately start with action + instructions and add chat, UI, or app-state later when humans need to browse, approve, configure, or share it.
 
-## What Agent Native includes {#what-you-get-for-free}
+## What Agent-Native includes {#what-you-get-for-free}
 
 Adopting the framework is valuable mostly because of what you stop having to build. The moment your app follows the five rules above, you inherit:
 
@@ -503,7 +503,7 @@ These sit on top of the same contract and have their own deep dives:
 
 <Cards>
 
-### [What Is Agent-Native?](/docs/what-is-agent-native)
+### [What is Agent-Native?](/docs/what-is-agent-native)
 
 The vision and philosophy behind these rules.
 

--- a/packages/core/docs/content/key-concepts.mdx
+++ b/packages/core/docs/content/key-concepts.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Key Concepts"
-description: "How agent-native apps work across three layers: the Core framework, optional Toolkit building blocks, and optional Templates, plus the shared actions, SQL database, app-agent loop, and portability rules."
+description: "How Agent-Native apps work across three layers: the Core framework, optional Toolkit building blocks, and optional Templates, plus the shared actions, SQL database, app-agent loop, and portability rules."
 ---
 
 # Key Concepts
 
-How agent-native apps work under the hood: the principles and the architecture. This page is the contract: the fixed rules an app has to follow to count as agent-native. For the vision and the case for building this way, see [What is Agent-Native?](/docs/what-is-agent-native).
+How Agent-Native apps work under the hood: the principles and the architecture. This page is the contract: the fixed rules an app has to follow to count as Agent-Native. For the vision and the case for building this way, see [What is Agent-Native?](/docs/what-is-agent-native).
 
 ## The three layers {#three-layers}
 
@@ -21,7 +21,7 @@ Core is the foundation. Toolkit and Templates are optional: a template can use T
 
 ## The architecture {#the-architecture}
 
-At runtime, every agent-native app is three things working together:
+At runtime, every Agent-Native app is three things working together:
 
 - **Agent:** The autonomous AI. It reads data, writes data, runs actions, and uses whatever tools are configured. When its frame is intentionally granted workspace access and write tooling, it can also modify the app's own source. Customizable with skills and instructions.
 - **Application:** The product surface around the agent. It may start as chat, add native inline results, grow into a small control plane, or become a full React UI with dashboards, flows, and visualizations.
@@ -94,7 +94,7 @@ That same agent-application-computer loop is what runs locally and in production
 
 ## Agent building blocks {#agent-building-blocks}
 
-Every agent-native app has the same agent building blocks, regardless of whether
+Every Agent-Native app has the same agent building blocks, regardless of whether
 the product surface is chat-first, automation-first, or a full UI. Each one lives
 in its own file:
 
@@ -141,7 +141,7 @@ Five rules govern the architecture:
 
 ## The four-area checklist {#four-area-checklist}
 
-Every user-facing feature should update all applicable areas. Skipping an applicable area breaks the agent-native contract; forcing a screen onto an automation that no human needs to browse is also a smell.
+Every user-facing feature should update all applicable areas. Skipping an applicable area breaks the Agent-Native contract; forcing a screen onto an automation that no human needs to browse is also a smell.
 
 - **1. UI:** Page, component, or dialog the user interacts with.
 - **2. Action:** Agent-callable action in `actions/` for the same operation.
@@ -156,7 +156,7 @@ Adopting the framework is valuable mostly because of what you stop having to bui
 
 | Feature                              | What it gives you                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| One action = every surface           | Every action defined with `defineAction()` is simultaneously an agent tool, a typesafe frontend hook (`useActionQuery` / `useActionMutation`), a framework-owned HTTP transport, a CLI command, an MCP tool for external clients, and an A2A tool for other agent-native apps. Optional `link` and `mcpApp` metadata add deep links and MCP Apps UI without a second implementation. |
+| One action = every surface           | Every action defined with `defineAction()` is simultaneously an agent tool, a typesafe frontend hook (`useActionQuery` / `useActionMutation`), a framework-owned HTTP transport, a CLI command, an MCP tool for external clients, and an A2A tool for other Agent-Native apps. Optional `link` and `mcpApp` metadata add deep links and MCP Apps UI without a second implementation. |
 | Full agent resources per user        | Skills, shared `LEARNINGS.md`, personal `memory/MEMORY.md`, `AGENTS.md`, custom sub-agents, scheduled jobs, and connected MCP servers. All SQL-backed, no dev-box required. See [Agent Resources](/docs/agent-resources).                                                                                                                                                            |
 | Drop-in React components             | `<AgentPanel />` and `<AgentSidebar />` render chat + resources anywhere in your app. See [Drop-in Agent](/docs/drop-in-agent).                                                                                                                                                                                                                                                      |
 | BYO agent chat runtimes              | The same chat UI can sit on top of OpenAI Agents, OpenAI Responses, Claude Agent SDK, Vercel AI SDK, AG-UI, or your own normalized HTTP stream. See [Native Chat UI](/docs/native-chat-ui#byo-agent-runtimes).                                                                                                                                                                       |
@@ -441,7 +441,7 @@ This works in all deployment environments, including serverless and edge, becaus
 
 A _frame_ is the environment that hosts the agent next to your app. Locally that's the embedded panel; in the cloud it's Builder.io's managed surface. See [Frames](/docs/frames).
 
-Agent-native apps include an embedded agent panel that provides the AI agent alongside the app UI. This is what makes the architecture work: the agent needs a computer (database, browser, code execution), and the app needs the agent for AI work.
+Agent-Native apps include an embedded agent panel that provides the AI agent alongside the app UI. This is what makes the architecture work: the agent needs a computer (database, browser, code execution), and the app needs the agent for AI work.
 
 - **Embedded Agent Panel:** Chat and optional CLI terminal built into every app. Supports Claude Code, Codex, Gemini, OpenCode, and Builder.io. Runs locally, free and open source.
 - **Cloud:** Deploy to any cloud with real-time collaboration, visual editing, roles, and permissions. Best for teams.

--- a/packages/core/docs/content/using-your-agent.mdx
+++ b/packages/core/docs/content/using-your-agent.mdx
@@ -105,7 +105,7 @@ A few examples of what that looks like in practice:
 
 ## You embed it {#you-embed-it}
 
-The agent isn't a separate app you tab over to. Wherever you see a chat panel in an agent-native app, it can be docked next to any screen — toggle it open, and it's right there next to whatever you're working on. App builders can also wire a button to hand a specific task straight to the agent instead of building a one-off "AI" feature for it. If you're building the app rather than using it, see [Drop-in Agent](/docs/drop-in-agent) for the components that make this work.
+The agent isn't a separate app you tab over to. Wherever you see a chat panel in an Agent-Native app, it can be docked next to any screen — toggle it open, and it's right there next to whatever you're working on. App builders can also wire a button to hand a specific task straight to the agent instead of building a one-off "AI" feature for it. If you're building the app rather than using it, see [Drop-in Agent](/docs/drop-in-agent) for the components that make this work.
 
 ## You can go UI-light {#ui-light}
 

--- a/packages/core/docs/content/using-your-agent.mdx
+++ b/packages/core/docs/content/using-your-agent.mdx
@@ -5,7 +5,7 @@ description: "The day-to-day loop of working with the agent: it sees what you're
 
 # Using Your Agent
 
-The defining idea behind agent-native is that the agent and the UI are **equal partners** — see [What Is Agent-Native?](/docs/what-is-agent-native) for the why. This section is about the other half of that promise: what it feels like to actually work with the agent once it's docked next to your app.
+The defining idea behind Agent-Native is that the agent and the UI are **equal partners** — see [What is Agent-Native?](/docs/what-is-agent-native) for the reasoning. This section is about the other half of that promise: what it feels like to actually work with the agent once it's docked next to your app.
 
 There's a simple through-line. The agent **sees** what you're looking at, you **direct** it toward what you want, you can **embed** it anywhere, you can go fully **UI-light** when that's the better fit, and you can **co-edit** the same documents at the same time. Each of those is a page in this section.
 

--- a/packages/core/docs/content/what-is-agent-native.mdx
+++ b/packages/core/docs/content/what-is-agent-native.mdx
@@ -1,260 +1,111 @@
 ---
-title: "What Is Agent-Native?"
-description: "Why most AI apps feel half-built, what makes an app truly agent-native, and what your day-to-day experience looks like as a result."
+title: "What is Agent-Native?"
+description: "What Agent-Native is, how its shared action architecture works, and when to build an app this way."
 ---
 
-# What Is Agent-Native?
+# What is Agent-Native?
 
-Most "AI features" today are a chat box bolted onto an existing product. You can ask questions and get summaries, but you can't ask the AI to actually _do_ anything in the app — and even when you can, the UI has no idea what the agent just did.
+Agent-Native is an open-source TypeScript framework for building agentic apps.
+Define your app's functionality once, then make it available to people through
+a React UI and to AI agents as tools. The UI and agent work with shared data and
+application state, so work can move between them.
 
-Agent-native is the fix. It's a way of building software where **the AI agent and the UI are equal partners** — they share the same actions, the same database, and the same state. Everything the agent can do is also a button. Everything the user clicks is also something the agent can do. One system, two ways in.
+## Why build apps this way
 
-<Callout tone="decision">
+Most applications are designed around a person working through the UI. Adding
+an agent introduces another way to use the product. For both to work as one
+product, three things need to be true:
 
-If you only remember one thing from this page: most AI apps stop one step short of being useful — and that gap is the biggest mistake in the space right now.
+- **The agent needs access to the product.** If it receives a smaller, separate
+  set of tools, it remains constrained. The UI and agent also become two
+  implementations that drift as the application changes.
+- **People still need an application UI.** Chat works well for delegating work,
+  but not always for browsing information, comparing options, reviewing
+  changes, or sharing results with a team.
+- **Work needs to move between them.** A person should be able to inspect or
+  change the agent's work, and the agent should be able to continue from there
+  without starting over.
 
-</Callout>
+Agent-Native architecture is built around these requirements. People can work
+directly through the UI or delegate an outcome to the agent, then move between
+the two without losing progress.
 
-## What it looks like as a user {#what-it-looks-like}
+<Video
+  src="https://cdn.builder.io/o/assets%2Fc5b47d20f6a943e485717e5895739988%2Fc88d506c160142ae9b8618616ceedcea%2Fcompressed?apiKey=c5b47d20f6a943e485717e5895739988&token=c88d506c160142ae9b8618616ceedcea&alt=media&optimized=true"
+  alt="A comparison of a person using an application directly and working through an AI agent in the same application."
+  align="full"
+  caption="Watch a four-minute introduction to agent-native architecture."
+/>
 
-Picture a mail client, analytics dashboard, or project tracker. Chat might be the first screen — or docked on the side of a full app. Either way:
+## How Agent-Native works
 
-<Cards>
+An Agent-Native application gives people and agents two ways to work with the
+same product:
 
-### Just ask
+- **The UI** gives people a familiar way to browse, edit, review, and share
+  work.
+- **The agent** handles work people delegate to it.
 
-Type "reply to the email from Sara saying I'll be there by 3." The agent opens the thread, drafts the reply, and shows it to you for approval.
+Three shared foundations make this possible:
 
-### Or click
-
-Every button, list, form, and keyboard shortcut still works — and calls the same operation the agent uses.
-
-### See what it sees
-
-Open an email and the agent knows which one. Highlight a paragraph and press `Cmd+I` — the agent acts on exactly that.
-
-### Watch it work
-
-The UI updates in real time as the agent opens views, edits drafts, and runs reports. Interrupt, redirect, or take over with the mouse at any moment.
-
-### Steer it like a teammate
-
-Give feedback, queue tasks, audit what it did, and edit its instructions.
-
-</Cards>
-
-Here's why most products don't get there.
-
-## Why most "AI apps" fall short {#the-ladder}
-
-There's a progression most teams climb, and most stop one rung too early.
-
-```mermaid
-graph LR
-  R1["Rung 1: Single LLM call"]
-  R2["Rung 2: Chat with tools"]
-  R3["Rung 3: Agent + UI parity"]
-  R1 --> R2 --> R3
-```
-
-**Rung 1** — A text box sends a prompt, the AI returns a string. No way to course-correct, no persistence, no audit trail. This is what most "AI features" actually are: a Summarize button bolted onto a SaaS product. Impressive in demos, breaks in production.
-
-**Rung 2** — The AI has tools and a chat interface. Claude, ChatGPT, and Cursor all look like this under the hood. Real step up — but it's still a chat window. No dashboards, no forms, no collaboration. Non-developers struggle to get real work done here.
-
-**Rung 3** — Every agent action is also a button; every button runs the same logic the agent uses. The agent has real context (it sees what you're looking at and writes to the same database), and external agents can call it too over A2A and MCP.
-
-<Callout tone="success">
-
-**Rung 3 is agent-native.** You stopped adding buttons to a chatbot. You added an agent to an app. That's a much higher-quality product on both sides.
-
-</Callout>
-
-See [Key Concepts — Protocols](/docs/key-concepts#protocols) for how all of this hangs off the same action definition.
-
-## How agent and UI share the same actions {#agent-ui-parity}
-
-In a normal app, the UI and any "AI features" live in separate worlds — the buttons call one set of code, the AI calls another. Agent-native collapses that into one.
-
-Every operation is defined as a typed **action**: a name, a schema, and a `run` function. The agent calls those actions as tools. The UI calls the same actions when a button is clicked. There's no translation layer, no duplication, and no drift.
+- **Shared operations.** People trigger them through the UI, while agents call
+  them directly. Agent-Native defines each operation once as an
+  [action](/docs/actions-overview).
+- **[Shared data](/docs/database)** holds the work and information the
+  application needs to preserve. Depending on the application, that might be
+  customer records, project plans, conversations, or reports. The UI and agent
+  read and update the same data.
+- **[Shared application state](/docs/context-awareness)** describes what is
+  happening right now, such as the current page, selected record, or active
+  view. The framework gives relevant state to the agent as context, so it knows
+  what the person is working with.
 
 ```mermaid
 graph TD
-  UI_IN["Click a button"]
-  AG_IN["Type a message to the agent"]
-  ACTION["Same typed action"]
-  DB["Shared database"]
-  UI_OUT["UI updates instantly"]
-  AG_OUT["Agent sees the change"]
-
-  UI_IN --> ACTION
-  AG_IN --> ACTION
-  ACTION --> DB
-  DB --> UI_OUT
-  DB --> AG_OUT
+  UI[UI] --> App[One application]
+  Agent[Agent] --> App
+  App --- Operations[Shared operations]
+  App --- Data[Shared data]
+  App --- State[Shared application state]
 ```
 
-The diagram above shows what this looks like at runtime: both the user and the agent submit actions to the same layer, which writes to the same database and sends updates back to both surfaces. When the agent creates a draft email, it appears in your inbox immediately. When you click Send, the agent knows it was sent. See [Key Concepts](/docs/key-concepts) for the full architecture.
+The agent does not click through the UI. It calls the same actions as the UI,
+with the same validation, permissions, and implementation.
 
-## Why agents need a UI — and apps need an agent {#why-both}
+For example, a person can assign a support ticket through the UI or ask the
+agent to do it. Both paths run the same action and update the same ticket. The
+person can inspect or change the result in the UI, then let the agent continue
+from there.
 
-These two questions answer each other.
+## When should you use Agent-Native?
 
-<Comparison>
+Agent-Native is a good fit when:
 
-### Agents need a UI
+- The agent should do real work in the app, not only answer questions.
+- People need a UI to inspect, edit, approve, or share the work.
+- Work should move between the UI and agent without losing progress or context.
 
-Even when the agent does all the heavy lifting, humans still need to see what it's doing, steer it, inspect its work, and share its output. At minimum that's an observability dashboard. At maximum it's a full app with the agent as a co-pilot. The surface can grow from one to the other without a rewrite.
+If you only need one generated response, call a model directly. If the workflow
+follows a fixed, predictable sequence, ordinary application logic or automation
+is simpler. Use Agent-Native when the UI and agent both need an ongoing role in
+the same work.
 
-### Apps need an agent
-
-Even in a full app with every button working, natural language makes a huge difference. Because every action is defined once and exposed as both a button and a tool, the agent can do everything the buttons can — and more. Natural language becomes a first-class input alongside clicks, with no separate "AI world" to maintain.
-
-</Comparison>
-
-The argument isn't "agents replace UI." It's **agents belong inside applications, as equal partners**. See [Agent Surfaces](/docs/agent-surfaces) for the concrete shapes and APIs.
-
-## Per-user customization — without the complexity {#workspace-customization}
-
-What makes tools like Claude Code feel powerful isn't the model — it's the customization layer: per-project instructions, skills, memory, sub-agents, connected services.
-
-Agent-native gives every user that same layer, inside your app, stored in the database rather than on the filesystem. No dev environment per user, no container per user — just rows in a table.
-
-<Cards>
-
-### Team-wide rules
-
-Instructions every agent on the team reads — house style, escalation policy, whatever your team needs the agent to always know.
-
-### Personal memory
-
-The agent builds this automatically as you correct it. Over time it learns your preferences without you having to write anything down.
-
-### `/slash` commands
-
-Reusable how-to guides for common workflows. Type `/weekly-report` and the agent knows exactly what to do.
-
-### `@sub-agents`
-
-Specialized agents for specific tasks, scoped to a user or team. Delegate the routine stuff without writing a new integration.
-
-### Scheduled jobs
-
-Set it and forget it. "Every Monday, summarize last week and draft the team update."
-
-### External services
-
-Per-user MCP server connections. Each person can plug in their own tools without affecting anyone else's setup.
-
-</Cards>
-
-That's Claude Code-level flexibility in a multi-tenant SaaS product. See [Agent Resources](/docs/agent-resources) for the full concept.
-
-## What does it look like in code? {#what-does-it-look-like-in-code}
-
-Every operation in an agent-native app is an **action** — defined once, available to both the agent and the UI.
-
-<AnnotatedCode
-  id="doc-block-n4jy5o"
-  title="One action, defined once"
-  filename="actions/reply-to-email.ts"
-  language="ts"
-  code={
-    'import { defineAction } from "@agent-native/core/action";\nimport { z } from "zod";\n\nimport { getDb, schema } from "../server/db/index.js";\n\nexport default defineAction({\n  description: "Reply to an email thread",\n  schema: z.object({ emailId: z.string(), body: z.string() }),\n  run: async ({ emailId, body }) => {\n    const db = getDb();\n    await db.insert(schema.replies).values({ emailId, body });\n  },\n});'
-  }
-  annotations={[
-    {
-      lines: "7",
-      label: "Tool surface",
-      note: "The `description` is what the agent reads to decide when to call this as a tool.",
-    },
-    {
-      lines: "8",
-      label: "Typed contract",
-      note: "One zod `schema` validates input from **every** surface — agent, UI, HTTP, MCP, and A2A.",
-    },
-    {
-      lines: "9-12",
-      label: "One implementation",
-      note: "The `run` body is the single source of truth. The UI button and the agent tool both execute exactly this. `getDb()` and `schema` come from your app's `server/db/index.ts` — see [Database](/docs/database).",
-    },
-  ]}
-/>
-
-The same action is then callable from a React component, from the agent in chat, and from any external agent or MCP host:
-
-```tsx
-// In any React component — same action, called from a button
-const { mutate } = useActionMutation("reply-to-email");
-
-<Button onClick={() => mutate({ emailId, body: "Thanks!" })}>
-  Send Reply
-</Button>;
-```
-
-```tsx
-// And the agent panel mounted anywhere in your app
-import { AgentSidebar } from "@agent-native/core/client/agent-chat";
-<AgentSidebar />;
-```
-
-One action definition powers the UI button, the agent tool, an HTTP endpoint, an MCP surface, an A2A integration, and a CLI command. See [Actions](/docs/actions-overview) for the full reference.
-
-## How to get started {#how-to-get-started}
-
-Agent-native apps follow a start-from-a-working-app model. Pick a template — Calendar, Mail, Analytics, Forms, and more — and make it yours.
-
-<Steps>
-
-### Pick a template
-
-Browse [agent-native.com/templates](/templates) and pick the one closest to what you want to build.
-
-### Use it immediately
-
-Many first-party templates are available as hosted apps (e.g. `mail.agent-native.com`). Try one before you touch any code.
-
-### Clone and customize
-
-When you're ready to change something — "connect our Stripe account," "add a cohort chart" — create your own app from the template and customize the source in your own repository.
-
-### Deploy to your domain
-
-Ship your app to your own domain, or stay on agent-native.com. Because it's _your_ app, you own the source and can evolve it independently.
-
-</Steps>
-
-Not ready for a whole template? Add a **skill** to a coding agent you already use: `npx @agent-native/core@latest skills add visual-plan`. See the [Skills Guide](/docs/skills-guide#app-backed-skills).
-
-## Composable agents {#composable-agents}
-
-Agent-native apps can talk to each other. From inside the mail app, you can tag the analytics agent to query data and include the result in a draft. The agents discover what other agents are available, hand off work, and surface results in the UI you're already in — powered by [A2A](/docs/a2a-protocol) and [MCP](/docs/mcp-protocol) under the hood.
-
-## What's next {#whats-next}
+## Next steps
 
 <Cards>
 
 ### [Getting Started](/docs/getting-started)
 
-Build a working chat app in under five minutes, then add an action and a page. Add your own database tables when you need to persist domain data.
+Create an app and call the same action from the agent and the interface.
 
 ### [Key Concepts](/docs/key-concepts)
 
-The architecture underneath everything on this page: SQL, actions, polling sync, and context awareness.
+Learn how actions, SQL data, application context, access, and live sync fit
+together.
 
-### [Agent Surfaces](/docs/agent-surfaces)
+### [App Patterns](/docs/agent-surfaces)
 
-All the shapes an agent-native app can take: chat, inline UI, full app pages, sidecars, automation, and external agents.
-
-### [Templates](/docs/cloneable-saas)
-
-Complete, working products you own and customize — not blank scaffolds.
-
-### [Agent Resources](/docs/agent-resources)
-
-The per-user customization layer: skills, memory, instructions, and MCP connections — backed by SQL, not files.
-
-### [FAQ](/docs/faq)
-
-Quick answers on cost, hosting, models, and templates.
+See how the same model supports apps led by an interface, conversation,
+automation, or another agent.
 
 </Cards>

--- a/packages/core/docs/content/what-is-agent-native.mdx
+++ b/packages/core/docs/content/what-is-agent-native.mdx
@@ -5,10 +5,10 @@ description: "What Agent-Native is, how its shared action architecture works, an
 
 # What is Agent-Native?
 
-Agent-Native is an open-source TypeScript framework for building agentic apps.
-Define your app's functionality once, then make it available to people through
-a React UI and to AI agents as tools. The UI and agent work with shared data and
-application state, so work can move between them.
+Agent-Native is an open-source TypeScript framework for building apps that
+serve both people and AI agents. You define your app's functionality once as
+[actions](/docs/actions-overview)—typed functions that your React UI calls
+from code and agents use as tools.
 
 ## Why build apps this way
 
@@ -17,7 +17,7 @@ an agent introduces another way to use the product. For both to work as one
 product, three things need to be true:
 
 - **The agent needs access to the product.** If it receives a smaller, separate
-  set of tools, it remains constrained. The UI and agent also become two
+  set of tools, it remains constrained. You also end up maintaining two
   implementations that drift as the application changes.
 - **People still need an application UI.** Chat works well for delegating work,
   but not always for browsing information, comparing options, reviewing
@@ -54,7 +54,7 @@ Three shared foundations make this possible:
 - **[Shared data](/docs/database)** holds the work and information the
   application needs to preserve. Depending on the application, that might be
   customer records, project plans, conversations, or reports. The UI and agent
-  read and update the same data.
+  both read and update this shared data.
 - **[Shared application state](/docs/context-awareness)** describes what is
   happening right now, such as the current page, selected record, or active
   view. The framework gives relevant state to the agent as context, so it knows
@@ -96,16 +96,16 @@ the same work.
 
 ### [Getting Started](/docs/getting-started)
 
-Create an app and call the same action from the agent and the interface.
+Create an app and call the same action from the agent and UI.
 
 ### [Key Concepts](/docs/key-concepts)
 
 Learn how actions, SQL data, application context, access, and live sync fit
 together.
 
-### [App Patterns](/docs/agent-surfaces)
+### [Agent Surfaces](/docs/agent-surfaces)
 
-See how the same model supports apps led by an interface, conversation,
-automation, or another agent.
+See how the same model supports apps led by a UI, chat, automation, or another
+agent.
 
 </Cards>

--- a/packages/core/docs/content/what-is-agent-native.mdx
+++ b/packages/core/docs/content/what-is-agent-native.mdx
@@ -34,7 +34,7 @@ the two without losing progress.
   src="https://cdn.builder.io/o/assets%2Fc5b47d20f6a943e485717e5895739988%2Fc88d506c160142ae9b8618616ceedcea%2Fcompressed?apiKey=c5b47d20f6a943e485717e5895739988&token=c88d506c160142ae9b8618616ceedcea&alt=media&optimized=true"
   alt="A comparison of a person using an application directly and working through an AI agent in the same application."
   align="full"
-  caption="Watch a four-minute introduction to agent-native architecture."
+  caption="Watch a four-minute introduction to Agent-Native architecture."
 />
 
 ## How Agent-Native works

--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -83,21 +83,23 @@ describe("DocsSidebar", () => {
     expect(html).not.toContain('aria-controls="docs-sidebar-section-0"');
   });
 
-  it("keeps Deployment directly discoverable in Overview", () => {
+  it("keeps Deployment under Build Apps", () => {
     const sections = getDocsNavSections("en-US");
     const overview = sections.find((section) => section.id === "overview");
-    const architecture = sections.find(
-      (section) => section.id === "core-architecture",
-    );
+    const buildApps = sections.find((section) => section.id === "build-apps");
 
-    expect(overview?.items.some((item) => item.id === "deployment")).toBe(true);
-    expect(overview?.items.slice(0, 3).map((item) => item.id)).toEqual([
+    expect(overview?.items.map((item) => item.id)).toEqual([
       "getting-started",
       "what-is-agent-native",
-      "deployment",
+      "key-concepts",
+      "agent-surfaces",
+      "faq",
     ]);
-    expect(architecture?.items.some((item) => item.id === "deployment")).toBe(
+    expect(overview?.items.some((item) => item.id === "deployment")).toBe(
       false,
+    );
+    expect(buildApps?.items.some((item) => item.id === "deployment")).toBe(
+      true,
     );
   });
 

--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -91,6 +91,11 @@ describe("DocsSidebar", () => {
     );
 
     expect(overview?.items.some((item) => item.id === "deployment")).toBe(true);
+    expect(overview?.items.slice(0, 3).map((item) => item.id)).toEqual([
+      "getting-started",
+      "what-is-agent-native",
+      "deployment",
+    ]);
     expect(architecture?.items.some((item) => item.id === "deployment")).toBe(
       false,
     );

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -40,12 +40,12 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
         labelKey: "gettingStarted",
         slug: "getting-started",
       },
-      { id: "deployment", labelKey: "deployment", slug: "deployment" },
       {
         id: "what-is-agent-native",
         labelKey: "whatIsAgentNative",
         slug: "what-is-agent-native",
       },
+      { id: "deployment", labelKey: "deployment", slug: "deployment" },
       { id: "key-concepts", labelKey: "keyConcepts", slug: "key-concepts" },
       {
         id: "agent-surfaces",

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -45,7 +45,6 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
         labelKey: "whatIsAgentNative",
         slug: "what-is-agent-native",
       },
-      { id: "deployment", labelKey: "deployment", slug: "deployment" },
       { id: "key-concepts", labelKey: "keyConcepts", slug: "key-concepts" },
       {
         id: "agent-surfaces",
@@ -827,6 +826,7 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
       },
       { id: "embedding-sdk", labelKey: "embeddingSdk", slug: "embedding-sdk" },
       { id: "frames", labelKey: "frames", slug: "frames" },
+      { id: "deployment", labelKey: "deployment", slug: "deployment" },
     ],
   },
   {

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -39,18 +39,6 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
         id: "getting-started",
         labelKey: "gettingStarted",
         slug: "getting-started",
-        children: [
-          {
-            id: "getting-started-actions",
-            labelKey: "gettingStartedActions",
-            slug: "getting-started-actions",
-          },
-          {
-            id: "getting-started-pages",
-            labelKey: "gettingStartedPages",
-            slug: "getting-started-pages",
-          },
-        ],
       },
       { id: "deployment", labelKey: "deployment", slug: "deployment" },
       {

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -353,6 +353,21 @@ h4 {
   margin: 8px 0;
 }
 
+.docs-content blockquote {
+  margin: 12px 0;
+  padding: 10px 14px;
+  border-inline-start: 3px solid var(--docs-accent);
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  border-start-end-radius: 8px;
+  border-end-end-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.docs-content blockquote p {
+  margin: 0;
+}
+
 .docs-content p:has(> .docs-image-frame:only-child) {
   margin: 20px 0 24px;
 }

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -435,7 +435,7 @@ const enUS = {
       "Independent apps maintained by their authors. Install from a public GitHub repository, or try a hosted version when one is available.",
     submitCommunityTemplate: "Submit your template",
     communityEmpty:
-      "Community listings are open. Publish a focused agent-native app in a public repository and submit it for the catalog.",
+      "Community listings are open. Publish a focused Agent-Native app in a public repository and submit it for the catalog.",
     publishGuide: "Read the publishing guide",
     communityTrust:
       "Community templates are third-party code. Review the repository, license, dependencies, and install scripts before running it.",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -435,7 +435,7 @@ const enUS = {
       "Independent apps maintained by their authors. Install from a public GitHub repository, or try a hosted version when one is available.",
     submitCommunityTemplate: "Submit your template",
     communityEmpty:
-      "Community listings are open. Publish a focused Agent Native app in a public repository and submit it for the catalog.",
+      "Community listings are open. Publish a focused agent-native app in a public repository and submit it for the catalog.",
     publishGuide: "Read the publishing guide",
     communityTrust:
       "Community templates are third-party code. Review the repository, license, dependencies, and install scripts before running it.",
@@ -1485,7 +1485,7 @@ const enUS = {
     gettingStarted: "Getting Started",
     gettingStartedActions: "Add an Action",
     gettingStartedPages: "Add a Page",
-    whatIsAgentNative: "What Is Agent-Native?",
+    whatIsAgentNative: "What is Agent-Native?",
     agentSurfaces: "Agent Surfaces",
     keyConcepts: "Key Concepts",
     agentNativeToolkit: "Toolkit",

--- a/packages/docs/tests/prerender-paths.test.ts
+++ b/packages/docs/tests/prerender-paths.test.ts
@@ -37,6 +37,7 @@ describe("buildPrerenderPaths", () => {
     expect(paths).toContain("/");
     expect(paths).toContain("/docs");
     expect(paths).toContain("/docs/actions-overview");
+    expect(paths).toContain("/docs/what-is-agent-native");
     expect(paths).toContain("/ja-JP/docs/actions-overview");
     expect(paths.every((page) => !isRedirectedDocsPath(page))).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Rewrite Getting Started as one linear tutorial that calls the same action from the agent and a React UI, then points readers to HTTP, CLI, MCP, and A2A.
- Align the tutorial with the current local sign-in and LLM connection screens, make the first agent result explicit, and end with a concise recap of the shared-action pattern.
- Rework What is Agent-Native around what the framework is, why the architecture matters, how shared actions, data, and application state work, and when the framework is a good fit.
- Keep Overview focused on Getting Started, What is Agent-Native, Key Concepts, Agent Surfaces, and FAQ by placing Deployment under Build Apps instead.
- Use Agent-Native consistently as the framework name while preserving lowercase package names, routes, commands, and domains.

## Why

Developers need a fast path to first success and a concise page they can use to understand what Agent-Native is, why an app should be built this way, and whether it fits their use case. The previous overview split the introductory flow across pages and repeated or mixed conceptual and implementation details.

## Impact

The Overview section now provides a more linear learning path and consistently explains how people use the React UI while agents use the same app functionality as tools.

## Validation

- `pnpm --filter @agent-native/docs validate-doc-blocks` — 12 tests passed
- `pnpm --filter @agent-native/docs exec vitest run app/components/DocsSidebar.test.tsx` — 8 tests passed
- `git diff --check` passed
- Rebased onto the latest `origin/main` with no conflicts

## Localization follow-up

The English source changed. The matching pages under `ar-SA`, `de-DE`, `es-ES`, `fr-FR`, `hi-IN`, `ja-JP`, `ko-KR`, `pt-BR`, `zh-CN`, and `zh-TW` still need translation updates.
