### PR TITLE
perf(deploy): keep several containers warm, not one

### DIFF
--- a/.changeset/warm-moons-smile.md
+++ b/.changeset/warm-moons-smile.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": patch
+---
+
+Keep-warm now holds several containers open instead of one.
+
+A single sequential health request warms exactly one container. Measured on
+www.agent-native.com, roughly half of requests still reported `cold` with
+keep-warm running every minute, because each cold render occupies its container
+for ~4s and anything arriving meanwhile lands on a new one. The scheduled
+function now issues its warm requests concurrently — overlap is what makes the
+platform hold more than one open. Defaults to 3, configurable through
+`AGENT_NATIVE_KEEP_WARM_CONCURRENCY` and capped at 10.

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -2370,6 +2370,99 @@ describe("durable-background Netlify function emit (single-template, default-on)
     expect(entry).not.toMatch(/^\s*path:/m);
   });
 
+  it("warms several containers CONCURRENTLY, not one after another", async () => {
+    // Executing the emitted module, not just grepping its text: this is
+    // generated code, and one sequential request is exactly the bug — it holds
+    // a single container while a cold render occupies it for seconds, so the
+    // next visitor still cold-starts. Overlap is the whole mechanism.
+    process.env.AGENT_NATIVE_ENABLE_KEEP_WARM = "1";
+    process.env.AGENT_NATIVE_KEEP_WARM_CONCURRENCY = "3";
+    const cwd = setupNetlifyOutput();
+    emitSingleTemplateNetlifyKeepWarmFunction(cwd);
+    const entryPath = path.join(keepWarmDir(cwd), "agent-native-keep-warm.mjs");
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let healthCalls = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: any) => {
+      const url = String(input);
+      if (!url.includes("/_agent-native/health")) {
+        return new Response(null, { status: 200 });
+      }
+      healthCalls++;
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight--;
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const mod = await import(
+        `${pathToFileURL(entryPath).href}?t=${Date.now()}`
+      );
+      const response = await mod.default(
+        new Request(
+          "https://example.test/.netlify/functions/agent-native-keep-warm",
+        ),
+      );
+      expect(response.status).toBe(204);
+      expect(healthCalls).toBe(3);
+      // The assertion that matters: they overlapped.
+      expect(maxInFlight).toBe(3);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.AGENT_NATIVE_KEEP_WARM_CONCURRENCY;
+    }
+  });
+
+  it("fails loudly when every warm request fails, and reports a partial warm", async () => {
+    process.env.AGENT_NATIVE_ENABLE_KEEP_WARM = "1";
+    process.env.AGENT_NATIVE_KEEP_WARM_CONCURRENCY = "2";
+    const cwd = setupNetlifyOutput();
+    emitSingleTemplateNetlifyKeepWarmFunction(cwd);
+    const entryPath = path.join(keepWarmDir(cwd), "agent-native-keep-warm.mjs");
+
+    const originalFetch = globalThis.fetch;
+    let mode: "all-fail" | "partial" = "all-fail";
+    let health = 0;
+    globalThis.fetch = (async (input: any) => {
+      const url = String(input);
+      if (!url.includes("/_agent-native/health")) {
+        return new Response(null, { status: 200 });
+      }
+      health++;
+      if (mode === "all-fail") return new Response("nope", { status: 500 });
+      return health === 1
+        ? new Response("nope", { status: 500 })
+        : new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const mod = await import(
+        `${pathToFileURL(entryPath).href}?t=${Date.now()}`
+      );
+      const req = () =>
+        new Request(
+          "https://example.test/.netlify/functions/agent-native-keep-warm",
+        );
+      // Zero warmed is a failure and must not read as success.
+      await expect(mod.default(req())).rejects.toThrow(
+        /All 2 warm requests failed/,
+      );
+
+      // One warmed is a real but reduced success — distinguishable from both.
+      mode = "partial";
+      health = 0;
+      const partial = await mod.default(req());
+      expect(partial.status).toBe(207);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.AGENT_NATIVE_KEEP_WARM_CONCURRENCY;
+    }
+  });
+
   it("emits a durable recurring-job handoff beside the background worker", () => {
     const cwd = setupNetlifyOutput();
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -3306,6 +3306,12 @@ export default async function handler(request) {
   console.log(
     "[agent-native-keep-warm] Warmed " + warmed + "/" + WARM_CONCURRENCY + " containers via " + url.toString(),
   );
+  // 207 is deliberately a SUCCESS to the scheduler, not a retry signal. The
+  // next run is 60s away, so retrying a warm buys nothing, and failing the
+  // invocation because one probe of three flaked would alert on a
+  // reduced-but-real success every time the platform hiccups. The ratio is
+  // logged and every failure is warned, so a persistently degraded warm stays
+  // visible without paging. Zero warmed still throws.
   return new Response(null, { status: warmed === WARM_CONCURRENCY ? 204 : 207 });
 }
 

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -3092,6 +3092,42 @@ export function isKeepWarmDeployEnabled(): boolean {
   );
 }
 
+/** Default number of containers the scheduled warm tries to hold open. */
+const DEFAULT_KEEP_WARM_CONCURRENCY = 3;
+const MAX_KEEP_WARM_CONCURRENCY = 10;
+
+/**
+ * How many warm requests the scheduled function issues CONCURRENTLY.
+ *
+ * One sequential request holds exactly one container, which is why a warmed
+ * site can still serve cold responses: measured on www.agent-native.com, roughly
+ * half of probe requests reported `cold` even with keep-warm running every
+ * minute. Each cold render there occupies its container for ~4s, so any request
+ * arriving during one lands on a new, cold container.
+ *
+ * Concurrency is what holds more than one open — sequential requests reuse the
+ * same container and warm nothing extra. Kept small by default: this multiplies
+ * scheduled invocations and health-probe DB round trips by the same factor.
+ */
+export function resolveKeepWarmConcurrency(): number {
+  const raw = process.env.AGENT_NATIVE_KEEP_WARM_CONCURRENCY?.trim();
+  if (!raw) return DEFAULT_KEEP_WARM_CONCURRENCY;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `AGENT_NATIVE_KEEP_WARM_CONCURRENCY must be a positive integer; got "${raw}".`,
+    );
+  }
+  if (parsed > MAX_KEEP_WARM_CONCURRENCY) {
+    throw new Error(
+      `AGENT_NATIVE_KEEP_WARM_CONCURRENCY is capped at ${MAX_KEEP_WARM_CONCURRENCY}; got ${parsed}. ` +
+        `Holding more containers than that open on a schedule is provisioned ` +
+        `concurrency wearing a cron, and should be a deliberate platform choice.`,
+    );
+  }
+  return parsed;
+}
+
 /**
  * The background warm is a separate, much more expensive knob than the server
  * warm and gets its own switch. Warming `server` is one health request; warming
@@ -3197,9 +3233,11 @@ export function emitSingleTemplateNetlifyKeepWarmFunction(
     fs.existsSync(backgroundEntryPath)
       ? JSON.stringify(AGENT_BACKGROUND_FUNCTION_URL_PATH)
       : "null";
+  const warmConcurrency = resolveKeepWarmConcurrency();
   const entry = `const HEALTH_PATH = "/_agent-native/health";
 const BACKGROUND_WARM_PATH = ${backgroundWarmPath};
 const REQUEST_TIMEOUT_MS = 25_000;
+const WARM_CONCURRENCY = ${warmConcurrency};
 
 function siteOrigin(request) {
   return new URL(request.url).origin;
@@ -3230,30 +3268,45 @@ export default async function handler(request) {
   const origin = siteOrigin(request);
   const backgroundWarm = warmBackgroundFunction(origin);
   const url = new URL(HEALTH_PATH, origin);
-  let response;
-  try {
-    response = await fetch(url, {
-      headers: { "user-agent": "agent-native-netlify-keep-warm" },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-  } catch (error) {
-    console.error("[agent-native-keep-warm] Health request failed:", url.toString(), error);
-    throw error;
-  }
 
-  if (!response.ok) {
-    const body = await response.text();
+  // Issued together on purpose. Sequential requests reuse one container and
+  // warm nothing extra; only overlapping ones make the platform hold several
+  // open, which is what stops a cache miss from landing on a cold start.
+  const results = await Promise.allSettled(
+    Array.from({ length: WARM_CONCURRENCY }, async () => {
+      const response = await fetch(url, {
+        headers: { "user-agent": "agent-native-netlify-keep-warm" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          "health request failed with " + response.status + ": " + body.slice(0, 300),
+        );
+      }
+      return true;
+    }),
+  );
+
+  const warmed = results.filter((r) => r.status === "fulfilled").length;
+  for (const result of results) {
+    if (result.status === "rejected") {
+      console.warn("[agent-native-keep-warm] One warm request failed:", result.reason);
+    }
+  }
+  // A partial warm is a real, reduced success and must not read as a clean run;
+  // zero is a failure and must not read as a partial one.
+  if (warmed === 0) {
     throw new Error(
-      "[agent-native-keep-warm] Health request failed with " +
-        response.status +
-        ": " +
-        body.slice(0, 500),
+      "[agent-native-keep-warm] All " + WARM_CONCURRENCY + " warm requests failed for " + url.toString(),
     );
   }
 
   await backgroundWarm;
-  console.log("[agent-native-keep-warm] Warmed", url.toString());
-  return new Response(null, { status: 204 });
+  console.log(
+    "[agent-native-keep-warm] Warmed " + warmed + "/" + WARM_CONCURRENCY + " containers via " + url.toString(),
+  );
+  return new Response(null, { status: warmed === WARM_CONCURRENCY ? 204 : 207 });
 }
 
 export const config = {
@@ -3271,6 +3324,7 @@ export const config = {
   console.log(
     `[build] Emitted Netlify scheduled keep-warm function ` +
       `"${NETLIFY_KEEP_WARM_FUNCTION_NAME}" (schedule "${keepWarmSchedule}", ` +
+      `concurrency ${warmConcurrency}, ` +
       `background warm ${backgroundWarmPath === "null" ? "off" : "on"}).`,
   );
 }


### PR DESCRIPTION
Directly targets the remaining half of the original report: `www.agent-native.com/<unknown-path>` taking seconds.

## Why keep-warm wasn't working

It was enabled and running every minute — I checked the deploy log, the function is emitted with `schedule: "* * * * *"`. It still didn't help, because **one sequential request holds exactly one container**.

Measured today across 8 probes of production: roughly half reported `cold`, including `/_agent-native/ping`, which does no DB work and still took 2.8–3.0s. Each cold render occupies its container for ~4s, so any request arriving during one lands on a new, cold container. Every low-traffic beta host cold-started once and then stayed warm; production flapped.

Sequential requests reuse the same container and warm nothing extra. **Overlap is the entire mechanism.**

## The change

The scheduled function now issues its warm requests concurrently. Default 3, configurable via `AGENT_NATIVE_KEEP_WARM_CONCURRENCY`, capped at 10 — beyond that you are buying provisioned concurrency through a cron and should decide that deliberately rather than by raising a number.

Partial outcomes stay distinguishable, per the repo's no-silent-coercion rule:

| warmed | result |
| --- | --- |
| all | 204 |
| some | 207, logs the ratio and each failure |
| none | throws |

A partial warm must not read as a clean run, and zero must not read as partial.

## Verification

Two tests **execute the emitted module** rather than asserting on its text. That matters here: this is generated code, and "one request at a time" is precisely the defect — a text assertion like `toContain("await fetch(url")` passes either way.

- **Concurrency**: stubs `fetch`, tracks in-flight count, asserts `maxInFlight === 3`. Sequential emission fails this.
- **Failure semantics**: all-fail throws with the count; partial returns 207.

All 145 `build.spec.ts` tests pass, 202 across `src/deploy/`, all 64 guards pass.

## Scope note

This changes behaviour for **every** app with keep-warm enabled: 3 scheduled invocations per minute instead of 1, and 3 health-probe DB round trips instead of 1. That is the intended trade and it's why the default is 3 rather than something larger.

I can't prove the production effect until this deploys — the measurement I'd want is the cold-hit rate across a probe series before and after. I'll run exactly that once it lands rather than assert the improvement now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)