### PR TITLE
Stop failed Content blocks from loading forever

### DIFF
--- a/.changeset/calm-mermaids-settle.md
+++ b/.changeset/calm-mermaids-settle.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/toolkit": patch
+"@agent-native/core": patch
+---
+
+Show a terminal raw-source error when a persisted registry block cannot hydrate instead of leaving it indefinitely loading.

--- a/packages/toolkit/src/editor/RegistryBlockContext.tsx
+++ b/packages/toolkit/src/editor/RegistryBlockContext.tsx
@@ -5,6 +5,10 @@ export interface RegistryBlockSideMapBlock {
   title?: string;
   summary?: string;
   data: unknown;
+  loadError?: {
+    message: string;
+    rawSource?: string;
+  };
 }
 
 export interface RegistryBlockNestedBlock {

--- a/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
+++ b/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
@@ -6,13 +6,36 @@ import { NodeSelection } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createRegistryBlockNode,
   LegacyJsonEditSurface,
+  RegistryBlockLoadErrorView,
   type RegistryBlockSideMapBlock,
 } from "./RegistryBlockNode.js";
+
+describe("RegistryBlockLoadErrorView", () => {
+  it("preserves unreadable source and reports a terminal load error", () => {
+    const rawSource = '<Mermaid id="broken" source={nope} />';
+    const markup = renderToStaticMarkup(
+      React.createElement(RegistryBlockLoadErrorView, {
+        message:
+          "Could not load mermaid block: Persisted block source is unreadable.",
+        rawSource,
+      }),
+    );
+
+    expect(markup).toContain(
+      "&lt;Mermaid id=&quot;broken&quot; source={nope} /&gt;",
+    );
+    expect(markup).toContain(
+      "Could not load mermaid block: Persisted block source is unreadable.",
+    );
+    expect(markup).not.toContain("Loading mermaid block");
+  });
+});
 
 const PlanBlockNode = createRegistryBlockNode({
   nodeName: "planBlock",

--- a/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
+++ b/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
@@ -13,6 +13,7 @@ import {
   createRegistryBlockNode,
   LegacyJsonEditSurface,
   RegistryBlockLoadErrorView,
+  selectRegistryBlockNode,
   type RegistryBlockSideMapBlock,
 } from "./RegistryBlockNode.js";
 
@@ -118,6 +119,32 @@ afterEach(() => {
 });
 
 describe("RegistryBlockNode keyboard guard", () => {
+  it("selects and removes an errored registry atom from its interactive error surface", () => {
+    const editor = createEditor();
+    const target = document.createElement("pre");
+    target.setAttribute("data-plan-interactive", "true");
+
+    try {
+      expect(
+        selectRegistryBlockNode({
+          editable: true,
+          allowInteractiveChild: true,
+          target,
+          getPos: () => findPlanBlockPos(editor),
+          view: editor.view,
+          preventDefault: vi.fn(),
+          stopPropagation: vi.fn(),
+        }),
+      ).toBe(true);
+      expect(editor.state.selection).toBeInstanceOf(NodeSelection);
+
+      expect(editor.commands.deleteSelection()).toBe(true);
+      expect(() => findPlanBlockPos(editor)).toThrow("Expected planBlock node");
+    } finally {
+      editor.destroy();
+    }
+  });
+
   it("keeps selected registry atoms immutable for text entry and preserves undo history", () => {
     const editor = createEditor();
 

--- a/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
+++ b/packages/toolkit/src/editor/RegistryBlockNode.spec.ts
@@ -121,7 +121,7 @@ afterEach(() => {
 describe("RegistryBlockNode keyboard guard", () => {
   it("selects and removes an errored registry atom from its interactive error surface", () => {
     const editor = createEditor();
-    const target = document.createElement("pre");
+    const target = document.createElement("div");
     target.setAttribute("data-plan-interactive", "true");
 
     try {
@@ -140,6 +140,34 @@ describe("RegistryBlockNode keyboard guard", () => {
 
       expect(editor.commands.deleteSelection()).toBe(true);
       expect(() => findPlanBlockPos(editor)).toThrow("Expected planBlock node");
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  it("preserves native raw-source selection inside an errored registry atom", () => {
+    const editor = createEditor();
+    const errorSurface = document.createElement("div");
+    const rawSource = document.createElement("pre");
+    errorSurface.appendChild(rawSource);
+    const preventDefault = vi.fn();
+    const stopPropagation = vi.fn();
+
+    try {
+      expect(
+        selectRegistryBlockNode({
+          editable: true,
+          allowInteractiveChild: true,
+          target: rawSource,
+          getPos: () => findPlanBlockPos(editor),
+          view: editor.view,
+          preventDefault,
+          stopPropagation,
+        }),
+      ).toBe(false);
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(stopPropagation).not.toHaveBeenCalled();
+      expect(editor.state.selection).not.toBeInstanceOf(NodeSelection);
     } finally {
       editor.destroy();
     }

--- a/packages/toolkit/src/editor/RegistryBlockNode.tsx
+++ b/packages/toolkit/src/editor/RegistryBlockNode.tsx
@@ -104,6 +104,12 @@ export function selectRegistryBlockNode({
     clickedInteractiveChild(target)
   )
     return false;
+  if (
+    allowInteractiveChild &&
+    target instanceof HTMLElement &&
+    target.closest("pre")
+  )
+    return false;
   const pos = typeof getPos === "function" ? getPos() : null;
   if (typeof pos !== "number") return false;
   try {
@@ -114,9 +120,12 @@ export function selectRegistryBlockNode({
     );
     view.focus();
     return true;
-  } catch { // coercion-ok: false is the explicit failure result for a stale node position.
-    // Ignore stale positions during React/ProseMirror reconciliation.
-    return false;
+  } catch (error) {
+    // A node can disappear between the mousedown and selection dispatch during
+    // reconciliation. Keep that expected stale-position race recoverable, but
+    // do not hide unrelated editor failures.
+    if (error instanceof RangeError) return false;
+    throw error;
   }
 }
 

--- a/packages/toolkit/src/editor/RegistryBlockNode.tsx
+++ b/packages/toolkit/src/editor/RegistryBlockNode.tsx
@@ -80,6 +80,46 @@ function clickedInteractiveChild(target: HTMLElement) {
   return !!blockNode && !!editable && blockNode.contains(editable);
 }
 
+export function selectRegistryBlockNode({
+  editable,
+  allowInteractiveChild,
+  target,
+  getPos,
+  view,
+  preventDefault,
+  stopPropagation,
+}: {
+  editable: boolean;
+  allowInteractiveChild: boolean;
+  target: EventTarget | null;
+  getPos: (() => number | undefined) | boolean;
+  view: NodeViewProps["editor"]["view"];
+  preventDefault: () => void;
+  stopPropagation: () => void;
+}): boolean {
+  if (!editable) return false;
+  if (
+    !allowInteractiveChild &&
+    target instanceof HTMLElement &&
+    clickedInteractiveChild(target)
+  )
+    return false;
+  const pos = typeof getPos === "function" ? getPos() : null;
+  if (typeof pos !== "number") return false;
+  try {
+    preventDefault();
+    stopPropagation();
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)),
+    );
+    view.focus();
+    return true;
+  } catch { // coercion-ok: false is the explicit failure result for a stale node position.
+    // Ignore stale positions during React/ProseMirror reconciliation.
+    return false;
+  }
+}
+
 /* -------------------------------------------------------------------------- */
 /* B. RegistryBlockNodeView (React)                                           */
 /* -------------------------------------------------------------------------- */
@@ -139,6 +179,21 @@ export function RegistryBlockNodeView(props: NodeViewProps) {
     (sideMap?.notionSync ?? false) &&
     (sideMap?.isNotionIncompatibleType?.(blockType) ?? false);
 
+  const selectNode = (
+    event: ReactMouseEvent<HTMLElement>,
+    allowInteractiveChild = false,
+  ) => {
+    selectRegistryBlockNode({
+      editable,
+      allowInteractiveChild,
+      target: event.target,
+      getPos: props.getPos,
+      view: props.editor.view,
+      preventDefault: () => event.preventDefault(),
+      stopPropagation: () => event.stopPropagation(),
+    });
+  };
+
   // The block data isn't in the side-map yet (e.g. a freshly inserted node whose
   // store entry hasn't been seeded). Render a graceful placeholder.
   if (!block) {
@@ -157,7 +212,13 @@ export function RegistryBlockNodeView(props: NodeViewProps) {
 
   if (block.loadError) {
     return (
-      <NodeViewWrapper className="plan-block-node" data-block-id={blockId}>
+      <NodeViewWrapper
+        className="plan-block-node"
+        data-block-id={blockId}
+        onMouseDownCapture={(event: ReactMouseEvent<HTMLElement>) =>
+          selectNode(event, true)
+        }
+      >
         <RegistryBlockLoadErrorView
           message={block.loadError.message}
           rawSource={block.loadError.rawSource}
@@ -166,25 +227,6 @@ export function RegistryBlockNodeView(props: NodeViewProps) {
     );
   }
 
-  const selectNode = (event: ReactMouseEvent<HTMLElement>) => {
-    if (!editable) return;
-    const target = event.target;
-    if (target instanceof HTMLElement && clickedInteractiveChild(target))
-      return;
-    const pos = typeof props.getPos === "function" ? props.getPos() : null;
-    if (typeof pos !== "number") return;
-    try {
-      event.preventDefault();
-      event.stopPropagation();
-      const { view } = props.editor;
-      view.dispatch(
-        view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)),
-      );
-      view.focus();
-    } catch {
-      // Ignore stale positions during React/ProseMirror reconciliation.
-    }
-  };
   const updateShellHover = (event: ReactMouseEvent<HTMLElement>) => {
     const target = event.target;
     setShellHovered(

--- a/packages/toolkit/src/editor/RegistryBlockNode.tsx
+++ b/packages/toolkit/src/editor/RegistryBlockNode.tsx
@@ -155,6 +155,17 @@ export function RegistryBlockNodeView(props: NodeViewProps) {
     );
   }
 
+  if (block.loadError) {
+    return (
+      <NodeViewWrapper className="plan-block-node" data-block-id={blockId}>
+        <RegistryBlockLoadErrorView
+          message={block.loadError.message}
+          rawSource={block.loadError.rawSource}
+        />
+      </NodeViewWrapper>
+    );
+  }
+
   const selectNode = (event: ReactMouseEvent<HTMLElement>) => {
     if (!editable) return;
     const target = event.target;
@@ -274,6 +285,31 @@ export function RegistryBlockNodeView(props: NodeViewProps) {
         )}
       </div>
     </NodeViewWrapper>
+  );
+}
+
+export function RegistryBlockLoadErrorView({
+  message,
+  rawSource,
+}: {
+  message: string;
+  rawSource?: string;
+}) {
+  return (
+    <div
+      contentEditable={false}
+      data-plan-interactive
+      className="plan-block-node__load-error space-y-2 rounded-md border border-border px-3 py-2 text-sm"
+    >
+      {rawSource ? (
+        <pre className="overflow-auto whitespace-pre-wrap font-mono text-xs text-foreground">
+          {rawSource}
+        </pre>
+      ) : null}
+      <p role="alert" className="text-muted-foreground">
+        {message}
+      </p>
+    </div>
   );
 }
 

--- a/templates/content/app/components/editor/VisualEditor.registry-hydration.test.ts
+++ b/templates/content/app/components/editor/VisualEditor.registry-hydration.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { hydrateRegistryBlockRaw } from "./VisualEditor";
+
+describe("registry block hydration", () => {
+  it("returns typed Mermaid data for valid persisted source", async () => {
+    const result = await hydrateRegistryBlockRaw(
+      '<Mermaid id="mermaid-1" source={"flowchart TD\\n  A --> B"} />',
+    );
+
+    expect(result.status).toBe("loaded");
+    if (result.status === "loaded") {
+      expect(result.block.type).toBe("mermaid");
+      expect(result.block.data).toEqual({
+        source: "flowchart TD\n  A --> B",
+        caption: undefined,
+      });
+    }
+  });
+
+  it("preserves malformed persisted source in a terminal error result", async () => {
+    const rawSource = '<Mermaid id="mermaid-1" source={nope} />';
+    const result = await hydrateRegistryBlockRaw(rawSource);
+
+    expect(result.status).toBe("error");
+    if (result.status === "error") {
+      expect(result.rawSource).toBe(rawSource);
+      expect(result.message).toContain("Unsupported MDX attribute expression");
+    }
+  });
+
+  it("classifies missing persisted source as a terminal error", async () => {
+    await expect(hydrateRegistryBlockRaw("")).resolves.toEqual({
+      status: "error",
+      message: "unreadable",
+      rawSource: "",
+    });
+  });
+});

--- a/templates/content/app/components/editor/VisualEditor.registry-hydration.test.ts
+++ b/templates/content/app/components/editor/VisualEditor.registry-hydration.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { hydrateRegistryBlockRaw } from "./VisualEditor";
+import {
+  hydrateRegistryBlockRaw,
+  isRegistryBlockHydrationCurrent,
+} from "./VisualEditor";
 
 describe("registry block hydration", () => {
   it("returns typed Mermaid data for valid persisted source", async () => {
@@ -35,5 +38,20 @@ describe("registry block hydration", () => {
       message: "unreadable",
       rawSource: "",
     });
+  });
+
+  it("rejects a hydration completion when the live or pending source changed", () => {
+    const original = '<Mermaid id="mermaid-1" source="graph TD; A --> B" />';
+    const replacement = '<Mermaid id="mermaid-1" source="graph TD; B --> C" />';
+
+    expect(isRegistryBlockHydrationCurrent(original, original, original)).toBe(
+      true,
+    );
+    expect(
+      isRegistryBlockHydrationCurrent(original, original, replacement),
+    ).toBe(false);
+    expect(
+      isRegistryBlockHydrationCurrent(original, replacement, replacement),
+    ).toBe(false);
   });
 });

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -1742,6 +1742,7 @@ export function createVisualEditorExtensions({
  */
 interface RegistryBlockStoreEntry {
   type: string;
+  rawSource: string;
   base?: {
     title?: string;
     summary?: string;
@@ -1750,8 +1751,7 @@ interface RegistryBlockStoreEntry {
   data: unknown;
   edited: boolean;
   loadError?: {
-    message: string;
-    rawSource?: string;
+    reason: string;
   };
 }
 
@@ -1778,6 +1778,14 @@ export async function hydrateRegistryBlockRaw(
       rawSource,
     };
   }
+}
+
+export function isRegistryBlockHydrationCurrent(
+  expectedRaw: string,
+  pendingRaw: string | undefined,
+  liveRaw: string,
+): boolean {
+  return pendingRaw === expectedRaw && liveRaw === expectedRaw;
 }
 
 function serializeRegistryBlockRaw(
@@ -1835,7 +1843,7 @@ function isNotionIncompatibleBlockType(blockType: string): boolean {
 function useRegistryBlockStore(editor: CoreEditor | null) {
   const t = useT();
   const cacheRef = useRef<Map<string, RegistryBlockStoreEntry>>(new Map());
-  const pendingRef = useRef<Set<string>>(new Set());
+  const pendingRef = useRef<Map<string, string>>(new Map());
   // Bumping this state forces the NodeViews to re-read the cache once async
   // hydration (or an edit) lands. The `version` is surfaced to the side-map
   // value so the context reference changes on each bump — otherwise the Tiptap
@@ -1876,24 +1884,57 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
         typeof node.attrs.title === "string" ? node.attrs.title : undefined;
       const summary =
         typeof node.attrs.summary === "string" ? node.attrs.summary : undefined;
+      const raw = typeof node.attrs.__raw === "string" ? node.attrs.__raw : "";
 
       const cached = cacheRef.current.get(blockId);
-      if (cached) {
+      if (cached?.rawSource === raw) {
         return {
           id: blockId,
           title,
           summary,
           data: cached.data,
-          loadError: cached.loadError,
+          loadError: cached.loadError
+            ? {
+                message: t("editor.registryBlockLoadError", {
+                  type:
+                    typeof node.attrs.blockType === "string"
+                      ? node.attrs.blockType
+                      : "registry",
+                  message:
+                    cached.loadError.reason === "unreadable"
+                      ? t("editor.registryBlockUnreadable")
+                      : cached.loadError.reason,
+                }),
+                rawSource: cached.rawSource,
+              }
+            : undefined,
         };
       }
+      if (cached) cacheRef.current.delete(blockId);
 
       // Not hydrated yet: kick off a one-shot async parse of the verbatim MDX.
-      const raw = typeof node.attrs.__raw === "string" ? node.attrs.__raw : "";
-      if (!pendingRef.current.has(blockId)) {
-        pendingRef.current.add(blockId);
+      if (pendingRef.current.get(blockId) !== raw) {
+        pendingRef.current.set(blockId, raw);
         void hydrateRegistryBlockRaw(raw)
           .then((result) => {
+            const live = findNode(blockId);
+            const liveRaw =
+              live && typeof live.node.attrs.__raw === "string"
+                ? live.node.attrs.__raw
+                : "";
+            if (
+              !isRegistryBlockHydrationCurrent(
+                raw,
+                pendingRef.current.get(blockId),
+                liveRaw,
+              )
+            ) {
+              if (pendingRef.current.get(blockId) === raw) {
+                pendingRef.current.delete(blockId);
+                bump();
+              }
+              return;
+            }
             if (result.status === "loaded") {
               const parsed = result.block;
               const existing = cacheRef.current.get(blockId);
@@ -1902,6 +1943,7 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
               if (!existing) {
                 cacheRef.current.set(blockId, {
                   type: parsed.type,
+                  rawSource: raw,
                   base: parsed.base,
                   data: parsed.data,
                   edited: false,
@@ -1940,6 +1982,8 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
                         },
                       );
                       editor.view.dispatch(tr);
+                      const entry = cacheRef.current.get(blockId);
+                      if (entry) entry.rawSource = refreshedRaw;
                     } catch {
                       /* Keep the parsed cache; leave raw untouched if invalid. */
                     }
@@ -1953,27 +1997,20 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
                   typeof node.attrs.blockType === "string"
                     ? node.attrs.blockType
                     : "",
+                rawSource: result.rawSource,
                 data: undefined,
                 edited: false,
                 loadError: {
-                  message: t("editor.registryBlockLoadError", {
-                    type:
-                      typeof node.attrs.blockType === "string"
-                        ? node.attrs.blockType
-                        : "registry",
-                    message:
-                      result.message === "unreadable"
-                        ? t("editor.registryBlockUnreadable")
-                        : result.message,
-                  }),
-                  rawSource: result.rawSource,
+                  reason: result.message,
                 },
               });
               bump();
             }
           })
           .finally(() => {
-            pendingRef.current.delete(blockId);
+            if (pendingRef.current.get(blockId) === raw) {
+              pendingRef.current.delete(blockId);
+            }
           });
       }
       return undefined;
@@ -1997,6 +2034,7 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
       cacheRef.current.set(blockId, {
         type,
         base,
+        rawSource: typeof node.attrs.__raw === "string" ? node.attrs.__raw : "",
         data: nextData,
         edited: true,
       });
@@ -2012,6 +2050,8 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
         bump();
         return;
       }
+      const updated = cacheRef.current.get(blockId);
+      if (updated) updated.rawSource = raw;
 
       const tr = editor.state.tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -16,6 +16,7 @@ import { canonicalizeNfm, docToNfm, nfmToDoc } from "@shared/nfm";
 import {
   serializeRegistryBlockToMdx,
   parseRegistryBlockData,
+  type ParsedRegistryBlock,
 } from "@shared/nfm-registry";
 import { IconMusic, IconPhoto, IconVideo } from "@tabler/icons-react";
 import {
@@ -1748,6 +1749,35 @@ interface RegistryBlockStoreEntry {
   };
   data: unknown;
   edited: boolean;
+  loadError?: {
+    message: string;
+    rawSource?: string;
+  };
+}
+
+export async function hydrateRegistryBlockRaw(
+  rawSource: string,
+): Promise<
+  | { status: "loaded"; block: ParsedRegistryBlock }
+  | { status: "error"; message: string; rawSource: string }
+> {
+  try {
+    const block = await parseRegistryBlockData(rawSource);
+    if (!block) {
+      return {
+        status: "error",
+        message: "unreadable",
+        rawSource,
+      };
+    }
+    return { status: "loaded", block };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "unreadable",
+      rawSource,
+    };
+  }
 }
 
 function serializeRegistryBlockRaw(
@@ -1803,6 +1833,7 @@ function isNotionIncompatibleBlockType(blockType: string): boolean {
  * serializes identically to before.
  */
 function useRegistryBlockStore(editor: CoreEditor | null) {
+  const t = useT();
   const cacheRef = useRef<Map<string, RegistryBlockStoreEntry>>(new Map());
   const pendingRef = useRef<Set<string>>(new Set());
   // Bumping this state forces the NodeViews to re-read the cache once async
@@ -1848,16 +1879,23 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
 
       const cached = cacheRef.current.get(blockId);
       if (cached) {
-        return { id: blockId, title, summary, data: cached.data };
+        return {
+          id: blockId,
+          title,
+          summary,
+          data: cached.data,
+          loadError: cached.loadError,
+        };
       }
 
       // Not hydrated yet: kick off a one-shot async parse of the verbatim MDX.
       const raw = typeof node.attrs.__raw === "string" ? node.attrs.__raw : "";
-      if (raw && !pendingRef.current.has(blockId)) {
+      if (!pendingRef.current.has(blockId)) {
         pendingRef.current.add(blockId);
-        void parseRegistryBlockData(raw)
-          .then((parsed) => {
-            if (parsed) {
+        void hydrateRegistryBlockRaw(raw)
+          .then((result) => {
+            if (result.status === "loaded") {
+              const parsed = result.block;
               const existing = cacheRef.current.get(blockId);
               // A concurrent edit may have populated the cache first — don't
               // clobber it with the stale parse.
@@ -1909,10 +1947,30 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
                 }
                 bump();
               }
+            } else if (!cacheRef.current.has(blockId)) {
+              cacheRef.current.set(blockId, {
+                type:
+                  typeof node.attrs.blockType === "string"
+                    ? node.attrs.blockType
+                    : "",
+                data: undefined,
+                edited: false,
+                loadError: {
+                  message: t("editor.registryBlockLoadError", {
+                    type:
+                      typeof node.attrs.blockType === "string"
+                        ? node.attrs.blockType
+                        : "registry",
+                    message:
+                      result.message === "unreadable"
+                        ? t("editor.registryBlockUnreadable")
+                        : result.message,
+                  }),
+                  rawSource: result.rawSource,
+                },
+              });
+              bump();
             }
-          })
-          .catch(() => {
-            /* Leave uncached; the NodeView keeps showing its placeholder. */
           })
           .finally(() => {
             pendingRef.current.delete(blockId);
@@ -1920,7 +1978,7 @@ function useRegistryBlockStore(editor: CoreEditor | null) {
       }
       return undefined;
     },
-    [editor, findNode, bump],
+    [editor, findNode, bump, t],
   );
 
   const onBlockDataChange = useCallback(

--- a/templates/content/app/i18n-data.ts
+++ b/templates/content/app/i18n-data.ts
@@ -3167,6 +3167,8 @@ const enUS = {
     searchLanguages: "Search languages...",
     noBlocksFields: "No Blocks fields. Add one from the property menu.",
     noDocumentSelected: "No document selected",
+    registryBlockLoadError: "Could not load {{type}} block: {{message}}",
+    registryBlockUnreadable: "Persisted block source is unreadable.",
     blocksFieldRevisionConflict:
       "This Blocks field changed elsewhere. Your edit wasn't saved; the latest version is now shown.",
     couldNotReadLocalSourceFile: "Could not read local source file",
@@ -5762,6 +5764,8 @@ const editorMessagesByLocale = {
       red: "红色",
     },
     noDocumentSelected: "未选择文档",
+    registryBlockLoadError: "无法加载 {{type}} 块：{{message}}",
+    registryBlockUnreadable: "无法读取已保存的块源内容。",
     blocksFieldRevisionConflict:
       "此 Blocks 字段已在其他位置更改。你的编辑未保存；现已显示最新版本。",
     collabConnectingReadOnly: "正在连接实时编辑器。显示只读快照。",
@@ -6127,6 +6131,8 @@ const editorMessagesByLocale = {
       red: "Rojo",
     },
     noDocumentSelected: "Ningún documento seleccionado",
+    registryBlockLoadError: "No se pudo cargar el bloque {{type}}: {{message}}",
+    registryBlockUnreadable: "No se puede leer el origen guardado del bloque.",
     blocksFieldRevisionConflict:
       "Este campo de bloques cambió en otro lugar. Tu edición no se guardó; ahora se muestra la versión más reciente.",
     collabConnectingReadOnly:
@@ -6505,6 +6511,9 @@ const editorMessagesByLocale = {
       red: "Rouge",
     },
     noDocumentSelected: "Aucun document sélectionné",
+    registryBlockLoadError:
+      "Impossible de charger le bloc {{type}} : {{message}}",
+    registryBlockUnreadable: "La source enregistrée du bloc est illisible.",
     blocksFieldRevisionConflict:
       "Ce champ de blocs a été modifié ailleurs. Votre modification n’a pas été enregistrée ; la dernière version est maintenant affichée.",
     collabConnectingReadOnly:
@@ -6888,6 +6897,10 @@ const editorMessagesByLocale = {
       red: "Rot",
     },
     noDocumentSelected: "Kein Dokument ausgewählt",
+    registryBlockLoadError:
+      "Der Block {{type}} konnte nicht geladen werden: {{message}}",
+    registryBlockUnreadable:
+      "Die gespeicherte Blockquelle kann nicht gelesen werden.",
     blocksFieldRevisionConflict:
       "Dieses Blocks-Feld wurde an anderer Stelle geändert. Deine Bearbeitung wurde nicht gespeichert; jetzt wird die neueste Version angezeigt.",
     collabConnectingReadOnly:
@@ -7274,6 +7287,9 @@ const editorMessagesByLocale = {
       red: "赤",
     },
     noDocumentSelected: "ドキュメントが選択されていません",
+    registryBlockLoadError:
+      "{{type}} ブロックを読み込めませんでした: {{message}}",
+    registryBlockUnreadable: "保存されたブロックソースを読み取れません。",
     blocksFieldRevisionConflict:
       "このブロックフィールドは別の場所で変更されました。編集内容は保存されず、最新バージョンが表示されています。",
     collabConnectingReadOnly:
@@ -7649,6 +7665,8 @@ const editorMessagesByLocale = {
       red: "빨간색",
     },
     noDocumentSelected: "선택한 문서가 없습니다.",
+    registryBlockLoadError: "{{type}} 블록을 불러올 수 없습니다: {{message}}",
+    registryBlockUnreadable: "저장된 블록 소스를 읽을 수 없습니다.",
     blocksFieldRevisionConflict:
       "이 블록 필드가 다른 곳에서 변경되었습니다. 편집 내용은 저장되지 않았으며 최신 버전이 표시됩니다.",
     collabConnectingReadOnly:
@@ -8023,6 +8041,9 @@ const editorMessagesByLocale = {
       red: "Vermelho",
     },
     noDocumentSelected: "Nenhum documento selecionado",
+    registryBlockLoadError:
+      "Não foi possível carregar o bloco {{type}}: {{message}}",
+    registryBlockUnreadable: "Não foi possível ler a origem salva do bloco.",
     blocksFieldRevisionConflict:
       "Este campo de blocos foi alterado em outro lugar. Sua edição não foi salva; a versão mais recente agora está sendo exibida.",
     collabConnectingReadOnly:
@@ -8403,6 +8424,8 @@ const editorMessagesByLocale = {
       red: "लाल",
     },
     noDocumentSelected: "कोई दस्तावेज़ चयनित नहीं",
+    registryBlockLoadError: "{{type}} ब्लॉक लोड नहीं किया जा सका: {{message}}",
+    registryBlockUnreadable: "सहेजा गया ब्लॉक स्रोत पढ़ा नहीं जा सकता।",
     blocksFieldRevisionConflict:
       "यह ब्लॉक फ़ील्ड कहीं और बदल गया है। आपका संपादन सहेजा नहीं गया; अब नवीनतम संस्करण दिखाया जा रहा है।",
     collabConnectingReadOnly:
@@ -8773,6 +8796,8 @@ const editorMessagesByLocale = {
       red: "أحمر",
     },
     noDocumentSelected: "لم يتم تحديد أي مستند",
+    registryBlockLoadError: "تعذر تحميل كتلة {{type}}: {{message}}",
+    registryBlockUnreadable: "تعذرت قراءة مصدر الكتلة المحفوظ.",
     blocksFieldRevisionConflict:
       "تم تغيير حقل الكتل هذا في مكان آخر. لم يتم حفظ تعديلك؛ ويظهر الآن أحدث إصدار.",
     collabConnectingReadOnly:

--- a/templates/content/app/i18n/zh-TW.ts
+++ b/templates/content/app/i18n/zh-TW.ts
@@ -121,6 +121,8 @@ const messages = {
     searchLanguages: "搜尋語言...",
     noBlocksFields: "沒有 Blocks 欄位。請從屬性選單新增一個。",
     noDocumentSelected: "未選取檔案",
+    registryBlockLoadError: "無法載入 {{type}} 區塊：{{message}}",
+    registryBlockUnreadable: "無法讀取已儲存的區塊來源。",
     blocksFieldRevisionConflict:
       "此 Blocks 欄位已在其他位置變更。你的編輯未儲存；現在顯示的是最新版本。",
     couldNotReadLocalSourceFile: "無法讀取本機來源檔案",

--- a/templates/content/docs/solutions/2026-08-21-content-mermaid-rendering-shape.md
+++ b/templates/content/docs/solutions/2026-08-21-content-mermaid-rendering-shape.md
@@ -177,3 +177,57 @@ blocked until Slack file access is reauthenticated or Lautaro's document/source
 is otherwise recovered from an authorized source. Work should first retry that
 read-only retrieval and bind the hosted artifact before choosing whether any
 code change is needed.
+
+## Approved replacement acceptance revision
+
+Alice explicitly approved this material acceptance and risk-policy change on
+2026-08-21 for PR #3350. This revision supersedes the reporter-exact hosted
+replay, exact-head approval-age distinction, and base-drift acceptance
+objections for this merge decision. The earlier story remains above as
+historical context, but it is no longer the governing Land gate for this PR.
+
+Replacement successful-user story:
+
+> PR #3350 is acceptable to integrate when its intended current head is
+> mergeable under the repository's live GitHub policy and every
+> repository-required CI check for that head has passed or reached another
+> repository-permitted terminal state.
+
+Required assertions:
+
+1. The live PR head equals the intended pushed branch head.
+2. Every repository-required CI check for that head is successful or otherwise
+   accepted by the repository's live merge policy.
+3. GitHub reports the PR mergeable and permits a normal, non-admin merge.
+4. The PR title and description accurately describe the current diff and its
+   verification evidence.
+
+Replacement acceptance policy:
+
+- Modality: `automated`
+- Independence: `not-required`
+- Custody: `same-context-allowed`
+- Interface: the live GitHub PR, checks, mergeability state, and normal merge
+  operation for PR #3350
+- Rationale: Alice explicitly accepted current repository mergeability and
+  required CI as sufficient evidence for this PR and discarded the earlier
+  reporter-exact, approval-age, and base-drift gates
+
+Revised frozen five:
+
+- **Outcome:** Integrate PR #3350 once the live repository accepts its current
+  head and required CI.
+- **Shipping surface:** `BuilderIO/agent-native`; Content authenticated document
+  editor for Content users; durable destination is `main`; ordinary integration
+  action is a normal GitHub merge of PR #3350.
+- **Governing architecture:** Unchanged from the original shape; inline NFM/MDX
+  remains authoritative, Content owns registry hydration, and core owns shared
+  Mermaid rendering.
+- **Acceptance story:** `content-mermaid-repository-mergeable-v2`, exactly as
+  frozen in this revision.
+- **Risk strategy:** `system-ready`; production validation after merge remains
+  `false`, with Alice explicitly accepting repository mergeability and required
+  CI as sufficient for this merge decision.
+
+Lifecycle authority is restored for the already-requested direct Land handoff
+at ledger revision `content-mermaid-repository-mergeable-v2-20260821`.

--- a/templates/content/docs/solutions/2026-08-21-content-mermaid-rendering-shape.md
+++ b/templates/content/docs/solutions/2026-08-21-content-mermaid-rendering-shape.md
@@ -1,0 +1,179 @@
+# Repair Content Mermaid rendering — Shape
+
+## Status
+
+Shape complete. This brief is read-only product and architecture guidance for
+Bowerbird task `c42a4e5a-631a-420d-8052-2fc867df8855`, supplied revision
+`b774078aa6c7f7f0492c9788ee2912df54ee92933ecdd4094c2963656698a0f9`.
+No implementation, test fixture, deployment, production mutation, push, or pull
+request is authorized by this artifact.
+
+Repository evidence is bound to `BuilderIO/agent-native` commit
+`17f227e777dd8dfe8727390ea0ca852225cf2548`.
+
+## Reporter evidence
+
+The exact Slack parent is in `#product-agent-native-feedback`
+(`C0ATH3CCZT4`) at `1786440893.568689`, posted by Lautaro Lihue Galarza on
+2026-08-11. It says only: ``Content` mermaid is not loading.`The thread has no
+replies and contains one file,`image.png` (`F0BPECYC57U`). Slack search returns
+no document link or Mermaid source in the message or surrounding context.
+
+The attachment could not be materialized because the current Slack connection
+lacks the file-read scope. Therefore the screenshot, reporter document, exact
+stored NFM/MDX, Mermaid source, hosted artifact identity, console output, and
+network trace remain unavailable. Do not invent a reproduction from the seeded
+slash-command example and do not treat that example passing as reporter-exact
+acceptance.
+
+## Current boundary
+
+Content registers the shared core block library in its browser registry. A
+persisted Mermaid atom remains inline in `documents.content` as NFM/MDX on the
+Tiptap node's `__raw` attribute; Content has no Mermaid-specific sidecar store.
+On first render, `useRegistryBlockStore` asynchronously parses that raw source
+into typed registry data and exposes it to the shared registry NodeView.
+
+There are two distinct failure boundaries:
+
+1. **Content registry hydration.** Successful parsing is cached and forces the
+   NodeView to reread its side map. A missing raw value, a `null` parse result, or
+   a rejected parse remains indistinguishable from “still loading”; the rejection
+   is swallowed and the NodeView stays on its placeholder. This is a directly
+   evidenced indefinite-state defect at the host boundary, independent of
+   Mermaid syntax.
+2. **Shared Mermaid rendering.** Once typed data exists, core dynamically loads
+   the Excalidraw converter and renderer, then falls back to Mermaid. When both
+   paths reject, it already shows the raw source plus `Could not render diagram`
+   and both error messages. The current focused render test proves only the
+   mocked Excalidraw success/expand path; round-trip coverage proves seeded
+   Mermaid source fidelity, not failed hydration, dynamic-import failure, or the
+   reporter's source.
+
+Direct evidence does not identify which boundary Lautaro encountered. The
+visible “not loading” symptom is consistent with Content hydration never
+settling, an older hosted bundle, or a browser/runtime request that never
+settles. Unsupported Mermaid syntax alone should reach the existing bounded
+dual-renderer error after hydration and is therefore a weaker fit, but remains
+an inference until the exact source is recovered.
+
+## Product classification
+
+This is a **contract repair** in Content's document editing workflow. The
+accepted behavior is that a persisted structured block becomes either usable
+content or an explicit recoverable error; absence, unreadability, and pending
+work must not collapse into the same successful-looking placeholder. No current
+Feature or Capability record specifically names registry-block hydration or
+Mermaid rendering, so Work must not invent a stable product ID solely for PR
+metadata. If the advisory Content impact declaration requires an ID, record the
+catalog gap rather than broadening this repair into a new product contract.
+
+## Smallest compatible delta
+
+Keep inline NFM/MDX as the authority and keep the shared block registry and
+shared Mermaid renderer. Change only the boundary proven to fail by the
+reporter-exact replay:
+
+- If persisted registry hydration fails or produces no typed block, carry a
+  distinct typed error through the side-map/NodeView and render the preserved raw
+  block source with a bounded, useful error. Do not silently retry forever or
+  coerce unreadable data to an empty block.
+- If hydration succeeds and the reporter artifact instead proves a shared
+  dynamic-import or renderer defect, repair the shared core Mermaid boundary,
+  preserving Excalidraw-first rendering and Mermaid fallback.
+- If current accepted hosted code renders the exact artifact, classify the
+  report as stale deployment or already repaired and close with artifact-bound
+  evidence; do not create a speculative code change.
+
+Do not redesign registry storage, add a Mermaid table/sidecar, change the NFM
+format, merge this with native Code Block or media insertion, add a new route or
+Action, or expand into generic registry observability.
+
+## Frozen successful-user story
+
+> When Lautaro opens the originally reported Content document on the exact
+> accepted hosted artifact, its persisted Mermaid block leaves loading in a
+> bounded time: valid source renders and remains rendered after navigation and
+> reload; invalid, unsupported, or unreadable persisted source preserves the raw
+> source and shows a useful error. A failed browser chunk/import is visible in
+> console/network evidence and never becomes an indefinite placeholder.
+
+Required assertions:
+
+1. Retrieve the reporter's exact document and persisted Mermaid source, or
+   record with evidence that they are unavailable; do not substitute seeded
+   source for the reporter-exact assertion.
+2. On the exact accepted hosted artifact, valid reporter source renders and
+   survives navigation plus reload without changing the persisted source.
+3. Invalid/unsupported Mermaid source reaches the existing raw-source plus
+   bounded-error state when hydration succeeds.
+4. Missing, malformed, or rejected registry hydration reaches a distinct
+   raw-source plus bounded-error state and cannot remain indefinitely loading.
+5. Excalidraw failure followed by Mermaid success renders; dual-renderer failure
+   preserves raw source and reports both failures.
+6. Real-interface evidence includes the artifact identity, document identity,
+   persisted source identity or sanitized exact source, console and network
+   inspection for dynamic imports, and a screenshot or recording of final valid
+   and error states.
+
+Acceptance policy:
+
+- Modality: `real-interface`
+- Independence: `preferred`
+- Custody: `same-context-allowed`
+- Interface: the authenticated hosted Content editor on the exact accepted
+  artifact, using the reporter document or an exact sanitized copy when access
+  policy forbids direct replay
+- Rationale: the failure spans persisted source, async browser hydration, and
+  runtime chunks, so unit tests alone cannot prove the user story; independent
+  review is useful but not part of the reporter's requested outcome
+
+## Frozen five
+
+- **Outcome:** Persisted Mermaid blocks always settle to a correct rendered
+  diagram or an explicit raw-source error; never indefinite loading.
+- **Shipping surface:** `BuilderIO/agent-native`; Content authenticated document
+  editor for Content users; durable destination is the Content template and any
+  necessary shared core registry/Mermaid boundary; ordinary integration action
+  is `merge` through a review-ready pull request after Work and Land authority.
+- **Governing architecture:** Inline NFM/MDX remains authoritative; Content owns
+  registry hydration and core owns shared Mermaid rendering. Repair the first
+  demonstrated failing boundary without introducing parallel storage or a
+  caller-specific renderer.
+- **Acceptance story:** `content-mermaid-settles-v1`, exactly as frozen above.
+- **Risk strategy:** `system-ready`; production validation after merge is
+  `false`. Work must reproduce and verify on an accepted hosted artifact before
+  Land rather than merge first and test in production.
+
+## Architecture grounding
+
+- Applicability: required, because the defect crosses Content's registry host
+  and the shared core block renderer.
+- Demonstrated caller: Lautaro opening a persisted Mermaid block in Content;
+  exact document/source unresolved.
+- Existing primitives: Content browser registry, inline `__raw` NFM/MDX,
+  `parseRegistryBlockData`, registry side-map/NodeView, shared `MermaidRead`,
+  Excalidraw dynamic import, Mermaid fallback.
+- Ownership: Content owns persistence hydration and error transport into the
+  NodeView; core owns shared Mermaid conversion/rendering and renderer errors.
+- Legacy contracts: byte-preserving inline round-trip for untouched blocks;
+  shared registry types; Excalidraw-first house style; Mermaid fallback; raw
+  source retained on errors; unrelated registry blocks unchanged.
+- Smallest compatible delta: typed, terminal hydration failure at the Content
+  boundary unless the reporter-exact replay directly proves a core renderer or
+  deployment defect.
+- Deferred: storage redesign, generic block telemetry, new Actions/routes,
+  native Code Block/media behavior, registry-wide migration.
+- Reversibility: a narrow state/error-path change with focused hydration and
+  renderer tests; no schema or persisted-format migration.
+- Unresolved owner questions: none that change a public/shared contract. The
+  missing reporter artifact is an acceptance prerequisite, not a product
+  decision.
+
+## Work entry condition
+
+Work may begin from this shape, but reporter-exact system-ready acceptance is
+blocked until Slack file access is reauthenticated or Lautaro's document/source
+is otherwise recovered from an authorized source. Work should first retry that
+read-only retrieval and bind the hosted artifact before choosing whether any
+code change is needed.


### PR DESCRIPTION
## Problem

Content documents hydrate persisted registry blocks, including Mermaid diagrams, after the editor first renders. When persisted block source could not be parsed, that asynchronous hydration failure was swallowed. The block therefore remained on its loading placeholder indefinitely, with neither the original source nor a useful error available to the user.

This change repairs that indefinite-loading boundary without changing the downstream Mermaid rendering path.

## Approach

Treat registry-block hydration as a source-bound terminal state machine instead of an implicit cache miss. Successful parses populate the existing side map exactly as before. Failed parses populate an explicit error state that preserves the persisted source and gives the node renderer enough information to stop showing a loading placeholder.

Hydration results are committed only while both the pending request and the live node still carry the source that was parsed. A source replacement with the same block ID invalidates cached data and errors, then hydrates the current source. Errored blocks remain selectable so users can delete or replace them, while their preserved raw source retains native text selection and copy behavior.

The shared Mermaid renderer remains responsible for Excalidraw-first rendering, Mermaid fallback, and its own render-time diagnostics. This PR only owns the earlier Content hydration boundary.

## What changed

- Added a typed hydration result for loaded and failed persisted registry blocks.
- Bound cache and pending hydration entries to their exact persisted source, discarding stale completions after collaboration, reconciliation, or undo/redo changes.
- Cached failed hydration attempts once, preserving the raw source and a concrete parser error when available.
- Added a shared registry-block error surface that renders preserved source plus a localized terminal message while retaining block selection, deletion, and native source copying.
- Materialized localized error copy when the side map is read so mounted errors follow locale changes.
- Added translations for every configured Content locale.
- Added focused tests for valid Mermaid hydration, malformed and empty persisted source, stale-source rejection, source preservation, error-state selection/deletion, native source selection, and the absence of an indefinite loading state.
- Added a package changeset and the durable Shape evidence document.

## Safety and operations

There are no schema changes, data migrations, credential changes, or production mutations. Existing valid blocks follow the same parse and render path. Failed source is displayed as escaped text, not interpreted markup. Rollback is the commit revert; no persisted data is rewritten by this change.

## Verification

- 58 focused toolkit and Content hydration/round-trip tests passed, demonstrating successful hydration, terminal malformed-source handling, stale-source rejection, deletion of an errored block, and native selection of preserved source.
- The existing shared Mermaid renderer suite passed 9 tests, confirming the downstream Mermaid and Excalidraw fallback boundary remains green.
- Toolkit and core package builds passed; Content typecheck exited successfully.
- The repository-wide formatter and all 63 repository guards passed, including localization, no-silent-coercion, and Content product conformance.
- In an isolated local Content database, a persisted Mermaid document rendered in the real editor, survived a full reload, showed no loading placeholder, and produced no browser errors.

## Review focus

- Is hydration failure represented at the correct registry side-map boundary rather than inside the Mermaid renderer?
- Does source-bound cache invalidation cover collaboration, reconciliation, and undo/redo without clobbering a newer edit?
- Does the terminal error preserve enough source and editing affordance to recover a document without exposing interpreted markup?