### PR TITLE
docs: prevent repeated feedback clarification asks

### DIFF
--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -162,19 +162,26 @@ specific reporter or product input is still missing.
 Treat a clarification reply as new evidence, not as a fresh blank report.
 Re-read the whole thread after the reply, update the ledger, and try the fix
 before posting another question. If the reply answers the earlier question,
-do not repeat it. If it only answers part of it, ask only for the one remaining
-missing value. A `Clarification needed` reply is invalid when the requested
- information is already present anywhere in the thread or accessible linked
- evidence. If the information is only known to be inside an inaccessible
- artifact, request access or a fresh/replacement link when that artifact is
- the blocker instead of asking for the information again.
+do not repeat it. Treat an answer or explicit resolution from any participant
+as sufficient when it supplies the exact requested detail. A partial or
+unrelated reply does not clear the earlier request - keep it as the sole
+pending handoff and do not ask a second question. Ask a new question only
+after that request is answered or resolved and one specific, non-repeating
+detail still blocks the fix. A `Clarification needed` reply is invalid when the
+requested information is already present anywhere in the thread or accessible
+linked evidence. If the information is only known to be inside an inaccessible
+artifact, request access or a fresh/replacement link when that artifact is the
+blocker instead of asking for the information again.
 
 There may be only one unanswered clarification request per thread. Before
-posting, check the complete thread for an earlier question from this workflow
-or `@agent-native`. If the reporter has not replied after it, keep that request
-as the sole pending handoff and do not post another question. Once the reporter
-replies, attempt the fix from the new evidence first; ask at most one new,
-non-repeating question only if one specific required detail still blocks it.
+posting, re-read the complete thread for an earlier question from this workflow
+or `@agent-native` and check whether its exact requested detail has been
+semantically answered or explicitly resolved anywhere in the thread. If it is
+still unresolved, including after a partial or unrelated reply, keep that
+request as the sole pending handoff and do not post another question. Once it
+is answered or resolved, attempt the fix from the new evidence first; ask at
+most one new, non-repeating question only if one specific required detail still
+blocks it.
 
 ## Workflow
 
@@ -253,13 +260,14 @@ non-repeating question only if one specific required detail still blocks it.
    **In progress**, or **Clarification needed**. If any parent has only `👀`, a generic bot
    forward, or another person's reply, keep working and post the missing reply
    before finishing.
-   If a reporter replies after the post, re-read the entire thread again before
-   deciding whether to fix, close, or ask anything else.
-7. If a reporter answers a clarification question, re-read the full thread and
-   use that new evidence in the same follow-up pass. Attempt the fix now; do
-   not repeat the question unless one specific required detail is still
-   missing. Replace an open clarification with a **Fixed** reply once the fix
-   is verified.
+   If any participant replies after the post, re-read the entire thread again
+   before deciding whether to fix, close, or ask anything else.
+7. If any participant supplies the requested detail or an explicit resolution,
+   re-read the full thread and use that new evidence in the same follow-up pass.
+   Attempt the fix now; do not repeat the question. If the reply is partial or
+   unrelated, keep the existing clarification pending instead of asking a
+   second question. Replace an open clarification with a **Fixed** reply once
+   the fix is verified.
 8. If the user says earlier replies were too technical, harsh, or incomplete,
    search for every reply authored in this sweep and edit the bad replies in
    place. Do not fix only the newest example or leave the other addressed

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -169,6 +169,13 @@ missing value. A `Clarification needed` reply is invalid when the requested
  artifact, request access or a fresh/replacement link when that artifact is
  the blocker instead of asking for the information again.
 
+There may be only one unanswered clarification request per thread. Before
+posting, check the complete thread for an earlier question from this workflow
+or `@agent-native`. If the reporter has not replied after it, keep that request
+as the sole pending handoff and do not post another question. Once the reporter
+replies, attempt the fix from the new evidence first; ask at most one new,
+non-repeating question only if one specific required detail still blocks it.
+
 ## Workflow
 
 1. Build a per-thread checklist with the symptom, expected behavior, evidence,

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -174,14 +174,14 @@ artifact, request access or a fresh/replacement link when that artifact is the
 blocker instead of asking for the information again.
 
 There may be only one unanswered clarification request per thread. Before
