### PR TITLE
fix(clips): open Google sign-in in a popup

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -67,6 +67,7 @@ import {
   startBubbleWebrtc,
   type BubbleWebrtcHandle,
 } from "./lib/bubble-webrtc";
+import { openBoundOAuthWindow } from "./lib/desktop-oauth-window";
 import {
   getCameraStreamWithFallback,
   isMediaConstraintFailure,
@@ -2126,15 +2127,17 @@ export function App() {
     void tick();
   }
 
-  // Google verification stays in the bound Tauri WebView so the callback sees
-  // the same browser-binding cookie. Magic-link verification still completes
-  // in the system browser through its own exchange flow.
+  // Google verification stays in a child of the bound Tauri WebView so the
+  // callback sees the same browser-binding cookie. Magic-link verification
+  // still completes in the system browser through its own exchange flow.
   async function signInExternal() {
     if (signInInflightRef.current) return;
     signInInflightRef.current = true;
+    let oauthWindow: ReturnType<typeof openBoundOAuthWindow> | null = null;
 
     try {
       setSignInError(null);
+      oauthWindow = openBoundOAuthWindow();
       const flowId = crypto.randomUUID?.() ?? null;
       const verifier = (() => {
         const randomUuid = crypto.randomUUID;
@@ -2163,7 +2166,6 @@ export function App() {
       const authParams = new URLSearchParams({
         desktop: "1",
         flow_id: flowId,
-        webview: "1",
       });
       const authResponse = await fetch(
         `${base}/_agent-native/google/auth-url?${authParams.toString()}`,
@@ -2194,13 +2196,12 @@ export function App() {
               : "Could not start Google sign-in.";
         throw new Error(message);
       }
+      oauthWindow.location.href = authPayload.url;
       setSignInPending("google");
-      // Stay in this exact WebView: the auth bootstrap set the HttpOnly
-      // browser-binding cookie here, and the callback returns this page with
-      // the staged session cookie after Google completes.
-      window.location.href = authPayload.url;
+      startDesktopAuthExchange(flowId, "google", verifier);
     } catch (err) {
       console.error("[clips-tray] signInExternal failed:", err);
+      oauthWindow?.close();
       signInInflightRef.current = false;
       setSignInPending(null);
       setSignInError(
@@ -3962,8 +3963,8 @@ export function App() {
   // (not a separate Tauri window). This avoids Tauri 2's separate-WebKit-
   // data-store-per-WebviewWindow cookie-jar issue — the cookie is set in
   // the same webview that reads it on the next /auth/session poll.
-  // Google verification uses the bound WebView, while magic-link verification
-  // uses the system browser and password stays inline here.
+  // Google verification uses a popup in the bound WebView, while magic-link
+  // verification uses the system browser and password stays inline here.
   if (authStatus === "anon") {
     return (
       <div className="app" ref={appRef}>

--- a/templates/clips/desktop/src/lib/desktop-oauth-window.test.ts
+++ b/templates/clips/desktop/src/lib/desktop-oauth-window.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { openBoundOAuthWindow } from "./desktop-oauth-window";
+
+describe("openBoundOAuthWindow", () => {
+  it("opens the callback in the bound WebView window", () => {
+    const oauthWindow = {
+      close: vi.fn(),
+      location: { href: "about:blank" },
+    };
+    const openWindow = vi.fn(() => oauthWindow);
+
+    const result = openBoundOAuthWindow(openWindow);
+    result.location.href = "https://accounts.google.com/o/oauth2/v2/auth";
+
+    expect(openWindow).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(result).toBe(oauthWindow);
+    expect(result.location.href).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+  });
+});

--- a/templates/clips/desktop/src/lib/desktop-oauth-window.ts
+++ b/templates/clips/desktop/src/lib/desktop-oauth-window.ts
@@ -1,0 +1,23 @@
+type OAuthWindow = Pick<Window, "close"> & {
+  location: Pick<Location, "href">;
+};
+
+type OpenOAuthWindow = (url: string, target: string) => OAuthWindow | null;
+
+/**
+ * Open a same-WebView OAuth child before awaiting the auth URL.
+ *
+ * The parent keeps polling the exchange while the child completes Google
+ * OAuth. Using window.open keeps both pages in the Tauri WebView cookie
+ * partition; the system-browser shell opener would lose the binding cookie.
+ */
+export function openBoundOAuthWindow(
+  openWindow: OpenOAuthWindow = (url, target) =>
+    window.open(url, target) as OAuthWindow | null,
+): OAuthWindow {
+  const oauthWindow = openWindow("about:blank", "_blank");
+  if (!oauthWindow) {
+    throw new Error("Could not open the Google sign-in window.");
+  }
+  return oauthWindow;
+}


### PR DESCRIPTION
## Summary
- restore the same-WebView OAuth child window for Clips Google sign-in
- keep the verifier-bound POST exchange and browser-binding cookie on the parent/child flow
- close the popup if auth bootstrap fails

## Verification
- `pnpm --filter clips-desktop test -- src/lib/desktop-oauth-window.test.ts` - 34 files, 172 tests passed
- `pnpm --filter clips-desktop typecheck` passed
- `pnpm --filter clips-desktop build` passed
- `pnpm prep:urgent` reached the full workspace gate but remains red on unrelated missing generated artifacts, native better-sqlite3 bindings, and existing core/i18n baseline failures

Urgent production auth outage fix; authorized for admin merge.