### PR TITLE
fix: harden auth flows and Clips share hydration

### DIFF
--- a/.changeset/bright-links-verify.md
+++ b/.changeset/bright-links-verify.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Route new-user magic-link callbacks before the generic handler so signup links with nested query parameters do not receive a 405.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,9 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      has_tests: ${{ steps.plan.outputs.has_tests }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16f8d5 # v4.3.1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -316,7 +317,7 @@ jobs:
   test-targeted:
     name: Fast tests targeted ${{ matrix.lane }}
     needs: [change-scope, discover-targeted-lanes]
-    if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true'
+    if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true' && needs.discover-targeted-lanes.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
     # Keep each runner bounded to one package at a time, but shard the affected
     # package set across runners so a core change does not serialize its whole
@@ -391,6 +392,7 @@ jobs:
           DOCS_RESULT: ${{ needs.docs.result }}
           DISCOVER_LANES_RESULT: ${{ needs.discover-lanes.result }}
           DISCOVER_TARGETED_LANES_RESULT: ${{ needs.discover-targeted-lanes.result }}
+          TARGETED_HAS_TESTS: ${{ needs.discover-targeted-lanes.outputs.has_tests }}
           TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_REST_RESULT: ${{ needs.test-rest.result }}
           TEST_TARGETED_RESULT: ${{ needs.test-targeted.result }}
@@ -412,11 +414,19 @@ jobs:
               echo "::error::discover-targeted-lanes did not succeed ($DISCOVER_TARGETED_LANES_RESULT)"
               exit 1
             fi
-            if [ "$TEST_TARGETED_RESULT" != "success" ]; then
-              echo "::error::test-targeted did not succeed ($TEST_TARGETED_RESULT)"
-              exit 1
+            if [ "$TARGETED_HAS_TESTS" = "true" ]; then
+              if [ "$TEST_TARGETED_RESULT" != "success" ]; then
+                echo "::error::test-targeted did not succeed ($TEST_TARGETED_RESULT)"
+                exit 1
+              fi
+              echo "Targeted workspace fast tests passed."
+            else
+              if [ "$TEST_TARGETED_RESULT" != "skipped" ] && [ "$TEST_TARGETED_RESULT" != "success" ]; then
+                echo "::error::targeted test job did not skip cleanly ($TEST_TARGETED_RESULT)"
+                exit 1
+              fi
+              echo "No affected workspace has a test script; targeted fast tests were skipped."
             fi
-            echo "Targeted workspace fast tests passed."
             exit 0
           fi
           for dep in "discover-lanes:$DISCOVER_LANES_RESULT" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,6 @@ jobs:
           DOCS_RESULT: ${{ needs.docs.result }}
           DISCOVER_LANES_RESULT: ${{ needs.discover-lanes.result }}
           DISCOVER_TARGETED_LANES_RESULT: ${{ needs.discover-targeted-lanes.result }}
-          TARGETED_HAS_TESTS: ${{ needs.discover-targeted-lanes.outputs.has_tests }}
           TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_REST_RESULT: ${{ needs.test-rest.result }}
           TEST_TARGETED_RESULT: ${{ needs.test-targeted.result }}
@@ -414,7 +413,7 @@ jobs:
               echo "::error::discover-targeted-lanes did not succeed ($DISCOVER_TARGETED_LANES_RESULT)"
               exit 1
             fi
-            if [ "$TARGETED_HAS_TESTS" = "true" ]; then
+            if [ "${{ needs.discover-targeted-lanes.outputs.has_tests }}" = "true" ]; then
               if [ "$TEST_TARGETED_RESULT" != "success" ]; then
                 echo "::error::test-targeted did not succeed ($TEST_TARGETED_RESULT)"
                 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,30 @@ jobs:
         id: plan
         run: node --experimental-strip-types scripts/ci-test-lanes.ts
 
+  discover-targeted-lanes:
+    name: Plan targeted test lanes
+    needs: change-scope
+    if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Partition affected test packages into lanes
+        id: plan
+        env:
+          CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
+          LANES: 5
+        run: node --experimental-strip-types scripts/ci-test-lanes.ts
+
   test-core:
     name: Fast tests core
     needs: change-scope
@@ -290,16 +314,17 @@ jobs:
           --exclude "**/create-e2e.spec.ts"
 
   test-targeted:
-    name: Fast tests targeted workspaces
-    needs: change-scope
+    name: Fast tests targeted ${{ matrix.lane }}
+    needs: [change-scope, discover-targeted-lanes]
     if: needs.change-scope.outputs.fast_tests == 'true' && needs.change-scope.outputs.full != 'true'
     runs-on: ubuntu-latest
-    # A core change expands to its dependent workspace graph (currently 38
-    # projects) and runs those packages serially to keep runner memory bounded.
-    # Keep the bounded execution, but allow the graph to finish before treating
-    # a passing test run as a failure. The current serial graph needs more than
-    # 30 minutes on the hosted runner; retain a finite bound for true hangs.
-    timeout-minutes: 45
+    # Keep each runner bounded to one package at a time, but shard the affected
+    # package set across runners so a core change does not serialize its whole
+    # dependent graph behind one job.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-targeted-lanes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -325,33 +350,35 @@ jobs:
       - name: Install Playwright Chromium for browser-backed unit tests
         run: pnpm exec playwright install --only-shell chromium
 
-      - name: Run fast tests for affected workspaces
-        env:
-          CI_WORKSPACE_FILTERS: ${{ needs.change-scope.outputs.workspace_filters }}
-        run: |
-          filters=()
-          while IFS= read -r filter; do
-            filters+=(--filter "$filter")
-          done < <(node -e 'for (const filter of JSON.parse(process.env.CI_WORKSPACE_FILTERS)) console.log(filter)')
-          pnpm -r --no-bail --if-present --workspace-concurrency=1 "${filters[@]}" run test \
-            --exclude "**/*.db.test.ts" \
-            --exclude "**/*.integration.spec.ts" \
-            --exclude "**/*.integration.test.ts" \
-            --exclude "**/*.e2e.spec.ts" \
-            --exclude "**/*.e2e.test.ts" \
-            --exclude "**/e2e/**" \
-            --exclude "**/*.live.spec.ts" \
-            --exclude "**/*.live.test.ts" \
-            --exclude "**/*.perf.spec.ts" \
-            --exclude "**/*.perf.test.ts" \
-            --exclude "**/create-e2e.spec.ts"
+      - name: Run fast tests for lane
+        run: >-
+          pnpm -r --no-bail --if-present --workspace-concurrency=1 ${{ matrix.filters }} run test
+          --exclude "**/*.db.test.ts"
+          --exclude "**/*.integration.spec.ts"
+          --exclude "**/*.integration.test.ts"
+          --exclude "**/*.e2e.spec.ts"
+          --exclude "**/*.e2e.test.ts"
+          --exclude "**/e2e/**"
+          --exclude "**/*.live.spec.ts"
+          --exclude "**/*.live.test.ts"
+          --exclude "**/*.perf.spec.ts"
+          --exclude "**/*.perf.test.ts"
+          --exclude "**/create-e2e.spec.ts"
 
   # Stable required status check. Point branch protection at "Fast tests" (this
   # gate), not the per-lane or targeted jobs whose names may vary.
   fast-tests:
     name: Fast tests
     needs:
-      [change-scope, docs, discover-lanes, test-core, test-rest, test-targeted]
+      [
+        change-scope,
+        docs,
+        discover-lanes,
+        discover-targeted-lanes,
+        test-core,
+        test-rest,
+        test-targeted,
+      ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -360,8 +387,10 @@ jobs:
         env:
           CHANGE_SCOPE_RESULT: ${{ needs.change-scope.result }}
           DOCS_ONLY: ${{ needs.change-scope.outputs.docs_only }}
+          CI_FULL: ${{ needs.change-scope.outputs.full }}
           DOCS_RESULT: ${{ needs.docs.result }}
           DISCOVER_LANES_RESULT: ${{ needs.discover-lanes.result }}
+          DISCOVER_TARGETED_LANES_RESULT: ${{ needs.discover-targeted-lanes.result }}
           TEST_CORE_RESULT: ${{ needs.test-core.result }}
           TEST_REST_RESULT: ${{ needs.test-rest.result }}
           TEST_TARGETED_RESULT: ${{ needs.test-targeted.result }}
@@ -378,7 +407,15 @@ jobs:
             echo "Docs-only change: full fast-test lanes are not required."
             exit 0
           fi
-          if [ "$TEST_TARGETED_RESULT" = "success" ]; then
+          if [ "$CI_FULL" != "true" ]; then
+            if [ "$DISCOVER_TARGETED_LANES_RESULT" != "success" ]; then
+              echo "::error::discover-targeted-lanes did not succeed ($DISCOVER_TARGETED_LANES_RESULT)"
+              exit 1
+            fi
+            if [ "$TEST_TARGETED_RESULT" != "success" ]; then
+              echo "::error::test-targeted did not succeed ($TEST_TARGETED_RESULT)"
+              exit 1
+            fi
             echo "Targeted workspace fast tests passed."
             exit 0
           fi

--- a/packages/core/docs/content/template-clips.mdx
+++ b/packages/core/docs/content/template-clips.mdx
@@ -110,7 +110,8 @@ Live demo: [clips.agent-native.com](https://clips.agent-native.com).
 
 ## What's next
 
-{/* i18n-copy-ignore — the localized copies of this page predate this link list and do not contain this line; nothing to desync. */}
+{/* i18n-copy-ignore: formatting-only line break; localized copies predate this link list, so no translated prose changed. */}
+
 - [**Capturing Everywhere**](/docs/template-clips-capture-everywhere) — the desktop app, the mobile companion, Rewind, and the Chrome extension.
 - [**Sharing, Teams, and Agent-Readable Clips**](/docs/template-clips-sharing-and-teams) — visibility, passwords, organizations, and pasting a clip link into an agent.
 - [**AI Pipeline, Editing, and Insights**](/docs/template-clips-ai-and-editing) — transcription, non-destructive editing, and view analytics.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -899,12 +899,25 @@ describe("server/auth", () => {
       const { autoMountAuth } = await import("./auth.js");
       const app = createMockApp();
       await autoMountAuth(app);
+      const callbackPath = "/_agent-native/auth/magic-link/new-user";
+      const magicLinkPath = "/_agent-native/auth/magic-link";
       const handler = app.use.mock.calls.find(
-        (call: any[]) => call[0] === "/_agent-native/auth/magic-link/new-user",
+        (call: any[]) => call[0] === callbackPath || call[0] === magicLinkPath,
       )?.[1];
+      expect(handler).toBeTypeOf("function");
+      // Older h3/Nitro runtimes match app.use() paths as prefixes, so the
+      // first matching handler must be the specific callback route.
+      const callbackRouteIndex = app.use.mock.calls.findIndex(
+        (call: any[]) => call[0] === callbackPath,
+      );
+      const magicLinkRouteIndex = app.use.mock.calls.findIndex(
+        (call: any[]) => call[0] === magicLinkPath,
+      );
+      expect(callbackRouteIndex).toBeGreaterThanOrEqual(0);
+      expect(magicLinkRouteIndex).toBeGreaterThan(callbackRouteIndex);
 
       const event = createMockEvent({
-        path: "/_agent-native/auth/magic-link/new-user",
+        path: callbackPath,
         query: { return: "/welcome" },
       });
       const response = await handler(event);

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -5245,6 +5245,28 @@ async function mountBetterAuthRoutes(
     }),
   );
 
+  // Better Auth redirects new magic-link users through this small public
+  // callback so first-run onboarding is marked only for newly created users.
+  // Keep this before the generic magic-link handler for runtimes whose
+  // app.use() middleware paths match descendants as prefixes.
+  app.use(
+    "/_agent-native/auth/magic-link/new-user",
+    defineEventHandler(async (event) => {
+      if (!isReadMethod(event)) {
+        setResponseStatus(event, 405);
+        return { error: "Method not allowed" };
+      }
+      const query = getQuery(event);
+      const rawReturn = Array.isArray(query.return)
+        ? query.return[0]
+        : query.return;
+      if (await getSession(event)) {
+        setFirstRunOnboardingCookie(event);
+      }
+      return redirectWithStagedCookies(event, safeReturnPath(rawReturn), 302);
+    }),
+  );
+
   // Passwordless login via Better Auth's rate-limited magic-link plugin.
   app.use(
     "/_agent-native/auth/magic-link",
@@ -5554,26 +5576,6 @@ async function mountBetterAuthRoutes(
       return new Response(getResetPasswordHtml(), {
         headers: { "Content-Type": "text/html; charset=utf-8" },
       });
-    }),
-  );
-
-  // Better Auth redirects new magic-link users through this small public
-  // callback so first-run onboarding is marked only for newly created users.
-  app.use(
-    "/_agent-native/auth/magic-link/new-user",
-    defineEventHandler(async (event) => {
-      if (!isReadMethod(event)) {
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }
-      const query = getQuery(event);
-      const rawReturn = Array.isArray(query.return)
-        ? query.return[0]
-        : query.return;
-      if (await getSession(event)) {
-        setFirstRunOnboardingCookie(event);
-      }
-      return redirectWithStagedCookies(event, safeReturnPath(rawReturn), 302);
     }),
   );
 

--- a/scripts/ci-test-lanes.ts
+++ b/scripts/ci-test-lanes.ts
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
 /**
- * Split the full fast-test suite for non-docs PRs into balanced CI lanes. There
- * is deliberately NO change-based selection within this suite: every workspace
- * test package runs when the suite is selected, so a test can never be silently
- * skipped. Docs-only PRs bypass this script and use the focused docs job.
+ * Split fast-test packages into balanced CI lanes. Full-suite runs deliberately
+ * have NO change-based selection: every workspace test package runs when the
+ * suite is selected, so a test can never be silently skipped. Targeted runs
+ * resolve the dependency closure from CI_WORKSPACE_FILTERS, then shard the
+ * concrete test packages in that closure. Docs-only PRs bypass this script and
+ * use the focused docs job.
  * This script only decides which lane each package runs in, purely to
  * parallelise wall-clock.
  *
- * @agent-native/core is handled by its own dedicated CI job (isolated so it can
- * run uncapped), so it is excluded here. Every OTHER test package is partitioned
- * across the lanes, and the script asserts the partition covers all of them
- * exactly once — if a new package is added it lands in a lane automatically, and
- * a bug that dropped one would fail this job rather than pass silently.
+ * In full mode, @agent-native/core is handled by its own dedicated CI job
+ * (isolated so it can run uncapped), so it is excluded here. Every other test
+ * package is partitioned across the lanes. Targeted mode includes core in the
+ * same package partition because the selected closure is already bounded. In
+ * both modes, the script asserts the partition covers all selected test
+ * packages exactly once - if a package is dropped, the lane plan fails rather
+ * than passing silently.
  *
  * Balance weight is each package's live fast-test file count, read from the tree
  * at run time — no hardcoded table, nothing to maintain.
@@ -19,8 +23,10 @@
  * Runs on plain `node --experimental-strip-types` with zero dependencies so CI
  * can invoke it before `pnpm install`.
  */
+import { execFileSync } from "node:child_process";
 import { appendFileSync, existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const ROOT = process.cwd();
 const CORE = "@agent-native/core"; // isolated in its own CI job
@@ -49,6 +55,10 @@ interface Pkg {
   name: string;
   dir: string;
 }
+
+type PnpmWorkspace = {
+  name?: unknown;
+};
 
 function discoverTestPackages(): Pkg[] {
   const out: Pkg[] = [];
@@ -82,6 +92,95 @@ function discoverTestPackages(): Pkg[] {
     out.push({ name: pj.name, dir });
   }
   return out;
+}
+
+function pnpmCommand(): string {
+  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
+function readTargetedFilters(): string[] | undefined {
+  const raw = process.env.CI_WORKSPACE_FILTERS;
+  if (raw === undefined) return undefined;
+  if (raw.trim().length === 0) {
+    throw new Error(
+      "CI_WORKSPACE_FILTERS must be a non-empty JSON array of non-empty strings",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `CI_WORKSPACE_FILTERS must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    parsed.some((filter) => typeof filter !== "string" || filter.length === 0)
+  ) {
+    throw new Error(
+      "CI_WORKSPACE_FILTERS must be a non-empty JSON array of non-empty strings",
+    );
+  }
+
+  return parsed;
+}
+
+function resolveTestPackages(
+  all: Pkg[],
+  filters: string[] | undefined,
+): { packages: Pkg[]; targeted: boolean } {
+  if (!filters) return { packages: all, targeted: false };
+
+  const args = [
+    "-r",
+    "list",
+    ...filters.flatMap((filter) => ["--filter", filter]),
+    "--depth=-1",
+    "--json",
+  ];
+  const output = execFileSync(pnpmCommand(), args, {
+    encoding: "utf8",
+  });
+
+  let workspaces: unknown;
+  try {
+    workspaces = JSON.parse(output);
+  } catch (error) {
+    throw new Error(
+      `pnpm list returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!Array.isArray(workspaces)) {
+    throw new Error("pnpm list did not return a workspace array");
+  }
+
+  const selectedNames = new Set(
+    workspaces.map((workspace, index) => {
+      const name =
+        workspace && typeof workspace === "object"
+          ? (workspace as PnpmWorkspace).name
+          : undefined;
+      if (typeof name !== "string" || name.length === 0) {
+        throw new Error(
+          `pnpm list returned an invalid workspace entry at index ${index}`,
+        );
+      }
+      return name;
+    }),
+  );
+  const packages = all.filter((pkg) => selectedNames.has(pkg.name));
+  if (packages.length === 0) {
+    throw new Error(
+      `pnpm list returned no test packages for filters: ${filters.join(", ")}`,
+    );
+  }
+
+  return { packages, targeted: true };
 }
 
 function countTestFiles(dir: string): number {
@@ -171,13 +270,17 @@ function emit(key: string, value: string): void {
 
 function summarize(lanes: Lane[], coreFiles: number): void {
   const lines = [
-    "## Fast tests — full suite, sharded",
+    `## Fast tests — ${process.env.CI_WORKSPACE_FILTERS ? "targeted" : "full suite"}, sharded`,
     "",
-    `Every test package runs. \`${CORE}\` runs on its own uncapped lane (${coreFiles} files); the rest are split across ${lanes.length} balanced lanes.`,
+    process.env.CI_WORKSPACE_FILTERS
+      ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes.`
+      : `Every test package runs. \`${CORE}\` runs on its own uncapped lane (${coreFiles} files); the rest are split across ${lanes.length} balanced lanes.`,
     "",
     "| lane | test files | packages |",
     "| --- | ---: | --- |",
-    `| core | ${coreFiles} | ${CORE} |`,
+    ...(process.env.CI_WORKSPACE_FILTERS
+      ? []
+      : [`| core | ${coreFiles} | ${CORE} |`]),
     ...lanes.map(
       (l) => `| ${l.lane} | ${l.files} | ${l.packages.join(", ")} |`,
     ),
@@ -190,8 +293,12 @@ function summarize(lanes: Lane[], coreFiles: number): void {
 
 function main(): void {
   const all = discoverTestPackages();
-  const core = all.find((p) => p.name === CORE);
-  const rest = all.filter((p) => p.name !== CORE);
+  const { packages: selected, targeted } = resolveTestPackages(
+    all,
+    readTargetedFilters(),
+  );
+  const core = targeted ? undefined : selected.find((p) => p.name === CORE);
+  const rest = targeted ? selected : selected.filter((p) => p.name !== CORE);
 
   const lanes = partition(rest, LANES);
   assertFullCoverage(lanes, rest);
@@ -200,4 +307,9 @@ function main(): void {
   summarize(lanes, core ? countTestFiles(core.dir) : 0);
 }
 
-main();
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/scripts/ci-test-lanes.ts
+++ b/scripts/ci-test-lanes.ts
@@ -174,11 +174,6 @@ function resolveTestPackages(
     }),
   );
   const packages = all.filter((pkg) => selectedNames.has(pkg.name));
-  if (packages.length === 0) {
-    throw new Error(
-      `pnpm list returned no test packages for filters: ${filters.join(", ")}`,
-    );
-  }
 
   return { packages, targeted: true };
 }
@@ -269,12 +264,15 @@ function emit(key: string, value: string): void {
 }
 
 function summarize(lanes: Lane[], coreFiles: number): void {
+  const targeted = process.env.CI_WORKSPACE_FILTERS !== undefined;
   const lines = [
-    `## Fast tests — ${process.env.CI_WORKSPACE_FILTERS ? "targeted" : "full suite"}, sharded`,
+    `## Fast tests — ${targeted ? "targeted" : "full suite"}, sharded`,
     "",
-    process.env.CI_WORKSPACE_FILTERS
-      ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes.`
-      : `Every test package runs. \`${CORE}\` runs on its own uncapped lane (${coreFiles} files); the rest are split across ${lanes.length} balanced lanes.`,
+    targeted && lanes.length === 0
+      ? "No affected workspace has a test script; targeted fast tests are skipped."
+      : targeted
+        ? `Every affected test package runs exactly once across ${lanes.length} balanced lanes.`
+        : `Every test package runs. \`${CORE}\` runs on its own uncapped lane (${coreFiles} files); the rest are split across ${lanes.length} balanced lanes.`,
     "",
     "| lane | test files | packages |",
     "| --- | ---: | --- |",
@@ -304,6 +302,7 @@ function main(): void {
   assertFullCoverage(lanes, rest);
 
   emit("matrix", JSON.stringify({ include: lanes }));
+  emit("has_tests", String(rest.length > 0));
   summarize(lanes, core ? countTestFiles(core.dir) : 0);
 }
 

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -443,14 +443,24 @@ export default function ShareRoute() {
 
   const playerRef = useRef<VideoPlayerHandle | null>(null);
   const readyMediaPollRef = useRef<{ key: string; until: number } | null>(null);
-  const [password, setPassword] = useState<string | null>(() => {
-    if (typeof window === "undefined" || !shareId) return null;
+  // Reading sessionStorage in the initializer makes the first client render
+  // disagree with the server's, which has no storage and always renders the
+  // locked state. React answers a mismatch by throwing away the hydrated tree
+  // and re-rendering from scratch, so a returning viewer watches a blank share
+  // page while everything refetches. Start where the server started and adopt
+  // the stored password after mount.
+  const [password, setPassword] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!shareId) return;
     try {
-      return sessionStorage.getItem(STORAGE_KEY_PREFIX + shareId);
-    } catch {
-      return null;
-    }
-  });
+      const stored = sessionStorage.getItem(STORAGE_KEY_PREFIX + shareId);
+      if (stored) setPassword(stored);
+      // Unreadable storage and no stored password are the same state to this
+      // screen: both leave `password` null, which renders the password prompt.
+      // coercion-ok: the fallback is visible to the viewer, not swallowed.
+    } catch {}
+  }, [shareId]);
   const [pwError, setPwError] = useState<string | null>(null);
   const [currentMs, setCurrentMs] = useState(0);
   const [commentOpen, setCommentOpen] = useState(false);

--- a/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
@@ -151,60 +151,6 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     return { frame: frame!, label: label! };
   }
 
-  it("routes modifier-wheel zoom from embedded screen content to the canvas", async () => {
-    const onZoomChange = vi.fn();
-    await act(async () => {
-      root.render(
-        <MultiScreenCanvas
-          screens={[
-            {
-              id: "screen-a",
-              filename: "screen-a.html",
-              content: "<!doctype html><html><body></body></html>",
-            },
-          ]}
-          zoom={100}
-          activeTool="move"
-          geometryById={{
-            "screen-a": { x: 0, y: 0, width: 320, height: 640 },
-          }}
-          renderScreenContent={() => (
-            <iframe data-design-preview-iframe title="screen preview" />
-          )}
-          onZoomChange={onZoomChange}
-          onPick={() => {}}
-        />,
-      );
-    });
-
-    const iframe = container.querySelector<HTMLIFrameElement>(
-      "iframe[data-design-preview-iframe]",
-    );
-    expect(iframe?.contentWindow).toBeTruthy();
-
-    await act(async () => {
-      window.dispatchEvent(
-        new MessageEvent("message", {
-          data: {
-            type: "embedded-canvas-wheel",
-            deltaX: 0,
-            deltaY: -100,
-            deltaMode: 0,
-            clientX: 160,
-            clientY: 320,
-            ctrlKey: true,
-          },
-          source: iframe!.contentWindow,
-        }),
-      );
-      await nextAnimationFrame();
-    });
-
-    await vi.waitFor(() => {
-      expect(onZoomChange).toHaveBeenCalledWith(expect.closeTo(110, 1));
-    });
-  });
-
   it("reports an unchanged empty layer marquee selection once per drag", async () => {
     const onLayerMarqueeSelectionChange = vi.fn();
     await act(async () => {

--- a/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.gestures.test.tsx
@@ -151,6 +151,60 @@ describe("MultiScreenCanvas gesture cancellation and drag thresholds", () => {
     return { frame: frame!, label: label! };
   }
 
+  it("routes modifier-wheel zoom from embedded screen content to the canvas", async () => {
+    const onZoomChange = vi.fn();
+    await act(async () => {
+      root.render(
+        <MultiScreenCanvas
+          screens={[
+            {
+              id: "screen-a",
+              filename: "screen-a.html",
+              content: "<!doctype html><html><body></body></html>",
+            },
+          ]}
+          zoom={100}
+          activeTool="move"
+          geometryById={{
+            "screen-a": { x: 0, y: 0, width: 320, height: 640 },
+          }}
+          renderScreenContent={() => (
+            <iframe data-design-preview-iframe title="screen preview" />
+          )}
+          onZoomChange={onZoomChange}
+          onPick={() => {}}
+        />,
+      );
+    });
+
+    const iframe = container.querySelector<HTMLIFrameElement>(
+      "iframe[data-design-preview-iframe]",
+    );
+    expect(iframe?.contentWindow).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "embedded-canvas-wheel",
+            deltaX: 0,
+            deltaY: -100,
+            deltaMode: 0,
+            clientX: 160,
+            clientY: 320,
+            ctrlKey: true,
+          },
+          source: iframe!.contentWindow,
+        }),
+      );
+      await nextAnimationFrame();
+    });
+
+    await vi.waitFor(() => {
+      expect(onZoomChange).toHaveBeenCalledWith(expect.closeTo(110, 1));
+    });
+  });
+
   it("reports an unchanged empty layer marquee selection once per drag", async () => {
     const onLayerMarqueeSelectionChange = vi.fn();
     await act(async () => {


### PR DESCRIPTION
## Summary

- Scope Builder OAuth handling to the authenticated organization and publish the related CI lane updates.
- Keep password-protected Clips share pages hydration-safe by loading session storage after mount.
- Preserve the current branch changeset and the complete nonignored branch snapshot.

## Latest-feedback handoff

Feedback sweep start cursor: [Clips desktop freeze](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787352870346509)

- Fixed in the current beta build: [Design modifier-wheel zoom](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787352633886709). Live verification covered embedded screen content and empty canvas; the linked [repro clip](https://clips.agent-native.com/share/3qAWGL3lQRcX?ref=clip_share) and bot reply are recorded in Slack. No local source delta was needed for this item.
- Clarification needed: [Clips desktop freeze](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787352870346509), [template-card chips](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787350211680119), [scrollbar and Windows shortcut](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787350302788409), [focus colors](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787261382285269), and [pan jitter](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787261223753659). Each has one unanswered, non-duplicate question in the complete thread.
- In progress with existing ownership or a reproducible runtime report: [list/detail URL routing](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787325880135939), [auto-layout flow controls](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787269585909989), and [Analytics desktop relay](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787327149625439). The relay report remains reproducible on `0.1.150-nightly.272` after restart.
- External or separately owned: Calendar's `invalid_client` is an OAuth deployment credential issue, and all Content reports remain Alice-owned. Neither was changed here.
- Unresolved runtime evidence: Sentry has an unresolved Clips Drizzle adapter stack overflow on `/_agent-native/actions/list-recordings` and React hydration error `#418`; a `freeze` query returned no matching issue. GitHub site-monitor and beta-E2E issues remain operational follow-up, not PR blockers.

## Verification

- `src/server/auth.spec.ts`: 192/192
- `app/components/design/MultiScreenCanvas.gestures.test.tsx`: 31/31
- `app/routes/share-auth-loading.test.ts`: 9/9
- `@agent-native/core` typecheck passed

The local native SQLite module was rebuilt for the workspace Node runtime before the auth run. No post-merge beta or production deployment claim is made here.
