### PR TITLE
fix(dispatch): move workspace app sharing into settings

### DIFF
--- a/.changeset/quiet-app-share-actions.md
+++ b/.changeset/quiet-app-share-actions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Move workspace-app sharing into each app's settings menu so cards keep their primary open action focused.

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -388,6 +388,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
     expect(hubSource).toContain("AppOpenActions");
     expect(hubSource).toContain("desktop-app-card__actions");
+    expect(hubSource).not.toContain("ShareButton");
     expect(hubSource).toContain("Open in browser");
     expect(hubSource).toContain("Pin this app");
     expect(hubSource).toContain("Unpin this app");

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -276,6 +276,17 @@ describe("WorkspaceAppCard", () => {
     expect(
       document.body.querySelector("[data-agent-native-share-overlay]"),
     ).not.toBeNull();
+
+    const shareButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Share"]',
+    );
+    expect(shareButton).not.toBeNull();
+
+    await act(async () => shareButton?.click());
+    expect(animationFrameCallbacks).toHaveLength(1);
+
+    await act(async () => animationFrameCallbacks.shift()?.(0));
+    expect(document.activeElement).toBe(settingsButton);
   });
 
   it("keeps pinning in the app open menu", async () => {

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -8,10 +8,20 @@ import { TooltipProvider } from "./ui/tooltip";
 import { WorkspaceAppCard } from "./workspace-app-card";
 
 vi.mock("@agent-native/core/client/sharing", () => ({
-  ShareButton: ({ resourceTitle }: { resourceTitle?: string }) =>
+  ShareButton: ({
+    resourceTitle,
+    defaultOpen,
+  }: {
+    resourceTitle?: string;
+    defaultOpen?: boolean;
+  }) =>
     React.createElement(
       "button",
-      { type: "button", "aria-label": `Share ${resourceTitle ?? "app"}` },
+      {
+        type: "button",
+        "aria-label": `Share ${resourceTitle ?? "app"}`,
+        "data-default-open": defaultOpen ? "true" : undefined,
+      },
       "Share",
     ),
 }));
@@ -193,6 +203,56 @@ describe("WorkspaceAppCard", () => {
     }
   });
 
+  it("opens Share from the app settings menu instead of the card actions", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <TooltipProvider>
+            <WorkspaceAppCard
+              app={{
+                id: "analytics",
+                name: "Analytics",
+                path: "/analytics",
+                status: "ready",
+              }}
+            />
+          </TooltipProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    expect(
+      container.querySelector('button[aria-label="Share Analytics"]'),
+    ).toBeNull();
+
+    const settingsButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Settings for Analytics"]',
+    );
+    expect(settingsButton).not.toBeNull();
+
+    await act(async () => {
+      settingsButton?.dispatchEvent(
+        new MouseEvent("pointerdown", { bubbles: true, button: 0 }),
+      );
+    });
+
+    const shareItem = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.trim() === "Share");
+    expect(shareItem).not.toBeUndefined();
+
+    await act(async () => shareItem?.click());
+
+    expect(
+      container.querySelector('button[aria-label="Share Analytics"]'),
+    ).not.toBeNull();
+    expect(
+      container
+        .querySelector('button[aria-label="Share Analytics"]')
+        ?.getAttribute("data-default-open"),
+    ).toBe("true");
+  });
+
   it("keeps pinning in the app open menu", async () => {
     const onTogglePinned = vi.fn();
     await act(async () => {
@@ -270,7 +330,7 @@ describe("WorkspaceAppCard", () => {
     expect(settingsMenu?.className).toContain("w-48");
     expect(settingsMenu?.className).toContain("bg-popover");
     expect(settingsMenu?.className).toContain("shadow-md");
-    expect(document.querySelectorAll('[role="menuitem"] svg').length).toBe(4);
+    expect(document.querySelectorAll('[role="menuitem"] svg').length).toBe(5);
 
     await act(async () => resourcesItem?.click());
 

--- a/packages/dispatch/src/components/workspace-app-card.spec.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.spec.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
@@ -7,23 +8,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "./ui/tooltip";
 import { WorkspaceAppCard } from "./workspace-app-card";
 
-vi.mock("@agent-native/core/client/sharing", () => ({
-  ShareButton: ({
-    resourceTitle,
-    defaultOpen,
-  }: {
-    resourceTitle?: string;
-    defaultOpen?: boolean;
-  }) =>
-    React.createElement(
-      "button",
-      {
-        type: "button",
-        "aria-label": `Share ${resourceTitle ?? "app"}`,
-        "data-default-open": defaultOpen ? "true" : undefined,
-      },
-      "Share",
-    ),
+vi.mock("../../../core/dist/client/use-action.js", () => ({
+  useActionMutation: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useActionQuery: () => ({
+    data: {
+      ownerEmail: "owner@example.com",
+      orgId: null,
+      visibility: "private",
+      role: "owner",
+      shares: [],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("../../../core/dist/client/i18n.js", () => ({
+  useT: () => (key: string, values?: Record<string, unknown>) =>
+    String(values?.defaultValue ?? key),
 }));
 
 vi.mock("@agent-native/core/client/hooks", () => ({
@@ -54,6 +61,7 @@ vi.mock("@agent-native/core/client/host", () => ({
 describe("WorkspaceAppCard", () => {
   let container: HTMLDivElement;
   let root: Root;
+  let queryClient: QueryClient;
 
   beforeEach(() => {
     frameState.inBuilderFrame = false;
@@ -61,10 +69,17 @@ describe("WorkspaceAppCard", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
   });
 
   afterEach(() => {
     act(() => root.unmount());
+    queryClient.clear();
     container.remove();
     vi.unstubAllGlobals();
   });
@@ -204,26 +219,32 @@ describe("WorkspaceAppCard", () => {
   });
 
   it("opens Share from the app settings menu instead of the card actions", async () => {
+    const animationFrameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+
     await act(async () => {
       root.render(
-        <MemoryRouter>
-          <TooltipProvider>
-            <WorkspaceAppCard
-              app={{
-                id: "analytics",
-                name: "Analytics",
-                path: "/analytics",
-                status: "ready",
-              }}
-            />
-          </TooltipProvider>
-        </MemoryRouter>,
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <TooltipProvider>
+              <WorkspaceAppCard
+                app={{
+                  id: "analytics",
+                  name: "Analytics",
+                  path: "/analytics",
+                  status: "ready",
+                }}
+              />
+            </TooltipProvider>
+          </MemoryRouter>
+        </QueryClientProvider>,
       );
     });
 
-    expect(
-      container.querySelector('button[aria-label="Share Analytics"]'),
-    ).toBeNull();
+    expect(container.querySelector('button[aria-label="Share"]')).toBeNull();
 
     const settingsButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Settings for Analytics"]',
@@ -243,14 +264,18 @@ describe("WorkspaceAppCard", () => {
 
     await act(async () => shareItem?.click());
 
+    expect(container.querySelector('button[aria-label="Share"]')).toBeNull();
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+    expect(animationFrameCallbacks).toHaveLength(1);
+
+    await act(async () => animationFrameCallbacks.shift()?.(0));
+
     expect(
-      container.querySelector('button[aria-label="Share Analytics"]'),
+      container.querySelector('button[aria-label="Share"]'),
     ).not.toBeNull();
     expect(
-      container
-        .querySelector('button[aria-label="Share Analytics"]')
-        ?.getAttribute("data-default-open"),
-    ).toBe("true");
+      document.body.querySelector("[data-agent-native-share-overlay]"),
+    ).not.toBeNull();
   });
 
   it("keeps pinning in the app open menu", async () => {

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -68,6 +68,23 @@ import { AppResourceEffectiveStack } from "./workspace-resource-effective-stack"
 const APP_CARD_ACTION_CLASS =
   "size-7 rounded-md p-0 text-muted-foreground transition-[background-color,color] hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-foreground";
 
+function deferWorkspaceAppOverlayOpen(
+  event: { preventDefault: () => void },
+  closeMenu: () => void,
+  openOverlay: () => void,
+): void {
+  event.preventDefault();
+  closeMenu();
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    window.requestAnimationFrame(() => openOverlay());
+  } else {
+    setTimeout(openOverlay, 0);
+  }
+}
+
 export function WorkspaceAppCard({
   app,
   className,
@@ -394,10 +411,11 @@ function WorkspaceAppSettings({
   labels: WorkspaceAppMetadataLabels;
 }) {
   const [shareOpen, setShareOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={settingsOpen} onOpenChange={setSettingsOpen}>
         <Tooltip>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
@@ -423,7 +441,15 @@ function WorkspaceAppSettings({
             Edit details
           </DropdownMenuItem>
           {!isPending ? (
-            <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+            <DropdownMenuItem
+              onSelect={(event) =>
+                deferWorkspaceAppOverlayOpen(
+                  event,
+                  () => setSettingsOpen(false),
+                  () => setShareOpen(true),
+                )
+              }
+            >
               <IconShare3 size={14} aria-hidden="true" />
               {labels.share}
             </DropdownMenuItem>

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -15,6 +15,7 @@ import {
   IconFileText,
   IconKey,
   IconPin,
+  IconShare3,
   IconSettings,
   IconTrash,
   IconUser,
@@ -211,17 +212,6 @@ export function WorkspaceAppCard({
             pendingOpenLabel={pendingOpenLabel}
             onTogglePinned={onTogglePinned}
           />
-          {!isPending ? (
-            <div className="pointer-events-auto">
-              <ShareButton
-                resourceType="workspace-app"
-                resourceId={app.id}
-                resourceTitle={app.name}
-                trigger="icon"
-                triggerClassName={APP_CARD_ACTION_CLASS}
-              />
-            </div>
-          ) : null}
           <WorkspaceAppSettings
             app={app}
             isArchived={isArchived}
@@ -236,6 +226,7 @@ export function WorkspaceAppCard({
               createdBy: t("agents.dashboardMetadataCreatedBy"),
               owner: t("dispatch.pages.appMetadataOwner"),
               teams: t("dispatch.pages.appMetadataTeams"),
+              share: t("share.share", { defaultValue: "Share" }),
             }}
           />
         </div>
@@ -376,6 +367,7 @@ type WorkspaceAppMetadataLabels = {
   createdBy: string;
   owner: string;
   teams: string;
+  share: string;
 };
 
 function WorkspaceAppSettings({
@@ -401,66 +393,86 @@ function WorkspaceAppSettings({
   onRemovePending: () => void;
   labels: WorkspaceAppMetadataLabels;
 }) {
+  const [shareOpen, setShareOpen] = useState(false);
+
   return (
-    <DropdownMenu>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label={`Settings for ${app.name}`}
-              className={APP_CARD_ACTION_CLASS}
+    <>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`Settings for ${app.name}`}
+                className={APP_CARD_ACTION_CLASS}
+              >
+                <IconSettings size={15} />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>App settings</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent
+          align="end"
+          className={cn(APP_ACTION_MENU_CONTENT_CLASS, "min-w-max")}
+        >
+          <DropdownMenuItem onSelect={onEdit}>
+            <IconEdit size={14} aria-hidden="true" />
+            Edit details
+          </DropdownMenuItem>
+          {!isPending ? (
+            <DropdownMenuItem onSelect={() => setShareOpen(true)}>
+              <IconShare3 size={14} aria-hidden="true" />
+              {labels.share}
+            </DropdownMenuItem>
+          ) : null}
+          {!isPending && !isArchived ? (
+            <>
+              <DropdownMenuItem onSelect={onKeys}>
+                <IconKey size={14} aria-hidden="true" />
+                Manage keys
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={onResources}>
+                <IconFileText size={14} aria-hidden="true" />
+                Agent resources
+              </DropdownMenuItem>
+            </>
+          ) : null}
+          {isPending ? (
+            <DropdownMenuItem
+              onSelect={onRemovePending}
+              className="text-destructive focus:text-destructive"
             >
-              <IconSettings size={15} />
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent>App settings</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent
-        align="end"
-        className={cn(APP_ACTION_MENU_CONTENT_CLASS, "min-w-max")}
-      >
-        <DropdownMenuItem onSelect={onEdit}>
-          <IconEdit size={14} aria-hidden="true" />
-          Edit details
-        </DropdownMenuItem>
-        {!isPending && !isArchived ? (
-          <>
-            <DropdownMenuItem onSelect={onKeys}>
-              <IconKey size={14} aria-hidden="true" />
-              Manage keys
+              <IconTrash size={14} aria-hidden="true" />
+              Remove from list
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={onResources}>
-              <IconFileText size={14} aria-hidden="true" />
-              Agent resources
+          ) : isArchived ? (
+            <DropdownMenuItem onSelect={onUnarchive}>
+              <IconEye size={14} aria-hidden="true" />
+              Restore to list
             </DropdownMenuItem>
-          </>
-        ) : null}
-        {isPending ? (
-          <DropdownMenuItem
-            onSelect={onRemovePending}
-            className="text-destructive focus:text-destructive"
-          >
-            <IconTrash size={14} aria-hidden="true" />
-            Remove from list
-          </DropdownMenuItem>
-        ) : isArchived ? (
-          <DropdownMenuItem onSelect={onUnarchive}>
-            <IconEye size={14} aria-hidden="true" />
-            Restore to list
-          </DropdownMenuItem>
-        ) : (
-          <DropdownMenuItem onSelect={onArchive}>
-            <IconEyeOff size={14} aria-hidden="true" />
-            Hide from list
-          </DropdownMenuItem>
-        )}
-        <WorkspaceAppMetadata app={app} labels={labels} />
-      </DropdownMenuContent>
-    </DropdownMenu>
+          ) : (
+            <DropdownMenuItem onSelect={onArchive}>
+              <IconEyeOff size={14} aria-hidden="true" />
+              Hide from list
+            </DropdownMenuItem>
+          )}
+          <WorkspaceAppMetadata app={app} labels={labels} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {!isPending && shareOpen ? (
+        <ShareButton
+          resourceType="workspace-app"
+          resourceId={app.id}
+          resourceTitle={app.name}
+          defaultOpen
+          onOpenChange={setShareOpen}
+          triggerClassName="sr-only"
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/packages/dispatch/src/components/workspace-app-card.tsx
+++ b/packages/dispatch/src/components/workspace-app-card.tsx
@@ -22,7 +22,7 @@ import {
   IconUsersGroup,
   IconWorld,
 } from "@tabler/icons-react";
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 
@@ -412,6 +412,22 @@ function WorkspaceAppSettings({
 }) {
   const [shareOpen, setShareOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const settingsTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleShareOpenChange = (open: boolean) => {
+    setShareOpen(open);
+    if (open) return;
+
+    const restoreSettingsFocus = () => settingsTriggerRef.current?.focus();
+    if (
+      typeof window !== "undefined" &&
+      typeof window.requestAnimationFrame === "function"
+    ) {
+      window.requestAnimationFrame(restoreSettingsFocus);
+    } else {
+      setTimeout(restoreSettingsFocus, 0);
+    }
+  };
 
   return (
     <>
@@ -423,6 +439,7 @@ function WorkspaceAppSettings({
                 type="button"
                 variant="ghost"
                 size="sm"
+                ref={settingsTriggerRef}
                 aria-label={`Settings for ${app.name}`}
                 className={APP_CARD_ACTION_CLASS}
               >
@@ -494,7 +511,7 @@ function WorkspaceAppSettings({
           resourceId={app.id}
           resourceTitle={app.name}
           defaultOpen
-          onOpenChange={setShareOpen}
+          onOpenChange={handleShareOpenChange}
           triggerClassName="sr-only"
         />
       ) : null}


### PR DESCRIPTION
## Summary
- move workspace-app Share out of the card action row and into the existing settings menu
- keep Electron app cards free of inline Share controls while preserving their chevron menu
- add focused Dispatch and Electron regression coverage

## Verification
- corepack pnpm --dir packages/dispatch exec vitest run src/components/workspace-app-card.spec.tsx
- corepack pnpm --dir packages/desktop-app exec vitest run src/renderer/components/CodeAgentsHub.spec.ts
- Dispatch and Electron typechecks
- oxfmt check
- corepack pnpm guards - all 59 checks passed

Source and focused rendered-DOM verification are complete. No production deployment claim is made here.
