### PR TITLE
Reconcile Builder design-system imports after indexing

### DIFF
--- a/.changeset/quiet-dsi-refresh.md
+++ b/.changeset/quiet-dsi-refresh.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Builder design-system hydration in progress until the provider confirms completion, including explicit status metadata from docs responses.

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -270,6 +270,55 @@ describe("Builder design-system helpers", () => {
     });
   });
 
+  it("preserves failed status over completion flags and normalizes cancellation variants", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          docs: [],
+          status: "error",
+          complete: true,
+          completed: true,
+        }),
+        { status: 200 },
+      ),
+    );
+    await expect(
+      hydrateBuilderDesignSystemReference({
+        source: "builder",
+        builderDesignSystemId: "ds-1",
+        builderJobId: "job-1",
+        builderStatus: "in-progress",
+      }),
+    ).resolves.toMatchObject({
+      builderStatus: "error",
+      completionConfirmed: false,
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ docs: [], status: "canceled" }), {
+        status: 200,
+      }),
+    );
+    await expect(
+      hydrateBuilderDesignSystemReference({
+        source: "builder",
+        builderDesignSystemId: "ds-1",
+        builderJobId: "job-1",
+        builderStatus: "in-progress",
+      }),
+    ).resolves.toMatchObject({
+      builderStatus: "cancelled",
+      completionConfirmed: false,
+    });
+  });
+
   it("persists replayable GitHub source scope in the local proxy", () => {
     const fields = createBuilderDesignSystemProxyFields({
       result: {

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -4,6 +4,7 @@ import {
   buildBuilderDesignSystemIndexFiles,
   collectBuilderDesignSystemGitHubFiles,
   createBuilderDesignSystemProxyFields,
+  hydrateBuilderDesignSystemReference,
   localBuilderDesignSystemId,
   mimeTypeForBuilderDesignSystemFilename,
   parseBuilderDesignSystemProxyReference,
@@ -168,6 +169,39 @@ describe("Builder design-system helpers", () => {
       builderProjectId: "project-1",
       builderUrl: "https://builder.io/app/design-system-intelligence/ds-1",
       builderStatus: "in-progress",
+    });
+  });
+
+  it("requires an explicit Builder completion signal when hydrating docs", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              docs: [{ tokenValues: { "--brand-primary": "#123456" } }],
+              status: "complete",
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+
+    await expect(
+      hydrateBuilderDesignSystemReference({
+        source: "builder",
+        builderDesignSystemId: "ds-1",
+        builderJobId: "job-1",
+        builderStatus: "in-progress",
+      }),
+    ).resolves.toMatchObject({
+      docCount: 1,
+      tokenValues: { "--brand-primary": "#123456" },
+      completionConfirmed: true,
     });
   });
 

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -205,6 +205,71 @@ describe("Builder design-system helpers", () => {
     });
   });
 
+  it("hydrates every Builder docs page and preserves terminal failure status", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    let requestCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          return new Response(
+            JSON.stringify(
+              Array.from({ length: 40 }, (_, index) => ({
+                id: `doc-${index}`,
+              })),
+            ),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            docs: [{ id: "doc-40" }],
+            status: "complete",
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    await expect(
+      hydrateBuilderDesignSystemReference({
+        source: "builder",
+        builderDesignSystemId: "ds-1",
+        builderJobId: "job-1",
+        builderStatus: "in-progress",
+      }),
+    ).resolves.toMatchObject({
+      docCount: 41,
+      completionConfirmed: true,
+    });
+    expect(requestCount).toBe(2);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ docs: [], status: "failed" }), {
+            status: 200,
+          }),
+      ),
+    );
+    await expect(
+      hydrateBuilderDesignSystemReference({
+        source: "builder",
+        builderDesignSystemId: "ds-1",
+        builderJobId: "job-1",
+        builderStatus: "in-progress",
+      }),
+    ).resolves.toMatchObject({
+      builderStatus: "failed",
+      completionConfirmed: false,
+    });
+  });
+
   it("persists replayable GitHub source scope in the local proxy", () => {
     const fields = createBuilderDesignSystemProxyFields({
       result: {

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -159,7 +159,8 @@ export type BuilderDesignSystemStatus =
   | "complete"
   | "completed"
   | "error"
-  | "failed";
+  | "failed"
+  | "cancelled";
 
 interface BuilderDesignSystemCredentials {
   privateKey: string;
@@ -1072,6 +1073,9 @@ function normalizeBuilderDesignSystemStatus(
     case "failed":
     case "failure":
       return "failed";
+    case "cancelled":
+    case "canceled":
+      return "cancelled";
     default:
       return "in-progress";
   }
@@ -1134,12 +1138,15 @@ async function fetchBuilderDesignSystemDocsResponse(
     typeof rawStatus === "string"
       ? normalizeBuilderDesignSystemStatus(rawStatus)
       : undefined;
+  const isTerminalFailure =
+    status === "error" || status === "failed" || status === "cancelled";
   return {
     docs: rawDocs.map(normalizeBuilderDesignSystemDocument),
     completionConfirmed:
-      envelope.complete === true ||
-      envelope.completed === true ||
-      isConfirmedBuilderDesignSystemStatus(status),
+      !isTerminalFailure &&
+      (envelope.complete === true ||
+        envelope.completed === true ||
+        isConfirmedBuilderDesignSystemStatus(status)),
     ...(status ? { status } : {}),
   };
 }

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -213,6 +213,8 @@ export interface BuilderDesignSystemDecodeJobStatus {
 
 const DEFAULT_MAX_CODE_FILES = 50;
 const DEFAULT_MAX_TOTAL_CODE_BYTES = 2 * 1024 * 1024;
+const DEFAULT_BUILDER_DOC_PAGE_SIZE = 40;
+const MAX_BUILDER_DOC_PAGES = 100;
 const MAX_DOC_CONTENT_CHARS = 4_000;
 const MAX_GITHUB_FILES = 50;
 const MAX_GITHUB_TOTAL_BYTES = 2 * 1024 * 1024;
@@ -1060,14 +1062,16 @@ function normalizeBuilderDesignSystemStatus(
     case "ready":
       return "ready";
     case "complete":
-    case "completed":
     case "done":
     case "success":
       return "complete";
+    case "completed":
+      return "completed";
     case "error":
+      return "error";
     case "failed":
     case "failure":
-      return "error";
+      return "failed";
     default:
       return "in-progress";
   }
@@ -1081,6 +1085,7 @@ function isConfirmedBuilderDesignSystemStatus(value: unknown): boolean {
 interface BuilderDesignSystemDocsResponse {
   docs: BuilderDesignSystemDocument[];
   completionConfirmed: boolean;
+  status?: BuilderDesignSystemStatus;
 }
 
 async function fetchBuilderDesignSystemDocsResponse(
@@ -1124,14 +1129,18 @@ async function fetchBuilderDesignSystemDocsResponse(
       "Builder design-system docs fetch returned an invalid response.",
     );
   }
+  const rawStatus = envelope.status ?? envelope.builderStatus;
+  const status =
+    typeof rawStatus === "string"
+      ? normalizeBuilderDesignSystemStatus(rawStatus)
+      : undefined;
   return {
     docs: rawDocs.map(normalizeBuilderDesignSystemDocument),
     completionConfirmed:
       envelope.complete === true ||
       envelope.completed === true ||
-      isConfirmedBuilderDesignSystemStatus(
-        envelope.status ?? envelope.builderStatus,
-      ),
+      isConfirmedBuilderDesignSystemStatus(status),
+    ...(status ? { status } : {}),
   };
 }
 
@@ -1145,13 +1154,35 @@ export async function fetchBuilderDesignSystemDocs(
 
 export async function hydrateBuilderDesignSystemReference(
   reference: BuilderDesignSystemProxyReference,
-  options: BuilderDesignSystemDocsOptions = { page: 0, pageSize: 40 },
+  options: BuilderDesignSystemDocsOptions = {
+    page: 0,
+    pageSize: DEFAULT_BUILDER_DOC_PAGE_SIZE,
+  },
 ): Promise<BuilderDesignSystemHydratedReference> {
-  const response = await fetchBuilderDesignSystemDocsResponse(
-    reference.builderDesignSystemId,
-    options,
-  );
-  const docs = response.docs;
+  const pageSize =
+    options.pageSize && options.pageSize > 0
+      ? options.pageSize
+      : DEFAULT_BUILDER_DOC_PAGE_SIZE;
+  const docs: BuilderDesignSystemDocument[] = [];
+  let page = Math.max(0, options.page ?? 0);
+  let completionConfirmed = false;
+  let builderStatus = reference.builderStatus;
+  for (let pageNumber = 0; pageNumber < MAX_BUILDER_DOC_PAGES; pageNumber++) {
+    const response = await fetchBuilderDesignSystemDocsResponse(
+      reference.builderDesignSystemId,
+      { ...options, page, pageSize },
+    );
+    docs.push(...response.docs);
+    completionConfirmed ||= response.completionConfirmed;
+    builderStatus = response.status ?? builderStatus;
+    if (response.docs.length < pageSize) break;
+    page += 1;
+    if (pageNumber === MAX_BUILDER_DOC_PAGES - 1) {
+      throw new Error(
+        "Builder design-system docs fetch exceeded the safe pagination limit.",
+      );
+    }
+  }
   const tokenValues: Record<string, string> = {};
   for (const doc of docs) {
     if (!doc.tokenValues) continue;
@@ -1161,12 +1192,13 @@ export async function hydrateBuilderDesignSystemReference(
   }
   return {
     ...reference,
+    ...(builderStatus ? { builderStatus } : {}),
     docs,
     tokenValues,
     docCount: docs.length,
     completionConfirmed:
-      response.completionConfirmed ||
-      isConfirmedBuilderDesignSystemStatus(reference.builderStatus),
+      completionConfirmed ||
+      isConfirmedBuilderDesignSystemStatus(builderStatus),
   };
 }
 

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -118,6 +118,8 @@ export interface BuilderDesignSystemHydratedReference extends BuilderDesignSyste
   docs: BuilderDesignSystemDocument[];
   tokenValues: Record<string, string>;
   docCount: number;
+  /** True only when Builder explicitly confirms that indexing is complete. */
+  completionConfirmed?: boolean;
 }
 
 export interface BuilderDesignSystemIndexOptions {
@@ -148,8 +150,16 @@ export interface BuilderDesignSystemIndexResult {
   designSystemId: string;
   suggestedTitle: string | null;
   builderUrl: string;
-  status: "in-progress";
+  status: BuilderDesignSystemStatus;
 }
+
+export type BuilderDesignSystemStatus =
+  | "in-progress"
+  | "ready"
+  | "complete"
+  | "completed"
+  | "error"
+  | "failed";
 
 interface BuilderDesignSystemCredentials {
   privateKey: string;
@@ -167,6 +177,7 @@ interface IndexResponse {
   projectId?: string;
   branchUrl?: string;
   branchName?: string;
+  status?: unknown;
 }
 
 export interface BuilderDesignSystemUploadAttachment {
@@ -1041,10 +1052,41 @@ function normalizeBuilderDesignSystemDocument(
   };
 }
 
-export async function fetchBuilderDesignSystemDocs(
+function normalizeBuilderDesignSystemStatus(
+  value: unknown,
+): BuilderDesignSystemStatus {
+  if (typeof value !== "string") return "in-progress";
+  switch (value.trim().toLowerCase()) {
+    case "ready":
+      return "ready";
+    case "complete":
+    case "completed":
+    case "done":
+    case "success":
+      return "complete";
+    case "error":
+    case "failed":
+    case "failure":
+      return "error";
+    default:
+      return "in-progress";
+  }
+}
+
+function isConfirmedBuilderDesignSystemStatus(value: unknown): boolean {
+  const status = normalizeBuilderDesignSystemStatus(value);
+  return status === "ready" || status === "complete" || status === "completed";
+}
+
+interface BuilderDesignSystemDocsResponse {
+  docs: BuilderDesignSystemDocument[];
+  completionConfirmed: boolean;
+}
+
+async function fetchBuilderDesignSystemDocsResponse(
   designSystemId: string,
-  options: BuilderDesignSystemDocsOptions = {},
-): Promise<BuilderDesignSystemDocument[]> {
+  options: BuilderDesignSystemDocsOptions,
+): Promise<BuilderDesignSystemDocsResponse> {
   const credentials = await resolveBuilderDesignSystemCredentials();
   const url = makeBuilderDesignSystemUrl(
     `${encodeURIComponent(designSystemId)}/docs`,
@@ -1064,22 +1106,52 @@ export async function fetchBuilderDesignSystemDocs(
   });
   await assertOk(response, "Builder design-system docs fetch failed");
   const json = (await response.json()) as unknown;
-  if (!Array.isArray(json)) {
+  if (Array.isArray(json)) {
+    return {
+      docs: json.map(normalizeBuilderDesignSystemDocument),
+      completionConfirmed: false,
+    };
+  }
+  if (!json || typeof json !== "object") {
     throw new Error(
       "Builder design-system docs fetch returned an invalid response.",
     );
   }
-  return json.map(normalizeBuilderDesignSystemDocument);
+  const envelope = json as Record<string, unknown>;
+  const rawDocs = envelope.docs ?? envelope.items;
+  if (!Array.isArray(rawDocs)) {
+    throw new Error(
+      "Builder design-system docs fetch returned an invalid response.",
+    );
+  }
+  return {
+    docs: rawDocs.map(normalizeBuilderDesignSystemDocument),
+    completionConfirmed:
+      envelope.complete === true ||
+      envelope.completed === true ||
+      isConfirmedBuilderDesignSystemStatus(
+        envelope.status ?? envelope.builderStatus,
+      ),
+  };
+}
+
+export async function fetchBuilderDesignSystemDocs(
+  designSystemId: string,
+  options: BuilderDesignSystemDocsOptions = {},
+): Promise<BuilderDesignSystemDocument[]> {
+  return (await fetchBuilderDesignSystemDocsResponse(designSystemId, options))
+    .docs;
 }
 
 export async function hydrateBuilderDesignSystemReference(
   reference: BuilderDesignSystemProxyReference,
   options: BuilderDesignSystemDocsOptions = { page: 0, pageSize: 40 },
 ): Promise<BuilderDesignSystemHydratedReference> {
-  const docs = await fetchBuilderDesignSystemDocs(
+  const response = await fetchBuilderDesignSystemDocsResponse(
     reference.builderDesignSystemId,
     options,
   );
+  const docs = response.docs;
   const tokenValues: Record<string, string> = {};
   for (const doc of docs) {
     if (!doc.tokenValues) continue;
@@ -1092,6 +1164,9 @@ export async function hydrateBuilderDesignSystemReference(
     docs,
     tokenValues,
     docCount: docs.length,
+    completionConfirmed:
+      response.completionConfirmed ||
+      isConfirmedBuilderDesignSystemStatus(reference.builderStatus),
   };
 }
 
@@ -1189,7 +1264,7 @@ export async function indexBuilderDesignSystem(
       branchUrl ||
       builderProjectBranchUrl(indexed.projectId, indexed.branchName) ||
       builderDesignSystemUrl(indexed.designSystemId),
-    status: "in-progress",
+    status: normalizeBuilderDesignSystemStatus(indexed.status),
   };
 }
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -591,6 +591,7 @@ export {
   type BuilderDesignSystemIndexFromSourcesOptions,
   type BuilderDesignSystemIndexOptions,
   type BuilderDesignSystemIndexResult,
+  type BuilderDesignSystemStatus,
   type BuilderDesignSystemGitHubFile,
   type BuilderDesignSystemGitHubFileCollection,
   type BuilderDesignSystemGitHubSource,

--- a/templates/design/actions/get-design-system.spec.ts
+++ b/templates/design/actions/get-design-system.spec.ts
@@ -26,6 +26,7 @@ describe("get-design-system", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolveAccess.mockResolvedValue({
+      role: "owner",
       resource: {
         id: "builder-ds-1",
         title: "Acme System",
@@ -146,6 +147,37 @@ describe("get-design-system", () => {
 
     expect(result.agentContext).toContain("no usable docs or token values");
     expect(result.agentContext).toContain("Core design-system tokens:");
+  });
+
+  it("does not ask viewers to call the editor-only refresh action", async () => {
+    mockResolveAccess.mockResolvedValueOnce({
+      role: "viewer",
+      resource: {
+        id: "builder-ds-1",
+        title: "Acme System",
+        data: JSON.stringify({
+          source: "builder",
+          builderDesignSystemId: "ds-1",
+          builderJobId: "job-1",
+          builderStatus: "in-progress",
+        }),
+        assets: "[]",
+        customInstructions: "",
+        isDefault: false,
+        visibility: "org",
+        createdAt: "2026-07-08T00:00:00.000Z",
+        updatedAt: "2026-07-08T00:00:00.000Z",
+      },
+    });
+
+    const result = await action.run({ id: "builder-ds-1" });
+
+    expect(result.agentContext).toContain(
+      "refreshing the shared system requires editor access",
+    );
+    expect(result.agentContext).not.toContain(
+      "call refresh-design-system-with-builder once",
+    );
   });
 
   it("returns a client-safe not-found error when the design system is unavailable", async () => {

--- a/templates/design/actions/get-design-system.ts
+++ b/templates/design/actions/get-design-system.ts
@@ -154,7 +154,7 @@ function buildDesignSystemAgentContext({
       builder.builderUrl ? `- URL: ${builder.builderUrl}` : "",
       builder.builderStatus ? `- Status: ${builder.builderStatus}` : "",
       "- Builder DSI docs and token values override local proxy placeholders.",
-      "- Do not substitute a generic style if DSI docs or tokens are unavailable; call get-design-system again or tell the user Builder indexing is not ready.",
+      "- If no usable DSI docs or tokens are returned, call refresh-design-system-with-builder once, then call get-design-system again before generating; if it is still empty, tell the user Builder indexing is not ready.",
     );
 
     if (builder.warning) {

--- a/templates/design/actions/get-design-system.ts
+++ b/templates/design/actions/get-design-system.ts
@@ -114,6 +114,7 @@ function buildDesignSystemAgentContext({
   assets,
   customInstructions,
   builder,
+  canRefreshBuilder,
 }: {
   id: string;
   title: string;
@@ -122,6 +123,7 @@ function buildDesignSystemAgentContext({
   assets?: string | null;
   customInstructions?: string | null;
   builder: BuilderGenerationContext | null;
+  canRefreshBuilder: boolean;
 }): string {
   const lines: string[] = [
     "## Selected Design System Context",
@@ -154,7 +156,9 @@ function buildDesignSystemAgentContext({
       builder.builderUrl ? `- URL: ${builder.builderUrl}` : "",
       builder.builderStatus ? `- Status: ${builder.builderStatus}` : "",
       "- Builder DSI docs and token values override local proxy placeholders.",
-      "- If no usable DSI docs or tokens are returned, call refresh-design-system-with-builder once, then call get-design-system again before generating; if it is still empty, tell the user Builder indexing is not ready.",
+      canRefreshBuilder
+        ? "- If no usable DSI docs or tokens are returned, call refresh-design-system-with-builder once, then call get-design-system again before generating; if it is still empty, tell the user Builder indexing is not ready."
+        : "- If no usable DSI docs or tokens are returned, tell the user Builder indexing is not ready; refreshing the shared system requires editor access.",
     );
 
     if (builder.warning) {
@@ -297,6 +301,7 @@ export default defineAction({
         data: row.data,
         assets: row.assets,
         customInstructions: row.customInstructions,
+        canRefreshBuilder: ["owner", "admin", "editor"].includes(access.role),
         builder,
       }),
     };

--- a/templates/design/actions/refresh-design-system-with-builder.spec.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.spec.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockHydrate = vi.fn();
+const mockParseReference = vi.fn();
+const mockAssertAccess = vi.fn();
+const mockResolveAccess = vi.fn();
+const mockWhere = vi.fn();
+const mockSet = vi.fn(() => ({ where: mockWhere }));
+const mockUpdate = vi.fn(() => ({ set: mockSet }));
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (config: unknown) => config,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  hydrateBuilderDesignSystemReference: (...args: unknown[]) =>
+    mockHydrate(...args),
+  parseBuilderDesignSystemProxyReference: (...args: unknown[]) =>
+    mockParseReference(...args),
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: (...args: unknown[]) => mockAssertAccess(...args),
+  resolveAccess: (...args: unknown[]) => mockResolveAccess(...args),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => args,
+  eq: (...args: unknown[]) => args,
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => ({ update: mockUpdate }),
+  schema: {
+    designSystems: {
+      id: "designSystems.id",
+      data: "designSystems.data",
+    },
+  },
+}));
+
+import action from "./refresh-design-system-with-builder.js";
+
+describe("refresh-design-system-with-builder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParseReference.mockReturnValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "in-progress",
+    });
+    mockResolveAccess.mockResolvedValue({
+      resource: {
+        id: "local-ds-1",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+          colors: { primary: "var(--primary)" },
+        }),
+      },
+    });
+    mockHydrate.mockResolvedValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "in-progress",
+      docs: [],
+      docCount: 1,
+      tokenValues: { "--brand-primary": "#123456" },
+    });
+  });
+
+  it("persists concrete values when Builder DSI is ready", async () => {
+    const result = await action.run({ id: "local-ds-1" });
+
+    expect(result).toMatchObject({
+      id: "local-ds-1",
+      synced: true,
+      status: "ready",
+      tokenCount: 1,
+    });
+    expect(mockAssertAccess).toHaveBeenCalledWith(
+      "design-system",
+      "local-ds-1",
+      "editor",
+    );
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.stringContaining('"builderStatus":"ready"'),
+      }),
+    );
+    expect(mockWhere).toHaveBeenCalledWith([
+      ["designSystems.id", "local-ds-1"],
+      [
+        "designSystems.data",
+        JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+          colors: { primary: "var(--primary)" },
+        }),
+      ],
+    ]);
+  });
+
+  it("leaves the proxy untouched while Builder is still processing", async () => {
+    mockHydrate.mockResolvedValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "in-progress",
+      docs: [],
+      docCount: 0,
+      tokenValues: {},
+    });
+
+    await expect(action.run({ id: "local-ds-1" })).resolves.toMatchObject({
+      id: "local-ds-1",
+      synced: false,
+      status: "in-progress",
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/templates/design/actions/refresh-design-system-with-builder.spec.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.spec.ts
@@ -163,6 +163,46 @@ describe("refresh-design-system-with-builder", () => {
     });
   });
 
+  it("settles a completed Builder import even when it has no storable tokens", async () => {
+    mockHydrate.mockResolvedValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "complete",
+      docs: [],
+      docCount: 0,
+      tokenValues: {},
+      completionConfirmed: true,
+    });
+
+    await expect(action.run({ id: "local-ds-1" })).resolves.toMatchObject({
+      id: "local-ds-1",
+      synced: true,
+      status: "ready",
+      tokenCount: 0,
+    });
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it("stops on a terminal Builder failure instead of retrying it", async () => {
+    mockHydrate.mockResolvedValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "failed",
+      docs: [],
+      docCount: 0,
+      tokenValues: {},
+    });
+
+    await expect(action.run({ id: "local-ds-1" })).resolves.toMatchObject({
+      id: "local-ds-1",
+      synced: false,
+      status: "failed",
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("surfaces rejected Builder tokens without writing the proxy", async () => {
     mockHydrate.mockResolvedValue({
       source: "builder",

--- a/templates/design/actions/refresh-design-system-with-builder.spec.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.spec.ts
@@ -58,7 +58,13 @@ describe("refresh-design-system-with-builder", () => {
     mockResolveAccess.mockResolvedValueOnce({
       resource: { id: "local-ds-1", data: initialData },
     });
-    mockResolveAccess.mockImplementationOnce(async () => ({
+    mockResolveAccess.mockResolvedValueOnce({
+      resource: {
+        id: "local-ds-1",
+        data: initialData,
+      },
+    });
+    mockResolveAccess.mockImplementation(async () => ({
       resource: {
         id: "local-ds-1",
         data: mockSet.mock.calls[0]?.[0]?.data ?? initialData,
@@ -72,6 +78,7 @@ describe("refresh-design-system-with-builder", () => {
       docs: [],
       docCount: 1,
       tokenValues: { "--brand-primary": "#123456" },
+      completionConfirmed: true,
     });
   });
 
@@ -89,6 +96,7 @@ describe("refresh-design-system-with-builder", () => {
       "local-ds-1",
       "editor",
     );
+    expect(mockAssertAccess).toHaveBeenCalledTimes(2);
     expect(mockSet).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.stringContaining('"builderStatus":"ready"'),
@@ -153,5 +161,26 @@ describe("refresh-design-system-with-builder", () => {
       synced: false,
       status: "conflict",
     });
+  });
+
+  it("surfaces rejected Builder tokens without writing the proxy", async () => {
+    mockHydrate.mockResolvedValue({
+      source: "builder",
+      builderDesignSystemId: "ds-1",
+      builderJobId: "job-1",
+      builderStatus: "in-progress",
+      docs: [],
+      docCount: 1,
+      tokenValues: { "--bad token": "#123456" },
+      completionConfirmed: true,
+    });
+
+    await expect(action.run({ id: "local-ds-1" })).resolves.toMatchObject({
+      id: "local-ds-1",
+      synced: false,
+      status: "incomplete",
+      rejectedTokenCount: 1,
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
   });
 });

--- a/templates/design/actions/refresh-design-system-with-builder.spec.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.spec.ts
@@ -50,16 +50,20 @@ describe("refresh-design-system-with-builder", () => {
       builderJobId: "job-1",
       builderStatus: "in-progress",
     });
-    mockResolveAccess.mockResolvedValue({
+    const initialData = JSON.stringify({
+      source: "builder",
+      builderStatus: "in-progress",
+      colors: { primary: "var(--primary)" },
+    });
+    mockResolveAccess.mockResolvedValueOnce({
+      resource: { id: "local-ds-1", data: initialData },
+    });
+    mockResolveAccess.mockImplementationOnce(async () => ({
       resource: {
         id: "local-ds-1",
-        data: JSON.stringify({
-          source: "builder",
-          builderStatus: "in-progress",
-          colors: { primary: "var(--primary)" },
-        }),
+        data: mockSet.mock.calls[0]?.[0]?.data ?? initialData,
       },
-    });
+    }));
     mockHydrate.mockResolvedValue({
       source: "builder",
       builderDesignSystemId: "ds-1",
@@ -120,5 +124,34 @@ describe("refresh-design-system-with-builder", () => {
       status: "in-progress",
     });
     expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reports a concurrent local edit instead of claiming synchronization", async () => {
+    mockResolveAccess.mockReset();
+    mockResolveAccess.mockResolvedValueOnce({
+      resource: {
+        id: "local-ds-1",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+        }),
+      },
+    });
+    mockResolveAccess.mockResolvedValueOnce({
+      resource: {
+        id: "local-ds-1",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+          colors: { primary: "#654321" },
+        }),
+      },
+    });
+
+    await expect(action.run({ id: "local-ds-1" })).resolves.toMatchObject({
+      id: "local-ds-1",
+      synced: false,
+      status: "conflict",
+    });
   });
 });

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -10,6 +10,18 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { reconcileBuilderProxyData } from "../server/lib/builder-design-system-proxy.js";
 
+function persistedBuilderSyncMatches(data: unknown, syncedAt: string): boolean {
+  if (typeof data !== "string") return false;
+  try {
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    return (
+      parsed.builderStatus === "ready" && parsed.builderSyncedAt === syncedAt
+    );
+  } catch {
+    return false;
+  }
+}
+
 export default defineAction({
   description:
     "Refresh a Builder-backed design-system proxy after DSI indexing finishes. " +
@@ -58,6 +70,19 @@ export default defineAction({
           eq(schema.designSystems.data, access.resource.data),
         ),
       );
+
+    const persisted = await resolveAccess("design-system", id);
+    if (!persistedBuilderSyncMatches(persisted?.resource?.data, syncedAt)) {
+      return {
+        id,
+        synced: false,
+        status: "conflict",
+        docCount: hydrated.docCount,
+        tokenCount: 0,
+        message:
+          "The design system changed while Builder DSI was syncing. Retry the refresh.",
+      };
+    }
 
     return {
       id,

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -17,10 +17,9 @@ function persistedBuilderSyncMatches(data: unknown, syncedAt: string): boolean {
     return (
       parsed.builderStatus === "ready" && parsed.builderSyncedAt === syncedAt
     );
-  } catch (error) {
+  } catch {
     throw new Error(
       "The design system data became invalid while Builder DSI was syncing.",
-      { cause: error },
     );
   }
 }

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -1,0 +1,72 @@
+import { defineAction } from "@agent-native/core";
+import {
+  hydrateBuilderDesignSystemReference,
+  parseBuilderDesignSystemProxyReference,
+} from "@agent-native/core/server";
+import { assertAccess, resolveAccess } from "@agent-native/core/sharing";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb, schema } from "../server/db/index.js";
+import { reconcileBuilderProxyData } from "../server/lib/builder-design-system-proxy.js";
+
+export default defineAction({
+  description:
+    "Refresh a Builder-backed design-system proxy after DSI indexing finishes. " +
+    "Requires editor access. If Builder is still processing, returns synced=false " +
+    "without replacing the local proxy with partial data.",
+  schema: z.object({
+    id: z.string().min(1).describe("Local design system id"),
+  }),
+  run: async ({ id }) => {
+    await assertAccess("design-system", id, "editor");
+    const access = await resolveAccess("design-system", id);
+    if (!access) throw new Error("Design system not found");
+
+    const reference = parseBuilderDesignSystemProxyReference(
+      access.resource.data,
+    );
+    if (!reference) {
+      throw new Error("This design system is not a Builder-backed proxy.");
+    }
+
+    const hydrated = await hydrateBuilderDesignSystemReference(reference);
+    const syncedAt = new Date().toISOString();
+    const reconciliation = reconcileBuilderProxyData(
+      access.resource.data,
+      hydrated,
+      syncedAt,
+    );
+    if (!reconciliation) {
+      return {
+        id,
+        synced: false,
+        status: reference.builderStatus ?? "in-progress",
+        docCount: hydrated.docCount,
+        tokenCount: 0,
+        message: "Builder DSI has not returned usable token values yet.",
+      };
+    }
+
+    const db = getDb();
+    await db
+      .update(schema.designSystems)
+      .set({ data: reconciliation.data, updatedAt: syncedAt })
+      .where(
+        and(
+          eq(schema.designSystems.id, access.resource.id),
+          eq(schema.designSystems.data, access.resource.data),
+        ),
+      );
+
+    return {
+      id,
+      synced: true,
+      status: "ready",
+      docCount: hydrated.docCount,
+      tokenCount: reconciliation.tokenCount,
+      rejectedTokenCount: reconciliation.rejectedTokenCount,
+      syncedAt,
+    };
+  },
+});

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -17,8 +17,11 @@ function persistedBuilderSyncMatches(data: unknown, syncedAt: string): boolean {
     return (
       parsed.builderStatus === "ready" && parsed.builderSyncedAt === syncedAt
     );
-  } catch {
-    return false;
+  } catch (error) {
+    throw new Error(
+      "The design system data became invalid while Builder DSI was syncing.",
+      { cause: error },
+    );
   }
 }
 

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -62,14 +62,58 @@ export default defineAction({
       };
     }
 
+    if (reconciliation.rejectedTokenCount > 0) {
+      return {
+        id,
+        synced: false,
+        status: "incomplete",
+        docCount: hydrated.docCount,
+        tokenCount: reconciliation.tokenCount,
+        rejectedTokenCount: reconciliation.rejectedTokenCount,
+        message: `Builder DSI returned ${reconciliation.rejectedTokenCount} token(s) that could not be safely imported.`,
+      };
+    }
+
+    if (!reconciliation.completionConfirmed) {
+      return {
+        id,
+        synced: false,
+        status: reference.builderStatus ?? "in-progress",
+        docCount: hydrated.docCount,
+        tokenCount: reconciliation.tokenCount,
+        rejectedTokenCount: 0,
+        message:
+          "Builder DSI returned token values without confirming that indexing is complete. Retry after Builder reports completion.",
+      };
+    }
+
+    await assertAccess("design-system", id, "editor");
+    const latestAccess = await resolveAccess("design-system", id);
+    if (!latestAccess) throw new Error("Design system not found");
+    if (
+      latestAccess.resource.id !== access.resource.id ||
+      latestAccess.resource.data !== access.resource.data
+    ) {
+      return {
+        id,
+        synced: false,
+        status: "conflict",
+        docCount: hydrated.docCount,
+        tokenCount: reconciliation.tokenCount,
+        rejectedTokenCount: 0,
+        message:
+          "The design system changed while Builder DSI was syncing. Retry the refresh.",
+      };
+    }
+
     const db = getDb();
     await db
       .update(schema.designSystems)
       .set({ data: reconciliation.data, updatedAt: syncedAt })
       .where(
         and(
-          eq(schema.designSystems.id, access.resource.id),
-          eq(schema.designSystems.data, access.resource.data),
+          eq(schema.designSystems.id, latestAccess.resource.id),
+          eq(schema.designSystems.data, latestAccess.resource.data),
         ),
       );
 
@@ -80,7 +124,8 @@ export default defineAction({
         synced: false,
         status: "conflict",
         docCount: hydrated.docCount,
-        tokenCount: 0,
+        tokenCount: reconciliation.tokenCount,
+        rejectedTokenCount: 0,
         message:
           "The design system changed while Builder DSI was syncing. Retry the refresh.",
       };

--- a/templates/design/actions/refresh-design-system-with-builder.ts
+++ b/templates/design/actions/refresh-design-system-with-builder.ts
@@ -55,7 +55,8 @@ export default defineAction({
       return {
         id,
         synced: false,
-        status: reference.builderStatus ?? "in-progress",
+        status:
+          hydrated.builderStatus ?? reference.builderStatus ?? "in-progress",
         docCount: hydrated.docCount,
         tokenCount: 0,
         message: "Builder DSI has not returned usable token values yet.",
@@ -78,7 +79,8 @@ export default defineAction({
       return {
         id,
         synced: false,
-        status: reference.builderStatus ?? "in-progress",
+        status:
+          hydrated.builderStatus ?? reference.builderStatus ?? "in-progress",
         docCount: hydrated.docCount,
         tokenCount: reconciliation.tokenCount,
         rejectedTokenCount: 0,

--- a/templates/design/app/lib/design-system-data.ts
+++ b/templates/design/app/lib/design-system-data.ts
@@ -1,0 +1,63 @@
+export interface DesignSystemData {
+  source?: string;
+  builderJobId?: string;
+  builderStatus?: string;
+  colors?: {
+    primary?: unknown;
+    secondary?: unknown;
+    accent?: unknown;
+    background?: unknown;
+    surface?: unknown;
+    text?: unknown;
+    textMuted?: unknown;
+  };
+  typography?: {
+    headingFont?: unknown;
+    bodyFont?: unknown;
+    headingWeight?: unknown;
+    bodyWeight?: unknown;
+  };
+  spacing?: Record<string, unknown>;
+  borders?: Record<string, unknown>;
+  logos?: Array<{ url?: string; name?: string; variant?: string }>;
+  defaults?: Record<string, unknown>;
+  notes?: unknown;
+  /** The source system's own named vocabulary; absent on kits predating it. */
+  tokens?: unknown;
+}
+
+export function parseDesignSystemData(
+  dataStr: string,
+): DesignSystemData | null {
+  try {
+    const parsed = JSON.parse(dataStr);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as DesignSystemData;
+  } catch (error) {
+    if (error instanceof SyntaxError) return null;
+    throw error;
+  }
+}
+
+export function shouldRefreshBuilderDesignSystem(
+  system: Pick<{ accessRole?: string; data: string }, "accessRole" | "data">,
+): boolean {
+  const parsed = parseDesignSystemData(system.data);
+  return (
+    (system.accessRole === "owner" ||
+      system.accessRole === "admin" ||
+      system.accessRole === "editor") &&
+    parsed?.source === "builder" &&
+    parsed.builderStatus === "in-progress"
+  );
+}
+
+export function builderRefreshKey(system: {
+  id: string;
+  data: string;
+}): string {
+  const parsed = parseDesignSystemData(system.data);
+  return `${system.id}:${parsed?.builderJobId ?? "unknown"}`;
+}

--- a/templates/design/app/lib/design-system-data.ts
+++ b/templates/design/app/lib/design-system-data.ts
@@ -2,6 +2,7 @@ export interface DesignSystemData {
   source?: string;
   builderJobId?: string;
   builderStatus?: string;
+  builderSyncedAt?: string;
   colors?: {
     primary?: unknown;
     secondary?: unknown;
@@ -50,7 +51,11 @@ export function shouldRefreshBuilderDesignSystem(
       system.accessRole === "admin" ||
       system.accessRole === "editor") &&
     parsed?.source === "builder" &&
-    parsed.builderStatus === "in-progress"
+    (parsed.builderStatus === "in-progress" ||
+      ((parsed.builderStatus === "ready" ||
+        parsed.builderStatus === "complete" ||
+        parsed.builderStatus === "completed") &&
+        typeof parsed.builderSyncedAt !== "string"))
   );
 }
 

--- a/templates/design/app/pages/DesignSystems.refresh.test.ts
+++ b/templates/design/app/pages/DesignSystems.refresh.test.ts
@@ -22,7 +22,11 @@ describe("shouldRefreshBuilderDesignSystem", () => {
     expect(
       shouldRefreshBuilderDesignSystem({
         accessRole: "editor",
-        data: JSON.stringify({ source: "builder", builderStatus: "ready" }),
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "ready",
+          builderSyncedAt: "2026-08-21T00:00:00.000Z",
+        }),
       }),
     ).toBe(false);
     expect(
@@ -34,6 +38,18 @@ describe("shouldRefreshBuilderDesignSystem", () => {
         }),
       }),
     ).toBe(false);
+  });
+
+  it("refreshes terminal Builder imports that have not synced local values", () => {
+    expect(
+      shouldRefreshBuilderDesignSystem({
+        accessRole: "editor",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "complete",
+        }),
+      }),
+    ).toBe(true);
   });
 
   it("starts a new refresh cycle for a re-indexed Builder job", () => {

--- a/templates/design/app/pages/DesignSystems.refresh.test.ts
+++ b/templates/design/app/pages/DesignSystems.refresh.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRefreshBuilderDesignSystem } from "./DesignSystems";
+
+describe("shouldRefreshBuilderDesignSystem", () => {
+  it("refreshes only editable Builder systems that are still indexing", () => {
+    expect(
+      shouldRefreshBuilderDesignSystem({
+        accessRole: "editor",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not refresh ready systems or viewers", () => {
+    expect(
+      shouldRefreshBuilderDesignSystem({
+        accessRole: "editor",
+        data: JSON.stringify({ source: "builder", builderStatus: "ready" }),
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshBuilderDesignSystem({
+        accessRole: "viewer",
+        data: JSON.stringify({
+          source: "builder",
+          builderStatus: "in-progress",
+        }),
+      }),
+    ).toBe(false);
+  });
+});

--- a/templates/design/app/pages/DesignSystems.refresh.test.ts
+++ b/templates/design/app/pages/DesignSystems.refresh.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldRefreshBuilderDesignSystem } from "./DesignSystems";
+import {
+  builderRefreshKey,
+  shouldRefreshBuilderDesignSystem,
+} from "../lib/design-system-data";
 
 describe("shouldRefreshBuilderDesignSystem", () => {
   it("refreshes only editable Builder systems that are still indexing", () => {
@@ -31,5 +34,27 @@ describe("shouldRefreshBuilderDesignSystem", () => {
         }),
       }),
     ).toBe(false);
+  });
+
+  it("starts a new refresh cycle for a re-indexed Builder job", () => {
+    expect(
+      builderRefreshKey({
+        id: "local-1",
+        data: JSON.stringify({
+          source: "builder",
+          builderJobId: "job-1",
+          builderStatus: "in-progress",
+        }),
+      }),
+    ).not.toBe(
+      builderRefreshKey({
+        id: "local-1",
+        data: JSON.stringify({
+          source: "builder",
+          builderJobId: "job-2",
+          builderStatus: "in-progress",
+        }),
+      }),
+    );
   });
 });

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -73,6 +73,12 @@ import {
 } from "@/lib/design-system-preview";
 
 import { QueryErrorState } from "../components/QueryErrorState";
+import {
+  builderRefreshKey,
+  parseDesignSystemData,
+  shouldRefreshBuilderDesignSystem,
+  type DesignSystemData,
+} from "../lib/design-system-data";
 
 interface DesignSystem {
   id: string;
@@ -89,33 +95,6 @@ interface DesignSystem {
   updatedAt?: string;
 }
 
-interface DesignSystemData {
-  source?: string;
-  builderStatus?: string;
-  colors?: {
-    primary?: unknown;
-    secondary?: unknown;
-    accent?: unknown;
-    background?: unknown;
-    surface?: unknown;
-    text?: unknown;
-    textMuted?: unknown;
-  };
-  typography?: {
-    headingFont?: unknown;
-    bodyFont?: unknown;
-    headingWeight?: unknown;
-    bodyWeight?: unknown;
-  };
-  spacing?: Record<string, unknown>;
-  borders?: Record<string, unknown>;
-  logos?: Array<{ url?: string; name?: string; variant?: string }>;
-  defaults?: Record<string, unknown>;
-  notes?: unknown;
-  /** The source system's own named vocabulary; absent on kits predating it. */
-  tokens?: unknown;
-}
-
 type BuilderRefreshResult = {
   synced: boolean;
   status?: string;
@@ -129,19 +108,6 @@ function isTerminalBuilderStatus(status?: string): boolean {
     status === "error" ||
     status === "failed" ||
     status === "cancelled"
-  );
-}
-
-export function shouldRefreshBuilderDesignSystem(
-  system: Pick<DesignSystem, "accessRole" | "data">,
-): boolean {
-  const parsed = parseDesignSystemData(system.data);
-  return (
-    (system.accessRole === "owner" ||
-      system.accessRole === "admin" ||
-      system.accessRole === "editor") &&
-    parsed?.source === "builder" &&
-    parsed.builderStatus === "in-progress"
   );
 }
 
@@ -174,7 +140,8 @@ export default function DesignSystems() {
     refreshBuilderSystemMutation.mutateAsync,
   );
   refreshBuilderSystemRef.current = refreshBuilderSystemMutation.mutateAsync;
-  const completedBuilderRefreshesRef = useRef(new Set<string>());
+  const settledBuilderRefreshesRef = useRef(new Set<string>());
+  const stoppedBuilderRefreshesRef = useRef(new Set<string>());
   const activeBuilderRefreshesRef = useRef(new Set<string>());
 
   const designSystems = data?.designSystems ?? [];
@@ -407,50 +374,68 @@ export default function DesignSystems() {
   }, [selectedSystemIds, queryClient, exitSelectionMode, deleteMutation, t]);
 
   useEffect(() => {
-    const builderSystemIds = designSystems
+    const builderSystemEntries = designSystems
       .filter(shouldRefreshBuilderDesignSystem)
-      .map((system) => system.id)
+      .map((system) => ({
+        id: system.id,
+        key: builderRefreshKey(system),
+      }))
       .filter(
-        (id) =>
-          !completedBuilderRefreshesRef.current.has(id) &&
-          !activeBuilderRefreshesRef.current.has(id),
+        ({ key }) =>
+          !settledBuilderRefreshesRef.current.has(key) &&
+          !stoppedBuilderRefreshesRef.current.has(key) &&
+          !activeBuilderRefreshesRef.current.has(key),
       );
-    if (builderSystemIds.length === 0) return;
+    if (builderSystemEntries.length === 0) return;
 
     let disposed = false;
     const timers: Array<ReturnType<typeof setTimeout>> = [];
     const maxAttempts = 5;
+    const maxPolls = 3;
     const retryDelayMs = 5_000;
     const retryPollDelayMs = 30_000;
 
     const scheduleRetry = (
-      id: string,
+      entry: { id: string; key: string },
       delayMs: number,
       attempt: number,
+      pollCount: number,
     ): void => {
       if (disposed) return;
       timers.push(
         setTimeout(() => {
-          void refresh(id, attempt);
+          void refresh(entry, attempt, pollCount);
         }, delayMs),
       );
     };
 
-    const refresh = async (id: string, attempt: number): Promise<void> => {
+    const refresh = async (
+      entry: { id: string; key: string },
+      attempt: number,
+      pollCount: number,
+    ): Promise<void> => {
       try {
-        const result = await refreshBuilderSystemRef.current({ id });
+        const result = await refreshBuilderSystemRef.current({ id: entry.id });
         if (disposed) return;
         if (result.synced) {
-          activeBuilderRefreshesRef.current.delete(id);
-          completedBuilderRefreshesRef.current.add(id);
+          activeBuilderRefreshesRef.current.delete(entry.key);
+          settledBuilderRefreshesRef.current.add(entry.key);
+          await queryClient.invalidateQueries({
+            queryKey: ["action", "list-design-systems"],
+          });
+          return;
+        }
+        if (result.status === "conflict") {
+          activeBuilderRefreshesRef.current.delete(entry.key);
+          stoppedBuilderRefreshesRef.current.add(entry.key);
           await queryClient.invalidateQueries({
             queryKey: ["action", "list-design-systems"],
           });
           return;
         }
         if (isTerminalBuilderStatus(result.status)) {
-          activeBuilderRefreshesRef.current.delete(id);
-          completedBuilderRefreshesRef.current.add(id);
+          activeBuilderRefreshesRef.current.delete(entry.key);
+          settledBuilderRefreshesRef.current.add(entry.key);
           return;
         }
       } catch {
@@ -458,23 +443,29 @@ export default function DesignSystems() {
       }
       if (disposed) return;
       const exhausted = attempt >= maxAttempts;
+      if (exhausted && pollCount >= maxPolls) {
+        activeBuilderRefreshesRef.current.delete(entry.key);
+        stoppedBuilderRefreshesRef.current.add(entry.key);
+        return;
+      }
       scheduleRetry(
-        id,
+        entry,
         exhausted ? retryPollDelayMs : retryDelayMs,
         exhausted ? 0 : attempt + 1,
+        exhausted ? pollCount + 1 : pollCount,
       );
     };
 
-    for (const id of builderSystemIds) {
-      activeBuilderRefreshesRef.current.add(id);
-      void refresh(id, 0);
+    for (const entry of builderSystemEntries) {
+      activeBuilderRefreshesRef.current.add(entry.key);
+      void refresh(entry, 0, 0);
     }
 
     return () => {
       disposed = true;
       for (const timer of timers) clearTimeout(timer);
-      for (const id of builderSystemIds) {
-        activeBuilderRefreshesRef.current.delete(id);
+      for (const entry of builderSystemEntries) {
+        activeBuilderRefreshesRef.current.delete(entry.key);
       }
     };
   }, [designSystems, queryClient]);
@@ -1104,18 +1095,6 @@ function EmptyPreviewLine({
       {children}
     </div>
   );
-}
-
-function parseDesignSystemData(dataStr: string): DesignSystemData | null {
-  try {
-    const parsed = JSON.parse(dataStr);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as DesignSystemData;
-  } catch {
-    return null;
-  }
 }
 
 function parseDesignSystemAssets(

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -26,6 +26,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -89,6 +90,7 @@ interface DesignSystem {
 }
 
 interface DesignSystemData {
+  source?: string;
   colors?: {
     primary?: unknown;
     secondary?: unknown;
@@ -132,6 +134,17 @@ export default function DesignSystems() {
   const setDefaultMutation = useActionMutation("set-default-design-system");
   const deleteMutation = useActionMutation("delete-design-system");
   const updateMutation = useActionMutation("update-design-system");
+  const refreshBuilderSystemMutation = useActionMutation<
+    { synced: boolean },
+    { id: string }
+  >("refresh-design-system-with-builder", {
+    skipActionQueryInvalidation: true,
+  });
+  const refreshBuilderSystemRef = useRef(
+    refreshBuilderSystemMutation.mutateAsync,
+  );
+  refreshBuilderSystemRef.current = refreshBuilderSystemMutation.mutateAsync;
+  const attemptedBuilderRefreshesRef = useRef(new Set<string>());
 
   const designSystems = data?.designSystems ?? [];
   const selectedDesignSystemId = searchParams.get("designSystemId");
@@ -369,6 +382,56 @@ export default function DesignSystems() {
       return null;
     }
   };
+
+  useEffect(() => {
+    const builderSystemIds = designSystems
+      .filter(
+        (system) =>
+          (system.accessRole === "owner" ||
+            system.accessRole === "admin" ||
+            system.accessRole === "editor") &&
+          parseData(system.data)?.source === "builder",
+      )
+      .map((system) => system.id)
+      .filter((id) => !attemptedBuilderRefreshesRef.current.has(id));
+    if (builderSystemIds.length === 0) return;
+
+    let disposed = false;
+    const timers: Array<ReturnType<typeof setTimeout>> = [];
+    const maxAttempts = 5;
+    const retryDelayMs = 5_000;
+
+    const refresh = async (id: string, attempt: number): Promise<void> => {
+      try {
+        const result = await refreshBuilderSystemRef.current({ id });
+        if (disposed) return;
+        if (result.synced) {
+          await queryClient.invalidateQueries({
+            queryKey: ["action", "list-design-systems"],
+          });
+          return;
+        }
+        if (attempt >= maxAttempts) return;
+      } catch {
+        if (disposed || attempt >= maxAttempts) return;
+      }
+      timers.push(
+        setTimeout(() => {
+          void refresh(id, attempt + 1);
+        }, retryDelayMs),
+      );
+    };
+
+    for (const id of builderSystemIds) {
+      attemptedBuilderRefreshesRef.current.add(id);
+      void refresh(id, 0);
+    }
+
+    return () => {
+      disposed = true;
+      for (const timer of timers) clearTimeout(timer);
+    };
+  }, [designSystems, queryClient]);
 
   useSetPageTitle(t("navigation.designSystems"));
 

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -98,6 +98,7 @@ interface DesignSystem {
 type BuilderRefreshResult = {
   synced: boolean;
   status?: string;
+  rejectedTokenCount?: number;
 };
 
 function isTerminalBuilderStatus(status?: string): boolean {
@@ -431,6 +432,11 @@ export default function DesignSystems() {
           await queryClient.invalidateQueries({
             queryKey: ["action", "list-design-systems"],
           });
+          return;
+        }
+        if (result.status === "incomplete" || result.rejectedTokenCount) {
+          activeBuilderRefreshesRef.current.delete(entry.key);
+          stoppedBuilderRefreshesRef.current.add(entry.key);
           return;
         }
         if (isTerminalBuilderStatus(result.status)) {

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -116,6 +116,22 @@ interface DesignSystemData {
   tokens?: unknown;
 }
 
+type BuilderRefreshResult = {
+  synced: boolean;
+  status?: string;
+};
+
+function isTerminalBuilderStatus(status?: string): boolean {
+  return (
+    status === "ready" ||
+    status === "complete" ||
+    status === "completed" ||
+    status === "error" ||
+    status === "failed" ||
+    status === "cancelled"
+  );
+}
+
 export function shouldRefreshBuilderDesignSystem(
   system: Pick<DesignSystem, "accessRole" | "data">,
 ): boolean {
@@ -149,7 +165,7 @@ export default function DesignSystems() {
   const deleteMutation = useActionMutation("delete-design-system");
   const updateMutation = useActionMutation("update-design-system");
   const refreshBuilderSystemMutation = useActionMutation<
-    { synced: boolean },
+    BuilderRefreshResult,
     { id: string }
   >("refresh-design-system-with-builder", {
     skipActionQueryInvalidation: true,
@@ -405,6 +421,20 @@ export default function DesignSystems() {
     const timers: Array<ReturnType<typeof setTimeout>> = [];
     const maxAttempts = 5;
     const retryDelayMs = 5_000;
+    const retryPollDelayMs = 30_000;
+
+    const scheduleRetry = (
+      id: string,
+      delayMs: number,
+      attempt: number,
+    ): void => {
+      if (disposed) return;
+      timers.push(
+        setTimeout(() => {
+          void refresh(id, attempt);
+        }, delayMs),
+      );
+    };
 
     const refresh = async (id: string, attempt: number): Promise<void> => {
       try {
@@ -418,24 +448,20 @@ export default function DesignSystems() {
           });
           return;
         }
-        if (attempt >= maxAttempts) {
+        if (isTerminalBuilderStatus(result.status)) {
           activeBuilderRefreshesRef.current.delete(id);
           completedBuilderRefreshesRef.current.add(id);
           return;
         }
       } catch {
         if (disposed) return;
-        if (attempt >= maxAttempts) {
-          activeBuilderRefreshesRef.current.delete(id);
-          completedBuilderRefreshesRef.current.add(id);
-          return;
-        }
       }
       if (disposed) return;
-      timers.push(
-        setTimeout(() => {
-          void refresh(id, attempt + 1);
-        }, retryDelayMs),
+      const exhausted = attempt >= maxAttempts;
+      scheduleRetry(
+        id,
+        exhausted ? retryPollDelayMs : retryDelayMs,
+        exhausted ? 0 : attempt + 1,
       );
     };
 

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -91,6 +91,7 @@ interface DesignSystem {
 
 interface DesignSystemData {
   source?: string;
+  builderStatus?: string;
   colors?: {
     primary?: unknown;
     secondary?: unknown;
@@ -113,6 +114,19 @@ interface DesignSystemData {
   notes?: unknown;
   /** The source system's own named vocabulary; absent on kits predating it. */
   tokens?: unknown;
+}
+
+export function shouldRefreshBuilderDesignSystem(
+  system: Pick<DesignSystem, "accessRole" | "data">,
+): boolean {
+  const parsed = parseDesignSystemData(system.data);
+  return (
+    (system.accessRole === "owner" ||
+      system.accessRole === "admin" ||
+      system.accessRole === "editor") &&
+    parsed?.source === "builder" &&
+    parsed.builderStatus === "in-progress"
+  );
 }
 
 export default function DesignSystems() {
@@ -144,7 +158,8 @@ export default function DesignSystems() {
     refreshBuilderSystemMutation.mutateAsync,
   );
   refreshBuilderSystemRef.current = refreshBuilderSystemMutation.mutateAsync;
-  const attemptedBuilderRefreshesRef = useRef(new Set<string>());
+  const completedBuilderRefreshesRef = useRef(new Set<string>());
+  const activeBuilderRefreshesRef = useRef(new Set<string>());
 
   const designSystems = data?.designSystems ?? [];
   const selectedDesignSystemId = searchParams.get("designSystemId");
@@ -375,25 +390,15 @@ export default function DesignSystems() {
       });
   }, [selectedSystemIds, queryClient, exitSelectionMode, deleteMutation, t]);
 
-  const parseData = (dataStr: string): DesignSystemData | null => {
-    try {
-      return JSON.parse(dataStr);
-    } catch {
-      return null;
-    }
-  };
-
   useEffect(() => {
     const builderSystemIds = designSystems
-      .filter(
-        (system) =>
-          (system.accessRole === "owner" ||
-            system.accessRole === "admin" ||
-            system.accessRole === "editor") &&
-          parseData(system.data)?.source === "builder",
-      )
+      .filter(shouldRefreshBuilderDesignSystem)
       .map((system) => system.id)
-      .filter((id) => !attemptedBuilderRefreshesRef.current.has(id));
+      .filter(
+        (id) =>
+          !completedBuilderRefreshesRef.current.has(id) &&
+          !activeBuilderRefreshesRef.current.has(id),
+      );
     if (builderSystemIds.length === 0) return;
 
     let disposed = false;
@@ -406,15 +411,27 @@ export default function DesignSystems() {
         const result = await refreshBuilderSystemRef.current({ id });
         if (disposed) return;
         if (result.synced) {
+          activeBuilderRefreshesRef.current.delete(id);
+          completedBuilderRefreshesRef.current.add(id);
           await queryClient.invalidateQueries({
             queryKey: ["action", "list-design-systems"],
           });
           return;
         }
-        if (attempt >= maxAttempts) return;
+        if (attempt >= maxAttempts) {
+          activeBuilderRefreshesRef.current.delete(id);
+          completedBuilderRefreshesRef.current.add(id);
+          return;
+        }
       } catch {
-        if (disposed || attempt >= maxAttempts) return;
+        if (disposed) return;
+        if (attempt >= maxAttempts) {
+          activeBuilderRefreshesRef.current.delete(id);
+          completedBuilderRefreshesRef.current.add(id);
+          return;
+        }
       }
+      if (disposed) return;
       timers.push(
         setTimeout(() => {
           void refresh(id, attempt + 1);
@@ -423,13 +440,16 @@ export default function DesignSystems() {
     };
 
     for (const id of builderSystemIds) {
-      attemptedBuilderRefreshesRef.current.add(id);
+      activeBuilderRefreshesRef.current.add(id);
       void refresh(id, 0);
     }
 
     return () => {
       disposed = true;
       for (const timer of timers) clearTimeout(timer);
+      for (const id of builderSystemIds) {
+        activeBuilderRefreshesRef.current.delete(id);
+      }
     };
   }, [designSystems, queryClient]);
 
@@ -549,7 +569,7 @@ export default function DesignSystems() {
 
                   {/* Design system cards */}
                   {designSystems.map((ds) => {
-                    const parsed = parseData(ds.data);
+                    const parsed = parseDesignSystemData(ds.data);
                     const colors = parsed?.colors;
                     const primaryColor = getCssColorToken(colors?.primary);
                     const secondaryColor = getCssColorToken(colors?.secondary);

--- a/templates/design/changelog/2026-08-21-builder-design-system-imports-reconcile-after-indexing.md
+++ b/templates/design/changelog/2026-08-21-builder-design-system-imports-reconcile-after-indexing.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-21
+---
+
+Completed Builder design-system imports now update the local Design system with indexed tokens instead of leaving placeholder values.

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { reconcileBuilderProxyData } from "./builder-design-system-proxy.js";
+
+describe("reconcileBuilderProxyData", () => {
+  const reference = {
+    source: "builder" as const,
+    builderDesignSystemId: "ds-1",
+    builderJobId: "job-1",
+    builderStatus: "in-progress",
+    docs: [],
+    tokenValues: {
+      "--brand-primary": "#123456",
+      "--brand-accent": "#abcdef",
+      "--brand-surface": "#f8fafc",
+      "--brand-text-muted": "#64748b",
+      "--radius-card": "16px",
+      "--space-element-gap": "20px",
+    },
+    docCount: 1,
+  };
+
+  it("replaces proxy placeholders with concrete Builder values", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({
+        source: "builder",
+        builderStatus: "in-progress",
+        colors: {
+          primary: "var(--primary)",
+          accent: "var(--accent)",
+        },
+        typography: { headingFont: "inherit", bodyFont: "inherit" },
+        spacing: { pagePadding: "48px", elementGap: "24px" },
+        borders: { radius: "12px", accentWidth: "1px" },
+        defaults: { background: "var(--background)" },
+        logos: [],
+      }),
+      reference,
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    expect(result).toMatchObject({ tokenCount: 6, rejectedTokenCount: 0 });
+    const data = JSON.parse(result!.data) as Record<string, any>;
+    expect(data.builderStatus).toBe("ready");
+    expect(data.builderSyncedAt).toBe("2026-08-21T00:00:00.000Z");
+    expect(data.colors).toMatchObject({
+      primary: "#123456",
+      accent: "#abcdef",
+      surface: "#f8fafc",
+      textMuted: "#64748b",
+    });
+    expect(data.borders.radius).toBe("16px");
+    expect(data.spacing.elementGap).toBe("20px");
+    expect(data.tokens).toHaveLength(6);
+  });
+
+  it("does not mark an incomplete Builder response as synchronized", () => {
+    expect(
+      reconcileBuilderProxyData(
+        JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
+        { ...reference, tokenValues: {}, docCount: 0 },
+        "2026-08-21T00:00:00.000Z",
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects malformed local proxy data instead of overwriting it", () => {
+    expect(() =>
+      reconcileBuilderProxyData(
+        "not-json",
+        reference,
+        "2026-08-21T00:00:00.000Z",
+      ),
+    ).toThrow("not valid JSON");
+  });
+});

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -88,6 +88,35 @@ describe("reconcileBuilderProxyData", () => {
     ).toBeNull();
   });
 
+  it("chooses semantic color shades and explicit font-family tokens", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
+      {
+        ...reference,
+        tokenValues: {
+          "--color-primary-50": "#f8fafc",
+          "--color-primary-500": "#64748b",
+          "--color-primary-900": "#0f172a",
+          "--text-primary": "#111827",
+          "--heading-size": "48px",
+          "--heading-line-height": "1.2",
+          "--heading-font-weight": "700",
+          "--font-family-heading": "Inter",
+          "--font-family-body": "Arial",
+        },
+      },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    const data = JSON.parse(result!.data) as Record<string, any>;
+    expect(data.colors.primary).toBe("#64748b");
+    expect(data.colors.text).toBe("#111827");
+    expect(data.typography).toMatchObject({
+      headingFont: "Inter",
+      bodyFont: "Arial",
+    });
+  });
+
   it("rejects malformed local proxy data instead of overwriting it", () => {
     expect(() =>
       reconcileBuilderProxyData(

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -34,6 +34,20 @@ describe("reconcileBuilderProxyData", () => {
         borders: { radius: "12px", accentWidth: "1px" },
         defaults: { background: "var(--background)" },
         logos: [],
+        tokens: [
+          {
+            name: "Old Builder token",
+            cssVar: "--old-builder-token",
+            value: "#111111",
+            source: "Builder DSI",
+          },
+          {
+            name: "Local token",
+            cssVar: "--local-token",
+            value: "#222222",
+            source: "Local",
+          },
+        ],
       }),
       reference,
       "2026-08-21T00:00:00.000Z",
@@ -51,7 +65,17 @@ describe("reconcileBuilderProxyData", () => {
     });
     expect(data.borders.radius).toBe("16px");
     expect(data.spacing.elementGap).toBe("20px");
-    expect(data.tokens).toHaveLength(6);
+    expect(data.tokens).toHaveLength(7);
+    expect(data.tokens).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ cssVar: "--old-builder-token" }),
+      ]),
+    );
+    expect(data.tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ cssVar: "--local-token" }),
+      ]),
+    );
   });
 
   it("does not mark an incomplete Builder response as synchronized", () => {

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -83,10 +83,37 @@ describe("reconcileBuilderProxyData", () => {
     expect(
       reconcileBuilderProxyData(
         JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
-        { ...reference, tokenValues: {}, docCount: 0 },
+        {
+          ...reference,
+          completionConfirmed: false,
+          tokenValues: {},
+          docCount: 0,
+        },
         "2026-08-21T00:00:00.000Z",
       ),
     ).toBeNull();
+  });
+
+  it("marks an explicitly completed tokenless import as ready", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({
+        source: "builder",
+        builderStatus: "in-progress",
+        colors: { primary: "var(--primary)" },
+      }),
+      { ...reference, completionConfirmed: true, tokenValues: {} },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    expect(result).toMatchObject({
+      completionConfirmed: true,
+      tokenCount: 0,
+      rejectedTokenCount: 0,
+    });
+    const data = JSON.parse(result!.data) as Record<string, any>;
+    expect(data.builderStatus).toBe("ready");
+    expect(data.builderSyncedAt).toBe("2026-08-21T00:00:00.000Z");
+    expect(data.colors.primary).toBe("var(--primary)");
   });
 
   it("keeps valid tokens in progress until Builder confirms completion", () => {

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -8,6 +8,7 @@ describe("reconcileBuilderProxyData", () => {
     builderDesignSystemId: "ds-1",
     builderJobId: "job-1",
     builderStatus: "in-progress",
+    completionConfirmed: true,
     docs: [],
     tokenValues: {
       "--brand-primary": "#123456",
@@ -88,6 +89,27 @@ describe("reconcileBuilderProxyData", () => {
     ).toBeNull();
   });
 
+  it("keeps valid tokens in progress until Builder confirms completion", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
+      {
+        ...reference,
+        completionConfirmed: false,
+        tokenValues: { "--brand-primary": "#123456" },
+      },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    expect(result).toMatchObject({
+      completionConfirmed: false,
+      tokenCount: 1,
+      rejectedTokenCount: 0,
+    });
+    const data = JSON.parse(result!.data) as Record<string, any>;
+    expect(data.builderStatus).toBe("in-progress");
+    expect(data.builderSyncedAt).toBeUndefined();
+  });
+
   it("chooses semantic color shades and explicit font-family tokens", () => {
     const result = reconcileBuilderProxyData(
       JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
@@ -114,6 +136,51 @@ describe("reconcileBuilderProxyData", () => {
     expect(data.typography).toMatchObject({
       headingFont: "Inter",
       bodyFont: "Arial",
+    });
+  });
+
+  it("gives Builder semantic aliases precedence over local aliases", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({
+        source: "builder",
+        builderStatus: "in-progress",
+        tokens: [
+          {
+            name: "Local primary",
+            cssVar: "--primary",
+            value: "#111111",
+            source: "Local",
+          },
+        ],
+      }),
+      {
+        ...reference,
+        tokenValues: {
+          "--brand-primary": "#222222",
+          "--primary": "#333333",
+        },
+      },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    const data = JSON.parse(result!.data) as Record<string, any>;
+    expect(data.colors.primary).toBe("#333333");
+  });
+
+  it("surfaces rejected Builder tokens instead of returning a ready proxy", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({ source: "builder", builderStatus: "in-progress" }),
+      {
+        ...reference,
+        tokenValues: { "--bad token": "#123456" },
+      },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    expect(result).toMatchObject({
+      completionConfirmed: false,
+      tokenCount: 0,
+      rejectedTokenCount: 1,
     });
   });
 

--- a/templates/design/server/lib/builder-design-system-proxy.spec.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.spec.ts
@@ -117,6 +117,23 @@ describe("reconcileBuilderProxyData", () => {
     });
   });
 
+  it("preserves local tokens stored only in custom CSS", () => {
+    const result = reconcileBuilderProxyData(
+      JSON.stringify({
+        source: "builder",
+        builderStatus: "in-progress",
+        customCSS: ":root { --legacy-local: #334155; }",
+      }),
+      {
+        ...reference,
+        tokenValues: { "--brand-primary": "#123456" },
+      },
+      "2026-08-21T00:00:00.000Z",
+    );
+
+    expect(result!.data).toContain('"cssVar":"--legacy-local"');
+  });
+
   it("rejects malformed local proxy data instead of overwriting it", () => {
     expect(() =>
       reconcileBuilderProxyData(

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -100,7 +100,9 @@ export function reconcileBuilderProxyData(
   );
   if (extracted.tokens.length === 0) return null;
 
-  const existing = normalizeBrandKitTokens(parsed.tokens).tokens;
+  const existing = normalizeBrandKitTokens(parsed.tokens).tokens.filter(
+    (token) => token.source !== "Builder DSI",
+  );
   const tokensByCssVar = new Map(
     existing.map((token) => [token.cssVar, token]),
   );

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -27,6 +27,11 @@ type ProxyData = Record<string, unknown> & {
   tokens?: unknown;
 };
 
+type HydratedBuilderDesignSystemReference =
+  BuilderDesignSystemHydratedReference & {
+    completionConfirmed?: boolean;
+  };
+
 export interface BuilderProxyReconciliation {
   data: string;
   tokenCount: number;
@@ -159,7 +164,7 @@ function findTokenByPattern(
  */
 export function reconcileBuilderProxyData(
   data: string,
-  hydrated: BuilderDesignSystemHydratedReference,
+  hydrated: HydratedBuilderDesignSystemReference,
   syncedAt: string,
 ): BuilderProxyReconciliation | null {
   const parsed = parseProxyData(data);
@@ -177,14 +182,25 @@ export function reconcileBuilderProxyData(
     hydrated.builderStatus === "complete" ||
     hydrated.builderStatus === "completed";
   if (extracted.tokens.length === 0) {
-    return extracted.rejected.length > 0
-      ? {
-          data,
-          tokenCount: 0,
-          rejectedTokenCount: extracted.rejected.length,
-          completionConfirmed: false,
-        }
-      : null;
+    if (extracted.rejected.length > 0) {
+      return {
+        data,
+        tokenCount: 0,
+        rejectedTokenCount: extracted.rejected.length,
+        completionConfirmed: false,
+      };
+    }
+    if (!completionConfirmed) return null;
+    return {
+      data: JSON.stringify({
+        ...parsed,
+        builderStatus: "ready",
+        builderSyncedAt: syncedAt,
+      }),
+      tokenCount: 0,
+      rejectedTokenCount: 0,
+      completionConfirmed: true,
+    };
   }
 
   const legacyCssTokens =

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -2,6 +2,7 @@ import {
   friendlyTokenName,
   isColorTokenValue,
   normalizeBrandKitTokens,
+  resolveBrandKitTokens,
 } from "@agent-native/core/brand-kit";
 import {
   createBuilderDesignSystemProxyFields,
@@ -22,6 +23,7 @@ type ProxyData = Record<string, unknown> & {
   spacing?: Record<string, unknown>;
   borders?: Record<string, unknown>;
   defaults?: Record<string, unknown>;
+  customCSS?: unknown;
   tokens?: unknown;
 };
 
@@ -160,9 +162,14 @@ export function reconcileBuilderProxyData(
   );
   if (extracted.tokens.length === 0) return null;
 
-  const existing = normalizeBrandKitTokens(parsed.tokens).tokens.filter(
-    (token) => token.source !== "Builder DSI",
-  );
+  const legacyCssTokens =
+    typeof parsed.customCSS === "string"
+      ? resolveBrandKitTokens({ customCSS: parsed.customCSS }, "Local CSS")
+      : [];
+  const existing = [
+    ...legacyCssTokens,
+    ...normalizeBrandKitTokens(parsed.tokens).tokens,
+  ].filter((token) => token.source !== "Builder DSI");
   const tokensByCssVar = new Map(
     existing.map((token) => [token.cssVar, token]),
   );

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -31,6 +31,7 @@ export interface BuilderProxyReconciliation {
   data: string;
   tokenCount: number;
   rejectedTokenCount: number;
+  completionConfirmed: boolean;
 }
 
 function parseProxyData(data: string): ProxyData {
@@ -80,7 +81,7 @@ function findTokenValue(
     );
   const exactCandidates = candidates
     .filter((candidate) => names.includes(candidate.name))
-    .sort((a, b) => a.score - b.score);
+    .sort((a, b) => b.score - a.score);
   if (exactCandidates.length > 0) {
     return exactCandidates[0].token.value;
   }
@@ -141,6 +142,16 @@ function findTypedTokenValue(
   return candidates[0]?.token.value;
 }
 
+function findTokenByPattern(
+  tokens: Array<{ cssVar: string; value: string; type: string }>,
+  type: string,
+  pattern: RegExp,
+): string | undefined {
+  return tokens.find(
+    (token) => token.type === type && pattern.test(token.cssVar),
+  )?.value;
+}
+
 /**
  * Merge completed Builder token extraction into the local selectable proxy.
  * The Builder docs remain the source of truth, but the local row must carry
@@ -160,7 +171,21 @@ export function reconcileBuilderProxyData(
       source: "Builder DSI",
     })),
   );
-  if (extracted.tokens.length === 0) return null;
+  const completionConfirmed =
+    hydrated.completionConfirmed === true ||
+    hydrated.builderStatus === "ready" ||
+    hydrated.builderStatus === "complete" ||
+    hydrated.builderStatus === "completed";
+  if (extracted.tokens.length === 0) {
+    return extracted.rejected.length > 0
+      ? {
+          data,
+          tokenCount: 0,
+          rejectedTokenCount: extracted.rejected.length,
+          completionConfirmed: false,
+        }
+      : null;
+  }
 
   const legacyCssTokens =
     typeof parsed.customCSS === "string"
@@ -178,6 +203,9 @@ export function reconcileBuilderProxyData(
   }
   const tokens = [...tokensByCssVar.values()];
   const colorTokens = tokens.filter((token) => token.type === "color");
+  const builderColorTokens = extracted.tokens.filter(
+    (token) => token.type === "color",
+  );
   const nextColors = { ...(parsed.colors ?? {}) };
   const colorRoles: Record<string, string[]> = {
     primary: ["primary", "color-primary", "brand-primary"],
@@ -189,51 +217,69 @@ export function reconcileBuilderProxyData(
     textMuted: ["text-muted", "muted-foreground", "text-secondary", "muted"],
   };
   for (const [role, names] of Object.entries(colorRoles)) {
-    const value = findTokenValue(
-      colorTokens,
-      names,
-      role === "primary" ? /(?:^|-)text(?:-|$)/i : undefined,
-    );
+    const excludedNamePattern =
+      role === "primary" ? /(?:^|-)text(?:-|$)/i : undefined;
+    const value =
+      findTokenValue(builderColorTokens, names, excludedNamePattern) ??
+      findTokenValue(colorTokens, names, excludedNamePattern);
     if (value) nextColors[role] = value;
   }
 
   const nextTypography = { ...(parsed.typography ?? {}) };
-  const headingFont = findTypedTokenValue(tokens, [
+  const builderTypographyTokens = extracted.tokens.filter(
+    (token) => token.type === "typography",
+  );
+  const headingPatterns = [
     /(?:^|-)heading(?:-|$)/i,
     /(?:^|-)display(?:-|$)/i,
     /(?:^|-)title(?:-|$)/i,
-  ]);
-  const bodyFont = findTypedTokenValue(
-    tokens,
-    [
-      /(?:^|-)body(?:-|$)/i,
-      /(?:^|-)base(?:-|$)/i,
-      /(?:^|-)text(?:-|$)/i,
-      /(?:^|-)font-family(?:-|$)/i,
-    ],
-    /(?:^|-)heading(?:-|$)|(?:^|-)display(?:-|$)|(?:^|-)title(?:-|$)/i,
-  );
+  ];
+  const bodyPatterns = [
+    /(?:^|-)body(?:-|$)/i,
+    /(?:^|-)base(?:-|$)/i,
+    /(?:^|-)text(?:-|$)/i,
+    /(?:^|-)font-family(?:-|$)/i,
+  ];
+  const headingFont =
+    findTypedTokenValue(builderTypographyTokens, headingPatterns) ??
+    findTypedTokenValue(tokens, headingPatterns);
+  const bodyFont =
+    findTypedTokenValue(
+      builderTypographyTokens,
+      bodyPatterns,
+      /(?:^|-)heading(?:-|$)|(?:^|-)display(?:-|$)|(?:^|-)title(?:-|$)/i,
+    ) ??
+    findTypedTokenValue(
+      tokens,
+      bodyPatterns,
+      /(?:^|-)heading(?:-|$)|(?:^|-)display(?:-|$)|(?:^|-)title(?:-|$)/i,
+    );
   if (headingFont) nextTypography.headingFont = headingFont;
   if (bodyFont) nextTypography.bodyFont = bodyFont;
 
   const nextSpacing = { ...(parsed.spacing ?? {}) };
-  const gap = tokens.find(
-    (token) =>
-      /gap|gutter|spacing/i.test(token.cssVar) && token.type === "spacing",
-  )?.value;
-  const pagePadding = tokens.find(
-    (token) =>
-      /padding|page-space|outer-space/i.test(token.cssVar) &&
-      token.type === "spacing",
-  )?.value;
+  const builderSpacingTokens = extracted.tokens.filter(
+    (token) => token.type === "spacing",
+  );
+  const spacingGapPattern = /gap|gutter|spacing/i;
+  const spacingPaddingPattern = /padding|page-space|outer-space/i;
+  const gap =
+    findTokenByPattern(builderSpacingTokens, "spacing", spacingGapPattern) ??
+    findTokenByPattern(tokens, "spacing", spacingGapPattern);
+  const pagePadding =
+    findTokenByPattern(
+      builderSpacingTokens,
+      "spacing",
+      spacingPaddingPattern,
+    ) ?? findTokenByPattern(tokens, "spacing", spacingPaddingPattern);
   if (gap) nextSpacing.elementGap = gap;
   if (pagePadding) nextSpacing.pagePadding = pagePadding;
 
   const nextBorders = { ...(parsed.borders ?? {}) };
-  const radius = tokens.find(
-    (token) =>
-      /radius|rounded|corner/i.test(token.cssVar) && token.type === "radius",
-  )?.value;
+  const radiusPattern = /radius|rounded|corner/i;
+  const radius =
+    findTokenByPattern(extracted.tokens, "radius", radiusPattern) ??
+    findTokenByPattern(tokens, "radius", radiusPattern);
   if (radius) nextBorders.radius = radius;
 
   const nextDefaults = { ...(parsed.defaults ?? {}) };
@@ -244,8 +290,8 @@ export function reconcileBuilderProxyData(
   return {
     data: JSON.stringify({
       ...parsed,
-      builderStatus: "ready",
-      builderSyncedAt: syncedAt,
+      builderStatus: completionConfirmed ? "ready" : "in-progress",
+      ...(completionConfirmed ? { builderSyncedAt: syncedAt } : {}),
       colors: nextColors,
       typography: nextTypography,
       spacing: nextSpacing,
@@ -255,6 +301,7 @@ export function reconcileBuilderProxyData(
     }),
     tokenCount: extracted.tokens.length,
     rejectedTokenCount: extracted.rejected.length,
+    completionConfirmed,
   };
 }
 

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -1,6 +1,12 @@
 import {
+  friendlyTokenName,
+  isColorTokenValue,
+  normalizeBrandKitTokens,
+} from "@agent-native/core/brand-kit";
+import {
   createBuilderDesignSystemProxyFields,
   localBuilderDesignSystemId,
+  type BuilderDesignSystemHydratedReference,
   type BuilderDesignSystemIndexResult,
   type BuilderDesignSystemGitHubSource,
   type BuilderDesignSystemSourceKind,
@@ -9,6 +15,168 @@ import { and, eq, isNull } from "drizzle-orm";
 import { nanoid } from "nanoid";
 
 import { getDb, schema } from "../db/index.js";
+
+type ProxyData = Record<string, unknown> & {
+  colors?: Record<string, unknown>;
+  typography?: Record<string, unknown>;
+  spacing?: Record<string, unknown>;
+  borders?: Record<string, unknown>;
+  defaults?: Record<string, unknown>;
+  tokens?: unknown;
+};
+
+export interface BuilderProxyReconciliation {
+  data: string;
+  tokenCount: number;
+  rejectedTokenCount: number;
+}
+
+function parseProxyData(data: string): ProxyData {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    throw new Error("Builder design-system proxy data is not valid JSON.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Builder design-system proxy data must be a JSON object.");
+  }
+  return parsed as ProxyData;
+}
+
+function normalizedTokenName(value: string): string {
+  return value.toLowerCase().replace(/^--/, "").replace(/_/g, "-");
+}
+
+function findTokenValue(
+  tokens: Array<{ cssVar: string; value: string; type: string }>,
+  names: string[],
+): string | undefined {
+  const candidates = tokens
+    .filter((token) => isColorTokenValue(token.value))
+    .map((token) => {
+      const name = normalizedTokenName(token.cssVar);
+      const exactIndex = names.indexOf(name);
+      const hasName = names.some((candidate) =>
+        new RegExp(`(?:^|-)${candidate}(?:-|$)`, "i").test(name),
+      );
+      return {
+        token,
+        score: exactIndex >= 0 ? 100 - exactIndex : hasName ? 10 : 0,
+      };
+    })
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return candidates[0]?.token.value;
+}
+
+function findTypedTokenValue(
+  tokens: Array<{ cssVar: string; value: string; type: string }>,
+  pattern: RegExp,
+): string | undefined {
+  return tokens.find(
+    (token) => token.type === "typography" && pattern.test(token.cssVar),
+  )?.value;
+}
+
+/**
+ * Merge completed Builder token extraction into the local selectable proxy.
+ * The Builder docs remain the source of truth, but the local row must carry
+ * concrete values because list/detail UI and token indexing read that row.
+ */
+export function reconcileBuilderProxyData(
+  data: string,
+  hydrated: BuilderDesignSystemHydratedReference,
+  syncedAt: string,
+): BuilderProxyReconciliation | null {
+  const parsed = parseProxyData(data);
+  const extracted = normalizeBrandKitTokens(
+    Object.entries(hydrated.tokenValues).map(([cssVar, value]) => ({
+      name: friendlyTokenName(cssVar),
+      cssVar,
+      value,
+      source: "Builder DSI",
+    })),
+  );
+  if (extracted.tokens.length === 0) return null;
+
+  const existing = normalizeBrandKitTokens(parsed.tokens).tokens;
+  const tokensByCssVar = new Map(
+    existing.map((token) => [token.cssVar, token]),
+  );
+  for (const token of extracted.tokens) {
+    tokensByCssVar.set(token.cssVar, token);
+  }
+  const tokens = [...tokensByCssVar.values()];
+  const colorTokens = tokens.filter((token) => token.type === "color");
+  const nextColors = { ...(parsed.colors ?? {}) };
+  const colorRoles: Record<string, string[]> = {
+    primary: ["primary", "color-primary", "brand-primary"],
+    secondary: ["secondary", "color-secondary", "brand-secondary"],
+    accent: ["accent", "color-accent", "brand-accent"],
+    background: ["background", "color-background", "page-background"],
+    surface: ["surface", "color-surface", "card-background"],
+    text: ["text", "color-text", "foreground", "text-primary"],
+    textMuted: ["text-muted", "muted-foreground", "text-secondary", "muted"],
+  };
+  for (const [role, names] of Object.entries(colorRoles)) {
+    const value = findTokenValue(colorTokens, names);
+    if (value) nextColors[role] = value;
+  }
+
+  const nextTypography = { ...(parsed.typography ?? {}) };
+  const headingFont = findTypedTokenValue(
+    tokens,
+    /heading|display|title|font-family-heading/i,
+  );
+  const bodyFont = findTypedTokenValue(
+    tokens,
+    /body|font-family-body|font-family/i,
+  );
+  if (headingFont) nextTypography.headingFont = headingFont;
+  if (bodyFont) nextTypography.bodyFont = bodyFont;
+
+  const nextSpacing = { ...(parsed.spacing ?? {}) };
+  const gap = tokens.find(
+    (token) =>
+      /gap|gutter|spacing/i.test(token.cssVar) && token.type === "spacing",
+  )?.value;
+  const pagePadding = tokens.find(
+    (token) =>
+      /padding|page-space|outer-space/i.test(token.cssVar) &&
+      token.type === "spacing",
+  )?.value;
+  if (gap) nextSpacing.elementGap = gap;
+  if (pagePadding) nextSpacing.pagePadding = pagePadding;
+
+  const nextBorders = { ...(parsed.borders ?? {}) };
+  const radius = tokens.find(
+    (token) =>
+      /radius|rounded|corner/i.test(token.cssVar) && token.type === "radius",
+  )?.value;
+  if (radius) nextBorders.radius = radius;
+
+  const nextDefaults = { ...(parsed.defaults ?? {}) };
+  if (typeof nextColors.background === "string") {
+    nextDefaults.background = nextColors.background;
+  }
+
+  return {
+    data: JSON.stringify({
+      ...parsed,
+      builderStatus: "ready",
+      builderSyncedAt: syncedAt,
+      colors: nextColors,
+      typography: nextTypography,
+      spacing: nextSpacing,
+      borders: nextBorders,
+      defaults: nextDefaults,
+      tokens,
+    }),
+    tokenCount: extracted.tokens.length,
+    rejectedTokenCount: extracted.rejected.length,
+  };
+}
 
 export async function upsertBuilderProxyDesignSystem({
   result,

--- a/templates/design/server/lib/builder-design-system-proxy.ts
+++ b/templates/design/server/lib/builder-design-system-proxy.ts
@@ -48,9 +48,15 @@ function normalizedTokenName(value: string): string {
   return value.toLowerCase().replace(/^--/, "").replace(/_/g, "-");
 }
 
+function tokenShade(name: string): number | undefined {
+  const match = name.match(/(?:^|-)(\d{2,4})(?:-|$)/);
+  return match ? Number(match[1]) : undefined;
+}
+
 function findTokenValue(
   tokens: Array<{ cssVar: string; value: string; type: string }>,
   names: string[],
+  excludedNamePattern?: RegExp,
 ): string | undefined {
   const candidates = tokens
     .filter((token) => isColorTokenValue(token.value))
@@ -62,21 +68,75 @@ function findTokenValue(
       );
       return {
         token,
+        name,
         score: exactIndex >= 0 ? 100 - exactIndex : hasName ? 10 : 0,
       };
     })
-    .filter((candidate) => candidate.score > 0)
-    .sort((a, b) => b.score - a.score);
-  return candidates[0]?.token.value;
+    .filter(
+      (candidate) =>
+        candidate.score > 0 && !excludedNamePattern?.test(candidate.name),
+    );
+  const exactCandidates = candidates
+    .filter((candidate) => names.includes(candidate.name))
+    .sort((a, b) => a.score - b.score);
+  if (exactCandidates.length > 0) {
+    return exactCandidates[0].token.value;
+  }
+
+  const fallbackCandidates = candidates.sort((a, b) => {
+    const aShade = tokenShade(a.name);
+    const bShade = tokenShade(b.name);
+    const aShadeRank = aShade === 500 ? 0 : aShade === undefined ? 1 : 2;
+    const bShadeRank = bShade === 500 ? 0 : bShade === undefined ? 1 : 2;
+    return (
+      aShadeRank - bShadeRank ||
+      (aShade === undefined
+        ? Number.MAX_SAFE_INTEGER
+        : Math.abs(aShade - 500)) -
+        (bShade === undefined
+          ? Number.MAX_SAFE_INTEGER
+          : Math.abs(bShade - 500)) ||
+      a.name.localeCompare(b.name)
+    );
+  });
+  return fallbackCandidates[0]?.token.value;
 }
 
 function findTypedTokenValue(
   tokens: Array<{ cssVar: string; value: string; type: string }>,
-  pattern: RegExp,
+  patterns: RegExp[],
+  excludedNamePattern?: RegExp,
 ): string | undefined {
-  return tokens.find(
-    (token) => token.type === "typography" && pattern.test(token.cssVar),
-  )?.value;
+  const candidates = tokens
+    .filter((token) => {
+      if (token.type !== "typography") return false;
+      const name = normalizedTokenName(token.cssVar);
+      if (
+        excludedNamePattern?.test(name) ||
+        !/(?:^|-)font(?:-family)?(?:-|$)|(?:^|-)family(?:-|$)/i.test(name) ||
+        /(?:^|-)weight(?:-|$)|(?:^|-)size(?:-|$)|line-?height|leading|letter|tracking/i.test(
+          name,
+        ) ||
+        /^-?\d*\.?\d+(?:px|rem|em|ex|ch|%|vh|vw|vmin|vmax|pt|pc|cm|mm|in|s|ms|deg|fr)?$/i.test(
+          token.value.trim(),
+        )
+      ) {
+        return false;
+      }
+      return true;
+    })
+    .map((token) => ({
+      token,
+      name: normalizedTokenName(token.cssVar),
+      patternIndex: patterns.findIndex((pattern) =>
+        pattern.test(normalizedTokenName(token.cssVar)),
+      ),
+    }))
+    .filter((candidate) => candidate.patternIndex >= 0)
+    .sort(
+      (a, b) => a.patternIndex - b.patternIndex || a.name.localeCompare(b.name),
+    );
+  return candidates[0]?.token.value;
 }
 
 /**
@@ -122,18 +182,29 @@ export function reconcileBuilderProxyData(
     textMuted: ["text-muted", "muted-foreground", "text-secondary", "muted"],
   };
   for (const [role, names] of Object.entries(colorRoles)) {
-    const value = findTokenValue(colorTokens, names);
+    const value = findTokenValue(
+      colorTokens,
+      names,
+      role === "primary" ? /(?:^|-)text(?:-|$)/i : undefined,
+    );
     if (value) nextColors[role] = value;
   }
 
   const nextTypography = { ...(parsed.typography ?? {}) };
-  const headingFont = findTypedTokenValue(
-    tokens,
-    /heading|display|title|font-family-heading/i,
-  );
+  const headingFont = findTypedTokenValue(tokens, [
+    /(?:^|-)heading(?:-|$)/i,
+    /(?:^|-)display(?:-|$)/i,
+    /(?:^|-)title(?:-|$)/i,
+  ]);
   const bodyFont = findTypedTokenValue(
     tokens,
-    /body|font-family-body|font-family/i,
+    [
+      /(?:^|-)body(?:-|$)/i,
+      /(?:^|-)base(?:-|$)/i,
+      /(?:^|-)text(?:-|$)/i,
+      /(?:^|-)font-family(?:-|$)/i,
+    ],
+    /(?:^|-)heading(?:-|$)|(?:^|-)display(?:-|$)|(?:^|-)title(?:-|$)/i,
   );
   if (headingFont) nextTypography.headingFont = headingFont;
   if (bodyFont) nextTypography.bodyFont = bodyFont;


### PR DESCRIPTION
## Summary

- Reconcile completed Builder DSI token extraction into the local Design system proxy instead of leaving placeholder values and an in-progress status.
- Add an editor-scoped refresh action with compare-and-set persistence, retry the refresh while indexing completes, and teach the Design agent to use the refresh path before generating.
- Carry recent high-signal Design feedback dispositions through the normal ship handoff, including existing Dispatch route-sync, layer-selection, Escape, auto-layout, and export-toast fixes.

## Latest-feedback handoff

Sweep window: 2026-08-14 00:00 through 2026-08-21 America/Los_Angeles.
Slack source: channel `C0ATH3CCZT4`, start cursor `1786735782.299719` and the full seven-day history re-read before ship. GitHub, Sentry, and Analytics were also checked; no connector was unavailable.

| Feedback group | Disposition | Evidence |
| --- | --- | --- |
| Builder DSI completion leaves local proxy placeholders (`1787329827.102809`) | Fixed in this PR | `reconcileBuilderProxyData`, refresh action/UI retry, 11 focused reconciliation tests; bot reply `1787357732.011649` |
| Dispatch list/detail URL and back navigation (`1787325880.135939`) | Already fixed on current main | route/host tests pass; bot reply `1787357732.189669` |
| Escape selects parent instead of deselecting (`1787074435.440709`) | Already fixed on current main | Escape tests pass; bot reply `1787357732.363099` |
| Layers tab selects the containing frame (`1787074187.416389`) | Already fixed on current main | selection suite: 193 passed; bot reply `1787357732.530879` |
| Auto-layout controls stale except grid (`1787269585.909989`) | Existing owner/in progress | current flow wiring and 9 focused matrix tests pass; existing bot handoff remains open pending live verification |
| Export report says PNG / PDF and PNG capture fails (`1786735782.299719`) | PDF copy fixed; PNG failure remains unverified | source has separate PDF/PNG errors; bot reply `1787357732.716839` records the missing reproducible browser case |
| Windows scrollbar/zoom, template chips, Figma import, pan jitter, focus colors | Awaiting reporter clarification or unavailable artifact | existing clarification requests preserved; no duplicate questions or reactions added |
| Subjective redesigns, new shortcuts, and broad behavior requests | Deferred/routed to Design owner | no source-level fix identified in the available evidence |
| Content feedback and open Clips/Analytics/Sentry investigations | Already owned or in progress elsewhere | preserved in the cross-app sweep; not silently folded into this PR |

## Verification

- Design focused Vitest: 8 files, 27 passed, including Builder reconciliation, auto-layout flow controls, and Escape paths.
- Design selection Vitest: 193 passed.
- Dispatch route/host Vitest: 2 files, 19 passed.
- `corepack pnpm guards`: all 63 checks passed.
- `corepack pnpm --filter design exec agent-native build`: passed.
- `corepack pnpm --filter design exec agent-native typecheck`: exit 0; it prints existing deployment diagnostics for missing production auth secret/database configuration.
- No live beta or production verification is claimed by this normal `/ship` flow.
