### PR TITLE
fix(guards): let no-boot-data-work see the framework's own plugins

### DIFF
--- a/scripts/guard-no-boot-data-work.mjs
+++ b/scripts/guard-no-boot-data-work.mjs
@@ -33,9 +33,18 @@
  *   - lazily, behind the first caller that actually needs the data, memoized.
  *
  * Scope: only lines ADDED on this branch (via scripts/lib/changed-lines.mjs),
- * under a template's, app's, or package's server directory. The existing
- * boot-time backlog is a separate, schedulable cleanup — this stops the habit
- * from growing, which is the only thing a guard can honestly do.
+ * under a template's, app's, or package's server directory, plus any Nitro
+ * plugin implementation anywhere in `packages/`, `templates/`, or `apps/`. The
+ * existing boot-time backlog is a separate, schedulable cleanup — this stops
+ * the habit from growing, which is the only thing a guard can honestly do.
+ *
+ * Known limitation, stated so nobody reads a pass as full coverage: this is a
+ * line-oriented heuristic bounded by `MAX_STARTUP_INDENT`, so boot work nested
+ * deeper stays invisible. `agent-chat-plugin.ts` builds its action registries
+ * inside an `initPromise` IIFE at indent 6+, and none of it is reachable here.
+ * Closing that needs real structural analysis, not a wider regex — widening
+ * the indent alone would flag request handlers in the same file and turn the
+ * pragma into noise.
  *
  * Opt-out, when the work genuinely must happen before serving and is bounded:
  *
@@ -63,6 +72,18 @@ const PRAGMA = /(?:\/\/|\/\*)\s*guard:allow-boot-data-work\b/;
 /** Server startup code. A route handler is per-request and not this guard's business. */
 const IN_SCOPE =
   /^(templates\/[^/]+\/server\/|packages\/[^/]+\/(?:src\/)?server\/|apps\/[^/]+\/server\/)/;
+/**
+ * Nitro plugin implementations that do NOT live under a `server/` directory.
+ *
+ * `IN_SCOPE` keys on directory, so it never even read `org/plugin.ts`,
+ * `agent/context-xray/plugin.ts`, `agent/observational-memory/plugin.ts`, or
+ * `terminal/terminal-plugin.ts` — the default plugins whose bootstrap runs
+ * sequentially on every cold start. The thin per-template wrapper under
+ * `server/plugins/` was in scope, but it only calls `createXPlugin({...})`;
+ * the awaits it stands for are all in these files.
+ */
+const PLUGIN_FILE =
+  /^(packages|templates|apps)\/.*(^|\/)[\w.-]*plugin\.[jt]sx?$/;
 const SKIPPED = /(\.spec\.|\.test\.|\/__tests__\/|\/dist\/|\/node_modules\/)/;
 
 /**
@@ -91,6 +112,11 @@ const DATA_WORK = new RegExp(
       // Schema/migration work. Bounded in principle, 5-8s in practice on a
       // large database — and paid on every cold start, forever.
       "\\w*[Mm]igrations?\\w*",
+      // `migrate(...)` is not matched by the pattern above — it has no
+      // "igration" substring — and that is exactly the name the default
+      // plugins call at bootstrap (`org/plugin.ts`, `context-xray/plugin.ts`,
+      // `observational-memory/plugin.ts`).
+      "\\w*[Mm]igrate\\w*",
       "ensureTable\\w*",
       "ensureColumn\\w*",
       "ensureAdditiveColumns",
@@ -137,7 +163,10 @@ function isStartupContext(line, file) {
   const indent = line.length - line.trimStart().length;
   if (indent > MAX_STARTUP_INDENT) return false;
   // Plugin files are startup by definition; elsewhere only module scope counts.
-  if (/\/server\/plugins\//.test(file)) return true;
+  // Match the implementations too, not just `server/plugins/` wrappers — a
+  // default plugin's `await migrate(...)` sits at indent 4 inside its exported
+  // plugin function, so requiring module scope hid every one of them.
+  if (/\/server\/plugins\//.test(file) || PLUGIN_FILE.test(file)) return true;
   return indent === 0;
 }
 
@@ -146,7 +175,8 @@ const added = requireAddedLines(REPO_ROOT, "guard-no-boot-data-work");
 const violations = [];
 for (const [absPath, lineNumbers] of added) {
   const rel = path.relative(REPO_ROOT, absPath);
-  if (!IN_SCOPE.test(rel) || SKIPPED.test(rel)) continue;
+  if (!(IN_SCOPE.test(rel) || PLUGIN_FILE.test(rel)) || SKIPPED.test(rel))
+    continue;
   if (!/\.(ts|tsx|mjs|js)$/.test(rel)) continue;
 
   let lines;


### PR DESCRIPTION
Found while profiling serverless cold start for #3404's follow-up. `guard:no-boot-data-work` has been reporting PASS on files it never opened.

## Three compounding gaps

1. **`IN_SCOPE` keys on a `server/` directory.** So `packages/core/src/org/plugin.ts`, `agent/context-xray/plugin.ts`, `agent/observational-memory/plugin.ts`, and `terminal/terminal-plugin.ts` were never read at all — the default plugins whose bootstrap runs sequentially on every cold start.

2. **`isStartupContext` only treated `/server/plugins/` as plugin context.** That path matches the thin per-template wrapper, which contains a single `createXPlugin({...})` call and no awaits. The awaits it stands for all live in the implementations, which fell through to the `indent === 0` module-scope rule and were skipped at indent 4.

3. **`DATA_WORK` never matched `migrate(`.** The existing `\w*[Mm]igrations?\w*` needs an "igration" substring, and `migrate` has none — which is precisely the call those plugins make at bootstrap.

Each gap alone would have hidden this; together they made the guard structurally blind to the framework's own boot path, on every branch, regardless of what was added.

## Verification

Injected `await backfillSyntheticGuardProbe(nitroApp);` into `org/plugin.ts` at indent 4.

- Before: guard passes, silent.
- After: `packages/core/src/org/plugin.ts:81 — await backfillSyntheticGuardProbe(...)`, exit 1.

Probe reverted; tree clean. `pnpm guards` — all 63 pass.

The scoping regex was checked against real paths to confirm it catches the implementations (`org/plugin.ts`, `context-xray/plugin.ts`, `terminal-plugin.ts`, `agent-chat-plugin.ts`) without matching unrelated files like `chat-threads/store.ts`.

## What this still cannot see

Recorded in the header rather than left implicit, since the whole point is that a pass shouldn't be misread as coverage: the check is a line-oriented heuristic bounded by `MAX_STARTUP_INDENT`. `agent-chat-plugin.ts` builds its action registries inside an `initPromise` IIFE at indent 6+, and none of that is reachable. Closing it needs structural analysis, not a wider indent — raising the threshold alone would flag request handlers in the same file and turn the opt-out pragma into noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)