### PR TITLE
Hide unavailable Google integrations

### DIFF
--- a/.changeset/quiet-google-gates.md
+++ b/.changeset/quiet-google-gates.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Hide managed Google OAuth integrations and onboarding until the shared client credentials are available.

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -152,6 +152,27 @@ describe("onboarding plugin routes", () => {
     expect(isComplete).not.toHaveBeenCalled();
   });
 
+  it("propagates availability failures so callers can retry", async () => {
+    registerOnboardingStep({
+      id: "google",
+      order: 10,
+      title: "Connect Google",
+      description: "Requires managed Google OAuth.",
+      methods: [],
+      isAvailable: () => {
+        throw new Error("credential store unavailable");
+      },
+      isComplete: () => false,
+    });
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(nitroApp, "/_agent-native/onboarding/steps");
+
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({ error: "credential store unavailable" });
+  });
+
   it("uses the same request context when reporting dismissed/allComplete state", async () => {
     registerRequestContextProbeStep();
     appStateGetMock.mockImplementation(async (_sessionId, key) =>

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -22,6 +22,7 @@ vi.mock("../org/context.js", () => ({
   getOrgContext: (...args: any[]) => getOrgContextMock(...args),
 }));
 
+import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
 import {
   getRequestOrgId,
   getRequestUserEmail,
@@ -195,6 +196,33 @@ describe("onboarding plugin routes", () => {
       "alice@example.com",
       "onboarding:dismissed",
     );
+  });
+
+  it("propagates availability failures from the dismissed state route", async () => {
+    registerOnboardingStep({
+      id: "google",
+      order: 10,
+      title: "Connect Google",
+      description: "Requires managed Google OAuth.",
+      methods: [],
+      isAvailable: () => {
+        throw new CredentialStoreUnavailableError();
+      },
+      isComplete: () => false,
+    });
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/onboarding/dismissed",
+    );
+
+    expect(result.status).toBe(500);
+    expect(result.body).toEqual({
+      error:
+        "Could not read your saved connections — the app database did not answer. This is temporary; try again in a moment.",
+    });
   });
 
   it("keeps first-run onboarding tied to the signup cookie and completion state", async () => {

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -131,6 +131,27 @@ describe("onboarding plugin routes", () => {
     ]);
   });
 
+  it("omits unavailable steps without running their completion resolver", async () => {
+    const isComplete = vi.fn(() => true);
+    registerOnboardingStep({
+      id: "google",
+      order: 10,
+      title: "Connect Google",
+      description: "Requires managed Google OAuth.",
+      methods: [],
+      isAvailable: () => false,
+      isComplete,
+    });
+    const nitroApp = createNitroApp();
+    await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
+
+    const result = await dispatch(nitroApp, "/_agent-native/onboarding/steps");
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual([]);
+    expect(isComplete).not.toHaveBeenCalled();
+  });
+
   it("uses the same request context when reporting dismissed/allComplete state", async () => {
     registerRequestContextProbeStep();
     appStateGetMock.mockImplementation(async (_sessionId, key) =>

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -23,6 +23,7 @@ import {
 import { appStateGet, appStatePut } from "../application-state/store.js";
 import { getOrgContext } from "../org/context.js";
 import { getSession } from "../server/auth.js";
+import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
 import {
   awaitBootstrap,
   getH3App,
@@ -277,7 +278,8 @@ export function createOnboardingPlugin(
               allComplete: allRequiredComplete(statuses),
             };
           });
-        } catch {
+        } catch (error) {
+          if (error instanceof CredentialStoreUnavailableError) throw error;
           return { dismissed: false, allComplete: false };
         }
       }),

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -98,8 +98,19 @@ async function serializeSteps(
   // chain of credential/settings reads — walking them one at a time made this
   // route cost the SUM of every step's round trips against a remote database
   // instead of the slowest one. `Promise.all` preserves `steps` order.
-  return Promise.all(
+  const serialized = await Promise.all(
     steps.map(async (step) => {
+      if (!options.preview && step.isAvailable) {
+        try {
+          // Fail closed: a capability without a proven configuration should
+          // not render a CTA that can only end in a provider error. The next
+          // poll retries the availability check.
+          if (!(await step.isAvailable(context))) return null;
+          // coercion-ok: hide unavailable OAuth setup and retry on the next poll.
+        } catch {
+          return null;
+        }
+      }
       let complete = false;
       if (!options.preview) {
         try {
@@ -121,6 +132,9 @@ async function serializeSteps(
         methods: step.methods,
       };
     }),
+  );
+  return serialized.filter(
+    (step): step is OnboardingStepStatus => step !== null,
   );
 }
 

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -101,15 +101,7 @@ async function serializeSteps(
   const serialized = await Promise.all(
     steps.map(async (step) => {
       if (!options.preview && step.isAvailable) {
-        try {
-          // Fail closed: a capability without a proven configuration should
-          // not render a CTA that can only end in a provider error. The next
-          // poll retries the availability check.
-          if (!(await step.isAvailable(context))) return null;
-          // coercion-ok: hide unavailable OAuth setup and retry on the next poll.
-        } catch {
-          return null;
-        }
+        if (!(await step.isAvailable(context))) return null;
       }
       let complete = false;
       if (!options.preview) {

--- a/packages/core/src/onboarding/types.ts
+++ b/packages/core/src/onboarding/types.ts
@@ -72,6 +72,10 @@ export interface OnboardingStep {
   /** Required steps block onboarding dismissal when incomplete. */
   required?: boolean;
   methods: OnboardingMethod[];
+  /** Hide the step when its backing capability is not configured. */
+  isAvailable?: (
+    context?: OnboardingResolveContext,
+  ) => boolean | Promise<boolean>;
   /** Resolver — called on every `GET /_agent-native/onboarding/steps` request. */
   isComplete: (
     context?: OnboardingResolveContext,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -529,6 +529,8 @@ export {
   exchangeWorkspaceProviderOAuthCode,
   handleWorkspaceProviderOAuthCallback,
   handleWorkspaceProviderOAuthStart,
+  hasWorkspaceProviderOAuthCredentials,
+  isGoogleWorkspaceOAuthProvider,
   isWorkspaceProviderOAuthFlowValid,
   mergeWorkspaceOAuthValues,
   resolveWorkspaceProviderIdentity,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -540,6 +540,7 @@ export {
 } from "./workspace-provider-oauth.js";
 
 export {
+  CredentialStoreUnavailableError,
   FeatureNotConfiguredError,
   hasBuilderPrivateKey,
   isBuilderEnvManaged,

--- a/packages/core/src/server/workspace-provider-oauth.spec.ts
+++ b/packages/core/src/server/workspace-provider-oauth.spec.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const resolveSecretMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./credential-provider.js", () => ({
+  resolveSecret: (...args: unknown[]) => resolveSecretMock(...args),
+}));
+
 import { getWorkspaceConnectionProvider } from "../connections/catalog.js";
 import {
   buildWorkspaceProviderAuthorizationUrl,
   canConnectWorkspaceProviderOAuth,
   exchangeWorkspaceProviderOAuthCode,
+  hasWorkspaceProviderOAuthCredentials,
   isGoogleWorkspaceOAuthProvider,
   isWorkspaceProviderOAuthScope,
   isWorkspaceProviderOAuthFlowValid,
@@ -19,6 +26,7 @@ import {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  resolveSecretMock.mockReset();
 });
 
 describe("workspace provider OAuth", () => {
@@ -38,6 +46,20 @@ describe("workspace provider OAuth", () => {
     expect(isGoogleWorkspaceOAuthProvider("gmail")).toBe(true);
     expect(isGoogleWorkspaceOAuthProvider("google_calendar")).toBe(true);
     expect(isGoogleWorkspaceOAuthProvider("figma")).toBe(false);
+  });
+
+  it("requires both managed OAuth client credentials", async () => {
+    resolveSecretMock.mockImplementation(async (key: string) =>
+      key === "GOOGLE_CLIENT_ID" ? "google-client" : null,
+    );
+    await expect(hasWorkspaceProviderOAuthCredentials("gmail")).resolves.toBe(
+      false,
+    );
+
+    resolveSecretMock.mockResolvedValue("google-secret");
+    await expect(hasWorkspaceProviderOAuthCredentials("gmail")).resolves.toBe(
+      true,
+    );
   });
 
   it("keeps portal and site OAuth token keys owner-scoped", () => {

--- a/packages/core/src/server/workspace-provider-oauth.ts
+++ b/packages/core/src/server/workspace-provider-oauth.ts
@@ -93,6 +93,14 @@ export function isGoogleWorkspaceOAuthProvider(provider: string): boolean {
   );
 }
 
+export async function hasWorkspaceProviderOAuthCredentials(
+  provider: GenericWorkspaceOAuthProvider,
+): Promise<boolean> {
+  const [clientId, clientSecret] =
+    await resolveProviderClientCredentials(provider);
+  return Boolean(clientId && clientSecret);
+}
+
 export interface WorkspaceProviderOAuthFlow {
   provider: GenericWorkspaceOAuthProvider;
   flowId: string;

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -103,6 +103,7 @@ export function GoogleConnectBanner({
 
   const accounts = googleStatus.data?.accounts ?? [];
   const hasAccounts = accounts.length > 0;
+  const googleConfigured = googleStatus.data?.configured === true;
   const canOfferOAuthSetup = useMemo(() => shouldOfferGoogleOAuthSetup(), []);
 
   const isBuilderFrame = useMemo(() => isInBuilderFrame(), []);
@@ -307,6 +308,7 @@ export function GoogleConnectBanner({
   }, [wantAddAccount, addAccountUrl.data, isBuilderFrame]);
 
   function handleConnect() {
+    if (!googleConfigured && !canOfferOAuthSetup) return;
     setDesktopAuthIssue(null);
     if (isDesktopGoogleAuth) {
       startDesktopGoogleAuth({ previousAccountCount: accounts.length });
@@ -316,6 +318,7 @@ export function GoogleConnectBanner({
   }
 
   function handleAddAccount() {
+    if (!googleConfigured && !canOfferOAuthSetup) return;
     if (isDesktopGoogleAuth) {
       startDesktopGoogleAuth({
         addAccount: true,
@@ -381,6 +384,8 @@ export function GoogleConnectBanner({
   }
 
   if (dismissed) return null;
+  if (!googleStatus.data && !canOfferOAuthSetup) return null;
+  if (!googleConfigured && !canOfferOAuthSetup && !hasAccounts) return null;
 
   if (variant === "hero") {
     return (
@@ -394,25 +399,25 @@ export function GoogleConnectBanner({
         <p className="mt-2 max-w-xs text-[13px] text-muted-foreground leading-relaxed">
           {t("googleConnect.syncEventsDescription")}
         </p>
-        <Button
-          size="sm"
-          className="mt-6 gap-2 px-4 h-8 text-[13px] font-medium"
-          onClick={handleConnect}
-          disabled={
-            authUrl.isLoading ||
-            authUrl.isFetching ||
-            isGoogleDesktopAuthPending
-          }
-        >
-          <GoogleIcon className="h-3.5 w-3.5" />
-          {authUrl.isLoading
-            ? t("common.connecting")
-            : hasAccounts
-              ? t("googleConnect.addAccount")
-              : allConfigured
-                ? t("googleConnect.connectGoogle")
+        {(googleConfigured || canOfferOAuthSetup) && (
+          <Button
+            size="sm"
+            className="mt-6 gap-2 px-4 h-8 text-[13px] font-medium"
+            onClick={handleConnect}
+            disabled={
+              authUrl.isLoading ||
+              authUrl.isFetching ||
+              isGoogleDesktopAuthPending
+            }
+          >
+            <GoogleIcon className="h-3.5 w-3.5" />
+            {authUrl.isLoading
+              ? t("common.connecting")
+              : hasAccounts
+                ? t("googleConnect.addAccount")
                 : t("googleConnect.connectGoogle")}
-        </Button>
+          </Button>
+        )}
 
         <GoogleAuthIssuePanel
           issue={desktopAuthIssue}
@@ -486,17 +491,19 @@ export function GoogleConnectBanner({
                 )}
               </div>
             ))}
-            <button
-              onClick={handleAddAccount}
-              disabled={
-                addAccountUrl.isLoading ||
-                addAccountUrl.isFetching ||
-                isGoogleDesktopAuthPending
-              }
-              className="text-xs text-foreground/40 hover:text-foreground/60 transition-colors whitespace-nowrap"
-            >
-              {t("googleConnect.addAccountWithPlus")}
-            </button>
+            {(googleConfigured || canOfferOAuthSetup) && (
+              <button
+                onClick={handleAddAccount}
+                disabled={
+                  addAccountUrl.isLoading ||
+                  addAccountUrl.isFetching ||
+                  isGoogleDesktopAuthPending
+                }
+                className="text-xs text-foreground/40 hover:text-foreground/60 transition-colors whitespace-nowrap"
+              >
+                {t("googleConnect.addAccountWithPlus")}
+              </button>
+            )}
           </div>
           <Button
             variant="ghost"

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -384,8 +384,15 @@ export function GoogleConnectBanner({
   }
 
   if (dismissed) return null;
-  if (!googleStatus.data && !canOfferOAuthSetup) return null;
-  if (!googleConfigured && !canOfferOAuthSetup && !hasAccounts) return null;
+  if (!googleStatus.data && !canOfferOAuthSetup && !googleStatus.isError)
+    return null;
+  if (
+    !googleConfigured &&
+    !canOfferOAuthSetup &&
+    !hasAccounts &&
+    !googleStatus.isError
+  )
+    return null;
 
   if (variant === "hero") {
     return (
@@ -399,7 +406,17 @@ export function GoogleConnectBanner({
         <p className="mt-2 max-w-xs text-[13px] text-muted-foreground leading-relaxed">
           {t("googleConnect.syncEventsDescription")}
         </p>
-        {(googleConfigured || canOfferOAuthSetup) && (
+        {googleStatus.isError ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-6 gap-2 px-4 h-8 text-[13px] font-medium"
+            onClick={() => void googleStatus.refetch()}
+            disabled={googleStatus.isFetching}
+          >
+            {t("common.retry")}
+          </Button>
+        ) : googleConfigured || canOfferOAuthSetup ? (
           <Button
             size="sm"
             className="mt-6 gap-2 px-4 h-8 text-[13px] font-medium"
@@ -417,7 +434,7 @@ export function GoogleConnectBanner({
                 ? t("googleConnect.addAccount")
                 : t("googleConnect.connectGoogle")}
           </Button>
-        )}
+        ) : null}
 
         <GoogleAuthIssuePanel
           issue={desktopAuthIssue}

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -537,6 +537,17 @@ export function GoogleConnectBanner({
           onDismiss={() => setDesktopAuthIssue(null)}
           className="mx-4 mb-3"
         />
+        {googleStatus.isError && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mx-4 mb-2"
+            onClick={() => void googleStatus.refetch()}
+            disabled={googleStatus.isFetching}
+          >
+            {t("common.retry")}
+          </Button>
+        )}
       </div>
     );
   }
@@ -560,7 +571,17 @@ export function GoogleConnectBanner({
         </div>
 
         <div className="flex items-center gap-1.5 shrink-0">
-          {showWizard && !allConfigured && canOfferOAuthSetup ? (
+          {googleStatus.isError ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5 text-xs h-7 font-medium"
+              onClick={() => void googleStatus.refetch()}
+              disabled={googleStatus.isFetching}
+            >
+              {t("common.retry")}
+            </Button>
+          ) : showWizard && !allConfigured && canOfferOAuthSetup ? (
             <Button
               size="sm"
               variant="outline"

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -442,13 +442,13 @@ export function AppLayout({ children }: AppLayoutProps) {
 
                   {/* Show the full-page Google prompt only on the calendar view. */}
                   {!googleStatus.isLoading &&
-                  !googleStatus.isError &&
                   !hasAccounts &&
                   !eventDraft &&
                   isCalendarPage &&
                   !isSettingsPage &&
                   (googleStatus.data?.configured === true ||
-                    canOfferGoogleOAuthSetup) ? (
+                    canOfferGoogleOAuthSetup ||
+                    googleStatus.isError) ? (
                     <main className="agent-native-app-main flex-1 overflow-y-auto">
                       <GoogleConnectBanner variant="hero" />
                     </main>

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -29,6 +29,7 @@ import { useHiddenCalendars } from "@/hooks/use-hidden-calendars";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useNavigationState } from "@/hooks/use-navigation-state";
 import { prefetchPeopleContacts } from "@/hooks/use-people";
+import { shouldOfferGoogleOAuthSetup } from "@/lib/google-oauth-setup";
 
 import { Sidebar } from "./Sidebar";
 
@@ -228,6 +229,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();
   const hasAccounts = (googleStatus.data?.accounts?.length ?? 0) > 0;
+  const canOfferGoogleOAuthSetup = useMemo(
+    () => shouldOfferGoogleOAuthSetup(),
+    [],
+  );
   const isSettingsPage =
     location.pathname === "/settings" ||
     location.pathname.startsWith("/settings/");
@@ -441,7 +446,9 @@ export function AppLayout({ children }: AppLayoutProps) {
                   !hasAccounts &&
                   !eventDraft &&
                   isCalendarPage &&
-                  !isSettingsPage ? (
+                  !isSettingsPage &&
+                  (googleStatus.data?.configured === true ||
+                    canOfferGoogleOAuthSetup) ? (
                     <main className="agent-native-app-main flex-1 overflow-y-auto">
                       <GoogleConnectBanner variant="hero" />
                     </main>

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -422,9 +422,11 @@ function ColorPickerPopover({
 
 function GoogleAccountsSection({
   accounts,
+  canAddAccount,
   onClose,
 }: {
   accounts: Array<{ email: string }>;
+  canAddAccount: boolean;
   onClose: () => void;
 }) {
   const t = useT();
@@ -507,19 +509,21 @@ function GoogleAccountsSection({
               {t("sidebar.googleCalendarSettings")}
             </TooltipContent>
           </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={handleAddAccount}
-                disabled={isGoogleDesktopAuthPending}
-                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-              >
-                <IconPlus className="h-3.5 w-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>{t("sidebar.addGoogleAccount")}</TooltipContent>
-          </Tooltip>
+          {canAddAccount && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleAddAccount}
+                  disabled={isGoogleDesktopAuthPending}
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                >
+                  <IconPlus className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{t("sidebar.addGoogleAccount")}</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       </div>
 
@@ -878,14 +882,17 @@ export function Sidebar({
               </nav>
 
               {/* Google status / connect CTA */}
-              {!googleStatus.isLoading && !isConnected && (
-                <GoogleConnectSidebarButton />
-              )}
+              {!googleStatus.isLoading &&
+                !isConnected &&
+                googleStatus.data?.configured === true && (
+                  <GoogleConnectSidebarButton />
+                )}
 
               {isConnected &&
                 (googleStatus.data?.accounts?.length ?? 0) > 0 && (
                   <GoogleAccountsSection
                     accounts={googleStatus.data!.accounts!}
+                    canAddAccount={googleStatus.data?.configured === true}
                     onClose={onClose}
                   />
                 )}

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -85,6 +85,7 @@ import {
   type CalendarColorMode,
 } from "@/lib/calendar-view-preferences";
 import { EVENT_CATEGORY_COLORS } from "@/lib/event-colors";
+import { shouldOfferGoogleOAuthSetup } from "@/lib/google-oauth-setup";
 import { cn } from "@/lib/utils";
 
 import { useCalendarContext } from "./AppLayout";
@@ -660,6 +661,10 @@ export function Sidebar({
   const removeExternal = useRemoveExternalCalendar();
   const updateExternalColor = useUpdateExternalCalendarColor();
   const isConnected = googleStatus.data?.connected ?? false;
+  const canOfferGoogleOAuthSetup = useMemo(
+    () => shouldOfferGoogleOAuthSetup(),
+    [],
+  );
   const [peopleGroupOpen, setPeopleGroupOpen] = useState(
     () => overlayPeople.length <= 2, // i18n-ignore scanner false positive
   );
@@ -884,15 +889,17 @@ export function Sidebar({
               {/* Google status / connect CTA */}
               {!googleStatus.isLoading &&
                 !isConnected &&
-                googleStatus.data?.configured === true && (
-                  <GoogleConnectSidebarButton />
-                )}
+                (googleStatus.data?.configured === true ||
+                  canOfferGoogleOAuthSetup) && <GoogleConnectSidebarButton />}
 
               {isConnected &&
                 (googleStatus.data?.accounts?.length ?? 0) > 0 && (
                   <GoogleAccountsSection
                     accounts={googleStatus.data!.accounts!}
-                    canAddAccount={googleStatus.data?.configured === true}
+                    canAddAccount={
+                      googleStatus.data?.configured === true ||
+                      canOfferGoogleOAuthSetup
+                    }
                     onClose={onClose}
                   />
                 )}

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -271,7 +271,8 @@ export default function Settings() {
           </SettingsGroup>
 
           {/* Google Calendar Connection */}
-          {(googleStatus.data?.connected ||
+          {(googleStatus.isError ||
+            googleStatus.data?.connected ||
             googleStatus.data?.configured === true ||
             canOfferGoogleOAuthSetup) && (
             <Card id="google-calendar" className="scroll-mt-16">
@@ -312,10 +313,19 @@ export default function Settings() {
                     )}
                   </div>
 
-                  {googleStatus.data?.connected &&
-                  googleStatus.data.accounts.some(
-                    (account) => !account.shared,
-                  ) ? (
+                  {googleStatus.isError ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void googleStatus.refetch()}
+                      disabled={googleStatus.isFetching}
+                    >
+                      {t("common.retry")}
+                    </Button>
+                  ) : googleStatus.data?.connected &&
+                    googleStatus.data.accounts.some(
+                      (account) => !account.shared,
+                    ) ? (
                     <Button
                       variant="outline"
                       size="sm"

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -271,70 +271,75 @@ export default function Settings() {
           </SettingsGroup>
 
           {/* Google Calendar Connection */}
-          <Card id="google-calendar" className="scroll-mt-16">
-            <CardHeader>
-              <CardTitle className="text-lg">
-                {t("settings.googleCalendar")}
-              </CardTitle>
-              <CardDescription>
-                {t("settings.googleDescription")}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  {googleStatus.data?.connected ? (
-                    <>
-                      <IconCircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                      <div>
-                        <p className="text-sm font-medium">
-                          {t("common.connected")}
-                        </p>
-                        {googleStatus.data.accounts?.length > 0 && (
-                          <p className="text-xs text-muted-foreground">
-                            {googleStatus.data.accounts
-                              .map((a) => a.email)
-                              .join(", ")}
+          {(googleStatus.data?.connected ||
+            googleStatus.data?.configured === true ||
+            canOfferGoogleOAuthSetup) && (
+            <Card id="google-calendar" className="scroll-mt-16">
+              <CardHeader>
+                <CardTitle className="text-lg">
+                  {t("settings.googleCalendar")}
+                </CardTitle>
+                <CardDescription>
+                  {t("settings.googleDescription")}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {googleStatus.data?.connected ? (
+                      <>
+                        <IconCircleCheck className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+                        <div>
+                          <p className="text-sm font-medium">
+                            {t("common.connected")}
                           </p>
-                        )}
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <IconCircleX className="h-5 w-5 text-muted-foreground" />
-                      <p className="text-sm text-muted-foreground">
-                        {t("common.notConnected")}
-                      </p>
-                    </>
-                  )}
-                </div>
+                          {googleStatus.data.accounts?.length > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                              {googleStatus.data.accounts
+                                .map((a) => a.email)
+                                .join(", ")}
+                            </p>
+                          )}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <IconCircleX className="h-5 w-5 text-muted-foreground" />
+                        <p className="text-sm text-muted-foreground">
+                          {t("common.notConnected")}
+                        </p>
+                      </>
+                    )}
+                  </div>
 
-                {googleStatus.data?.connected &&
-                googleStatus.data.accounts.some(
-                  (account) => !account.shared,
-                ) ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleDisconnect}
-                    disabled={disconnectGoogle.isPending}
-                  >
-                    <IconUnlink className="me-1.5 h-3.5 w-3.5" />
-                    {t("common.disconnect")}
-                  </Button>
-                ) : (
-                  <Button
-                    size="sm"
-                    onClick={handleConnect}
-                    disabled={isGoogleDesktopAuthPending}
-                  >
-                    <IconExternalLink className="me-1.5 h-3.5 w-3.5" />
-                    {t("common.connect")}
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+                  {googleStatus.data?.connected &&
+                  googleStatus.data.accounts.some(
+                    (account) => !account.shared,
+                  ) ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDisconnect}
+                      disabled={disconnectGoogle.isPending}
+                    >
+                      <IconUnlink className="me-1.5 h-3.5 w-3.5" />
+                      {t("common.disconnect")}
+                    </Button>
+                  ) : googleStatus.data?.configured === true ||
+                    canOfferGoogleOAuthSetup ? (
+                    <Button
+                      size="sm"
+                      onClick={handleConnect}
+                      disabled={isGoogleDesktopAuthPending}
+                    >
+                      <IconExternalLink className="me-1.5 h-3.5 w-3.5" />
+                      {t("common.connect")}
+                    </Button>
+                  ) : null}
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           <Card id="zoom" className="scroll-mt-16">
             <CardHeader>

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -5,6 +5,7 @@ import {
   isElectron,
   getAppUrl,
   GOOGLE_PRIMARY_PROVIDER_CREDENTIAL_KEYS,
+  hasWorkspaceProviderOAuthCredentials,
   resolveGoogleSignInCredentials,
   resolveGoogleProviderCredentialCandidatesWithReader,
   resolveOAuthRedirectUri,
@@ -687,7 +688,12 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {
     const session = await getSession(event);
-    return await getAuthStatus(session?.email, session?.orgId);
+    const status = await getAuthStatus(session?.email, session?.orgId);
+    const configured = await runWithRequestContext(
+      { userEmail: session?.email, orgId: session?.orgId },
+      () => hasWorkspaceProviderOAuthCredentials("google_calendar"),
+    );
+    return { ...status, configured };
   } catch (error: any) {
     setResponseStatus(event, 500);
     return { error: error.message };

--- a/templates/calendar/server/onboarding.ts
+++ b/templates/calendar/server/onboarding.ts
@@ -1,5 +1,6 @@
 import { listOAuthAccountsByOwner } from "@agent-native/core/oauth-tokens";
 import { registerOnboardingStep } from "@agent-native/core/onboarding";
+import { hasWorkspaceProviderOAuthCredentials } from "@agent-native/core/server";
 import { resolveWorkspaceConnectionForApp } from "@agent-native/core/workspace-connections";
 
 const CALENDAR_SCOPES = [
@@ -23,6 +24,7 @@ registerOnboardingStep({
   required: false,
   title: "Connect Google Calendar",
   description: "Manage events and availability with your Google account.",
+  isAvailable: () => hasWorkspaceProviderOAuthCredentials("google_calendar"),
   methods: [
     {
       id: "oauth",

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -315,6 +315,7 @@ export interface BookingLink {
 }
 
 export interface GoogleAuthStatus {
+  configured?: boolean;
   connected: boolean;
   accounts: Array<{
     email: string;

--- a/templates/dispatch/actions/list-workspace-connections.ts
+++ b/templates/dispatch/actions/list-workspace-connections.ts
@@ -9,6 +9,10 @@ import {
   listProviderApiCatalog,
 } from "@agent-native/core/provider-api";
 import {
+  hasWorkspaceProviderOAuthCredentials,
+  isGoogleWorkspaceOAuthProvider,
+} from "@agent-native/core/server";
+import {
   getWorkspaceConnectionAppAccess,
   listWorkspaceConnectionGrants,
   listWorkspaceConnections,
@@ -117,12 +121,18 @@ export default defineAction({
   }),
   http: { method: "GET" },
   run: async (args) => {
-    const providers = listWorkspaceConnectionProviders({
+    const catalogProviders = listWorkspaceConnectionProviders({
       capability: args.capability as WorkspaceConnectionCapability | undefined,
       templateUse: args.templateUse as
         | WorkspaceConnectionTemplateUse
         | undefined,
     });
+    const googleOAuthConfigured =
+      await hasWorkspaceProviderOAuthCredentials("gmail");
+    const providers = catalogProviders.filter(
+      (provider) =>
+        googleOAuthConfigured || !isGoogleWorkspaceOAuthProvider(provider.id),
+    );
     const connections = await listWorkspaceConnections({
       provider: args.provider,
       appId: args.appId,

--- a/templates/dispatch/actions/list-workspace-connections.ts
+++ b/templates/dispatch/actions/list-workspace-connections.ts
@@ -9,7 +9,6 @@ import {
   listProviderApiCatalog,
 } from "@agent-native/core/provider-api";
 import {
-  CredentialStoreUnavailableError,
   hasWorkspaceProviderOAuthCredentials,
   isGoogleWorkspaceOAuthProvider,
 } from "@agent-native/core/server";
@@ -51,7 +50,7 @@ type GrantSummary = {
   lastUsedAt?: string | null;
 };
 
-type GoogleOAuthAvailability = "configured" | "unconfigured" | "unavailable";
+type GoogleOAuthAvailability = "configured" | "unconfigured";
 
 function unique(values: string[]) {
   return Array.from(
@@ -130,17 +129,10 @@ export default defineAction({
         | WorkspaceConnectionTemplateUse
         | undefined,
     });
-    let googleOAuthAvailability: GoogleOAuthAvailability;
-    try {
-      googleOAuthAvailability = (await hasWorkspaceProviderOAuthCredentials(
-        "gmail",
-      ))
+    const googleOAuthAvailability: GoogleOAuthAvailability =
+      (await hasWorkspaceProviderOAuthCredentials("gmail"))
         ? "configured"
         : "unconfigured";
-    } catch (error) {
-      if (!(error instanceof CredentialStoreUnavailableError)) throw error;
-      googleOAuthAvailability = "unavailable";
-    }
     const googleOAuthConfigured = googleOAuthAvailability === "configured";
     const providers = catalogProviders.filter(
       (provider) =>
@@ -282,7 +274,7 @@ export default defineAction({
       availability: {
         googleOAuth: {
           status: googleOAuthAvailability,
-          retryable: googleOAuthAvailability === "unavailable",
+          retryable: false,
         },
       },
       providers: providersWithReadiness,

--- a/templates/dispatch/actions/list-workspace-connections.ts
+++ b/templates/dispatch/actions/list-workspace-connections.ts
@@ -9,6 +9,7 @@ import {
   listProviderApiCatalog,
 } from "@agent-native/core/provider-api";
 import {
+  CredentialStoreUnavailableError,
   hasWorkspaceProviderOAuthCredentials,
   isGoogleWorkspaceOAuthProvider,
 } from "@agent-native/core/server";
@@ -49,6 +50,8 @@ type GrantSummary = {
   access: "all-apps" | "selected-app" | "explicit-grant";
   lastUsedAt?: string | null;
 };
+
+type GoogleOAuthAvailability = "configured" | "unconfigured" | "unavailable";
 
 function unique(values: string[]) {
   return Array.from(
@@ -127,21 +130,41 @@ export default defineAction({
         | WorkspaceConnectionTemplateUse
         | undefined,
     });
-    const googleOAuthConfigured =
-      await hasWorkspaceProviderOAuthCredentials("gmail");
+    let googleOAuthAvailability: GoogleOAuthAvailability;
+    try {
+      googleOAuthAvailability = (await hasWorkspaceProviderOAuthCredentials(
+        "gmail",
+      ))
+        ? "configured"
+        : "unconfigured";
+    } catch (error) {
+      if (!(error instanceof CredentialStoreUnavailableError)) throw error;
+      googleOAuthAvailability = "unavailable";
+    }
+    const googleOAuthConfigured = googleOAuthAvailability === "configured";
     const providers = catalogProviders.filter(
       (provider) =>
         googleOAuthConfigured || !isGoogleWorkspaceOAuthProvider(provider.id),
     );
-    const connections = await listWorkspaceConnections({
+    const allConnections = await listWorkspaceConnections({
       provider: args.provider,
       appId: args.appId,
       includeDisabled: args.includeDisabled,
     });
-    const explicitGrants = await listWorkspaceConnectionGrants({
+    const connections = allConnections.filter(
+      (connection) =>
+        googleOAuthConfigured ||
+        !isGoogleWorkspaceOAuthProvider(connection.provider),
+    );
+    const allExplicitGrants = await listWorkspaceConnectionGrants({
       provider: args.provider,
       appId: args.appId,
     });
+    const explicitGrants = allExplicitGrants.filter(
+      (grant) =>
+        googleOAuthConfigured ||
+        !isGoogleWorkspaceOAuthProvider(grant.provider),
+    );
     const grantApps = await listGrantApps();
     const legacyGrants = connections.flatMap<GrantSummary>((connection) => {
       if (connection.allowedApps.length === 0) {
@@ -256,6 +279,12 @@ export default defineAction({
     });
 
     return {
+      availability: {
+        googleOAuth: {
+          status: googleOAuthAvailability,
+          retryable: googleOAuthAvailability === "unavailable",
+        },
+      },
       providers: providersWithReadiness,
       connections,
       grants,

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -136,6 +136,7 @@ export function GoogleConnectBanner({
 
   const accounts = googleStatus.data?.accounts ?? [];
   const hasAccounts = accounts.length > 0;
+  const googleConfigured = googleStatus.data?.configured === true;
   const canOfferOAuthSetup = useMemo(() => shouldOfferGoogleOAuthSetup(), []);
 
   const isBuilderFrame = useMemo(() => isInBuilderFrame(), []);
@@ -433,6 +434,7 @@ export function GoogleConnectBanner({
   }, [wantAddAccount, addAccountUrl.data, isBuilderFrame]);
 
   function handleConnect() {
+    if (!googleConfigured && !canOfferOAuthSetup) return;
     setDesktopAuthIssue(null);
     if (useDesktopAuth) {
       signInViaDesktopBrowser();
@@ -442,6 +444,7 @@ export function GoogleConnectBanner({
   }
 
   function handleAddAccount() {
+    if (!googleConfigured && !canOfferOAuthSetup) return;
     if (useDesktopAuth) {
       signInViaDesktopBrowser(true);
       return;
@@ -503,6 +506,8 @@ export function GoogleConnectBanner({
   }
 
   if (dismissed) return null;
+  if (!googleStatus.data && !canOfferOAuthSetup) return null;
+  if (!googleConfigured && !canOfferOAuthSetup && !hasAccounts) return null;
 
   // Full-page hero for setup / reconnection
   if (variant === "hero") {
@@ -517,22 +522,24 @@ export function GoogleConnectBanner({
         <p className="mt-2 max-w-sm text-sm text-muted-foreground leading-relaxed">
           {t("mail.googleConnect.heroDescription")}
         </p>
-        <Button
-          size="sm"
-          className="mt-8 gap-2 px-5 h-9 text-sm font-medium bg-white text-black hover:bg-white/90"
-          onClick={() => {
-            setAuthError(null);
-            handleConnect();
-          }}
-          disabled={authUrl.isLoading || authUrl.isFetching}
-        >
-          <GoogleIcon className="h-4 w-4" />
-          {authUrl.isLoading
-            ? t("mail.accounts.connecting")
-            : allConfigured
-              ? t("mail.accounts.signInWithGoogle")
-              : t("mail.accounts.connectGoogle")}
-        </Button>
+        {(googleConfigured || canOfferOAuthSetup) && (
+          <Button
+            size="sm"
+            className="mt-8 gap-2 px-5 h-9 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90"
+            onClick={() => {
+              setAuthError(null);
+              handleConnect();
+            }}
+            disabled={authUrl.isLoading || authUrl.isFetching}
+          >
+            <GoogleIcon className="h-4 w-4" />
+            {authUrl.isLoading
+              ? t("mail.accounts.connecting")
+              : allConfigured
+                ? t("mail.accounts.signInWithGoogle")
+                : t("mail.accounts.connectGoogle")}
+          </Button>
+        )}
 
         <GoogleAuthIssuePanel
           issue={desktopAuthIssue}
@@ -735,13 +742,15 @@ export function GoogleConnectBanner({
                 )}
               </div>
             ))}
-            <button
-              onClick={handleAddAccount}
-              disabled={addAccountUrl.isLoading || addAccountUrl.isFetching}
-              className="text-xs text-foreground/40 hover:text-foreground/60 transition-colors whitespace-nowrap"
-            >
-              + {t("mail.accounts.addAccount")}
-            </button>
+            {(googleConfigured || canOfferOAuthSetup) && (
+              <button
+                onClick={handleAddAccount}
+                disabled={addAccountUrl.isLoading || addAccountUrl.isFetching}
+                className="text-xs text-foreground/40 hover:text-foreground/60 transition-colors whitespace-nowrap"
+              >
+                + {t("mail.accounts.addAccount")}
+              </button>
+            )}
           </div>
           <Button
             variant="ghost"

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -506,8 +506,15 @@ export function GoogleConnectBanner({
   }
 
   if (dismissed) return null;
-  if (!googleStatus.data && !canOfferOAuthSetup) return null;
-  if (!googleConfigured && !canOfferOAuthSetup && !hasAccounts) return null;
+  if (!googleStatus.data && !canOfferOAuthSetup && !googleStatus.isError)
+    return null;
+  if (
+    !googleConfigured &&
+    !canOfferOAuthSetup &&
+    !hasAccounts &&
+    !googleStatus.isError
+  )
+    return null;
 
   // Full-page hero for setup / reconnection
   if (variant === "hero") {
@@ -522,7 +529,17 @@ export function GoogleConnectBanner({
         <p className="mt-2 max-w-sm text-sm text-muted-foreground leading-relaxed">
           {t("mail.googleConnect.heroDescription")}
         </p>
-        {(googleConfigured || canOfferOAuthSetup) && (
+        {googleStatus.isError ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-8 gap-2 px-5 h-9 text-sm font-medium"
+            onClick={() => void googleStatus.refetch()}
+            disabled={googleStatus.isFetching}
+          >
+            {t("mail.error.tryAgain")}
+          </Button>
+        ) : googleConfigured || canOfferOAuthSetup ? (
           <Button
             size="sm"
             className="mt-8 gap-2 px-5 h-9 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90"
@@ -539,7 +556,7 @@ export function GoogleConnectBanner({
                 ? t("mail.accounts.signInWithGoogle")
                 : t("mail.accounts.connectGoogle")}
           </Button>
-        )}
+        ) : null}
 
         <GoogleAuthIssuePanel
           issue={desktopAuthIssue}
@@ -767,6 +784,17 @@ export function GoogleConnectBanner({
           onDismiss={() => setDesktopAuthIssue(null)}
           className="mx-4 mb-3"
         />
+        {googleStatus.isError && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mx-4 mb-2"
+            onClick={() => void googleStatus.refetch()}
+            disabled={googleStatus.isFetching}
+          >
+            {t("mail.error.tryAgain")}
+          </Button>
+        )}
       </div>
     );
   }
@@ -788,7 +816,17 @@ export function GoogleConnectBanner({
         </div>
 
         <div className="flex items-center gap-1.5 shrink-0">
-          {showWizard && !allConfigured && canOfferOAuthSetup ? (
+          {googleStatus.isError ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5 text-xs h-7 font-medium"
+              onClick={() => void googleStatus.refetch()}
+              disabled={googleStatus.isFetching}
+            >
+              {t("mail.error.tryAgain")}
+            </Button>
+          ) : showWizard && !allConfigured && canOfferOAuthSetup ? (
             <Button
               size="sm"
               variant="outline"

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -83,6 +83,7 @@ import {
 } from "@/hooks/use-keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { runUndo } from "@/hooks/use-undo";
+import { shouldOfferGoogleOAuthSetup } from "@/lib/google-oauth-setup";
 import {
   OTHER_INBOX_TAB_ID,
   OTHER_INBOX_TAB_PARAM,
@@ -329,6 +330,11 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   const googleStatus = useGoogleAuthStatus();
   const accounts = googleStatus.data?.accounts ?? [];
   const hasAccounts = accounts.length > 0;
+  const googleConfigured = googleStatus.data?.configured === true;
+  const canOfferGoogleOAuthSetup = useMemo(
+    () => shouldOfferGoogleOAuthSetup(),
+    [],
+  );
   const googleStatusReady = !googleStatus.isLoading && !googleStatus.isError;
   const [accountPopoverOpen, setAccountPopoverOpen] = useState(false);
   // Account filter: which accounts' emails to show. Empty set = all accounts.
@@ -1495,6 +1501,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
               >
                 <AccountPopover
                   accounts={accounts}
+                  canAddAccount={googleConfigured || canOfferGoogleOAuthSetup}
                   activeAccounts={activeAccounts}
                   onToggleAccount={(email) => {
                     setActiveAccounts((prev) => {
@@ -1906,7 +1913,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           !hasAccounts &&
           !hasLocalMailboxData &&
           view !== "settings" &&
-          view !== "draft-queue" ? (
+          view !== "draft-queue" &&
+          (googleConfigured || canOfferGoogleOAuthSetup) ? (
             <GoogleConnectBanner variant="hero" />
           ) : (
             <main className="agent-native-app-main flex flex-1 overflow-hidden">
@@ -2562,6 +2570,7 @@ function TabSettingsPopover({
 
 function AccountPopover({
   accounts,
+  canAddAccount,
   activeAccounts,
   onToggleAccount,
   onRemoveAccount,
@@ -2572,6 +2581,7 @@ function AccountPopover({
     photoUrl?: string;
     shared?: boolean;
   }>;
+  canAddAccount: boolean;
   activeAccounts: Set<string>;
   onToggleAccount: (email: string) => void;
   onRemoveAccount: (email: string) => void;
@@ -2690,25 +2700,27 @@ function AccountPopover({
         })}
       </div>
 
-      <div className="border-t border-border/30 px-3 py-2">
-        <button
-          onClick={() => {
-            const returnPath = `${window.location.pathname}${window.location.search}`;
-            startWorkspaceProviderOAuth("gmail", {
-              appId: "mail",
-              returnPath,
-              scope: "user",
-            });
-          }}
-          disabled={authUrl.isLoading || authUrl.isFetching}
-          className="flex items-center gap-2 w-full text-[13px] text-muted-foreground hover:text-foreground transition-colors py-1"
-        >
-          <IconPlus className="h-3.5 w-3.5" />
-          {authUrl.isFetching
-            ? t("mail.accounts.connecting")
-            : t("mail.accounts.addAccount")}
-        </button>
-      </div>
+      {canAddAccount ? (
+        <div className="border-t border-border/30 px-3 py-2">
+          <button
+            onClick={() => {
+              const returnPath = `${window.location.pathname}${window.location.search}`;
+              startWorkspaceProviderOAuth("gmail", {
+                appId: "mail",
+                returnPath,
+                scope: "user",
+              });
+            }}
+            disabled={authUrl.isLoading || authUrl.isFetching}
+            className="flex items-center gap-2 w-full text-[13px] text-muted-foreground hover:text-foreground transition-colors py-1"
+          >
+            <IconPlus className="h-3.5 w-3.5" />
+            {authUrl.isFetching
+              ? t("mail.accounts.connecting")
+              : t("mail.accounts.addAccount")}
+          </button>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1914,7 +1914,9 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           !hasLocalMailboxData &&
           view !== "settings" &&
           view !== "draft-queue" &&
-          (googleConfigured || canOfferGoogleOAuthSetup) ? (
+          (googleConfigured ||
+            canOfferGoogleOAuthSetup ||
+            googleStatus.isError) ? (
             <GoogleConnectBanner variant="hero" />
           ) : (
             <main className="agent-native-app-main flex flex-1 overflow-hidden">

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1914,9 +1914,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           !hasLocalMailboxData &&
           view !== "settings" &&
           view !== "draft-queue" &&
-          (googleConfigured ||
-            canOfferGoogleOAuthSetup ||
-            googleStatus.isError) ? (
+          (googleConfigured || canOfferGoogleOAuthSetup) ? (
             <GoogleConnectBanner variant="hero" />
           ) : (
             <main className="agent-native-app-main flex flex-1 overflow-hidden">

--- a/templates/mail/app/hooks/use-google-auth.ts
+++ b/templates/mail/app/hooks/use-google-auth.ts
@@ -12,6 +12,7 @@ export interface GoogleAuthAccount {
 }
 
 export interface GoogleAuthStatus {
+  configured?: boolean;
   connected: boolean;
   accounts: GoogleAuthAccount[];
 }

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -7,6 +7,7 @@ import {
   getSession,
   isElectron,
   getAppUrl,
+  hasWorkspaceProviderOAuthCredentials,
   resolveOAuthRedirectUri,
   encodeOAuthState,
   decodeOAuthState,
@@ -21,6 +22,7 @@ import {
   safeReturnPath,
   setDesktopExchange,
   setDesktopExchangeError,
+  runWithRequestContext,
 } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import {
@@ -490,7 +492,12 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {
     const session = await getSession(event);
-    return await getAuthStatus(session?.email);
+    const status = await getAuthStatus(session?.email);
+    const configured = await runWithRequestContext(
+      { userEmail: session?.email, orgId: session?.orgId },
+      () => hasWorkspaceProviderOAuthCredentials("gmail"),
+    );
+    return { ...status, configured };
   } catch (error: any) {
     setResponseStatus(event, 500);
     return { error: error.message };

--- a/templates/mail/server/onboarding.ts
+++ b/templates/mail/server/onboarding.ts
@@ -10,6 +10,7 @@
 
 import { listOAuthAccountsByOwner } from "@agent-native/core/oauth-tokens";
 import { registerOnboardingStep } from "@agent-native/core/onboarding";
+import { hasWorkspaceProviderOAuthCredentials } from "@agent-native/core/server";
 import { resolveWorkspaceConnectionForApp } from "@agent-native/core/workspace-connections";
 
 const GMAIL_SCOPES = [
@@ -35,6 +36,7 @@ registerOnboardingStep({
   required: false,
   title: "Connect Gmail",
   description: "Send, read, and organize real email.",
+  isAvailable: () => hasWorkspaceProviderOAuthCredentials("gmail"),
   methods: [
     {
       id: "oauth",


### PR DESCRIPTION
## Summary
- hide managed Google Gmail, Calendar, Drive, Docs, Sheets, and Slides connections until the shared OAuth client pair resolves
- hide Mail and Calendar onboarding/connect surfaces when Google OAuth is unavailable
- preserve the explicit localhost/dev setup wizard as an opt-in fallback

## Validation
- core focused tests and build
- Mail and Calendar focused tests and typechecks
- Dispatch typecheck
- all 63 repository guards
- git diff --check

No production promotion is included.