### PR TITLE
docs: add stable and Nightly download toggle

### DIFF
--- a/packages/docs/app/components/DownloadPage.test.tsx
+++ b/packages/docs/app/components/DownloadPage.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@agent-native/core/client/api-path", () => ({
+  appBasePath: () => "",
+}));
+
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT: () => (key: string) => {
+    const messages: Record<string, string> = {
+      "downloadPage.title": "Download Agent Native",
+      "downloadPage.body": "All your apps in one desktop shell.",
+      "downloadPage.downloadInstaller": "Download installer",
+      "downloadPage.checkingRelease": "Checking the latest desktop release...",
+      "downloadPage.loadError": "Could not load the latest desktop installer.",
+      "downloadPage.unavailable": "Installer unavailable for this platform",
+      "downloadPage.stable": "Stable",
+      "downloadPage.nightly": "Nightly",
+      "downloadPage.switchToNightly": "Switch to Nightly builds",
+      "downloadPage.switchToStable": "Switch to stable builds",
+      "downloadPage.runFromSource": "Or run from source",
+      "downloadPage.runFromSourceBody": "Run locally.",
+      "downloadPage.platforms.mac.primary": "Download for Apple Silicon",
+      "downloadPage.platforms.mac.alternative": "Intel Mac",
+    };
+    return messages[key] ?? key;
+  },
+}));
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+vi.mock("./TemplateCard", () => ({ trackEvent }));
+
+import DownloadPage from "../routes/download";
+
+const productionManifest = {
+  version: "1.2.3",
+  tag: "v1.2.3",
+  pub_date: "2026-08-20T00:00:00Z",
+  assets: [
+    {
+      name: "Agent-Native-arm64.dmg",
+      url: "https://downloads.example.com/production.dmg",
+      size: 123,
+      kind: "mac-arm64",
+    },
+  ],
+};
+
+const nightlyManifest = {
+  version: "1.2.4-nightly.1",
+  tag: "v1.2.4-nightly.1",
+  pub_date: "2026-08-20T00:00:00Z",
+  assets: [
+    {
+      name: "Agent Native Nightly-arm64.dmg",
+      url: "https://downloads.example.com/nightly.dmg",
+      size: 123,
+      kind: "mac-arm64",
+    },
+  ],
+};
+
+describe("DownloadPage", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)",
+    });
+    fetchMock = vi.fn(async (input: string) => ({
+      ok: true,
+      json: async () =>
+        input.includes("channel=nightly")
+          ? nightlyManifest
+          : productionManifest,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("switches the title and direct installer links between stable and Nightly", async () => {
+    render(<DownloadPage />);
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("link", { name: "Download for Apple Silicon" })
+          .getAttribute("href"),
+      ).toBe(productionManifest.assets[0].url);
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "Download Agent Native" }),
+    ).toBeTruthy();
+    expect(screen.queryByText(productionManifest.version)).toBeNull();
+    expect(screen.queryByText(nightlyManifest.version)).toBeNull();
+    expect(screen.queryByRole("link", { name: /GitHub/i })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Switch to Nightly builds" }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Download Agent Native Nightly" }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("link", { name: "Download for Apple Silicon" })
+          .getAttribute("href"),
+      ).toBe(nightlyManifest.assets[0].url);
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/desktop-latest.json?channel=nightly",
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Switch to stable builds" }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Download Agent Native" }),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("link", { name: "Download for Apple Silicon" })
+          .getAttribute("href"),
+      ).toBe(productionManifest.assets[0].url);
+    });
+  });
+});

--- a/packages/docs/app/components/DownloadPage.test.tsx
+++ b/packages/docs/app/components/DownloadPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@agent-native/core/client/i18n", () => ({
       "downloadPage.downloadInstaller": "Download installer",
       "downloadPage.checkingRelease": "Checking the latest desktop release...",
       "downloadPage.loadError": "Could not load the latest desktop installer.",
+      "downloadPage.retry": "Retry",
       "downloadPage.unavailable": "Installer unavailable for this platform",
       "downloadPage.stable": "Stable",
       "downloadPage.nightly": "Nightly",
