### PR TITLE
fix: address review findings across the run-lifecycle stack

### DIFF
--- a/.changeset/address-run-lifecycle-review.md
+++ b/.changeset/address-run-lifecycle-review.md
@@ -1,0 +1,34 @@
+---
+"@agent-native/core": patch
+---
+
+Address review findings across the background-run hardening stack.
+
+- **A recovered `run_timeout` boundary had nothing left to continue with.** The
+  run manager armed a soft-timeout timer on the same wall the agent-loop wrapper
+  already races with its own cumulative per-round budget, so it fired exactly
+  when the wrapper had no budget left — a boundary recoverable in name only, and
+  the tail of the automation's budget reachable by nothing. The run manager no
+  longer arms that timer for a caller that recovers boundaries in-invocation:
+  one wall, one clock, with the caller's hard abort still behind it. The
+  wind-down headroom drops from 60s to 20s now that it covers wind-down only.
+- **A hard-aborted run was reported as `canceled`**, byte-identical to a user
+  pressing Stop, which is what made it indistinguishable in `$ai_error`. The
+  wrapper now reports the server-owned abort reason as a `failed` outcome with
+  that reason as its code — matching what the no-timeout path already did — so
+  the code reaches `$ai_error` through the existing path. This replaces the
+  bespoke automation-only classifier, which is deleted.
+- **The turn-run ledger allowed one row past its documented ceiling.** Both call
+  sites compared `turnRunCount > budget` while the current run's row was already
+  counted and the successor's is inserted after. Replaced by a
+  `turnRunLedgerExhausted()` predicate so the two sites cannot disagree about
+  the boundary again.
+- **The background no-progress default is clamped to the chunk it guards.** A
+  deployment lowering the global `runSoftTimeoutMs` shrank the chunk without
+  shrinking the backstop, leaving it unreachable. Unchanged at shipped values.
+- **Trace finalization can no longer alter the run it observes.** Assembly ran
+  unguarded inside a `finally`, where a throw replaces the block's result — so a
+  malformed payload could report a completed run as failed. Now guarded and
+  reported as its own error.
+- Fixes a stale trigger-dispatcher assertion left failing by the `dispatch_mode`
+  change.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -192,7 +192,7 @@ import {
   countRunsForTurn,
   RUN_DIAG_STAGE,
   UNCLAIMED_BACKGROUND_RUN_GRACE_MS,
-  resolveTurnRunLedgerBudget,
+  turnRunLedgerExhausted,
 } from "./run-store.js";
 import { buildCurrentTimeUserContext } from "./runtime-context.js";
 import {
@@ -8095,7 +8095,7 @@ export async function chainServerDrivenContinuation(opts: {
     }
   };
 
-  if (turnRunCount !== null && turnRunCount > resolveTurnRunLedgerBudget()) {
+  if (turnRunCount !== null && turnRunLedgerExhausted(turnRunCount)) {
     await stopTurn(
       "turn_continuation_budget_exhausted",
       `turn ${effectiveTurnId} consumed ${turnRunCount} runs — refusing to chain further`,

--- a/packages/core/src/agent/run-lifecycle-config.spec.ts
+++ b/packages/core/src/agent/run-lifecycle-config.spec.ts
@@ -41,10 +41,12 @@ import {
   resolveMaxTurnWallClockMs,
   resolveModelStreamNoProgressTimeoutMs,
   resolveRunNoProgressTimeoutMs,
+  resolveRunSoftTimeoutMs,
 } from "./run-manager.js";
 import {
   TURN_RUN_LEDGER_SLACK,
   resolveTurnRunLedgerBudget,
+  turnRunLedgerExhausted,
 } from "./run-store.js";
 
 afterEach(() => {
@@ -102,6 +104,23 @@ describe("run-lifecycle configuration", () => {
     );
   });
 
+  // A deployment lowering the GLOBAL soft timeout used to shrink the chunk
+  // without shrinking the background backstop, so the backstop stopped being
+  // reachable inside the chunk it guards — silently, with nothing asserting it.
+  it("keeps the background backstop inside a chunk shrunk by global configuration", () => {
+    defineAppConfig({ agent: { runSoftTimeoutMs: 20_000 } });
+    const soft = resolveRunSoftTimeoutMs(undefined, {
+      useHostedDefault: true,
+      backgroundFunction: true,
+    });
+    const backstop = resolveRunNoProgressTimeoutMs({
+      softTimeoutMs: soft,
+      backgroundFunction: true,
+    });
+    expect(soft).toBe(20_000);
+    expect(backstop).toBeLessThan(soft);
+  });
+
   it("keeps a per-call override above configuration", () => {
     defineAppConfig({ agent: { backgroundNoProgressTimeoutMs: 300_000 } });
     expect(
@@ -137,6 +156,16 @@ describe("run-lifecycle configuration", () => {
     expect(resolveTurnRunLedgerBudget()).toBeGreaterThan(
       resolveMaxBackgroundRunContinuations(),
     );
+  });
+
+  // Both call sites had `turnRunCount > budget` while the current run's row was
+  // already counted and the successor's row is inserted after the check, so at
+  // equality they allowed one row past the documented ceiling.
+  it("refuses the run that would take the turn past its ceiling, not one after", () => {
+    const budget = resolveTurnRunLedgerBudget();
+    expect(turnRunLedgerExhausted(budget - 1)).toBe(false);
+    expect(turnRunLedgerExhausted(budget)).toBe(true);
+    expect(turnRunLedgerExhausted(budget + 1)).toBe(true);
   });
 
   it("moves the turn-run budget with the configured chain bound", () => {

--- a/packages/core/src/agent/run-loop-with-resume.spec.ts
+++ b/packages/core/src/agent/run-loop-with-resume.spec.ts
@@ -1664,6 +1664,79 @@ describe("chunk-boundary recovery", () => {
     expect(continuationNote).toBeDefined();
   });
 
+  it("names the server bound that ended the turn instead of calling it a cancel", async () => {
+    const turn = new AbortController();
+    const { control } = makeControl(turn.signal);
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async (opts: any) => {
+      turn.abort("background_automation_hard_timeout");
+      await waitForAbort(opts.signal);
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+
+    const outcomes: AgentLoopOutcome[] = [];
+    await expect(
+      runAgentLoopDirectWithSoftTimeout(
+        makeOpts(
+          messages,
+          control.chunkSignal,
+          undefined,
+          "thread-hard",
+          outcomes,
+        ),
+        60_000,
+        { backgroundFunction: true },
+        control,
+      ),
+    ).rejects.toThrow();
+
+    // `canceled` here is what made a hard-timed-out automation byte-identical
+    // to a user Stop in `$ai_error`.
+    expect(outcomes.at(-1)).toMatchObject({
+      state: "failed",
+      code: "background_automation_hard_timeout",
+      retryable: false,
+    });
+  });
+
+  it("still reports a cancel when the abort reason came from the client", async () => {
+    const turn = new AbortController();
+    const { control } = makeControl(turn.signal);
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "go" }] },
+    ];
+    mockRunAgentLoop.mockImplementation(async (opts: any) => {
+      // The abort route accepts any /^[a-z0-9_-]{1,64}$/i reason from the
+      // client, so "not `user`" is not a safe test for "not a Stop".
+      turn.abort("stopped_by_reviewer");
+      await waitForAbort(opts.signal);
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+
+    const outcomes: AgentLoopOutcome[] = [];
+    await expect(
+      runAgentLoopDirectWithSoftTimeout(
+        makeOpts(
+          messages,
+          control.chunkSignal,
+          undefined,
+          "thread-client-stop",
+          outcomes,
+        ),
+        60_000,
+        { backgroundFunction: true },
+        control,
+      ),
+    ).rejects.toThrow();
+
+    expect(outcomes.at(-1)).toEqual({
+      state: "canceled",
+      message: "Agent run was aborted.",
+    });
+  });
+
   it("treats a Stop as a Stop even when a chunk control is present", async () => {
     const turn = new AbortController();
     const { control } = makeControl(turn.signal);
@@ -1673,7 +1746,7 @@ describe("chunk-boundary recovery", () => {
     let attempts = 0;
     mockRunAgentLoop.mockImplementation(async (opts: any) => {
       attempts++;
-      turn.abort("user_stop");
+      turn.abort("user");
       await waitForAbort(opts.signal);
       throw Object.assign(new Error("aborted"), { name: "AbortError" });
     });

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -306,6 +306,20 @@ function waitForBackgroundRateLimitCooldown(
   });
 }
 
+/**
+ * Abort reasons the SERVER sets on a run's own controller. Everything else —
+ * including any reason a client passes to the abort route — is a user Stop.
+ *
+ * Kept deliberately short. Each entry is a bound this package owns and can name
+ * in a terminal outcome; if you are adding a fourth, check first whether the
+ * bound belongs in `run-manager.ts` at all.
+ */
+const SERVER_OWNED_ABORT_REASONS = new Set([
+  "no_progress",
+  "run_timeout",
+  "background_automation_hard_timeout",
+]);
+
 /** Machine-readable code carried on the give-up terminal `error` event so the
  * client renders a loud "stopped before finishing" terminal instead of an
  * ambiguous silent stall. Deliberately NOT in the client's auto-recoverable
@@ -424,6 +438,33 @@ export async function runAgentLoopDirectWithSoftTimeout(
   // a control, which is what keeps the foreground/HTTP paths byte-for-byte
   // unchanged.
   const turnSignal = control?.turnSignal ?? opts.signal;
+  /**
+   * A turn someone pressed Stop on is `canceled`. A turn that ended because a
+   * SERVER bound fired is not: nobody cancelled it, it ran out of something,
+   * and the abort reason says which.
+   *
+   * Reporting both as `canceled` made a hard-timed-out automation
+   * byte-identical to a user Stop in every consumer, `$ai_error` included, and
+   * contradicted the no-timeout path above, which has always reported an
+   * unfinished reason as `failed` with that reason as its code.
+   *
+   * Allowlisted rather than "anything that isn't `user`", because the abort
+   * route accepts a client-supplied reason string: an inverted test would
+   * relabel a genuine Stop the moment a caller sent its own word for it.
+   */
+  const turnAbortOutcome = (): AgentLoopOutcome => {
+    const reason =
+      typeof turnSignal.reason === "string" ? turnSignal.reason.trim() : "";
+    if (!SERVER_OWNED_ABORT_REASONS.has(reason)) {
+      return { state: "canceled", message: "Agent run was aborted." };
+    }
+    return {
+      state: "failed",
+      code: reason,
+      retryable: false,
+      message: `Agent run was aborted (${reason}).`,
+    };
+  };
   let chunkSignal = control?.chunkSignal ?? opts.signal;
   const recoverableChunkBoundary = (): AgentLoopContinuationReason | null => {
     if (!control || turnSignal.aborted) return null;
@@ -608,7 +649,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
       }
       reportFinalOutcome(
         turnSignal.aborted
-          ? { state: "canceled", message: "Agent run was aborted." }
+          ? turnAbortOutcome()
           : (attemptOutcome ?? { state: "completed" }),
       );
       return usage;
@@ -716,10 +757,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
         continue;
       }
       if (turnSignal.aborted) {
-        reportFinalOutcome({
-          state: "canceled",
-          message: "Agent run was aborted.",
-        });
+        reportFinalOutcome(turnAbortOutcome());
         throw err;
       }
       const candidate = err as { errorCode?: unknown; message?: unknown };
@@ -776,10 +814,7 @@ export async function runAgentLoopDirectWithSoftTimeout(
       message: RUN_BUDGET_EXHAUSTED_MESSAGE,
     });
   } else if (turnSignal.aborted) {
-    reportFinalOutcome({
-      state: "canceled",
-      message: "Agent run was aborted.",
-    });
+    reportFinalOutcome(turnAbortOutcome());
   }
 
   return usage;

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -251,22 +251,34 @@ export function resolveRunNoProgressTimeoutMs(params: {
   // Per-call override wins, then configuration, then the shipped default —
   // the same ladder `resolveRunSoftTimeoutMs` implements.
   const configured = getAppConfig().agent;
+  // Largest window that can still fire inside the chunk it is guarding. A
+  // backstop at or above the chunk budget is not a loose backstop, it is an
+  // absent one.
+  const budgetCeilingMs = Math.floor(
+    softTimeoutMs * FOREGROUND_NO_PROGRESS_SOFT_TIMEOUT_FRACTION,
+  );
 
   if (backgroundFunction === true) {
+    // The background override exists to RAISE this window, so it is honoured
+    // as given — a caller asking for a longer one is making an explicit choice
+    // and stays bounded by its own hard abort.
     const override =
       explicit(params.backgroundOverrideMs) ?? explicit(params.overrideMs);
     if (override !== undefined) return override;
-    return softTimeoutMs > 0 ? configured.backgroundNoProgressTimeoutMs : 0;
+    if (!(softTimeoutMs > 0)) return 0;
+    // Clamped, unlike before: the background window was returned flat, so a
+    // deployment that lowered the GLOBAL `runSoftTimeoutMs` shrank the chunk
+    // without shrinking the backstop, and the backstop silently stopped being
+    // reachable. Nothing changes at the shipped values —
+    // min(150s, 0.75 x 13min) is still 150s.
+    return Math.min(configured.backgroundNoProgressTimeoutMs, budgetCeilingMs);
   }
 
   const override = explicit(params.overrideMs);
   // Local dev keeps runs unbounded unless a caller explicitly asks otherwise.
   if (!(softTimeoutMs > 0)) return override ?? 0;
 
-  const ceiling = Math.min(
-    configured.runNoProgressTimeoutMs,
-    Math.floor(softTimeoutMs * FOREGROUND_NO_PROGRESS_SOFT_TIMEOUT_FRACTION),
-  );
+  const ceiling = Math.min(configured.runNoProgressTimeoutMs, budgetCeilingMs);
   if (override === undefined) return ceiling;
   return override === 0 ? 0 : Math.min(override, ceiling);
 }
@@ -1759,8 +1771,14 @@ export function startRun(
     overrideMs: options?.noProgressTimeoutMs,
     backgroundOverrideMs: options?.backgroundNoProgressTimeoutMs,
   });
+  // Not armed for a runFn that recovers boundaries in this invocation. That
+  // runFn already races the SAME wall with its own per-round timer, budgeted
+  // against cumulative elapsed time — so this timer fires at the moment the
+  // wrapper has nothing left to continue with, producing a boundary that is
+  // recoverable in name only and burning the tail of the budget on nothing.
+  // One wall, one clock; the caller's hard abort still backstops it.
   const softTimeoutTimer =
-    softTimeoutMs > 0
+    softTimeoutMs > 0 && !recoverChunkBoundaries
       ? setTimeout(() => {
           reachRunBoundary("run_timeout", {
             lastEventType: run.events.at(-1)?.event.type,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -251,6 +251,21 @@ export function resolveTurnRunLedgerBudget(): number {
 }
 
 /**
+ * True when a turn holding `turnRunCount` run rows must not be given another.
+ *
+ * A predicate rather than a number the callers compare themselves, because
+ * both call sites had `turnRunCount > budget` and both were off by one: the
+ * current run's row is already inserted when they check, and the successor's
+ * row is inserted after — so at equality they permitted a row past the
+ * documented ceiling. Two sites, one comparison, no way for them to disagree
+ * about the boundary again. That is the third time in this area that one
+ * number had two spellings.
+ */
+export function turnRunLedgerExhausted(turnRunCount: number): boolean {
+  return turnRunCount >= resolveTurnRunLedgerBudget();
+}
+
+/**
  * Circuit breaker for a DETERMINISTIC dead-on-arrival loop: some request
  * shapes make the worker hang almost immediately every single time (e.g. an
  * un-timed-out provider fetch that blocks the event loop) rather than merely
@@ -1769,10 +1784,7 @@ async function attemptStaleRunRecovery(
   const turnRunCount = Number(
     (countRows?.[0] as { run_count?: unknown } | undefined)?.run_count,
   );
-  if (
-    Number.isFinite(turnRunCount) &&
-    turnRunCount > resolveTurnRunLedgerBudget()
-  ) {
+  if (Number.isFinite(turnRunCount) && turnRunLedgerExhausted(turnRunCount)) {
     return { outcome: "budget_exhausted" };
   }
 

--- a/packages/core/src/app-config/run-lifecycle-invariants.ts
+++ b/packages/core/src/app-config/run-lifecycle-invariants.ts
@@ -1,9 +1,14 @@
 import type { AppConfig } from "./schema.js";
 
 /**
- * Wall-clock reserved between a background automation's chunk budget and its
- * own hard abort, so the boundary the run manager owns can actually fire and
- * be recovered before the runner kills the process.
+ * Wall-clock reserved between a background automation's round budget and its
+ * own hard abort.
+ *
+ * It covers wind-down only — emit the terminal event, persist the turn, let
+ * `finalized` settle — because the recoverable boundary on this path belongs to
+ * the agent-loop wrapper's own per-round timer, not to a second timer in the
+ * run manager. It was 60s, subtracted from the TOTAL, which left the last
+ * minute of every automation's budget reachable by nothing at all.
  *
  * This is the constant that makes `automation soft timeout < automation hard
  * abort` true by construction rather than by hoping two independently chosen
@@ -12,7 +17,7 @@ import type { AppConfig } from "./schema.js";
  * the recoverable boundary was dead code and the only boundary an automation
  * could reach was the terminal one.
  */
-export const BACKGROUND_AUTOMATION_SOFT_TIMEOUT_HEADROOM_MS = 60_000;
+export const BACKGROUND_AUTOMATION_SOFT_TIMEOUT_HEADROOM_MS = 20_000;
 
 /**
  * The host's hard kill for a background function (Netlify: 15 minutes).

--- a/packages/core/src/jobs/background-automation-runner.spec.ts
+++ b/packages/core/src/jobs/background-automation-runner.spec.ts
@@ -97,11 +97,8 @@ vi.mock("../secrets/storage.js", async (importOriginal) => ({
   readAppSecrets: vi.fn(async () => new Map()),
 }));
 
-const {
-  BACKGROUND_RUN_HARD_TIMEOUT_MS,
-  classifyBackgroundAutomationTraceError,
-  runBackgroundAutomation,
-} = await import("./background-automation-runner.js");
+const { BACKGROUND_RUN_HARD_TIMEOUT_MS, runBackgroundAutomation } =
+  await import("./background-automation-runner.js");
 
 function dispatchModeOf(runId: string): string | null {
   const row = sqlite
@@ -324,48 +321,6 @@ function assistantContent() {
   const content = assistantMessage().content;
   return Array.isArray(content) ? content : [];
 }
-
-// A hard-aborted automation reached PostHog as "Agent run was aborted" — the
-// same string a user Stop produces — so the two were indistinguishable in the
-// one view you go to to tell them apart.
-describe("classifyBackgroundAutomationTraceError", () => {
-  it("names the hard timeout with the code the taxonomy already computed", () => {
-    expect(
-      classifyBackgroundAutomationTraceError({
-        error: new Error("Background automation timed out after 10 minutes"),
-        hardTimedOut: true,
-        hardTimeoutMs: 600_000,
-      }),
-    ).toEqual({
-      status: "error",
-      errorMessage: "Background automation timed out after 10 minutes",
-      metadata: {
-        terminal_code: "background_automation_hard_timeout",
-        hard_timeout_ms: 600_000,
-      },
-    });
-  });
-
-  it("leaves every other failure to the instrumentation's own classification", () => {
-    expect(
-      classifyBackgroundAutomationTraceError({
-        error: new Error("provider exploded"),
-        hardTimedOut: false,
-        hardTimeoutMs: 600_000,
-      }),
-    ).toBeNull();
-  });
-
-  it("carries a non-Error rejection through as its own text", () => {
-    expect(
-      classifyBackgroundAutomationTraceError({
-        error: "socket hang up",
-        hardTimedOut: true,
-        hardTimeoutMs: 600_000,
-      })?.errorMessage,
-    ).toBe("socket hang up");
-  });
-});
 
 describe("runBackgroundAutomation — thread transcript", () => {
   it("persists the prompt and tool-call turn, keeping the Job title", async () => {

--- a/packages/core/src/jobs/background-automation-runner.ts
+++ b/packages/core/src/jobs/background-automation-runner.ts
@@ -80,39 +80,6 @@ export class BackgroundAutomationRunError extends Error {
   }
 }
 
-/**
- * Terminal classification for an automation's LLM trace.
- *
- * A hard-aborted automation reached PostHog as "Agent run was aborted" — the
- * same string a user pressing Stop produces — because the abort is what the
- * loop actually sees. The taxonomy code this runner already computes never left
- * the process. The two failures call for different responses, so they need
- * different codes in the one view you go to to tell them apart.
- *
- * Returns `null` for anything else, which leaves `instrumentAgentLoop`'s own
- * classification untouched.
- */
-export function classifyBackgroundAutomationTraceError(input: {
-  error: unknown;
-  hardTimedOut: boolean;
-  hardTimeoutMs: number;
-}): {
-  status: "error";
-  errorMessage: string;
-  metadata: Record<string, unknown>;
-} | null {
-  if (!input.hardTimedOut) return null;
-  return {
-    status: "error",
-    errorMessage:
-      input.error instanceof Error ? input.error.message : String(input.error),
-    metadata: {
-      terminal_code: "background_automation_hard_timeout",
-      hard_timeout_ms: input.hardTimeoutMs,
-    },
-  };
-}
-
 /** Terminal state of one background automation run, for `onRunOutcome`. */
 export interface BackgroundAutomationOutcome {
   automation: string;
@@ -808,12 +775,6 @@ async function executeBackgroundAutomation(
                     trigger: "background_automation",
                     scope: orgId ? "organization" : "personal",
                   },
-                  classifyError: (error) =>
-                    classifyBackgroundAutomationTraceError({
-                      error,
-                      hardTimedOut,
-                      hardTimeoutMs,
-                    }),
                 });
                 return;
               }

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -318,6 +318,50 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     expect(trace!.userId).toBe("alice@example.com");
   });
 
+  // A throw from inside a `finally` REPLACES what the block was doing, so an
+  // assembly failure in trace finalization would have turned a completed run
+  // into a failed one — instrumentation altering the run it observes.
+  it("does not let a trace-assembly failure change the run's own result", async () => {
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: {
+        // `buildGenerationContent` walks messages; a getter that throws stands
+        // in for any malformed payload it could trip on.
+        get length() {
+          throw new Error("assembly blew up");
+        },
+      },
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    const usage = await instrumentAgentLoop({
+      runAgentLoop: async () => ({
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "claude-test",
+        usageReported: true,
+      }),
+      loopOpts,
+      runId: "run-assembly-throw",
+      threadId: "thread-assembly-throw",
+      userId: "alice@example.com",
+      config: {
+        ...DEFAULT_OBSERVABILITY_CONFIG,
+        enabled: true,
+        capturePrompts: true,
+      },
+    });
+
+    expect(usage).toMatchObject({ model: "claude-test", inputTokens: 1 });
+  });
+
   it("does not count a planned run_timeout boundary as an error", async () => {
     const events: TrackingEvent[] = [];
     registerTrackingProvider({

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -3,6 +3,7 @@ import type {
   AgentLoopUsage,
 } from "../agent/production-agent.js";
 import type { AgentChatEvent, AgentToolInput } from "../agent/types.js";
+import { captureError } from "../server/capture-error.js";
 import { getRequestContext } from "../server/request-context.js";
 import {
   MAX_AI_CONTENT_BYTES,
@@ -867,395 +868,417 @@ export async function instrumentAgentLoop(opts: {
         : null;
     throw err;
   } finally {
-    const runEnd = Date.now();
-    const totalDurationMs = runEnd - runStart;
+    // A throw from inside a `finally` REPLACES whatever the block was doing —
+    // including a successful return — so an assembly failure here (a content
+    // builder tripping on an odd payload, a span mapper on a malformed tool
+    // result) would report a completed run as a failed one, and a failed run
+    // with the wrong error. Every emit below already guards itself; this guards
+    // the assembly between them, so the module's contract holds without each
+    // future line having to remember it.
+    try {
+      const runEnd = Date.now();
+      const totalDurationMs = runEnd - runStart;
 
-    if (pendingTools.size > 0) {
-      if (runStatus === "success") {
-        runStatus = "error";
-        errorMessage ??= "Agent run ended with interrupted tool calls";
-      }
-      for (const [counter, pending] of pendingTools) {
-        toolCallCount += 1;
-        failedTools += 1;
-        const interruptedMessage = "Tool call interrupted before completion";
-        if (counter < MAX_TRACKED_GENERATION_TOOL_CALLS) {
-          generationToolCalls.set(counter, {
+      if (pendingTools.size > 0) {
+        if (runStatus === "success") {
+          runStatus = "error";
+          errorMessage ??= "Agent run ended with interrupted tool calls";
+        }
+        for (const [counter, pending] of pendingTools) {
+          toolCallCount += 1;
+          failedTools += 1;
+          const interruptedMessage = "Tool call interrupted before completion";
+          if (counter < MAX_TRACKED_GENERATION_TOOL_CALLS) {
+            generationToolCalls.set(counter, {
+              name: pending.toolName,
+              started_offset_ms: Math.max(0, pending.startMs - runStart),
+              duration_ms: Math.max(0, runEnd - pending.startMs),
+              status: "error",
+              error_class: "interrupted",
+              error_message: config.captureToolResults
+                ? interruptedMessage
+                : undefined,
+            });
+          }
+          if (pending.otelSpan) {
+            openOtelToolSpans.delete(pending.otelSpan);
+            endAgentSpan(pending.otelSpan, {
+              status: "error",
+              errorMessage: interruptedMessage,
+              attributes: { "tool.name": pending.toolName },
+            });
+          } else {
+            pending.endResult = {
+              status: "error",
+              errorMessage: interruptedMessage,
+            };
+          }
+          spans.push({
+            id: pending.spanId,
+            runId,
+            threadId,
+            userId,
+            parentSpanId,
+            spanType: "tool_call",
             name: pending.toolName,
-            started_offset_ms: Math.max(0, pending.startMs - runStart),
-            duration_ms: Math.max(0, runEnd - pending.startMs),
-            status: "error",
-            error_class: "interrupted",
-            error_message: config.captureToolResults
-              ? interruptedMessage
-              : undefined,
-          });
-        }
-        if (pending.otelSpan) {
-          openOtelToolSpans.delete(pending.otelSpan);
-          endAgentSpan(pending.otelSpan, {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            costCentsX100: 0,
+            durationMs: Math.max(0, runEnd - pending.startMs),
             status: "error",
             errorMessage: interruptedMessage,
-            attributes: { "tool.name": pending.toolName },
+            metadata: null,
+            createdAt: runEnd,
           });
-        } else {
-          pending.endResult = {
-            status: "error",
-            errorMessage: interruptedMessage,
-          };
         }
-        spans.push({
-          id: pending.spanId,
-          runId,
-          threadId,
-          userId,
-          parentSpanId,
-          spanType: "tool_call",
-          name: pending.toolName,
+        pendingTools.clear();
+        toolNameToCounters.clear();
+        toolCallIdToCounter.clear();
+      }
+
+      let costCentsX100 = 0;
+      try {
+        const { calculateCost } = await import("../usage/store.js");
+        if (usage) {
+          costCentsX100 = calculateCost(
+            usage.inputTokens,
+            usage.outputTokens,
+            usage.model,
+            usage.cacheReadTokens,
+            usage.cacheWriteTokens,
+          );
+        }
+        // Cost estimation is enrichment: a pricing-table miss leaves the span
+        // without a cost rather than failing the trace.
+      } catch {} // coercion-ok: see above
+
+      // A cut-off run never reaches the loop's outcome classification, so stand in
+      // for it here rather than reporting no terminal state at all. `failed` +
+      // `retryable` is the honest encoding available in `AgentLoopOutcome`: the
+      // turn did not finish, and the continuation machinery is expected to
+      // recover it. A real reported outcome always wins.
+      const effectiveTerminalOutcome: AgentLoopOutcome | undefined =
+        terminalOutcome ??
+        (cutOffReason && !EXPECTED_CONTINUATION_REASONS.has(cutOffReason)
+          ? {
+              state: "failed",
+              code: cutOffReason,
+              retryable: true,
+              message: `Agent run was cut off before finishing (${cutOffReason}).`,
+            }
+          : undefined);
+
+      let llmCallCount = 0;
+      if (usage || runStatus === "error") {
+        llmCallCount =
+          usage?.llmCalls ??
+          // Compatibility for custom loop implementations that predate the
+          // attempt counter: a measured run still counts as one call.
+          1;
+        const generationUsage = usage ?? {
           inputTokens: 0,
           outputTokens: 0,
           cacheReadTokens: 0,
           cacheWriteTokens: 0,
-          costCentsX100: 0,
-          durationMs: Math.max(0, runEnd - pending.startMs),
-          status: "error",
-          errorMessage: interruptedMessage,
+          model: loopOpts.model,
+        };
+        // The engine never reported a `usage` event for this run (killed for
+        // silence before any provider response, or the loop threw before
+        // returning). `generationUsage`'s token fields are placeholder zeros in
+        // that case, not measured values — the tracking event below must omit
+        // them rather than report a fabricated 0.
+        const usageReported = usage?.usageReported === true;
+        const firstTokenMs =
+          usage?.firstEngineEventAtMs !== undefined
+            ? Math.max(0, usage.firstEngineEventAtMs - runStart)
+            : undefined;
+        const llmSpanId = spanId();
+        const generationContent = buildGenerationContent({
+          config,
+          messages: loopOpts.messages,
+          tools: loopOpts.tools,
+          assistantText: assistantTextParts.join(""),
+          toolSpans: spans.filter((s) => s.spanType === "tool_call"),
+        });
+        const llmSpan: TraceSpan = {
+          id: llmSpanId,
+          runId,
+          threadId,
+          userId,
+          parentSpanId,
+          spanType: "llm_call",
+          name: generationUsage.model,
+          inputTokens: generationUsage.inputTokens,
+          outputTokens: generationUsage.outputTokens,
+          cacheReadTokens: generationUsage.cacheReadTokens,
+          cacheWriteTokens: generationUsage.cacheWriteTokens,
+          costCentsX100,
+          durationMs: totalDurationMs,
+          status: runStatus,
+          errorMessage,
           metadata: null,
-          createdAt: runEnd,
+          createdAt: runStart,
+        };
+        spans.push(llmSpan);
+        emitLlmGenerationTrackingEvent({
+          runId,
+          threadId,
+          userId,
+          parentSpanId,
+          llmSpanId,
+          engineName:
+            typeof loopOpts.engine?.name === "string"
+              ? loopOpts.engine.name
+              : undefined,
+          model: generationUsage.model,
+          inputTokens: usageReported ? generationUsage.inputTokens : undefined,
+          outputTokens: usageReported
+            ? generationUsage.outputTokens
+            : undefined,
+          cacheReadTokens: usageReported
+            ? generationUsage.cacheReadTokens
+            : undefined,
+          cacheWriteTokens: usageReported
+            ? generationUsage.cacheWriteTokens
+            : undefined,
+          costCentsX100: usageReported ? costCentsX100 : undefined,
+          durationMs: totalDurationMs,
+          firstTokenMs,
+          status: runStatus,
+          errorMessage,
+          toolCalls: toolCallCount,
+          successfulTools,
+          failedTools,
+          tools: [...generationToolCalls.entries()]
+            .sort(([a], [b]) => a - b)
+            .map(([, detail]) => detail),
+          toolsTruncated:
+            toolInvocationCounter > MAX_TRACKED_GENERATION_TOOL_CALLS,
+          terminalOutcome: effectiveTerminalOutcome,
+          delegation: opts.delegation,
+          createdAt: runStart,
+          experimentAssignments: opts.experimentAssignments,
+          modelSelectionSource: opts.modelSelectionSource,
+          browserSessionId,
+          ...generationContent,
         });
       }
-      pendingTools.clear();
-      toolNameToCounters.clear();
-      toolCallIdToCounter.clear();
-    }
 
-    let costCentsX100 = 0;
-    try {
-      const { calculateCost } = await import("../usage/store.js");
-      if (usage) {
-        costCentsX100 = calculateCost(
-          usage.inputTokens,
-          usage.outputTokens,
-          usage.model,
-          usage.cacheReadTokens,
-          usage.cacheWriteTokens,
-        );
-      }
-    } catch {}
-
-    // A cut-off run never reaches the loop's outcome classification, so stand in
-    // for it here rather than reporting no terminal state at all. `failed` +
-    // `retryable` is the honest encoding available in `AgentLoopOutcome`: the
-    // turn did not finish, and the continuation machinery is expected to
-    // recover it. A real reported outcome always wins.
-    const effectiveTerminalOutcome: AgentLoopOutcome | undefined =
-      terminalOutcome ??
-      (cutOffReason && !EXPECTED_CONTINUATION_REASONS.has(cutOffReason)
-        ? {
-            state: "failed",
-            code: cutOffReason,
-            retryable: true,
-            message: `Agent run was cut off before finishing (${cutOffReason}).`,
-          }
-        : undefined);
-
-    let llmCallCount = 0;
-    if (usage || runStatus === "error") {
-      llmCallCount =
-        usage?.llmCalls ??
-        // Compatibility for custom loop implementations that predate the
-        // attempt counter: a measured run still counts as one call.
-        1;
-      const generationUsage = usage ?? {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        model: loopOpts.model,
-      };
-      // The engine never reported a `usage` event for this run (killed for
-      // silence before any provider response, or the loop threw before
-      // returning). `generationUsage`'s token fields are placeholder zeros in
-      // that case, not measured values — the tracking event below must omit
-      // them rather than report a fabricated 0.
-      const usageReported = usage?.usageReported === true;
-      const firstTokenMs =
-        usage?.firstEngineEventAtMs !== undefined
-          ? Math.max(0, usage.firstEngineEventAtMs - runStart)
-          : undefined;
-      const llmSpanId = spanId();
-      const generationContent = buildGenerationContent({
-        config,
-        messages: loopOpts.messages,
-        tools: loopOpts.tools,
-        assistantText: assistantTextParts.join(""),
-        toolSpans: spans.filter((s) => s.spanType === "tool_call"),
-      });
-      const llmSpan: TraceSpan = {
-        id: llmSpanId,
+      const parentSpan: TraceSpan = {
+        id: parentSpanId,
         runId,
         threadId,
         userId,
-        parentSpanId,
-        spanType: "llm_call",
-        name: generationUsage.model,
-        inputTokens: generationUsage.inputTokens,
-        outputTokens: generationUsage.outputTokens,
-        cacheReadTokens: generationUsage.cacheReadTokens,
-        cacheWriteTokens: generationUsage.cacheWriteTokens,
+        parentSpanId: null,
+        spanType: "agent_run",
+        name: spanName,
+        inputTokens: usage?.inputTokens ?? 0,
+        outputTokens: usage?.outputTokens ?? 0,
+        cacheReadTokens: usage?.cacheReadTokens ?? 0,
+        cacheWriteTokens: usage?.cacheWriteTokens ?? 0,
         costCentsX100,
         durationMs: totalDurationMs,
         status: runStatus,
         errorMessage,
-        metadata: null,
+        metadata: runMetadata,
         createdAt: runStart,
       };
-      spans.push(llmSpan);
-      emitLlmGenerationTrackingEvent({
-        runId,
-        threadId,
-        userId,
-        parentSpanId,
-        llmSpanId,
-        engineName:
+      spans.push(parentSpan);
+
+      // PostHog LLM analytics: the run is a `$ai_trace`, each tool call an
+      // `$ai_span` under it. Emitted from the collected spans rather than from a
+      // second instrumentation pass, so the tree PostHog shows and the tree we
+      // persist cannot drift apart.
+      try {
+        const aiError =
+          runStatus === "error"
+            ? toAiErrorDetail(errorMessage, {
+                state: effectiveTerminalOutcome?.state,
+                code:
+                  effectiveTerminalOutcome?.state === "failed" ||
+                  effectiveTerminalOutcome?.state === "input_required"
+                    ? effectiveTerminalOutcome.code
+                    : undefined,
+                retryable:
+                  effectiveTerminalOutcome?.state === "failed"
+                    ? effectiveTerminalOutcome.retryable
+                    : undefined,
+              })
+            : undefined;
+        const provider = llmProviderFromEngine(
           typeof loopOpts.engine?.name === "string"
             ? loopOpts.engine.name
             : undefined,
-        model: generationUsage.model,
-        inputTokens: usageReported ? generationUsage.inputTokens : undefined,
-        outputTokens: usageReported ? generationUsage.outputTokens : undefined,
-        cacheReadTokens: usageReported
-          ? generationUsage.cacheReadTokens
-          : undefined,
-        cacheWriteTokens: usageReported
-          ? generationUsage.cacheWriteTokens
-          : undefined,
-        costCentsX100: usageReported ? costCentsX100 : undefined,
-        durationMs: totalDurationMs,
-        firstTokenMs,
-        status: runStatus,
-        errorMessage,
-        toolCalls: toolCallCount,
-        successfulTools,
-        failedTools,
-        tools: [...generationToolCalls.entries()]
-          .sort(([a], [b]) => a - b)
-          .map(([, detail]) => detail),
-        toolsTruncated:
-          toolInvocationCounter > MAX_TRACKED_GENERATION_TOOL_CALLS,
-        terminalOutcome: effectiveTerminalOutcome,
-        delegation: opts.delegation,
-        createdAt: runStart,
-        experimentAssignments: opts.experimentAssignments,
-        modelSelectionSource: opts.modelSelectionSource,
-        browserSessionId,
-        ...generationContent,
-      });
-    }
+          usage?.model ?? loopOpts.model,
+        );
 
-    const parentSpan: TraceSpan = {
-      id: parentSpanId,
-      runId,
-      threadId,
-      userId,
-      parentSpanId: null,
-      spanType: "agent_run",
-      name: spanName,
-      inputTokens: usage?.inputTokens ?? 0,
-      outputTokens: usage?.outputTokens ?? 0,
-      cacheReadTokens: usage?.cacheReadTokens ?? 0,
-      cacheWriteTokens: usage?.cacheWriteTokens ?? 0,
-      costCentsX100,
-      durationMs: totalDurationMs,
-      status: runStatus,
-      errorMessage,
-      metadata: runMetadata,
-      createdAt: runStart,
-    };
-    spans.push(parentSpan);
+        const toolSpans = config.captureLlmSpans
+          ? spans.filter((s) => s.spanType === "tool_call")
+          : [];
+        const emittedToolSpans = toolSpans.slice(0, MAX_AI_SPANS_PER_RUN);
+        const droppedToolSpans = toolSpans.length - emittedToolSpans.length;
 
-    // PostHog LLM analytics: the run is a `$ai_trace`, each tool call an
-    // `$ai_span` under it. Emitted from the collected spans rather than from a
-    // second instrumentation pass, so the tree PostHog shows and the tree we
-    // persist cannot drift apart.
-    try {
-      const aiError =
-        runStatus === "error"
-          ? toAiErrorDetail(errorMessage, {
-              state: effectiveTerminalOutcome?.state,
-              code:
-                effectiveTerminalOutcome?.state === "failed" ||
-                effectiveTerminalOutcome?.state === "input_required"
-                  ? effectiveTerminalOutcome.code
-                  : undefined,
-              retryable:
-                effectiveTerminalOutcome?.state === "failed"
-                  ? effectiveTerminalOutcome.retryable
-                  : undefined,
-            })
-          : undefined;
-      const provider = llmProviderFromEngine(
-        typeof loopOpts.engine?.name === "string"
-          ? loopOpts.engine.name
-          : undefined,
-        usage?.model ?? loopOpts.model,
-      );
-
-      const toolSpans = config.captureLlmSpans
-        ? spans.filter((s) => s.spanType === "tool_call")
-        : [];
-      const emittedToolSpans = toolSpans.slice(0, MAX_AI_SPANS_PER_RUN);
-      const droppedToolSpans = toolSpans.length - emittedToolSpans.length;
-
-      emitAiTraceEvent({
-        runId,
-        threadId,
-        userId,
-        spanName,
-        model: usage?.model ?? loopOpts.model,
-        provider,
-        latencySeconds: Math.round(totalDurationMs) / 1000,
-        isError: runStatus === "error",
-        error: aiError,
-        inputTokens: usage?.usageReported ? usage.inputTokens : undefined,
-        outputTokens: usage?.usageReported ? usage.outputTokens : undefined,
-        costUsd: usage?.usageReported
-          ? costUsdFromCenticents(costCentsX100)
-          : undefined,
-        createdAt: runStart,
-        browserSessionId,
-        extraProperties: {
-          ...trackingIdentityProperties(),
-          source: "agent_observability",
-          run_id: runId,
-          thread_id: threadId,
-          ...aiTraceMetadataProperties(runMetadata),
-          // Present for planned boundaries too, which are not errors: the ratio
-          // of run_timeout to no_progress is the signal, and it is unreadable
-          // if only one side of it is recorded.
-          ...(cutOffReason ? { terminal_reason: cutOffReason } : {}),
-          // A truncated run must not read as a complete one.
-          ...(droppedToolSpans > 0
-            ? {
-                $ai_spans_dropped: droppedToolSpans,
-                $ai_spans_emitted: emittedToolSpans.length,
-              }
-            : {}),
-        },
-      });
-
-      for (const span of emittedToolSpans) {
-        // `span.errorMessage` is the raw tool result. It routinely contains
-        // upstream response bodies with Authorization headers and standalone
-        // API keys, so it gets the same redaction + bounding the generation
-        // event's `tools[].error_message` already applies, and the same
-        // `captureToolResults` gate — exporting it here otherwise reintroduced
-        // the leak that gate exists to prevent. `$ai_is_error` still marks the
-        // failure when the content is withheld.
-        const toolErrorMessage =
-          span.status === "error" &&
-          span.errorMessage &&
-          config.captureToolResults
-            ? truncateToolErrorMessage(
-                redactToolErrorMessage(span.errorMessage),
-              )
-            : undefined;
-
-        emitAiSpanEvent({
+        emitAiTraceEvent({
           runId,
           threadId,
           userId,
-          spanId: span.id,
-          spanName: span.name,
-          latencySeconds: Math.round(span.durationMs) / 1000,
-          isError: span.status === "error",
-          error: toolErrorMessage
-            ? toAiErrorDetail(toolErrorMessage)
+          spanName,
+          model: usage?.model ?? loopOpts.model,
+          provider,
+          latencySeconds: Math.round(totalDurationMs) / 1000,
+          isError: runStatus === "error",
+          error: aiError,
+          inputTokens: usage?.usageReported ? usage.inputTokens : undefined,
+          outputTokens: usage?.usageReported ? usage.outputTokens : undefined,
+          costUsd: usage?.usageReported
+            ? costUsdFromCenticents(costCentsX100)
             : undefined,
-          createdAt: span.createdAt,
+          createdAt: runStart,
           browserSessionId,
-          // `metadata.input` is already redacted and only present when
-          // `captureToolArgs` is on; absent stays absent.
-          inputState: (span.metadata as { input?: unknown } | null)?.input,
-          outputState: toolErrorMessage,
           extraProperties: {
             ...trackingIdentityProperties(),
             source: "agent_observability",
-            span_type: "tool_call",
+            run_id: runId,
+            thread_id: threadId,
+            ...aiTraceMetadataProperties(runMetadata),
+            // Present for planned boundaries too, which are not errors: the ratio
+            // of run_timeout to no_progress is the signal, and it is unreadable
+            // if only one side of it is recorded.
+            ...(cutOffReason ? { terminal_reason: cutOffReason } : {}),
+            // A truncated run must not read as a complete one.
+            ...(droppedToolSpans > 0
+              ? {
+                  $ai_spans_dropped: droppedToolSpans,
+                  $ai_spans_emitted: emittedToolSpans.length,
+                }
+              : {}),
           },
         });
+
+        for (const span of emittedToolSpans) {
+          // `span.errorMessage` is the raw tool result. It routinely contains
+          // upstream response bodies with Authorization headers and standalone
+          // API keys, so it gets the same redaction + bounding the generation
+          // event's `tools[].error_message` already applies, and the same
+          // `captureToolResults` gate — exporting it here otherwise reintroduced
+          // the leak that gate exists to prevent. `$ai_is_error` still marks the
+          // failure when the content is withheld.
+          const toolErrorMessage =
+            span.status === "error" &&
+            span.errorMessage &&
+            config.captureToolResults
+              ? truncateToolErrorMessage(
+                  redactToolErrorMessage(span.errorMessage),
+                )
+              : undefined;
+
+          emitAiSpanEvent({
+            runId,
+            threadId,
+            userId,
+            spanId: span.id,
+            spanName: span.name,
+            latencySeconds: Math.round(span.durationMs) / 1000,
+            isError: span.status === "error",
+            error: toolErrorMessage
+              ? toAiErrorDetail(toolErrorMessage)
+              : undefined,
+            createdAt: span.createdAt,
+            browserSessionId,
+            // `metadata.input` is already redacted and only present when
+            // `captureToolArgs` is on; absent stays absent.
+            inputState: (span.metadata as { input?: unknown } | null)?.input,
+            outputState: toolErrorMessage,
+            extraProperties: {
+              ...trackingIdentityProperties(),
+              source: "agent_observability",
+              span_type: "tool_call",
+            },
+          });
+        }
+        // coercion-ok: a throw here would skip trace persistence below
+      } catch {
+        // LLM analytics must never affect the run or trace persistence.
       }
-      // coercion-ok: a throw here would skip trace persistence below
-    } catch {
-      // LLM analytics must never affect the run or trace persistence.
-    }
 
-    const summary: TraceSummary = {
-      runId,
-      threadId,
-      userId,
-      totalSpans: spans.length,
-      llmCalls: llmCallCount,
-      toolCalls: toolCallCount,
-      successfulTools,
-      failedTools,
-      totalDurationMs,
-      totalCostCentsX100: costCentsX100,
-      totalInputTokens: usage?.inputTokens ?? 0,
-      totalOutputTokens: usage?.outputTokens ?? 0,
-      model: usage?.model ?? loopOpts.model,
-      createdAt: runStart,
-    };
+      const summary: TraceSummary = {
+        runId,
+        threadId,
+        userId,
+        totalSpans: spans.length,
+        llmCalls: llmCallCount,
+        toolCalls: toolCallCount,
+        successfulTools,
+        failedTools,
+        totalDurationMs,
+        totalCostCentsX100: costCentsX100,
+        totalInputTokens: usage?.inputTokens ?? 0,
+        totalOutputTokens: usage?.outputTokens ?? 0,
+        model: usage?.model ?? loopOpts.model,
+        createdAt: runStart,
+      };
 
-    writeTraceData(spans, summary, runId, config).catch(() => {});
+      writeTraceData(spans, summary, runId, config).catch(() => {});
 
-    // OpenTelemetry export (no-op unless a provider is registered). Emit a
-    // self-contained `llm.call` span carrying model + token usage, end any
-    // tool spans still open (loop threw mid-tool), and end the run span. Awaited
-    // so the spans are emitted before the function returns; cheap when no-op.
-    try {
-      if (usage) {
-        endAgentSpan(await startAgentSpan("llm.call", {}), {
+      // OpenTelemetry export (no-op unless a provider is registered). Emit a
+      // self-contained `llm.call` span carrying model + token usage, end any
+      // tool spans still open (loop threw mid-tool), and end the run span. Awaited
+      // so the spans are emitted before the function returns; cheap when no-op.
+      try {
+        if (usage) {
+          endAgentSpan(await startAgentSpan("llm.call", {}), {
+            status: runStatus,
+            errorMessage,
+            attributes: {
+              "llm.model": usage.model,
+              "llm.input_tokens": usage.inputTokens,
+              "llm.output_tokens": usage.outputTokens,
+              "llm.cache_read_tokens": usage.cacheReadTokens,
+              "llm.cache_write_tokens": usage.cacheWriteTokens,
+              "llm.cost_cents_x100": costCentsX100,
+            },
+          });
+        }
+        for (const toolSpan of openOtelToolSpans) {
+          endAgentSpan(toolSpan, {
+            status: "error",
+            errorMessage: "Agent run ended before tool_done.",
+          });
+        }
+        openOtelToolSpans.clear();
+        endAgentSpan(await otelRunSpanPromise, {
           status: runStatus,
           errorMessage,
           attributes: {
-            "llm.model": usage.model,
-            "llm.input_tokens": usage.inputTokens,
-            "llm.output_tokens": usage.outputTokens,
-            "llm.cache_read_tokens": usage.cacheReadTokens,
-            "llm.cache_write_tokens": usage.cacheWriteTokens,
-            "llm.cost_cents_x100": costCentsX100,
+            "agent.tool_calls": toolCallCount,
+            "agent.successful_tools": successfulTools,
+            "agent.failed_tools": failedTools,
+            "agent.duration_ms": totalDurationMs,
+            "agent.input_tokens": usage?.inputTokens ?? 0,
+            "agent.output_tokens": usage?.outputTokens ?? 0,
+            "agent.cost_cents_x100": costCentsX100,
+            "agent.terminal_state": effectiveTerminalOutcome?.state,
+            "agent.terminal_code":
+              effectiveTerminalOutcome?.state === "failed" ||
+              effectiveTerminalOutcome?.state === "input_required"
+                ? effectiveTerminalOutcome.code
+                : undefined,
           },
         });
+        // coercion-ok: OTel export must never break the run.
+      } catch {
+        // OTel export must never break the run.
       }
-      for (const toolSpan of openOtelToolSpans) {
-        endAgentSpan(toolSpan, {
-          status: "error",
-          errorMessage: "Agent run ended before tool_done.",
-        });
-      }
-      openOtelToolSpans.clear();
-      endAgentSpan(await otelRunSpanPromise, {
-        status: runStatus,
-        errorMessage,
-        attributes: {
-          "agent.tool_calls": toolCallCount,
-          "agent.successful_tools": successfulTools,
-          "agent.failed_tools": failedTools,
-          "agent.duration_ms": totalDurationMs,
-          "agent.input_tokens": usage?.inputTokens ?? 0,
-          "agent.output_tokens": usage?.outputTokens ?? 0,
-          "agent.cost_cents_x100": costCentsX100,
-          "agent.terminal_state": effectiveTerminalOutcome?.state,
-          "agent.terminal_code":
-            effectiveTerminalOutcome?.state === "failed" ||
-            effectiveTerminalOutcome?.state === "input_required"
-              ? effectiveTerminalOutcome.code
-              : undefined,
-        },
+    } catch (instrumentationError) {
+      // Deliberately not rethrown and deliberately not silent: the run's own
+      // outcome stands, and the telemetry failure is reported as its own.
+      captureError(instrumentationError, {
+        tags: { source: "agent-observability", phase: "trace-finalize" },
+        aiTraceId: runId,
+        extra: { runId, threadId },
       });
-    } catch {
-      // OTel export must never break the run.
     }
   }
 

--- a/packages/core/src/triggers/dispatcher.spec.ts
+++ b/packages/core/src/triggers/dispatcher.spec.ts
@@ -718,10 +718,14 @@ Read the calendar.`,
         ]),
       }),
     );
-    // dispatch_mode is now set via the runner's own pre-claim (insertRun +
-    // claimBackgroundRun) before startRun is even called, not through
-    // startRun's options — see background-automation-runner.spec.ts.
-    expect(startRunMock.mock.calls[0]?.[4]).not.toHaveProperty("dispatchMode");
+    // dispatch_mode reaches the ROW through the runner's own pre-claim
+    // (insertRun + claimBackgroundRun) before startRun is called — see
+    // background-automation-runner.spec.ts. It is ALSO passed to startRun,
+    // which is what puts it on the terminal and boundary analytics events;
+    // without that every triggered run reported itself as `foreground`.
+    expect(startRunMock.mock.calls[0]?.[4]).toMatchObject({
+      dispatchMode: "background",
+    });
   });
 
   it("fails loudly before execution when a requested event MCP tool is unavailable", async () => {


### PR DESCRIPTION
Addresses every finding the reviewer raised across #3341, #3342, #3343 and
#3346. Four of the six fixes **delete** code rather than add it.

## #3341 🔴 HIGH — a recovered `run_timeout` boundary had nothing to continue with

Correct, and it is the same "dead minute" flagged in #3341's own description.
The run manager armed a soft-timeout timer on the **same wall** the agent-loop
wrapper already races with its own cumulative per-round budget. Both were set to
the same value, so the run-manager timer fired at the exact moment the wrapper
had zero budget left — a boundary recoverable in name only — and the tail of
every automation's budget was reachable by nothing at all.

Fixed by **removing the redundant clock**, not by adding a second budget: the
run manager no longer arms that timer for a caller that recovers boundaries
in-invocation. One wall, one clock, with the caller's hard abort still behind
it. The wind-down headroom drops 60s → 20s now that it covers wind-down only.

## #3343 🟡 — the classifier's code never reached `$ai_error`

Correct. `$ai_error` derives its code from `effectiveTerminalOutcome`, and a
hard abort produced `{state: "canceled"}` with no code, so the structured fields
still matched a user Stop.

The root cause was upstream of the classifier: **the wrapper reported every
abort as `canceled`**, discarding the reason the signal already carried — and
contradicting its own no-timeout path, which has always reported an unfinished
reason as `failed` with that reason as its code. Making the wrapped path agree
sends the code through the existing `$ai_error` construction, so the bespoke
automation-only classifier from #3343 is **deleted**, tests included.

Allowlisted (`no_progress`, `run_timeout`, `background_automation_hard_timeout`)
rather than "anything that isn't `user`", because the abort route accepts a
client-supplied reason matching `/^[a-z0-9_-]{1,64}$/i` — an inverted test would
relabel a genuine Stop the moment a caller sent its own word for it. Both cases
are pinned by tests.

## #3342 🟡 — the ledger allowed one row past its ceiling

Correct. Both call sites compared `turnRunCount > budget` while the current
run's row was already inserted and counted, and the successor's row is inserted
after the check.

Rather than fix two comparisons that can drift apart again — this is the **third
time** one number in this area had two spellings — they now call a
`turnRunLedgerExhausted()` predicate. Boundary test at `budget - 1`, `budget`,
`budget + 1`.

## #3341 🟡 — the invariant missed a lowered global `runSoftTimeoutMs`

Correct: the background no-progress window was returned flat, so a deployment
lowering the global soft timeout shrank the chunk without shrinking the
backstop, leaving it unreachable inside the chunk it guards. It is now clamped
to a fraction of whatever budget the chunk actually got — the same clamp the
foreground path already applied — so it holds by construction rather than by an
assertion that has to know about it. **Unchanged at shipped values:**
`min(150s, 0.75 × 13min)` is still 150s.

I tried to unify the two branches into one expression and reverted it: the
regimes genuinely differ on override semantics (the background override exists
to *raise* the window), and forcing them together broke that. Noting it because
the reverted version looked like a simplification and was not.

## #3341 🟡 — instrumentation failures indistinguishable from loop failures

Correct, and broader than the automation path. Trace assembly runs inside a
`finally`, where **a throw replaces whatever the block was doing — including a
successful return.** `buildGenerationContent` and the span mappers ran unguarded
there, so a malformed payload could report a completed run as failed, and a
failed run with the wrong error. Guarded in `traces.ts` so it holds for all four
entry points, and reported through `captureError` as its own failure rather than
swallowed. Test drives a throwing payload and asserts the run's own usage still
returns.

## #3346 🟡 — stale trigger-dispatcher assertion

Correct, and my miss: I never ran `src/triggers` after that change. The
assertion required `dispatchMode` to be **absent** from `startRun`'s options,
which is exactly what made every triggered run report itself as `foreground`.
Updated along with its now-stale explanation.

---

63/63 guards. Full suite: 12548 passing, 32 failures all pre-existing on `main`
(unbuilt toolkit, `dist`, gitignored `templates/content/.generated`).

**Note on placement:** these land as one layer on top of the stack rather than
amended into each PR. Reviewing #3341 in isolation still shows the HIGH finding.
Happy to restack if you'd rather each fix sat in the PR that introduced it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
