### PR TITLE
feat(design): import design.md guidance

### DIFF
--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -1478,6 +1478,9 @@ const enUS = {
     continue: "Continue to generation",
     starting: "Starting...",
     githubIndexStarted: "GitHub indexing started",
+    designMdIndexStarted: "design.md indexing started",
+    designMdUpload: "Upload design.md",
+    designMdHelp: "Import design.md guidance into Builder DSI",
     title: "Set up your design system",
     description:
       "Connect Figma, code, and optional design.md guidance through Builder DSI. More context gives the agent a more accurate system.",
@@ -1542,6 +1545,10 @@ const enUS = {
         "Use a full GitHub repository URL, like https://github.com/org/repo.",
       githubIndex:
         "Could not start GitHub indexing. Check your Builder connection and repository access.",
+      chooseDesignMd: "Please choose a design.md or design.mdx file.",
+      readDesignMd: "Could not read the design.md file.",
+      designMdIndex:
+        "Could not start design.md indexing. Check your Builder connection.",
       noSources: "Add at least one source before generating a design system.",
     },
     sections: {
@@ -1558,6 +1565,10 @@ const enUS = {
         title: "Connect Code",
         description:
           "GitHub repos, local source files, and optional design.md guidance for Builder DSI",
+      },
+      designMd: {
+        title: "Import design.md",
+        description: "Use a design.md file as the design system source",
       },
       designFiles: {
         title: "Reference files",
@@ -1960,6 +1971,9 @@ const designLocaleOverrides = {
       continue: "继续生成",
       starting: "正在启动…",
       githubIndexStarted: "GitHub 索引已开始",
+      designMdIndexStarted: "design.md 索引已开始",
+      designMdUpload: "上传 design.md",
+      designMdHelp: "将 design.md 指引导入 Builder DSI",
       title: "设置您的设计系统",
       description:
         "通过 Builder DSI 连接 Figma、代码和可选的 design.md 指引。上下文越多，代理得到的系统越准确。",
@@ -2016,6 +2030,9 @@ const designLocaleOverrides = {
           "使用完整的 GitHub 存储库 URL，例如 https://github.com/org/repo。",
         githubIndex:
           "无法启动 GitHub 索引。请检查 Builder 连接和仓库访问权限。",
+        chooseDesignMd: "请选择 design.md 或 design.mdx 文件。",
+        readDesignMd: "无法读取 design.md 文件。",
+        designMdIndex: "无法启动 design.md 索引。请检查 Builder 连接。",
         noSources: "在生成设计系统之前至少添加一个源。",
       },
       sections: {
@@ -2032,6 +2049,10 @@ const designLocaleOverrides = {
           title: "连接代码",
           description:
             "GitHub 存储库、本地代码文件或 design.md 会交给 Builder DSI 索引。",
+        },
+        designMd: {
+          title: "导入 design.md",
+          description: "使用 design.md 文件作为设计系统来源",
         },
         designFiles: {
           title: "参考文件",
@@ -2376,6 +2397,9 @@ const designLocaleOverrides = {
       continue: "continuar con la generación",
       starting: "Iniciando…",
       githubIndexStarted: "La indexación de GitHub ha comenzado",
+      designMdIndexStarted: "La indexación de design.md ha comenzado",
+      designMdUpload: "Importar design.md",
+      designMdHelp: "Importa las directrices de design.md a Builder DSI",
       title: "Configure su sistema de diseño",
       description:
         "Conecta Figma, código y guía opcional de design.md mediante Builder DSI. Más contexto le da al agente un sistema más preciso.",
@@ -2442,6 +2466,10 @@ const designLocaleOverrides = {
           "Utilice un repositorio GitHub completo URL, como https://github.com/org/repo.",
         githubIndex:
           "No se pudo iniciar la indexación de GitHub. Comprueba la conexión de Builder y el acceso al repositorio.",
+        chooseDesignMd: "Elija un archivo design.md o design.mdx.",
+        readDesignMd: "No se pudo leer el archivo design.md.",
+        designMdIndex:
+          "No se pudo iniciar la indexación de design.md. Comprueba la conexión de Builder.",
         noSources:
           "Agregue al menos una fuente antes de generar un sistema de diseño.",
       },
@@ -2459,6 +2487,11 @@ const designLocaleOverrides = {
           title: "Conectar código",
           description:
             "Repositorios de GitHub, archivos de código locales o design.md se indexan con Builder DSI.",
+        },
+        designMd: {
+          title: "Importar design.md",
+          description:
+            "Usa un archivo design.md como fuente del sistema de diseño",
         },
         designFiles: {
           title: "Archivos de referencia",
@@ -2814,6 +2847,9 @@ const designLocaleOverrides = {
       continue: "Continuer jusqu'à la génération",
       starting: "Démarrage…",
       githubIndexStarted: "L’indexation GitHub a démarré",
+      designMdIndexStarted: "L’indexation de design.md a démarré",
+      designMdUpload: "Importer design.md",
+      designMdHelp: "Importez les consignes design.md dans Builder DSI",
       title: "Configurez votre système de conception",
       description:
         "Connectez Figma, le code et les consignes design.md facultatives via Builder DSI. Plus le contexte est riche, plus le système de l’agent est précis.",
@@ -2881,6 +2917,10 @@ const designLocaleOverrides = {
           "Utilisez un référentiel GitHub complet URL, comme https://github.com/org/repo.",
         githubIndex:
           "Impossible de démarrer l’indexation GitHub. Vérifiez la connexion à Builder et l’accès au dépôt.",
+        chooseDesignMd: "Veuillez choisir un fichier design.md ou design.mdx.",
+        readDesignMd: "Impossible de lire le fichier design.md.",
+        designMdIndex:
+          "Impossible de démarrer l’indexation de design.md. Vérifiez la connexion à Builder.",
         noSources:
           "Ajoutez au moins une source avant de générer un système de conception.",
       },
@@ -2898,6 +2938,11 @@ const designLocaleOverrides = {
           title: "Connecter le code",
           description:
             "Les dépôts GitHub, fichiers de code locaux ou design.md sont indexés par Builder DSI.",
+        },
+        designMd: {
+          title: "Importer design.md",
+          description:
+            "Utilisez un fichier design.md comme source du système de conception",
         },
         designFiles: {
           title: "Fichiers de référence",
@@ -3253,6 +3298,9 @@ const designLocaleOverrides = {
       continue: "Weiter zur Generation",
       starting: "Wird gestartet…",
       githubIndexStarted: "GitHub-Indizierung gestartet",
+      designMdIndexStarted: "design.md-Indizierung gestartet",
+      designMdUpload: "design.md importieren",
+      designMdHelp: "design.md-Anweisungen in Builder DSI importieren",
       title: "Richten Sie Ihr Designsystem ein",
       description:
         "Verbinde Figma, Code und optionale design.md-Anweisungen über Builder DSI. Mehr Kontext gibt dem Agenten ein genaueres System.",
@@ -3321,6 +3369,10 @@ const designLocaleOverrides = {
           "Verwenden Sie ein vollständiges GitHub-Repository URL, wie https://github.com/org/repo.",
         githubIndex:
           "GitHub-Indizierung konnte nicht gestartet werden. Prüfe die Builder-Verbindung und den Repository-Zugriff.",
+        chooseDesignMd: "Wählen Sie eine design.md- oder design.mdx-Datei aus.",
+        readDesignMd: "Die design.md-Datei konnte nicht gelesen werden.",
+        designMdIndex:
+          "Die design.md-Indizierung konnte nicht gestartet werden. Prüfen Sie die Builder-Verbindung.",
         noSources:
           "Fügen Sie mindestens eine Quelle hinzu, bevor Sie ein Designsystem erstellen.",
       },
@@ -3338,6 +3390,11 @@ const designLocaleOverrides = {
           title: "Code verbinden",
           description:
             "GitHub-Repositories, lokale Code-Dateien oder design.md werden mit Builder DSI indexiert.",
+        },
+        designMd: {
+          title: "design.md importieren",
+          description:
+            "Eine design.md-Datei als Quelle für das Designsystem verwenden",
         },
         designFiles: {
           title: "Referenzdateien",
@@ -3691,6 +3748,9 @@ const designLocaleOverrides = {
       continue: "世代を継続する",
       starting: "開始中…",
       githubIndexStarted: "GitHub のインデックス作成を開始しました",
+      designMdIndexStarted: "design.md のインデックス作成を開始しました",
+      designMdUpload: "design.md をインポート",
+      designMdHelp: "design.md ガイドを Builder DSI にインポートします",
       title: "デザインシステムをセットアップする",
       description:
         "Figma、コード、任意の design.md ガイドを Builder DSI で接続します。コンテキストが多いほど、エージェントのシステムは正確になります。",
@@ -3757,6 +3817,11 @@ const designLocaleOverrides = {
           "https://github.com/org/repo など、完全な GitHub リポジトリ URL を使用します。",
         githubIndex:
           "GitHub のインデックス作成を開始できませんでした。Builder の接続とリポジトリへのアクセスを確認してください。",
+        chooseDesignMd:
+          "design.md または design.mdx ファイルを選択してください。",
+        readDesignMd: "design.md ファイルを読み込めませんでした。",
+        designMdIndex:
+          "design.md のインデックス作成を開始できませんでした。Builder の接続を確認してください。",
         noSources:
           "デザイン システムを生成する前に、少なくとも 1 つのソースを追加します。",
       },
@@ -3774,6 +3839,10 @@ const designLocaleOverrides = {
           title: "コードを接続",
           description:
             "GitHub リポジトリ、ローカルコードファイル、design.md は Builder DSI でインデックス化されます。",
+        },
+        designMd: {
+          title: "design.md をインポート",
+          description: "design.md ファイルをデザインシステムのソースとして使用",
         },
         designFiles: {
           title: "参照ファイル",
@@ -4124,6 +4193,9 @@ const designLocaleOverrides = {
       continue: "세대를 이어가다",
       starting: "시작 중…",
       githubIndexStarted: "GitHub 인덱싱이 시작되었습니다",
+      designMdIndexStarted: "design.md 인덱싱이 시작되었습니다",
+      designMdUpload: "design.md 가져오기",
+      designMdHelp: "design.md 지침을 Builder DSI로 가져오기",
       title: "디자인 시스템 설정",
       description:
         "Figma, 코드, 선택적 design.md 지침을 Builder DSI로 연결하세요. 맥락이 많을수록 에이전트의 시스템이 더 정확해집니다.",
@@ -4186,6 +4258,10 @@ const designLocaleOverrides = {
           "https://github.com/org/repo와 같은 전체 GitHub 저장소 URL를 사용하세요.",
         githubIndex:
           "GitHub 인덱싱을 시작할 수 없습니다. Builder 연결과 저장소 접근 권한을 확인하세요.",
+        chooseDesignMd: "design.md 또는 design.mdx 파일을 선택하세요.",
+        readDesignMd: "design.md 파일을 읽을 수 없습니다.",
+        designMdIndex:
+          "design.md 인덱싱을 시작할 수 없습니다. Builder 연결을 확인하세요.",
         noSources: "디자인 시스템을 생성하기 전에 소스를 하나 이상 추가하세요.",
       },
       sections: {
@@ -4202,6 +4278,10 @@ const designLocaleOverrides = {
           title: "코드 연결",
           description:
             "GitHub 저장소, 로컬 코드 파일 또는 design.md가 Builder DSI로 색인화됩니다.",
+        },
+        designMd: {
+          title: "design.md 가져오기",
+          description: "design.md 파일을 디자인 시스템 소스로 사용",
         },
         designFiles: {
           title: "참조 파일",
@@ -4551,6 +4631,9 @@ const designLocaleOverrides = {
       continue: "Continuar para a geração",
       starting: "Iniciando…",
       githubIndexStarted: "Indexação do GitHub iniciada",
+      designMdIndexStarted: "Indexação do design.md iniciada",
+      designMdUpload: "Importar design.md",
+      designMdHelp: "Importe as orientações de design.md para o Builder DSI",
       title: "Configure seu sistema de design",
       description:
         "Conecte Figma, código e orientações opcionais de design.md pelo Builder DSI. Mais contexto dá ao agente um sistema mais preciso.",
@@ -4616,6 +4699,10 @@ const designLocaleOverrides = {
           "Use um repositório GitHub completo URL, como https://github.com/org/repo.",
         githubIndex:
           "Não foi possível iniciar a indexação do GitHub. Verifique a conexão do Builder e o acesso ao repositório.",
+        chooseDesignMd: "Escolha um arquivo design.md ou design.mdx.",
+        readDesignMd: "Não foi possível ler o arquivo design.md.",
+        designMdIndex:
+          "Não foi possível iniciar a indexação do design.md. Verifique a conexão do Builder.",
         noSources:
           "Adicione pelo menos uma fonte antes de gerar um sistema de design.",
       },
@@ -4633,6 +4720,11 @@ const designLocaleOverrides = {
           title: "Conectar código",
           description:
             "Repositórios GitHub, arquivos de código locais ou design.md são indexados com Builder DSI.",
+        },
+        designMd: {
+          title: "Importar design.md",
+          description:
+            "Usar um arquivo design.md como fonte do sistema de design",
         },
         designFiles: {
           title: "Arquivos de referência",
@@ -4984,6 +5076,9 @@ const designLocaleOverrides = {
       continue: "पीढ़ी तक जारी रखें",
       starting: "शुरू हो रहा है…",
       githubIndexStarted: "GitHub इंडेक्सिंग शुरू हो गई",
+      designMdIndexStarted: "design.md इंडेक्सिंग शुरू हो गई",
+      designMdUpload: "design.md आयात करें",
+      designMdHelp: "design.md मार्गदर्शन को Builder DSI में आयात करें",
       title: "अपना डिज़ाइन सिस्टम सेट करें",
       description:
         "Figma, कोड और वैकल्पिक design.md मार्गदर्शन को Builder DSI से कनेक्ट करें. अधिक संदर्भ एजेंट को अधिक सटीक सिस्टम देता है.",
@@ -5044,6 +5139,9 @@ const designLocaleOverrides = {
           "https://github.com/org/repo जैसे पूर्ण GitHub रिपॉजिटरी URL का उपयोग करें।",
         githubIndex:
           "GitHub इंडेक्सिंग शुरू नहीं हो सकी। Builder कनेक्शन और रिपॉजिटरी एक्सेस जाँचें।",
+        chooseDesignMd: "कृपया design.md या design.mdx फ़ाइल चुनें।",
+        readDesignMd: "design.md फ़ाइल पढ़ी नहीं जा सकी।",
+        designMdIndex: "design.md इंडेक्सिंग शुरू नहीं हो सकी। Builder कनेक्शन जाँचें।",
         noSources: "डिज़ाइन सिस्टम तैयार करने से पहले कम से कम एक स्रोत जोड़ें।",
       },
       sections: {
@@ -5060,6 +5158,10 @@ const designLocaleOverrides = {
           title: "कोड कनेक्ट करें",
           description:
             "GitHub रिपॉज़िटरी, स्थानीय कोड फ़ाइलें या design.md Builder DSI से index होते हैं.",
+        },
+        designMd: {
+          title: "design.md आयात करें",
+          description: "डिज़ाइन सिस्टम के स्रोत के रूप में design.md फ़ाइल का उपयोग करें",
         },
         designFiles: {
           title: "संदर्भ फ़ाइलें",
@@ -5407,6 +5509,9 @@ const designLocaleOverrides = {
       continue: "الاستمرار في الجيل",
       starting: "جارٍ البدء…",
       githubIndexStarted: "بدأت فهرسة GitHub",
+      designMdIndexStarted: "بدأت فهرسة design.md",
+      designMdUpload: "استيراد design.md",
+      designMdHelp: "استيراد إرشادات design.md إلى Builder DSI",
       title: "قم بإعداد نظام التصميم الخاص بك",
       description:
         "اربط Figma والكود وإرشادات design.md الاختيارية عبر Builder DSI. كلما زاد السياق، حصل الوكيل على نظام أدق.",
@@ -5469,6 +5574,9 @@ const designLocaleOverrides = {
           "استخدم مستودع GitHub الكامل URL، مثل https://github.com/org/repo.",
         githubIndex:
           "تعذر بدء فهرسة GitHub. تحقق من اتصال Builder ومن صلاحية الوصول إلى المستودع.",
+        chooseDesignMd: "يرجى اختيار ملف design.md أو design.mdx.",
+        readDesignMd: "تعذر قراءة ملف design.md.",
+        designMdIndex: "تعذر بدء فهرسة design.md. تحقق من اتصال Builder.",
         noSources: "أضف مصدرًا واحدًا على الأقل قبل إنشاء نظام التصميم.",
       },
       sections: {
@@ -5485,6 +5593,10 @@ const designLocaleOverrides = {
           title: "ربط الكود",
           description:
             "تتم فهرسة مستودعات GitHub أو ملفات الكود المحلية أو design.md عبر Builder DSI.",
+        },
+        designMd: {
+          title: "استيراد design.md",
+          description: "استخدم ملف design.md كمصدر لنظام التصميم",
         },
         designFiles: {
           title: "ملفات مرجعية",

--- a/templates/design/app/i18n-data.ts
+++ b/templates/design/app/i18n-data.ts
@@ -1547,6 +1547,7 @@ const enUS = {
         "Could not start GitHub indexing. Check your Builder connection and repository access.",
       chooseDesignMd: "Please choose a design.md or design.mdx file.",
       readDesignMd: "Could not read the design.md file.",
+      designMdTooLarge: "design.md must be 2 MB or smaller.",
       designMdIndex:
         "Could not start design.md indexing. Check your Builder connection.",
       noSources: "Add at least one source before generating a design system.",
@@ -2032,6 +2033,7 @@ const designLocaleOverrides = {
           "无法启动 GitHub 索引。请检查 Builder 连接和仓库访问权限。",
         chooseDesignMd: "请选择 design.md 或 design.mdx 文件。",
         readDesignMd: "无法读取 design.md 文件。",
+        designMdTooLarge: "design.md 必须不超过 2 MB。",
         designMdIndex: "无法启动 design.md 索引。请检查 Builder 连接。",
         noSources: "在生成设计系统之前至少添加一个源。",
       },
@@ -2468,6 +2470,7 @@ const designLocaleOverrides = {
           "No se pudo iniciar la indexación de GitHub. Comprueba la conexión de Builder y el acceso al repositorio.",
         chooseDesignMd: "Elija un archivo design.md o design.mdx.",
         readDesignMd: "No se pudo leer el archivo design.md.",
+        designMdTooLarge: "design.md debe tener un tamaño máximo de 2 MB.",
         designMdIndex:
           "No se pudo iniciar la indexación de design.md. Comprueba la conexión de Builder.",
         noSources:
@@ -2919,6 +2922,7 @@ const designLocaleOverrides = {
           "Impossible de démarrer l’indexation GitHub. Vérifiez la connexion à Builder et l’accès au dépôt.",
         chooseDesignMd: "Veuillez choisir un fichier design.md ou design.mdx.",
         readDesignMd: "Impossible de lire le fichier design.md.",
+        designMdTooLarge: "design.md doit faire 2 Mo ou moins.",
         designMdIndex:
           "Impossible de démarrer l’indexation de design.md. Vérifiez la connexion à Builder.",
         noSources:
@@ -3371,6 +3375,7 @@ const designLocaleOverrides = {
           "GitHub-Indizierung konnte nicht gestartet werden. Prüfe die Builder-Verbindung und den Repository-Zugriff.",
         chooseDesignMd: "Wählen Sie eine design.md- oder design.mdx-Datei aus.",
         readDesignMd: "Die design.md-Datei konnte nicht gelesen werden.",
+        designMdTooLarge: "design.md darf höchstens 2 MB groß sein.",
         designMdIndex:
           "Die design.md-Indizierung konnte nicht gestartet werden. Prüfen Sie die Builder-Verbindung.",
         noSources:
@@ -3820,6 +3825,7 @@ const designLocaleOverrides = {
         chooseDesignMd:
           "design.md または design.mdx ファイルを選択してください。",
         readDesignMd: "design.md ファイルを読み込めませんでした。",
+        designMdTooLarge: "design.md は 2 MB 以下にしてください。",
         designMdIndex:
           "design.md のインデックス作成を開始できませんでした。Builder の接続を確認してください。",
         noSources:
@@ -4260,6 +4266,7 @@ const designLocaleOverrides = {
           "GitHub 인덱싱을 시작할 수 없습니다. Builder 연결과 저장소 접근 권한을 확인하세요.",
         chooseDesignMd: "design.md 또는 design.mdx 파일을 선택하세요.",
         readDesignMd: "design.md 파일을 읽을 수 없습니다.",
+        designMdTooLarge: "design.md 파일은 2MB 이하여야 합니다.",
         designMdIndex:
           "design.md 인덱싱을 시작할 수 없습니다. Builder 연결을 확인하세요.",
         noSources: "디자인 시스템을 생성하기 전에 소스를 하나 이상 추가하세요.",
@@ -4701,6 +4708,7 @@ const designLocaleOverrides = {
           "Não foi possível iniciar a indexação do GitHub. Verifique a conexão do Builder e o acesso ao repositório.",
         chooseDesignMd: "Escolha um arquivo design.md ou design.mdx.",
         readDesignMd: "Não foi possível ler o arquivo design.md.",
+        designMdTooLarge: "design.md deve ter no máximo 2 MB.",
         designMdIndex:
           "Não foi possível iniciar a indexação do design.md. Verifique a conexão do Builder.",
         noSources:
@@ -5141,6 +5149,7 @@ const designLocaleOverrides = {
           "GitHub इंडेक्सिंग शुरू नहीं हो सकी। Builder कनेक्शन और रिपॉजिटरी एक्सेस जाँचें।",
         chooseDesignMd: "कृपया design.md या design.mdx फ़ाइल चुनें।",
         readDesignMd: "design.md फ़ाइल पढ़ी नहीं जा सकी।",
+        designMdTooLarge: "design.md 2 MB या उससे छोटा होना चाहिए।",
         designMdIndex: "design.md इंडेक्सिंग शुरू नहीं हो सकी। Builder कनेक्शन जाँचें।",
         noSources: "डिज़ाइन सिस्टम तैयार करने से पहले कम से कम एक स्रोत जोड़ें।",
       },
@@ -5576,6 +5585,7 @@ const designLocaleOverrides = {
           "تعذر بدء فهرسة GitHub. تحقق من اتصال Builder ومن صلاحية الوصول إلى المستودع.",
         chooseDesignMd: "يرجى اختيار ملف design.md أو design.mdx.",
         readDesignMd: "تعذر قراءة ملف design.md.",
+        designMdTooLarge: "يجب ألا يتجاوز حجم design.md ‏2 ميغابايت.",
         designMdIndex: "تعذر بدء فهرسة design.md. تحقق من اتصال Builder.",
         noSources: "أضف مصدرًا واحدًا على الأقل قبل إنشاء نظام التصميم.",
       },

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -1342,6 +1342,7 @@ const messages = {
         "無法啟動 GitHub 索引。請檢查 Builder 連線和儲存庫存取權限。",
       chooseDesignMd: "請選取 design.md 或 design.mdx 檔案。",
       readDesignMd: "無法讀取 design.md 檔案。",
+      designMdTooLarge: "design.md 必須為 2 MB 或更小。",
       designMdIndex: "無法啟動 design.md 索引。請檢查 Builder 連線。",
       noSources: "在生成設計系統之前至少新增一個來源。",
     },

--- a/templates/design/app/i18n/zh-TW.ts
+++ b/templates/design/app/i18n/zh-TW.ts
@@ -1280,6 +1280,9 @@ const messages = {
     continue: "繼續生成",
     starting: "正在啟動…",
     githubIndexStarted: "GitHub 索引已開始",
+    designMdIndexStarted: "design.md 索引已開始",
+    designMdUpload: "上傳 design.md",
+    designMdHelp: "將 design.md 指引匯入 Builder DSI",
     title: "設定您的設計系統",
     description:
       "透過 Builder DSI 連接 Figma、程式碼和選用的 design.md 指引。脈絡越多，代理得到的系統越準確。",
@@ -1337,6 +1340,9 @@ const messages = {
         "使用完整的 GitHub 儲存庫 URL，例如 https://github.com/org/repo。",
       githubIndex:
         "無法啟動 GitHub 索引。請檢查 Builder 連線和儲存庫存取權限。",
+      chooseDesignMd: "請選取 design.md 或 design.mdx 檔案。",
+      readDesignMd: "無法讀取 design.md 檔案。",
+      designMdIndex: "無法啟動 design.md 索引。請檢查 Builder 連線。",
       noSources: "在生成設計系統之前至少新增一個來源。",
     },
     sections: {
@@ -1353,6 +1359,10 @@ const messages = {
         title: "連接程式碼",
         description:
           "GitHub 儲存庫、本機程式碼檔案或 design.md 會交給 Builder DSI 索引。",
+      },
+      designMd: {
+        title: "匯入 design.md",
+        description: "使用 design.md 檔案作為設計系統來源",
       },
       designFiles: {
         title: "參考檔案",

--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -97,6 +97,8 @@ interface BuilderIndexInput {
   designMd?: string;
 }
 
+const MAX_INLINE_DESIGN_MD_BYTES = 2 * 1024 * 1024;
+
 export default function DesignSystemSetup() {
   const t = useT();
   const navigate = useNavigate();
@@ -127,6 +129,7 @@ export default function DesignSystemSetup() {
   const assetInputRef = useRef<HTMLInputElement>(null);
   const codeInputRef = useRef<HTMLInputElement>(null);
   const designMdInputRef = useRef<HTMLInputElement>(null);
+  const designMdUploadGenerationRef = useRef(0);
   const appliedSourceIdRef = useRef<string | null>(null);
 
   const { data: designsData } = useActionQuery<{
@@ -407,8 +410,14 @@ export default function DesignSystemSetup() {
       const file = files[0];
       e.target.value = "";
       if (!file) return;
+      const uploadGeneration = ++designMdUploadGenerationRef.current;
+      setDesignMdFiles([]);
       if (!isDesignMdFile({ name: file.name })) {
         setValidationError(t("designSystemSetup.errors.chooseDesignMd"));
+        return;
+      }
+      if (file.size > MAX_INLINE_DESIGN_MD_BYTES) {
+        setValidationError(t("designSystemSetup.errors.designMdTooLarge"));
         return;
       }
       const uploadedFile: UploadedFile = {
@@ -420,10 +429,16 @@ export default function DesignSystemSetup() {
       file
         .text()
         .then((text) => {
+          if (designMdUploadGenerationRef.current !== uploadGeneration) {
+            return;
+          }
           setDesignMdFiles([{ ...uploadedFile, textContent: text }]);
           setValidationError(null);
         })
         .catch(() => {
+          if (designMdUploadGenerationRef.current !== uploadGeneration) {
+            return;
+          }
           setValidationError(t("designSystemSetup.errors.readDesignMd"));
         });
     },

--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -55,7 +55,13 @@ interface UploadedFile {
   textContent?: string;
 }
 
-type OtherSource = "brand" | "code" | "files" | "existing" | "notes";
+type OtherSource =
+  | "brand"
+  | "code"
+  | "design-md"
+  | "files"
+  | "existing"
+  | "notes";
 
 interface BuilderIndexResult {
   ok: boolean;
@@ -105,6 +111,7 @@ export default function DesignSystemSetup() {
   const [githubPaths, setGithubPaths] = useState("");
   const [githubLinks, setGithubLinks] = useState<GitHubLink[]>([]);
   const [codeFiles, setCodeFiles] = useState<UploadedFile[]>([]);
+  const [designMdFiles, setDesignMdFiles] = useState<UploadedFile[]>([]);
   const [docFiles, setDocFiles] = useState<UploadedFile[]>([]);
   const [imageFiles, setImageFiles] = useState<UploadedFile[]>([]);
   const [assets, setAssets] = useState<UploadedFile[]>([]);
@@ -119,6 +126,7 @@ export default function DesignSystemSetup() {
   const imageInputRef = useRef<HTMLInputElement>(null);
   const assetInputRef = useRef<HTMLInputElement>(null);
   const codeInputRef = useRef<HTMLInputElement>(null);
+  const designMdInputRef = useRef<HTMLInputElement>(null);
   const appliedSourceIdRef = useRef<string | null>(null);
 
   const { data: designsData } = useActionQuery<{
@@ -264,6 +272,7 @@ export default function DesignSystemSetup() {
       githubUrl.trim() ||
       githubLinks.length > 0 ||
       codeFiles.length > 0 ||
+      designMdFiles.length > 0 ||
       builderIndexResult ||
       docFiles.length > 0 ||
       imageFiles.length > 0 ||
@@ -279,6 +288,7 @@ export default function DesignSystemSetup() {
     githubUrl,
     githubLinks,
     codeFiles,
+    designMdFiles,
     builderIndexResult,
     docFiles,
     imageFiles,
@@ -390,6 +400,36 @@ export default function DesignSystemSetup() {
     [readTextFiles],
   );
 
+  const handleDesignMdUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files) return;
+      const file = files[0];
+      e.target.value = "";
+      if (!file) return;
+      if (!isDesignMdFile({ name: file.name })) {
+        setValidationError(t("designSystemSetup.errors.chooseDesignMd"));
+        return;
+      }
+      const uploadedFile: UploadedFile = {
+        id: crypto.randomUUID(),
+        name: file.name,
+        type: file.type || "text/markdown",
+        size: file.size,
+      };
+      file
+        .text()
+        .then((text) => {
+          setDesignMdFiles([{ ...uploadedFile, textContent: text }]);
+          setValidationError(null);
+        })
+        .catch(() => {
+          setValidationError(t("designSystemSetup.errors.readDesignMd"));
+        });
+    },
+    [t],
+  );
+
   const handleDocUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!e.target.files) return;
@@ -487,6 +527,7 @@ export default function DesignSystemSetup() {
       normalizedGithubLinks.length > 0 &&
       normalizedWebsiteUrls.length === 0 &&
       codeFiles.length === 0 &&
+      designMdFiles.length === 0 &&
       !builderIndexResult &&
       docFiles.length === 0 &&
       imageFiles.length === 0 &&
@@ -521,11 +562,53 @@ export default function DesignSystemSetup() {
     }
 
     const readableCodeFiles = codeFiles.filter((f) => f.textContent);
-    const designMdFiles = readableCodeFiles.filter(isDesignMdFile);
+    const codeDesignMdFiles = readableCodeFiles.filter(isDesignMdFile);
     const builderCodeFiles = readableCodeFiles.filter(
       (file) => !isDesignMdFile(file),
     );
     const unreadableCodeFiles = codeFiles.filter((f) => !f.textContent);
+    const readableDesignMdFiles = designMdFiles.filter(
+      (file) => file.textContent,
+    );
+
+    if (designMdFiles.length > 0 && readableDesignMdFiles.length === 0) {
+      setValidationError(t("designSystemSetup.errors.readDesignMd"));
+      return;
+    }
+
+    const isDesignMdOnlySource =
+      readableDesignMdFiles.length > 0 &&
+      normalizedGithubLinks.length === 0 &&
+      normalizedWebsiteUrls.length === 0 &&
+      codeFiles.length === 0 &&
+      !builderIndexResult &&
+      docFiles.length === 0 &&
+      imageFiles.length === 0 &&
+      assets.length === 0 &&
+      !selectedProjectId;
+
+    if (isDesignMdOnlySource) {
+      setValidationError(null);
+      try {
+        await indexSystemMutation.mutateAsync({
+          projectName: companyInfo.trim() || undefined,
+          description:
+            [notes.trim(), customInstructions.trim()]
+              .filter(Boolean)
+              .join("\n\n") || undefined,
+          designMd: readableDesignMdFiles[0]?.textContent,
+        });
+        toast.success(t("designSystemSetup.designMdIndexStarted"));
+        navigate("/design-systems");
+      } catch (error) {
+        setValidationError(
+          error instanceof Error
+            ? error.message
+            : t("designSystemSetup.errors.designMdIndex"),
+        );
+      }
+      return;
+    }
 
     const parts: string[] = [];
     parts.push(
@@ -569,11 +652,11 @@ export default function DesignSystemSetup() {
           );
         }
       }
-      if (designMdFiles.length > 0) {
+      if (codeDesignMdFiles.length > 0) {
         parts.push(
-          `\n## Optional design.md (${designMdFiles.length} file${designMdFiles.length === 1 ? "" : "s"})\nPass this content as the \`designMd\` argument to \`index-design-system-with-builder\` alongside any Figma/code sources:`,
+          `\n## Optional design.md (${codeDesignMdFiles.length} file${codeDesignMdFiles.length === 1 ? "" : "s"})\nPass this content as the \`designMd\` argument to \`index-design-system-with-builder\` alongside any Figma/code sources:`,
         );
-        for (const f of designMdFiles) {
+        for (const f of codeDesignMdFiles) {
           parts.push(
             `\n### ${f.name}\n\`\`\`md\n${f.textContent!.slice(0, 5000)}\n\`\`\``,
           );
@@ -582,6 +665,17 @@ export default function DesignSystemSetup() {
       if (unreadableCodeFiles.length > 0) {
         parts.push(
           `\nBinary code files (could not read):\n${unreadableCodeFiles.map((f) => `- ${f.name}`).join("\n")}`,
+        );
+      }
+    }
+
+    if (designMdFiles.length > 0) {
+      parts.push(
+        `\n## design.md\nPass this content as the \`designMd\` argument to \`index-design-system-with-builder\` alongside any Figma/code sources:`,
+      );
+      for (const f of readableDesignMdFiles) {
+        parts.push(
+          `\n### ${f.name}\n\`\`\`md\n${f.textContent!.slice(0, 5000)}\n\`\`\``,
         );
       }
     }
@@ -680,6 +774,7 @@ export default function DesignSystemSetup() {
     githubPaths,
     githubLinks,
     codeFiles,
+    designMdFiles,
     builderIndexResult,
     docFiles,
     imageFiles,
@@ -781,6 +876,14 @@ export default function DesignSystemSetup() {
                   title={t("designSystemSetup.sections.code.title")}
                   selected={sourcePanel === "other" && otherSource === "code"}
                   onClick={() => selectOtherSource("code")}
+                />
+                <SourceChoice
+                  icon={IconFileDescription}
+                  title={t("designSystemSetup.sections.designMd.title")}
+                  selected={
+                    sourcePanel === "other" && otherSource === "design-md"
+                  }
+                  onClick={() => selectOtherSource("design-md")}
                 />
                 <SourceChoice
                   icon={IconFileDescription}
@@ -1101,6 +1204,45 @@ export default function DesignSystemSetup() {
                   </div>
                 )}
               </div>
+            </Section>
+
+            {/* Import design.md guidance directly into Builder DSI. */}
+            <Section
+              title={t("designSystemSetup.sections.designMd.title")}
+              description={t("designSystemSetup.sections.designMd.description")}
+              hidden={sourcePanel !== "other" || otherSource !== "design-md"}
+              hideHeading
+              id="design-system-design-md-source"
+              className="rounded-lg border border-border bg-card p-4"
+            >
+              <button
+                type="button"
+                onClick={() => designMdInputRef.current?.click()}
+                className="w-full rounded-xl border border-dashed border-border bg-card p-8 text-center hover:border-foreground/15 cursor-pointer"
+              >
+                <div className="flex flex-col items-center gap-2">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+                    <IconFileDescription className="size-6 text-primary" />
+                  </div>
+                  <p className="text-sm font-medium text-foreground/90">
+                    {t("designSystemSetup.designMdUpload")}
+                  </p>
+                  <p className="text-xs text-muted-foreground/70">
+                    {t("designSystemSetup.designMdHelp")}
+                  </p>
+                </div>
+              </button>
+              <input
+                ref={designMdInputRef}
+                type="file"
+                accept=".md,.mdx"
+                onChange={handleDesignMdUpload}
+                className="hidden"
+              />
+              <FileList
+                files={designMdFiles}
+                onRemove={() => setDesignMdFiles([])}
+              />
             </Section>
 
             {/* Design Files */}
@@ -1507,7 +1649,7 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
-function isDesignMdFile(file: UploadedFile): boolean {
+function isDesignMdFile(file: Pick<UploadedFile, "name">): boolean {
   const name = file.name.split(/[\\/]/).pop()?.toLowerCase() ?? file.name;
   return name === "design.md" || name === "design.mdx";
 }

--- a/templates/design/e2e/design-system-design-md-import.spec.ts
+++ b/templates/design/e2e/design-system-design-md-import.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("imports design.md guidance through Builder DSI", async ({ page }) => {
-  let capturedInput: Record<string, unknown> | null = null;
-
+test.beforeEach(async ({ page }) => {
   await page.route("**/_agent-native/actions/list-designs**", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -18,6 +16,11 @@ test("imports design.md guidance through Builder DSI", async ({ page }) => {
       });
     },
   );
+});
+
+test("imports design.md guidance through Builder DSI", async ({ page }) => {
+  let capturedInput: Record<string, unknown> | null = null;
+
   await page.route(
     "**/_agent-native/actions/index-design-system-with-builder**",
     async (route) => {
@@ -68,4 +71,22 @@ test("imports design.md guidance through Builder DSI", async ({ page }) => {
     designMd:
       "# Acme Design System\n\nUse cobalt accents and compact controls.",
   });
+});
+
+test("rejects design.md files larger than the inline Builder limit", async ({
+  page,
+}) => {
+  await page.goto("/design-systems/setup");
+  await page
+    .getByRole("button", { name: "Import design.md", exact: true })
+    .click();
+  await page.locator('input[accept=".md,.mdx"]').setInputFiles({
+    name: "design.md",
+    mimeType: "text/markdown",
+    buffer: Buffer.alloc(2 * 1024 * 1024 + 1, "x"),
+  });
+
+  await expect(page.getByRole("alert")).toHaveText(
+    "design.md must be 2 MB or smaller.",
+  );
 });

--- a/templates/design/e2e/design-system-design-md-import.spec.ts
+++ b/templates/design/e2e/design-system-design-md-import.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+test("imports design.md guidance through Builder DSI", async ({ page }) => {
+  let capturedInput: Record<string, unknown> | null = null;
+
+  await page.route("**/_agent-native/actions/list-designs**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ designs: [] }),
+    });
+  });
+  await page.route(
+    "**/_agent-native/actions/list-design-systems**",
+    async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ designSystems: [] }),
+      });
+    },
+  );
+  await page.route(
+    "**/_agent-native/actions/index-design-system-with-builder**",
+    async (route) => {
+      capturedInput = route.request().postDataJSON() as Record<string, unknown>;
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          source: "builder",
+          projectId: "project-design-md-e2e",
+          jobId: "job-design-md-e2e",
+          designSystemId: "ds-design-md-e2e",
+          suggestedTitle: "Acme",
+          builderUrl:
+            "https://builder.io/app/design-system-intelligence/ds-design-md-e2e",
+          status: "in-progress",
+          localDesignSystemId: "builder-ds-design-md-e2e",
+          uploadedFileCount: 1,
+        }),
+      });
+    },
+  );
+
+  await page.goto("/design-systems/setup");
+  await page
+    .getByRole("button", { name: "Import design.md", exact: true })
+    .click();
+  await page.locator('input[accept=".md,.mdx"]').setInputFiles({
+    name: "design.md",
+    mimeType: "text/markdown",
+    buffer: Buffer.from(
+      "# Acme Design System\n\nUse cobalt accents and compact controls.",
+    ),
+  });
+
+  await expect(
+    page.locator("#design-system-design-md-source").getByText("design.md", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await page
+    .getByRole("banner")
+    .getByRole("button", { name: "Continue to generation", exact: true })
+    .click();
+
+  await expect(page).toHaveURL(/\/design-systems$/);
+  expect(capturedInput).toMatchObject({
+    designMd:
+      "# Acme Design System\n\nUse cobalt accents and compact controls.",
+  });
+});


### PR DESCRIPTION
## Summary

- Add an Import design.md source to Design System setup.
- Route design.md-only imports through the existing Builder DSI action and preserve mixed-source agent handoff.
- Add localized copy and a real-browser regression.

Source feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787248885488419

## Verification

- pnpm --filter design e2e e2e/design-system-design-md-import.spec.ts
- env BETTER_AUTH_SECRET=local-test-secret DATABASE_URL=file:/tmp/design-typecheck.db pnpm --filter design typecheck
- pnpm guard:i18n-changed-copy
- pnpm guard:i18n-catalogs is blocked by nine pre-existing packages/docs catalog issues.
- The broader Design Vitest run was stopped after unrelated Happy DOM/live-edit teardown noise; the focused browser flow passed.