### PR TITLE
Fix opening workspace apps from Dispatch in Builder Desktop

### DIFF
--- a/.changeset/action-request-origin-gateway.md
+++ b/.changeset/action-request-origin-gateway.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix action request context to use the forwarded workspace gateway origin instead of the internal dev proxy host.

--- a/.changeset/action-request-origin-gateway.md
+++ b/.changeset/action-request-origin-gateway.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/dispatch": patch
 ---
 
 Fix action request context to use the forwarded workspace gateway origin instead of the internal dev proxy host.

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -565,6 +565,45 @@ describe("mountActionRoutes", () => {
     });
   });
 
+  it("uses the forwarded gateway origin for request context behind a dev proxy", async () => {
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const { getRequestContext } = await import("./request-context.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    const actions: Record<string, ActionEntry> = {
+      ping: {
+        run: vi.fn(async () => ({
+          requestOrigin: getRequestContext()?.requestOrigin,
+        })),
+      } as any,
+    };
+
+    mountActionRoutes(nitroApp, actions, {
+      getOwnerFromEvent: async () => "alice@example.com",
+    });
+
+    const proxied = {
+      _method: "POST",
+      _headers: {
+        host: "127.0.0.1:8092",
+        "x-forwarded-host": "127.0.0.1:8080",
+        "x-forwarded-proto": "http",
+      },
+      req: {
+        url: "http://127.0.0.1:8092/dispatch/_agent-native/actions/ping",
+        json: async () => ({}),
+      },
+    };
+
+    expect(await mounted[0].handler(proxied)).toEqual({
+      requestOrigin: "http://127.0.0.1:8080",
+    });
+  });
+
   it("runs optional-auth actions with an anonymous request context when auth resolution returns 401", async () => {
     const { mountActionRoutes } = await import("./action-routes.js");
     const { getRequestUserEmail } = await import("./request-context.js");

--- a/packages/core/src/server/action-routes.spec.ts
+++ b/packages/core/src/server/action-routes.spec.ts
@@ -29,6 +29,8 @@ vi.mock("h3", () => ({
   getMethod: (event: any) => event._method ?? "GET",
   getQuery: (event: any) => event._query ?? {},
   getHeader: (event: any, name: string) => event._headers?.[name.toLowerCase()],
+  getRequestHeader: (event: any, name: string) =>
+    event._headers?.[name.toLowerCase()],
   getRequestURL: (event: any) =>
     new URL(event.req?.url ?? "http://localhost/_agent-native/actions/test"),
   setResponseStatus: (event: any, status: number) => {
@@ -599,6 +601,50 @@ describe("mountActionRoutes", () => {
       },
     };
 
+    expect(await mounted[0].handler(proxied)).toEqual({
+      requestOrigin: "http://127.0.0.1:8080",
+    });
+  });
+
+  it("keeps the forwarded gateway origin when workspace OAuth relay is configured", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv("APP_URL", "https://dispatch.agent-native.com");
+    const { mountActionRoutes } = await import("./action-routes.js");
+    const { getRequestContext } = await import("./request-context.js");
+    const { getOrigin } = await import("./google-oauth.js");
+    const mounted: Array<{ path: string; handler: any }> = [];
+    const nitroApp = {
+      use: vi.fn((path: string, handler: any) =>
+        mounted.push({ path, handler }),
+      ),
+    };
+    const actions: Record<string, ActionEntry> = {
+      ping: {
+        run: vi.fn(async () => ({
+          requestOrigin: getRequestContext()?.requestOrigin,
+        })),
+      } as any,
+    };
+
+    mountActionRoutes(nitroApp, actions, {
+      getOwnerFromEvent: async () => "alice@example.com",
+    });
+
+    const proxied = {
+      _method: "POST",
+      _headers: {
+        host: "127.0.0.1:8092",
+        "x-forwarded-host": "127.0.0.1:8080",
+        "x-forwarded-proto": "http",
+      },
+      req: {
+        url: "http://127.0.0.1:8092/dispatch/_agent-native/actions/ping",
+        json: async () => ({}),
+      },
+    };
+
+    expect(getOrigin(proxied as any)).toBe("https://dispatch.agent-native.com");
     expect(await mounted[0].handler(proxied)).toEqual({
       requestOrigin: "http://127.0.0.1:8080",
     });

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -38,9 +38,9 @@ import {
   resolveEmbedSessionFromRequest,
   resolvedEmbedCapabilityScope,
 } from "./embed-session.js";
-import { getOrigin } from "./google-oauth.js";
 import { getHttpRequestTelemetryId } from "./http-response-telemetry.js";
 import { consumeOneTimeJti } from "./identity-sso-store.js";
+import { getForwardedRequestOrigin } from "./request-origin.js";
 
 declare const __AGENT_NATIVE_BUILD_ID__: string | undefined;
 declare const __AGENT_NATIVE_CLIENT_COMPATIBILITY_VERSION__: string | undefined;
@@ -588,7 +588,7 @@ export function mountActionRoutes(
             timezone,
             browserSessionId,
             clientPlatform,
-            requestOrigin: getOrigin(event),
+            requestOrigin: getForwardedRequestOrigin(event),
             // Captured here because this is the last layer that still holds
             // the h3 event; everything below reads it off the request store.
             isLoopbackRequest: isLoopbackRequest(event),

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -6,7 +6,6 @@ import {
   getMethod,
   getQuery,
   getHeader,
-  getRequestURL,
 } from "h3";
 
 import { verifyA2ATokenWithClaims } from "../a2a-claims.js";
@@ -39,6 +38,7 @@ import {
   resolveEmbedSessionFromRequest,
   resolvedEmbedCapabilityScope,
 } from "./embed-session.js";
+import { getOrigin } from "./google-oauth.js";
 import { getHttpRequestTelemetryId } from "./http-response-telemetry.js";
 import { consumeOneTimeJti } from "./identity-sso-store.js";
 
@@ -588,7 +588,7 @@ export function mountActionRoutes(
             timezone,
             browserSessionId,
             clientPlatform,
-            requestOrigin: getRequestURL(event).origin,
+            requestOrigin: getOrigin(event),
             // Captured here because this is the last layer that still holds
             // the h3 event; everything below reads it off the request store.
             isLoopbackRequest: isLoopbackRequest(event),

--- a/packages/core/src/server/request-origin.spec.ts
+++ b/packages/core/src/server/request-origin.spec.ts
@@ -5,11 +5,35 @@ vi.mock("h3", () => ({
     event.headers?.[name] ?? event.headers?.[name.toLowerCase()],
 }));
 
-import { isSameOriginRequest } from "./request-origin.js";
+import {
+  getForwardedRequestOrigin,
+  isSameOriginRequest,
+} from "./request-origin.js";
 
 function fakeEvent(headers: Record<string, string> = {}) {
   return { headers } as any;
 }
+
+describe("getForwardedRequestOrigin", () => {
+  it.each([
+    {
+      name: "forwarded gateway host behind an internal dev proxy",
+      headers: {
+        host: "127.0.0.1:8092",
+        "x-forwarded-host": "127.0.0.1:8080",
+        "x-forwarded-proto": "http",
+      },
+      expected: "http://127.0.0.1:8080",
+    },
+    {
+      name: "direct host when no proxy forwarded headers are present",
+      headers: { host: "dispatch.agent-native.com" },
+      expected: "http://dispatch.agent-native.com",
+    },
+  ])("handles $name", ({ headers, expected }) => {
+    expect(getForwardedRequestOrigin(fakeEvent(headers))).toBe(expected);
+  });
+});
 
 describe("isSameOriginRequest", () => {
   it.each([

--- a/packages/core/src/server/request-origin.ts
+++ b/packages/core/src/server/request-origin.ts
@@ -1,5 +1,20 @@
 import { getRequestHeader, type H3Event } from "h3";
 
+/**
+ * Browser-visible origin from proxy-forwarded headers. Unlike `getOrigin()`,
+ * this ignores OAuth callback and configured-public-origin overrides so action
+ * CSRF checks match the Referer the browser actually sent.
+ */
+export function getForwardedRequestOrigin(event: H3Event): string {
+  const headerHost =
+    getRequestHeader(event, "x-forwarded-host") ||
+    getRequestHeader(event, "host");
+  const isProd = process.env.NODE_ENV === "production";
+  const headerProto =
+    getRequestHeader(event, "x-forwarded-proto") || (isProd ? "https" : "http");
+  return `${headerProto}://${headerHost ?? "localhost"}`;
+}
+
 function isLoopbackHost(host: string): boolean {
   return host.startsWith("localhost:") || host.startsWith("127.0.0.1:");
 }

--- a/packages/dispatch/src/actions/create_workspace_app_embed_session.spec.ts
+++ b/packages/dispatch/src/actions/create_workspace_app_embed_session.spec.ts
@@ -76,6 +76,34 @@ describe("assertWorkspaceEmbedSessionCaller", () => {
     });
   });
 
+  it("allows a workspace gateway caller when requestOrigin matches forwarded host", async () => {
+    server.getRequestContext.mockReturnValue({
+      requestOrigin: "http://127.0.0.1:8080",
+    });
+    await expect(
+      assertWorkspaceEmbedSessionCaller(
+        new Headers({
+          Referer: "http://127.0.0.1:8080/dispatch/apps/calendar",
+          "Sec-Fetch-Site": "same-origin",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when the browser gateway origin does not match requestOrigin", async () => {
+    server.getRequestContext.mockReturnValue({
+      requestOrigin: "http://127.0.0.1:8092",
+    });
+    await expect(
+      assertWorkspaceEmbedSessionCaller(
+        new Headers({
+          Referer: "http://127.0.0.1:8080/dispatch/apps/calendar",
+          "Sec-Fetch-Site": "same-origin",
+        }),
+      ),
+    ).rejects.toThrow("requested by Dispatch");
+  });
+
   it("rejects cross-site and child-app browser callers", async () => {
     await expect(
       assertWorkspaceEmbedSessionCaller(


### PR DESCRIPTION
## Summary
- Dispatch no longer rejects embed sessions when the browser uses the workspace gateway on port 8080 but the server saw the internal dev app port.
- Opening apps like Calendar from Dispatch in Builder Desktop should load instead of showing an internal server error.

## Test plan
- [ ] Restart Builder Desktop dev and open Dispatch at `http://127.0.0.1:8080/dispatch`
- [ ] Open Calendar from the workspace apps list; confirm the pane loads without `create-workspace-app-embed-session` failing
- [ ] `npx vitest run packages/core/src/server/action-routes.spec.ts packages/dispatch/src/actions/create_workspace_app_embed_session.spec.ts`