### PR TITLE
fix: read Netlify production build state from repo settings

### DIFF
--- a/.github/workflows/deploy-docs-production.yml
+++ b/.github/workflows/deploy-docs-production.yml
@@ -112,7 +112,7 @@ jobs:
                 await fetch(`${api}/sites/${siteId}`, { headers, signal: AbortSignal.timeout(30_000) }),
                 `${label} verification attempt ${attempt}`,
               );
-              actual = site.build_settings?.stop_builds;
+              actual = site.build_settings?.stop_builds ?? site.repo?.stop_builds;
               if (actual === expected) return;
               if (attempt < 15) {
                 await new Promise((resolve) => setTimeout(resolve, 2_000));
@@ -127,7 +127,7 @@ jobs:
               await fetch(siteUrl, { headers, signal: AbortSignal.timeout(30_000) }),
               'Netlify docs site lookup',
             );
-            if (current.build_settings?.stop_builds !== true) {
+            if ((current.build_settings?.stop_builds ?? current.repo?.stop_builds) !== true) {
               await readJson(
                 await fetch(siteUrl, {
                   method: 'PATCH',

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -292,7 +292,7 @@ jobs:
                 await request(`${api}/sites/${siteId}`),
                 `${label} verification attempt ${attempt}`,
               );
-              actual = site.build_settings?.stop_builds;
+              actual = site.build_settings?.stop_builds ?? site.repo?.stop_builds;
               if (actual === expected) return true;
               if (attempt < 15) {
                 await new Promise((resolve) => setTimeout(resolve, 2_000));
@@ -307,7 +307,8 @@ jobs:
             await request(`${api}/sites/${siteId}`),
             "Netlify build setting lookup",
           );
-          const wasStopped = site.build_settings?.stop_builds === true;
+          const wasStopped =
+            (site.build_settings?.stop_builds ?? site.repo?.stop_builds) === true;
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `was_stopped=${wasStopped}\n`);
           if (!wasStopped) {
             await readJson(
@@ -828,7 +829,7 @@ jobs:
                 await request(`${api}/sites/${siteId}`),
                 `${label} verification attempt ${attempt}`,
               );
-              actual = site.build_settings?.stop_builds;
+              actual = site.build_settings?.stop_builds ?? site.repo?.stop_builds;
               if (actual === expected) return;
               if (attempt < 15) {
                 await new Promise((resolve) => setTimeout(resolve, 2_000));

--- a/templates/clips/changelog/2026-08-20-preparing-recording-countdown-overlay.md
+++ b/templates/clips/changelog/2026-08-20-preparing-recording-countdown-overlay.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-20
 ---
+
 Recording preparation now uses a centered full-screen overlay that transitions smoothly into the 3-2-1 countdown.


### PR DESCRIPTION
The production docs cutover reached Netlify but the site response omitted build_settings.stop_builds, so the new retry verification failed with got undefined. Netlify documents stop_builds under both build_settings and repo; read either location for the existing pause/resume ownership flow.

This is required to promote the already-merged docs Builder CDN image optimization to production.