### PR TITLE
fix: make beta switcher available before sign-in

### DIFF
--- a/.changeset/quiet-beta-badges.md
+++ b/.changeset/quiet-beta-badges.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the beta environment switcher visible to signed-out visitors, including the standalone auth page.

--- a/packages/core/src/client/EnvironmentBadge.render.spec.tsx
+++ b/packages/core/src/client/EnvironmentBadge.render.spec.tsx
@@ -46,9 +46,21 @@ describe("EnvironmentBadge render", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the beta chip only for an authenticated builder.io user", () => {
+  it("renders the beta chip for signed-out visitors", () => {
     useSessionMock.mockReturnValue({
-      session: { email: "employee@builder.io" },
+      session: null,
+      status: "unauthenticated",
+    });
+
+    act(() => root.render(<EnvironmentBadge />));
+
+    expect(container.querySelector("button")?.textContent).toContain("beta");
+    expect(container.textContent).toContain("beta");
+  });
+
+  it("renders the beta chip for non-builder users", () => {
+    useSessionMock.mockReturnValue({
+      session: { email: "person@example.com" },
       status: "authenticated",
     });
 
@@ -58,7 +70,45 @@ describe("EnvironmentBadge render", () => {
     expect(container.textContent).toContain("beta");
   });
 
-  it("hides the chip for non-employee sessions", () => {
+  it("keeps the beta chip linked to production for every visitor", () => {
+    useSessionMock.mockReturnValue({
+      session: null,
+      status: "unauthenticated",
+    });
+
+    act(() => root.render(<EnvironmentBadge />));
+    const trigger = container.querySelector("button");
+    expect(trigger).not.toBeNull();
+
+    act(() => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true }),
+      );
+      trigger?.click();
+    });
+
+    const productionLink = [...document.body.querySelectorAll("a")].find(
+      (link) => link.textContent?.includes("Switch to production"),
+    );
+    const productionHref = productionLink?.getAttribute("href");
+    expect(productionHref).toContain(
+      "https://plan.agent-native.com/inbox?tab=all&agentNativeBetaOptOut=",
+    );
+    const expiry = Number(
+      new URL(productionHref!).searchParams.get("agentNativeBetaOptOut"),
+    );
+    expect(expiry).toBeGreaterThan(Date.now());
+  });
+
+  it("hides the production chip for non-employee sessions", () => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        hostname: "plan.agent-native.com",
+        href: "https://plan.agent-native.com/inbox?tab=all#runs",
+        replace: vi.fn(),
+      },
+    });
     useSessionMock.mockReturnValue({
       session: { email: "person@example.com" },
       status: "authenticated",

--- a/packages/core/src/client/EnvironmentBadge.tsx
+++ b/packages/core/src/client/EnvironmentBadge.tsx
@@ -10,60 +10,30 @@ import type {
   AgentNativeDeploymentEnvironment,
   AgentNativeConfig,
 } from "../config.js";
+import {
+  BETA_OPT_OUT_QUERY_PARAM,
+  buildEnvironmentOptOutUrl,
+  buildEnvironmentUrl,
+  resolveEnvironmentTargets,
+  type EnvironmentBadgeTargets,
+} from "../shared/environment-lanes.js";
 import { trackEvent } from "./analytics.js";
 import { injectedAgentNativeConfig } from "./app-config.js";
 import { useSession } from "./use-session.js";
 
-export const BETA_OPT_OUT_QUERY_PARAM = "agentNativeBetaOptOut";
 export const BETA_OPT_OUT_STORAGE_KEY = "agent-native:beta-opt-out-until";
-export const BETA_OPT_OUT_DURATION_MS = 24 * 60 * 60 * 1000;
 
-const ENVIRONMENT_BETA_HOSTS = {
-  "agent-workspace.builder.io": "beta.agent-workspace.builder.io",
-  "analytics.agent-native.com": "beta.analytics.agent-native.com",
-  "assets.agent-native.com": "beta.assets.agent-native.com",
-  "brain.agent-native.com": "beta.brain.agent-native.com",
-  "calendar.agent-native.com": "beta.calendar.agent-native.com",
-  "chat.agent-native.com": "beta.chat.agent-native.com",
-  "clips.agent-native.com": "beta.clips.agent-native.com",
-  "content.agent-native.com": "beta.content.agent-native.com",
-  "crm.agent-native.com": "beta.crm.agent-native.com",
-  "design.agent-native.com": "beta.design.agent-native.com",
-  "dispatch.agent-native.com": "beta.dispatch.agent-native.com",
-  "factory.agent-native.com": "beta.factory.agent-native.com",
-  "forms.agent-native.com": "beta.forms.agent-native.com",
-  "macros.agent-native.com": "beta.macros.agent-native.com",
-  "mail.agent-native.com": "beta.mail.agent-native.com",
-  "plan.agent-native.com": "beta.plan.agent-native.com",
-  "slides.agent-native.com": "beta.slides.agent-native.com",
-} as const;
-
-export interface EnvironmentBadgeTargets {
-  betaHost: string;
-  productionHost: string;
-}
+export {
+  BETA_OPT_OUT_DURATION_MS,
+  BETA_OPT_OUT_QUERY_PARAM,
+  buildEnvironmentOptOutUrl,
+  buildEnvironmentUrl,
+  resolveEnvironmentTargets,
+  type EnvironmentBadgeTargets,
+} from "../shared/environment-lanes.js";
 
 export function isBuilderIoEmployee(email: string | null | undefined): boolean {
   return email?.trim().toLowerCase().endsWith("@builder.io") ?? false;
-}
-
-export function resolveEnvironmentTargets(
-  hostname: string | undefined,
-): EnvironmentBadgeTargets | null {
-  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "");
-  if (!normalized) return null;
-
-  const productionHost = normalized.replace(/^beta\./, "");
-  const betaHost =
-    ENVIRONMENT_BETA_HOSTS[
-      productionHost as keyof typeof ENVIRONMENT_BETA_HOSTS
-    ];
-  if (!betaHost) return null;
-
-  return {
-    betaHost,
-    productionHost,
-  };
 }
 
 export function resolveEnvironmentChannel(
@@ -82,49 +52,12 @@ export function resolveEnvironmentChannel(
     : "production";
 }
 
-export function buildEnvironmentUrl(
-  sourceHref: string,
-  targetHost: string,
-): string | null {
-  try {
-    const target = new URL(sourceHref);
-    target.protocol = "https:";
-    target.hostname = targetHost;
-    target.port = "";
-    return target.toString();
-  } catch {
-    // coercion-ok: Invalid navigation input is an explicit absent target.
-    return null;
-  }
-}
-
 export function isBetaOptOutActive(
   value: string | number | null | undefined,
   now = Date.now(),
 ): boolean {
   const expiry = typeof value === "number" ? value : Number(value);
   return Number.isFinite(expiry) && expiry > now;
-}
-
-export function buildEnvironmentOptOutUrl(
-  sourceHref: string,
-  targetHost: string,
-  now = Date.now(),
-): string | null {
-  const targetHref = buildEnvironmentUrl(sourceHref, targetHost);
-  if (!targetHref) return null;
-
-  try {
-    const target = new URL(targetHref);
-    target.searchParams.set(
-      BETA_OPT_OUT_QUERY_PARAM,
-      String(now + BETA_OPT_OUT_DURATION_MS),
-    );
-    return target.toString();
-  } catch {
-    // coercion-ok: buildEnvironmentUrl already validated the URL.
-    return null;
-  }
 }
 
 function readBetaOptOutUntil(now = Date.now()): number | null {
@@ -189,63 +122,14 @@ function EnvironmentLink({ label, href }: { label: string; href: string }) {
   );
 }
 
-/**
- * Small internal-only lane switcher for first-party hosted Agent-Native apps.
- * It is mounted inside the authenticated AppProviders shell so public pages,
- * embeds, and signed-out visitors never receive environment navigation.
- */
-export function EnvironmentBadge() {
-  const { session, status } = useSession();
-  const config = useMemo(injectedAgentNativeConfig, []);
-  const didAutoRedirect = useRef(false);
-  const hostname =
-    typeof window === "undefined" ? undefined : window.location.hostname;
-  const environment = resolveEnvironmentChannel(config, hostname);
-  const targets = resolveEnvironmentTargets(hostname);
-  const isEligible =
-    typeof window !== "undefined" &&
-    window.parent === window &&
-    status === "authenticated" &&
-    isBuilderIoEmployee(session?.email) &&
-    !!environment &&
-    !!targets;
-
-  useEffect(() => {
-    if (
-      !isEligible ||
-      environment !== "production" ||
-      !targets ||
-      didAutoRedirect.current
-    ) {
-      return;
-    }
-
-    if (readBetaOptOutUntil() !== null) return;
-    if (consumeBetaOptOutQueryParam(window.location.href)) return;
-
-    const betaHref = buildEnvironmentUrl(
-      window.location.href,
-      targets.betaHost,
-    );
-    if (!betaHref || typeof window.location.replace !== "function") return;
-
-    didAutoRedirect.current = true;
-    trackEvent("environment switched", {
-      from_environment: "production",
-      to_environment: "beta",
-      trigger: "automatic_redirect",
-    });
-    window.location.replace(betaHref);
-  }, [environment, isEligible, session?.email, status, targets?.betaHost]);
-
-  if (
-    !isEligible ||
-    !environment ||
-    !targets ||
-    typeof window === "undefined"
-  ) {
-    return null;
-  }
+function EnvironmentBadgeContent({
+  environment,
+  targets,
+}: {
+  environment: "beta" | "production";
+  targets: EnvironmentBadgeTargets;
+}) {
+  if (typeof window === "undefined") return null;
 
   const currentHref = window.location.href;
   const betaHref = buildEnvironmentUrl(currentHref, targets.betaHost);
@@ -253,7 +137,7 @@ export function EnvironmentBadge() {
     currentHref,
     targets.productionHost,
   );
-  if (!betaHref || !productionHref) return null;
+  if (environment === "beta" ? !productionHref : !betaHref) return null;
 
   const label = environment === "beta" ? "beta" : "prod";
   const title =
@@ -286,14 +170,87 @@ export function EnvironmentBadge() {
         <div className="grid gap-2">
           {environment === "beta" ? (
             <EnvironmentLink
-              href={productionHref}
+              href={productionHref!}
               label="Switch to production"
             />
           ) : (
-            <EnvironmentLink href={betaHref} label="Go to beta" />
+            <EnvironmentLink href={betaHref!} label="Go to beta" />
           )}
         </div>
       </PopoverContent>
     </Popover>
   );
+}
+
+function ProductionEnvironmentBadge({
+  targets,
+}: {
+  targets: EnvironmentBadgeTargets;
+}) {
+  const { session, status } = useSession();
+  const isEligible =
+    typeof window !== "undefined" &&
+    window.parent === window &&
+    status === "authenticated" &&
+    isBuilderIoEmployee(session?.email);
+  const didAutoRedirect = useRef(false);
+
+  useEffect(() => {
+    if (!isEligible || didAutoRedirect.current) {
+      return;
+    }
+
+    if (readBetaOptOutUntil() !== null) return;
+    if (consumeBetaOptOutQueryParam(window.location.href)) return;
+
+    const betaHref = buildEnvironmentUrl(
+      window.location.href,
+      targets.betaHost,
+    );
+    if (!betaHref || typeof window.location.replace !== "function") return;
+
+    didAutoRedirect.current = true;
+    trackEvent("environment switched", {
+      from_environment: "production",
+      to_environment: "beta",
+      trigger: "automatic_redirect",
+    });
+    window.location.replace(betaHref);
+  }, [isEligible, session?.email, status, targets.betaHost]);
+
+  if (!isEligible) return null;
+  return <EnvironmentBadgeContent environment="production" targets={targets} />;
+}
+
+/**
+ * First-party hosted lane switcher. Beta is intentionally visible before
+ * authentication so a visitor can always leave beta from the sign-in page.
+ * Production remains an internal auto-redirect lane for authenticated staff.
+ */
+export function EnvironmentBadge({
+  showProduction = true,
+}: {
+  showProduction?: boolean;
+} = {}) {
+  const config = useMemo(injectedAgentNativeConfig, []);
+  const hostname =
+    typeof window === "undefined" ? undefined : window.location.hostname;
+  const environment = resolveEnvironmentChannel(config, hostname);
+  const targets = resolveEnvironmentTargets(hostname);
+
+  if (
+    typeof window === "undefined" ||
+    window.parent !== window ||
+    !environment ||
+    !targets
+  ) {
+    return null;
+  }
+
+  if (environment === "beta") {
+    return <EnvironmentBadgeContent environment="beta" targets={targets} />;
+  }
+
+  if (!showProduction) return null;
+  return <ProductionEnvironmentBadge targets={targets} />;
 }

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -260,6 +260,7 @@ function ProvidersInner({
   disableThemeTransitions = true,
   i18n,
   documentTitleFallback,
+  showProductionEnvironmentBadge,
   children,
 }: {
   queryClient: QueryClient;
@@ -270,6 +271,7 @@ function ProvidersInner({
   disableThemeTransitions?: boolean;
   i18n?: Omit<AgentNativeI18nProviderProps, "children"> | false;
   documentTitleFallback?: string;
+  showProductionEnvironmentBadge: boolean;
   children: React.ReactNode;
 }) {
   const localizedChildren =
@@ -295,6 +297,7 @@ function ProvidersInner({
           <DocumentTitleGuard fallbackTitle={documentTitleFallback} />
           <RuntimeConfigNotice />
           <RoutedAppEnhancements />
+          <EnvironmentBadge showProduction={showProductionEnvironmentBadge} />
           {toaster}
         </TooltipProvider>
       </ThemeProvider>
@@ -329,6 +332,7 @@ export function AppProviders({
         disableThemeTransitions={disableThemeTransitions}
         i18n={i18n}
         documentTitleFallback={documentTitleFallback}
+        showProductionEnvironmentBadge={false}
       >
         {children}
       </ProvidersInner>
@@ -346,6 +350,7 @@ export function AppProviders({
         disableThemeTransitions={disableThemeTransitions}
         i18n={i18n}
         documentTitleFallback={documentTitleFallback}
+        showProductionEnvironmentBadge={!sessionBypass}
       >
         <RequireSession bypass={sessionBypass} fallback={fallback}>
           {sessionBypass ? (
@@ -353,7 +358,6 @@ export function AppProviders({
           ) : (
             <FirstRunOnboardingStartupGate>
               {children}
-              <EnvironmentBadge />
             </FirstRunOnboardingStartupGate>
           )}
         </RequireSession>

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -25,6 +25,19 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain('id="upgrade-note"');
   });
 
+  it("includes a beta switcher on the standalone auth page", () => {
+    const html = getOnboardingHtml({
+      requestHost: "beta.analytics.agent-native.com",
+    });
+
+    expect(html).toContain('id="environment-badge"');
+    expect(html).toContain("You're on Agent Native Beta");
+    expect(html).toContain("Switch to production");
+    expect(html).toContain("__anInitEnvironmentBadge");
+    expect(html).toContain("agentNativeBetaOptOut");
+    expect(html).toContain('id="environment-badge" aria-expanded="false"');
+  });
+
   it("redirects signed-in visitors without a cache-buster query loop", () => {
     const html = getOnboardingHtml();
 

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -20,6 +20,11 @@ import {
 import { NATIVE_AUTH_COPY } from "../shared/auth-copy.js";
 import { docsUrl } from "../shared/docs-url.js";
 import {
+  BETA_OPT_OUT_DURATION_MS,
+  BETA_OPT_OUT_QUERY_PARAM,
+  ENVIRONMENT_BETA_HOSTS,
+} from "../shared/environment-lanes.js";
+import {
   PASSWORD_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
 } from "../shared/password-policy.js";
@@ -1252,6 +1257,15 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
 ${localeMenuItemsHtml}
   </div>
 </div>`;
+  const environmentBadgeHtml = `
+<div class="environment-switcher" id="environment-switcher" hidden>
+  <button type="button" class="environment-badge" id="environment-badge" aria-expanded="false" aria-controls="environment-popover">beta</button>
+  <div class="environment-popover" id="environment-popover" role="dialog" aria-labelledby="environment-popover-title" hidden>
+    <div class="environment-popover-title" id="environment-popover-title">You're on Agent Native Beta</div>
+    <div class="environment-popover-copy">Choose where you want to continue.</div>
+    <a class="environment-production-link" id="environment-production-link" href="">Switch to production</a>
+  </div>
+</div>`;
   const hostedSignupLegalNotice: SignupLegalNoticeOptions | undefined =
     opts.signupLegalNotice === undefined &&
     isAgentNativeHostedHost(opts.requestHost)
@@ -1645,8 +1659,53 @@ ${marketing!.description ? `      <p class="app-desc" data-marketing-field="desc
       }
     }
     if (!reducedMotion) startAnimation();
-  })();`
+    })();`
     : "";
+  const environmentBadgeScript = `
+  (function __anInitEnvironmentBadge() {
+    var switcher = document.getElementById('environment-switcher');
+    var button = document.getElementById('environment-badge');
+    var popover = document.getElementById('environment-popover');
+    var productionLink = document.getElementById('environment-production-link');
+    if (!switcher || !button || !popover || !productionLink) return;
+    if (window.parent !== window) return;
+
+    var betaHosts = ${JSON.stringify(ENVIRONMENT_BETA_HOSTS)};
+    var hostname = (window.location.hostname || '').toLowerCase().replace(/\\.$/, '');
+    var productionHost = hostname.indexOf('beta.') === 0 ? hostname.slice(5) : '';
+    if (!productionHost || betaHosts[productionHost] !== hostname) return;
+
+    try {
+      var productionUrl = new URL(window.location.href);
+      productionUrl.protocol = 'https:';
+      productionUrl.hostname = productionHost;
+      productionUrl.port = '';
+      productionUrl.searchParams.set(
+        ${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)},
+        String(Date.now() + ${BETA_OPT_OUT_DURATION_MS}),
+      );
+      productionLink.href = productionUrl.toString();
+    } catch (error) {
+      void error;
+      return;
+    }
+
+    function setOpen(open) {
+      popover.hidden = !open;
+      button.setAttribute('aria-expanded', String(open));
+    }
+
+    switcher.hidden = false;
+    button.addEventListener('click', function() {
+      setOpen(popover.hidden);
+    });
+    document.addEventListener('click', function(event) {
+      if (!switcher.contains(event.target)) setOpen(false);
+    });
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape') setOpen(false);
+    });
+  })();`;
 
   return `<!DOCTYPE html>
 <html lang="${DEFAULT_LOCALE}" dir="ltr">
@@ -1789,6 +1848,69 @@ ${
   .locale-menu-item[aria-checked="true"] .locale-menu-check {
     opacity: 1;
   }
+  /* guard:allow-raw-color - standalone auth HTML has no app theme token layer */
+  .environment-switcher {
+    position: fixed;
+    right: max(0.75rem, env(safe-area-inset-right));
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    z-index: 100;
+  }
+  .environment-switcher[hidden],
+  .environment-popover[hidden] { display: none; }
+  .environment-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 1.5rem;
+    min-width: 0;
+    padding: 0 0.5rem;
+    background: #3a3a3a;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.16);
+    border-radius: 0.75rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+    font: inherit;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.03125rem;
+    line-height: 1;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+  .environment-badge:hover,
+  .environment-badge[aria-expanded="true"] { background: #4a4a4a; }
+  .environment-badge:focus-visible,
+  .environment-production-link:focus-visible {
+    outline: 2px solid #33c4ff;
+    outline-offset: 2px;
+  }
+  .environment-popover {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.5rem);
+    width: min(17.5rem, calc(100vw - 1.5rem));
+    padding: 1.25rem;
+    background: #141414;
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 0.75rem;
+    box-shadow: 0 18px 50px rgba(0,0,0,0.42);
+  }
+  .environment-popover-title { margin-bottom: 0.25rem; font-size: 0.875rem; font-weight: 600; line-height: 1.25rem; }
+  .environment-popover-copy { margin-bottom: 1rem; color: #888; font-size: 0.875rem; line-height: 1.25rem; }
+  .environment-production-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    padding: 0.375rem 0.75rem;
+    color: #e5e5e5;
+    border: 1px solid rgba(255,255,255,0.16);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    text-decoration: none;
+  }
+  .environment-production-link:hover { background: #242424; }
   .card {
     width: 100%;
     max-width: 400px;
@@ -2208,6 +2330,7 @@ ${embeddedAuthCss}
 </head>
 <body${simplifiedAuth ? ' class="simplified-auth"' : hasMarketing ? ' class="has-marketing"' : ""}>
 ${localePickerHtml}
+${environmentBadgeHtml}
 ${marketingPanelHtml}
 <div class="card">
   <h1 id="heading"${i18nAttr(googleOnly ? "signInTitle" : "welcomeTitle")}>${esc(t(googleOnly ? "signInTitle" : "welcomeTitle"))}</h1>
@@ -2305,6 +2428,7 @@ ${signupLocalModeNoteHtml}
   <span${i18nAttr("localNotePrefix")}>${esc(t("localNotePrefix"))}</span> (<strong>${getConnectionLabel()}</strong>)<span${i18nAttr("localNoteSuffix")}>${esc(t("localNoteSuffix"))}</span>
 </p>${marketingCloseHtml}
 <script>
+${environmentBadgeScript}
   function __anBasePath() {
     var configured = ${JSON.stringify(appBasePath)};
     if (configured) return configured;

--- a/packages/core/src/shared/environment-lanes.ts
+++ b/packages/core/src/shared/environment-lanes.ts
@@ -1,0 +1,83 @@
+export const BETA_OPT_OUT_QUERY_PARAM = "agentNativeBetaOptOut";
+export const BETA_OPT_OUT_DURATION_MS = 24 * 60 * 60 * 1000;
+
+export const ENVIRONMENT_BETA_HOSTS = {
+  "agent-workspace.builder.io": "beta.agent-workspace.builder.io",
+  "analytics.agent-native.com": "beta.analytics.agent-native.com",
+  "assets.agent-native.com": "beta.assets.agent-native.com",
+  "brain.agent-native.com": "beta.brain.agent-native.com",
+  "calendar.agent-native.com": "beta.calendar.agent-native.com",
+  "chat.agent-native.com": "beta.chat.agent-native.com",
+  "clips.agent-native.com": "beta.clips.agent-native.com",
+  "content.agent-native.com": "beta.content.agent-native.com",
+  "crm.agent-native.com": "beta.crm.agent-native.com",
+  "design.agent-native.com": "beta.design.agent-native.com",
+  "dispatch.agent-native.com": "beta.dispatch.agent-native.com",
+  "factory.agent-native.com": "beta.factory.agent-native.com",
+  "forms.agent-native.com": "beta.forms.agent-native.com",
+  "macros.agent-native.com": "beta.macros.agent-native.com",
+  "mail.agent-native.com": "beta.mail.agent-native.com",
+  "plan.agent-native.com": "beta.plan.agent-native.com",
+  "slides.agent-native.com": "beta.slides.agent-native.com",
+} as const;
+
+export interface EnvironmentBadgeTargets {
+  betaHost: string;
+  productionHost: string;
+}
+
+export function resolveEnvironmentTargets(
+  hostname: string | undefined,
+): EnvironmentBadgeTargets | null {
+  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalized) return null;
+
+  const productionHost = normalized.replace(/^beta\./, "");
+  const betaHost =
+    ENVIRONMENT_BETA_HOSTS[
+      productionHost as keyof typeof ENVIRONMENT_BETA_HOSTS
+    ];
+  if (!betaHost) return null;
+
+  return {
+    betaHost,
+    productionHost,
+  };
+}
+
+export function buildEnvironmentUrl(
+  sourceHref: string,
+  targetHost: string,
+): string | null {
+  try {
+    const target = new URL(sourceHref);
+    target.protocol = "https:";
+    target.hostname = targetHost;
+    target.port = "";
+    return target.toString();
+  } catch {
+    // coercion-ok: Invalid navigation input is an explicit absent target.
+    return null;
+  }
+}
+
+export function buildEnvironmentOptOutUrl(
+  sourceHref: string,
+  targetHost: string,
+  now = Date.now(),
+): string | null {
+  const targetHref = buildEnvironmentUrl(sourceHref, targetHost);
+  if (!targetHref) return null;
+
+  try {
+    const target = new URL(targetHref);
+    target.searchParams.set(
+      BETA_OPT_OUT_QUERY_PARAM,
+      String(now + BETA_OPT_OUT_DURATION_MS),
+    );
+    return target.toString();
+  } catch {
+    // coercion-ok: buildEnvironmentUrl already validated the URL.
+    return null;
+  }
+}

--- a/templates/clips/changelog/2026-08-19-social-preview-video-frames.md
+++ b/templates/clips/changelog/2026-08-19-social-preview-video-frames.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-19
 ---
+
 Shared clips now show a video frame in social previews when no thumbnail is stored.


### PR DESCRIPTION
## Summary
- show the beta environment badge for signed-out and non-Builder visitors
- add the same compact switcher to the standalone auth page
- keep the 24-hour production opt-out when leaving beta
- preserve production auto-redirect eligibility for authenticated Builder users

## Verification
- Core typecheck passed
- focused EnvironmentBadge, AppProviders, and onboarding HTML tests passed (62 tests)
- live Analytics beta auth endpoint returned a Google authorization URL and the beta project has the Google and email provider env keys
- full urgent prep was attempted; unrelated existing dispatch, mobile-app, and desktop-app typecheck failures stopped the aggregate lane, and the full Core suite was blocked by the local better-sqlite3 Node ABI mismatch
