### PR TITLE
fix: run scheduled beta E2E with shared key

### DIFF
--- a/.github/workflows/beta-e2e-scheduled.yml
+++ b/.github/workflows/beta-e2e-scheduled.yml
@@ -24,7 +24,7 @@ jobs:
       apps: all
       lane: public+authed
       grep: ""
-      key_source: dedicated
+      key_source: shared
     secrets: inherit
     permissions:
       contents: read


### PR DESCRIPTION
Use the existing repository OPENAI_API_KEY for the scheduled authenticated beta E2E lane.

This keeps the scheduled workflow from requiring the absent dedicated key while preserving the explicit shared-key opt-in in the reusable workflow. Session credentials remain separate GitHub secrets.