### PR TITLE
fix: promote beta E2E sessions through auth route

### DIFF
--- a/.github/workflows/beta-e2e-scheduled.yml
+++ b/.github/workflows/beta-e2e-scheduled.yml
@@ -24,7 +24,7 @@ jobs:
       apps: all
       lane: public+authed
       grep: ""
-      key_source: dedicated
+      key_source: shared
     secrets: inherit
     permissions:
       contents: read

--- a/e2e/beta/lib/session.ts
+++ b/e2e/beta/lib/session.ts
@@ -216,7 +216,7 @@ export async function bootstrapAppSession(
         });
         const promoted = await page.evaluate(async (sessionToken: string) => {
           const response = await fetch(
-            `/sign-in?_session=${encodeURIComponent(sessionToken)}`,
+            `/_agent-native/auth/session?_session=${encodeURIComponent(sessionToken)}`,
             { redirect: "manual", credentials: "include" },
           );
           return response.status;


### PR DESCRIPTION
The authenticated beta E2E bootstrap exchanged replay tokens through the public /sign-in page. That path is intentionally cacheable and does not run session promotion for every auth plugin, so custom-auth hosts rejected otherwise-valid tokens in CI.

Use the framework auth session handler for the exchange, which executes query-session promotion consistently across the fleet.

Checks: typecheck:e2e, guard:beta-e2e-suite, local token exchange probe.