### PR TITLE
fix: stabilize desktop app tab switching and settings navigation

### DIFF
--- a/packages/desktop-app/shared/desktop-shortcuts.spec.ts
+++ b/packages/desktop-app/shared/desktop-shortcuts.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatDesktopShortcutAccelerator,
   isDesktopChatToggleShortcut,
+  isDesktopSettingsShortcut,
   normalizeDesktopShortcutAccelerator,
 } from "./desktop-shortcuts";
 
@@ -38,6 +39,18 @@ describe("normalizeDesktopShortcutAccelerator", () => {
     expect(normalizeDesktopShortcutAccelerator("Command+H")).toEqual({
       error: expect.stringContaining("does not override"),
     });
+  });
+});
+
+describe("isDesktopSettingsShortcut", () => {
+  it("recognizes Cmd+, from either keyboard representation", () => {
+    expect(isDesktopSettingsShortcut({ key: "," })).toBe(true);
+    expect(isDesktopSettingsShortcut({ code: "Comma" })).toBe(true);
+  });
+
+  it("does not treat modified comma keys as the settings shortcut", () => {
+    expect(isDesktopSettingsShortcut({ key: ",", shift: true })).toBe(false);
+    expect(isDesktopSettingsShortcut({ key: ",", alt: true })).toBe(false);
   });
 });
 

--- a/packages/desktop-app/shared/desktop-shortcuts.ts
+++ b/packages/desktop-app/shared/desktop-shortcuts.ts
@@ -49,6 +49,20 @@ export function isDesktopChatToggleShortcut(input: {
   );
 }
 
+export function isDesktopSettingsShortcut(input: {
+  key?: string;
+  code?: string;
+  shift?: boolean;
+  alt?: boolean;
+}): boolean {
+  const key = input.key?.toLowerCase();
+  return (
+    !input.shift &&
+    !input.alt &&
+    (key === "," || (!key && input.code === "Comma"))
+  );
+}
+
 const MODIFIER_ALIASES: Record<string, string> = {
   alt: "Alt",
   cmd: "Command",

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -3069,6 +3069,45 @@ describe("DesktopIdentityBroker", () => {
     );
   });
 
