### PR TITLE
Various clips fixes

### DIFF
--- a/templates/clips/actions/list-recordings.ts
+++ b/templates/clips/actions/list-recordings.ts
@@ -210,6 +210,9 @@ export default defineAction({
     // Lifecycle view filters
     if (args.view === "trash") {
       whereClauses.push(isNotNull(schema.recordings.trashedAt));
+      if (orgId) {
+        whereClauses.push(eq(schema.recordings.organizationId, orgId));
+      }
     } else {
       whereClauses.push(isNull(schema.recordings.trashedAt));
       if (args.view === "archive") {

--- a/templates/clips/actions/search-meetings.ts
+++ b/templates/clips/actions/search-meetings.ts
@@ -38,6 +38,7 @@ const MEETING_COLUMNS = {
   source: schema.meetings.source,
   platform: schema.meetings.platform,
   trashedAt: schema.meetings.trashedAt,
+  ownerEmail: schema.meetings.ownerEmail,
 } as const;
 
 type MeetingRow = Pick<

--- a/templates/clips/app/components/meetings/meeting-history-row.test.ts
+++ b/templates/clips/app/components/meetings/meeting-history-row.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { formatParticipantNames } from "./meeting-history-row";
+import { formatOwnerHint, formatParticipantNames } from "./meeting-history-row";
 
 const viewer = "dev@local.test";
+const fakeT = (key: string, options?: Record<string, unknown>) => {
+  if (key === "meetingDetail.recordedBy") return `Recorded by ${options?.name}`;
+  if (key === "meetingDetail.me") return "Me";
+  return key;
+};
 
 describe("formatParticipantNames", () => {
   it("names the one other person on a 1:1", () => {
@@ -32,8 +37,9 @@ describe("formatParticipantNames", () => {
     ).toBe("Jason, Elaine & 2 others");
   });
 
-  // A solo note renders a document icon instead, so the subtitle must go empty
-  // rather than telling the reader they were in a meeting with themselves.
+  // The attendee subtitle must go empty rather than telling the reader they
+  // were in a meeting with themselves; `formatOwnerHint` is what still
+  // surfaces the owner's avatar/name on a solo note.
   it("returns nothing when the viewer is the only attendee", () => {
     expect(
       formatParticipantNames([{ email: viewer, name: "Dev" }], viewer),
@@ -66,5 +72,25 @@ describe("formatParticipantNames", () => {
     expect(formatParticipantNames([{ email: "fred@builder.io" }], viewer)).toBe(
       "fred",
     );
+  });
+});
+
+describe("formatOwnerHint", () => {
+  it("names the owner of a shared meeting", () => {
+    expect(formatOwnerHint("sidharth@builder.io", viewer, fakeT)).toBe(
+      "Recorded by sidharth",
+    );
+  });
+
+  it("shows the owner even on the viewer's own meetings, as 'Me'", () => {
+    expect(formatOwnerHint(viewer, viewer, fakeT)).toBe("Recorded by Me");
+    expect(formatOwnerHint("  DEV@Local.TEST  ", viewer, fakeT)).toBe(
+      "Recorded by Me",
+    );
+  });
+
+  it("returns nothing without an owner", () => {
+    expect(formatOwnerHint(null, viewer, fakeT)).toBe("");
+    expect(formatOwnerHint(undefined, viewer, fakeT)).toBe("");
   });
 });

--- a/templates/clips/app/components/meetings/meeting-history-row.tsx
+++ b/templates/clips/app/components/meetings/meeting-history-row.tsx
@@ -90,11 +90,9 @@ export function MeetingHistoryRow({
   const { session } = useSession();
   const participants = meeting.participants ?? [];
   const ownerHint = formatOwnerHint(meeting.ownerEmail, session?.email, t);
-  const subtitle =
-    snippet?.trim() ||
-    [formatParticipantNames(participants, session?.email), ownerHint]
-      .filter(Boolean)
-      .join(" · ");
+  const primaryText =
+    snippet?.trim() || formatParticipantNames(participants, session?.email);
+  const subtitle = [primaryText, ownerHint].filter(Boolean).join(" · ");
   const time = formatTime(
     meeting.actualStart ?? meeting.scheduledStart ?? meeting.createdAt,
   );

--- a/templates/clips/app/components/meetings/meeting-history-row.tsx
+++ b/templates/clips/app/components/meetings/meeting-history-row.tsx
@@ -26,6 +26,7 @@ export interface MeetingHistoryItem {
   actualEnd?: string | null;
   createdAt?: string | null;
   participants?: AttendeeStackParticipant[];
+  ownerEmail?: string | null;
 }
 
 function formatTime(iso?: string | null): string {
@@ -56,6 +57,28 @@ export function formatParticipantNames(
   return `${names.slice(0, 2).join(", ")} & ${names.length - 2} others`;
 }
 
+/**
+ * A meeting's owner — who actually recorded it in Clips — isn't necessarily
+ * on the attendee list (an ad-hoc note has none at all), and two attendees on
+ * the same call can each hold their own copy. Unlike the attendee subtitle,
+ * this is shown unconditionally, including the viewer's own meetings, so
+ * ownership is never ambiguous once a meeting is shared.
+ */
+export function formatOwnerHint(
+  ownerEmail: string | null | undefined,
+  viewerEmail: string | null | undefined,
+  t: ReturnType<typeof useT>,
+): string {
+  const owner = ownerEmail?.trim();
+  if (!owner) return "";
+  const viewer = viewerEmail?.trim().toLowerCase();
+  const name =
+    viewer && owner.toLowerCase() === viewer
+      ? t("meetingDetail.me")
+      : owner.replace(/@.*$/, "");
+  return t("meetingDetail.recordedBy", { name });
+}
+
 export function MeetingHistoryRow({
   meeting,
   snippet,
@@ -66,11 +89,19 @@ export function MeetingHistoryRow({
   const t = useT();
   const { session } = useSession();
   const participants = meeting.participants ?? [];
+  const ownerHint = formatOwnerHint(meeting.ownerEmail, session?.email, t);
   const subtitle =
-    snippet?.trim() || formatParticipantNames(participants, session?.email);
+    snippet?.trim() ||
+    [formatParticipantNames(participants, session?.email), ownerHint]
+      .filter(Boolean)
+      .join(" · ");
   const time = formatTime(
     meeting.actualStart ?? meeting.scheduledStart ?? meeting.createdAt,
   );
+  const soloOwnerAvatar: AttendeeStackParticipant[] =
+    participants.length === 0 && ownerHint && meeting.ownerEmail
+      ? [{ email: meeting.ownerEmail }]
+      : [];
 
   return (
     <NavLink
@@ -79,6 +110,8 @@ export function MeetingHistoryRow({
     >
       {participants.length > 0 ? (
         <AttendeeStack participants={participants} size="md" max={2} />
+      ) : soloOwnerAvatar.length > 0 ? (
+        <AttendeeStack participants={soloOwnerAvatar} size="md" max={1} />
       ) : (
         <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
           <IconFileText className="h-3.5 w-3.5" />

--- a/templates/clips/app/components/player/delete-recording-menu.tsx
+++ b/templates/clips/app/components/player/delete-recording-menu.tsx
@@ -94,7 +94,7 @@ export function RecordingOptionsMenu({
           <Button
             variant="ghost"
             size="icon"
-            className="-mx-1.5 h-auto w-auto shrink-0 px-0.5 py-1.5"
+            className="h-auto w-auto shrink-0 px-0.5 py-1.5"
             aria-label={t("deleteRecordingMenu.clipOptions")}
           >
             <IconDotsVertical className="h-4 w-4" />

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -348,6 +348,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "لقاء بلا عنوان",
+    recordedBy: "سجّله {{name}}",
     unassigned: "غير معين",
     them: "هم",
     me: "أنا",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -368,6 +368,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "Treffen ohne Titel",
+    recordedBy: "Aufgezeichnet von {{name}}",
     unassigned: "Nicht zugewiesen",
     them: "Ihnen",
     me: "Mich",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -351,6 +351,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "Untitled meeting",
+    recordedBy: "Recorded by {{name}}",
     unassigned: "Unassigned",
     them: "Them",
     me: "Me",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -363,6 +363,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "Reunión sin título",
+    recordedBy: "Grabado por {{name}}",
     unassigned: "No asignado",
     them: "A ellos",
     me: "A mí",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -362,6 +362,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "Réunion sans titre",
+    recordedBy: "Enregistré par {{name}}",
     unassigned: "Non attribué",
     them: "Eux",
     me: "Moi",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -349,6 +349,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "शीर्षकहीन बैठक",
+    recordedBy: "{{name}} द्वारा रिकॉर्ड किया गया",
     unassigned: "सौंपे नहीं गए",
     them: "उन्हें",
     me: "मुझे",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -361,6 +361,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "無題の会議",
+    recordedBy: "{{name}} が記録",
     unassigned: "未割り当て",
     them: "彼ら",
     me: "自分",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -355,6 +355,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "제목 없는 회의",
+    recordedBy: "{{name}} 님이 기록함",
     unassigned: "할당되지 않음",
     them: "그들을",
     me: "나",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -359,6 +359,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "Reunião sem título",
+    recordedBy: "Gravado por {{name}}",
     unassigned: "Não atribuído",
     them: "Eles",
     me: "Meu",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -336,6 +336,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "无标题会议",
+    recordedBy: "由 {{name}} 记录",
     unassigned: "未分配",
     them: "他们",
     me: "我",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -336,6 +336,7 @@ const messages = {
   },
   meetingDetail: {
     untitledMeeting: "無標題會議",
+    recordedBy: "由 {{name}} 記錄",
     unassigned: "未指派",
     them: "他們",
     me: "我",

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -94,6 +94,7 @@ interface Meeting {
   userNotesMd?: string | null;
   source?: "calendar" | "adhoc" | "manual";
   participants?: AttendeeStackParticipant[];
+  ownerEmail?: string | null;
 }
 
 interface SearchMeetingResult extends Meeting {

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1275,11 +1275,13 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
         return Ok(());
     }
     if let Some(w) = app.get_webview_window("popover") {
-        let max_logical_height = w
+        let monitor = w
             .current_monitor()
             .ok()
             .flatten()
-            .or_else(|| w.primary_monitor().ok().flatten())
+            .or_else(|| w.primary_monitor().ok().flatten());
+        let max_logical_height = monitor
+            .as_ref()
             .map(|monitor| {
                 let scale = monitor.scale_factor().max(1.0);
                 ((monitor.size().height as f64) / scale
@@ -1288,16 +1290,39 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
                     .clamp(260.0, 820.0)
             })
             .unwrap_or(820.0);
+        // Same idea as height: a monitor narrower than the requested width
+        // (e.g. settings' 720) must not let the window grow past the screen
+        // edge, since `position_popover`'s x-clamp can only slide a
+        // too-wide window, not shrink it back onto the display.
+        let max_logical_width = monitor
+            .map(|monitor| {
+                let scale = monitor.scale_factor().max(1.0);
+                ((monitor.size().width as f64) / scale - 16.0 - POPOVER_SHADOW_GUTTER_LOGICAL * 2.0)
+                    .clamp(320.0, 960.0)
+            })
+            .unwrap_or(960.0);
         let clamped = height.clamp(200.0, max_logical_height);
-        let width = width.unwrap_or(320.0).clamp(320.0, 960.0);
+        let width = width
+            .unwrap_or(320.0)
+            .clamp(320.0, max_logical_width.max(320.0));
         let (window_width, window_height) = popover_window_size_logical(width, clamped);
         let _ = w.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
             window_width,
             window_height,
         )));
         // Re-anchor to the tray icon so the window doesn't drift below the
-        // bottom of the monitor after a growth.
-        position_popover(&app, &w);
+        // bottom of the monitor after a growth. Pass the size we just asked
+        // for rather than letting `position_popover` re-read `outer_size()`:
+        // macOS doesn't always commit `set_size()` synchronously, so a
+        // stale (pre-resize) read here would center/clamp against the old,
+        // narrower width and let the window balloon past the screen edge
+        // once the real resize lands a moment later.
+        let target_scale = w.scale_factor().unwrap_or(1.0).max(1.0);
+        let target_physical = PhysicalSize::new(
+            (window_width * target_scale).round() as u32,
+            (window_height * target_scale).round() as u32,
+        );
+        position_popover_with_size(&app, &w, target_physical);
     }
     Ok(())
 }
@@ -2668,13 +2693,25 @@ pub fn toggle_popover(app: &AppHandle) {
 }
 
 pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
+    let win_size = window.outer_size().unwrap_or(PhysicalSize::new(360, 440));
+    position_popover_with_size(app, window, win_size);
+}
+
+/// Same as `position_popover`, but takes the window's size explicitly instead
+/// of querying `window.outer_size()`. Callers that just called `set_size()`
+/// must pass the size they requested — see the comment at that call site in
+/// `resize_popover` for why re-querying there is unsafe.
+pub fn position_popover_with_size(
+    app: &AppHandle,
+    window: &WebviewWindow,
+    win_size: PhysicalSize<u32>,
+) {
     // If we have a recent tray icon rect, anchor the popover's top edge just
     // below the icon and center it horizontally on the icon — same feel as
     // Loom / Raycast / 1Password.
     let anchor = app.state::<TrayAnchor>();
     let tray_rect = anchor.0.lock().ok().and_then(|g| *g);
 
-    let win_size: PhysicalSize<u32> = window.outer_size().unwrap_or(PhysicalSize::new(360, 440));
     // IMPORTANT: `current_monitor()` returns None when the window is offscreen
     // (we park it at 99999,99999 on boot to hide the initial flash). Fall back
     // to the primary monitor so we can still position correctly on first show.

--- a/templates/clips/desktop/src-tauri/src/tray.rs
+++ b/templates/clips/desktop/src-tauri/src/tray.rs
@@ -135,8 +135,17 @@ fn build_menu_with_meetings(
     )?;
     let devtools_item =
         MenuItem::with_id(app, "devtools", "Toggle DevTools", true, Some("Cmd+Alt+I"))?;
+    let version_item = MenuItem::with_id(
+        app,
+        "version",
+        format!("Clips v{}", env!("CARGO_PKG_VERSION")),
+        false,
+        None::<&str>,
+    )?;
     let quit_item = MenuItem::with_id(app, "quit", "Quit Clips", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
+    let separator2 = PredefinedMenuItem::separator(app)?;
+    let separator3 = PredefinedMenuItem::separator(app)?;
     let menu = Menu::with_items(
         app,
         &[
@@ -147,6 +156,9 @@ fn build_menu_with_meetings(
             &paste_last_dictation_item,
             &region_guides_item,
             &devtools_item,
+            &separator2,
+            &version_item,
+            &separator3,
             &quit_item,
         ],
     )?;

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3292,11 +3292,14 @@ export function App({
       // A restart hands off the already-live display stream from the take
       // it's replacing (see `discardForRestart`/`preAcquiredDisplayStream`
       // below) — it must keep recording the same screen, not re-prompt.
-      if (source === "full-screen" && !options?.resumeCapture) {
+      if (
+        (source === "full-screen" || source === "region") &&
+        !options?.resumeCapture
+      ) {
         try {
           // Must resolve before `recordingFlowActive` flips the toolbar on
-          // below — the toolbar reads the pick to place itself on the
-          // chosen screen the first time it's shown.
+          // below — the toolbar and region selector read the pick to place
+          // themselves on the chosen screen the first time they are shown.
           await pickFullscreenRecordingDisplay();
         } catch (err) {
           recordingFlowGateRef.current = false;
@@ -3834,22 +3837,25 @@ export function App({
   const showCameraRow = mode !== "screen"; // screen-only has no camera
   const showSourceRow = mode !== "camera"; // camera-only has no screen source
 
-  const pendingUploadBanner = recordingStopFinalizing ? (
-    <FinalizingUploadBanner />
-  ) : pendingUploads.length > 0 ? (
-    <PendingUploadBanner
-      uploads={pendingUploads}
-      retryingUploadId={retryingUploadId}
-      retryingUploadStatus={retryingUploadStatus}
-      exportingUploadId={exportingUploadId}
-      dismissingUploadId={dismissingUploadId}
-      onExport={exportPendingUpload}
-      onRetry={retryPendingUpload}
-      onDismiss={dismissPendingUpload}
-      onOpenFolder={openPendingUploadFolder}
-      onConnectStorage={(upload) => openVideoStorageSetup(upload.serverUrl)}
-    />
-  ) : null;
+  const pendingUploadBanner =
+    authStatus === "authed" ? (
+      recordingStopFinalizing ? (
+        <FinalizingUploadBanner />
+      ) : pendingUploads.length > 0 ? (
+        <PendingUploadBanner
+          uploads={pendingUploads}
+          retryingUploadId={retryingUploadId}
+          retryingUploadStatus={retryingUploadStatus}
+          exportingUploadId={exportingUploadId}
+          dismissingUploadId={dismissingUploadId}
+          onExport={exportPendingUpload}
+          onRetry={retryPendingUpload}
+          onDismiss={dismissPendingUpload}
+          onOpenFolder={openPendingUploadFolder}
+          onConnectStorage={(upload) => openVideoStorageSetup(upload.serverUrl)}
+        />
+      ) : null
+    ) : null;
 
   async function copyRewindAgentPrompt() {
     try {


### PR DESCRIPTION
## Changes

- Every meeting in the Past list now shows who recorded it, labeled "Recorded by <name>" (or "Recorded by Me" for your own meetings). Before this, a shared meeting with no attendees listed gave no way to tell whose notes you were looking at.
<img width="930" height="270" alt="image" src="https://github.com/user-attachments/assets/cd61e211-aa1c-4b45-ba0c-a56931f82fa1" />

- The recordings trash view could return recordings from other organizations. It now stays scoped to the current organization, like every other view.
- The three-dot options button on a recording was nudged slightly out of alignment with its neighbors. The extra offset is removed.
- The recording popover window now also respects the screen's width when resizing, not just its height, so it can no longer grow past the edge of a narrow monitor. Repositioning after a resize also uses the size that was just requested instead of a possibly stale one, fixing a case where the window could briefly balloon past the screen edge.
- Starting a region recording now lets you pick which display to record on first, the same way full-screen recording already did.
- The pending-upload and finalizing banners no longer appear while signed out.
- The tray menu now shows the current app version.
<img width="386" height="283" alt="image" src="https://github.com/user-attachments/assets/f3a98465-0d1b-40df-af04-69cc13b1a3c6" />
