### PR TITLE
fix: make beta lane switcher dismissible

### DIFF
--- a/.changeset/hide-environment-badge.md
+++ b/.changeset/hide-environment-badge.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Shorten production lane opt-out to eight hours, add a per-page badge hide control, and support `?force=true` for a browser-session production override.

--- a/packages/core/src/client/EnvironmentBadge.render.spec.tsx
+++ b/packages/core/src/client/EnvironmentBadge.render.spec.tsx
@@ -38,6 +38,7 @@ describe("EnvironmentBadge render", () => {
       },
     });
     window.localStorage?.removeItem("agent-native:beta-opt-out-until");
+    window.sessionStorage?.removeItem("agent-native:force-production");
   });
 
   afterEach(() => {
@@ -166,6 +167,37 @@ describe("EnvironmentBadge render", () => {
     expect(expiry).toBeGreaterThan(Date.now());
   });
 
+  it("hides the badge for the current page without persisting the choice", () => {
+    useSessionMock.mockReturnValue({
+      session: null,
+      status: "unauthenticated",
+    });
+
+    act(() => root.render(<EnvironmentBadge />));
+    const trigger = container.querySelector("button");
+    expect(trigger).not.toBeNull();
+
+    act(() => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true }),
+      );
+      trigger?.click();
+    });
+
+    const hideButton = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Hide badge"),
+    );
+    expect(hideButton).not.toBeUndefined();
+
+    act(() => hideButton?.click());
+
+    expect(container.innerHTML).toBe("");
+    expect(document.body.querySelector('[data-side="top"]')).toBeNull();
+    expect(window.sessionStorage.getItem("agent-native:force-production")).toBe(
+      null,
+    );
+  });
+
   it("hides the production chip for non-employee sessions", () => {
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -204,6 +236,29 @@ describe("EnvironmentBadge render", () => {
 
     expect(replace).toHaveBeenCalledWith(
       "https://beta.plan.agent-native.com/inbox?tab=all#runs",
+    );
+  });
+
+  it("keeps an employee on production for a forced browser session", () => {
+    const replace = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        hostname: "plan.agent-native.com",
+        href: "https://plan.agent-native.com/inbox?force=true",
+        replace,
+      },
+    });
+    useSessionMock.mockReturnValue({
+      session: { email: "employee@builder.io" },
+      status: "authenticated",
+    });
+
+    act(() => root.render(<EnvironmentBadge />));
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("agent-native:force-production")).toBe(
+      "1",
     );
   });
 

--- a/packages/core/src/client/EnvironmentBadge.spec.ts
+++ b/packages/core/src/client/EnvironmentBadge.spec.ts
@@ -56,8 +56,9 @@ describe("EnvironmentBadge", () => {
     ).toBe("https://plan.agent-native.com/projects/42?tab=activity#runs");
   });
 
