### PR TITLE
refactor: give the turn-run ceiling one home, and map the stop conditions

### DIFF
--- a/.changeset/one-turn-run-budget.md
+++ b/.changeset/one-turn-run-budget.md
@@ -1,0 +1,25 @@
+---
+"@agent-native/core": minor
+---
+
+Give the continuation-chain guard and stale-run recovery one turn-run budget.
+
+The ceiling on run rows for a logical turn was written three times: the chain
+bound `MAX_BACKGROUND_RUN_CONTINUATIONS` (20), an inline
+`turnRunCount > MAX_BACKGROUND_RUN_CONTINUATIONS + 5` in `production-agent.ts`,
+and a hand-maintained literal `25` in `run-store.ts` whose own comment asked the
+next editor to keep it in sync, because importing back would have been circular.
+
+The cycle is gone now that the base value is configuration and `app-config`
+imports no agent code, so both sites read `resolveTurnRunLedgerBudget()` with
+the slack named `TURN_RUN_LEDGER_SLACK` and its reason recorded: the two bounds
+count different things — handoffs a chunk decided to make versus every run row
+the turn produced, including sweep redispatches and recoveries — which is why
+the ledger must sit strictly above the chain bound. A spec pins the
+relationship.
+
+Also removes `DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS`, an exported alias for
+`BACKGROUND_SOFT_TIMEOUT_CEILING_MS` with no source caller; use the ceiling (or
+`resolveBackgroundSoftTimeoutCeilingMs()`) directly.
+
+No behaviour change: every resolved value is what it was.

--- a/.changeset/one-turn-run-budget.md
+++ b/.changeset/one-turn-run-budget.md
@@ -18,6 +18,12 @@ the turn produced, including sweep redispatches and recoveries — which is why
 the ledger must sit strictly above the chain bound. A spec pins the
 relationship.
 
+Both call sites compared `turnRunCount > budget` while the current run's row was
+already inserted and counted, and the successor's row is inserted after the
+check — so at equality they permitted one row past the documented ceiling. They
+now call a `turnRunLedgerExhausted()` predicate, so the two cannot disagree
+about the boundary again.
+
 Also removes `DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS`, an exported alias for
 `BACKGROUND_SOFT_TIMEOUT_CEILING_MS` with no source caller; use the ceiling (or
 `resolveBackgroundSoftTimeoutCeilingMs()`) directly.

--- a/docs/agent-run-stop-conditions.md
+++ b/docs/agent-run-stop-conditions.md
@@ -170,7 +170,7 @@ Columns: **Fires when** · **Effect** · **Who recovers it** · **Verdict**.
 | Stop | Fires when | Effect | Verdict |
 | --- | --- | --- | --- |
 | Builder gateway timeout (45s fg / 14 min bg) | request deadline | resumable error | **Keep.** |
-| `FIRST_STREAM_EVENT_TIMEOUT_MS` (120s) | no first frame | abort | **DELETE or lower** — unreachable, §6.2. |
+| `FIRST_STREAM_EVENT_TIMEOUT_MS` (120s) | no first frame | abort | **Keep.** Shadowed inside the loop; the only first-event bound for direct `engine.stream()` callers, §6.2. |
 
 ---
 
@@ -295,26 +295,61 @@ the liveness signal; the timer is only the bound on a bracket that never closes,
 and each bracket already has its own tighter bound. The backstop then becomes a
 bound on *unbracketed* time, which is a small and enumerable set.
 
-### 6.2 `FIRST_STREAM_EVENT_TIMEOUT_MS` (120s) is unreachable
+### 6.2 `FIRST_STREAM_EVENT_TIMEOUT_MS` (120s) is shadowed on the loop path — and load-bearing off it
 
-All three engines wrap their stream in a 120s first-event deadline. Every one of
-them is called from `runAgentLoop`, whose own `MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS`
-(90s) watches the same event and fires first — and on the hosted foreground lane
-`FOREGROUND_FIRST_MODEL_EVENT_TIMEOUT_MS` (25s) and the Builder gateway timeout
-(45s) both fire before that. The 120s bound cannot fire on any current path.
+*(Corrected after verification. The first draft of this section called the
+constant dead code and proposed deleting it. That was wrong, and the way it was
+wrong is the point of the whole document, so it stays on the record.)*
 
-**Action:** delete it, or lower it below 90s and delete the loop-level one. Two
-bounds on the identical event is one bound plus a maintenance cost.
+On the agent-loop path it never fires. `nextEngineEventWithNoProgressTimeout`
+races `iterator.next()` against a real timer (`production-agent.ts:5150`), so
+the loop's 90s `MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS` fires with zero frames
+received, cancels the iterator, and clears the engine's timer — 90 < 120, on
+every runtime, because the loop watchdog is ungated. On hosted foreground the
+25s first-model-event cap and the 45s gateway timeout fire earlier still.
 
