### PR TITLE
fix(clips,slides): close the remaining sessionStorage hydration mismatches

### DIFF
--- a/templates/clips/app/routes/access-request.approve.tsx
+++ b/templates/clips/app/routes/access-request.approve.tsx
@@ -43,16 +43,23 @@ export default function ApproveRecordingAccessRequestRoute() {
   const approvalTokenFromUrl = searchParams.get("token") ?? "";
   const approvalTokenStorageKey =
     recordingAccessApprovalSessionKey(recordingId);
-  const [approvalToken, setApprovalToken] = useState(() => {
-    if (approvalTokenFromUrl) return approvalTokenFromUrl;
-    if (typeof window === "undefined" || !recordingId) return "";
+  // Only the URL token is knowable on the server, so reading storage in the
+  // initializer makes the first client render disagree with the server's and
+  // React re-renders the page from scratch. Adopt the stored token after mount.
+  const [approvalToken, setApprovalToken] = useState(
+    () => approvalTokenFromUrl ?? "",
+  );
+
+  useEffect(() => {
+    if (approvalTokenFromUrl || !recordingId) return;
     try {
-      return sessionStorage.getItem(approvalTokenStorageKey) ?? "";
-    } catch {
-      // coercion-ok: unavailable tab storage is an absent continuation.
-      return "";
-    }
-  });
+      const stored = sessionStorage.getItem(approvalTokenStorageKey);
+      if (stored) setApprovalToken(stored);
+      // Unavailable tab storage is an absent continuation: the page then asks
+      // for the token rather than silently continuing without one.
+      // coercion-ok: the absent case is visible to the user, not swallowed.
+    } catch {}
+  }, [approvalTokenFromUrl, recordingId, approvalTokenStorageKey]);
   const [state, setState] = useState<ApprovalState>({ kind: "loading" });
 
   useEffect(() => {

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -71,14 +71,24 @@ export default function EmbedRoute() {
     [searchParams],
   );
 
-  const [password, setPassword] = useState<string | null>(() => {
-    if (typeof window === "undefined" || !shareId) return null;
+  // Same hydration trap the share route had: reading sessionStorage in the
+  // initializer makes the first client render disagree with the server's,
+  // which has no storage and always renders the locked state. React discards
+  // the hydrated tree and re-renders from scratch, so an embedded player goes
+  // blank for a returning viewer. Start where the server started and adopt the
+  // stored password after mount.
+  const [password, setPassword] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!shareId) return;
     try {
-      return sessionStorage.getItem(STORAGE_KEY_PREFIX + shareId);
-    } catch {
-      return null;
-    }
-  });
+      const stored = sessionStorage.getItem(STORAGE_KEY_PREFIX + shareId);
+      if (stored) setPassword(stored);
+      // Unreadable storage and no stored password are the same state here:
+      // both leave `password` null, which renders the password prompt.
+      // coercion-ok: the fallback is visible to the viewer, not swallowed.
+    } catch {}
+  }, [shareId]);
   const [pwError, setPwError] = useState<string | null>(null);
   const readyMediaPollRef = useRef<{ key: string; until: number } | null>(null);
 

--- a/templates/slides/app/routes/access-request.approve.tsx
+++ b/templates/slides/app/routes/access-request.approve.tsx
@@ -42,16 +42,23 @@ export default function ApproveDeckAccessRequestRoute() {
   const deckId = searchParams.get("deckId") ?? "";
   const approvalTokenFromUrl = searchParams.get("token") ?? "";
   const approvalTokenStorageKey = deckAccessApprovalSessionKey(deckId);
-  const [approvalToken, setApprovalToken] = useState(() => {
-    if (approvalTokenFromUrl) return approvalTokenFromUrl;
-    if (typeof window === "undefined" || !deckId) return "";
+  // Only the URL token is knowable on the server, so reading storage in the
+  // initializer makes the first client render disagree with the server's and
+  // React re-renders the page from scratch. Adopt the stored token after mount.
+  const [approvalToken, setApprovalToken] = useState(
+    () => approvalTokenFromUrl ?? "",
+  );
+
+  useEffect(() => {
+    if (approvalTokenFromUrl || !deckId) return;
     try {
-      return sessionStorage.getItem(approvalTokenStorageKey) ?? "";
-    } catch {
-      // coercion-ok: unavailable tab storage is an absent continuation.
-      return "";
-    }
-  });
+      const stored = sessionStorage.getItem(approvalTokenStorageKey);
+      if (stored) setApprovalToken(stored);
+      // Unavailable tab storage is an absent continuation: the page then asks
+      // for the token rather than silently continuing without one.
+      // coercion-ok: the absent case is visible to the user, not swallowed.
+    } catch {}
+  }, [approvalTokenFromUrl, deckId, approvalTokenStorageKey]);
   const [state, setState] = useState<ApprovalState>({ kind: "loading" });
 
   useEffect(() => {


### PR DESCRIPTION
Follow-up to #3382. That PR fixed the clips share route; three siblings had the identical shape — a `useState` initializer reading `sessionStorage`, so the first client render disagrees with the server's, React discards the hydrated tree, and the page re-renders from scratch. For a returning viewer that reads as a blank page.

- `clips/embed.$shareId.tsx` — the embedded player, same saved-password read
- `clips/access-request.approve.tsx` and `slides/access-request.approve.tsx` — the saved approval token

Each now starts from the value the server can also compute and adopts the stored one after mount.

Found by grepping for the pattern after #3382 rather than waiting for the next report. 63/63 guards, typecheck clean on both templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)