### PR TITLE
Polish beta badge hide control spacing

### DIFF
--- a/.changeset/beta-badge-hide-spacing.md
+++ b/.changeset/beta-badge-hide-spacing.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Center the beta badge hide control and balance its surrounding spacing.

--- a/packages/core/src/client/EnvironmentBadge.render.spec.tsx
+++ b/packages/core/src/client/EnvironmentBadge.render.spec.tsx
@@ -220,6 +220,10 @@ describe("EnvironmentBadge render", () => {
       (button) => button.textContent?.includes("Hide badge"),
     );
     expect(hideButton).not.toBeUndefined();
+    expect(hideButton?.className).toContain("mt-2");
+    expect(hideButton?.className).toContain("-mb-2");
+    expect(hideButton?.className).toContain("w-full");
+    expect(hideButton?.className).toContain("justify-center");
 
     act(() => hideButton?.click());
 

--- a/packages/core/src/client/EnvironmentBadge.tsx
+++ b/packages/core/src/client/EnvironmentBadge.tsx
@@ -231,7 +231,7 @@ function EnvironmentBadgeContent({
             <EnvironmentLink href={betaHref!} label="Go to beta" />
           )}
           <Button
-            className="w-full justify-center text-muted-foreground"
+            className="mt-2 -mb-2 w-full justify-center text-muted-foreground"
             onClick={() => setIsHidden(true)}
             size="sm"
             type="button"

--- a/packages/core/src/server/beta-opt-out-html.spec.ts
+++ b/packages/core/src/server/beta-opt-out-html.spec.ts
@@ -27,6 +27,9 @@ describe("injectBetaOptOutPersistence", () => {
     expect(html).toContain("left: max(0.75rem, env(safe-area-inset-left));");
     expect(html).toContain("left: 0;");
     expect(html).toContain(
+      "width: 100%;\n    min-height: 2rem;\n    margin-top: 0.5rem;\n    margin-bottom: -0.5rem;",
+    );
+    expect(html).toContain(
       "width: min(17.5rem, calc(100vw - 1.5rem));\n    box-sizing: border-box;\n    padding: 1.25rem;",
     );
     expect(html).not.toContain("safe-area-inset-right");

--- a/packages/core/src/server/beta-opt-out-html.ts
+++ b/packages/core/src/server/beta-opt-out-html.ts
@@ -116,7 +116,10 @@ const environmentSwitcherStyles = `<style ${ENVIRONMENT_SWITCHER_STYLE_MARKER}>
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100%;
     min-height: 2rem;
+    margin-top: 0.5rem;
+    margin-bottom: -0.5rem;
     padding: 0.375rem 0.75rem;
     color: GrayText;
     border: 0;

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -44,6 +44,9 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain("left: max(0.75rem, env(safe-area-inset-left));");
     expect(html).toContain("left: 0;");
     expect(html).toContain(
+      "width: 100%;\n    min-height: 2rem;\n    margin-top: 0.5rem;\n    margin-bottom: -0.5rem;",
+    );
+    expect(html).toContain(
       "width: min(17.5rem, calc(100vw - 1.5rem));\n    box-sizing: border-box;\n    padding: 1.25rem;",
     );
     expect(html).toContain('id="environment-badge" aria-expanded="false"');

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1963,7 +1963,10 @@ ${
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100%;
     min-height: 2rem;
+    margin-top: 0.5rem;
+    margin-bottom: -0.5rem;
     padding: 0.375rem 0.75rem;
     color: inherit;
     opacity: 0.65;


### PR DESCRIPTION
Adjust the beta badge Hide badge control to add balanced vertical spacing and center it across the React and standalone auth render paths.

Validation: focused core badge and auth HTML tests (62 passed).

Generated from the current worktree snapshot.