### PR TITLE
fix(auth): keep browser OAuth callback binding available

### DIFF
--- a/.changeset/fix-browser-oauth-callback.md
+++ b/.changeset/fix-browser-oauth-callback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Google sign-in callbacks in browsers by keeping the OAuth binding cookie available across the provider redirect.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1381,6 +1381,19 @@ describe("server/auth", () => {
           state.desktopBrowserBindingHash!,
         ),
       ).toBe(true);
+
+      const httpsInitiator = createJsonPostEvent(
+        "/_agent-native/google/auth-url?desktop=1&flow_id=bound-flow-https",
+        {},
+        { "x-agent-native-desktop-verifier": "w".repeat(32) },
+        "https://localhost",
+      );
+      const httpsResult = await authUrlHandler(httpsInitiator);
+      expect(httpsResult.url).toBeTypeOf("string");
+      const httpsSetCookie = httpsInitiator.res.headers.get("set-cookie") ?? "";
+      expect(httpsSetCookie).toContain("SameSite=None");
+      expect(httpsSetCookie).toContain("Secure");
+      expect(httpsSetCookie).not.toContain("Partitioned");
     });
 
     it("lets templates own Google OAuth routes when opted out", async () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1820,7 +1820,7 @@ export function prepareDesktopOAuthBrowserBinding(event: H3Event): string {
   if (!binding || !/^[A-Za-z0-9_-]{43}$/.test(binding)) {
     binding = crypto.randomBytes(32).toString("base64url");
     setCookie(event, DESKTOP_OAUTH_BROWSER_BINDING_COOKIE, binding, {
-      ...crossSiteCookieAttrs(event),
+      ...desktopOAuthBrowserBindingCookieAttrs(event),
       httpOnly: true,
       path: "/",
       maxAge: Math.floor(DESKTOP_EXCHANGE_TTL_MS / 1_000),
@@ -3737,6 +3737,22 @@ function crossSiteCookieAttrs(event: H3Event): {
 } {
   return isHttpsRequest(event)
     ? { sameSite: "none", secure: true, partitioned: true }
+    : { sameSite: "lax", secure: false };
+}
+
+/**
+ * The binding cookie is set before navigating to Google and read after the
+ * provider redirects back. A partitioned cookie uses the top-level site from
+ * the bootstrap request, so it is unavailable when the callback starts from
+ * Google's top-level site. Keep this host-scoped cookie unpartitioned while
+ * retaining the cross-site and transport protections required by the flow.
+ */
+function desktopOAuthBrowserBindingCookieAttrs(event: H3Event): {
+  sameSite: "lax" | "none";
+  secure: boolean;
+} {
+  return isHttpsRequest(event)
+    ? { sameSite: "none", secure: true }
     : { sameSite: "lax", secure: false };
 }
 


### PR DESCRIPTION
## Summary

- Keep the verifier binding cookie host-scoped and available across the Google top-level redirect.
- Preserve `SameSite=None; Secure` for HTTPS while removing `Partitioned` from this OAuth-only cookie.
- Add regression coverage for the HTTPS cookie attributes.

## Verification

- `pnpm --filter @agent-native/core exec vitest --run src/server/auth.spec.ts --config vitest.config.ts` - 186 passed
- `pnpm --filter @agent-native/core exec vitest --run src/server/onboarding-html.spec.ts --config vitest.config.ts` - 45 passed
- `pnpm --filter @agent-native/core typecheck`
- `pnpm guards` - 56 passed,