-posting, re-read the complete thread for an earlier question from this workflow
-or `@agent-native` and check whether its exact requested detail has been
-semantically answered or explicitly resolved anywhere in the thread. If it is
-still unresolved, including after a partial or unrelated reply, keep that
-request as the sole pending handoff and do not post another question. Once it
-is answered or resolved, attempt the fix from the new evidence first; ask at
-most one new, non-repeating question only if one specific required detail still
-blocks it.
+posting, re-read the complete thread for an earlier question from this
+workflow, the companion `review-latest-feedback` workflow, or `@agent-native`,
+and check whether its exact requested detail has been semantically answered or
+explicitly resolved anywhere in the thread. If it is still unresolved,
+including after a partial or unrelated reply, keep that request as the sole
+pending handoff and do not post another question. Once it is answered or
+resolved, attempt the fix from the new evidence first; ask at most one new,
+non-repeating question only if one specific required detail still blocks it.
 
 ## Workflow
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -94,10 +94,11 @@ for the artifact's contents again. If the available evidence is enough without
 it, continue and record the limitation instead of creating a reporter blocker.
 
 There may be only one unanswered clarification request per thread. Before
-posting, re-read the complete thread for an earlier question from this workflow
-or the `@agent-native` bot and determine whether its exact requested detail has
-been semantically answered or explicitly resolved anywhere in the thread. A
-partial or unrelated reply does not clear the pending request. If no answer or
+posting, re-read the complete thread for an earlier question from this
+workflow, the companion `address-feedback-with-replies` workflow, or the
+`@agent-native` bot and determine whether its exact requested detail has been
+semantically answered or explicitly resolved anywhere in the thread. A partial
+or unrelated reply does not clear the pending request. If no answer or
 resolution exists, leave that request as the sole pending handoff and record
 its timestamp; do not stack another question in the same thread. After the
 requested detail is answered or resolved, re-read the thread and attempt the

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -106,9 +106,13 @@ still blocks the fix.
 
 ## Answered clarifications come first
 
-A clarification question is a pending state, not a disposition. Before scanning
-for new messages, re-read every thread this workflow asked a question in that
-has not since been fixed or otherwise dispositioned, oldest question first.
+A clarification question is a pending state, not a disposition, regardless of
+which in-scope workflow posted it. Before scanning for new messages, re-read
+every thread this workflow, the companion `address-feedback-with-replies`
+workflow, or `@agent-native` asked a question in that has not since been fixed
+or otherwise dispositioned, oldest question first. Treat the complete thread
+as the source of truth for whether the request is answered, not the workflow
+that posted it.
 
 - **The requested detail was answered or resolved** - re-read the complete
   thread and rebuild its evidence ledger first. That thread is the run's first
@@ -120,8 +124,9 @@ has not since been fixed or otherwise dispositioned, oldest question first.
   does not clear it. Do not add a second clarification to the same thread; an
   unanswered request stays visible instead of ageing out of the cursor.
 
-When any participant semantically answers the exact question this workflow
-previously asked or explicitly resolves it, do not just record the answer or
+When any participant semantically answers the exact question previously asked
+by this workflow, the companion `address-feedback-with-replies` workflow, or
+`@agent-native`, or explicitly resolves it, do not just record the answer or
 leave the old clarification as the disposition. Read the entire thread again,
 use the new evidence to attempt the fix in this run, and post a new **Fixed**
 reply when the fix is verified. A partial or unrelated reply does not clear the
@@ -130,9 +135,10 @@ one specific, non-repeating detail that still blocks the fix after the earlier
 request is answered or resolved. An answered clarification is never a reason
 to skip the thread or continue scanning newer messages.
 
