### PR TITLE
fix: stabilize desktop app sign-in and chat switching

### DIFF
--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -21,6 +21,7 @@ import {
   resolveAppWebviewAuthState,
   resolveAppWebviewUrl,
   isDesktopIdentityGateEligible,
+  shouldUseDesktopIdentityGate,
   shouldSuppressDesktopSignInPrompt,
   resolveGuestChatCommand,
   resolveDesktopIdentityLazySyncStatus,
@@ -54,6 +55,30 @@ beforeAll(() => {
 });
 
 describe("Desktop identity lazy child synchronization", () => {
+  it("keeps the Electron gate active while its setting is unresolved", () => {
+    expect(
+      shouldUseDesktopIdentityGate({
+        eligible: true,
+        active: true,
+        enabled: null,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDesktopIdentityGate({
+        eligible: true,
+        active: true,
+        enabled: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseDesktopIdentityGate({
+        eligible: true,
+        active: false,
+        enabled: null,
+      }),
+    ).toBe(false);
+  });
+
   it("does not demote a verified workspace session when child sync fails", () => {
     expect(resolveDesktopIdentityLazySyncStatus("signed-in", false)).toBe(
       "signed-in",

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -131,6 +131,14 @@ export function isDesktopIdentityGateEligible(
   return canonical !== undefined;
 }
 
+export function shouldUseDesktopIdentityGate(input: {
+  eligible: boolean;
+  active: boolean;
+  enabled: boolean | null;
+}): boolean {
+  return input.eligible && input.active && input.enabled !== false;
+}
+
 export function shouldSuppressDesktopSignInPrompt(
   app: Pick<AppDefinition, "id">,
   appConfig: Pick<
@@ -422,13 +430,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     >("idle");
     const [desktopIdentityEnabled, setDesktopIdentityEnabled] = useState<
       boolean | null
-    >(() => (desktopIdentityGateEligible && isActive ? null : false));
+    >(() => (desktopIdentityGateEligible ? null : false));
     const [desktopIdentitySessionReady, setDesktopIdentitySessionReady] =
-      useState(() => !desktopIdentityGateEligible || !isActive);
-    const desktopIdentityGateActive =
-      desktopIdentityGateEligible &&
-      isActive &&
-      desktopIdentityEnabled === true;
+      useState(() => !desktopIdentityGateEligible);
+    const desktopIdentityGateActive = shouldUseDesktopIdentityGate({
+      eligible: desktopIdentityGateEligible,
+      active: isActive,
+      enabled: desktopIdentityEnabled,
+    });
     const optimizeDepRecoveryRef = useRef(false);
     const prevUrlRef = useRef(url);
     const prevUrlOpenNonceRef = useRef(urlOpenNonce);
@@ -476,15 +485,21 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
 
     useEffect(() => {
       const identity = window.electronAPI?.identity;
-      if (!identity || !desktopIdentityGateEligible || !isActive) {
+      if (!identity || !desktopIdentityGateEligible) {
+        setDesktopIdentityEnabled(false);
+        setDesktopIdentityStatus("idle");
+        setDesktopIdentitySessionReady(true);
+        return;
+      }
+      if (!isActive) {
         const rememberedSignedIn = shouldReuseRememberedDesktopIdentitySession(
           rememberedDesktopIdentityStatus,
           undefined,
           rememberedDesktopIdentityStatusAt,
         );
-        setDesktopIdentityEnabled(false);
+        setDesktopIdentityEnabled(null);
         setDesktopIdentityStatus(rememberedSignedIn ? "signed-in" : "idle");
-        setDesktopIdentitySessionReady(true);
+        setDesktopIdentitySessionReady(false);
         return;
       }
       let active = true;

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2381,6 +2381,7 @@ export default function CodeAgentsHub({
               <DesktopAppChatShell
                 appId={surfaceApp.id}
                 appName={surfaceApp.name}
+                isActive={isTabActive}
                 onLocalCodeChangeStarted={onLocalCodeChangeStarted}
               >
                 <AppWebview

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -2,7 +2,30 @@ import { readFileSync } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
+import { shouldAnimateDesktopAppChatSidebar } from "./DesktopAppChatShell.js";
+
 describe("desktop app chat shell", () => {
+  it("animates only the first active presentation of a cached app tab", () => {
+    expect(
+      shouldAnimateDesktopAppChatSidebar({
+        isActive: true,
+        hasSwitchedAway: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAnimateDesktopAppChatSidebar({
+        isActive: false,
+        hasSwitchedAway: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAnimateDesktopAppChatSidebar({
+        isActive: true,
+        hasSwitchedAway: true,
+      }),
+    ).toBe(false);
+  });
+
   it("keeps the shell open state shared while chat threads stay app-scoped", () => {
     const source = readFileSync(
       new URL("./DesktopAppChatShell.tsx", import.meta.url),

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -72,9 +72,17 @@ export interface DesktopAppChatShellProps {
   appId: string;
   appName: string;
   children: ReactNode;
+  isActive?: boolean;
   onLocalCodeChangeStarted?: (
     result: DesktopPrepareLocalCodeChangeResult,
   ) => void;
+}
+
+export function shouldAnimateDesktopAppChatSidebar(input: {
+  isActive: boolean;
+  hasSwitchedAway: boolean;
+}): boolean {
+  return input.isActive && !input.hasSwitchedAway;
 }
 
 type LocalCodeChangeState =
@@ -87,9 +95,12 @@ export default function DesktopAppChatShell({
   appId,
   appName,
   children,
+  isActive = true,
   onLocalCodeChangeStarted,
 }: DesktopAppChatShellProps) {
   const shellRootRef = useRef<HTMLDivElement>(null);
+  const hasBeenActiveRef = useRef(isActive);
+  const hasSwitchedAwayRef = useRef(false);
   const [apiUrl, setApiUrl] = useState<string | null>(null);
   const [localAgentModels, setLocalAgentModels] = useState<
     CodeAgentModelOption[]
@@ -99,6 +110,19 @@ export default function DesktopAppChatShell({
   const [localCodeChangePrompt, setLocalCodeChangePrompt] = useState("");
   const [localCodeChange, setLocalCodeChange] = useState<LocalCodeChangeState>({
     status: "idle",
+  });
+
+  useEffect(() => {
+    if (isActive) {
+      hasBeenActiveRef.current = true;
+    } else if (hasBeenActiveRef.current) {
+      hasSwitchedAwayRef.current = true;
+    }
+  }, [isActive]);
+
+  const animateDesktopChatSidebar = shouldAnimateDesktopAppChatSidebar({
+    isActive,
+    hasSwitchedAway: hasSwitchedAwayRef.current,
   });
 
   useEffect(() => {
@@ -424,6 +448,7 @@ export default function DesktopAppChatShell({
               <AgentSidebar
                 position="left"
                 defaultOpen
+                animateDesktop={animateDesktopChatSidebar}
                 openStorageKey="desktop-app-chat"
                 storageKey={`desktop-app-chat:${appId}`}
                 scope={{


### PR DESCRIPTION
## Summary
- Keep the Electron identity gate visible until the packaged desktop SSO decision resolves, including cached app reactivation.
- Preserve the app-owned sign-in only for unsupported or explicitly unavailable desktop SSO paths.
- Animate each desktop app chat sidebar only on its first active presentation, not on later tab switches.

## Validation
- Focused renderer tests: 4 files, 49 tests passed
- Desktop app typecheck passed
- Desktop production build passed
- Packaged local macOS bundle showed the canonical Electron Welcome sign-in gate for app tabs; switching tabs kept the left chat composer mounted

No package changeset is needed; packages/desktop-app is private.