### PR TITLE
fix: bound site monitoring and recap authoring

### DIFF
--- a/.changeset/bound-recap-and-site-monitor-work.md
+++ b/.changeset/bound-recap-and-site-monitor-work.md
@@ -1,4 +1,5 @@
 ---
+"@agent-native/core": patch
 "@agent-native/recap-cli": patch
 ---
 

--- a/.changeset/bound-recap-and-site-monitor-work.md
+++ b/.changeset/bound-recap-and-site-monitor-work.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/recap-cli": patch
+---
+
+Bound public-site monitor requests and clarify unified-diff framing in visual recap authoring prompts.

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -54,12 +54,14 @@ jobs:
             ...manifest.workspace.map((host) => ({ environment: "workspace", host })),
           ];
           const timeoutMs = 15_000;
-          const probeAttemptTimeoutMs = 45_000;
+          const probeAttemptTimeoutMs = 30_000;
           const maxDocumentBytes = 2_000_000;
           const maxAssetCount = 500;
           const maxRedirects = 5;
           const maxAttempts = 3;
-          const hostConcurrency = 4;
+          // Three 30-second attempts plus retry delays take at most 93 seconds
+          // per host; twelve workers finish the 36-host manifest in three waves.
+          const hostConcurrency = 12;
           const assetConcurrency = 4;
 
           async function mapWithConcurrency(items, concurrency, mapper) {

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -59,6 +59,24 @@ jobs:
           const maxAssetCount = 500;
           const maxRedirects = 5;
           const maxAttempts = 3;
+          const hostConcurrency = 4;
+          const assetConcurrency = 4;
+
+          async function mapWithConcurrency(items, concurrency, mapper) {
+            const results = new Array(items.length);
+            let nextIndex = 0;
+            const workerCount = Math.min(concurrency, items.length);
+            await Promise.all(
+              Array.from({ length: workerCount }, async () => {
+                while (nextIndex < items.length) {
+                  const index = nextIndex;
+                  nextIndex += 1;
+                  results[index] = await mapper(items[index]);
+                }
+              }),
+            );
+            return results;
+          }
 
           async function fetchOnVerifiedOrigin(url, origin, options) {
             let currentUrl = url;
@@ -164,7 +182,6 @@ jobs:
 
                   const assetFailures = [];
                   const assetUrls = [...assets];
-                  const assetConcurrency = 12;
                   for (let i = 0; i < assetUrls.length; i += assetConcurrency) {
                     if (Date.now() >= deadline) {
                       assetFailures.push("asset probe deadline exceeded");
@@ -228,7 +245,7 @@ jobs:
           }
 
           (async () => {
-            const results = await Promise.all(hosts.map(probe));
+            const results = await mapWithConcurrency(hosts, hostConcurrency, probe);
             results.sort((left, right) => left.host.localeCompare(right.host));
             for (const result of results) {
               console.log(

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -14,7 +14,9 @@ permissions:
 
 concurrency:
   group: monitor-agent-native-sites
-  cancel-in-progress: true
+  # Let an active outage run finish its paging and issue-reporting steps;
+  # GitHub still keeps at most one pending replacement for this concurrency group.
+  cancel-in-progress: false
 
 jobs:
   monitor:

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -1321,6 +1321,9 @@ describe("recap prompt builder", () => {
     expect(prompt).toContain("Do not wait, sleep, back off");
     expect(prompt).toContain("schedule wakeups");
     expect(prompt).toContain("Do not write `recap-url.txt`");
+    expect(prompt).toContain(
+      "never copy leading `+` or `-` markers, context-space prefixes, or `@@` hunk headers",
+    );
     expect(prompt).not.toContain("mcp__plan__create-visual-recap");
     expect(prompt).not.toContain(
       "mcp__agent-native-plans__create-visual-recap",

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -1360,6 +1360,9 @@ describe("recap prompt builder", () => {
     expect(prompt).toContain(
       "npx @agent-native/core@latest plan local preview",
     );
+    expect(prompt).toContain(
+      "never copy leading `+` or `-` markers, context-space prefixes, or `@@` hunk headers",
+    );
     expect(prompt).not.toContain("preview.html");
     expect(prompt).toContain("recap-url.txt");
     expect(prompt).not.toContain("mcp__plan__create-visual-recap");

--- a/packages/recap-cli/src/recap.ts
+++ b/packages/recap-cli/src/recap.ts
@@ -2060,6 +2060,9 @@ export function buildRecapPrompt(input: {
       `- The diff is LARGE — produce a **summarized** recap (top files + schema/API deltas), not an exhaustive one. The diff was truncated at the size cap — \`${input.statPath ?? "recap.stat"}\` contains the complete file list with per-file stats; for any file missing from \`${input.diffPath}\`, fetch it directly with \`git diff <base>...<head> -- <path>\`.`,
     );
   }
+  lines.push(
+    "Unified-diff framing is metadata, not recap content: never copy leading `+` or `-` markers, context-space prefixes, or `@@` hunk headers into the authored MDX. Every tag, paragraph, and block in `plan.mdx` must use the source content without patch markers.",
+  );
   lines.push("");
   if (input.localFiles) {
     lines.push(
@@ -2098,9 +2101,6 @@ export function buildRecapPrompt(input: {
     );
     lines.push(
       "3. Do not write `recap-url.txt`; the deterministic CLI publisher writes that after it successfully POSTs your source to `create-visual-recap`.",
-    );
-    lines.push(
-      "Unified-diff framing is metadata, not recap content: never copy leading `+` or `-` markers, context-space prefixes, or `@@` hunk headers into the authored MDX. Every tag, paragraph, and block in `plan.mdx` must use the source content without patch markers.",
     );
   }
   lines.push("");

--- a/packages/recap-cli/src/recap.ts
+++ b/packages/recap-cli/src/recap.ts
@@ -2099,6 +2099,9 @@ export function buildRecapPrompt(input: {
     lines.push(
       "3. Do not write `recap-url.txt`; the deterministic CLI publisher writes that after it successfully POSTs your source to `create-visual-recap`.",
     );
+    lines.push(
+      "Unified-diff framing is metadata, not recap content: never copy leading `+` or `-` markers, context-space prefixes, or `@@` hunk headers into the authored MDX. Every tag, paragraph, and block in `plan.mdx` must use the source content without patch markers.",
+    );
   }
   lines.push("");
   lines.push(


### PR DESCRIPTION
## Summary

- Bound public-host monitor concurrency to avoid self-induced asset-fetch failures while retaining asset validation.
- Tell visual recap agents to keep unified-diff framing out of authored MDX.
- Add a focused prompt regression assertion and a recap CLI changeset.

Related feedback: #3196 and PR #3278 comment 5361312004.

## Validation

- `corepack pnpm --filter @agent-native/recap-cli typecheck`
- `corepack pnpm --filter @agent-native/recap-cli build`
- `corepack pnpm --filter @agent-native/recap-cli test`
- Focused `packages/core/src/cli/recap.spec.ts` tests: 3 passed
- Monitor workflow YAML parse and bounded-concurrency assertion passed
- Workflow formatting check passed