-Our own question is what makes a thread eligible for the first work item,
-which is why this pass runs first. Without it every thread we asked about can
-become invisible on later runs and the reporter's answer is never read.
+An in-scope clarification question is what makes a thread eligible for the
+first work item, which is why this pass runs first. Without it every thread
+with a question can become invisible on later runs and the answer is never
+read.
 
 Before choosing a new start cursor, re-read every thread that this workflow
 left in **In progress**, oldest open ownership first. Verify the claimed fix or

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -82,23 +82,27 @@ is not the same as absent evidence.
 
 The clarification question must be derived from that missing-evidence list.
 Never ask for a URL, screenshot, error, run ID, or repro detail that is already
-in the parent or a reply. If the reporter supplies it later, re-read the whole
-thread before doing anything else, remove that field from the missing list,
-and try the fix from the new evidence before asking another question. If the
-answer only partially fills the gap, ask only for the one remaining field. If a
-needed linked artifact is inaccessible, ask for access or a fresh/replacement
-link rather than asking for the artifact's contents again. If the available
-evidence is enough without it, continue and record the limitation instead of
-creating a reporter blocker.
+in the parent or a reply. If any participant supplies it later, re-read the
+whole thread before doing anything else, remove that field from the missing
+list, and try the fix from the new evidence before asking another question. If
+the answer only partially or incidentally fills the gap, keep the original
+clarification pending rather than stacking a second question. Ask a new
+question only after the exact earlier request is answered or resolved and one
+specific, non-repeating detail still blocks the fix. If a needed linked artifact
+is inaccessible, ask for access or a fresh/replacement link rather than asking
+for the artifact's contents again. If the available evidence is enough without
+it, continue and record the limitation instead of creating a reporter blocker.
 
 There may be only one unanswered clarification request per thread. Before
-posting, check every reply for an earlier question from this workflow or the
-`@agent-native` bot. If that question has no reporter reply after it, leave it
-as the sole pending request and record its timestamp; do not stack another
-question in the same thread, even when other details are still missing. After
-the reporter replies, re-read the thread and attempt the fix first. Ask a new
-question only when one specific required detail still blocks the fix, and never
-repeat the earlier question.
+posting, re-read the complete thread for an earlier question from this workflow
+or the `@agent-native` bot and determine whether its exact requested detail has
+been semantically answered or explicitly resolved anywhere in the thread. A
+partial or unrelated reply does not clear the pending request. If no answer or
+resolution exists, leave that request as the sole pending handoff and record
+its timestamp; do not stack another question in the same thread. After the
+requested detail is answered or resolved, re-read the thread and attempt the
+fix first. Ask a new question only when one specific, non-repeating detail
+still blocks the fix.
 
 ## Answered clarifications come first
 
@@ -106,22 +110,25 @@ A clarification question is a pending state, not a disposition. Before scanning
 for new messages, re-read every thread this workflow asked a question in that
 has not since been fixed or otherwise dispositioned, oldest question first.
 
-- **The reporter replied** - re-read the complete thread and rebuild its
-  evidence ledger first. That thread is the run's first work item. It re-enters
-  triage as a concrete bug carrying the new evidence, ahead of anything newer
-  in the channel: someone answered and is waiting on a fix.
-- **No reply yet** - leave the existing clarification pending and record its
-  timestamp in the recap. Do not add a second clarification to the same thread;
-  an unanswered question stays visible instead of ageing out of the cursor.
-- **The reply does not supply what was asked** - ask the one remaining question
-  only if it is still the blocker; otherwise fix from what is now available.
+- **The requested detail was answered or resolved** - re-read the complete
+  thread and rebuild its evidence ledger first. That thread is the run's first
+  work item. It re-enters triage as a concrete bug carrying the new evidence,
+  ahead of anything newer in the channel: someone answered and is waiting on a
+  fix.
+- **No semantic answer or resolution yet** - leave the existing clarification
+  pending and record its timestamp in the recap. A partial or unrelated reply
+  does not clear it. Do not add a second clarification to the same thread; an
+  unanswered request stays visible instead of ageing out of the cursor.
 
