### PR TITLE
Fix frequent calendar reconnect prompts in Clips

### DIFF
--- a/templates/clips/actions/list-meetings.test.ts
+++ b/templates/clips/actions/list-meetings.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   rows: [] as Array<Record<string, unknown>>,
+  calendarAccounts: [] as Array<Record<string, unknown>>,
   // The action now issues two `.where()` calls per run — the meetings query
   // and, when persisted rows come back, a second batched participants fetch —
   // so both must be captured rather than one overwriting the other.
@@ -73,14 +74,21 @@ vi.mock("../server/db/index.js", () => {
     meetings,
     meetingParticipants,
     meetingShares: "meetingShares",
-    calendarAccounts: {},
+    calendarAccounts: {
+      id: "calendarAccounts.id",
+      status: "calendarAccounts.status",
+    },
     calendarAccountShares: {},
     calendarEvents: {},
   };
   const db = {
     select: vi.fn(() => {
       const builder: Record<string, (...args: any[]) => any> = {};
-      builder.from = vi.fn(() => builder);
+      let selectedTable: unknown;
+      builder.from = vi.fn((table: unknown) => {
+        selectedTable = table;
+        return builder;
+      });
       builder.where = vi.fn((condition: unknown) => {
         state.whereCalls.push(condition);
         return builder;
@@ -99,7 +107,12 @@ vi.mock("../server/db/index.js", () => {
       // resolves to no participants here since these tests don't exercise
       // that path; `.offset()` above (a real async function) still governs
       // the meetings query's own resolution.
-      builder.then = (resolve: (value: unknown[]) => void) => resolve([]);
+      builder.then = (resolve: (value: unknown[]) => void) =>
+        resolve(
+          selectedTable === schema.calendarAccounts
+            ? state.calendarAccounts
+            : [],
+        );
       return builder;
     }),
   };
@@ -120,6 +133,10 @@ vi.mock("../server/lib/google-calendar-client.js", () => ({
   listEvents: vi.fn(),
 }));
 
+import {
+  recordCalendarFetchError,
+  resolveCalendarAccessToken,
+} from "../server/lib/calendar-event-meetings";
 import action from "./list-meetings";
 
 const meeting = (id: string) => ({
@@ -143,9 +160,36 @@ const meeting = (id: string) => ({
 describe("list-meetings history", () => {
   beforeEach(() => {
     state.rows = [];
+    state.calendarAccounts = [];
     state.whereCalls = [];
+    vi.mocked(recordCalendarFetchError).mockReset();
+    vi.mocked(resolveCalendarAccessToken).mockReset();
     state.limit = null;
     state.offset = null;
+  });
+
+  it("marks a null calendar token as an explicit reauthentication failure", async () => {
+    const calendarAccount = {
+      id: "calendar-1",
+      provider: "google",
+      ownerEmail: "owner@example.com",
+    };
+    state.calendarAccounts = [calendarAccount];
+    vi.mocked(resolveCalendarAccessToken).mockResolvedValue(null);
+    vi.mocked(recordCalendarFetchError).mockResolvedValue({
+      accountId: calendarAccount.id,
+      error: "Token refresh failed",
+      needsReauth: true,
+    });
+    const parsed = action.schema.parse({ view: "upcoming" });
+
+    await action.run(parsed);
+
+    expect(recordCalendarFetchError).toHaveBeenCalledWith(
+      calendarAccount,
+      expect.objectContaining({ message: "Token refresh failed" }),
+      { needsReauth: true },
+    );
   });
 
   it("accepts content-aware history queries without recordedOnly", () => {

--- a/templates/clips/actions/list-meetings.ts
+++ b/templates/clips/actions/list-meetings.ts
@@ -372,6 +372,7 @@ export default defineAction({
               await recordCalendarFetchError(
                 account,
                 new Error("Token refresh failed"),
+                { needsReauth: true },
               ),
             );
             continue;

--- a/templates/clips/actions/sync-calendars.test.ts
+++ b/templates/clips/actions/sync-calendars.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  accounts: [] as Array<Record<string, unknown>>,
+  emit: vi.fn(),
+  listEvents: vi.fn(),
+  recordCalendarFetchError: vi.fn(),
+  recordCalendarFetchSuccess: vi.fn(),
+  resolveCalendarAccessToken: vi.fn(),
+  writeAppState: vi.fn(),
+}));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: mocks.writeAppState,
+}));
+
+vi.mock("@agent-native/core/event-bus", () => ({
+  emit: mocks.emit,
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  accessFilter: vi.fn(() => ({ kind: "access-filter" })),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ kind: "and", conditions }),
+  eq: (column: unknown, value: unknown) => ({ kind: "eq", column, value }),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => ({
+    select: () => {
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(async () => mocks.accounts),
+      };
+      return builder;
+    },
+  }),
+  schema: {
+    calendarAccounts: {
+      id: "calendarAccounts.id",
+      status: "calendarAccounts.status",
+    },
+    calendarAccountShares: "calendarAccountShares",
+  },
+}));
+
+vi.mock("../server/lib/calendar-event-meetings.js", () => ({
+  recordCalendarFetchError: mocks.recordCalendarFetchError,
+  recordCalendarFetchSuccess: mocks.recordCalendarFetchSuccess,
+  resolveCalendarAccessToken: mocks.resolveCalendarAccessToken,
+  shouldMarkNeedsReauth: vi.fn(() => false),
+}));
+
+vi.mock("../server/lib/google-calendar-client.js", () => ({
+  listEvents: mocks.listEvents,
+  pickJoinUrl: vi.fn(),
+}));
+
+import action from "./sync-calendars";
+
+const calendarAccount = {
+  id: "calendar-1",
+  provider: "google",
+  ownerEmail: "owner@example.com",
+};
+
+describe("sync-calendars calendar status writes", () => {
+  beforeEach(() => {
+    mocks.accounts = [calendarAccount];
+    mocks.emit.mockReset();
+    mocks.listEvents.mockReset();
+    mocks.recordCalendarFetchError.mockReset();
+    mocks.recordCalendarFetchSuccess.mockReset();
+    mocks.resolveCalendarAccessToken.mockReset();
+    mocks.writeAppState.mockReset();
+  });
+
+  it("marks a null token as an explicit reauthentication failure", async () => {
+    mocks.resolveCalendarAccessToken.mockResolvedValue(null);
+    mocks.recordCalendarFetchError.mockResolvedValue({
+      accountId: calendarAccount.id,
+      error: "Token refresh failed",
+      needsReauth: true,
+    });
+
+    await action.run(action.schema.parse({}));
+
+    expect(mocks.recordCalendarFetchError).toHaveBeenCalledWith(
+      calendarAccount,
+      expect.objectContaining({ message: "Token refresh failed" }),
+      { needsReauth: true },
+    );
+    expect(mocks.recordCalendarFetchSuccess).not.toHaveBeenCalled();
+  });
+
+  it("uses the guarded shared helper after a successful sweep", async () => {
+    mocks.resolveCalendarAccessToken.mockResolvedValue("access-token");
+    mocks.listEvents.mockResolvedValue({ items: [] });
+    mocks.recordCalendarFetchSuccess.mockResolvedValue(undefined);
+
+    await action.run(action.schema.parse({}));
+
+    expect(mocks.recordCalendarFetchSuccess).toHaveBeenCalledWith(
+      calendarAccount,
+    );
+    expect(mocks.emit).toHaveBeenCalledWith(
+      "calendar-synced",
+      expect.objectContaining({ accountId: calendarAccount.id }),
+    );
+  });
+});

--- a/templates/clips/actions/sync-calendars.ts
+++ b/templates/clips/actions/sync-calendars.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
+  recordCalendarFetchError,
   resolveCalendarAccessToken,
   shouldMarkNeedsReauth,
 } from "../server/lib/calendar-event-meetings.js";
@@ -98,24 +99,11 @@ export default defineAction({
         // sync error via shouldMarkNeedsReauth without flipping status.
         const accessToken = await resolveCalendarAccessToken(account);
         if (!accessToken) {
-          // Fix 10: isolate this account's needs-reauth write in its own
-          // try/catch so a downstream throw on a different account doesn't
-          // leave the flag unpersisted.
-          try {
-            await db
-              .update(schema.calendarAccounts)
-              .set({
-                status: "needs-reauth",
-                lastSyncError: "Token refresh failed — reconnect required.",
-                updatedAt: new Date().toISOString(),
-              })
-              .where(eq(schema.calendarAccounts.id, account.id));
-          } catch (writeErr: any) {
-            console.warn(
-              `[sync-calendars] failed to flag account ${account.id} as needs-reauth:`,
-              writeErr?.message ?? writeErr,
-            );
-          }
+          await recordCalendarFetchError(
+            account,
+            new Error("Token refresh failed"),
+            { needsReauth: true },
+          );
           errors.push({
             accountId: account.id,
             error: "needs-reauth",

--- a/templates/clips/actions/sync-calendars.ts
+++ b/templates/clips/actions/sync-calendars.ts
@@ -24,6 +24,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import {
   recordCalendarFetchError,
+  recordCalendarFetchSuccess,
   resolveCalendarAccessToken,
   shouldMarkNeedsReauth,
 } from "../server/lib/calendar-event-meetings.js";
@@ -194,18 +195,10 @@ export default defineAction({
           perAccountEvents += 1;
         }
 
-        // Fix 10: isolate the success-path status write so other accounts'
-        // needs-reauth flags can't be wiped by a later account-level throw.
+        // Keep the success write isolated and guarded so an in-flight sweep
+        // cannot overwrite a concurrent needs-reauth decision.
         try {
-          await db
-            .update(schema.calendarAccounts)
-            .set({
-              lastSyncedAt: new Date().toISOString(),
-              lastSyncError: null,
-              status: "connected",
-              updatedAt: new Date().toISOString(),
-            })
-            .where(eq(schema.calendarAccounts.id, account.id));
+          await recordCalendarFetchSuccess(account);
         } catch (writeErr: any) {
           console.warn(
             `[sync-calendars] failed to update account ${account.id} after success:`,

--- a/templates/clips/server/lib/calendar-event-meetings.test.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const calendarMocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
   readAppSecret: vi.fn(),
   refreshAccessTokenWithFallback: vi.fn(),
   resolveGoogleOAuthCredentialCandidates: vi.fn(),
@@ -16,9 +17,20 @@ vi.mock("@agent-native/core/sharing", () => ({
   resolveAccess: vi.fn(),
 }));
 
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+}));
+
 vi.mock("../db/index.js", () => ({
-  getDb: vi.fn(),
-  schema: {},
+  getDb: calendarMocks.getDb,
+  schema: {
+    calendarAccounts: {
+      id: "id",
+      ownerEmail: "ownerEmail",
+    },
+  },
 }));
 
 vi.mock("./google-calendar-client.js", () => ({
@@ -54,6 +66,7 @@ import {
   isSoloCalendarEvent,
 } from "./calendar-event-classification";
 import {
+  recordCalendarFetchError,
   resolveCalendarAccessToken,
   shouldMarkNeedsReauth,
 } from "./calendar-event-meetings";
@@ -200,6 +213,38 @@ describe("calendar reconnect classification", () => {
   });
 });
 
+describe("calendar fetch error recording", () => {
+  it("persists and returns an explicit reauthentication decision", async () => {
+    const where = vi.fn().mockResolvedValue(undefined);
+    const set = vi.fn(() => ({ where }));
+    calendarMocks.getDb.mockReturnValue({
+      update: vi.fn(() => ({ set })),
+    });
+
+    const result = await recordCalendarFetchError(
+      {
+        id: "calendar_1",
+        provider: "google",
+        ownerEmail: "user@example.com",
+      },
+      new Error("Token refresh failed"),
+      { needsReauth: true },
+    );
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "needs-reauth",
+        lastSyncError: "Google Calendar needs to be reconnected.",
+      }),
+    );
+    expect(result).toEqual({
+      accountId: "calendar_1",
+      error: "Token refresh failed",
+      needsReauth: true,
+    });
+  });
+});
+
 describe("calendar access token refresh", () => {
   const calendarAccount = {
     id: "calendar_1",
@@ -230,8 +275,8 @@ describe("calendar access token refresh", () => {
       .mockResolvedValueOnce({ value: "refresh-token" });
   }
 
-  it("reuses an unexpired access token when refresh fails transiently", async () => {
-    mockStoredTokens(Date.now() + 60_000);
+  it("reuses an access token above the request safety margin when refresh fails transiently", async () => {
+    mockStoredTokens(Date.now() + 2 * 60_000);
     calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(
       new Error("Google token refresh failed (503): backend unavailable"),
     );
@@ -251,8 +296,18 @@ describe("calendar access token refresh", () => {
     );
   });
 
+  it("throws a transient refresh failure inside the request safety margin", async () => {
+    mockStoredTokens(Date.now() + 30_000);
+    const error = new Error("Google token refresh failed (503): unavailable");
+    calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(error);
+
+    await expect(resolveCalendarAccessToken(calendarAccount)).rejects.toBe(
+      error,
+    );
+  });
+
   it("returns null for a permanent refresh failure", async () => {
-    mockStoredTokens(Date.now() + 60_000);
+    mockStoredTokens(Date.now() + 2 * 60_000);
     calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(
       new Error("Google token refresh failed (400): invalid_grant"),
     );

--- a/templates/clips/server/lib/calendar-event-meetings.test.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.test.ts
@@ -18,8 +18,8 @@ vi.mock("@agent-native/core/sharing", () => ({
 }));
 
 vi.mock("drizzle-orm", () => ({
-  and: vi.fn(),
-  eq: vi.fn(),
+  and: (...conditions: unknown[]) => ({ kind: "and", conditions }),
+  eq: (column: unknown, value: unknown) => ({ kind: "eq", column, value }),
   isNull: vi.fn(),
 }));
 
@@ -29,6 +29,7 @@ vi.mock("../db/index.js", () => ({
     calendarAccounts: {
       id: "id",
       ownerEmail: "ownerEmail",
+      status: "status",
     },
   },
 }));
@@ -67,6 +68,7 @@ import {
 } from "./calendar-event-classification";
 import {
   recordCalendarFetchError,
+  recordCalendarFetchSuccess,
   resolveCalendarAccessToken,
   shouldMarkNeedsReauth,
 } from "./calendar-event-meetings";
@@ -213,20 +215,43 @@ describe("calendar reconnect classification", () => {
   });
 });
 
-describe("calendar fetch error recording", () => {
-  it("persists and returns an explicit reauthentication decision", async () => {
+describe("calendar fetch status recording", () => {
+  const calendarAccount = {
+    id: "calendar_1",
+    provider: "google",
+    ownerEmail: "user@example.com",
+  };
+
+  function mockAccountUpdate() {
     const where = vi.fn().mockResolvedValue(undefined);
-    const set = vi.fn(() => ({ where }));
+    const set = vi.fn((_values: Record<string, unknown>) => ({ where }));
     calendarMocks.getDb.mockReturnValue({
       update: vi.fn(() => ({ set })),
     });
+    return { set, where };
+  }
+
+  it("does not promote a soft failure to connected", async () => {
+    const { set } = mockAccountUpdate();
 
     const result = await recordCalendarFetchError(
-      {
-        id: "calendar_1",
-        provider: "google",
-        ownerEmail: "user@example.com",
-      },
+      calendarAccount,
+      new Error("Calendar unavailable"),
+      { needsReauth: false },
+    );
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ lastSyncError: "Calendar unavailable" }),
+    );
+    expect(set.mock.calls[0][0]).not.toHaveProperty("status");
+    expect(result.needsReauth).toBe(false);
+  });
+
+  it("persists and returns an explicit reauthentication decision", async () => {
+    const { set } = mockAccountUpdate();
+
+    const result = await recordCalendarFetchError(
+      calendarAccount,
       new Error("Token refresh failed"),
       { needsReauth: true },
     );
@@ -241,6 +266,25 @@ describe("calendar fetch error recording", () => {
       accountId: "calendar_1",
       error: "Token refresh failed",
       needsReauth: true,
+    });
+  });
+
+  it("records success only while the account remains connected", async () => {
+    const { set, where } = mockAccountUpdate();
+
+    await recordCalendarFetchSuccess(calendarAccount);
+
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ lastSyncError: null }),
+    );
+    expect(set.mock.calls[0][0]).not.toHaveProperty("status");
+    expect(where).toHaveBeenCalledWith({
+      kind: "and",
+      conditions: [
+        { kind: "eq", column: "id", value: "calendar_1" },
+        { kind: "eq", column: "ownerEmail", value: "user@example.com" },
+        { kind: "eq", column: "status", value: "connected" },
+      ],
     });
   });
 });

--- a/templates/clips/server/lib/calendar-event-meetings.test.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.test.ts
@@ -1,4 +1,51 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const calendarMocks = vi.hoisted(() => ({
+  readAppSecret: vi.fn(),
+  refreshAccessTokenWithFallback: vi.fn(),
+  resolveGoogleOAuthCredentialCandidates: vi.fn(),
+  writeAppSecret: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/secrets", () => ({
+  readAppSecret: calendarMocks.readAppSecret,
+  writeAppSecret: calendarMocks.writeAppSecret,
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  resolveAccess: vi.fn(),
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: vi.fn(),
+  schema: {},
+}));
+
+vi.mock("./google-calendar-client.js", () => ({
+  detectPlatform: vi.fn(),
+  getEvent: vi.fn(),
+  isPermanentRefreshFailure: (error: unknown) => {
+    const message =
+      error instanceof Error ? error.message : String(error || "");
+    const lower = message.toLowerCase();
+    return (
+      lower.includes("invalid_grant") ||
+      lower.includes("unauthorized_client") ||
+      lower.includes("invalid_client")
+    );
+  },
+  pickJoinUrl: vi.fn(),
+  refreshAccessTokenWithFallback: calendarMocks.refreshAccessTokenWithFallback,
+  resolveGoogleOAuthCredentialCandidates:
+    calendarMocks.resolveGoogleOAuthCredentialCandidates,
+}));
+
+vi.mock("./recordings.js", () => ({
+  getActiveOrganizationId: vi.fn(),
+  getCurrentOwnerEmail: vi.fn(),
+  getDefaultRecordingVisibility: vi.fn(),
+  nanoid: vi.fn(),
+}));
 
 import {
   isDeclinedCalendarEvent,
@@ -6,6 +53,10 @@ import {
   isPersonalSoloCalendarEvent,
   isSoloCalendarEvent,
 } from "./calendar-event-classification";
+import {
+  resolveCalendarAccessToken,
+  shouldMarkNeedsReauth,
+} from "./calendar-event-meetings";
 import type { CalendarEvent } from "./google-calendar-client";
 
 const account: CalendarAccountForEventClassification = {
@@ -123,6 +174,92 @@ describe("calendar solo event detection", () => {
         }),
       }),
     ).toBe(false);
+  });
+});
+
+describe("calendar reconnect classification", () => {
+  it("keeps transient token refresh failures connected", () => {
+    expect(
+      shouldMarkNeedsReauth(
+        "Google token refresh failed (503): backend unavailable",
+      ),
+    ).toBe(false);
+    expect(
+      shouldMarkNeedsReauth("Google token refresh failed (429): rate limited"),
+    ).toBe(false);
+  });
+
+  it("requires reconnect for confirmed authorization failures", () => {
+    expect(shouldMarkNeedsReauth("invalid_grant: token revoked")).toBe(true);
+    expect(
+      shouldMarkNeedsReauth("Google Calendar list failed (401): nope"),
+    ).toBe(true);
+    expect(
+      shouldMarkNeedsReauth("Google Calendar event failed (401): nope"),
+    ).toBe(true);
+  });
+});
+
+describe("calendar access token refresh", () => {
+  const calendarAccount = {
+    id: "calendar_1",
+    provider: "google",
+    ownerEmail: "user@example.com",
+    accessTokenSecretRef: "calendar-access-token",
+    refreshTokenSecretRef: "calendar-refresh-token",
+  };
+
+  beforeEach(() => {
+    calendarMocks.readAppSecret.mockReset();
+    calendarMocks.refreshAccessTokenWithFallback.mockReset();
+    calendarMocks.resolveGoogleOAuthCredentialCandidates.mockReset();
+    calendarMocks.writeAppSecret.mockReset();
+    calendarMocks.resolveGoogleOAuthCredentialCandidates.mockResolvedValue([
+      { clientId: "client-id", clientSecret: "client-secret" },
+    ]);
+  });
+
+  function mockStoredTokens(expiresAt: number) {
+    calendarMocks.readAppSecret
+      .mockResolvedValueOnce({
+        value: JSON.stringify({
+          accessToken: "existing-access-token",
+          expiresAt,
+        }),
+      })
+      .mockResolvedValueOnce({ value: "refresh-token" });
+  }
+
+  it("reuses an unexpired access token when refresh fails transiently", async () => {
+    mockStoredTokens(Date.now() + 60_000);
+    calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(
+      new Error("Google token refresh failed (503): backend unavailable"),
+    );
+
+    await expect(resolveCalendarAccessToken(calendarAccount)).resolves.toBe(
+      "existing-access-token",
+    );
+  });
+
+  it("throws a transient refresh failure when the access token is expired", async () => {
+    mockStoredTokens(Date.now() - 1);
+    const error = new Error("Google token refresh failed (429): rate limited");
+    calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(error);
+
+    await expect(resolveCalendarAccessToken(calendarAccount)).rejects.toBe(
+      error,
+    );
+  });
+
+  it("returns null for a permanent refresh failure", async () => {
+    mockStoredTokens(Date.now() + 60_000);
+    calendarMocks.refreshAccessTokenWithFallback.mockRejectedValue(
+      new Error("Google token refresh failed (400): invalid_grant"),
+    );
+
+    await expect(
+      resolveCalendarAccessToken(calendarAccount),
+    ).resolves.toBeNull();
   });
 });
 

--- a/templates/clips/server/lib/calendar-event-meetings.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.ts
@@ -74,8 +74,7 @@ export function shouldMarkNeedsReauth(message: string): boolean {
     lower.includes("google calendar event failed (401)") ||
     lower.includes("invalid_grant") ||
     lower.includes("invalid_token") ||
-    lower.includes("insufficient_scope") ||
-    lower.includes("token refresh failed")
+    lower.includes("insufficient_scope")
   );
 }
 
@@ -122,10 +121,16 @@ export async function resolveCalendarAccessToken(
     });
   } catch (err) {
     // Only a permanent failure (dead refresh token / bad OAuth client) means
-    // "needs-reauth" — collapse those to `null` as before. A transient
-    // failure (network error, 429, 5xx, timeout) is rethrown so callers can
-    // record it as a soft sync error without flipping account status.
+    // "needs-reauth" — collapse those to `null` as before. During the refresh
+    // buffer, a transient failure can safely reuse the still-valid token.
     if (isPermanentRefreshFailure(err)) return null;
+    if (
+      bundle?.accessToken &&
+      bundle.expiresAt &&
+      bundle.expiresAt > Date.now()
+    ) {
+      return bundle.accessToken;
+    }
     throw err;
   }
   if (!refreshed.access_token) return null;

--- a/templates/clips/server/lib/calendar-event-meetings.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.ts
@@ -165,13 +165,13 @@ export async function recordCalendarFetchSuccess(
     .set({
       lastSyncedAt: now,
       lastSyncError: null,
-      status: "connected",
       updatedAt: now,
     })
     .where(
       and(
         eq(schema.calendarAccounts.id, account.id),
         eq(schema.calendarAccounts.ownerEmail, account.ownerEmail),
+        eq(schema.calendarAccounts.status, "connected"),
       ),
     );
 }
@@ -191,7 +191,7 @@ export async function recordCalendarFetchError(
   await db
     .update(schema.calendarAccounts)
     .set({
-      status: needsReauth ? "needs-reauth" : "connected",
+      ...(needsReauth ? { status: "needs-reauth" as const } : {}),
       lastSyncError: needsReauth
         ? "Google Calendar needs to be reconnected."
         : message,

--- a/templates/clips/server/lib/calendar-event-meetings.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.ts
@@ -23,6 +23,8 @@ import {
 
 export const CALENDAR_MEETING_ID_PREFIX = "gcal";
 
+const CALENDAR_REQUEST_SAFETY_MARGIN_MS = 60 * 1000;
+
 export interface CalendarAccountForEvents {
   id: string;
   provider: string;
@@ -127,7 +129,7 @@ export async function resolveCalendarAccessToken(
     if (
       bundle?.accessToken &&
       bundle.expiresAt &&
-      bundle.expiresAt > Date.now()
+      bundle.expiresAt > Date.now() + CALENDAR_REQUEST_SAFETY_MARGIN_MS
     ) {
       return bundle.accessToken;
     }
@@ -177,10 +179,11 @@ export async function recordCalendarFetchSuccess(
 export async function recordCalendarFetchError(
   account: CalendarAccountForEvents,
   error: unknown,
+  options: { needsReauth?: boolean } = {},
 ): Promise<CalendarFetchError> {
   const message =
     error instanceof Error ? error.message : String(error || "Calendar failed");
-  const needsReauth = shouldMarkNeedsReauth(message);
+  const needsReauth = options.needsReauth ?? shouldMarkNeedsReauth(message);
   if (!account.ownerEmail) {
     return { accountId: account.id, error: message, needsReauth };
   }
@@ -325,7 +328,9 @@ export async function fetchLiveCalendarEventFromId(virtualId: string) {
     return null;
   }
   if (!accessToken) {
-    await recordCalendarFetchError(account, new Error("Token refresh failed"));
+    await recordCalendarFetchError(account, new Error("Token refresh failed"), {
+      needsReauth: true,
+    });
     return null;
   }
 


### PR DESCRIPTION
### Summary
Fixes an issue where users were repeatedly prompted to reconnect their calendar every few minutes in the Clips meetings templates, caused by transient token refresh failures being incorrectly treated as authentication failures.

### Problem
Users saw a "reconnect calendar" prompt roughly every 3-5 minutes even though their calendar connection was still valid. This happened because any token refresh failure — including transient network errors or rate limits (429/5xx) — was being classified the same as a real authorization failure, flipping the account status to `needs-reauth` and clearing the "connected" state on every sync sweep.

### Solution
- Stop treating generic "token refresh failed" messages as an automatic reauth trigger; only explicit, well-defined failure paths now mark an account as needing reauthentication.
- When a token refresh fails transiently but the existing access token is still valid within a safety margin, reuse the cached token instead of forcing a reauth or throwing.
- Guard the "success" status write so it can only move an account back to `connected` state, preventing a stale/failed request from clobbering a valid needs-reauth state, and vice versa.
- Centralize error/success status recording through shared helpers used by both `list-meetings` and `sync-calendars`.

### Key Changes
- `calendar-event-meetings.ts`:
  - Removed `"token refresh failed"` from `shouldMarkNeedsReauth` heuristic so transient refresh errors don't force reauth.
  - Added `CALENDAR_REQUEST_SAFETY_MARGIN_MS` (60s) buffer; `resolveCalendarAccessToken` now returns the still-valid cached access token on a transient refresh error if it hasn't expired within that margin, instead of throwing.
  - `recordCalendarFetchError` now accepts an explicit `{ needsReauth }` option, allowing callers to force a reauth decision instead of relying solely on message-based heuristics; when not marking reauth, the `status` field is left untouched (no forced `"connected"`).
  - `recordCalendarFetchSuccess` no longer unconditionally sets `status: "connected"`; the update query now only applies when the account's current status is already `"connected"`, so it can't overwrite a `needs-reauth` state.
  - `fetchLiveCalendarEventFromId` now explicitly passes `{ needsReauth: true }` when a null access token is returned.
- `sync-calendars.ts`: replaced inline `db.update(...)` calls for both the failure and success paths with calls to the shared `recordCalendarFetchError` / `recordCalendarFetchSuccess` helpers, keeping status writes consistent and centrally guarded.
- `list-meetings.ts`: passes `{ needsReauth: true }` explicitly when recording a null-token calendar fetch error.
- Added/updated tests:
  - New `sync-calendars.test.ts` covering explicit reauth marking on null token and use of the guarded success helper.
  - Expanded `calendar-event-meetings.test.ts` with coverage for transient vs. permanent refresh failure classification, safety-margin token reuse, and status-write guarding for both success and error recording paths.
  - Updated `list-meetings.test.ts` mocks to support querying `calendarAccounts` and verify the explicit reauth error path.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/essential-meteor-2kluqbpi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-essential-meteor-2kluqbpi.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3347`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>essential-meteor-2kluqbpi</branchName>-->