### PR TITLE
fix(desktop): lighten Electron chat composer in light mode

### DIFF
--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -215,6 +215,20 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(shellCss).toContain('@import "@agent-native/toolkit/styles.css";');
   });
 
+  it("lightens only the Electron light-mode chat composer", () => {
+    const shellCss = readFileSync("src/renderer/shell.css", "utf8");
+
+    expect(shellCss).toContain(
+      "--desktop-chat-composer-background: 0 0% 100%;",
+    );
+    expect(shellCss).toMatch(
+      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{[\s\S]*?background: hsl\(var\(--desktop-chat-composer-background\)\);/,
+    );
+    expect(shellCss).not.toMatch(
+      /\.dark\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root/,
+    );
+  });
+
   it("keeps the chat-first chat column aligned and narrower than its apps grid", () => {
     const shellCss = readFileSync("src/renderer/shell.css", "utf8");
 

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -215,20 +215,6 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(shellCss).toContain('@import "@agent-native/toolkit/styles.css";');
   });
 
-  it("lightens only the Electron light-mode chat composer", () => {
-    const shellCss = readFileSync("src/renderer/shell.css", "utf8");
-
-    expect(shellCss).toContain(
-      "--desktop-chat-composer-background: 0 0% 100%;",
-    );
-    expect(shellCss).toMatch(
-      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{[\s\S]*?background: hsl\(var\(--desktop-chat-composer-background\)\);/,
-    );
-    expect(shellCss).not.toMatch(
-      /\.dark\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root/,
-    );
-  });
-
   it("keeps the chat-first chat column aligned and narrower than its apps grid", () => {
     const shellCss = readFileSync("src/renderer/shell.css", "utf8");
 

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -238,6 +238,7 @@ body {
   --sidebar-accent: 0 0% 95%;
   --sidebar-accent-foreground: 0 0% 15%;
   --sidebar-border: 0 0% 90%;
+  --desktop-chat-composer-background: 0 0% 100%;
   --agent-native-lower-surface: hsl(var(--sidebar-background));
   position: relative;
   display: grid;
@@ -246,6 +247,16 @@ body {
   min-width: 0;
   min-height: 0;
   background: var(--shell-bg);
+}
+
+/* The light desktop chat shell needs more contrast between the composer and
+   its surrounding surface; leave the shared card treatment unchanged. */
+.light
+  .desktop-chat-first-hub
+  [data-chat-first-app-pane]
+  .agent-sidebar-panel
+  .agent-composer-root {
+  background: hsl(var(--desktop-chat-composer-background));
 }
 
 @supports (background: color-mix(in srgb, white, black)) {


### PR DESCRIPTION
## Summary
- lighten only the Electron light-mode composer inside an embedded app chat sidebar
- leave shared composer styling and dark mode unchanged

## Verification
- corepack pnpm --dir packages/desktop-app exec vitest run src/renderer/components/CodeAgentsHub.spec.ts
- corepack pnpm --dir packages/desktop-app exec electron-vite build
- corepack pnpm guards
- rebuilt Electron runtime computed the scoped composer as rgb(255, 255, 255) in light mode and retained the dark muted background