### PR TITLE
Fix GitHub prebuilt deploy matrices

### DIFF
--- a/.changeset/report-telegram-webhook-failures.md
+++ b/.changeset/report-telegram-webhook-failures.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Report Telegram webhook registration failures instead of treating rejected `setWebhook` responses as successful setup.

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -77,12 +77,13 @@ jobs:
           const sites = JSON.parse(
             fs.readFileSync('scripts/netlify-beta-sites.json', 'utf8'),
           );
+          if (!sites.length) throw new Error('No beta sites configured.');
           const matrix = { include: sites.map(({ id }) => ({ site: id })) };
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `matrix=${JSON.stringify(matrix)}\n`,
           );
-          console.log(`Discovered ${matrix.length} beta sites.`);
+          console.log(`Discovered ${sites.length} beta sites.`);
           NODE
 
   deploy:

--- a/.github/workflows/deploy-beta-sites-prebuilt.yml
+++ b/.github/workflows/deploy-beta-sites-prebuilt.yml
@@ -77,7 +77,7 @@ jobs:
           const sites = JSON.parse(
             fs.readFileSync('scripts/netlify-beta-sites.json', 'utf8'),
           );
-          const matrix = sites.map(({ id }) => ({ site: id }));
+          const matrix = { include: sites.map(({ id }) => ({ site: id })) };
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
             `matrix=${JSON.stringify(matrix)}\n`,

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -232,7 +232,6 @@ jobs:
         if: inputs.deploy
         env:
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
-          BUILD_CONTEXT: ${{ inputs.build_context }}
           FUNCTIONS_DIRECTORY: ${{ steps.target.outputs.functions_directory }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
@@ -246,7 +245,6 @@ jobs:
             --dir "$PUBLISH_DIRECTORY"
             --functions "$FUNCTIONS_DIRECTORY"
             --filter "$SOURCE_TEMPLATE"
-            --context "$BUILD_CONTEXT"
             --no-build
             --message "GitHub Actions prebuilt deploy ${GITHUB_SHA}"
           )

--- a/.github/workflows/deploy-production-sites-prebuilt.yml
+++ b/.github/workflows/deploy-production-sites-prebuilt.yml
@@ -129,7 +129,7 @@ jobs:
 
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `matrix=${JSON.stringify(buildable)}\n`,
+            `matrix=${JSON.stringify({ include: buildable })}\n`,
           );
           console.log(`Discovered ${buildable.length} buildable production sites.`);
           NODE

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -582,6 +582,90 @@ describe("integrations plugin routes", () => {
     expect(saveIntegrationConfigMock).not.toHaveBeenCalled();
   });
 
