### PR TITLE
Add hover tooltips to desktop sidebar

### DIFF
--- a/.changeset/chat-first-app-rail-tooltip.md
+++ b/.changeset/chat-first-app-rail-tooltip.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show immediate tooltips for apps and navigation controls in the collapsed chat-first rail.

--- a/packages/core/src/client/chat-first/apps-rail.spec.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.spec.tsx
@@ -131,6 +131,71 @@ describe("ChatFirstAppsRail", () => {
     ).toBe("false");
   });
 
+  it("shows a collapsed app name immediately on hover", async () => {
+    act(() => {
+      root.render(
+        <ChatFirstAppsRail
+          apps={[{ id: "calendar", name: "Calendar" }]}
+          collapsed
+          onOpenApp={vi.fn()}
+          renderIcon={(app) => <span>{app.name}</span>}
+        />,
+      );
+    });
+
+    const appButton = container.querySelector<HTMLButtonElement>(
+      '[data-app-id="calendar"]',
+    );
+    expect(appButton).not.toBeNull();
+
+    await act(async () => {
+      appButton?.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          pointerType: "mouse",
+        }),
+      );
+      await new Promise((resolve) => window.setTimeout(resolve));
+    });
+
+    expect(
+      document.querySelector('[data-agent-native-tooltip="true"]')?.textContent,
+    ).toContain("Calendar");
+  });
+
+  it("shows the all-apps label immediately on hover", async () => {
+    act(() => {
+      root.render(
+        <ChatFirstAppsRail
+          apps={[]}
+          collapsed
+          onOpenAllApps={vi.fn()}
+          onOpenApp={vi.fn()}
+          renderIcon={() => null}
+        />,
+      );
+    });
+
+    const allApps = container.querySelector<HTMLButtonElement>(
+      "[data-chat-first-all-apps]",
+    );
+    expect(allApps).not.toBeNull();
+
+    await act(async () => {
+      allApps?.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          pointerType: "mouse",
+        }),
+      );
+      await new Promise((resolve) => window.setTimeout(resolve));
+    });
+
+    expect(
+      document.querySelector('[data-agent-native-tooltip="true"]')?.textContent,
+    ).toContain("All apps");
+  });
+
   it("hides the create-app trigger when the rail is collapsed", () => {
     act(() => {
       root.render(

--- a/packages/core/src/client/chat-first/apps-rail.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.tsx
@@ -7,6 +7,7 @@ import {
   Skeleton,
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@agent-native/toolkit/ui";
 import {
@@ -366,58 +367,67 @@ export const ChatFirstAppsRail = memo(function ChatFirstAppsRail({
 
   if (collapsed) {
     return (
-      <section
-        data-chat-first-apps-rail
-        className="flex flex-col items-center gap-1 px-1.5 pt-2"
-        aria-label={copy("workspaceApps")}
-      >
-        {loading && apps.length === 0
-          ? [0, 1, 2].map((index) => (
-              <Skeleton key={index} className="size-9 rounded-md" />
-            ))
-          : visibleApps.map((app) => (
-              <button
-                key={app.id}
-                type="button"
-                data-chat-first-app
-                data-app-id={app.id}
-                className={cn(
-                  "flex size-9 items-center justify-center rounded-md",
-                  activeAppId === app.id
-                    ? "text-sidebar-foreground"
-                    : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                )}
-                onClick={() => onOpenApp(app)}
-                aria-label={copy("openApp", { name: app.name })}
-                title={app.name}
-              >
-                <ChatFirstRailAppIcon
-                  app={app}
-                  activeAppId={activeAppId}
-                  renderIcon={renderIcon}
-                />
-              </button>
-            ))}
-        {onOpenAllApps ? (
-          <button
-            type="button"
-            data-chat-first-all-apps
-            className="flex size-9 items-center justify-center rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            onClick={onOpenAllApps}
-            aria-label={copy("allApps")}
-            title={copy("allApps")}
-          >
-            <IconApps size={16} aria-hidden="true" />
-          </button>
-        ) : null}
-        {error ? (
-          <span
-            className="size-1.5 rounded-full bg-destructive"
-            title={error}
-            aria-label={error}
-          />
-        ) : null}
-      </section>
+      <TooltipProvider>
+        <section
+          data-chat-first-apps-rail
+          className="flex flex-col items-center gap-1 px-1.5 pt-2"
+          aria-label={copy("workspaceApps")}
+        >
+          {loading && apps.length === 0
+            ? [0, 1, 2].map((index) => (
+                <Skeleton key={index} className="size-9 rounded-md" />
+              ))
+            : visibleApps.map((app) => (
+                <Tooltip key={app.id} delayDuration={0}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      data-chat-first-app
+                      data-app-id={app.id}
+                      className={cn(
+                        "flex size-9 items-center justify-center rounded-md",
+                        activeAppId === app.id
+                          ? "text-sidebar-foreground"
+                          : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                      )}
+                      onClick={() => onOpenApp(app)}
+                      aria-label={copy("openApp", { name: app.name })}
+                    >
+                      <ChatFirstRailAppIcon
+                        app={app}
+                        activeAppId={activeAppId}
+                        renderIcon={renderIcon}
+                      />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">{app.name}</TooltipContent>
+                </Tooltip>
+              ))}
+          {onOpenAllApps ? (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-chat-first-all-apps
+                  className="flex size-9 items-center justify-center rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                  onClick={onOpenAllApps}
+                  aria-label={copy("allApps")}
+                >
+                  <IconApps size={16} aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{copy("allApps")}</TooltipContent>
+            </Tooltip>
+          ) : null}
+          {error ? (
+            <span
+              className="size-1.5 rounded-full bg-destructive"
+              title={error}
+              aria-label={error}
+            />
+          ) : null}
+        </section>
+      </TooltipProvider>
     );
   }
 

--- a/packages/core/src/client/chat-first/primary-nav.spec.tsx
+++ b/packages/core/src/client/chat-first/primary-nav.spec.tsx
@@ -108,6 +108,39 @@ describe("ChatFirstPrimaryNavigation", () => {
     expect(container.querySelector(".code-agents-nav-list")).not.toBeNull();
   });
 
+  it("shows collapsed navigation labels immediately on hover", async () => {
+    act(() => {
+      root.render(
+        <ChatFirstPrimaryNavigation
+          collapsed
+          onNewChat={vi.fn()}
+          onOpenIntegrations={vi.fn()}
+          onOpenScheduled={vi.fn()}
+          onSearch={vi.fn()}
+        />,
+      );
+    });
+
+    const integrations = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Integrations"]',
+    );
+    expect(integrations).not.toBeNull();
+
+    await act(async () => {
+      integrations?.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          pointerType: "mouse",
+        }),
+      );
+      await new Promise((resolve) => window.setTimeout(resolve));
+    });
+
+    expect(
+      document.querySelector('[data-agent-native-tooltip="true"]')?.textContent,
+    ).toContain("Integrations");
+  });
+
   it("keeps collapsed New chat icon-only with an accessible tooltip", () => {
     act(() => {
       root.render(
@@ -127,7 +160,7 @@ describe("ChatFirstPrimaryNavigation", () => {
     expect(newChat).not.toBeNull();
     expect(newChat?.querySelector("span")?.className).toContain("sr-only");
     expect(newChat?.getAttribute("aria-label")).toBe("New chat");
-    expect(newChat?.getAttribute("title")).toBe("New chat");
+    expect(newChat?.getAttribute("title")).toBeNull();
   });
 
   it("keeps every collapsed primary action icon-only and accessible", () => {
@@ -148,7 +181,7 @@ describe("ChatFirstPrimaryNavigation", () => {
         `button[aria-label="${label}"]`,
       );
       expect(control).not.toBeNull();
-      expect(control?.getAttribute("title")).toBe(label);
+      expect(control?.getAttribute("title")).toBeNull();
       expect(control?.className).toContain("justify-center");
       expect(control?.className).toContain("px-0");
       expect(control?.querySelector("span")?.className).toContain("sr-only");

--- a/packages/core/src/client/chat-first/primary-nav.tsx
+++ b/packages/core/src/client/chat-first/primary-nav.tsx
@@ -1,4 +1,10 @@
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@agent-native/toolkit/ui";
+import {
   IconClock,
   IconPlus,
   IconPlugConnected,
@@ -51,19 +57,30 @@ export function ChatFirstPrimaryNavigation({
     content: ReactNode,
     onSelect: () => void,
     className?: string,
-  ) => (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={activeTab === tab}
-      aria-label={collapsed || tab === "new-chat" ? tabLabel(tab) : undefined}
-      title={collapsed ? tabLabel(tab) : undefined}
-      className={[tabClassName(tab), className].filter(Boolean).join(" ")}
-      onClick={onSelect}
-    >
-      {content}
-    </button>
-  );
+  ) => {
+    const label = tabLabel(tab);
+    const control = (
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === tab}
+        aria-label={collapsed || tab === "new-chat" ? label : undefined}
+        className={[tabClassName(tab), className].filter(Boolean).join(" ")}
+        onClick={onSelect}
+      >
+        {content}
+      </button>
+    );
+
+    return collapsed ? (
+      <Tooltip>
+        <TooltipTrigger asChild>{control}</TooltipTrigger>
+        <TooltipContent side="right">{label}</TooltipContent>
+      </Tooltip>
+    ) : (
+      control
+    );
+  };
 
   const newChatTab = onNewChat
     ? renderTab(
@@ -98,54 +115,67 @@ export function ChatFirstPrimaryNavigation({
     </>,
     onOpenScheduled,
   );
-  const searchAction = onSearch ? (
-    <button
-      type="button"
-      aria-label={collapsed ? copy("search") : undefined}
-      title={collapsed ? copy("search") : undefined}
-      className={`mt-px flex h-8 w-full items-center gap-2 rounded-md text-[13px] font-medium text-sidebar-foreground/80 transition-[background-color,color] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${collapsed ? "justify-center px-0" : "px-2"}`}
-      onClick={onSearch}
-    >
-      <IconSearch size={15} className="shrink-0" aria-hidden="true" />
-      <span className={collapsed ? "sr-only" : undefined}>
-        {copy("search")}
-      </span>
-    </button>
-  ) : null;
+  const searchAction = onSearch
+    ? (() => {
+        const label = copy("search");
+        const control = (
+          <button
+            type="button"
+            aria-label={collapsed ? label : undefined}
+            className={`mt-px flex h-8 w-full items-center gap-2 rounded-md text-[13px] font-medium text-sidebar-foreground/80 transition-[background-color,color] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${collapsed ? "justify-center px-0" : "px-2"}`}
+            onClick={onSearch}
+          >
+            <IconSearch size={15} className="shrink-0" aria-hidden="true" />
+            <span className={collapsed ? "sr-only" : undefined}>{label}</span>
+          </button>
+        );
 
-  if (stickyNewChat) {
-    return (
-      <>
-        {newChatTab ? (
-          <div className="code-agents-primary-new-chat-shell">{newChatTab}</div>
-        ) : null}
-        <div className="code-agents-nav-list" aria-label="Agent navigation">
+        return collapsed ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{control}</TooltipTrigger>
+            <TooltipContent side="right">{label}</TooltipContent>
+          </Tooltip>
+        ) : (
+          control
+        );
+      })()
+    : null;
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      {stickyNewChat ? (
+        <>
+          {newChatTab ? (
+            <div className="code-agents-primary-new-chat-shell">
+              {newChatTab}
+            </div>
+          ) : null}
+          <div className="code-agents-nav-list" aria-label="Agent navigation">
+            <div
+              role="tablist"
+              aria-label="Primary navigation"
+              className="grid gap-px"
+            >
+              {integrationsTab}
+              {scheduledTab}
+            </div>
+            {searchAction}
+          </div>
+        </>
+      ) : (
+        <div>
           <div
             role="tablist"
             aria-label="Primary navigation"
             className="grid gap-px"
           >
+            {newChatTab}
             {integrationsTab}
             {scheduledTab}
           </div>
           {searchAction}
         </div>
-      </>
-    );
-  }
-
-  return (
-    <div>
-      <div
-        role="tablist"
-        aria-label="Primary navigation"
-        className="grid gap-px"
-      >
-        {newChatTab}
-        {integrationsTab}
-        {scheduledTab}
-      </div>
-      {searchAction}
-    </div>
+      )}
+    </TooltipProvider>
   );
 }

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -275,11 +275,14 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
 
     expect(hubSource).toContain("desktop-chat-first-rail-footer-actions");
     expect(hubSource).toContain(
-      'desktop-chat-first-rail-settings"\n                    onClick',
+      'className="code-agents-nav-link desktop-chat-first-rail-settings"',
     );
+    expect(hubSource).toContain('<DesktopRailTooltip label="Settings">');
+    expect(hubSource).toContain("<TooltipProvider delayDuration={0}>");
     expect(hubSource).toContain("IconLayoutSidebarLeftCollapse");
     expect(hubSource).toContain("desktop-chat-first-rail-collapse");
     expect(hubSource).toContain("data-chat-first-rail-collapse");
+    expect(hubSource).toContain("<DesktopRailTooltip");
     expect(hubSource).toContain("setChatFirstRailCollapsed(true)");
     expect(hubSource).not.toContain(
       '{chatFirstRailCollapsed ? "Expand" : "Collapse"}',

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -59,6 +59,12 @@ import {
 } from "@agent-native/core/client/chat-first";
 import { createAgentNativeQueryClient } from "@agent-native/core/client/hooks";
 import { cn } from "@agent-native/toolkit";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@agent-native/toolkit/ui";
 import { Input } from "@agent-native/toolkit/ui/input";
 import {
   Select,
@@ -95,6 +101,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type ReactElement,
 } from "react";
 
 import type {
@@ -148,6 +155,21 @@ import {
 } from "./MultiFrontierWorkspace.js";
 import { UpdateIndicator } from "./UpdateIndicator.js";
 import UpdatePrompt from "./UpdatePrompt.js";
+
+function DesktopRailTooltip({
+  children,
+  label,
+}: {
+  children: ReactElement;
+  label: string;
+}) {
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 const agentNativeIconUrl = new URL(
   "../assets/agent-native-icon-dark.svg",
@@ -2885,56 +2907,62 @@ export default function CodeAgentsHub({
             />
           }
           railFooterSlot={
-            <>
-              <UpdatePrompt />
-              <UpdateIndicator />
-              <div className="desktop-chat-first-rail-footer-actions">
-                {onOpenSettings ? (
-                  <button
-                    type="button"
-                    className="code-agents-nav-link desktop-chat-first-rail-settings"
-                    onClick={() => onOpenSettings()}
-                    aria-label="Settings"
-                    title="Settings"
+            <TooltipProvider delayDuration={0}>
+              <>
+                <UpdatePrompt />
+                <UpdateIndicator />
+                <div className="desktop-chat-first-rail-footer-actions">
+                  {onOpenSettings ? (
+                    <DesktopRailTooltip label="Settings">
+                      <button
+                        type="button"
+                        className="code-agents-nav-link desktop-chat-first-rail-settings"
+                        onClick={() => onOpenSettings()}
+                        aria-label="Settings"
+                      >
+                        <IconSettings
+                          size={15}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
+                        <span>Settings</span>
+                      </button>
+                    </DesktopRailTooltip>
+                  ) : null}
+                  <DesktopRailTooltip
+                    label={
+                      chatFirstRailCollapsed ? "Expand rail" : "Collapse rail"
+                    }
                   >
-                    <IconSettings
-                      size={15}
-                      strokeWidth={1.8}
-                      aria-hidden="true"
-                    />
-                    <span>Settings</span>
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  className="code-agents-nav-link desktop-chat-first-rail-collapse"
-                  data-chat-first-rail-collapse
-                  onClick={() =>
-                    setChatFirstRailCollapsed((collapsed) => !collapsed)
-                  }
-                  aria-label={
-                    chatFirstRailCollapsed ? "Expand rail" : "Collapse rail"
-                  }
-                  title={
-                    chatFirstRailCollapsed ? "Expand rail" : "Collapse rail"
-                  }
-                >
-                  {chatFirstRailCollapsed ? (
-                    <IconLayoutSidebarLeftExpand
-                      size={15}
-                      strokeWidth={1.8}
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <IconLayoutSidebarLeftCollapse
-                      size={15}
-                      strokeWidth={1.8}
-                      aria-hidden="true"
-                    />
-                  )}
-                </button>
-              </div>
-            </>
+                    <button
+                      type="button"
+                      className="code-agents-nav-link desktop-chat-first-rail-collapse"
+                      data-chat-first-rail-collapse
+                      onClick={() =>
+                        setChatFirstRailCollapsed((collapsed) => !collapsed)
+                      }
+                      aria-label={
+                        chatFirstRailCollapsed ? "Expand rail" : "Collapse rail"
+                      }
+                    >
+                      {chatFirstRailCollapsed ? (
+                        <IconLayoutSidebarLeftExpand
+                          size={15}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <IconLayoutSidebarLeftCollapse
+                          size={15}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
+                      )}
+                    </button>
+                  </DesktopRailTooltip>
+                </div>
+              </>
+            </TooltipProvider>
           }
           newSessionExtension={multiFrontierExtension}
           openDetailRequest={multiFrontierOpenDetailRequest}


### PR DESCRIPTION
The collapsed desktop sidebar now shows clear labels when people hover over navigation controls, app icons, the app switcher, Settings, and the expand or collapse control. This makes the compact sidebar easier to understand without changing its existing layout or visual style.
<img width="1190" height="813" alt="image" src="https://github.com/user-attachments/assets/d908b497-7df1-4d71-8078-2ebd6c9b9177" />
