### PR TITLE
fix: keep desktop app surfaces stable during auth transitions

### DIFF
--- a/.changeset/desktop-app-surface-stability.md
+++ b/.changeset/desktop-app-surface-stability.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep app surfaces mounted when a host temporarily disables the chat sidebar.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -363,6 +363,18 @@ describe("AgentPanel header overflow actions", () => {
 });
 
 describe("AgentSidebar wide drawer layout", () => {
+  it("can disable the panel without unmounting the app surface", () => {
+    const source = readFileSync("src/client/AgentPanel.tsx", {
+      encoding: "utf8",
+    });
+
+    expect(source).toContain("enabled?: boolean");
+    expect(source).toContain("enabled &&");
+    expect(source).toMatch(
+      /const shouldRenderPanel =\s+enabled &&\s+\(sidebarAnimationEnabled \? renderAnimatedPanel : shouldMountPanel\)/,
+    );
+  });
+
   it("does not reserve the drawer placeholder after the panel closes", () => {
     const source = readFileSync("src/client/AgentPanel.tsx", {
       encoding: "utf8",

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -3022,6 +3022,8 @@ export function AgentChatSurface({
 
 export interface AgentSidebarProps {
   children: React.ReactNode;
+  /** Keep the app surface mounted while temporarily disabling the chat panel. */
+  enabled?: boolean;
   /** Placeholder text for the empty chat state */
   emptyStateText?: string;
   /** Suggestion prompts shown when no messages */
@@ -3129,6 +3131,7 @@ interface HostedHarnessStatus {
  */
 export function AgentSidebar({
   children,
+  enabled = true,
   emptyStateText = "How can I help you?",
   suggestions,
   dynamicSuggestions,
@@ -3382,6 +3385,7 @@ export function AgentSidebar({
     () => new Set(),
   );
   const shouldMountPanel =
+    enabled &&
     !isPerAppChatHosted &&
     !presentationMode &&
     (!frameCodeMode || !shouldParentFrameOwnAgentPanel()) &&
@@ -3399,9 +3403,11 @@ export function AgentSidebar({
     // dispatches the correct value.
     if (frameOwned && !hasFrameSidebarState && !isPerAppChatHosted) return;
     dispatchAgentSidebarStateChange({
-      open: isPerAppChatHosted
-        ? perAppChatState.open
-        : !presentationMode && (frameOwned ? frameSidebarOpen : open),
+      open:
+        enabled &&
+        (isPerAppChatHosted
+          ? perAppChatState.open
+          : !presentationMode && (frameOwned ? frameSidebarOpen : open)),
       source: frameOwned ? "frame" : "app",
       mode: frameOwned ? "code" : "app",
     });
@@ -3413,6 +3419,7 @@ export function AgentSidebar({
     hasFrameSidebarState,
     isPerAppChatHosted,
     perAppChatState.open,
+    enabled,
   ]);
 
   useEffect(() => {
@@ -3422,7 +3429,7 @@ export function AgentSidebar({
     if (frameOwned && !hasFrameSidebarState) return;
 
     const openState =
-      !presentationMode && (frameOwned ? frameSidebarOpen : open);
+      enabled && !presentationMode && (frameOwned ? frameSidebarOpen : open);
     const message = buildAppChatSidebarStateMessage(openState);
 
     window.dispatchEvent(
@@ -3450,6 +3457,7 @@ export function AgentSidebar({
     isPerAppChatSidebar,
     open,
     presentationMode,
+    enabled,
   ]);
 
   useEffect(() => {
@@ -3813,10 +3821,10 @@ export function AgentSidebar({
     };
   }, [shouldMountPanel, sidebarAnimationEnabled]);
 
-  const shouldRenderPanel = sidebarAnimationEnabled
-    ? renderAnimatedPanel
-    : shouldMountPanel;
-  const panelOpen = open && shouldMountPanel;
+  const shouldRenderPanel =
+    enabled &&
+    (sidebarAnimationEnabled ? renderAnimatedPanel : shouldMountPanel);
+  const panelOpen = enabled && open && shouldMountPanel;
   const panelLayout = isMobile
     ? "mobile"
     : wideDrawerEnabled
@@ -4035,6 +4043,7 @@ export function AgentSidebar({
           {isMobile &&
             !isPerAppChatHosted &&
             !presentationMode &&
+            enabled &&
             (mobileAnimationEnabled ? shouldRenderPanel : open) && (
               <div
                 className={cn(

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -652,6 +652,12 @@ describe("AppWebview auth state", () => {
 
   it("falls back only when the app does not expose the session endpoint", () => {
     expect(
+      resolveAppWebviewAuthStateFromProbe(undefined, "authenticated"),
+    ).toBe("unknown");
+    expect(
+      resolveAppWebviewAuthStateFromProbe("not-an-object", "authenticated"),
+    ).toBe("unknown");
+    expect(
       resolveAppWebviewAuthStateFromProbe({ status: 404 }, "authenticated"),
     ).toBe("authenticated");
     expect(

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -183,7 +183,9 @@ export function resolveAppWebviewAuthStateFromProbe(
   result: unknown,
   fallbackState: AppWebviewAuthState,
 ): AppWebviewAuthState {
-  if (!result || typeof result !== "object") return fallbackState;
+  // A missing probe result is a failed read, not evidence that the route is
+  // authenticated. The fallback is reserved for a known-unsupported 404.
+  if (!result || typeof result !== "object") return "unknown";
   const probe = result as {
     authenticated?: unknown;
     invalidJson?: unknown;
@@ -389,6 +391,11 @@ interface AppWebviewProps {
   onTitleChange?: (title: string) => void;
   /** Emits the guest page's coarse session state for host-owned UI. */
   onAuthStateChange?: (state: AppWebviewAuthState) => void;
+  /** Emits terminal main-frame failures so host-owned overlays can recover. */
+  onMainFrameLoadFailure?: (details: {
+    errorCode?: number;
+    errorDescription: string;
+  }) => void;
   /** Emits the native desktop identity state for sibling host surfaces. */
   onDesktopIdentityStatusChange?: (
     status: DesktopIdentityStatus | "checking",
@@ -624,6 +631,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       refreshKey = 0,
       onTitleChange,
       onAuthStateChange,
+      onMainFrameLoadFailure,
       onDesktopIdentityStatusChange,
       onWebContentsIdChange,
       onAppsChanged,
@@ -699,6 +707,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     const prevIsActiveRef = useRef(isActive);
     const onTitleChangeRef = useRef(onTitleChange);
     const onAuthStateChangeRef = useRef(onAuthStateChange);
+    const onMainFrameLoadFailureRef = useRef(onMainFrameLoadFailure);
     const onDesktopIdentityStatusChangeRef = useRef(
       onDesktopIdentityStatusChange,
     );
@@ -783,6 +792,10 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     useEffect(() => {
       onAuthStateChangeRef.current = onAuthStateChange;
     }, [onAuthStateChange]);
+
+    useEffect(() => {
+      onMainFrameLoadFailureRef.current = onMainFrameLoadFailure;
+    }, [onMainFrameLoadFailure]);
 
     useEffect(() => {
       onDesktopIdentityStatusChangeRef.current = onDesktopIdentityStatusChange;
@@ -1201,8 +1214,13 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           return;
         }
         loadFailureRef.current = true;
+        authProbeSequenceRef.current += 1;
         setError(true);
         setIsLoading(false);
+        onMainFrameLoadFailureRef.current?.({
+          errorCode,
+          errorDescription: description,
+        });
       };
       const onConsoleMessage = (e: Event) => {
         const message = String((e as WebviewConsoleMessageEvent).message || "");
@@ -1415,8 +1433,12 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         () => {
           if (isLoading) {
             loadFailureRef.current = true;
+            authProbeSequenceRef.current += 1;
             setError(true);
             setIsLoading(false);
+            onMainFrameLoadFailureRef.current?.({
+              errorDescription: "Timed out while loading the app.",
+            });
           }
         },
         isDevMode ? DEV_APP_LOAD_TIMEOUT_MS : APP_LOAD_TIMEOUT_MS,

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2680,6 +2680,14 @@ export default function CodeAgentsHub({
                       onAuthStateChange={(state) =>
                         handleAppAuthStateChange(tab.id, state)
                       }
+                      onMainFrameLoadFailure={() => {
+                        if (
+                          !nativeOAuthActive &&
+                          isNativeDesktopIntegrationsPath(tab.path)
+                        ) {
+                          handleAppAuthStateChange(tab.id, "unauthenticated");
+                        }
+                      }}
                       onDesktopIdentityStatusChange={(status) =>
                         handleDesktopIdentityStatusChange(tab.id, status)
                       }

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.relay.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.relay.spec.tsx
@@ -42,6 +42,13 @@ function RelayProbe({ appId }: { appId: string }) {
   return null;
 }
 
+function MountProbe({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+  return null;
+}
+
 describe("desktop app chat shell relay attribution", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -69,6 +76,8 @@ describe("desktop app chat shell relay attribution", () => {
   async function mountShells(
     appIds: readonly string[],
     activeAppId: string | null = appIds[0] ?? null,
+    appAuthState: "authenticated" | "unauthenticated" = "unauthenticated",
+    childrenForApp?: (appId: string) => React.ReactNode,
   ) {
     await act(async () => {
       root.render(
@@ -79,8 +88,9 @@ describe("desktop app chat shell relay attribution", () => {
               appId={appId}
               appName={appId}
               isActive={activeAppId === appId}
+              appAuthState={appAuthState}
             >
-              <RelayProbe appId={appId} />
+              {childrenForApp?.(appId) ?? <RelayProbe appId={appId} />}
             </DesktopAppChatShell>
           ))}
         </>,
@@ -133,5 +143,21 @@ describe("desktop app chat shell relay attribution", () => {
     expect(requested).toEqual([
       "http://127.0.0.1:43101/desktop-chat/mail-secret/mail/_agent-native/poll",
     ]);
+  });
+
+  it("keeps the app surface mounted while the chat relay becomes available", async () => {
+    let mounts = 0;
+    const onMount = () => mounts++;
+
+    await mountShells(["mail"], "mail", "authenticated", () => (
+      <MountProbe onMount={onMount} />
+    ));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mounts).toBe(1);
   });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -46,6 +46,10 @@ describe("desktop app chat shell", () => {
     expect(source).toContain("storageKey={`desktop-app-chat:${appId}`}");
     expect(source).toContain('position="left"');
     expect(source).toContain('agentChatSurface="desktop"');
+    expect(source).toContain("enabled={showChatSidebar}");
+    expect(source).not.toContain(
+      "{showChatSidebar ? (\n          <MemoryRouter>",
+    );
     expect(source).not.toContain("Sign in on the right");
     expect(source).not.toContain("data-desktop-app-sign-in");
   });

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -508,53 +508,50 @@ export default function DesktopAppChatShell({
         ref={shellRootRef}
         className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
       >
-        {showChatSidebar ? (
-          <MemoryRouter>
-            <QueryClientProvider client={desktopChatQueryClient}>
-              <AgentSidebar
-                position="left"
-                defaultOpen
-                animateDesktop={animateDesktopChatSidebar}
-                openStorageKey="desktop-app-chat"
-                storageKey={`desktop-app-chat:${appId}`}
-                scope={{
-                  type: "desktop-app",
-                  id: appId,
-                  label: appName,
-                  contextKey: `desktop-app:${appId}`,
-                }}
-                apiUrl={apiUrl ?? undefined}
-                isolateHistoryByScope
-                agentChatSurface="desktop"
-                desktopIdentityUnauthenticated={desktopIdentityUnauthenticated}
-                desktopIdentityAuthenticated={desktopIdentityAuthenticated}
-                onConnectProvider={() => {
-                  void window.electronAPI?.codeAgents?.connectBuilderProvider?.();
-                }}
-                showTabBar
-                suppressInlineOpenApp
-                dynamicSuggestions={false}
-                suggestions={[]}
-                emptyStateText={`Ask about ${appName}`}
-                availableAgents={availableAgents}
-                selectedAgent={selectedAgent}
-                onAgentChange={handleAgentChange}
-                onConnectLocalRuntime={handleLocalRuntimeSetup}
-                availableModels={
-                  localAgentModelsLoading || localAgentModels.length > 0
-                    ? availableModels
-                    : undefined
-                }
-                modelListLoading={localAgentModelsLoading}
-                runtime={localRuntime}
-              >
-                {appSurface}
-              </AgentSidebar>
-            </QueryClientProvider>
-          </MemoryRouter>
-        ) : (
-          appSurface
-        )}
+        <MemoryRouter>
+          <QueryClientProvider client={desktopChatQueryClient}>
+            <AgentSidebar
+              enabled={showChatSidebar}
+              position="left"
+              defaultOpen
+              animateDesktop={animateDesktopChatSidebar}
+              openStorageKey="desktop-app-chat"
+              storageKey={`desktop-app-chat:${appId}`}
+              scope={{
+                type: "desktop-app",
+                id: appId,
+                label: appName,
+                contextKey: `desktop-app:${appId}`,
+              }}
+              apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
+              isolateHistoryByScope
+              agentChatSurface="desktop"
+              desktopIdentityUnauthenticated={desktopIdentityUnauthenticated}
+              desktopIdentityAuthenticated={desktopIdentityAuthenticated}
+              onConnectProvider={() => {
+                void window.electronAPI?.codeAgents?.connectBuilderProvider?.();
+              }}
+              showTabBar
+              suppressInlineOpenApp
+              dynamicSuggestions={false}
+              suggestions={[]}
+              emptyStateText={`Ask about ${appName}`}
+              availableAgents={availableAgents}
+              selectedAgent={selectedAgent}
+              onAgentChange={handleAgentChange}
+              onConnectLocalRuntime={handleLocalRuntimeSetup}
+              availableModels={
+                localAgentModelsLoading || localAgentModels.length > 0
+                  ? availableModels
+                  : undefined
+              }
+              modelListLoading={localAgentModelsLoading}
+              runtime={localRuntime}
+            >
+              {appSurface}
+            </AgentSidebar>
+          </QueryClientProvider>
+        </MemoryRouter>
         {localCodeChangeDialog}
       </div>
     </DesktopChatRelayAppContext.Provider>


### PR DESCRIPTION
## Summary
- keep the desktop app surface mounted while chat eligibility changes
- treat failed auth probes and terminal webview loads as recoverable states
- preserve the unauthenticated login-only layout and native integrations recovery path

## Validation
- focused core and desktop Vitest suites
- desktop typecheck
- all repository guards