### PR TITLE
docs: group deployment providers in sidebar

### DIFF
--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -83,10 +83,10 @@ describe("DocsSidebar", () => {
     expect(html).not.toContain('aria-controls="docs-sidebar-section-0"');
   });
 
-  it("keeps Deployment last in Overview before FAQ", () => {
+  it("keeps Deployment in its own top-level section with grouped links", () => {
     const sections = getDocsNavSections("en-US");
     const overview = sections.find((section) => section.id === "overview");
-    const buildApps = sections.find((section) => section.id === "build-apps");
+    const deployment = sections.find((section) => section.id === "deployment");
     const coreArchitecture = sections.find(
       (section) => section.id === "core-architecture",
     );
@@ -96,19 +96,41 @@ describe("DocsSidebar", () => {
       "getting-started",
       "what-is-agent-native",
       "key-concepts",
-      "deployment-section",
       "faq",
     ]);
-    const deploymentSection = overview?.items.find(
-      (item) => item.id === "deployment-section",
+    expect(deployment?.items.map((item) => item.id)).toEqual([
+      "deployment",
+      "deploy-an-app",
+      "workspace-deployment",
+      "deployment-providers",
+      "deployment-production",
+    ]);
+    const providerGroup = deployment?.items.find(
+      (item) => item.id === "deployment-providers",
     );
-    expect(deploymentSection).toBeDefined();
-    expect(
-      deploymentSection?.children?.some((item) => item.id === "deployment"),
-    ).toBe(true);
-    expect(
-      buildApps?.items.some((item) => item.id === "deployment-section"),
-    ).toBe(false);
+    expect(providerGroup?.children?.map((item) => item.id)).toEqual([
+      "node-js",
+      "docker",
+      "vercel",
+      "netlify",
+      "cloudflare",
+      "aws-lambda",
+      "deno-deploy",
+      "azure-static-web-apps",
+      "koyeb",
+      "render",
+    ]);
+    const productionGroup = deployment?.items.find(
+      (item) => item.id === "deployment-production",
+    );
+    expect(productionGroup?.children?.map((item) => item.id)).toEqual([
+      "ssr-caching",
+      "deployment-environment-variables",
+      "updating-ui-in-production",
+    ]);
+    expect(sectionIds.indexOf("overview")).toBeLessThan(
+      sectionIds.indexOf("deployment"),
+    );
     const coreItemIds = coreArchitecture?.items.map((item) => item.id) ?? [];
     expect(coreItemIds).toContain("agent-surfaces");
     expect(coreItemIds.indexOf("actions-section")).toBeLessThan(

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -47,24 +47,35 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
       },
       { id: "key-concepts", labelKey: "keyConcepts", slug: "key-concepts" },
       {
-        id: "deployment-section",
-        labelKey: "deployment",
+        id: "faq",
+        labelKey: "faq",
+        slug: "faq",
+      },
+    ],
+  },
+  {
+    id: "deployment",
+    titleKey: "deployment",
+    items: [
+      {
+        id: "deployment",
+        labelKey: "deploymentOverview",
+        slug: "deployment",
+      },
+      {
+        id: "deploy-an-app",
+        labelKey: "deployAnApp",
+        slug: "deploy-an-app",
+      },
+      {
+        id: "workspace-deployment",
+        labelKey: "workspaceDeployment",
+        slug: "workspace-deployment",
+      },
+      {
+        id: "deployment-providers",
+        labelKey: "deploymentProviders",
         children: [
-          {
-            id: "deployment",
-            labelKey: "deploymentOverview",
-            slug: "deployment",
-          },
-          {
-            id: "deploy-an-app",
-            labelKey: "deployAnApp",
-            slug: "deploy-an-app",
-          },
-          {
-            id: "workspace-deployment",
-            labelKey: "workspaceDeployment",
-            slug: "workspace-deployment",
-          },
           {
             id: "node-js",
             labelKey: "deploymentNodeDocker",
@@ -115,6 +126,12 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
             labelKey: "deploymentRender",
             slug: "render",
           },
+        ],
+      },
+      {
+        id: "deployment-production",
+        labelKey: "deploymentProduction",
+        children: [
           { id: "ssr-caching", labelKey: "ssrCaching", slug: "ssr-caching" },
           {
             id: "deployment-environment-variables",
@@ -128,7 +145,6 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
           },
         ],
       },
-      { id: "faq", labelKey: "faq", slug: "faq" },
     ],
   },
   {

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -1541,6 +1541,8 @@ const arSA = {
     fileUploads: "تحميلات الملفات",
     deployment: "Deployment",
     deploymentOverview: "نظرة عامة",
+    deploymentProviders: "المزوّدون",
+    deploymentProduction: "الإنتاج والمتقدم",
     deployAnApp: "نشر تطبيق",
     workspaceDeployment: "نشر مساحة العمل",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -1553,6 +1553,8 @@ const deDE = {
     fileUploads: "Datei-Uploads",
     deployment: "Deployment",
     deploymentOverview: "Überblick",
+    deploymentProviders: "Anbieter",
+    deploymentProduction: "Produktion & erweitert",
     deployAnApp: "Eine App bereitstellen",
     workspaceDeployment: "Workspace-Deployment",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -1543,6 +1543,8 @@ const enUS = {
     fileUploads: "File Uploads",
     deployment: "Deployment",
     deploymentOverview: "Overview",
+    deploymentProviders: "Providers",
+    deploymentProduction: "Production & advanced",
     deployAnApp: "Deploy an app",
     workspaceDeployment: "Workspace Deployment",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -1553,6 +1553,8 @@ const esES = {
     fileUploads: "Subidas de archivos",
     deployment: "Despliegue",
     deploymentOverview: "Resumen",
+    deploymentProviders: "Proveedores",
+    deploymentProduction: "Producción y avanzado",
     deployAnApp: "Desplegar una aplicación",
     workspaceDeployment: "Despliegue del Workspace",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -1554,6 +1554,8 @@ const frFR = {
     fileUploads: "Téléversements",
     deployment: "Déploiement",
     deploymentOverview: "Vue d’ensemble",
+    deploymentProviders: "Fournisseurs",
+    deploymentProduction: "Production et avancé",
     deployAnApp: "Déployer une application",
     workspaceDeployment: "Déploiement du Workspace",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -1543,6 +1543,8 @@ const hiIN = {
     fileUploads: "File uploads",
     deployment: "Deployment",
     deploymentOverview: "अवलोकन",
+    deploymentProviders: "प्रदाता",
+    deploymentProduction: "प्रोडक्शन और उन्नत",
     deployAnApp: "ऐप परिनियोजित करें",
     workspaceDeployment: "वर्कस्पेस परिनियोजन",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -1550,6 +1550,8 @@ const jaJP = {
     fileUploads: "ファイルアップロード",
     deployment: "デプロイ",
     deploymentOverview: "概要",
+    deploymentProviders: "プロバイダー",
+    deploymentProduction: "本番環境と高度な設定",
     deployAnApp: "アプリをデプロイ",
     workspaceDeployment: "ワークスペースのデプロイ",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -1546,6 +1546,8 @@ const koKR = {
     fileUploads: "파일 업로드",
     deployment: "배포",
     deploymentOverview: "개요",
+    deploymentProviders: "프로바이더",
+    deploymentProduction: "프로덕션 및 고급",
     deployAnApp: "앱 배포",
     workspaceDeployment: "워크스페이스 배포",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -1549,6 +1549,8 @@ const ptBR = {
     fileUploads: "Uploads de arquivos",
     deployment: "Deploy",
     deploymentOverview: "Visão geral",
+    deploymentProviders: "Provedores",
+    deploymentProduction: "Produção e avançado",
     deployAnApp: "Fazer deploy de um app",
     workspaceDeployment: "Deploy do Workspace",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -1525,6 +1525,8 @@ const zhCN = {
     fileUploads: "文件上传",
     deployment: "部署",
     deploymentOverview: "概览",
+    deploymentProviders: "提供商",
+    deploymentProduction: "生产与高级",
     deployAnApp: "部署应用",
     workspaceDeployment: "工作区部署",
     deploymentNodeDocker: "Node.js",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -1523,6 +1523,8 @@ const messages = {
     fileUploads: "檔案上傳",
     deployment: "部署",
     deploymentOverview: "總覽",
+    deploymentProviders: "提供者",
+    deploymentProduction: "正式環境與進階",
     deployAnApp: "部署應用程式",
     workspaceDeployment: "工作區部署",
     deploymentNodeDocker: "Node.js",


### PR DESCRIPTION
## Summary

- Move Deployment into its own top-level docs section after Overview.
- Group provider links under Providers and production guidance under Production & advanced.
- Keep localized navigation labels and sidebar coverage tests in sync.

## Validation

- Focused docs Vitest suite: 38 tests passed.
- @agent-native/docs typecheck passed.
- 57 repository guards passed.
- Local browser screenshots verified the collapsed top-level section and expanded Providers group.