### PR TITLE
fix: enforce the client-above-server budgets against resolved config

### DIFF
--- a/.changeset/client-above-server-invariant.md
+++ b/.changeset/client-above-server-invariant.md
@@ -1,0 +1,24 @@
+---
+"@agent-native/core": patch
+---
+
+Enforce the client-above-server follow budgets against resolved configuration.
+
+The browser's per-turn follow budgets must stay above the server's own ceilings,
+because the client fires on a clock and cannot tell looping from working while
+the server can. They shipped inverted once — 10 min / 6 runs against a 13-minute
+legal chunk — and killed healthy turns the server was still streaming, which was
+the top non-auth cause of "the chat just stopped".
+
+That relationship was pinned in `agent-chat-adapter.spec.ts` against the
+server's module constants. Making those constants configurable moved the real
+values out from under the test without moving the test: a deployment could raise
+`maxTurnWallClockMs`, `maxBackgroundRunContinuations`, or
+`backgroundSoftTimeoutCeilingMs` past what the shipped client can follow, and
+every check still passed.
+
+The client budgets now live in `app-config/run-lifecycle-invariants.ts` (which
+has no runtime imports, so the browser bundle is unaffected) and
+`assertRunLifecycleInvariants` asserts all three relationships against the
+resolved configuration. The spec keeps pinning the defaults — one fails fast on
+a bad default, the other on a bad deploy.

--- a/.changeset/client-above-server-invariant.md
+++ b/.changeset/client-above-server-invariant.md
@@ -22,3 +22,14 @@ has no runtime imports, so the browser bundle is unaffected) and
 `assertRunLifecycleInvariants` asserts all three relationships against the
 resolved configuration. The spec keeps pinning the defaults — one fails fast on
 a bad default, the other on a bad deploy.
+
+Comparing the configured numbers alone also hid a real inversion in the shipped
+values, so the check now uses the EFFECTIVE server limits: the turn ceiling is
+tested at chunk boundaries, so a turn passing it one chunk short still gets a
+whole further chunk (90min + 13min against a client following 95min), and the
+durable ledger allows the chain bound plus the recovery slack in run rows
+(20 + 5 = 25 against a client following 24). Both were inverted. The client
+follow budgets move to 110 minutes and 30 runs so the shipped defaults are
+consistent; killing a turn that is not progressing is still covered by the 210s
+idle timeout and the repeated-terminal-reason detector, neither of which is a
+clock on the whole turn.

--- a/packages/core/src/agent/run-lifecycle-config.spec.ts
+++ b/packages/core/src/agent/run-lifecycle-config.spec.ts
@@ -7,6 +7,8 @@ import {
 } from "../app-config/index.js";
 import {
   BACKGROUND_AUTOMATION_SOFT_TIMEOUT_HEADROOM_MS,
+  MAX_BACKGROUND_FOLLOW_WALL_TIME_MS,
+  MAX_FOLLOWED_BACKGROUND_RUNS,
   BACKGROUND_FUNCTION_WALL_HEADROOM_MS,
   BACKGROUND_FUNCTION_WALL_MS,
   RunLifecycleInvariantError,
@@ -253,6 +255,44 @@ describe("run-lifecycle invariants", () => {
         backgroundSoftTimeoutCeilingMs: BACKGROUND_SOFT_TIMEOUT_CEILING_MS,
       }),
     ).not.toThrow();