+  it("does not replace an existing child session during activation reconciliation", async () => {
+    const authority = authorityFixture();
+    const mail = appFixture();
+    const mailCookies = cookieStore([
+      sessionCookie("an_session_mail", mail.origin, "mail-session"),
+    ]);
+    mail.session = {
+      cookies: mailCookies,
+      fetch: vi.fn(async () => new Response(null, { status: 401 })),
+    } as unknown as Electron.Session;
+    const identityCookies = cookieStore([
+      sessionCookie(
+        "an_session_dispatch",
+        authority.origin,
+        "dispatch-session",
+      ),
+    ]);
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: identityCookies,
+        fetch: vi.fn(async () => sessionResponse("steve@example.com")),
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      openExternal: vi.fn(),
+      resolveApp: (id) =>
+        id === authority.id ? authority : id === mail.id ? mail : null,
+      listApps: () => [authority, mail],
+      createWindow: vi.fn() as never,
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+    broker.setStatusForSetting("signed-in");
+
+    await expect(
+      broker.ensureAppSession(mail.id, { preserveExistingSession: true }),
+    ).resolves.toBe(false);
+    expect(mailCookies.remove).not.toHaveBeenCalled();
+  });
+
   it("keeps a failed lazy app synchronization scoped to the child", async () => {
     const authority = authorityFixture();
     const custom = {

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -689,6 +689,7 @@ export class DesktopIdentityBroker {
     const pendingKey = this.pendingOperationKey(
       appId,
       options.expectedSessionValue,
+      options.preserveExistingSession,
     );
     const existing = this.pendingByApp.get(pendingKey);
     if (existing) return existing;
@@ -777,7 +778,7 @@ export class DesktopIdentityBroker {
     expectedEmail?: string,
     options: DesktopIdentityEnsureAppSessionOptions = {},
   ): Promise<boolean> {
-    const pendingKey = `${generation}:${appId}`;
+    const pendingKey = `${generation}:${appId}:${options.preserveExistingSession ? "preserve" : "replace"}`;
     if (this.completedModernAppSessions.has(pendingKey)) {
       const app = this.options.resolveApp(appId);
       if (!app) return Promise.resolve(false);
@@ -1534,7 +1535,9 @@ export class DesktopIdentityBroker {
           });
         }
         if (succeeded && this.isCeremonyCurrent(generation)) {
-          this.completedModernAppSessions.add(`${generation}:${app.id}`);
+          this.completedModernAppSessions.add(
+            `${generation}:${app.id}:replace`,
+          );
         }
         if (app.id === appId && !requestedResultSettled) {
           requestedResultSettled = true;
@@ -3491,8 +3494,9 @@ export class DesktopIdentityBroker {
   private pendingOperationKey(
     appId: string,
     expectedSessionValue?: string,
+    preserveExistingSession = false,
   ): string {
-    return `${appId}\u0000${expectedSessionValue ?? ""}`;
+    return `${appId}\u0000${expectedSessionValue ?? ""}\u0000${preserveExistingSession ? "preserve" : "replace"}`;
   }
 
   private assertCeremonyCurrent(generation: number): void {

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -147,6 +147,10 @@ export type DesktopIdentityStatus =
   | "sign-in-required"
   | "failed";
 
+export interface DesktopIdentityEnsureAppSessionOptions {
+  preserveExistingSession?: boolean;
+}
+
 export function shouldStartDesktopIdentitySignIn(
   status: DesktopIdentityStatus,
   authorityApp: Pick<DesktopIdentityApp, "origin"> | null,
@@ -679,6 +683,7 @@ export class DesktopIdentityBroker {
       waitForSignOut?: boolean;
       skipAvailabilityProbe?: boolean;
       preserveStatus?: boolean;
+      preserveExistingSession?: boolean;
     } = {},
   ): Promise<boolean> {
     const pendingKey = this.pendingOperationKey(
@@ -708,7 +713,10 @@ export class DesktopIdentityBroker {
           await this.syncAlternateSessionCookies(app);
           return true;
         }
-        if (hasExistingSession) await this.clearAppSessionCookies(app);
+        if (hasExistingSession) {
+          if (options.preserveExistingSession) return false;
+          await this.clearAppSessionCookies(app);
+        }
       }
       return this.runCeremony(appId, generation, options);
     });
@@ -730,7 +738,10 @@ export class DesktopIdentityBroker {
    * signed in. This stays in the main process and is intentionally a no-op
    * while the broker is unavailable or signed out.
    */
-  ensureAppSession(appId: string): Promise<boolean> {
+  ensureAppSession(
+    appId: string,
+    options: DesktopIdentityEnsureAppSessionOptions = {},
+  ): Promise<boolean> {
     if (
       this.status !== "signed-in" ||
       this.signOutOperation ||
@@ -742,11 +753,17 @@ export class DesktopIdentityBroker {
     }
 
     const operation = this.options.openExternal
-      ? this.ensureModernAppSessionDeduped(appId)
+      ? this.ensureModernAppSessionDeduped(
+          appId,
+          this.ceremonyGeneration,
+          undefined,
+          options,
+        )
       : this.ensureAppSessionInternal(appId, {
           interactive: false,
           skipIfPresent: true,
           verifyExistingSession: true,
+          preserveExistingSession: options.preserveExistingSession,
           // Lazy child synchronization is scoped to the requested WebView. Do
           // not replace the workspace-level signed-in state while it runs.
           preserveStatus: true,
@@ -758,6 +775,7 @@ export class DesktopIdentityBroker {
     appId: string,
     generation = this.ceremonyGeneration,
     expectedEmail?: string,
+    options: DesktopIdentityEnsureAppSessionOptions = {},
   ): Promise<boolean> {
     const pendingKey = `${generation}:${appId}`;
     if (this.completedModernAppSessions.has(pendingKey)) {
@@ -770,6 +788,7 @@ export class DesktopIdentityBroker {
           appId,
           generation,
           expectedEmail,
+          options,
         );
       });
     }
@@ -780,6 +799,7 @@ export class DesktopIdentityBroker {
       appId,
       generation,
       expectedEmail,
+      options,
     );
     this.pendingModernAppSessions.set(pendingKey, operation);
     void operation.then(
@@ -1596,6 +1616,7 @@ export class DesktopIdentityBroker {
     appId: string,
     generation = this.ceremonyGeneration,
     expectedEmail?: string,
+    options: DesktopIdentityEnsureAppSessionOptions = {},
   ): Promise<boolean> {
     const app = this.options.resolveApp(appId);
     const authority = this.resolveIdentityAuthority();
@@ -1616,6 +1637,7 @@ export class DesktopIdentityBroker {
       return true;
     }
     if (await this.hasAppSession(app)) {
+      if (options.preserveExistingSession) return false;
       await this.clearAppSessionCookies(app);
     }
     this.reloadedModernAppSessions.delete(`${generation}:${app.id}`);

--- a/packages/desktop-app/src/main/desktop-navigation-shortcuts.spec.ts
+++ b/packages/desktop-app/src/main/desktop-navigation-shortcuts.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { forwardDesktopNavigationShortcutInput } from "./desktop-navigation-shortcuts.js";
+
+describe("desktop navigation shortcut forwarding", () => {
+  it("forwards Cmd+, to the shell settings shortcut", () => {
+    const event = { preventDefault: vi.fn() };
+    const send = vi.fn();
+
+    expect(
+      forwardDesktopNavigationShortcutInput(
+        event,
+        { type: "keyDown", key: ",", code: "Comma", meta: true },
+        send,
+      ),
+    ).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(send).toHaveBeenCalledWith({
+      key: ",",
+      code: "Comma",
+      shiftKey: false,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: true,
+    });
+  });
+
+  it("leaves unrelated key events for the guest app", () => {
+    const event = { preventDefault: vi.fn() };
+    const send = vi.fn();
+
+    expect(
+      forwardDesktopNavigationShortcutInput(
+        event,
+        { type: "keyDown", key: "x", meta: true },
+        send,
+      ),
+    ).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-app/src/main/desktop-navigation-shortcuts.ts
+++ b/packages/desktop-app/src/main/desktop-navigation-shortcuts.ts
@@ -1,0 +1,58 @@
+import { isDesktopSettingsShortcut } from "@shared/desktop-shortcuts";
+
+export type DesktopNavigationShortcutInput = {
+  type: string;
+  key: string;
+  code?: string;
+  meta?: boolean;
+  control?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+};
+
+export type DesktopShortcutKeydown = {
+  key: string;
+  code?: string;
+  shiftKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey?: boolean;
+};
+
+export function forwardDesktopNavigationShortcutInput(
+  event: { preventDefault(): void },
+  input: DesktopNavigationShortcutInput,
+  send: (payload: DesktopShortcutKeydown) => void,
+): boolean {
+  if (!(input.meta || input.control) || input.type !== "keyDown") return false;
+
+  const key = input.key.toLowerCase();
+  const isNumericShortcut = !input.shift && !input.alt && /^[1-9]$/.test(key);
+  const isBracketLeft =
+    input.code === "BracketLeft" || key === "[" || key === "{";
+  const isBracketRight =
+    input.code === "BracketRight" || key === "]" || key === "}";
+  const isBracketShortcut =
+    Boolean(input.shift) && !input.alt && (isBracketLeft || isBracketRight);
+  const isSettingsShortcut = isDesktopSettingsShortcut(input);
+  if (!isNumericShortcut && !isBracketShortcut && !isSettingsShortcut) {
+    return false;
+  }
+
+  event.preventDefault();
+  send({
+    key: isSettingsShortcut
+      ? ","
+      : isNumericShortcut
+        ? key
+        : isBracketLeft
+          ? "["
+          : "]",
+    code: input.code,
+    shiftKey: Boolean(input.shift),
+    altKey: Boolean(input.alt),
+    ctrlKey: Boolean(input.control),
+    metaKey: Boolean(input.meta),
+  });
+  return true;
+}

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -40,6 +40,7 @@ import {
 import {
   formatDesktopShortcutAccelerator,
   isDesktopChatToggleShortcut,
+  isDesktopSettingsShortcut,
   normalizeDesktopShortcutAccelerator,
   shortcutOpenPathForBinding,
   type DesktopShortcutBinding,
@@ -420,13 +421,22 @@ function forwardDesktopNavigationShortcut(
     input.code === "BracketRight" || key === "]" || key === "}";
   const isBracketShortcut =
     Boolean(input.shift) && !input.alt && (isBracketLeft || isBracketRight);
-  if (!isNumericShortcut && !isBracketShortcut) return false;
+  const isSettingsShortcut = isDesktopSettingsShortcut(input);
+  if (!isNumericShortcut && !isBracketShortcut && !isSettingsShortcut) {
+    return false;
+  }
 
   event.preventDefault();
   const win = mainWindow;
   if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return true;
   win.webContents.send("shortcut:keydown", {
-    key: isNumericShortcut ? key : isBracketLeft ? "[" : "]",
+    key: isSettingsShortcut
+      ? ","
+      : isNumericShortcut
+        ? key
+        : isBracketLeft
+          ? "["
+          : "]",
     code: input.code,
     shiftKey: Boolean(input.shift),
     altKey: Boolean(input.alt),

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -40,7 +40,6 @@ import {
 import {
   formatDesktopShortcutAccelerator,
   isDesktopChatToggleShortcut,
-  isDesktopSettingsShortcut,
   normalizeDesktopShortcutAccelerator,
   shortcutOpenPathForBinding,
   type DesktopShortcutBinding,
@@ -251,6 +250,10 @@ import {
   getLogFilePath,
 } from "./desktop-logger";
 import {
+  forwardDesktopNavigationShortcutInput,
+  type DesktopNavigationShortcutInput,
+} from "./desktop-navigation-shortcuts.js";
+import {
   desktopRequestedUserDataPath,
   initializeDesktopStartup,
   resolveDesktopSsoBrokerStatePath,
@@ -397,53 +400,15 @@ const desktopWebviewAppIds = new WeakMap<Electron.WebContents, string>();
 let browserNativeHostManifestPath: string | null = null;
 const pendingOpenRequests: DesktopOpenRequest[] = [];
 
-type DesktopNavigationShortcutInput = {
-  type: string;
-  key: string;
-  code?: string;
-  meta?: boolean;
-  control?: boolean;
-  shift?: boolean;
-  alt?: boolean;
-};
-
 function forwardDesktopNavigationShortcut(
   event: { preventDefault(): void },
   input: DesktopNavigationShortcutInput,
 ): boolean {
-  if (!(input.meta || input.control) || input.type !== "keyDown") return false;
-
-  const key = input.key.toLowerCase();
-  const isNumericShortcut = !input.shift && !input.alt && /^[1-9]$/.test(key);
-  const isBracketLeft =
-    input.code === "BracketLeft" || key === "[" || key === "{";
-  const isBracketRight =
-    input.code === "BracketRight" || key === "]" || key === "}";
-  const isBracketShortcut =
-    Boolean(input.shift) && !input.alt && (isBracketLeft || isBracketRight);
-  const isSettingsShortcut = isDesktopSettingsShortcut(input);
-  if (!isNumericShortcut && !isBracketShortcut && !isSettingsShortcut) {
-    return false;
-  }
-
-  event.preventDefault();
-  const win = mainWindow;
-  if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return true;
-  win.webContents.send("shortcut:keydown", {
-    key: isSettingsShortcut
-      ? ","
-      : isNumericShortcut
-        ? key
-        : isBracketLeft
-          ? "["
-          : "]",
-    code: input.code,
-    shiftKey: Boolean(input.shift),
-    altKey: Boolean(input.alt),
-    ctrlKey: Boolean(input.control),
-    metaKey: Boolean(input.meta),
+  return forwardDesktopNavigationShortcutInput(event, input, (payload) => {
+    const win = mainWindow;
+    if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
+    win.webContents.send("shortcut:keydown", payload);
   });
-  return true;
 }
 
 const PENDING_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
@@ -1393,18 +1358,29 @@ ipcMain.handle(IPC.IDENTITY_SSO_ENABLED_SET, async (event, enabled) => {
   return true;
 });
 
-ipcMain.handle(IPC.IDENTITY_APP_SESSION_ENSURE, async (event, appId) => {
-  if (
-    !isShellIdentityIpc(event) ||
-    !isDesktopSsoEnabled() ||
-    typeof appId !== "string" ||
-    !appId.trim()
-  ) {
-    return false;
-  }
-  const broker = ensureDesktopIdentityBroker();
-  return broker?.ensureAppSession(appId.trim()) ?? false;
-});
+ipcMain.handle(
+  IPC.IDENTITY_APP_SESSION_ENSURE,
+  async (event, appId, options) => {
+    if (
+      !isShellIdentityIpc(event) ||
+      !isDesktopSsoEnabled() ||
+      typeof appId !== "string" ||
+      !appId.trim()
+    ) {
+      return false;
+    }
+    const broker = ensureDesktopIdentityBroker();
+    const preserveExistingSession =
+      typeof options === "object" &&
+      options !== null &&
+      (options as { preserveExistingSession?: unknown })
+        .preserveExistingSession === true;
+    return (
+      broker?.ensureAppSession(appId.trim(), { preserveExistingSession }) ??
+      false
+    );
+  },
+);
 
 ipcMain.handle(IPC.IDENTITY_SIGN_IN, async (event) => {
   if (!isShellIdentityIpc(event) || !isDesktopSsoEnabled()) return false;

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -277,8 +277,13 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.IDENTITY_SETTINGS_GET),
     setSsoEnabled: (enabled: boolean): Promise<boolean> =>
       ipcRenderer.invoke(IPC.IDENTITY_SSO_ENABLED_SET, enabled),
-    ensureAppSession: (appId: string): Promise<boolean> =>
-      ipcRenderer.invoke(IPC.IDENTITY_APP_SESSION_ENSURE, appId),
+    ensureAppSession: (
+      appId: string,
+      options?: { preserveExistingSession?: boolean },
+    ): Promise<boolean> =>
+      options
+        ? ipcRenderer.invoke(IPC.IDENTITY_APP_SESSION_ENSURE, appId, options)
+        : ipcRenderer.invoke(IPC.IDENTITY_APP_SESSION_ENSURE, appId),
     getAvailability: (): Promise<boolean> =>
       ipcRenderer.invoke(IPC.IDENTITY_AVAILABILITY_GET),
     signIn: (): Promise<boolean> => ipcRenderer.invoke(IPC.IDENTITY_SIGN_IN),

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import {
   MIGRATION_APP_ID,
   getCodeAgentGoal,
 } from "@shared/code-agents";
+import { isDesktopSettingsShortcut } from "@shared/desktop-shortcuts";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Toaster, toast } from "sonner";
 
@@ -122,6 +123,24 @@ export default function App() {
     setSettingsTab(tab ?? "general");
     setShowSettings(true);
   }, []);
+
+  useEffect(() => {
+    const onKeydown = window.electronAPI?.shortcuts?.onKeydown;
+    if (!onKeydown) return;
+    return onKeydown((input) => {
+      if (
+        !isDesktopSettingsShortcut({
+          key: input.key,
+          code: input.code,
+          shift: input.shiftKey,
+          alt: input.altKey,
+        })
+      ) {
+        return;
+      }
+      handleOpenSettings();
+    });
+  }, [handleOpenSettings]);
 
   const handleChatFirstAppSelectionChange = useCallback((appId?: string) => {
     setActiveChatFirstAppId(appId ?? "");

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -325,7 +325,10 @@ describe("Desktop identity activation", () => {
   });
 
   it("reconciles a loaded app without replacing its session on activation", async () => {
-    const ensureAppSession = vi.fn(async () => true);
+    const ensureAppSession = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
     Object.defineProperty(window, "electronAPI", {
       configurable: true,
       value: {
@@ -407,6 +410,32 @@ describe("Desktop identity activation", () => {
     });
     expect(ensureAppSession).toHaveBeenCalledTimes(2);
     expect(ensureAppSession).toHaveBeenNthCalledWith(2, "mail", {
+      preserveExistingSession: true,
+    });
+
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: false,
+          theme: "dark" as const,
+        }),
+      );
+    });
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: true,
+          theme: "dark" as const,
+        }),
+      );
+    });
+
+    await vi.waitFor(() => expect(ensureAppSession).toHaveBeenCalledTimes(3));
+    expect(ensureAppSession).toHaveBeenNthCalledWith(3, "mail", {
       preserveExistingSession: true,
     });
   });

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -324,6 +324,90 @@ describe("Desktop identity activation", () => {
     ).toHaveLength(initialSourceAssignmentCount);
   });
 
+  it("does not resynchronize a loaded app during remembered tab activation", async () => {
+    const ensureAppSession = vi.fn(async () => true);
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: {
+        identity: {
+          getSettings: vi.fn(async () => ({ ssoEnabled: true })),
+          getStatus: vi.fn(async () => "signed-in"),
+          ensureAppSession,
+          onStatusChange: vi.fn(() => () => {}),
+        },
+      },
+    });
+    rememberDesktopIdentityStatus("signed-in");
+    root = createRoot(container);
+
+    const app = {
+      id: "mail",
+      name: "Mail",
+      icon: "mail",
+      description: "",
+      devPort: 3000,
+    };
+    const appConfig = {
+      ...app,
+      url: "https://mail.agent-native.com",
+      isBuiltIn: true,
+      enabled: true,
+      mode: "prod" as const,
+    };
+
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: true,
+          theme: "dark" as const,
+        }),
+      );
+    });
+
+    await vi.waitFor(() => expect(ensureAppSession).toHaveBeenCalledTimes(1));
+    const webview = container.querySelector("webview");
+    expect(webview).not.toBeNull();
+    Object.defineProperties(webview!, {
+      getTitle: { configurable: true, value: () => "" },
+      getURL: {
+        configurable: true,
+        value: () => webview!.getAttribute("src") ?? "",
+      },
+    });
+    await act(async () => {
+      webview?.dispatchEvent(new Event("dom-ready"));
+      await Promise.resolve();
+    });
+
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: false,
+          theme: "dark" as const,
+        }),
+      );
+    });
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: true,
+          theme: "dark" as const,
+        }),
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(ensureAppSession).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a remembered session gated until child synchronization completes", async () => {
     let resolveSynchronization!: (synchronized: boolean) => void;
     const ensureAppSession = vi.fn(

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -324,7 +324,7 @@ describe("Desktop identity activation", () => {
     ).toHaveLength(initialSourceAssignmentCount);
   });
 
-  it("does not resynchronize a loaded app during remembered tab activation", async () => {
+  it("reconciles a loaded app without replacing its session on activation", async () => {
     const ensureAppSession = vi.fn(async () => true);
     Object.defineProperty(window, "electronAPI", {
       configurable: true,
@@ -405,7 +405,10 @@ describe("Desktop identity activation", () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(ensureAppSession).toHaveBeenCalledTimes(1);
+    expect(ensureAppSession).toHaveBeenCalledTimes(2);
+    expect(ensureAppSession).toHaveBeenNthCalledWith(2, "mail", {
+      preserveExistingSession: true,
+    });
   });
 
   it("keeps a remembered session gated until child synchronization completes", async () => {

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -897,6 +897,13 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           const preserveLoadedSession =
             hasLoadedGuestPageRef.current &&
             desktopIdentitySessionReadyRef.current;
+          if (preserveLoadedSession && fromRememberedSession) {
+            // Tab activation is a visibility change, not a new child-session
+            // ceremony that can safely replace a verified cookie.
+            updateDesktopIdentitySessionReady(true);
+            setDesktopIdentityStatus("signed-in");
+            return;
+          }
           if (!preserveLoadedSession) {
             updateDesktopIdentitySessionReady(false);
           }

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -897,19 +897,17 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           const preserveLoadedSession =
             hasLoadedGuestPageRef.current &&
             desktopIdentitySessionReadyRef.current;
-          if (preserveLoadedSession && fromRememberedSession) {
-            // Tab activation is a visibility change, not a new child-session
-            // ceremony that can safely replace a verified cookie.
-            updateDesktopIdentitySessionReady(true);
-            setDesktopIdentityStatus("signed-in");
-            return;
-          }
           if (!preserveLoadedSession) {
             updateDesktopIdentitySessionReady(false);
           }
           let synchronized: boolean | null;
           try {
-            synchronized = await identity.ensureAppSession(app.id);
+            synchronized =
+              preserveLoadedSession && fromRememberedSession
+                ? await identity.ensureAppSession(app.id, {
+                    preserveExistingSession: true,
+                  })
+                : await identity.ensureAppSession(app.id);
           } catch (error) {
             console.warn("[desktop-identity] lazy app synchronization failed", {
               appId: app.id,

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -866,8 +866,12 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         undefined,
         rememberedDesktopIdentityStatusAt,
       );
+      const preserveLoadedSession =
+        hasLoadedGuestPageRef.current && desktopIdentitySessionReadyRef.current;
       setDesktopIdentityEnabled(rememberedSignedIn ? true : null);
-      setDesktopIdentityStatus(rememberedSignedIn ? "signed-in" : "idle");
+      setDesktopIdentityStatus(
+        rememberedSignedIn || preserveLoadedSession ? "signed-in" : "idle",
+      );
       // Reactivating a tab whose guest page is already loaded and verified must
       // not hide it behind the loading gate again — the recheck below is cheap
       // and runs fine underneath a usable page. Clearing this on every
@@ -902,12 +906,11 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           }
           let synchronized: boolean | null;
           try {
-            synchronized =
-              preserveLoadedSession && fromRememberedSession
-                ? await identity.ensureAppSession(app.id, {
-                    preserveExistingSession: true,
-                  })
-                : await identity.ensureAppSession(app.id);
+            synchronized = preserveLoadedSession
+              ? await identity.ensureAppSession(app.id, {
+                  preserveExistingSession: true,
+                })
+              : await identity.ensureAppSession(app.id);
           } catch (error) {
             console.warn("[desktop-identity] lazy app synchronization failed", {
               appId: app.id,
@@ -916,7 +919,10 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
             synchronized = null;
           }
           if (!active || request !== statusRequest) return;
-          if (fromRememberedSession && synchronized !== true) {
+          if (
+            (preserveLoadedSession || fromRememberedSession) &&
+            synchronized !== true
+          ) {
             // A failed lazy sync can mean the broker is in the middle of
             // sign-out while its public status is still signed-in. Do not
             // keep reusing this renderer cache during that ceremony. Keep the
@@ -955,7 +961,9 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           }
           setDesktopIdentityEnabled(true);
           const needsRemoteStatus =
-            nextStatus === undefined && !reuseRememberedSession;
+            nextStatus === undefined &&
+            !reuseRememberedSession &&
+            !preserveLoadedSession;
           if (needsRemoteStatus) {
             setDesktopIdentityStatus("checking");
             updateDesktopIdentitySessionReady(false);
@@ -968,6 +976,12 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           // An older or unavailable preload must fail closed to the legacy
           // app-owned login surface rather than strand the WebView behind SSO.
           if (active && request === statusRequest) {
+            if (preserveLoadedSession) {
+              setDesktopIdentityEnabled(true);
+              setDesktopIdentityStatus("signed-in");
+              updateDesktopIdentitySessionReady(true);
+              return;
+            }
             if (
               shouldReuseRememberedDesktopIdentitySession(
                 rememberedDesktopIdentityStatus,

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -282,8 +282,10 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain(
       "https://forms.agent-native.com/f/agent-native-feedback/_16ewV",
     );
-    expect(hubSource).not.toContain("desktop-chat-first-rail-settings");
-    expect(hubSource).not.toContain('<DesktopRailTooltip label="Settings">');
+    expect(hubSource).toContain("desktop-chat-first-rail-settings");
+    expect(hubSource).toContain('<DesktopRailTooltip label="Settings">');
+    expect(hubSource).toContain("onClick={() => onOpenSettings()}");
+    expect(hubSource).toContain("<IconSettings");
     expect(hubSource).toContain("<TooltipProvider delayDuration={0}>");
     expect(hubSource).toContain("IconLayoutSidebarLeftCollapse");
     expect(hubSource).toContain("desktop-chat-first-rail-collapse");
@@ -306,6 +308,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(shellCss).toMatch(
       /\.desktop-chat-first-rail-footer-actions\s*>\s*\.desktop-chat-first-rail-feedback\s*\{[\s\S]*?flex: 1 1 auto;/,
     );
+    expect(shellCss).toContain("desktop-chat-first-rail-settings");
     expect(shellCss).toContain("visibility: hidden;");
     expect(shellCss).toContain("margin-top: auto;");
     expect(shellCss).toContain("height: 100%;");
@@ -332,6 +335,16 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       "if (forwardDesktopNavigationShortcut(event, input)) return;",
     );
     expect(mainSource).toContain("if (isDesktopChatToggleShortcut(input)) {");
+  });
+
+  it("routes Cmd+, to the desktop settings surface", () => {
+    const appSource = readFileSync("src/renderer/App.tsx", "utf8");
+    const mainSource = readFileSync("src/main/index.ts", "utf8");
+
+    expect(appSource).toContain("isDesktopSettingsShortcut");
+    expect(appSource).toContain("handleOpenSettings();");
+    expect(mainSource).toContain("isSettingsShortcut");
+    expect(mainSource).toContain('? ","');
   });
 
   it("orders pinned desktop apps ahead of unpinned apps and filters by name or description", () => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -340,11 +340,17 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
   it("routes Cmd+, to the desktop settings surface", () => {
     const appSource = readFileSync("src/renderer/App.tsx", "utf8");
     const mainSource = readFileSync("src/main/index.ts", "utf8");
+    const shortcutSource = readFileSync(
+      "src/main/desktop-navigation-shortcuts.ts",
+      "utf8",
+    );
 
     expect(appSource).toContain("isDesktopSettingsShortcut");
     expect(appSource).toContain("handleOpenSettings();");
-    expect(mainSource).toContain("isSettingsShortcut");
-    expect(mainSource).toContain('? ","');
+    expect(mainSource).toContain('contents.on("before-input-event"');
+    expect(mainSource).toContain('win.webContents.on("before-input-event"');
+    expect(shortcutSource).toContain("isDesktopSettingsShortcut");
+    expect(shortcutSource).toContain('? ","');
   });
 
   it("orders pinned desktop apps ahead of unpinned apps and filters by name or description", () => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -92,6 +92,7 @@ import {
   IconPlus,
   IconPin,
   IconSearch,
+  IconSettings,
   IconWorld,
 } from "@tabler/icons-react";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -2922,6 +2923,24 @@ export default function CodeAgentsHub({
               <>
                 <UpdatePrompt />
                 <UpdateIndicator />
+                {onOpenSettings ? (
+                  <DesktopRailTooltip label="Settings">
+                    <button
+                      type="button"
+                      className="code-agents-nav-link desktop-chat-first-rail-settings"
+                      onClick={() => onOpenSettings()}
+                      aria-label="Settings"
+                      title="Settings"
+                    >
+                      <IconSettings
+                        size={15}
+                        strokeWidth={1.8}
+                        aria-hidden="true"
+                      />
+                      <span>Settings</span>
+                    </button>
+                  </DesktopRailTooltip>
+                ) : null}
                 <div className="desktop-chat-first-rail-footer-actions">
                   <FeedbackButton
                     url={DESKTOP_FEEDBACK_FORM_URL}

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -55,6 +55,33 @@ describe("desktop app chat shell", () => {
     expect(source).not.toContain("data-desktop-app-sign-in");
   });
 
+  it("keeps the resolved chat endpoint across app tab switches", () => {
+    const source = readFileSync(
+      new URL("./DesktopAppChatShell.tsx", import.meta.url),
+      "utf8",
+    );
+    const apiUrlEffectStart = source.indexOf("setApiUrl(null);");
+    const apiUrlEffectEnd = source.indexOf(
+      "  useEffect(() => {\n    void preloadAgentChatSurface();",
+      apiUrlEffectStart,
+    );
+    const apiUrlEffect = source.slice(apiUrlEffectStart, apiUrlEffectEnd);
+
+    expect(apiUrlEffect).toContain("}, [appId]);");
+    expect(apiUrlEffect).not.toContain("setDesktopChatRelayActive");
+  });
+
+  it("keeps the app webview boundary visible with or without chat", () => {
+    const shellCss = readFileSync(
+      new URL("../shell.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(shellCss).toMatch(
+      /\.desktop-app-webview-surface,\s*\.code-agents-embedded-app-surface\s*\{\s*border-left: 1px solid hsl\(var\(--border\)\);\s*\}/,
+    );
+  });
+
   it("shows chat while the guest app is still loading", () => {
     expect(
       shouldShowDesktopAppChatSidebar({

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -301,7 +301,6 @@ export default function DesktopAppChatShell({
     let cancelled = false;
     setApiUrl(null);
     setDesktopChatRelayBase(appId, null);
-    setDesktopChatRelayActive(appId, false);
 
     const getApiUrl = window.electronAPI?.desktopChat?.getApiUrl;
     if (!getApiUrl) return () => undefined;
@@ -310,33 +309,30 @@ export default function DesktopAppChatShell({
       .then((nextApiUrl) => {
         if (cancelled) return;
         setDesktopChatRelayBase(appId, nextApiUrl);
-        setDesktopChatRelayActive(appId, isActive);
         setApiUrl(nextApiUrl);
       })
       .catch(() => {
         if (cancelled) return;
         setDesktopChatRelayBase(appId, null);
-        setDesktopChatRelayActive(appId, false);
         setApiUrl(null);
       });
 
     return () => {
       cancelled = true;
       setDesktopChatRelayBase(appId, null);
-      setDesktopChatRelayActive(appId, false);
     };
-  }, [appId, isActive]);
+  }, [appId]);
 
   useEffect(() => {
     void preloadAgentChatSurface();
   }, []);
 
   useEffect(() => {
-    setDesktopChatRelayActive(appId, isActive);
+    setDesktopChatRelayActive(appId, isActive && Boolean(apiUrl));
     return () => {
       setDesktopChatRelayActive(appId, false);
     };
-  }, [appId, isActive]);
+  }, [apiUrl, appId, isActive]);
 
   const startLocalCodeChange = useCallback(
     async (prompt: string) => {

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -872,7 +872,10 @@ interface ElectronAPI {
     getStatus(): Promise<DesktopIdentityStatus>;
     getSettings(): Promise<DesktopIdentitySettings>;
     setSsoEnabled(enabled: boolean): Promise<boolean>;
-    ensureAppSession(appId: string): Promise<boolean>;
+    ensureAppSession(
+      appId: string,
+      options?: { preserveExistingSession?: boolean },
+    ): Promise<boolean>;
     getAvailability(): Promise<boolean>;
     signIn(): Promise<boolean>;
     authenticate(

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -477,6 +477,10 @@ body {
   span,
 .desktop-chat-first-hub
   .code-agents-rail--collapsed
+  .desktop-chat-first-rail-settings
+  span,
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
   .code-agents-rail-footer
   > .update-indicator
   > span {
@@ -1016,6 +1020,14 @@ body {
 
 .desktop-chat-first-hub
   .code-agents-rail--collapsed
+  .desktop-chat-first-rail-settings {
+  width: 40px;
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
   [data-chat-first-rail-collapse] {
   background: hsl(var(--sidebar-accent));
   color: hsl(var(--sidebar-accent-foreground));
@@ -1065,6 +1077,11 @@ body {
   overflow: hidden;
   isolation: isolate;
   background: var(--shell-bg);
+}
+
+.desktop-app-webview-surface,
+.code-agents-embedded-app-surface {
+  border-left: 1px solid hsl(var(--border));
 }
 
 .code-agents-primary-app-surface {


### PR DESCRIPTION
## Summary
- Keep per-app chat relay URLs stable while switching app tabs so the left chat surface does not flash away.
- Preserve a verified loaded Mail webview session during ordinary tab activation instead of re-running child-session cookie synchronization.
- Add the standard border seam at every embedded app webview, restore the Settings rail button above Feedback, and route Cmd+, to Settings.

## Validation
- 64 repository guards passed.
- Desktop targeted Vitest suite passed: 83 tests across 4 files.
- AppWebview targeted suite passed: 37 tests.
- Code Agents UI suite passed: 29 tests.
- Shared core active-app rail suite passed: 9 tests.
- Desktop typecheck and production build passed.
- Built Electron runtime verified stable chat visibility across repeated app switches, the persistent webview border with chat expanded and collapsed, full-width active app-row highlighting, Settings placement, and native Cmd+, opening Settings.