@@ -137,6 +138,26 @@ describe("DownloadPage", () => {
     expect(
       screen.getByRole("heading", { name: "Download Agent Native" }),
     ).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("link", { name: "Download for Apple Silicon" })
+          .getAttribute("href"),
+      ).toBe(productionManifest.assets[0].url);
+    });
+  });
+
+  it("offers a retry action when the manifest request fails", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("temporary failure"));
+
+    render(<DownloadPage />);
+
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    expect((retry as HTMLButtonElement).disabled).toBe(false);
+    expect(retry.getAttribute("aria-busy")).toBe("false");
+
+    fireEvent.click(retry);
+
     await waitFor(() => {
       expect(
         screen

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -1226,17 +1226,16 @@ const arSA = {
     body: "كل تطبيقاتك agent-native في واجهة سطح مكتب واحدة. تطبيقات الإنتاج مدمجة، مع تبديل وضع التطوير للتطوير المحلي.",
     openDesktop: "افتح Agent Native",
     downloadInstaller: "تنزيل المثبّت",
-    viewInstallers: "عرض المثبّتات",
-    viewInstallersOnGithub: "عرض المثبّتات على GitHub",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "تعذر تحميل أحدث إصدار لسطح المكتب. تحتوي صفحة releases على كل المثبّتات.",
+    loadError: "تعذر تحميل أحدث مثبّت لسطح المكتب.",
     checkingRelease: "جارٍ التحقق من أحدث إصدار لسطح المكتب...",
-    nightlyBuilds: "هل تبحث عن إصدار Nightly؟",
+    unavailable: "المثبّت غير متاح لهذه المنصة",
+    stable: "مستقر",
+    nightly: "Nightly",
+    switchToNightly: "التبديل إلى إصدارات Nightly",
+    switchToStable: "التبديل إلى الإصدارات المستقرة",
     runFromSource: "أو شغّله من المصدر",
     runFromSourceBody:
       "لا يوجد مثبّت لمنصتك بعد، أو تفضّل CLI؟ أنشئ تطبيقًا جديدًا باستخدام npm وشغّله محليًا — يعمل على macOS وWindows وLinux.",
-    viewAllReleases: "عرض كل releases على GitHub",
     platforms: {
       mac: {
         primary: "تنزيل لإصدار Apple Silicon",

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -1228,6 +1228,7 @@ const arSA = {
     downloadInstaller: "تنزيل المثبّت",
     loadError: "تعذر تحميل أحدث مثبّت لسطح المكتب.",
     checkingRelease: "جارٍ التحقق من أحدث إصدار لسطح المكتب...",
+    retry: "إعادة المحاولة",
     unavailable: "المثبّت غير متاح لهذه المنصة",
     stable: "مستقر",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -1234,17 +1234,16 @@ const deDE = {
     body: "Alle agent-native Apps in einer Desktop-Shell. Produktions-Apps sind integriert, mit Dev-Modus für lokale Entwicklung.",
     openDesktop: "Agent Native öffnen",
     downloadInstaller: "Installer herunterladen",
-    viewInstallers: "Installer ansehen",
-    viewInstallersOnGithub: "Installer auf GitHub ansehen",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "Die neueste Desktop-Version konnte nicht geladen werden. Die Releases-Seite enthält alle Installer.",
+    loadError: "Der neueste Desktop-Installer konnte nicht geladen werden.",
     checkingRelease: "Neueste Desktop-Version wird geprüft...",
-    nightlyBuilds: "Suchst du die Nightly-Version?",
+    unavailable: "Installer für diese Plattform nicht verfügbar",
+    stable: "Stabil",
+    nightly: "Nightly",
+    switchToNightly: "Zu Nightly-Builds wechseln",
+    switchToStable: "Zu stabilen Builds wechseln",
     runFromSource: "Oder aus dem Quellcode starten",
     runFromSourceBody:
       "Noch kein Installer für Ihre Plattform, oder lieber die CLI? Erstellen Sie mit npm eine neue App und führen Sie sie lokal aus; funktioniert auf macOS, Windows und Linux.",
-    viewAllReleases: "Alle Releases auf GitHub ansehen",
     platforms: {
       mac: {
         primary: "Für Apple Silicon herunterladen",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -1236,6 +1236,7 @@ const deDE = {
     downloadInstaller: "Installer herunterladen",
     loadError: "Der neueste Desktop-Installer konnte nicht geladen werden.",
     checkingRelease: "Neueste Desktop-Version wird geprüft...",
+    retry: "Erneut versuchen",
     unavailable: "Installer für diese Plattform nicht verfügbar",
     stable: "Stabil",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -1229,6 +1229,7 @@ const enUS = {
     downloadInstaller: "Download installer",
     loadError: "Could not load the latest desktop installer.",
     checkingRelease: "Checking the latest desktop release...",
+    retry: "Retry",
     unavailable: "Installer unavailable for this platform",
     stable: "Stable",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -1227,17 +1227,16 @@ const enUS = {
     body: "All your agent-native apps in one desktop shell. Production apps built-in, with a dev mode toggle for local development.",
     openDesktop: "Open Agent Native",
     downloadInstaller: "Download installer",
-    viewInstallers: "View installers",
-    viewInstallersOnGithub: "View installers on GitHub",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "Could not load the latest desktop release. The releases page has all installers.",
+    loadError: "Could not load the latest desktop installer.",
     checkingRelease: "Checking the latest desktop release...",
-    nightlyBuilds: "Looking for the Nightly build?",
+    unavailable: "Installer unavailable for this platform",
+    stable: "Stable",
+    nightly: "Nightly",
+    switchToNightly: "Switch to Nightly builds",
+    switchToStable: "Switch to stable builds",
     runFromSource: "Or run from source",
     runFromSourceBody:
       "No installer for your platform yet, or prefer the CLI? Scaffold a new app with npm and run it locally — works on macOS, Windows, and Linux.",
-    viewAllReleases: "View all releases on GitHub",
     platforms: {
       mac: {
         primary: "Download for Apple Silicon",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -1234,17 +1234,16 @@ const esES = {
     body: "Todas tus apps agent-native en una sola shell de escritorio. Apps de producción integradas, con un modo de desarrollo para trabajo local.",
     openDesktop: "Abrir Agent Native",
     downloadInstaller: "Descargar instalador",
-    viewInstallers: "Ver instaladores",
-    viewInstallersOnGithub: "Ver instaladores en GitHub",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "No se pudo cargar la última versión de escritorio. La página de releases incluye todos los instaladores.",
+    loadError: "No se pudo cargar el instalador de escritorio más reciente.",
     checkingRelease: "Buscando la versión de escritorio más reciente...",
-    nightlyBuilds: "¿Buscas la versión Nightly?",
+    unavailable: "Instalador no disponible para esta plataforma",
+    stable: "Estable",
+    nightly: "Nightly",
+    switchToNightly: "Cambiar a las compilaciones Nightly",
+    switchToStable: "Cambiar a las compilaciones estables",
     runFromSource: "O ejecutar desde el código fuente",
     runFromSourceBody:
       "¿Aún no hay instalador para tu plataforma o prefieres la CLI? Crea una app nueva con npm y ejecútala localmente; funciona en macOS, Windows y Linux.",
-    viewAllReleases: "Ver todas las releases en GitHub",
     platforms: {
       mac: {
         primary: "Descargar para Apple Silicon",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -1236,6 +1236,7 @@ const esES = {
     downloadInstaller: "Descargar instalador",
     loadError: "No se pudo cargar el instalador de escritorio más reciente.",
     checkingRelease: "Buscando la versión de escritorio más reciente...",
+    retry: "Reintentar",
     unavailable: "Instalador no disponible para esta plataforma",
     stable: "Estable",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -1234,17 +1234,16 @@ const frFR = {
     body: "Toutes vos apps agent-native dans une seule interface de bureau. Apps de production intégrées, avec un mode dev pour le développement local.",
     openDesktop: "Ouvrir Agent Native",
     downloadInstaller: "Télécharger l'installateur",
-    viewInstallers: "Voir les installateurs",
-    viewInstallersOnGithub: "Voir les installateurs sur GitHub",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "Impossible de charger la dernière version desktop. La page des releases contient tous les installateurs.",
+    loadError: "Impossible de charger le dernier installateur desktop.",
     checkingRelease: "Recherche de la dernière version desktop...",
-    nightlyBuilds: "Vous cherchez la version Nightly ?",
+    unavailable: "Installateur indisponible pour cette plateforme",
+    stable: "Stable",
+    nightly: "Nightly",
+    switchToNightly: "Passer aux builds Nightly",
+    switchToStable: "Passer aux builds stables",
     runFromSource: "Ou lancer depuis le code source",
     runFromSourceBody:
       "Pas encore d'installateur pour votre plateforme, ou vous préférez la CLI ? Créez une nouvelle app avec npm et lancez-la localement; fonctionne sur macOS, Windows et Linux.",
-    viewAllReleases: "Voir toutes les releases sur GitHub",
     platforms: {
       mac: {
         primary: "Télécharger pour Apple Silicon",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -1236,6 +1236,7 @@ const frFR = {
     downloadInstaller: "Télécharger l'installateur",
     loadError: "Impossible de charger le dernier installateur desktop.",
     checkingRelease: "Recherche de la dernière version desktop...",
+    retry: "Réessayer",
     unavailable: "Installateur indisponible pour cette plateforme",
     stable: "Stable",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -1229,6 +1229,7 @@ const hiIN = {
     downloadInstaller: "Installer डाउनलोड करें",
     loadError: "नवीनतम desktop installer लोड नहीं हो सका।",
     checkingRelease: "नवीनतम desktop release जांच रहे हैं...",
+    retry: "फिर कोशिश करें",
     unavailable: "इस platform के लिए installer उपलब्ध नहीं है",
     stable: "स्थिर",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -1227,17 +1227,16 @@ const hiIN = {
     body: "आपके सभी agent-native ऐप एक ही desktop shell में। Production apps built-in हैं, और local development के लिए dev mode toggle है।",
     openDesktop: "Agent Native खोलें",
     downloadInstaller: "Installer डाउनलोड करें",
-    viewInstallers: "Installers देखें",
-    viewInstallersOnGithub: "GitHub पर installers देखें",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "नवीनतम desktop release लोड नहीं हो सका। releases page में सभी installers हैं।",
+    loadError: "नवीनतम desktop installer लोड नहीं हो सका।",
     checkingRelease: "नवीनतम desktop release जांच रहे हैं...",
-    nightlyBuilds: "Nightly बिल्ड चाहिए?",
+    unavailable: "इस platform के लिए installer उपलब्ध नहीं है",
+    stable: "स्थिर",
+    nightly: "Nightly",
+    switchToNightly: "Nightly builds पर जाएं",
+    switchToStable: "स्थिर builds पर जाएं",
     runFromSource: "या source से चलाएं",
     runFromSourceBody:
       "आपके platform के लिए अभी installer नहीं है, या CLI पसंद है? npm से नया app scaffold करें और local चलाएं — macOS, Windows और Linux पर काम करता है।",
-    viewAllReleases: "GitHub पर सभी releases देखें",
     platforms: {
       mac: {
         primary: "Apple Silicon के लिए डाउनलोड करें",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -1232,6 +1232,7 @@ const jaJP = {
     downloadInstaller: "インストーラーをダウンロード",
     loadError: "最新のデスクトップインストーラーを読み込めませんでした。",
     checkingRelease: "最新のデスクトップリリースを確認しています...",
+    retry: "再試行",
     unavailable: "このプラットフォームではインストーラーを利用できません",
     stable: "安定版",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -1230,17 +1230,16 @@ const jaJP = {
     body: "すべての agent-native アプリを 1 つのデスクトップシェルに集約。プロダクションアプリを内蔵し、ローカル開発向けの dev モード切り替えも備えています。",
     openDesktop: "Agent Native を開く",
     downloadInstaller: "インストーラーをダウンロード",
-    viewInstallers: "インストーラーを表示",
-    viewInstallersOnGithub: "GitHub でインストーラーを表示",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "最新のデスクトップリリースを読み込めませんでした。releases ページにすべてのインストーラーがあります。",
+    loadError: "最新のデスクトップインストーラーを読み込めませんでした。",
     checkingRelease: "最新のデスクトップリリースを確認しています...",
-    nightlyBuilds: "Nightly ビルドをお探しですか？",
+    unavailable: "このプラットフォームではインストーラーを利用できません",
+    stable: "安定版",
+    nightly: "Nightly",
+    switchToNightly: "Nightly ビルドに切り替え",
+    switchToStable: "安定版ビルドに切り替え",
     runFromSource: "またはソースから実行",
     runFromSourceBody:
       "お使いのプラットフォーム向けインストーラーがまだない場合、または CLI を使いたい場合は、npm で新しいアプリを作成してローカル実行できます。macOS、Windows、Linux で動作します。",
-    viewAllReleases: "GitHub ですべての releases を表示",
     platforms: {
       mac: {
         primary: "Apple Silicon 向けをダウンロード",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -1230,17 +1230,16 @@ const koKR = {
     body: "모든 agent-native 앱을 하나의 데스크톱 셸에서 사용하세요. 프로덕션 앱이 내장되어 있고 로컬 개발용 dev 모드 토글이 있습니다.",
     openDesktop: "Agent Native 열기",
     downloadInstaller: "설치 프로그램 다운로드",
-    viewInstallers: "설치 프로그램 보기",
-    viewInstallersOnGithub: "GitHub에서 설치 프로그램 보기",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "최신 데스크톱 릴리스를 불러올 수 없습니다. releases 페이지에 모든 설치 프로그램이 있습니다.",
+    loadError: "최신 데스크톱 설치 프로그램을 불러올 수 없습니다.",
     checkingRelease: "최신 데스크톱 릴리스를 확인하는 중...",
-    nightlyBuilds: "Nightly 빌드를 찾고 계신가요?",
+    unavailable: "이 플랫폼에서는 설치 프로그램을 사용할 수 없습니다",
+    stable: "안정",
+    nightly: "Nightly",
+    switchToNightly: "Nightly 빌드로 전환",
+    switchToStable: "안정 빌드로 전환",
     runFromSource: "또는 소스에서 실행",
     runFromSourceBody:
       "아직 해당 플랫폼용 설치 프로그램이 없거나 CLI를 선호하시나요? npm으로 새 앱을 스캐폴드하고 로컬에서 실행하세요. macOS, Windows, Linux에서 작동합니다.",
-    viewAllReleases: "GitHub에서 모든 releases 보기",
     platforms: {
       mac: {
         primary: "Apple Silicon용 다운로드",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -1232,6 +1232,7 @@ const koKR = {
     downloadInstaller: "설치 프로그램 다운로드",
     loadError: "최신 데스크톱 설치 프로그램을 불러올 수 없습니다.",
     checkingRelease: "최신 데스크톱 릴리스를 확인하는 중...",
+    retry: "다시 시도",
     unavailable: "이 플랫폼에서는 설치 프로그램을 사용할 수 없습니다",
     stable: "안정",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -1232,6 +1232,7 @@ const ptBR = {
     downloadInstaller: "Baixar instalador",
     loadError: "Não foi possível carregar o instalador desktop mais recente.",
     checkingRelease: "Verificando a versão desktop mais recente...",
+    retry: "Tentar novamente",
     unavailable: "Instalador indisponível para esta plataforma",
     stable: "Estável",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -1230,17 +1230,16 @@ const ptBR = {
     body: "Todos os seus apps agent-native em uma única shell de desktop. Apps de produção integrados, com alternância de modo dev para desenvolvimento local.",
     openDesktop: "Abrir Agent Native",
     downloadInstaller: "Baixar instalador",
-    viewInstallers: "Ver instaladores",
-    viewInstallersOnGithub: "Ver instaladores no GitHub",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError:
-      "Não foi possível carregar a versão desktop mais recente. A página de releases tem todos os instaladores.",
+    loadError: "Não foi possível carregar o instalador desktop mais recente.",
     checkingRelease: "Verificando a versão desktop mais recente...",
-    nightlyBuilds: "Procurando a versão Nightly?",
+    unavailable: "Instalador indisponível para esta plataforma",
+    stable: "Estável",
+    nightly: "Nightly",
+    switchToNightly: "Mudar para builds Nightly",
+    switchToStable: "Mudar para builds estáveis",
     runFromSource: "Ou executar a partir do código-fonte",
     runFromSourceBody:
       "Ainda não há instalador para sua plataforma, ou prefere a CLI? Crie um novo app com npm e rode localmente; funciona em macOS, Windows e Linux.",
-    viewAllReleases: "Ver todas as releases no GitHub",
     platforms: {
       mac: {
         primary: "Baixar para Apple Silicon",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -1217,16 +1217,16 @@ const zhCN = {
     body: "所有 agent-native 应用都在一个桌面外壳中。内置生产应用，并提供用于本地开发的开发模式开关。",
     openDesktop: "打开 Agent Native",
     downloadInstaller: "下载安装程序",
-    viewInstallers: "查看安装程序",
-    viewInstallersOnGithub: "在 GitHub 查看安装程序",
-    latestRelease: "Latest desktop release: {{version}}",
-    loadError: "无法加载最新桌面版。releases 页面包含所有安装程序。",
+    loadError: "无法加载最新桌面安装程序。",
     checkingRelease: "正在检查最新桌面版...",
-    nightlyBuilds: "想要 Nightly 版本？",
+    unavailable: "此平台暂无安装程序",
+    stable: "稳定版",
+    nightly: "Nightly",
+    switchToNightly: "切换到 Nightly 构建",
+    switchToStable: "切换到稳定版构建",
     runFromSource: "或从源码运行",
     runFromSourceBody:
       "还没有适用于你平台的安装程序，或更喜欢 CLI？使用 npm 创建新应用并在本地运行；支持 macOS、Windows 和 Linux。",
-    viewAllReleases: "在 GitHub 查看所有 releases",
     platforms: {
       mac: {
         primary: "下载 Apple Silicon 版本",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -1219,6 +1219,7 @@ const zhCN = {
     downloadInstaller: "下载安装程序",
     loadError: "无法加载最新桌面安装程序。",
     checkingRelease: "正在检查最新桌面版...",
+    retry: "重试",
     unavailable: "此平台暂无安装程序",
     stable: "稳定版",
     nightly: "Nightly",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -1215,16 +1215,16 @@ const messages = {
     body: "所有 agent-native 應用都在一個桌面外殼中。內建正式環境應用，並提供用於本機開發的開發模式開關。",
     openDesktop: "開啟 Agent Native",
     downloadInstaller: "下載安裝程式",
-    viewInstallers: "檢視安裝程式",
-    viewInstallersOnGithub: "在 GitHub 檢視安裝程式",
-    latestRelease: "最新桌面版：{{version}}",
-    loadError: "無法載入最新桌面版。releases 頁面包含所有安裝程式。",
+    loadError: "無法載入最新桌面安裝程式。",
     checkingRelease: "正在檢查最新桌面版...",
-    nightlyBuilds: "想要 Nightly 版本嗎？",
+    unavailable: "此平台沒有可用的安裝程式",
+    stable: "穩定版",
+    nightly: "Nightly",
+    switchToNightly: "切換至 Nightly 建置",
+    switchToStable: "切換至穩定版建置",
     runFromSource: "或從來源碼執行",
     runFromSourceBody:
       "還沒有適用於你平台的安裝程式，或更喜歡 CLI？使用 npm 建立新應用並在本機執行；支援 macOS、Windows 和 Linux。",
-    viewAllReleases: "在 GitHub 檢視所有 releases",
     platforms: {
       mac: {
         primary: "下載 Apple Silicon 版本",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -1217,6 +1217,7 @@ const messages = {
     downloadInstaller: "下載安裝程式",
     loadError: "無法載入最新桌面安裝程式。",
     checkingRelease: "正在檢查最新桌面版...",
+    retry: "重試",
     unavailable: "此平台沒有可用的安裝程式",
     stable: "穩定版",
     nightly: "Nightly",

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -3,7 +3,6 @@ import { useT } from "@agent-native/core/client/i18n";
 import {
   IconAppWindow,
   IconBrandApple,
-  IconBrandGithub,
   IconBrandWindows,
   IconDownload,
   IconTerminal2,
@@ -13,14 +12,11 @@ import { useEffect, useMemo, useState } from "react";
 import { trackEvent } from "../components/TemplateCard";
 
 const LATEST_JSON_URL = `${appBasePath()}/api/desktop-latest.json`;
-const RELEASES =
-  "https://github.com/BuilderIO/agent-native/releases?q=Agent-Native";
-const NIGHTLY_RELEASES =
-  "https://github.com/BuilderIO/agent-native/releases?q=Agent+Native+Nightly";
 const OPEN_DESKTOP_URL = "agentnative://open";
-const MANIFEST_STORAGE_KEY = "agent-native-desktop-download-manifest-v1";
+const MANIFEST_STORAGE_KEY = "agent-native-desktop-download-manifest-v2";
 
 type Platform = "mac" | "windows" | "linux";
+type DesktopReleaseChannel = "production" | "nightly";
 type DesktopAssetKind =
   | "mac-arm64"
   | "mac-x64"
@@ -132,10 +128,14 @@ function isManifest(value: unknown): value is Manifest {
   );
 }
 
-function readCachedManifest(): Manifest | null {
+function manifestStorageKey(channel: DesktopReleaseChannel): string {
+  return `${MANIFEST_STORAGE_KEY}-${channel}`;
+}
+
+function readCachedManifest(channel: DesktopReleaseChannel): Manifest | null {
   if (typeof window === "undefined") return null;
   try {
-    const cached = window.localStorage.getItem(MANIFEST_STORAGE_KEY);
+    const cached = window.localStorage.getItem(manifestStorageKey(channel));
     if (!cached) return null;
     const parsed: unknown = JSON.parse(cached);
     return isManifest(parsed) ? parsed : null;
@@ -144,10 +144,16 @@ function readCachedManifest(): Manifest | null {
   }
 }
 
-function writeCachedManifest(manifest: Manifest): void {
+function writeCachedManifest(
+  channel: DesktopReleaseChannel,
+  manifest: Manifest,
+): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(MANIFEST_STORAGE_KEY, JSON.stringify(manifest));
+    window.localStorage.setItem(
+      manifestStorageKey(channel),
+      JSON.stringify(manifest),
+    );
   } catch {
     // Storage can be unavailable in private browsing or locked-down contexts.
   }
@@ -173,6 +179,7 @@ function pickAsset(manifest: Manifest | null, option: DownloadOption) {
 export default function DownloadPage() {
   const t = useT();
   const [platform, setPlatform] = useState<Platform>("mac");
+  const [channel, setChannel] = useState<DesktopReleaseChannel>("production");
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
   const [isDesktopApp, setIsDesktopApp] = useState(false);
@@ -184,12 +191,15 @@ export default function DownloadPage() {
 
   useEffect(() => {
     let cancelled = false;
-    const cachedManifest = readCachedManifest();
-    if (cachedManifest) {
-      setManifest(cachedManifest);
-    }
+    const cachedManifest = readCachedManifest(channel);
+    setManifest(cachedManifest);
+    setManifestError(false);
+    const manifestUrl =
+      channel === "nightly"
+        ? `${LATEST_JSON_URL}?channel=nightly`
+        : LATEST_JSON_URL;
 
-    fetch(LATEST_JSON_URL)
+    fetch(manifestUrl)
       .then((response) =>
         response.ok ? response.json() : Promise.reject(new Error("failed")),
       )
@@ -198,7 +208,7 @@ export default function DownloadPage() {
         if (!cancelled) {
           setManifest(json);
           setManifestError(false);
-          writeCachedManifest(json);
+          writeCachedManifest(channel, json);
         }
       })
       .catch(() => {
@@ -207,8 +217,9 @@ export default function DownloadPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [channel]);
 
+  const isNightly = channel === "nightly";
   const info = PLATFORMS[platform];
   const downloads = useMemo(() => {
     const options = [info.primary, ...(info.alternatives ?? [])];
@@ -222,26 +233,33 @@ export default function DownloadPage() {
   const primaryAsset = primaryDownload?.asset ?? null;
   const alternativeDownloads = downloads.filter(
     (download) =>
-      download.option !== primaryDownload?.option &&
-      (download.asset || !manifest || manifestError),
+      download.option !== primaryDownload?.option && Boolean(download.asset),
   );
-  const releaseStatus = manifest
-    ? t("downloadPage.latestRelease", { version: manifest.version })
-    : manifestError
-      ? t("downloadPage.loadError")
-      : t("downloadPage.checkingRelease");
-  const primaryHref = primaryAsset?.url ?? RELEASES;
+  const releaseStatus = manifestError
+    ? t("downloadPage.loadError")
+    : !manifest
+      ? t("downloadPage.checkingRelease")
+      : null;
   const primaryLabel = primaryAsset
     ? t(primaryDownload?.option.labelKey ?? info.primary.labelKey)
-    : manifestError || !manifest
-      ? t("downloadPage.viewInstallersOnGithub")
-      : t(primaryDownload?.option.labelKey ?? info.primary.labelKey);
+    : manifestError
+      ? t("downloadPage.loadError")
+      : !manifest
+        ? t("downloadPage.checkingRelease")
+        : t("downloadPage.unavailable");
   const desktopDownloadLabel = primaryAsset
     ? t("downloadPage.downloadInstaller")
-    : t("downloadPage.viewInstallers");
+    : primaryLabel;
+
+  function handleChannelChange(nextChannel: DesktopReleaseChannel) {
+    if (nextChannel === channel) return;
+    setManifest(null);
+    setManifestError(false);
+    setChannel(nextChannel);
+  }
 
   function handleDownload(label: string) {
-    trackEvent("desktop download", { platform, label });
+    trackEvent("desktop download", { channel, platform, label });
   }
 
   function handleOpenDesktop() {
@@ -253,6 +271,14 @@ export default function DownloadPage() {
       <div className="mb-14 text-center">
         <h1 className="mb-3 text-3xl font-bold tracking-tight md:text-4xl">
           {t("downloadPage.title")}
+          {isNightly && (
+            <>
+              {" "}
+              <span className="text-blue-600 dark:text-blue-400">
+                {t("downloadPage.nightly")}
+              </span>
+            </>
+          )}
         </h1>
         <p className="mx-auto max-w-xl text-base leading-relaxed text-[var(--fg-secondary)]">
           {t("downloadPage.body")}
@@ -297,24 +323,40 @@ export default function DownloadPage() {
             </a>
           )}
 
-          <a
-            href={primaryHref}
-            onClick={() =>
-              handleDownload(
-                primaryDownload?.option.labelKey
-                  ? t(primaryDownload.option.labelKey)
-                  : t(info.primary.labelKey),
-              )
-            }
-            className={
-              isDesktopApp
-                ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline hover:bg-[var(--sidebar-hover)] hover:no-underline"
-                : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
-            }
-          >
-            <IconDownload size={18} />
-            {isDesktopApp ? desktopDownloadLabel : primaryLabel}
-          </a>
+          {primaryAsset ? (
+            <a
+              href={primaryAsset.url}
+              onClick={() =>
+                handleDownload(
+                  primaryDownload?.option.labelKey
+                    ? t(primaryDownload.option.labelKey)
+                    : t(info.primary.labelKey),
+                )
+              }
+              className={
+                isDesktopApp
+                  ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline hover:bg-[var(--sidebar-hover)] hover:no-underline"
+                  : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
+              }
+            >
+              <IconDownload size={18} />
+              {isDesktopApp ? desktopDownloadLabel : primaryLabel}
+            </a>
+          ) : (
+            <button
+              type="button"
+              disabled
+              aria-busy={!manifest}
+              className={`inline-flex cursor-not-allowed items-center gap-2.5 rounded-lg px-8 py-3.5 text-base font-medium opacity-60 ${
+                isDesktopApp
+                  ? "border border-[var(--docs-border)] text-[var(--fg)]"
+                  : "bg-[var(--fg)] text-[var(--bg)]"
+              }`}
+            >
+              <IconDownload size={18} />
+              {isDesktopApp ? desktopDownloadLabel : primaryLabel}
+            </button>
+          )}
         </div>
 
         {alternativeDownloads.length > 0 && (
@@ -322,7 +364,7 @@ export default function DownloadPage() {
             {alternativeDownloads.map(({ option, asset }) => (
               <a
                 key={option.labelKey}
-                href={asset?.url ?? RELEASES}
+                href={asset!.url}
                 onClick={() => handleDownload(t(option.labelKey))}
                 className="text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)] hover:underline"
               >
@@ -332,18 +374,53 @@ export default function DownloadPage() {
           </div>
         )}
 
-        <p className="mt-4 text-xs text-[var(--fg-secondary)]">
-          {releaseStatus}
-          {info.note && <span className="block mt-1">{t(info.note)}</span>}
-        </p>
-        <a
-          href={NIGHTLY_RELEASES}
-          target="_blank"
-          rel="noreferrer"
-          className="mt-2 inline-block text-[11px] text-[var(--fg-secondary)] opacity-70 no-underline hover:text-[var(--fg)] hover:opacity-100 hover:underline"
-        >
-          {t("downloadPage.nightlyBuilds")}
-        </a>
+        {releaseStatus && (
+          <p className="mt-4 text-xs text-[var(--fg-secondary)]">
+            {releaseStatus}
+          </p>
+        )}
+        {info.note && (
+          <p className="mt-4 text-xs text-[var(--fg-secondary)]">
+            {t(info.note)}
+          </p>
+        )}
+        <div className="mt-5 flex justify-center">
+          <div className="flex items-center gap-2 text-xs text-[var(--fg-secondary)]">
+            <span>{t("downloadPage.stable")}</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isNightly}
+              aria-label={t(
+                isNightly
+                  ? "downloadPage.switchToStable"
+                  : "downloadPage.switchToNightly",
+              )}
+              onClick={() =>
+                handleChannelChange(isNightly ? "production" : "nightly")
+              }
+              className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-[var(--docs-border)] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${
+                isNightly ? "bg-blue-600" : "bg-[var(--sidebar-hover)]"
+              }`}
+            >
+              <span
+                aria-hidden="true"
+                className={`block size-3.5 rounded-full bg-white shadow-sm transition-transform ${
+                  isNightly ? "translate-x-[18px]" : "translate-x-[2px]"
+                }`}
+              />
+            </button>
+            <span
+              className={
+                isNightly
+                  ? "font-medium text-blue-600 dark:text-blue-400"
+                  : "text-blue-600 dark:text-blue-400"
+              }
+            >
+              {t("downloadPage.nightly")}
+            </span>
+          </div>
+        </div>
       </div>
 
       {/* Run from source */}
@@ -362,19 +439,6 @@ cd my-platform
 pnpm install && pnpm dev`}</code>
           </pre>
         </div>
-      </div>
-
-      {/* All releases link */}
-      <div className="mt-12 text-center">
-        <a
-          href="https://github.com/BuilderIO/agent-native/releases"
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-2 text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)]"
-        >
-          <IconBrandGithub size={16} />
-          {t("downloadPage.viewAllReleases")}
-        </a>
       </div>
     </main>
   );

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -182,6 +182,7 @@ export default function DownloadPage() {
   const [channel, setChannel] = useState<DesktopReleaseChannel>("production");
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
+  const [manifestRequest, setManifestRequest] = useState(0);
   const [isDesktopApp, setIsDesktopApp] = useState(false);
 
   useEffect(() => {
@@ -217,7 +218,7 @@ export default function DownloadPage() {
     return () => {
       cancelled = true;
     };
-  }, [channel]);
+  }, [channel, manifestRequest]);
 
   const isNightly = channel === "nightly";
   const info = PLATFORMS[platform];
@@ -243,19 +244,26 @@ export default function DownloadPage() {
   const primaryLabel = primaryAsset
     ? t(primaryDownload?.option.labelKey ?? info.primary.labelKey)
     : manifestError
-      ? t("downloadPage.loadError")
+      ? t("downloadPage.retry")
       : !manifest
         ? t("downloadPage.checkingRelease")
         : t("downloadPage.unavailable");
   const desktopDownloadLabel = primaryAsset
     ? t("downloadPage.downloadInstaller")
     : primaryLabel;
+  const isManifestLoading = !manifest && !manifestError;
 
   function handleChannelChange(nextChannel: DesktopReleaseChannel) {
     if (nextChannel === channel) return;
     setManifest(null);
     setManifestError(false);
     setChannel(nextChannel);
+  }
+
+  function handleRetry() {
+    setManifest(null);
+    setManifestError(false);
+    setManifestRequest((request) => request + 1);
   }
 
   function handleDownload(label: string) {
@@ -345,13 +353,20 @@ export default function DownloadPage() {
           ) : (
             <button
               type="button"
-              disabled
-              aria-busy={!manifest}
-              className={`inline-flex cursor-not-allowed items-center gap-2.5 rounded-lg px-8 py-3.5 text-base font-medium opacity-60 ${
-                isDesktopApp
-                  ? "border border-[var(--docs-border)] text-[var(--fg)]"
-                  : "bg-[var(--fg)] text-[var(--bg)]"
-              }`}
+              onClick={manifestError ? handleRetry : undefined}
+              disabled={!manifestError}
+              aria-busy={isManifestLoading}
+              className={
+                manifestError
+                  ? isDesktopApp
+                    ? "inline-flex items-center gap-2.5 rounded-lg border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] hover:bg-[var(--sidebar-hover)]"
+                    : "inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] hover:opacity-85"
+                  : `inline-flex cursor-not-allowed items-center gap-2.5 rounded-lg px-8 py-3.5 text-base font-medium opacity-60 ${
+                      isDesktopApp
+                        ? "border border-[var(--docs-border)] text-[var(--fg)]"
+                        : "bg-[var(--fg)] text-[var(--bg)]"
+                    }`
+              }
             >
               <IconDownload size={18} />
               {isDesktopApp ? desktopDownloadLabel : primaryLabel}

--- a/packages/docs/server/routes/api/desktop-latest.json.get.spec.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getQuery: (event: { query?: Record<string, unknown> }) => event.query ?? {},
+  setResponseHeaders: (
+    event: { headers: Record<string, string> },
+    headers: Record<string, string>,
+  ) => {
+    event.headers = { ...event.headers, ...headers };
+  },
+  setResponseStatus: () => undefined,
+  createError: (options: { statusCode: number; statusMessage?: string }) =>
+    Object.assign(new Error(options.statusMessage), options),
+}));
+
+import { resetDesktopDownloadManifestCacheForTests } from "../../../lib/desktop-releases";
+import handler from "./desktop-latest.json.get";
+
+function jsonResponse(json: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => json,
+  } as Response;
+}
+
+function createEvent(query: Record<string, unknown> = {}) {
+  return { query, headers: {} as Record<string, string> };
+}
+
+describe("desktop latest manifest route", () => {
+  beforeEach(() => {
+    resetDesktopDownloadManifestCacheForTests();
+  });
+
+  afterEach(() => {
+    resetDesktopDownloadManifestCacheForTests();
+    vi.unstubAllGlobals();
+  });
+
+  it("serves the Nightly manifest when requested by the download page", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse([
+        {
+          tag_name: "v1.2.4-nightly.1",
+          name: "Agent Native Nightly v1.2.4-nightly.1",
+          published_at: "2026-08-20T00:00:00Z",
+          draft: false,
+          prerelease: true,
+          assets: [
+            {
+              name: "Agent Native Nightly-arm64.dmg",
+              browser_download_url: "https://downloads.example.com/nightly.dmg",
+              size: 123,
+            },
+          ],
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const event = createEvent({ channel: "nightly" });
+    const manifest = await handler(event as never);
+
+    expect(manifest).toMatchObject({
+      version: "1.2.4-nightly.1",
+      tag: "v1.2.4-nightly.1",
+    });
+    if (!manifest || !("assets" in manifest)) {
+      throw new Error("Expected a desktop download manifest");
+    }
+    expect(manifest.assets[0]).toMatchObject({
+      url: "https://downloads.example.com/nightly.dmg",
+      kind: "mac-arm64",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(event.headers).toMatchObject({
+      "cache-control":
+        "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+    });
+  });
+});

--- a/packages/docs/server/routes/api/desktop-latest.json.get.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.ts
@@ -1,4 +1,9 @@
-import { defineEventHandler, setResponseHeaders, setResponseStatus } from "h3";
+import {
+  defineEventHandler,
+  getQuery,
+  setResponseHeaders,
+  setResponseStatus,
+} from "h3";
 
 import {
   DESKTOP_RELEASE_CACHE_HEADERS,
@@ -8,9 +13,11 @@ import {
 } from "../../../lib/desktop-releases";
 
 export default defineEventHandler(async (event) => {
+  const channel =
+    getQuery(event).channel === "nightly" ? "nightly" : "production";
   let manifest: DesktopDownloadManifest;
   try {
-    manifest = await getDesktopDownloadManifest();
+    manifest = await getDesktopDownloadManifest(channel);
   } catch (error) {
     const e = getDesktopReleaseError(error);
     setResponseStatus(event, e.statusCode, e.statusMessage);


### PR DESCRIPTION
## Summary
- replace the release-page link and visible version noise with a compact Stable/Nightly switch
- load channel-specific manifests and link download buttons directly to the selected installer assets
- keep the Nightly title accent blue and add UI/API coverage across the localized download page

## Validation
- focused download UI/API tests: 10 passed
- @agent-native/docs tests: 204 passed
- docs typecheck and production build passed
- repository guards: 57 passed