### PR TITLE
fix: address Mail feedback and desktop chat shortcut

### DIFF
--- a/packages/desktop-app/shared/desktop-shortcuts.spec.ts
+++ b/packages/desktop-app/shared/desktop-shortcuts.spec.ts
@@ -2,8 +2,36 @@ import { describe, expect, it } from "vitest";
 
 import {
   formatDesktopShortcutAccelerator,
+  isDesktopChatToggleShortcut,
   normalizeDesktopShortcutAccelerator,
 } from "./desktop-shortcuts";
+
+describe("isDesktopChatToggleShortcut", () => {
+  it("recognizes backslash from either keyboard representation", () => {
+    expect(isDesktopChatToggleShortcut({ key: "\\" })).toBe(true);
+    expect(isDesktopChatToggleShortcut({ code: "Backslash" })).toBe(true);
+    expect(isDesktopChatToggleShortcut({ key: "|", code: "Backslash" })).toBe(
+      false,
+    );
+  });
+
+  it("does not treat modified backslash keys as the chat toggle", () => {
+    expect(
+      isDesktopChatToggleShortcut({
+        key: "\\",
+        code: "Backslash",
+        shift: true,
+      }),
+    ).toBe(false);
+    expect(
+      isDesktopChatToggleShortcut({
+        key: "\\",
+        code: "Backslash",
+        alt: true,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("normalizeDesktopShortcutAccelerator", () => {
   it("keeps the native macOS hide shortcut available", () => {

--- a/packages/desktop-app/shared/desktop-shortcuts.ts
+++ b/packages/desktop-app/shared/desktop-shortcuts.ts
@@ -35,6 +35,20 @@ export interface DesktopShortcutUpdateResult {
   error?: string;
 }
 
+export function isDesktopChatToggleShortcut(input: {
+  key?: string;
+  code?: string;
+  shift?: boolean;
+  alt?: boolean;
+}): boolean {
+  const key = input.key?.toLowerCase();
+  return (
+    !input.shift &&
+    !input.alt &&
+    (key === "\\" || (!key && input.code === "Backslash"))
+  );
+}
+
 const MODIFIER_ALIASES: Record<string, string> = {
   alt: "Alt",
   cmd: "Command",

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -39,6 +39,7 @@ import {
 } from "@shared/code-agents";
 import {
   formatDesktopShortcutAccelerator,
+  isDesktopChatToggleShortcut,
   normalizeDesktopShortcutAccelerator,
   shortcutOpenPathForBinding,
   type DesktopShortcutBinding,
@@ -400,6 +401,7 @@ function forwardDesktopNavigationShortcut(
   if (!(input.meta || input.control) || input.type !== "keyDown") return false;
 
   const key = input.key.toLowerCase();
+  const isChatToggleShortcut = isDesktopChatToggleShortcut(input);
   const isNumericShortcut = !input.shift && !input.alt && /^[1-9]$/.test(key);
   const isBracketLeft =
     input.code === "BracketLeft" || key === "[" || key === "{";
@@ -407,13 +409,21 @@ function forwardDesktopNavigationShortcut(
     input.code === "BracketRight" || key === "]" || key === "}";
   const isBracketShortcut =
     Boolean(input.shift) && !input.alt && (isBracketLeft || isBracketRight);
-  if (!isNumericShortcut && !isBracketShortcut) return false;
+  if (!isNumericShortcut && !isBracketShortcut && !isChatToggleShortcut) {
+    return false;
+  }
 
   event.preventDefault();
   const win = mainWindow;
   if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return true;
   win.webContents.send("shortcut:keydown", {
-    key: isNumericShortcut ? key : isBracketLeft ? "[" : "]",
+    key: isChatToggleShortcut
+      ? "\\"
+      : isNumericShortcut
+        ? key
+        : isBracketLeft
+          ? "["
+          : "]",
     code: input.code,
     shiftKey: Boolean(input.shift),
     altKey: Boolean(input.alt),
@@ -13138,12 +13148,7 @@ app.on("web-contents-created", (_event, contents) => {
       return;
     }
 
-    const isAgentSidebarToggleShortcut =
-      !input.alt &&
-      !input.shift &&
-      (key === "\\" || input.code === "Backslash");
-
-    // Forward other Cmd+ shortcuts: F, L, R, T, Shift+T, 1-9, [, ], \
+    // Forward other Cmd+ shortcuts: F, L, R, T, Shift+T, 1-9, [, ]
     const isShortcut =
       key === "f" ||
       key === "l" ||
@@ -13151,13 +13156,12 @@ app.on("web-contents-created", (_event, contents) => {
       key === "t" ||
       key === "[" ||
       key === "]" ||
-      isAgentSidebarToggleShortcut ||
       (key >= "1" && key <= "9");
 
     if (isShortcut) {
       event.preventDefault();
       win.webContents.send("shortcut:keydown", {
-        key: isAgentSidebarToggleShortcut ? "\\" : input.key,
+        key: input.key,
         shiftKey: input.shift,
         altKey: false,
         ctrlKey: input.control,
@@ -13816,21 +13820,6 @@ app.whenReady().then(async () => {
       win.webContents.send("shortcut:keydown", {
         key: "l",
         shiftKey: input.shift,
-        ctrlKey: input.control,
-      });
-      return;
-    }
-
-    // Cmd+\ — toggle the agent sidebar for the active webview
-    if (
-      !input.alt &&
-      !input.shift &&
-      (key === "\\" || input.code === "Backslash")
-    ) {
-      _event.preventDefault();
-      win.webContents.send("shortcut:keydown", {
-        key: "\\",
-        shiftKey: false,
         ctrlKey: input.control,
       });
       return;

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -401,7 +401,6 @@ function forwardDesktopNavigationShortcut(
   if (!(input.meta || input.control) || input.type !== "keyDown") return false;
 
   const key = input.key.toLowerCase();
-  const isChatToggleShortcut = isDesktopChatToggleShortcut(input);
   const isNumericShortcut = !input.shift && !input.alt && /^[1-9]$/.test(key);
   const isBracketLeft =
     input.code === "BracketLeft" || key === "[" || key === "{";
@@ -409,21 +408,13 @@ function forwardDesktopNavigationShortcut(
     input.code === "BracketRight" || key === "]" || key === "}";
   const isBracketShortcut =
     Boolean(input.shift) && !input.alt && (isBracketLeft || isBracketRight);
-  if (!isNumericShortcut && !isBracketShortcut && !isChatToggleShortcut) {
-    return false;
-  }
+  if (!isNumericShortcut && !isBracketShortcut) return false;
 
   event.preventDefault();
   const win = mainWindow;
   if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return true;
   win.webContents.send("shortcut:keydown", {
-    key: isChatToggleShortcut
-      ? "\\"
-      : isNumericShortcut
-        ? key
-        : isBracketLeft
-          ? "["
-          : "]",
+    key: isNumericShortcut ? key : isBracketLeft ? "[" : "]",
     code: input.code,
     shiftKey: Boolean(input.shift),
     altKey: Boolean(input.alt),
@@ -13148,20 +13139,22 @@ app.on("web-contents-created", (_event, contents) => {
       return;
     }
 
-    // Forward other Cmd+ shortcuts: F, L, R, T, Shift+T, 1-9, [, ]
+    if (forwardDesktopNavigationShortcut(event, input)) return;
+
+    const isAgentSidebarToggleShortcut = isDesktopChatToggleShortcut(input);
+
+    // Forward other Cmd+ shortcuts: F, L, R, T, Shift+T, \
     const isShortcut =
       key === "f" ||
       key === "l" ||
       key === "r" ||
       key === "t" ||
-      key === "[" ||
-      key === "]" ||
-      (key >= "1" && key <= "9");
+      isAgentSidebarToggleShortcut;
 
     if (isShortcut) {
       event.preventDefault();
       win.webContents.send("shortcut:keydown", {
-        key: input.key,
+        key: isAgentSidebarToggleShortcut ? "\\" : input.key,
         shiftKey: input.shift,
         altKey: false,
         ctrlKey: input.control,
@@ -13707,9 +13700,6 @@ app.whenReady().then(async () => {
 
   app.on("web-contents-created", (_event, wc) => {
     if (wc.getType() !== "webview") return;
-    wc.on("before-input-event", (event, input) => {
-      forwardDesktopNavigationShortcut(event, input);
-    });
     let id = resolveDesktopWebviewAppId(wc);
     configureWebviewSession(wc.session, id);
     if (id) desktopWebviewAppIds.set(wc, id);
@@ -13820,6 +13810,17 @@ app.whenReady().then(async () => {
       win.webContents.send("shortcut:keydown", {
         key: "l",
         shiftKey: input.shift,
+        ctrlKey: input.control,
+      });
+      return;
+    }
+
+    // Cmd+\\ — toggle the agent sidebar for the active webview
+    if (isDesktopChatToggleShortcut(input)) {
+      _event.preventDefault();
+      win.webContents.send("shortcut:keydown", {
+        key: "\\",
+        shiftKey: false,
         ctrlKey: input.control,
       });
       return;

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -300,6 +300,18 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(shellCss).toContain("[data-chat-first-rail-collapse]");
   });
 
+  it("routes Electron-forwarded Cmd+backslash to the chat sidebar", () => {
+    const hubSource = readFileSync(
+      "src/renderer/components/CodeAgentsHub.tsx",
+      "utf8",
+    );
+
+    expect(hubSource).toContain("isDesktopChatToggleShortcut");
+    expect(hubSource).toContain(
+      'window.dispatchEvent(new Event("agent-panel:toggle"))',
+    );
+  });
+
   it("orders pinned desktop apps ahead of unpinned apps and filters by name or description", () => {
     const apps = [
       {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -305,11 +305,19 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       "src/renderer/components/CodeAgentsHub.tsx",
       "utf8",
     );
+    const mainSource = readFileSync("src/main/index.ts", "utf8");
 
     expect(hubSource).toContain("isDesktopChatToggleShortcut");
     expect(hubSource).toContain(
       'window.dispatchEvent(new Event("agent-panel:toggle"))',
     );
+    expect(mainSource).toContain(
+      "const isAgentSidebarToggleShortcut = isDesktopChatToggleShortcut(input);",
+    );
+    expect(mainSource).toContain(
+      "if (forwardDesktopNavigationShortcut(event, input)) return;",
+    );
+    expect(mainSource).toContain("if (isDesktopChatToggleShortcut(input)) {");
   });
 
   it("orders pinned desktop apps ahead of unpinned apps and filters by name or description", () => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -75,6 +75,7 @@ import {
   toAppDefinition,
   type AppConfig,
 } from "@shared/app-registry";
+import { isDesktopChatToggleShortcut } from "@shared/desktop-shortcuts";
 import {
   IconArrowLeft,
   IconGripVertical,
@@ -1051,6 +1052,23 @@ export default function CodeAgentsHub({
       selectChatFirstAppFromKeyboard,
     ],
   );
+  useEffect(() => {
+    const shortcutApi = window.electronAPI?.shortcuts;
+    if (!shortcutApi?.onKeydown) return;
+    return shortcutApi.onKeydown((input) => {
+      if (
+        !isDesktopChatToggleShortcut({
+          key: input.key,
+          code: input.code,
+          shift: input.shiftKey,
+          alt: input.altKey,
+        })
+      ) {
+        return;
+      }
+      window.dispatchEvent(new Event("agent-panel:toggle"));
+    });
+  }, []);
   const openChatFirstAppInBrowser = useCallback((app: AppConfig) => {
     const url = resolveAppWebviewUrl(toAppDefinition(app), app);
     if (url === "about:blank") return;

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -6,6 +6,7 @@ import { emailMessageMatchesSearch } from "@shared/search.js";
 import { z } from "zod";
 
 import {
+  augmentSelfSentLabels,
   filterInboxTabEmails,
   OTHER_INBOX_TAB_PARAM,
   resolvePinnedLabels,
@@ -51,12 +52,31 @@ async function fetchEmailList(
   search?: string,
   _label?: string,
   activeInboxTab?: string,
+  activeAccounts?: string[],
 ): Promise<any[]> {
   try {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
     const shouldFilterOther =
       view === "inbox" && !search && activeInboxTab === OTHER_INBOX_TAB_PARAM;
+    const selectedAccountEmails = Array.isArray(activeAccounts)
+      ? [
+          ...new Set(
+            activeAccounts
+              .filter((email): email is string => typeof email === "string")
+              .map((email) => email.toLowerCase()),
+          ),
+        ]
+      : [];
+    const selectedAccountSet = new Set(selectedAccountEmails);
+    const filterSelectedAccounts = (emails: any[]) => {
+      if (selectedAccountEmails.length === 0) return emails;
+      return emails.filter(
+        (email) =>
+          typeof email.accountEmail === "string" &&
+          selectedAccountSet.has(email.accountEmail.toLowerCase()),
+      );
+    };
 
     if (view === "snoozed" || view === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, view);
@@ -65,23 +85,37 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, search),
         );
       }
-      return emails.slice(0, 50);
+      return filterSelectedAccounts(emails).slice(0, 50);
     }
 
     const googleConnected = await isConnected(ownerEmail);
-    const settings = shouldFilterOther
-      ? await readSettings(ownerEmail)
-      : undefined;
+    const settings =
+      googleConnected || shouldFilterOther
+        ? await readSettings(ownerEmail)
+        : undefined;
+    const userPinnedLabels = settings?.pinnedLabels;
     const pinnedLabels =
-      settings?.pinnedLabels === undefined
+      userPinnedLabels === undefined
         ? resolvePinnedLabels([], googleConnected)
-        : resolvePinnedLabels(settings.pinnedLabels, googleConnected);
+        : resolvePinnedLabels(userPinnedLabels, googleConnected);
+    const hasNoteToSelf = pinnedLabels.includes("note-to-self");
+    const clients = googleConnected ? await getClients(ownerEmail) : [];
+    const connectedEmails = new Set(
+      clients.map(({ email }) => email.toLowerCase()),
+    );
+    const prepareEmails = (emails: any[]) => {
+      const augmented = augmentSelfSentLabels(emails as EmailMessage[], {
+        isGoogleConnected: googleConnected,
+        connectedEmails,
+        hasNoteToSelf,
+      });
+      return filterSelectedAccounts(augmented);
+    };
     const applyActiveInboxTab = (emails: any[]) =>
       shouldFilterOther
-        ? filterInboxTabEmails(emails as EmailMessage[], null, pinnedLabels)
-        : emails;
+        ? filterInboxTabEmails(prepareEmails(emails), null, pinnedLabels)
+        : prepareEmails(emails);
     if (googleConnected) {
-      const clients = await getClients(ownerEmail);
       const labelMap = new Map<string, string>();
       await Promise.all(
         clients.map(async ({ accessToken }) => {
@@ -103,6 +137,10 @@ async function fetchEmailList(
         {
           mode: "threads",
           threadFormat: "metadata",
+          accountEmails:
+            selectedAccountEmails.length > 0
+              ? selectedAccountEmails
+              : undefined,
           threadCandidateLimit: search ? 500 : undefined,
           threadRecentMessageCandidateLimit:
             !search && (view === "inbox" || view === "unread")
@@ -286,6 +324,7 @@ export default defineAction({
         nav.search,
         nav.label,
         nav.activeInboxTab,
+        nav.activeAccounts,
       );
       const selectedThreadIds = Array.isArray(nav.selectedThreadIds)
         ? new Set(
@@ -311,6 +350,7 @@ export default defineAction({
         view: nav.view,
         label: nav.label ?? null,
         activeInboxTab: nav.activeInboxTab ?? null,
+        activeAccounts: nav.activeAccounts ?? [],
         search: nav.search ?? null,
         selectedThreadIds: Array.from(selectedThreadIds),
         count: compact.length,

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -279,6 +279,7 @@ export default defineAction({
       screen.emailList = {
         view: nav.view,
         label: nav.label ?? null,
+        activeInboxTab: nav.activeInboxTab ?? null,
         search: nav.search ?? null,
         selectedThreadIds: Array.from(selectedThreadIds),
         count: compact.length,

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -5,6 +5,11 @@ import { getSetting } from "@agent-native/core/settings";
 import { emailMessageMatchesSearch } from "@shared/search.js";
 import { z } from "zod";
 
+import {
+  filterInboxTabEmails,
+  OTHER_INBOX_TAB_PARAM,
+  resolvePinnedLabels,
+} from "../app/lib/inbox-tabs.js";
 import { buildGmailEmailSearchQuery } from "../server/lib/gmail-query.js";
 import { gmailGetThread } from "../server/lib/google-api.js";
 import {
@@ -16,10 +21,12 @@ import {
   fetchGmailLabelMap,
 } from "../server/lib/google-auth.js";
 import { getSyntheticEmailsForView } from "../server/lib/jobs.js";
+import { readSettings } from "../server/lib/mail-settings.js";
 import {
   listQueuedDrafts,
   requireQueuedDraft,
 } from "../server/lib/queued-drafts.js";
+import type { EmailMessage } from "../shared/types.js";
 import { getAccessTokens, fetchLabelMap } from "./helpers.js";
 
 function latestPerThread(emails: any[]): any[] {
@@ -43,10 +50,14 @@ async function fetchEmailList(
   view: string,
   search?: string,
   _label?: string,
+  activeInboxTab?: string,
 ): Promise<any[]> {
   try {
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
+    const shouldFilterOther =
+      view === "inbox" && !search && activeInboxTab === OTHER_INBOX_TAB_PARAM;
+
     if (view === "snoozed" || view === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, view);
       if (search) {
@@ -56,7 +67,20 @@ async function fetchEmailList(
       }
       return emails.slice(0, 50);
     }
-    if (await isConnected(ownerEmail)) {
+
+    const googleConnected = await isConnected(ownerEmail);
+    const settings = shouldFilterOther
+      ? await readSettings(ownerEmail)
+      : undefined;
+    const pinnedLabels =
+      settings?.pinnedLabels === undefined
+        ? resolvePinnedLabels([], googleConnected)
+        : resolvePinnedLabels(settings.pinnedLabels, googleConnected);
+    const applyActiveInboxTab = (emails: any[]) =>
+      shouldFilterOther
+        ? filterInboxTabEmails(emails as EmailMessage[], null, pinnedLabels)
+        : emails;
+    if (googleConnected) {
       const clients = await getClients(ownerEmail);
       const labelMap = new Map<string, string>();
       await Promise.all(
@@ -87,9 +111,11 @@ async function fetchEmailList(
         },
       );
 
-      return latestPerThread(
-        messages.map((m: any) =>
-          gmailToEmailMessage(m, m._accountEmail, labelMap),
+      return applyActiveInboxTab(
+        latestPerThread(
+          messages.map((m: any) =>
+            gmailToEmailMessage(m, m._accountEmail, labelMap),
+          ),
         ),
       ).slice(0, 50);
     }
@@ -136,7 +162,7 @@ async function fetchEmailList(
           emailMessageMatchesSearch(e, search),
         );
       }
-      return emails.slice(0, 50);
+      return applyActiveInboxTab(emails).slice(0, 50);
     }
     return [];
   } catch {
@@ -255,7 +281,12 @@ export default defineAction({
         };
       }
     } else if (nav?.view) {
-      const emails = await fetchEmailList(nav.view, nav.search, nav.label);
+      const emails = await fetchEmailList(
+        nav.view,
+        nav.search,
+        nav.label,
+        nav.activeInboxTab,
+      );
       const selectedThreadIds = Array.isArray(nav.selectedThreadIds)
         ? new Set(
             nav.selectedThreadIds.filter(

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -48,6 +48,7 @@ import {
   useBulkToggleStar,
   useBulkMarkRead,
   useLabels,
+  EMPTY_LABELS,
   useMoveEmail,
   unsuppressThread,
 } from "@/hooks/use-emails";
@@ -435,7 +436,8 @@ export function EmailList({
   const bulkTrashEmails = useBulkTrashEmails();
   const bulkToggleStar = useBulkToggleStar();
   const bulkMarkRead = useBulkMarkRead();
-  const { data: labels = [] } = useLabels();
+  const { data: labelsData } = useLabels();
+  const labels = labelsData ?? EMPTY_LABELS;
   const moveEmail = useMoveEmail();
   const cancelScheduledJob = useDeleteScheduledJob();
   const sendScheduledJobNow = useSendScheduledJobNow();

--- a/templates/mail/app/components/email/EmailListItem.tsx
+++ b/templates/mail/app/components/email/EmailListItem.tsx
@@ -21,6 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useAccountFilter } from "@/hooks/use-account-filter";
+import { getLabelStyle } from "@/lib/label-colors";
 import type { ThreadSummary } from "@/lib/threads";
 import { cn, formatEmailDate, truncate } from "@/lib/utils";
 
@@ -96,29 +97,6 @@ function formatParticipants(participants: string[], maxWidth = 3): string {
   return `${firstNames[0]} .. ${firstNames.slice(-(maxWidth - 1)).join(", ")}`;
 }
 
-// Map common label IDs to display colors
-const labelColors: Record<string, { bg: string; text: string }> = {
-  automated: { bg: "bg-pink-500/20", text: "text-pink-700 dark:text-pink-300" },
-  social: { bg: "bg-blue-500/20", text: "text-blue-700 dark:text-blue-300" },
-  updates: {
-    bg: "bg-yellow-500/20",
-    text: "text-yellow-700 dark:text-yellow-300",
-  },
-  promotions: {
-    bg: "bg-green-500/20",
-    text: "text-green-700 dark:text-green-300",
-  },
-  forums: {
-    bg: "bg-sky-500/20",
-    text: "text-sky-700 dark:text-sky-300",
-  },
-  finance: {
-    bg: "bg-emerald-500/20",
-    text: "text-emerald-700 dark:text-emerald-300",
-  },
-  travel: { bg: "bg-cyan-500/20", text: "text-cyan-700 dark:text-cyan-300" },
-};
-
 /** Stable dot colors for distinguishing accounts */
 const accountDotColors = [
   "bg-blue-400",
@@ -137,18 +115,6 @@ function getAccountColor(
 ): string {
   const idx = allAccounts.findIndex((a) => a.email === email);
   return accountDotColors[(idx >= 0 ? idx : 0) % accountDotColors.length];
-}
-
-function getLabelStyle(labelId: string): { bg: string; text: string } {
-  const normalized = labelId.toLowerCase().replace(/^label:/, "");
-  if (labelColors[normalized]) return labelColors[normalized];
-  // Fallback: hash to a color
-  let hash = 0;
-  for (let i = 0; i < normalized.length; i++) {
-    hash = normalized.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  const options = Object.values(labelColors);
-  return options[Math.abs(hash) % options.length];
 }
 
 export const EmailListItem = memo(function EmailListItem({

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -64,6 +64,7 @@ import {
   decodeHtmlEntities,
   processHtmlImages,
 } from "@/lib/email-image-policy";
+import { getLabelStyle } from "@/lib/label-colors";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { getResolvedTheme } from "@/lib/theme";
 import { ensureThread, warmThreads } from "@/lib/thread-cache";
@@ -1138,14 +1139,21 @@ export function EmailThread({
               <h1 className="text-base sm:text-lg font-semibold leading-tight text-foreground line-clamp-2">
                 {threadSubject}
               </h1>
-              {displayLabels.map((labelId) => (
-                <span
-                  key={labelId}
-                  className="label-badge shrink-0 bg-pink-500/20 text-pink-700 dark:text-pink-300 mt-1"
-                >
-                  {labelId}
-                </span>
-              ))}
+              {displayLabels.map((labelId) => {
+                const style = getLabelStyle(labelId);
+                return (
+                  <span
+                    key={labelId}
+                    className={cn(
+                      "label-badge shrink-0 mt-1",
+                      style.bg,
+                      style.text,
+                    )}
+                  >
+                    {labelId}
+                  </span>
+                );
+              })}
               {/* Action bar */}
               <div className="hidden sm:flex items-center gap-0.5 ml-auto shrink-0">
                 <Tooltip>

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -34,7 +34,8 @@ describe("AppLayout inbox rail count", () => {
   it("keeps the explicit Other inbox tab and search restoration path", () => {
     const source = appLayoutSource();
 
-    expect(source).toContain('href: "/inbox?tab=other"');
+    expect(source).toContain("href: `/inbox?tab=${OTHER_INBOX_TAB_PARAM}`");
+    expect(source).toContain("id: OTHER_INBOX_TAB_ID");
     expect(source).toContain('params.set("tab", tab)');
   });
 
@@ -42,13 +43,22 @@ describe("AppLayout inbox rail count", () => {
     const source = appLayoutSource();
 
     expect(source).toContain(
-      'const inboxPartitionTabIds = new Set<string>(["other"]);',
+      "const inboxPartitionTabIds = new Set<string>([OTHER_INBOX_TAB_ID]);",
     );
     expect(source).toContain(
       "if (inboxPartitionTabIds.has(viewId)) return localCount;",
     );
     expect(source).toContain("const mobileInboxTabs = visibleTabs.filter(");
     expect(source).toContain("{mobileInboxTabs.map((tab) => {");
+  });
+
+  it("preserves labels and exposes a retry when Gmail label reads fail", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain("data: labelsData");
+    expect(source).toContain("isError: labelsError");
+    expect(source).toContain("refetch: refetchLabels");
+    expect(source).toContain('role="alert"');
   });
 });
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -37,6 +37,19 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain('href: "/inbox?tab=other"');
     expect(source).toContain('params.set("tab", tab)');
   });
+
+  it("keeps exclusive tab badges local and mirrors primary tabs on mobile", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      'const inboxPartitionTabIds = new Set<string>(["other"]);',
+    );
+    expect(source).toContain(
+      "if (inboxPartitionTabIds.has(viewId)) return localCount;",
+    );
+    expect(source).toContain("const mobileInboxTabs = visibleTabs.filter(");
+    expect(source).toContain("{mobileInboxTabs.map((tab) => {");
+  });
 });
 
 describe("labelTabHref", () => {

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -20,6 +20,12 @@ describe("AppLayout inbox rail count", () => {
     );
   });
 
+  it("uses the whole-Inbox local count for the Inbox tab", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain('const localCount = localCounts["__inboxTotal"]');
+  });
+
   it("collapses the native rail while the per-app chat is open", () => {
     const source = appLayoutSource();
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -30,6 +30,13 @@ describe("AppLayout inbox rail count", () => {
       "(sidebarPinned ? sidebarCollapsed : perAppChatOpen)",
     );
   });
+
+  it("keeps the explicit Other inbox tab and search restoration path", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain('href: "/inbox?tab=other"');
+    expect(source).toContain('params.set("tab", tab)');
+  });
 });
 
 describe("labelTabHref", () => {

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -272,22 +272,31 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       { replace: true },
     );
   }, [location.pathname, navigate, searchParams]);
-  // Remember which view (and label tab) the user was in before searching —
+  // Remember which view (label or inbox tab) the user was in before searching —
   // SearchBar always routes searches through /all?q=..., so on clear we'd
   // otherwise drop a user searching from Starred/Sent/Archive or from a
   // label-filtered tab back into plain Inbox.
-  const preSearchViewRef = useRef<{ view: string; label: string | null }>({
-    view,
-    label: activeLabel,
-  });
+  const preSearchViewRef = useRef<{
+    view: string;
+    label: string | null;
+    tab: string | null;
+  }>({ view, label: activeLabel, tab: activeInboxTab });
   useEffect(() => {
     if (!activeSearchQuery) {
-      preSearchViewRef.current = { view, label: activeLabel };
+      preSearchViewRef.current = {
+        view,
+        label: activeLabel,
+        tab: activeInboxTab,
+      };
     }
-  }, [view, activeLabel, activeSearchQuery]);
+  }, [view, activeLabel, activeInboxTab, activeSearchQuery]);
   const restorePreSearchPath = useCallback(() => {
-    const { view: v, label: l } = preSearchViewRef.current;
-    return `/${v}${l ? `?label=${encodeURIComponent(l)}` : ""}`;
+    const { view: v, label: l, tab } = preSearchViewRef.current;
+    const params = new URLSearchParams();
+    if (l) params.set("label", l);
+    if (tab) params.set("tab", tab);
+    const search = params.toString();
+    return `/${v}${search ? `?${search}` : ""}`;
   }, []);
   // When the search param is cleared externally (browser back/forward,
   // agent navigation), drop the searchFocused flag — otherwise the bar
@@ -401,14 +410,14 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       localStorage.removeItem(SIDEBAR_COLLAPSE_KEY);
     }
   }, [sidebarCollapsed]);
-  const showSidebar = sidebarOpen || sidebarPinned;
+  const showSidebar = isMobile ? sidebarOpen : sidebarOpen || sidebarPinned;
   const showCollapsedSidebar =
     !isMobile &&
     showSidebar &&
     (sidebarPinned ? sidebarCollapsed : perAppChatOpen);
   const closeSidebar = useCallback(() => {
-    if (!sidebarPinned) setSidebarOpen(false);
-  }, [sidebarPinned]);
+    if (!sidebarPinned || isMobile) setSidebarOpen(false);
+  }, [sidebarPinned, isMobile]);
 
   const collapseButton =
     sidebarPinned && !isMobile ? (
@@ -1489,7 +1498,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         {/* Sidebar overlay / pinned rail */}
         {showSidebar && (
           <>
-            {!sidebarPinned && (
+            {(!sidebarPinned || isMobile) && (
               <div
                 className="fixed inset-0 z-30 bg-[var(--mail-overlay-scrim)]"
                 onClick={() => setSidebarOpen(false)}

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -34,6 +34,7 @@ import {
   IconMailForward,
   IconStar,
   IconTrash,
+  IconAlertCircle,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
@@ -68,6 +69,7 @@ import {
   useBlockSender,
   useMuteThread,
   markExternalEmailRefresh,
+  EMPTY_LABELS,
 } from "@/hooks/use-emails";
 import {
   useGoogleAuthStatus,
@@ -81,6 +83,8 @@ import {
 import { useIsMobile } from "@/hooks/use-mobile";
 import { runUndo } from "@/hooks/use-undo";
 import {
+  OTHER_INBOX_TAB_ID,
+  OTHER_INBOX_TAB_PARAM,
   qualifiesForInboxTab,
   pinnedTriageLabels,
   augmentSelfSentLabels,
@@ -310,7 +314,15 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     }
     prevSearchQueryRef.current = activeSearchQuery;
   }, [activeSearchQuery]);
-  const { data: labels = [], isLoading: labelsLoading } = useLabels();
+  const {
+    data: labelsData,
+    isLoading: labelsLoading,
+    isError: labelsError,
+    error: labelsQueryError,
+    isFetching: labelsFetching,
+    refetch: refetchLabels,
+  } = useLabels();
+  const labels = labelsData ?? EMPTY_LABELS;
   const { data: settings, isLoading: settingsLoading } = useSettings();
   const updateSettings = useUpdateSettings();
   const googleStatus = useGoogleAuthStatus();
@@ -570,7 +582,9 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         label: t("mail.views.inbox"),
         href: "/inbox",
         isActive:
-          view === "inbox" && !activeLabel && activeInboxTab !== "other",
+          view === "inbox" &&
+          !activeLabel &&
+          activeInboxTab !== OTHER_INBOX_TAB_PARAM,
         type: "system",
       });
     }
@@ -626,11 +640,13 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
     if (hasPinnedFilters) {
       tabs.push({
-        id: "other",
+        id: OTHER_INBOX_TAB_ID,
         label: t("mail.views.other"),
-        href: "/inbox?tab=other",
+        href: `/inbox?tab=${OTHER_INBOX_TAB_PARAM}`,
         isActive:
-          view === "inbox" && !activeLabel && activeInboxTab === "other",
+          view === "inbox" &&
+          !activeLabel &&
+          activeInboxTab === OTHER_INBOX_TAB_PARAM,
         type: "system",
       });
     }
@@ -1034,7 +1050,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
   // Gmail totals overlap across labels, while these tabs are an exclusive
   // partition of the loaded inbox. Keep their badges tied to that partition.
-  const inboxPartitionTabIds = new Set<string>(["other"]);
+  const inboxPartitionTabIds = new Set<string>([OTHER_INBOX_TAB_ID]);
   for (const pinnedId of pinnedTriageLabels(pinnedLabels)) {
     inboxPartitionTabIds.add(pinnedId);
     const label = resolveLabelForCount(pinnedId);
@@ -1073,7 +1089,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   };
 
   const getTabCount = (viewId: string, kind: CountKind) => {
-    if (viewId === "other") return getOtherCount(kind);
+    if (viewId === OTHER_INBOX_TAB_ID) return getOtherCount(kind);
     if (viewId === "inbox") return getInboxCount(kind);
     const label = resolveLabelForCount(viewId);
     const countField = countFieldForKind(kind);
@@ -1857,6 +1873,31 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           )}
         >
           <InvitationBanner />
+
+          {labelsError && (
+            <div
+              role="alert"
+              className="flex shrink-0 items-center gap-2 border-b border-destructive/20 bg-destructive/5 px-4 py-2 text-xs text-muted-foreground"
+            >
+              <IconAlertCircle className="h-3.5 w-3.5 shrink-0 text-destructive" />
+              <span className="min-w-0 flex-1 truncate">
+                {labelsQueryError instanceof Error && labelsQueryError.message
+                  ? labelsQueryError.message
+                  : t("mail.error.loadTitle")}
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                disabled={labelsFetching}
+                onClick={() => void refetchLabels()}
+              >
+                {labelsFetching
+                  ? t("mail.error.retrying")
+                  : t("mail.error.tryAgain")}
+              </Button>
+            </div>
+          )}
 
           {/* Show full-page takeover when no accounts connected (except on settings page) */}
           {!googleStatus.isLoading &&

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1073,7 +1073,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     const serverCount = useServerLabelCounts
       ? (inboxLabel?.[countField] ?? 0)
       : 0;
-    const localCount = localCounts["inbox"] ?? 0;
+    const localCount = localCounts["__inboxTotal"] ?? 0;
     return Math.max(serverCount, localCount);
   };
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -674,6 +674,15 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     [pinnedLabels],
   );
 
+  // The top-bar inbox tabs are hidden on mobile, so mirror their non-standard
+  // entries in the drawer. Collapsible system views already appear in the
+  // fixed drawer list below and must not be duplicated here.
+  const mobileInboxTabs = visibleTabs.filter(
+    (tab) =>
+      tab.id !== "inbox" &&
+      !collapsibleViews.some((view) => view.id === tab.id),
+  );
+
   // Is current view one of the hidden ones? If so force-show it
   const currentInHidden = hiddenViews.some((v) => v.id === view);
 
@@ -1023,6 +1032,15 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
   const useServerLabelCounts = activeAccounts.size === 0;
 
+  // Gmail totals overlap across labels, while these tabs are an exclusive
+  // partition of the loaded inbox. Keep their badges tied to that partition.
+  const inboxPartitionTabIds = new Set<string>(["other"]);
+  for (const pinnedId of pinnedTriageLabels(pinnedLabels)) {
+    inboxPartitionTabIds.add(pinnedId);
+    const label = resolveLabelForCount(pinnedId);
+    if (label) inboxPartitionTabIds.add(label.id);
+  }
+
   type CountKind = "unread" | "total";
   const countFieldForKind = (kind: CountKind) =>
     kind === "total" ? "totalCount" : "unreadCount";
@@ -1066,6 +1084,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       useServerLabelCounts && viewId !== "note-to-self"
         ? (label?.[countField] ?? 0)
         : 0;
+    if (inboxPartitionTabIds.has(viewId)) return localCount;
     return Math.max(serverCount, localCount);
   };
   const getTopBarCount = (viewId: string) => getTabCount(viewId, "total");
@@ -1732,63 +1751,56 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                         ))}
                       </div>
 
-                      {/* Pinned labels */}
-                      {pinnedLabels.filter(
-                        (l) => !collapsibleViews.some((v) => v.id === l),
-                      ).length > 0 && (
+                      {/* Mobile equivalents for the hidden top-bar inbox tabs */}
+                      {mobileInboxTabs.length > 0 && (
                         <>
                           <h2 className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider mt-5 mb-3">
                             {t("mail.views.labels")}
                           </h2>
                           <div className="space-y-0.5">
-                            {visibleTabs
-                              .filter(
-                                (t) => t.id !== "inbox" && t.type === "label",
-                              )
-                              .map((tab) => {
-                                const count = getUnreadCount(tab.id);
-                                const depth = labelDepth(
-                                  tab.fullLabel ?? tab.label,
-                                );
-                                return (
-                                  <Link
-                                    key={tab.id}
-                                    to={tab.href}
-                                    onClick={closeSidebar}
-                                    className={cn(
-                                      "flex items-center justify-between rounded-md px-3 py-2.5 text-[14px] transition-colors min-h-[44px]",
-                                      tab.isActive
-                                        ? "bg-accent/60 text-foreground font-medium"
-                                        : "text-foreground/70 hover:bg-accent/30",
-                                    )}
+                            {mobileInboxTabs.map((tab) => {
+                              const count = getUnreadCount(tab.id);
+                              const depth =
+                                tab.type === "label"
+                                  ? labelDepth(tab.fullLabel ?? tab.label)
+                                  : 0;
+                              return (
+                                <Link
+                                  key={tab.id}
+                                  to={tab.href}
+                                  onClick={closeSidebar}
+                                  className={cn(
+                                    "flex items-center justify-between rounded-md px-3 py-2.5 text-[14px] transition-colors min-h-[44px]",
+                                    tab.isActive
+                                      ? "bg-accent/60 text-foreground font-medium"
+                                      : "text-foreground/70 hover:bg-accent/30",
+                                  )}
+                                >
+                                  <span
+                                    className="flex min-w-0 items-center gap-2"
+                                    style={{ paddingLeft: depth * 12 }}
                                   >
-                                    <span
-                                      className="flex min-w-0 items-center gap-2"
-                                      style={{ paddingLeft: depth * 12 }}
-                                    >
-                                      {tab.color && (
-                                        <span
-                                          className="h-2 w-2 rounded-full shrink-0"
-                                          style={{ backgroundColor: tab.color }}
-                                        />
-                                      )}
+                                    {tab.color && (
                                       <span
-                                        className="truncate"
-                                        title={tab.fullLabel}
-                                      >
-                                        {shortLabelName(
-                                          tab.fullLabel ?? tab.label,
-                                        )}
-                                      </span>
-                                    </span>
-                                    {count > 0 && (
-                                      <span className="text-[12px] text-muted-foreground/50 tabular-nums">
-                                        {count}
-                                      </span>
+                                        className="h-2 w-2 rounded-full shrink-0"
+                                        style={{ backgroundColor: tab.color }}
+                                      />
                                     )}
-                                  </Link>
-                                );
-                              })}
+                                    <span
+                                      className="truncate"
+                                      title={tab.fullLabel ?? tab.label}
+                                    >
+                                      {tab.label}
+                                    </span>
+                                  </span>
+                                  {count > 0 && (
+                                    <span className="text-[12px] text-muted-foreground/50 tabular-nums">
+                                      {count}
+                                    </span>
+                                  )}
+                                </Link>
+                              );
+                            })}
                           </div>
                         </>
                       )}

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -256,6 +256,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   const [searchParams] = useSearchParams();
   const activeSearchQuery = searchParams.get("q");
   const activeLabel = searchParams.get("label");
+  const activeInboxTab = searchParams.get("tab");
   const composeInitialExpanded =
     searchParams.get(COMPOSE_FULLSCREEN_PARAM) === "1";
   const clearComposeInitialExpanded = useCallback(() => {
@@ -400,14 +401,14 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       localStorage.removeItem(SIDEBAR_COLLAPSE_KEY);
     }
   }, [sidebarCollapsed]);
-  const showSidebar = sidebarOpen || (sidebarPinned && !isMobile);
+  const showSidebar = sidebarOpen || sidebarPinned;
   const showCollapsedSidebar =
     !isMobile &&
     showSidebar &&
     (sidebarPinned ? sidebarCollapsed : perAppChatOpen);
   const closeSidebar = useCallback(() => {
-    if (!sidebarPinned || isMobile) setSidebarOpen(false);
-  }, [sidebarPinned, isMobile]);
+    if (!sidebarPinned) setSidebarOpen(false);
+  }, [sidebarPinned]);
 
   const collapseButton =
     sidebarPinned && !isMobile ? (
@@ -559,7 +560,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         id: "inbox",
         label: t("mail.views.inbox"),
         href: "/inbox",
-        isActive: view === "inbox" && !activeLabel,
+        isActive:
+          view === "inbox" && !activeLabel && activeInboxTab !== "other",
         type: "system",
       });
     }
@@ -615,10 +617,11 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
     if (hasPinnedFilters) {
       tabs.push({
-        id: "inbox",
+        id: "other",
         label: t("mail.views.other"),
-        href: "/inbox",
-        isActive: view === "inbox" && !activeLabel,
+        href: "/inbox?tab=other",
+        isActive:
+          view === "inbox" && !activeLabel && activeInboxTab === "other",
         type: "system",
       });
     }
@@ -630,6 +633,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     labelAliases,
     view,
     activeLabel,
+    activeInboxTab,
     hasPinnedFilters,
     t,
   ]);
@@ -1030,20 +1034,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     return Math.max(serverCount, localCount);
   };
 
-  const isExclusivePinnedTab = (viewId: string) => {
-    if (!hasPinnedFilters) return false;
-    // Pinned label rows (the ones that contribute to the "Other" remainder)
-    // are exclusive: each inbox thread is counted in exactly one tab. Gmail's
-    // server label counts don't have that exclusivity (e.g. server "important"
-    // returns *all* important threads, regardless of whether they're also
-    // categorized elsewhere), so we can't mix the two — use local only.
-    return pinnedLabels.some((id) => {
-      if (collapsibleViews.some((view) => view.id === id)) return false;
-      const label = resolveLabelForCount(id);
-      return (label?.id ?? id) === viewId || id === viewId;
-    });
-  };
-
   const getOtherCount = (kind: CountKind) => {
     if (!hasPinnedFilters) return getInboxCount(kind);
     const localCounts = localCountsForKind(kind);
@@ -1056,16 +1046,13 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   };
 
   const getTabCount = (viewId: string, kind: CountKind) => {
-    if (viewId === "inbox") return getOtherCount(kind);
+    if (viewId === "other") return getOtherCount(kind);
+    if (viewId === "inbox") return getInboxCount(kind);
     const label = resolveLabelForCount(viewId);
     const countField = countFieldForKind(kind);
     const localCounts = localCountsForKind(kind);
     const localCount =
       localCounts[viewId] ?? (label ? (localCounts[label.id] ?? 0) : 0);
-    // Exclusive pinned tabs (when hasPinnedFilters is on, a thread belongs to
-    // exactly one tab) can't fall back to Gmail's non-exclusive server count
-    // — that would over-report the badge relative to what the tab renders.
-    if (isExclusivePinnedTab(viewId)) return localCount;
     const serverCount =
       useServerLabelCounts && viewId !== "note-to-self"
         ? (label?.[countField] ?? 0)
@@ -1158,7 +1145,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           {/* Primary tabs stay mounted during search so navigation does not jump. */}
           <>
             {tabsLoading ? (
-              <nav className="flex items-center gap-2 overflow-x-auto hide-scrollbar">
+              <nav className="hidden sm:flex items-center gap-2 overflow-x-auto hide-scrollbar">
                 {[1, 2, 3].map((i) => (
                   <span
                     key={i}
@@ -1168,7 +1155,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                 ))}
               </nav>
             ) : (
-              <nav className="flex min-w-0 items-center gap-0.5 overflow-x-auto hide-scrollbar">
+              <nav className="hidden sm:flex min-w-0 items-center gap-0.5 overflow-x-auto hide-scrollbar">
                 {topBarTabs.map((tab, idx) => {
                   const visibleIndex = visibleTabs.findIndex(
                     (item) => item.id === tab.id,
@@ -1252,7 +1239,12 @@ function AppLayoutInner({ children }: AppLayoutProps) {
             )}
 
             {/* Tab settings cog */}
-            <div className={cn("relative", tabsLoading && "invisible")}>
+            <div
+              className={cn(
+                "relative hidden sm:block",
+                tabsLoading && "invisible",
+              )}
+            >
               <Popover
                 open={tabSettingsOpen}
                 onOpenChange={(open) => {
@@ -1497,7 +1489,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         {/* Sidebar overlay / pinned rail */}
         {showSidebar && (
           <>
-            {(!sidebarPinned || isMobile) && (
+            {!sidebarPinned && (
               <div
                 className="fixed inset-0 z-30 bg-[var(--mail-overlay-scrim)]"
                 onClick={() => setSidebarOpen(false)}
@@ -1531,7 +1523,12 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                           <button
                             type="button"
                             onClick={() => {
-                              setSidebarPinned((value) => !value);
+                              if (sidebarPinned) {
+                                setSidebarPinned(false);
+                                setSidebarOpen(!isMobile);
+                                return;
+                              }
+                              setSidebarPinned(true);
                               setSidebarOpen(true);
                             }}
                             className={cn(

--- a/templates/mail/app/global.css
+++ b/templates/mail/app/global.css
@@ -43,6 +43,20 @@
   --mail-toast-surface: hsl(var(--card));
   --mail-toast-border: hsl(var(--border));
   --mail-overlay-scrim: hsl(0 0% 0% / 0.2);
+  --mail-label-automated-bg: 330 81% 60% / 0.2;
+  --mail-label-automated-text: 336 69% 36%;
+  --mail-label-social-bg: 217 91% 60% / 0.2;
+  --mail-label-social-text: 224 76% 48%;
+  --mail-label-updates-bg: 45 93% 47% / 0.2;
+  --mail-label-updates-text: 32 95% 44%;
+  --mail-label-promotions-bg: 142 71% 45% / 0.2;
+  --mail-label-promotions-text: 142 72% 29%;
+  --mail-label-forums-bg: 199 89% 48% / 0.2;
+  --mail-label-forums-text: 201 96% 32%;
+  --mail-label-finance-bg: 160 84% 39% / 0.2;
+  --mail-label-finance-text: 163 94% 24%;
+  --mail-label-travel-bg: 187 85% 53% / 0.2;
+  --mail-label-travel-text: 192 91% 36%;
 }
 
 .dark {
@@ -81,6 +95,13 @@
   --mail-toast-surface: hsl(0 0% 15%);
   --mail-toast-border: hsl(0 0% 26%);
   --mail-overlay-scrim: hsl(0 0% 6% / 0.32);
+  --mail-label-automated-text: 336 75% 75%;
+  --mail-label-social-text: 213 94% 68%;
+  --mail-label-updates-text: 48 96% 64%;
+  --mail-label-promotions-text: 141 76% 73%;
+  --mail-label-forums-text: 199 95% 74%;
+  --mail-label-finance-text: 152 76% 70%;
+  --mail-label-travel-text: 188 86% 74%;
 }
 
 @layer base {

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import type { EmailMessage } from "@shared/types";
 import { describe, expect, it, afterEach, vi } from "vitest";
 
@@ -25,6 +27,10 @@ function makeEmail(id: string, threadId: string): EmailMessage {
     isTrashed: false,
     labelIds: ["inbox"],
   };
+}
+
+function emailsHookSource(): string {
+  return readFileSync(new URL("./use-emails.ts", import.meta.url), "utf8");
 }
 
 describe("filterSuppressedThreads", () => {
@@ -85,5 +91,14 @@ describe("consumeExternalEmailRefresh", () => {
     vi.advanceTimersByTime(5000);
 
     expect(consumeExternalEmailRefresh()).toBeUndefined();
+  });
+});
+
+describe("useLabels", () => {
+  it("keeps the last label data during a failed refresh", () => {
+    const source = emailsHookSource();
+
+    expect(source).toContain("placeholderData: (previousData) => previousData");
+    expect(source).toContain("export const EMPTY_LABELS: Label[] = [];");
   });
 });

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -1453,10 +1453,16 @@ export function useContacts() {
 
 // ─── Labels ──────────────────────────────────────────────────────────────────
 
+export const EMPTY_LABELS: Label[] = [];
+
 export function useLabels() {
   return useQuery<Label[]>({
     queryKey: ["labels"],
     queryFn: () => apiFetch("/api/labels"),
+    // A failed background refresh must not erase the last complete label map.
+    // The layout still surfaces isError so an initial failure has an explicit
+    // retry path instead of looking like an empty mailbox.
+    placeholderData: (previousData) => previousData,
     staleTime: 60_000,
   });
 }

--- a/templates/mail/app/hooks/use-navigation-state.ts
+++ b/templates/mail/app/hooks/use-navigation-state.ts
@@ -10,6 +10,7 @@ export interface NavigationState {
   selectedThreadIds?: string[];
   search?: string;
   label?: string;
+  activeInboxTab?: string;
   queuedDraftId?: string;
   queueScope?: string;
   settingsSection?: string;

--- a/templates/mail/app/hooks/use-navigation-state.ts
+++ b/templates/mail/app/hooks/use-navigation-state.ts
@@ -11,6 +11,7 @@ export interface NavigationState {
   search?: string;
   label?: string;
   activeInboxTab?: string;
+  activeAccounts?: string[];
   queuedDraftId?: string;
   queueScope?: string;
   settingsSection?: string;

--- a/templates/mail/app/lib/inbox-tabs.ts
+++ b/templates/mail/app/lib/inbox-tabs.ts
@@ -24,6 +24,11 @@ export const COLLAPSIBLE_VIEW_IDS = [
   "trash",
 ] as const;
 
+// Keep the synthetic remainder tab's UI identity separate from user-label IDs.
+// Its public URL remains `tab=other` for existing links and agent commands.
+export const OTHER_INBOX_TAB_ID = "__inbox_other__";
+export const OTHER_INBOX_TAB_PARAM = "other";
+
 /** Pinned labels include a virtual "important" tab when Google is connected. */
 export function resolvePinnedLabels(
   userPinnedLabels: readonly string[],

--- a/templates/mail/app/lib/label-colors.spec.ts
+++ b/templates/mail/app/lib/label-colors.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { getLabelStyle } from "./label-colors";
+
+describe("getLabelStyle", () => {
+  it("keeps a label color consistent between list and detail views", () => {
+    expect(getLabelStyle("social")).toEqual(getLabelStyle("SOCIAL"));
+    expect(getLabelStyle("label:custom")).toEqual(getLabelStyle("custom"));
+  });
+
+  it("uses distinct palette entries for known Gmail categories", () => {
+    expect(getLabelStyle("social")).not.toEqual(getLabelStyle("updates"));
+  });
+});

--- a/templates/mail/app/lib/label-colors.ts
+++ b/templates/mail/app/lib/label-colors.ts
@@ -4,25 +4,34 @@ export type LabelStyle = {
 };
 
 const labelColors: Record<string, LabelStyle> = {
-  automated: { bg: "bg-pink-500/20", text: "text-pink-700 dark:text-pink-300" },
-  social: { bg: "bg-blue-500/20", text: "text-blue-700 dark:text-blue-300" },
+  automated: {
+    bg: "bg-[hsl(var(--mail-label-automated-bg))]",
+    text: "text-[hsl(var(--mail-label-automated-text))]",
+  },
+  social: {
+    bg: "bg-[hsl(var(--mail-label-social-bg))]",
+    text: "text-[hsl(var(--mail-label-social-text))]",
+  },
   updates: {
-    bg: "bg-yellow-500/20",
-    text: "text-yellow-700 dark:text-yellow-300",
+    bg: "bg-[hsl(var(--mail-label-updates-bg))]",
+    text: "text-[hsl(var(--mail-label-updates-text))]",
   },
   promotions: {
-    bg: "bg-green-500/20",
-    text: "text-green-700 dark:text-green-300",
+    bg: "bg-[hsl(var(--mail-label-promotions-bg))]",
+    text: "text-[hsl(var(--mail-label-promotions-text))]",
   },
   forums: {
-    bg: "bg-sky-500/20",
-    text: "text-sky-700 dark:text-sky-300",
+    bg: "bg-[hsl(var(--mail-label-forums-bg))]",
+    text: "text-[hsl(var(--mail-label-forums-text))]",
   },
   finance: {
-    bg: "bg-emerald-500/20",
-    text: "text-emerald-700 dark:text-emerald-300",
+    bg: "bg-[hsl(var(--mail-label-finance-bg))]",
+    text: "text-[hsl(var(--mail-label-finance-text))]",
   },
-  travel: { bg: "bg-cyan-500/20", text: "text-cyan-700 dark:text-cyan-300" },
+  travel: {
+    bg: "bg-[hsl(var(--mail-label-travel-bg))]",
+    text: "text-[hsl(var(--mail-label-travel-text))]",
+  },
 };
 
 export function getLabelStyle(labelId: string): LabelStyle {

--- a/templates/mail/app/lib/label-colors.ts
+++ b/templates/mail/app/lib/label-colors.ts
@@ -1,0 +1,38 @@
+export type LabelStyle = {
+  bg: string;
+  text: string;
+};
+
+const labelColors: Record<string, LabelStyle> = {
+  automated: { bg: "bg-pink-500/20", text: "text-pink-700 dark:text-pink-300" },
+  social: { bg: "bg-blue-500/20", text: "text-blue-700 dark:text-blue-300" },
+  updates: {
+    bg: "bg-yellow-500/20",
+    text: "text-yellow-700 dark:text-yellow-300",
+  },
+  promotions: {
+    bg: "bg-green-500/20",
+    text: "text-green-700 dark:text-green-300",
+  },
+  forums: {
+    bg: "bg-sky-500/20",
+    text: "text-sky-700 dark:text-sky-300",
+  },
+  finance: {
+    bg: "bg-emerald-500/20",
+    text: "text-emerald-700 dark:text-emerald-300",
+  },
+  travel: { bg: "bg-cyan-500/20", text: "text-cyan-700 dark:text-cyan-300" },
+};
+
+export function getLabelStyle(labelId: string): LabelStyle {
+  const normalized = labelId.toLowerCase().replace(/^label:/, "");
+  if (labelColors[normalized]) return labelColors[normalized];
+
+  let hash = 0;
+  for (let i = 0; i < normalized.length; i++) {
+    hash = normalized.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const options = Object.values(labelColors);
+  return options[Math.abs(hash) % options.length];
+}

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -23,6 +23,7 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import {
+  OTHER_INBOX_TAB_PARAM,
   resolvePinnedLabels,
   pinnedTriageLabels,
   augmentSelfSentLabels,
@@ -306,7 +307,9 @@ export function InboxPage() {
     mailLabelsInclude(triageLabels, activeLabel);
   const clientSliceTab = isPinnedTab && !searchQuery;
   const isOtherTab =
-    view === "inbox" && activeInboxTab === "other" && !searchQuery;
+    view === "inbox" &&
+    activeInboxTab === OTHER_INBOX_TAB_PARAM &&
+    !searchQuery;
   const effectiveLabel = clientSliceTab
     ? undefined
     : (activeLabel ?? undefined);
@@ -432,10 +435,19 @@ export function InboxPage() {
       focusedEmailId: focusedId ?? undefined,
       search: searchQ,
       label: activeLabel ?? undefined,
+      activeInboxTab: activeInboxTab ?? undefined,
       selectedThreadIds:
         selectedThreadIds.length > 0 ? selectedThreadIds : undefined,
     });
-  }, [view, threadId, focusedId, searchQ, activeLabel, selectedThreadIds]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    view,
+    threadId,
+    focusedId,
+    searchQ,
+    activeLabel,
+    activeInboxTab,
+    selectedThreadIds,
+  ]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // One-shot agent navigation: agent writes navigate.json, UI reads it, navigates, deletes it
   const { data: navCommand } = navState.command;

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -436,6 +436,8 @@ export function InboxPage() {
       search: searchQ,
       label: activeLabel ?? undefined,
       activeInboxTab: activeInboxTab ?? undefined,
+      activeAccounts:
+        activeAccounts.size > 0 ? Array.from(activeAccounts) : undefined,
       selectedThreadIds:
         selectedThreadIds.length > 0 ? selectedThreadIds : undefined,
     });
@@ -446,6 +448,7 @@ export function InboxPage() {
     searchQ,
     activeLabel,
     activeInboxTab,
+    activeAccounts,
     selectedThreadIds,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -418,7 +418,10 @@ export function InboxPage() {
   // Clear multi-selection when switching views or label tabs. Do NOT clear on
   // threadId changes — shift+j/k in detail view navigates between threads while
   // extending the selection, so selection must persist across thread nav.
-  useEffect(() => setSelectedIds(new Set()), [view, activeLabel]);
+  useEffect(
+    () => setSelectedIds(new Set()),
+    [view, activeLabel, activeInboxTab],
+  );
 
   // Sync current navigation state to file (write-only, so agent can read it)
   const searchQ = searchParams.get("q") ?? undefined;

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -260,6 +260,7 @@ export function InboxPage() {
   const { data: settings } = useSettings();
   const [searchParams] = useSearchParams();
   const activeLabel = searchParams.get("label");
+  const activeInboxTab = searchParams.get("tab");
   const routeSearchSuffix = searchParams.toString()
     ? `?${searchParams.toString()}`
     : "";
@@ -304,6 +305,8 @@ export function InboxPage() {
     view === "inbox" &&
     mailLabelsInclude(triageLabels, activeLabel);
   const clientSliceTab = isPinnedTab && !searchQuery;
+  const isOtherTab =
+    view === "inbox" && activeInboxTab === "other" && !searchQuery;
   const effectiveLabel = clientSliceTab
     ? undefined
     : (activeLabel ?? undefined);
@@ -349,12 +352,7 @@ export function InboxPage() {
       return filterInboxTabEmails(filtered, activeLabel, pinnedLabels);
     }
     // "Other" tab — the inbox remainder, same partition as its badge.
-    if (
-      !searchQuery &&
-      view === "inbox" &&
-      !activeLabel &&
-      triageLabels.length > 0
-    ) {
+    if (isOtherTab) {
       return filterInboxTabEmails(filtered, null, pinnedLabels);
     }
 
@@ -407,6 +405,7 @@ export function InboxPage() {
     view,
     searchQuery,
     activeLabel,
+    isOtherTab,
     clientSliceTab,
     pinnedLabels,
     triageLabels,

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -13,6 +13,20 @@ function emailListSource(): string {
   );
 }
 
+function navigationHookSource(): string {
+  return readFileSync(
+    new URL("../hooks/use-navigation-state.ts", import.meta.url),
+    "utf8",
+  );
+}
+
+function viewScreenSource(): string {
+  return readFileSync(
+    new URL("../../actions/view-screen.ts", import.meta.url),
+    "utf8",
+  );
+}
+
 describe("Inbox navigation commands", () => {
   it("focuses compose drafts opened by MCP deep links", () => {
     const source = inboxSource();
@@ -25,6 +39,16 @@ describe("Inbox navigation commands", () => {
     const source = inboxSource();
 
     expect(source).toContain("[view, activeLabel, activeInboxTab]");
+  });
+
+  it("syncs the active inbox partition into agent navigation state", () => {
+    expect(navigationHookSource()).toContain("activeInboxTab?: string;");
+    expect(inboxSource()).toContain(
+      "activeInboxTab: activeInboxTab ?? undefined",
+    );
+    expect(viewScreenSource()).toContain(
+      "activeInboxTab: nav.activeInboxTab ?? null",
+    );
   });
 });
 

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -50,6 +50,15 @@ describe("Inbox navigation commands", () => {
       "activeInboxTab: nav.activeInboxTab ?? null",
     );
   });
+
+  it("filters the view-screen snapshot to the active Other partition", () => {
+    const source = viewScreenSource();
+
+    expect(source).toContain("activeInboxTab?: string");
+    expect(source).toContain("activeInboxTab === OTHER_INBOX_TAB_PARAM");
+    expect(source).toContain("filterInboxTabEmails");
+    expect(source).toContain("nav.activeInboxTab");
+  });
 });
 
 describe("Inbox pagination", () => {

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -20,6 +20,12 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain("compose.setActiveId(navCommand.composeDraftId)");
     expect(source).toContain("FOCUS_COMPOSE_DRAFT_EVENT");
   });
+
+  it("clears selection when switching inbox partitions", () => {
+    const source = inboxSource();
+
+    expect(source).toContain("[view, activeLabel, activeInboxTab]");
+  });
 });
 
 describe("Inbox pagination", () => {

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -43,8 +43,12 @@ describe("Inbox navigation commands", () => {
 
   it("syncs the active inbox partition into agent navigation state", () => {
     expect(navigationHookSource()).toContain("activeInboxTab?: string;");
+    expect(navigationHookSource()).toContain("activeAccounts?: string[];");
     expect(inboxSource()).toContain(
       "activeInboxTab: activeInboxTab ?? undefined",
+    );
+    expect(inboxSource()).toContain(
+      "activeAccounts.size > 0 ? Array.from(activeAccounts) : undefined",
     );
     expect(viewScreenSource()).toContain(
       "activeInboxTab: nav.activeInboxTab ?? null",
@@ -55,9 +59,14 @@ describe("Inbox navigation commands", () => {
     const source = viewScreenSource();
 
     expect(source).toContain("activeInboxTab?: string");
+    expect(source).toContain("activeAccounts?: string[]");
     expect(source).toContain("activeInboxTab === OTHER_INBOX_TAB_PARAM");
+    expect(source).toContain("augmentSelfSentLabels");
+    expect(source).toContain("selectedAccountSet");
+    expect(source).toContain("accountEmails:");
     expect(source).toContain("filterInboxTabEmails");
     expect(source).toContain("nav.activeInboxTab");
+    expect(source).toContain("nav.activeAccounts");
   });
 });
 

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -21,3 +21,12 @@ describe("emails handler Gmail draft listing", () => {
     expect(source).toContain("requestAccountEmail ?? attachment.accountEmail");
   });
 });
+
+describe("emails handler Gmail label listing", () => {
+  it("does not turn a full Gmail label read failure into local fallback data", () => {
+    const source = emailsHandlerSource();
+
+    expect(source).toContain("setResponseStatus(_event, 502)");
+    expect(source).toContain("Unable to load Gmail labels. Please retry.");
+  });
+});

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -27,6 +27,7 @@ describe("emails handler Gmail label listing", () => {
     const source = emailsHandlerSource();
 
     expect(source).toContain("setResponseStatus(_event, 502)");
+    expect(source).toContain("failedAccountReads > 0");
     expect(source).toContain("Unable to load Gmail labels. Please retry.");
   });
 });

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -1743,10 +1743,13 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
           totalCount: number;
         }
       >();
+      let successfulAccountReads = 0;
+      let failedAccountReads = 0;
       // Fetch labels from each account sequentially to avoid race conditions on the shared map
       for (const { accessToken } of accountTokens) {
         try {
           const res = await gmailListLabels(accessToken);
+          successfulAccountReads += 1;
           for (const label of res.labels || []) {
             if (!label.id || !label.name) continue;
             const gmailId = label.id;
@@ -1791,7 +1794,21 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
               });
             }
           }
-        } catch {}
+        } catch {
+          // Keep labels from accounts that succeeded, but never present an
+          // empty map as a successful response when every Gmail read failed.
+          failedAccountReads += 1;
+        }
+      }
+      if (failedAccountReads > 0) {
+        console.warn(
+          `[listLabels] ${failedAccountReads} Gmail account label read(s) failed`,
+        );
+      }
+      if (accountTokens.length === 0 || successfulAccountReads === 0) {
+        console.error("[listLabels] Gmail label fetch failed");
+        setResponseStatus(_event, 502);
+        return { error: "Unable to load Gmail labels. Please retry." };
       }
       const labels: Label[] = Array.from(labelMap.values());
 
@@ -1821,7 +1838,11 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
       }
 
       return labels;
-    } catch {}
+    } catch {
+      console.error("[listLabels] Gmail label request failed");
+      setResponseStatus(_event, 502);
+      return { error: "Unable to load Gmail labels. Please retry." };
+    }
   }
   return readLabels(email);
 });

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -1795,8 +1795,8 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
             }
           }
         } catch {
-          // Keep labels from accounts that succeeded, but never present an
-          // empty map as a successful response when every Gmail read failed.
+          // A partial label map is not safe to return because it drops labels
+          // from accounts that failed and makes counts look authoritative.
           failedAccountReads += 1;
         }
       }
@@ -1805,7 +1805,11 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
           `[listLabels] ${failedAccountReads} Gmail account label read(s) failed`,
         );
       }
-      if (accountTokens.length === 0 || successfulAccountReads === 0) {
+      if (
+        accountTokens.length === 0 ||
+        successfulAccountReads === 0 ||
+        failedAccountReads > 0
+      ) {
         console.error("[listLabels] Gmail label fetch failed");
         setResponseStatus(_event, 502);
         return { error: "Unable to load Gmail labels. Please retry." };


### PR DESCRIPTION
## Summary
- make Cmd+\ reliable for desktop app chat sidebars from host or webview focus
- fix Mail inbox partitioning, counts, label colors, label-load errors, and mobile sidebar controls

## Verification
- desktop test suite: 461 passed
- Mail test suite: 336 passed
- desktop typecheck and production build passed
- all 60 repository guards passed

Slack feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787261722727189