### PR TITLE
Fix feedback recovery paths and Clips cross-tab controls

### DIFF
--- a/.changeset/provider-recovery-and-dispatch-templates.md
+++ b/.changeset/provider-recovery-and-dispatch-templates.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Improve provider failure recovery and remove the retired Videos template from Dispatch app creation.

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act } from "react";
+import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,6 +23,142 @@ vi.mock("../agent-engine-key.js", () => ({
   saveAgentEngineProviderSettings:
     agentEngineKeyMock.saveAgentEngineProviderSettings,
   setAgentEngineProvider: agentEngineKeyMock.setAgentEngineProvider,
+}));
+
+const i18nMock = vi.hoisted(() => ({
+  locale: "en-US",
+}));
+
+vi.mock("../i18n.js", () => ({
+  AgentNativeI18nProvider: ({
+    children,
+    initialLocale,
+  }: {
+    children: React.ReactNode;
+    initialLocale?: string;
+  }) => {
+    i18nMock.locale = initialLocale ?? "en-US";
+    return React.createElement(React.Fragment, null, children);
+  },
+  useFormatters: () => ({
+    formatNumber: (value: number) =>
+      new Intl.NumberFormat(i18nMock.locale).format(value),
+  }),
+  useT: () => (key: string, options?: Record<string, unknown>) => {
+    const translations: Record<string, Record<string, string>> = {
+      "en-US": {
+        "agentChat.setup.connectBuilder": "Connect Builder.io",
+        "agentPanel.connectAi": "Connect AI",
+        "agentPanel.builderOrOwnKeys": "Choose Builder.io or custom keys.",
+        "agentPanel.addOwnKeys": "Custom keys",
+        "agentChat.common.waiting": "Waiting",
+        "agentChat.common.connect": "Connect",
+        "agentChat.common.retry": "Retry",
+        "agentChat.common.details": "Details",
+        "agentChat.common.dismiss": "Dismiss",
+        "agentChat.common.copied": "Copied",
+        "agentChat.recovery.copyDebug": "Copy debug info",
+        "agentChat.recovery.copyFailed": "Copy failed",
+        "agentChat.recovery.credentialRejected":
+          "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+        "agentChat.recovery.newChatHint":
+          "This run can be continued in a new chat.",
+        "agentChat.recovery.reconnectBuilder": "Reconnect Builder.io",
+        "agentChat.recovery.connectingBuilder": "Connecting Builder.io",
+        "agentChat.error.stopped": "The agent stopped before finishing",
+        "agentChat.error.failed": "The agent hit an error",
+        "agentChat.limit.reached": "Step limit reached",
+        "agentChat.limit.descriptionWithCount":
+          "{{formattedCount}} steps remain for {{scope}}.",
+        "agentChat.limit.descriptionAll": "More steps remain for {{scope}}.",
+        "agentChat.limit.namedOrganization": "{{organization}}",
+        "agentChat.limit.organization": "your organization",
+        "agentChat.limit.account": "your account",
+        "agentChat.limit.maxSteps": "Max steps",
+        "agentChat.limit.saveAndContinue": "Save and continue",
+        "agentChat.limit.keepGoing": "Keep going",
+        "agentChat.limit.ownerOnly": "Only the owner can change this.",
+        "agentChat.common.save": "Save",
+        "agentChat.common.settings": "Settings",
+        "agentChat.tabs.newChat": "New chat",
+        "agentChat.message.forkChat": "Fork chat",
+        "agentChat.recovery.forkDescription": "Fork this chat",
+        "agentChat.recovery.forkFailed": "Fork failed",
+        "agentChat.recovery.forking": "Forking",
+      },
+      "de-DE": {
+        "agentChat.error.stopped": "The agent stopped before finishing",
+        "agentChat.error.failed": "The agent hit an error",
+        "agentChat.recovery.copyDebug": "Debug-Informationen kopieren",
+        "agentChat.recovery.copyFailed": "Kopieren fehlgeschlagen",
+        "agentChat.common.copied": "Kopiert",
+        "agentChat.common.details": "Details",
+        "agentChat.common.dismiss": "Schließen",
+        "agentChat.common.retry": "Retry",
+        "agentChat.errorMessages.providerAuthentication":
+          "Der Modellanbieter hat den gespeicherten API-Schlüssel abgelehnt.",
+        "agentChat.limit.descriptionWithCount":
+          "{{formattedCount}} Schritte bleiben für {{scope}}.",
+      },
+    };
+    const table =
+      translations[i18nMock.locale as keyof typeof translations] ??
+      translations["en-US"];
+    const template =
+      table[key] ?? (options?.defaultValue as string | undefined) ?? key;
+    return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, name: string) =>
+      String(options?.[name] ?? ""),
+    );
+  },
+}));
+
+vi.mock("../settings/ProviderSetupForm.js", () => ({
+  AgentProviderSetupForm: ({ onConnected }: { onConnected?: () => void }) => {
+    const [providerOpen, setProviderOpen] = React.useState(false);
+    const [apiKey, setApiKey] = React.useState("");
+    return (
+      <div>
+        <button
+          type="button"
+          aria-label="Choose a provider"
+          onClick={() => setProviderOpen((open) => !open)}
+        >
+          Choose a provider
+        </button>
+        {providerOpen ? (
+          <div>
+            <button type="button">OpenRouter</button>
+            <button type="button">Ollama</button>
+          </div>
+        ) : null}
+        <div>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => {
+              void agentEngineKeyMock.saveAgentEngineProviderSettings({
+                provider: "anthropic",
+                key: "ANTHROPIC_API_KEY",
+                apiKey,
+                scope: "user",
+              });
+              void agentEngineKeyMock.setAgentEngineProvider({
+                provider: "anthropic",
+                model: "mock-model",
+              });
+              onConnected?.();
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    );
+  },
 }));
 
 vi.mock("../settings/useBuilderStatus.js", () => ({
@@ -201,7 +337,7 @@ describe("run recovery surfaces", () => {
     });
   });
 
-  it("shows the AI setup flow and retry for a rejected provider key", async () => {
+  it("shows the AI setup flow without a direct retry button for a rejected provider key", async () => {
     await act(async () => {
       root.render(
         <AgentNativeI18nProvider
@@ -211,9 +347,8 @@ describe("run recovery surfaces", () => {
         >
           <RunErrorRecoveryCard
             info={{
-              message:
-                "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
-              errorCode: "authentication_error",
+              message: "Missing Authentication header",
+              errorCode: "http_401",
               details: '401 {"error":{"type":"authentication_error"}}',
             }}
             onContinue={vi.fn()}
@@ -226,7 +361,10 @@ describe("run recovery surfaces", () => {
 
     expect(container.textContent).toContain("Connect Builder.io");
     expect(container.textContent).toContain("Custom keys");
-    expect(container.textContent).toContain("Retry");
+    const buttonLabels = Array.from(container.querySelectorAll("button")).map(
+      (button) => button.textContent?.trim() ?? "",
+    );
+    expect(buttonLabels).not.toContain("Retry");
   });
 
   it("renders missing-provider errors as inline setup and retries on click", async () => {

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -511,11 +511,16 @@ export function RunErrorRecoveryCard({
     info.errorCode,
   );
   // Blocked on something the reader goes and fixes elsewhere, then comes back
-  // to. Without a retry the card is a dead end and its own copy ("then retry")
-  // points at a button that isn't there.
+  // to. Recoverable runs and email verification keep a retry path; rejected
+  // provider credentials use the setup flow below so the same bad key is not
+  // replayed.
   const isUnblockableExternally =
     info.errorCode === "email_verification_required";
-  const canRetry = canRecover || isProviderAuthError || isUnblockableExternally;
+  // Rejected provider keys already have a recovery path: update/connect the
+  // credential, then let the setup callback re-run the turn. Exposing a
+  // separate retry button here just replays the same rejected credential and
+  // turns a permanent auth failure into a loop.
+  const canRetry = canRecover || isUnblockableExternally;
   const builderReconnectResolved =
     shouldShowBuilderReconnect &&
     builderReconnect.hasFetchedStatus &&

--- a/packages/core/src/provider-api/actions/provider-api-staging-error.spec.ts
+++ b/packages/core/src/provider-api/actions/provider-api-staging-error.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+const stagingExecuteRequest = vi.fn();
+
+vi.mock("../staging.js", () => ({
+  stagingExecuteRequest,
+}));
+
+const { createProviderApiRequestAction } = await import("./provider-api.js");
+
+describe("provider API staging errors", () => {
+  it("adds recovery guidance when staged dataset byte cap is exhausted", async () => {
+    stagingExecuteRequest.mockRejectedValue(
+      new Error(
+        "Staged dataset byte cap exceeded: this app already stores 50.0 MB (limit 50 MB). Delete older datasets before staging more data.",
+      ),
+    );
+
+    const action = createProviderApiRequestAction(
+      { executeRequest: vi.fn() },
+      {
+        appId: "analytics",
+        getOwnerEmail: () => "ada@example.com",
+      },
+    );
+
+    await expect(
+      action.run({
+        provider: "gong",
+        method: "POST",
+        path: "/calls/extensive",
+        stageAs: "gong_calls",
+      }),
+    ).rejects.toThrow(
+      /Recover by deleting older staged datasets with list-staged-datasets\/delete-staged-dataset, or switch this request to saveToFile \/ a smaller staged result before trying again\./,
+    );
+  });
+});

--- a/packages/core/src/provider-api/actions/provider-api-staging-error.spec.ts
+++ b/packages/core/src/provider-api/actions/provider-api-staging-error.spec.ts
@@ -9,30 +9,36 @@ vi.mock("../staging.js", () => ({
 const { createProviderApiRequestAction } = await import("./provider-api.js");
 
 describe("provider API staging errors", () => {
-  it("adds recovery guidance when staged dataset byte cap is exhausted", async () => {
-    stagingExecuteRequest.mockRejectedValue(
-      new Error(
-        "Staged dataset byte cap exceeded: this app already stores 50.0 MB (limit 50 MB). Delete older datasets before staging more data.",
-      ),
-    );
+  it.each([
+    "Staged dataset byte cap exceeded: this app already stores 50.0 MB (limit 50 MB). Delete older datasets before staging more data.",
+    "Staged dataset cap exceeded: this app already has 100000 rows stored (limit 100000). Delete older datasets before staging more data.",
+  ])(
+    "adds recovery guidance for staged dataset caps while preserving the original error: %s",
+    async (message) => {
+      const originalError = new Error(message);
+      stagingExecuteRequest.mockRejectedValue(originalError);
+      const recoveryGuidance =
+        "Recover by deleting older staged datasets with list-staged-datasets/delete-staged-dataset, or switch this request to saveToFile / a smaller staged result before trying again.";
 
-    const action = createProviderApiRequestAction(
-      { executeRequest: vi.fn() },
-      {
-        appId: "analytics",
-        getOwnerEmail: () => "ada@example.com",
-      },
-    );
+      const action = createProviderApiRequestAction(
+        { executeRequest: vi.fn() },
+        {
+          appId: "analytics",
+          getOwnerEmail: () => "ada@example.com",
+        },
+      );
 
-    await expect(
-      action.run({
-        provider: "gong",
-        method: "POST",
-        path: "/calls/extensive",
-        stageAs: "gong_calls",
-      }),
-    ).rejects.toThrow(
-      /Recover by deleting older staged datasets with list-staged-datasets\/delete-staged-dataset, or switch this request to saveToFile \/ a smaller staged result before trying again\./,
-    );
-  });
+      await expect(
+        action.run({
+          provider: "gong",
+          method: "POST",
+          path: "/calls/extensive",
+          stageAs: "gong_calls",
+        }),
+      ).rejects.toMatchObject({
+        cause: originalError,
+        message: `${message} ${recoveryGuidance}`,
+      });
+    },
+  );
 });

--- a/packages/core/src/provider-api/actions/provider-api.ts
+++ b/packages/core/src/provider-api/actions/provider-api.ts
@@ -291,6 +291,20 @@ type ProviderRequestActionArgs = StagingRequestArgs & {
   fetchAllPages?: ProviderApiRequestArgs["fetchAllPages"];
 };
 
+const STAGED_DATASET_BYTE_CAP_ERROR = /Staged dataset byte cap exceeded/i;
+
+function rethrowStagingError(error: unknown): never {
+  if (
+    error instanceof Error &&
+    STAGED_DATASET_BYTE_CAP_ERROR.test(error.message)
+  ) {
+    throw new Error(
+      `${error.message} Recover by deleting older staged datasets with list-staged-datasets/delete-staged-dataset, or switch this request to saveToFile / a smaller staged result before trying again.`,
+    );
+  }
+  throw error;
+}
+
 interface ProviderApiActionBaseOptions<TSchema extends ZodTypeAny> {
   schema?: TSchema;
   description?: string;
@@ -379,10 +393,14 @@ export function createProviderApiRequestAction<
         if (!ownerEmail) {
           throw new Error("No authenticated context for provider API staging.");
         }
-        return stagingExecuteRequest(args, runtime.executeRequest, {
-          appId: options.appId,
-          ownerEmail,
-        });
+        try {
+          return await stagingExecuteRequest(args, runtime.executeRequest, {
+            appId: options.appId,
+            ownerEmail,
+          });
+        } catch (error) {
+          rethrowStagingError(error);
+        }
       }
       return runtime.executeRequest(args);
     },

--- a/packages/core/src/provider-api/actions/provider-api.ts
+++ b/packages/core/src/provider-api/actions/provider-api.ts
@@ -291,15 +291,13 @@ type ProviderRequestActionArgs = StagingRequestArgs & {
   fetchAllPages?: ProviderApiRequestArgs["fetchAllPages"];
 };
 
-const STAGED_DATASET_BYTE_CAP_ERROR = /Staged dataset byte cap exceeded/i;
+const STAGED_DATASET_CAP_ERROR = /Staged dataset (?:byte )?cap exceeded/i;
 
 function rethrowStagingError(error: unknown): never {
-  if (
-    error instanceof Error &&
-    STAGED_DATASET_BYTE_CAP_ERROR.test(error.message)
-  ) {
+  if (error instanceof Error && STAGED_DATASET_CAP_ERROR.test(error.message)) {
     throw new Error(
       `${error.message} Recover by deleting older staged datasets with list-staged-datasets/delete-staged-dataset, or switch this request to saveToFile / a smaller staged result before trying again.`,
+      { cause: error },
     );
   }
   throw error;

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -808,7 +808,7 @@ describe("listWorkspaceApps", () => {
     ).toBe("Tracks customer onboarding risks and handoffs.");
   });
 
-  it("offers Brain and Assets as workspace template tiles", async () => {
+  it("offers Brain and Assets as workspace template tiles and excludes retired Videos", async () => {
     stubNoPendingContext();
     stubManifest([{ id: "dispatch", name: "Dispatch", path: "/dispatch" }]);
 
@@ -820,6 +820,7 @@ describe("listWorkspaceApps", () => {
     expect(templates.map((template) => template.name)).toEqual(
       expect.arrayContaining(["brain", "assets"]),
     );
+    expect(templates.map((template) => template.name)).not.toContain("videos");
   });
 
   it("hides local scaffold templates in hosted runtimes", async () => {

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -1935,15 +1935,6 @@ const ADDABLE_TEMPLATES: AvailableWorkspaceTemplate[] = [
     colorRgb: "244 114 182",
     core: true,
   },
-  {
-    name: "videos",
-    label: "Video",
-    hint: "Video editing with Remotion",
-    icon: "Video",
-    color: "#EF4444",
-    colorRgb: "239 68 68",
-    core: false,
-  },
 ];
 
 export async function listAvailableWorkspaceTemplates(): Promise<

--- a/templates/analytics/changelog/2026-08-20-staged-data-limit-recovery.md
+++ b/templates/analytics/changelog/2026-08-20-staged-data-limit-recovery.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-20
+---
+Analytics now explains how to recover when staged data reaches its size limit.

--- a/templates/clips/changelog/2026-08-20-cross-tab-recording-controls.md
+++ b/templates/clips/changelog/2026-08-20-cross-tab-recording-controls.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-20
+---
+Recording controls now follow you across browser tabs and page navigations.

--- a/templates/clips/changelog/2026-08-20-overlay-follow-review-fixes.md
+++ b/templates/clips/changelog/2026-08-20-overlay-follow-review-fixes.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-20
+---
+Clips overlays now follow tab switches during the recording countdown and recover cleanly on tabs opened before Clips.

--- a/templates/clips/changelog/2026-08-20-provider-key-recovery.md
+++ b/templates/clips/changelog/2026-08-20-provider-key-recovery.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-20
+---
+Clips now opens provider setup instead of retrying a rejected key in a loop.

--- a/templates/clips/chrome-extension/PERMISSIONS.md
+++ b/templates/clips/chrome-extension/PERMISSIONS.md
@@ -1,41 +1,45 @@
 # Permissions model
 
-This extension ships **activeTab-only for recording overlays**: it deliberately
-does **not** request the broad `<all_urls>` host permission for recording UI.
+This extension ships **cross-tab follow for recording overlays**: it declares
+the broad `<all_urls>` host permission and a matching declarative content script
+so the camera bubble and controls can survive tab switches and navigations.
 
 ## Why
 
 A declarative content script on `<all_urls>` (and the matching `<all_urls>` host
 permission) triggers Chrome Web Store's **broad host permission in-depth review**,
-which significantly delays publishing and updates. We avoid that.
+which significantly delays publishing and updates. We take that review path only
+for the release that re-enables cross-tab follow.
 
-The only declarative content script is scoped to `https://github.com/*`. It
-looks for Clips links in GitHub issue/PR markdown and replaces them with a
-playable preview iframe owned by the extension. That adds a narrow GitHub host
-disclosure, but does not grant broad access to every page.
+The declarative content scripts are scoped to:
+
+- `https://github.com/*` for Clips link previews in GitHub issue/PR markdown.
+- `<all_urls>` for the recording overlay host that keeps the face bubble and
+  controls mounted across pages while a recording is active.
+
+The GitHub preview script adds a narrow host disclosure, while the overlay host
+is the broad review boundary.
 
 ## How the overlay gets on the page
 
 When the user clicks the extension and starts a recording, the background service
-worker injects the content script into the **launch tab** with
-`chrome.scripting.executeScript({ target: { tabId }, files: ["assets/content-script.js"] })`.
-That call is authorized by the **`activeTab`** permission, which Chrome grants for
-the tab that was active when the user invoked the extension — no broad host access
-needed. The content script then mounts the overlay iframes (countdown, camera
-bubble, controls). `web_accessible_resources` stays `<all_urls>` — that is **not**
-a host permission and does not trigger the review.
+worker mounts the overlay on the active tab and keeps rebroadcasting it as the
+active tab changes. The content script then mounts the overlay iframes
+(countdown, camera bubble, controls). `web_accessible_resources` stays
+`<all_urls>` — that is **not** a host permission and does not trigger the review.
 
 Declared permissions: `activeTab`, `debugger`, `offscreen`, `scripting`,
-`storage`. Host permissions: only the configured Clips app + `forms.agent-native.com`
+`storage`. Host permissions: the configured Clips app + `forms.agent-native.com`
 
 - `localhost`/`127.0.0.1`.
-- `https://github.com/*` is content-script scoped for link previews only.
+- `https://github.com/*` is content-script scoped for link previews.
+- `<all_urls>` is the overlay host required for cross-tab follow.
 
 ## What this costs
 
-- The overlay (countdown, camera bubble, recording controls) lives **only on the
-  tab the recording was launched from**. It does **not** follow the user to other
-  tabs during a full-screen or multi-tab recording.
+- The overlay (countdown, camera bubble, recording controls) follows the user
+  across tabs while a recording is active. Navigating to a new page or tab keeps
+  the face bubble and controls mounted once the page loads.
 - **Recording itself is unaffected.** Capture runs in the offscreen document via
   `getDisplayMedia`, independent of any tab's content script — full-screen,
   window, and other-tab content are all still captured normally. Only the on-page
@@ -43,36 +47,15 @@ Declared permissions: `activeTab`, `debugger`, `offscreen`, `scripting`,
 
 ## Re-enabling cross-tab follow
 
-The full cross-tab behavior is gated behind a single flag in
-`src/background.ts`:
+The full cross-tab behavior is gated behind a single flag in `src/background.ts`:
 
 ```ts
-const CROSS_TAB_FOLLOW = false; // flip to true
+const CROSS_TAB_FOLLOW = true;
 ```
 
-Flipping it to `true` restores the all-tabs broadcast in `broadcastMount()` /
-`broadcastUnmount()` and the `chrome.tabs.onActivated` follow listener. To make
-that actually work you must **also** restore broad host access so the worker can
-inject into arbitrary tabs. Two options:
-
-1. **Static (simplest, but in-depth review):** re-add to `public/manifest.json`:
-   - `"<all_urls>"` in `host_permissions`, and
-   - the `content_scripts` block:
-     ```json
-     "content_scripts": [
-       {
-         "matches": ["<all_urls>"],
-         "js": ["assets/content-script.js"],
-         "run_at": "document_idle",
-         "all_frames": false
-       }
-     ],
-     ```
-
-2. **Optional (preferred — keeps the default install lean):** declare
-   `"optional_host_permissions": ["<all_urls>"]` in the manifest and call
-   `chrome.permissions.request({ origins: ["<all_urls>"] })` at runtime (e.g. from
-   a settings toggle) before enabling follow. The user grants the broad access
-   explicitly, only if they want cross-tab overlays.
+That keeps the all-tabs broadcast in `broadcastMount()` / `broadcastUnmount()`
+and the `chrome.tabs.onActivated` follow listener live. The manifest must keep
+the broad host permission and the `<all_urls>` declarative content script in
+place so the worker can inject into arbitrary tabs.
 
 After any change: `pnpm build`, then re-zip `dist/`.

--- a/templates/clips/chrome-extension/STORE_DRAFT.md
+++ b/templates/clips/chrome-extension/STORE_DRAFT.md
@@ -56,7 +56,7 @@ Upload the generated artifact (the version matches `public/manifest.json`; the
 Chrome Web Store requires each upload to use a higher version than the last):
 
 ```txt
-templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.18.zip
+templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.19.zip
 ```
 
 ## Web App Rollout Gate

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Agent-Native Clips",
   "short_name": "Clips",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Start Clips recordings from Chrome, capture optional diagnostics, and preview Clips links on GitHub and Jira.",
   "minimum_chrome_version": "116",
   "action": {
@@ -31,7 +31,8 @@
     "https://clips.agent-native.com/*",
     "https://forms.agent-native.com/*",
     "http://localhost/*",
-    "http://127.0.0.1/*"
+    "http://127.0.0.1/*",
+    "<all_urls>"
   ],
   "content_scripts": [
     {
@@ -41,6 +42,12 @@
         "https://*.jira.com/*"
       ],
       "js": ["assets/github-preview-content.js"],
+      "run_at": "document_idle",
+      "all_frames": false
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["assets/content-script.js"],
       "run_at": "document_idle",
       "all_frames": false
     }

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -6,6 +6,10 @@ import {
   shouldReconcilePersistedRecording,
   type OffscreenRecordingState,
 } from "./native-recording-state";
+import {
+  sendWithInjectionFallback,
+  shouldFollowOverlay,
+} from "./overlay-follow";
 import { captureExtensionError, initExtensionSentry } from "./sentry";
 
 initExtensionSentry("background");
@@ -433,20 +437,19 @@ async function restoreRuntimeState(): Promise<void> {
 function sendTabMessage(
   tabId: number,
   message: Record<string, unknown>,
-): Promise<void> {
+): Promise<boolean> {
   return new Promise((resolve) => {
     try {
       chrome.tabs.sendMessage(tabId, message, () => {
-        void chrome.runtime.lastError;
-        resolve();
+        resolve(!chrome.runtime.lastError);
       });
     } catch {
-      resolve();
+      resolve(false);
     }
   });
 }
 
-async function ensureContentScript(tabId: number): Promise<void> {
+async function injectContentScript(tabId: number): Promise<boolean> {
   const scripting = (
     chrome as typeof chrome & {
       scripting?: {
@@ -457,18 +460,32 @@ async function ensureContentScript(tabId: number): Promise<void> {
       };
     }
   ).scripting;
-  if (!scripting) return;
-  await scripting
-    .executeScript({ target: { tabId }, files: ["assets/content-script.js"] })
-    .catch(() => undefined);
+  if (!scripting) return false;
+  try {
+    await scripting.executeScript({
+      target: { tabId },
+      files: ["assets/content-script.js"],
+    });
+    return true;
+  } catch {
+    // Unsupported pages (chrome://, the Chrome Web Store, and similar) reject
+    // injection. They still need to record without an in-page overlay.
+    return false;
+  }
 }
 
-async function mountOverlayOnTab(tabId: number): Promise<void> {
-  await ensureContentScript(tabId);
-  await sendTabMessage(tabId, {
-    type: "CLIPS_OVERLAY_MOUNT",
-    parts: desiredParts(),
-  });
+async function mountOverlayOnTab(
+  tabId: number,
+  parts: OverlayPart[] = desiredParts(),
+): Promise<boolean> {
+  return sendWithInjectionFallback(
+    () =>
+      sendTabMessage(tabId, {
+        type: "CLIPS_OVERLAY_MOUNT",
+        parts,
+      }),
+    () => injectContentScript(tabId),
+  );
 }
 
 function allTabs(): Promise<chrome.tabs.Tab[]> {
@@ -542,12 +559,9 @@ async function startPreview(wantsCamera: boolean): Promise<void> {
   if (!tab || typeof tab.id !== "number") return;
   if (previewTabId !== null && previewTabId !== tab.id) await stopPreview();
   previewTabId = tab.id;
-  await ensureContentScript(tab.id);
-  // Injection / send fail silently on unsupported pages (chrome://, etc.).
-  await sendTabMessage(tab.id, {
-    type: "CLIPS_OVERLAY_MOUNT",
-    parts: ["bubble"],
-  });
+  // Message delivery reuses the declarative script; fallback injection fails
+  // silently on unsupported pages (chrome://, the Web Store, and similar).
+  await mountOverlayOnTab(tab.id, ["bubble"]);
 }
 
 async function stopPreview(): Promise<void> {
@@ -2554,14 +2568,21 @@ async function dispatchRuntimeMessage(message: unknown): Promise<unknown> {
   }
 }
 
-// While a recording is active, keep the overlay following the user as they
-// switch tabs (programmatic injection covers tabs opened before the extension
-// loaded; declared content scripts cover navigations).
+// While a recording is active or arming, keep the overlay following the user as
+// they switch tabs. The message-first path reuses declarative scripts and only
+// injects for tabs that predate the extension or otherwise have no receiver.
 chrome.tabs.onActivated.addListener((info) => {
   if (!CROSS_TAB_FOLLOW) return;
   void (async () => {
     await ensureRestored();
-    if (overlayPhase === "idle" || !activeNativeRecording) return;
+    if (
+      !shouldFollowOverlay(
+        overlayPhase,
+        Boolean(activeNativeRecording),
+        Boolean(armingNativeRecordingSessionId),
+      )
+    )
+      return;
     await mountOverlayOnTab(info.tabId);
   })();
 });
@@ -2573,7 +2594,14 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status !== "complete") return;
   void (async () => {
     await ensureRestored();
-    if (overlayPhase === "idle" || !activeNativeRecording) return;
+    if (
+      !shouldFollowOverlay(
+        overlayPhase,
+        Boolean(activeNativeRecording),
+        Boolean(armingNativeRecordingSessionId),
+      )
+    )
+      return;
     if (tabId !== overlayTabId) return;
     await mountOverlayOnTab(tabId);
     broadcastOverlayState();

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -276,16 +276,11 @@ let overlayBaseEpochMs = 0;
 // up, for both camera-only AND screen+camera recording (recordingShowsBubble).
 let overlayShowsBubble = false;
 let recordingShowsBubble = false;
-// Cross-tab follow: when true, the overlay is pushed to whatever tab the user
-// switches to mid-recording. That requires "<all_urls>" + a declarative content
-// script, which triggers Chrome's broad-host in-depth review. Shipped OFF
-// (activeTab-only: the overlay lives on the launch tab the user invoked the
-// extension from). Capture is unaffected — it runs in the offscreen document via
-// getDisplayMedia regardless. See PERMISSIONS.md to re-enable.
-// Typed `boolean` (not inferred literal `false`) so the cross-tab branches below
-// don't read as unreachable code; flip the value to re-enable. See PERMISSIONS.md.
-const CROSS_TAB_FOLLOW: boolean = false;
-// The tab the recording was launched from — the only tab activeTab lets us touch.
+// Cross-tab follow stays enabled for the next release. It needs the manifest's
+// broad-host review path (`<all_urls>` + declarative content script coverage) so
+// the face bubble and controls keep following the user across tabs and reloads.
+const CROSS_TAB_FOLLOW: boolean = true;
+// The launch tab stays the anchor for the explicit reload recovery path.
 let overlayTabId: number | null = null;
 let countdownEndsAtMs = 0;
 let armingNativeRecordingSessionId: string | null = null;
@@ -483,9 +478,8 @@ function allTabs(): Promise<chrome.tabs.Tab[]> {
 }
 
 async function broadcastMount(): Promise<void> {
-  // activeTab-only: keep the overlay on the launch tab (re-ensures the injected
-  // content script too, so it survives a worker suspend). Cross-tab broadcast is
-  // gated behind CROSS_TAB_FOLLOW because it needs broad host access.
+  // Cross-tab follow uses the declarative content script path, so every mounted
+  // tab can receive the current overlay parts and survive reloads.
   if (!CROSS_TAB_FOLLOW) {
     if (overlayTabId !== null) await mountOverlayOnTab(overlayTabId);
     return;
@@ -2564,7 +2558,7 @@ async function dispatchRuntimeMessage(message: unknown): Promise<unknown> {
 // switch tabs (programmatic injection covers tabs opened before the extension
 // loaded; declared content scripts cover navigations).
 chrome.tabs.onActivated.addListener((info) => {
-  if (!CROSS_TAB_FOLLOW) return; // activeTab-only: overlay stays on the launch tab
+  if (!CROSS_TAB_FOLLOW) return;
   void (async () => {
     await ensureRestored();
     if (overlayPhase === "idle" || !activeNativeRecording) return;
@@ -2572,12 +2566,9 @@ chrome.tabs.onActivated.addListener((info) => {
   })();
 });
 
-// The overlay content script is injected on demand (activeTab), so reloading the
-// launch tab wipes it — the camera bubble and toolbar would vanish for the rest
-// of the recording even though capture keeps running in the offscreen document.
-// Re-inject and re-mount once the launch tab finishes reloading while a recording
-// is active. Scoped to the launch tab (the only tab activeTab lets us touch); a
-// same-URL reload keeps that grant.
+// Keep the launch tab in sync after a reload. Declarative follow covers the
+// other tabs; this is the explicit recovery path for the tab that originally
+// started the recording.
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.status !== "complete") return;
   void (async () => {

--- a/templates/clips/chrome-extension/src/content-script.ts
+++ b/templates/clips/chrome-extension/src/content-script.ts
@@ -1,12 +1,10 @@
-// Loom-style in-page overlay host. The background service worker injects this
-// into the LAUNCH TAB on demand via chrome.scripting.executeScript (covered by
-// the activeTab permission the user grants when they click the extension), NOT
-// declaratively on every page — that would need broad "<all_urls>" host access
-// and Chrome's in-depth review. So the overlay lives on the tab the recording
-// was started from; it does not follow across tabs unless CROSS_TAB_FOLLOW is
-// re-enabled in background.ts (see PERMISSIONS.md). Wrapped in an IIFE so it
-// emits a single self-contained classic script with no module imports/exports
-// and leaks no names into the shared global scope. Its only job is to
+// Loom-style in-page overlay host. The next release declares this on every page
+// so the face bubble and controls can survive tab switches and navigations; the
+// background worker can also inject it into the launch tab for immediate and
+// reload recovery. That broad "<all_urls>" host access is the Chrome Web Store
+// in-depth review boundary. Wrapped in an IIFE so it emits a single self-contained
+// classic script with no module imports/exports and leaks no names into the shared
+// global scope. Its only job is to
 // mount/unmount the overlay iframes; all UI and control logic lives inside the
 // extension-origin overlay pages (src/overlay.html). The worker is the source of
 // truth for which "parts" are visible and pushes them here.

--- a/templates/clips/chrome-extension/src/content-script.ts
+++ b/templates/clips/chrome-extension/src/content-script.ts
@@ -16,6 +16,12 @@
   const ALL_PARTS: OverlayPart[] = ["bubble", "countdown", "toolbar", "saving"];
   const flags = window as unknown as { __clipsOverlayHostReady?: boolean };
 
+  // Declarative and recovery injection can target the same document. Return
+  // before any side effects so global listeners remain one-per-page.
+  if (flags.__clipsOverlayHostReady) return;
+  flags.__clipsOverlayHostReady = true;
+  let recordingActive = false;
+
   function errorPayload(error: unknown): {
     name: string;
     message: string;
@@ -38,6 +44,7 @@
     error: unknown,
     context: Record<string, unknown> = {},
   ): void {
+    if (!recordingActive) return;
     try {
       chrome.runtime.sendMessage(
         {
@@ -70,6 +77,15 @@
       mechanism: "unhandled-rejection",
     });
   });
+
+  try {
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+      if (areaName !== "local" || !changes.clipsRecordingActive) return;
+      recordingActive = changes.clipsRecordingActive.newValue === true;
+    });
+  } catch {
+    /* storage unavailable */
+  }
 
   // ----- Draggable, resizable camera bubble ---------------------------------
   // Size + position persist in storage so the bubble stays where the user put it
@@ -337,7 +353,8 @@
     try {
       chrome.storage.local.get("clipsRecordingActive", (value) => {
         if (chrome.runtime.lastError) return;
-        if (value && value.clipsRecordingActive) requestState();
+        recordingActive = value?.clipsRecordingActive === true;
+        if (recordingActive) requestState();
       });
     } catch {
       /* ignore */
@@ -590,13 +607,6 @@
     if (gateCountdown) showConnecting(container);
     lastWantedParts = wanted;
   }
-
-  // Guard against rare double-injection (SPA soft-reloads re-running the script).
-  if (flags.__clipsOverlayHostReady) {
-    syncIfRecording();
-    return;
-  }
-  flags.__clipsOverlayHostReady = true;
 
   chrome.runtime.onMessage.addListener((message) => {
     if (!message || typeof message !== "object") return;

--- a/templates/clips/chrome-extension/src/overlay-follow-logic.test.ts
+++ b/templates/clips/chrome-extension/src/overlay-follow-logic.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  sendWithInjectionFallback,
+  shouldFollowOverlay,
+} from "./overlay-follow";
+
+describe("overlay follow runtime", () => {
+  it("uses the declarative content script when message delivery succeeds", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(true);
+    const injectContentScript = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      sendWithInjectionFallback(sendMessage, injectContentScript),
+    ).resolves.toBe(true);
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(injectContentScript).not.toHaveBeenCalled();
+  });
+
+  it("injects once and retries when the current tab has no receiver", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const injectContentScript = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      sendWithInjectionFallback(sendMessage, injectContentScript),
+    ).resolves.toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(injectContentScript).toHaveBeenCalledOnce();
+  });
+
+  it("follows an active countdown while recording creation is still arming", () => {
+    expect(shouldFollowOverlay("countdown", false, true)).toBe(true);
+    expect(shouldFollowOverlay("countdown", true, false)).toBe(true);
+    expect(shouldFollowOverlay("countdown", false, false)).toBe(false);
+    expect(shouldFollowOverlay("idle", false, true)).toBe(false);
+  });
+});

--- a/templates/clips/chrome-extension/src/overlay-follow.test.ts
+++ b/templates/clips/chrome-extension/src/overlay-follow.test.ts
@@ -3,6 +3,23 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("Clips overlay follow permissions", () => {
+  it("gates page error telemetry on active recording and guards reinjection", () => {
+    const contentScriptSource = readFileSync(
+      new URL("./content-script.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(contentScriptSource).toMatch(
+      /function reportContentScriptError[\s\S]*?if \(!recordingActive\) return;/,
+    );
+    expect(contentScriptSource).toContain(
+      "chrome.storage.onChanged.addListener",
+    );
+    expect(contentScriptSource).toContain(
+      "if (flags.__clipsOverlayHostReady) return;",
+    );
+  });
+
   it("keeps cross-tab follow enabled and declares the broad-host manifest path", () => {
     const backgroundSource = readFileSync(
       new URL("./background.ts", import.meta.url),

--- a/templates/clips/chrome-extension/src/overlay-follow.test.ts
+++ b/templates/clips/chrome-extension/src/overlay-follow.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+describe("Clips overlay follow permissions", () => {
+  it("keeps cross-tab follow enabled and declares the broad-host manifest path", () => {
+    const backgroundSource = readFileSync(
+      new URL("./background.ts", import.meta.url),
+      "utf8",
+    );
+    expect(backgroundSource).toContain(
+      "const CROSS_TAB_FOLLOW: boolean = true;",
+    );
+
+    const manifest = JSON.parse(
+      readFileSync(new URL("../public/manifest.json", import.meta.url), "utf8"),
+    ) as {
+      host_permissions?: string[];
+      content_scripts?: Array<{
+        matches?: string[];
+        js?: string[];
+        run_at?: string;
+        all_frames?: boolean;
+      }>;
+    };
+
+    expect(manifest.host_permissions).toEqual(
+      expect.arrayContaining(["<all_urls>"]),
+    );
+
+    const overlayScript = manifest.content_scripts?.find((entry) =>
+      entry.js?.includes("assets/content-script.js"),
+    );
+    expect(overlayScript).toEqual(
+      expect.objectContaining({
+        matches: expect.arrayContaining(["<all_urls>"]),
+        js: ["assets/content-script.js"],
+        run_at: "document_idle",
+        all_frames: false,
+      }),
+    );
+  });
+});

--- a/templates/clips/chrome-extension/src/overlay-follow.test.ts
+++ b/templates/clips/chrome-extension/src/overlay-follow.test.ts
@@ -56,5 +56,8 @@ describe("Clips overlay follow permissions", () => {
         all_frames: false,
       }),
     );
+
+    expect(backgroundSource).toContain("sendWithInjectionFallback");
+    expect(backgroundSource).toContain("shouldFollowOverlay");
   });
 });

--- a/templates/clips/chrome-extension/src/overlay-follow.ts
+++ b/templates/clips/chrome-extension/src/overlay-follow.ts
@@ -1,0 +1,25 @@
+export type OverlayFollowPhase =
+  | "idle"
+  | "countdown"
+  | "recording"
+  | "paused"
+  | "saving";
+
+export function shouldFollowOverlay(
+  phase: OverlayFollowPhase,
+  hasActiveNativeRecording: boolean,
+  hasArmingNativeRecording: boolean,
+): boolean {
+  return (
+    phase !== "idle" && (hasActiveNativeRecording || hasArmingNativeRecording)
+  );
+}
+
+export async function sendWithInjectionFallback(
+  sendMessage: () => Promise<boolean>,
+  injectContentScript: () => Promise<boolean>,
+): Promise<boolean> {
+  if (await sendMessage()) return true;
+  if (!(await injectContentScript())) return false;
+  return sendMessage();
+}


### PR DESCRIPTION
## Summary
- Remove the retired Videos template from local Dispatch app creation.
- Make staged-dataset cap errors actionable and stop rejected provider keys from retrying in a loop.
- Re-enable Clips cross-tab overlay follow, update the Chrome manifest and release version, and add regression coverage.

## Feedback dispositions
- `1787240000.580299` - Fixed: removed the retired `videos` template entry while preserving Brain.
- `1787239531.128779` - Fixed: staged-data limit errors now point to dataset cleanup or smaller/file-backed results.
- `1787238969.478999` - External/non-repo-owned: the current source intentionally fails closed; the live workspace-app registry/internal-token configuration needs repair.
- `1787239013.341939` - External/non-repo-owned: local-dev auth is intentionally gated by host/deployment configuration; no safe source change was confirmed.
- `1787240826.552269` - Fixed in source: Clips cross-tab follow is enabled and the broad-host manifest/release path is updated; Chrome Web Store review remains external.
- `1787229540.005059` - Fixed: rejected provider keys open setup without replaying the same credential.

## Verification
- Core focused tests: 3 files, 19 tests passed.
- Dispatch focused tests: 3 files, 43 tests passed.
- Clips extension tests: 6 files, 22 tests passed; typecheck and production build passed.
- `oxfmt` and `git diff --check` passed.

`pnpm guards` also ran; the changed-line guards passed, while four repository checks were blocked by existing workspace baseline/dependency issues (missing built `@agent-native/recap-cli`, i18n catalog baseline/import debt, and migration-export drift).