### PR TITLE
fix: resolve the lazy db proxy before building view-screen's meetings subquery

### DIFF
--- a/.changeset/lazy-db-unresolved-chain-guard.md
+++ b/.changeset/lazy-db-unresolved-chain-guard.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore the loud failure when an unresolved `getDb()` query chain is embedded as a raw value instead of being awaited. drizzle duck-types SQL entities by reading `getSQL`/`shouldOmitSQLParens` synchronously, so the lazy cold-start proxy answering that probe with another proxy produced `RangeError: Maximum call stack size exceeded` deep inside drizzle instead of naming the misuse. The guard was lost as collateral in a wholesale revert of `packages/core/src/db`.

--- a/packages/core/src/db/create-get-db.spec.ts
+++ b/packages/core/src/db/create-get-db.spec.ts
@@ -330,3 +330,79 @@ describe("isSqlRead", () => {
     expect(isSqlRead("DELETE FROM sessions WHERE id=$1")).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// createGetDb — lazy proxy returned before `_dbReady` resolves
+//
+// drizzle-orm duck-types "is this an SQL entity" via
+// `typeof value.getSQL === "function"` (isSQLWrapper, sql/sql.js), reading
+// the property synchronously — it never awaits first. If a caller embeds an
+// un-awaited chain from the lazy proxy as a raw value (e.g. a subquery
+// passed straight into `notInArray(col, subqueryChain)` instead of awaiting
+// it), the proxy must not answer that probe with something that looks like
+// a resolved SQL entity: doing so lets drizzle call `.getSQL()` on it, which
+// again duck-types as a wrapper, forever — the exact `RangeError: Maximum
+// call stack size exceeded` seen in production.
+// ---------------------------------------------------------------------------
+describe("createGetDb — lazy proxy before init resolves", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  // Returns the `getDb` factory (never the proxy it produces): the proxy's
+  // `then` trap forwards to `_dbReady`, so returning or awaiting the proxy
+  // itself here — rather than calling it synchronously in the test body —
+  // would make the test await the same promise this suite deliberately
+  // leaves pending, and hang.
+  async function getLazyDbFactory(): Promise<() => any> {
+    vi.doMock("./client.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./client.js")>();
+      return {
+        ...actual,
+        getDialect: vi.fn(() => "sqlite" as const),
+        getCloudflareD1Binding: vi.fn(() => undefined),
+        // Route init through the pglite branch and never resolve it, so
+        // `getDb()` is guaranteed to return the lazy proxy, not the real db.
+        isPgliteUrl: vi.fn(() => true),
+        loadPgliteDrizzle: vi.fn(() => new Promise(() => {})),
+      };
+    });
+    const { createGetDb } = await import("./create-get-db.js");
+    return createGetDb({});
+  }
+
+  it("fails loudly instead of masquerading as a resolved SQL entity when probed via getSQL/shouldOmitSQLParens", async () => {
+    const getDb = await getLazyDbFactory();
+    const db = getDb();
+
+    // Mirrors templates/clips/actions/list-recordings.ts embedding an
+    // un-awaited subquery chain as a raw value.
+    const subqueryChain = db.select({ id: "recordingId" }).from("meetings");
+
+    for (const prop of ["getSQL", "shouldOmitSQLParens"] as const) {
+      expect(() => subqueryChain[prop]).toThrow(/unresolved|await/i);
+    }
+  });
+
+  it("does not recurse forever when duck-typed the way SQL.buildQueryFromSourceParams does", async () => {
+    const getDb = await getLazyDbFactory();
+    const db = getDb();
+    const subqueryChain = db.select({ id: "recordingId" }).from("meetings");
+
+    // Same shape as drizzle-orm's isSQLWrapper() + SQL.buildQueryFromSourceParams:
+    // while the value duck-types as an SQL wrapper, keep unwrapping it via getSQL().
+    function isSQLWrapper(value: any): boolean {
+      return (
+        value !== null &&
+        value !== undefined &&
+        typeof value.getSQL === "function"
+      );
+    }
+    function drainAsSql(value: any): any {
+      if (isSQLWrapper(value)) return drainAsSql(value.getSQL());
+      return value;
+    }
+
+    expect(() => drainAsSql(subqueryChain)).toThrow(/unresolved|await/i);
+  });
+});

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -628,6 +628,26 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
           });
           return (promise as any)[prop].bind(promise);
         }
