### PR TITLE
Prevent stale Analytics asset shells after deploys

### DIFF
--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -63,18 +63,26 @@ jobs:
               const startedAt = Date.now();
               const deadline = startedAt + probeAttemptTimeoutMs;
               try {
-                const response = await fetch(`https://${host}/`, {
+                const documentUrl = `https://${host}/`;
+                const response = await fetch(documentUrl, {
                   headers: { "user-agent": "agent-native-site-monitor" },
                   redirect: "follow",
                   signal: AbortSignal.timeout(
                     Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
                   ),
                 });
+                const finalDocumentUrl = response.url || documentUrl;
+                if (new URL(finalDocumentUrl).origin !== new URL(documentUrl).origin) {
+                  await response.body?.cancel();
+                  throw new Error(
+                    `document redirected off origin to ${new URL(finalDocumentUrl).origin}`,
+                  );
+                }
                 const ms = Date.now() - startedAt;
                 const ok = response.status >= 200 && response.status < 400;
                 if (ok) {
                   const html = await response.text();
-                  const baseUrl = response.url || `https://${host}/`;
+                  const baseUrl = finalDocumentUrl;
                   const assets = new Set();
                   for (const match of html.matchAll(/<(link|script)\b[^>]*>/gi)) {
                     const tag = match[0];

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -54,17 +54,21 @@ jobs:
             ...manifest.workspace.map((host) => ({ environment: "workspace", host })),
           ];
           const timeoutMs = 15_000;
+          const probeAttemptTimeoutMs = 45_000;
           const maxAttempts = 3;
 
           async function probe({ environment, host }) {
             let lastFailure = "unknown error";
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
               const startedAt = Date.now();
+              const deadline = startedAt + probeAttemptTimeoutMs;
               try {
                 const response = await fetch(`https://${host}/`, {
                   headers: { "user-agent": "agent-native-site-monitor" },
                   redirect: "follow",
-                  signal: AbortSignal.timeout(timeoutMs),
+                  signal: AbortSignal.timeout(
+                    Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
+                  ),
                 });
                 const ms = Date.now() - startedAt;
                 const ok = response.status >= 200 && response.status < 400;
@@ -99,12 +103,18 @@ jobs:
                   const assetUrls = [...assets];
                   const assetConcurrency = 12;
                   for (let i = 0; i < assetUrls.length; i += assetConcurrency) {
+                    if (Date.now() >= deadline) {
+                      assetFailures.push("asset probe deadline exceeded");
+                      break;
+                    }
                     await Promise.all(assetUrls.slice(i, i + assetConcurrency).map(async (assetUrl) => {
                       try {
                         const assetResponse = await fetch(assetUrl, {
                           headers: { "user-agent": "agent-native-site-monitor" },
                           redirect: "follow",
-                          signal: AbortSignal.timeout(timeoutMs),
+                          signal: AbortSignal.timeout(
+                            Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
+                          ),
                         });
                         await assetResponse.body?.cancel();
                         if (assetResponse.status < 200 || assetResponse.status >= 300) {
@@ -119,6 +129,7 @@ jobs:
                   }
 
                   if (assetFailures.length > 0) {
+                    assetFailures.sort();
                     lastFailure = `HTTP ${response.status}; ${assetFailures.slice(0, 5).join(", ")}`;
                   } else {
                     return {

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -116,6 +116,13 @@ jobs:
                             Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
                           ),
                         });
+                        if (new URL(assetResponse.url).origin !== new URL(assetUrl).origin) {
+                          assetFailures.push(
+                            `${new URL(assetUrl).pathname} redirected off origin to ${new URL(assetResponse.url).origin}`,
+                          );
+                          await assetResponse.body?.cancel();
+                          return;
+                        }
                         await assetResponse.body?.cancel();
                         if (assetResponse.status < 200 || assetResponse.status >= 300) {
                           assetFailures.push(`${new URL(assetUrl).pathname} HTTP ${assetResponse.status}`);
@@ -139,6 +146,8 @@ jobs:
                       detail: `HTTP ${response.status} with ${assets.size} referenced assets in ${ms}ms (attempt ${attempt})`,
                     };
                   }
+                } else {
+                  await response.body?.cancel();
                 }
                 if (!ok) lastFailure = `HTTP ${response.status}`;
               } catch (error) {

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -55,7 +55,57 @@ jobs:
           ];
           const timeoutMs = 15_000;
           const probeAttemptTimeoutMs = 45_000;
+          const maxDocumentBytes = 2_000_000;
+          const maxAssetCount = 500;
+          const maxRedirects = 5;
           const maxAttempts = 3;
+
+          async function fetchOnVerifiedOrigin(url, origin, options) {
+            let currentUrl = url;
+            for (let redirect = 0; redirect <= maxRedirects; redirect += 1) {
+              const response = await fetch(currentUrl, {
+                ...options,
+                redirect: "manual",
+              });
+              if (response.status < 300 || response.status >= 400) {
+                return { response, url: currentUrl };
+              }
+              const location = response.headers.get("location");
+              await response.body?.cancel();
+              if (!location) {
+                throw new Error(`redirect from ${currentUrl} did not include a location`);
+              }
+              const nextUrl = new URL(location, currentUrl);
+              if (nextUrl.protocol !== "https:" || nextUrl.origin !== origin) {
+                throw new Error(`redirected off origin to ${nextUrl.href}`);
+              }
+              currentUrl = nextUrl.href;
+            }
+            throw new Error(`exceeded ${maxRedirects} redirects from ${url}`);
+          }
+
+          async function readResponseText(response, maxBytes) {
+            const reader = response.body?.getReader();
+            if (!reader) return "";
+            const decoder = new TextDecoder();
+            let bytes = 0;
+            let text = "";
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                bytes += value.byteLength;
+                if (bytes > maxBytes) {
+                  throw new Error(`document exceeded ${maxBytes} bytes`);
+                }
+                text += decoder.decode(value, { stream: true });
+              }
+              return text + decoder.decode();
+            } catch (error) {
+              await reader.cancel().catch(() => undefined);
+              throw error;
+            }
+          }
 
           async function probe({ environment, host }) {
             let lastFailure = "unknown error";
@@ -64,26 +114,24 @@ jobs:
               const deadline = startedAt + probeAttemptTimeoutMs;
               try {
                 const documentUrl = `https://${host}/`;
-                const response = await fetch(documentUrl, {
-                  headers: { "user-agent": "agent-native-site-monitor" },
-                  redirect: "follow",
-                  signal: AbortSignal.timeout(
-                    Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
-                  ),
-                });
-                const finalDocumentUrl = response.url || documentUrl;
-                if (new URL(finalDocumentUrl).origin !== new URL(documentUrl).origin) {
-                  await response.body?.cancel();
-                  throw new Error(
-                    `document redirected off origin to ${new URL(finalDocumentUrl).origin}`,
-                  );
-                }
+                const documentOrigin = new URL(documentUrl).origin;
+                const { response, url: finalDocumentUrl } = await fetchOnVerifiedOrigin(
+                  documentUrl,
+                  documentOrigin,
+                  {
+                    headers: { "user-agent": "agent-native-site-monitor" },
+                    signal: AbortSignal.timeout(
+                      Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
+                    ),
+                  },
+                );
                 const ms = Date.now() - startedAt;
                 const ok = response.status >= 200 && response.status < 400;
                 if (ok) {
-                  const html = await response.text();
+                  const html = await readResponseText(response, maxDocumentBytes);
                   const baseUrl = finalDocumentUrl;
                   const assets = new Set();
+                  let assetLimitExceeded = false;
                   for (const match of html.matchAll(/<(link|script)\b[^>]*>/gi)) {
                     const tag = match[0];
                     const rel = tag.match(/\brel=["']([^"']+)["']/i)?.[1] || "";
@@ -98,13 +146,20 @@ jobs:
                     if (!value || value.startsWith("#") || value.startsWith("data:")) continue;
                     try {
                       const url = new URL(value, baseUrl);
-                      if (url.origin === new URL(baseUrl).origin) {
+                      if (url.origin === documentOrigin) {
+                        if (!assets.has(url.href) && assets.size >= maxAssetCount) {
+                          assetLimitExceeded = true;
+                          break;
+                        }
                         assets.add(url.href);
                       }
                     } catch {
                       // Ignore malformed or non-URL markup; the document probe
                       // still reports the host itself as healthy.
                     }
+                  }
+                  if (assetLimitExceeded) {
+                    throw new Error(`document referenced more than ${maxAssetCount} assets`);
                   }
 
                   const assetFailures = [];
@@ -117,20 +172,16 @@ jobs:
                     }
                     await Promise.all(assetUrls.slice(i, i + assetConcurrency).map(async (assetUrl) => {
                       try {
-                        const assetResponse = await fetch(assetUrl, {
-                          headers: { "user-agent": "agent-native-site-monitor" },
-                          redirect: "follow",
-                          signal: AbortSignal.timeout(
-                            Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
-                          ),
-                        });
-                        if (new URL(assetResponse.url).origin !== new URL(assetUrl).origin) {
-                          assetFailures.push(
-                            `${new URL(assetUrl).pathname} redirected off origin to ${new URL(assetResponse.url).origin}`,
-                          );
-                          await assetResponse.body?.cancel();
-                          return;
-                        }
+                        const { response: assetResponse } = await fetchOnVerifiedOrigin(
+                          assetUrl,
+                          documentOrigin,
+                          {
+                            headers: { "user-agent": "agent-native-site-monitor" },
+                            signal: AbortSignal.timeout(
+                              Math.min(timeoutMs, Math.max(1, deadline - Date.now())),
+                            ),
+                          },
+                        );
                         await assetResponse.body?.cancel();
                         if (assetResponse.status < 200 || assetResponse.status >= 300) {
                           assetFailures.push(`${new URL(assetUrl).pathname} HTTP ${assetResponse.status}`);

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -63,21 +63,73 @@ jobs:
               try {
                 const response = await fetch(`https://${host}/`, {
                   headers: { "user-agent": "agent-native-site-monitor" },
-                  redirect: "manual",
+                  redirect: "follow",
                   signal: AbortSignal.timeout(timeoutMs),
                 });
-                await response.body?.cancel();
                 const ms = Date.now() - startedAt;
                 const ok = response.status >= 200 && response.status < 400;
                 if (ok) {
-                  return {
-                    environment,
-                    host,
-                    ok: true,
-                    detail: `HTTP ${response.status} in ${ms}ms (attempt ${attempt})`,
-                  };
+                  const html = await response.text();
+                  const baseUrl = response.url || `https://${host}/`;
+                  const assets = new Set();
+                  for (const match of html.matchAll(/<(link|script)\b[^>]*>/gi)) {
+                    const tag = match[0];
+                    const rel = tag.match(/\brel=["']([^"']+)["']/i)?.[1] || "";
+                    const attribute = match[1].toLowerCase() === "script"
+                      ? "src"
+                      : /(?:^|\s)modulepreload(?:\s|$)/i.test(rel) ||
+                          /(?:^|\s)stylesheet(?:\s|$)/i.test(rel)
+                        ? "href"
+                        : null;
+                    if (!attribute) continue;
+                    const value = tag.match(new RegExp(`\\b${attribute}=["']([^"']+)["']`, "i"))?.[1];
+                    if (!value || value.startsWith("#") || value.startsWith("data:")) continue;
+                    try {
+                      const url = new URL(value, baseUrl);
+                      if (url.origin === new URL(baseUrl).origin) {
+                        assets.add(url.href);
+                      }
+                    } catch {
+                      // Ignore malformed or non-URL markup; the document probe
+                      // still reports the host itself as healthy.
+                    }
+                  }
+
+                  const assetFailures = [];
+                  const assetUrls = [...assets];
+                  const assetConcurrency = 12;
+                  for (let i = 0; i < assetUrls.length; i += assetConcurrency) {
+                    await Promise.all(assetUrls.slice(i, i + assetConcurrency).map(async (assetUrl) => {
+                      try {
+                        const assetResponse = await fetch(assetUrl, {
+                          headers: { "user-agent": "agent-native-site-monitor" },
+                          redirect: "follow",
+                          signal: AbortSignal.timeout(timeoutMs),
+                        });
+                        await assetResponse.body?.cancel();
+                        if (assetResponse.status < 200 || assetResponse.status >= 300) {
+                          assetFailures.push(`${new URL(assetUrl).pathname} HTTP ${assetResponse.status}`);
+                        }
+                      } catch (error) {
+                        assetFailures.push(
+                          `${new URL(assetUrl).pathname} ${String(error?.message ?? error)}`,
+                        );
+                      }
+                    }));
+                  }
+
+                  if (assetFailures.length > 0) {
+                    lastFailure = `HTTP ${response.status}; ${assetFailures.slice(0, 5).join(", ")}`;
+                  } else {
+                    return {
+                      environment,
+                      host,
+                      ok: true,
+                      detail: `HTTP ${response.status} with ${assets.size} referenced assets in ${ms}ms (attempt ${attempt})`,
+                    };
+                  }
                 }
-                lastFailure = `HTTP ${response.status}`;
+                if (!ok) lastFailure = `HTTP ${response.status}`;
               } catch (error) {
                 lastFailure =
                   error?.name === "TimeoutError"

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -22,6 +22,10 @@ AGENT_CHAT_DURABLE_BACKGROUND = "true"
 AGENT_NATIVE_HOSTED_HARNESS = "true"
 AGENT_NATIVE_ENABLE_KEEP_WARM = "1"
 AGENT_NATIVE_DISABLE_KEEP_WARM_BACKGROUND = "1"
+# Keep the public shell close to the current deploy. A stale shell can retain
+# hashed modulepreload URLs after a Netlify asset publish and leave the app on
+# its loading screen while those chunks return 404.
+AGENT_NATIVE_SSR_CACHE = "30s"
 # Analytics owns its schema at release time (`migrate:production` above), so
 # production request functions skip migrations. Preview functions still run
 # request-path migrations because previews do not run the production release


### PR DESCRIPTION
## Summary

- Shorten Analytics production SSR shell caching to 30 seconds so hashed modulepreload URLs refresh promptly after deploys.
- Extend the public-site monitor to follow the shell and verify same-origin JS/CSS assets with bounded concurrency.

## Verification

- Source/tests: focused cache and SSR suites pass (73 tests); extracted monitor script passes `node --check`; all 55 repository guards pass.
- Observed live: Analytics `/ask` returned HTTP 200 with 106 referenced assets healthy at the time of verification.
- Deployment: this PR has not yet been deployed; production verification remains after merge.