### PR TITLE
Share Clips from a Timestamp

### DIFF
--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -98,6 +98,16 @@ describe("recording share popover", () => {
     expect(shareDialogSource).toContain('t("shareDialog.copyEmailPreview")');
   });
 
+  it("offers a visible timestamped public share link control", () => {
+    const shareDialogSource = readSource("./share-dialog.tsx");
+
+    expect(shareDialogSource).toContain('url.searchParams.set("at",');
+    expect(shareDialogSource).toContain('t("shareDialog.startAtTimestamp"');
+    expect(shareDialogSource).not.toContain(
+      'typeof currentMs === "number" ? (',
+    );
+  });
+
   it("offers commenter as a distinct recording role", () => {
     const shareDialogSource = readSource("./share-dialog.tsx");
     const shareUiSource = readSource("../sharing/share-ui.tsx");

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { formatMs } from "@/lib/timestamp-mapping";
 import { cn } from "@/lib/utils";
 
 import { buildAgentApiUrls } from "../../../shared/agent-context";
@@ -70,6 +71,7 @@ export interface ShareRecordingPopoverProps {
   thumbnailUrl?: string | null;
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
+  currentMs?: number;
   hasPassword?: boolean;
   /**
    * Restricts the dialog to a bare copy-link control for viewers who can
@@ -108,6 +110,7 @@ export function ShareRecordingPopover({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording = false,
+  currentMs,
   hasPassword,
   viewerReshareOnly = false,
   children,
@@ -131,6 +134,7 @@ export function ShareRecordingPopover({
           thumbnailUrl={thumbnailUrl}
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
+          currentMs={currentMs}
           hasPassword={hasPassword}
           viewerReshareOnly={viewerReshareOnly}
         />
@@ -153,6 +157,7 @@ export function ShareRecordingDialog({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording = false,
+  currentMs,
   open,
   onOpenChange,
   hasPassword,
@@ -176,6 +181,7 @@ export function ShareRecordingDialog({
           thumbnailUrl={thumbnailUrl}
           animatedThumbnailUrl={animatedThumbnailUrl}
           isLoomRecording={isLoomRecording}
+          currentMs={currentMs}
           hasPassword={hasPassword}
           viewerReshareOnly={viewerReshareOnly}
           reserveCloseButton
@@ -194,6 +200,7 @@ function ShareRecordingContent({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording = false,
+  currentMs,
   reserveCloseButton = false,
   hasPassword,
   viewerReshareOnly = false,
@@ -206,6 +213,7 @@ function ShareRecordingContent({
   thumbnailUrl?: string | null;
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
+  currentMs?: number;
   reserveCloseButton?: boolean;
   hasPassword?: boolean;
   viewerReshareOnly?: boolean;
@@ -292,6 +300,7 @@ function ShareRecordingContent({
             thumbnailUrl={thumbnailUrl}
             animatedThumbnailUrl={animatedThumbnailUrl}
             isLoomRecording={isLoomRecording}
+            currentMs={currentMs}
             hasPassword={hasPassword}
             canViewShares={canViewShares}
           />
@@ -328,6 +337,7 @@ function LinkTab({
   thumbnailUrl,
   animatedThumbnailUrl,
   isLoomRecording: isLoomRecordingProp,
+  currentMs = 0,
   hasPassword,
   canViewShares,
 }: {
@@ -341,6 +351,7 @@ function LinkTab({
   thumbnailUrl?: string | null;
   animatedThumbnailUrl?: string | null;
   isLoomRecording?: boolean;
+  currentMs?: number;
   hasPassword?: boolean;
   canViewShares: boolean;
 }) {
@@ -352,6 +363,16 @@ function LinkTab({
   );
   const isPublic = visibility === "public";
   const sharesLoaded = visibility !== null;
+  const timestampMs = Number.isFinite(currentMs)
+    ? Math.max(0, Math.floor(currentMs! / 1000) * 1000)
+    : 0;
+  const [shareFromTimestamp, setShareFromTimestamp] = useState(false);
+  const linkUrl = useMemo(() => {
+    if (!shareFromTimestamp || timestampMs === 0) return shareUrl;
+    const url = new URL(shareUrl);
+    url.searchParams.set("at", String(timestampMs / 1000));
+    return url.toString();
+  }, [shareFromTimestamp, shareUrl, timestampMs]);
   const visibilityPending = isPending || sharesQuery.isLoading;
   const isLoomRecording = isLoomRecordingProp || isLoomEmbedUrl(videoUrl);
   const needsScopedAgentContext = !isPublic || hasPassword !== false;
@@ -504,9 +525,22 @@ function LinkTab({
             ? t("shareDialog.shareLink")
             : t("shareDialog.shareWithHumans")
         }
-        value={shareUrl}
+        value={linkUrl}
         disabled={visibilityPending || !sharesLoaded}
       />
+
+      <div className="flex items-center justify-between gap-3">
+        <Label className="text-sm" htmlFor="share-from-timestamp">
+          {t("shareDialog.startAtTimestamp", {
+            time: formatMs(timestampMs),
+          })}
+        </Label>
+        <Switch
+          id="share-from-timestamp"
+          checked={shareFromTimestamp}
+          onCheckedChange={setShareFromTimestamp}
+        />
+      </div>
 
       {canViewShares ? (
         visibility ? (
@@ -594,7 +628,7 @@ function LinkTab({
           }
           onMakePublic={() =>
             setResourceVisibility("public", {
-              onSuccess: () => copyToClipboard(shareUrl),
+              onSuccess: () => copyToClipboard(linkUrl),
             })
           }
         />

--- a/templates/clips/app/components/player/signed-out-share-actions.test.tsx
+++ b/templates/clips/app/components/player/signed-out-share-actions.test.tsx
@@ -55,6 +55,22 @@ describe("SignedOutShareActions", () => {
     expect(container.textContent).toContain("sharePage.tryClips");
   });
 
+  it("preserves only the timestamp in the sign-in return path", () => {
+    expect(buildShareSignInHref("clip/1", "90")).toBe(
+      "/_agent-native/sign-in?return=%2Fshare%2Fclip%2F1%3Fat%3D90",
+    );
+
+    act(() => {
+      root.render(
+        <SignedOutShareActions recordingId="clip/1" startAt="1:30" />,
+      );
+    });
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(
+      "/_agent-native/sign-in?return=%2Fshare%2Fclip%2F1%3Fat%3D1%253A30",
+    );
+  });
+
   it("tracks both signed-out header destinations", () => {
     const onCtaClick = vi.fn();
 

--- a/templates/clips/app/components/player/signed-out-share-actions.tsx
+++ b/templates/clips/app/components/player/signed-out-share-actions.tsx
@@ -7,15 +7,25 @@ import { Button } from "@/components/ui/button";
 
 export type SignedOutShareCta = "signin" | "try_clips";
 
-export function buildShareSignInHref(recordingId: string): string {
-  return buildSignInReturnHref({ returnTo: `/share/${recordingId}` });
+export function buildShareSignInHref(
+  recordingId: string,
+  startAt?: string | null,
+): string {
+  const params = new URLSearchParams();
+  if (startAt) params.set("at", startAt);
+  const query = params.toString();
+  return buildSignInReturnHref({
+    returnTo: `/share/${recordingId}${query ? `?${query}` : ""}`,
+  });
 }
 
 export function SignedOutShareActions({
   recordingId,
+  startAt,
   onCtaClick,
 }: {
   recordingId: string;
+  startAt?: string | null;
   onCtaClick?: (cta: SignedOutShareCta) => void;
 }) {
   const t = useT();
@@ -24,7 +34,7 @@ export function SignedOutShareActions({
     <>
       <Button variant="outline" size="sm" asChild>
         <a
-          href={buildShareSignInHref(recordingId)}
+          href={buildShareSignInHref(recordingId, startAt)}
           className="gap-1.5"
           onClick={() => onCtaClick?.("signin")}
         >

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -518,6 +518,7 @@ const messages = {
     height: "ارتفاع",
     autoplay: "التشغيل التلقائي",
     startAt: "البدء عند (ثواني)",
+    startAtTimestamp: "البدء عند {{time}}",
     embedCode: "كود التضمين",
     sharePlainTitle: "مشاركة {{title}}",
   },

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -535,6 +535,7 @@ const messages = {
     height: "Höhe",
     autoplay: "Übersetzt: Autoplay",
     startAt: "Beginnen bei (Sekunden)",
+    startAtTimestamp: "Bei {{time}} starten",
     embedCode: "Einbettungscode",
     sharePlainTitle: "Teilen {{title}}",
   },

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -515,6 +515,7 @@ const messages = {
     height: "Height",
     autoplay: "Autoplay",
     startAt: "Start at (seconds)",
+    startAtTimestamp: "Start at {{time}}",
     embedCode: "Embed code",
   },
   shareUi: {

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -531,6 +531,7 @@ const messages = {
     height: "Altura",
     autoplay: "Reproducción automática",
     startAt: "Empezar en (segundos)",
+    startAtTimestamp: "Empezar en {{time}}",
     embedCode: "Código de inserción",
     sharePlainTitle: "Compartir {{title}}",
   },

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -529,6 +529,7 @@ const messages = {
     height: "Hauteur",
     autoplay: "Lecture automatique",
     startAt: "Commencer à (secondes)",
+    startAtTimestamp: "Commencer à {{time}}",
     embedCode: "Code d’intégration",
     sharePlainTitle: "Partager {{title}}",
   },

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -512,6 +512,7 @@ const messages = {
     height: "ऊंचाई",
     autoplay: "स्वत: प्ले",
     startAt: "प्रारंभ करें (सेकंड)",
+    startAtTimestamp: "{{time}} पर शुरू करें",
     embedCode: "एम्बेड कोड",
     sharePlainTitle: "{{title}} साझा करें",
   },

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -527,6 +527,7 @@ const messages = {
     height: "身長",
     autoplay: "自動再生",
     startAt: "(秒)から開始",
+    startAtTimestamp: "{{time}} から開始",
     embedCode: "埋め込みコード",
     sharePlainTitle: "{{title}}を共有する",
   },

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -518,6 +518,7 @@ const messages = {
     height: "키",
     autoplay: "자동재생",
     startAt: "(초)에 시작",
+    startAtTimestamp: "{{time}}부터 시작",
     embedCode: "임베드 코드",
     sharePlainTitle: "{{title}} 공유",
   },

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -526,6 +526,7 @@ const messages = {
     height: "Altura",
     autoplay: "Reprodução automática",
     startAt: "Começar em (segundos)",
+    startAtTimestamp: "Começar em {{time}}",
     embedCode: "Código de incorporação",
     sharePlainTitle: "Compartilhar {{title}}",
   },

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -494,6 +494,7 @@ const messages = {
     height: "高度",
     autoplay: "自动播放",
     startAt: "开始时间（秒）",
+    startAtTimestamp: "从 {{time}} 开始",
     embedCode: "嵌入代码",
     sharePlainTitle: "分享 {{title}}",
   },

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -494,6 +494,7 @@ const messages = {
     height: "高度",
     autoplay: "自動播放",
     startAt: "開始時間（秒）",
+    startAtTimestamp: "從 {{time}} 開始",
     embedCode: "嵌入程式碼",
     sharePlainTitle: "分享 {{title}}",
   },

--- a/templates/clips/app/lib/time-param.test.ts
+++ b/templates/clips/app/lib/time-param.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTimeParam, resolveStartMs } from "./time-param";
+
+describe("parseTimeParam", () => {
+  it("parses supported timestamp formats", () => {
+    expect(parseTimeParam("90")).toBe(90_000);
+    expect(parseTimeParam("1:30")).toBe(90_000);
+    expect(parseTimeParam("1m30s")).toBe(90_000);
+    expect(parseTimeParam("1h2m3s")).toBe(3_723_000);
+  });
+
+  it("returns zero for invalid timestamp formats", () => {
+    expect(parseTimeParam(null)).toBe(0);
+    expect(parseTimeParam("-1")).toBe(0);
+    expect(parseTimeParam("not-a-time")).toBe(0);
+  });
+
+  it("resets invalid and out-of-range start times", () => {
+    expect(resolveStartMs(-1, 90_000)).toBe(0);
+    expect(resolveStartMs(90_001, 90_000)).toBe(0);
+    expect(resolveStartMs(90_000, 90_000)).toBe(90_000);
+  });
+});

--- a/templates/clips/app/lib/time-param.ts
+++ b/templates/clips/app/lib/time-param.ts
@@ -1,0 +1,40 @@
+export function resolveStartMs(
+  startMs: number,
+  durationMs?: number | null,
+): number {
+  if (!Number.isFinite(startMs) || startMs < 0) return 0;
+  if (
+    typeof durationMs === "number" &&
+    Number.isFinite(durationMs) &&
+    durationMs > 0 &&
+    startMs > durationMs
+  ) {
+    return 0;
+  }
+  return startMs;
+}
+
+export function parseTimeParam(raw: string | null): number {
+  if (!raw) return 0;
+  const value = raw.trim();
+  if (!value) return 0;
+
+  if (/^\d+(\.\d+)?$/.test(value)) {
+    return Math.floor(parseFloat(value) * 1000);
+  }
+
+  if (/^\d+:\d+(:\d+)?$/.test(value)) {
+    const parts = value.split(":").map((part) => parseInt(part, 10));
+    if (parts.length === 2) return (parts[0] * 60 + parts[1]) * 1000;
+    if (parts.length === 3) {
+      return (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000;
+    }
+  }
+
+  const match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!match) return 0;
+  const hours = parseInt(match[1] ?? "0", 10);
+  const minutes = parseInt(match[2] ?? "0", 10);
+  const seconds = parseInt(match[3] ?? "0", 10);
+  return (hours * 3600 + minutes * 60 + seconds) * 1000;
+}

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -12,6 +12,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
+import { parseTimeParam, resolveStartMs } from "@/lib/time-param";
 
 import { isLoomEmbedBackedRecording } from "../../shared/loom";
 
@@ -22,40 +23,6 @@ export function meta() {
 const STORAGE_KEY_PREFIX = "clips-share-pw-";
 const READY_MEDIA_SETTLE_POLL_MS = 20 * 1000;
 const READY_MEDIA_SETTLE_POLL_INTERVAL_MS = 1000;
-
-/**
- * Parse `t` URL param into ms (supports plain seconds or `1m20s` / `1h2m3s`).
- *   "80"      → 80_000
- *   "1m20s"   → 80_000
- *   "1h2m3s"  → 3_723_000
- *   "1:20"    → 80_000  (MM:SS)
- */
-function parseTimeParam(raw: string | null): number {
-  if (!raw) return 0;
-  const v = raw.trim();
-  if (!v) return 0;
-
-  // Plain seconds
-  if (/^\d+(\.\d+)?$/.test(v)) return Math.floor(parseFloat(v) * 1000);
-
-  // MM:SS or HH:MM:SS
-  if (/^\d+:\d+(:\d+)?$/.test(v)) {
-    const parts = v.split(":").map((n) => parseInt(n, 10));
-    if (parts.length === 2) return (parts[0] * 60 + parts[1]) * 1000;
-    if (parts.length === 3)
-      return (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000;
-  }
-
-  // 1h2m3s style
-  const m = v.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
-  if (m) {
-    const h = parseInt(m[1] ?? "0", 10);
-    const mm = parseInt(m[2] ?? "0", 10);
-    const s = parseInt(m[3] ?? "0", 10);
-    return (h * 3600 + mm * 60 + s) * 1000;
-  }
-  return 0;
-}
 
 export default function EmbedRoute() {
   const t = useT();
@@ -251,7 +218,7 @@ export default function EmbedRoute() {
         thumbnailUrl={recording.thumbnailUrl}
         defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}
         autoPlay={autoplay}
-        startMs={startMs}
+        startMs={resolveStartMs(startMs, recording.durationMs)}
         comments={comments}
         chapters={chapters}
         transcriptSegments={transcriptSegments}

--- a/templates/clips/app/routes/r.$recordingId.test.ts
+++ b/templates/clips/app/routes/r.$recordingId.test.ts
@@ -8,6 +8,27 @@ function readRoute(name: string): string {
 }
 
 describe("direct recording route shell cue", () => {
+  it("prefers public-share timestamps over legacy owner timestamps", () => {
+    const route = readRoute("r.$recordingId.tsx");
+
+    expect(route).toContain('searchParams.get("at") ?? searchParams.get("t")');
+  });
+
+  it("clamps route playback state before exposing it", () => {
+    const recordingRoute = readRoute("r.$recordingId.tsx");
+    const shareRoute = readRoute("share.$shareId.tsx");
+
+    expect(recordingRoute).toContain(
+      "const playbackMs = resolveStartMs(currentMs, recording?.durationMs)",
+    );
+    expect(recordingRoute).toContain("currentMs: Math.round(playbackMs)");
+    expect(recordingRoute).toContain("currentMs={playbackMs}");
+    expect(shareRoute).toContain(
+      "const playbackMs = resolveStartMs(currentMs, recording?.durationMs)",
+    );
+    expect(shareRoute).toContain("currentMs={playbackMs}");
+  });
+
   it("keeps the main header return control icon-only and shared", () => {
     const route = readRoute("r.$recordingId.tsx");
     const headerStart = route.indexOf(

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -102,6 +102,7 @@ import enMessages from "@/i18n/en-US";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { recordingShareUrl } from "@/lib/recording-link";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
+import { parseTimeParam, resolveStartMs } from "@/lib/time-param";
 import { cn } from "@/lib/utils";
 
 import { STALE_PENDING_TRANSCRIPT_REASON } from "../../shared/transcript-status";
@@ -270,31 +271,6 @@ export function BackButton({ onBack }: { onBack: () => void }) {
   );
 }
 
-function parseTimeParam(raw: string | null): number {
-  if (!raw) return 0;
-  const value = raw.trim();
-  if (!value) return 0;
-
-  if (/^\d+(\.\d+)?$/.test(value)) {
-    return Math.floor(parseFloat(value) * 1000);
-  }
-
-  if (/^\d+:\d+(:\d+)?$/.test(value)) {
-    const parts = value.split(":").map((part) => parseInt(part, 10));
-    if (parts.length === 2) return (parts[0] * 60 + parts[1]) * 1000;
-    if (parts.length === 3) {
-      return (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000;
-    }
-  }
-
-  const match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
-  if (!match) return 0;
-  const hours = parseInt(match[1] ?? "0", 10);
-  const minutes = parseInt(match[2] ?? "0", 10);
-  const seconds = parseInt(match[3] ?? "0", 10);
-  return (hours * 3600 + minutes * 60 + seconds) * 1000;
-}
-
 export default function RecordingPage() {
   const t = useT();
   useAutoTitleBridge();
@@ -302,7 +278,9 @@ export default function RecordingPage() {
   const { recordingId } = useParams<{ recordingId: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const startMs = parseTimeParam(searchParams.get("t"));
+  const startMs = parseTimeParam(
+    searchParams.get("at") ?? searchParams.get("t"),
+  );
   const panelParam = searchParams.get("panel");
   const { session, isLoading: sessionLoading } = useSession();
   const playerRef = useRef<VideoPlayerHandle | null>(null);
@@ -310,19 +288,12 @@ export default function RecordingPage() {
   const [panel, setPanel] = useState<SidePanel>("comments");
   const [theaterMode, setTheaterMode] = useState(false);
   const [editing, setEditing] = useState(false);
-  const [currentMs, setCurrentMs] = useState(0);
+  const [currentMs, setCurrentMs] = useState(startMs);
   const [commentOpen, setCommentOpen] = useState(false);
   const [commentAtMs, setCommentAtMs] = useState(0);
   const [commentDraft, setCommentDraft] = useState("");
   const [isPlayerFullscreen, setIsPlayerFullscreen] = useState(false);
   const isCompactLayout = useIsCompactRecordingLayout();
-  // Resolve the playback position for reactions/comments. Native <video> exposes
-  // a live `currentTime`; Loom embeds render in a cross-origin iframe with no
-  // live time bridge, so we fall back to the last position the player reported
-  // via onTimeUpdate (seek/initial start).
-  const resolvePlaybackMs = useCallback(() => {
-    return playerRef.current?.getCurrentOriginalMs() ?? currentMs;
-  }, [currentMs]);
   // The compact layout stacks the panel below the video, so switching tabs
   // alone leaves the user looking at the player. Desktop always renders the
   // side aside, so nothing to scroll there.
@@ -458,6 +429,14 @@ export default function RecordingPage() {
   }, [recordingId, playerDataForbidden, navigate]);
 
   const recording = playerDataQ.data?.recording;
+  const playbackMs = resolveStartMs(currentMs, recording?.durationMs);
+  // Resolve the playback position for reactions/comments. Native <video> exposes
+  // a live `currentTime`; Loom embeds render in a cross-origin iframe with no
+  // live time bridge, so we fall back to the last position the player reported
+  // via onTimeUpdate (seek/initial start).
+  const resolvePlaybackMs = useCallback(() => {
+    return playerRef.current?.getCurrentOriginalMs() ?? playbackMs;
+  }, [playbackMs]);
   const verificationPending = recording?.verificationPending === true;
   const role = playerDataQ.data?.role as
     | "owner"
@@ -541,14 +520,14 @@ export default function RecordingPage() {
       {
         view: "recording",
         recordingId: recording.id,
-        currentMs: Math.max(0, Math.round(currentMs)),
+        currentMs: Math.round(playbackMs),
         durationMs: recording.durationMs,
         panel,
         updatedAt: new Date(now).toISOString(),
       },
       { requestSource: browserTabId },
     ).catch(() => {});
-  }, [browserTabId, currentMs, panel, recording?.durationMs, recording?.id]);
+  }, [browserTabId, panel, playbackMs, recording?.durationMs, recording?.id]);
   const appStateVersion = useChangeVersions(["app-state", "action"]);
   const generatedWorkflowQ = useQuery<GeneratedWorkflowState | null>({
     queryKey: [
@@ -1283,7 +1262,7 @@ export default function RecordingPage() {
             segments={transcriptSegments}
             fullText={transcriptFullText}
             durationMs={recording.durationMs}
-            currentMs={currentMs}
+            currentMs={playbackMs}
             onSeek={(ms) => playerRef.current?.seek(ms)}
             status={
               requestTranscript.isPending && transcriptStatus === "failed"
@@ -1322,7 +1301,7 @@ export default function RecordingPage() {
           <CommentsPanel
             recordingId={recording.id}
             comments={comments}
-            currentMs={currentMs}
+            currentMs={playbackMs}
             currentUserEmail={session?.email}
             enableComments={recording.enableComments}
             canComment={canComment}
@@ -1611,6 +1590,7 @@ export default function RecordingPage() {
               thumbnailUrl={recording.thumbnailUrl}
               animatedThumbnailUrl={recording.animatedThumbnailUrl}
               isLoomRecording={isLoomEmbedBacked}
+              currentMs={playbackMs}
               hasPassword={Boolean(recording.hasPassword)}
               viewerReshareOnly={viewerReshareOnly}
             >
@@ -1662,7 +1642,7 @@ export default function RecordingPage() {
                   defaultSpeed={
                     parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2
                   }
-                  startMs={startMs}
+                  startMs={resolveStartMs(startMs, recording.durationMs)}
                   comments={comments}
                   chapters={chapters}
                   reactions={reactions}

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -29,6 +29,10 @@ describe("authenticated recording route loading", () => {
     expect(route).toContain("...(userEmail ? { viewerEmail: userEmail } : {})");
     expect(route).toContain("apiAccessDeniedStatus");
     expect(route).toContain("accessDeniedStatus");
+    expect(route).toContain('const startAt = searchParams.get("at")');
+    expect(route).toContain(
+      "buildShareContinuationQuery(attribution, startAt)",
+    );
     expect(route).toContain('IconLock className="h-5 w-5"');
   });
 

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -387,10 +387,8 @@ export default function ShareRoute() {
   const { shareId } = useParams<{ shareId: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const startMs = useMemo(
-    () => parseTimeParam(searchParams.get("at")),
-    [searchParams],
-  );
+  const startAt = searchParams.get("at");
+  const startMs = useMemo(() => parseTimeParam(startAt), [startAt]);
 
   // Viral attribution: read the `ref`/`via` the visitor arrived on (the tagged
   // share link) so we can fire funnel events and forward attribution into the
@@ -519,9 +517,9 @@ export default function ShareRoute() {
   const shareReturnTo = useMemo(() => {
     const path = `/share/${encodeURIComponent(recordingId)}`;
     if (typeof window === "undefined") return path;
-    const query = buildShareContinuationQuery(attribution);
+    const query = buildShareContinuationQuery(attribution, startAt);
     return query ? `${path}?${query}` : path;
-  }, [attribution, recordingId]);
+  }, [attribution, recordingId, startAt]);
   const signInHref = buildSignInReturnHref({ returnTo: shareReturnTo });
 
   const submitAccessRequest = useCallback(
@@ -1174,7 +1172,7 @@ export default function ShareRoute() {
             {session ? null : (
               <SignedOutShareActions
                 recordingId={recording.id}
-                startAt={searchParams.get("at")}
+                startAt={startAt}
                 onCtaClick={fireShareCtaClick}
               />
             )}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -85,6 +85,7 @@ import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { isStorageSetupFailureReason } from "@/lib/storage-failures";
+import { parseTimeParam, resolveStartMs } from "@/lib/time-param";
 
 import { getDb, schema } from "../../server/db";
 import { resolvePlayerThumbnailUrl } from "../../server/lib/player-thumbnail-url";
@@ -386,6 +387,10 @@ export default function ShareRoute() {
   const { shareId } = useParams<{ shareId: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const startMs = useMemo(
+    () => parseTimeParam(searchParams.get("at")),
+    [searchParams],
+  );
 
   // Viral attribution: read the `ref`/`via` the visitor arrived on (the tagged
   // share link) so we can fire funnel events and forward attribution into the
@@ -462,7 +467,7 @@ export default function ShareRoute() {
     } catch {}
   }, [shareId]);
   const [pwError, setPwError] = useState<string | null>(null);
-  const [currentMs, setCurrentMs] = useState(0);
+  const [currentMs, setCurrentMs] = useState(startMs);
   const [commentOpen, setCommentOpen] = useState(false);
   const [commentAtMs, setCommentAtMs] = useState(0);
   const [commentDraft, setCommentDraft] = useState("");
@@ -652,6 +657,7 @@ export default function ShareRoute() {
   });
 
   const recording = dataQ.data?.data?.recording;
+  const playbackMs = resolveStartMs(currentMs, recording?.durationMs);
   const verificationPending = recording?.verificationPending === true;
   const comments = dataQ.data?.data?.comments ?? [];
   const reactions = dataQ.data?.data?.reactions ?? [];
@@ -1181,6 +1187,7 @@ export default function ShareRoute() {
                 thumbnailUrl={recording.thumbnailUrl}
                 animatedThumbnailUrl={recording.animatedThumbnailUrl}
                 isLoomRecording={isLoomEmbedBacked}
+                currentMs={playbackMs}
                 hasPassword={Boolean(recording.hasPassword)}
                 viewerReshareOnly={viewerReshareOnly}
               >
@@ -1248,6 +1255,7 @@ export default function ShareRoute() {
               videoFormat={recording.videoFormat}
               embedProvider={isLoomEmbedBacked ? "loom" : null}
               durationMs={recording.durationMs}
+              startMs={resolveStartMs(startMs, recording.durationMs)}
               persistPlaybackPosition={Boolean(session)}
               editsJson={recording.editsJson}
               thumbnailUrl={recording.thumbnailUrl}
@@ -1285,7 +1293,7 @@ export default function ShareRoute() {
                         liveCt >= 0 &&
                         liveCt < 1e7
                           ? Math.floor(liveCt * 1000)
-                          : currentMs;
+                          : playbackMs;
                       setCommentAtMs(liveMs);
                       setCommentOpen(true);
                     }
@@ -1311,7 +1319,7 @@ export default function ShareRoute() {
                         liveCt >= 0 &&
                         liveCt < 1e7
                           ? Math.floor(liveCt * 1000)
-                          : currentMs;
+                          : playbackMs;
                       return fetch(
                         agentNativePath(
                           "/_agent-native/actions/react-to-recording",
@@ -1389,7 +1397,7 @@ export default function ShareRoute() {
                         return;
                       }
                       const liveMs =
-                        playerRef.current?.getCurrentOriginalMs() ?? currentMs;
+                        playerRef.current?.getCurrentOriginalMs() ?? playbackMs;
                       setCommentAtMs(liveMs);
                       setCommentOpen(true);
                     }}
@@ -1406,7 +1414,7 @@ export default function ShareRoute() {
                       }
                       tracking.reportReaction(emoji);
                       const liveMs =
-                        playerRef.current?.getCurrentOriginalMs() ?? currentMs;
+                        playerRef.current?.getCurrentOriginalMs() ?? playbackMs;
                       return fetch(
                         agentNativePath(
                           "/_agent-native/actions/react-to-recording",
@@ -1517,7 +1525,7 @@ export default function ShareRoute() {
               segments={transcriptSegments}
               fullText={transcriptFullText}
               durationMs={recording.durationMs}
-              currentMs={currentMs}
+              currentMs={playbackMs}
               onSeek={(ms) => playerRef.current?.seek(ms)}
               status={transcriptStatus}
               failureReason={transcriptFailureReason}
@@ -1531,7 +1539,7 @@ export default function ShareRoute() {
             <CommentsPanel
               recordingId={recording.id}
               comments={comments}
-              currentMs={currentMs}
+              currentMs={playbackMs}
               currentUserEmail={session?.email}
               enableComments={recording.enableComments}
               canComment={viewerCanComment}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1174,6 +1174,7 @@ export default function ShareRoute() {
             {session ? null : (
               <SignedOutShareActions
                 recordingId={recording.id}
+                startAt={searchParams.get("at")}
                 onCtaClick={fireShareCtaClick}
               />
             )}

--- a/templates/clips/shared/share-attribution.test.ts
+++ b/templates/clips/shared/share-attribution.test.ts
@@ -6,13 +6,13 @@ import {
 } from "./share-attribution";
 
 describe("buildShareContinuationQuery", () => {
-  it("preserves attribution without forwarding share secrets", () => {
+  it("preserves attribution and timestamps without forwarding share secrets", () => {
     const attribution = readShareAttribution(
       "?ref=clip_share&via=owner-1&password=secret&agent_access_token=token",
     );
 
-    expect(buildShareContinuationQuery(attribution)).toBe(
-      "ref=clip_share&via=owner-1",
+    expect(buildShareContinuationQuery(attribution, "90")).toBe(
+      "ref=clip_share&via=owner-1&at=90",
     );
   });
 

--- a/templates/clips/shared/share-attribution.ts
+++ b/templates/clips/shared/share-attribution.ts
@@ -52,15 +52,17 @@ export type ShareAttribution = {
 };
 
 /**
- * Keep only non-sensitive attribution state when a share page redirects to
- * sign-in. Passwords and capability tokens must never enter auth URLs.
+ * Keep only non-sensitive attribution and playback state when a share page
+ * redirects to sign-in. Passwords and capability tokens must never enter auth URLs.
  */
 export function buildShareContinuationQuery(
   attribution: ShareAttribution,
+  startAt?: string | null,
 ): string {
   const params = new URLSearchParams();
   if (attribution.ref) params.set(REF_PARAM, attribution.ref);
   if (attribution.via) params.set(VIA_PARAM, attribution.via);
+  if (startAt) params.set("at", startAt);
   return params.toString();
 }
 

--- a/templates/clips/shared/share-dashboard-redirect.test.ts
+++ b/templates/clips/shared/share-dashboard-redirect.test.ts
@@ -64,9 +64,9 @@ describe("resolveDashboardRedirect", () => {
       resolveDashboardRedirect({
         recordingId: "rec_1",
         canOpenDashboard: true,
-        search: "?t=1500&panel=transcript&agent_access=secret&via=slack",
+        search: "?t=1500&at=90&panel=transcript&agent_access=secret&via=slack",
       }),
-    ).toBe("/r/rec_1?t=1500&panel=transcript");
+    ).toBe("/r/rec_1?t=1500&at=90&panel=transcript");
   });
 
   it("never forwards a share access token to the authenticated route", () => {

--- a/templates/clips/shared/share-dashboard-redirect.ts
+++ b/templates/clips/shared/share-dashboard-redirect.ts
@@ -4,7 +4,7 @@ import {
 } from "./share-attribution.js";
 
 /** Query params worth carrying from /share/:id over to /r/:id. */
-const FORWARDED_PARAMS = ["t", "panel"] as const;
+const FORWARDED_PARAMS = ["t", "at", "panel"] as const;
 
 export interface DashboardRedirectInput {
   recordingId: string | null | undefined;

--- a/templates/factory/changelog/2026-08-21-activity-runs-use-automation-display-names.md
+++ b/templates/factory/changelog/2026-08-21-activity-runs-use-automation-display-names.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-21
 ---
+
 Activity run history labels each run with the automation's display name instead of its full resource path.

--- a/templates/factory/changelog/2026-08-21-create-and-settings-source-cards.md
+++ b/templates/factory/changelog/2026-08-21-create-and-settings-source-cards.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-21
 ---
+
 Create Factory and Settings now share the same labeled source cards, Enable polling toggles, and uncrowded scheduler health rows.

--- a/templates/factory/changelog/2026-08-21-keep-automations-visible-while-running.md
+++ b/templates/factory/changelog/2026-08-21-keep-automations-visible-while-running.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-21
 ---
+
 Automations remain visible while running, with live status updates in Automations and Activity.

--- a/templates/factory/changelog/2026-08-21-nested-factory-automations-can-poll.md
+++ b/templates/factory/changelog/2026-08-21-nested-factory-automations-can-poll.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-21
 ---
+
 Factory Slack, GitHub, and Sentry automations now run for nested factories instead of failing before they can poll.

--- a/templates/factory/changelog/2026-08-21-settings-sticky-unsaved-bar.md
+++ b/templates/factory/changelog/2026-08-21-settings-sticky-unsaved-bar.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-21
 ---
+
 Factory settings now show a sticky Save and Discard bar at the top as soon as a field changes, instead of a save button buried below the page.


### PR DESCRIPTION

Let people share a Clip starting at the current video position.

## What changed

- Added a “Start at” option to the Clip share dialog.
- Shared links can open public Clips at the selected timestamp and keep that timestamp when people sign in or move to the recording page.
- Kept existing timestamp links working for recording and embed pages.
- Invalid timestamps now start at the beginning of the video, including negative values and values past the video length.
<img width="558" height="219" alt="image" src="https://github.com/user-attachments/assets/11bf697e-9237-4f97-8c0a-5829faa11e27" />