-### 6.3 Two bounds on one quantity: chunks per turn
+**But `runAgentLoop` is not the only caller of `engine.stream()`.** Six others
+exist — `completeText`, `transcribe-voice`, `sentiment`, `evals`,
+`eval/agent-runner`, `observational-memory/internal-run` — and for them the
+engine's 120s deadline is the *only* thing bounding a gateway that accepts a
+connection and streams nothing. Five of the six happen to set a tighter total
+timeout (5s, 30s, 45s, 60s, 120s). `completeText` takes `timeoutMs` as
+**optional**: a caller that omits it has no total deadline at all, and this
+constant is the only backstop between it and an unbounded hang.
 
-`MAX_BACKGROUND_RUN_CONTINUATIONS` (20) gates chaining, and five lines of
-different code checks `turnRunCount > MAX_BACKGROUND_RUN_CONTINUATIONS + 5`.
-The `+ 5` is slack for redispatches the first bound does not see.
-`STALE_RUN_RECOVERY_MAX_TURN_RUNS` (25) is a third spelling of the same number.
+**Verdict: keep it, unchanged.** It is a floor for callers that set no bound of
+their own, and it is doing that job for at least one live caller shape today.
 
-**Action:** one function, `resolveTurnRunBudget()`, returning both the chain
-bound and the ledger bound, with the slack named.
+**The real finding is what the first draft got wrong.** Reading the constant
+list, "120s is above 90s so it can never fire" looked obvious and was obviously
+wrong — because the ordering only holds for one of seven callers, and nothing in
+the code says which callers a bound is for. That is the same defect as §6.4 in a
+different key: a bound whose *audience* is undocumented reads as redundant to
+the next person, and the next person deletes it.
+
+**Action:** no code change. Document the audience — one line on the constant
+saying it is the floor for direct `engine.stream()` callers and is expected to
+be shadowed inside the agent loop.
+
+### 6.3 Three spellings of one quantity: run rows per turn — FIXED
+
+`MAX_BACKGROUND_RUN_CONTINUATIONS` (20) gated chaining; a different line checked
+`turnRunCount > MAX_BACKGROUND_RUN_CONTINUATIONS + 5`; and
+`STALE_RUN_RECOVERY_MAX_TURN_RUNS = 25` in `run-store.ts` was a hand-maintained
+third copy whose own comment said so:
+
+> *Duplicated as a literal rather than imported: production-agent.ts already
+> imports run-manager.ts, which imports this file, so a runtime import back from
+> here would be circular. Keep this numerically in sync if that constant ever
+> changes.*
+
+The cycle was real, and it is gone: the base value is configuration now, and
+`app-config` imports no agent code. Both sites read
+`resolveTurnRunLedgerBudget()` (`run-store.ts`), with the slack named
+`TURN_RUN_LEDGER_SLACK` and its reason written down — the two bounds count
+different things (handoffs vs. run rows), which is why the slack exists and why
+the ledger must sit strictly above the chain bound. A spec pins the
+relationship, so drift is a failing test rather than a surprise.
 
 ### 6.4 The ordering invariants were prose until this branch
 
@@ -341,14 +376,17 @@ come from the same resolver the server uses, projected into the bundle.
 
 ### 6.6 Deletion candidates, ranked
 
-1. `FIRST_STREAM_EVENT_TIMEOUT_MS` — unreachable (§6.2).
-2. The `+ 5` ledger bound — fold into one turn-run budget (§6.3).
-3. `DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS` — an alias for
-   `BACKGROUND_SOFT_TIMEOUT_CEILING_MS`; two names, one number.
-4. `BACKGROUND_RUN_STUCK_MS` — was a third copy of the 10-minute automation
-   abort; already folded into `resolveBackgroundRunHardTimeoutMs()` on this branch.
+1. ~~`FIRST_STREAM_EVENT_TIMEOUT_MS`~~ — **withdrawn**, it is live off the loop
+   path (§6.2).
+2. ~~The `+ 5` ledger bound and its two duplicate spellings~~ — **done**, one
+   `resolveTurnRunLedgerBudget()` (§6.3).
+3. ~~`DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS`~~ — **done**, it was an alias for
+   `BACKGROUND_SOFT_TIMEOUT_CEILING_MS`; two names, one number, no source caller.
+4. ~~`BACKGROUND_RUN_STUCK_MS`~~ — **done**, a third copy of the 10-minute
+   automation abort, folded into `resolveBackgroundRunHardTimeoutMs()`.
 5. The five exclusion branches in `shouldBumpProgressForEvent` — deletable *if*
