### PR TITLE
fix: avoid false production health alerts from cold probes

### DIFF
--- a/scripts/keep-warm.mjs
+++ b/scripts/keep-warm.mjs
@@ -249,8 +249,12 @@ async function main() {
           ? ` shell:${r.ms}ms`
           : "";
       const pressure = strict ? describePressure(r.pressure) : null;
-      const slow =
-        r.ms > SLOW_HEALTH_MS || (shell && shell.ms > SLOW_HEALTH_MS);
+      // The health route and the public shell are separate serverless entry
+      // points. A cold health function can take seconds while the user-facing
+      // shell is already fast, so only the shell latency should mark an app
+      // slow when that measurement exists. Keep the health response and
+      // database-pressure checks for correctness and backend degradation.
+      const slow = shell ? shell.ms > SLOW_HEALTH_MS : r.ms > SLOW_HEALTH_MS;
       const pressured = pressure ? pressure.warnings.length > 0 : false;
       console.log(
         `  ${slow || pressured ? "!" : "✓"} ${r.name.padEnd(12)} ${String(r.ms).padStart(5)}ms  ${dbState}${shellState}${

--- a/templates/analytics/changelog/2026-08-20-staged-data-limit-recovery.md
+++ b/templates/analytics/changelog/2026-08-20-staged-data-limit-recovery.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-20
 ---
+
 Analytics now explains how to recover when staged data reaches its size limit.

--- a/templates/clips/changelog/2026-08-20-cross-tab-recording-controls.md
+++ b/templates/clips/changelog/2026-08-20-cross-tab-recording-controls.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-20
 ---
+
 Recording controls now follow you across browser tabs and page navigations.

--- a/templates/clips/changelog/2026-08-20-overlay-follow-review-fixes.md
+++ b/templates/clips/changelog/2026-08-20-overlay-follow-review-fixes.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-20
 ---
+
 Clips overlays now follow tab switches during the recording countdown and recover cleanly on tabs opened before Clips.

--- a/templates/clips/changelog/2026-08-20-provider-key-recovery.md
+++ b/templates/clips/changelog/2026-08-20-provider-key-recovery.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-20
 ---
+
 Clips now opens provider setup instead of retrying a rejected key in a loop.


### PR DESCRIPTION
## Summary

- Use the public shell latency as the user-facing slowness signal when the health route and shell are separate serverless entry points.
- Keep health status and database-pressure checks enforced so backend degradation still fails the strict audit.

## Verification

- `node --check scripts/keep-warm.mjs`
- `git diff --check`
- `node scripts/keep-warm.mjs --strict` against the live fleet: 14/14 warmed, no slow-app or pressure warnings.

The live check is source/runtime evidence for the current monitor behavior; this PR does not claim a production deployment.
