### PR TITLE
fix: few design ux fixes

### DIFF
--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -3070,6 +3070,53 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
     ],
   );
 
+  /** Selects the layer under a client point inside one screen. Shared by the
+   *  double-click drill-in and by a click on an already-selected frame's body,
+   *  so both resolve the same candidate and keep the same repeat-click walk. */
+  const drillIntoScreenAtPoint = useCallback(
+    (id: string, clientX: number, clientY: number) => {
+      const point = getCanvasPoint(clientX, clientY);
+      const previousKey =
+        drillInTargetRef.current?.screenId === id
+          ? drillInTargetRef.current.key
+          : null;
+      const requestId = drillInRequestRef.current + 1;
+      drillInRequestRef.current = requestId;
+      void collectLayerMarqueeCandidates(new Set([id])).then((candidates) => {
+        if (drillInRequestRef.current !== requestId) return;
+        const target = resolveDrillInTarget({
+          candidates,
+          screenId: id,
+          point,
+          previousKey,
+        });
+        if (!target) {
+          // Nothing selectable under the pointer (e.g. an empty frame). Leave
+          // the frame itself selected rather than falling back to Interact.
+          drillInTargetRef.current = null;
+          return;
+        }
+        drillInTargetRef.current = {
+          screenId: id,
+          key: drillInCandidateKey(target),
+        };
+        updateSelectedDraftIds(() => []);
+        updateSelectedIds(() => []);
+        onLayerMarqueeSelectionChange?.(
+          [{ screenId: target.screenId, info: target.info }],
+          { source: "pointer" },
+        );
+      });
+    },
+    [
+      collectLayerMarqueeCandidates,
+      getCanvasPoint,
+      onLayerMarqueeSelectionChange,
+      updateSelectedDraftIds,
+      updateSelectedIds,
+    ],
+  );
+
   const scheduleFeedbackClear = useCallback(() => {
     if (feedbackTimerRef.current !== null) {
       window.clearTimeout(feedbackTimerRef.current);
@@ -5411,6 +5458,10 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
       const targetIds = currentSelectedIds.includes(id)
         ? currentSelectedIds
         : [id];
+      // Figma parity: this surface covers the frame body, so a press that
+      // never becomes a drag has to hand the click back to the content
+      // underneath — otherwise selecting a screen makes it unclickable.
+      const wasAlreadySelected = currentSelectedIds.includes(id);
       if (activeId !== id) {
         onPick(id);
       }
@@ -5687,17 +5738,19 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         }
       };
 
-      const handleMouseUp = () => {
+      const handleMouseUp = (ev: MouseEvent) => {
         const state = dragState.current;
         const dropTarget = primitiveDropTargetRef.current;
         if (state?.type === "move" && !state.hasMoved) {
-          // Belt-and-braces: the live transform above already skips committing
-          // until hasMoved, but restore origin here too in case any geometry
-          // slipped through (e.g. a future code path that writes frameGeometry
-          // directly) so a below-threshold click never leaves a phantom nudge.
+          // Belt-and-braces against a below-threshold click leaving a phantom
+          // nudge, in case any geometry slipped past the live transform's own
+          // hasMoved guard.
           updateFrameGeometry((current) =>
             frameGeometryWithOverrides(current, state.originFrames),
           );
+          if (wasAlreadySelected) {
+            drillIntoScreenAtPoint(id, ev.clientX, ev.clientY);
+          }
         }
         if (state?.type === "move" && state.hasMoved) {
           // If all dragged ids are committed primitive nodeIds (not screen
@@ -5751,6 +5804,7 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
     [
       activeId,
       beginDuplicateGesture,
+      drillIntoScreenAtPoint,
       findPrimitiveDropTarget,
       finishDrag,
       getCanvasPoint,
@@ -6562,48 +6616,9 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
         onEdit?.(id);
         return;
       }
-      const point = getCanvasPoint(e.clientX, e.clientY);
-      const previousKey =
-        drillInTargetRef.current?.screenId === id
-          ? drillInTargetRef.current.key
-          : null;
-      const requestId = drillInRequestRef.current + 1;
-      drillInRequestRef.current = requestId;
-      void collectLayerMarqueeCandidates(new Set([id])).then((candidates) => {
-        if (drillInRequestRef.current !== requestId) return;
-        const target = resolveDrillInTarget({
-          candidates,
-          screenId: id,
-          point,
-          previousKey,
-        });
-        if (!target) {
-          // Nothing selectable under the pointer (e.g. an empty frame). Leave
-          // the frame itself selected rather than falling back to Interact.
-          drillInTargetRef.current = null;
-          return;
-        }
-        drillInTargetRef.current = {
-          screenId: id,
-          key: drillInCandidateKey(target),
-        };
-        updateSelectedDraftIds(() => []);
-        updateSelectedIds(() => []);
-        onLayerMarqueeSelectionChange?.(
-          [{ screenId: target.screenId, info: target.info }],
-          { source: "pointer" },
-        );
-      });
+      drillIntoScreenAtPoint(id, e.clientX, e.clientY);
     },
-    [
-      collectLayerMarqueeCandidates,
-      getCanvasPoint,
-      lockedScreenIdSet,
-      onEdit,
-      onLayerMarqueeSelectionChange,
-      updateSelectedDraftIds,
-      updateSelectedIds,
-    ],
+    [drillIntoScreenAtPoint, lockedScreenIdSet, onEdit],
   );
 
   const handleMouseDown = useCallback(
@@ -8406,9 +8421,9 @@ export const MultiScreenCanvas = memo(function MultiScreenCanvas({
               beginRotate(singleSelectedFrame.id, event)
             }
             onStartDrag={
-              // A running app's frame is dragged by its label. Blanketing its
-              // content with a drag surface would make the app unclickable the
-              // moment it is selected, which is most of the time.
+              // A running app's frame is dragged by its label: its content
+              // wants the raw click, not a layer selection, so the drag
+              // surface must never cover it.
               singleSelectedFrameIsRunningApp
                 ? undefined
                 : (event) => beginFrameDrag(singleSelectedFrame.id, event)

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -13178,7 +13178,6 @@ function DesignEditor() {
         activeBreakpointWidthStateRef,
         activeTool,
         cancelActiveEditorDrag,
-        codeLayerOwnerByNodeIdRef,
         drawMode,
         enterOverviewFromZoom,
         focusedAnnotationSending,
@@ -13191,11 +13190,8 @@ function DesignEditor() {
         overviewAnnotationSending,
         pinMode,
         selectedElement,
-        selectedLayerIdsState,
-        setActiveFileId,
         setActiveTool,
         setDrawMode,
-        setExpandedLayerIds,
         setHoveredElement,
         setMode,
         setOverviewClearSelectionRequest,
@@ -13220,7 +13216,6 @@ function DesignEditor() {
       overviewAnnotationSending,
       pinMode,
       selectedElement,
-      selectedLayerIdsState,
       viewMode,
     ],
   );
@@ -13477,12 +13472,8 @@ function DesignEditor() {
       owner.node.parentId,
     );
     if (!parentOwner || parentOwner.fileId !== owner.fileId) return;
-    // BUG-ESCAPE-SHELL (same mechanism as handleEscapeHotkey's pop walk): the
-    // flat ownership map still resolves a top-level layer's parentId to the
-    // collapsed <html>/<body> shell node, which the layers panel never shows
-    // as selectable. Without this guard, Shift+Enter/"\\" on a top-level
-    // layer would select <body> instead of no-op'ing like the comment above
-    // already documents.
+    // The flat ownership map still resolves a top-level layer's parentId to
+    // the collapsed <html>/<body> shell node the layers panel never shows.
     if (!hasSelectableCodeLayerParent({ parentNode: parentOwner.node })) {
       return;
     }
@@ -15626,6 +15617,20 @@ function DesignEditor() {
 
   useLayoutEffect(() => {
     selectedLayerTargetsRef.current = selectedLayerTargets;
+  }, [selectedLayerTargets]);
+
+  /** The overview canvas keeps a layer's owning screen in `selectedScreenIds`
+   *  (z-order and "topmost screen" read it), so without this the screen's own
+   *  full-bleed SelectionBox stays mounted over the element and its drag
+   *  surface swallows the gesture — the frame moves instead of the layer. */
+  const selectedElementScreenId = useMemo(() => {
+    const first = selectedLayerTargets[0];
+    if (!first) return null;
+    return selectedLayerTargets.every(
+      (target) => target.fileId === first.fileId,
+    )
+      ? first.fileId
+      : null;
   }, [selectedLayerTargets]);
 
   const selectedLayerSelectorGroupsByScreen = useMemo(() => {
@@ -19813,6 +19818,7 @@ function DesignEditor() {
                         cameraCommand={cameraCommand}
                         activeId={activeFileId}
                         selectedScreenIds={overviewSelectedScreenIds}
+                        selectedElementScreenId={selectedElementScreenId}
                         hiddenScreenIds={hiddenLayerIds}
                         lockedScreenIds={lockedLayerIds}
                         fullViewScreenIds={fullViewScreenIds}

--- a/templates/design/app/pages/design-editor/commands/escape-hotkey.spec.ts
+++ b/templates/design/app/pages/design-editor/commands/escape-hotkey.spec.ts
@@ -1,0 +1,79 @@
+import type { RefObject } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ElementInfo } from "@/components/design/types";
+
+import { runEscapeHotkey, type EscapeHotkeyArgs } from "./escape-hotkey";
+
+const SELECTED_ELEMENT = {
+  id: "kid-one",
+  selector: '[data-agent-native-node-id="kid-one"]',
+  tagName: "div",
+} as unknown as ElementInfo;
+
+function harness(overrides: Partial<EscapeHotkeyArgs> = {}) {
+  const calls = {
+    setSelectedElement: vi.fn(),
+    setHoveredElement: vi.fn(),
+    setOverviewSelectedScreenIds: vi.fn(),
+    setSelectedLayerIdsState: vi.fn(),
+    setOverviewClearSelectionRequest: vi.fn(),
+  };
+  const args: EscapeHotkeyArgs = {
+    activeBreakpointWidthStateRef: {
+      current: undefined,
+    } as RefObject<number | undefined>,
+    activeTool: "move",
+    cancelActiveEditorDrag: () => false,
+    drawMode: false,
+    enterOverviewFromZoom: vi.fn(),
+    focusedAnnotationSending: false,
+    handleBreakpointBarSelect: vi.fn(),
+    handleCloseKeyboardShortcuts: vi.fn(),
+    handleExitFocusedDrawMode: vi.fn(),
+    handleExitOverviewDrawMode: vi.fn(),
+    keyboardShortcutsOpen: false,
+    mode: "edit",
+    overviewAnnotationSending: false,
+    pinMode: false,
+    selectedElement: SELECTED_ELEMENT,
+    setActiveTool: vi.fn(),
+    setDrawMode: vi.fn(),
+    setMode: vi.fn(),
+    setPinMode: vi.fn(),
+    viewMode: "overview",
+    ...calls,
+    ...overrides,
+  };
+  return { args, calls };
+}
+
+describe("runEscapeHotkey", () => {
+  it("deselects instead of promoting the selection to its parent layer", () => {
+    const { args, calls } = harness();
+
+    runEscapeHotkey(args);
+
+    expect(calls.setSelectedElement).toHaveBeenCalledWith(null);
+    expect(calls.setSelectedLayerIdsState).toHaveBeenCalledWith([]);
+    expect(calls.setOverviewSelectedScreenIds).toHaveBeenCalledWith([]);
+    expect(calls.setOverviewClearSelectionRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back to selecting the containing screen frame", () => {
+    const { args, calls } = harness({ viewMode: "overview" });
+
+    runEscapeHotkey(args);
+
+    expect(calls.setOverviewSelectedScreenIds).toHaveBeenCalledTimes(1);
+    expect(calls.setOverviewSelectedScreenIds).toHaveBeenCalledWith([]);
+  });
+
+  it("still lets a higher-priority consumer take the keypress", () => {
+    const { args, calls } = harness({ cancelActiveEditorDrag: () => true });
+
+    runEscapeHotkey(args);
+
+    expect(calls.setSelectedElement).not.toHaveBeenCalled();
+  });
+});

--- a/templates/design/app/pages/design-editor/commands/escape-hotkey.ts
+++ b/templates/design/app/pages/design-editor/commands/escape-hotkey.ts
@@ -1,33 +1,13 @@
-import type { CodeLayerNode, CodeLayerTreeNode } from "@shared/code-layer";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 
 import type { ElementInfo } from "@/components/design/types";
-import {
-  collectCodeLayerAncestors,
-  elementInfoFromCodeLayerNode,
-} from "@/pages/design-editor/code-layer-state";
-import {
-  hasSelectableCodeLayerParent,
-  resolveEscapePopSelectionAction,
-  shouldEscapeToOverview,
-} from "@/pages/design-editor/selection-state";
+import { shouldEscapeToOverview } from "@/pages/design-editor/selection-state";
 import type { DesignTool, EditorMode } from "@/pages/design-editor/types";
 
 export interface EscapeHotkeyArgs {
   activeBreakpointWidthStateRef: RefObject<number | undefined>;
   activeTool: DesignTool;
   cancelActiveEditorDrag: () => boolean;
-  codeLayerOwnerByNodeIdRef: RefObject<
-    Map<
-      string,
-      {
-        fileId: string;
-        node: CodeLayerNode;
-        tree: CodeLayerTreeNode[];
-        runtimeOnly: boolean;
-      }
-    >
-  >;
   drawMode: boolean;
   enterOverviewFromZoom: (nextMode?: EditorMode) => void;
   focusedAnnotationSending: boolean;
@@ -40,11 +20,8 @@ export interface EscapeHotkeyArgs {
   overviewAnnotationSending: boolean;
   pinMode: boolean;
   selectedElement: ElementInfo | null;
-  selectedLayerIdsState: string[];
-  setActiveFileId: Dispatch<SetStateAction<string | null>>;
   setActiveTool: Dispatch<SetStateAction<DesignTool>>;
   setDrawMode: Dispatch<SetStateAction<boolean>>;
-  setExpandedLayerIds: Dispatch<SetStateAction<string[]>>;
   setHoveredElement: Dispatch<SetStateAction<ElementInfo | null>>;
   setMode: Dispatch<SetStateAction<EditorMode>>;
   setOverviewClearSelectionRequest: Dispatch<SetStateAction<number>>;
@@ -59,7 +36,6 @@ export function runEscapeHotkey({
   activeBreakpointWidthStateRef,
   activeTool,
   cancelActiveEditorDrag,
-  codeLayerOwnerByNodeIdRef,
   drawMode,
   enterOverviewFromZoom,
   focusedAnnotationSending,
@@ -72,11 +48,8 @@ export function runEscapeHotkey({
   overviewAnnotationSending,
   pinMode,
   selectedElement,
-  selectedLayerIdsState,
-  setActiveFileId,
   setActiveTool,
   setDrawMode,
-  setExpandedLayerIds,
   setHoveredElement,
   setMode,
   setOverviewClearSelectionRequest,
@@ -133,68 +106,9 @@ export function runEscapeHotkey({
     enterOverviewFromZoom();
     return;
   }
-  // Figma parity — pop the plain-canvas selection one level at a time
-  // (child layer -> parent layer -> containing screen/frame -> fully
-  // deselected) instead of deselecting everything on the first Escape.
-  // The decision itself is a pure, unit-tested function
-  // (resolveEscapePopSelectionAction in design-editor/selection-state.ts);
-  // this reuses the same codeLayerOwnerByNodeIdRef/parentId ancestor walk
-  // handleSelectParentLayer (Shift+Enter / "\\") already uses, inlined
-  // here (rather than calling selectCodeLayerNodesForHotkey directly)
-  // since that helper is declared later in this component and referencing
-  // it from this callback's deps would hit its temporal-dead-zone before
-  // this render's declarations run.
-  const escapeSelectedLayerId =
-    selectedLayerIdsState[selectedLayerIdsState.length - 1];
-  const escapeOwner = escapeSelectedLayerId
-    ? codeLayerOwnerByNodeIdRef.current.get(escapeSelectedLayerId)
-    : undefined;
-  // BUG-ESCAPE-SHELL: the flat codeLayerOwnerByNodeIdRef map (built from
-  // projection.nodes) still contains <html>/<body> entries with real
-  // parentId links even though the VISUAL layers tree collapses them away
-  // (shared/code-layer.ts's isCollapsibleDocumentShellNode). A bare
-  // Boolean(escapeOwner?.node.parentId) check treats a top-level layer's
-  // collapsed <body> ancestor as a selectable parent, so popping from the
-  // screen root would select <body> then <html> instead of stopping at the
-  // screen/frame level. hasSelectableCodeLayerParent excludes those shell
-  // nodes so the pop walk matches what the layers panel shows.
-  const escapeParentOwner = escapeOwner?.node.parentId
-    ? codeLayerOwnerByNodeIdRef.current.get(escapeOwner.node.parentId)
-    : undefined;
-  const popAction = resolveEscapePopSelectionAction({
-    hasSelectedLayer: Boolean(escapeOwner),
-    hasLayerParent: hasSelectableCodeLayerParent({
-      parentNode: escapeParentOwner?.node,
-    }),
-    viewMode,
-  });
-  if (popAction.kind === "pop-to-parent-layer" && escapeOwner) {
-    const parentOwner = escapeParentOwner;
-    if (parentOwner && parentOwner.fileId === escapeOwner.fileId) {
-      setActiveFileId(parentOwner.fileId);
-      setOverviewSelectedScreenIds([]);
-      setSelectedLayerIdsState([parentOwner.node.id]);
-      setSelectedElement(elementInfoFromCodeLayerNode(parentOwner.node));
-      setExpandedLayerIds((current) => {
-        const next = new Set(current);
-        next.add(parentOwner.fileId);
-        collectCodeLayerAncestors(
-          parentOwner.tree,
-          parentOwner.node.id,
-        ).forEach((ancestorId) => next.add(ancestorId));
-        return next.size === current.length ? current : Array.from(next);
-      });
-      return;
-    }
-    // Parent couldn't be resolved (e.g. cross-file) — fall through to a
-    // full deselect below rather than silently doing nothing.
-  } else if (popAction.kind === "pop-to-screen-frame" && escapeOwner) {
-    setSelectedElement(null);
-    setSelectedLayerIdsState([]);
-    setOverviewSelectedScreenIds([escapeOwner.fileId]);
-    setOverviewClearSelectionRequest((request) => request + 1);
-    return;
-  }
+  // Figma's Esc is "select none". Walking up one ancestor per press belongs to
+  // Shift+Enter / "\\" (handleSelectParentLayer) — Escape must never leave
+  // something selected, or there is no keystroke that reaches an empty canvas.
   setSelectedElement(null);
   setHoveredElement(null);
   setOverviewSelectedScreenIds([]);

--- a/templates/design/app/pages/design-editor/selection-state.spec.ts
+++ b/templates/design/app/pages/design-editor/selection-state.spec.ts
@@ -6,7 +6,6 @@ import {
   isDocumentShellCodeLayerNode,
   overviewSelectionTargetsElement,
   pendingEditTargetsSelectedElement,
-  resolveEscapePopSelectionAction,
   shouldClearSelectionForReviewThreadTarget,
   shouldEscapeToOverview,
 } from "./selection-state";
@@ -52,63 +51,6 @@ describe("getOverviewScreenContentKey", () => {
       useRuntimeReplacement: false,
     });
     expect(after).not.toBe(before);
-  });
-});
-
-describe("resolveEscapePopSelectionAction", () => {
-  it("pops to the parent layer when the selected layer has a code-layer parent", () => {
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: true,
-        hasLayerParent: true,
-        viewMode: "single",
-      }),
-    ).toEqual({ kind: "pop-to-parent-layer" });
-
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: true,
-        hasLayerParent: true,
-        viewMode: "overview",
-      }),
-    ).toEqual({ kind: "pop-to-parent-layer" });
-  });
-
-  it("pops a top-level (parentless) selected layer to its screen/frame in overview mode", () => {
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: true,
-        hasLayerParent: false,
-        viewMode: "overview",
-      }),
-    ).toEqual({ kind: "pop-to-screen-frame" });
-  });
-
-  it("deselects a top-level selected layer in single-screen mode (no separate frame to pop to)", () => {
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: true,
-        hasLayerParent: false,
-        viewMode: "single",
-      }),
-    ).toEqual({ kind: "deselect" });
-  });
-
-  it("deselects when nothing is selected, regardless of view mode", () => {
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: false,
-        hasLayerParent: false,
-        viewMode: "single",
-      }),
-    ).toEqual({ kind: "deselect" });
-    expect(
-      resolveEscapePopSelectionAction({
-        hasSelectedLayer: false,
-        hasLayerParent: false,
-        viewMode: "overview",
-      }),
-    ).toEqual({ kind: "deselect" });
   });
 });
 

