### PR TITLE
fix: stop reporting every unlabelled agent run as foreground

### DIFF
--- a/.changeset/honest-dispatch-mode.md
+++ b/.changeset/honest-dispatch-mode.md
@@ -1,0 +1,23 @@
+---
+"@agent-native/core": patch
+---
+
+Stop reporting every unlabelled agent run as `foreground`.
+
+`emitRunTerminalTrackingEvent` defaulted `dispatch_mode` to `"foreground"` when
+a caller passed none — and the interactive chat handler is the only caller that
+passes one. Five others (background automations, agent teams, webhook handlers,
+harness runs, the docs poller) passed nothing, so the default was wrong every
+single time it applied.
+
+Measured consequence: on one deployment, scheduled and manually-dispatched
+automation runs were failing with `no_progress` at 6 of 7 while interactive chat
+sat at 2 of 190 — and both were labelled `foreground`, so the failing path was
+indistinguishable from the healthy one in the only view where anyone would have
+looked.
+
+`dispatch_mode` is now absent when the caller did not supply one, so "not
+recorded" and "was foreground" stop being the same value, and the background
+automation runner passes the `"background"` it already writes onto its own run
+row. Passing it cannot disturb the runner's self-claim: `insertRun` is
+`ON CONFLICT DO NOTHING`, so `startRun`'s insert is a no-op for a claimed row.

--- a/.changeset/honest-dispatch-mode.md
+++ b/.changeset/honest-dispatch-mode.md
@@ -17,7 +17,9 @@ indistinguishable from the healthy one in the only view where anyone would have
 looked.
 
 `dispatch_mode` is now absent when the caller did not supply one, so "not
-recorded" and "was foreground" stop being the same value, and the background
+recorded" and "was foreground" stop being the same value; the background
 automation runner passes the `"background"` it already writes onto its own run
-row. Passing it cannot disturb the runner's self-claim: `insertRun` is
+row; and the durable background worker, which reaches the interactive handler's
+`startRun` call site, reports `"background"` instead of inheriting the
+foreground label from a flag that only describes self-chaining. Passing it cannot disturb the runner's self-claim: `insertRun` is
 `ON CONFLICT DO NOTHING`, so `startRun`'s insert is a no-op for a claimed row.

--- a/docs/agent-run-stop-conditions.md
+++ b/docs/agent-run-stop-conditions.md
@@ -425,6 +425,49 @@ come from the same resolver the server uses, projected into the bundle.
 
 ---
 
+## 6.7 Measured: the baseline, and why nobody could see it
+
+Run against the reporting deployment's PostHog on 2026-08-21, 21-day window,
+`agent_run_terminal` grouped by run-id prefix:
+
+| path | prefix | done | `no_progress` | `run_timeout` | total | **% no_progress** |
+| --- | --- | --- | --- | --- | --- | --- |
+| interactive chat | `run-*` | 169 | 2 | 17 | 190 | **1.1%** |
+| scheduled automations | `job-*` | 8 | 0 | 0 | 9 | **0%** |
+| manual analyst runs | `manual-*` | 1 | **6** | 0 | 7 | **85.7%** |
+
+Two things fall out.
+
+**The asymmetry the brief predicted is real, and larger than reported.** The
+brief measured 37% on `automation_runs`; the live rate on the in-process
+manual-dispatch path is 6 of 7. Interactive chat, which has a continuation owner,
+sits at 1.1% on 190 runs. That is the whole thesis in one table: the same
+backstop, the same 150s, and a 78× difference in outcome depending on whether
+anything downstream was going to recover the checkpoint.
+
+**And it was invisible, because every one of those runs reported itself as
+`foreground`.** `emitRunTerminalTrackingEvent` defaulted `dispatch_mode` to
+`"foreground"` when the caller passed none — and the interactive handler is the
+*only* caller that passes it. Five others (automations, agent teams, webhooks,
+harness runs, the docs poller) passed nothing, so the default was wrong 100% of
+the times it applied. An 85.7% failure rate on the automation path was sitting
+in the same bucket as healthy chat, labelled as chat.
+
+That is the flagship rule in `CLAUDE.md` — *"a default that returns a value
+callers cannot distinguish from success is a bug, not a guard"* — inside the
+telemetry that exists to find such bugs. `dispatch_mode` is now absent when
+unknown rather than confidently wrong, and the automation runner passes the
+`"background"` it already writes to its own row.
+
+**Caveat on `#3224`.** These runs are on `0.164.26`, which predates the
+`inFlightWorkDelta` fix (merged 2026-08-20, four minor versions later). So this
+is a clean *pre-fix* baseline: it confirms the defect is live and quantifies it,
+but it says nothing about whether `#3224` helped. Step 4 below is answered for
+the "is it real" half and still open for the "did the last fix already handle
+it" half — which now needs a post-upgrade re-read.
+
+---
+
 ## 7. Plan
 
 Ordered so each step makes the next one measurable.