+        // drizzle-orm duck-types "is this an SQL entity" by reading these two
+        // properties directly off a value — synchronously, without awaiting
+        // (see `isSQLWrapper` in drizzle-orm/sql/sql.js). Because this proxy's
+        // target is a function, answering that probe with another proxy would
+        // make an un-awaited chain (e.g. a subquery chain embedded as a raw
+        // value instead of being awaited — the pattern that broke
+        // list-recordings.ts) masquerade as a resolved SQL entity. drizzle
+        // then calls `.getSQL()` on it, which duck-types as a wrapper again,
+        // forever — `RangeError: Maximum call stack size exceeded` deep
+        // inside drizzle internals instead of a message pointing at the
+        // actual bug. Fail loudly here instead, at the point of misuse.
+        if (prop === "getSQL" || prop === "shouldOmitSQLParens") {
+          throw new Error(
+            "getDb(): accessed an unresolved query chain synchronously " +
+              `(reading '${String(prop)}'). This chain was embedded as a raw ` +
+              "value instead of being awaited first — e.g. a subquery passed " +
+              "straight into another expression. Await the chain before " +
+              "using its result.",
+          );
+        }
         // Symbol.toStringTag, Symbol.iterator, etc. — return another proxy
         // Property access (e.g. db.query) — record and return another proxy
         return createLazyProxy(ready, [...chain, { prop }]);

