### PR TITLE
Show attached files in new deck reference step

### DIFF
--- a/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.test.tsx
@@ -282,4 +282,21 @@ describe("<NewDeckReferenceStep>", () => {
       screen.getByRole("combobox", { name: "Reference deck" }).textContent,
     ).toContain("Last used deck");
   });
+
+  it("lists files attached to the prompt so the upload is visibly kept", () => {
+    renderStep({
+      promptSummary: "Some prompt",
+      promptFiles: [
+        {
+          path: "uploads/article-setup.pdf",
+          originalName: "Article Setup Requirements.pdf",
+          filename: "article-setup.pdf",
+          type: "application/pdf",
+          size: 1024,
+        },
+      ],
+    });
+
+    expect(screen.getByText("Article Setup Requirements.pdf")).toBeTruthy();
+  });
 });

--- a/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
+++ b/templates/slides/app/components/editor/NewDeckReferenceStep.tsx
@@ -7,6 +7,7 @@ import {
   IconChevronDown,
   IconFileText,
   IconFileTypePdf,
+  IconPaperclip,
   IconPresentation,
   IconWorld,
 } from "@tabler/icons-react";
@@ -40,6 +41,16 @@ import { sortDecksByRecency } from "@/lib/deck-sorting";
 import { cn } from "@/lib/utils";
 
 import { GoogleDriveConnectionCta } from "./GoogleDriveConnectionCta";