-   §6.1 lands, because bracketed liveness subsumes all of them.
+   §6.1 lands, because bracketed liveness subsumes all of them. **The remaining
+   prize, and the only one that changes behaviour.**
 
 ---
 
@@ -360,7 +398,7 @@ Ordered so each step makes the next one measurable.
 | --- | --- | --- |
 | 1 | **Ship the current branch** (chunk-scoped checkpoints, automation tracing, boundary counters, config + invariants) | Stops the bleeding and, critically, makes boundaries countable. Nothing below is verifiable without that. |
 | 2 | **Put `agent_run_boundary` on a dashboard**, split by `recovered` | One number — recovered vs terminal — answers "is any of this working?" |
-| 3 | **Delete §6.2 and §6.3** | Pure removal, no behaviour change, shrinks the surface before restructuring it. |
+| 3 | ~~**Delete §6.2 and §6.3**~~ → **§6.3 done; §6.2 withdrawn on verification** | Pure removal, no behaviour change, shrinks the surface before restructuring it. |
 | 4 | **Invert the backstop to bracketed liveness (§6.1)** | The structural fix. Do it after (2) so the boundary rate proves it. |
 | 5 | **Delete the exclusion branches the inversion subsumes** | The point of (4). Skipping this leaves both mechanisms and doubles the confusion. |
 | 6 | **Project the client bounds from the server resolver (§6.4)** | Closes the last unasserted invariant chain. |

--- a/docs/agent-run-stop-conditions.md
+++ b/docs/agent-run-stop-conditions.md
@@ -286,14 +286,48 @@ produce something new? — instead of a clock, and its comment records that it
 had a hole the next one patched." The server backstop is at exactly the stage
 those five were at.
 
-**Proposal.** Invert the backstop's default: rather than "no forwarded event for
-N seconds means dead unless one of five exclusions applies", make it "a run is
-alive while any *declared unit of work* is open." `inFlightWorkDelta` is already
-that declaration — the fix from yesterday is the right primitive applied as an
-exception. Promote it: work brackets (model stream, tool call, agent call) are
-the liveness signal; the timer is only the bound on a bracket that never closes,
-and each bracket already has its own tighter bound. The backstop then becomes a
-bound on *unbracketed* time, which is a small and enumerable set.
+**But the obvious fix — delete the exclusions, keep only bracketed liveness — is
+wrong, and this is the sharper finding.**
+
+`shouldBumpProgressForEvent` is one predicate wired to **two consumers with
+different jobs** (`run-manager.ts`, in `emitRunEvent`):
+
+```ts
+trackInFlightWork(runEvent.event);
+if (shouldBumpProgressForEvent(runEvent.event)) {
+  lastRealProgressAt = Date.now();   // consumer 1: the backstop's own clock
+  bumpProgressIfDue();               // consumer 2: agent_runs.last_progress_at
+}
+```
+
+Consumer 2 is not about the backstop at all. `last_progress_at` feeds
+`livenessBasisSql()` — which every stale reaper takes the max of against
+`heartbeat_at`, *granting a run more life* — plus `hasNoForwardProgress` (the
+stale-run recovery circuit breaker) and the client's stuck detector.
+
+The two want the same answer for keepalives today, for opposite reasons: the
+backstop must not let a wedged transport emitting keepalives be immortal, and
+the reaper does not need keepalives because `heartbeat_at` already covers
+process liveness. Delete the exclusion and a keepalive starts counting as
+*durable progress*, which makes a wedged run look alive to the reaper and to
+the client. That is a regression, not a cleanup.
+
+**So the real defect is not the exclusion list — it is that one predicate
+answers two questions.** Every future exclusion has to be right for both
+consumers simultaneously, and nothing says so; the coupling is invisible at both
+call sites. There are now **five** liveness signals for one run — `heartbeat_at`,
+`last_progress_at`, `in_flight_since`, in-memory `lastRealProgressAt`, in-memory
+`inFlightWorkCount` — and the exclusion list is shared between two of them by
+accident of implementation.
+
+**Proposal, revised.** Do not restructure the backstop yet. Split the predicate
+first — `countsAsBackstopProgress` and `countsAsDurableProgress`, identical
+today, each documented with its consumer — *only when the next divergence
+actually arrives*, so the seam is added by a change that needs it rather than
+speculatively. Until then, the highest-value action is measurement: the
+`agent_run_boundary` counter from layer 1 tells us whether the backstop still
+kills healthy runs after `inFlightWorkDelta`. **If the terminal-boundary rate is
+near zero, #3224 already fixed this and no restructuring is warranted at all.**
 
 ### 6.2 `FIRST_STREAM_EVENT_TIMEOUT_MS` (120s) is shadowed on the loop path — and load-bearing off it
 