--- a/templates/clips/actions/view-screen.test.ts
+++ b/templates/clips/actions/view-screen.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// fetchLibrary() runs the recordings query, the meetings subquery, and the
+// folders query off the same mock db, so from() tells them apart by a column
+// only that table has. Hoisted so the vi.mock factories below (which vitest
+// lifts above the imports) can read them.
+const TABLES = vi.hoisted(() => ({
+  recordings: {
+    id: "recordings.id",
+    ownerEmail: "recordings.ownerEmail",
+    organizationId: "recordings.organizationId",
+    archivedAt: "recordings.archivedAt",
+    trashedAt: "recordings.trashedAt",
+    folderId: "recordings.folderId",
+    updatedAt: "recordings.updatedAt",
+  },
+  meetings: { recordingId: "meetings.recordingId" },
+  folders: {
+    ownerEmail: "folders.ownerEmail",
+    spaceId: "folders.spaceId",
+    position: "folders.position",
+  },
+}));
+
+const mockRecordingsWhere = vi.hoisted(() =>
+  vi.fn((condition: unknown) => ({
+    orderBy: () => ({ limit: async () => [] }),
+    __condition: condition,
+  })),
+);
+const mockMeetingsWhere = vi.hoisted(() =>
+  vi.fn((condition: unknown) => ({
+    // A drizzle query-builder chain, deliberately never awaited: notInArray()
+    // compiles it to `NOT IN (SELECT ...)`. `resolvedDb` marks which db
+    // instance it was built off.
+    kind: "meetings-subquery",
+    condition,
+    resolvedDb: true,
+  })),
+);
+
+/**
+ * The real drizzle instance the lazy proxy resolves to. Chains replayed
+ * through the proxy land here, and so does anything built off `await db`.
+ */
+const makeRealDb = vi.hoisted(() => () => ({
+  select: (_projection?: unknown) => ({
+    from: (table: any) => {
+      if (table && "recordingId" in table) return { where: mockMeetingsWhere };
+      if (table && "position" in table) {
+        return { where: () => ({ orderBy: async () => [] }) };
+      }
+      return { where: mockRecordingsWhere };
+    },
+  }),
+}));
+
+/**
+ * Mirrors createLazyProxy() in packages/core/src/db/create-get-db.ts: on a
+ * cold-start request getDb() hands back a proxy that records the chain and
+ * replays it once the driver finishes loading. Awaiting it with no chain
+ * yields the real instance. Reading `getSQL`/`shouldOmitSQLParens` — which is
+ * what drizzle does synchronously to duck-type an SQL entity — throws, because
+ * an unresolved chain cannot answer that probe correctly.
+ */
+const makeLazyProxy = vi.hoisted(
+  () =>
+    function makeLazyProxy(
+      realDb: any,
+      chain: Array<{ prop: string | symbol; args?: any[] }> = [],
+    ): any {
+      return new Proxy(function () {} as any, {
+        get(_target, prop) {
+          if (prop === "then" || prop === "catch" || prop === "finally") {
+            const promise = Promise.resolve().then(() => {
+              let result: any = realDb;
+              for (const step of chain) {
+                const val = result[step.prop];
+                result =
+                  typeof val === "function"
+                    ? val.apply(result, step.args)
+                    : val;
+              }
+              return result;
+            });
+            return (promise as any)[prop].bind(promise);
+          }
+          if (prop === "getSQL" || prop === "shouldOmitSQLParens") {
+            throw new Error(
+              "getDb(): accessed an unresolved query chain synchronously " +
+                `(reading '${String(prop)}'). This chain was embedded as a raw ` +
+                "value instead of being awaited first.",
+            );
+          }
+          return makeLazyProxy(realDb, [...chain, { prop }]);
+        },
+        apply(_target, _thisArg, args) {
+          if (chain.length === 0) return makeLazyProxy(realDb, []);
+          const last = chain[chain.length - 1];
+          return makeLazyProxy(realDb, [
+            ...chain.slice(0, -1),
+            { prop: last.prop, args },
+          ]);
+        },
+      });
+    },
+);
+
+const mockNotInArray = vi.hoisted(() =>
+  vi.fn((column: unknown, values: unknown) => {
+    // drizzle-orm's isSQLWrapper() reads `.getSQL` off the value synchronously,
+    // without awaiting (drizzle-orm/sql/sql.js). Reproduce that probe so an
+    // unresolved chain fails here exactly as it does in production.
+    const probed =
+      values !== null && values !== undefined
+        ? typeof (values as any).getSQL
+        : "undefined";
+    return { kind: "not-in-array", column, values, probed };
+  }),
+);
+
+vi.mock("@agent-native/core", () => ({
+  defineAction: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: async () => null,
+  readAppStateForCurrentTab: async (key: string) =>
+    key === "navigation" ? { view: "library" } : null,
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: () => "viewer@example.com",
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  accessFilter: () => ({ kind: "access-filter" }),
+  resolveAccess: async () => null,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ kind: "and", conditions }),
+  asc: (column: unknown) => ({ kind: "asc", column }),
+  desc: (column: unknown) => ({ kind: "desc", column }),
+  eq: (column: unknown, value: unknown) => ({ kind: "eq", column, value }),
+  gte: vi.fn(),
+  isNotNull: (column: unknown) => ({ kind: "is-not-null", column }),
+  isNull: (column: unknown) => ({ kind: "is-null", column }),
+  lte: vi.fn(),
+  not: (value: unknown) => ({ kind: "not", value }),
+  notInArray: (column: unknown, values: unknown) =>
+    mockNotInArray(column, values),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  // Always the cold-start proxy — the state every first request after a
+  // serverless cold boot sees.
+  getDb: () => makeLazyProxy(makeRealDb()),
+  schema: {
+    meetings: TABLES.meetings,
+    folders: TABLES.folders,
+    recordings: TABLES.recordings,
+    recordingShares: "recordingShares",
+    recordingViewers: "recordingViewers",
+  },
+}));
+
+vi.mock("../server/lib/agent-recording-access.js", () => ({
+  agentRecordingAccessFilter: () => ({ kind: "agent-access-filter" }),
+}));
+
+vi.mock("../server/lib/recordings.js", () => ({
+  getActiveOrganizationId: async () => "org_123",
+  ownerEmailMatches: (column: unknown, email: string) => ({
+    kind: "owner-email",
+    column,
+    email,
+  }),
+  parseSpaceIds: vi.fn(),
+}));
+
+vi.mock("../shared/browser-diagnostics.js", () => ({
+  parseBrowserDiagnosticsRow: () => null,
+}));
+
+vi.mock("./lib/transcript-preview.js", () => ({
+  buildTranscriptPreview: () => null,
+}));
+
+import action from "./view-screen";
+
+describe("view-screen library view on a cold start", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds the meeting-exclusion subquery off a resolved db, not the lazy proxy", async () => {
+    // Regression: fetchLibrary() used to build the meetings subquery straight
+    // off the `db` returned by getDb() and hand that still-unresolved chain to
+    // notInArray(). On a cold-start request getDb() returns the lazy proxy, and
+    // drizzle probes the embedded value with `.getSQL()` synchronously — which
+    // the proxy cannot answer. Awaiting `db` first resolves it to the real
+    // instance, so the chain handed to notInArray() is always a real one.
+    await expect(action.run({})).resolves.toBeTypeOf("string");
+
+    expect(mockNotInArray).toHaveBeenCalledTimes(1);
+    const [column, values] = mockNotInArray.mock.calls[0]!;
+    expect(column).toBe("recordings.id");
+    // "undefined" means the drizzle duck-type probe read the property without
+    // throwing; a lazy proxy throws on that read instead.
+    expect((mockNotInArray.mock.results[0]!.value as any).probed).toBe(
+      "undefined",
+    );
+    expect((values as any).resolvedDb).toBe(true);
+  });
+
+  it("excludes meeting recordings database-side rather than materializing ids", async () => {
+    // The other direction: an earlier revision awaited the meeting rows into a
+    // plain string[] and bound every id as a query parameter. That grows with
+    // the whole meetings table and can hit SQLite variable / Postgres parameter
+    // limits, so the value must stay a query-builder chain.
+    await action.run({});
+
+    const [, values] = mockNotInArray.mock.calls[0]!;
+    expect(Array.isArray(values)).toBe(false);
+    expect((values as any).kind).toBe("meetings-subquery");
+    // NULL recordingIds are filtered in SQL, so NOT IN can't collapse to empty.
+    expect((values as any).condition).toEqual({
+      kind: "is-not-null",
+      column: TABLES.meetings.recordingId,
+    });
+  });
+
+  it("keeps the meeting exclusion in the recordings where-clause", async () => {
+    await action.run({});
+
+    expect(mockRecordingsWhere).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "and",
+        conditions: expect.arrayContaining([
+          mockNotInArray.mock.results[0]!.value,
+        ]),
+      }),
+    );
+  });
+});

