### PR TITLE
fix: clarify integration connection scope

### DIFF
--- a/.changeset/clear-mcp-scope-ambiguity.md
+++ b/.changeset/clear-mcp-scope-ambiguity.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show the personal or workspace scope choice before connecting an integration in an organization, including a clear owner/admin requirement for members.

--- a/packages/core/src/client/integrations/IntegrationConnectionChoice.tsx
+++ b/packages/core/src/client/integrations/IntegrationConnectionChoice.tsx
@@ -1,10 +1,15 @@
 import { IconLoader2, IconUser, IconUsersGroup } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 
+import { useT } from "../i18n.js";
+
 export interface IntegrationConnectionChoiceProps {
   name: string;
   logo?: ReactNode;
   showWorkspaceOption: boolean;
+  workspaceOptionDisabled?: boolean;
+  workspaceOptionDisabledReason?: string;
+  personalOnlyReason?: string;
   busy?: boolean;
   onPersonal: () => void;
   onWorkspace: () => void;
@@ -15,10 +20,15 @@ export function IntegrationConnectionChoice({
   name,
   logo,
   showWorkspaceOption,
+  workspaceOptionDisabled = false,
+  workspaceOptionDisabledReason,
+  personalOnlyReason,
   busy = false,
   onPersonal,
   onWorkspace,
 }: IntegrationConnectionChoiceProps) {
+  const t = useT();
+
   return (
     <div className="flex min-h-full flex-1 flex-col bg-background">
       <header className="flex min-h-16 items-center border-b border-border px-6 sm:px-10">
@@ -29,7 +39,7 @@ export function IntegrationConnectionChoice({
             </span>
           ) : null}
           <span className="truncate text-sm font-medium text-foreground">
-            Connect {name}
+            {t("mcpIntegrations.connect")} {name}
           </span>
         </div>
       </header>
@@ -37,10 +47,10 @@ export function IntegrationConnectionChoice({
       <main className="flex flex-1 justify-center overflow-y-auto px-6 py-12 sm:px-10 sm:py-[12vh]">
         <div className="w-full max-w-[420px] self-start">
           <h1 className="text-2xl font-semibold tracking-[-0.03em] text-foreground sm:text-[28px]">
-            Who should use this?
+            {t("mcpIntegrations.scopeChoiceTitle")}
           </h1>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            Choose where this connection is available.
+            {t("mcpIntegrations.scopeChoiceDescription")}
           </p>
 
           <div className="mt-8 grid gap-2.5">
@@ -53,7 +63,7 @@ export function IntegrationConnectionChoice({
             >
               <IconUser className="size-4 shrink-0 opacity-75" />
               <span className="min-w-0 flex-1 text-sm font-medium">
-                Connect for me
+                {t("mcpIntegrations.connectForMe")}
               </span>
               {busy ? (
                 <IconLoader2 className="size-4 shrink-0 animate-spin" />
@@ -64,16 +74,34 @@ export function IntegrationConnectionChoice({
               <button
                 type="button"
                 onClick={onWorkspace}
-                disabled={busy}
-                className="flex min-h-12 items-center gap-3 rounded-lg bg-muted/50 px-4 py-3 text-left text-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-wait disabled:opacity-60"
+                disabled={busy || workspaceOptionDisabled}
+                aria-describedby={
+                  workspaceOptionDisabledReason
+                    ? "integration-workspace-scope-restriction"
+                    : undefined
+                }
+                className="flex min-h-12 items-center gap-3 rounded-lg bg-muted/50 px-4 py-3 text-left text-foreground transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <IconUsersGroup className="size-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0 flex-1 text-sm font-medium">
-                  Set up for workspace
+                  {t("mcpIntegrations.setUpForWorkspace")}
                 </span>
+                {workspaceOptionDisabledReason ? (
+                  <span
+                    id="integration-workspace-scope-restriction"
+                    className="shrink-0 text-[11px] font-normal text-muted-foreground"
+                  >
+                    {workspaceOptionDisabledReason}
+                  </span>
+                ) : null}
               </button>
             ) : null}
           </div>
+          {personalOnlyReason ? (
+            <p className="mt-3 text-[11px] leading-relaxed text-muted-foreground">
+              {personalOnlyReason}
+            </p>
+          ) : null}
         </div>
       </main>
     </div>

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -38,6 +38,8 @@ vi.mock("../resources/use-mcp-servers.js", () => ({
   useMcpServersApi: mocks.useMcpServersApi,
   formatMcpServerError: (error: unknown) =>
     error instanceof Error ? error.message : String(error),
+  formatMcpServersLoadError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
 }));
 
 describe("FirstRunOnboarding", () => {
@@ -64,6 +66,10 @@ describe("FirstRunOnboarding", () => {
     mocks.useMcpServers.mockReturnValue({
       data: { user: [], org: [], orgId: null, role: null },
       isSuccess: true,
+      isError: false,
+      error: null,
+      isFetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
     });
     mocks.useMcpServersApi.mockReturnValue({ test: mocks.testMcpServer });
     mocks.createMcpServerMutation.mockReset();
@@ -284,6 +290,56 @@ describe("FirstRunOnboarding", () => {
     ).toBeTruthy();
     expect(document.body.textContent).not.toContain("This app is an agent.");
     expect(document.body.textContent).not.toContain("Agent integrations");
+  });
+
+  it("keeps first-run integrations disabled until scope metadata is ready", () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    mocks.useMcpServers.mockReturnValue({
+      data: { user: [], org: [], orgId: null, role: null },
+      isSuccess: false,
+      isError: true,
+      error: new Error("Scope metadata unavailable"),
+      isFetching: false,
+      refetch,
+    });
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+    act(() => {
+      document.body
+        .querySelector("[data-testid='first-run-use-own-keys']")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue to tools")
+        ?.click();
+    });
+
+    expect(
+      document.body.querySelector('[role="alert"]')?.textContent,
+    ).toContain("Scope metadata unavailable");
+    expect(
+      document.body.querySelector('button[aria-label="Connect Context7"]'),
+    ).toHaveProperty("disabled", true);
+
+    const retry = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Retry",
+    );
+    act(() => retry?.click());
+    expect(refetch).toHaveBeenCalledOnce();
+    expect(mocks.createMcpServerMutation).not.toHaveBeenCalled();
   });
 
   it("asks a workspace admin for scope before connecting a shared-capable integration", () => {

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -336,9 +336,68 @@ describe("FirstRunOnboarding", () => {
         ?.click();
     });
 
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(mocks.createMcpServerMutation).not.toHaveBeenCalled();
+  });
+
+  it("shows the workspace permission requirement to a non-admin", () => {
+    mocks.useMcpServers.mockReturnValue({
+      data: { user: [], org: [], orgId: "org-builder", role: "member" },
+      isSuccess: true,
+    });
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+    act(() => {
+      document.body
+        .querySelector("[data-testid='first-run-use-own-keys']")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue to tools")
+        ?.click();
+    });
+
+    const search = document.body.querySelector(
+      'input[aria-label="Search integrations"]',
+    ) as HTMLInputElement | null;
+    expect(search).toBeTruthy();
+
+    act(() => {
+      if (!search) return;
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(search, "Context7");
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    act(() => {
+      document.body
+        .querySelector('button[aria-label="Connect Context7"]')
+        ?.click();
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
     expect(document.body.textContent).toContain(
-      "Who should be able to use this connection?",
+      "Workspace owner or admin required.",
     );
+    const workspace = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Set up for workspace") ?? false,
+    );
+    expect(workspace).toHaveProperty("disabled", true);
     expect(mocks.createMcpServerMutation).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -34,6 +34,7 @@ import { McpIntegrationDialog } from "../resources/McpIntegrationDialog.js";
 import { McpIntegrationLogo } from "../resources/McpIntegrationLogo.js";
 import {
   formatMcpServerError,
+  formatMcpServersLoadError,
   useCreateMcpServer,
   useMcpServers,
 } from "../resources/use-mcp-servers.js";
@@ -222,6 +223,8 @@ export function FirstRunOnboarding({
     ) {
       return;
     }
+
+    if (!mcpServersQuery.isSuccess) return;
 
     if (hasOrg) {
       setIntegrationDialogId(integration.id);
@@ -611,6 +614,22 @@ export function FirstRunOnboarding({
                   {connectError}
                 </p>
               )}
+              {mcpServersQuery.isError ? (
+                <div
+                  role="alert"
+                  className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+                >
+                  <p>{formatMcpServersLoadError(mcpServersQuery.error)}</p>
+                  <button
+                    type="button"
+                    onClick={() => void mcpServersQuery.refetch()}
+                    disabled={mcpServersQuery.isFetching}
+                    className="mt-2 font-medium underline underline-offset-2 hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {mcpServersQuery.isFetching ? "Retrying…" : "Retry"}
+                  </button>
+                </div>
+              ) : null}
             </div>
 
             <IntegrationGrid
@@ -635,7 +654,9 @@ export function FirstRunOnboarding({
                   statusClassName: "text-emerald-600 dark:text-emerald-400",
                   actionLabel: connected ? "Connected" : "Connect",
                   disabled:
-                    connected || connectingIntegrationId === integration.id,
+                    connected ||
+                    connectingIntegrationId === integration.id ||
+                    !mcpServersQuery.isSuccess,
                   onAction: () => void connectIntegration(integration),
                 };
               })}

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -28,7 +28,6 @@ import {
   filterMcpIntegrations,
   getDefaultMcpIntegrations,
   navigateToMcpOAuthStart,
-  shouldOfferMcpIntegrationOrganizationScope,
   type DefaultMcpIntegration,
 } from "../resources/mcp-integration-catalog.js";
 import { McpIntegrationDialog } from "../resources/McpIntegrationDialog.js";
@@ -224,13 +223,7 @@ export function FirstRunOnboarding({
       return;
     }
 
-    if (
-      shouldOfferMcpIntegrationOrganizationScope(
-        integration,
-        hasOrg,
-        canCreateOrgMcp,
-      )
-    ) {
+    if (hasOrg) {
       setIntegrationDialogId(integration.id);
       return;
     }

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -271,6 +271,82 @@ describe("McpIntegrationDialog", () => {
     expect(onCreateMcpServer).not.toHaveBeenCalled();
   });
 
+  it("disables catalog connections while scope metadata is loading", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    mocks.mcpServersQuery.isSuccess = false;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={vi.fn()}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Loading connection scope…");
+    expect(
+      document.body.querySelector('button[aria-label="Connect Context7"]'),
+    ).toHaveProperty("disabled", true);
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+  });
+
+  it("waits for scope metadata before opening an initial setup", () => {
+    const gong = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "gong",
+    )!;
+    mocks.mcpServersQuery.isSuccess = false;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            initialIntegrationId="gong"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={vi.fn()}
+            integrations={[gong]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Loading connection scope…");
+    expect(document.body.textContent).not.toContain("Provider setup required");
+
+    mocks.mcpServersQuery.isSuccess = true;
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            initialIntegrationId="gong"
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={vi.fn()}
+            integrations={[gong]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+  });
+
   it("surfaces a retry when scope metadata fails before direct connecting", () => {
     const context7 = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "context7",

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -101,7 +101,7 @@ describe("McpIntegrationDialog", () => {
           <McpIntegrationDialog
             open
             onOpenChange={() => {}}
-            initialIntegrationId="context7"
+            connectIntegrationId="context7"
             defaultScope="user"
             canCreateOrgMcp
             hasOrg
@@ -112,34 +112,20 @@ describe("McpIntegrationDialog", () => {
       );
     });
 
-    expect(document.body.textContent).toContain(
-      "Who should be able to use this connection?",
-    );
-    expect(document.body.textContent).toContain(
-      "Only you can use this connection.",
-    );
+    expect(document.body.textContent).toContain("Who should use this?");
 
     const shared = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "Shared with workspace",
+      (button) => button.textContent === "Set up for workspace",
     );
     expect(shared).toBeTruthy();
     act(() => shared?.click());
-    expect(document.body.textContent).toContain(
-      "Permitted workspace members can use this connection. Provider permissions still apply.",
-    );
-
-    const connectButton = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "Connect",
-    );
-    expect(connectButton).toBeTruthy();
-    act(() => connectButton?.click());
 
     expect(onCreateMcpServer).toHaveBeenCalledWith(
       expect.objectContaining({ scope: "org" }),
     );
   });
 
-  it("quick-connects catalog integrations personally by default", () => {
+  it("asks for scope before quick connecting in an organization", () => {
     const context7 = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "context7",
     )!;
@@ -162,15 +148,95 @@ describe("McpIntegrationDialog", () => {
       );
     });
 
-    expect(document.body.textContent).not.toContain(
-      "Who should be able to use this connection?",
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
+
+    const personal = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect for me",
     );
+    expect(personal).toBeTruthy();
+    act(() => personal?.click());
+
     expect(onCreateMcpServer).toHaveBeenCalledWith(
       expect.objectContaining({ scope: "user" }),
     );
   });
 
-  it("does not show organization scope to a member", () => {
+  it("routes catalog connections through the scope choice in an organization", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    const onCreateMcpServer = vi.fn().mockResolvedValue(undefined);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => {
+      document.body
+        .querySelector('button[aria-label="Connect Context7"]')
+        ?.click();
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("shows a disabled workspace option to a member", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    const onCreateMcpServer = vi.fn().mockResolvedValue(undefined);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            connectIntegrationId="context7"
+            defaultScope="org"
+            canCreateOrgMcp={false}
+            hasOrg
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(document.body.textContent).toContain(
+      "Workspace owner or admin required.",
+    );
+    const workspace = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Set up for workspace") ?? false,
+    );
+    expect(workspace).toBeTruthy();
+    expect(workspace).toHaveProperty("disabled", true);
+
+    const personal = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect for me",
+    );
+    act(() => personal?.click());
+    expect(onCreateMcpServer).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "user" }),
+    );
+  });
+
+  it("explains personal-only integrations before connecting in an organization", () => {
     const linear = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "linear",
     )!;
@@ -181,9 +247,9 @@ describe("McpIntegrationDialog", () => {
           <McpIntegrationDialog
             open
             onOpenChange={() => {}}
-            initialIntegrationId="linear"
+            connectIntegrationId="linear"
             defaultScope="org"
-            canCreateOrgMcp={false}
+            canCreateOrgMcp
             hasOrg
             onCreateMcpServer={vi.fn()}
             integrations={[linear]}
@@ -192,8 +258,11 @@ describe("McpIntegrationDialog", () => {
       );
     });
 
-    expect(document.body.textContent).not.toContain("Organization");
-    expect(document.body.textContent).not.toContain("owners and admins");
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(document.body.textContent).toContain(
+      "Only personal connections are supported for this integration.",
+    );
+    expect(document.body.textContent).not.toContain("Set up for workspace");
   });
 
   it("does not offer an unauthenticated test for setup-gated integrations", () => {
@@ -268,6 +337,12 @@ describe("McpIntegrationDialog", () => {
     expect(viewSetupButton).toBeTruthy();
 
     act(() => viewSetupButton?.click());
+    expect(document.body.textContent).toContain("Who should use this?");
+    const personal = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect for me",
+    );
+    expect(personal).toBeTruthy();
+    act(() => personal?.click());
     expect(document.body.textContent).toContain("Provider setup required");
   });
 

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -295,6 +295,51 @@ describe("McpIntegrationDialog", () => {
     expect(onCreateMcpServer).not.toHaveBeenCalled();
   });
 
+  it("routes an initial workspace-capable setup through the scope choice", () => {
+    const gong = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "gong",
+    )!;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            initialIntegrationId="gong"
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={vi.fn()}
+            integrations={[gong]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(document.body.textContent).not.toContain("Provider setup required");
+
+    const workspace = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Set up for workspace",
+    );
+    expect(workspace).toBeTruthy();
+    act(() => workspace?.click());
+
+    expect(document.body.textContent).toContain("Provider setup required");
+    const continueButton = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "I've completed setup",
+    );
+    expect(continueButton).toBeTruthy();
+
+    act(() => continueButton?.click());
+
+    const url = mocks.navigateToMcpOAuthStart.mock.calls[0]?.[0];
+    expect(
+      new URL(url, "https://analytics.example.com").searchParams.get("scope"),
+    ).toBe("org");
+  });
+
   it("shows a disabled workspace option to a member", () => {
     const context7 = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "context7",

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -18,6 +18,10 @@ const mocks = vi.hoisted(() => ({
       role: "owner",
     },
     isSuccess: true,
+    isError: false,
+    error: null as Error | null,
+    isFetching: false,
+    refetch: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -39,6 +43,10 @@ describe("McpIntegrationDialog", () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     mocks.navigateToMcpOAuthStart.mockReset();
     mocks.mcpServersQuery.isSuccess = true;
+    mocks.mcpServersQuery.isError = false;
+    mocks.mcpServersQuery.error = null;
+    mocks.mcpServersQuery.isFetching = false;
+    mocks.mcpServersQuery.refetch.mockReset().mockResolvedValue(undefined);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -261,6 +269,84 @@ describe("McpIntegrationDialog", () => {
     expect(document.body.textContent).toContain("Who should use this?");
     expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
     expect(onCreateMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a retry when scope metadata fails before direct connecting", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    mocks.mcpServersQuery.isSuccess = false;
+    mocks.mcpServersQuery.isError = true;
+    mocks.mcpServersQuery.error = new Error("Scope metadata unavailable");
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            connectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={vi.fn()}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(
+      document.body.querySelector('[role="alert"]')?.textContent,
+    ).toContain("Scope metadata unavailable");
+    const retry = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Retry",
+    );
+    expect(retry).toBeTruthy();
+
+    act(() => retry?.click());
+
+    expect(mocks.mcpServersQuery.refetch).toHaveBeenCalledOnce();
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a retry when scope metadata fails before quick connecting", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    mocks.mcpServersQuery.isSuccess = false;
+    mocks.mcpServersQuery.isError = true;
+    mocks.mcpServersQuery.error = new Error("Scope metadata unavailable");
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            quickConnectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={true}
+            onCreateMcpServer={vi.fn()}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(
+      document.body.querySelector('[role="alert"]')?.textContent,
+    ).toContain("Scope metadata unavailable");
+    const retry = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Retry",
+    );
+    expect(retry).toBeTruthy();
+
+    act(() => retry?.click());
+
+    expect(mocks.mcpServersQuery.refetch).toHaveBeenCalledOnce();
+    expect(document.body.textContent).not.toContain("Who should use this?");
   });
 
   it("routes catalog connections through the scope choice in an organization", () => {

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -10,6 +10,15 @@ import { McpIntegrationDialog } from "./McpIntegrationDialog.js";
 
 const mocks = vi.hoisted(() => ({
   navigateToMcpOAuthStart: vi.fn(),
+  mcpServersQuery: {
+    data: {
+      user: [],
+      org: [],
+      orgId: "org-builder",
+      role: "owner",
+    },
+    isSuccess: true,
+  },
 }));
 
 vi.mock("./mcp-integration-catalog.js", async (importOriginal) => ({
@@ -19,15 +28,7 @@ vi.mock("./mcp-integration-catalog.js", async (importOriginal) => ({
 
 vi.mock("./use-mcp-servers.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./use-mcp-servers.js")>()),
-  useMcpServers: () => ({
-    data: {
-      user: [],
-      org: [],
-      orgId: "org-builder",
-      role: "owner",
-    },
-    isSuccess: true,
-  }),
+  useMcpServers: () => mocks.mcpServersQuery,
 }));
 
 describe("McpIntegrationDialog", () => {
@@ -37,6 +38,7 @@ describe("McpIntegrationDialog", () => {
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     mocks.navigateToMcpOAuthStart.mockReset();
+    mocks.mcpServersQuery.isSuccess = true;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -160,6 +162,105 @@ describe("McpIntegrationDialog", () => {
     expect(onCreateMcpServer).toHaveBeenCalledWith(
       expect.objectContaining({ scope: "user" }),
     );
+  });
+
+  it("waits for scope metadata before auto-connecting", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    const onCreateMcpServer = vi.fn().mockResolvedValue(undefined);
+    mocks.mcpServersQuery.isSuccess = false;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            connectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).not.toContain("Who should use this?");
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
+
+    mocks.mcpServersQuery.isSuccess = true;
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            connectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
+  });
+
+  it("waits for scope metadata before quick connecting", () => {
+    const context7 = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "context7",
+    )!;
+    const onCreateMcpServer = vi.fn().mockResolvedValue(undefined);
+    mocks.mcpServersQuery.isSuccess = false;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            quickConnectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp={false}
+            hasOrg={false}
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
+
+    mocks.mcpServersQuery.isSuccess = true;
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            quickConnectIntegrationId="context7"
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={onCreateMcpServer}
+            integrations={[context7]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain("Who should use this?");
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+    expect(onCreateMcpServer).not.toHaveBeenCalled();
   });
 
   it("routes catalog connections through the scope choice in an organization", () => {

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -31,6 +31,7 @@ import {
   resolveMcpIntegrationScope,
   shouldOfferMcpIntegrationOrganizationScope,
   shouldOfferMcpOrganizationScope,
+  supportsMcpIntegrationOrganizationScope,
   type DefaultMcpIntegration,
 } from "./mcp-integration-catalog.js";
 import { McpIntegrationLogo } from "./McpIntegrationLogo.js";
@@ -368,6 +369,11 @@ export function McpIntegrationDialog({
   };
 
   const quickConnect = (integration: DefaultMcpIntegration) => {
+    if (hasOrg) {
+      setSelected(integration);
+      setMode("choice");
+      return;
+    }
     if (requiresMcpIntegrationSetup(integration)) {
       openForm(integration);
       return;
@@ -391,6 +397,11 @@ export function McpIntegrationDialog({
   };
 
   const selectCatalogConnection = (integration: DefaultMcpIntegration) => {
+    if (hasOrg) {
+      setSelected(integration);
+      setMode("choice");
+      return;
+    }
     if (requiresMcpIntegrationSetup(integration)) {
       const apiFallback = getMcpIntegrationApiFallback(integration);
       if (apiFallback) {
@@ -398,17 +409,6 @@ export function McpIntegrationDialog({
       } else {
         openForm(integration);
       }
-      return;
-    }
-    if (
-      shouldOfferMcpIntegrationOrganizationScope(
-        integration,
-        hasOrg,
-        canCreateOrgMcp,
-      )
-    ) {
-      setSelected(integration);
-      setMode("choice");
       return;
     }
     quickConnect(integration);
@@ -433,7 +433,7 @@ export function McpIntegrationDialog({
     if (!integration) return;
     quickConnectAttemptedRef.current = quickConnectIntegrationId;
     quickConnectRef.current?.(integration);
-  }, [defaultIntegrations, open, quickConnectIntegrationId]);
+  }, [defaultIntegrations, hasOrg, open, quickConnectIntegrationId]);
 
   useEffect(() => {
     if (!open || !connectIntegrationId) return;
@@ -444,20 +444,16 @@ export function McpIntegrationDialog({
     const attemptKey = `connect:${connectIntegrationId}`;
     if (quickConnectAttemptedRef.current === attemptKey) return;
     quickConnectAttemptedRef.current = attemptKey;
+    if (hasOrg) {
+      setSelected(integration);
+      setMode("choice");
+      return;
+    }
     if (requiresMcpIntegrationSetup(integration)) {
       openForm(integration);
       return;
     }
-    const showWorkspaceChoice = shouldOfferMcpIntegrationOrganizationScope(
-      integration,
-      hasOrg,
-      canCreateOrgMcp,
-    );
-    if (!showWorkspaceChoice) {
-      quickConnectRef.current?.(integration);
-    } else {
-      setMode("choice");
-    }
+    quickConnectRef.current?.(integration);
   }, [
     canCreateOrgMcp,
     connectIntegrationId,
@@ -467,6 +463,15 @@ export function McpIntegrationDialog({
   ]);
 
   const connectPersonal = (integration: DefaultMcpIntegration) => {
+    if (requiresMcpIntegrationSetup(integration)) {
+      const apiFallback = getMcpIntegrationApiFallback(integration);
+      if (apiFallback) {
+        openAgentSettings(`secrets:${apiFallback.secretKey}`);
+      } else {
+        openForm(integration, { scope: "user" });
+      }
+      return;
+    }
     if (integration.authMode === "oauth") {
       connectWithOAuth(integration, { scope: "user" });
       return;
@@ -487,6 +492,11 @@ export function McpIntegrationDialog({
   };
 
   const connectWorkspace = (integration: DefaultMcpIntegration) => {
+    if (!canCreateOrgMcp) return;
+    if (requiresMcpIntegrationSetup(integration)) {
+      openForm(integration, { scope: "org" });
+      return;
+    }
     if (integration.authMode === "oauth") {
       connectWithOAuth(integration, { scope: "org" });
       return;
@@ -603,7 +613,9 @@ export function McpIntegrationDialog({
         {mode === "choice" && selected ? (
           <>
             <DialogHeader className="sr-only">
-              <DialogTitle>Connect {selected.name}</DialogTitle>
+              <DialogTitle>
+                {t("mcpIntegrations.connect")} {selected.name}
+              </DialogTitle>
             </DialogHeader>
             <IntegrationConnectionChoice
               name={selected.name}
@@ -616,11 +628,20 @@ export function McpIntegrationDialog({
                   imageClassName="size-full p-1"
                 />
               }
-              showWorkspaceOption={shouldOfferMcpIntegrationOrganizationScope(
+              showWorkspaceOption={supportsMcpIntegrationOrganizationScope(
                 selected,
-                hasOrg,
-                canCreateOrgMcp,
               )}
+              workspaceOptionDisabled={!canCreateOrgMcp}
+              workspaceOptionDisabledReason={
+                !canCreateOrgMcp
+                  ? t("mcpIntegrations.workspaceAdminRequired")
+                  : undefined
+              }
+              personalOnlyReason={
+                !supportsMcpIntegrationOrganizationScope(selected)
+                  ? t("mcpIntegrations.personalOnlyDescription")
+                  : undefined
+              }
               busy={busy}
               onPersonal={() => connectPersonal(selected)}
               onWorkspace={() => connectWorkspace(selected)}

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -194,6 +194,7 @@ export function McpIntegrationDialog({
 
   useEffect(() => {
     if (!open) return;
+    if (initialIntegrationId && !mcpServersQuery.isSuccess) return;
     const initialIntegration = initialIntegrationId
       ? defaultIntegrations.find(
           (integration) => integration.id === initialIntegrationId,
@@ -241,6 +242,7 @@ export function McpIntegrationDialog({
     open,
     safeDefaultScope,
     showCatalog,
+    mcpServersQuery.isSuccess,
   ]);
 
   useEffect(() => {
@@ -410,6 +412,7 @@ export function McpIntegrationDialog({
   };
 
   const selectCatalogConnection = (integration: DefaultMcpIntegration) => {
+    if (!mcpServersQuery.isSuccess) return;
     if (hasOrg) {
       setSelected(integration);
       setMode("choice");
@@ -731,6 +734,14 @@ export function McpIntegrationDialog({
                     {error}
                   </div>
                 )}
+                {!mcpServersQuery.isSuccess && !mcpServersQuery.isError ? (
+                  <div
+                    role="status"
+                    className="mb-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-[12px] leading-relaxed text-muted-foreground"
+                  >
+                    {t("mcpIntegrations.loadingScopeMetadata")}
+                  </div>
+                ) : null}
                 <IntegrationGrid
                   items={filteredIntegrations.map((integration) => {
                     const connected = connectedUrls.has(
@@ -767,7 +778,7 @@ export function McpIntegrationDialog({
                           : setupOnly
                             ? t("mcpIntegrations.viewSetup")
                             : t("mcpIntegrations.connect"),
-                      disabled: connected || busy,
+                      disabled: connected || busy || !mcpServersQuery.isSuccess,
                       onAction: () => {
                         if (connected) {
                           openForm(integration);

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -427,16 +427,24 @@ export function McpIntegrationDialog({
     ) {
       return;
     }
+    if (!mcpServersQuery.isSuccess) return;
     const integration = defaultIntegrations.find(
       (candidate) => candidate.id === quickConnectIntegrationId,
     );
     if (!integration) return;
     quickConnectAttemptedRef.current = quickConnectIntegrationId;
     quickConnectRef.current?.(integration);
-  }, [defaultIntegrations, hasOrg, open, quickConnectIntegrationId]);
+  }, [
+    defaultIntegrations,
+    hasOrg,
+    mcpServersQuery.isSuccess,
+    open,
+    quickConnectIntegrationId,
+  ]);
 
   useEffect(() => {
     if (!open || !connectIntegrationId) return;
+    if (!mcpServersQuery.isSuccess) return;
     const integration = defaultIntegrations.find(
       (candidate) => candidate.id === connectIntegrationId,
     );
@@ -459,6 +467,7 @@ export function McpIntegrationDialog({
     connectIntegrationId,
     defaultIntegrations,
     hasOrg,
+    mcpServersQuery.isSuccess,
     open,
   ]);
 

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -200,7 +200,19 @@ export function McpIntegrationDialog({
       : null;
     const initialDefaults =
       createMcpIntegrationFormDefaults(initialIntegration);
-    setMode(initialIntegration || !showCatalog ? "form" : "catalog");
+    const initialNeedsScopeChoice = Boolean(
+      initialIntegration &&
+      hasOrg &&
+      requiresMcpIntegrationSetup(initialIntegration) &&
+      supportsMcpIntegrationOrganizationScope(initialIntegration),
+    );
+    setMode(
+      initialNeedsScopeChoice
+        ? "choice"
+        : initialIntegration || !showCatalog
+          ? "form"
+          : "catalog",
+    );
     setQuery("");
     setSelected(initialIntegration ?? null);
     setScope(

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -37,6 +37,7 @@ import {
 import { McpIntegrationLogo } from "./McpIntegrationLogo.js";
 import {
   formatMcpServerError,
+  formatMcpServersLoadError,
   getMcpUrlValidationError,
   useMcpServersApi,
   useMcpServers,
@@ -439,6 +440,7 @@ export function McpIntegrationDialog({
     ) {
       return;
     }
+    if (mcpServersQuery.isError) return;
     if (!mcpServersQuery.isSuccess) return;
     const integration = defaultIntegrations.find(
       (candidate) => candidate.id === quickConnectIntegrationId,
@@ -449,6 +451,7 @@ export function McpIntegrationDialog({
   }, [
     defaultIntegrations,
     hasOrg,
+    mcpServersQuery.isError,
     mcpServersQuery.isSuccess,
     open,
     quickConnectIntegrationId,
@@ -456,6 +459,7 @@ export function McpIntegrationDialog({
 
   useEffect(() => {
     if (!open || !connectIntegrationId) return;
+    if (mcpServersQuery.isError) return;
     if (!mcpServersQuery.isSuccess) return;
     const integration = defaultIntegrations.find(
       (candidate) => candidate.id === connectIntegrationId,
@@ -479,6 +483,7 @@ export function McpIntegrationDialog({
     connectIntegrationId,
     defaultIntegrations,
     hasOrg,
+    mcpServersQuery.isError,
     mcpServersQuery.isSuccess,
     open,
   ]);
@@ -631,6 +636,24 @@ export function McpIntegrationDialog({
         aria-describedby={undefined}
         className="inset-0 flex h-[100dvh] max-h-none w-full max-w-none translate-x-0 translate-y-0 flex-col gap-0 overflow-hidden rounded-none p-0"
       >
+        {mcpServersQuery.isError ? (
+          <div
+            role="alert"
+            className="mx-7 mt-4 shrink-0 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive sm:mx-10"
+          >
+            <p>{formatMcpServersLoadError(mcpServersQuery.error)}</p>
+            <button
+              type="button"
+              onClick={() => void mcpServersQuery.refetch()}
+              disabled={mcpServersQuery.isFetching}
+              className="mt-2 font-medium underline underline-offset-2 hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+            >
+              {mcpServersQuery.isFetching
+                ? t("mcpIntegrations.retrying")
+                : t("mcpIntegrations.retry")}
+            </button>
+          </div>
+        ) : null}
         {mode === "choice" && selected ? (
           <>
             <DialogHeader className="sr-only">

--- a/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.spec.ts
@@ -18,6 +18,7 @@ import {
   resolveMcpIntegrationScope,
   shouldOfferMcpIntegrationOrganizationScope,
   shouldOfferMcpOrganizationScope,
+  supportsMcpIntegrationOrganizationScope,
 } from "./mcp-integration-catalog.js";
 
 describe("MCP integration catalog", () => {
@@ -53,6 +54,8 @@ describe("MCP integration catalog", () => {
     expect(exa.supportsOrganizationScope).toBe(true);
     expect(gong.supportsOrganizationScope).toBe(true);
     expect(hubspot.supportsOrganizationScope).not.toBe(true);
+    expect(supportsMcpIntegrationOrganizationScope(context7)).toBe(true);
+    expect(supportsMcpIntegrationOrganizationScope(hubspot)).toBe(false);
     expect(
       shouldOfferMcpIntegrationOrganizationScope(context7, true, true),
     ).toBe(true);

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -1005,6 +1005,15 @@ export function shouldOfferMcpOrganizationScope(
   return hasOrg && canCreateOrgMcp;
 }
 
+export function supportsMcpIntegrationOrganizationScope(
+  integration: DefaultMcpIntegration,
+): boolean {
+  return (
+    integration.supportsOrganizationScope === true &&
+    integration.managedOAuth !== true
+  );
+}
+
 export function shouldOfferMcpIntegrationOrganizationScope(
   integration: DefaultMcpIntegration,
   hasOrg: boolean,
@@ -1012,8 +1021,7 @@ export function shouldOfferMcpIntegrationOrganizationScope(
 ): boolean {
   return (
     shouldOfferMcpOrganizationScope(hasOrg, canCreateOrgMcp) &&
-    integration.supportsOrganizationScope === true &&
-    integration.managedOAuth !== true
+    supportsMcpIntegrationOrganizationScope(integration)
   );
 }
 

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -1119,6 +1119,13 @@ const messages = {
     personal: "Personal",
     organization: "Organization",
     scopeQuestion: "Who should be able to use this connection?",
+    scopeChoiceTitle: "Who should use this?",
+    scopeChoiceDescription: "Choose where this connection is available.",
+    connectForMe: "Connect for me",
+    setUpForWorkspace: "Set up for workspace",
+    workspaceAdminRequired: "Workspace owner or admin required.",
+    personalOnlyDescription:
+      "Only personal connections are supported for this integration.",
     personalDescription: "Only you can use this connection.",
     sharedWithWorkspace: "Shared with workspace",
     organizationDescription:

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -1126,6 +1126,8 @@ const messages = {
     workspaceAdminRequired: "Workspace owner or admin required.",
     personalOnlyDescription:
       "Only personal connections are supported for this integration.",
+    retry: "Retry",
+    retrying: "Retrying…",
     personalDescription: "Only you can use this connection.",
     sharedWithWorkspace: "Shared with workspace",
     organizationDescription:

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -1126,6 +1126,7 @@ const messages = {
     workspaceAdminRequired: "Workspace owner or admin required.",
     personalOnlyDescription:
       "Only personal connections are supported for this integration.",
+    loadingScopeMetadata: "Loading connection scope…",
     retry: "Retry",
     retrying: "Retrying…",
     personalDescription: "Only you can use this connection.",


### PR DESCRIPTION
## Summary

- Route catalog, quick-connect, and first-run integration connections through the personal/workspace scope choice when an organization is present.
- Keep verified provider scope metadata authoritative, and explain personal-only integrations instead of silently falling back.
- Show a disabled workspace option with an explicit owner/admin requirement for members.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest run src/client/resources/McpIntegrationDialog.spec.tsx src/client/resources/mcp-integration-catalog.spec.ts src/client/onboarding/FirstRunOnboarding.spec.tsx --config vitest.config.ts --no-file-parallelism`
- `corepack pnpm --filter @agent-native/core typecheck`
- Diff-scoped guards pass, including no-silent-coercion, no-raw-colors, no-default-chrome, and no-secret-literals.

Source feedback: Slack thread 1787237728.155069.