### PR TITLE
fix(dispatch): keep sidebar utility controls at the bottom

### DIFF
--- a/.changeset/flush-dispatch-footer.md
+++ b/.changeset/flush-dispatch-footer.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep Dispatch's Feedback, Search, and Collapse controls flush with the bottom of the left sidebar.

--- a/packages/dispatch/src/components/layout/Layout.spec.tsx
+++ b/packages/dispatch/src/components/layout/Layout.spec.tsx
@@ -226,7 +226,7 @@ describe("Dispatch NavContent", () => {
     { mode: "chat-first", chatFirstMode: true, collapsed: false },
     { mode: "chat-first", chatFirstMode: true, collapsed: true },
   ])(
-    "reserves environment pill space in the $mode desktop footer when collapsed is $collapsed",
+    "keeps footer controls flush with the bottom in the $mode desktop footer when collapsed is $collapsed",
     async ({ mode, chatFirstMode, collapsed }) => {
       await act(async () => {
         root.render(
@@ -234,11 +234,7 @@ describe("Dispatch NavContent", () => {
             initialEntries={[chatFirstMode ? "/chat" : "/overview"]}
           >
             <TooltipProvider>
-              <NavContent
-                chatFirstMode={chatFirstMode}
-                collapsed={collapsed}
-                reserveEnvironmentBadgeSpace
-              />
+              <NavContent chatFirstMode={chatFirstMode} collapsed={collapsed} />
             </TooltipProvider>
           </MemoryRouter>,
         );
@@ -258,7 +254,7 @@ describe("Dispatch NavContent", () => {
 
       expect(footer?.className).toContain("mt-auto");
       expect(footer?.className).toContain("shrink-0");
-      expect(footer?.className).toContain("pb-10");
+      expect(footer?.className).not.toContain("pb-10");
       if (mode === "standard") {
         expect(footer?.closest(".overflow-y-auto")).toBeNull();
       }
@@ -277,23 +273,6 @@ describe("Dispatch NavContent", () => {
       );
     },
   );
-
-  it("reserves environment pill space in the mobile footer", async () => {
-    await act(async () => {
-      root.render(
-        <MemoryRouter initialEntries={["/overview"]}>
-          <TooltipProvider>
-            <NavContent reserveEnvironmentBadgeSpace />
-          </TooltipProvider>
-        </MemoryRouter>,
-      );
-    });
-
-    expect(
-      container.querySelector('[data-dispatch-sidebar-footer="standard"]')
-        ?.className,
-    ).toContain("pb-10");
-  });
 
   it("keeps chat-first primary actions in the collapsed sidebar", async () => {
     await act(async () => {

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -953,7 +953,6 @@ export function NavContent({
   chatFirstEmbedded = false,
   collapsed = false,
   collapsible = false,
-  reserveEnvironmentBadgeSpace = false,
   onCollapsedChange,
   chatFirstAppLayout,
   onChatFirstAppLayoutChange,
@@ -972,7 +971,6 @@ export function NavContent({
   chatFirstEmbedded?: boolean;
   collapsed?: boolean;
   collapsible?: boolean;
-  reserveEnvironmentBadgeSpace?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   chatFirstAppLayout?: ChatFirstAppLayoutPreference;
   onChatFirstAppLayoutChange?: (layout: ChatFirstAppLayoutPreference) => void;
@@ -1314,10 +1312,7 @@ export function NavContent({
         </div>
       ) : null}
       <div
-        className={cn(
-          "mt-auto shrink-0",
-          reserveEnvironmentBadgeSpace && "pb-10",
-        )}
+        className="mt-auto shrink-0"
         data-dispatch-sidebar-footer={chatFirstMode ? "chat-first" : "standard"}
       >
         {bottomNavigation}
@@ -2463,7 +2458,6 @@ export function Layout({
               }}
               onChatFirstAppsRetry={() => void chatFirstAppsQuery.refetch()}
               collapsible
-              reserveEnvironmentBadgeSpace
               onCollapsedChange={setSidebarCollapsed}
             />
           </aside>
@@ -2485,7 +2479,6 @@ export function Layout({
                   chatFirstMode={chatFirstMode}
                   chatFirstEmbedded={chatFirstEmbedded}
                   collapsed={false}
-                  reserveEnvironmentBadgeSpace
                   chatFirstAppLayout={chatFirstAppLayout}
                   onChatFirstAppLayoutChange={persistChatFirstAppLayout}
                   chatFirstApps={chatFirstAppItems}

--- a/packages/dispatch/src/styles/dispatch-css.spec.ts
+++ b/packages/dispatch/src/styles/dispatch-css.spec.ts
@@ -27,6 +27,9 @@ describe("dispatch Tailwind styles", () => {
       '@source "../components/**/*.{js,mjs,ts,tsx}"',
     );
     expect(stylesheet).toContain('@source "../routes/**/*.{js,mjs,ts,tsx}"');
+    expect(stylesheet).toContain(
+      "body:has(.fixed.bottom-3.left-3) [data-dispatch-sidebar-footer]",
+    );
   });
 
   it("imports package source directives from the Dispatch template", () => {

--- a/packages/dispatch/src/styles/dispatch.css
+++ b/packages/dispatch/src/styles/dispatch.css
@@ -40,6 +40,11 @@
   font-weight: 600;
 }
 
+body:has(.fixed.bottom-3.left-3) [data-dispatch-sidebar-footer] {
+  /* The fixed environment badge only needs this space when it is rendered. */
+  padding-bottom: 2.5rem;
+}
+
 @media (max-width: 767px) {
   .dispatch-chat-first-surface {
     position: relative;


### PR DESCRIPTION
## Summary
- Remove the stale environment-badge bottom reservation from the Dispatch left sidebar footer.
- Keep the footer regression coverage for expanded and collapsed sidebars.

## Validation
- `corepack pnpm --filter @agent-native/dispatch exec vitest --run src/components/layout/Layout.spec.tsx --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/dispatch typecheck`
- `corepack pnpm exec oxfmt --check packages/dispatch/src/components/layout/Layout.tsx packages/dispatch/src/components/layout/Layout.spec.tsx`
- Local browser check: expanded and collapsed footer action rows ended at the viewport bottom with no hidden footer nodes.