+  it("registers the Telegram webhook and returns the provider result", async () => {
+    getSessionMock.mockResolvedValueOnce({ email: "owner@example.test" });
+    resolveSecretMock.mockImplementation((key: string) =>
+      key === "TELEGRAM_BOT_TOKEN"
+        ? "telegram-bot-token-example"
+        : key === "TELEGRAM_WEBHOOK_SECRET"
+          ? "telegram-webhook-secret-example"
+          : null,
+    );
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toEqual({
+        url: "https://app.test/_agent-native/integrations/telegram/webhook",
+        secret_token: "telegram-webhook-secret-example",
+      });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          result: { url: "https://app.test/webhook" },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({
+      adapters: [{ ...adapter, platform: "telegram", label: "Telegram" }],
+    })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/telegram/setup",
+      "POST",
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      ok: true,
+      platform: "telegram",
+      webhookUrl:
+        "https://app.test/_agent-native/integrations/telegram/webhook",
+      result: { ok: true },
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces Telegram setWebhook failures instead of reporting success", async () => {
+    getSessionMock.mockResolvedValueOnce({ email: "owner@example.test" });
+    resolveSecretMock.mockImplementation((key: string) =>
+      key === "TELEGRAM_BOT_TOKEN"
+        ? "telegram-bot-token-example"
+        : key === "TELEGRAM_WEBHOOK_SECRET"
+          ? "telegram-webhook-secret-example"
+          : null,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              ok: false,
+              description: "Bad Request: webhook URL is invalid",
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({
+      adapters: [{ ...adapter, platform: "telegram", label: "Telegram" }],
+    })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/telegram/setup",
+      "POST",
+    );
+
+    expect(result.status).toBe(502);
+    expect(result.body).toEqual({
+      error: "Telegram setWebhook failed: Bad Request: webhook URL is invalid",
+    });
+  });
+
   it("answers platform verification challenges before requiring enablement", async () => {
     const challengeAdapter: PlatformAdapter = {
       ...adapter,

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -666,6 +666,42 @@ describe("integrations plugin routes", () => {
     });
   });
 
+  it("surfaces non-JSON Telegram setWebhook failures as provider errors", async () => {
+    getSessionMock.mockResolvedValueOnce({ email: "owner@example.test" });
+    resolveSecretMock.mockImplementation((key: string) =>
+      key === "TELEGRAM_BOT_TOKEN"
+        ? "telegram-bot-token-example"
+        : key === "TELEGRAM_WEBHOOK_SECRET"
+          ? "telegram-webhook-secret-example"
+          : null,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("upstream gateway failure", {
+            status: 502,
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({
+      adapters: [{ ...adapter, platform: "telegram", label: "Telegram" }],
+    })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/telegram/setup",
+      "POST",
+    );
+
+    expect(result.status).toBe(502);
+    expect(result.body).toEqual({
+      error: "Telegram setWebhook failed: HTTP 502",
+    });
+  });
+
   it("answers platform verification challenges before requiring enablement", async () => {
     const challengeAdapter: PlatformAdapter = {
       ...adapter,

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -3488,15 +3488,24 @@ export function createIntegrationsPlugin(
                   }),
                 },
               );
-              const data = (await res.json()) as {
+              const body = await res.text();
+              let data: {
                 ok?: boolean;
                 description?: string;
                 [key: string]: unknown;
-              };
-              if (!res.ok || data.ok !== true) {
+              } | null = null;
+              try {
+                const parsed = JSON.parse(body);
+                if (parsed && typeof parsed === "object") {
+                  data = parsed as typeof data;
+                }
+              } catch {
+                // Keep provider and proxy failures distinguishable from a successful setup.
+              }
+              if (!res.ok || data?.ok !== true) {
                 setResponseStatus(event, 502);
                 return {
-                  error: `Telegram setWebhook failed: ${data.description ?? `HTTP ${res.status}`}`,
+                  error: `Telegram setWebhook failed: ${data?.description ?? `HTTP ${res.status}`}`,
                 };
               }
               return { ok: true, platform, webhookUrl, result: data };

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -3502,6 +3502,7 @@ export function createIntegrationsPlugin(
                 }
               } catch {
                 // Keep provider and proxy failures distinguishable from a successful setup.
+                data = null;
               }
               if (!res.ok || data?.ok !== true) {
                 setResponseStatus(event, 502);

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -3489,15 +3489,16 @@ export function createIntegrationsPlugin(
                 },
               );
               const body = await res.text();
-              let data: {
+              type TelegramSetWebhookResponse = {
                 ok?: boolean;
                 description?: string;
                 [key: string]: unknown;
-              } | null = null;
+              };
+              let data: TelegramSetWebhookResponse | null = null;
               try {
                 const parsed = JSON.parse(body);
                 if (parsed && typeof parsed === "object") {
-                  data = parsed as typeof data;
+                  data = parsed as TelegramSetWebhookResponse;
                 }
               } catch {
                 // Keep provider and proxy failures distinguishable from a successful setup.

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -3488,7 +3488,17 @@ export function createIntegrationsPlugin(
                   }),
                 },
               );
-              const data = await res.json();
+              const data = (await res.json()) as {
+                ok?: boolean;
+                description?: string;
+                [key: string]: unknown;
+              };
+              if (!res.ok || data.ok !== true) {
+                setResponseStatus(event, 502);
+                return {
+                  error: `Telegram setWebhook failed: ${data.description ?? `HTTP ${res.status}`}`,
+                };
+              }
               return { ok: true, platform, webhookUrl, result: data };
             } catch (err: any) {
               setResponseStatus(event, 500);


### PR DESCRIPTION
The initial main deploy exposed that the generated reusable-workflow matrices were emitted as bare arrays. GitHub requires a matrix object, so the caller jobs were not planned.

This changes beta and production discovery outputs to {include: [...]} while preserving the existing reusable deploy lane.

Checks:
- actionlint
- netlify-prebuilt-target tests 6/6
- git diff --check