### PR TITLE
fix: preserve beta auth secrets in prebuilt Plan builds

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -245,14 +245,16 @@ jobs:
             export AGENT_NATIVE_DISABLE_KEEP_WARM_BACKGROUND=1
             export AGENT_NATIVE_HOSTED_HARNESS=true
           fi
-          if [[ "$SOURCE_TEMPLATE" == "clips" ]]; then
-            # Netlify's local CLI receives masked site secrets. Clips only needs
-            # valid build-time shapes here; the uploaded Functions read the real
-            # site-scoped values at runtime.
+          if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
+            # Netlify's local CLI receives masked site secrets. These templates
+            # only need valid build-time shapes; uploaded Functions read the
+            # real site-scoped values at runtime.
             export agentNativePrebuiltBuild=true
-            export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
             agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
             export agentNativePrebuiltAuthSecret
+          fi
+          if [[ "$SOURCE_TEMPLATE" == "clips" ]]; then
+            export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
           netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"
 

--- a/templates/plan/netlify.toml
+++ b/templates/plan/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs plan"
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter plan migrate:production; fi"
+command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter plan migrate:production; fi"
 publish = "templates/plan/dist"
 functions = "templates/plan/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary\n- provide a strong build-time placeholder when Netlify masks the Plan auth secret\n- keep the real site-scoped secret for deployed runtime functions\n\n## Verification\n- corepack pnpm exec tsx scripts/guard-netlify-release-migrations.ts\n- git diff --check\n\nFollow-up to the beta E2E fixes for #3312.