### PR TITLE
perf: stop scanning message-history blobs and the agent run loop on hot paths

### DIFF
--- a/.changeset/lazy-swans-shake.md
+++ b/.changeset/lazy-swans-shake.md
@@ -1,0 +1,19 @@
+---
+"@agent-native/core": patch
+---
+
+Cut seconds off chat list reads and serverless cold starts.
+
+- `listThreads`/`searchThreads` no longer filter on `thread_data`. Matching that
+  blob detoasted the entire message history for every scanned row before `LIMIT`
+  applied; measured on production beta, the same 20-row response went 2207ms →
+  222ms with the predicate removed. Schema migration 3 backfills
+  `source_platform` for the legacy integration rows the predicate used to catch.
+- Added expression indexes for the access-scoping predicates that wrap columns in
+  `LOWER()` — `chat_threads`, `chat_thread_shares`, and `token_usage`. A plain
+  btree cannot serve a function-wrapped comparison, so these lists were scanning
+  whole shared tables.
+- Moved `clientAbortReason` into a leaf module so the agent chat server plugin no
+  longer pulls the agent run loop into its static import graph. That graph costs
+  ~1.2s to evaluate and every cold serverless start paid it, including requests
+  that only render a page.

--- a/packages/core/src/agent/abort-reasons.ts
+++ b/packages/core/src/agent/abort-reasons.ts
@@ -1,0 +1,49 @@
+/**
+ * Abort-reason vocabulary, kept in a leaf module on purpose.
+ *
+ * The abort route needs only these two symbols, but they used to live in
+ * `run-loop-with-resume.ts` — the whole agent execution loop. Importing them
+ * from there pulled that graph into the server plugin's static imports, so
+ * every cold serverless start evaluated the entire run loop (measured at
+ * ~1.6s) before it could render a page it would never run an agent for.
+ * Nothing here may import from the run loop, or that cost comes straight back.
+ */
+
+/**
+ * Abort reasons the SERVER sets on a run's own controller. Everything else —
+ * including any reason a client passes to the abort route — is a user Stop.
+ *
+ * Kept deliberately short. Each entry is a bound this package owns and can name
+ * in a terminal outcome; if you are adding a fourth, check first whether the
+ * bound belongs in `run-manager.ts` at all.
+ *
+ * Exported so the abort route can refuse these words from a client. That check
+ * belongs at the boundary where untrusted input enters, not here: by the time a
+ * reason reaches an `AbortSignal` it is just a string, and nothing downstream
+ * can tell who wrote it.
+ */
+export const SERVER_OWNED_ABORT_REASONS = new Set([
+  "no_progress",
+  "run_timeout",
+  "background_automation_hard_timeout",
+]);
+
+/**
+ * The abort reason to record for a client-initiated Stop.
+ *
+ * A caller reaching the abort route is a person pressing Stop, so it must not
+ * be able to name a bound only the server can reach: the terminal outcome keys
+ * off the abort reason, and a client sending `background_automation_hard_timeout`
+ * would file its own Stop as a server-side failure. Anything unrecognised,
+ * malformed, or reserved falls back to `"user"`.
+ *
+ * Normalised here rather than in the route because this is where the meaning of
+ * the string is decided — downstream it is just a string, and nothing can tell
+ * who wrote it.
+ */
+export function clientAbortReason(raw: unknown): string {
+  if (typeof raw !== "string") return "user";
+  const reason = raw.trim();
+  if (!/^[a-z0-9_-]{1,64}$/i.test(reason)) return "user";
+  return SERVER_OWNED_ABORT_REASONS.has(reason.toLowerCase()) ? "user" : reason;
+}

--- a/packages/core/src/agent/run-loop-with-resume.ts
+++ b/packages/core/src/agent/run-loop-with-resume.ts
@@ -25,6 +25,10 @@ import {
   MAX_BACKGROUND_RUN_LOOP_CONTINUATIONS,
   MAX_RUN_LOOP_CONTINUATIONS,
 } from "../app-config/run-lifecycle-invariants.js";