-  it("adds a 24-hour opt-out when switching back to production", () => {
+  it("adds an 8-hour opt-out when switching back to production", () => {
     const now = 1_700_000_000_000;
+    expect(BETA_OPT_OUT_DURATION_MS).toBe(8 * 60 * 60 * 1000);
     expect(
       buildEnvironmentOptOutUrl(
         "https://beta.plan.agent-native.com/projects/42?tab=activity#runs",

--- a/packages/core/src/client/EnvironmentBadge.tsx
+++ b/packages/core/src/client/EnvironmentBadge.tsx
@@ -4,13 +4,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@agent-native/toolkit/ui/popover";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   AgentNativeDeploymentEnvironment,
   AgentNativeConfig,
 } from "../config.js";
 import {
+  BETA_FORCE_QUERY_PARAM,
+  BETA_FORCE_SESSION_STORAGE_KEY,
   BETA_OPT_OUT_QUERY_PARAM,
   BETA_OPT_OUT_STORAGE_KEY,
   buildEnvironmentOptOutUrl,
@@ -24,6 +26,8 @@ import { useSession } from "./use-session.js";
 import { cn } from "./utils.js";
 
 export {
+  BETA_FORCE_QUERY_PARAM,
+  BETA_FORCE_SESSION_STORAGE_KEY,
   BETA_OPT_OUT_DURATION_MS,
   BETA_OPT_OUT_QUERY_PARAM,
   BETA_OPT_OUT_STORAGE_KEY,
@@ -91,6 +95,31 @@ function readBetaOptOutUntil(now = Date.now()): number | null {
   return null;
 }
 
+function rememberForcedProductionSession(sourceHref: string): boolean {
+  let forcedByQuery = false;
+  try {
+    forcedByQuery =
+      new URL(sourceHref).searchParams.get(BETA_FORCE_QUERY_PARAM) === "true";
+  } catch {
+    // coercion-ok: the browser supplied an invalid location.
+  }
+
+  if (typeof window === "undefined") return forcedByQuery;
+
+  try {
+    if (forcedByQuery) {
+      window.sessionStorage.setItem(BETA_FORCE_SESSION_STORAGE_KEY, "1");
+    }
+    return (
+      forcedByQuery ||
+      window.sessionStorage.getItem(BETA_FORCE_SESSION_STORAGE_KEY) === "1"
+    );
+  } catch {
+    // coercion-ok: session storage is optional; the current URL remains authoritative.
+    return forcedByQuery;
+  }
+}
+
 function consumeBetaOptOutQueryParam(
   sourceHref: string,
   now = Date.now(),
@@ -146,7 +175,10 @@ function EnvironmentBadgeContent({
   environment: "beta" | "production";
   targets: EnvironmentBadgeTargets;
 }) {
+  const [isHidden, setIsHidden] = useState(false);
+
   if (typeof window === "undefined") return null;
+  if (isHidden) return null;
 
   const currentHref = window.location.href;
   const betaHref = buildEnvironmentUrl(currentHref, targets.betaHost);
@@ -198,6 +230,15 @@ function EnvironmentBadgeContent({
           ) : (
             <EnvironmentLink href={betaHref!} label="Go to beta" />
           )}
+          <Button
+            className="w-full justify-center text-muted-foreground"
+            onClick={() => setIsHidden(true)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Hide badge
+          </Button>
         </div>
       </PopoverContent>
     </Popover>
@@ -233,6 +274,8 @@ function ProductionEnvironmentBadge({
   const didAutoRedirect = useRef(false);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (rememberForcedProductionSession(window.location.href)) return;
     if (!isEligible || didAutoRedirect.current) {
       return;
     }

--- a/packages/core/src/server/beta-opt-out-html.spec.ts
+++ b/packages/core/src/server/beta-opt-out-html.spec.ts
@@ -18,7 +18,10 @@ describe("injectBetaOptOutPersistence", () => {
     expect(html).toContain("window.history.replaceState");
     expect(html).toContain('id="environment-switcher"');
     expect(html).toContain('id="environment-production-link"');
+    expect(html).toContain('id="environment-hide-badge"');
     expect(html).toContain("__anInitEnvironmentBadge");
+    expect(html).toContain("agent-native:force-production");
+    expect(html).toContain("switcher.hidden = true");
     expect(html).toContain("betaHosts");
     expect(html).toContain("agent-native-environment-switcher-style");
     expect(html).toContain("left: max(0.75rem, env(safe-area-inset-left));");
@@ -50,6 +53,7 @@ describe("injectBetaOptOutPersistence", () => {
     expect(reinjected.match(/id="environment-production-link"/g)).toHaveLength(
       1,
     );
+    expect(reinjected.match(/id="environment-hide-badge"/g)).toHaveLength(1);
     expect(reinjected.match(/__anInitEnvironmentBadge/g)).toHaveLength(1);
   });
 
@@ -58,6 +62,7 @@ describe("injectBetaOptOutPersistence", () => {
       <html><head></head><body>
         <div class="environment-switcher" id="environment-switcher" hidden>
           <a id="environment-production-link" href="">Switch to production</a>
+          <button id="environment-hide-badge" type="button">Hide badge</button>
         </div>
         <script>function __anInitEnvironmentBadge() {}</script>
       </body></html>
@@ -66,6 +71,7 @@ describe("injectBetaOptOutPersistence", () => {
     expect(html).toContain(BETA_OPT_OUT_PERSISTENCE_MARKER);
     expect(html.match(/id="environment-switcher"/g)).toHaveLength(1);
     expect(html.match(/id="environment-production-link"/g)).toHaveLength(1);
+    expect(html.match(/id="environment-hide-badge"/g)).toHaveLength(1);
     expect(html.match(/__anInitEnvironmentBadge/g)).toHaveLength(1);
     expect(html).not.toContain(
       'data-agent-native-environment-switcher-style="1"',

--- a/packages/core/src/server/beta-opt-out-html.ts
+++ b/packages/core/src/server/beta-opt-out-html.ts
@@ -1,4 +1,6 @@
 import {
+  BETA_FORCE_QUERY_PARAM,
+  BETA_FORCE_SESSION_STORAGE_KEY,
   BETA_OPT_OUT_DURATION_MS,
   BETA_OPT_OUT_QUERY_PARAM,
   BETA_OPT_OUT_STORAGE_KEY,
@@ -32,6 +34,7 @@ const environmentSwitcherMarkup = `<div class="environment-switcher" id="environ
     <div class="environment-popover-title" id="environment-popover-title">You're on Agent Native Beta</div>
     <div class="environment-popover-copy">Choose where you want to continue.</div>
     <a class="environment-production-link" id="environment-production-link" href="">Switch to production</a>
+    <button type="button" class="environment-hide-badge" id="environment-hide-badge">Hide badge</button>
   </div>
 </div>`;
 
@@ -70,7 +73,8 @@ const environmentSwitcherStyles = `<style ${ENVIRONMENT_SWITCHER_STYLE_MARKER}>
     background: color-mix(in srgb, CanvasText 85%, Canvas);
   }
   .environment-badge:focus-visible,
-  .environment-production-link:focus-visible {
+  .environment-production-link:focus-visible,
+  .environment-hide-badge:focus-visible {
     outline: 2px solid LinkText;
     outline-offset: 2px;
   }
@@ -104,6 +108,20 @@ const environmentSwitcherStyles = `<style ${ENVIRONMENT_SWITCHER_STYLE_MARKER}>
   .environment-production-link:hover {
     background: color-mix(in srgb, CanvasText 12%, Canvas);
   }
+  .environment-hide-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    padding: 0.375rem 0.75rem;
+    color: GrayText;
+    border: 0;
+    background: transparent;
+    font: inherit;
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+  .environment-hide-badge:hover { color: CanvasText; }
 </style>`;
 
 const environmentSwitcherScript = `<script ${ENVIRONMENT_SWITCHER_SCRIPT_MARKER}>
@@ -112,8 +130,18 @@ const environmentSwitcherScript = `<script ${ENVIRONMENT_SWITCHER_SCRIPT_MARKER}
   var button = document.getElementById('environment-badge');
   var popover = document.getElementById('environment-popover');
   var productionLink = document.getElementById('environment-production-link');
-  if (!switcher || !button || !popover || !productionLink) return;
+  var hideButton = document.getElementById('environment-hide-badge');
+  if (!switcher || !button || !popover || !productionLink || !hideButton) return;
   if (window.parent !== window) return;
+
+  try {
+    var forceUrl = new URL(window.location.href);
+    if (forceUrl.searchParams.get(${JSON.stringify(BETA_FORCE_QUERY_PARAM)}) === 'true') {
+      window.sessionStorage.setItem(${JSON.stringify(BETA_FORCE_SESSION_STORAGE_KEY)}, '1');
+    }
+  } catch (error) {
+    void error;
+  }
 
   var betaHosts = ${JSON.stringify(ENVIRONMENT_BETA_HOSTS)};
   var hostname = (window.location.hostname || '').toLowerCase().replace(/\\.$/, '');
@@ -150,6 +178,10 @@ const environmentSwitcherScript = `<script ${ENVIRONMENT_SWITCHER_SCRIPT_MARKER}
   document.addEventListener('keydown', function(event) {
     if (event.key === 'Escape') setOpen(false);
   });
+  hideButton.addEventListener('click', function() {
+    setOpen(false);
+    switcher.hidden = true;
+  });
 })();
 </script>`;
 
@@ -157,6 +189,10 @@ const betaOptOutPersistenceScript = `<script data-agent-native-beta-opt-out>
 // ${BETA_OPT_OUT_PERSISTENCE_MARKER}.
 (function __anPersistBetaOptOut() {
   try {
+    var forceUrl = new URL(window.location.href);
+    if (forceUrl.searchParams.get(${JSON.stringify(BETA_FORCE_QUERY_PARAM)}) === 'true') {
+      window.sessionStorage.setItem(${JSON.stringify(BETA_FORCE_SESSION_STORAGE_KEY)}, '1');
+    }
     var optOutUrl = new URL(window.location.href);
     var optOutValue = optOutUrl.searchParams.get(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
     if (optOutValue === null) return;

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -33,9 +33,12 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain('id="environment-badge"');
     expect(html).toContain("You're on Agent Native Beta");
     expect(html).toContain("Switch to production");
+    expect(html).toContain('id="environment-hide-badge"');
+    expect(html).toContain("switcher.hidden = true");
     expect(html).toContain("__anInitEnvironmentBadge");
     expect(html).toContain("agentNativeBetaOptOut");
     expect(html).toContain("agent-native:beta-opt-out-until");
+    expect(html).toContain("agent-native:force-production");
     expect(html).toContain("window.localStorage.setItem");
     expect(html).toContain("window.history.replaceState");
     expect(html).toContain("left: max(0.75rem, env(safe-area-inset-left));");

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -20,6 +20,8 @@ import {
 import { NATIVE_AUTH_COPY } from "../shared/auth-copy.js";
 import { docsUrl } from "../shared/docs-url.js";
 import {
+  BETA_FORCE_QUERY_PARAM,
+  BETA_FORCE_SESSION_STORAGE_KEY,
   BETA_OPT_OUT_DURATION_MS,
   BETA_OPT_OUT_QUERY_PARAM,
   BETA_OPT_OUT_STORAGE_KEY,
@@ -1265,6 +1267,7 @@ ${localeMenuItemsHtml}
     <div class="environment-popover-title" id="environment-popover-title">You're on Agent Native Beta</div>
     <div class="environment-popover-copy">Choose where you want to continue.</div>
     <a class="environment-production-link" id="environment-production-link" href="">Switch to production</a>
+    <button type="button" class="environment-hide-badge" id="environment-hide-badge">Hide badge</button>
   </div>
 </div>`;
   const hostedSignupLegalNotice: SignupLegalNoticeOptions | undefined =
@@ -1668,8 +1671,18 @@ ${marketing!.description ? `      <p class="app-desc" data-marketing-field="desc
     var button = document.getElementById('environment-badge');
     var popover = document.getElementById('environment-popover');
     var productionLink = document.getElementById('environment-production-link');
-    if (!switcher || !button || !popover || !productionLink) return;
+    var hideButton = document.getElementById('environment-hide-badge');
+    if (!switcher || !button || !popover || !productionLink || !hideButton) return;
     if (window.parent !== window) return;
+
+    try {
+      var forceUrl = new URL(window.location.href);
+      if (forceUrl.searchParams.get(${JSON.stringify(BETA_FORCE_QUERY_PARAM)}) === 'true') {
+        window.sessionStorage.setItem(${JSON.stringify(BETA_FORCE_SESSION_STORAGE_KEY)}, '1');
+      }
+    } catch (error) {
+      void error;
+    }
 
     // Persist the beta opt-out before authentication replaces this cached shell.
     try {
@@ -1733,6 +1746,10 @@ ${marketing!.description ? `      <p class="app-desc" data-marketing-field="desc
     });
     document.addEventListener('keydown', function(event) {
       if (event.key === 'Escape') setOpen(false);
+    });
+    hideButton.addEventListener('click', function() {
+      setOpen(false);
+      switcher.hidden = true;
     });
   })();`;
 
@@ -1909,7 +1926,8 @@ ${
   .environment-badge:hover,
   .environment-badge[aria-expanded="true"] { background: #4a4a4a; }
   .environment-badge:focus-visible,
-  .environment-production-link:focus-visible {
+  .environment-production-link:focus-visible,
+  .environment-hide-badge:focus-visible {
     outline: 2px solid #33c4ff;
     outline-offset: 2px;
   }
@@ -1941,6 +1959,21 @@ ${
     text-decoration: none;
   }
   .environment-production-link:hover { background: #242424; }
+  .environment-hide-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    padding: 0.375rem 0.75rem;
+    color: inherit;
+    opacity: 0.65;
+    border: 0;
+    background: transparent;
+    font: inherit;
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+  .environment-hide-badge:hover { opacity: 1; }
   .card {
     width: 100%;
     max-width: 400px;

--- a/packages/core/src/shared/environment-lanes.ts
+++ b/packages/core/src/shared/environment-lanes.ts
@@ -1,6 +1,8 @@
 export const BETA_OPT_OUT_QUERY_PARAM = "agentNativeBetaOptOut";
-export const BETA_OPT_OUT_DURATION_MS = 24 * 60 * 60 * 1000;
+export const BETA_OPT_OUT_DURATION_MS = 8 * 60 * 60 * 1000;
 export const BETA_OPT_OUT_STORAGE_KEY = "agent-native:beta-opt-out-until";
+export const BETA_FORCE_QUERY_PARAM = "force";
+export const BETA_FORCE_SESSION_STORAGE_KEY = "agent-native:force-production";
 
 export const ENVIRONMENT_BETA_HOSTS = {
   "agent-workspace.builder.io": "beta.agent-workspace.builder.io",

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -28,6 +28,13 @@ export {
 export { injectDocumentMarkup } from "./html-document.js";
 export { withBuilderUtmTrackingParams } from "./builder-link-tracking.js";
 export {
+  BETA_FORCE_QUERY_PARAM,
+  BETA_FORCE_SESSION_STORAGE_KEY,
+  BETA_OPT_OUT_DURATION_MS,
+  BETA_OPT_OUT_QUERY_PARAM,
+  BETA_OPT_OUT_STORAGE_KEY,
+} from "./environment-lanes.js";
+export {
   SSR_HTML_CONTENT_TYPE,
   SSR_QUERY_CACHE_KEY_HEADER,
   type SsrHtmlContentTypeOptions,

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -236,7 +236,7 @@ describe("Desktop identity activation", () => {
       const firstUrl = webview?.getAttribute("src");
       expect(
         Number(new URL(firstUrl!).searchParams.get("agentNativeBetaOptOut")),
-      ).toBe(87_400_000);
+      ).toBe(29_800_000);
 
       now.mockReturnValue(2_000_000);
       act(() => {

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -3,6 +3,10 @@ import {
   APP_CHAT_SIDEBAR_STATE_MESSAGE,
 } from "@agent-native/core/client/hooks";
 import {
+  BETA_OPT_OUT_DURATION_MS,
+  BETA_OPT_OUT_QUERY_PARAM,
+} from "@agent-native/core/shared";
+import {
   DESKTOP_DEFAULT_APPS,
   getTemplate,
   type AppDefinition,
@@ -44,9 +48,6 @@ export const APP_WEBVIEW_PREFERENCES =
 // minted against the configured production origin, so keep first-party
 // production webviews on that same origin unless a beta URL was explicitly
 // supplied. The query is consumed by the hosted app and removed from history.
-const DESKTOP_BETA_OPT_OUT_QUERY_PARAM = "agentNativeBetaOptOut";
-const DESKTOP_BETA_OPT_OUT_DURATION_MS = 24 * 60 * 60 * 1000;
-
 type WebviewTitleUpdatedEvent = Event & { title?: string };
 type WebviewLoadFailedEvent = Event & {
   errorCode?: number;
@@ -498,8 +499,8 @@ export function withDesktopEnvironmentOptOut(rawUrl: string): string {
   try {
     const target = new URL(rawUrl);
     target.searchParams.set(
-      DESKTOP_BETA_OPT_OUT_QUERY_PARAM,
-      String(Date.now() + DESKTOP_BETA_OPT_OUT_DURATION_MS),
+      BETA_OPT_OUT_QUERY_PARAM,
+      String(Date.now() + BETA_OPT_OUT_DURATION_MS),
     );
     return target.toString();
   } catch {


### PR DESCRIPTION
## Summary
- shorten the beta-to-production opt-out to eight hours
- add a secondary Hide badge action to hosted and auth-page switchers
- honor `?force=true` for the current browser session on production hosts

## Validation
- focused core EnvironmentBadge and auth HTML tests
- focused desktop AppWebview tests
- core and desktop typechecks
- `pnpm guards`
- local Plan app browser smoke check