### PR TITLE
fix: reconcile temperature handling with Anthropic thinking block

### DIFF
--- a/.changeset/thinking-temperature-conflict.md
+++ b/.changeset/thinking-temperature-conflict.md
@@ -1,0 +1,9 @@
+---
+"@agent-native/core": patch
+---
+
+Stop sending a temperature Anthropic always rejects when extended thinking is on.
+
+Anthropic returns `400 invalid_request_error: temperature may only be set to 1 when thinking is enabled or in adaptive mode`. Both sides of that combination were ordinary defaults: `temperature` is a documented `completeText` option, and thinking is on unless the model rules it out, because an absent reasoning effort resolves to `DEFAULT_REASONING_EFFORT`. So `completeText({ temperature: 0.7 })` failed on every Claude reasoning model, surfacing as an opaque 500 from whatever action made the call — a generated app asking for creative output hit it immediately.
+
+The Anthropic and AI SDK engines now drop a conflicting temperature and warn once, naming the value and model. An explicit `1` is passed through, since the provider accepts it, and models that take no thinking block keep their temperature unchanged.

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -39,6 +39,7 @@ import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
 } from "./output-tokens.js";
+import { temperatureForThinkingRequest } from "./thinking-temperature.js";
 import {
   engineToolsToAISDK,
   engineMessagesToAISDK,
@@ -448,6 +449,14 @@ class AISDKEngine implements AgentEngine {
       }
     }
 
+    // After `providerOpts.anthropic.thinking` is resolved above, not beside it.
+    const resolvedTemperature = temperatureForThinkingRequest(
+      opts.temperature,
+      (providerOpts.anthropic as { thinking?: unknown } | undefined)
+        ?.thinking !== undefined,
+      { engine: `ai-sdk-engine:${this.provider}`, model: opts.model },
+    );
+
     let assistantContent: EngineContentPart[] = [];
     const firstEventAbort = createFirstEventAbortController(opts.abortSignal);
     const toolInputs = createStreamedToolInputState();
