### PR TITLE
fix(clips): restore Google OAuth in system browser

### DIFF
--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -2,6 +2,7 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
@@ -13,6 +14,7 @@ use crate::state::{
 };
 
 const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 24.0;
+static OAUTH_WINDOW_COUNTER: AtomicU64 = AtomicU64::new(0);
 const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 320.0;
 const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
 
@@ -109,6 +111,7 @@ pub fn set_capture_included(window: &WebviewWindow) {
 
 pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri::Error> {
     let gutter = POPOVER_SHADOW_GUTTER_LOGICAL * 2.0;
+    let app_handle = app.handle().clone();
     WebviewWindowBuilder::new(app, "popover", WebviewUrl::App("index.html".into()))
         .title("Clips")
         .inner_size(
@@ -126,6 +129,35 @@ pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri
         .focused(true)
         .shadow(false)
         .accept_first_mouse(true)
+        // Tauri does not create a native child for window.open by default.
+        // Create it here with the opener's webview configuration so Google
+        // OAuth stays in a visible child window and shares the binding cookie.
+        .on_new_window(move |url, features| {
+            let label = format!(
+                "google-oauth-{}",
+                OAUTH_WINDOW_COUNTER.fetch_add(1, Ordering::Relaxed)
+            );
+            let popup = WebviewWindowBuilder::new(&app_handle, label, WebviewUrl::External(url))
+                .title("Sign in to Clips")
+                .inner_size(520.0, 720.0)
+                .resizable(true)
+                .always_on_top(false)
+                .focused(true)
+                .window_features(features)
+                .build();
+
+            match popup {
+                Ok(window) => {
+                    set_capture_excluded(&window);
+                    configure_overlay_behavior(&window);
+                    tauri::webview::NewWindowResponse::Create { window }
+                }
+                Err(error) => {
+                    eprintln!("[clips-tray] failed to create OAuth popup: {error}");
+                    tauri::webview::NewWindowResponse::Deny
+                }
+            }
+        })
         .build()
 }
 

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -2,7 +2,6 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    sync::atomic::{AtomicU64, Ordering},
 };
 
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
@@ -14,7 +13,6 @@ use crate::state::{
 };
 
 const POPOVER_SHADOW_GUTTER_LOGICAL: f64 = 24.0;
-static OAUTH_WINDOW_COUNTER: AtomicU64 = AtomicU64::new(0);
 const POPOVER_DEFAULT_WIDTH_LOGICAL: f64 = 320.0;
 const POPOVER_DEFAULT_HEIGHT_LOGICAL: f64 = 520.0;
 
@@ -111,7 +109,6 @@ pub fn set_capture_included(window: &WebviewWindow) {
 
 pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri::Error> {
     let gutter = POPOVER_SHADOW_GUTTER_LOGICAL * 2.0;
-    let app_handle = app.handle().clone();
     WebviewWindowBuilder::new(app, "popover", WebviewUrl::App("index.html".into()))
         .title("Clips")
         .inner_size(
@@ -129,35 +126,6 @@ pub fn build_popover_window(app: &mut tauri::App) -> Result<WebviewWindow, tauri
         .focused(true)
         .shadow(false)
         .accept_first_mouse(true)
-        // Tauri does not create a native child for window.open by default.
-        // Create it here with the opener's webview configuration so Google
-        // OAuth stays in a visible child window and shares the binding cookie.
-        .on_new_window(move |url, features| {
-            let label = format!(
-                "google-oauth-{}",
-                OAUTH_WINDOW_COUNTER.fetch_add(1, Ordering::Relaxed)
-            );
-            let popup = WebviewWindowBuilder::new(&app_handle, label, WebviewUrl::External(url))
-                .title("Sign in to Clips")
-                .inner_size(520.0, 720.0)
-                .resizable(true)
-                .always_on_top(false)
-                .focused(true)
-                .window_features(features)
-                .build();
-
-            match popup {
-                Ok(window) => {
-                    set_capture_excluded(&window);
-                    configure_overlay_behavior(&window);
-                    tauri::webview::NewWindowResponse::Create { window }
-                }
-                Err(error) => {
-                    eprintln!("[clips-tray] failed to create OAuth popup: {error}");
-                    tauri::webview::NewWindowResponse::Deny
-                }
-            }
-        })
         .build()
 }
 

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -67,7 +67,6 @@ import {
   startBubbleWebrtc,
   type BubbleWebrtcHandle,
 } from "./lib/bubble-webrtc";
-import { openBoundOAuthWindow } from "./lib/desktop-oauth-window";
 import {
   getCameraStreamWithFallback,
   isMediaConstraintFailure,
@@ -2127,17 +2126,15 @@ export function App() {
     void tick();
   }
 
-  // Google verification stays in a child of the bound Tauri WebView so the
-  // callback sees the same browser-binding cookie. Magic-link verification
-  // still completes in the system browser through its own exchange flow.
+  // Google verification opens in the system browser so the user's Google
+  // cookies are available. The client-held verifier still gates the exchange
+  // back into this Tauri app.
   async function signInExternal() {
     if (signInInflightRef.current) return;
     signInInflightRef.current = true;
-    let oauthWindow: ReturnType<typeof openBoundOAuthWindow> | null = null;
 
     try {
       setSignInError(null);
-      oauthWindow = openBoundOAuthWindow();
       const flowId = crypto.randomUUID?.() ?? null;
       const verifier = (() => {
         const randomUuid = crypto.randomUUID;
@@ -2196,12 +2193,11 @@ export function App() {
               : "Could not start Google sign-in.";
         throw new Error(message);
       }
-      oauthWindow.location.href = authPayload.url;
+      await openExternal(authPayload.url);
       setSignInPending("google");
       startDesktopAuthExchange(flowId, "google", verifier);
     } catch (err) {
       console.error("[clips-tray] signInExternal failed:", err);
-      oauthWindow?.close();
       signInInflightRef.current = false;
       setSignInPending(null);
       setSignInError(

--- a/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
@@ -64,6 +64,7 @@ export default defineEventHandler(async (event: H3Event) => {
     }
     const calendarConnect =
       q.calendar === "1" || q.calendar === "true" || q.product === "calendar";
+    const desktopWebview = desktop && q.webview === "1" && !calendarConnect;
     let desktopVerifierHash: string | undefined;
     let desktopBrowserBindingHash: string | undefined;
     if (flowId && !calendarConnect) {
@@ -77,12 +78,20 @@ export default defineEventHandler(async (event: H3Event) => {
         return { error: "Invalid desktop exchange challenge." };
       }
       try {
-        desktopBrowserBindingHash = prepareDesktopOAuthBrowserBinding(event);
-        desktopVerifierHash = await registerDesktopExchange(
-          flowId,
-          verifier,
-          desktopBrowserBindingHash,
-        );
+        // The system-browser flow deliberately uses the user's existing
+        // Google cookies. The client-held verifier still gates the exchange
+        // token returned to the initiating Tauri app. Only an in-app WebView
+        // needs the additional browser-partition binding.
+        if (desktopWebview) {
+          desktopBrowserBindingHash = prepareDesktopOAuthBrowserBinding(event);
+          desktopVerifierHash = await registerDesktopExchange(
+            flowId,
+            verifier,
+            desktopBrowserBindingHash,
+          );
+        } else {
+          desktopVerifierHash = await registerDesktopExchange(flowId, verifier);
+        }
       } catch {
         setResponseStatus(event, 400);
         return { error: "Invalid desktop exchange challenge." };
@@ -116,13 +125,10 @@ export default defineEventHandler(async (event: H3Event) => {
       redirectUri,
       owner,
       desktop,
-      desktopWebview: desktop && q.webview === "1" && !calendarConnect,
+      desktopWebview,
       addAccount: calendarConnect,
       app: CLIPS_GOOGLE_OAUTH_APP_ID,
-      returnUrl:
-        desktop && q.webview === "1" && !calendarConnect
-          ? "/?desktop_auth=complete"
-          : returnUrl,
+      returnUrl: desktopWebview ? "/?desktop_auth=complete" : returnUrl,
       flowId: calendarConnect ? undefined : flowId,
       desktopVerifierHash,
       desktopBrowserBindingHash,

--- a/templates/clips/server/routes/_agent-native/google/callback.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.ts
@@ -35,11 +35,12 @@ async function handleGoogleSignInCallback(
   if (
     flowId &&
     (!state.desktopVerifierHash ||
-      !state.desktopBrowserBindingHash ||
-      !matchesDesktopOAuthBrowserBinding(
-        event,
-        state.desktopBrowserBindingHash,
-      ))
+      (state.desktopWebview &&
+        (!state.desktopBrowserBindingHash ||
+          !matchesDesktopOAuthBrowserBinding(
+            event,
+            state.desktopBrowserBindingHash,
+          ))))
   ) {
     return oauthErrorPage("Desktop OAuth browser binding is invalid.");
   }


### PR DESCRIPTION
## Summary
- restore Clips desktop Google sign-in to the system browser so Google cookies are available
- keep the client-held verifier on the desktop exchange and retain browser binding for in-WebView flows
- remove the Tauri child-window handlers that can abort in WebKit createNewPage

## Validation
- Clips desktop tests: 171 passed
- Clips desktop typecheck: passed
- Clips desktop Vite build: passed
- Tauri cargo check and fmt: passed
- local Tauri auth surface exercised; full exchange requires the matching server route deployment

Ship-now requested for urgent Clips auth outage.