--- a/templates/design/app/pages/design-editor/selection-state.ts
+++ b/templates/design/app/pages/design-editor/selection-state.ts
@@ -401,15 +401,8 @@ export function shouldEscapeToOverview(args: {
  * node already carries `tag`/`layerNameSource` without needing a separate
  * lookup map.
  *
- * Both the Escape pop-one-level walk (`resolveEscapePopSelectionAction`) and
- * the shared Shift+Enter / "\\" select-parent walk (`handleSelectParentLayer`
- * in DesignEditor.tsx) must treat a parent that resolves to a document-shell
- * node as NO parent at all — otherwise popping from a top-level layer selects
- * the raw `<body>`/`<html>` DOM nodes instead of stopping at the screen/frame
- * level (or fully deselecting), which produces a permanently broken 0x0
- * inspector with no way back to a deselected state.
- *
- * Exported for unit testing.
+ * Select-parent must treat a document-shell parent as NO parent, or walking up
+ * from a top-level layer selects raw `<body>` and strands the inspector at 0x0.
  */
 export function isDocumentShellCodeLayerNode(node: {
   tag: string;
@@ -422,14 +415,9 @@ export function isDocumentShellCodeLayerNode(node: {
 }
 
 /**
- * True only when `parentNode` exists AND is not a document-shell node — see
- * `isDocumentShellCodeLayerNode`. Callers walking the flat code-layer
- * ownership map (Escape pop-one-level, Shift+Enter select-parent) must use
- * this instead of a bare `Boolean(parentNode)` truthiness check, or a
- * top-level layer's collapsed `<body>`/`<html>` ancestor gets treated as a
- * selectable parent layer.
- *
- * Exported for unit testing.
+ * Callers walking the flat code-layer ownership map must use this instead of a
+ * bare `Boolean(parentNode)` check, or a top-level layer's collapsed
+ * `<body>`/`<html>` ancestor gets treated as a selectable parent layer.
  */
 export function hasSelectableCodeLayerParent(args: {
   parentNode: { tag: string; layerNameSource: string } | null | undefined;
@@ -437,48 +425,6 @@ export function hasSelectableCodeLayerParent(args: {
   return (
     args.parentNode != null && !isDocumentShellCodeLayerNode(args.parentNode)
   );
-}
-
-export type EscapePopSelectionAction =
-  | { kind: "pop-to-parent-layer" }
-  | { kind: "pop-to-screen-frame" }
-  | { kind: "deselect" };
-
-/**
- * Figma parity — Escape on a plain canvas selection pops one level at a
- * time (child layer -> parent layer -> containing screen/frame -> fully
- * deselected) instead of deselecting everything on the first press.
- *
- * - A selected layer that has a code-layer parent (`hasLayerParent`) pops to
- *   that parent, reusing the same ancestor-walk `handleSelectParentLayer`
- *   (Shift+Enter / "\\") already uses via `codeLayerOwnerByNodeIdRef`.
- * - A selected TOP-level layer (no code-layer parent) in overview mode pops
- *   to selecting its containing screen/frame — the same selection kind
- *   (`overviewSelectedScreenIds`) clicking a frame directly in overview
- *   already produces.
- * - Anything else — nothing selected, or a top-level layer in single-screen
- *   mode where there's no separate "frame" to pop to (the screen already
- *   fills the view, so top-level already reads as "the frame boundary") —
- *   falls straight through to a full deselect, matching the previous
- *   unconditional Escape behavior.
- *
- * Callers must have already handled every higher-priority Escape consumer
- * (an in-progress marquee/drag, an active breakpoint edit target,
- * `shouldEscapeToOverview`'s zoom-out-to-overview case) before calling this
- * — it only decides the remaining plain-canvas-selection case.
- *
- * Exported for unit testing.
- */
-export function resolveEscapePopSelectionAction(args: {
-  hasSelectedLayer: boolean;
-  hasLayerParent: boolean;
-  viewMode: "single" | "overview";
-}): EscapePopSelectionAction {
-  if (args.hasSelectedLayer) {
-    if (args.hasLayerParent) return { kind: "pop-to-parent-layer" };
-    if (args.viewMode === "overview") return { kind: "pop-to-screen-frame" };
-  }
-  return { kind: "deselect" };
 }
 
 /**

--- a/templates/design/e2e/canvas-invariants.spec.ts
+++ b/templates/design/e2e/canvas-invariants.spec.ts
@@ -920,7 +920,7 @@ test.describe("moving", () => {
 // ── Selection ─────────────────────────────────────────────────────────────
 
 test.describe("selection", () => {
-  test("clicking selects the deepest node, and Escape walks up to the parent", async ({
+  test("clicking selects the deepest node, and Backslash walks up to the parent", async ({
     page,
   }) => {
     const id = await newDesign(page, INTRO_PAGE);
@@ -941,7 +941,7 @@ test.describe("selection", () => {
       `a plain click selects the deepest node under the pointer; got "${clicked}"`,
     ).toContain("Title");
 
-    await page.keyboard.press("Escape");
+    await page.keyboard.press("\\");
     await page.waitForTimeout(1500);
     const parent = (
       await page
@@ -951,9 +951,57 @@ test.describe("selection", () => {
     )?.trim();
     expect(
       parent,
-      `Escape is how this editor reaches the ancestor Figma would have picked ` +
+      `"\\" is how this editor reaches the ancestor Figma would have picked ` +
         `on click; got "${parent}"`,
     ).toContain("Intro");
+
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(1500);
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+      "Escape is select-none, not one more step up the ancestor chain",
+    ).toHaveCount(0);
+  });
+
+  test("Escape on a rect drawn inside a frame clears, and never lands on the screen", async ({
+    page,
+  }) => {
+    const id = await newDesign(page, BLANK_PAGE);
+    await openEditor(page, id);
+    await drawWith(page, "Frame", {
+      left: 60,
+      top: 80,
+      width: 320,
+      height: 260,
+    });
+    await drawWith(page, "Rectangle", {
+      left: 110,
+      top: 130,
+      width: 140,
+      height: 110,
+    });
+
+    const rect = inFrame(page, '[data-an-primitive="rectangle"]').first();
+    const box = await rect.boundingBox();
+    if (!box) throw new Error("drawn rectangle has no hit box");
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await page.waitForTimeout(1800);
+
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(1800);
+    const selectedName = await page
+      .locator('[role="treeitem"][aria-selected="true"]')
+      .first()
+      .textContent()
+      .catch(() => null);
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+      `Escape left "${selectedName?.trim()}" selected instead of clearing`,
+    ).toHaveCount(0);
+    await expect(
+      page.locator("[data-frame-selection-box]"),
+      "Escape escalated the selection to the screen frame",
+    ).toHaveCount(0);
   });
 
   test("selecting a second element deselects the first", async ({ page }) => {

--- a/templates/design/e2e/drag-and-drop.spec.ts
+++ b/templates/design/e2e/drag-and-drop.spec.ts
@@ -290,6 +290,75 @@ test.describe("selection chrome", () => {
     expect(await activeOverlays(page)).toContain("selection");
   });
 
+  test("a selected screen still lets you click an element inside it", async ({
+    page,
+  }) => {
+    const id = await newDesign(page);
+    await openEditor(page, id);
+    await page.locator("[data-frame-label]").first().click();
+    await page.waitForTimeout(1200);
+
+    const target = (await node(page, "box-a").boundingBox())!;
+    await page.mouse.click(
+      target.x + target.width / 2,
+      target.y + target.height / 2,
+    );
+    await page.waitForTimeout(1600);
+    const selected = await layersTree(page)
+      .getByRole("treeitem")
+      .filter({ has: page.locator('[aria-selected="true"]') })
+      .first()
+      .textContent()
+      .catch(() => null);
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+      `clicking into a selected screen selected "${selected}" instead of the element`,
+    ).toHaveCount(1);
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+    ).toContainText("Box A");
+  });
+
+  test("a layer row selection leaves the screen frame unselected", async ({
+    page,
+  }) => {
+    const id = await newDesign(page);
+    await openEditor(page, id);
+    await selectViaTree(page, "Box A");
+    expect(
+      await page.locator("[data-frame-drag-surface]").count(),
+      "the frame's full-bleed drag surface covers the layer you selected, so " +
+        "the next drag moves the whole screen instead of the layer",
+    ).toBe(0);
+  });
+
+  test("dragging a layer-row selection moves the layer, not the screen", async ({
+    page,
+  }) => {
+    const id = await newDesign(page);
+    await openEditor(page, id);
+    await selectViaTree(page, "Box A");
+    const cardBefore = (await page
+      .locator("[data-screen-card]")
+      .first()
+      .boundingBox())!;
+    const before = await geom(page, id, "box-a");
+    await dragBy(page, (await node(page, "box-a").boundingBox())!, 120, 60);
+    const after = await geom(page, id, "box-a");
+    const cardAfter = (await page
+      .locator("[data-screen-card]")
+      .first()
+      .boundingBox())!;
+    expect(
+      [after.left - before.left > 60, after.top - before.top > 30],
+      `the layer did not move: (${before.left},${before.top}) → (${after.left},${after.top})`,
+    ).toEqual([true, true]);
+    expect(
+      [Math.round(cardAfter.x), Math.round(cardAfter.y)],
+      "the screen frame moved with the drag",
+    ).toEqual([Math.round(cardBefore.x), Math.round(cardBefore.y)]);
+  });
+
   test("selecting a different element moves the chrome to it", async ({
     page,
   }) => {

--- a/templates/design/e2e/structure-selection.spec.ts
+++ b/templates/design/e2e/structure-selection.spec.ts
@@ -199,7 +199,22 @@ test.describe("keyboard selection traversal", () => {
     ).toMatch(/Kid/);
   });
 
-  test("Escape selects the parent of the current selection", async ({
+  test("Backslash selects the parent of the current selection", async ({
+    page,
+  }) => {
+    const id = await newDesign(page);
+    await openEditor(page, id);
+    await selectViaTree(page, "Kid One");
+    await page.keyboard.press("\\");
+    await page.waitForTimeout(1500);
+    const name = await selectedLayerName(page);
+    expect(
+      name,
+      `Figma: "\\" selects the parent. Selection is "${name}".`,
+    ).toBe("Wrap");
+  });
+
+  test("Escape deselects rather than walking up to the parent", async ({
     page,
   }) => {
     const id = await newDesign(page);
@@ -207,11 +222,31 @@ test.describe("keyboard selection traversal", () => {
     await selectViaTree(page, "Kid One");
     await page.keyboard.press("Escape");
     await page.waitForTimeout(1500);
-    const name = await selectedLayerName(page);
-    expect(
-      name,
-      `Escape should walk up to the parent; selection is "${name}".`,
-    ).toBe("Wrap");
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+      `Figma: Esc is "select none". Selection is "${await selectedLayerName(page)}".`,
+    ).toHaveCount(0);
+  });
+
+  // A top-level layer's parent is the collapsed <body>, which the layers panel
+  // never shows — the pop walk treated that as "no parent" and selected the
+  // containing screen instead of clearing.
+  test("Escape on a top-level layer does not select the containing screen", async ({
+    page,
+  }) => {
+    const id = await newDesign(page);
+    await openEditor(page, id);
+    await selectViaTree(page, "Loose A");
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(1500);
+    await expect(
+      page.locator('[role="treeitem"][aria-selected="true"]'),
+      `Selection is "${await selectedLayerName(page)}".`,
+    ).toHaveCount(0);
+    await expect(
+      page.locator("[data-frame-selection-box]"),
+      "Escape promoted the selection to the screen frame instead of clearing it",
+    ).toHaveCount(0);
   });
 
   test("Tab selects the next sibling", async ({ page }) => {


### PR DESCRIPTION
1. Selecting a layer in the Layers panel also selected the screen, so dragging moved the whole frame
MultiScreenCanvas already had a selectedElementScreenId prop built to suppress a screen's SelectionBox when the selection is an element inside it — DesignEditor.tsx never passed it, so it sat at null and the frame's full-bleed data-frame-drag-surface ate the gesture. 
2. Esc selected the parent layer, then the screen, instead of deselecting
runEscapeHotkey ran a "Figma parity" pop-one-level walk (child → parent → screen → clear). Figma's Esc is select none; walking up is \ / Shift+Enter, both already wired. Deleted the walk and the now-dead resolveEscapePopSelectionAction.
3. A selected screen swallowed every click into its content — cursor stuck on move, only draggable
beginFrameDrag's mouseup did nothing when the press never crossed DRAG_THRESHOLD. Now a sub-threshold press on an already-selected frame drills into the element under the cursor, reusing the double-click drill-in (hoisted to drillIntoScreenAtPoint, so click and double-click share one resolver).