-When a reporter answers a question this workflow previously asked, do not just
-record the answer or leave the old clarification as the disposition. Read the
-entire thread again, use the new evidence to attempt the fix in this run, and
-post a new **Fixed** reply when the fix is verified. Ask another question only
-for the one remaining missing detail. An answered clarification is never a
-reason to skip the thread or continue scanning newer messages.
+When any participant semantically answers the exact question this workflow
+previously asked or explicitly resolves it, do not just record the answer or
+leave the old clarification as the disposition. Read the entire thread again,
+use the new evidence to attempt the fix in this run, and post a new **Fixed**
+reply when the fix is verified. A partial or unrelated reply does not clear the
+old clarification or authorize another question. Ask a new question only for
+one specific, non-repeating detail that still blocks the fix after the earlier
+request is answered or resolved. An answered clarification is never a reason
+to skip the thread or continue scanning newer messages.
 
 Our own question is what makes a thread eligible for the first work item,
 which is why this pass runs first. Without it every thread we asked about can
@@ -287,9 +294,14 @@ failure modes, surfaces, or owners.
    also confirm that no participant or `@agent-native` has already identified,
    fixed, or started fixing the issue. If either the field or a resolution
    signal is present, use it and keep investigating instead of asking again.
-   Check for an earlier unanswered clarification from this workflow or
-   `@agent-native`. If one exists, do not post another question; preserve its
-   timestamp and leave the thread pending until the reporter replies.
+   Check the complete thread for an earlier clarification from this workflow or
+   `@agent-native`. Determine whether the exact requested detail has been
+   answered or explicitly resolved anywhere in the thread, including by another
+   participant or accessible linked evidence. A partial or unrelated reply does
+   not clear it. If it remains unresolved, do not post another question;
+   preserve its timestamp and leave the thread pending. If it is resolved, use
+   the evidence and attempt the fix before considering one new question for one
+   specific remaining blocker.
    If a needed linked artifact is recorded as inaccessible, the access or
    replacement request is valid - do not describe its contents as absent. Do
    not post vague progress, technical internals, or a diagnosis that leaves a
@@ -298,7 +310,8 @@ failure modes, surfaces, or owners.
    own identity is a handled marker on the next run; a clarification reply
    satisfies this run's reply obligation but leaves the thread pending an
    answer. The answered-clarifications pass must re-enter the thread and try the
-   fix when the reporter answers.
+   fix when any participant supplies the requested detail or an explicit
+   resolution.
 7. Do not close, label, assign, or comment on GitHub issues or Sentry unless
    the invocation explicitly authorizes those mutations. Link the issue or
    event in the recap instead.

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -91,6 +91,15 @@ link rather than asking for the artifact's contents again. If the available
 evidence is enough without it, continue and record the limitation instead of
 creating a reporter blocker.
 
+There may be only one unanswered clarification request per thread. Before
+posting, check every reply for an earlier question from this workflow or the
+`@agent-native` bot. If that question has no reporter reply after it, leave it
+as the sole pending request and record its timestamp; do not stack another
+question in the same thread, even when other details are still missing. After
+the reporter replies, re-read the thread and attempt the fix first. Ask a new
+question only when one specific required detail still blocks the fix, and never
+repeat the earlier question.
+
 ## Answered clarifications come first
 
 A clarification question is a pending state, not a disposition. Before scanning
@@ -101,9 +110,9 @@ has not since been fixed or otherwise dispositioned, oldest question first.
   evidence ledger first. That thread is the run's first work item. It re-enters
   triage as a concrete bug carrying the new evidence, ahead of anything newer
   in the channel: someone answered and is waiting on a fix.
-- **No reply yet** - leave it pending and record it in the recap with the date
-  the question was asked, so an unanswered question stays visible instead of
-  ageing out of the cursor.
+- **No reply yet** - leave the existing clarification pending and record its
+  timestamp in the recap. Do not add a second clarification to the same thread;
+  an unanswered question stays visible instead of ageing out of the cursor.
 - **The reply does not supply what was asked** - ask the one remaining question
   only if it is still the blocker; otherwise fix from what is now available.
 
@@ -278,6 +287,9 @@ failure modes, surfaces, or owners.
    also confirm that no participant or `@agent-native` has already identified,
    fixed, or started fixing the issue. If either the field or a resolution
    signal is present, use it and keep investigating instead of asking again.
