### PR TITLE
fix: address Electron chat feedback

### DIFF
--- a/.changeset/fix-electron-chat-feedback.md
+++ b/.changeset/fix-electron-chat-feedback.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Fix Electron chat feedback around app visibility, local development tools, and run recovery.

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -394,7 +394,7 @@ describe("createAgentChatAdapter", () => {
     );
   });
 
-  it("publishes the terminal stop signal even when another active run exists", async () => {
+  it("does not publish terminal cleanup after another run claims active state", async () => {
     vi.stubGlobal("sessionStorage", createMemoryStorage());
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
@@ -436,7 +436,7 @@ describe("createAgentChatAdapter", () => {
       } as any),
     );
 
-    expect(dispatchEvent).toHaveBeenCalledWith(
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agentNative.chatRunning",
         detail: { isRunning: false, tabId: "chat-terminal-stop" },

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getActiveRun,
   getPendingTurn,
+  clearActiveRun,
   setActiveRun,
 } from "./active-run-state.js";
 import {
@@ -179,6 +180,7 @@ describe("createAgentChatAdapter", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     analyticsMock.captureError.mockReset();
+    clearActiveRun();
   });
 
   it("publishes the client turn id before dispatch and clears it when the run id arrives", async () => {
@@ -388,6 +390,56 @@ describe("createAgentChatAdapter", () => {
       expect.objectContaining({
         type: "agentNative.chatRunning",
         detail: { isRunning: false, tabId: "chat-qa" },
+      }),
+    );
+  });
+
+  it("publishes the terminal stop signal even when another active run exists", async () => {
+    vi.stubGlobal("sessionStorage", createMemoryStorage());
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+    setActiveRun({
+      threadId: "thread-existing",
+      runId: "run-existing",
+      lastSeq: 3,
+    });
+
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-terminal-stop",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "stop this turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agentNative.chatRunning",
+        detail: { isRunning: false, tabId: "chat-terminal-stop" },
       }),
     );
   });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -2137,6 +2137,14 @@ export function createAgentChatAdapter(
             activeRun.runId === runId)
         );
       };
+      const clearOwnedActiveRun = () => {
+        if (!ownsActiveRunState()) return;
+        if (threadId && runId) {
+          clearActiveRunIfMatches(threadId, runId);
+        } else {
+          clearActiveRun();
+        }
+      };
       // The adapter's own stream outranks AssistantChat's reconnect fallback:
       // when it attaches to a run, any reconnect reader folding the same run
       // must stop writing UI state or both folds render at once.
@@ -2546,7 +2554,7 @@ export function createAgentChatAdapter(
               );
               if (!reconnectRes.ok || !reconnectRes.body) {
                 if (reconnectRes.status === 404) {
-                  clearActiveRun();
+                  clearOwnedActiveRun();
                   return false;
                 }
                 lastReconnectError = new Error(
@@ -2592,7 +2600,7 @@ export function createAgentChatAdapter(
                 yield nextResult;
               }
               if (ownsActiveRunState()) {
-                clearActiveRun();
+                clearOwnedActiveRun();
               }
               return true;
             } catch (reconnectErr: unknown) {
@@ -2600,7 +2608,7 @@ export function createAgentChatAdapter(
                 reconnectErr instanceof Error &&
                 reconnectErr.name === "AbortError"
               ) {
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return true;
               }
               if (reconnectErr instanceof AgentAutoContinueSignal) {
@@ -2679,7 +2687,7 @@ export function createAgentChatAdapter(
                 activeErr instanceof Error &&
                 activeErr.name === "AbortError"
               ) {
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return true;
               }
               lastActiveRunError = activeErr;
@@ -2762,7 +2770,7 @@ export function createAgentChatAdapter(
                   activeErr instanceof Error &&
                   activeErr.name === "AbortError"
                 ) {
-                  clearActiveRun();
+                  clearOwnedActiveRun();
                   return true;
                 }
                 lastActiveRunError = activeErr;
@@ -2820,7 +2828,7 @@ export function createAgentChatAdapter(
             status: { type: "incomplete" as const, reason: "error" as const },
             metadata: { custom: { ...(runId ? { runId } : {}), runError } },
           } as ChatModelRunResult;
-          clearActiveRun();
+          clearOwnedActiveRun();
         };
 
         // Final outcome for a background turn the follow loop can no longer
@@ -2855,7 +2863,7 @@ export function createAgentChatAdapter(
                 },
               },
             } as ChatModelRunResult;
-            clearActiveRun();
+            clearOwnedActiveRun();
             return;
           }
           // terminal_reason is either a bare reason ("dispatch_payload_missing")
@@ -2938,7 +2946,7 @@ export function createAgentChatAdapter(
                 },
               },
             } as ChatModelRunResult;
-            clearActiveRun();
+            clearOwnedActiveRun();
             return;
           }
 
@@ -3046,16 +3054,16 @@ export function createAgentChatAdapter(
               }
               settleTerminalChatRun();
               yield missingFinalResponseResult;
-              clearActiveRun();
+              clearOwnedActiveRun();
               return "completed";
             }
             // readSSEStream returned normally: a terminal done/error was
             // consumed and rendered — the turn is over.
