### PR TITLE
fix: retry Netlify production build setting verification

### DIFF
--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -105,6 +105,22 @@ jobs:
             return body;
           }
 
+          async function waitForBuildSetting(siteId, expected, label) {
+            let actual;
+            for (let attempt = 1; attempt <= 15; attempt += 1) {
+              const site = await readJson(
+                await fetch(`${api}/sites/${siteId}`, { headers, signal: AbortSignal.timeout(30_000) }),
+                `${label} verification attempt ${attempt}`,
+              );
+              actual = site.build_settings?.stop_builds;
+              if (actual === expected) return;
+              if (attempt < 15) {
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+              }
+            }
+            throw new Error(`${label} expected stop_builds=${expected}, got ${actual}.`);
+          }
+
           (async () => {
             const siteUrl = `${api}/sites/${siteId}`;
             const current = await readJson(
@@ -123,13 +139,7 @@ jobs:
               );
             }
 
-            const paused = await readJson(
-              await fetch(siteUrl, { headers, signal: AbortSignal.timeout(30_000) }),
-              'Netlify docs build pause verification',
-            );
-            if (paused.build_settings?.stop_builds !== true) {
-              throw new Error('Netlify docs Git-connected builds were not disabled.');
-            }
+            await waitForBuildSetting(siteId, true, 'Netlify docs build pause');
             console.log('Docs site is now owned by the GitHub Actions prebuilt publisher.');
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -285,6 +285,22 @@ jobs:
             return body;
           }
 
+          async function waitForBuildSetting(siteId, expected, label) {
+            let actual;
+            for (let attempt = 1; attempt <= 15; attempt += 1) {
+              const site = await readJson(
+                await request(`${api}/sites/${siteId}`),
+                `${label} verification attempt ${attempt}`,
+              );
+              actual = site.build_settings?.stop_builds;
+              if (actual === expected) return;
+              if (attempt < 15) {
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+              }
+            }
+            throw new Error(`${label} expected stop_builds=${expected}, got ${actual}.`);
+          }
+
           const siteId = process.env.NETLIFY_SITE_ID;
           if (!siteId) throw new Error("Netlify site id is required to pause automatic builds.");
           const site = await readJson(
@@ -304,13 +320,7 @@ jobs:
             );
           }
           fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\n");
-          const paused = await readJson(
-            await request(`${api}/sites/${siteId}`),
-            "Netlify automatic build pause verification",
-          );
-          if (paused.build_settings?.stop_builds !== true) {
-            throw new Error("Netlify automatic builds were not paused before production cutover.");
-          }
+          await waitForBuildSetting(siteId, true, "Netlify automatic build pause");
           console.log(`Automatic Netlify builds paused for production cutover (previously stopped: ${wasStopped}).`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);
@@ -810,13 +820,22 @@ jobs:
             }),
             "Netlify automatic build resume",
           );
-          const resumed = await readJson(
-            await request(`${api}/sites/${siteId}`),
-            "Netlify automatic build resume verification",
-          );
-          if (resumed.build_settings?.stop_builds !== false) {
-            throw new Error("Netlify automatic builds were not resumed after production cutover.");
+          async function waitForBuildSetting(expected, label) {
+            let actual;
+            for (let attempt = 1; attempt <= 15; attempt += 1) {
+              const site = await readJson(
+                await request(`${api}/sites/${siteId}`),
+                `${label} verification attempt ${attempt}`,
+              );
+              actual = site.build_settings?.stop_builds;
+              if (actual === expected) return;
+              if (attempt < 15) {
+                await new Promise((resolve) => setTimeout(resolve, 2_000));
+              }
+            }
+            throw new Error(`${label} expected stop_builds=${expected}, got ${actual}.`);
           }
+          await waitForBuildSetting(false, "Netlify automatic build resume");
           console.log("Automatic Netlify builds resumed after production cutover.");
           NODE
 

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -293,7 +293,7 @@ jobs:
                 `${label} verification attempt ${attempt}`,
               );
               actual = site.build_settings?.stop_builds;
-              if (actual === expected) return;
+              if (actual === expected) return true;
               if (attempt < 15) {
                 await new Promise((resolve) => setTimeout(resolve, 2_000));
               }
@@ -320,7 +320,8 @@ jobs:
             );
           }
           fs.appendFileSync(process.env.GITHUB_OUTPUT, "cutover_acquired=true\n");
-          await waitForBuildSetting(siteId, true, "Netlify automatic build pause");
+          const paused = await waitForBuildSetting(siteId, true, "Netlify automatic build pause");
+          if (!paused) throw new Error("Netlify automatic build pause was not verified.");
           console.log(`Automatic Netlify builds paused for production cutover (previously stopped: ${wasStopped}).`);
           })().catch((error) => {
             console.error(error instanceof Error ? error.message : error);


### PR DESCRIPTION
## Summary
- retry Netlify stop_builds read-backs after pause/resume writes
- apply the same bounded verification to docs ownership cleanup
- preserve the existing guarded production lock and cleanup flow

## Verification
- actionlint passes for both changed workflows
- git diff --check passes

This is the deployment reliability follow-up needed to promote the already-merged docs image optimization.