@@ -463,8 +472,8 @@ class AISDKEngine implements AgentEngine {
         // backoff. Leaving the SDK on its default (2) multiplies the two retry
         // layers into ~12 HTTP requests per failed run.
         maxRetries: 1,
-        ...(opts.temperature !== undefined
-          ? { temperature: opts.temperature }
+        ...(resolvedTemperature !== undefined
+          ? { temperature: resolvedTemperature }
           : {}),
         abortSignal: firstEventAbort.signal,
         onStepFinish: (step: any) => {

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -134,6 +134,59 @@ describe("createAnthropicEngine", () => {
     vi.doUnmock("@anthropic-ai/sdk");
   });
 
+  // The 400 this guards against: "`temperature` may only be set to 1 when
+  // thinking is enabled or in adaptive mode." Thinking is on by DEFAULT here
+  // (an absent reasoning effort becomes DEFAULT_REASONING_EFFORT), so passing
+  // only a temperature — an ordinary completeText option — used to make every
+  // request on a Claude reasoning model fail.
+  it("omits a non-1 temperature when it defaults thinking on", async () => {
+    const requestParams = await captureRequestParams({
+      model: "claude-sonnet-5",
+      systemPrompt: "You write haiku.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "mondays" }] },
+      ],
+      tools: [],
+      abortSignal: new AbortController().signal,
+      temperature: 0.7,
+    });
+
+    expect(requestParams.thinking).toBeDefined();
+    expect(requestParams).not.toHaveProperty("temperature");
+  });
+
+  it("keeps a temperature of 1, which is legal alongside thinking", async () => {
+    const requestParams = await captureRequestParams({
+      model: "claude-sonnet-5",
+      systemPrompt: "You write haiku.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "mondays" }] },
+      ],
+      tools: [],
+      abortSignal: new AbortController().signal,
+      temperature: 1,
+    });
+
+    expect(requestParams.thinking).toBeDefined();
+    expect(requestParams.temperature).toBe(1);
+  });
+
+  it("still sends the temperature on a model that takes no thinking block", async () => {
+    const requestParams = await captureRequestParams({
+      model: "claude-3-5-haiku-20241022",
+      systemPrompt: "You write haiku.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "mondays" }] },
+      ],
+      tools: [],
+      abortSignal: new AbortController().signal,
+      temperature: 0.7,
+    });
+
+    expect(requestParams.thinking).toBeUndefined();
+    expect(requestParams.temperature).toBe(0.7);
+  });
+
   it("adds a moving cache breakpoint on the last user message's last content block", async () => {
     const requestParams = await captureRequestParams({
       model: "claude-haiku-4-5-20251001",

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -36,6 +36,7 @@ import {
   splitSystemPromptForCache,
   stablePrefixCacheControl,
 } from "./prompt-cache.js";
+import { temperatureForThinkingRequest } from "./thinking-temperature.js";
 import {
   engineToolsToAnthropic,
   engineMessagesToAnthropic,
@@ -194,14 +195,22 @@ class AnthropicEngine implements AgentEngine {
       }
     }
 
+    // `extra.thinking` is set above from the reasoning effort, which defaults
+    // to on — so this has to run after it, not beside it.
+    const resolvedTemperature = temperatureForThinkingRequest(
+      opts.temperature,
+      extra.thinking !== undefined,
+      { engine: "anthropic-engine", model: opts.model },
+    );
+
     const requestParams: any = {
       model: opts.model,
       max_tokens: resolvedMaxOutputTokens,
       system: systemBlocks,
       tools: cachedTools.length > 0 ? cachedTools : undefined,
       messages: cachedMessages,
-      ...(opts.temperature !== undefined
-        ? { temperature: opts.temperature }
+      ...(resolvedTemperature !== undefined
+        ? { temperature: resolvedTemperature }
         : {}),
       ...extra,
     };

--- a/packages/core/src/agent/engine/thinking-temperature.spec.ts
+++ b/packages/core/src/agent/engine/thinking-temperature.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetThinkingTemperatureWarningForTests,
+  temperatureForThinkingRequest,
+} from "./thinking-temperature.js";
+
+const ctx = { engine: "anthropic-engine", model: "claude-sonnet-4-5" };
+
+beforeEach(() => {
+  __resetThinkingTemperatureWarningForTests();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("temperatureForThinkingRequest", () => {
+  // The exact combination that 400s: "`temperature` may only be set to 1 when
+  // thinking is enabled or in adaptive mode."
+  it("drops a non-1 temperature when a thinking block is present", () => {
+    expect(temperatureForThinkingRequest(0.7, true, ctx)).toBeUndefined();
+  });
+
+  it("keeps an explicit 1, which the provider accepts alongside thinking", () => {
+    expect(temperatureForThinkingRequest(1, true, ctx)).toBe(1);
+  });
+
+  it("leaves the temperature alone when thinking is off", () => {
+    expect(temperatureForThinkingRequest(0.7, false, ctx)).toBe(0.7);
+    expect(temperatureForThinkingRequest(0, false, ctx)).toBe(0);
+  });
+
+  it("passes through an absent temperature either way", () => {
+    expect(temperatureForThinkingRequest(undefined, true, ctx)).toBeUndefined();
+    expect(
+      temperatureForThinkingRequest(undefined, false, ctx),
+    ).toBeUndefined();
+  });
+
+  // 0 is falsy: a truthiness check here would silently keep it and 400.
+  it("drops a temperature of 0 rather than treating it as absent", () => {
+    expect(temperatureForThinkingRequest(0, true, ctx)).toBeUndefined();
+  });
+
+  // Dropping an explicit request is a silent change unless it says so.
+  it("warns once, naming the value and model, rather than dropping quietly", () => {
+    temperatureForThinkingRequest(0.7, true, ctx);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(console.warn).mock.calls[0]?.[0] as string;
+    expect(message).toContain("0.7");
+    expect(message).toContain("claude-sonnet-4-5");
+  });
+
+  it("does not repeat the warning on every request", () => {
+    for (let i = 0; i < 5; i += 1) {
+      temperatureForThinkingRequest(0.7, true, ctx);
+    }
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when there is nothing to reconcile", () => {
+    temperatureForThinkingRequest(1, true, ctx);
+    temperatureForThinkingRequest(0.7, false, ctx);
+    temperatureForThinkingRequest(undefined, true, ctx);
+
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/agent/engine/thinking-temperature.ts
+++ b/packages/core/src/agent/engine/thinking-temperature.ts
@@ -1,0 +1,57 @@
+/**
+ * Reconcile `temperature` with an Anthropic thinking block.
+ *
+ * Anthropic rejects the request outright when a thinking block is present and
+ * `temperature` is anything other than 1:
+ *
+ *   400 invalid_request_error: `temperature` may only be set to 1 when
+ *   thinking is enabled or in adaptive mode.
+ *
+ * Both are ordinary public options — `completeText({ temperature })` is
+ * documented, and thinking is on by DEFAULT rather than opt-in, because
+ * `normalizeReasoningEffortForModel` turns an absent effort into
+ * `DEFAULT_REASONING_EFFORT`. So a caller who sets only a temperature gets a
+ * guaranteed 400 on every Claude reasoning model, surfacing as an opaque 500
+ * from whatever action made the call.
+ *
+ * Dropping the temperature is the resolution rather than throwing: 1 is the
+ * only value the provider accepts here and is also its default, so omitting the
+ * field sends exactly the request the caller would have had to write by hand.
+ * Throwing would convert a recoverable combination into a hard failure for a
+ * choice the caller cannot express any other way. It IS still a silent change
+ * to an explicit request, so it warns rather than dropping the value quietly.
+ */
+
+let _warned = false;
+
+/** Test seam — the warn-once latch is module state. */
+export function __resetThinkingTemperatureWarningForTests(): void {
+  _warned = false;
+}
+
+export function temperatureForThinkingRequest(
+  temperature: number | undefined,
+  thinkingEnabled: boolean,
+  context: { engine: string; model?: string },
+): number | undefined {
+  if (temperature === undefined || !thinkingEnabled) {
+    return temperature;
+  }
+  // 1 is legal alongside thinking, so an explicit 1 is passed through
+  // untouched rather than being dropped as if it conflicted.
+  if (temperature === 1) {
+    return 1;
+  }
+  if (!_warned) {
+    _warned = true;
+    console.warn(
+      `[${context.engine}] Ignoring temperature=${temperature} for ${
+        context.model ?? "this model"
+      }: Anthropic only accepts temperature 1 while extended thinking is ` +
+        "enabled, and thinking is on by default. Set reasoning effort to a " +
+        "value the model does not support, or drop the temperature option, to " +
+        "silence this.",
+    );
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Stop sending a temperature Anthropic always rejects

Anthropic returns:

400 invalid_request_error: temperature may only be set to 1 when thinking
is enabled or in adaptive mode.

Both sides of that combination were ordinary defaults. `temperature` is a
documented `completeText` option, and thinking is on unless the model rules it
out, because an absent reasoning effort resolves to `DEFAULT_REASONING_EFFORT`
in `normalizeReasoningEffortForModel`. Nothing reconciled the two, so
`completeText({ temperature: 0.7 })` failed on every Claude reasoning model.

It surfaced as an opaque 500 from whatever action made the call. Found it when a
generated app asked for creative output and every request 400'd.

### Changes

- New `agent/engine/thinking-temperature.ts`: one helper that reconciles the two.
- `anthropic-engine.ts` and `ai-sdk-engine.ts` now call it, each after their own
  thinking block is resolved rather than beside it.

A conflicting temperature is dropped and warned once, naming the value and the
model. An explicit `1` passes through, since the provider accepts it. Models
with no thinking block keep their temperature unchanged.

Dropping rather than throwing: `1` is the only value the provider accepts there
and is also its default, so omitting the field sends exactly the request the
caller would have had to write by hand. Throwing would turn a recoverable
combination into a hard failure for something the caller cannot express any
other way. It is still a silent change to an explicit request, which is why it
warns instead of dropping quietly.

`builder-engine.ts` is deliberately untouched. It sends `reasoning_effort` and
never builds a thinking block itself, so whether a conflict appears depends on
the gateway's translation. I did not change code I could not prove was broken.