### PR TITLE
fix: unblock docs production deploys — plain index builds + drop INVALID indexes

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+Build the `LOWER(...)` expression indexes without `CONCURRENTLY`.
+
+The release schema step runs over the pooled Neon endpoint, and a
+transaction-pooled connection cannot carry `CREATE INDEX CONCURRENTLY` to
+completion. The statement returned without creating the index, the verifying
+probe then failed the whole release, and every docs production deploy was
+blocked. Plain `CREATE INDEX` is the form that actually lands here.

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -10,7 +10,6 @@ import { createGetDb } from "../db/create-get-db.js";
 import {
   ensureColumnExists,
   ensureIndexExists,
-  ensureIndexExistsConcurrently,
   ensureTableExists,
 } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
@@ -157,18 +156,20 @@ async function ensureTable(): Promise<void> {
         // serve that predicate — without the expression index the list falls
         // back to scanning every row in the (shared, multi-tenant) table.
         //
-        // Built CONCURRENTLY: these land on tables that already hold every
-        // tenant's threads, and a plain `CREATE INDEX` holds a SHARE lock for
-        // the whole build, queueing chat writes behind it. That is why they are
-        // not in the migration list — `runMigrations` wraps statements in a
-        // transaction, and Postgres forbids CONCURRENTLY inside one.
-        await ensureIndexExistsConcurrently(
+        // NOT built CONCURRENTLY, despite the SHARE lock. This ensure path runs
+        // at release over the pooled Neon endpoint, and a transaction-pooled
+        // connection cannot carry `CREATE INDEX CONCURRENTLY` to completion:
+        // the statement returned without creating anything and the verifying
+        // probe failed the whole release, so no docs production deploy could
+        // publish. Release already runs locking DDL; a plain build here is the
+        // form that actually lands.
+        await ensureIndexExists(
           "chat_threads_owner_lower_updated_idx",
-          `CREATE INDEX CONCURRENTLY IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
+          `CREATE INDEX IF NOT EXISTS chat_threads_owner_lower_updated_idx ON chat_threads (LOWER(owner_email), updated_at)`,
         );
-        await ensureIndexExistsConcurrently(
+        await ensureIndexExists(
           "chat_thread_shares_principal_lower_idx",
-          `CREATE INDEX CONCURRENTLY IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
+          `CREATE INDEX IF NOT EXISTS chat_thread_shares_principal_lower_idx ON chat_thread_shares (resource_id, principal_type, LOWER(principal_id))`,
         );
         await ensureIndexExists(
           "chat_threads_scope_updated_idx",

--- a/packages/core/src/db/ddl-guard.spec.ts
+++ b/packages/core/src/db/ddl-guard.spec.ts
@@ -694,4 +694,90 @@ describe("ddl-guard", () => {
     );
     expect(calls).not.toContain("BEGIN");
   });
+
+  it("drops an INVALID index before rebuilding it", async () => {
+    // A failed CREATE INDEX CONCURRENTLY leaves the index present but unusable.
+    // `pgIndexExists` reports it missing (it requires indisvalid), yet
+    // `CREATE INDEX IF NOT EXISTS` skips because the NAME is taken — so without
+    // the drop, every later repair re-probes, still fails, and the release can
+    // never recover. This happened in production and blocked docs deploys.
+    vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+    const { ensureIndexExists } = await import("./ddl-guard.js");
+    const calls: string[] = [];
+    let dropped = false;
+    let created = false;
+    const client = {
+      execute: async (sql: string | { sql: string; args?: unknown[] }) => {
+        const text = typeof sql === "string" ? sql : sql.sql;
+        calls.push(text);
+        if (/NOT index_state\.indisvalid/.test(text)) {
+          return { rows: dropped ? [] : [{ "?column?": 1 }], rowsAffected: 0 };
+        }
+        if (/^DROP INDEX/.test(text)) {
+          dropped = true;
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (/FROM information_schema\.columns/.test(text)) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (/CREATE INDEX/.test(text)) {
+          created = true;
+          return { rows: [], rowsAffected: 0 };
+        }
+        // Reports present only once a real CREATE has run. The invalid index
+        // never satisfies this probe, which is the whole point.
+        if (/FROM pg_indexes/.test(text)) {
+          return { rows: created ? [{ indexname: "t_idx" }] : [] };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ execute: client.execute }),
+    } as any;
+
+    await ensureIndexExists(
+      "t_idx",
+      "CREATE INDEX IF NOT EXISTS t_idx ON t (a)",
+      {
+        injectedClient: client,
+        dialectIsPostgres: true,
+      },
+    );
+
+    const dropAt = calls.findIndex((sql) => /^DROP INDEX/.test(sql));
+    const createAt = calls.findIndex((sql) => /CREATE INDEX/.test(sql));
+    expect(dropAt).toBeGreaterThanOrEqual(0);
+    // Order matters: creating first is exactly the no-op that stranded prod.
+    expect(dropAt).toBeLessThan(createAt);
+  });
+
+  it("does not drop an index that is valid", async () => {
+    vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+    const { ensureIndexExists } = await import("./ddl-guard.js");
+    const calls: string[] = [];
+    const client = {
+      execute: async (sql: string | { sql: string; args?: unknown[] }) => {
+        const text = typeof sql === "string" ? sql : sql.sql;
+        calls.push(text);
+        // No invalid row, and the index already probes as present and valid.
+        if (/NOT index_state\.indisvalid/.test(text)) return { rows: [] };
+        if (/FROM pg_indexes/.test(text))
+          return { rows: [{ indexname: "t_idx" }] };
+        return { rows: [], rowsAffected: 0 };
+      },
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ execute: client.execute }),
+    } as any;
+
+    await ensureIndexExists(
+      "t_idx",
+      "CREATE INDEX IF NOT EXISTS t_idx ON t (a)",
+      {
+        injectedClient: client,
+        dialectIsPostgres: true,
+      },
+    );
+
+    expect(calls.some((sql) => /^DROP INDEX/.test(sql))).toBe(false);
+  });
 });

