### PR TITLE
Make Share the primary clip viewer action

### DIFF
--- a/templates/clips/CHANGELOG.md
+++ b/templates/clips/CHANGELOG.md
@@ -9,6 +9,7 @@ Older updates live in [the changelog folder](./changelog/) and are included in t
 
 ### Improved
 
+- Clip viewers now make Share the primary action and keep the overflow control compact and vertical.
 - Recording controls now follow you across browser tabs and page navigations.
 
 ### Fixed

--- a/templates/clips/app/components/player/clips-share-trigger.tsx
+++ b/templates/clips/app/components/player/clips-share-trigger.tsx
@@ -1,0 +1,17 @@
+import {
+  ShareTrigger,
+  type ShareTriggerProps,
+} from "@agent-native/toolkit/sharing";
+
+import { cn } from "@/lib/utils";
+
+export function ClipsShareTrigger({ className, ...props }: ShareTriggerProps) {
+  return (
+    <ShareTrigger
+      {...props}
+      intent="primary"
+      emphasis="solid"
+      className={cn("clips-share-trigger shrink-0", className)}
+    />
+  );
+}

--- a/templates/clips/app/components/player/delete-recording-menu.test.tsx
+++ b/templates/clips/app/components/player/delete-recording-menu.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@agent-native/core/client/i18n", () => ({
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 
 vi.mock("@tabler/icons-react", () => ({
-  IconDots: () => <span />,
+  IconDotsVertical: () => <span data-testid="vertical-dots" />,
   IconDownload: () => <span />,
   IconTrash: () => <span />,
 }));
@@ -155,5 +155,28 @@ describe("RecordingOptionsMenu", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
     expect(onDeleted).toHaveBeenCalledOnce();
+  });
+
+  it("uses a narrow vertical overflow trigger", () => {
+    act(() => {
+      root.render(
+        <RecordingOptionsMenu
+          recordingId="recording-1"
+          canDelete={false}
+          canDownload
+          onDownload={vi.fn()}
+        />,
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="deleteRecordingMenu.clipOptions"]',
+    );
+
+    expect(button?.className).toContain("px-0.5");
+    expect(button?.className).toContain("py-1.5");
+    expect(container.querySelector('[data-testid="vertical-dots"]')).not.toBe(
+      null,
+    );
   });
 });