+   Check for an earlier unanswered clarification from this workflow or
+   `@agent-native`. If one exists, do not post another question; preserve its
+   timestamp and leave the thread pending until the reporter replies.
    If a needed linked artifact is recorded as inaccessible, the access or
    replacement request is valid - do not describe its contents as absent. Do
    not post vague progress, technical internals, or a diagnosis that leaves a

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -96,8 +96,9 @@ ask again for contents already known to be in the inaccessible artifact. If the
 available evidence is enough without it, continue and record the limitation as
 unavailable/unverified in the ship ledger.
 
-Before carrying an item forward as awaiting clarification, check the complete
-source thread and handoff for a resolution or ownership signal. If
+Before carrying an item forward as awaiting clarification, always re-read the
+complete source thread and current handoff for a resolution or ownership signal.
+If
 `@agent-native` or another participant already supplied the needed details,
 identified the cause, linked a fix, or said the issue is fixed, landed, or being
 fixed, do not reopen it as a clarification request or ask for duplicate
@@ -109,11 +110,14 @@ must thank the person first and ask the question second; `Clarification needed`
 is an internal state, not an opening line.
 
 There may be only one unanswered clarification request per feedback thread. If
-the existing handoff already contains a question from this workflow or
-`@agent-native` with no reporter reply after it, carry that timestamp forward
-as the sole pending request and do not add another question. After a reporter
-reply, re-read the thread and try the fix first; ask one new question only for
-one specific remaining detail, without repeating the earlier request.
+the existing handoff or complete source thread contains a question from this
+workflow or `@agent-native`, re-read both and determine whether the exact
+requested detail has been semantically answered or explicitly resolved anywhere
+in the thread. A partial or unrelated reply does not clear the request. If it
+remains unresolved, carry its timestamp forward as the sole pending request and
+do not add another question. Once it is answered or resolved, re-read the
+thread and try the fix first; ask one new question only for one specific,
+non-repeating detail that still blocks the fix.
 
 Do not ship a feedback fix that is only a wording-specific rule or that lacks
 the evidence needed to identify its owner. Re-run or refresh the feedback sweep

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -74,9 +74,12 @@ Honor the feedback ownership and reaction gates from `/review-latest-feedback`:
 
 - Never add or duplicate `👀` on a Slack parent. If the latest readable parent
   already has an `👀` reaction from anyone, preserve that fact as an existing
-  marker and do not create a new reaction or a new automatic work item. If the
-  reaction state is unavailable, record the item as unavailable/unverified and
-  refresh the feedback thread instead of guessing.
+  investigation marker, but do not treat it as a disposition or suppression
+  signal. Re-read the complete thread and require a verified `@agent-native`
+  **Fixed**, **In progress**, or **Clarification needed** disposition; an
+  eye-only or stale eye-only item remains actionable for that handoff check.
+  If the reaction state is unavailable, record the item as
+  unavailable/unverified and refresh the feedback thread instead of guessing.
 - UX or interaction bugs in the Design app are owned by Sid. All Content app
   feedback is owned by Alice. Keep those source links and ownership decisions
   in the ship ledger, but do not include them as this workflow's fixes,
@@ -96,9 +99,12 @@ ask again for contents already known to be in the inaccessible artifact. If the
 available evidence is enough without it, continue and record the limitation as
 unavailable/unverified in the ship ledger.
 
-Before carrying an item forward as awaiting clarification, always re-read the
-complete source thread and current handoff for a resolution or ownership signal.
-If
+Before carrying any item forward from a prior handoff - fixed, in progress,
+awaiting clarification, already owned or duplicate, deferred or informational,
+external, or unavailable/unverified - always re-read the complete source thread
+and current handoff and reconcile them for new replies, reactions, linked
+evidence, resolution, or ownership signals. The handoff is a prior record, not
+the source of truth. After that refresh, if
 `@agent-native` or another participant already supplied the needed details,
 identified the cause, linked a fix, or said the issue is fixed, landed, or being
 fixed, do not reopen it as a clarification request or ask for duplicate
