### PR TITLE
fix(deploy): force clean production Netlify builds

### DIFF
--- a/.github/workflows/manage-production-sites.yml
+++ b/.github/workflows/manage-production-sites.yml
@@ -249,7 +249,7 @@ jobs:
             }
 
             async function deployMain(name, site, sourceSha) {
-              const query = new URLSearchParams({ branch: 'main' });
+              const query = new URLSearchParams({ branch: 'main', clear_cache: 'true' });
               const build = await readJson(
                 await request(`${API}/sites/${site.siteId}/builds?${query}`, {
                   method: 'POST',


### PR DESCRIPTION
Force the manual production promotion workflow to clear Netlify's build cache before rebuilding the selected main sites. This allows production promotion to publish the merged OAuth callback fix when a release tip is otherwise reported as no content change.