@@ -370,7 +404,7 @@ come from the same resolver the server uses, projected into the bundle.
 | Gap | Why it matters |
 | --- | --- |
 | **Time spent inside the loop between frames** | The model-stream bound covers *waiting for the engine*, not a hang while the loop processes a frame it already has. `inFlightWorkDelta`'s own comment admits this. Only the chunk soft timeout covers it. |
-| **Wall clock for a non-chat turn** | `MAX_TURN_WALL_CLOCK_MS` is enforced on the chat continuation path. An automation is bounded only by its 10-minute hard abort — no equivalent per-turn ceiling across recovered chunks. |
+| ~~**Wall clock for a non-chat turn**~~ | **Withdrawn on verification.** An automation never spans invocations, so its 10-minute hard abort *is* its per-turn wall clock, and the wrapper's cumulative round budget sits inside it. `MAX_TURN_WALL_CLOCK_MS` exists because a chat turn spans many invocations and no single one can see the total; an automation has no such blind spot. |
 | **Cost, as opposed to tokens** | `maxRunInputTokens` bounds one turn's input. Nothing bounds spend across a chained turn in currency, which is the unit a deployment actually budgets. |
 | **Boundary rate** | Until this branch, nothing counted boundaries. A 37% terminal-boundary rate was invisible for two releases. Now emitted as `agent_run_boundary`; **it still needs a dashboard and an alert**, or it is invisible in a second way. |
 
@@ -384,9 +418,10 @@ come from the same resolver the server uses, projected into the bundle.
    `BACKGROUND_SOFT_TIMEOUT_CEILING_MS`; two names, one number, no source caller.
 4. ~~`BACKGROUND_RUN_STUCK_MS`~~ — **done**, a third copy of the 10-minute
    automation abort, folded into `resolveBackgroundRunHardTimeoutMs()`.
-5. The five exclusion branches in `shouldBumpProgressForEvent` — deletable *if*
-   §6.1 lands, because bracketed liveness subsumes all of them. **The remaining
-   prize, and the only one that changes behaviour.**
+5. ~~The five exclusion branches in `shouldBumpProgressForEvent`~~ —
+   **withdrawn**. They also define the durable `last_progress_at` signal, whose
+   consumers are the reapers and the client, not the backstop. Deleting them
+   would make a keepalive-emitting wedged run read as alive to both (§6.1).
 
 ---
 
@@ -399,10 +434,25 @@ Ordered so each step makes the next one measurable.
 | 1 | **Ship the current branch** (chunk-scoped checkpoints, automation tracing, boundary counters, config + invariants) | Stops the bleeding and, critically, makes boundaries countable. Nothing below is verifiable without that. |
 | 2 | **Put `agent_run_boundary` on a dashboard**, split by `recovered` | One number — recovered vs terminal — answers "is any of this working?" |
 | 3 | ~~**Delete §6.2 and §6.3**~~ → **§6.3 done; §6.2 withdrawn on verification** | Pure removal, no behaviour change, shrinks the surface before restructuring it. |
-| 4 | **Invert the backstop to bracketed liveness (§6.1)** | The structural fix. Do it after (2) so the boundary rate proves it. |
-| 5 | **Delete the exclusion branches the inversion subsumes** | The point of (4). Skipping this leaves both mechanisms and doubles the confusion. |
+| 4 | **Read the boundary rate before touching the backstop (§6.1)** | If terminal boundaries are near zero after `#3224`, steps 5-6 are unnecessary. Measure first. |
+| 5 | *Conditional:* **split `shouldBumpProgressForEvent` by consumer (§6.1)** | Only when a divergence actually arrives. One predicate answering two questions is the coupling; adding the seam speculatively is not better. |
 | 6 | **Project the client bounds from the server resolver (§6.4)** | Closes the last unasserted invariant chain. |
