### PR TITLE
fix: treat Builder OAuth as enough to start chat

### DIFF
--- a/.changeset/oauth-chat-preflight.md
+++ b/.changeset/oauth-chat-preflight.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Treat a usable Builder OAuth connection as enough to start chat. The connect flow already saves OAuth tokens, but run preflight still required a legacy private/public key pair, so new hosted workspace apps showed "No LLM provider is connected" after a successful connect.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -363,19 +363,6 @@ describe("AgentEngine registry", () => {
 
   it("treats per-user Builder OAuth as a runnable engine without legacy keys", async () => {
     const identity = { userEmail: "person@example.com", orgId: "org-builder" };
-    const hasBuilderOAuthSession = vi.fn(
-      async (email: string) => email === identity.userEmail,
-    );
-    const resolveBuilderOAuthRequestAccess = vi.fn(async () => ({
-      accessToken: "oauth-access-token",
-      scopes: ["builder:ai:invoke"],
-      ownerEmail: identity.userEmail,
-    }));
-    vi.doMock("../../server/builder-oauth.js", () => ({
-      BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
-      hasBuilderOAuthSession,
-      resolveBuilderOAuthRequestAccess,
-    }));
     const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
       privateKey: null,
       publicKey: null,
@@ -389,6 +376,18 @@ describe("AgentEngine registry", () => {
         resolveBuilderGatewayCredentialsDetailed,
       }),
     );
+    const {
+      hasBuilderOAuthSession,
+      resolveBuilderOAuthRequestAccess,
+    } = await import("../../server/builder-oauth.js");
+    vi.mocked(hasBuilderOAuthSession).mockImplementation(
+      async (email: string) => email === identity.userEmail,
+    );
+    vi.mocked(resolveBuilderOAuthRequestAccess).mockResolvedValue({
+      accessToken: "oauth-access-token",
+      scopes: ["builder:ai:invoke"],
+      ownerEmail: identity.userEmail,
+    });
 
     const {
       registerAgentEngine,
@@ -420,11 +419,6 @@ describe("AgentEngine registry", () => {
 
   it("does not fall through to gateway keys when Builder OAuth custody is unusable", async () => {
     const identity = { userEmail: "person@example.com", orgId: "org-builder" };
-    vi.doMock("../../server/builder-oauth.js", () => ({
-      BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
-      hasBuilderOAuthSession: vi.fn(async () => true),
-      resolveBuilderOAuthRequestAccess: vi.fn(async () => null),
-    }));
     const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
       privateKey: "btk-site-token",
       publicKey: "space-abc",
@@ -438,6 +432,12 @@ describe("AgentEngine registry", () => {
         resolveBuilderGatewayCredentialsDetailed,
       }),
     );
+    const {
+      hasBuilderOAuthSession,
+      resolveBuilderOAuthRequestAccess,
+    } = await import("../../server/builder-oauth.js");
+    vi.mocked(hasBuilderOAuthSession).mockResolvedValue(true);
+    vi.mocked(resolveBuilderOAuthRequestAccess).mockResolvedValue(null);
 
     const { registerAgentEngine, isResolvedEngineUsableForRequest } =
       await import("./registry.js");

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -42,6 +42,11 @@ describe("AgentEngine registry", () => {
     vi.doUnmock("../../secrets/storage.js");
     vi.doUnmock("../../db/client.js");
     vi.doUnmock("../../org/context.js");
+    vi.doMock("../../server/builder-oauth.js", () => ({
+      BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
+      hasBuilderOAuthSession: vi.fn(async () => false),
+      resolveBuilderOAuthRequestAccess: vi.fn(async () => null),
+    }));
     vi.unstubAllEnvs();
     // Clear env vars that influence resolveEngine
     delete process.env.AGENT_ENGINE;
@@ -354,6 +359,106 @@ describe("AgentEngine registry", () => {
         credentialIdentity: identity,
       }),
     ).resolves.toBe(true);
+  });
+
+  it("treats per-user Builder OAuth as a runnable engine without legacy keys", async () => {
+    const identity = { userEmail: "person@example.com", orgId: "org-builder" };
+    const hasBuilderOAuthSession = vi.fn(
+      async (email: string) => email === identity.userEmail,
+    );
+    const resolveBuilderOAuthRequestAccess = vi.fn(async () => ({
+      accessToken: "oauth-access-token",
+      scopes: ["builder:ai:invoke"],
+      ownerEmail: identity.userEmail,
+    }));
+    vi.doMock("../../server/builder-oauth.js", () => ({
+      BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
+      hasBuilderOAuthSession,
+      resolveBuilderOAuthRequestAccess,
+    }));
+    const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
+      privateKey: null,
+      publicKey: null,
+      lookupFailed: false,
+      lane: null,
+    }));
+    vi.doMock(
+      "../../server/credential-provider.js",
+      async (importOriginal) => ({
+        ...(await importOriginal()),
+        resolveBuilderGatewayCredentialsDetailed,
+      }),
+    );
+
+    const {
+      registerAgentEngine,
+      detectEngineFromUserSecrets,
+      isResolvedEngineUsableForRequest,
+    } = await import("./registry.js");
+    const builderEngine = { name: "builder", stream: vi.fn() } as any;
+    registerAgentEngine({
+      name: "builder",
+      label: "Builder",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "builder-model",
+      supportedModels: ["builder-model"],
+      requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+      create: vi.fn().mockReturnValue(builderEngine),
+    });
+
+    await expect(detectEngineFromUserSecrets(identity)).resolves.toMatchObject({
+      name: "builder",
+    });
+    await expect(
+      isResolvedEngineUsableForRequest(builderEngine, {
+        credentialIdentity: identity,
+      }),
+    ).resolves.toBe(true);
+    expect(resolveBuilderGatewayCredentialsDetailed).not.toHaveBeenCalled();
+  });
+
+  it("does not fall through to gateway keys when Builder OAuth custody is unusable", async () => {
+    const identity = { userEmail: "person@example.com", orgId: "org-builder" };
+    vi.doMock("../../server/builder-oauth.js", () => ({
+      BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
+      hasBuilderOAuthSession: vi.fn(async () => true),
+      resolveBuilderOAuthRequestAccess: vi.fn(async () => null),
+    }));
+    const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
+      privateKey: "btk-site-token",
+      publicKey: "space-abc",
+      lookupFailed: false,
+      lane: "gateway-deploy" as const,
+    }));
+    vi.doMock(
+      "../../server/credential-provider.js",
+      async (importOriginal) => ({
+        ...(await importOriginal()),
+        resolveBuilderGatewayCredentialsDetailed,
+      }),
+    );
+
+    const { registerAgentEngine, isResolvedEngineUsableForRequest } =
+      await import("./registry.js");
+    const builderEngine = { name: "builder", stream: vi.fn() } as any;
+    registerAgentEngine({
+      name: "builder",
+      label: "Builder",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "builder-model",
+      supportedModels: ["builder-model"],
+      requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+      create: vi.fn().mockReturnValue(builderEngine),
+    });
+
+    await expect(
+      isResolvedEngineUsableForRequest(builderEngine, {
+        credentialIdentity: identity,
+      }),
+    ).resolves.toBe(false);
+    expect(resolveBuilderGatewayCredentialsDetailed).not.toHaveBeenCalled();
   });
 
   describe("getStoredModelForEngine", () => {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -780,12 +780,20 @@ async function hasUsableBuilderConnection(
 }
 
 /**
- * Either lane. Not {@link hasUsableBuilderConnection}, which asks the narrower
- * "did this user connect Builder" and is false on every credits-only site.
+ * Either lane. {@link hasUsableBuilderConnection} asks the narrower "did this
+ * user connect Builder" and is false on every credits-only site, so this still
+ * accepts the gateway-credits pair. When the user has Builder OAuth custody,
+ * match the Builder engine stream path: usable OAuth is enough to run, and
+ * unusable custody must not fall through to a legacy or deploy key.
  */
 async function canRunBuilderEngine(
   identity?: BuilderCredentialLookupIdentity,
 ): Promise<boolean> {
+  const ownerEmail =
+    identity?.userEmail?.trim().toLowerCase() || getRequestUserEmail();
+  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) {
+    return hasUsableBuilderConnection(identity);
+  }
   const creds = await resolveBuilderGatewayCredentialsDetailed(identity);
   assertCredentialStoreReadable(creds);
   return Boolean(creds.privateKey && creds.publicKey);


### PR DESCRIPTION
## Summary
- Chat run preflight (`canRunBuilderEngine`) required a legacy `BUILDER_PRIVATE_KEY` / `BUILDER_PUBLIC_KEY` pair even after Builder connect succeeded via OAuth.
- Status and engine selection already treated that OAuth session as connected, so a net-new hosted workspace app showed "No LLM provider is connected" / `missing_credentials` after a successful connect popup.
- The Builder gateway already accepts the OAuth bearer token; this change makes preflight match `BuilderEngine.stream()`: usable OAuth is enough to start, and unusable OAuth custody does not fall through to a deploy/legacy key.

## Test plan
- [ ] `pnpm exec vitest --run src/agent/engine/registry.spec.ts` in `packages/core` (covers OAuth-only runnable + unusable custody does not use gateway keys)
- [ ] In a hosted AN Code / workspace app with no legacy Builder keys, connect Builder.io, then send a chat turn — it should run instead of `missing_credentials`
- [ ] Confirm a credits-only site with no user OAuth still runs on the gateway-credits pair
- [ ] Confirm unusable/expired OAuth custody still asks to reconnect and does not silently use a deploy key


Made with [Cursor](https://cursor.com)