-            clearActiveRun();
+            clearOwnedActiveRun();
             return "completed";
           } catch (attachErr: unknown) {
             if (attachErr instanceof Error && attachErr.name === "AbortError") {
-              clearActiveRun();
+              clearOwnedActiveRun();
               return "aborted";
             }
             if (attachErr instanceof AgentAutoContinueSignal) {
@@ -3232,7 +3240,7 @@ export function createAgentChatAdapter(
 
           while (true) {
             if (abortSignal.aborted) {
-              clearActiveRun();
+              clearOwnedActiveRun();
               return "completed";
             }
             if (
@@ -3274,7 +3282,7 @@ export function createAgentChatAdapter(
               }
             } catch (pollErr: unknown) {
               if (pollErr instanceof Error && pollErr.name === "AbortError") {
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return "completed";
               }
               activeUnreadable = true;
@@ -3283,7 +3291,7 @@ export function createAgentChatAdapter(
               // Unreadable: learn nothing, decide nothing, wait and re-ask.
               await delay(BACKGROUND_FOLLOW_POLL_INTERVAL_MS, abortSignal);
               if (abortSignal.aborted) {
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return "completed";
               }
               continue;
@@ -3380,7 +3388,7 @@ export function createAgentChatAdapter(
                   const graceOutcome =
                     await awaitBackgroundErrorRecoverySuccessor(activeRunId);
                   if (graceOutcome === "aborted") {
-                    clearActiveRun();
+                    clearOwnedActiveRun();
                     return "completed";
                   }
                   if (graceOutcome === "successor") {
@@ -3514,7 +3522,7 @@ export function createAgentChatAdapter(
                     refetchErr instanceof Error &&
                     refetchErr.name === "AbortError"
                   ) {
-                    clearActiveRun();
+                    clearOwnedActiveRun();
                     return "completed";
                   }
                   secondOpinionUnreadable = true;
@@ -3633,7 +3641,7 @@ export function createAgentChatAdapter(
             );
             await delay(nextPollDelayMs, abortSignal);
             if (abortSignal.aborted) {
-              clearActiveRun();
+              clearOwnedActiveRun();
               return "completed";
             }
           }
@@ -3802,7 +3810,7 @@ export function createAgentChatAdapter(
           includeReferences = Boolean(runConfig?.custom?.references);
           internalContinuationRequest = true;
           startupRecoveryAttempts = 0;
-          clearActiveRun();
+          clearOwnedActiveRun();
           if (!isTransient) {
             return {
               ok: true,
@@ -4159,17 +4167,17 @@ export function createAgentChatAdapter(
               }
               settleTerminalChatRun();
               yield missingFinalResponseResult;
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
             // Run completed normally — clear active run state
-            clearActiveRun();
+            clearOwnedActiveRun();
             return;
           } catch (err: unknown) {
             if (err instanceof Error && err.name === "AbortError") {
               // User-initiated abort (Stop button) — clear active run
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
@@ -4232,7 +4240,7 @@ export function createAgentChatAdapter(
                       },
                     },
                   };
-                  clearActiveRun();
+                  clearOwnedActiveRun();
                   return;
                 }
                 const preservedError =
@@ -4294,7 +4302,7 @@ export function createAgentChatAdapter(
                     custom: { ...(runId ? { runId } : {}), runError },
                   },
                 };
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return;
               }
               if (continuation.resetVisibleContent) {
@@ -4371,7 +4379,7 @@ export function createAgentChatAdapter(
                   custom: { ...(runId ? { runId } : {}), runError },
                 },
               };
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
@@ -4398,7 +4406,7 @@ export function createAgentChatAdapter(
                   reason: "error" as const,
                 },
               };
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
@@ -4422,7 +4430,7 @@ export function createAgentChatAdapter(
                 },
                 metadata: { custom: { runError: failure.runError } },
               };
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
@@ -4486,7 +4494,7 @@ export function createAgentChatAdapter(
                 },
                 metadata: { custom: { ...(runId ? { runId } : {}), runError } },
               };
-              clearActiveRun();
+              clearOwnedActiveRun();
               return;
             }
 
@@ -4520,7 +4528,7 @@ export function createAgentChatAdapter(
                       },
                     },
                   };
-                  clearActiveRun();
+                  clearOwnedActiveRun();
                   return;
                 }
                 const message = exhaustedRecoveryMessage("stream_ended");
@@ -4557,7 +4565,7 @@ export function createAgentChatAdapter(
                     custom: { ...(runId ? { runId } : {}), runError },
                   },
                 };
-                clearActiveRun();
+                clearOwnedActiveRun();
                 return;
               }
               if (continuation.resetVisibleContent) {
@@ -4625,7 +4633,9 @@ export function createAgentChatAdapter(
           }
         }
       } finally {
-        publishTerminalChatUiStopped();
+        if (ownsActiveRunState()) {
+          publishTerminalChatUiStopped();
+        }
       }
     },
   };

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -2146,6 +2146,18 @@ export function createAgentChatAdapter(
           preemptRunStream(threadId, runId, streamOwnershipToken);
         }
       };
+      let terminalChatUiStopped = false;
+      const publishTerminalChatUiStopped = () => {
+        if (terminalChatUiStopped) return;
+        terminalChatUiStopped = true;
+        if (typeof window === "undefined") return;
+        dispatchTerminalChatUiCleanup(tabId);
+        window.dispatchEvent(
+          new CustomEvent("agentNative.chatRunning", {
+            detail: { isRunning: false, tabId },
+          }),
+        );
+      };
       const settleTerminalChatRun = () => {
         if (threadId && runId) {
           releaseRunStream(threadId, runId, streamOwnershipToken);
@@ -2156,13 +2168,7 @@ export function createAgentChatAdapter(
         } else {
           clearActiveRun();
         }
-        if (typeof window === "undefined") return;
-        dispatchTerminalChatUiCleanup(tabId);
-        window.dispatchEvent(
-          new CustomEvent("agentNative.chatRunning", {
-            detail: { isRunning: false, tabId },
-          }),
-        );
+        publishTerminalChatUiStopped();
       };
       const seenRunSeqs = new Map<string, number>();
       const preparingActionStatesByRun = new Map<
@@ -4619,14 +4625,7 @@ export function createAgentChatAdapter(
           }
         }
       } finally {
-        if (typeof window !== "undefined" && ownsActiveRunState()) {
-          dispatchTerminalChatUiCleanup(tabId);
-          window.dispatchEvent(
-            new CustomEvent("agentNative.chatRunning", {
-              detail: { isRunning: false, tabId },
-            }),
-          );
-        }
+        publishTerminalChatUiStopped();
       }
     },
   };

