### PR TITLE
test(core): make the rejected-gateway-token test see its own settings mock

### DIFF
--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1295,6 +1295,11 @@ describe("AgentEngine registry", () => {
         ),
         deleteSetting: vi.fn(),
       }));
+      // The enclosing beforeEach already registered an always-null
+      // settings/store factory and imported through it. `doMock` only governs
+      // the NEXT import, so without this reset the module instance built there
+      // keeps answering and this failure marker is never seen.
+      vi.resetModules();
 
       const { registerAgentEngine, detectEngineFromEnvForRequest } =
         await import("./registry.js");


### PR DESCRIPTION
`registry.spec.ts > Builder-credits env pair > skips a Builder-credits token the gateway already rejected` failed roughly **one run in ten** — enough to fail `pnpm prep` on branches that never touch core, and then cost someone the time to prove the failure wasn't theirs.

## It wasn't env leakage or test order

That's what it looks like from the outside, and it's wrong on both counts:

- Execution order inside the file is **deterministic** — I diffed the verbose order across runs.
- The top-level `beforeEach` already deletes every Builder env var.
- The file flakes **1 in 10 unshuffled**, so ordering isn't the variable.

## What it actually is

Instrumenting the lookup made it obvious:

```
[dbg] TEST expects fingerprint 52de4755b598cdf9e7d1a226
[dbg] BEFOREEACH-MOCK getSetting provider-auth-failure:52de4755b598cdf9e7d1a226   ← wrong factory
```

The enclosing `beforeEach` calls `vi.resetModules()` and then registers an always-null `settings/store` factory. The test registers its own factory — one that returns the auth-failure marker for exactly that fingerprint — but **`doMock` only governs the next import**, and the module instance built under the `beforeEach` factory was already resolved. The marker was never seen, `getProviderCredentialAuthFailure` reported "no failure", and the builder engine came back where the test expects `null`.

`vi.resetModules()` after the test's own `doMock` makes the subsequent `import("./registry.js")` build its graph against the test's factory.

## Verification

- **0 failures in 15** consecutive full-file runs, against 1 in 10 before.
- Sharper proof — **isolation**: `-t` on this test alone failed **100%** of the time before (nothing else had populated the module graph) and passes now. A fix that only reduced the flake rate wouldn't do that.
- Full core suite: 911 files / 12699 tests green. `pnpm guards` 63/63, `fmt:check` clean, core typecheck clean.

The three sibling auth-failure tests were checked the same way — all pass in isolation, so they don't share the bug and are left untouched.

## Left alone deliberately

`src/cli/create-e2e.spec.ts` also flakes, but it's a different class and I didn't want to guess at a fix. It scaffolds real apps and builds tarballs behind a 180s timeout, uses a fresh `mkdtempSync` dir per test with `afterEach` cleanup, and restores its one env var in a `finally` — clean on exactly the dimension that broke the registry test. 0 failures in 8 isolated runs; it only fails under full-suite load. That reads as resource contention, not shared state, and wants a timeout/concurrency change rather than a state fix.

`src/cli/code-agent-executor.spec.ts` flaked once during this investigation too (`pauses a canceled Codex CLI run and can recover it on a later invocation`) and likely wants the same treatment. Across 3 full core runs I saw ~1 failure per run spread over 3 different files, so this fix removes one of several.