@@ -131,9 +137,10 @@ deployed, and observed-live claims separate. A green test or PR does not prove
 that a feedback fix is live; verify the affected production surface after merge.
 Before merging, `/babysit-pr` must re-check that every actionable feedback or
 review item has a fix or a concise reply and that no new evidence has been left
-without a disposition. Items routed to Sid or Alice, and parents already marked
-with `👀`, are not new actionable work for this workflow; preserve their
-dispositions without manufacturing a fix, reply, or duplicate reaction.
+without a disposition. Items routed to Sid or Alice remain outside this
+workflow's ownership. A parent marked with `👀` is not thereby complete or
+non-actionable: preserve the reaction without duplicating it, and do not merge
+while an eye-only or stale eye-only item lacks a verified bot disposition.
 
 ## Worktree and branch setup
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -108,6 +108,13 @@ is still missing after that check. Any eventual reporter-facing clarification
 must thank the person first and ask the question second; `Clarification needed`
 is an internal state, not an opening line.
 
+There may be only one unanswered clarification request per feedback thread. If
+the existing handoff already contains a question from this workflow or
+`@agent-native` with no reporter reply after it, carry that timestamp forward
+as the sole pending request and do not add another question. After a reporter
+reply, re-read the thread and try the fix first; ask one new question only for
+one specific remaining detail, without repeating the earlier request.
+
 Do not ship a feedback fix that is only a wording-specific rule or that lacks
 the evidence needed to identify its owner. Re-run or refresh the feedback sweep
 when the branch changes after triage or when new comments, Slack replies,

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -75,10 +75,13 @@ Honor the feedback ownership and reaction gates from `/review-latest-feedback`:
 - Never add or duplicate `👀` on a Slack parent. If the latest readable parent
   already has an `👀` reaction from anyone, preserve that fact as an existing
   investigation marker, but do not treat it as a disposition or suppression
-  signal. Re-read the complete thread and require a verified `@agent-native`
-  **Fixed**, **In progress**, or **Clarification needed** disposition; an
-  eye-only or stale eye-only item remains actionable for that handoff check.
-  If the reaction state is unavailable, record the item as
+  signal. After classifying the parent, re-read the complete thread and, for
+  an actionable in-scope item, require a verified `@agent-native` **Fixed**,
+  **In progress**, or **Clarification needed** disposition; an eye-only or
+  stale eye-only item remains actionable for that handoff check. For items
+  routed to Sid or Alice, or classified as external, duplicate, deferred, or
+  informational, honor that owning disposition and do not turn the eye into a
+  merge blocker. If the reaction state is unavailable, record the item as
   unavailable/unverified and refresh the feedback thread instead of guessing.
 - UX or interaction bugs in the Design app are owned by Sid. All Content app
   feedback is owned by Alice. Keep those source links and ownership decisions
@@ -138,8 +141,10 @@ that a feedback fix is live; verify the affected production surface after merge.
 Before merging, `/babysit-pr` must re-check that every actionable feedback or
 review item has a fix or a concise reply and that no new evidence has been left
 without a disposition. Items routed to Sid or Alice remain outside this
-workflow's ownership. A parent marked with `👀` is not thereby complete or
-non-actionable: preserve the reaction without duplicating it, and do not merge
+workflow's ownership. External, duplicate, deferred, and informational items
+also follow their recorded disposition rather than blocking this workflow. A
+parent marked with `👀` is not thereby complete or non-actionable: preserve the
+reaction without duplicating it, and for actionable in-scope items do not merge
 while an eye-only or stale eye-only item lacks a verified bot disposition.
 
 ## Worktree and branch setup


### PR DESCRIPTION
## Summary

- allow only one unanswered clarification request per feedback thread
- keep an existing question pending instead of stacking another before the reporter replies
- apply the same guard in feedback replies and ship handoff guidance

## Validation

- `corepack pnpm sync:workspace-skills`
- `corepack pnpm guard:workspace-skills`
- `git diff --check`