--- a/templates/clips/actions/view-screen.ts
+++ b/templates/clips/actions/view-screen.ts
@@ -210,7 +210,14 @@ async function fetchLibrary({
       conditions.push(eq(schema.recordings.organizationId, organizationId));
     }
   }
-  const meetingRecordingIds = db
+  // Meeting recordings are transcript-only and live on /meetings, so keep them
+  // out of clip library views. `await db` with no chain resolves the lazy proxy
+  // from create-get-db.ts to the real instance without issuing a query; the
+  // subquery must be built off *that*. Building it off `db` hands an unresolved
+  // chain to notInArray(), which reads `.getSQL()` synchronously on a cold-start
+  // proxy. The subquery filters NULLs so NOT IN doesn't collapse to empty.
+  const resolvedDb = await db;
+  const meetingRecordingIds = resolvedDb
     .select({ id: schema.meetings.recordingId })
     .from(schema.meetings)
     .where(isNotNull(schema.meetings.recordingId));

--- a/templates/clips/changelog/2026-08-23-the-agent-can-see-your-library-right-after-server-start.md
+++ b/templates/clips/changelog/2026-08-23-the-agent-can-see-your-library-right-after-server-start.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-23
+---
+
+Asking the agent what is in your library or shared clips no longer fails on the first request right after the app starts.


### PR DESCRIPTION
## What

`templates/clips/actions/view-screen.ts` had the same cold-start defect that was fixed in `list-recordings.ts`: the meetings subquery was built off the `db` returned by `getDb()` and handed to `notInArray()` still unresolved.

On a cold-start request `getDb()` returns the lazy proxy from `create-get-db.ts`, and drizzle duck-types the embedded value by reading `.getSQL()` synchronously. The proxy cannot answer that, so the agent's `view-screen` failed on the `library` and `shared` views for the first request after a cold boot.

The fix matches `list-recordings.ts`: resolve the proxy with `await db` first, then build the subquery off the real instance. The exclusion stays database-side as `NOT IN (SELECT ...)` — an earlier revision materialized every meeting id into a `string[]` and bound them as parameters, which grows with the whole meetings table and can hit SQLite variable / Postgres parameter limits.

## Also restores a core guard that was lost

`packages/core/src/db/create-get-db.ts` used to throw a named error when an unresolved chain was probed via `getSQL`/`shouldOmitSQLParens`. That guard was collateral damage in `8638b61067`, which reverted `packages/core/src/db` wholesale to back out unrelated SQLite connection-sharing work.

Without it the same class of bug surfaces as `RangeError: Maximum call stack size exceeded` deep inside drizzle instead of naming the misuse — and `list-recordings.test.ts` on `main` already cites the guard as if it exists. Restored verbatim, along with its two tests.

## Boundary sweep

Scanned `templates/`, `packages/`, and `apps/` for query-builder chains embedded as raw values in `inArray`/`notInArray`. Exactly two sites exist; `list-recordings.ts` was already fixed, so `view-screen.ts` was the last one.

## Verification

- New `templates/clips/actions/view-screen.test.ts` reproduces the cold start with a proxy mirroring `createLazyProxy`, and mocks `notInArray` to run drizzle's real `isSQLWrapper` probe. All 3 tests fail against the pre-fix source with the exact production error at `view-screen.ts:217`, and pass after.
- Restored core guard tests fail without the guard (`Maximum call stack size exceeded`) and pass with it.
- `templates/clips` full suite: 242 files, 1422 tests passing.
- `packages/core/src/db`: 12 files, 207 tests passing.
- `pnpm guards`: all 64 checks passed.
- `agent-native typecheck` in `templates/clips`: exit 0.
- Full `packages/core` suite: 11 files / 83 tests fail both with and without this change. Baseline without the guard is 12 files / 85 tests; the only delta is the 2 restored guard tests. The 83 are pre-existing and unrelated (client render, e2e, deploy specs).

Note: a real cold-boot run through the CLI could not reproduce the original failure locally — migrations resolve the DB before the action runs, so `getDb()` never returns the proxy on that path. It did confirm the fixed path returns the library snapshot end-to-end. The unresolved-proxy state is specific to a serverless cold start where the first request races async init, which is why the unit reproduction mirrors `createLazyProxy` directly.

Source-tested and built only; this claims no beta or production deployment.