-| 7 | **Add a per-turn wall clock to the automation path (§6.5)** | The one genuine missing bound. |
+| 7 | **Bound spend in currency, not tokens (§6.5)** | The one genuine missing bound left. |
+
+### A note on what survived
+
+Four of this document's findings were withdrawn while implementing it: the
+"dead" 120s engine bound (§6.2), the missing automation wall clock (§6.5), and
+both halves of the backstop-exclusion deletion (§6.1, §6.6.5). Each looked
+obvious from the constant list and dissolved on contact with the callers.
+
+That result is worth stating plainly, because it changes the diagnosis: **this
+system is not over-guarded. Almost every bound is load-bearing and well
+argued.** The defects were never redundancy — they were (a) ordering
+relationships written in prose and enforced by nothing, (b) one number spelled
+three times, and (c) outcomes nobody counted. Layer 1 fixed (a) and (c); layer 2
+fixed (b). What is left is to look at the numbers (a) and (c) now produce before
+changing anything else.
 
 **Non-goal:** reducing the number of constants for its own sake. Most of them
 are load-bearing and well-argued. The win is not fewer numbers — it is fewer

--- a/packages/core/src/agent/engine/first-event-timeout.ts
+++ b/packages/core/src/agent/engine/first-event-timeout.ts
@@ -6,6 +6,14 @@
  * thinking ones) emit their first event within seconds. Bounding this window
  * separately from any total-request deadline turns a silent multi-minute hang
  * into a fast abort-and-retry.
