### PR TITLE
Improve Clips recording preparation overlay

### DIFF
--- a/templates/clips/changelog/2026-08-20-preparing-recording-countdown-overlay.md
+++ b/templates/clips/changelog/2026-08-20-preparing-recording-countdown-overlay.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-20
+---
+Recording preparation now uses a centered full-screen overlay that transitions smoothly into the 3-2-1 countdown.

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -472,25 +472,17 @@ fn stop_countdown_control_tracking() {
     COUNTDOWN_CONTROL_TRACKING.store(false, Ordering::SeqCst);
 }
 
-/// Compact visible readiness state for the slow work that intentionally runs
-/// before the numeric countdown. This capture-excluded card briefly takes
-/// focus as the first stage of the explicit modal start flow, so the user sees
-/// that Start was accepted without changing the exact countdown-zero boundary.
+/// Full-screen visible readiness state for the slow work that intentionally
+/// runs before the numeric countdown. This capture-excluded overlay briefly
+/// takes focus as the first stage of the explicit modal start flow, so the user
+/// sees that Start was accepted without changing the exact countdown-zero
+/// boundary.
 #[tauri::command]
 pub async fn show_preparing(app: AppHandle) -> Result<(), String> {
     if let Some(existing) = app.get_webview_window(PREPARING_LABEL) {
         let _ = existing.close();
     }
     let (mx, my, mw, mh) = tray_monitor_physical_rect(&app);
-    let scale = overlay_scale_factor(&app);
-    let content_w: u32 = (260.0 * scale).round() as u32;
-    let content_h: u32 = (58.0 * scale).round() as u32;
-    let margin: i32 = (14.0 * scale).round() as i32;
-    let gutter = overlay_shadow_gutter_physical(&app);
-    let w = content_w + gutter * 2;
-    let h = content_h + gutter * 2;
-    let x = (mx + (mw.saturating_sub(w) / 2) as i32).max(mx);
-    let y = (my + mh as i32 - h as i32 - margin).max(my);
     let win = WebviewWindowBuilder::new(&app, PREPARING_LABEL, build_overlay_url("preparing"))
         .title("Preparing recording")
         .decorations(false)
@@ -503,14 +495,14 @@ pub async fn show_preparing(app: AppHandle) -> Result<(), String> {
         .focused(true)
         .build()
         .map_err(|error| format!("preparing window build failed: {error}"))?;
-    let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
-    let _ = win.set_position(PhysicalPosition::new(x, y));
+    let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(mw, mh)));
+    let _ = win.set_position(PhysicalPosition::new(mx, my));
     let _ = win.set_ignore_cursor_events(true);
     set_capture_excluded(&win);
     configure_overlay_behavior(&win);
     // Preparation and countdown are one explicit modal start flow. Making the
-    // compact readiness card key ensures it gets a real first paint and is
-    // announced before the full-screen countdown replaces it.
+    // readiness overlay key ensures it gets a real first paint and is announced
+    // before the countdown replaces it.
     present_interactive_window(&win);
     let _ = app.emit("clips:toolbar-preparing", true);
     // A newly-created webview needs one paint before the async preparation can

--- a/templates/clips/desktop/src/overlays/preparing.tsx
+++ b/templates/clips/desktop/src/overlays/preparing.tsx
@@ -1,12 +1,10 @@
-/** Visible readiness state shown while the shared Rewind Clip writer and
- * resumable upload session are prepared. The numeric countdown replaces it
- * only after zero can be an immediate media boundary. */
+/** Visible readiness state shown before the numeric countdown takes over. */
 export function Preparing() {
   return (
     <div className="preparing-root">
-      <div className="preparing-card" role="status" aria-live="polite">
+      <div className="preparing-content" role="status" aria-live="polite">
+        <span className="preparing-label">Preparing recording</span>
         <div className="preparing-spinner" aria-hidden="true" />
-        <span>Preparing recording…</span>
       </div>
     </div>
   );

--- a/templates/clips/desktop/src/overlays/preparing.tsx
+++ b/templates/clips/desktop/src/overlays/preparing.tsx
@@ -1,7 +1,7 @@
 /** Visible readiness state shown before the numeric countdown takes over. */
 export function Preparing() {
   return (
-    <div className="preparing-root">
+    <div className="countdown-root preparing-root">
       <div className="preparing-content" role="status" aria-live="polite">
         <span className="preparing-label">Preparing recording</span>
         <div className="preparing-spinner" aria-hidden="true" />

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -4250,41 +4250,40 @@ body[data-clips-route="recording-pill"] #root {
 }
 
 /* ------------------------------------------------------------------------- */
-/* Overlay: finalizing spinner                                                */
+/* Overlay: recording preparation                                              */
 /* ------------------------------------------------------------------------- */
 
 .preparing-root {
   position: fixed;
   inset: 0;
   display: flex;
-  align-items: flex-end;
-  justify-content: flex-start;
-  padding: 10px;
-  background: transparent;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.42);
+  pointer-events: none;
 }
 
-.preparing-card {
+.preparing-content {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 12px 14px;
-  border-radius: 16px;
-  background: rgba(20, 22, 28, 0.94);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 16px;
   color: white;
-  font-size: 13px;
-  font-weight: 600;
+}
+
+.preparing-label {
+  font-size: 20px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  line-height: 1;
 }
 
 .preparing-spinner {
-  width: 18px;
-  height: 18px;
+  width: 28px;
+  height: 28px;
   flex: 0 0 auto;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.18);
+  border: 3px solid rgba(255, 255, 255, 0.18);
   border-top-color: #ffffff;
   animation: finalizing-spin 0.9s linear infinite;
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -4259,7 +4259,6 @@ body[data-clips-route="recording-pill"] #root {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.42);
   pointer-events: none;
 }
 
@@ -4283,8 +4282,8 @@ body[data-clips-route="recording-pill"] #root {
   height: 28px;
   flex: 0 0 auto;
   border-radius: 50%;
-  border: 3px solid rgba(255, 255, 255, 0.18);
-  border-top-color: #ffffff;
+  border: 3px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-top-color: currentColor;
   animation: finalizing-spin 0.9s linear infinite;
 }
 


### PR DESCRIPTION
## Summary
- replace the compact preparing card with a full-screen dark overlay
- center the larger preparation label and spinner before the 3-2-1 countdown
- update the Clips changelog

## Verification
- `pnpm --dir templates/clips/desktop run build`
- `cargo fmt --manifest-path templates/clips/desktop/src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path templates/clips/desktop/src-tauri/Cargo.toml`
- browser screenshot at `#preparing` confirms centered layout at 1280x720

TypeScript tests could not start because the filtered install did not build the workspace `@agent-native/core` artifacts (`@agent-native/core/voice` and `@agent-native/core/vitest-config` were unavailable).