### PR TITLE
fix: optimize Builder CDN images in docs

### DIFF
--- a/packages/docs/app/components/CommunityTemplateCard.tsx
+++ b/packages/docs/app/components/CommunityTemplateCard.tsx
@@ -6,6 +6,7 @@ import {
 } from "@tabler/icons-react";
 import { useState } from "react";
 
+import { BuilderImage } from "./builder-image";
 import { trackEvent } from "./TemplateCard";
 
 export interface CommunityTemplate {
@@ -82,8 +83,9 @@ export function CommunityTemplateCard({
           rel="noopener noreferrer"
           className="-mx-[24px] -mt-[24px] block aspect-[924/729] overflow-hidden border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]"
         >
-          <img
+          <BuilderImage
             src={template.screenshot}
+            sizes="(max-width: 768px) 100vw, 400px"
             alt=""
             loading="lazy"
             decoding="async"

--- a/packages/docs/app/components/MarkdownRenderer.test.ts
+++ b/packages/docs/app/components/MarkdownRenderer.test.ts
@@ -45,6 +45,17 @@ describe("renderMarkdownToHtml", () => {
     expect(html).toContain('decoding="async"');
   });
 
+  it("renders Builder CDN images as responsive WebP", () => {
+    const source =
+      "https://cdn.builder.io/api/v1/image/assets%2Fspace%2Fasset-id";
+    const html = renderMarkdownToHtml(`![Builder image](${source})`);
+
+    expect(html).toContain(`${source}?format=webp&amp;width=800`);
+    expect(html).toContain(`${source}?format=webp&amp;width=240 240w`);
+    expect(html).toContain('sizes="(max-width: 900px) 100vw, 900px"');
+    expect(html).not.toContain(`src="${source}"`);
+  });
+
   it("infers markdown highlighting for generic markdown-like snippets", () => {
     const html = renderMarkdownToHtml(`
 \`\`\`text

--- a/packages/docs/app/components/MarkdownRenderer.tsx
+++ b/packages/docs/app/components/MarkdownRenderer.tsx
@@ -9,6 +9,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { codeToHtml } from "shiki";
 
 import {
+  BUILDER_IMAGE_WIDTHS,
+  getBuilderImageSrcSet,
+  getBuilderImageUrl,
+  isBuilderImageUrl,
+} from "./builder-image-urls";
+import {
   DEFAULT_DOCS_LOCALE,
   localizeDocsHref,
   type DocsLocale,
@@ -33,6 +39,9 @@ interface ImageDimensions {
 const DEFAULT_CODE_MAX_LINES = 17;
 const MAX_CONFIGURED_CODE_LINES = 2000;
 const MAX_RENDERED_MARKDOWN_CACHE_ENTRIES = 64;
+const DOCS_BUILDER_IMAGE_SIZES = "(max-width: 900px) 100vw, 900px";
+const DOCS_BUILDER_IMAGE_FALLBACK_WIDTH =
+  BUILDER_IMAGE_WIDTHS[BUILDER_IMAGE_WIDTHS.length - 1] ?? 800;
 
 const DOCS_IMAGE_DIMENSIONS: Record<string, ImageDimensions> = {
   "/screenshots/analytics.png": { width: 1400, height: 710 },
@@ -331,7 +340,14 @@ function createRenderer(locale: DocsLocale) {
     const sizeAttributes = dimensions
       ? ` width="${dimensions.width}" height="${dimensions.height}"`
       : "";
-    const image = `<img src="${escapeHtml(token.href)}" alt="${escapeHtml(token.text)}"${title} class="docs-image" loading="lazy" decoding="async"${sizeAttributes}>`;
+    const builderImageAttributes = isBuilderImageUrl(token.href)
+      ? [
+          `src="${escapeHtml(getBuilderImageUrl(token.href, DOCS_BUILDER_IMAGE_FALLBACK_WIDTH))}"`,
+          `srcset="${escapeHtml(getBuilderImageSrcSet(token.href) ?? "")}"`,
+          `sizes="${escapeHtml(DOCS_BUILDER_IMAGE_SIZES)}"`,
+        ].join(" ")
+      : `src="${escapeHtml(token.href)}"`;
+    const image = `<img ${builderImageAttributes} alt="${escapeHtml(token.text)}"${title} class="docs-image" loading="lazy" decoding="async"${sizeAttributes}>`;
 
     if (!dimensions) return image;
 

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -4,6 +4,7 @@ import { IconExternalLink } from "@tabler/icons-react";
 import { useState } from "react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "./builder-image";
 import { BuilderWaitlistContent } from "./BuilderWaitlistPopover";
 import { sitePathForLocale } from "./docs-locale";
 import { applyFirstTouchAttributionToLink } from "./marketing-attribution";
@@ -384,12 +385,13 @@ export function TemplateCard({ template }: { template: Template }) {
         }
       >
         {template.screenshot ? (
-          <img
+          <BuilderImage
             src={
               template.slug === "clips"
                 ? "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Febc2a7d837664382853cbfb481592b31?format=webp&width=800&height=1200"
                 : template.screenshot
             }
+            sizes="(max-width: 768px) 100vw, 400px"
             crossOrigin="anonymous"
             alt={t("templateCard.screenshotAlt", { name: template.name })}
             loading="lazy"

--- a/packages/docs/app/components/blocks/image.tsx
+++ b/packages/docs/app/components/blocks/image.tsx
@@ -1,6 +1,7 @@
 import { defineBlock } from "@agent-native/core/blocks";
 import type { BlockReadProps } from "@agent-native/core/blocks";
 
+import { BuilderImage } from "../builder-image";
 import { imageSchema, imageMdx, type ImageData } from "./image.config";
 import { MediaFrame } from "./media-layout";
 
@@ -16,7 +17,18 @@ export function ImageBlock({ data, ctx }: BlockReadProps<ImageData>) {
       text={data.text}
       ctx={ctx}
       media={
-        <img src={data.src} alt={data.alt} loading="lazy" decoding="async" />
+        <BuilderImage
+          src={data.src}
+          alt={data.alt}
+          sizes={
+            data.align && data.text
+              ? `(max-width: 900px) 100vw, ${data.width ?? 400}px`
+              : "(max-width: 900px) 100vw, 900px"
+          }
+          width={data.width}
+          loading="lazy"
+          decoding="async"
+        />
       }
       expandable
     />

--- a/packages/docs/app/components/builder-image-urls.test.ts
+++ b/packages/docs/app/components/builder-image-urls.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILDER_IMAGE_WIDTHS,
+  getBuilderImageSrcSet,
+  getBuilderImageUrl,
+  getBuilderImageWidths,
+  isBuilderImageUrl,
+} from "./builder-image-urls";
+
+const cdnImage =
+  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F619e278a05eb4fddaffdaa0668037a8b";
+
+describe("Builder image URLs", () => {
+  it("detects Builder image endpoints", () => {
+    expect(isBuilderImageUrl(cdnImage)).toBe(true);
+    expect(isBuilderImageUrl("https://cdn.builder.io/foo")).toBe(false);
+    expect(isBuilderImageUrl("/local-image.png")).toBe(false);
+  });
+
+  it("adds WebP and width params", () => {
+    expect(getBuilderImageUrl(cdnImage, 400)).toBe(
+      `${cdnImage}?format=webp&width=400`,
+    );
+  });
+
+  it("replaces existing format and width params", () => {
+    expect(getBuilderImageUrl(`${cdnImage}?format=jpg&width=2400`, 800)).toBe(
+      `${cdnImage}?format=webp&width=800`,
+    );
+  });
+
+  it("preserves unrelated query params", () => {
+    expect(getBuilderImageUrl(`${cdnImage}?quality=80`, 1200)).toBe(
+      `${cdnImage}?quality=80&format=webp&width=1200`,
+    );
+  });
+
+  it("normalizes responsive width candidates", () => {
+    expect(getBuilderImageWidths([800, 200.4, 0, -1, 200, 100])).toEqual([
+      100, 200, 800,
+    ]);
+  });
+
+  it("builds responsive WebP srcset candidates", () => {
+    expect(getBuilderImageSrcSet(cdnImage, [100, 200, 400])).toBe(
+      [100, 200, 400]
+        .map((width) => `${cdnImage}?format=webp&width=${width} ${width}w`)
+        .join(", "),
+    );
+  });
+
+  it("uses the capped default candidate ladder", () => {
+    expect(getBuilderImageSrcSet(cdnImage)).toContain(
+      `${cdnImage}?format=webp&width=${BUILDER_IMAGE_WIDTHS.at(-1)} ${BUILDER_IMAGE_WIDTHS.at(-1)}w`,
+    );
+    expect(getBuilderImageSrcSet(cdnImage)).not.toContain("width=2400");
+  });
+
+  it("does not create srcset for non-Builder URLs", () => {
+    expect(getBuilderImageSrcSet("https://example.com/image.png")).toBe(
+      undefined,
+    );
+  });
+});

--- a/packages/docs/app/components/builder-image-urls.ts
+++ b/packages/docs/app/components/builder-image-urls.ts
@@ -1,0 +1,47 @@
+export const BUILDER_IMAGE_WIDTHS = [240, 320, 400, 600, 800];
+
+const BUILDER_IMAGE_HOSTS = new Set(["cdn.builder.io", "api.builder.io"]);
+
+export function isBuilderImageUrl(src: string) {
+  try {
+    const url = new URL(src);
+    return (
+      BUILDER_IMAGE_HOSTS.has(url.hostname) &&
+      url.pathname.startsWith("/api/v1/image/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getBuilderImageWidths(
+  widths: readonly number[] = BUILDER_IMAGE_WIDTHS,
+) {
+  return [
+    ...new Set(
+      widths
+        .map((width) => Math.round(width))
+        .filter((width) => Number.isFinite(width) && width > 0),
+    ),
+  ].sort((a, b) => a - b);
+}
+
+export function getBuilderImageUrl(src: string, width: number) {
+  const url = new URL(src);
+  url.searchParams.delete("width");
+  url.searchParams.delete("format");
+  url.searchParams.set("format", "webp");
+  url.searchParams.set("width", String(width));
+  return url.toString();
+}
+
+export function getBuilderImageSrcSet(
+  src: string,
+  widths: readonly number[] = BUILDER_IMAGE_WIDTHS,
+) {
+  if (!isBuilderImageUrl(src)) return undefined;
+
+  return getBuilderImageWidths(widths)
+    .map((width) => `${getBuilderImageUrl(src, width)} ${width}w`)
+    .join(", ");
+}

--- a/packages/docs/app/components/builder-image.tsx
+++ b/packages/docs/app/components/builder-image.tsx
@@ -1,0 +1,63 @@
+import type { ImgHTMLAttributes } from "react";
+
+import {
+  BUILDER_IMAGE_WIDTHS,
+  getBuilderImageSrcSet,
+  getBuilderImageUrl,
+  getBuilderImageWidths,
+  isBuilderImageUrl,
+} from "./builder-image-urls";
+
+function getFallbackWidth(
+  width: ImgHTMLAttributes<HTMLImageElement>["width"],
+  widths: readonly number[],
+) {
+  const maxWidth = widths[widths.length - 1] ?? 800;
+
+  if (typeof width === "number") return Math.min(width, maxWidth);
+  if (typeof width === "string") {
+    const parsed = Number.parseInt(width, 10);
+    if (Number.isFinite(parsed)) return Math.min(parsed, maxWidth);
+  }
+
+  return widths[Math.min(3, widths.length - 1)] ?? maxWidth;
+}
+
+interface BuilderImageProps extends Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "src" | "srcSet" | "sizes"
+> {
+  src: string;
+  sizes: string;
+  widths?: readonly number[];
+}
+
+export function BuilderImage({
+  src,
+  sizes,
+  widths = BUILDER_IMAGE_WIDTHS,
+  width,
+  ...props
+}: BuilderImageProps) {
+  const resolvedWidths = getBuilderImageWidths(widths);
+  const isBuilderImage = isBuilderImageUrl(src);
+  const optimizedSrc =
+    isBuilderImage && resolvedWidths.length > 0
+      ? getBuilderImageUrl(src, getFallbackWidth(width, resolvedWidths))
+      : src;
+  const srcSet = isBuilderImage
+    ? getBuilderImageSrcSet(src, resolvedWidths)
+    : undefined;
+
+  return (
+    <img
+      loading="lazy"
+      decoding="async"
+      {...props}
+      width={width}
+      sizes={isBuilderImage ? sizes : undefined}
+      srcSet={srcSet}
+      src={optimizedSrc}
+    />
+  );
+}

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -2,6 +2,7 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { useState } from "react";
 import { Link } from "react-router";
 
+import { getBuilderImageUrl } from "../components/builder-image-urls";
 import { BuildFromScratchCta } from "../components/BuildFromScratchCta";
 import CodeBlock from "../components/CodeBlock";
 import { sitePathForLocale } from "../components/docs-locale";
@@ -505,7 +506,10 @@ function ComparisonSection() {
           <video
             className="homepage-comparison-video"
             src="https://cdn.builder.io/o/assets%2Fc5b47d20f6a943e485717e5895739988%2Fc88d506c160142ae9b8618616ceedcea%2Fcompressed?apiKey=c5b47d20f6a943e485717e5895739988&token=c88d506c160142ae9b8618616ceedcea&alt=media&optimized=true"
-            poster="https://cdn.builder.io/api/v1/image/assets%2Fc5b47d20f6a943e485717e5895739988%2F3d99ddf85c9040e38cb7c989fa4a7735"
+            poster={getBuilderImageUrl(
+              "https://cdn.builder.io/api/v1/image/assets%2Fc5b47d20f6a943e485717e5895739988%2F3d99ddf85c9040e38cb7c989fa4a7735",
+              800,
+            )}
             autoPlay
             controls
             muted

--- a/packages/docs/app/routes/homepage-new.tsx
+++ b/packages/docs/app/routes/homepage-new.tsx
@@ -26,6 +26,7 @@ import {
 import type { ComponentType, ReactNode } from "react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import {
   featuredTemplates,
@@ -326,8 +327,9 @@ function HeroScreens() {
               index % 2 === 0 ? "translate-y-16" : "-translate-y-2"
             }`}
           >
-            <img
+            <BuilderImage
               src={template.screenshot}
+              sizes="(max-width: 768px) 50vw, 300px"
               alt=""
               className="aspect-[4/3] w-full object-cover"
               loading="lazy"
@@ -379,8 +381,9 @@ function ExampleAppCard({ app }: { app: ExampleApp }) {
   return (
     <article className="group flex min-w-0 flex-col overflow-hidden rounded-lg border border-[var(--docs-border)] bg-[var(--bg)]">
       <div className="relative border-b border-[var(--docs-border)] bg-[var(--bg-secondary)]">
-        <img
+        <BuilderImage
           src={app.template.screenshot}
+          sizes="(max-width: 768px) 100vw, 400px"
           alt={`${displayName} app screenshot`}
           className="aspect-[16/10] w-full object-cover transition duration-300 group-hover:scale-[1.015]"
           loading="lazy"

--- a/packages/docs/app/routes/templates.$slug.tsx
+++ b/packages/docs/app/routes/templates.$slug.tsx
@@ -2,6 +2,7 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { IconArrowLeft } from "@tabler/icons-react";
 import { Link, useParams, type LoaderFunctionArgs } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -69,8 +70,9 @@ function TemplateFallbackArt({ template }: { template: Template }) {
 
   if (screenshot) {
     return (
-      <img
+      <BuilderImage
         src={screenshot}
+        sizes="(max-width: 900px) 100vw, 800px"
         crossOrigin="anonymous"
         alt={t("templateCard.screenshotAlt", { name: template.name })}
         loading="lazy"

--- a/packages/docs/app/routes/templates.analytics.tsx
+++ b/packages/docs/app/routes/templates.analytics.tsx
@@ -11,6 +11,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -172,8 +173,9 @@ export default function AnalyticsTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F816761dfcd484a79b71ba38379f7beda"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.analytics.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.calendar.tsx
+++ b/packages/docs/app/routes/templates.calendar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -137,8 +138,9 @@ export default function CalendarTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F172f704cfbd54a12a49839aeb582055a"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.calendar.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.clips.tsx
+++ b/packages/docs/app/routes/templates.clips.tsx
@@ -1,6 +1,7 @@
 import { useT } from "@agent-native/core/client/i18n";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
+import { BuilderImage } from "../components/builder-image";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
 import { TemplateDocsLink } from "../components/template-docs";
@@ -167,8 +168,9 @@ const ClipPreviewSlider = forwardRef<ClipPreviewSliderHandle>(
                 })
               }
             >
-              <img
+              <BuilderImage
                 src={clip.thumbnail}
+                sizes="(max-width: 768px) 82vw, 300px"
                 alt=""
                 loading="lazy"
                 decoding="async"
@@ -256,8 +258,9 @@ export default function ClipsTemplate() {
         }
         description={<p>{t("templateLanding.clips.s008")}</p>}
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Ff41728ef6fa644aaad100c96df09c1d6"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.clips.s001")}
             loading="lazy"
@@ -640,8 +643,9 @@ export default function ClipsTemplate() {
             </p>
           </div>
           <div className="flex items-center justify-center px-6 py-10 sm:px-10 lg:w-2/3 lg:py-16">
-            <img
+            <BuilderImage
               src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F82f67949705e405898c665ecf4a2d8d4?format=webp&width=1400"
+              sizes="(max-width: 768px) 100vw, 560px"
               crossOrigin="anonymous"
               alt={t("templateLanding.clips.s026")}
               loading="lazy"

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -129,8 +130,9 @@ export default function ContentTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F5cbd796ed40a43eb9e044c33d7d7fdea"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.content.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.design.tsx
+++ b/packages/docs/app/routes/templates.design.tsx
@@ -2,6 +2,7 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -120,8 +121,9 @@ export default function DesignTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fac64659497d24eacad0777227843535f"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.design.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.dispatch.tsx
+++ b/packages/docs/app/routes/templates.dispatch.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -128,8 +129,9 @@ export default function DispatchTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fd0bd7821c20a41c59924a0cc5101a149"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.dispatch.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.forms.tsx
+++ b/packages/docs/app/routes/templates.forms.tsx
@@ -2,6 +2,7 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -131,8 +132,9 @@ export default function FormsTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F90cd8fab274242b1a78c3c4d1ddadb78"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.forms.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.mail.tsx
+++ b/packages/docs/app/routes/templates.mail.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -146,8 +147,9 @@ export default function MailTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbcf3d06c52364153a913c15b77f2418d"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.mail.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.plan.tsx
+++ b/packages/docs/app/routes/templates.plan.tsx
@@ -13,6 +13,7 @@ import {
 } from "@tabler/icons-react";
 import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
+import { BuilderImage } from "../components/builder-image";
 import { SectionDivider } from "../components/SectionDivider";
 import {
   TemplateCapabilityGrid,
@@ -126,8 +127,9 @@ const PlanVideoCarousel = forwardRef<PlanVideoCarouselHandle>(
               })
             }
           >
-            <img
+            <BuilderImage
               src={video.thumbnail}
+              sizes="(max-width: 768px) 82vw, 300px"
               alt=""
               loading="lazy"
               decoding="async"
@@ -245,8 +247,9 @@ export default function PlanTemplate() {
         }
         description={<p className="m-0">{t("templateLanding.plan.s016")}</p>}
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fde31fbcbb81b4b799146d46dd4719eb0"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.plan.s001")}
             loading="lazy"

--- a/packages/docs/app/routes/templates.slides.tsx
+++ b/packages/docs/app/routes/templates.slides.tsx
@@ -2,6 +2,7 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { IconCheck } from "@tabler/icons-react";
 import { Link } from "react-router";
 
+import { BuilderImage } from "../components/builder-image";
 import { sitePathForLocale } from "../components/docs-locale";
 import { applyFirstTouchAttributionToLink } from "../components/marketing-attribution";
 import { SectionDivider } from "../components/SectionDivider";
@@ -172,8 +173,9 @@ export default function SlidesTemplate() {
           </a>
         }
         media={
-          <img
+          <BuilderImage
             src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F74bf2e432b544b848f2dd6255b570178"
+            sizes="(max-width: 900px) 100vw, 800px"
             crossOrigin="anonymous"
             alt={t("templateLanding.slides.s001")}
             loading="lazy"


### PR DESCRIPTION
## Summary
- apply the site Builder CDN image contract to docs images
- emit WebP fallback URLs, responsive srcset candidates, and sizes for Builder-hosted images
- cover Markdown-rendered images, content blocks, template cards, template landing pages, homepage media, and video posters

## Verification
- focused docs tests: 24 passed
- docs typecheck passed
- docs production build passed
- generated HTML contains WebP Builder CDN srcset candidates

Production promotion will be performed after merge.