### PR TITLE
chore: refresh app changelog windows

### DIFF
--- a/templates/analytics/CHANGELOG.md
+++ b/templates/analytics/CHANGELOG.md
@@ -5,6 +5,12 @@ time from the command menu (Cmd+K → "What's new") or from Settings.
 
 Older updates live in [the changelog folder](./changelog/) and are included in the in-app "What's new" view.
 
+## 2026-08-20
+
+### Improved
+
+- Analytics now explains how to recover when staged data reaches its size limit.
+
 ## 2026-08-18
 
 ### Fixed
@@ -36,16 +42,3 @@ Older updates live in [the changelog folder](./changelog/) and are included in t
 
 - Feature flags can be managed across apps whose workspace records use different local IDs
 - Kept feature flag details readable by stacking rollout controls at narrow widths.
-
-## 2026-08-11
-
-### Improved
-
-- Full-page chat composers stay at a focused 750px width.
-
-### Fixed
-
-- Analytics custom blocks keep loading when they use the legacy BigQuery query action name.
-- Analytics dashboards keep the selected tab when reopened
-- Analytics routes company-knowledge and Slack-context questions to Brain
-- Chrome no longer offers to install Analytics as a desktop app.

--- a/templates/clips/CHANGELOG.md
+++ b/templates/clips/CHANGELOG.md
@@ -5,6 +5,17 @@ from the command menu (Cmd+K → "What's new") or from Settings.
 
 Older updates live in [the changelog folder](./changelog/) and are included in the in-app "What's new" view.
 
+## 2026-08-20
+
+### Improved
+
+- Recording controls now follow you across browser tabs and page navigations.
+
+### Fixed
+
+- Clips overlays now follow tab switches during the recording countdown and recover cleanly on tabs opened before Clips.
+- Clips now opens provider setup instead of retrying a rejected key in a loop.
+
 ## 2026-08-19
 
 ### Added
@@ -50,13 +61,3 @@ Older updates live in [the changelog folder](./changelog/) and are included in t
 
 - Long desktop recordings now complete or abort resumable uploads cleanly, preserve local recovery copies, and show the actual upload error when saving fails.
 - Clips now uses consistent text-only share controls with compact copy actions and an expandable Share with agents section across recordings and meetings.
-
-## 2026-08-13
-
-### Added
-
-- Private meeting notes can be shared with an external agent through a temporary link.
-
-### Improved
-
-- Comments now render inline Markdown for emphasis, inline code, links, and line breaks while keeping headings out of compact comment surfaces.


### PR DESCRIPTION
Refreshes the two app changelog windows that gained newer folder-backed entries after the main cleanup PR shipped.

- Includes the latest 2026-08-20 Analytics and Clips updates in each top-level CHANGELOG.md.
- Keeps the five-entry recent window and folder-backed older history contract idempotent.

Validation: node --experimental-strip-types scripts/compact-changelogs.ts --check