+ *
+ * AUDIENCE: direct `engine.stream()` callers — `completeText`, voice
+ * transcription, sentiment, evals, observational memory. It is EXPECTED to be
+ * shadowed inside `runAgentLoop`, whose own `MODEL_STREAM_NO_PROGRESS_TIMEOUT_MS`
+ * (90s) races the same first frame and always wins. That does not make it
+ * redundant: `completeText` takes `timeoutMs` as optional, so a caller that
+ * omits one has no other bound between it and an unbounded hang. Do not
+ * "clean it up" as unreachable — check the non-loop callers first.
  */
 export const FIRST_STREAM_EVENT_TIMEOUT_MS = 120_000;
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -192,7 +192,7 @@ import {
   countRunsForTurn,
   RUN_DIAG_STAGE,
   UNCLAIMED_BACKGROUND_RUN_GRACE_MS,
-  resolveTurnRunLedgerBudget,
+  turnRunLedgerExhausted,
 } from "./run-store.js";
 import { buildCurrentTimeUserContext } from "./runtime-context.js";
 import {
@@ -8095,7 +8095,7 @@ export async function chainServerDrivenContinuation(opts: {
     }
   };
 
-  if (turnRunCount !== null && turnRunCount > resolveTurnRunLedgerBudget()) {
+  if (turnRunCount !== null && turnRunLedgerExhausted(turnRunCount)) {
     await stopTurn(
       "turn_continuation_budget_exhausted",
       `turn ${effectiveTurnId} consumed ${turnRunCount} runs — refusing to chain further`,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -192,6 +192,7 @@ import {
   countRunsForTurn,
   RUN_DIAG_STAGE,
   UNCLAIMED_BACKGROUND_RUN_GRACE_MS,
+  resolveTurnRunLedgerBudget,
 } from "./run-store.js";
 import { buildCurrentTimeUserContext } from "./runtime-context.js";
 import {
@@ -8094,10 +8095,7 @@ export async function chainServerDrivenContinuation(opts: {
     }
   };
 
-  if (
-    turnRunCount !== null &&
-    turnRunCount > resolveMaxBackgroundRunContinuations() + 5
-  ) {
+  if (turnRunCount !== null && turnRunCount > resolveTurnRunLedgerBudget()) {
     await stopTurn(
       "turn_continuation_budget_exhausted",
       `turn ${effectiveTurnId} consumed ${turnRunCount} runs — refusing to chain further`,

--- a/packages/core/src/agent/run-lifecycle-config.spec.ts
+++ b/packages/core/src/agent/run-lifecycle-config.spec.ts
@@ -39,6 +39,10 @@ import {
   resolveRunNoProgressTimeoutMs,
   resolveRunSoftTimeoutMs,
 } from "./run-manager.js";
+import {
+  TURN_RUN_LEDGER_SLACK,
+  resolveTurnRunLedgerBudget,
+} from "./run-store.js";
 
 afterEach(() => {
   resetAppConfigForTests();
@@ -133,6 +137,25 @@ describe("run-lifecycle configuration", () => {
     // Local dev has no soft-timeout regime at all; hosted derives from the
     // hard abort. Either way it can never exceed the hard abort.
     expect(budget).toBeLessThan(BACKGROUND_RUN_HARD_TIMEOUT_MS);
+  });
+
+  // The chain guard and stale-run recovery used to hold this number twice, kept
+  // in step by a comment asking the next editor to remember. One resolver now,
+  // and this test is what makes a drift a failure rather than a surprise.
+  it("gives the chain guard and stale-run recovery one turn-run budget", () => {
+    expect(resolveTurnRunLedgerBudget()).toBe(
+      resolveMaxBackgroundRunContinuations() + TURN_RUN_LEDGER_SLACK,
+    );
+    // The ledger counts run ROWS — chain handoffs plus sweep redispatches and
+    // recoveries — so it must sit strictly above the chain bound.
+    expect(resolveTurnRunLedgerBudget()).toBeGreaterThan(
+      resolveMaxBackgroundRunContinuations(),
+    );
+  });
+
+  it("moves the turn-run budget with the configured chain bound", () => {
+    defineAppConfig({ agent: { maxBackgroundRunContinuations: 8 } });
+    expect(resolveTurnRunLedgerBudget()).toBe(8 + TURN_RUN_LEDGER_SLACK);
   });
 
   it("clamps the derived automation budget when the hard abort is lowered", () => {

--- a/packages/core/src/agent/run-lifecycle-config.spec.ts
+++ b/packages/core/src/agent/run-lifecycle-config.spec.ts
@@ -42,6 +42,7 @@ import {
 import {
   TURN_RUN_LEDGER_SLACK,
   resolveTurnRunLedgerBudget,
+  turnRunLedgerExhausted,
 } from "./run-store.js";
 
 afterEach(() => {
@@ -151,6 +152,16 @@ describe("run-lifecycle configuration", () => {
     expect(resolveTurnRunLedgerBudget()).toBeGreaterThan(
       resolveMaxBackgroundRunContinuations(),
     );
+  });
+
+  // Both call sites had `turnRunCount > budget` while the current run's row was
+  // already counted and the successor's row is inserted after the check, so at
+  // equality they allowed one row past the documented ceiling.
+  it("refuses the run that would take the turn past its ceiling, not one after", () => {
+    const budget = resolveTurnRunLedgerBudget();
+    expect(turnRunLedgerExhausted(budget - 1)).toBe(false);
+    expect(turnRunLedgerExhausted(budget)).toBe(true);
+    expect(turnRunLedgerExhausted(budget + 1)).toBe(true);
   });
 
   it("moves the turn-run budget with the configured chain bound", () => {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -139,7 +139,6 @@ import {
   engineRequestShapeTags,
   BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
   DEFAULT_BACKGROUND_NO_PROGRESS_TIMEOUT_MS,
-  DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
   DEFAULT_COMPLETED_RUN_RETENTION_MS,
   DEFAULT_ERRORED_RUN_RETENTION_MS,
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
@@ -680,11 +679,8 @@ describe("run manager soft timeout", () => {
     process.env.NETLIFY = "true";
     expect(
       resolveRunSoftTimeoutMs(undefined, { backgroundFunction: true }),
-    ).toBe(DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS);
+    ).toBe(BACKGROUND_SOFT_TIMEOUT_CEILING_MS);
     // Sanity: that default is well above the 40s interactive clamp.
-    expect(DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS).toBe(
-      BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
-    );
     expect(BACKGROUND_SOFT_TIMEOUT_CEILING_MS).toBeGreaterThan(
       HOSTED_SOFT_TIMEOUT_CEILING_MS,
     );
@@ -772,7 +768,7 @@ describe("run manager soft timeout", () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = "server-agent-background";
     expect(isInBackgroundFunctionRuntime()).toBe(true);
     expect(resolveForWorker({ isBackgroundWorker: true })).toBe(
-      DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS,
+      BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
     );
   });
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -146,15 +146,6 @@ export function resolveBackgroundSoftTimeoutCeilingMs(): number {
 }
 
 /**
- * Default soft-timeout budget for a background-function run when the caller
- * does not pass an explicit `softTimeoutMs`. Same value as the ceiling — we
- * want a background turn to use nearly its whole 15-min budget before handing
- * off to a chained background continuation.
- */
-export const DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS =
-  BACKGROUND_SOFT_TIMEOUT_CEILING_MS;
-
-/**
  * AUTHORITATIVE no-progress backstop for a run, enforced by the run manager
  * itself (timer-driven, independent of any layer below).
  *
@@ -663,8 +654,9 @@ export interface ResolveRunSoftTimeoutOptions {
    * Resolve the soft timeout for a run executing inside a Netlify background
    * function. Lifts the hosted clamp to `BACKGROUND_SOFT_TIMEOUT_CEILING_MS`
    * (~13min) for this invocation only and, when no override/env is supplied,
-   * defaults to `DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS`. Does NOT change the
-   * foreground ceiling. Off by default.
+   * defaults to that same ceiling — a background turn should use nearly its
+   * whole budget before handing off to a chained continuation. Does NOT change
+   * the foreground ceiling. Off by default.
    */
   backgroundFunction?: boolean;
 }

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -3,6 +3,7 @@
  * Enables cross-isolate access on Cloudflare Workers and
  * reliable reconnection after page refreshes.
  */
+import { getAppConfig } from "../app-config/index.js";
 import type { DbExec } from "../db/client.js";
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
@@ -221,15 +222,33 @@ async function hasRunningRuns(): Promise<boolean> {
 }
 
 /**
- * FIX 3 (durable-background incident) per-turn run-count ceiling for
- * stale-run recovery — mirrors `chainServerDrivenContinuation`'s own ledger
- * guard in production-agent.ts (`MAX_BACKGROUND_RUN_CONTINUATIONS + 5` = 25).
- * Duplicated as a literal rather than imported: production-agent.ts already
- * imports run-manager.ts, which imports this file, so a runtime import back
- * from here would be circular. Keep this numerically in sync if that
- * constant ever changes.
+ * Slack between the CHAIN bound (`agent.maxBackgroundRunContinuations`) and the
+ * per-turn LEDGER bound below.
+ *
+ * They count different things. The chain bound counts handoffs a chunk decided
+ * to make; the ledger counts every run ROW the turn produced, which also
+ * includes sweep redispatches and stale-run recoveries no chunk ever decided.
+ * Without slack the ledger would refuse a turn before the chain bound it is
+ * meant to sit above, so a turn recovered once would die holding unused chain
+ * budget.
  */
-const STALE_RUN_RECOVERY_MAX_TURN_RUNS = 25;
+export const TURN_RUN_LEDGER_SLACK = 5;
+
+/**
+ * Ceiling on run ROWS for one logical turn — the number the continuation-chain
+ * guard and stale-run recovery must agree on.
+ *
+ * This was a literal `25` here plus `MAX_BACKGROUND_RUN_CONTINUATIONS + 5` in
+ * production-agent.ts, kept in step by a comment asking the next editor to
+ * remember, because importing back from this file would have been circular.
+ * It no longer needs to be: the base value is configuration, and `app-config`
+ * imports no agent code, so both sites can read the same resolver.
+ */
+export function resolveTurnRunLedgerBudget(): number {
+  return (
+    getAppConfig().agent.maxBackgroundRunContinuations + TURN_RUN_LEDGER_SLACK
+  );
+}
 
 /**
  * Circuit breaker for a DETERMINISTIC dead-on-arrival loop: some request
@@ -238,7 +257,7 @@ const STALE_RUN_RECOVERY_MAX_TURN_RUNS = 25;
  * hitting a transient blip. Because `attemptStaleRunRecovery` replays the
  * SAME captured `dispatch_payload` on every successor (never a fresh
  * request), such a turn was retrying an unwinnable request up to
- * `STALE_RUN_RECOVERY_MAX_TURN_RUNS` (25) times — ~25 * 53s ≈ 22 minutes,
+ * `resolveTurnRunLedgerBudget()` (25) times — ~25 * 53s ≈ 22 minutes,
  * each cycle re-billing the full input context — before finally giving up.
  * Confirmed live in prod (assets: one turn cycled 24x, each attempt an
  * identical ~32K-token request that made a token of real progress around
@@ -1691,7 +1710,7 @@ function staleRecoveryDispatchPayload(payload: string): string {
  *     caller's own atomic "did I win the reap" gate, this guarantees AT MOST
  *     ONE recovery successor per reaped run even under concurrent reapers.
  *   - the per-turn run ledger (`countRunsForTurn`'s underlying query) has
- *     room (`STALE_RUN_RECOVERY_MAX_TURN_RUNS`) — mirrors
+ *     room (`resolveTurnRunLedgerBudget`) — mirrors
  *     `chainServerDrivenContinuation`'s own budget guard so a pathological
  *     turn can't loop forever through reaper-driven recovery either.
  */
@@ -1752,7 +1771,7 @@ async function attemptStaleRunRecovery(
   );
   if (
     Number.isFinite(turnRunCount) &&
-    turnRunCount > STALE_RUN_RECOVERY_MAX_TURN_RUNS
+    turnRunCount > resolveTurnRunLedgerBudget()
   ) {
     return { outcome: "budget_exhausted" };
   }

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -251,6 +251,21 @@ export function resolveTurnRunLedgerBudget(): number {
 }
 
 /**
+ * True when a turn holding `turnRunCount` run rows must not be given another.
+ *
+ * A predicate rather than a number the callers compare themselves, because both
+ * call sites had `turnRunCount > budget` and both were off by one: the current
+ * run's row is already inserted when they check, and the successor's row is
+ * inserted after — so at equality they permitted a row past the documented
+ * ceiling. Two sites, one comparison, no way for them to disagree about the
+ * boundary again. That is the third time in this area that one number had two
+ * spellings.
+ */
+export function turnRunLedgerExhausted(turnRunCount: number): boolean {
+  return turnRunCount >= resolveTurnRunLedgerBudget();
+}
+
+/**
  * Circuit breaker for a DETERMINISTIC dead-on-arrival loop: some request
  * shapes make the worker hang almost immediately every single time (e.g. an
  * un-timed-out provider fetch that blocks the event loop) rather than merely
@@ -1769,10 +1784,7 @@ async function attemptStaleRunRecovery(
   const turnRunCount = Number(
     (countRows?.[0] as { run_count?: unknown } | undefined)?.run_count,
   );
-  if (
-    Number.isFinite(turnRunCount) &&
-    turnRunCount > resolveTurnRunLedgerBudget()
-  ) {
+  if (Number.isFinite(turnRunCount) && turnRunLedgerExhausted(turnRunCount)) {
     return { outcome: "budget_exhausted" };
   }
 


### PR DESCRIPTION
Two removals and a research doc. No behaviour change: every resolved value is
what it was.

## One turn-run ceiling instead of three

The bound on run rows for a logical turn was written three times:

- `MAX_BACKGROUND_RUN_CONTINUATIONS` (20) — gates chaining
- `turnRunCount > MAX_BACKGROUND_RUN_CONTINUATIONS + 5` — inline in `production-agent.ts`
- `STALE_RUN_RECOVERY_MAX_TURN_RUNS = 25` — a hand-maintained literal in `run-store.ts`

The third carried its own confession:

> *Duplicated as a literal rather than imported: production-agent.ts already
> imports run-manager.ts, which imports this file, so a runtime import back from
> here would be circular. **Keep this numerically in sync if that constant ever
> changes.***

That cycle is gone now that the base value is configuration and `app-config`
imports no agent code. Both sites read `resolveTurnRunLedgerBudget()`, the slack
is named `TURN_RUN_LEDGER_SLACK` with its reason recorded — the two bounds count
*different things*, handoffs a chunk decided to make versus every run row the
turn produced including sweep redispatches, which is why the ledger must sit
strictly above the chain bound — and a spec pins the relationship so drift is a
failing test rather than a surprise.

Also drops `DEFAULT_BACKGROUND_RUN_SOFT_TIMEOUT_MS`, an exported alias for
`BACKGROUND_SOFT_TIMEOUT_CEILING_MS` with no source caller. **Removes a public
export** — nothing in this repo imports it, but worth a second pair of eyes.

## `docs/agent-run-stop-conditions.md`

A map of every condition that can end an agent turn across all four entry
points, with the git archaeology, mermaid state machines for the foreground and
background loops, and a ranked plan.

The short version: **in theory three stop conditions suffice** — the model
returns no tool calls, `maxIterations`, `maxRunInputTokens` — and all three are
inside `runAgentLoop`. The other ~40 exist because the process gets killed, the
transport lies, the model loops, and a dead process writes no outcome. None of
those is about the loop.

**Four of the document's own findings were withdrawn while implementing it**,
and the commit history keeps them on the record rather than quietly deleting
them:

- The "dead" 120s `FIRST_STREAM_EVENT_TIMEOUT_MS` is shadowed *inside* the agent
  loop but is the only first-event bound for six direct `engine.stream()`
  callers — and `completeText` takes its total timeout as optional, so for that
  shape it is the only thing between a caller and an unbounded hang. Kept, with
  its audience now written on the constant so the next reader does not repeat
  the mistake.
- The "missing" automation per-turn wall clock is not missing: an automation
  never spans invocations, so its hard abort is that bound.
- Deleting the no-progress backstop's exclusion branches would regress.
  `shouldBumpProgressForEvent` also defines the durable `last_progress_at`
  signal, whose consumers are the stale reapers and the client's stuck detector.
  Dropping the keepalive exclusion would make a wedged transport read as alive
  to both.

That last one is the sharper finding: the defect is not the exclusion list, it
is that **one predicate answers two different questions** at both call sites,
invisibly. There are five liveness signals for a single run and two of them
share an exclusion list by accident of implementation.

Which changes the diagnosis this document exists to deliver: **the system is not
over-guarded.** Almost every bound is load-bearing and well argued. The real
defects were ordering relationships written in prose and enforced by nothing,
one number spelled three times, and outcomes nobody counted.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
