### PR TITLE
Keep Content database columns in user-defined order

### DIFF
--- a/templates/content/actions/update-content-database-view.test.ts
+++ b/templates/content/actions/update-content-database-view.test.ts
@@ -56,6 +56,7 @@ describe("update content database view", () => {
         },
       ],
       collapsedGroupIds: ["status:done"],
+      propertyOrderIds: ["name", "status"],
       hideEmptyGroups: true,
       calculations: { status: "count_values" },
       wrapCells: true,

--- a/templates/content/app/components/editor/database/DatabaseView.test.ts
+++ b/templates/content/app/components/editor/database/DatabaseView.test.ts
@@ -54,6 +54,8 @@ import {
   databaseNextBuilderHydrationSource,
   databasePreviewItem,
   databaseItemPagePath,
+  orderDatabasePropertiesForView,
+  reorderDatabaseViewProperty,
   databaseRecordBuilderContinuationAttempt,
   databaseSourceOperationIsPending,
   databaseSourceChangeSetsAreComplete,
@@ -1268,6 +1270,87 @@ const baseProperty = (
   },
   value: null,
   editable: true,
+});
+
+describe("database property column order", () => {
+  const view = {
+    id: "table",
+    name: "Table",
+    type: "table" as const,
+    sorts: [],
+    filters: [],
+    columnWidths: {},
+  };
+  const propertyIds = (properties: DocumentProperty[]) =>
+    properties.map((property) => property.definition.id);
+
+  it("moves a visible property before another while preserving hidden columns", () => {
+    const allProperties = [
+      baseProperty("alpha"),
+      baseProperty("hidden"),
+      baseProperty("bravo"),
+      baseProperty("charlie"),
+    ];
+    const visibleProperties = [
+      allProperties[0],
+      allProperties[2],
+      allProperties[3],
+    ];
+
+    const reordered = reorderDatabaseViewProperty(
+      view,
+      "charlie",
+      "alpha",
+      { allProperties, visibleProperties },
+      "before",
+    );
+
+    expect(reordered.propertyOrderIds).toEqual([
+      "charlie",
+      "alpha",
+      "hidden",
+      "bravo",
+    ]);
+    expect(
+      propertyIds(orderDatabasePropertiesForView(allProperties, reordered)),
+    ).toEqual(["charlie", "alpha", "hidden", "bravo"]);
+  });
+
+  it("keeps surviving explicit order and appends new properties", () => {
+    const properties = [
+      baseProperty("alpha"),
+      baseProperty("bravo"),
+      baseProperty("charlie"),
+      baseProperty("delta"),
+    ];
+
+    expect(
+      propertyIds(
+        orderDatabasePropertiesForView(properties, {
+          propertyOrderIds: ["deleted", "charlie", "alpha", "bravo"],
+        }),
+      ),
+    ).toEqual(["charlie", "alpha", "bravo", "delta"]);
+  });
+
+  it("does not reorder from or onto a hidden property", () => {
+    const allProperties = [
+      baseProperty("alpha"),
+      baseProperty("hidden"),
+      baseProperty("bravo"),
+    ];
+    const visibleProperties = [allProperties[0], allProperties[2]];
+
+    expect(
+      reorderDatabaseViewProperty(
+        view,
+        "hidden",
+        "alpha",
+        { allProperties, visibleProperties },
+        "before",
+      ),
+    ).toBe(view);
+  });
 });
 
 const builderRowItem = (id: string): ContentDatabaseItem => ({

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -2431,6 +2431,14 @@ function DatabaseTable({
                 : nextViewConfig,
             );
           },
+          onError: (err) => {
+            toast.error(dbText("failedToSaveView"), {
+              description:
+                err instanceof Error
+                  ? err.message
+                  : dbText("somethingWentWrong"),
+            });
+          },
         },
       );
     }, 350);

--- a/templates/content/changelog/2026-08-24-database-columns-keep-their-chosen-order-across-reloads-visi.md
+++ b/templates/content/changelog/2026-08-24-database-columns-keep-their-chosen-order-across-reloads-visi.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-24
+---
+
+Database columns keep their chosen order across reloads, visibility changes, and newly added fields


### PR DESCRIPTION
## Problem

Content database users can drag table columns into a preferred order, but the durable behavior was not covered across the cases that most often destabilize ordering: hidden properties, stale or newly added properties, and saved-view serialization. A failed saved-view write was also silent, which could leave the table looking reordered without telling the user that the change did not persist.

## Approach

Keep the existing saved-view property order as the source of truth and freeze its behavior at the smallest boundaries. The tests cover how visible drag operations update the complete property order without losing hidden columns, how removed identifiers are ignored, and how new properties append without disturbing surviving user order. The table now also reports a saved-view persistence failure through the existing localized error copy.

## What changed

- Add focused ordering tests for drag reorder with hidden columns, stale identifiers, new-property append, and invalid hidden-property drag targets.
- Assert that the update-content-database-view action preserves propertyOrderIds in parsed saved-view config.
- Surface debounced saved-view write failures with the existing localized toast instead of leaving the optimistic order unexplained.
- Add a user-facing Content changelog entry for stable database column order.

## Safety and operations

This is an additive UI, regression-test, and changelog change. It introduces no schema migration, backfill, feature flag, credential change, or production data operation. Rollback is the commit revert; no persisted data requires reversal.

## Verification

- Content typecheck passed for the implementation commit; the follow-up changes only a Markdown changelog entry.
- The focused Vitest suite passed again at the current head: 3 files, 82 tests.
- All 63 repository guards passed again at the current head.
- The generated changelog entry is formatter-clean and appears as a pending fixed Content note.
- Real-interface acceptance against a disposable local SQLite database demonstrated that dragging Charlie before Alpha persisted after reload, remained specific to the selected saved view, survived hiding and restoring Bravo, and kept the reordered columns ahead of a newly added property. Direct SQLite read-back confirmed the saved propertyOrderIds. The disposable browser, server, database, WAL/SHM files, and screenshots were removed afterward.

## Review focus

- Does the full-property reorder preserve hidden-property placement without letting hidden properties become drag endpoints?
- Is deterministic append the right compatibility behavior for newly discovered properties and stale saved identifiers?
- Is the existing saved-view error toast sufficient when the optimistic drag cannot be persisted?
- Does the changelog note describe the user-visible outcome without exposing implementation detail?