### PR TITLE
fix: harden MCP OAuth reconnect replacement

### DIFF
--- a/.changeset/harden-mcp-oauth-reconnect.md
+++ b/.changeset/harden-mcp-oauth-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden MCP OAuth reconnect redirects and concurrent credential replacement.

--- a/.changeset/preserve-workspace-sso-projection.md
+++ b/.changeset/preserve-workspace-sso-projection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Preserve server-validated workspace app SSO eligibility through Dispatch app discovery.

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -19,7 +19,7 @@ import {
 } from "@tabler/icons-react";
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 
-import { agentNativePath } from "../api-path.js";
+import { agentNativePath, appBasePath } from "../api-path.js";
 import {
   Tooltip,
   TooltipContent,
@@ -671,8 +671,18 @@ function compareMcpUrl(value: string): string {
   }
 }
 
+function appRelativeMcpOAuthReturnUrl(): string {
+  const basePath = appBasePath();
+  const pathname = window.location.pathname;
+  const path =
+    basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+      ? pathname.slice(basePath.length) || "/"
+      : pathname;
+  return `${path}${window.location.search}${window.location.hash}`;
+}
+
 function startMcpOAuthReconnect(server: McpServer): void {
-  const returnUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  const returnUrl = appRelativeMcpOAuthReturnUrl();
   const params = new URLSearchParams({
     serverId: server.id,
     scope: server.scope,

--- a/packages/core/src/mcp-client/oauth-client.spec.ts
+++ b/packages/core/src/mcp-client/oauth-client.spec.ts
@@ -675,7 +675,7 @@ describe("MCP OAuth client", () => {
     );
   });
 
-  it("fails closed instead of posting a token to a loopback revocation endpoint", async () => {
+  it("retains custody when revocation fails so cleanup can retry", async () => {
     getOAuthTokensMock.mockResolvedValue({
       ...credentials,
       discoveryState: {
@@ -698,7 +698,7 @@ describe("MCP OAuth client", () => {
         scopeId: "alice@example.com",
         serverUrl: "https://mcp.example.com/mcp",
       }),
-    ).resolves.toEqual({ remote: "failed", local: "deleted" });
+    ).resolves.toEqual({ remote: "failed", local: "retained" });
 
     expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
       "http://127.0.0.1:9000/revoke",
@@ -708,6 +708,8 @@ describe("MCP OAuth client", () => {
         maxRedirects: 0,
       }),
     );
+    expect(getOAuthTokensMock).toHaveBeenCalledTimes(1);
+    expect(deleteOAuthTokensIfRevisionMock).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/mcp-client/oauth-client.ts
+++ b/packages/core/src/mcp-client/oauth-client.ts
@@ -637,6 +637,7 @@ export async function revokeMcpOAuthCredentials(options: {
   return revokeOAuthCredential<McpOAuthCredentialBundle>(identity, {
     allowLegacy: true,
     legacyAccountKey: true,
+    retainOnRemoteFailure: true,
     validateCredential: (credential) =>
       serverUrlsMatch(credential.serverUrl, serverUrl),
     revoke: async ({ credential }) => {

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -15,6 +15,7 @@ import {
   resolveMcpOAuthScope,
   resolveManagedMcpOAuthClient,
   setMcpOAuthFlowCookie,
+  stripMcpOAuthAppBasePath,
   type McpOAuthFlow,
 } from "./oauth-routes.js";
 
@@ -33,6 +34,18 @@ const baseFlow: McpOAuthFlow = {
 };
 
 describe("MCP OAuth callback flow validation", () => {
+  it("strips a mounted app path before the callback rebuilds its URL", () => {
+    expect(
+      stripMcpOAuthAppBasePath(
+        "/workspace/settings/integrations?connected=mcp-linear",
+        "/workspace",
+      ),
+    ).toBe("/settings/integrations?connected=mcp-linear");
+    expect(
+      stripMcpOAuthAppBasePath("/settings/integrations", "/workspace"),
+    ).toBe("/settings/integrations");
+  });
+
   it("carries staged cookies on native redirects", () => {
     const event = {
       res: { headers: new Headers() },

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -18,7 +18,11 @@ import { decryptSecretValue, encryptSecretValue } from "../secrets/crypto.js";
 import { getSession, safeReturnPath } from "../server/auth.js";
 import { resolveSecret } from "../server/credential-provider.js";
 import { getH3App } from "../server/framework-request-handler.js";
-import { getAppUrl, resolveOAuthRedirectUri } from "../server/google-oauth.js";
+import {
+  getAppBasePath,
+  getAppUrl,
+  resolveOAuthRedirectUri,
+} from "../server/google-oauth.js";
 import { runWithRequestContext } from "../server/request-context.js";
 import {
   finishMcpOAuthAuthorization,
@@ -298,6 +302,18 @@ export function resolveMcpOAuthScope(
   return requestedScope === "org" ? "org" : "user";
 }
 
+export function stripMcpOAuthAppBasePath(
+  path: string,
+  basePath: string,
+): string {
+  const normalizedBase = `/${basePath.replace(/^\/+|\/+$/g, "")}`;
+  if (normalizedBase === "/") return path;
+  if (path === normalizedBase) return "/";
+  return path.startsWith(`${normalizedBase}/`)
+    ? path.slice(normalizedBase.length)
+    : path;
+}
+
 export async function resolveManagedMcpOAuthClient(
   serverUrl: URL,
 ): Promise<StoredOAuthClientInformation | undefined> {
@@ -400,7 +416,10 @@ async function handleMcpOAuthCallback(
     const returnPath =
       flow.returnUrl ??
       `/settings/integrations?connected=mcp-${encodeURIComponent(flow.name)}`;
-    return redirectWithStagedCookies(event, getAppUrl(event, returnPath));
+    return redirectWithStagedCookies(
+      event,
+      getAppUrl(event, stripMcpOAuthAppBasePath(returnPath, getAppBasePath())),
+    );
   } catch {
     setResponseStatus(event, 400);
     return { error: "MCP OAuth authorization could not be completed." };

--- a/packages/core/src/mcp-client/remote-store.spec.ts
+++ b/packages/core/src/mcp-client/remote-store.spec.ts
@@ -6,6 +6,7 @@ const oauthMocks = vi.hoisted(() => ({
   save: vi.fn(),
 }));
 const getUserSettingMock = vi.hoisted(() => vi.fn());
+const mutateUserSettingMock = vi.hoisted(() => vi.fn());
 const putUserSettingMock = vi.hoisted(() => vi.fn());
 const deleteUserSettingMock = vi.hoisted(() => vi.fn());
 
@@ -19,6 +20,7 @@ vi.mock("./oauth-client.js", () => ({
 vi.mock("../settings/user-settings.js", () => ({
   deleteUserSetting: deleteUserSettingMock,
   getUserSetting: getUserSettingMock,
+  mutateUserSetting: mutateUserSettingMock,
   putUserSetting: putUserSettingMock,
 }));
 
@@ -43,6 +45,19 @@ vi.mock("../mcp/org-directory.js", () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   getUserSettingMock.mockResolvedValue(null);
+  mutateUserSettingMock.mockImplementation(
+    async (
+      email: string,
+      key: string,
+      updater: (
+        current: Record<string, unknown> | null,
+      ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+    ) => {
+      const next = await updater(await getUserSettingMock(email, key));
+      await putUserSettingMock(email, key, next);
+      return next;
+    },
+  );
   oauthMocks.revoke.mockResolvedValue({
     remote: "succeeded",
     local: "deleted",
@@ -113,7 +128,7 @@ describe("OAuth remote MCP metadata", () => {
   });
 
   it("replaces an OAuth grant in place while preserving the server id", async () => {
-    getUserSettingMock.mockResolvedValueOnce({
+    getUserSettingMock.mockResolvedValue({
       servers: [
         {
           id: "mcps_oauth",
@@ -164,6 +179,86 @@ describe("OAuth remote MCP metadata", () => {
         key: "mcp_oauth:old",
         serverUrl: "https://mcp.example.com/",
       }),
+    );
+  });
+
+  it("keeps the replacement row when old-grant cleanup fails", async () => {
+    getUserSettingMock.mockResolvedValue({
+      servers: [
+        {
+          id: "mcps_oauth",
+          name: "sigma",
+          url: "https://mcp.example.com/",
+          oauthSecretKey: "mcp_oauth:old",
+          createdAt: 1,
+        },
+      ],
+    });
+    oauthMocks.revoke.mockRejectedValueOnce(new Error("old grant unavailable"));
+
+    await expect(
+      replaceOAuthRemoteServer("user", "user@example.com", "mcps_oauth", {
+        serverUrl: "https://mcp.example.com",
+        clientInformation: { client_id: "example-client" },
+        tokens: { access_token: "<NEW_ACCESS_TOKEN>", token_type: "bearer" },
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(oauthMocks.revoke).toHaveBeenCalledTimes(1);
+    expect(oauthMocks.revoke).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "mcp_oauth:old" }),
+    );
+  });
+
+  it("revokes a replacement grant when the server changes before the CAS", async () => {
+    getUserSettingMock.mockResolvedValueOnce({
+      servers: [
+        {
+          id: "mcps_oauth",
+          name: "sigma",
+          url: "https://mcp.example.com/",
+          oauthSecretKey: "mcp_oauth:old",
+          createdAt: 1,
+        },
+      ],
+    });
+    mutateUserSettingMock.mockImplementationOnce(
+      async (
+        _email: string,
+        _key: string,
+        updater: (
+          current: Record<string, unknown> | null,
+        ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+      ) =>
+        updater({
+          servers: [
+            {
+              id: "mcps_oauth",
+              name: "sigma",
+              url: "https://mcp.example.com/",
+              oauthSecretKey: "mcp_oauth:newer",
+              createdAt: 1,
+            },
+          ],
+        }),
+    );
+
+    await expect(
+      replaceOAuthRemoteServer("user", "user@example.com", "mcps_oauth", {
+        serverUrl: "https://mcp.example.com",
+        clientInformation: { client_id: "example-client" },
+        tokens: { access_token: "<NEW_ACCESS_TOKEN>", token_type: "bearer" },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("MCP server changed while reconnecting"),
+    });
+
+    expect(oauthMocks.revoke).toHaveBeenCalledWith(
+      expect.objectContaining({ key: expect.stringMatching(/^mcp_oauth:/) }),
+    );
+    expect(oauthMocks.revoke).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: "mcp_oauth:old" }),
     );
   });
 

--- a/packages/core/src/mcp-client/remote-store.spec.ts
+++ b/packages/core/src/mcp-client/remote-store.spec.ts
@@ -210,6 +210,45 @@ describe("OAuth remote MCP metadata", () => {
     );
   });
 
+  it("queues old-grant cleanup when a concurrent refresh replaces its revision", async () => {
+    getUserSettingMock.mockResolvedValue({
+      servers: [
+        {
+          id: "mcps_oauth",
+          name: "sigma",
+          url: "https://mcp.example.com/",
+          oauthSecretKey: "mcp_oauth:old",
+          createdAt: 1,
+        },
+      ],
+    });
+    oauthMocks.revoke.mockResolvedValueOnce({
+      remote: "succeeded",
+      local: "replaced",
+    });
+
+    await expect(
+      replaceOAuthRemoteServer("user", "user@example.com", "mcps_oauth", {
+        serverUrl: "https://mcp.example.com",
+        clientInformation: { client_id: "example-client" },
+        tokens: { access_token: "<NEW_ACCESS_TOKEN>", token_type: "bearer" },
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(putUserSettingMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "mcp-oauth-pending-cleanups",
+      {
+        cleanups: [
+          {
+            key: "mcp_oauth:old",
+            serverUrl: "https://mcp.example.com/",
+          },
+        ],
+      },
+    );
+  });
+
   it("revokes a replacement grant when the server changes before the CAS", async () => {
     getUserSettingMock.mockResolvedValueOnce({
       servers: [
@@ -259,6 +298,67 @@ describe("OAuth remote MCP metadata", () => {
     );
     expect(oauthMocks.revoke).not.toHaveBeenCalledWith(
       expect.objectContaining({ key: "mcp_oauth:old" }),
+    );
+  });
+
+  it("queues replacement cleanup when CAS conflict cleanup fails", async () => {
+    getUserSettingMock.mockResolvedValueOnce({
+      servers: [
+        {
+          id: "mcps_oauth",
+          name: "sigma",
+          url: "https://mcp.example.com/",
+          oauthSecretKey: "mcp_oauth:old",
+          createdAt: 1,
+        },
+      ],
+    });
+    mutateUserSettingMock.mockImplementationOnce(
+      async (
+        _email: string,
+        _key: string,
+        updater: (
+          current: Record<string, unknown> | null,
+        ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+      ) =>
+        updater({
+          servers: [
+            {
+              id: "mcps_oauth",
+              name: "sigma",
+              url: "https://mcp.example.com/",
+              oauthSecretKey: "mcp_oauth:newer",
+              createdAt: 1,
+            },
+          ],
+        }),
+    );
+    oauthMocks.revoke.mockRejectedValueOnce(
+      new Error("credential store unavailable"),
+    );
+
+    await expect(
+      replaceOAuthRemoteServer("user", "user@example.com", "mcps_oauth", {
+        serverUrl: "https://mcp.example.com",
+        clientInformation: { client_id: "example-client" },
+        tokens: { access_token: "<NEW_ACCESS_TOKEN>", token_type: "bearer" },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("MCP server changed while reconnecting"),
+    });
+
+    expect(putUserSettingMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "mcp-oauth-pending-cleanups",
+      {
+        cleanups: [
+          expect.objectContaining({
+            key: expect.stringMatching(/^mcp_oauth:/),
+            serverUrl: "https://mcp.example.com/",
+          }),
+        ],
+      },
     );
   });
 

--- a/packages/core/src/mcp-client/remote-store.spec.ts
+++ b/packages/core/src/mcp-client/remote-store.spec.ts
@@ -249,6 +249,81 @@ describe("OAuth remote MCP metadata", () => {
     );
   });
 
+  it("treats an already-missing cleanup credential as idempotently removed", async () => {
+    const cleanup = {
+      key: "mcp_oauth:old",
+      serverUrl: "https://mcp.example.com/",
+    };
+    let serverReads = 0;
+    getUserSettingMock.mockImplementation(
+      async (_email: string, key: string) => {
+        if (key === "mcp-oauth-pending-cleanups") {
+          return { cleanups: [cleanup] };
+        }
+        serverReads += 1;
+        return {
+          servers: [
+            {
+              id: "mcps_oauth",
+              name: "sigma",
+              url: "https://mcp.example.com/",
+              oauthSecretKey: serverReads === 1 ? cleanup.key : "mcp_oauth:new",
+              createdAt: 1,
+            },
+          ],
+        };
+      },
+    );
+    mutateUserSettingMock.mockImplementation(
+      async (
+        email: string,
+        key: string,
+        updater: (
+          current: Record<string, unknown> | null,
+        ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+      ) => {
+        const current =
+          key === "mcp-oauth-pending-cleanups"
+            ? { cleanups: [cleanup] }
+            : {
+                servers: [
+                  {
+                    id: "mcps_oauth",
+                    name: "sigma",
+                    url: "https://mcp.example.com/",
+                    oauthSecretKey: cleanup.key,
+                    createdAt: 1,
+                  },
+                ],
+              };
+        const next = await updater(current);
+        await putUserSettingMock(email, key, next);
+        return next;
+      },
+    );
+    oauthMocks.revoke.mockResolvedValueOnce({
+      remote: "not_attempted",
+      local: "missing",
+    });
+
+    await expect(
+      replaceOAuthRemoteServer("user", "user@example.com", "mcps_oauth", {
+        serverUrl: "https://mcp.example.com",
+        clientInformation: { client_id: "example-client" },
+        tokens: { access_token: "<NEW_ACCESS_TOKEN>", token_type: "bearer" },
+      }),
+    ).resolves.toMatchObject({ ok: true });
+
+    expect(oauthMocks.revoke).toHaveBeenCalledWith(
+      expect.objectContaining({ key: cleanup.key }),
+    );
+    expect(putUserSettingMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "mcp-oauth-pending-cleanups",
+      { cleanups: [] },
+    );
+  });
+
   it("revokes a replacement grant when the server changes before the CAS", async () => {
     getUserSettingMock.mockResolvedValueOnce({
       servers: [

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -52,6 +52,7 @@ import { validateRemoteUrl } from "./remote-url.js";
 export { validateRemoteUrl } from "./remote-url.js";
 
 const SETTINGS_KEY = "mcp-servers-remote";
+const OAUTH_CLEANUP_SETTINGS_KEY = "mcp-oauth-pending-cleanups";
 
 export type RemoteMcpScope = "user" | "org";
 
@@ -198,6 +199,152 @@ function parseServerList(
   return ((raw as any).servers as StoredRemoteMcpServer[]).filter(
     (s) => s && typeof s.id === "string" && typeof s.url === "string",
   );
+}
+
+interface PendingOAuthCleanup {
+  key: string;
+  serverUrl: string;
+}
+
+function parsePendingOAuthCleanups(
+  raw: Record<string, unknown> | null,
+): PendingOAuthCleanup[] {
+  if (!raw || !Array.isArray(raw.cleanups)) return [];
+  return raw.cleanups.filter(
+    (cleanup): cleanup is PendingOAuthCleanup =>
+      !!cleanup &&
+      typeof cleanup === "object" &&
+      typeof (cleanup as PendingOAuthCleanup).key === "string" &&
+      typeof (cleanup as PendingOAuthCleanup).serverUrl === "string",
+  );
+}
+
+function pendingOAuthCleanupId(cleanup: PendingOAuthCleanup): string {
+  return `${cleanup.key}\u0000${cleanup.serverUrl}`;
+}
+
+function getScopedSetting(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  return scope === "user"
+    ? getUserSetting(scopeId, key)
+    : getOrgSetting(scopeId, key);
+}
+
+function mutateScopedSetting(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  key: string,
+  updater: (
+    current: Record<string, unknown> | null,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  return scope === "user"
+    ? mutateUserSetting(scopeId, key, updater)
+    : mutateOrgSetting(scopeId, key, updater);
+}
+
+async function enqueueOAuthCleanup(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  cleanup: PendingOAuthCleanup,
+): Promise<void> {
+  await mutateScopedSetting(
+    scope,
+    scopeId,
+    OAUTH_CLEANUP_SETTINGS_KEY,
+    (current) => {
+      const cleanups = parsePendingOAuthCleanups(current);
+      if (
+        cleanups.some(
+          (candidate) =>
+            pendingOAuthCleanupId(candidate) === pendingOAuthCleanupId(cleanup),
+        )
+      ) {
+        return { cleanups };
+      }
+      return { cleanups: [...cleanups, cleanup] };
+    },
+  );
+}
+
+async function drainOAuthCleanup(
+  scope: RemoteMcpScope,
+  scopeId: string,
+): Promise<void> {
+  const pending = parsePendingOAuthCleanups(
+    await getScopedSetting(scope, scopeId, OAUTH_CLEANUP_SETTINGS_KEY),
+  );
+  if (pending.length === 0) return;
+
+  const servers = await readList(scope, scopeId);
+  const retained = [] as PendingOAuthCleanup[];
+  for (const cleanup of pending) {
+    // A later reconnect may have reused this key. Keep the marker rather than
+    // revoking credentials that are referenced by the current settings row.
+    if (servers.some((server) => server.oauthSecretKey === cleanup.key)) {
+      retained.push(cleanup);
+      continue;
+    }
+    try {
+      const result = await revokeMcpOAuthCredentials({
+        key: cleanup.key,
+        scope,
+        scopeId,
+        serverUrl: cleanup.serverUrl,
+      });
+      if (result.local !== "deleted") retained.push(cleanup);
+    } catch {
+      retained.push(cleanup);
+    }
+  }
+
+  const attemptedIds = new Set(pending.map(pendingOAuthCleanupId));
+  const retainedIds = new Set(retained.map(pendingOAuthCleanupId));
+  await mutateScopedSetting(
+    scope,
+    scopeId,
+    OAUTH_CLEANUP_SETTINGS_KEY,
+    (current) => ({
+      cleanups: parsePendingOAuthCleanups(current).filter(
+        (cleanup) =>
+          !attemptedIds.has(pendingOAuthCleanupId(cleanup)) ||
+          retainedIds.has(pendingOAuthCleanupId(cleanup)),
+      ),
+    }),
+  );
+}
+
+async function cleanupOAuthGrant(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  cleanup: PendingOAuthCleanup,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let reason: string;
+  try {
+    const result = await revokeMcpOAuthCredentials({
+      key: cleanup.key,
+      scope,
+      scopeId,
+      serverUrl: cleanup.serverUrl,
+    });
+    if (result.local === "deleted") return { ok: true };
+    reason = "the credential revision changed during cleanup";
+  } catch (err: any) {
+    reason = err?.message ?? String(err);
+  }
+
+  try {
+    await enqueueOAuthCleanup(scope, scopeId, cleanup);
+    return { ok: true };
+  } catch (err: any) {
+    return {
+      ok: false,
+      error: `${reason}; failed to queue retry: ${err?.message ?? String(err)}`,
+    };
+  }
 }
 
 async function mutateServerList(
@@ -365,6 +512,8 @@ export async function replaceOAuthRemoteServer(
     };
   }
 
+  await drainOAuthCleanup(scope, scopeId);
+
   const nextSecretKey = `mcp_oauth:${shortId()}`;
   const nextCredentials = {
     ...credentials,
@@ -397,26 +546,29 @@ export async function replaceOAuthRemoteServer(
       return next;
     });
   } catch (err: any) {
-    await revokeMcpOAuthCredentials({
+    const cleanup = await cleanupOAuthGrant(scope, scopeId, {
       key: nextSecretKey,
-      scope,
-      scopeId,
       serverUrl: nextCredentials.serverUrl,
-    }).catch(() => undefined);
+    });
+    const cleanupError = cleanup.ok ? "" : `; ${cleanup.error}`;
     return {
       ok: false,
-      error: `Failed to replace MCP OAuth credentials: ${err?.message ?? err}`,
+      error: `Failed to replace MCP OAuth credentials: ${err?.message ?? err}${cleanupError}`,
     };
   }
 
   // The settings row now points at the replacement grant. Old-grant cleanup
   // is best effort and must not roll back or invalidate the committed row.
-  await revokeMcpOAuthCredentials({
+  const cleanup = await cleanupOAuthGrant(scope, scopeId, {
     key: current.oauthSecretKey,
-    scope,
-    scopeId,
     serverUrl: current.url,
-  }).catch(() => undefined);
+  });
+  if (!cleanup.ok) {
+    return {
+      ok: false,
+      error: `MCP OAuth replacement committed, but old-grant cleanup failed: ${cleanup.error}`,
+    };
+  }
   const server = updated.find((candidate) => candidate.id === serverId);
   return server
     ? { ok: true, server }

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -30,11 +30,13 @@ import {
 } from "../secrets/storage.js";
 import {
   getOrgSetting,
+  mutateOrgSetting,
   putOrgSetting,
   deleteOrgSetting,
 } from "../settings/org-settings.js";
 import {
   getUserSetting,
+  mutateUserSetting,
   putUserSetting,
   deleteUserSetting,
 } from "../settings/user-settings.js";
@@ -186,10 +188,30 @@ async function readList(
     scope === "user"
       ? await getUserSetting(scopeId, SETTINGS_KEY)
       : await getOrgSetting(scopeId, SETTINGS_KEY);
+  return parseServerList(raw);
+}
+
+function parseServerList(
+  raw: Record<string, unknown> | null,
+): StoredRemoteMcpServer[] {
   if (!raw || !Array.isArray((raw as any).servers)) return [];
   return ((raw as any).servers as StoredRemoteMcpServer[]).filter(
     (s) => s && typeof s.id === "string" && typeof s.url === "string",
   );
+}
+
+async function mutateServerList(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  updater: (
+    servers: StoredRemoteMcpServer[],
+  ) => StoredRemoteMcpServer[] | Promise<StoredRemoteMcpServer[]>,
+): Promise<StoredRemoteMcpServer[]> {
+  const mutate = scope === "user" ? mutateUserSetting : mutateOrgSetting;
+  const next = await mutate(scopeId, SETTINGS_KEY, async (raw) => ({
+    servers: await updater(parseServerList(raw)),
+  }));
+  return parseServerList(next);
 }
 
 async function writeList(
@@ -348,6 +370,7 @@ export async function replaceOAuthRemoteServer(
     ...credentials,
     serverUrl: credentialResource.url.toString(),
   };
+  let updated: StoredRemoteMcpServer[];
   try {
     await saveMcpOAuthCredentials({
       key: nextSecretKey,
@@ -355,22 +378,24 @@ export async function replaceOAuthRemoteServer(
       scopeId,
       credentials: nextCredentials,
     });
-    const server: StoredRemoteMcpServer = {
-      ...current,
-      url: nextCredentials.serverUrl,
-      oauthSecretKey: nextSecretKey,
-    };
-    const next = [...existing];
-    next[index] = server;
-    await writeList(scope, scopeId, next);
-
-    await revokeMcpOAuthCredentials({
-      key: current.oauthSecretKey,
-      scope,
-      scopeId,
-      serverUrl: current.url,
-    }).catch(() => undefined);
-    return { ok: true, server };
+    updated = await mutateServerList(scope, scopeId, (servers) => {
+      const latestIndex = servers.findIndex((server) => server.id === serverId);
+      const latest = latestIndex >= 0 ? servers[latestIndex] : undefined;
+      if (
+        !latest ||
+        latest.oauthSecretKey !== current.oauthSecretKey ||
+        latest.url !== current.url
+      ) {
+        throw new Error("MCP server changed while reconnecting");
+      }
+      const next = [...servers];
+      next[latestIndex] = {
+        ...latest,
+        url: nextCredentials.serverUrl,
+        oauthSecretKey: nextSecretKey,
+      };
+      return next;
+    });
   } catch (err: any) {
     await revokeMcpOAuthCredentials({
       key: nextSecretKey,
@@ -383,6 +408,19 @@ export async function replaceOAuthRemoteServer(
       error: `Failed to replace MCP OAuth credentials: ${err?.message ?? err}`,
     };
   }
+
+  // The settings row now points at the replacement grant. Old-grant cleanup
+  // is best effort and must not roll back or invalidate the committed row.
+  await revokeMcpOAuthCredentials({
+    key: current.oauthSecretKey,
+    scope,
+    scopeId,
+    serverUrl: current.url,
+  }).catch(() => undefined);
+  const server = updated.find((candidate) => candidate.id === serverId);
+  return server
+    ? { ok: true, server }
+    : { ok: false, error: "MCP server was not found" };
 }
 
 export async function addFirstPartyRemoteServer(

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -295,7 +295,9 @@ async function drainOAuthCleanup(
         scopeId,
         serverUrl: cleanup.serverUrl,
       });
-      if (result.local !== "deleted") retained.push(cleanup);
+      if (result.local !== "deleted" && result.local !== "missing") {
+        retained.push(cleanup);
+      }
     } catch {
       retained.push(cleanup);
     }
@@ -330,7 +332,9 @@ async function cleanupOAuthGrant(
       scopeId,
       serverUrl: cleanup.serverUrl,
     });
-    if (result.local === "deleted") return { ok: true };
+    if (result.local === "deleted" || result.local === "missing") {
+      return { ok: true };
+    }
     reason = "the credential revision changed during cleanup";
   } catch (err: any) {
     reason = err?.message ?? String(err);

--- a/packages/core/src/oauth-tokens/lifecycle.ts
+++ b/packages/core/src/oauth-tokens/lifecycle.ts
@@ -101,7 +101,7 @@ export interface OAuthRefreshContext<T extends OAuthCredential> {
 
 export interface OAuthRevocationResult {
   remote: "succeeded" | "failed" | "unsupported" | "not_attempted";
-  local: "deleted" | "missing" | "replaced";
+  local: "deleted" | "missing" | "replaced" | "retained";
 }
 
 interface LifecycleDependencies {
@@ -716,6 +716,8 @@ export async function revokeOAuthCredential<T extends OAuthCredential>(
     allowLegacy?: boolean;
     legacyAccountKey?: boolean;
     validateCredential?: (credential: T) => boolean;
+    /** Keep custody when remote revocation fails so a caller can retry. */
+    retainOnRemoteFailure?: boolean;
   } = {},
 ): Promise<OAuthRevocationResult> {
   const state = await readStoredOAuthCredentialState<T>(identity, {
@@ -740,6 +742,9 @@ export async function revokeOAuthCredential<T extends OAuthCredential>(
     }
   } else if (state.kind === "malformed") {
     remote = "not_attempted";
+  }
+  if (options.retainOnRemoteFailure && remote === "failed") {
+    return { remote, local: "retained" };
   }
   if (state.kind === "malformed" && state.reason !== "structure") {
     return { remote, local: "replaced" };

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -23,6 +23,7 @@ export { readSetting, writeSetting, removeSetting } from "./script-helpers.js";
 export {
   getUserSetting,
   putUserSetting,
+  mutateUserSetting,
   deleteUserSetting,
 } from "./user-settings.js";
 

--- a/packages/core/src/settings/user-settings.spec.ts
+++ b/packages/core/src/settings/user-settings.spec.ts
@@ -2,17 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock the store module
 const mockGetSetting = vi.fn();
+const mockMutateSetting = vi.fn();
 const mockPutSetting = vi.fn();
 const mockDeleteSetting = vi.fn();
 
 vi.mock("./store.js", () => ({
   getSetting: (...args: any[]) => mockGetSetting(...args),
+  mutateSetting: (...args: any[]) => mockMutateSetting(...args),
   putSetting: (...args: any[]) => mockPutSetting(...args),
   deleteSetting: (...args: any[]) => mockDeleteSetting(...args),
 }));
 
 import {
   getUserSetting,
+  mutateUserSetting,
   putUserSetting,
   deleteUserSetting,
 } from "./user-settings.js";
@@ -20,6 +23,14 @@ import {
 describe("user-settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMutateSetting.mockImplementation(
+      async (
+        _key: string,
+        updater: (
+          current: Record<string, unknown> | null,
+        ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+      ) => updater(null),
+    );
   });
 
   describe("getUserSetting", () => {
@@ -76,6 +87,29 @@ describe("user-settings", () => {
         "u:alice@test.com:pref",
         { v: 1 },
         { requestSource: "tab-1" },
+      );
+    });
+  });
+
+  describe("mutateUserSetting", () => {
+    it("uses the legacy mixed-case row when the normalized row is absent", async () => {
+      mockGetSetting.mockResolvedValueOnce({ servers: [{ id: "legacy" }] });
+
+      await expect(
+        mutateUserSetting(
+          "Alice@Test.com",
+          "mcp-servers-remote",
+          (current) => current ?? {},
+        ),
+      ).resolves.toEqual({ servers: [{ id: "legacy" }] });
+
+      expect(mockMutateSetting).toHaveBeenCalledWith(
+        "u:alice@test.com:mcp-servers-remote",
+        expect.any(Function),
+        undefined,
+      );
+      expect(mockGetSetting).toHaveBeenCalledWith(
+        "u:Alice@Test.com:mcp-servers-remote",
       );
     });
   });

--- a/packages/core/src/settings/user-settings.ts
+++ b/packages/core/src/settings/user-settings.ts
@@ -10,6 +10,7 @@
 
 import {
   getSetting,
+  mutateSetting,
   putSetting,
   deleteSetting,
   type StoreWriteOptions,
@@ -47,6 +48,18 @@ export async function putUserSetting(
   options?: StoreWriteOptions,
 ): Promise<void> {
   return putSetting(userKey(email, key), value, options);
+}
+
+/** Atomically derive and persist one user-scoped setting. */
+export async function mutateUserSetting(
+  email: string,
+  key: string,
+  updater: (
+    current: Record<string, unknown> | null,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+  options?: StoreWriteOptions,
+): Promise<Record<string, unknown>> {
+  return mutateSetting(userKey(email, key), updater, options);
 }
 
 /** Delete a user-scoped setting. */

--- a/packages/core/src/settings/user-settings.ts
+++ b/packages/core/src/settings/user-settings.ts
@@ -59,7 +59,16 @@ export async function mutateUserSetting(
   ) => Record<string, unknown> | Promise<Record<string, unknown>>,
   options?: StoreWriteOptions,
 ): Promise<Record<string, unknown>> {
-  return mutateSetting(userKey(email, key), updater, options);
+  const normalized = userKey(email, key);
+  const legacy = legacyUserKey(email, key);
+  return mutateSetting(
+    normalized,
+    async (current) =>
+      updater(
+        current ?? (legacy === normalized ? null : await getSetting(legacy)),
+      ),
+    options,
+  );
 }
 
 /** Delete a user-scoped setting. */

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -546,6 +546,28 @@ describe("listWorkspaceApps", () => {
     });
   });
 
+  it("preserves the workspace inventory SSO projection", async () => {
+    stubNoPendingContext();
+    stubManifest([
+      {
+        id: "workspace-reports",
+        name: "Workspace Reports",
+        path: "/workspace-reports",
+        url: "https://reports.example.com/workspace-reports",
+        workspaceSso: true,
+      },
+    ]);
+
+    const apps = await runWithRequestContext(
+      { userEmail: "dev@example.test" },
+      () => listWorkspaceApps({ includeAgentCards: false }),
+    );
+
+    expect(apps.find((app) => app.id === "workspace-reports")).toMatchObject({
+      workspaceSso: true,
+    });
+  });
+
   it("filters workspace apps by audience", async () => {
     stubNoPendingContext();
     vi.stubEnv(

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -673,6 +673,7 @@ function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
         publicPaths: normalizeWorkspaceAppPathList(entry.publicPaths),
         protectedPaths: normalizeWorkspaceAppPathList(entry.protectedPaths),
         status: "ready",
+        ...(entry.workspaceSso === true ? { workspaceSso: true } : {}),
         ...metadata,
       } satisfies WorkspaceAppSummary;
     })

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1482,6 +1482,44 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
     ).rejects.toThrow(/not registered/);
   });
 
+  it("allows a mounted app carrying the server-derived SSO projection", async () => {
+    mocks.discoverAgents.mockResolvedValue([]);
+    mocks.listWorkspaceApps.mockResolvedValue([
+      {
+        id: "workspace-reports",
+        name: "Workspace Reports",
+        description: "Custom workspace app",
+        path: "/workspace-reports",
+        url: "https://reports.example.com/workspace-reports",
+        isDispatch: false,
+        audience: "internal",
+        publicPaths: [],
+        protectedPaths: [],
+        workspaceSso: true,
+      },
+    ]);
+    mocks.managerCallTool.mockResolvedValueOnce({
+      structuredContent: {
+        startUrl:
+          "https://reports.example.com/workspace-reports/_agent-native/embed/start?ticket=remote",
+      },
+    });
+
+    const result = await runWithRequestContext(
+      {
+        userEmail: "owner@example.test",
+        requestOrigin: "https://dispatch.agent-native.com",
+      },
+      () =>
+        createWorkspaceSsoEmbedSession({
+          app: "workspace-reports",
+          path: "/home",
+        }),
+    );
+
+    expect(result).toMatchObject({ app: "workspace-reports" });
+  });
+
   it("rejects traversal into Dispatch-owned embed routes on sibling apps", async () => {
     await expect(
       runWithRequestContext(

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -72,6 +72,8 @@ export interface DispatchMcpAccessibleApp {
   name: string;
   description: string;
   url: string;
+  /** Server-validated workspace inventory projection for mounted apps. */
+  workspaceSso?: boolean;
   /** Canonical browser entry point when `url` is a deep A2A/agent link. */
   homeUrl?: string;
   color: string;
@@ -718,6 +720,7 @@ async function listWorkspaceSsoApps(): Promise<DispatchMcpAccessibleApp[]> {
       name: app.name,
       description: app.description,
       url: app.url,
+      ...(app.workspaceSso === true ? { workspaceSso: true } : {}),
       color: DISPATCH_COLOR,
       granted: true,
     });

--- a/packages/dispatch/src/shared/workspace-sso.ts
+++ b/packages/dispatch/src/shared/workspace-sso.ts
@@ -145,11 +145,16 @@ function isLoopbackOrigin(origin: string): boolean {
  * caller so this shared module never reads process or browser environment.
  */
 export function isWorkspaceSsoAppUrl(
-  app: { id: string; url?: unknown },
+  app: { id: string; url?: unknown; workspaceSso?: boolean },
   options: { nodeEnv?: string; registryRaw?: unknown } = {},
 ): boolean {
   const origin = appOrigin(app.url);
   if (!origin) return false;
+
+  // Workspace inventory already returns this as a server-validated projection
+  // for mounted apps. Keep the URL parse above as the boundary check while
+  // preserving that decision across the Dispatch app-listing seams.
+  if (app.workspaceSso === true) return true;
 
   const appId = app.id.trim().toLowerCase();
   const canonicalOrigin =

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -38,6 +38,18 @@ const nodeHeredocs = [
 ].map((match) => match[1]);
 
 describe("production Netlify site concurrency guard", () => {
+  it("uses exponential backoff when Netlify omits Retry-After", () => {
+    const workflow = readFileSync(
+      ".github/workflows/manage-production-sites.yml",
+      "utf8",
+    );
+    assert.match(
+      workflow,
+      /retryAfterHeader === null \? Number\.NaN : Number\(retryAfterHeader\)/,
+    );
+    assert.match(workflow, /Math\.min\(120_000, 30_000 \* 2 \*\* attempt\)/);
+  });
+
   it("requires a distinct reusable child queue selected by the caller input", () => {
     assert.deepEqual(
       validateReusableWorkflowConcurrency(


### PR DESCRIPTION
## Summary

- Keep mounted-app OAuth reconnect return paths app-relative before callback URL construction.
- Replace OAuth server rows with an atomic settings CAS and revoke losing grants on conflicts.
- Keep old-grant cleanup post-commit so cleanup failures cannot invalidate the live replacement.
- Add regression coverage for the existing exponential Netlify 429 fallback when Retry-After is absent.

## Verification

- Core focused OAuth suites: 29/29
- Netlify workflow guard tests: 19/19
- Core typecheck: passed
- `pnpm guards`: all 58 checks passed
- Prettier and diff checks: passed