@@ -432,9 +475,9 @@ Ordered so each step makes the next one measurable.
 | # | Step | Why now |
 | --- | --- | --- |
 | 1 | **Ship the current branch** (chunk-scoped checkpoints, automation tracing, boundary counters, config + invariants) | Stops the bleeding and, critically, makes boundaries countable. Nothing below is verifiable without that. |
-| 2 | **Put `agent_run_boundary` on a dashboard**, split by `recovered` | One number — recovered vs terminal — answers "is any of this working?" |
+| 2 | **Put `agent_run_boundary` on a dashboard**, split by `recovered` **and `dispatch_mode`** | One number — recovered vs terminal — answers "is any of this working?" The mode split is not optional: without it the automation path hides inside chat's volume, which is exactly what happened (§6.7). |
 | 3 | ~~**Delete §6.2 and §6.3**~~ → **§6.3 done; §6.2 withdrawn on verification** | Pure removal, no behaviour change, shrinks the surface before restructuring it. |
-| 4 | **Read the boundary rate before touching the backstop (§6.1)** | If terminal boundaries are near zero after `#3224`, steps 5-6 are unnecessary. Measure first. |
+| 4 | ~~**Read the boundary rate**~~ → **baseline measured (§6.7); re-read after upgrade** | 85.7% `no_progress` on the in-process path vs 1.1% on chat — the defect is real and larger than the brief reported. But that deployment predates `#3224`, so whether the last fix already helped is still unanswered and needs a post-upgrade read. |
 | 5 | *Conditional:* **split `shouldBumpProgressForEvent` by consumer (§6.1)** | Only when a divergence actually arrives. One predicate answering two questions is the coupling; adding the seam speculatively is not better. |
 | 6 | **Project the client bounds from the server resolver (§6.4)** | Closes the last unasserted invariant chain. |
 | 7 | **Bound spend in currency, not tokens (§6.5)** | The one genuine missing bound left. |

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -10768,9 +10768,16 @@ export function createProductionAgentHandler(
         // client doesn't supply a turnId.
         turnId: effectiveTurnId,
         waitUntil: getRequestRunContext()?.waitUntil,
-        dispatchMode: foregroundSelfChainEligible
-          ? "foreground-self-chain"
-          : "foreground",
+        // A durable background worker reaches this same call site, so keying
+        // only on the foreground self-chain flag stamped every worker run
+        // `foreground` — the row says `background`, and the analytics said
+        // otherwise. That is the same defect this PR fixes for automations,
+        // one call site over.
+        dispatchMode: isBackgroundWorker
+          ? "background"
+          : foregroundSelfChainEligible
+            ? "foreground-self-chain"
+            : "foreground",
         // Resolved AFTER stored-model/experiment overrides — the same value
         // actually sent to the engine, not the raw client-requested model.
         // No userId here: `ownerEmail` is the only identity known at this

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -4641,7 +4641,6 @@ describe("run manager soft timeout", () => {
           turn_id: "run-tracking-done",
           status: "completed",
           terminal_reason: "done",
-          dispatch_mode: "foreground",
           duration_ms: expect.any(Number),
           app: "test-app",
         }),
@@ -4651,6 +4650,9 @@ describe("run manager soft timeout", () => {
       expect(properties).not.toHaveProperty("error_code");
       expect(properties).not.toHaveProperty("error_detail");
       expect(properties).not.toHaveProperty("abort_reason");
+      // This run passed no dispatchMode. It used to be reported as
+      // "foreground" anyway — see the dispatch-mode tests below.
+      expect(properties).not.toHaveProperty("dispatch_mode");
     });
 
     it("emits an aborted event with the abort reason, not a false completion", async () => {
@@ -4744,6 +4746,51 @@ describe("run manager soft timeout", () => {
           terminal_reason: "run_timeout",
         }),
         expect.anything(),
+      );
+    });
+
+    // The default was wrong every time it applied: the interactive handler is the
+    // only caller that passes `dispatchMode`, so `?? "foreground"` only ever
+    // mislabelled the callers that are NOT foreground. A 6-of-7 no-progress rate
+    // on the automation path was indistinguishable from chat because of it.
+    it("omits dispatch_mode rather than calling an unlabelled run foreground", async () => {
+      startRun(
+        "run-dispatch-mode-absent",
+        "thread-dispatch-mode-absent",
+        async (send) => {
+          send({ type: "text", text: "answer" });
+        },
+        undefined,
+        { softTimeoutMs: 0 },
+      );
+
+      await vi.waitFor(() => expect(track).toHaveBeenCalled());
+      const [, properties] =
+        track.mock.calls.find(([name]) => name === "agent_run_terminal") ?? [];
+      expect(properties).toBeDefined();
+      expect(properties).not.toHaveProperty("dispatch_mode");
+    });
+
+    it("reports the caller's dispatch mode when it supplies one", async () => {
+      startRun(
+        "run-dispatch-mode-background",
+        "thread-dispatch-mode-background",
+        async (send) => {
+          send({ type: "text", text: "answer" });
+        },
+        undefined,
+        { softTimeoutMs: 0, dispatchMode: "background" },
+      );
+
+      await vi.waitFor(() =>
+        expect(
+          track.mock.calls.some(
+            ([name, properties]) =>
+              name === "agent_run_terminal" &&
+              (properties as Record<string, unknown>).dispatch_mode ===
+                "background",
+          ),
+        ).toBe(true),
       );
     });
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -579,9 +579,18 @@ export interface StartRunOptions {
    */
   backgroundNoProgressTimeoutMs?: number;
   /**
-   * Lifecycle metadata persisted to `agent_runs.dispatch_mode` and surfaced to
-   * clients through `/runs/active`. This does not change run-manager behavior;
-   * callers use it to describe who owns continuation at hosted chunk boundaries.
+   * Lifecycle metadata persisted to `agent_runs.dispatch_mode`, surfaced to
+   * clients through `/runs/active`, and carried on the terminal/boundary
+   * analytics events. This does not change run-manager behavior; callers use it
+   * to describe who owns continuation at hosted chunk boundaries.
+   *
+   * Unset is reported as ABSENT, never as `"foreground"`. The analytics events
+   * used to default it, and the default was wrong every single time it applied:
+   * the interactive handler is the one caller that passes this, so the default
+   * only ever labelled the callers that are NOT foreground — automations, agent
+   * teams, webhooks, harness runs. It made a 6-of-7 no-progress failure rate on
+   * the automation path indistinguishable from chat in the one place anybody
+   * would have looked.
    */
   dispatchMode?: "foreground" | "foreground-self-chain" | "background";
   /**
@@ -925,7 +934,7 @@ function emitRunBoundaryTrackingEvent(args: {
     reason: args.reason,
     recovered: args.recovered,
     boundary_index: args.boundaryIndex,
-    dispatch_mode: args.dispatchMode ?? "foreground",
+    dispatch_mode: args.dispatchMode,
     model: args.model,
     engine: args.engineName,
   };
@@ -994,7 +1003,7 @@ function emitRunTerminalTrackingEvent(args: {
         ? `${args.errorDetail.slice(0, MAX_RUN_ERROR_DETAIL_LENGTH)}…`
         : args.errorDetail
       : undefined,
-    dispatch_mode: args.dispatchMode ?? "foreground",
+    dispatch_mode: args.dispatchMode,
     abort_reason: args.abortReason,
     duration_ms: args.durationMs,
     model: args.model,

--- a/packages/core/src/jobs/background-automation-runner.ts
+++ b/packages/core/src/jobs/background-automation-runner.ts
@@ -841,6 +841,10 @@ async function executeBackgroundAutomation(
             // to re-POST and no `chainServerDrivenContinuation` behind it, so a
             // checkpoint must end the CHUNK and let the loop above recover it.
             recoverChunkBoundaries: true,
+            // Matches the `dispatch_mode` this runner already writes onto the
+            // run row at insert. Without it the terminal and boundary analytics
+            // events reported every scheduled run as foreground.
+            dispatchMode: "background",
             noProgressTimeoutMs: options.noProgressTimeoutMs,
             backgroundNoProgressTimeoutMs:
               options.backgroundNoProgressTimeoutMs,

--- a/packages/core/src/jobs/scheduler.spec.ts
+++ b/packages/core/src/jobs/scheduler.spec.ts
@@ -1171,9 +1171,15 @@ Post the digest.`,
     // dispatch_mode NULL falls through to RUN_STALE_MS (15s) in
     // backgroundAwareStaleCutoffSql — a window sized for a foreground run a
     // browser is streaming. Nothing streams a job, so it gets reaped mid-run.
-    // dispatch_mode now gets there via the runner's own pre-claim, not via
-    // startRun's options — see background-automation-runner.spec.ts for the
-    // dedicated self-claim regression test.
+    //
+    // It reaches the ROW through the runner's own pre-claim (see
+    // background-automation-runner.spec.ts for the self-claim regression test),
+    // and it is ALSO passed to startRun, which is what puts it on the terminal
+    // and boundary analytics events. This assertion used to require its
+    // absence; that left every scheduled run reported as `foreground`, which is
+    // why a 6-of-7 no-progress rate on the automation path was invisible.
+    // Passing it cannot clobber the claim: `insertRun` is ON CONFLICT DO
+    // NOTHING, so startRun's insert is a no-op for an already-claimed row.
     await processRecurringJobs({
       getActions: () => ({}),
       getSystemPrompt: async () => "system",
@@ -1182,7 +1188,9 @@ Post the digest.`,
     });
 
     expect(startRunMock).toHaveBeenCalledOnce();
-    expect(startRunMock.mock.calls[0][4]).not.toHaveProperty("dispatchMode");
+    expect(startRunMock.mock.calls[0][4]).toMatchObject({
+      dispatchMode: "background",
+    });
   });
 
   it("runs the job through the resume wrapper instead of calling runAgentLoop raw", async () => {

--- a/packages/core/src/triggers/dispatcher.spec.ts
+++ b/packages/core/src/triggers/dispatcher.spec.ts
@@ -718,10 +718,14 @@ Read the calendar.`,
         ]),
       }),
     );
-    // dispatch_mode is now set via the runner's own pre-claim (insertRun +
-    // claimBackgroundRun) before startRun is even called, not through
-    // startRun's options — see background-automation-runner.spec.ts.
-    expect(startRunMock.mock.calls[0]?.[4]).not.toHaveProperty("dispatchMode");
+    // dispatch_mode reaches the ROW through the runner's own pre-claim
+    // (insertRun + claimBackgroundRun) before startRun is called — see
+    // background-automation-runner.spec.ts. It is ALSO passed to startRun,
+    // which is what puts it on the terminal and boundary analytics events;
+    // without that every triggered run reported itself as `foreground`.
+    expect(startRunMock.mock.calls[0]?.[4]).toMatchObject({
+      dispatchMode: "background",
+    });
   });
 
   it("fails loudly before execution when a requested event MCP tool is unavailable", async () => {


### PR DESCRIPTION
Step 4 of the plan says *measure before touching the backstop*. Doing that
surfaced a defect in the measurement itself.

## The baseline

`agent_run_terminal` on the reporting deployment, 21-day window, grouped by
run-id prefix:

| path | prefix | done | `no_progress` | `run_timeout` | total | **% no_progress** |
| --- | --- | --- | --- | --- | --- | --- |
| interactive chat | `run-*` | 169 | 2 | 17 | 190 | **1.1%** |
| scheduled automations | `job-*` | 8 | 0 | 0 | 9 | **0%** |
| manual analyst runs | `manual-*` | 1 | **6** | 0 | 7 | **85.7%** |

The asymmetry the original brief predicted is real and larger than it reported —
it measured 37% on `automation_runs`; the live rate on the in-process
manual-dispatch path is 6 of 7. Same backstop, same 150s, **78× difference in
outcome** depending only on whether anything downstream was going to recover the
checkpoint.

## Why nobody could see it

Every one of those runs reported itself as `dispatch_mode: "foreground"`.

`emitRunTerminalTrackingEvent` defaulted the property when a caller passed none —
and the interactive chat handler is the **only** `startRun` caller that passes
one. Five others (background automations, agent teams, webhook handlers, harness
runs, the docs poller) pass nothing. So the default was wrong **100% of the times
it applied**: it only ever labelled the callers that are *not* foreground.

An 85.7% failure rate on the automation path was sitting in the same bucket as
healthy chat, labelled as chat.

That is `CLAUDE.md`'s flagship rule — *"a catch, default, or coercion that
returns a value callers cannot distinguish from success is a bug, not a guard"* —
living inside the telemetry that exists to find such bugs.

## The change

- `dispatch_mode` is **absent** when the caller supplied none, so "not recorded"
  and "was foreground" stop being the same value.
- The background automation runner passes the `"background"` it already writes
  onto its own run row at insert.
- An existing test asserted `dispatch_mode: "foreground"` for a run that passed
  none — it encoded the bug, and is updated to assert absence.

**Safety:** passing `dispatchMode` to `startRun` cannot disturb the runner's
self-claim (`background` → `background-processing`). `insertRun` is
`ON CONFLICT (id) DO NOTHING`, so `startRun`'s insert is a no-op for an
already-claimed row — the dedicated self-claim regression test still passes
unchanged.

## Caveat, stated in the doc too

Those runs are on `0.164.26`, which **predates `#3224`** (the `inFlightWorkDelta`
fix, merged 2026-08-20, four minor versions later). So this is a clean *pre-fix*
baseline: it confirms the defect is live and quantifies it, but says nothing
about whether `#3224` already helped. That half of step 4 needs a post-upgrade
re-read — and the dashboard in step 2 now has to split by `dispatch_mode`, not
just `recovered`, or the automation path hides inside chat's volume all over
again.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