--- a/packages/core/src/client/agent-chat/index.ts
+++ b/packages/core/src/client/agent-chat/index.ts
@@ -48,6 +48,7 @@ export {
   type SaveAgentEngineProviderSettingsOptions,
 } from "../agent-engine-key.js";
 export { useAgentChatGenerating } from "../use-agent-chat.js";
+export { useActiveAgentChatRunId } from "../use-active-agent-chat-run.js";
 export {
   useAgentChatContext,
   type UseAgentChatContextResult,

--- a/packages/core/src/client/chat-first/apps-rail.spec.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.spec.tsx
@@ -12,9 +12,42 @@ import {
 describe("ChatFirstAppsRail", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let localStorageDescriptor: PropertyDescriptor | undefined;
+
+  function createMemoryStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+      get length() {
+        return values.size;
+      },
+      clear() {
+        values.clear();
+      },
+      getItem(key) {
+        return values.get(key) ?? null;
+      },
+      key(index) {
+        return [...values.keys()][index] ?? null;
+      },
+      removeItem(key) {
+        values.delete(key);
+      },
+      setItem(key, value) {
+        values.set(String(key), String(value));
+      },
+    };
+  }
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    localStorageDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "localStorage",
+    );
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -24,6 +57,11 @@ describe("ChatFirstAppsRail", () => {
     act(() => root.unmount());
     window.localStorage.removeItem(CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY);
     container.remove();
+    if (localStorageDescriptor) {
+      Object.defineProperty(window, "localStorage", localStorageDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "localStorage");
+    }
   });
 
   it("grays non-selected app icons while keeping the selected icon in color", () => {

--- a/packages/core/src/client/chat-first/apps-rail.spec.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.spec.tsx
@@ -4,7 +4,10 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ChatFirstAppsRail } from "./apps-rail.js";
+import {
+  CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY,
+  ChatFirstAppsRail,
+} from "./apps-rail.js";
 
 describe("ChatFirstAppsRail", () => {
   let container: HTMLDivElement;
@@ -19,6 +22,7 @@ describe("ChatFirstAppsRail", () => {
 
   afterEach(() => {
     act(() => root.unmount());
+    window.localStorage.removeItem(CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY);
     container.remove();
   });
 
@@ -201,5 +205,52 @@ describe("ChatFirstAppsRail", () => {
         (app) => app.dataset.appId,
       ),
     ).toEqual(defaultAppIds);
+  });
+
+  it("persists the expanded rail state across remounts", () => {
+    const apps = Array.from({ length: 7 }, (_, index) => ({
+      id: `app-${index}`,
+      name: `App ${index}`,
+    }));
+
+    act(() => {
+      root.render(
+        <ChatFirstAppsRail
+          apps={apps}
+          onOpenApp={vi.fn()}
+          renderIcon={(app) => <span>{app.name}</span>}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll("[data-chat-first-app]")).toHaveLength(5);
+    const showMore = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Show more",
+    );
+    expect(showMore).toBeDefined();
+
+    act(() => {
+      showMore?.click();
+    });
+
+    expect(container.querySelectorAll("[data-chat-first-app]")).toHaveLength(7);
+
+    act(() => {
+      root.unmount();
+    });
+    root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ChatFirstAppsRail
+          apps={apps}
+          collapsed
+          onOpenApp={vi.fn()}
+          renderIcon={(app) => <span>{app.name}</span>}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll("[data-chat-first-app]")).toHaveLength(7);
   });
 });

--- a/packages/core/src/client/chat-first/apps-rail.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.tsx
@@ -17,7 +17,7 @@ import {
   IconPlus,
   IconTrash,
 } from "@tabler/icons-react";
-import { memo, useMemo, useState, type ReactNode } from "react";
+import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
 
 import {
   CHAT_FIRST_DEFAULT_APP_IDS,
@@ -34,6 +34,32 @@ import type {
   ChatFirstAppRailProps,
   ChatFirstCopy,
 } from "./types.js";
+
+const CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY =
+  "agent-native:chat-first-app-rail-show-all:v1";
+
+function readChatFirstAppRailShowAll(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(
+      CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY,
+    ) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeChatFirstAppRailShowAll(showAllApps: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY,
+      String(showAllApps),
+    );
+  } catch {
+    // Keep the in-memory toggle usable when device storage is unavailable.
+  }
+}
 
 function ChatFirstRailAppIcon({
   app,
@@ -240,7 +266,14 @@ export const ChatFirstAppsRail = memo(function ChatFirstAppsRail({
   );
   const layout = controlledLayout ?? localLayout;
   const [draggedAppId, setDraggedAppId] = useState<string | null>(null);
-  const [showAllApps, setShowAllApps] = useState(false);
+  const [showAllApps, setShowAllApps] = useState(() =>
+    readChatFirstAppRailShowAll(),
+  );
+
+  useEffect(() => {
+    writeChatFirstAppRailShowAll(showAllApps);
+  }, [showAllApps]);
+
   const orderedApps = useMemo(() => {
     const orderedIds = orderChatFirstAppIds(
       apps.map((app) => app.id),

--- a/packages/core/src/client/chat-first/apps-rail.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.tsx
@@ -35,15 +35,16 @@ import type {
   ChatFirstCopy,
 } from "./types.js";
 
-const CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY =
+export const CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY =
   "agent-native:chat-first-app-rail-show-all:v1";
 
 function readChatFirstAppRailShowAll(): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem(
-      CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY,
-    ) === "true";
+    return (
+      window.localStorage.getItem(CHAT_FIRST_APP_RAIL_SHOW_ALL_STORAGE_KEY) ===
+      "true"
+    );
   } catch {
     return false;
   }

--- a/packages/core/src/client/chat-first/apps-rail.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.tsx
@@ -46,6 +46,7 @@ function readChatFirstAppRailShowAll(): boolean {
       "true"
     );
   } catch {
+    // coercion-ok: localStorage is optional; false keeps the rail usable in-memory.
     return false;
   }
 }
@@ -58,7 +59,7 @@ function writeChatFirstAppRailShowAll(showAllApps: boolean) {
       String(showAllApps),
     );
   } catch {
-    // Keep the in-memory toggle usable when device storage is unavailable.
+    // coercion-ok: localStorage is optional; the in-memory toggle remains usable.
   }
 }
 

--- a/packages/core/src/client/use-active-agent-chat-run.spec.tsx
+++ b/packages/core/src/client/use-active-agent-chat-run.spec.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { clearActiveRun, setActiveRun } from "./active-run-state.js";
+import { useActiveAgentChatRunId } from "./use-active-agent-chat-run.js";
+
+describe("useActiveAgentChatRunId", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    clearActiveRun();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    clearActiveRun();
+  });
+
+  it("returns the active run only for its matching thread", async () => {
+    setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 0 });
+
+    function Probe() {
+      return <output>{useActiveAgentChatRunId("thread-1") ?? "none"}</output>;
+    }
+
+    await act(async () => root.render(<Probe />));
+    expect(container.textContent).toBe("run-1");
+
+    await act(async () => {
+      setActiveRun({ threadId: "thread-2", runId: "run-2", lastSeq: 0 });
+    });
+    expect(container.textContent).toBe("none");
+  });
+
+  it("clears the run ID when the active run ends", async () => {
+    function Probe() {
+      return <output>{useActiveAgentChatRunId("thread-1") ?? "none"}</output>;
+    }
+
+    await act(async () => root.render(<Probe />));
+    expect(container.textContent).toBe("none");
+
+    await act(async () => {
+      setActiveRun({ threadId: "thread-1", runId: "run-1", lastSeq: 0 });
+    });
+    expect(container.textContent).toBe("run-1");
+
+    await act(async () => clearActiveRun());
+    expect(container.textContent).toBe("none");
+  });
+});

