### PR TITLE
fix: collapse active Design sidebar tabs

### DIFF
--- a/templates/design/app/components/design/editor/DesignWorkspaceRail.test.tsx
+++ b/templates/design/app/components/design/editor/DesignWorkspaceRail.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import { DesignWorkspaceRail } from "./DesignWorkspaceRail";
+
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT: () => (key: string) => key,
+}));
+
+function renderRail(activePanel: "file" | "agent" | null) {
+  const onPanelChange = vi.fn();
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+
+  const mount = async () => {
+    await act(async () => {
+      root.render(
+        <TooltipProvider>
+          <DesignWorkspaceRail
+            activePanel={activePanel}
+            projectMenu={null}
+            onPanelChange={onPanelChange}
+          />
+        </TooltipProvider>,
+      );
+    });
+  };
+
+  const click = async (label: string) => {
+    const button = host.querySelector(`button[aria-label="${label}"]`);
+    if (!button) throw new Error(`no button labelled ${label}`);
+    await act(async () => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  };
+
+  return { click, host, onPanelChange, root, mount };
+}
+
+describe("DesignWorkspaceRail", () => {
+  it("collapses the active panel when its rail tab is clicked again", async () => {
+    const rail = renderRail("file");
+    await rail.mount();
+    await rail.click("designEditor.leftRail.file");
+
+    expect(rail.onPanelChange).toHaveBeenCalledWith(null);
+    rail.root.unmount();
+  });
+
+  it("opens the clicked panel when another panel is active", async () => {
+    const rail = renderRail("file");
+    await rail.mount();
+    await rail.click("designEditor.leftRail.agent");
+
+    expect(rail.onPanelChange).toHaveBeenCalledWith("agent");
+    rail.root.unmount();
+  });
+});

--- a/templates/design/app/components/design/editor/DesignWorkspaceRail.tsx
+++ b/templates/design/app/components/design/editor/DesignWorkspaceRail.tsx
@@ -39,14 +39,14 @@ export function DesignWorkspaceRail({
   onMotionToggle,
   onPanelChange,
 }: {
-  activePanel: DesignLeftPanel;
+  activePanel: DesignLeftPanel | null;
   disabledPanels?: ReadonlySet<DesignLeftPanel>;
   hiddenPanels?: ReadonlySet<DesignLeftPanel>;
   motionOpen?: boolean;
   motionDisabled?: boolean;
   projectMenu: ReactNode;
   onMotionToggle?: () => void;
-  onPanelChange: (panel: DesignLeftPanel) => void;
+  onPanelChange: (panel: DesignLeftPanel | null) => void;
 }) {
   const t = useT();
   const items: Array<{
@@ -137,7 +137,7 @@ export function DesignWorkspaceRail({
                         event.preventDefault();
                         return;
                       }
-                      onPanelChange(item.panel);
+                      onPanelChange(active ? null : item.panel);
                     }}
                     onPointerEnter={() => {
                       if (item.panel === "code") preloadCodeWorkbench();
@@ -175,7 +175,7 @@ export function DesignWorkspaceRail({
           );
         })}
       </div>
-      {onMotionToggle ? (
+      {onMotionToggle && SHOW_DESIGN_SECONDARY_LEFT_PANELS ? (
         <div className="mt-4 flex w-full flex-col items-center border-t border-border/70 pt-3">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/templates/design/app/pages/DesignEditor.motion-dock.test.ts
+++ b/templates/design/app/pages/DesignEditor.motion-dock.test.ts
@@ -59,5 +59,8 @@ describe("DesignEditor motion dock transition", () => {
     expect(source).toContain(
       'if (!initialGenerationChromeLimited) return;\n    setActiveLeftPanel("agent");\n  }, [initialGenerationChromeLimited]);',
     );
+    expect(source).toContain(
+      "if (panel === null && initialGenerationChromeLimited) return;",
+    );
   });
 });

--- a/templates/design/app/pages/DesignEditor.motion-dock.test.ts
+++ b/templates/design/app/pages/DesignEditor.motion-dock.test.ts
@@ -39,4 +39,10 @@ describe("DesignEditor motion dock transition", () => {
     expect(source).toContain("window.cancelAnimationFrame");
     expect(source).toContain("clearMotionDockOpenAnimationFrame();\n    },");
   });
+
+  it("keeps the motion dock behind the secondary-panel experiment", () => {
+    expect(source).toContain(
+      "SHOW_DESIGN_SECONDARY_LEFT_PANELS &&\n      activeFile &&\n      motionDockMounted",
+    );
+  });
 });

--- a/templates/design/app/pages/DesignEditor.motion-dock.test.ts
+++ b/templates/design/app/pages/DesignEditor.motion-dock.test.ts
@@ -42,7 +42,10 @@ describe("DesignEditor motion dock transition", () => {
 
   it("keeps the motion dock behind the secondary-panel experiment", () => {
     expect(source).toContain(
-      "SHOW_DESIGN_SECONDARY_LEFT_PANELS &&\n      activeFile &&\n      motionDockMounted",
+      "SHOW_DESIGN_SECONDARY_LEFT_PANELS &&\n      !initialGenerationChromeLimited &&\n      activeFile &&\n      motionDockMounted",
+    );
+    expect(source).toContain(
+      "motionDisabled={!activeFile || initialGenerationChromeLimited}",
     );
   });
 

--- a/templates/design/app/pages/DesignEditor.motion-dock.test.ts
+++ b/templates/design/app/pages/DesignEditor.motion-dock.test.ts
@@ -45,4 +45,16 @@ describe("DesignEditor motion dock transition", () => {
       "SHOW_DESIGN_SECONDARY_LEFT_PANELS &&\n      activeFile &&\n      motionDockMounted",
     );
   });
+
+  it("keeps inspector motion controls gated and preserves explicit collapse", () => {
+    expect(source).toContain(
+      "motionKeyframeState: SHOW_DESIGN_SECONDARY_LEFT_PANELS\n      ? motionKeyframeState\n      : undefined,",
+    );
+    expect(source).toContain(
+      "onToggleMotionKeyframe:\n      SHOW_DESIGN_SECONDARY_LEFT_PANELS && canEditDesign\n        ? handleToggleMotionKeyframe",
+    );
+    expect(source).toContain(
+      'if (!initialGenerationChromeLimited) return;\n    setActiveLeftPanel("agent");\n  }, [initialGenerationChromeLimited]);',
+    );
+  });
 });

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -6096,9 +6096,9 @@ function DesignEditor() {
     latestActiveContentRef.current = activeContent;
   }, [activeContent]);
   useEffect(() => {
-    if (!initialGenerationChromeLimited || activeLeftPanel === "agent") return;
+    if (!initialGenerationChromeLimited) return;
     setActiveLeftPanel("agent");
-  }, [activeLeftPanel, initialGenerationChromeLimited]);
+  }, [initialGenerationChromeLimited]);
   const fileContentById = useMemo(() => {
     const map = new Map<string, string>();
     for (const file of files) {
@@ -19030,10 +19030,13 @@ function DesignEditor() {
     onRequestTweaks: handleRequestTweaks,
     onStyleChange: handleStyleChange,
     onStylesChange: handleStylesChange,
-    motionKeyframeState,
-    onToggleMotionKeyframe: canEditDesign
-      ? handleToggleMotionKeyframe
+    motionKeyframeState: SHOW_DESIGN_SECONDARY_LEFT_PANELS
+      ? motionKeyframeState
       : undefined,
+    onToggleMotionKeyframe:
+      SHOW_DESIGN_SECONDARY_LEFT_PANELS && canEditDesign
+        ? handleToggleMotionKeyframe
+        : undefined,
     breakpointContext,
     onExport: handleInspectorExport,
     onRenderExportPreview: handleRenderExportPreview,

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -19112,7 +19112,10 @@ function DesignEditor() {
               motionDisabled={!activeFile || initialGenerationChromeLimited}
               projectMenu={hostEmbeddedEditor ? null : projectMenu}
               onMotionToggle={() => setMotionDockOpenAnimated(!motionDockOpen)}
-              onPanelChange={setActiveLeftPanel}
+              onPanelChange={(panel) => {
+                if (panel === null && initialGenerationChromeLimited) return;
+                setActiveLeftPanel(panel);
+              }}
             />
             <div
               ref={leftSidebarContentRef}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -19109,7 +19109,7 @@ function DesignEditor() {
                   : undefined
               }
               motionOpen={motionDockOpen}
-              motionDisabled={!activeFile}
+              motionDisabled={!activeFile || initialGenerationChromeLimited}
               projectMenu={hostEmbeddedEditor ? null : projectMenu}
               onMotionToggle={() => setMotionDockOpenAnimated(!motionDockOpen)}
               onPanelChange={setActiveLeftPanel}
@@ -20504,6 +20504,7 @@ function DesignEditor() {
           canvas iframe; track/duration edits autosave through apply-motion-edit. */}
       {!hostOwnsChrome &&
       SHOW_DESIGN_SECONDARY_LEFT_PANELS &&
+      !initialGenerationChromeLimited &&
       activeFile &&
       motionDockMounted ? (
         <MotionDock

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1364,7 +1364,7 @@ function DesignEditor() {
   } | null>(null);
   const reviewFocusNonceRef = useRef(0);
   const [activeLeftPanel, setActiveLeftPanel] =
-    useState<DesignLeftPanel>("file");
+    useState<DesignLeftPanel | null>("file");
   const [activeCodeFile, setActiveCodeFile] =
     useState<CodeWorkbenchActiveFile | null>(null);
   const initialSearchCommandAppliedForIdRef = useRef<string | null>(null);
@@ -19113,8 +19113,13 @@ function DesignEditor() {
             />
             <div
               ref={leftSidebarContentRef}
-              className="flex min-h-0 max-w-[calc(100dvw-57px)] shrink-0 flex-col border-r border-[var(--design-editor-panel-divider-color)] bg-[var(--design-editor-panel-bg)] transition-[width] duration-150 ease-out md:max-w-none"
-              style={{ width: leftContentWidth }}
+              aria-hidden={activeLeftPanel === null}
+              className={cn(
+                "flex min-h-0 max-w-[calc(100dvw-57px)] shrink-0 flex-col overflow-hidden border-r border-[var(--design-editor-panel-divider-color)] bg-[var(--design-editor-panel-bg)] transition-[width] duration-150 ease-out md:max-w-none",
+                activeLeftPanel === null &&
+                  "pointer-events-none invisible border-r-0",
+              )}
+              style={{ width: activeLeftPanel ? leftContentWidth : 0 }}
             >
               <div
                 className={cn(
@@ -19348,13 +19353,15 @@ function DesignEditor() {
                 </>
               ) : null}
             </div>
-            <div
-              role="separator"
-              aria-orientation="vertical"
-              aria-label={t("layersPanel.title")}
-              className="absolute right-[-2px] top-0 z-[80] h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--design-editor-selection-color)]"
-              onPointerDown={(event) => startSidebarResize("left", event)}
-            />
+            {activeLeftPanel ? (
+              <div
+                role="separator"
+                aria-orientation="vertical"
+                aria-label={t("layersPanel.title")}
+                className="absolute right-[-2px] top-0 z-[80] h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-[var(--design-editor-selection-color)]"
+                onPointerDown={(event) => startSidebarResize("left", event)}
+              />
+            ) : null}
           </div>
         ) : null}
 
@@ -20492,7 +20499,10 @@ function DesignEditor() {
           closing. Canvas remains visible above.
           Preview-only scrubbing fires a motion-preview postMessage to the
           canvas iframe; track/duration edits autosave through apply-motion-edit. */}
-      {!hostOwnsChrome && activeFile && motionDockMounted ? (
+      {!hostOwnsChrome &&
+      SHOW_DESIGN_SECONDARY_LEFT_PANELS &&
+      activeFile &&
+      motionDockMounted ? (
         <MotionDock
           tracks={motionTracks}
           durationMs={motionDurationMs}

--- a/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-design-editor-command.ts
@@ -37,7 +37,7 @@ export interface ApplyDesignEditorCommandArgs {
   overviewScreens: OverviewScreen[];
   setActiveFileId: Dispatch<SetStateAction<string | null>>;
   setActiveInspectorTab: Dispatch<SetStateAction<InspectorTab>>;
-  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel>>;
+  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel | null>>;
   setActiveTool: Dispatch<SetStateAction<DesignTool>>;
   setDrawMode: Dispatch<SetStateAction<boolean>>;
   setInteractDeviceName: Dispatch<SetStateAction<string>>;

--- a/templates/design/app/pages/design-editor/commands/apply-pending-visual-styles-with-agent.ts
+++ b/templates/design/app/pages/design-editor/commands/apply-pending-visual-styles-with-agent.ts
@@ -50,7 +50,7 @@ export interface ApplyPendingVisualStylesWithAgentArgs {
   pendingStructureVerificationStatus: PendingStructureVerificationStatus;
   pendingVisualStyleEdits: PendingVisualStyleEdit[];
   pendingVisualStylePrompt: string;
-  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel>>;
+  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel | null>>;
   setApplyingViaHost: Dispatch<SetStateAction<boolean>>;
   setPendingAgentHandoffBusy: Dispatch<SetStateAction<boolean>>;
   setPendingStructureAckRequest: Dispatch<

--- a/templates/design/app/pages/design-editor/commands/send-runtime-layer-move-semantic-handoff.ts
+++ b/templates/design/app/pages/design-editor/commands/send-runtime-layer-move-semantic-handoff.ts
@@ -29,7 +29,7 @@ export interface SendRuntimeLayerMoveSemanticHandoffArgs {
   localhostConnectionRootPathByIdRef: RefObject<Map<string, string>>;
   overviewScreens: OverviewScreen[];
   runtimeLayerSnapshotsById: Record<string, RuntimeLayerSnapshot>;
-  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel>>;
+  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel | null>>;
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 

--- a/templates/design/app/pages/design-editor/commands/send-runtime-layer-semantic-handoff.ts
+++ b/templates/design/app/pages/design-editor/commands/send-runtime-layer-semantic-handoff.ts
@@ -29,7 +29,7 @@ export interface SendRuntimeLayerSemanticHandoffArgs {
   localhostConnectionRootPathByIdRef: RefObject<Map<string, string>>;
   overviewScreens: OverviewScreen[];
   runtimeLayerSnapshotsById: Record<string, RuntimeLayerSnapshot>;
-  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel>>;
+  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel | null>>;
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 

--- a/templates/design/app/pages/design-editor/commands/send-runtime-layer-state-semantic-handoff.ts
+++ b/templates/design/app/pages/design-editor/commands/send-runtime-layer-state-semantic-handoff.ts
@@ -32,7 +32,7 @@ export interface SendRuntimeLayerStateSemanticHandoffArgs {
   localhostConnectionRootPathByIdRef: RefObject<Map<string, string>>;
   overviewScreens: OverviewScreen[];
   runtimeLayerSnapshotsById: Record<string, RuntimeLayerSnapshot>;
-  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel>>;
+  setActiveLeftPanel: Dispatch<SetStateAction<DesignLeftPanel | null>>;
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 

--- a/templates/design/app/pages/design-editor/commands/start-sidebar-resize.ts
+++ b/templates/design/app/pages/design-editor/commands/start-sidebar-resize.ts
@@ -8,7 +8,7 @@ import type {
 import type { DesignLeftPanel } from "@/pages/design-editor/types";
 
 export interface StartSidebarResizeArgs {
-  activeLeftPanel: DesignLeftPanel;
+  activeLeftPanel: DesignLeftPanel | null;
   leftSidebarContentRef: RefObject<HTMLDivElement | null>;
   leftSidebarWidth: number;
   rightSidebarContentRef: RefObject<HTMLDivElement | null>;

--- a/templates/design/app/pages/design-editor/effects/publish-agent-selection-context.ts
+++ b/templates/design/app/pages/design-editor/effects/publish-agent-selection-context.ts
@@ -20,7 +20,7 @@ export interface PublishAgentSelectionContextArgs {
   activeCodeFile: CodeWorkbenchActiveFile | null;
   activeFile: DesignFile;
   activeInspectorTab: InspectorTab;
-  activeLeftPanel: DesignLeftPanel;
+  activeLeftPanel: DesignLeftPanel | null;
   activeTool: DesignTool;
   design: DesignData | null;
   designDataJson: Record<string, unknown>;

--- a/templates/design/app/pages/design-editor/types.ts
+++ b/templates/design/app/pages/design-editor/types.ts
@@ -36,9 +36,9 @@ export type DesignLeftPanel =
 /**
  * Keep the still-evolving Design editor side panels out of the default
  * surface until their Figma parity work is ready. Flip this switch to expose
- * Assets, Tools, Tokens, and Code together while iterating on them. The E2E
- * harness sets the Vite flag so those existing advanced-surface tests keep
- * exercising the gated panels.
+ * Assets, Tools, Tokens, Code, and Motion together while iterating on them.
+ * The E2E harness sets the Vite flag so those existing advanced-surface tests
+ * keep exercising the gated panels.
  */
 const designSecondaryLeftPanelsSetting =
   typeof import.meta !== "undefined"


### PR DESCRIPTION
## Summary
- Clicking the active Design left-rail tab collapses its sidebar.
- The experimental secondary-panel setting now gates Motion alongside Assets, Tools, Tokens, and Code.
- Added focused rail and Motion gating coverage.

## Verification
- `corepack pnpm --filter design typecheck`
- Focused Vitest: 4 files, 14 tests passed
- Local browser: active File/Agent tabs collapsed to width 0 with no console errors.