### PR TITLE
fix: keep operational beta checks focused

### DIFF
--- a/.github/workflows/beta-e2e-scheduled.yml
+++ b/.github/workflows/beta-e2e-scheduled.yml
@@ -24,6 +24,7 @@ jobs:
       apps: all
       lane: public+authed
       grep: ""
+      key_source: dedicated
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: ""
         type: string
+      key_source:
+        description: "Which OpenAI credential the agent turns bill"
+        required: false
+        default: dedicated
+        type: string
     secrets:
       BETA_E2E_EMAIL:
         required: false
@@ -282,7 +287,6 @@ jobs:
     name: Advisory findings (non-gating)
     if: ${{ always() && needs.discover.result == 'success' }}
     needs: discover
-    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -294,9 +298,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/beta-e2e-setup
       - name: Advisory findings
+        continue-on-error: true
         # Always runs: it costs no credentials and no tokens, and findings that
-        # stop being reported stop being fixed. continue-on-error keeps a red
-        # here from meaning "do not promote".
+        # stop being reported stop being fixed. Step-level continue-on-error
+        # keeps the reusable workflow green while preserving the failed step
+        # and uploaded report for inspection.
         run: |
           if [ -n "$BETA_E2E_GREP" ]; then
             pnpm e2e:beta --project=advisory --grep "$BETA_E2E_GREP" --pass-with-no-tests

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -332,6 +332,20 @@ jobs:
               ...manifest.beta.map((host) => ({ environment: "beta", host })),
               ...manifest.workspace.map((host) => ({ environment: "workspace", host })),
             ];
+            // The public docs host intentionally has no Google sign-in
+            // credential. Keep it in the availability manifest, but do not
+            // turn that expected state into an auth outage.
+            const googleCredentialExemptions = new Set([
+              "production/www.agent-native.com",
+            ]);
+            const credentialHosts = hosts.filter(({ environment, host }) => {
+              const key = `${environment}/${host}`;
+              if (googleCredentialExemptions.has(key)) {
+                console.log(`INFO\\t${environment}\\t${host}\\tcredentials intentionally unconfigured`);
+                return false;
+              }
+              return true;
+            });
 
             // The whole step must finish inside the job timeout even when the
             // fleet is degraded, so probes run concurrently under one deadline
@@ -376,7 +390,7 @@ jobs:
             const mismatched = [];
             let checked = 0;
 
-            const queue = [...hosts];
+            const queue = [...credentialHosts];
             async function worker() {
               for (;;) {
                 const next = queue.shift();
@@ -436,7 +450,10 @@ jobs:
               }
             }
             await Promise.all(
-              Array.from({ length: Math.min(CONCURRENCY, hosts.length) }, worker),
+              Array.from(
+                { length: Math.min(CONCURRENCY, credentialHosts.length) },
+                worker,
+              ),
             );
 
             if (mismatched.length > 0) {


### PR DESCRIPTION
## Summary

- Keep the docs host in the general availability sweep without treating its intentionally unconfigured Google sign-in as an outage.
- Make the beta advisory lane non-gating at the step boundary so its findings stay visible without failing the reusable scheduled health workflow.
- Wire the reusable workflow's OpenAI key-source input explicitly for scheduled callers.

Related operational reports: #3328 and #3312.

## Verification

- `actionlint .github/workflows/beta-e2e.yml .github/workflows/beta-e2e-scheduled.yml .github/workflows/monitor-agent-native-sites.yml`
- `corepack pnpm guard:beta-e2e-suite`
- `corepack pnpm typecheck:e2e`
- `corepack pnpm --filter @agent-native/core exec vitest run src/server/google-credential-check.spec.ts src/server/google-oauth-credentials.spec.ts`