--- a/packages/core/src/db/ddl-guard.spec.ts
+++ b/packages/core/src/db/ddl-guard.spec.ts
@@ -751,6 +751,62 @@ describe("ddl-guard", () => {
     expect(dropAt).toBeLessThan(createAt);
   });
 
+  it("drops an INVALID index in the concurrent path too", async () => {
+    // The concurrent helper is what leaves an index invalid, so it must be able
+    // to clear one. Without this it is the only caller that cannot recover from
+    // its own failure mode — `sync_events_created_at_id_idx` in production.
+    vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
+    const { ensureIndexExistsConcurrently } = await import("./ddl-guard.js");
+    const concurrentCalls: string[] = [];
+    let concurrentDropped = false;
+    let concurrentCreated = false;
+    const concurrentClient = {
+      execute: async (sql: string | { sql: string; args?: unknown[] }) => {
+        const text = typeof sql === "string" ? sql : sql.sql;
+        concurrentCalls.push(text);
+        if (/NOT index_state\.indisvalid/.test(text)) {
+          return {
+            rows: concurrentDropped ? [] : [{ "?column?": 1 }],
+            rowsAffected: 0,
+          };
+        }
+        if (/^DROP INDEX/.test(text)) {
+          concurrentDropped = true;
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (/CREATE INDEX CONCURRENTLY/.test(text)) {
+          concurrentCreated = true;
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (/FROM information_schema\.columns/.test(text)) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (/FROM pg_indexes/.test(text)) {
+          return { rows: concurrentCreated ? [{ indexname: "sync_idx" }] : [] };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+      transaction: async () => {
+        throw new Error("concurrent index creation must not use a transaction");
+      },
+    } as any;
+
+    await expect(
+      ensureIndexExistsConcurrently(
+        "sync_idx",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS sync_idx ON t (a)",
+        { injectedClient: concurrentClient, dialectIsPostgres: true },
+      ),
+    ).resolves.toBe(true);
+
+    const cDropAt = concurrentCalls.findIndex((sql) => /^DROP INDEX/.test(sql));
+    const cCreateAt = concurrentCalls.findIndex((sql) =>
+      /CREATE INDEX CONCURRENTLY/.test(sql),
+    );
+    expect(cDropAt).toBeGreaterThanOrEqual(0);
+    expect(cDropAt).toBeLessThan(cCreateAt);
+  });
+
   it("does not drop an index that is valid", async () => {
     vi.stubEnv("DATABASE_URL", "postgres://u:p@h:5432/db");
     const { ensureIndexExists } = await import("./ddl-guard.js");

--- a/packages/core/src/db/ddl-guard.ts
+++ b/packages/core/src/db/ddl-guard.ts
@@ -488,6 +488,46 @@ export async function ensureColumnExists(
  * Convenience wrapper: ensure an INDEX exists (probe via `pgIndexExists`).
  * `createIndexSql` should be the full `CREATE INDEX IF NOT EXISTS <name> …`.
  */
+/**
+ * Drop an index that exists under this name but is INVALID.
+ *
+ * A failed `CREATE INDEX CONCURRENTLY` leaves the index present but unusable
+ * (`indisvalid = false`). That is a trap for every repair attempt that follows:
+ * `pgIndexExists` correctly reports it missing, but `CREATE INDEX IF NOT
+ * EXISTS` sees the NAME is taken and skips, so the re-probe fails again and the
+ * release never recovers on its own. Found in production on
+ * `chat_threads_owner_lower_updated_idx` and `sync_events_created_at_id_idx`.
+ *
+ * Dropping is safe: an invalid index serves no query and cannot be repaired in
+ * place — Postgres' own guidance is to drop and rebuild it.
+ */
+async function dropInvalidIndex(
+  indexName: string,
+  client: DbExec,
+): Promise<void> {
+  if (!PLAIN_IDENTIFIER.test(indexName)) return;
+  const { rows } = await client.execute({
+    sql: `SELECT 1
+          FROM pg_class AS index_class
+          JOIN pg_namespace AS index_namespace
+            ON index_namespace.oid = index_class.relnamespace
+           AND index_namespace.nspname = 'public'
+          JOIN pg_index AS index_state
+            ON index_state.indexrelid = index_class.oid
+          WHERE index_class.relname = ?
+            AND NOT index_state.indisvalid
+          LIMIT 1`,
+    args: [indexName],
+  });
+  if (rows.length === 0) return;
+  console.warn(
+    `[db] dropping INVALID index "${indexName}" so it can be rebuilt; ` +
+      `a previous CREATE INDEX left it unusable.`,
+  );
+  await client.execute(`DROP INDEX IF EXISTS "${indexName}"`);
+  invalidateSchemaSnapshot(client);
+}
+
 export async function ensureIndexExists(
   indexName: string,
   createIndexSql: string,
@@ -497,6 +537,9 @@ export async function ensureIndexExists(
     dialectIsPostgres?: boolean;
   } = {},
 ): Promise<boolean> {
+  if ((options.dialectIsPostgres ?? isPostgres()) && !schemaEnsureDisabled()) {
+    await dropInvalidIndex(indexName, options.injectedClient ?? getDbExec());
+  }
   return ensureSchemaObject({
     probe: () =>
       pgIndexExists(

--- a/packages/core/src/db/ddl-guard.ts
+++ b/packages/core/src/db/ddl-guard.ts
@@ -586,6 +586,14 @@ export async function ensureIndexExistsConcurrently(
     );
   }
 
+  // This helper is what STRANDS an invalid index in the first place: an
+  // interrupted concurrent build leaves the name taken and the index unusable,
+  // and `CREATE INDEX CONCURRENTLY IF NOT EXISTS` then skips it forever. Clear
+  // it here too, or the one caller that creates the mess is the one caller that
+  // cannot recover from it — which is how `sync_events_created_at_id_idx` has
+  // stayed invalid in production.
+  await dropInvalidIndex(indexName, client);
+
   await client.execute(createIndexSql);
   invalidateSchemaSnapshot(client);
   const existsAfterCreate = await pgIndexExists(

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -11,7 +11,6 @@ import { getDbExec, intType, isPostgres } from "../db/client.js";
 import {
   ensureColumnExists,
   ensureIndexExists,
-  ensureIndexExistsConcurrently,
   ensureTableExists,
 } from "../db/ddl-guard.js";
 import { widenIntColumnsToBigInt } from "../db/widen-columns.js";
@@ -295,12 +294,14 @@ export async function ensureUsageTable(): Promise<void> {
         // serve a function-wrapped predicate: without this expression index the
         // usage panel scans the whole table, which is the highest-row-count one
         // in the system (a row per LLM call, every app and org).
-        // Built CONCURRENTLY: `token_usage` is the highest-row-count table in
-        // the system, so a SHARE-locking build would queue every usage write
-        // for its duration.
-        await ensureIndexExistsConcurrently(
+        // NOT built CONCURRENTLY. This runs at release over the pooled Neon
+        // endpoint, and a transaction-pooled connection cannot carry
+        // `CREATE INDEX CONCURRENTLY` to completion — it returns without
+        // creating the index, which then fails the verifying probe and blocks
+        // the whole release. The SHARE lock is the cost of a build that lands.
+        await ensureIndexExists(
           "idx_token_usage_lower_owner_created",
-          `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
+          `CREATE INDEX IF NOT EXISTS idx_token_usage_lower_owner_created ON token_usage (LOWER(owner_email), created_at)`,
         );
         return;
       }


### PR DESCRIPTION
**This unblocks www.agent-native.com, which currently cannot publish.** My change in #3404 broke it. Two commits: revert the cause, then repair the state it left behind.

## 1. `CONCURRENTLY` can't work on this path

Review feedback on #3404 correctly noted a plain `CREATE INDEX` holds a SHARE lock, so I moved the three `LOWER(...)` expression indexes to `ensureIndexExistsConcurrently`. That was wrong here:

```
Release schema step failed while creating ChatThreads:
ensureIndexExistsConcurrently: index "chat_threads_owner_lower_updated_idx"
is still missing after CREATE INDEX CONCURRENTLY
```

The release schema step connects over the **pooled** Neon endpoint — independently confirmed, since the live site's `urlHash` matches sha256 of the pooled connection string byte-for-byte. A transaction-pooled connection can't carry `CREATE INDEX CONCURRENTLY` to completion; the statement returns having created nothing, the verifying probe throws, and `migrate:production` exits non-zero.

**The verification behaved exactly as intended.** Without that re-probe the release would have gone green with the index silently absent, and #3404's `LOWER()` scan fix would have been inert in production with nothing to show it.

## 2. A plain revert would NOT have fixed production

I checked the actual database rather than assuming the revert was sufficient:

```
INVALID indexes: chat_threads_owner_lower_updated_idx  (chat_threads)
                 sync_events_created_at_id_idx         (sync_events)
chat_threads_owner_lower_updated_idx → { valid: false, ready: true }
```

The failed `CONCURRENTLY` left the index **present but INVALID**. That's a trap for every subsequent repair: `pgIndexExists` requires `indisvalid` so it reports missing, `CREATE INDEX IF NOT EXISTS` sees the *name* is taken and skips, and the re-probe fails again. Reverting alone would have swapped one release failure for another.

So `ensureIndexExists` now drops an index that exists but is invalid before creating it. Dropping is safe and is Postgres' own guidance — an invalid index serves no query and can't be repaired in place.

**`sync_events_created_at_id_idx` is invalid too**, from the pre-existing `ensureIndexExistsConcurrently` call in `poll.ts`. So this failure mode predates my change and has been silently leaving an unusable index on that table; the same fix heals it on the next release.

## Verification

- Invalid-index state confirmed by querying `pg_index` on the docs production database directly.
- Two new tests: the drop must precede the create (creating first is exactly the no-op that stranded production), and a valid index must never be dropped.
- `pnpm typecheck` clean; **2,256 tests** across `db/` and `server/` pass; all **63 guards** pass.

## Follow-up, not in this PR

Making `CONCURRENTLY` genuinely work would mean routing that DDL through the direct (unpooled) endpoint `getMigrationDatabaseUrl()` already opens for migrations. Worth doing — but not while production can't deploy, and `poll.ts` should move with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)