--- a/templates/clips/app/components/player/delete-recording-menu.tsx
+++ b/templates/clips/app/components/player/delete-recording-menu.tsx
@@ -1,6 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconDots, IconDownload, IconTrash } from "@tabler/icons-react";
+import { IconDotsVertical, IconDownload, IconTrash } from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -93,10 +93,10 @@ export function RecordingOptionsMenu({
           <Button
             variant="ghost"
             size="icon"
-            className="shrink-0"
+            className="-mx-1.5 h-auto w-auto shrink-0 px-0.5 py-1.5"
             aria-label={t("deleteRecordingMenu.clipOptions")}
           >
-            <IconDots className="h-4 w-4" />
+            <IconDotsVertical className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">

--- a/templates/clips/app/global.css
+++ b/templates/clips/app/global.css
@@ -73,6 +73,10 @@
   --highlight-foreground: 0 0% 10%;
 }
 
+.dark .clips-share-trigger {
+  --primary: 0 0% 100%;
+}
+
 @theme inline {
   --color-highlight: hsl(var(--highlight));
   --color-highlight-foreground: hsl(var(--highlight-foreground));

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -16,7 +16,7 @@ import {
   isHumanReadableDocumentTitle,
   normalizeDocumentTitle,
 } from "@agent-native/core/shared";
-import { ShareCopyRow, ShareTrigger } from "@agent-native/toolkit/sharing";
+import { ShareCopyRow } from "@agent-native/toolkit/sharing";
 import {
   BUILDER_CREDITS_UPGRADE_URL,
   type BuilderCreditsStatus,
@@ -59,6 +59,7 @@ import { toast } from "sonner";
 
 import { EditableRecordingTitle } from "@/components/editable-recording-title";
 import { EditorLayout } from "@/components/editor/editor-layout";
+import { ClipsShareTrigger } from "@/components/player/clips-share-trigger";
 import { CommentsPanel } from "@/components/player/comments-panel";
 import { RecordingOptionsMenu } from "@/components/player/delete-recording-menu";
 import { InsightsPanel } from "@/components/player/insights-panel";
@@ -1051,7 +1052,7 @@ export default function RecordingPage() {
     if (!showRecoveryState) {
       return (
         <div className="flex min-h-screen w-full flex-col bg-background">
-          <header className="flex min-w-0 shrink-0 items-center gap-3 border-b border-border px-3 py-2 sm:px-4 sm:py-3">
+          <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3">
             <BackToLibraryButton />
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">{visibleTitle}</p>
@@ -1070,10 +1071,7 @@ export default function RecordingPage() {
               hasPassword={Boolean(recording.hasPassword)}
               viewerReshareOnly={viewerReshareOnly}
             >
-              <ShareTrigger
-                label={t("recordingPage.share")}
-                className="shrink-0"
-              />
+              <ClipsShareTrigger label={t("recordingPage.share")} />
             </ShareRecordingPopover>
           </header>
 
@@ -1370,7 +1368,7 @@ export default function RecordingPage() {
     <div className="flex min-h-screen w-full max-w-full flex-col overflow-x-hidden bg-background xl:h-screen xl:flex-row xl:overflow-hidden">
       {/* Main video column */}
       <div className="flex w-full min-w-0 flex-col xl:flex-1">
-        <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:gap-3 sm:px-4 sm:py-3">
+        <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3">
           <BackToLibraryButton />
           <div className="flex-1 min-w-0">
             <EditableRecordingTitle
@@ -1609,10 +1607,7 @@ export default function RecordingPage() {
               hasPassword={Boolean(recording.hasPassword)}
               viewerReshareOnly={viewerReshareOnly}
             >
-              <ShareTrigger
-                label={t("recordingPage.share")}
-                className="shrink-0"
-              />
+              <ClipsShareTrigger label={t("recordingPage.share")} />
             </ShareRecordingPopover>
           ) : null}
 

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -100,6 +100,33 @@ describe("authenticated recording route loading", () => {
     expect(recordingRoute).not.toContain("InsightsUnavailableState");
   });
 
+  it("keeps Share primary and places overflow after it in clip viewers", () => {
+    const recordingRoute = readRoute("r.$recordingId.tsx");
+    const shareRoute = readRoute("share.$shareId.tsx");
+    const trigger = readFileSync(
+      resolve(process.cwd(), "app/components/player/clips-share-trigger.tsx"),
+      "utf8",
+    );
+
+    expect(recordingRoute.match(/<ClipsShareTrigger/g)).toHaveLength(2);
+    expect(shareRoute).toContain("<ClipsShareTrigger");
+    expect(trigger).toContain('intent="primary"');
+    expect(trigger).toContain('emphasis="solid"');
+
+    const publicControlsStart = shareRoute.indexOf(
+      '<div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-1',
+    );
+    const publicControls = shareRoute.slice(publicControlsStart);
+    expect(publicControls.indexOf("<ClipsShareTrigger")).toBeLessThan(
+      publicControls.indexOf("IconDotsVertical"),
+    );
+    expect(publicControls.indexOf("<ClipsShareTrigger")).toBeLessThan(
+      publicControls.indexOf("<RecordingOptionsMenu"),
+    );
+    expect(shareRoute).toContain("IconDotsVertical");
+    expect(shareRoute).not.toContain("IconDots className");
+  });
+
   it("keeps meeting agent links scoped through both page and context loading", () => {
     const meetingRoute = readRoute("share.meeting.$meetingId.tsx");
     expect(meetingRoute).toContain("verifyScopedAgentAccessToken");

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -13,13 +13,12 @@ import {
 import { useT } from "@agent-native/core/client/i18n";
 import { buildSignInReturnHref } from "@agent-native/core/client/ui";
 import { docsUrl } from "@agent-native/core/shared";
-import { ShareTrigger } from "@agent-native/toolkit/sharing";
 import {
   IconAlertTriangle,
   IconArrowLeft,
   IconDeviceDesktop,
   IconDownload,
-  IconDots,
+  IconDotsVertical,
   IconLock,
   IconLogin2,
 } from "@tabler/icons-react";
@@ -51,6 +50,7 @@ import { toast } from "sonner";
 
 import { CaptureInstallButton } from "@/components/capture-install-options";
 import { AccessPasswordPrompt } from "@/components/player/access-password-prompt";
+import { ClipsShareTrigger } from "@/components/player/clips-share-trigger";
 import { CommentsPanel } from "@/components/player/comments-panel";
 import { RecordingOptionsMenu } from "@/components/player/delete-recording-menu";
 import { InsightsPanel } from "@/components/player/insights-panel";
@@ -1111,7 +1111,7 @@ export default function ShareRoute() {
     <div className="flex min-h-screen max-w-full flex-col overflow-x-hidden bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
       {agentDiscovery}
       <div className="flex w-full min-w-0 flex-col lg:flex-1">
-        <header className="flex min-w-0 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:gap-3 sm:px-4 sm:py-3 lg:flex-nowrap">
+        <header className="flex min-w-0 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3 lg:flex-nowrap">
           {session ? (
             <Button
               asChild
@@ -1147,7 +1147,7 @@ export default function ShareRoute() {
             )}
           </div>
 
-          <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-2 sm:w-auto sm:justify-end">
+          <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-1 sm:w-auto sm:justify-end">
             <RecordingViewsBadge
               recordingId={recording.id}
               viewCount={viewCount}
@@ -1161,6 +1161,22 @@ export default function ShareRoute() {
                 onCtaClick={fireShareCtaClick}
               />
             )}
+            {viewerCanEdit || canReshareLink ? (
+              <ShareRecordingPopover
+                recordingId={recording.id}
+                recordingTitle={recording.title}
+                initialVisibility={recording.visibility}
+                initialRole={viewerIsOwner ? "owner" : undefined}
+                videoUrl={shareVideoUrl}
+                thumbnailUrl={recording.thumbnailUrl}
+                animatedThumbnailUrl={recording.animatedThumbnailUrl}
+                isLoomRecording={isLoomEmbedBacked}
+                hasPassword={Boolean(recording.hasPassword)}
+                viewerReshareOnly={viewerReshareOnly}
+              >
+                <ClipsShareTrigger label={t("sharePage.share")} />
+              </ShareRecordingPopover>
+            ) : null}
             {!viewerCanEdit && canDownloadRecording ? (
               <DropdownMenu
                 open={downloadMenuOpen}
@@ -1170,10 +1186,10 @@ export default function ShareRoute() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-9 w-9 shrink-0 px-0"
+                    className="-mx-1.5 h-auto w-auto shrink-0 px-0.5 py-1.5"
                     aria-label={t("sharePage.clipOptions")}
                   >
-                    <IconDots className="h-4 w-4" />
+                    <IconDotsVertical className="h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44">
@@ -1205,25 +1221,6 @@ export default function ShareRoute() {
                 }}
                 onDeleted={() => navigate("/library", { replace: true })}
               />
-            ) : null}
-            {viewerCanEdit || canReshareLink ? (
-              <ShareRecordingPopover
-                recordingId={recording.id}
-                recordingTitle={recording.title}
-                initialVisibility={recording.visibility}
-                initialRole={viewerIsOwner ? "owner" : undefined}
-                videoUrl={shareVideoUrl}
-                thumbnailUrl={recording.thumbnailUrl}
-                animatedThumbnailUrl={recording.animatedThumbnailUrl}
-                isLoomRecording={isLoomEmbedBacked}
-                hasPassword={Boolean(recording.hasPassword)}
-                viewerReshareOnly={viewerReshareOnly}
-              >
-                <ShareTrigger
-                  label={t("sharePage.share")}
-                  className="shrink-0"
-                />
-              </ShareRecordingPopover>
             ) : null}
           </div>
         </header>

--- a/templates/clips/changelog/2026-08-20-clip-viewer-share-actions.md
+++ b/templates/clips/changelog/2026-08-20-clip-viewer-share-actions.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-20
+---
+
+Clip viewers now make Share the primary action and keep the overflow control compact and vertical.


### PR DESCRIPTION
## Summary

- Make Share the solid primary action across authenticated, recovery, and public clip viewer variants.
- Keep the overflow control after Share with a vertical dots icon and compact `6px 2px` padding.
- Add focused coverage and Clips changelog entries.

## Validation

- Focused Clips Vitest suite: 5 files, 28 tests passed.
- Clips typecheck passed.
- Clips production build passed.
- Repository guards: all 58 checks passed.
- Local Playwright proof covered dark desktop and narrow layouts, including computed white Share background and compact overflow spacing.
