### PR TITLE
fix: avoid loading resource blobs during metadata lists

### DIFF
--- a/.changeset/quiet-resource-lists.md
+++ b/.changeset/quiet-resource-lists.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Avoid loading full workspace resource content during metadata list reads.

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -245,14 +245,16 @@ jobs:
             export AGENT_NATIVE_DISABLE_KEEP_WARM_BACKGROUND=1
             export AGENT_NATIVE_HOSTED_HARNESS=true
           fi
-          if [[ "$SOURCE_TEMPLATE" == "clips" ]]; then
-            # Netlify's local CLI receives masked site secrets. Clips only needs
-            # valid build-time shapes here; the uploaded Functions read the real
-            # site-scoped values at runtime.
+          if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
+            # Netlify's local CLI receives masked site secrets. These templates
+            # only need valid build-time shapes; uploaded Functions read the
+            # real site-scoped values at runtime.
             export agentNativePrebuiltBuild=true
-            export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
             agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
             export agentNativePrebuiltAuthSecret
+          fi
+          if [[ "$SOURCE_TEMPLATE" == "clips" ]]; then
+            export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
           netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"
 

--- a/packages/core/src/resources/store.effective-context.spec.ts
+++ b/packages/core/src/resources/store.effective-context.spec.ts
@@ -153,6 +153,8 @@ describe("resourceEffectiveContext", () => {
         updated_at INTEGER NOT NULL
       );
     `);
+    const skillContent =
+      "---\nname: analytics-review\ndescription: Review analytics work\n---\n\n# Analytics Review \u{1F4CA}";
     sqlite
       .prepare("DELETE FROM workspace_resource_grants WHERE id = ?")
       .run("grant_skill_analytics");
@@ -175,7 +177,7 @@ describe("resourceEffectiveContext", () => {
         "Analytics Review",
         "Review analytics work",
         skillPath,
-        "---\nname: analytics-review\ndescription: Review analytics work\n---\n\n# Analytics Review",
+        skillContent,
         "selected",
         "owner@example.test",
         1,
@@ -213,6 +215,7 @@ describe("resourceEffectiveContext", () => {
       owner: WORKSPACE_OWNER,
       path: skillPath,
       mimeType: "text/markdown",
+      size: Buffer.byteLength(skillContent, "utf8"),
     });
 
     await expect(

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -530,15 +530,19 @@ function physicalWorkspaceResourceId(id: string): string | null {
 }
 
 function rowToGrantedWorkspaceResource(row: any): Resource {
+  const contentLoaded = Object.prototype.hasOwnProperty.call(row, "content");
   const content = String(row.content ?? "");
   const path = String(row.path ?? "");
+  const size = contentLoaded
+    ? Buffer.byteLength(content, "utf8")
+    : Number(row.content_size ?? 0);
   return {
     id: syntheticWorkspaceResourceId(String(row.id)),
     path,
     owner: WORKSPACE_OWNER,
     content,
     mimeType: workspaceResourceMimeType(path),
-    size: Buffer.byteLength(content, "utf8"),
+    size: Number.isFinite(size) ? size : 0,
     createdAt: Number(row.created_at ?? Date.now()),
     updatedAt: Number(row.updated_at ?? Date.now()),
     createdBy: "system",
@@ -687,14 +691,17 @@ function mergeResourceMetas(
   return merged;
 }
 
-async function selectGrantedWorkspaceResourceRows(input: {
-  resourceId?: string;
-  path?: string;
-  pathPrefix?: string;
-  workspaceAppId?: string | null;
-  userEmail?: string | null;
-  orgId?: string | null;
-}): Promise<any[]> {
+async function selectGrantedWorkspaceResourceRows(
+  input: {
+    resourceId?: string;
+    path?: string;
+    pathPrefix?: string;
+    workspaceAppId?: string | null;
+    userEmail?: string | null;
+    orgId?: string | null;
+  },
+  options: { includeContent?: boolean } = {},
+): Promise<any[]> {
   const appId = currentWorkspaceAppId(input.workspaceAppId);
   const { userEmail, orgId } = requestScopedResourceIdentity(input);
   if (!appId || (!userEmail && !orgId)) return [];
@@ -728,6 +735,10 @@ async function selectGrantedWorkspaceResourceRows(input: {
     args.push(userEmail, userEmail);
   }
 
+  const contentSelect =
+    options.includeContent === false
+      ? `${isPostgres() ? "octet_length" : "length"}(wr.content) AS content_size`
+      : "wr.content";
   const client = getDbExec();
   const { rows } = await client.execute({
     sql: `
@@ -737,7 +748,7 @@ async function selectGrantedWorkspaceResourceRows(input: {
         wr.name,
         wr.description,
         wr.path,
-        wr.content,
+        ${contentSelect},
         wr.created_at,
         wr.updated_at,
         wg.id AS grant_id,
@@ -759,7 +770,9 @@ async function grantedWorkspaceResources(input: {
   orgId?: string | null;
 }): Promise<Resource[]> {
   try {
-    const rows = await selectGrantedWorkspaceResourceRows(input);
+    const rows = await selectGrantedWorkspaceResourceRows(input, {
+      includeContent: false,
+    });
     return rows.map(rowToGrantedWorkspaceResource);
   } catch {
     // Dispatch workspace-resource tables are optional for standalone apps.

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -737,7 +737,7 @@ async function selectGrantedWorkspaceResourceRows(
 
   const contentSelect =
     options.includeContent === false
-      ? `${isPostgres() ? "octet_length" : "length"}(wr.content) AS content_size`
+      ? `${isPostgres() ? "octet_length(wr.content)" : "length(CAST(wr.content AS BLOB))"} AS content_size`
       : "wr.content";
   const client = getDbExec();
   const { rows } = await client.execute({

--- a/templates/plan/netlify.toml
+++ b/templates/plan/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs plan"
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter plan migrate:production; fi"
+command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if { [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; } && [ \"${agentNativePrebuiltBuild:-}\" != \"true\" ]; then pnpm --filter plan migrate:production; fi"
 publish = "templates/plan/dist"
 functions = "templates/plan/.netlify/functions-internal"
 

--- a/templates/plan/netlify.toml
+++ b/templates/plan/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs plan"
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter plan migrate:production; fi"
+command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter plan build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter plan migrate:production; fi"
 publish = "templates/plan/dist"
 functions = "templates/plan/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- avoid loading full workspace resource content for metadata list reads
- preserve content and byte sizes for direct resource reads
- add a core patch changeset

This keeps the shared Supabase pooler from being held by large workspace-resource list responses during beta E2E traffic.

## Verification
- `corepack pnpm --filter @agent-native/core exec vitest --run src/resources/store.effective-context.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`
