### PR TITLE
fix: stabilize desktop agent connections and picker

### DIFF
--- a/.changeset/bright-ui-mode-label.md
+++ b/.changeset/bright-ui-mode-label.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add localized fallback labels for the desktop agent picker mode options.

--- a/.changeset/quiet-desktop-agent-picker.md
+++ b/.changeset/quiet-desktop-agent-picker.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Fix the desktop agent picker readiness, tooltip stacking, and terminal mode control.

--- a/packages/code-agents-ui/src/CodeAgentsApp.tsx
+++ b/packages/code-agents-ui/src/CodeAgentsApp.tsx
@@ -191,7 +191,9 @@ export interface CodeAgentsHost {
   updateSchedule?: (input: unknown) => Promise<CodeAgentScheduleResult>;
   deleteSchedule?: (input: unknown) => Promise<CodeAgentScheduleResult>;
   runScheduleNow?: (input: unknown) => Promise<CodeAgentScheduleResult>;
-  listModels?: () => Promise<CodeAgentModelListResult>;
+  listModels?: (options?: {
+    refresh?: boolean;
+  }) => Promise<CodeAgentModelListResult>;
   getHostMetadata?: () => Promise<CodeAgentHostMetadata>;
   runComputerSetupAction?: (
     action: CodeAgentComputerSetupAction,
@@ -952,9 +954,7 @@ export default function CodeAgentsApp({
     useState<CodeAgentPermissionMode>(DEFAULT_CODE_AGENT_PERMISSION_MODE);
   const [selectedPermissionMode, setSelectedPermissionMode] =
     useState<CodeAgentPermissionMode>(DEFAULT_CODE_AGENT_PERMISSION_MODE);
-  const [modelOptions, setModelOptions] = useState<CodeAgentModelOption[]>(
-    DEFAULT_CODE_AGENT_MODEL_OPTIONS,
-  );
+  const [modelOptions, setModelOptions] = useState<CodeAgentModelOption[]>([]);
   const [projects, setProjects] = useState<CodeAgentProjectFolder[]>([]);
   const [selectedProjectPath, setSelectedProjectPath] = useState<string>("");
   const [newRunExecutionTarget, setNewRunExecutionTarget] =
@@ -1422,9 +1422,9 @@ export default function CodeAgentsApp({
         });
       }
       await loadHostMetadata();
-      const modelResult = await host.listModels?.();
+      const modelResult = await host.listModels?.({ refresh: true });
       let retrySelection = selectedModelSelection;
-      if (modelResult?.status === "ok" && modelResult.models.length > 0) {
+      if (modelResult?.status === "ok") {
         setModelOptions(modelResult.models);
         if (
           modelResult.selected &&
@@ -1534,8 +1534,8 @@ export default function CodeAgentsApp({
 
         let attempts = 0;
         const refresh = async (): Promise<void> => {
-          const modelResult = await host.listModels?.();
-          if (modelResult?.status === "ok" && modelResult.models.length > 0) {
+          const modelResult = await host.listModels?.({ refresh: true });
+          if (modelResult?.status === "ok") {
             setModelOptions(modelResult.models);
             if (modelResult.selected) {
               setModelSelection((current) =>
@@ -1763,7 +1763,7 @@ export default function CodeAgentsApp({
     void host
       .listModels?.()
       .then((result) => {
-        if (cancelled || result.status !== "ok" || result.models.length === 0) {
+        if (cancelled || result.status !== "ok") {
           return;
         }
         setModelOptions(result.models);

--- a/packages/core/src/localization/core-messages/ar-SA.ts
+++ b/packages/core/src/localization/core-messages/ar-SA.ts
@@ -35,6 +35,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "نسخ بيانات التشخيص",
   "aboutAgentNative.unknown": "غير معروف",
   "common.agent": "الوكيل",
+  "agentPanel.mode": "الوضع",
+  "agentPanel.uiMode": "واجهة المستخدم",
   "common.cancel": "إلغاء",
   "common.collapse": "طي",
   "common.connect": "اتصال",

--- a/packages/core/src/localization/core-messages/de-DE.ts
+++ b/packages/core/src/localization/core-messages/de-DE.ts
@@ -37,6 +37,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "Diagnosedaten kopieren",
   "aboutAgentNative.unknown": "Unbekannt",
   "common.agent": "Agent",
+  "agentPanel.mode": "Modus",
+  "agentPanel.uiMode": "Benutzeroberfläche",
   "common.cancel": "Abbrechen",
   "common.collapse": "Einklappen",
   "common.connect": "Verbinden",

--- a/packages/core/src/localization/core-messages/en-US.ts
+++ b/packages/core/src/localization/core-messages/en-US.ts
@@ -33,6 +33,8 @@ const messages = {
   "aboutAgentNative.copyDiagnostics": "Copy diagnostics",
   "aboutAgentNative.unknown": "Unknown",
   "common.agent": "Agent",
+  "agentPanel.mode": "Mode",
+  "agentPanel.uiMode": "UI",
   "common.cancel": "Cancel",
   "common.collapse": "Collapse",
   "common.connect": "Connect",

--- a/packages/core/src/localization/core-messages/es-ES.ts
+++ b/packages/core/src/localization/core-messages/es-ES.ts
@@ -36,6 +36,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "Copiar diagnóstico",
   "aboutAgentNative.unknown": "Desconocida",
   "common.agent": "Agente",
+  "agentPanel.mode": "Modo",
+  "agentPanel.uiMode": "Interfaz de usuario",
   "common.cancel": "Cancelar",
   "common.collapse": "Contraer",
   "common.connect": "Conectar",

--- a/packages/core/src/localization/core-messages/fr-FR.ts
+++ b/packages/core/src/localization/core-messages/fr-FR.ts
@@ -38,6 +38,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "Copier les diagnostics",
   "aboutAgentNative.unknown": "Inconnue",
   "common.agent": "Agent",
+  "agentPanel.mode": "Mode",
+  "agentPanel.uiMode": "Interface utilisateur",
   "common.cancel": "Annuler",
   "common.collapse": "Réduire",
   "common.connect": "Connecter",

--- a/packages/core/src/localization/core-messages/hi-IN.ts
+++ b/packages/core/src/localization/core-messages/hi-IN.ts
@@ -35,6 +35,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "डायग्नोस्टिक कॉपी करें",
   "aboutAgentNative.unknown": "अज्ञात",
   "common.agent": "एजेंट",
+  "agentPanel.mode": "मोड",
+  "agentPanel.uiMode": "यूआई",
   "common.cancel": "रद्द करें",
   "common.collapse": "समेटें",
   "common.connect": "कनेक्ट करें",

--- a/packages/core/src/localization/core-messages/ja-JP.ts
+++ b/packages/core/src/localization/core-messages/ja-JP.ts
@@ -36,6 +36,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "診断情報をコピー",
   "aboutAgentNative.unknown": "不明",
   "common.agent": "エージェント",
+  "agentPanel.mode": "モード",
+  "agentPanel.uiMode": "UI",
   "common.cancel": "キャンセル",
   "common.collapse": "折りたたむ",
   "common.connect": "接続",

--- a/packages/core/src/localization/core-messages/ko-KR.ts
+++ b/packages/core/src/localization/core-messages/ko-KR.ts
@@ -36,6 +36,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "진단 정보 복사",
   "aboutAgentNative.unknown": "알 수 없음",
   "common.agent": "에이전트",
+  "agentPanel.mode": "모드",
+  "agentPanel.uiMode": "UI",
   "common.cancel": "취소",
   "common.collapse": "접기",
   "common.connect": "연결",

--- a/packages/core/src/localization/core-messages/pt-BR.ts
+++ b/packages/core/src/localization/core-messages/pt-BR.ts
@@ -35,6 +35,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "Copiar diagnósticos",
   "aboutAgentNative.unknown": "Desconhecida",
   "common.agent": "Agente",
+  "agentPanel.mode": "Modo",
+  "agentPanel.uiMode": "Interface",
   "common.cancel": "Cancelar",
   "common.collapse": "Recolher",
   "common.connect": "Conectar",

--- a/packages/core/src/localization/core-messages/zh-CN.ts
+++ b/packages/core/src/localization/core-messages/zh-CN.ts
@@ -34,6 +34,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "复制诊断信息",
   "aboutAgentNative.unknown": "未知",
   "common.agent": "智能体",
+  "agentPanel.mode": "模式",
+  "agentPanel.uiMode": "界面",
   "common.cancel": "取消",
   "common.collapse": "收起",
   "common.connect": "连接",

--- a/packages/core/src/localization/core-messages/zh-TW.ts
+++ b/packages/core/src/localization/core-messages/zh-TW.ts
@@ -34,6 +34,8 @@ const messages: AgentChatTranslation = {
   "aboutAgentNative.copyDiagnostics": "複製診斷資訊",
   "aboutAgentNative.unknown": "未知",
   "common.agent": "代理",
+  "agentPanel.mode": "模式",
+  "agentPanel.uiMode": "介面",
   "common.cancel": "取消",
   "common.collapse": "收合",
   "common.connect": "連線",

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -479,6 +479,8 @@ const messages = {
     downloadDesktop: "Download Desktop",
     chatMode: "Chat mode",
     chat: "Chat",
+    mode: "Mode",
+    uiMode: "UI",
     cliTerminalMode: "CLI terminal mode",
     cli: "CLI",
     workspaceMode: "Files, agents, skills, and tasks",

--- a/packages/desktop-app/src/main/cli-status-cache.spec.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CLI_STATUS_TTL_MS,
   cachedCliStatus,
   createCliStatusCache,
   invalidateCliStatusCache,
@@ -58,6 +59,46 @@ describe("cachedCliStatus", () => {
     expect(asyncProbes).toBe(1);
     expect(
       cachedCliStatus(cache, probeSync, probeAsync, () => clock, 1000),
+    ).toBe("fresh");
+  });
+
+  it("refreshes explicitly without clearing the current value", async () => {
+    const cache = createCliStatusCache<string>();
+    let asyncProbes = 0;
+    let releaseProbe!: (value: string) => void;
+    const probe = new Promise<string>((resolve) => {
+      releaseProbe = resolve;
+    });
+
+    expect(
+      cachedCliStatus(
+        cache,
+        () => "stale",
+        async () => "initial async result",
+      ),
+    ).toBe("stale");
+    const current = cachedCliStatus(
+      cache,
+      () => "stale",
+      async () => {
+        asyncProbes += 1;
+        return probe;
+      },
+      Date.now,
+      CLI_STATUS_TTL_MS,
+      { refresh: true },
+    );
+
+    expect(current).toBe("stale");
+    expect(asyncProbes).toBe(1);
+    releaseProbe("fresh");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(
+      cachedCliStatus(
+        cache,
+        () => "stale",
+        async () => "unexpected second probe",
+      ),
     ).toBe("fresh");
   });
 

--- a/packages/desktop-app/src/main/cli-status-cache.spec.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.spec.ts
@@ -117,4 +117,54 @@ describe("cachedCliStatus", () => {
 
     expect(cachedCliStatus(cache, probe, async () => value)).toBe("signed in");
   });
+
+  it("does not let an older refresh overwrite an explicit refresh", async () => {
+    const cache = createCliStatusCache<string>();
+    let clock = 0;
+    let releaseOldProbe!: (value: string) => void;
+    const oldProbe = new Promise<string>((resolve) => {
+      releaseOldProbe = resolve;
+    });
+
+    cachedCliStatus(
+      cache,
+      () => "initial",
+      () => oldProbe,
+      () => clock,
+      1000,
+    );
+    clock = 5000;
+    expect(
+      cachedCliStatus(
+        cache,
+        () => "initial",
+        () => oldProbe,
+        () => clock,
+        1000,
+      ),
+    ).toBe("initial");
+
+    invalidateCliStatusCache(cache);
+    expect(
+      cachedCliStatus(
+        cache,
+        () => "explicit refresh",
+        async () => "unexpected stale result",
+        () => clock,
+        1000,
+      ),
+    ).toBe("explicit refresh");
+
+    releaseOldProbe("old async result");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(
+      cachedCliStatus(
+        cache,
+        () => "explicit refresh",
+        async () => "unexpected stale result",
+        () => clock,
+        1000,
+      ),
+    ).toBe("explicit refresh");
+  });
 });

--- a/packages/desktop-app/src/main/cli-status-cache.spec.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { cachedCliStatus, createCliStatusCache } from "./cli-status-cache.js";
+import {
+  cachedCliStatus,
+  createCliStatusCache,
+  invalidateCliStatusCache,
+} from "./cli-status-cache.js";
 
 describe("cachedCliStatus", () => {
   it("probes synchronously only on the first call, then serves the cache", () => {
@@ -100,5 +104,17 @@ describe("cachedCliStatus", () => {
         1000,
       ),
     ).toBe("fresh");
+  });
+
+  it("allows an explicit refresh to re-probe immediately", () => {
+    const cache = createCliStatusCache<string>();
+    let value = "signed out";
+    const probe = () => value;
+
+    expect(cachedCliStatus(cache, probe, async () => value)).toBe("signed out");
+    value = "signed in";
+    invalidateCliStatusCache(cache);
+
+    expect(cachedCliStatus(cache, probe, async () => value)).toBe("signed in");
   });
 });

--- a/packages/desktop-app/src/main/cli-status-cache.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.ts
@@ -18,6 +18,12 @@ export function createCliStatusCache<T>(): CliStatusCache<T> {
   return { probedAt: 0, refreshing: false };
 }
 
+export function invalidateCliStatusCache<T>(cache: CliStatusCache<T>): void {
+  cache.value = undefined;
+  cache.probedAt = 0;
+  cache.refreshing = false;
+}
+
 /**
  * Returns the cached probe result, refreshing in the background once it is
  * older than `ttlMs`.

--- a/packages/desktop-app/src/main/cli-status-cache.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.ts
@@ -12,16 +12,18 @@ export interface CliStatusCache<T> {
   value?: T;
   probedAt: number;
   refreshing: boolean;
+  generation: number;
 }
 
 export function createCliStatusCache<T>(): CliStatusCache<T> {
-  return { probedAt: 0, refreshing: false };
+  return { probedAt: 0, refreshing: false, generation: 0 };
 }
 
 export function invalidateCliStatusCache<T>(cache: CliStatusCache<T>): void {
   cache.value = undefined;
   cache.probedAt = 0;
   cache.refreshing = false;
+  cache.generation += 1;
 }
 
 /**
@@ -45,13 +47,16 @@ export function cachedCliStatus<T>(
     return cache.value;
   }
   if (!cache.refreshing && now() - cache.probedAt >= ttlMs) {
+    const generation = cache.generation;
     cache.refreshing = true;
     void probeAsync()
       .then((value) => {
+        if (cache.generation !== generation) return;
         cache.value = value;
         cache.probedAt = now();
       })
       .finally(() => {
+        if (cache.generation !== generation) return;
         cache.refreshing = false;
       });
   }

--- a/packages/desktop-app/src/main/cli-status-cache.ts
+++ b/packages/desktop-app/src/main/cli-status-cache.ts
@@ -26,6 +26,26 @@ export function invalidateCliStatusCache<T>(cache: CliStatusCache<T>): void {
   cache.generation += 1;
 }
 
+function startCliStatusRefresh<T>(
+  cache: CliStatusCache<T>,
+  probeAsync: () => Promise<T>,
+  now: () => number,
+): void {
+  if (cache.refreshing) return;
+  const generation = cache.generation;
+  cache.refreshing = true;
+  void probeAsync()
+    .then((value) => {
+      if (cache.generation !== generation) return;
+      cache.value = value;
+      cache.probedAt = now();
+    })
+    .finally(() => {
+      if (cache.generation !== generation) return;
+      cache.refreshing = false;
+    });
+}
+
 /**
  * Returns the cached probe result, refreshing in the background once it is
  * older than `ttlMs`.
@@ -40,25 +60,18 @@ export function cachedCliStatus<T>(
   probeAsync: () => Promise<T>,
   now: () => number = Date.now,
   ttlMs: number = CLI_STATUS_TTL_MS,
+  options: { refresh?: boolean } = {},
 ): T {
+  if (options.refresh && cache.value !== undefined) {
+    startCliStatusRefresh(cache, probeAsync, now);
+  }
   if (cache.value === undefined) {
     cache.value = probeSync();
     cache.probedAt = now();
     return cache.value;
   }
   if (!cache.refreshing && now() - cache.probedAt >= ttlMs) {
-    const generation = cache.generation;
-    cache.refreshing = true;
-    void probeAsync()
-      .then((value) => {
-        if (cache.generation !== generation) return;
-        cache.value = value;
-        cache.probedAt = now();
-      })
-      .finally(() => {
-        if (cache.generation !== generation) return;
-        cache.refreshing = false;
-      });
+    startCliStatusRefresh(cache, probeAsync, now);
   }
   return cache.value;
 }

--- a/packages/desktop-app/src/main/code-agent-runner.spec.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.spec.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { dispatchCodeAgentRunnerCommand } from "./code-agent-runner-dispatch.js";
 import {
   isCodeAgentRunnerInFlight,
+  resolveExecutable,
   resolveCodeAgentRunnerInvocation,
   runCodeAgentRunnerWithSignal,
 } from "./code-agent-runner.js";
@@ -203,6 +204,32 @@ describe("resolveCodeAgentRunnerInvocation", () => {
       repoRoot,
       "--filter",
     ]);
+  });
+});
+
+describe("resolveExecutable", () => {
+  it("finds CLIs in the standard desktop user-bin directory", () => {
+    const root = createTempRoot();
+    const bin = path.join(root, ".local", "bin");
+    const executable = path.join(bin, "codex");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(executable, "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveExecutable("codex", { HOME: root, PATH: "/usr/bin" })).toBe(
+      executable,
+    );
+  });
+
+  it("finds CLIs installed under an NVM-managed Node version", () => {
+    const root = createTempRoot();
+    const bin = path.join(root, ".nvm", "versions", "node", "v24.0.0", "bin");
+    const executable = path.join(bin, "codex");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(executable, "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(resolveExecutable("codex", { HOME: root, PATH: "/usr/bin" })).toBe(
+      executable,
+    );
   });
 });
 

--- a/packages/desktop-app/src/main/code-agent-runner.spec.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.spec.ts
@@ -11,6 +11,7 @@ import {
   resolveExecutable,
   resolveCodeAgentRunnerInvocation,
   runCodeAgentRunnerWithSignal,
+  withResolvedExecutablePaths,
 } from "./code-agent-runner.js";
 
 const tempRoots: string[] = [];
@@ -218,6 +219,20 @@ describe("resolveExecutable", () => {
     expect(resolveExecutable("codex", { HOME: root, PATH: "/usr/bin" })).toBe(
       executable,
     );
+  });
+
+  it("propagates GUI-only CLI directories into child PATH", () => {
+    const root = createTempRoot();
+    const bin = path.join(root, ".local", "bin");
+    fs.mkdirSync(bin, { recursive: true });
+    fs.writeFileSync(path.join(bin, "codex"), "#!/bin/sh\n", { mode: 0o755 });
+
+    expect(
+      withResolvedExecutablePaths({ HOME: root, PATH: "/usr/bin" }, [
+        "codex",
+        "claude",
+      ]).PATH?.split(path.delimiter),
+    ).toEqual([bin, "/usr/bin"]);
   });
 
   it("finds CLIs installed under an NVM-managed Node version", () => {

--- a/packages/desktop-app/src/main/code-agent-runner.spec.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.spec.ts
@@ -226,6 +226,7 @@ describe("resolveExecutable", () => {
     const bin = path.join(root, ".local", "bin");
     fs.mkdirSync(bin, { recursive: true });
     fs.writeFileSync(path.join(bin, "codex"), "#!/bin/sh\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(bin, "node"), "#!/bin/sh\n", { mode: 0o755 });
 
     expect(
       withResolvedExecutablePaths({ HOME: root, PATH: "/usr/bin" }, [
@@ -233,6 +234,34 @@ describe("resolveExecutable", () => {
         "claude",
       ]).PATH?.split(path.delimiter),
     ).toEqual([bin, "/usr/bin"]);
+  });
+
+  it("propagates the Node runtime directory for package-manager shims", () => {
+    const root = createTempRoot();
+    const pnpmHome = path.join(root, ".local", "share", "pnpm");
+    const nodeBin = path.join(
+      root,
+      ".nvm",
+      "versions",
+      "node",
+      "v24.0.0",
+      "bin",
+    );
+    fs.mkdirSync(pnpmHome, { recursive: true });
+    fs.mkdirSync(nodeBin, { recursive: true });
+    fs.writeFileSync(path.join(pnpmHome, "pi"), "#!/usr/bin/env node\n", {
+      mode: 0o755,
+    });
+    fs.writeFileSync(path.join(nodeBin, "node"), "#!/bin/sh\n", {
+      mode: 0o755,
+    });
+
+    expect(
+      withResolvedExecutablePaths(
+        { HOME: root, PATH: "/usr/bin", PNPM_HOME: pnpmHome },
+        ["pi"],
+      ).PATH?.split(path.delimiter),
+    ).toEqual([nodeBin, pnpmHome, "/usr/bin"]);
   });
 
   it("finds CLIs installed under an NVM-managed Node version", () => {

--- a/packages/desktop-app/src/main/code-agent-runner.spec.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.spec.ts
@@ -261,7 +261,48 @@ describe("resolveExecutable", () => {
         { HOME: root, PATH: "/usr/bin", PNPM_HOME: pnpmHome },
         ["pi"],
       ).PATH?.split(path.delimiter),
-    ).toEqual([nodeBin, pnpmHome, "/usr/bin"]);
+    ).toEqual([pnpmHome, nodeBin, "/usr/bin"]);
+  });
+
+  it("keeps an NVM CLI ahead of another Node version already on PATH", () => {
+    const root = createTempRoot();
+    const oldNodeBin = path.join(
+      root,
+      ".nvm",
+      "versions",
+      "node",
+      "v20.0.0",
+      "bin",
+    );
+    const selectedNodeBin = path.join(
+      root,
+      ".nvm",
+      "versions",
+      "node",
+      "v24.0.0",
+      "bin",
+    );
+    fs.mkdirSync(oldNodeBin, { recursive: true });
+    fs.mkdirSync(selectedNodeBin, { recursive: true });
+    fs.writeFileSync(path.join(oldNodeBin, "node"), "#!/bin/sh\n", {
+      mode: 0o755,
+    });
+    fs.writeFileSync(path.join(selectedNodeBin, "node"), "#!/bin/sh\n", {
+      mode: 0o755,
+    });
+    fs.writeFileSync(
+      path.join(selectedNodeBin, "pi"),
+      "#!/usr/bin/env node\n",
+      {
+        mode: 0o755,
+      },
+    );
+
+    expect(
+      withResolvedExecutablePaths({ HOME: root, PATH: oldNodeBin }, [
+        "pi",
+      ]).PATH?.split(path.delimiter),
+    ).toEqual([selectedNodeBin, oldNodeBin]);
   });
 
   it("finds CLIs installed under an NVM-managed Node version", () => {

--- a/packages/desktop-app/src/main/code-agent-runner.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.ts
@@ -207,3 +207,20 @@ export function resolveExecutable(
   }
   return null;
 }
+
+export function withResolvedExecutablePaths(
+  environment: NodeJS.ProcessEnv,
+  executables: readonly string[],
+): NodeJS.ProcessEnv {
+  const resolvedDirectories = executables
+    .map((executable) => resolveExecutable(executable, environment))
+    .filter((resolved): resolved is string => Boolean(resolved))
+    .map((resolved) => path.dirname(resolved));
+  const existingPath = (environment.PATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean);
+  const pathEntries = [...new Set([...resolvedDirectories, ...existingPath])];
+  return pathEntries.length > 0
+    ? { ...environment, PATH: pathEntries.join(path.delimiter) }
+    : environment;
+}

--- a/packages/desktop-app/src/main/code-agent-runner.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.ts
@@ -212,7 +212,7 @@ export function withResolvedExecutablePaths(
   environment: NodeJS.ProcessEnv,
   executables: readonly string[],
 ): NodeJS.ProcessEnv {
-  const resolvedDirectories = executables
+  const resolvedDirectories = ["node", ...executables]
     .map((executable) => resolveExecutable(executable, environment))
     .filter((resolved): resolved is string => Boolean(resolved))
     .map((resolved) => path.dirname(resolved));

--- a/packages/desktop-app/src/main/code-agent-runner.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.ts
@@ -212,10 +212,12 @@ export function withResolvedExecutablePaths(
   environment: NodeJS.ProcessEnv,
   executables: readonly string[],
 ): NodeJS.ProcessEnv {
-  const resolvedDirectories = ["node", ...executables]
+  const resolvedDirectories = executables
     .map((executable) => resolveExecutable(executable, environment))
     .filter((resolved): resolved is string => Boolean(resolved))
     .map((resolved) => path.dirname(resolved));
+  const resolvedNode = resolveExecutable("node", environment);
+  if (resolvedNode) resolvedDirectories.push(path.dirname(resolvedNode));
   const existingPath = (environment.PATH ?? "")
     .split(path.delimiter)
     .filter(Boolean);

--- a/packages/desktop-app/src/main/code-agent-runner.ts
+++ b/packages/desktop-app/src/main/code-agent-runner.ts
@@ -159,7 +159,7 @@ export function resolveCodeAgentRunnerInvocation(
   };
 }
 
-function resolveExecutable(
+export function resolveExecutable(
   executable: string,
   environment: NodeJS.ProcessEnv | undefined,
 ): string | null {
@@ -172,8 +172,25 @@ function resolveExecutable(
   const searchDirectories = [
     ...pathEntries,
     environment.PNPM_HOME,
+    home ? path.join(home, ".local", "bin") : undefined,
     home ? path.join(home, ".local", "share", "pnpm") : undefined,
     home ? path.join(home, "Library", "pnpm") : undefined,
+    home ? path.join(home, ".opencode", "bin") : undefined,
+    home ? path.join(home, ".cargo", "bin") : undefined,
+    ...(home
+      ? (() => {
+          try {
+            return fs
+              .readdirSync(path.join(home, ".nvm", "versions", "node"))
+              .map((version) =>
+                path.join(home, ".nvm", "versions", "node", version, "bin"),
+              );
+          } catch {
+            // coercion-ok: NVM is optional in desktop launch environments.
+            return [];
+          }
+        })()
+      : []),
     "/opt/homebrew/bin",
     "/usr/local/bin",
   ].filter((value): value is string => Boolean(value));

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -187,11 +187,13 @@ import { isClaudeSubscriptionAuthMethod } from "./claude-subscription.js";
 import {
   cachedCliStatus,
   createCliStatusCache,
+  invalidateCliStatusCache,
   type CliStatusCache,
 } from "./cli-status-cache.js";
 import { guardCodeAgentPersistence } from "./code-agent-persistence-guard.js";
 import {
   isCodeAgentRunnerInFlight,
+  resolveExecutable,
   resolveCodeAgentRunnerInvocation,
 } from "./code-agent-runner.js";
 import { DesktopCodeAgentScheduler } from "./code-agent-scheduler.js";
@@ -10930,6 +10932,12 @@ function getCodeAgentLlmProviderStatus(): NonNullable<
   const settings = AppStore.getCodeAgentProviderSettingsStatus();
   const codex = getLocalCodexCliStatus();
   const claude = getLocalClaudeCliStatus();
+  const pi = getLocalCliAvailability("pi", "Pi", localPiCliAvailabilityCache);
+  const opencode = getLocalCliAvailability(
+    "opencode",
+    "OpenCode",
+    localOpenCodeCliAvailabilityCache,
+  );
   const configuredCredentialKeys = new Set(
     settings.providers.flatMap((provider) => provider.configuredKeys),
   );
@@ -10937,6 +10945,8 @@ function getCodeAgentLlmProviderStatus(): NonNullable<
     ...(process.env.AGENT_ENGINE ? ["Custom"] : []),
     ...(codex.authenticated ? [codex.label] : []),
     ...(claude.authenticated ? [claude.label] : []),
+    ...(pi.available ? [pi.label] : []),
+    ...(opencode.available ? [opencode.label] : []),
     ...settings.configuredProviders,
   ];
 
@@ -11044,10 +11054,14 @@ interface CliRun {
 }
 
 function runCliSync(command: string, args: string[]): CliRun {
-  const result = spawnSync(command, args, {
-    encoding: "utf-8",
-    timeout: CLI_PROBE_TIMEOUT_MS,
-  });
+  const result = spawnSync(
+    resolveExecutable(command, process.env) ?? command,
+    args,
+    {
+      encoding: "utf-8",
+      timeout: CLI_PROBE_TIMEOUT_MS,
+    },
+  );
   return {
     status: result.status,
     stdout: result.stdout ?? "",
@@ -11059,7 +11073,7 @@ function runCliSync(command: string, args: string[]): CliRun {
 function runCliAsync(command: string, args: string[]): Promise<CliRun> {
   return new Promise((resolve) => {
     execFile(
-      command,
+      resolveExecutable(command, process.env) ?? command,
       args,
       { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS },
       (error, stdout, stderr) => {
@@ -11312,6 +11326,13 @@ function getCodeAgentProviderSettings(): CodeAgentProviderSettings {
   );
 }
 
+function invalidateLocalCliStatusCaches(): void {
+  invalidateCliStatusCache(localCodexCliStatusCache);
+  invalidateCliStatusCache(localClaudeCliStatusCache);
+  invalidateCliStatusCache(localPiCliAvailabilityCache);
+  invalidateCliStatusCache(localOpenCodeCliAvailabilityCache);
+}
+
 function withLocalCodexProviderStatus(
   settings: CodeAgentProviderSettings,
 ): CodeAgentProviderSettings {
@@ -11404,9 +11425,12 @@ function pushCodeAgentModelOptions(
   }
 }
 
-function getCodeAgentModelList(): CodeAgentModelListResult {
+function getCodeAgentModelList(input?: unknown): CodeAgentModelListResult {
   try {
-    const settings = AppStore.getCodeAgentProviderSettingsStatus();
+    if (isObject(input) && input.refresh === true) {
+      invalidateLocalCliStatusCaches();
+    }
+    const settings = getCodeAgentProviderSettings();
     const models: CodeAgentModelOption[] = [];
     const builderConfigured = Boolean(
       providerStatusById(settings, "builder")?.configured,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -185,9 +185,9 @@ import {
 } from "./browser-control/native-host";
 import { isClaudeSubscriptionAuthMethod } from "./claude-subscription.js";
 import {
+  CLI_STATUS_TTL_MS,
   cachedCliStatus,
   createCliStatusCache,
-  invalidateCliStatusCache,
   type CliStatusCache,
 } from "./cli-status-cache.js";
 import { guardCodeAgentPersistence } from "./code-agent-persistence-guard.js";
@@ -195,6 +195,7 @@ import {
   isCodeAgentRunnerInFlight,
   resolveExecutable,
   resolveCodeAgentRunnerInvocation,
+  withResolvedExecutablePaths,
 } from "./code-agent-runner.js";
 import { DesktopCodeAgentScheduler } from "./code-agent-scheduler.js";
 import {
@@ -5471,6 +5472,21 @@ function persistCodeAgentChildEvent(
   guardCodeAgentPersistence({ runId, source }, persist);
 }
 
+const LOCAL_CODE_AGENT_EXECUTABLES = [
+  "codex",
+  "claude",
+  "pi",
+  "opencode",
+] as const;
+
+function getCodeAgentChildEnvironment(
+  ...sources: Array<NodeJS.ProcessEnv | undefined>
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const source of sources) Object.assign(environment, source);
+  return withResolvedExecutablePaths(environment, LOCAL_CODE_AGENT_EXECUTABLES);
+}
+
 async function spawnCodeAgentRunner(
   runId: string,
   cwd: string,
@@ -5586,14 +5602,16 @@ async function spawnCodeAgentRunner(
       cwd: invocation.cwd,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...AppStore.getCodeAgentProviderProcessEnv(process.env),
-        AGENT_NATIVE_CODE_AGENTS_HOME: codeAgentStoreRoot(),
-        AGENT_NATIVE_CODE_AGENT_PERMISSION_MODE: normalizedPermissionMode,
-        ...invocation.env,
-        ...mcpEnvironment.env,
-        ...computerEnv,
-      },
+      env: getCodeAgentChildEnvironment(
+        AppStore.getCodeAgentProviderProcessEnv(process.env),
+        {
+          AGENT_NATIVE_CODE_AGENTS_HOME: codeAgentStoreRoot(),
+          AGENT_NATIVE_CODE_AGENT_PERMISSION_MODE: normalizedPermissionMode,
+        },
+        invocation.env,
+        mcpEnvironment.env,
+        computerEnv,
+      ),
     });
     const runnerStartedAt = new Date().toISOString();
     const runnerCommand = `${command} ${args.join(" ")}`;
@@ -5789,13 +5807,15 @@ function spawnCodeAgentApprovalRunner(
       cwd: invocation.cwd,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...AppStore.getCodeAgentProviderProcessEnv(process.env),
-        AGENT_NATIVE_CODE_AGENTS_HOME: codeAgentStoreRoot(),
-        AGENT_NATIVE_CODE_AGENT_PERMISSION_MODE: normalizedPermissionMode,
-        ...invocation.env,
-        ...computerEnv,
-      },
+      env: getCodeAgentChildEnvironment(
+        AppStore.getCodeAgentProviderProcessEnv(process.env),
+        {
+          AGENT_NATIVE_CODE_AGENTS_HOME: codeAgentStoreRoot(),
+          AGENT_NATIVE_CODE_AGENT_PERMISSION_MODE: normalizedPermissionMode,
+        },
+        invocation.env,
+        computerEnv,
+      ),
     });
     const runnerStartedAt = new Date().toISOString();
     const runnerCommand = `${command} ${args.join(" ")}`;
@@ -11106,9 +11126,13 @@ interface LocalCodexCliStatus {
   error?: string;
 }
 
+type CliStatusReadOptions = { refresh?: boolean };
+
 const localCodexCliStatusCache = createCliStatusCache<LocalCodexCliStatus>();
 
-function getLocalCodexCliStatus(): LocalCodexCliStatus {
+function getLocalCodexCliStatus(
+  options?: CliStatusReadOptions,
+): LocalCodexCliStatus {
   return cachedCliStatus(
     localCodexCliStatusCache,
     () => {
@@ -11127,6 +11151,9 @@ function getLocalCodexCliStatus(): LocalCodexCliStatus {
         await runCliAsync("codex", ["login", "status"]),
       );
     },
+    Date.now,
+    CLI_STATUS_TTL_MS,
+    options,
   );
 }
 
@@ -11199,7 +11226,9 @@ interface LocalClaudeCliStatus {
 
 const localClaudeCliStatusCache = createCliStatusCache<LocalClaudeCliStatus>();
 
-function getLocalClaudeCliStatus(): LocalClaudeCliStatus {
+function getLocalClaudeCliStatus(
+  options?: CliStatusReadOptions,
+): LocalClaudeCliStatus {
   return cachedCliStatus(
     localClaudeCliStatusCache,
     () => {
@@ -11218,6 +11247,9 @@ function getLocalClaudeCliStatus(): LocalClaudeCliStatus {
         await runCliAsync("claude", ["auth", "status", "--json"]),
       );
     },
+    Date.now,
+    CLI_STATUS_TTL_MS,
+    options,
   );
 }
 
@@ -11281,6 +11313,7 @@ function getLocalCliAvailability(
   command: string,
   label: string,
   cache: CliStatusCache<LocalCliAvailability>,
+  options?: CliStatusReadOptions,
 ): LocalCliAvailability {
   return cachedCliStatus(
     cache,
@@ -11296,6 +11329,9 @@ function getLocalCliAvailability(
         label,
         await runCliAsync(command, ["--version"]),
       ),
+    Date.now,
+    CLI_STATUS_TTL_MS,
+    options,
   );
 }
 
@@ -11324,13 +11360,6 @@ function getCodeAgentProviderSettings(): CodeAgentProviderSettings {
   return withLocalCodexProviderStatus(
     AppStore.getCodeAgentProviderSettingsStatus(),
   );
-}
-
-function invalidateLocalCliStatusCaches(): void {
-  invalidateCliStatusCache(localCodexCliStatusCache);
-  invalidateCliStatusCache(localClaudeCliStatusCache);
-  invalidateCliStatusCache(localPiCliAvailabilityCache);
-  invalidateCliStatusCache(localOpenCodeCliAvailabilityCache);
 }
 
 function withLocalCodexProviderStatus(
@@ -11427,21 +11456,28 @@ function pushCodeAgentModelOptions(
 
 function getCodeAgentModelList(input?: unknown): CodeAgentModelListResult {
   try {
-    if (isObject(input) && input.refresh === true) {
-      invalidateLocalCliStatusCaches();
-    }
+    const refreshLocalCliStatus = isObject(input) && input.refresh === true;
+    const cliStatusOptions = refreshLocalCliStatus
+      ? { refresh: true }
+      : undefined;
+    const codex = getLocalCodexCliStatus(cliStatusOptions);
     const settings = getCodeAgentProviderSettings();
     const models: CodeAgentModelOption[] = [];
     const builderConfigured = Boolean(
       providerStatusById(settings, "builder")?.configured,
     );
-    const codex = getLocalCodexCliStatus();
-    const claude = getLocalClaudeCliStatus();
-    const pi = getLocalCliAvailability("pi", "Pi", localPiCliAvailabilityCache);
+    const claude = getLocalClaudeCliStatus(cliStatusOptions);
+    const pi = getLocalCliAvailability(
+      "pi",
+      "Pi",
+      localPiCliAvailabilityCache,
+      cliStatusOptions,
+    );
     const opencode = getLocalCliAvailability(
       "opencode",
       "OpenCode",
       localOpenCodeCliAvailabilityCache,
+      cliStatusOptions,
     );
     const anthropicConfigured = Boolean(
       providerStatusById(settings, "anthropic")?.configured,

--- a/packages/desktop-app/src/main/ipc/code-agents.ts
+++ b/packages/desktop-app/src/main/ipc/code-agents.ts
@@ -81,7 +81,7 @@ export interface CodeAgentsIpcDeps {
   submitCodeAgentRemoteWaitlist: (
     input: unknown,
   ) => Promise<CodeAgentRemoteWaitlistResult>;
-  getCodeAgentModelList: () => CodeAgentModelListResult;
+  getCodeAgentModelList: (input?: unknown) => CodeAgentModelListResult;
   readCodeAgentTranscript: (input: unknown) => CodeAgentTranscriptResult;
   removeCodeAgentTranscriptSubscription: (subscriptionId: string) => void;
   initializeCodeAgentTranscriptSubscriptionKeys: (
@@ -301,7 +301,8 @@ export function registerCodeAgentsIpc(deps: CodeAgentsIpcDeps): void {
 
   ipcMain.handle(
     IPC.CODE_AGENTS_LIST_MODELS,
-    (): CodeAgentModelListResult => getCodeAgentModelList(),
+    (_event: IpcMainInvokeEvent, input?: unknown): CodeAgentModelListResult =>
+      getCodeAgentModelList(input),
   );
 
   ipcMain.handle(

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -412,8 +412,10 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.CODE_AGENTS_RUN_SCHEDULE_NOW, input),
     listWorktrees: (cwd?: string): Promise<CodeAgentWorktreeListResult> =>
       ipcRenderer.invoke(IPC.CODE_AGENTS_LIST_WORKTREES, cwd),
-    listModels: (): Promise<CodeAgentModelListResult> =>
-      ipcRenderer.invoke(IPC.CODE_AGENTS_LIST_MODELS),
+    listModels: (options?: {
+      refresh?: boolean;
+    }): Promise<CodeAgentModelListResult> =>
+      ipcRenderer.invoke(IPC.CODE_AGENTS_LIST_MODELS, options),
     createRun: (
       request: CodeAgentCreateRunRequest,
     ): Promise<CodeAgentCreateRunResult> =>

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2249,7 +2249,7 @@ export default function CodeAgentsHub({
         }
         return api.submitRemoteWaitlist(request);
       },
-      async listModels() {
+      async listModels(options?: { refresh?: boolean }) {
         const api = window.electronAPI?.codeAgents;
         if (!api?.listModels) {
           return {
@@ -2258,7 +2258,7 @@ export default function CodeAgentsHub({
             error: "Desktop bridge is not available.",
           };
         }
-        return api.listModels() as Promise<CodeAgentModelListResult>;
+        return api.listModels(options) as Promise<CodeAgentModelListResult>;
       },
       async getHostMetadata() {
         const api = window.electronAPI?.codeAgents;

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -937,7 +937,9 @@ interface ElectronAPI {
     deleteSchedule(input: unknown): Promise<CodeAgentScheduleResult>;
     runScheduleNow(input: unknown): Promise<CodeAgentScheduleResult>;
     listWorktrees(cwd?: string): Promise<CodeAgentWorktreeListResult>;
-    listModels(): Promise<CodeAgentModelListResult>;
+    listModels(options?: {
+      refresh?: boolean;
+    }): Promise<CodeAgentModelListResult>;
     createRun(
       request: CodeAgentCreateRunRequest,
     ): Promise<CodeAgentCreateRunResult>;

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -21,6 +21,7 @@ import {
   isOpenAiModelProviderGroup,
   isComposerEditorUsable,
   formatVoiceTranscriptForComposer,
+  hasConfiguredCloudProvider,
   MODEL_SELECTOR_POPOVER_STYLE,
   resolveContextChipBackspaceAction,
   resolveComposerPrimaryAction,
@@ -528,6 +529,24 @@ describe("createTiptapComposerExtensions", () => {
     ).toBe(false);
     // No CTA to fall back on — keep the list rather than empty the popover.
     expect(shouldShowOnlyConnectPath(false, unconfigured)).toBe(false);
+  });
+
+  it("keeps cloud setup readiness separate from local runtime readiness", () => {
+    expect(
+      hasConfiguredCloudProvider([
+        { engine: "pi-cli", configured: true },
+        { engine: "opencode-cli", configured: true },
+      ]),
+    ).toBe(false);
+    expect(
+      hasConfiguredCloudProvider([
+        { engine: "pi-cli", configured: true },
+        { engine: "builder", configured: true },
+      ]),
+    ).toBe(true);
+    expect(
+      hasConfiguredCloudProvider([{ engine: "builder", configured: false }]),
+    ).toBe(false);
   });
 
   it("still renders the picker when nothing is configured, even though that leaves selectedModel empty", () => {

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -1336,6 +1336,7 @@ function ModelSelector({
   providerConnectStatusEnabled = true,
   onConnectProvider,
   onConnectLocalRuntime,
+  terminalModeControl,
   imageModel,
 }: {
   model: string;
@@ -1360,6 +1361,7 @@ function ModelSelector({
   providerConnectStatusEnabled?: boolean;
   onConnectProvider?: () => void;
   onConnectLocalRuntime?: (engine: string) => void;
+  terminalModeControl?: ComposerTerminalModeControl;
   onModelSelectorOpenChange?: (open: boolean) => void;
   imageModel?: ComposerImageModelMenu;
   open?: boolean;
@@ -1463,7 +1465,7 @@ function ModelSelector({
   const selectedModelLabel = friendlyModelName(model, t).replace(/^GPT-/, "");
 
   const [detailSection, setDetailSection] = useState<
-    "agent" | "model" | "effort" | null
+    "agent" | "model" | "effort" | "mode" | null
   >(null);
   const resolvedSection = detailSection ?? (agentOnly ? "agent" : "model");
 
@@ -1482,9 +1484,8 @@ function ModelSelector({
     engines.length,
   );
 
-  // Keep setup actions beside model choices while any visible provider still
-  // needs configuration. The model rows remain visible so the user can see
-  // what becomes available after connecting or adding a key.
+  // Keep setup actions visible, but do not show unusable model rows until one
+  // provider or local agent is ready.
   const builderFlow = adapters.builder!.useConnectFlow!({
     enabled: providerConnectStatusEnabled,
     trackingSource: "composer_builder_cta",
@@ -1498,19 +1499,25 @@ function ModelSelector({
   const hasUnconfiguredVisibleModels = modelProviderGroups.some(
     (group) => !group.configured,
   );
+  const hasConfiguredProvider = providerGroups.some(
+    (group) => group.configured,
+  );
   const showBuilderAction =
-    hasUnconfiguredVisibleModels &&
+    !hasConfiguredProvider &&
     (Boolean(onConnectProvider) ||
       (providerConnectStatusEnabled &&
         !builderFlow.configured &&
         !builderFlow.envManaged &&
         !hasConfiguredBuilderModels &&
         !hasConnectedSubscription));
-  const showAddKeysAction = hasUnconfiguredVisibleModels;
+  const showAddKeysAction =
+    !hasConfiguredProvider &&
+    (hasUnconfiguredVisibleModels || showBuilderAction);
   const showProviderActions = showBuilderAction || showAddKeysAction;
-  const onlyConnectPathAvailable =
-    shouldShowOnlyConnectPath(showBuilderAction, providerGroups) &&
-    modelProviderGroups.length === 0;
+  const onlyConnectPathAvailable = shouldShowOnlyConnectPath(
+    showProviderActions,
+    providerGroups,
+  );
   const openLlmSettings = useCallback(() => {
     try {
       window.location.hash = "llm";
@@ -1617,7 +1624,7 @@ function ModelSelector({
                           />
                         </span>
                       </TooltipTrigger>
-                      <TooltipContent side="right" className="z-[400] max-w-xs">
+                      <TooltipContent side="right" className="max-w-xs">
                         <span className="block">
                           {hostedHarness
                             ? t("agentChat.composer.hostedHarnessDescription", {
@@ -1690,6 +1697,30 @@ function ModelSelector({
                   </span>
                   <span className="ms-auto min-w-0 max-w-[6rem] truncate text-end text-[11px] text-muted-foreground/80">
                     {effortLabel(selectedEffort)}
+                  </span>
+                  <IconChevronRight className="h-3 w-3 shrink-0 opacity-60 rtl:-scale-x-100" />
+                </button>
+              )}
+              {terminalModeControl && (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={resolvedSection === "mode"}
+                  onClick={() => setDetailSection("mode")}
+                  onMouseEnter={() => setDetailSection("mode")}
+                  className={`flex w-full min-w-0 items-center gap-1 rounded-md px-2 py-2 text-start transition-colors ${
+                    resolvedSection === "mode"
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                  }`}
+                >
+                  <span className="shrink-0 text-[12px] font-medium">
+                    {t("agentPanel.mode", { defaultValue: "Mode" })}
+                  </span>
+                  <span className="ms-auto min-w-0 max-w-[6rem] truncate text-end text-[11px] text-muted-foreground/80">
+                    {terminalModeControl.enabled
+                      ? t("agentPanel.cli", { defaultValue: "CLI" })
+                      : t("agentPanel.uiMode", { defaultValue: "UI" })}
                   </span>
                   <IconChevronRight className="h-3 w-3 shrink-0 opacity-60 rtl:-scale-x-100" />
                 </button>
@@ -1777,7 +1808,7 @@ function ModelSelector({
                                 </TooltipTrigger>
                                 <TooltipContent
                                   side="left"
-                                  className="z-[400] max-w-xs"
+                                  className="max-w-xs"
                                 >
                                   {agent.description}
                                 </TooltipContent>
@@ -1881,42 +1912,47 @@ function ModelSelector({
                         )}
                       </>
                     )}
-                    {imageModel && imageModel.options.length > 0 && (
-                      <div className="mt-2 pt-1">
-                        <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                          {imageModel.label ??
-                            t("agentChat.composer.imageModel", {
-                              defaultValue: "Image model",
-                            })}
-                        </div>
-                        {imageModel.options.map((option) => (
-                          <button
-                            key={option.value}
-                            type="button"
-                            onClick={() => {
-                              imageModel.onChange(option.value);
-                              setPickerOpen(false);
-                            }}
-                            className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-start hover:bg-accent/50"
-                          >
-                            <span
-                              className={`min-w-0 flex-1 truncate text-[12px] ${
-                                option.value === imageModel.value
-                                  ? "text-foreground"
-                                  : "text-muted-foreground"
-                              }`}
+                    {hasConfiguredProvider &&
+                      imageModel &&
+                      imageModel.options.length > 0 && (
+                        <div className="mt-2 pt-1">
+                          <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {imageModel.label ??
+                              t("agentChat.composer.imageModel", {
+                                defaultValue: "Image model",
+                              })}
+                          </div>
+                          {imageModel.options.map((option) => (
+                            <button
+                              key={option.value}
+                              type="button"
+                              onClick={() => {
+                                imageModel.onChange(option.value);
+                                setPickerOpen(false);
+                              }}
+                              className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-start hover:bg-accent/50"
                             >
-                              {option.label}
-                            </span>
-                            {option.value === imageModel.value && (
-                              <IconCheck className="size-4 shrink-0 text-primary" />
-                            )}
-                          </button>
-                        ))}
-                      </div>
+                              <span
+                                className={`min-w-0 flex-1 truncate text-[12px] ${
+                                  option.value === imageModel.value
+                                    ? "text-foreground"
+                                    : "text-muted-foreground"
+                                }`}
+                              >
+                                {option.label}
+                              </span>
+                              {option.value === imageModel.value && (
+                                <IconCheck className="size-4 shrink-0 text-primary" />
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    {hasConfiguredProvider && showModelListSkeleton && (
+                      <ModelSelectorSkeleton />
                     )}
-                    {showModelListSkeleton && <ModelSelectorSkeleton />}
-                    {isCodexAgent &&
+                    {hasConfiguredProvider &&
+                      isCodexAgent &&
                       !showModelListSkeleton &&
                       !onlyConnectPathAvailable &&
                       modelProviderGroups.length === 0 && (
@@ -1935,32 +1971,35 @@ function ModelSelector({
                           </span>
                         </button>
                       )}
-                    {autoModelGroup && !onlyConnectPathAvailable && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onChange("auto", autoModelGroup.engine);
-                          setPickerOpen(false);
-                        }}
-                        className="mt-1 flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-start hover:bg-accent/50"
-                      >
-                        <span
-                          className={`min-w-0 flex-1 truncate text-[13px] ${
-                            model === "auto"
-                              ? "text-foreground"
-                              : "text-muted-foreground"
-                          }`}
+                    {hasConfiguredProvider &&
+                      autoModelGroup &&
+                      !onlyConnectPathAvailable && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onChange("auto", autoModelGroup.engine);
+                            setPickerOpen(false);
+                          }}
+                          className="mt-1 flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-start hover:bg-accent/50"
                         >
-                          {t("agentChat.composer.auto", {
-                            defaultValue: "Auto",
-                          })}
-                        </span>
-                        {model === "auto" && (
-                          <IconCheck className="size-4 shrink-0 text-primary" />
-                        )}
-                      </button>
-                    )}
-                    {!onlyConnectPathAvailable &&
+                          <span
+                            className={`min-w-0 flex-1 truncate text-[13px] ${
+                              model === "auto"
+                                ? "text-foreground"
+                                : "text-muted-foreground"
+                            }`}
+                          >
+                            {t("agentChat.composer.auto", {
+                              defaultValue: "Auto",
+                            })}
+                          </span>
+                          {model === "auto" && (
+                            <IconCheck className="size-4 shrink-0 text-primary" />
+                          )}
+                        </button>
+                      )}
+                    {hasConfiguredProvider &&
+                      !onlyConnectPathAvailable &&
                       visibleProviderGroups.map((group, groupIndex) => {
                         const models = latestModelsOnly(group.models);
                         const showProviderLabels =
@@ -2094,6 +2133,43 @@ function ModelSelector({
                           {effortLabel(option)}
                         </span>
                         {option === selectedEffort && (
+                          <IconCheck className="size-4 shrink-0 text-primary" />
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {resolvedSection === "mode" && terminalModeControl && (
+                  <div className="flex flex-col">
+                    {[
+                      {
+                        enabled: false,
+                        label: t("agentPanel.uiMode", { defaultValue: "UI" }),
+                      },
+                      {
+                        enabled: true,
+                        label: t("agentPanel.cli", { defaultValue: "CLI" }),
+                      },
+                    ].map((option) => (
+                      <button
+                        key={option.label}
+                        type="button"
+                        onClick={() => {
+                          terminalModeControl.onChange(option.enabled);
+                          setPickerOpen(false);
+                        }}
+                        className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-start hover:bg-accent/50"
+                      >
+                        <span
+                          className={`min-w-0 flex-1 truncate text-[12px] ${
+                            option.enabled === terminalModeControl.enabled
+                              ? "text-foreground"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          {option.label}
+                        </span>
+                        {option.enabled === terminalModeControl.enabled && (
                           <IconCheck className="size-4 shrink-0 text-primary" />
                         )}
                       </button>
@@ -3714,6 +3790,7 @@ export function TiptapComposer({
             providerConnectStatusEnabled={providerConnectStatusEnabled}
             onConnectProvider={onConnectProvider}
             onConnectLocalRuntime={onConnectLocalRuntime}
+            terminalModeControl={terminalModeControl}
             imageModel={imageModelMenu}
           />
         )}

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -1024,6 +1024,14 @@ const LOCAL_RUNTIME_ENGINES = new Set([
   "opencode-cli",
 ]);
 
+export function hasConfiguredCloudProvider(
+  groups: ReadonlyArray<{ engine: string; configured: boolean }>,
+): boolean {
+  return groups.some(
+    (group) => group.configured && !LOCAL_RUNTIME_ENGINES.has(group.engine),
+  );
+}
+
 function isOpenAiModelId(model: string): boolean {
   const normalizedModel = model.toLowerCase();
   return (
@@ -1493,8 +1501,14 @@ function ModelSelector({
   const hasConfiguredBuilderModels = providerGroups.some(
     (group) => group.engine === "builder" && group.configured,
   );
+  const hasConfiguredCloudProviderReady =
+    hasConfiguredCloudProvider(providerGroups);
   const hasConnectedSubscription = providerGroups.some(
-    (group) => group.configured && group.isSubscription,
+    (group) =>
+      hasConfiguredCloudProviderReady &&
+      group.configured &&
+      group.isSubscription &&
+      !LOCAL_RUNTIME_ENGINES.has(group.engine),
   );
   const hasUnconfiguredVisibleModels = modelProviderGroups.some(
     (group) => !group.configured,
@@ -1503,7 +1517,7 @@ function ModelSelector({
     (group) => group.configured,
   );
   const showBuilderAction =
-    !hasConfiguredProvider &&
+    !hasConfiguredCloudProviderReady &&
     (Boolean(onConnectProvider) ||
       (providerConnectStatusEnabled &&
         !builderFlow.configured &&
@@ -1511,7 +1525,7 @@ function ModelSelector({
         !hasConfiguredBuilderModels &&
         !hasConnectedSubscription));
   const showAddKeysAction =
-    !hasConfiguredProvider &&
+    !hasConfiguredCloudProviderReady &&
     (hasUnconfiguredVisibleModels || showBuilderAction);
   const showProviderActions = showBuilderAction || showAddKeysAction;
   const onlyConnectPathAvailable = shouldShowOnlyConnectPath(

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -1926,7 +1926,7 @@ function ModelSelector({
                         )}
                       </>
                     )}
-                    {hasConfiguredProvider &&
+                    {hasConfiguredCloudProviderReady &&
                       imageModel &&
                       imageModel.options.length > 0 && (
                         <div className="mt-2 pt-1">

--- a/packages/toolkit/src/ui/tooltip.tsx
+++ b/packages/toolkit/src/ui/tooltip.tsx
@@ -36,7 +36,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         data-agent-native-tooltip="true"
         className={cn(
-          "z-[300] overflow-hidden rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-foreground shadow-md origin-[var(--radix-tooltip-content-transform-origin)] data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=delayed-open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:duration-150 data-[state=closed]:duration-100 motion-reduce:data-[state=delayed-open]:zoom-in-100 motion-reduce:data-[state=closed]:zoom-out-100",
+          "z-[500] overflow-hidden rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-foreground shadow-md origin-[var(--radix-tooltip-content-transform-origin)] data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=delayed-open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:duration-150 data-[state=closed]:duration-100 motion-reduce:data-[state=delayed-open]:zoom-in-100 motion-reduce:data-[state=closed]:zoom-out-100",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Fix Builder connection and local CLI-agent readiness refresh in the Electron app, including GUI PATH and NVM executable resolution.
- Hide provider model lists until a provider or local agent is configured, while keeping connect/add-key actions available.
- Add the UI/CLI mode control to the agent picker and raise shared tooltip stacking above popovers.

## Validation
- `corepack pnpm guards` - all 64 checks passed
- Focused toolkit, code-agents-ui, desktop CLI, and localization tests passed
- Core, toolkit, code-agents-ui, and desktop-app typechecks passed
- `corepack pnpm --filter @agent-native/desktop-app build` passed
- Live Electron smoke check exercised Agent, Model, Effort, Mode, and CLI mode selection

Post-merge deployment health is not claimed here.