--- a/packages/core/src/client/use-active-agent-chat-run.ts
+++ b/packages/core/src/client/use-active-agent-chat-run.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import {
+  ACTIVE_RUN_STATE_EVENT,
+  getActiveRun,
+  type ActiveRunState,
+} from "./active-run-state.js";
+
+/** Return the focused run for a thread and keep it current as the stream moves. */
+export function useActiveAgentChatRunId(
+  threadId: string | null | undefined,
+): string | null {
+  const [activeRun, setActiveRun] = useState<ActiveRunState | null>(() =>
+    getActiveRun(),
+  );
+
+  useEffect(() => {
+    const syncFromStorage = () => setActiveRun(getActiveRun());
+    const handleActiveRunChange = (event: Event) => {
+      const state = (event as CustomEvent<{ state?: ActiveRunState | null }>)
+        .detail?.state;
+      setActiveRun(state ?? null);
+    };
+
+    syncFromStorage();
+    window.addEventListener(ACTIVE_RUN_STATE_EVENT, handleActiveRunChange);
+    window.addEventListener("storage", syncFromStorage);
+    return () => {
+      window.removeEventListener(ACTIVE_RUN_STATE_EVENT, handleActiveRunChange);
+      window.removeEventListener("storage", syncFromStorage);
+    };
+  }, []);
+
+  return activeRun && activeRun.threadId === threadId ? activeRun.runId : null;
+}

--- a/packages/core/src/coding-tools/index.spec.ts
+++ b/packages/core/src/coding-tools/index.spec.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { actionsToEngineTools } from "../agent/production-agent.js";
 import { createDevScriptRegistry } from "../scripts/dev/index.js";
 import { createDbScriptEntries } from "../server/agent-chat/script-entries.js";
+import { runWithRequestContext } from "../server/request-context.js";
 import {
   BASH_OUTPUT_HEAD_CHARS,
   BASH_OUTPUT_TAIL_CHARS,
@@ -160,6 +161,29 @@ describe("shared coding tools", () => {
         command: 'pnpm action db-query --sql "SELECT 1"',
       }),
     ).resolves.toContain("raw database tools are disabled");
