### PR TITLE
fix(desktop): match light composer to navigation rail

### DIFF
--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -236,10 +236,10 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
   });
 
-  it("keeps the light desktop composer just above the rail gray", () => {
+  it("keeps the light desktop composer aligned with the rail gray", () => {
     const shellCss = readFileSync("src/renderer/shell.css", "utf8");
 
-    expect(shellCss).toContain("--desktop-chat-composer-background: 0 0% 98%;");
+    expect(shellCss).toContain("background: hsl(var(--sidebar-background));");
     expect(shellCss).toMatch(
       /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{/,
     );

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -239,9 +239,8 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
   it("keeps the light desktop composer aligned with the rail gray", () => {
     const shellCss = readFileSync("src/renderer/shell.css", "utf8");
 
-    expect(shellCss).toContain("background: hsl(var(--sidebar-background));");
     expect(shellCss).toMatch(
-      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{/,
+      /\.light\s+\.desktop-chat-first-hub\s+\[data-chat-first-app-pane\]\s+\.agent-sidebar-panel\s+\.agent-composer-root\s*\{\s*background:\s*hsl\(var\(--sidebar-background\)\);\s*\}/,
     );
   });
 

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -238,7 +238,6 @@ body {
   --sidebar-accent: 0 0% 95%;
   --sidebar-accent-foreground: 0 0% 15%;
   --sidebar-border: 0 0% 90%;
-  --desktop-chat-composer-background: 0 0% 98%;
   --agent-native-lower-surface: hsl(var(--sidebar-background));
   position: relative;
   display: grid;
@@ -249,14 +248,14 @@ body {
   background: var(--shell-bg);
 }
 
-/* The light desktop chat shell needs more contrast between the composer and
-   its surrounding surface; leave the shared card treatment unchanged. */
+/* Keep the chat composer aligned with the desktop rail, not the darker app
+   sidebar surface that contains it. */
 .light
   .desktop-chat-first-hub
   [data-chat-first-app-pane]
   .agent-sidebar-panel
   .agent-composer-root {
-  background: hsl(var(--desktop-chat-composer-background));
+  background: hsl(var(--sidebar-background));
 }
 
 @supports (background: color-mix(in srgb, white, black)) {


### PR DESCRIPTION
## Summary
- align the light desktop chat composer with the left navigation rail token
- keep the darker app sidebar surface distinct and cover the exact-token regression

## Validation
- focused CodeAgentsHub Vitest: 27 tests passed
- desktop-app build passed
- built Electron runtime: rail rgb(245, 245, 245), chat sidebar color(srgb 0.9408 0.9408 0.9408), composer rgb(245, 245, 245)