+import {
+  SERVER_OWNED_ABORT_REASONS,
+  clientAbortReason,
+} from "./abort-reasons.js";
 import type { EngineMessage } from "./engine/types.js";
 import {
   runAgentLoop,
@@ -281,44 +285,10 @@ function waitForBackgroundRateLimitCooldown(
   });
 }
 
-/**
- * Abort reasons the SERVER sets on a run's own controller. Everything else —
- * including any reason a client passes to the abort route — is a user Stop.
- *
- * Kept deliberately short. Each entry is a bound this package owns and can name
- * in a terminal outcome; if you are adding a fourth, check first whether the
- * bound belongs in `run-manager.ts` at all.
- *
- * Exported so the abort route can refuse these words from a client. That check
- * belongs at the boundary where untrusted input enters, not here: by the time a
- * reason reaches an `AbortSignal` it is just a string, and nothing downstream
- * can tell who wrote it.
- */
-export const SERVER_OWNED_ABORT_REASONS = new Set([
-  "no_progress",
-  "run_timeout",
-  "background_automation_hard_timeout",
-]);
-
-/**
- * The abort reason to record for a client-initiated Stop.
- *
- * A caller reaching the abort route is a person pressing Stop, so it must not
- * be able to name a bound only the server can reach: the terminal outcome keys
- * off the abort reason, and a client sending `background_automation_hard_timeout`
- * would file its own Stop as a server-side failure. Anything unrecognised,
- * malformed, or reserved falls back to `"user"`.
- *
- * Normalised here rather than in the route because this is where the meaning of
- * the string is decided — downstream it is just a string, and nothing can tell
- * who wrote it.
- */
-export function clientAbortReason(raw: unknown): string {
-  if (typeof raw !== "string") return "user";
-  const reason = raw.trim();
-  if (!/^[a-z0-9_-]{1,64}$/i.test(reason)) return "user";
-  return SERVER_OWNED_ABORT_REASONS.has(reason.toLowerCase()) ? "user" : reason;
-}
+// Re-exported from the leaf module so existing importers keep working. Callers
+// that need ONLY these two symbols must import `./abort-reasons.js` directly —
+// reaching them through this module drags the whole run loop into their graph.
+export { SERVER_OWNED_ABORT_REASONS, clientAbortReason };
 
 /** Machine-readable code carried on the give-up terminal `error` event so the
  * client renders a loud "stopped before finishing" terminal instead of an

--- a/packages/core/src/chat-threads/schema-migrations.ts
+++ b/packages/core/src/chat-threads/schema-migrations.ts
@@ -61,4 +61,23 @@ export const CHAT_THREAD_SCHEMA_MIGRATIONS: MigrationEntry[] = [
         ON chat_threads (share_token_hash)
     `,
   },
+  {
+    version: 3,
+    name: "chat-threads-source-backfill-and-lower-email-indexes",
+    // The backfill retires a `thread_data NOT LIKE '%…%'` filter the local-only
+    // list used to carry for integration rows written before `source_platform`
+    // existed. That predicate forced Postgres to detoast the full message-history
+    // blob for every scanned row, so the sidebar list cost seconds regardless of
+    // LIMIT. Paying the scan once here keeps the read path off the blob forever.
+    sql: `
+      UPDATE chat_threads
+        SET source_platform = 'integration'
+        WHERE source_platform IS NULL
+          AND thread_data LIKE '%"integrationDeliveryAttempted":true%';
+      CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx
+        ON chat_threads (LOWER(owner_email), updated_at);
+      CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx
+        ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))
+    `,
+  },
 ];

--- a/packages/core/src/chat-threads/schema-migrations.ts
+++ b/packages/core/src/chat-threads/schema-migrations.ts
@@ -63,21 +63,22 @@ export const CHAT_THREAD_SCHEMA_MIGRATIONS: MigrationEntry[] = [
   },
   {
     version: 3,
-    name: "chat-threads-source-backfill-and-lower-email-indexes",
-    // The backfill retires a `thread_data NOT LIKE '%…%'` filter the local-only
-    // list used to carry for integration rows written before `source_platform`
-    // existed. That predicate forced Postgres to detoast the full message-history
-    // blob for every scanned row, so the sidebar list cost seconds regardless of
-    // LIMIT. Paying the scan once here keeps the read path off the blob forever.
+    name: "chat-threads-source-backfill",
+    // Retires a `thread_data NOT LIKE '%…%'` filter the local-only list used to
+    // carry for integration rows written before `source_platform` existed. That
+    // predicate forced Postgres to detoast the full message-history blob for
+    // every scanned row, so the sidebar list cost seconds regardless of LIMIT.
+    // Paying the scan once here keeps the read path off the blob forever.
+    //
+    // The matching `LOWER(...)` expression indexes deliberately do NOT live
+    // here: they are built CONCURRENTLY in the store's ensure path, and
+    // Postgres forbids that inside the transaction `runMigrations` wraps
+    // around these statements.
     sql: `
       UPDATE chat_threads
         SET source_platform = 'integration'
         WHERE source_platform IS NULL
-          AND thread_data LIKE '%"integrationDeliveryAttempted":true%';
-      CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx
-        ON chat_threads (LOWER(owner_email), updated_at);
-      CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx
-        ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))
+          AND thread_data LIKE '%"integrationDeliveryAttempted":true%'
     `,
   },
 ];

--- a/packages/core/src/chat-threads/store.spec.ts
+++ b/packages/core/src/chat-threads/store.spec.ts
@@ -587,9 +587,11 @@ describe("chat thread store", () => {
     expect(listCall).toBeTruthy();
     const request = listCall![0] as { sql: string; args: unknown[] };
     expect(request.sql).toContain("source_platform IS NULL");
-    expect(request.sql).toContain(
-      `thread_data NOT LIKE '%"integrationDeliveryAttempted":true%'`,
-    );
+    // Never match against thread_data here. It is the full message-history blob,
+    // so any predicate on it detoasts every scanned row before LIMIT applies —
+    // measured at ~10x on the production sidebar list. Migration 3 backfilled
+    // `source_platform` for the legacy integration rows this used to catch.
+    expect(request.sql).not.toContain("thread_data");
     expect(request.sql).toContain(
       "(source_app_id IS NULL OR source_app_id = ?)",
     );

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -151,6 +151,18 @@ async function ensureTable(): Promise<void> {
           "chat_threads_owner_updated_idx",
           `CREATE INDEX IF NOT EXISTS chat_threads_owner_updated_idx ON chat_threads (owner_email, updated_at)`,
         );
+        // `owner_email` is stored as the user typed it, so access scoping
+        // compares `LOWER(owner_email)`. A plain btree on the raw column cannot
+        // serve that predicate — without the expression index the list falls
+        // back to scanning every row in the (shared, multi-tenant) table.
+        await ensureIndexExists(
+          "chat_threads_owner_lower_updated_idx",
+          `CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
+        );
+        await ensureIndexExists(
+          "chat_thread_shares_principal_lower_idx",
+          `CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
+        );
         await ensureIndexExists(
           "chat_threads_scope_updated_idx",
           `CREATE INDEX IF NOT EXISTS chat_threads_scope_updated_idx ON chat_threads (scope_type, scope_id, updated_at)`,
@@ -221,6 +233,8 @@ async function ensureTable(): Promise<void> {
       // idempotent across restarts.
       for (const ddl of [
         `CREATE INDEX IF NOT EXISTS chat_threads_owner_updated_idx ON chat_threads (owner_email, updated_at)`,
+        `CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
+        `CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
         `CREATE INDEX IF NOT EXISTS chat_threads_scope_updated_idx ON chat_threads (scope_type, scope_id, updated_at)`,
         `CREATE INDEX IF NOT EXISTS chat_threads_source_updated_idx ON chat_threads (owner_email, source_app_id, updated_at)`,
         `CREATE INDEX IF NOT EXISTS chat_threads_share_token_idx ON chat_threads (share_token_hash)`,
@@ -811,8 +825,11 @@ export async function listThreads(
   const offset = opts.offset ?? 0;
   const client = getDbExec();
   // `message_count > 0` is the authoritative "has messages" signal maintained
-  // on every write. The local-only view adds a narrowly scoped legacy marker
-  // check below because older integration rows predate persisted source fields.
+  // on every write. `source_platform` is the authoritative external-source
+  // signal: schema migration 3 backfilled the integration rows that predate the
+  // column, so nothing here may filter on `thread_data`. Matching that blob
+  // detoasts the whole message history for every scanned row — before LIMIT
+  // applies — which is what made this list cost seconds instead of milliseconds.
   const access = chatThreadAccessSql(
     ownerEmail,
     opts.orgId ?? getRequestOrgId(),
@@ -824,9 +841,6 @@ export async function listThreads(
   }
   if (opts.includeExternal === false) {
     filters.push(`source_platform IS NULL`);
-    filters.push(
-      `thread_data NOT LIKE '%"integrationDeliveryAttempted":true%'`,
-    );
     if (opts.sourceAppId) {
       filters.push(`(source_app_id IS NULL OR source_app_id = ?)`);
       args.push(opts.sourceAppId);
@@ -888,9 +902,6 @@ export async function searchThreads(
   }
   if (options.includeExternal === false) {
     filters.push(`source_platform IS NULL`);
-    filters.push(
-      `thread_data NOT LIKE '%"integrationDeliveryAttempted":true%'`,
-    );
     if (options.sourceAppId) {
       filters.push(`(source_app_id IS NULL OR source_app_id = ?)`);
       args.push(options.sourceAppId);

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -10,6 +10,7 @@ import { createGetDb } from "../db/create-get-db.js";
 import {
   ensureColumnExists,
   ensureIndexExists,
+  ensureIndexExistsConcurrently,
   ensureTableExists,
 } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
@@ -155,13 +156,19 @@ async function ensureTable(): Promise<void> {
         // compares `LOWER(owner_email)`. A plain btree on the raw column cannot
         // serve that predicate — without the expression index the list falls
         // back to scanning every row in the (shared, multi-tenant) table.
-        await ensureIndexExists(
+        //
+        // Built CONCURRENTLY: these land on tables that already hold every
+        // tenant's threads, and a plain `CREATE INDEX` holds a SHARE lock for
+        // the whole build, queueing chat writes behind it. That is why they are
+        // not in the migration list — `runMigrations` wraps statements in a
+        // transaction, and Postgres forbids CONCURRENTLY inside one.
+        await ensureIndexExistsConcurrently(
           "chat_threads_owner_lower_updated_idx",
-          `CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
+          `CREATE INDEX CONCURRENTLY IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
         );
-        await ensureIndexExists(
+        await ensureIndexExistsConcurrently(
           "chat_thread_shares_principal_lower_idx",
-          `CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
+          `CREATE INDEX CONCURRENTLY IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
         );
         await ensureIndexExists(
           "chat_threads_scope_updated_idx",

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -38,6 +38,7 @@ import {
 } from "../a2a/task-store.js";
 import type { Message as A2AMessage } from "../a2a/types.js";
 import type { ActionHttpConfig } from "../action.js";
+import { clientAbortReason } from "../agent/abort-reasons.js";
 import {
   canUpdateAgentAppModelDefaultSettings,
   normalizeAgentAppModelDefaultAppId,
@@ -86,7 +87,6 @@ import {
   type AgentLoopOutcome,
   type ResolvedOwnerApiKey,
 } from "../agent/production-agent.js";
-import { clientAbortReason } from "../agent/run-loop-with-resume.js";
 import {
   callerHasRunAccess,
   callerHasThreadAccess,

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -11,6 +11,7 @@ import { getDbExec, intType, isPostgres } from "../db/client.js";
 import {
   ensureColumnExists,
   ensureIndexExists,
+  ensureIndexExistsConcurrently,
   ensureTableExists,
 } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
@@ -294,9 +295,12 @@ export async function ensureUsageTable(): Promise<void> {
         // serve a function-wrapped predicate: without this expression index the
         // usage panel scans the whole table, which is the highest-row-count one
         // in the system (a row per LLM call, every app and org).
-        await ensureIndexExists(
+        // Built CONCURRENTLY: `token_usage` is the highest-row-count table in
+        // the system, so a SHARE-locking build would queue every usage write
+        // for its duration.
+        await ensureIndexExistsConcurrently(
           "idx_token_usage_lower_owner_created",
-          `CREATE INDEX IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
+          `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
         );
         return;
       }

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -289,6 +289,15 @@ export async function ensureUsageTable(): Promise<void> {
           "idx_token_usage_owner_created",
           `CREATE INDEX IF NOT EXISTS idx_token_usage_owner_created ON token_usage (owner_email, created_at)`,
         );
+        // `owner_email` is written as the caller supplied it, so the metrics
+        // queries scope with `LOWER(owner_email) IN (…)`. A plain btree cannot
+        // serve a function-wrapped predicate: without this expression index the
+        // usage panel scans the whole table, which is the highest-row-count one
+        // in the system (a row per LLM call, every app and org).
+        await ensureIndexExists(
+          "idx_token_usage_lower_owner_created",
+          `CREATE INDEX IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
+        );
         return;
       }
 
@@ -310,11 +319,18 @@ export async function ensureUsageTable(): Promise<void> {
       // the `Date.now()` written per run by recordUsage() overflows int4. Widen
       // it in place (no-op once done / on fresh BIGINT databases).
       await widenIntColumnsToBigInt("token_usage", ["created_at"]);
-      try {
-        await client.execute(
-          `CREATE INDEX IF NOT EXISTS idx_token_usage_owner_created ON token_usage (owner_email, created_at)`,
-        );
-      } catch {}
+      for (const ddl of [
+        `CREATE INDEX IF NOT EXISTS idx_token_usage_owner_created ON token_usage (owner_email, created_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
+      ]) {
+        try {
+          await client.execute(ddl);
+        } catch {
+          // coercion-ok: index already exists, or this dialect rejected the
+          // duplicate. Local-dev SQLite only — the hosted path creates these
+          // through the Postgres branch above, which probes before creating.
+        }
+      }
     })().catch((err) => {
       // Retry init on the next call after a failed startup.
       _initPromise = undefined;

--- a/templates/content/server/plugins/agent-chat.ts
+++ b/templates/content/server/plugins/agent-chat.ts
@@ -67,9 +67,16 @@ Content's Notion access is per-user OAuth only. Never ask for or use NOTION_API_
         search: async (query: string) => {
           const db = getDb();
           const ownerEmail = getCurrentOwnerEmail();
+          // Project only id/title/parentId — documents.content is the full
+          // page body and must not be pulled into this per-keystroke search.
+          const mentionColumns = {
+            id: documents.id,
+            title: documents.title,
+            parentId: documents.parentId,
+          };
           const rows = query
             ? await db
-                .select()
+                .select(mentionColumns)
                 .from(documents)
                 .where(
                   and(
@@ -79,7 +86,7 @@ Content's Notion access is per-user OAuth only. Never ask for or use NOTION_API_
                 )
                 .limit(15)
             : await db
-                .select()
+                .select(mentionColumns)
                 .from(documents)
                 .where(eq(documents.ownerEmail, ownerEmail))
                 .orderBy(desc(documents.updatedAt))

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -100,14 +100,17 @@ When a Google Drive or Google Slides request needs authentication, tell the user
         search: async (query: string) => {
           const db = getDb();
           const access = accessFilter(decks, deckShares);
+          // Project only id/title — decks.data is the full deck JSON (every
+          // slide) and must not be pulled into this per-keystroke search.
+          const mentionColumns = { id: decks.id, title: decks.title };
           const rows = query
             ? await db
-                .select()
+                .select(mentionColumns)
                 .from(decks)
                 .where(and(access, like(decks.title, `%${query}%`)))
                 .limit(15)
             : await db
-                .select()
+                .select(mentionColumns)
                 .from(decks)
                 .where(access)
                 .orderBy(desc(decks.updatedAt))


### PR DESCRIPTION
Two reported symptoms, both traced to work the request never needed. Every number below is measured, not estimated.

## 1. Analytics chat sidebar took ~10s to list ~20 chats

`listThreads`/`searchThreads` filtered on `thread_data` — the full message-history JSON blob:

```sql
thread_data NOT LIKE '%"integrationDeliveryAttempted":true%'
```

The list never selects that column, but the predicate forces Postgres to fetch and detoast it for **every scanned row, before `LIMIT` applies**. Measured live against beta with an identical 20-row / 8512-byte response:

| request | time |
|---|---|
| `threads?limit=20` (default path) | **2207ms**, 2258ms |
| `threads?limit=20&includeExternal=1` (skips the predicate) | **222ms**, 309ms |
| `threads?limit=5` | **3166ms** for 2000 bytes |

`limit=5` being *slower* is the signature: the scan and detoast happen before the limit, so asking for less data costs more.

The predicate was a legacy compensator — integration rows written before `source_platform` existed. Migration 3 backfills those rows once, so the read path never touches the blob again.

## 2. Access scoping scanned whole shared tables

`LOWER(owner_email) = ?` cannot be served by a plain btree on `owner_email`, so the chat list, chat search, and the usage/billing panel were sequential-scanning multi-tenant tables. Added expression indexes for `chat_threads`, `chat_thread_shares`, and `token_usage` (the highest-row-count table in the system — one row per LLM call). This follows the pattern `org/migrations.ts` already established for `org_members`.

## 3. agent-native.com cache misses took ~4s

Not a slow render — the `server-timing` header says it outright:

```
server-timing: origin;dur=1301;desc="… cold boot=1366 init=662"
```

Every request is a **cold** boot (the CDN serves everything else, so the origin function is rarely warm), and `HEAD` costs the same as `GET` while returning 0 bytes — the expense is before any rendering.

`boot` is module evaluation. Importing `@agent-native/core/server` measured **1467ms**, of which the agent chat plugin was the largest single contributor — and it was pulling in the entire agent run loop for one 6-line string validator, `clientAbortReason`. Moving that to a leaf module:

- built `agent-chat-plugin.js` now has **zero** references to `run-loop-with-resume` (was a static import)
- the leaf costs **2ms** to import; the run loop costs **1235ms**
- importing `core/server` dropped from ~1147ms to **~840ms** (median of 4 runs)

That saving lands on every cold start of every app, including requests that only render a page.

## 4. `@`-mention search read blobs on every keystroke

`mentionProviders()` in content and slides used bare `.select()`, pulling full document bodies and full deck JSON for up to 15 rows per keystroke while the mapper read only `id`/`title`/`parentId`. Now projected.

## Verification

- `pnpm guards` — **all 63 pass**, exit 0
- `pnpm typecheck` — exit 0
- Core `src/agent/`, `src/chat-threads/`, `src/usage/`, `src/server/` — **3,748 tests pass**
- `pnpm prep` reported 4 test failures; each passes in isolation (`code-agent-executor`, `vite/client`, dispatch `agent-chat`, design `html-integrity`). They are 5s-timeout and perf assertions that tripped because prep runs typecheck, tests, and guards concurrently. None touch the changed code paths.

## Deliberately not in this PR

The remaining cold-start cost is the rest of `core/server`'s module graph (~840ms) loading on every cold function, because Nitro emits one function and the framework plugins are static top-level imports. Fixing that properly means lazy route registration in a 7,171-line plugin with 79 top-level imports — worth doing deliberately, not in the same pass as a measured bug fix.

Also left: `packages/dispatch` `thread-debug-store.ts` wraps `LOWER()` around `thread_data` in an admin-only search, and analytics' first-party panels filter on `properties::jsonb ->> …`. Both are real but bounded, and the second needs ingest-time columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)