+  });
+
+  it("enforces request-scoped app actions through the local bash path", async () => {
+    const registry = await createDevScriptRegistry({ databaseTools: false });
+
+    await expect(
+      runWithRequestContext(
+        { run: { allowedActionNames: ["allowed-action"] } },
+        () =>
+          registry.bash.run({
+            command: "pnpm action denied-action --value=secret",
+          }),
+      ),
+    ).resolves.toContain(
+      'action "denied-action" is not available in this request\'s action surface',
+    );
+
+    await expect(
+      runWithRequestContext(
+        { run: { allowedActionNames: ["allowed-action"] } },
+        () => registry.bash.run({ command: "printf local-bash" }),
+      ),
+    ).resolves.toContain("local-bash");
   });
 
   it("can expose read-only database tools without raw SQL write tools", async () => {

--- a/packages/core/src/scripts/dev/index.ts
+++ b/packages/core/src/scripts/dev/index.ts
@@ -9,6 +9,7 @@
 import type { ActionEntry } from "../../agent/production-agent.js";
 import type { ActionTool } from "../../agent/types.js";
 import { createCodingToolRegistry } from "../../coding-tools/index.js";
+import { getRequestRunContext } from "../../server/request-context.js";
 import {
   normalizeDatabaseToolsMode,
   type DatabaseToolsOption,
@@ -89,6 +90,25 @@ function blockedDatabaseActionFromBash(
     return `Error: raw database write tools are disabled for this app (blocked ${actionName}).`;
   }
 
+  return null;
+}
+
+function unauthorizedActionFromBash(
+  command: string,
+  allowedActionNames?: readonly string[],
+): string | null {
+  if (!allowedActionNames) return null;
+
+  const allowed = new Set(allowedActionNames);
+  const actionCommands = command.matchAll(
+    /\b(?:pnpm|npm|yarn|bun)(?:\s+\S+){0,4}\s+action\s+([a-z][a-z0-9-]*)\b/g,
+  );
+  for (const match of actionCommands) {
+    const actionName = match[1];
+    if (actionName && !allowed.has(actionName)) {
+      return `Error: action "${actionName}" is not available in this request's action surface.`;
+    }
+  }
   return null;
 }
 
@@ -268,7 +288,10 @@ export async function createDevScriptRegistry(
     cwd: process.cwd(),
     bashThrowsOnNonZero: true,
     beforeBash: ({ command }) =>
-      blockedDatabaseActionFromBash(command, databaseToolsMode),
+      unauthorizedActionFromBash(
+        command,
+        getRequestRunContext()?.allowedActionNames,
+      ) ?? blockedDatabaseActionFromBash(command, databaseToolsMode),
   });
   const legacyEntries: Record<string, ActionEntry> = options.legacyAliases
     ? {

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -200,6 +200,21 @@ describe("request-scoped action surface", () => {
     );
   });
 
+  it("keeps request-scoped action surfaces out of the dev-native tool switch", () => {
+    const source = readFileSync("src/server/agent-chat-plugin.ts", {
+      encoding: "utf-8",
+    });
+    const devNativeBlock = source.match(
+      /const devNative =[\s\S]*?const basePrompt = prodPrompt;/,
+    )?.[0];
+
+    expect(source).toMatch(
+      /const devNative =[\s\S]*options\?\.nativeActionsInDev === true \|\| leanPrompt;/,
+    );
+    expect(devNativeBlock).toBeDefined();
+    expect(devNativeBlock).not.toContain("resolveActionSurface");
+  });
+
   it("removes denied actions before the actions prompt is generated", () => {
     const actions = {
       allowed: {

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -228,6 +228,22 @@ describe("request-scoped action surface", () => {
     );
   });
 
+  it("keeps local coding tools in every dev handler variant", () => {
+    const source = readFileSync("src/server/agent-chat-plugin.ts", {
+      encoding: "utf-8",
+    });
+
+    expect(source).toMatch(
+      /const devScriptRegistry = await createDevScriptRegistry\(\{[\s\S]*?databaseTools: databaseToolsMode,[\s\S]*?\}\);/,
+    );
+    expect(source).toMatch(
+      /leanPrompt\s+\? \{ \.\.\.devScriptRegistry, \.\.\.leanActions \}/,
+    );
+    expect(source).toMatch(
+      /devNative\s+\? \{ \.\.\.devScriptRegistry, \.\.\.prodActions \}/,
+    );
+  });
+
   it("removes denied actions before the actions prompt is generated", () => {
     const actions = {
       allowed: {

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -244,6 +244,25 @@ describe("request-scoped action surface", () => {
     );
   });
 
+  it("keeps local coding tools available while scoping app actions in dev", () => {
+    const source = readFileSync("src/server/agent-chat-plugin.ts", {
+      encoding: "utf-8",
+    });
+    const devSource = readFileSync("src/scripts/dev/index.ts", {
+      encoding: "utf-8",
+    });
+
+    expect(source).toMatch(
+      /const localDevActionNames = new Set\(Object\.keys\(devScriptRegistry\)\);/,
+    );
+    expect(source).toMatch(
+      /availableActionNames: appActionNames,[\s\S]*?allowedActionNames: \[[\s\S]*?\.\.\.surface\.allowedActionNames,[\s\S]*?\.\.\.localActionNames,/s,
+    );
+    expect(devSource).toMatch(
+      /unauthorizedActionFromBash\([\s\S]*?getRequestRunContext\(\)\?\.allowedActionNames/s,
+    );
+  });
+
   it("removes denied actions before the actions prompt is generated", () => {
     const actions = {
       allowed: {
@@ -281,7 +300,8 @@ describe("request-scoped action surface", () => {
 
     expect(
       source.match(/resolveActionSurface: options\?\.resolveActionSurface,/g),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
+    expect(source).toContain("resolveActionSurface: resolveDevActionSurface");
   });
 
   it("filters late-bound sandbox bridge registries to the request surface", async () => {

--- a/packages/core/src/server/agent-chat-plugin.surface.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.surface.spec.ts
@@ -215,6 +215,19 @@ describe("request-scoped action surface", () => {
     expect(devNativeBlock).not.toContain("resolveActionSurface");
   });
 
+  it("keeps request-scoped dev actions available without exposing them natively", () => {
+    const source = readFileSync("src/server/agent-chat-plugin.ts", {
+      encoding: "utf-8",
+    });
+
+    expect(source).toMatch(
+      /const requestScopedDevActions = options\?\.resolveActionSurface\s+\? Object\.fromEntries\([\s\S]*?discoveredActions, \.\.\.templateScripts[\s\S]*?agentTool: false/s,
+    );
+    expect(source).toMatch(
+      /\.\.\.requestScopedDevActions,\s+\.\.\.resourceScripts,/,
+    );
+  });
+
   it("removes denied actions before the actions prompt is generated", () => {
     const actions = {
       allowed: {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2379,9 +2379,7 @@ export function createAgentChatPlugin(
       // template actions via bash" guidance is wrong — use the prod prompt
       // + tool-format action list instead, same as production.
       const devNative =
-        options?.nativeActionsInDev === true ||
-        leanPrompt ||
-        Boolean(options?.resolveActionSurface);
+        options?.nativeActionsInDev === true || leanPrompt;
       // Keep legacy names for the composition below
       const basePrompt = prodPrompt;
       const getFrameworkPromptActions = (): Record<string, ActionEntry> =>

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2378,8 +2378,7 @@ export function createAgentChatPlugin(
       // `nativeActionsInDev` or `leanPrompt`), the dev prompt's "invoke
       // template actions via bash" guidance is wrong — use the prod prompt
       // + tool-format action list instead, same as production.
-      const devNative =
-        options?.nativeActionsInDev === true || leanPrompt;
+      const devNative = options?.nativeActionsInDev === true || leanPrompt;
       // Keep legacy names for the composition below
       const basePrompt = prodPrompt;
       const getFrameworkPromptActions = (): Record<string, ActionEntry> =>

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3765,12 +3765,24 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         // template's actions as native tools instead of routing through bash.
         // Templates with structured-arg actions (objects/arrays) need this to
         // avoid round-tripping JSON through the CLI parser.
+        // Request-scoped dev actions are present for authorization and the
+        // `pnpm action` prompt, but remain CLI-only instead of becoming native
+        // tools. The resolver therefore sees the same action names that the
+        // dev prompt can teach without changing the shell-backed dev surface.
+        const requestScopedDevActions = options?.resolveActionSurface
+          ? Object.fromEntries(
+              Object.entries({ ...discoveredActions, ...templateScripts }).map(
+                ([name, entry]) => [name, { ...entry, agentTool: false }],
+              ),
+            )
+          : {};
         const devActions = attachToolSearch(
           leanPrompt
             ? leanActions
             : devNative
               ? prodActions
               : {
+                  ...requestScopedDevActions,
                   ...resourceScripts,
                   ...docsScripts,
                   ...(lazyContext ? frameworkContextTool : {}),

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -81,6 +81,7 @@ import {
   abortTurnDurably,
   subscribeToRun,
   type ActionEntry,
+  type AgentActionSurfaceDetails,
   type AgentLoopOutcome,
   type ResolvedOwnerApiKey,
 } from "../agent/production-agent.js";
@@ -3782,6 +3783,29 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         const devScriptRegistry = await createDevScriptRegistry({
           databaseTools: databaseToolsMode,
         });
+        const localDevActionNames = new Set(Object.keys(devScriptRegistry));
+        const resolveDevActionSurface = options?.resolveActionSurface
+          ? async (details: AgentActionSurfaceDetails) => {
+              const appActionNames = details.availableActionNames.filter(
+                (name) => !localDevActionNames.has(name),
+              );
+              const surface = await options.resolveActionSurface!({
+                ...details,
+                availableActionNames: appActionNames,
+              });
+              const localActionNames = details.availableActionNames.filter(
+                (name) => localDevActionNames.has(name),
+              );
+              return {
+                allowedActionNames: [
+                  ...new Set([
+                    ...surface.allowedActionNames,
+                    ...localActionNames,
+                  ]),
+                ],
+              };
+            }
+          : undefined;
         const devActions = attachToolSearch(
           leanPrompt
             ? { ...devScriptRegistry, ...leanActions }
@@ -3937,7 +3961,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             }
             return options?.prepareRequest?.(details);
           },
-          resolveActionSurface: options?.resolveActionSurface,
+          resolveActionSurface: resolveDevActionSurface,
           skipFilesContext,
           initialToolNames: effectiveInitialToolNames,
           ...(options?.toolLimits ? { toolLimits: options.toolLimits } : {}),

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3776,11 +3776,17 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               ),
             )
           : {};
+        // Keep the local coding registry in every dev handler variant. Native
+        // action mode changes how app actions are called; it must not remove
+        // bash/read/edit/write from Electron's local chat surface.
+        const devScriptRegistry = await createDevScriptRegistry({
+          databaseTools: databaseToolsMode,
+        });
         const devActions = attachToolSearch(
           leanPrompt
-            ? leanActions
+            ? { ...devScriptRegistry, ...leanActions }
             : devNative
-              ? prodActions
+              ? { ...devScriptRegistry, ...prodActions }
               : {
                   ...requestScopedDevActions,
                   ...resourceScripts,
@@ -3804,9 +3810,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                   ...coreAttachmentTools,
                   ...browserTools,
                   ...mcpActionEntries,
-                  ...(await createDevScriptRegistry({
-                    databaseTools: databaseToolsMode,
-                  })),
+                  ...devScriptRegistry,
                   // Full-database admin tools (NODE_ENV=development gate — see
                   // dbAdminScripts; also in prodActions so App mode has them too).
                   ...dbAdminScripts,

--- a/packages/dispatch/src/routes/pages/chat.spec.tsx
+++ b/packages/dispatch/src/routes/pages/chat.spec.tsx
@@ -8,6 +8,7 @@ import ChatRoute from "./chat";
 
 const clientState = vi.hoisted(() => ({
   surfaceProps: null as Record<string, unknown> | null,
+  writeClipboardText: vi.fn(),
   agents: [] as Array<{
     id: string;
     name: string;
@@ -32,6 +33,10 @@ vi.mock("@agent-native/core/client/agent-chat", () => ({
     path: string,
   ) => navigate(path),
   sendToAgentChat: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/client/clipboard", () => ({
+  writeClipboardText: clientState.writeClipboardText,
 }));
 
 vi.mock("@agent-native/core/client/hooks", () => ({
@@ -179,5 +184,29 @@ describe("Dispatch ChatRoute", () => {
         }
       ).getPath("thread-1"),
     ).toBe("/chat/thread-1?agent=agents%2Fresearch-partner.md");
+  });
+
+  it("exposes a copyable request ID affordance on threaded chats", async () => {
+    clientState.writeClipboardText.mockResolvedValue(true);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/chat/chat-123"]}>
+          <ChatRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("Copy request ID"),
+    );
+    expect(button).toBeTruthy();
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(clientState.writeClipboardText).toHaveBeenCalledWith("chat-123");
   });
 });

--- a/packages/dispatch/src/routes/pages/chat.spec.tsx
+++ b/packages/dispatch/src/routes/pages/chat.spec.tsx
@@ -8,6 +8,7 @@ import ChatRoute from "./chat";
 
 const clientState = vi.hoisted(() => ({
   surfaceProps: null as Record<string, unknown> | null,
+  activeRunId: null as string | null,
   writeClipboardText: vi.fn(),
   agents: [] as Array<{
     id: string;
@@ -28,6 +29,7 @@ vi.mock("@agent-native/core/client/agent-chat", () => ({
   insertAgentComposerReference: vi.fn(),
   markAgentChatHomeHandoff: vi.fn(),
   readChatFirstMode: () => true,
+  useActiveAgentChatRunId: () => clientState.activeRunId,
   navigateWithAgentChatViewTransition: (
     navigate: (path: string) => void,
     path: string,
@@ -77,6 +79,7 @@ describe("Dispatch ChatRoute", () => {
     vi.useFakeTimers();
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     clientState.surfaceProps = null;
+    clientState.activeRunId = null;
     clientState.agents = [];
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -187,6 +190,7 @@ describe("Dispatch ChatRoute", () => {
   });
 
   it("exposes a copyable request ID affordance on threaded chats", async () => {
+    clientState.activeRunId = "run-456";
     clientState.writeClipboardText.mockResolvedValue(true);
 
     await act(async () => {
@@ -207,6 +211,22 @@ describe("Dispatch ChatRoute", () => {
       await Promise.resolve();
     });
 
-    expect(clientState.writeClipboardText).toHaveBeenCalledWith("chat-123");
+    expect(clientState.writeClipboardText).toHaveBeenCalledWith("run-456");
+  });
+
+  it("keeps the request ID affordance unavailable before a run starts", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/chat/chat-123"]}>
+          <ChatRoute />
+        </MemoryRouter>,
+      );
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("Request ID unavailable"),
+    );
+    expect(button).toBeTruthy();
+    expect(button).toHaveProperty("disabled", true);
   });
 });

--- a/packages/dispatch/src/routes/pages/chat.tsx
+++ b/packages/dispatch/src/routes/pages/chat.tsx
@@ -3,6 +3,7 @@ import {
   insertAgentComposerReference,
   markAgentChatHomeHandoff,
   readChatFirstMode,
+  useActiveAgentChatRunId,
 } from "@agent-native/core/client/agent-chat";
 import { appBasePath, appPath } from "@agent-native/core/client/api-path";
 import { writeClipboardText } from "@agent-native/core/client/clipboard";
@@ -90,11 +91,12 @@ function DispatchAgentChatSurface(props: DispatchAgentChatSurfaceProps) {
   return <AgentChatSurface {...props} />;
 }
 
-function DispatchRequestIdButton({ requestId }: { requestId: string }) {
+function DispatchRequestIdButton({ requestId }: { requestId: string | null }) {
   const t = useT();
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
+    if (!requestId) return;
     void writeClipboardText(requestId).then((ok) => {
       if (!ok) return;
       setCopied(true);
@@ -107,9 +109,10 @@ function DispatchRequestIdButton({ requestId }: { requestId: string }) {
       type="button"
       variant="outline"
       size="sm"
+      disabled={!requestId}
       onClick={handleCopy}
       aria-label={t("dispatch.pages.copyRequestId", {
-        defaultValue: "Copy request ID",
+        defaultValue: requestId ? "Copy request ID" : "Request ID unavailable",
       })}
     >
       {copied ? (
@@ -120,7 +123,9 @@ function DispatchRequestIdButton({ requestId }: { requestId: string }) {
       {copied
         ? t("dispatch.pages.copied", { defaultValue: "Copied" })
         : t("dispatch.pages.copyRequestId", {
-            defaultValue: "Copy request ID",
+            defaultValue: requestId
+              ? "Copy request ID"
+              : "Request ID unavailable",
           })}
     </Button>
   );
@@ -149,6 +154,7 @@ export default function ChatRoute() {
   const location = useLocation();
   const navigate = useNavigate();
   const routeThreadId = threadIdFromPath(location.pathname);
+  const activeRunId = useActiveAgentChatRunId(routeThreadId);
   const agentPath = new URLSearchParams(location.search).get("agent");
   const agentsQuery = useActionQuery<WorkspaceAgentResource[]>(
     "list-workspace-resources",
@@ -317,7 +323,7 @@ export default function ChatRoute() {
     <div className="flex h-full min-h-0 flex-col bg-background">
       {threadUrlSync.routeThreadId ? (
         <div className="flex justify-end px-4 pt-4 sm:px-6">
-          <DispatchRequestIdButton requestId={threadUrlSync.routeThreadId} />
+          <DispatchRequestIdButton requestId={activeRunId} />
         </div>
       ) : null}
       <DispatchAgentChatSurface

--- a/packages/dispatch/src/routes/pages/chat.tsx
+++ b/packages/dispatch/src/routes/pages/chat.tsx
@@ -21,8 +21,8 @@ import { useLocation, useNavigate } from "react-router";
 
 import { ActionQueryError } from "../../components/action-query-error";
 import { useDispatchExtensions } from "../../components/layout/Layout";
-import { Skeleton } from "../../components/ui/skeleton";
 import { Button } from "../../components/ui/button";
+import { Skeleton } from "../../components/ui/skeleton";
 import { submitOverviewPrompt } from "../../lib/overview-chat";
 
 interface WorkspaceAgentResource {

--- a/packages/dispatch/src/routes/pages/chat.tsx
+++ b/packages/dispatch/src/routes/pages/chat.tsx
@@ -5,13 +5,16 @@ import {
   readChatFirstMode,
 } from "@agent-native/core/client/agent-chat";
 import { appBasePath, appPath } from "@agent-native/core/client/api-path";
+import { writeClipboardText } from "@agent-native/core/client/clipboard";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { IconCheck, IconCopy } from "@tabler/icons-react";
 import {
   useCallback,
   useEffect,
   useMemo,
   useRef,
+  useState,
   type ComponentProps,
 } from "react";
 import { useLocation, useNavigate } from "react-router";
@@ -19,6 +22,7 @@ import { useLocation, useNavigate } from "react-router";
 import { ActionQueryError } from "../../components/action-query-error";
 import { useDispatchExtensions } from "../../components/layout/Layout";
 import { Skeleton } from "../../components/ui/skeleton";
+import { Button } from "../../components/ui/button";
 import { submitOverviewPrompt } from "../../lib/overview-chat";
 
 interface WorkspaceAgentResource {
@@ -84,6 +88,42 @@ type DispatchAgentChatSurfaceProps = ComponentProps<typeof AgentChatSurface> & {
 
 function DispatchAgentChatSurface(props: DispatchAgentChatSurfaceProps) {
   return <AgentChatSurface {...props} />;
+}
+
+function DispatchRequestIdButton({ requestId }: { requestId: string }) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void writeClipboardText(requestId).then((ok) => {
+      if (!ok) return;
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1000);
+    });
+  }, [requestId]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleCopy}
+      aria-label={t("dispatch.pages.copyRequestId", {
+        defaultValue: "Copy request ID",
+      })}
+    >
+      {copied ? (
+        <IconCheck aria-hidden="true" />
+      ) : (
+        <IconCopy aria-hidden="true" />
+      )}
+      {copied
+        ? t("dispatch.pages.copied", { defaultValue: "Copied" })
+        : t("dispatch.pages.copyRequestId", {
+            defaultValue: "Copy request ID",
+          })}
+    </Button>
+  );
 }
 
 interface DispatchChatLocationState {
@@ -275,6 +315,11 @@ export default function ChatRoute() {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
+      {threadUrlSync.routeThreadId ? (
+        <div className="flex justify-end px-4 pt-4 sm:px-6">
+          <DispatchRequestIdButton requestId={threadUrlSync.routeThreadId} />
+        </div>
+      ) : null}
       <DispatchAgentChatSurface
         key={agent ? `agent-${agent.id}` : "dispatch"}
         mode="page"


### PR DESCRIPTION
## Summary
- Persist the expanded Chat First app rail across Electron app reopen.
- Expose the active Dispatch run ID with a copy affordance and an unavailable state before a run starts.
- Clear terminal chat activity/running state on every adapter teardown path.
- Keep local Electron development on the filesystem/bash surface, including request-scoped action names as CLI-only; hosted production remains restricted and production skills must be imported/uploaded through the supported file or agent-pack path.

## Feedback dispositions
- [Where are my apps?](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787147068830159) - fixed: expanded app rail persists across reopen.
- [Request ID](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787147700554889) - fixed: threaded Dispatch chats expose the active run ID and show an unavailable state until one exists.
- [Slides stuck Thinking](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787149698494929) - fixed: terminal adapter paths publish cleanup signals.
- [Skills and local bash](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787149769034999) - fixed locally: Electron/dev keeps filesystem and bash access; hosted production stays restricted, with skills supplied through supported file or agent-pack import.

## Validation
- `corepack pnpm guards` - all 55 checks passed.
- Focused core and Dispatch Vitest suites passed.
- Core and Dispatch typechecks passed.