+import type { UploadedFile } from "./PromptDialog";
+
+const promptFileIcons: Record<string, typeof IconPaperclip> = {
+  pdf: IconFileTypePdf,
+  ppt: IconPresentation,
+  pptx: IconPresentation,
+  doc: IconFileText,
+  docx: IconFileText,
+  txt: IconFileText,
+};
 
 export interface NewDeckReferenceSelection {
   designSystemId?: string | null;
@@ -88,6 +99,7 @@ interface NewDeckReferenceStepProps {
   skipLabel: string;
   searchDecksLabel: string;
   promptSummary?: string;
+  promptFiles?: UploadedFile[];
 }
 
 export function NewDeckReferenceStep({
@@ -110,6 +122,7 @@ export function NewDeckReferenceStep({
   skipLabel,
   searchDecksLabel,
   promptSummary,
+  promptFiles,
 }: NewDeckReferenceStepProps) {
   const t = useT();
   const [selectedDesignSystemId, setSelectedDesignSystemId] = useState<
@@ -237,6 +250,29 @@ export function NewDeckReferenceStep({
             <p className="mt-2 max-w-xl truncate text-sm text-muted-foreground">
               “{promptSummary.trim()}”
             </p>
+          )}
+          {promptFiles && promptFiles.length > 0 && (
+            <div className="mt-4">
+              <span className="text-xs font-medium text-muted-foreground">
+                {t("home.attachedFiles")}
+              </span>
+              <ul className="mt-2 flex flex-wrap gap-2">
+                {promptFiles.map((file) => {
+                  const extension =
+                    file.originalName.toLowerCase().split(".").pop() ?? "";
+                  const FileIcon = promptFileIcons[extension] ?? IconPaperclip;
+                  return (
+                    <li
+                      key={file.path}
+                      className="flex max-w-full items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-sm"
+                    >
+                      <FileIcon className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="truncate">{file.originalName}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
           )}
 
           <div className="mt-10 space-y-6">

--- a/templates/slides/app/i18n/ar-SA.ts
+++ b/templates/slides/app/i18n/ar-SA.ts
@@ -737,6 +737,7 @@ const messages = {
     chooseReferences: "اختر المراجع",
     addDesignSystem: "+ نظام تصميم",
     importFrom: "استيراد من",
+    attachedFiles: "المرفقات",
     imported: "تم الاستيراد",
     importedReferenceDeck: "عرض مرجعي مستورد",
     referenceImportSuccess: "تم الاستيراد بنجاح",

--- a/templates/slides/app/i18n/de-DE.ts
+++ b/templates/slides/app/i18n/de-DE.ts
@@ -736,6 +736,7 @@ const messages = {
     chooseReferences: "Referenzen auswählen",
     addDesignSystem: "+ Designsystem",
     importFrom: "Importieren von",
+    attachedFiles: "Angehängt",
     imported: "Importiert",
     importedReferenceDeck: "Importiertes Referenz-Deck",
     referenceImportSuccess: "Erfolgreich importiert",

--- a/templates/slides/app/i18n/en-US.ts
+++ b/templates/slides/app/i18n/en-US.ts
@@ -721,6 +721,7 @@ const messages = {
     chooseReferences: "Choose references",
     addDesignSystem: "+ Design system",
     importFrom: "Import from",
+    attachedFiles: "Attached",
     imported: "Imported",
     importedReferenceDeck: "Imported reference deck",
     referenceImportSuccess: "Imported successfully",

--- a/templates/slides/app/i18n/es-ES.ts
+++ b/templates/slides/app/i18n/es-ES.ts
@@ -741,6 +741,7 @@ const messages = {
     chooseReferences: "Elegir referencias",
     addDesignSystem: "+ Sistema de diseño",
     importFrom: "Importar desde",
+    attachedFiles: "Adjuntos",
     imported: "Importado",
     importedReferenceDeck: "Deck de referencia importado",
     referenceImportSuccess: "Importado correctamente",

--- a/templates/slides/app/i18n/fr-FR.ts
+++ b/templates/slides/app/i18n/fr-FR.ts
@@ -745,6 +745,7 @@ const messages = {
     chooseReferences: "Choisir des références",
     addDesignSystem: "+ Système de design",
     importFrom: "Importer depuis",
+    attachedFiles: "Pièces jointes",
     imported: "Importé",
     importedReferenceDeck: "Deck de référence importé",
     referenceImportSuccess: "Importation réussie",

--- a/templates/slides/app/i18n/hi-IN.ts
+++ b/templates/slides/app/i18n/hi-IN.ts
@@ -714,6 +714,7 @@ const messages = {
     chooseReferences: "संदर्भ चुनें",
     addDesignSystem: "+ डिज़ाइन सिस्टम",
     importFrom: "इससे आयात करें",
+    attachedFiles: "अटैच किया गया",
     imported: "इंपोर्ट किया गया",
     importedReferenceDeck: "इंपोर्ट किया गया रेफरेंस डेक",
     referenceImportSuccess: "सफलतापूर्वक इंपोर्ट किया गया",

--- a/templates/slides/app/i18n/ja-JP.ts
+++ b/templates/slides/app/i18n/ja-JP.ts
@@ -721,6 +721,7 @@ const messages = {
     chooseReferences: "参照を選択",
     addDesignSystem: "+ デザインシステム",
     importFrom: "インポート元",
+    attachedFiles: "添付ファイル",
     imported: "インポート済み",
     importedReferenceDeck: "インポートした参考デッキ",
     referenceImportSuccess: "インポートしました",

--- a/templates/slides/app/i18n/ko-KR.ts
+++ b/templates/slides/app/i18n/ko-KR.ts
@@ -714,6 +714,7 @@ const messages = {
     chooseReferences: "참조 선택",
     addDesignSystem: "+ 디자인 시스템",
     importFrom: "가져오기",
+    attachedFiles: "첨부 파일",
     imported: "가져옴",
     importedReferenceDeck: "가져온 참고 덱",
     referenceImportSuccess: "성공적으로 가져왔습니다",

--- a/templates/slides/app/i18n/pt-BR.ts
+++ b/templates/slides/app/i18n/pt-BR.ts
@@ -736,6 +736,7 @@ const messages = {
     chooseReferences: "Escolher referências",
     addDesignSystem: "+ Sistema de design",
     importFrom: "Importar de",
+    attachedFiles: "Anexos",
     imported: "Importado",
     importedReferenceDeck: "Deck de referência importado",
     referenceImportSuccess: "Importado com sucesso",

--- a/templates/slides/app/i18n/zh-CN.ts
+++ b/templates/slides/app/i18n/zh-CN.ts
@@ -702,6 +702,7 @@ const messages = {
     chooseReferences: "选择参考资料",
     addDesignSystem: "+ 设计系统",
     importFrom: "导入自",
+    attachedFiles: "已附加文件",
     imported: "已导入",
     importedReferenceDeck: "已导入的参考幻灯片",
     referenceImportSuccess: "导入成功",

--- a/templates/slides/app/i18n/zh-TW.ts
+++ b/templates/slides/app/i18n/zh-TW.ts
@@ -697,6 +697,7 @@ const messages = {
     chooseReferences: "選擇參考資料",
     addDesignSystem: "+ 設計系統",
     importFrom: "匯入來源",
+    attachedFiles: "已附加檔案",
     imported: "已匯入",
     importedReferenceDeck: "已匯入的參考投影片",
     referenceImportSuccess: "匯入成功",

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1570,6 +1570,7 @@ export default function Index() {
         skipLabel={t("home.referenceDeckNone")}
         searchDecksLabel={t("root.searchDecks")}
         promptSummary={pendingDeck?.prompt}
+        promptFiles={pendingDeck?.files}
       />
 
       {/* Sign-in required to create a deck. Shown when an unauthenticated


### PR DESCRIPTION
### Summary
Displays files attached to the initial prompt in the New Deck Reference step so uploads are visibly preserved when the user moves to the next step.

### Problem
When a user uploaded files alongside their prompt when creating a new deck, those attachments were not shown in the reference selection step, making it unclear whether the uploads were actually carried through.

### Solution
Pass the pending deck's uploaded files down to `NewDeckReferenceStep` and render them as a list of file chips with an icon and file name, so users can visually confirm their uploads were kept.

### Key Changes
- Added `promptFiles` prop (typed as `UploadedFile[]`) to `NewDeckReferenceStepProps` and wired it from `Index.tsx` via `pendingDeck?.files`.
- Rendered a list of attached files below the prompt summary, showing a file-type icon and the original file name for each attachment.
- Added `promptFileIcons` mapping for common extensions (pdf, ppt/pptx, doc/docx, txt) with `IconPaperclip` as a fallback.
- Added `attachedFiles` translation key across all supported locales (en-US, ar-SA, de-DE, es-ES, fr-FR, hi-IN, ja-JP, ko-KR, pt-BR, zh-CN, zh-TW).
- Added a test verifying that attached files are listed and their original names are displayed.

---

<a href="https://builder.io/app/projects/88e92dea5bdd4ad396c8/angular-fang-1aw6h4ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://88e92dea5bdd4ad396c8-angular-fang-1aw6h4ec.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3143`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>88e92dea5bdd4ad396c8</projectId>-->
<!--<branchName>angular-fang-1aw6h4ec</branchName>-->