### PR TITLE
fix: handle absent production cutover state safely

### DIFF
--- a/.changeset/preserve-custom-login-beta-opt-out.md
+++ b/.changeset/preserve-custom-login-beta-opt-out.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve the beta environment opt-out when custom authentication pages are served.

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -351,6 +351,7 @@ jobs:
               signal: AbortSignal.timeout(30_000),
             });
           const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+          const DEPLOY_LOOKBACK_MS = 2 * 60 * 60 * 1000;
 
           function nextPageUrl(linkHeader) {
             if (!linkHeader) return null;
@@ -361,7 +362,7 @@ jobs:
             return null;
           }
 
-          async function listDeploys(label) {
+          async function listDeploys(label, cutoff) {
             const deploys = [];
             let url = `${api}/sites/${siteId}/deploys?per_page=100`;
             while (url) {
@@ -369,6 +370,10 @@ jobs:
               const page = await readJson(response, label);
               if (!Array.isArray(page)) throw new Error(`${label} returned a non-array response.`);
               deploys.push(...page);
+              const oldestCreatedAt = page[page.length - 1]?.created_at;
+              // Netlify returns deploys newest-first; historical pages cannot
+              // contain a pending cutover deploy and make the drain time out.
+              if (oldestCreatedAt && Date.parse(oldestCreatedAt) < cutoff) break;
               url = nextPageUrl(response.headers.get("link"));
             }
             return deploys;
@@ -387,9 +392,10 @@ jobs:
 
           async function drainPendingDeploys(publishedId, readyIsBlocking) {
             const deadline = Date.now() + 5 * 60 * 1000;
+            const cutoff = Date.now() - DEPLOY_LOOKBACK_MS;
             while (Date.now() < deadline) {
               let pending = pendingProductionDeploys(
-                await listDeploys("Netlify pending production deploy lookup"),
+                await listDeploys("Netlify pending production deploy lookup", cutoff),
                 publishedId,
                 readyIsBlocking,
               );
@@ -407,7 +413,7 @@ jobs:
               }
 
               pending = pendingProductionDeploys(
-                await listDeploys("Netlify production deploy drain verification"),
+                await listDeploys("Netlify production deploy drain verification", cutoff),
                 publishedId,
                 readyIsBlocking,
               );

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -703,7 +703,7 @@ jobs:
             return body;
           }
 
-          if (!process.env.cutoverWasStopped) {
+          if (process.env.cutoverWasStopped !== "true") {
             console.log("No production cutover state was acquired; automatic builds are unchanged.");
             process.exit(0);
           }
@@ -761,7 +761,7 @@ jobs:
             return body;
           }
 
-          if (!process.env.cutoverWasStopped) {
+          if (process.env.cutoverWasStopped !== "true") {
             console.log("No production cutover state was acquired; cleanup is not needed.");
             process.exit(0);
           }

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -801,8 +801,13 @@ jobs:
             return body;
           }
 
-          if (process.env.cutoverWasPaused !== "true") {
-            console.log("No production cutover state was acquired; cleanup is not needed.");
+          if (
+            process.env.cutoverWasPaused !== "true" ||
+            !process.env.cutoverPublishedDeployId
+          ) {
+            console.log(
+              "No production deploy lock state was recorded; lock cleanup is not needed.",
+            );
             process.exit(0);
           }
           const originalDeployId = process.env.cutoverPublishedDeployId;

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -294,6 +294,7 @@ jobs:
               "Netlify automatic build pause",
             );
           }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\n");
           const paused = await readJson(
             await request(`${api}/sites/${siteId}`),
             "Netlify automatic build pause verification",
@@ -301,7 +302,6 @@ jobs:
           if (paused.build_settings?.stop_builds !== true) {
             throw new Error("Netlify automatic builds were not paused before production cutover.");
           }
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\n");
           console.log(`Automatic Netlify builds paused for production cutover (previously stopped: ${wasStopped}).`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -622,6 +622,43 @@ jobs:
           curl --fail --silent --show-error --location --max-time 60 "${url%/}/" >/dev/null
           echo "Smoke check passed: ${url%/}/"
 
+      - name: Purge the production Netlify cache
+        if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const api = "https://api.netlify.com/api/v1";
+          (async () => {
+            const response = await fetch(`${api}/purge`, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
+                "Content-Type": "application/json",
+                "User-Agent": "agent-native-prebuilt-production-cache-purge",
+              },
+              body: JSON.stringify({ site_id: process.env.NETLIFY_SITE_ID }),
+              signal: AbortSignal.timeout(30_000),
+            });
+            const text = await response.text();
+            let body = null;
+            try {
+              body = text ? JSON.parse(text) : null;
+            } catch {
+              body = text;
+            }
+            if (!response.ok) {
+              throw new Error(`Netlify production cache purge failed with HTTP ${response.status}: ${JSON.stringify(body)}`);
+            }
+            console.log(`Purged the Netlify production cache for ${process.env.NETLIFY_SITE_ID} (HTTP ${response.status}).`);
+          })().catch((error) => {
+            console.error(error instanceof Error ? error.message : error);
+            process.exitCode = 1;
+          });
+          NODE
+
       - name: Lock the published production deploy
         if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()
         env:

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -775,6 +775,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
           cutoverPublishedDeployId: ${{ steps.unlock.outputs.published_deploy_id }}
+          cutoverNewDeployId: ${{ steps.deploy.outputs.deploy_id }}
           cutoverWasLocked: ${{ steps.unlock.outputs.was_locked }}
           cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
         run: |
@@ -804,8 +805,9 @@ jobs:
             console.log("No production cutover state was acquired; cleanup is not needed.");
             process.exit(0);
           }
