### PR TITLE
fix: preserve beta release migration markers

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -716,7 +716,7 @@ jobs:
           NODE
 
       - name: Smoke-test the uploaded deploy
-        if: inputs.deploy && inputs.smoke
+        if: inputs.deploy && inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'
         env:
           DEPLOY_MODE: ${{ inputs.deploy_mode }}
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
@@ -729,6 +729,23 @@ jobs:
           fi
           curl --fail --silent --show-error --location --max-time 60 "${url%/}/" >/dev/null
           echo "Smoke check passed: ${url%/}/"
+          curl --fail --silent --show-error --location --max-time 60 "${url%/}/_agent-native/health" >/dev/null
+          echo "Health check passed: ${url%/}/_agent-native/health"
+
+      - name: Smoke-test the static docs deploy
+        if: inputs.deploy && inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'
+        env:
+          DEPLOY_MODE: ${{ inputs.deploy_mode }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
+          HOST: ${{ steps.target.outputs.host }}
+        run: |
+          set -euo pipefail
+          url="$DEPLOY_URL"
+          if [[ "$DEPLOY_MODE" == "production" ]]; then
+            url="https://$HOST"
+          fi
+          curl --fail --silent --show-error --location --max-time 60 "${url%/}/" >/dev/null
+          echo "Static docs smoke check passed: ${url%/}/"
 
       - name: Purge the production Netlify cache
         if: inputs.target == 'production' && inputs.deploy && inputs.deploy_mode == 'production' && success()

--- a/packages/core/src/app-config/store.spec.ts
+++ b/packages/core/src/app-config/store.spec.ts
@@ -6,6 +6,7 @@ import { appConfigSchema } from "./schema.js";
 import {
   defineAppConfig,
   getAppConfig,
+  readConfigEnvironment,
   resetAppConfigForTests,
   setAppConfigLayer,
 } from "./store.js";
@@ -101,6 +102,38 @@ describe("app config store", () => {
     expect(() => getAppConfig()).toThrow(
       /AGENT_NATIVE_PRIVATE_BLOB_PUBLIC_UPLOAD_FALLBACK must be one of/,
     );
+  });
+
+  it("keeps build-only deployment markers when the runtime env omits them", () => {
+    const previousReleaseMigrations =
+      process.env.AGENT_NATIVE_RELEASE_MIGRATIONS;
+    const previousBetaSchemaOwner = process.env.AGENT_NATIVE_BETA_SCHEMA_OWNER;
+
+    delete process.env.AGENT_NATIVE_RELEASE_MIGRATIONS;
+    delete process.env.AGENT_NATIVE_BETA_SCHEMA_OWNER;
+
+    try {
+      const env = readConfigEnvironment({
+        AGENT_NATIVE_RELEASE_MIGRATIONS: "1",
+        AGENT_NATIVE_BETA_SCHEMA_OWNER: "production",
+      });
+
+      expect(readEnvConfigLayer(appConfigSchema, env).migration).toMatchObject({
+        releaseMigrations: true,
+        betaSchemaOwner: "production",
+      });
+    } finally {
+      if (previousReleaseMigrations === undefined) {
+        delete process.env.AGENT_NATIVE_RELEASE_MIGRATIONS;
+      } else {
+        process.env.AGENT_NATIVE_RELEASE_MIGRATIONS = previousReleaseMigrations;
+      }
+      if (previousBetaSchemaOwner === undefined) {
+        delete process.env.AGENT_NATIVE_BETA_SCHEMA_OWNER;
+      } else {
+        process.env.AGENT_NATIVE_BETA_SCHEMA_OWNER = previousBetaSchemaOwner;
+      }
+    }
   });
 });
 

--- a/packages/core/src/app-config/store.ts
+++ b/packages/core/src/app-config/store.ts
@@ -76,6 +76,27 @@ function resolve(envLayer: Record<string, unknown>): AppConfig {
 }
 
 /**
+ * Nitro embeds build-only deployment markers into direct env reads. Netlify's
+ * prebuilt beta lane has those markers while building, but does not copy them
+ * into the deployed Function environment. Keep the embedded values as the
+ * fallback for this one config boundary so a later dynamic `env[key]` read
+ * cannot erase the build decision from the server bundle.
+ */
+export function readConfigEnvironment(
+  embedded: Record<string, string | undefined> = {
+    AGENT_NATIVE_RELEASE_MIGRATIONS:
+      process.env.AGENT_NATIVE_RELEASE_MIGRATIONS,
+    AGENT_NATIVE_BETA_SCHEMA_OWNER: process.env.AGENT_NATIVE_BETA_SCHEMA_OWNER,
+  },
+): Record<string, string | undefined> {
+  const env = { ...process.env };
+  for (const [key, value] of Object.entries(embedded)) {
+    if (!env[key] && value) env[key] = value;
+  }
+  return env;
+}
+
+/**
  * Writes one layer of the ladder. Framework-internal: the deprecated setters
  * use it to keep working without reintroducing a second namespace.
  */
@@ -119,7 +140,7 @@ export function defineAppConfig(config: AppConfigInput): void {
  * remove.
  */
 export function getAppConfig(): AppConfig {
-  const envLayer = readEnvConfigLayer(appConfigSchema, process.env);
+  const envLayer = readEnvConfigLayer(appConfigSchema, readConfigEnvironment());
   const signature = JSON.stringify(envLayer);
   if (state.resolved && state.envSignature === signature) return state.resolved;
   state.envSignature = signature;

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -163,6 +163,35 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(String(artifact.run), /GUARD_SSR_CACHE_ARTIFACT_DIR/);
   });
 
+  it("smoke-tests app health while keeping static docs on a shell-only probe", () => {
+    const workflow = readWorkflow(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+    );
+    const jobs = workflow.jobs as Record<string, Workflow>;
+    const steps = (jobs.deploy.steps as Array<Workflow>).filter(Boolean);
+    const appSmoke = steps.find(
+      (step) => step.name === "Smoke-test the uploaded deploy",
+    );
+    const docsSmoke = steps.find(
+      (step) => step.name === "Smoke-test the static docs deploy",
+    );
+
+    assert(appSmoke);
+    assert.equal(
+      appSmoke.if,
+      "inputs.deploy && inputs.smoke && steps.target.outputs.source_template != '@agent-native/docs'",
+    );
+    assert.match(String(appSmoke.run), /\/_agent-native\/health/);
+    assert.match(String(appSmoke.run), /--max-time 60/);
+
+    assert(docsSmoke);
+    assert.equal(
+      docsSmoke.if,
+      "inputs.deploy && inputs.smoke && steps.target.outputs.source_template == '@agent-native/docs'",
+    );
+    assert.doesNotMatch(String(docsSmoke.run), /\/_agent-native\/health/);
+  });
+
   it("gives the beta branch-deploy build release and warm-runtime ownership", () => {
     const workflow = readFileSync(
       ".github/workflows/deploy-netlify-prebuilt.yml",


### PR DESCRIPTION
## Summary

- preserve build-only beta release-migration and schema-owner markers when Netlify does not inject them into deployed Functions
- smoke-test `/_agent-native/health` on prebuilt app deploys so a broken serverless lane cannot pass on the public shell alone
- keep static docs on its shell-only smoke path

## Verification

- `corepack pnpm guards`
- `corepack pnpm --filter @agent-native/core exec vitest run src/app-config/store.spec.ts src/db/migrations.spec.ts`
- `corepack pnpm --filter @agent-native/core exec vitest run src/deploy/build.spec.ts src/vite/client.spec.ts`
- `corepack pnpm exec tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts`
