### PR TITLE
feat: add beta Clips Nightly download picker

### DIFF
--- a/templates/clips/app/lib/download-release-channel.test.ts
+++ b/templates/clips/app/lib/download-release-channel.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BETA_CLIPS_HOSTNAME,
+  getDefaultDownloadChannel,
+} from "./download-release-channel";
+
+describe("getDefaultDownloadChannel", () => {
+  it("defaults beta Clips to Nightly", () => {
+    expect(getDefaultDownloadChannel(BETA_CLIPS_HOSTNAME)).toBe("nightly");
+  });
+
+  it("normalizes the beta hostname", () => {
+    expect(getDefaultDownloadChannel("BETA.CLIPS.AGENT-NATIVE.COM.")).toBe(
+      "nightly",
+    );
+  });
+
+  it("keeps production and local hosts on Stable", () => {
+    expect(getDefaultDownloadChannel("clips.agent-native.com")).toBe(
+      "production",
+    );
+    expect(getDefaultDownloadChannel("localhost")).toBe("production");
+    expect(getDefaultDownloadChannel(undefined)).toBe("production");
+  });
+});

--- a/templates/clips/app/lib/download-release-channel.ts
+++ b/templates/clips/app/lib/download-release-channel.ts
@@ -1,0 +1,10 @@
+export type DownloadReleaseChannel = "production" | "nightly";
+
+export const BETA_CLIPS_HOSTNAME = "beta.clips.agent-native.com";
+
+export function getDefaultDownloadChannel(
+  hostname: string | undefined,
+): DownloadReleaseChannel {
+  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "");
+  return normalized === BETA_CLIPS_HOSTNAME ? "nightly" : "production";
+}

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -4,12 +4,20 @@ import {
   IconBrandChrome,
   IconBrandApple,
   IconBrandWindows,
+  IconChevronDown,
   IconDeviceDesktop,
   IconExternalLink,
 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import enMessages from "@/i18n/en-US";
 import {
@@ -17,6 +25,10 @@ import {
   markDesktopAppDownloaded,
   useClipsChromeExtensionEnabled,
 } from "@/lib/capture-install-options";
+import {
+  getDefaultDownloadChannel,
+  type DownloadReleaseChannel,
+} from "@/lib/download-release-channel";
 
 export function meta() {
   return [
@@ -29,7 +41,6 @@ export function meta() {
 }
 
 type PlatformId = "mac" | "windows" | "linux";
-type ReleaseChannel = "production" | "nightly";
 
 interface PlatformVariant {
   id: PlatformId;
@@ -204,7 +215,8 @@ function secondaryDownloadButton(
 export default function DownloadPage() {
   const chromeExtensionEnabled = useClipsChromeExtensionEnabled();
   const t = useT();
-  const [channel, setChannel] = useState<ReleaseChannel>("production");
+  const [channel, setChannel] = useState<DownloadReleaseChannel>("production");
+  const [hostResolved, setHostResolved] = useState(false);
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
   const [detected, setDetected] = useState<PlatformId | null>(null);
@@ -215,6 +227,13 @@ export default function DownloadPage() {
   }, []);
 
   useEffect(() => {
+    setChannel(getDefaultDownloadChannel(window.location.hostname));
+    setHostResolved(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hostResolved) return;
+
     let cancelled = false;
     setManifest(null);
     setManifestError(false);
@@ -233,7 +252,7 @@ export default function DownloadPage() {
     return () => {
       cancelled = true;
     };
-  }, [channel, manifestRequest]);
+  }, [channel, hostResolved, manifestRequest]);
 
   const retryManifest = () => {
     setManifestRequest((request) => request + 1);
@@ -335,46 +354,53 @@ export default function DownloadPage() {
                 <>{t("downloadRoute.loadingRelease")}</>
               )}
             </div>
-            <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-              <span>{t("downloadRoute.stable")}</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={channel === "nightly"}
-                aria-label={t(
-                  channel === "nightly"
-                    ? "downloadRoute.switchToStable"
-                    : "downloadRoute.switchToNightly",
-                )}
-                onClick={() =>
-                  handleChannelChange(
-                    channel === "nightly" ? "production" : "nightly",
-                  )
-                }
-                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${
-                  channel === "nightly"
-                    ? "bg-foreground"
-                    : "bg-muted-foreground/20"
-                }`}
-              >
-                <span
-                  aria-hidden="true"
-                  className={`block size-3.5 rounded-full bg-primary-foreground shadow-sm transition-transform ${
-                    channel === "nightly"
-                      ? "translate-x-[18px]"
-                      : "translate-x-[2px]"
-                  }`}
-                />
-              </button>
-              <span
-                className={
-                  channel === "nightly"
-                    ? "font-medium text-foreground"
-                    : "text-muted-foreground"
-                }
-              >
-                {t("downloadRoute.nightly")}
-              </span>
+            <div className="mt-2 flex items-center justify-center text-xs text-muted-foreground">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 font-normal text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    aria-label={t(
+                      channel === "nightly"
+                        ? "downloadRoute.switchToStable"
+                        : "downloadRoute.switchToNightly",
+                    )}
+                    data-release-channel={channel}
+                  >
+                    <span
+                      className={
+                        channel === "nightly"
+                          ? "font-medium text-foreground"
+                          : undefined
+                      }
+                    >
+                      {channel === "nightly"
+                        ? t("downloadRoute.nightly")
+                        : t("downloadRoute.stable")}
+                    </span>
+                    <IconChevronDown className="size-3.5" aria-hidden="true" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="center" className="w-44">
+                  <DropdownMenuRadioGroup
+                    value={channel}
+                    onValueChange={(value) => {
+                      if (value === "production" || value === "nightly") {
+                        handleChannelChange(value);
+                      }
+                    }}
+                  >
+                    <DropdownMenuRadioItem value="production">
+                      {t("downloadRoute.stable")}
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="nightly">
+                      {t("downloadRoute.nightly")}
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
 

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -258,7 +258,7 @@ export default function DownloadPage() {
     setManifestRequest((request) => request + 1);
   };
 
-  const handleChannelChange = (nextChannel: ReleaseChannel) => {
+  const handleChannelChange = (nextChannel: DownloadReleaseChannel) => {
     setManifest(null);
     setManifestError(false);
     setChannel(nextChannel);

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -362,11 +362,6 @@ export default function DownloadPage() {
                     variant="ghost"
                     size="sm"
                     className="h-7 gap-1.5 px-2 font-normal text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                    aria-label={t(
-                      channel === "nightly"
-                        ? "downloadRoute.switchToStable"
-                        : "downloadRoute.switchToNightly",
-                    )}
                     data-release-channel={channel}
                   >
                     <span

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -259,6 +259,8 @@ export default function DownloadPage() {
   };
 
   const handleChannelChange = (nextChannel: DownloadReleaseChannel) => {
+    if (nextChannel === channel) return;
+
     setManifest(null);
     setManifestError(false);
     setChannel(nextChannel);


### PR DESCRIPTION
## What changed
- default the Clips download page to Nightly releases on beta.clips.agent-native.com
- replace the binary channel switch with an accessible Stable/Nightly chevron picker
- keep the existing per-channel manifests and add regression coverage for host selection

## Validation
- `corepack pnpm exec vitest --run app/lib/download-release-channel.test.ts`
- `corepack pnpm exec vitest --run actions/clips-latest.test.ts`
- browser verification and screenshot follow after CI starts