-          const deployId = process.env.cutoverPublishedDeployId;
-          if (!deployId) {
+          const originalDeployId = process.env.cutoverPublishedDeployId;
+          const newDeployId = process.env.cutoverNewDeployId;
+          if (!originalDeployId) {
             throw new Error("Cannot restore the production lock: unlock did not record the original published deploy.");
           }
           const site = await readJson(
@@ -816,37 +818,53 @@ jobs:
           if (!currentDeployId) {
             throw new Error("Cannot restore the production lock: site has no published deploy.");
           }
-          if (currentDeployId !== deployId) {
+          if (newDeployId && currentDeployId === newDeployId) {
+            const deployUrl = `${api}/deploys/${newDeployId}`;
+            const deploy = await readJson(await request(deployUrl), "Netlify newly published deploy lock lookup");
+            if (deploy.locked !== true) {
+              await readJson(
+                await request(`${deployUrl}/lock`, { method: "POST" }),
+                `Netlify newly published deploy ${newDeployId} failure lock`,
+              );
+            }
+            const locked = await readJson(await request(deployUrl), "Netlify newly published failure lock verification");
+            if (locked.locked !== true) {
+              throw new Error(`Netlify newly published deploy ${newDeployId} was not locked during failure cleanup.`);
+            }
+            console.log(`Locked newly published production deploy ${newDeployId} after cutover failure.`);
+            process.exit(0);
+          }
+          if (currentDeployId !== originalDeployId) {
             throw new Error(
-              `Refusing failure cleanup to modify published deploy ${currentDeployId}; cutover started from ${deployId}.`,
+              `Refusing failure cleanup to modify published deploy ${currentDeployId}; cutover started from ${originalDeployId}.`,
             );
           }
-          const deployUrl = `${api}/deploys/${deployId}`;
+          const deployUrl = `${api}/deploys/${originalDeployId}`;
           const deploy = await readJson(await request(deployUrl), "Netlify published deploy lock lookup");
           if (process.env.cutoverWasLocked === "true") {
             if (deploy.locked !== true) {
               await readJson(
                 await request(`${deployUrl}/lock`, { method: "POST" }),
-                `Netlify published deploy ${deployId} failure lock`,
+                `Netlify published deploy ${originalDeployId} failure lock`,
               );
             }
             const locked = await readJson(await request(deployUrl), "Netlify failure lock verification");
             if (locked.locked !== true) {
-              throw new Error(`Netlify published deploy ${deployId} was not locked during failure cleanup.`);
+              throw new Error(`Netlify published deploy ${originalDeployId} was not locked during failure cleanup.`);
             }
-            console.log(`Restored production lock on deploy ${deployId}.`);
+            console.log(`Restored production lock on deploy ${originalDeployId}.`);
           } else {
             if (deploy.locked === true) {
               await readJson(
                 await request(`${deployUrl}/unlock`, { method: "POST" }),
-                `Netlify published deploy ${deployId} failure unlock`,
+                `Netlify published deploy ${originalDeployId} failure unlock`,
               );
             }
             const unlocked = await readJson(await request(deployUrl), "Netlify failure unlock verification");
             if (unlocked.locked !== false) {
-              throw new Error(`Netlify published deploy ${deployId} was not unlocked during failure cleanup.`);
+              throw new Error(`Netlify published deploy ${originalDeployId} was not unlocked during failure cleanup.`);
             }
-            console.log(`Restored production unlock state on deploy ${deployId}.`);
+            console.log(`Restored production unlock state on deploy ${originalDeployId}.`);
           }
           NODE
 

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -301,6 +301,7 @@ jobs:
           if (paused.build_settings?.stop_builds !== true) {
             throw new Error("Netlify automatic builds were not paused before production cutover.");
           }
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\n");
           console.log(`Automatic Netlify builds paused for production cutover (previously stopped: ${wasStopped}).`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);
@@ -680,6 +681,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
           cutoverWasStopped: ${{ steps.pause.outputs.was_stopped }}
+          cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -703,7 +705,7 @@ jobs:
             return body;
           }
 
-          if (process.env.cutoverWasStopped !== "true") {
+          if (process.env.cutoverWasPaused !== "true") {
             console.log("No production cutover state was acquired; automatic builds are unchanged.");
             process.exit(0);
           }
@@ -737,7 +739,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
           cutoverPublishedDeployId: ${{ steps.unlock.outputs.published_deploy_id }}
           cutoverWasLocked: ${{ steps.unlock.outputs.was_locked }}
-          cutoverWasStopped: ${{ steps.pause.outputs.was_stopped }}
+          cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
         run: |
           set -euo pipefail
           node <<'NODE'
@@ -761,7 +763,7 @@ jobs:
             return body;
           }
 
-          if (process.env.cutoverWasStopped !== "true") {
+          if (process.env.cutoverWasPaused !== "true") {
             console.log("No production cutover state was acquired; cleanup is not needed.");
             process.exit(0);
           }

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -2488,6 +2488,39 @@ describe("server/auth", () => {
       }
     });
 
+    it("preserves the beta opt-out in custom login HTML before authentication", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml:
+          "<!doctype html><html><head></head><body><form>QA login</form></body></html>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(
+        createMockEvent({
+          path: "/sign-in?agentNativeBetaOptOut=4102444800000",
+        }),
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      const html = await (result as Response).text();
+      expect(html).toContain("Persist the beta opt-out before authentication");
+      expect(html).toContain("agent-native:beta-opt-out-until");
+      expect(html.indexOf("data-agent-native-beta-opt-out")).toBeLessThan(
+        html.indexOf("</body>"),
+      );
+    });
+
     it("simplifies login HTML when the return path contains an initial prompt", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("AUTH_MAGIC_LINK", "0");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -133,6 +133,7 @@ import {
   signupAttributionFromCookieHeader,
 } from "./attribution.js";
 import { getAuthLoginMode } from "./auth-login-mode.js";
+import { injectBetaOptOutPersistence } from "./beta-opt-out-html.js";
 import {
   createBetterAuthSessionForEmail,
   ensureGoogleAuthIdentity,
@@ -646,7 +647,9 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
   const rawPath = queryStart >= 0 ? url.slice(0, queryStart) : url;
   const loginHtml =
     config.getLoginHtml?.(event, rawPath) ?? config.loginHtml ?? null;
-  return loginHtml ? injectLoginSocialImageMeta(loginHtml, event) : null;
+  return loginHtml
+    ? injectLoginSocialImageMeta(injectBetaOptOutPersistence(loginHtml), event)
+    : null;
 }
 
 /**
@@ -2721,7 +2724,9 @@ function injectLoginSocialImageMeta(loginHtml: string, event: H3Event): string {
 
 function loginHtmlResponse(loginHtml: string, event: H3Event): Response {
   return new Response(
-    injectAnalyticsIntoHtml(injectLoginSocialImageMeta(loginHtml, event)),
+    injectAnalyticsIntoHtml(
+      injectLoginSocialImageMeta(injectBetaOptOutPersistence(loginHtml), event),
+    ),
     {
       status: 200,
       headers: {

--- a/packages/core/src/server/beta-opt-out-html.spec.ts
+++ b/packages/core/src/server/beta-opt-out-html.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BETA_OPT_OUT_PERSISTENCE_MARKER,
+  injectBetaOptOutPersistence,
+} from "./beta-opt-out-html.js";
+
+describe("injectBetaOptOutPersistence", () => {
+  it("injects the opt-out handoff into custom auth HTML before authentication", () => {
+    const html = injectBetaOptOutPersistence(
+      "<!doctype html><html><head></head><body><form>Sign in</form></body></html>",
+    );
+
+    expect(html).toContain(BETA_OPT_OUT_PERSISTENCE_MARKER);
+    expect(html).toContain("agentNativeBetaOptOut");
+    expect(html).toContain("agent-native:beta-opt-out-until");
+    expect(html).toContain("window.localStorage.setItem");
+    expect(html).toContain("window.history.replaceState");
+    expect(html.indexOf("data-agent-native-beta-opt-out")).toBeLessThan(
+      html.indexOf("</body>"),
+    );
+  });
+
+  it("does not duplicate the handoff on a second auth response pass", () => {
+    const html = injectBetaOptOutPersistence(
+      "<html><body>Sign in</body></html>",
+    );
+    const reinjected = injectBetaOptOutPersistence(html);
+
+    expect(reinjected).toBe(html);
+    expect(reinjected.match(/data-agent-native-beta-opt-out/g)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/server/beta-opt-out-html.ts
+++ b/packages/core/src/server/beta-opt-out-html.ts
@@ -1,0 +1,66 @@
+import {
+  BETA_OPT_OUT_QUERY_PARAM,
+  BETA_OPT_OUT_STORAGE_KEY,
+} from "../shared/environment-lanes.js";
+
+export const BETA_OPT_OUT_PERSISTENCE_MARKER =
+  "Persist the beta opt-out before authentication";
+
+/**
+ * Custom auth pages do not necessarily use the framework onboarding shell.
+ * Keep the production switcher's one-time opt-out behavior at the shared auth
+ * response boundary so those pages cannot drop the handoff before sign-in.
+ */
+export function injectBetaOptOutPersistence(loginHtml: string): string {
+  if (loginHtml.includes(BETA_OPT_OUT_PERSISTENCE_MARKER)) return loginHtml;
+
+  const script = `<script data-agent-native-beta-opt-out>
+// ${BETA_OPT_OUT_PERSISTENCE_MARKER}.
+(function __anPersistBetaOptOut() {
+  try {
+    var optOutUrl = new URL(window.location.href);
+    var optOutValue = optOutUrl.searchParams.get(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
+    if (optOutValue === null) return;
+    var optOutExpiry = Number(optOutValue);
+    var optOutStorageReady = false;
+    try {
+      if (Number.isFinite(optOutExpiry) && optOutExpiry > Date.now()) {
+        window.localStorage.setItem(
+          ${JSON.stringify(BETA_OPT_OUT_STORAGE_KEY)},
+          String(optOutExpiry),
+        );
+      }
+      optOutStorageReady = true;
+    } catch (error) {
+      void error;
+    }
+    if (optOutStorageReady) {
+      optOutUrl.searchParams.delete(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
+      window.history.replaceState(null, '', optOutUrl.toString());
+    }
+  } catch (error) {
+    void error;
+  }
+})();
+</script>`;
+
+  const bodyCloseIndex = loginHtml.indexOf("</body>");
+  if (bodyCloseIndex >= 0) {
+    return (
+      loginHtml.slice(0, bodyCloseIndex) +
+      script +
+      loginHtml.slice(bodyCloseIndex)
+    );
+  }
+
+  const headCloseIndex = loginHtml.indexOf("</head>");
+  if (headCloseIndex >= 0) {
+    return (
+      loginHtml.slice(0, headCloseIndex) +
+      script +
+      loginHtml.slice(headCloseIndex)
+    );
+  }
+
+  return loginHtml + script;
+}

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -10,6 +10,7 @@ import { parse } from "yaml";
 
 import {
   PRODUCTION_SITE_GROUP,
+  validateProductionPurgeCondition,
   validateReusableWorkflowConcurrency,
   validateProductionSiteConcurrency,
 } from "./guard-netlify-prebuilt-workflow.ts";
@@ -115,6 +116,24 @@ describe("production Netlify site concurrency guard", () => {
       /JSON\.stringify\(\{ site_id: process\.env\.NETLIFY_SITE_ID \}\)/,
     );
     assert.match(String(purge.run), /if \(!response\.ok\)/);
+  });
+
+  it("rejects a purge step that is no longer production-only and success-gated", () => {
+    const workflow = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    const jobs = workflow.jobs as Record<string, Workflow>;
+    const steps = (jobs.deploy.steps as Array<Workflow>).filter(Boolean);
+    const purge = steps.find(
+      (step) => step.name === "Purge the production Netlify cache",
+    );
+
+    assert(purge);
+    const mutatedIf = String(purge.if).replace(
+      "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()",
+      "inputs.deploy",
+    );
+    assert.notDeepEqual(validateProductionPurgeCondition(mutatedIf), []);
   });
 
   it("ignores stale ready deploys after a locked cutover", () => {
@@ -290,6 +309,10 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(
       String(cleanup?.run),
       /process\.env\.cutoverWasPaused !== "true"/,
+    );
+    assert.match(
+      String(cleanup?.run),
+      /!process\.env\.cutoverPublishedDeployId/,
     );
     assert.match(String(cleanup?.run), /currentDeployId === newDeployId/);
     assert.match(String(cleanup?.run), /newly published deploy/);

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -122,6 +122,82 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
+  it("bounds deploy pagination at the recent deploy window", async () => {
+    const unlock = nodeHeredocs[1];
+    const listStart = unlock.indexOf("async function listDeploys");
+    const pendingStart = unlock.indexOf(
+      "function pendingProductionDeploys",
+      listStart,
+    );
+    assert(listStart >= 0 && pendingStart > listStart);
+    const listDeploys = new Function(
+      "request",
+      "readJson",
+      "nextPageUrl",
+      "api",
+      "siteId",
+      `${unlock.slice(listStart, pendingStart)}; return listDeploys;`,
+    )(
+      async (url: string) => {
+        requests.push(url);
+        const page = pages.get(url);
+        assert(page, `unexpected deploy page ${url}`);
+        return {
+          headers: {
+            get: () => page.next,
+          },
+          page: page.deploys,
+        };
+      },
+      async (response: { page: Array<Record<string, unknown>> }) =>
+        response.page,
+      (link: string | null) => link,
+      "https://netlify.test/api",
+      "site-id",
+    ) as (
+      label: string,
+      cutoff: number,
+    ) => Promise<Array<Record<string, unknown>>>;
+    const requests: string[] = [];
+    const pages = new Map([
+      [
+        "https://netlify.test/api/sites/site-id/deploys?per_page=100",
+        {
+          deploys: [{ id: "recent-1", created_at: "2026-08-20T05:00:00Z" }],
+          next: "https://netlify.test/page-2",
+        },
+      ],
+      [
+        "https://netlify.test/page-2",
+        {
+          deploys: [{ id: "recent-2", created_at: "2026-08-20T04:00:00Z" }],
+          next: "https://netlify.test/page-3",
+        },
+      ],
+      [
+        "https://netlify.test/page-3",
+        {
+          deploys: [{ id: "historical", created_at: "2026-08-19T00:00:00Z" }],
+          next: null,
+        },
+      ],
+    ]);
+
+    const deploys = await listDeploys(
+      "test deploy lookup",
+      Date.parse("2026-08-20T02:00:00Z"),
+    );
+    assert.deepEqual(
+      deploys.map((deploy) => deploy.id),
+      ["recent-1", "recent-2", "historical"],
+    );
+    assert.deepEqual(requests, [
+      "https://netlify.test/api/sites/site-id/deploys?per_page=100",
+      "https://netlify.test/page-2",
+      "https://netlify.test/page-3",
+    ]);
+  });
+
   it("restores cutover state before failure lock cleanup", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -275,6 +275,10 @@ describe("production Netlify site concurrency guard", () => {
       "${{ steps.unlock.outputs.published_deploy_id }}",
     );
     assert.equal(
+      (cleanup?.env as Record<string, unknown>).cutoverNewDeployId,
+      "${{ steps.deploy.outputs.deploy_id }}",
+    );
+    assert.equal(
       (cleanup?.env as Record<string, unknown>).cutoverWasLocked,
       "${{ steps.unlock.outputs.was_locked }}",
     );
@@ -287,6 +291,8 @@ describe("production Netlify site concurrency guard", () => {
       String(cleanup?.run),
       /process\.env\.cutoverWasPaused !== "true"/,
     );
+    assert.match(String(cleanup?.run), /currentDeployId === newDeployId/);
+    assert.match(String(cleanup?.run), /newly published deploy/);
   });
 
   it("records cutover acquisition before pause verification", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -216,7 +216,10 @@ describe("production Netlify site concurrency guard", () => {
     );
     assert.equal(typeof resume?.if, "string");
     assert.match(resume?.if as string, /always\(\)/);
-    assert.match(String(resume?.run), /!process\.env\.cutoverWasStopped/);
+    assert.match(
+      String(resume?.run),
+      /process\.env\.cutoverWasStopped !== "true"/,
+    );
     assert.equal(typeof cleanup?.if, "string");
     assert.match(cleanup?.if as string, /failure\(\)/);
     assert.equal(
@@ -228,6 +231,10 @@ describe("production Netlify site concurrency guard", () => {
       "${{ steps.unlock.outputs.was_locked }}",
     );
     assert.doesNotMatch(String(cleanup?.run), /stop_builds/);
+    assert.match(
+      String(cleanup?.run),
+      /process\.env\.cutoverWasStopped !== "true"/,
+    );
   });
 
   it("requires the exact shared queue on deploy, manage, and promote jobs", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -220,7 +220,10 @@ describe("production Netlify site concurrency guard", () => {
       String(resume?.run),
       /process\.env\.cutoverWasPaused !== "true"/,
     );
-    assert.match(String(resume?.run), /process\.env\.cutoverWasStopped === "true"/);
+    assert.match(
+      String(resume?.run),
+      /process\.env\.cutoverWasStopped === "true"/,
+    );
     assert.equal(
       (resume?.env as Record<string, unknown>).cutoverWasStopped,
       "${{ steps.pause.outputs.was_stopped }}",

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -218,7 +218,16 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(resume?.if as string, /always\(\)/);
     assert.match(
       String(resume?.run),
-      /process\.env\.cutoverWasStopped !== "true"/,
+      /process\.env\.cutoverWasPaused !== "true"/,
+    );
+    assert.match(String(resume?.run), /process\.env\.cutoverWasStopped === "true"/);
+    assert.equal(
+      (resume?.env as Record<string, unknown>).cutoverWasStopped,
+      "${{ steps.pause.outputs.was_stopped }}",
+    );
+    assert.equal(
+      (resume?.env as Record<string, unknown>).cutoverWasPaused,
+      "${{ steps.pause.outputs.cutover_acquired }}",
     );
     assert.equal(typeof cleanup?.if, "string");
     assert.match(cleanup?.if as string, /failure\(\)/);
@@ -230,10 +239,14 @@ describe("production Netlify site concurrency guard", () => {
       (cleanup?.env as Record<string, unknown>).cutoverWasLocked,
       "${{ steps.unlock.outputs.was_locked }}",
     );
+    assert.equal(
+      (cleanup?.env as Record<string, unknown>).cutoverWasPaused,
+      "${{ steps.pause.outputs.cutover_acquired }}",
+    );
     assert.doesNotMatch(String(cleanup?.run), /stop_builds/);
     assert.match(
       String(cleanup?.run),
-      /process\.env\.cutoverWasStopped !== "true"/,
+      /process\.env\.cutoverWasPaused !== "true"/,
     );
   });
 

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -59,7 +59,7 @@ describe("production Netlify site concurrency guard", () => {
   });
 
   it("executes every reusable workflow heredoc under the pinned Node loader", () => {
-    assert.equal(nodeHeredocs.length, 6);
+    assert.equal(nodeHeredocs.length, 7);
     const directory = mkdtempSync(
       join(tmpdir(), "agent-native-netlify-heredocs-"),
     );
@@ -79,6 +79,42 @@ describe("production Netlify site concurrency guard", () => {
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
+  });
+
+  it("purges the production cache after smoke and before relocking the deploy", () => {
+    const workflow = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    const jobs = workflow.jobs as Record<string, Workflow>;
+    const steps = (jobs.deploy.steps as Array<Workflow>).filter(Boolean);
+    const smokeIndex = steps.findIndex(
+      (step) => step.name === "Smoke-test the uploaded deploy",
+    );
+    const purgeIndex = steps.findIndex(
+      (step) => step.name === "Purge the production Netlify cache",
+    );
+    const lockIndex = steps.findIndex(
+      (step) => step.name === "Lock the published production deploy",
+    );
+    assert(
+      smokeIndex >= 0 && smokeIndex < purgeIndex && purgeIndex < lockIndex,
+    );
+
+    const purge = steps[purgeIndex];
+    assert.match(String(purge.if), /inputs.target == 'production'/);
+    assert.match(String(purge.if), /inputs.deploy_mode == 'production'/);
+    assert.match(String(purge.if), /success\(\)/);
+    assert.match(
+      String(purge.run),
+      /const api = "https:\/\/api\.netlify\.com\/api\/v1"/,
+    );
+    assert.match(String(purge.run), /fetch\(`\$\{api\}\/purge`/);
+    assert.match(String(purge.run), /method: "POST"/);
+    assert.match(
+      String(purge.run),
+      /JSON\.stringify\(\{ site_id: process\.env\.NETLIFY_SITE_ID \}\)/,
+    );
+    assert.match(String(purge.run), /if \(!response\.ok\)/);
   });
 
   it("ignores stale ready deploys after a locked cutover", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -253,6 +253,16 @@ describe("production Netlify site concurrency guard", () => {
     );
   });
 
+  it("records cutover acquisition before pause verification", () => {
+    const pause = nodeHeredocs[0];
+    const acquiredIndex = pause.indexOf(
+      'fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\\n")',
+    );
+    const verificationIndex = pause.indexOf("const paused =");
+    assert(acquiredIndex >= 0);
+    assert(verificationIndex > acquiredIndex);
+  });
+
   it("requires the exact shared queue on deploy, manage, and promote jobs", () => {
     assert.deepEqual(validateProductionSiteConcurrency(workflows()), []);
   });

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -9,6 +9,7 @@ import { describe, it } from "node:test";
 import { parse } from "yaml";
 
 import {
+  PRODUCTION_PURGE_CONDITION,
   PRODUCTION_SITE_GROUP,
   validateProductionPurgeCondition,
   validateReusableWorkflowConcurrency,
@@ -129,11 +130,15 @@ describe("production Netlify site concurrency guard", () => {
     );
 
     assert(purge);
-    const mutatedIf = String(purge.if).replace(
-      "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()",
-      "inputs.deploy",
-    );
-    assert.notDeepEqual(validateProductionPurgeCondition(mutatedIf), []);
+    assert.equal(String(purge.if), PRODUCTION_PURGE_CONDITION);
+    for (const mutatedIf of [
+      "inputs.target == 'production' && inputs.deploy_mode == 'production' && success()",
+      "inputs.target == 'production' && !inputs.deploy && inputs.deploy_mode == 'production' && success()",
+      "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && !success()",
+      "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' || success()",
+    ]) {
+      assert.notDeepEqual(validateProductionPurgeCondition(mutatedIf), []);
+    }
   });
 
   it("ignores stale ready deploys after a locked cutover", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -312,9 +312,7 @@ const resumeStart = reusable.indexOf(
 const noCutoverStateCheck = 'process.env.cutoverWasPaused !== "true"';
 if (
   resumeStart < 0 ||
-  !reusable
-    .slice(resumeStart, cleanupStart)
-    .includes(noCutoverStateCheck)
+  !reusable.slice(resumeStart, cleanupStart).includes(noCutoverStateCheck)
 ) {
   issues.push(
     `${reusablePath} production resume must leave automatic builds unchanged when pause state was not acquired`,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -293,14 +293,15 @@ const pause = reusable.slice(pauseStart, unlockStart);
 if (
   !pause.includes("stop_builds") ||
   !pause.includes('method: "PATCH"') ||
-  !pause.includes("was_stopped")
+  !pause.includes("was_stopped") ||
+  !pause.includes("cutover_acquired")
 ) {
   issues.push(
     `${reusablePath} production cutovers must pause automatic Netlify builds and preserve the prior stop_builds setting`,
   );
 }
 const cleanup = reusable.slice(cleanupStart);
-if (!cleanup.includes("cutoverWasStopped") || cleanup.includes("stop_builds")) {
+if (!cleanup.includes("cutoverWasPaused") || cleanup.includes("stop_builds")) {
   issues.push(
     `${reusablePath} production cleanup must restore the prior automatic-build setting`,
   );
@@ -308,7 +309,7 @@ if (!cleanup.includes("cutoverWasStopped") || cleanup.includes("stop_builds")) {
 const resumeStart = reusable.indexOf(
   "name: Resume automatic Netlify builds after production cutover",
 );
-const noCutoverStateCheck = 'process.env.cutoverWasStopped !== "true"';
+const noCutoverStateCheck = 'process.env.cutoverWasPaused !== "true"';
 if (
   resumeStart < 0 ||
   !reusable

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -47,6 +47,21 @@ export function validateReusableWorkflowConcurrency(
   return [];
 }
 
+export function validateProductionPurgeCondition(ifValue: unknown): string[] {
+  if (
+    typeof ifValue !== "string" ||
+    !ifValue.includes("inputs.target == 'production'") ||
+    !ifValue.includes("inputs.deploy") ||
+    !ifValue.includes("inputs.deploy_mode == 'production'") ||
+    !ifValue.includes("success()")
+  ) {
+    return [
+      `${reusablePath} production cache purge must run only after a successful production deploy`,
+    ];
+  }
+  return [];
+}
+
 export function validateProductionSiteConcurrency(workflows: {
   production: Record<string, unknown>;
   manage: Record<string, unknown>;
@@ -234,6 +249,9 @@ if (
     `${reusablePath} must always attempt automatic-build restoration after a production cutover`,
   );
 }
+issues.push(
+  ...validateProductionPurgeCondition(reusableSteps[parsedPurgeIndex]?.if),
+);
 
 const uploadStart = reusable.indexOf("name: Upload the prebuilt deploy");
 const uploadEnd = reusable.indexOf(
@@ -352,9 +370,12 @@ if (
     `${reusablePath} production resume must leave automatic builds unchanged when pause state was not acquired`,
   );
 }
-if (!cleanup.includes(noCutoverStateCheck)) {
+if (
+  !cleanup.includes(noCutoverStateCheck) ||
+  !cleanup.includes("!process.env.cutoverPublishedDeployId")
+) {
   issues.push(
-    `${reusablePath} production cleanup must leave lock state unchanged when pause state was not acquired`,
+    `${reusablePath} production cleanup must leave lock state unchanged without a recorded unlock state`,
   );
 }
 if (uploadStart < 0 || uploadEnd <= uploadStart) {

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -177,6 +177,7 @@ const parsedUploadIndex = parsedStepIndex("Upload the prebuilt deploy");
 const parsedPublishWaitIndex = parsedStepIndex(
   "Wait for the Netlify deploy to publish",
 );
+const parsedPurgeIndex = parsedStepIndex("Purge the production Netlify cache");
 const parsedLockIndex = parsedStepIndex("Lock the published production deploy");
 const parsedResumeIndex = parsedStepIndex(
   "Resume automatic Netlify builds after production cutover",
@@ -189,6 +190,7 @@ if (
   parsedUnlockIndex < 0 ||
   parsedUploadIndex < 0 ||
   parsedPublishWaitIndex < 0 ||
+  parsedPurgeIndex < 0 ||
   parsedLockIndex < 0 ||
   parsedResumeIndex < 0 ||
   parsedCleanupIndex < 0
@@ -200,12 +202,13 @@ if (
   parsedPauseIndex >= parsedUnlockIndex ||
   parsedUnlockIndex >= parsedUploadIndex ||
   parsedUploadIndex >= parsedPublishWaitIndex ||
-  parsedPublishWaitIndex >= parsedLockIndex ||
+  parsedPublishWaitIndex >= parsedPurgeIndex ||
+  parsedPurgeIndex >= parsedLockIndex ||
   parsedLockIndex >= parsedResumeIndex ||
   parsedResumeIndex >= parsedCleanupIndex
 ) {
   issues.push(
-    `${reusablePath} parsed YAML steps must order unlock before upload before publish-wait before lock before resume before cleanup`,
+    `${reusablePath} parsed YAML steps must order unlock before upload before publish-wait before purge before lock before resume before cleanup`,
   );
 }
 const parsedUnlockIf = reusableSteps[parsedUnlockIndex]?.if;
@@ -237,6 +240,11 @@ const uploadEnd = reusable.indexOf(
   "name: Wait for the Netlify deploy to publish",
   uploadStart,
 );
+const purgeStart = reusable.indexOf("name: Purge the production Netlify cache");
+const purgeEnd = reusable.indexOf(
+  "name: Lock the published production deploy",
+  purgeStart,
+);
 const unlockStart = reusable.indexOf(
   "name: Unlock the published production deploy",
 );
@@ -260,6 +268,26 @@ if (unlockStart < 0 || (uploadStart >= 0 && unlockStart >= uploadStart)) {
   ) {
     issues.push(
       `${reusablePath} production unlock must handle ready deploys according to the published lock and verify locked=false`,
+    );
+  }
+}
+if (purgeStart < 0 || purgeEnd <= purgeStart) {
+  issues.push(
+    `${reusablePath} must purge the production cache before locking the published deploy`,
+  );
+} else {
+  const purge = reusable.slice(purgeStart, purgeEnd);
+  if (
+    !purge.includes('const api = "https://api.netlify.com/api/v1"') ||
+    !purge.includes("fetch(`${api}/purge`") ||
+    !purge.includes('method: "POST"') ||
+    !purge.includes(
+      "JSON.stringify({ site_id: process.env.NETLIFY_SITE_ID })",
+    ) ||
+    !purge.includes("response.ok")
+  ) {
+    issues.push(
+      `${reusablePath} production cache purge must POST the site_id to Netlify and fail on a non-success response`,
     );
   }
 }

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -310,8 +310,11 @@ if (
   !reusable.slice(lockStart, cleanupStart).includes("published_deploy") ||
   !reusable.slice(cleanupStart).includes("failure()") ||
   !reusable.slice(cleanupStart).includes("cutoverPublishedDeployId") ||
+  !reusable.slice(cleanupStart).includes("cutoverNewDeployId") ||
   !reusable.slice(cleanupStart).includes("cutoverWasLocked") ||
-  !reusable.slice(cleanupStart).includes("/lock")
+  !reusable.slice(cleanupStart).includes("/lock") ||
+  !reusable.slice(cleanupStart).includes("currentDeployId === newDeployId") ||
+  !reusable.slice(cleanupStart).includes("newly published deploy")
 ) {
   issues.push(
     `${reusablePath} must pause automatic builds before cutover, lock the new published deploy, and fail-safe the production lock after cutover errors`,

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -12,6 +12,8 @@ const promotePath = ".github/workflows/promote-netlify-deploy.yml";
 // all three production lanes must therefore share one per-site queue.
 export const PRODUCTION_SITE_GROUP =
   "agent-native-production-site-${{ matrix.site }}";
+export const PRODUCTION_PURGE_CONDITION =
+  "inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()";
 
 const reusable = readFileSync(reusablePath, "utf8");
 const production = readFileSync(productionPath, "utf8");
@@ -48,13 +50,9 @@ export function validateReusableWorkflowConcurrency(
 }
 
 export function validateProductionPurgeCondition(ifValue: unknown): string[] {
-  if (
-    typeof ifValue !== "string" ||
-    !ifValue.includes("inputs.target == 'production'") ||
-    !ifValue.includes("inputs.deploy") ||
-    !ifValue.includes("inputs.deploy_mode == 'production'") ||
-    !ifValue.includes("success()")
-  ) {
+  const normalized =
+    typeof ifValue === "string" ? ifValue.trim().replace(/\s+/g, " ") : "";
+  if (normalized !== PRODUCTION_PURGE_CONDITION) {
     return [
       `${reusablePath} production cache purge must run only after a successful production deploy`,
     ];

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -308,14 +308,20 @@ if (!cleanup.includes("cutoverWasStopped") || cleanup.includes("stop_builds")) {
 const resumeStart = reusable.indexOf(
   "name: Resume automatic Netlify builds after production cutover",
 );
+const noCutoverStateCheck = 'process.env.cutoverWasStopped !== "true"';
 if (
   resumeStart < 0 ||
   !reusable
     .slice(resumeStart, cleanupStart)
-    .includes("!process.env.cutoverWasStopped")
+    .includes(noCutoverStateCheck)
 ) {
   issues.push(
     `${reusablePath} production resume must leave automatic builds unchanged when pause state was not acquired`,
+  );
+}
+if (!cleanup.includes(noCutoverStateCheck)) {
+  issues.push(
+    `${reusablePath} production cleanup must leave lock state unchanged when pause state was not acquired`,
   );
 }
 if (uploadStart < 0 || uploadEnd <= uploadStart) {

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -290,14 +290,17 @@ if (
   );
 }
 const pause = reusable.slice(pauseStart, unlockStart);
+const cutoverAcquiredIndex = pause.indexOf("cutover_acquired=true");
+const pauseVerificationIndex = pause.indexOf("const paused =");
 if (
   !pause.includes("stop_builds") ||
   !pause.includes('method: "PATCH"') ||
   !pause.includes("was_stopped") ||
-  !pause.includes("cutover_acquired")
+  cutoverAcquiredIndex < 0 ||
+  pauseVerificationIndex <= cutoverAcquiredIndex
 ) {
   issues.push(
-    `${reusablePath} production cutovers must pause automatic Netlify builds and preserve the prior stop_builds setting`,
+    `${reusablePath} production cutovers must record acquisition before fallible pause verification and preserve the prior stop_builds setting`,
   );
 }
 const cleanup = reusable.slice(cleanupStart);

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -251,6 +251,9 @@ if (unlockStart < 0 || (uploadStart >= 0 && unlockStart >= uploadStart)) {
     !unlock.includes("locked !== false") ||
     !unlock.includes("/deploys?per_page=100") ||
     !unlock.includes("nextPageUrl") ||
+    !unlock.includes("DEPLOY_LOOKBACK_MS") ||
+    !unlock.includes("oldestCreatedAt") ||
+    !unlock.includes("Date.parse(oldestCreatedAt) < cutoff") ||
     !unlock.includes("readyIsBlocking") ||
     !unlock.includes('candidate.state !== "ready" || readyIsBlocking') ||
     !unlock.includes("candidate.published_at")


### PR DESCRIPTION
## Summary
- treat only an explicit true cutover state as acquired in resume and failure cleanup
- preserve bounded recent deploy pagination and guard coverage

## Validation
- `corepack pnpm test:netlify-prebuilt-workflow` (10/10)
- `corepack pnpm guards` (57/57)
- targeted actionlint