### PR TITLE
fix(clips): stack share description below reactions in narrow panes

### DIFF
--- a/templates/clips/app/global.css
+++ b/templates/clips/app/global.css
@@ -152,6 +152,33 @@
   animation: clips-collapsible-up 120ms ease-out;
 }
 
+.clips-share-content {
+  container: clips-share-content / inline-size;
+}
+
+.clips-share-metadata-description {
+  order: 2;
+}
+
+.clips-share-metadata-actions {
+  order: 1;
+}
+
+@container clips-share-content (min-width: 860px) {
+  .clips-share-metadata {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+
+  .clips-share-metadata-description {
+    order: 1;
+  }
+
+  .clips-share-metadata-actions {
+    order: 2;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .clips-collapsible-content[data-state] {
     animation-duration: 1ms;

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1110,7 +1110,7 @@ export default function ShareRoute() {
   return (
     <div className="flex min-h-screen max-w-full flex-col overflow-x-hidden bg-background text-foreground lg:h-screen lg:flex-row lg:overflow-hidden">
       {agentDiscovery}
-      <div className="flex w-full min-w-0 flex-col lg:flex-1">
+      <div className="clips-share-content flex w-full min-w-0 flex-col lg:flex-1">
         <header className="flex min-w-0 shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3 lg:flex-nowrap">
           {session ? (
             <Button
@@ -1358,15 +1358,15 @@ export default function ShareRoute() {
               : null}
           </div>
 
-          <div className="flex shrink-0 flex-col gap-3 px-4 pb-4 sm:flex-row sm:items-start sm:px-0 sm:pb-0">
-            <div className="min-w-0 flex-1">
+          <div className="clips-share-metadata flex shrink-0 flex-col gap-3 px-4 pb-4 sm:px-0 sm:pb-0">
+            <div className="clips-share-metadata-description min-w-0 flex-1">
               {recording.description ? (
                 <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
                   {recording.description}
                 </p>
               ) : null}
             </div>
-            <div className="flex max-w-full flex-col items-stretch gap-2 sm:items-end">
+            <div className="clips-share-metadata-actions flex max-w-full flex-col items-stretch gap-2 sm:items-end">
               <div className="flex flex-wrap items-center gap-2 sm:justify-end">
                 {recording.enableComments ? (
                   <TimestampedCommentButton


### PR DESCRIPTION
## Summary

- Measure the Clips share content pane independently from the right Activity/Transcript/Agent rail.
- Stack comments and reactions above the description below 860px of content width.
- Preserve the existing side-by-side layout at 860px and wider.

## Validation

- `git diff --check` passed.
- `pnpm --filter clips typecheck` passed with the repository's existing missing-production-config warnings.
- `pnpm --filter clips test -- app/routes/r.$recordingId.test.tsx app/routes/share-auth-loading.test.ts app/components/player/reactions-tray.test.tsx` passed 232 files / 1,376 tests.
- Local browser proof at content widths 859px and 860px with the 380px right rail: narrow actions above description; wide side-by-side; no console errors.