+  });
+
+  // These three used to be pinned only in `agent-chat-adapter.spec.ts`, against
+  // the server's module constants. Making those configurable moved the real
+  // values out from under that test without moving the test — a deployment
+  // could raise any of them past what the shipped client follows and every
+  // check still passed. The client bound is static in the bundle; the server
+  // bound is not; so the check has to run where the server bound resolves.
+  it("refuses a turn ceiling the shipped client would abandon first", () => {
+    expect(() =>
+      assertRunLifecycleInvariants({
+        ...base(),
+        maxTurnWallClockMs: MAX_BACKGROUND_FOLLOW_WALL_TIME_MS + 60_000,
+      }),
+    ).toThrow(RunLifecycleInvariantError);
+  });
+
+  it("refuses a chain bound the shipped client would stop following", () => {
+    expect(() =>
+      assertRunLifecycleInvariants({
+        ...base(),
+        maxBackgroundRunContinuations: MAX_FOLLOWED_BACKGROUND_RUNS,
+      }),
+    ).toThrow(RunLifecycleInvariantError);
+  });
+
+  it("refuses a chunk budget that leaves no room for a second chunk", () => {
+    // The exact inversion that shipped: one legal chunk longer than half the
+    // client's whole-turn budget means a turn needing two chunks dies mid-stream
+    // while the server is healthy.
+    expect(() =>
+      assertRunLifecycleInvariants({
+        ...base(),
+        backgroundSoftTimeoutCeilingMs: Math.floor(
+          MAX_BACKGROUND_FOLLOW_WALL_TIME_MS / 2,
+        ),
+      }),
+    ).toThrow(RunLifecycleInvariantError);
   });
 
   it("skips ordering checks for a disabled backstop", () => {

--- a/packages/core/src/agent/run-lifecycle-config.spec.ts
+++ b/packages/core/src/agent/run-lifecycle-config.spec.ts
@@ -272,11 +272,39 @@ describe("run-lifecycle invariants", () => {
     ).toThrow(RunLifecycleInvariantError);
   });
 
+  // The ceiling is checked at chunk boundaries, so a turn that passes one chunk
+  // short of it still gets a whole further chunk. Comparing the configured
+  // number alone hid a real inversion in the shipped values.
+  it("counts the chunk a turn can still start after passing the ceiling check", () => {
+    const agent = base();
+    const nominallyUnder =
+      MAX_BACKGROUND_FOLLOW_WALL_TIME_MS - agent.backgroundSoftTimeoutCeilingMs;
+    expect(nominallyUnder).toBeLessThan(MAX_BACKGROUND_FOLLOW_WALL_TIME_MS);
+    expect(() =>
+      assertRunLifecycleInvariants({
+        ...agent,
+        maxTurnWallClockMs: nominallyUnder + 60_000,
+      }),
+    ).toThrow(RunLifecycleInvariantError);
+  });
+
   it("refuses a chain bound the shipped client would stop following", () => {
     expect(() =>
       assertRunLifecycleInvariants({
         ...base(),
         maxBackgroundRunContinuations: MAX_FOLLOWED_BACKGROUND_RUNS,
+      }),
+    ).toThrow(RunLifecycleInvariantError);
+  });
+
+  // The durable ledger allows the chain bound PLUS the recovery slack in run
+  // ROWS, and the client counts rows.
+  it("counts the ledger's recovery slack against the client's run budget", () => {
+    expect(() =>
+      assertRunLifecycleInvariants({
+        ...base(),
+        maxBackgroundRunContinuations:
+          MAX_FOLLOWED_BACKGROUND_RUNS - TURN_RUN_LEDGER_SLACK,
       }),
     ).toThrow(RunLifecycleInvariantError);
   });

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -4,6 +4,7 @@
  * reliable reconnection after page refreshes.
  */
 import { getAppConfig } from "../app-config/index.js";
+import { TURN_RUN_LEDGER_SLACK } from "../app-config/run-lifecycle-invariants.js";
 import type { DbExec } from "../db/client.js";
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
@@ -221,18 +222,10 @@ async function hasRunningRuns(): Promise<boolean> {
   return false;
 }
 
-/**
- * Slack between the CHAIN bound (`agent.maxBackgroundRunContinuations`) and the
- * per-turn LEDGER bound below.
- *
- * They count different things. The chain bound counts handoffs a chunk decided
- * to make; the ledger counts every run ROW the turn produced, which also
- * includes sweep redispatches and stale-run recoveries no chunk ever decided.
- * Without slack the ledger would refuse a turn before the chain bound it is
- * meant to sit above, so a turn recovered once would die holding unused chain
- * budget.
- */
-export const TURN_RUN_LEDGER_SLACK = 5;
+// Re-exported from its home in `app-config/run-lifecycle-invariants.ts`, which
+// is where the client-above-server check needs it — importing back from here
+// would be circular.
+export { TURN_RUN_LEDGER_SLACK };
 
 /**
  * Ceiling on run ROWS for one logical turn — the number the continuation-chain

--- a/packages/core/src/app-config/run-lifecycle-invariants.ts
+++ b/packages/core/src/app-config/run-lifecycle-invariants.ts
@@ -41,6 +41,19 @@ export const BACKGROUND_FUNCTION_WALL_MS = 15 * 60_000;
 export const BACKGROUND_FUNCTION_WALL_HEADROOM_MS = 2 * 60_000;
 
 /**
+ * Slack between the CHAIN bound (`agent.maxBackgroundRunContinuations`) and the
+ * per-turn LEDGER bound below.
+ *
+ * They count different things. The chain bound counts handoffs a chunk decided
+ * to make; the ledger counts every run ROW the turn produced, which also
+ * includes sweep redispatches and stale-run recoveries no chunk ever decided.
+ * Without slack the ledger would refuse a turn before the chain bound it is
+ * meant to sit above, so a turn recovered once would die holding unused chain
+ * budget.
+ */
+export const TURN_RUN_LEDGER_SLACK = 5;
+
+/**
  * Per-TURN follow budgets the browser applies while reading a background turn.
  *
  * They live here, not in `client/agent-chat-adapter.ts`, because they are one
@@ -64,8 +77,8 @@ export const BACKGROUND_FUNCTION_WALL_HEADROOM_MS = 2 * 60_000;
  * `BACKGROUND_FOLLOW_IDLE_TIMEOUT_MS` and the repeated-terminal-reason
  * detector.
  */
-export const MAX_FOLLOWED_BACKGROUND_RUNS = 24;
-export const MAX_BACKGROUND_FOLLOW_WALL_TIME_MS = 95 * 60_000;
+export const MAX_FOLLOWED_BACKGROUND_RUNS = 30;
+export const MAX_BACKGROUND_FOLLOW_WALL_TIME_MS = 110 * 60_000;
 
 /**
  * Ordering relationships between the run-lifecycle bounds.
@@ -248,16 +261,25 @@ export function assertRunLifecycleInvariants(agent: AppConfig["agent"]): void {
   }, "a whole-turn client budget below two full-length chunks kills a healthy turn mid-stream — the exact inversion that shipped");
 
   require("server turn ceiling below the client's follow budget", {
-    key: "agent.maxTurnWallClockMs",
-    value: maxTurnWallClockMs,
+    // EFFECTIVE, not nominal: the ceiling is checked at chunk boundaries, so a
+    // turn passing the check one chunk short of it still gets a whole further
+    // chunk. Comparing the configured number alone hid a real inversion in the
+    // shipped values — 90min + a 13min chunk against a client that stopped
+    // following at 95min.
+    key: "agent.maxTurnWallClockMs + agent.backgroundSoftTimeoutCeilingMs",
+    value: maxTurnWallClockMs + backgroundSoftTimeoutCeilingMs,
   }, {
     key: "MAX_BACKGROUND_FOLLOW_WALL_TIME_MS",
     value: MAX_BACKGROUND_FOLLOW_WALL_TIME_MS,
   }, "the server must end the turn first, because it is the side that can tell progress from a loop and write a truthful terminal reason");
 
   require("server chain bound below the client's follow-run budget", {
-    key: "agent.maxBackgroundRunContinuations",
-    value: maxBackgroundRunContinuations,
+    // EFFECTIVE, not nominal: the durable ledger allows the chain bound PLUS
+    // the recovery slack in run ROWS, and the client counts rows. 20 + 5 = 25
+    // against a client that stopped at 24 — the same inversion, hidden the
+    // same way.
+    key: "agent.maxBackgroundRunContinuations + TURN_RUN_LEDGER_SLACK",
+    value: maxBackgroundRunContinuations + TURN_RUN_LEDGER_SLACK,
   }, {
     key: "MAX_FOLLOWED_BACKGROUND_RUNS",
     value: MAX_FOLLOWED_BACKGROUND_RUNS,

--- a/packages/core/src/app-config/run-lifecycle-invariants.ts
+++ b/packages/core/src/app-config/run-lifecycle-invariants.ts
@@ -41,6 +41,33 @@ export const BACKGROUND_FUNCTION_WALL_MS = 15 * 60_000;
 export const BACKGROUND_FUNCTION_WALL_HEADROOM_MS = 2 * 60_000;
 
 /**
+ * Per-TURN follow budgets the browser applies while reading a background turn.
+ *
+ * They live here, not in `client/agent-chat-adapter.ts`, because they are one
+ * half of an ordering relationship whose other half is server configuration —
+ * and a relationship checked in only one of its two homes is the failure this
+ * module exists to prevent. This file has no runtime imports (the `AppConfig`
+ * import is type-only and erased), so the browser bundle pays nothing to read
+ * them from here.
+ *
+ * CLIENT-ABOVE-SERVER: these MUST stay above the server's own ceilings. The
+ * client fires on a clock and cannot tell looping from working; the server can,
+ * so the server must always terminate a turn first and write a truthful
+ * terminal reason. They shipped at 10 min / 6 runs while ONE legal background
+ * chunk may run 13 minutes — so the client killed healthy turns the server was
+ * still streaming, measured in production as aborts at 11-25 minutes with
+ * progress recorded right up to the abort. That was the top non-auth cause of
+ * "the chat just stopped".
+ *
+ * Do NOT tighten these to catch a stuck turn. A turn that is not progressing is
+ * already caught twice by mechanisms that read progress rather than a clock:
+ * `BACKGROUND_FOLLOW_IDLE_TIMEOUT_MS` and the repeated-terminal-reason
+ * detector.
+ */
+export const MAX_FOLLOWED_BACKGROUND_RUNS = 24;
+export const MAX_BACKGROUND_FOLLOW_WALL_TIME_MS = 95 * 60_000;
+
+/**
  * Ordering relationships between the run-lifecycle bounds.
  *
  * Every one of these was already argued for in a source comment somewhere and
@@ -203,6 +230,38 @@ export function assertRunLifecycleInvariants(agent: AppConfig["agent"]): void {
     },
     "a streak bound above the chain bound can never trip, so a repeating failure runs to the chain limit instead",
   );
+
+  // ── Client-above-server ────────────────────────────────────────────────
+  //
+  // Until this branch these were pinned in `agent-chat-adapter.spec.ts` against
+  // the server's module CONSTANTS. Making those constants configurable moved
+  // the real values out from under that test without moving the test: a
+  // deployment could raise any of them past what the shipped client can follow
+  // and every check still passed. Asserting against the RESOLVED config is what
+  // closes that.
+  require("server chunk budget leaves the client room for more than one chunk", {
+    key: "agent.backgroundSoftTimeoutCeilingMs * 2",
+    value: backgroundSoftTimeoutCeilingMs * 2,
+  }, {
+    key: "MAX_BACKGROUND_FOLLOW_WALL_TIME_MS",
+    value: MAX_BACKGROUND_FOLLOW_WALL_TIME_MS,
+  }, "a whole-turn client budget below two full-length chunks kills a healthy turn mid-stream — the exact inversion that shipped");
+
+  require("server turn ceiling below the client's follow budget", {
+    key: "agent.maxTurnWallClockMs",
+    value: maxTurnWallClockMs,
+  }, {
+    key: "MAX_BACKGROUND_FOLLOW_WALL_TIME_MS",
+    value: MAX_BACKGROUND_FOLLOW_WALL_TIME_MS,
+  }, "the server must end the turn first, because it is the side that can tell progress from a loop and write a truthful terminal reason");
+
+  require("server chain bound below the client's follow-run budget", {
+    key: "agent.maxBackgroundRunContinuations",
+    value: maxBackgroundRunContinuations,
+  }, {
+    key: "MAX_FOLLOWED_BACKGROUND_RUNS",
+    value: MAX_FOLLOWED_BACKGROUND_RUNS,
+  }, "a client that stops following before the server stops chaining leaves the user watching a spinner over a live run");
 
   requireAtMost(
     "turn ceiling above one chunk budget",

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -8229,8 +8229,14 @@ describe("createAgentChatAdapter", () => {
     // The client is a backstop for a silent server, not the primary limit:
     // it fires on a clock and cannot tell looping from working. Anything that
     // is NOT progressing is already caught by BACKGROUND_FOLLOW_IDLE_TIMEOUT_MS
-    // and the repeated-terminal-reason detector. Imports the REAL server
-    // constants so this breaks the moment either side drifts.
+    // and the repeated-terminal-reason detector.
+    //
+    // This pins the DEFAULTS. It is no longer the whole enforcement: the server
+    // bounds below are runtime-configurable, so a deployment can move them
+    // without touching a constant this test can see. The live check is
+    // `assertRunLifecycleInvariants`, which asserts the same three
+    // relationships against the RESOLVED configuration when it resolves. Keep
+    // both — this one fails fast on a bad default, that one on a bad deploy.
     const { BACKGROUND_SOFT_TIMEOUT_CEILING_MS } =
       await import("../agent/run-manager.js");
     const { MAX_TURN_WALL_CLOCK_MS, MAX_BACKGROUND_RUN_CONTINUATIONS } =

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -258,29 +258,18 @@ export const BACKGROUND_FOLLOW_IDLE_TIMEOUT_MS = 210_000;
 // 22 minutes, all error:stale_run, user watching a spinner). These bound the
 // whole turn instead, and an identical repeated failure counts as no progress.
 //
-// CLIENT-ABOVE-SERVER INVARIANT (asserted in agent-chat-adapter.spec.ts).
-// These are a backstop for a server that has gone silent in a way the idle
-// timeout misses — NOT the primary limit. They must stay ABOVE the server's
-// own ceilings so the server, which can actually tell progress from looping,
-// always terminates a turn first and writes a truthful terminal reason:
-//   BACKGROUND_SOFT_TIMEOUT_CEILING_MS  (13 min, run-manager.ts)  — one chunk
-//   MAX_TURN_WALL_CLOCK_MS              (90 min, production-agent.ts) — one turn
-//   MAX_BACKGROUND_RUN_CONTINUATIONS    (20,     production-agent.ts)
-//
-// They were originally set to 10 min / 6 runs, which put the whole-turn client
-// budget BELOW the 13-minute ceiling of a single legal chunk. Any turn needing
-// a second full-length chunk was killed by the client while the server was
-// healthy and had 80 minutes left — measured in prod as turns dying at 11-25
-// minutes with `last_progress_at` tracking the abort, i.e. still streaming
-// tokens and completing tools when the client gave up. That is the top
-// non-auth cause of "the chat just stopped" reports.
-//
-// Killing a turn that is NOT progressing is already covered twice over, by
-// mechanisms that read progress rather than a clock: the 210s idle timeout
-// above, and MAX_REPEATED_BACKGROUND_TERMINAL_REASONS below. Do not re-tighten
-// these two to catch a stuck turn — fix the progress signal instead.
-export const MAX_FOLLOWED_BACKGROUND_RUNS = 24;
-export const MAX_BACKGROUND_FOLLOW_WALL_TIME_MS = 95 * 60_000;
+// Defined in `app-config/run-lifecycle-invariants.ts`, not here, because the
+// CLIENT-ABOVE-SERVER relationship they belong to is checked there against the
+// RESOLVED server configuration — the server bounds are runtime-configurable
+// now, so a spec pinning them against module constants stopped enforcing
+// anything. Re-exported under the same names so importers are unchanged; that
+// module has no runtime imports, so the bundle pays nothing for it.
+import {
+  MAX_BACKGROUND_FOLLOW_WALL_TIME_MS,
+  MAX_FOLLOWED_BACKGROUND_RUNS,
+} from "../app-config/run-lifecycle-invariants.js";
+
+export { MAX_BACKGROUND_FOLLOW_WALL_TIME_MS, MAX_FOLLOWED_BACKGROUND_RUNS };
 const MAX_REPEATED_BACKGROUND_TERMINAL_REASONS = 3;
 
 // A re-observed terminal run whose outcome would be an ERROR (never a


### PR DESCRIPTION
The browser's per-turn follow budgets must stay above the server's ceilings: the
client fires on a clock and cannot tell looping from working, the server can, so
the server has to end a turn first and write a truthful terminal reason. They
shipped inverted once and killed healthy turns mid-stream.

That relationship was pinned in agent-chat-adapter.spec.ts against the server's
module constants. Making those constants configurable moved the real values out
from under the test without moving the test — a deployment could raise any of
the three past what the shipped client follows and every check still passed. I
introduced that hole two layers ago.

The client budgets move to run-lifecycle-invariants.ts, which has no runtime
imports so the bundle is unaffected, and the resolved configuration is checked
against them where it resolves. The spec still pins the defaults: one fails on a
bad default, the other on a bad deploy.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>