### PR TITLE
fix: accept Builder OAuth for chat preflight

### DIFF
--- a/.changeset/oauth-chat-preflight.md
+++ b/.changeset/oauth-chat-preflight.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Treat a usable Builder OAuth connection as enough to start chat. The connect flow already saves OAuth tokens, but run preflight still required a legacy private/public key pair, so new hosted workspace apps showed "No LLM provider is connected" after a successful connect.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -2,10 +2,15 @@ import { createHash } from "node:crypto";
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+const builderOAuthState = vi.hoisted(() => ({
+  hasSession: vi.fn(async () => false),
+  resolveAccess: vi.fn(async () => null),
+}));
+
 vi.mock("../../server/builder-oauth.js", () => ({
   BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
-  hasBuilderOAuthSession: vi.fn(async () => false),
-  resolveBuilderOAuthRequestAccess: vi.fn(async () => null),
+  hasBuilderOAuthSession: builderOAuthState.hasSession,
+  resolveBuilderOAuthRequestAccess: builderOAuthState.resolveAccess,
 }));
 
 function providerFailureFingerprint(key: string, value: string): string {
@@ -42,6 +47,8 @@ describe("AgentEngine registry", () => {
     vi.doUnmock("../../secrets/storage.js");
     vi.doUnmock("../../db/client.js");
     vi.doUnmock("../../org/context.js");
+    builderOAuthState.hasSession.mockReset().mockResolvedValue(false);
+    builderOAuthState.resolveAccess.mockReset().mockResolvedValue(null);
     vi.unstubAllEnvs();
     // Clear env vars that influence resolveEngine
     delete process.env.AGENT_ENGINE;
@@ -354,6 +361,98 @@ describe("AgentEngine registry", () => {
         credentialIdentity: identity,
       }),
     ).resolves.toBe(true);
+  });
+
+  it("treats per-user Builder OAuth as a runnable engine without legacy keys", async () => {
+    const identity = { userEmail: "person@example.com", orgId: "org-builder" };
+    builderOAuthState.hasSession.mockImplementation(
+      async (email: string) => email === identity.userEmail,
+    );
+    builderOAuthState.resolveAccess.mockResolvedValue({
+      accessToken: "oauth-access-token",
+      scopes: ["builder:ai:invoke"],
+      ownerEmail: identity.userEmail,
+    });
+    const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
+      privateKey: null,
+      publicKey: null,
+      lookupFailed: false,
+      lane: null,
+    }));
+    vi.doMock(
+      "../../server/credential-provider.js",
+      async (importOriginal) => ({
+        ...(await importOriginal()),
+        resolveBuilderGatewayCredentialsDetailed,
+      }),
+    );
+
+    const {
+      registerAgentEngine,
+      detectEngineFromUserSecrets,
+      isResolvedEngineUsableForRequest,
+    } = await import("./registry.js");
+    const builderEngine = { name: "builder", stream: vi.fn() } as any;
+    registerAgentEngine({
+      name: "builder",
+      label: "Builder",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "builder-model",
+      supportedModels: ["builder-model"],
+      requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+      create: vi.fn().mockReturnValue(builderEngine),
+    });
+
+    await expect(detectEngineFromUserSecrets(identity)).resolves.toMatchObject({
+      name: "builder",
+    });
+    await expect(
+      isResolvedEngineUsableForRequest(builderEngine, {
+        credentialIdentity: identity,
+      }),
+    ).resolves.toBe(true);
+    expect(resolveBuilderGatewayCredentialsDetailed).not.toHaveBeenCalled();
+  });
+
+  it("does not fall through to gateway keys when Builder OAuth custody is unusable", async () => {
+    const identity = { userEmail: "person@example.com", orgId: "org-builder" };
+    builderOAuthState.hasSession.mockResolvedValue(true);
+    builderOAuthState.resolveAccess.mockResolvedValue(null);
+    const resolveBuilderGatewayCredentialsDetailed = vi.fn(async () => ({
+      privateKey: "btk-site-token",
+      publicKey: "space-abc",
+      lookupFailed: false,
+      lane: "gateway-deploy" as const,
+    }));
+    vi.doMock(
+      "../../server/credential-provider.js",
+      async (importOriginal) => ({
+        ...(await importOriginal()),
+        resolveBuilderGatewayCredentialsDetailed,
+      }),
+    );
+
+    const { registerAgentEngine, isResolvedEngineUsableForRequest } =
+      await import("./registry.js");
+    const builderEngine = { name: "builder", stream: vi.fn() } as any;
+    registerAgentEngine({
+      name: "builder",
+      label: "Builder",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "builder-model",
+      supportedModels: ["builder-model"],
+      requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+      create: vi.fn().mockReturnValue(builderEngine),
+    });
+
+    await expect(
+      isResolvedEngineUsableForRequest(builderEngine, {
+        credentialIdentity: identity,
+      }),
+    ).resolves.toBe(false);
+    expect(resolveBuilderGatewayCredentialsDetailed).not.toHaveBeenCalled();
   });
 
   describe("getStoredModelForEngine", () => {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -780,12 +780,20 @@ async function hasUsableBuilderConnection(
 }
 
 /**
- * Either lane. Not {@link hasUsableBuilderConnection}, which asks the narrower
- * "did this user connect Builder" and is false on every credits-only site.
+ * Either lane. {@link hasUsableBuilderConnection} asks the narrower "did this
+ * user connect Builder" and is false on every credits-only site, so this still
+ * accepts the gateway-credits pair. When the user has Builder OAuth custody,
+ * match the Builder engine stream path: usable OAuth is enough to run, and
+ * unusable custody must not fall through to a legacy or deploy key.
  */
 async function canRunBuilderEngine(
   identity?: BuilderCredentialLookupIdentity,
 ): Promise<boolean> {
+  const ownerEmail =
+    identity?.userEmail?.trim().toLowerCase() || getRequestUserEmail();
+  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) {
+    return hasUsableBuilderConnection(identity);
+  }
   const creds = await resolveBuilderGatewayCredentialsDetailed(identity);
   assertCredentialStoreReadable(creds);
   return Boolean(creds.privateKey && creds.publicKey);


### PR DESCRIPTION
## Summary
- treat a usable per-user Builder OAuth custody session as sufficient for Builder chat preflight
- keep unusable OAuth from falling through to legacy or deploy credentials
- add registry regression coverage and a core patch changeset

This fixes new hosted Forms/workspace apps showing a missing-provider error immediately after a successful Builder OAuth connection. The Slides no-progress report is covered by the existing in-flight work watchdog and recovery tests already present on main.

## Verification
- core registry, run-manager, stuck-banner, and SSE tests: 360 passed
- Slides add-slide and fit-check tests: 29 passed
- @agent-native/core typecheck
- Forms typecheck and production build
- all 58 repository guards