### PR TITLE
fix: design keyboard chords

### DIFF
--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -4339,6 +4339,14 @@ export const editorChromeBridgeScript: string = `"use strict";
       var key = e.key;
       return key && key.length === 1 ? key.toLowerCase() : key;
     }
+    function isApplePlatformBridge() {
+      var nav = navigator;
+      var platform = nav.userAgentData && nav.userAgentData.platform || nav.platform || "";
+      return /Mac|iPhone|iPad|iPod/i.test(platform);
+    }
+    function isPlatformPrimaryChord(e) {
+      return isApplePlatformBridge() ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+    }
     function isShowShortcutsChord(e) {
       if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
       return e.key === "?" || e.key === "/";
@@ -4382,10 +4390,6 @@ export const editorChromeBridgeScript: string = `"use strict";
           "[",
           // Cmd/Ctrl+U — toggle underline (useDesignHotkeys.ts onToggleUnderline).
           "u",
-          // Cmd/Ctrl+F — find (onFind). Bridge's "primary" doesn't distinguish
-          // Cmd from Ctrl the way isPlatformPrimaryModifier does host-side, but
-          // forwarding is harmless when the host has no match for the combo.
-          "f",
           // Cmd/Ctrl+Shift+R paste-to-replace. Bare primary+r stays native
           // so browser refresh keeps its expected meaning.
           // Cmd/Ctrl+K — open the host command menu even while the iframe has
@@ -4396,7 +4400,11 @@ export const editorChromeBridgeScript: string = `"use strict";
         // Cmd+H / Cmd+L — common OS "Hide app" / browser "focus address bar"
         // shortcuts the host has no bare-primary binding for — are left
         // alone (see useDesignHotkeys.ts: both require event.shiftKey).
-        e.shiftKey && (normalized === "h" || normalized === "l") || e.shiftKey && normalized === "r" || // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
+        // Cmd/Ctrl+F — find (onFind). Gated on the platform's own primary
+        // modifier, matching isPlatformPrimaryModifier host-side: forwarding
+        // is NOT harmless, because the shield preventDefaults before posting,
+        // so a forwarded-then-ignored macOS Ctrl+F loses browser Find.
+        isPlatformPrimaryChord(e) && !e.altKey && !e.shiftKey && normalized === "f" || e.shiftKey && (normalized === "h" || normalized === "l") || e.shiftKey && normalized === "r" || // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
         // (onDetachInstance / onCreateComponent). Gated on altKey so bare
         // Cmd+B is left alone — the host has no bare-primary binding for it.
         e.altKey && (normalized === "b" || normalized === "k") || // Ctrl+Alt+H/V/T distribute + tidy up: LITERAL Control on every
@@ -5783,14 +5791,32 @@ export const editorChromeBridgeScript: string = `"use strict";
         }
       }
     };
+    function rangeFormatIsOn(range, spec) {
+      var root = range.commonAncestorContainer;
+      var rootEl = root.nodeType === 1 ? root : root.parentElement;
+      if (!rootEl) return false;
+      var walker = document.createTreeWalker(rootEl, NodeFilter.SHOW_TEXT, null);
+      var sawText = false;
+      var current = walker.nextNode();
+      while (current) {
+        if (current.nodeValue && current.nodeValue.trim() && range.intersectsNode(current)) {
+          sawText = true;
+          var parent = current.parentElement;
+          if (!parent || !spec.isOn(window.getComputedStyle(parent))) {
+            return false;
+          }
+        }
+        current = walker.nextNode();
+      }
+      return sawText ? true : spec.isOn(window.getComputedStyle(rootEl));
+    }
     function applyTextEditFormat(key) {
       var spec = TEXT_EDIT_FORMATS[key];
       if (!spec) return false;
       var selection = window.getSelection ? window.getSelection() : null;
       if (!selection || selection.rangeCount === 0) return false;
-      var node = selection.getRangeAt(0).commonAncestorContainer;
-      var el = node && node.nodeType === 1 ? node : node && node.parentElement;
-      var next = el && spec.isOn(window.getComputedStyle(el)) ? spec.off : spec.on;
+      var range = selection.getRangeAt(0);
+      var next = rangeFormatIsOn(range, spec) ? spec.off : spec.on;
       return applyTextRangeStyle(spec.property, next);
     }
     function showTransformBadge(text, clientX, clientY) {

--- a/templates/design/.generated/bridge/editor-chrome.generated.ts
+++ b/templates/design/.generated/bridge/editor-chrome.generated.ts
@@ -4301,6 +4301,44 @@ export const editorChromeBridgeScript: string = `"use strict";
         'input, textarea, select, [contenteditable], [role="textbox"], [data-agent-native-text-editing]'
       );
     }
+    var ALT_CODE_KEYS = {
+      KeyA: "a",
+      KeyB: "b",
+      KeyC: "c",
+      KeyD: "d",
+      KeyE: "e",
+      KeyF: "f",
+      KeyG: "g",
+      KeyH: "h",
+      KeyI: "i",
+      KeyJ: "j",
+      KeyK: "k",
+      KeyL: "l",
+      KeyM: "m",
+      KeyN: "n",
+      KeyO: "o",
+      KeyP: "p",
+      KeyQ: "q",
+      KeyR: "r",
+      KeyS: "s",
+      KeyT: "t",
+      KeyU: "u",
+      KeyV: "v",
+      KeyW: "w",
+      KeyX: "x",
+      KeyY: "y",
+      KeyZ: "z",
+      BracketRight: "]",
+      BracketLeft: "["
+    };
+    function normalizedHotkeyChar(e) {
+      if (e.altKey) {
+        var fromCode = ALT_CODE_KEYS[e.code];
+        if (fromCode) return fromCode;
+      }
+      var key = e.key;
+      return key && key.length === 1 ? key.toLowerCase() : key;
+    }
     function isShowShortcutsChord(e) {
       if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
       return e.key === "?" || e.key === "/";
@@ -4311,7 +4349,7 @@ export const editorChromeBridgeScript: string = `"use strict";
       if (activeTextEditEl || isEditorTypingTarget(e.target) || e.isComposing)
         return false;
       var key = e.key;
-      var normalized = key && key.length === 1 ? key.toLowerCase() : key;
+      var normalized = normalizedHotkeyChar(e);
       var primary = e.metaKey || e.ctrlKey;
       if (key === "Escape" || key === "Enter") return true;
       if (key === " " && e.code === "Space") {
@@ -4361,17 +4399,40 @@ export const editorChromeBridgeScript: string = `"use strict";
         e.shiftKey && (normalized === "h" || normalized === "l") || e.shiftKey && normalized === "r" || // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
         // (onDetachInstance / onCreateComponent). Gated on altKey so bare
         // Cmd+B is left alone — the host has no bare-primary binding for it.
-        e.altKey && (normalized === "b" || normalized === "k") || // Ctrl+Alt+H / Ctrl+Alt+T — distribute horizontal / tidy up
-        // (onDistributeSelection / onTidyUp). useDesignHotkeys.ts keeps these
-        // on LITERAL Control on every platform (never remapped to Cmd), so
-        // this mirrors that exact gate instead of the generic "primary" flag
-        // — a blanket "t" entry above would otherwise swallow the common
-        // Cmd+T "new tab" browser shortcut for a combo the host never binds.
-        e.ctrlKey && e.altKey && !e.metaKey && !e.shiftKey && (normalized === "h" || normalized === "t");
+        e.altKey && (normalized === "b" || normalized === "k") || // Ctrl+Alt+H/V/T distribute + tidy up: LITERAL Control on every
+        // platform, so gate on ctrlKey rather than \`primary\` — a blanket "t"
+        // above would swallow Cmd+T, a combo the host never binds.
+        e.ctrlKey && e.altKey && !e.metaKey && !e.shiftKey && ["h", "v", "t"].indexOf(normalized) !== -1;
       }
-      if (e.shiftKey && (e.code === "Digit1" || e.code === "Digit2" || key === "1" || key === "2"))
-        return true;
-      return !e.altKey && !e.shiftKey && ["v", "f", "r", "t", "p", "h", "c", "k"].indexOf(normalized) !== -1;
+      if (e.altKey) {
+        if (e.shiftKey) return false;
+        return ["a", "d", "w", "s", "h", "v"].indexOf(normalized) !== -1 || e.code === "Digit1" || e.code === "Digit2";
+      }
+      if (e.shiftKey) {
+        return ["a", "h", "v", "x", "c", "l", "y", "n", "=", "+"].indexOf(
+          normalized
+        ) !== -1 || e.code === "Digit1" || e.code === "Digit2" || key === "1" || key === "2";
+      }
+      return [
+        "v",
+        "f",
+        "r",
+        "o",
+        "l",
+        "t",
+        "p",
+        "h",
+        "k",
+        "c",
+        "i",
+        "n",
+        "\\\\",
+        "]",
+        "[",
+        "=",
+        "+",
+        "-"
+      ].indexOf(normalized) !== -1 || /^Digit[0-9]$/.test(e.code || "") || /^[0-9]$/.test(key || "");
     }
     function blurActiveTextEditor() {
       var active = document.activeElement;
@@ -5694,6 +5755,43 @@ export const editorChromeBridgeScript: string = `"use strict";
       nextRange.selectNodeContents(span);
       selection.addRange(nextRange);
       return true;
+    }
+    var TEXT_EDIT_FORMATS = {
+      b: {
+        property: "font-weight",
+        on: "700",
+        off: "400",
+        isOn: function(styles) {
+          var weight = styles.fontWeight;
+          return weight === "bold" || Number(weight) >= 600;
+        }
+      },
+      i: {
+        property: "font-style",
+        on: "italic",
+        off: "normal",
+        isOn: function(styles) {
+          return styles.fontStyle === "italic";
+        }
+      },
+      u: {
+        property: "text-decoration",
+        on: "underline",
+        off: "none",
+        isOn: function(styles) {
+          return (styles.textDecorationLine || "").indexOf("underline") !== -1;
+        }
+      }
+    };
+    function applyTextEditFormat(key) {
+      var spec = TEXT_EDIT_FORMATS[key];
+      if (!spec) return false;
+      var selection = window.getSelection ? window.getSelection() : null;
+      if (!selection || selection.rangeCount === 0) return false;
+      var node = selection.getRangeAt(0).commonAncestorContainer;
+      var el = node && node.nodeType === 1 ? node : node && node.parentElement;
+      var next = el && spec.isOn(window.getComputedStyle(el)) ? spec.off : spec.on;
+      return applyTextRangeStyle(spec.property, next);
     }
     function showTransformBadge(text, clientX, clientY) {
       var line = chromeLineScale();
@@ -9620,21 +9718,10 @@ export const editorChromeBridgeScript: string = `"use strict";
           postDesignHotkey(ev);
           return;
         }
-        if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "b") {
+        var formatKey = metaOrCtrl && !ev.altKey ? ev.key.toLowerCase() : "";
+        if (TEXT_EDIT_FORMATS[formatKey]) {
           ev.preventDefault();
-          document.execCommand("bold");
-          scheduleTextEditingChromeUpdate();
-          return;
-        }
-        if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "i") {
-          ev.preventDefault();
-          document.execCommand("italic");
-          scheduleTextEditingChromeUpdate();
-          return;
-        }
-        if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "u") {
-          ev.preventDefault();
-          document.execCommand("underline");
+          applyTextEditFormat(formatKey);
           scheduleTextEditingChromeUpdate();
           return;
         }

--- a/templates/design/app/components/design/CanvasContextMenu.test.tsx
+++ b/templates/design/app/components/design/CanvasContextMenu.test.tsx
@@ -364,3 +364,22 @@ describe("CanvasContextMenu instance cluster (Go to main / Swap / Detach)", () =
     await view.cleanup();
   });
 });
+
+describe("CanvasContextMenu shortcut hints", () => {
+  it("spells shortcut hints in the viewer's own modifier words", async () => {
+    const view = await renderContextMenu({
+      selectedCount: 1,
+      onBringToFront: vi.fn(),
+      onSendToBack: vi.fn(),
+      onGroup: vi.fn(),
+    });
+
+    // happy-dom reports a non-Apple platform, which is exactly the case the
+    // hardcoded ⌘/⇧ glyphs used to get wrong.
+    expect(view.findButton("Group selection")?.textContent).toContain("Ctrl+G");
+    expect(view.container.textContent).not.toContain("⌘");
+    expect(view.container.textContent).not.toContain("⇧");
+
+    await view.cleanup();
+  });
+});

--- a/templates/design/app/components/design/CanvasContextMenu.tsx
+++ b/templates/design/app/components/design/CanvasContextMenu.tsx
@@ -26,9 +26,11 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import { cn } from "@/lib/utils";
 
 import { IconText } from "./inspector/design-icons";
+import { formatShortcutLabel } from "./keyboard-shortcuts";
 import type { CanvasLayerHitCandidate } from "./types";
 
 // LIVE-VERIFIED (real Figma, UI3) canvas context menus:
@@ -423,47 +425,67 @@ const DEFAULT_LABELS: CanvasContextMenuLabels = {
   toggleCommentsHide: "Hide comments",
 };
 
-const DEFAULT_SHORTCUTS: CanvasContextMenuShortcuts = {
+// Platform-agnostic bindings, rendered through formatShortcutLabel at draw
+// time: a Mac glyph written in here renders verbatim to Windows users.
+const DEFAULT_SHORTCUT_BINDINGS: Record<
+  keyof CanvasContextMenuShortcuts,
+  string
+> = {
   pasteHere: "",
-  selectAll: "⌘A",
-  zoomToFit: "⇧1",
-  zoomToSelection: "⇧2",
+  selectAll: "$mod+a",
+  zoomToFit: "shift+1",
+  zoomToSelection: "shift+2",
   zoomIn: "+",
   zoomOut: "-",
-  copy: "⌘C",
-  paste: "⌘V",
-  pasteOver: "⇧⌘V",
-  pasteToReplace: "⇧⌘R",
-  duplicate: "⌘D",
-  delete: "⌫",
-  bringForward: "⌘]",
+  copy: "$mod+c",
+  paste: "$mod+v",
+  pasteOver: "$mod+shift+v",
+  pasteToReplace: "$mod+shift+r",
+  duplicate: "$mod+d",
+  delete: "backspace",
+  bringForward: "$mod+]",
   bringToFront: "]",
-  sendBackward: "⌘[",
+  sendBackward: "$mod+[",
   sendToBack: "[",
-  group: "⌘G",
-  ungroup: "⇧⌘G",
-  frameSelection: "⌥⌘G",
-  addAutoLayout: "⇧A",
-  createComponent: "⌥⌘K",
+  group: "$mod+g",
+  ungroup: "$mod+shift+g",
+  frameSelection: "$mod+alt+g",
+  addAutoLayout: "shift+a",
+  createComponent: "$mod+alt+k",
   goToMainComponent: "",
   swapInstance: "",
-  detachInstance: "⌥⌘B",
-  rename: "⌘R",
-  toggleLock: "⇧⌘L",
-  toggleHide: "⇧⌘H",
-  copyProps: "⌥⌘C",
-  pasteProps: "⌥⌘V",
+  detachInstance: "$mod+alt+b",
+  rename: "$mod+r",
+  toggleLock: "$mod+shift+l",
+  toggleHide: "$mod+shift+h",
+  copyProps: "$mod+alt+c",
+  pasteProps: "$mod+alt+v",
   copyAnimation: "",
   pasteAnimation: "",
   copyAsCode: "",
   copyAsSvg: "",
-  copyAsPng: "⇧⌘C",
+  copyAsPng: "$mod+shift+c",
   rotateClockwise: "",
-  flipHorizontal: "⇧H",
-  flipVertical: "⇧V",
-  toggleUi: "⇧\\",
-  toggleComments: "⇧C",
+  flipHorizontal: "shift+h",
+  flipVertical: "shift+v",
+  toggleUi: "shift+\\",
+  toggleComments: "shift+c",
 };
+
+function defaultShortcutLabels(
+  applePlatform: boolean,
+): CanvasContextMenuShortcuts {
+  const labels = {} as CanvasContextMenuShortcuts;
+  for (const action of Object.keys(
+    DEFAULT_SHORTCUT_BINDINGS,
+  ) as (keyof CanvasContextMenuShortcuts)[]) {
+    labels[action] = formatShortcutLabel(
+      DEFAULT_SHORTCUT_BINDINGS[action],
+      applePlatform,
+    );
+  }
+  return labels;
+}
 
 type ActionCallbackMap = Partial<
   Record<CanvasContextMenuAction, CanvasContextMenuActionHandler>
@@ -511,7 +533,7 @@ export const CanvasContextMenu = forwardRef<
     canPasteOver = hasClipboard && selectedCount > 0,
     canPasteToReplace = hasClipboard && selectedCount > 0,
     canReorder = selectedCount > 0,
-    canGroup = selectedCount > 1,
+    canGroup = selectedCount > 0,
     canUngroup = false,
     canFrameSelection = selectedCount > 0,
     canAddAutoLayout = selectedCount > 0,
@@ -586,9 +608,10 @@ export const CanvasContextMenu = forwardRef<
     () => ({ ...DEFAULT_LABELS, ...labelsProp }),
     [labelsProp],
   );
+  const applePlatform = useApplePlatform();
   const shortcuts = useMemo(
-    () => ({ ...DEFAULT_SHORTCUTS, ...shortcutsProp }),
-    [shortcutsProp],
+    () => ({ ...defaultShortcutLabels(applePlatform), ...shortcutsProp }),
+    [applePlatform, shortcutsProp],
   );
   const hiddenActionSet = useMemo(
     () => new Set(hiddenActions),

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -2386,9 +2386,7 @@ const LayerRow = memo(function LayerRow({
               >
                 <IconStackFront className="size-3.5 text-muted-foreground" />
                 {labels.bringToFront}
-                <ContextMenuShortcut>
-                  {shortcut("$mod+shift+]")}
-                </ContextMenuShortcut>
+                <ContextMenuShortcut>{shortcut("]")}</ContextMenuShortcut>
               </ContextMenuItem>
               <ContextMenuItem
                 className="gap-2 text-[12px]"
@@ -2398,9 +2396,7 @@ const LayerRow = memo(function LayerRow({
               >
                 <IconStackBack className="size-3.5 text-muted-foreground" />
                 {labels.sendToBack}
-                <ContextMenuShortcut>
-                  {shortcut("$mod+shift+[")}
-                </ContextMenuShortcut>
+                <ContextMenuShortcut>{shortcut("[")}</ContextMenuShortcut>
               </ContextMenuItem>
             </>
           ) : null}

--- a/templates/design/app/components/design/LayersPanel.tsx
+++ b/templates/design/app/components/design/LayersPanel.tsx
@@ -38,6 +38,7 @@ import {
   type RefObject,
 } from "react";
 
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
 import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
@@ -54,6 +55,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import { cn } from "@/lib/utils";
 
 export type LayersPanelNodeType =
@@ -1691,6 +1693,9 @@ const LayerRow = memo(function LayerRow({
   onFlipVertical,
 }: LayerRowProps) {
   const t = useT();
+  const applePlatform = useApplePlatform();
+  const shortcut = (binding: string) =>
+    formatShortcutLabel(binding, applePlatform);
   const { node, depth, hasChildren, canAcceptChildren } = row;
   const isComponentLayer = layerNodeIsComponent(node);
   const selectable = node.selectable !== false;
@@ -2351,7 +2356,7 @@ const LayerRow = memo(function LayerRow({
             >
               <IconCopy className="size-3.5 text-muted-foreground" />
               {labels.copy}
-              <ContextMenuShortcut>⌘C</ContextMenuShortcut>
+              <ContextMenuShortcut>{shortcut("$mod+c")}</ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
           {onPasteToReplace ? (
@@ -2362,7 +2367,7 @@ const LayerRow = memo(function LayerRow({
               <IconClipboard className="size-3.5 text-muted-foreground" />
               {labels.pasteToReplace}
               <ContextMenuShortcut>
-                {"⇧⌘R" /* i18n-ignore keyboard shortcut glyph */}
+                {shortcut("$mod+shift+r")}
               </ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
@@ -2381,7 +2386,9 @@ const LayerRow = memo(function LayerRow({
               >
                 <IconStackFront className="size-3.5 text-muted-foreground" />
                 {labels.bringToFront}
-                <ContextMenuShortcut>]</ContextMenuShortcut>
+                <ContextMenuShortcut>
+                  {shortcut("$mod+shift+]")}
+                </ContextMenuShortcut>
               </ContextMenuItem>
               <ContextMenuItem
                 className="gap-2 text-[12px]"
@@ -2391,7 +2398,9 @@ const LayerRow = memo(function LayerRow({
               >
                 <IconStackBack className="size-3.5 text-muted-foreground" />
                 {labels.sendToBack}
-                <ContextMenuShortcut>[</ContextMenuShortcut>
+                <ContextMenuShortcut>
+                  {shortcut("$mod+shift+[")}
+                </ContextMenuShortcut>
               </ContextMenuItem>
             </>
           ) : null}
@@ -2411,7 +2420,7 @@ const LayerRow = memo(function LayerRow({
             >
               <IconLayersUnion className="size-3.5 text-muted-foreground" />
               {labels.group}
-              <ContextMenuShortcut>⌘G</ContextMenuShortcut>
+              <ContextMenuShortcut>{shortcut("$mod+g")}</ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
           {onFrameSelection ? (
@@ -2422,7 +2431,7 @@ const LayerRow = memo(function LayerRow({
               <IconFrame className="size-3.5 text-muted-foreground" />
               {labels.frameSelection}
               <ContextMenuShortcut>
-                {"⌥⌘G" /* i18n-ignore keyboard shortcut glyph */}
+                {shortcut("$mod+alt+g")}
               </ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
@@ -2436,7 +2445,7 @@ const LayerRow = memo(function LayerRow({
             >
               <IconPencil className="size-3.5 text-muted-foreground" />
               {labels.rename}
-              <ContextMenuShortcut>⌘R</ContextMenuShortcut>
+              <ContextMenuShortcut>{shortcut("$mod+r")}</ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
 
@@ -2452,7 +2461,7 @@ const LayerRow = memo(function LayerRow({
               <IconLayersSubtract className="size-3.5 text-muted-foreground" />
               {labels.ungroup}
               <ContextMenuShortcut>
-                {"⇧⌘G" /* i18n-ignore keyboard shortcut glyph */}
+                {shortcut("$mod+shift+g")}
               </ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
@@ -2476,7 +2485,7 @@ const LayerRow = memo(function LayerRow({
               )}
               {node.hidden ? labels.show : labels.hide}
               <ContextMenuShortcut>
-                {"⇧⌘H" /* i18n-ignore keyboard shortcut glyph */}
+                {shortcut("$mod+shift+h")}
               </ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
@@ -2492,7 +2501,7 @@ const LayerRow = memo(function LayerRow({
               )}
               {node.locked ? labels.unlock : labels.lock}
               <ContextMenuShortcut>
-                {"⇧⌘L" /* i18n-ignore keyboard shortcut glyph */}
+                {shortcut("$mod+shift+l")}
               </ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
@@ -2508,7 +2517,7 @@ const LayerRow = memo(function LayerRow({
             >
               <IconFlipHorizontal className="size-3.5 text-muted-foreground" />
               {labels.flipHorizontal}
-              <ContextMenuShortcut>⇧H</ContextMenuShortcut>
+              <ContextMenuShortcut>{shortcut("shift+h")}</ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
           {onFlipVertical ? (
@@ -2518,7 +2527,7 @@ const LayerRow = memo(function LayerRow({
             >
               <IconFlipVertical className="size-3.5 text-muted-foreground" />
               {labels.flipVertical}
-              <ContextMenuShortcut>⇧V</ContextMenuShortcut>
+              <ContextMenuShortcut>{shortcut("shift+v")}</ContextMenuShortcut>
             </ContextMenuItem>
           ) : null}
         </ContextMenuContent>

--- a/templates/design/app/components/design/bridge/bridge.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/bridge.guard.spec.ts
@@ -9956,6 +9956,125 @@ it(
   },
 );
 
+// ── shouldForwardDesignHotkey non-primary audit ─────────────────────────────
+//
+// The mirror of the primary-modifier audit above, for the families that have
+// no Cmd/Ctrl: Alt-only alignment, Shift-only transforms, and the unmodified
+// tool/arrange/zoom/opacity keys. Every row has a real handler in
+// useDesignHotkeys.ts. Alt rows carry an explicit `code` because macOS
+// composes Option+letter into a different character — matching on `key` alone
+// is what made the whole Alt family dead inside the canvas iframe.
+const NON_PRIMARY_HOTKEY_FORWARDING_CASES: Array<{
+  name: string;
+  key: string;
+  code: string;
+  shift?: boolean;
+  alt?: boolean;
+}> = [
+  { name: "Alt+A align left", key: "a", code: "KeyA", alt: true },
+  { name: "Alt+D align right", key: "d", code: "KeyD", alt: true },
+  { name: "Alt+W align top", key: "w", code: "KeyW", alt: true },
+  { name: "Alt+S align bottom", key: "s", code: "KeyS", alt: true },
+  { name: "Alt+H align center-h", key: "h", code: "KeyH", alt: true },
+  { name: "Alt+V align center-v", key: "v", code: "KeyV", alt: true },
+  { name: "Alt+1 layers panel", key: "1", code: "Digit1", alt: true },
+  { name: "Alt+2 assets panel", key: "2", code: "Digit2", alt: true },
+  // macOS composes Option+letter (Option+A -> "å"); the bridge must still
+  // recognise these from event.code the way useDesignHotkeys.ts does.
+  {
+    name: "Option+A align left (composed key)",
+    key: "å",
+    code: "KeyA",
+    alt: true,
+  },
+  {
+    name: "Option+H align center-h (composed key)",
+    key: "˙",
+    code: "KeyH",
+    alt: true,
+  },
+  { name: "Shift+A add auto layout", key: "A", code: "KeyA", shift: true },
+  { name: "Shift+H flip horizontal", key: "H", code: "KeyH", shift: true },
+  { name: "Shift+V flip vertical", key: "V", code: "KeyV", shift: true },
+  { name: "Shift+X swap fill/stroke", key: "X", code: "KeyX", shift: true },
+  { name: "Shift+C toggle comments", key: "C", code: "KeyC", shift: true },
+  { name: "Shift+L arrow tool", key: "L", code: "KeyL", shift: true },
+  { name: "Shift+N previous frame", key: "N", code: "KeyN", shift: true },
+  { name: "Shift+Y draw tool", key: "Y", code: "KeyY", shift: true },
+  { name: "O ellipse tool", key: "o", code: "KeyO" },
+  { name: "L line tool", key: "l", code: "KeyL" },
+  { name: "I eyedropper", key: "i", code: "KeyI" },
+  { name: "N next frame", key: "n", code: "KeyN" },
+  { name: "\\ select parent", key: "\\", code: "Backslash" },
+  { name: "] bring to front", key: "]", code: "BracketRight" },
+  { name: "[ send to back", key: "[", code: "BracketLeft" },
+  { name: "= zoom in", key: "=", code: "Equal" },
+  { name: "- zoom out", key: "-", code: "Minus" },
+  { name: "5 opacity 50%", key: "5", code: "Digit5" },
+  { name: "0 opacity 100%", key: "0", code: "Digit0" },
+];
+
+it(
+  "editor chrome bridge forwards every host-handled non-primary hotkey (Alt-only, Shift-only, and unmodified families)",
+  { timeout: 30_000 },
+  async () => {
+    const browser = await chromium.launch({ headless: true });
+    const pageErrors: string[] = [];
+    try {
+      const page = await browser.newPage({
+        viewport: { width: 900, height: 700 },
+      });
+      page.on("pageerror", (err) => pageErrors.push(err.message));
+      await page.setContent(`<!doctype html><html><body>
+        <div id="el" data-agent-native-node-id="el" style="position:absolute;left:40px;top:40px;width:80px;height:60px;background:#6366f1">El</div>
+      </body></html>`);
+      await page.addScriptTag({ content: hydratedEditorChromeBridgeScript() });
+      await page.waitForSelector('[data-agent-native-edit-overlay="shield"]');
+      await page.mouse.click(80, 70);
+      await page.waitForFunction(() => {
+        const overlay = document.querySelector<HTMLElement>(
+          '[data-agent-native-edit-overlay="selection"]',
+        );
+        return overlay && window.getComputedStyle(overlay).display === "block";
+      });
+      await collectBridgeMessages(page);
+
+      const failures: string[] = [];
+      for (const testCase of NON_PRIMARY_HOTKEY_FORWARDING_CASES) {
+        await page.evaluate(() => {
+          (window as any).__bridgeMessages = [];
+        });
+        // Dispatched rather than typed: Playwright cannot produce a macOS
+        // Option-composed `key` (å) alongside its QWERTY `code`, which is the
+        // exact pairing these rows exist to pin.
+        await page.evaluate((chord) => {
+          document.body.dispatchEvent(
+            new KeyboardEvent("keydown", {
+              key: chord.key,
+              code: chord.code,
+              altKey: Boolean(chord.alt),
+              shiftKey: Boolean(chord.shift),
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        }, testCase);
+        await page.waitForTimeout(20);
+        const messages = await readBridgeMessages(page);
+        const forwarded = messages.some(
+          (message) => message.type === "design-hotkey",
+        );
+        if (!forwarded) failures.push(testCase.name);
+      }
+
+      expect(failures).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    } finally {
+      await browser.close();
+    }
+  },
+);
+
 it(
   "editor chrome bridge forwards Cmd+K so the host command menu opens from an iframe",
   { timeout: 30_000 },

--- a/templates/design/app/components/design/bridge/bridge.guard.spec.ts
+++ b/templates/design/app/components/design/bridge/bridge.guard.spec.ts
@@ -9836,11 +9836,14 @@ const PRIMARY_HOTKEY_FORWARDING_CASES: Array<{
   shift?: boolean;
   alt?: boolean;
   ctrlOnly?: boolean;
+  /** Chord the bridge gates on the platform's own primary modifier, so the
+   *  test has to press Cmd on darwin and Ctrl everywhere else. */
+  platformPrimary?: boolean;
 }> = [
   { name: "Cmd/Ctrl+Z undo", key: "z" },
   { name: "Cmd/Ctrl+Shift+Z redo", key: "z", shift: true },
   { name: "Cmd/Ctrl+Y redo", key: "y" },
-  { name: "Cmd/Ctrl+F find", key: "f" },
+  { name: "Cmd/Ctrl+F find", key: "f", platformPrimary: true },
   { name: "Cmd/Ctrl+A select all", key: "a" },
   { name: "Cmd/Ctrl+X cut", key: "x" },
   { name: "Cmd/Ctrl+Shift+X strikethrough", key: "x", shift: true },
@@ -9927,7 +9930,11 @@ it(
         await page.evaluate(() => {
           (window as any).__bridgeMessages = [];
         });
-        const modifier = testCase.ctrlOnly ? "Control" : "Meta";
+        const modifier =
+          testCase.ctrlOnly ||
+          (testCase.platformPrimary && process.platform !== "darwin")
+            ? "Control"
+            : "Meta";
         await page.keyboard.down(modifier);
         if (testCase.alt) await page.keyboard.down("Alt");
         if (testCase.shift) await page.keyboard.down("Shift");

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -5847,6 +5847,49 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     );
   }
 
+  // Option composes a different character on macOS (Option+A -> "å"), so an
+  // alt-held chord matched on e.key forwards on Windows and vanishes on a Mac.
+  // Mirrors ALT_CODE_KEYS / normalizedKey in useDesignHotkeys.ts.
+  var ALT_CODE_KEYS = {
+    KeyA: "a",
+    KeyB: "b",
+    KeyC: "c",
+    KeyD: "d",
+    KeyE: "e",
+    KeyF: "f",
+    KeyG: "g",
+    KeyH: "h",
+    KeyI: "i",
+    KeyJ: "j",
+    KeyK: "k",
+    KeyL: "l",
+    KeyM: "m",
+    KeyN: "n",
+    KeyO: "o",
+    KeyP: "p",
+    KeyQ: "q",
+    KeyR: "r",
+    KeyS: "s",
+    KeyT: "t",
+    KeyU: "u",
+    KeyV: "v",
+    KeyW: "w",
+    KeyX: "x",
+    KeyY: "y",
+    KeyZ: "z",
+    BracketRight: "]",
+    BracketLeft: "[",
+  };
+
+  function normalizedHotkeyChar(e) {
+    if (e.altKey) {
+      var fromCode = ALT_CODE_KEYS[e.code];
+      if (fromCode) return fromCode;
+    }
+    var key = e.key;
+    return key && key.length === 1 ? key.toLowerCase() : key;
+  }
+
   function isShowShortcutsChord(e) {
     if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
     // macOS delivers Control+Shift+/ as "/" — Control suppresses the shifted
@@ -5872,7 +5915,7 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     if (activeTextEditEl || isEditorTypingTarget(e.target) || e.isComposing)
       return false;
     var key = e.key;
-    var normalized = key && key.length === 1 ? key.toLowerCase() : key;
+    var normalized = normalizedHotkeyChar(e);
     var primary = e.metaKey || e.ctrlKey;
     if (key === "Escape" || key === "Enter") return true;
     // Space arms Figma-style temporary hand-tool panning while the cursor is
@@ -5945,28 +5988,68 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         // (onDetachInstance / onCreateComponent). Gated on altKey so bare
         // Cmd+B is left alone — the host has no bare-primary binding for it.
         (e.altKey && (normalized === "b" || normalized === "k")) ||
-        // Ctrl+Alt+H / Ctrl+Alt+T — distribute horizontal / tidy up
-        // (onDistributeSelection / onTidyUp). useDesignHotkeys.ts keeps these
-        // on LITERAL Control on every platform (never remapped to Cmd), so
-        // this mirrors that exact gate instead of the generic "primary" flag
-        // — a blanket "t" entry above would otherwise swallow the common
-        // Cmd+T "new tab" browser shortcut for a combo the host never binds.
+        // Ctrl+Alt+H/V/T distribute + tidy up: LITERAL Control on every
+        // platform, so gate on ctrlKey rather than `primary` — a blanket "t"
+        // above would swallow Cmd+T, a combo the host never binds.
         (e.ctrlKey &&
           e.altKey &&
           !e.metaKey &&
           !e.shiftKey &&
-          (normalized === "h" || normalized === "t"))
+          ["h", "v", "t"].indexOf(normalized) !== -1)
       );
     }
-    if (
-      e.shiftKey &&
-      (e.code === "Digit1" || e.code === "Digit2" || key === "1" || key === "2")
-    )
-      return true;
+
+    // Non-primary families, mirroring handleDesignHotkey in
+    // useDesignHotkeys.ts. A chord absent here is dead for anyone whose focus
+    // is in the canvas iframe — where it lands the moment you click a layer.
+    if (e.altKey) {
+      if (e.shiftKey) return false;
+      // Alt+A/D/W/S/H/V align selection; Alt+1/Alt+2 navigation panels.
+      return (
+        ["a", "d", "w", "s", "h", "v"].indexOf(normalized) !== -1 ||
+        e.code === "Digit1" ||
+        e.code === "Digit2"
+      );
+    }
+    if (e.shiftKey) {
+      // Shift+A auto layout, Shift+H/V flip, Shift+X swap fill/stroke,
+      // Shift+C comments, Shift+L arrow tool, Shift+Y draw tool,
+      // Shift+N previous frame, Shift+1/2 zoom, Shift+= zoom in.
+      return (
+        ["a", "h", "v", "x", "c", "l", "y", "n", "=", "+"].indexOf(
+          normalized,
+        ) !== -1 ||
+        e.code === "Digit1" ||
+        e.code === "Digit2" ||
+        key === "1" ||
+        key === "2"
+      );
+    }
+    // Unmodified: tool shortcuts, next frame, select parent, z-order, zoom,
+    // and digit opacity.
     return (
-      !e.altKey &&
-      !e.shiftKey &&
-      ["v", "f", "r", "t", "p", "h", "c", "k"].indexOf(normalized) !== -1
+      [
+        "v",
+        "f",
+        "r",
+        "o",
+        "l",
+        "t",
+        "p",
+        "h",
+        "k",
+        "c",
+        "i",
+        "n",
+        "\\",
+        "]",
+        "[",
+        "=",
+        "+",
+        "-",
+      ].indexOf(normalized) !== -1 ||
+      /^Digit[0-9]$/.test(e.code || "") ||
+      /^[0-9]$/.test(key || "")
     );
   }
 
@@ -7804,6 +7887,63 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     nextRange.selectNodeContents(span);
     selection.addRange(nextRange);
     return true;
+  }
+
+  // Chromium's execCommand emits legacy <b>/<i>/<u> tags, which persist into
+  // the design source as child layers the text pipeline never models — T12's
+  // span normalizer above only ever sees spans. Keep these chords on the same
+  // span-based helper the inspector styling path uses.
+  var TEXT_EDIT_FORMATS: Record<
+    string,
+    {
+      property: string;
+      on: string;
+      off: string;
+      isOn: (styles: CSSStyleDeclaration) => boolean;
+    }
+  > = {
+    b: {
+      property: "font-weight",
+      on: "700",
+      off: "400",
+      isOn: function (styles) {
+        var weight = styles.fontWeight;
+        return weight === "bold" || Number(weight) >= 600;
+      },
+    },
+    i: {
+      property: "font-style",
+      on: "italic",
+      off: "normal",
+      isOn: function (styles) {
+        return styles.fontStyle === "italic";
+      },
+    },
+    u: {
+      property: "text-decoration",
+      on: "underline",
+      off: "none",
+      isOn: function (styles) {
+        return (styles.textDecorationLine || "").indexOf("underline") !== -1;
+      },
+    },
+  };
+
+  function applyTextEditFormat(key: string): boolean {
+    var spec = TEXT_EDIT_FORMATS[key];
+    if (!spec) return false;
+    var selection = window.getSelection ? window.getSelection() : null;
+    if (!selection || selection.rangeCount === 0) return false;
+    var node = selection.getRangeAt(0).commonAncestorContainer;
+    var el =
+      node && node.nodeType === 1
+        ? (node as Element)
+        : node && node.parentElement;
+    var next =
+      el && spec.isOn(window.getComputedStyle(el as Element))
+        ? spec.off
+        : spec.on;
+    return applyTextRangeStyle(spec.property, next);
   }
 
   function showTransformBadge(
@@ -13721,21 +13861,10 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         postDesignHotkey(ev);
         return;
       }
-      if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "b") {
+      var formatKey = metaOrCtrl && !ev.altKey ? ev.key.toLowerCase() : "";
+      if (TEXT_EDIT_FORMATS[formatKey]) {
         ev.preventDefault();
-        document.execCommand("bold");
-        scheduleTextEditingChromeUpdate();
-        return;
-      }
-      if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "i") {
-        ev.preventDefault();
-        document.execCommand("italic");
-        scheduleTextEditingChromeUpdate();
-        return;
-      }
-      if (metaOrCtrl && !ev.altKey && ev.key.toLowerCase() === "u") {
-        ev.preventDefault();
-        document.execCommand("underline");
+        applyTextEditFormat(formatKey);
         scheduleTextEditingChromeUpdate();
         return;
       }

--- a/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
+++ b/templates/design/app/components/design/bridge/editor-chrome.bridge.ts
@@ -5890,6 +5890,21 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     return key && key.length === 1 ? key.toLowerCase() : key;
   }
 
+  function isApplePlatformBridge(): boolean {
+    var nav = navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    };
+    var platform =
+      (nav.userAgentData && nav.userAgentData.platform) || nav.platform || "";
+    return /Mac|iPhone|iPad|iPod/i.test(platform);
+  }
+
+  function isPlatformPrimaryChord(e): boolean {
+    return isApplePlatformBridge()
+      ? e.metaKey && !e.ctrlKey
+      : e.ctrlKey && !e.metaKey;
+  }
+
   function isShowShortcutsChord(e) {
     if (!(e.metaKey || e.ctrlKey) || !e.shiftKey || e.altKey) return false;
     // macOS delivers Control+Shift+/ as "/" — Control suppresses the shifted
@@ -5963,10 +5978,6 @@ declare var __INITIAL_SOURCE_HEAD__: string;
           "[",
           // Cmd/Ctrl+U — toggle underline (useDesignHotkeys.ts onToggleUnderline).
           "u",
-          // Cmd/Ctrl+F — find (onFind). Bridge's "primary" doesn't distinguish
-          // Cmd from Ctrl the way isPlatformPrimaryModifier does host-side, but
-          // forwarding is harmless when the host has no match for the combo.
-          "f",
           // Cmd/Ctrl+Shift+R paste-to-replace. Bare primary+r stays native
           // so browser refresh keeps its expected meaning.
           // Cmd/Ctrl+K — open the host command menu even while the iframe has
@@ -5982,6 +5993,14 @@ declare var __INITIAL_SOURCE_HEAD__: string;
         // Cmd+H / Cmd+L — common OS "Hide app" / browser "focus address bar"
         // shortcuts the host has no bare-primary binding for — are left
         // alone (see useDesignHotkeys.ts: both require event.shiftKey).
+        // Cmd/Ctrl+F — find (onFind). Gated on the platform's own primary
+        // modifier, matching isPlatformPrimaryModifier host-side: forwarding
+        // is NOT harmless, because the shield preventDefaults before posting,
+        // so a forwarded-then-ignored macOS Ctrl+F loses browser Find.
+        (isPlatformPrimaryChord(e) &&
+          !e.altKey &&
+          !e.shiftKey &&
+          normalized === "f") ||
         (e.shiftKey && (normalized === "h" || normalized === "l")) ||
         (e.shiftKey && normalized === "r") ||
         // Cmd/Ctrl+Alt+B detach instance / Cmd/Ctrl+Alt+K create component
@@ -7929,20 +7948,46 @@ declare var __INITIAL_SOURCE_HEAD__: string;
     },
   };
 
+  // Select-all puts the common ancestor on the editable, not on the inline
+  // span carrying the format, so the toggle has to read every text run the
+  // range actually covers or Cmd+U stops being able to turn underline off.
+  function rangeFormatIsOn(
+    range: Range,
+    spec: { isOn: (styles: CSSStyleDeclaration) => boolean },
+  ): boolean {
+    var root = range.commonAncestorContainer;
+    var rootEl = root.nodeType === 1 ? (root as Element) : root.parentElement;
+    if (!rootEl) return false;
+    var walker = document.createTreeWalker(rootEl, NodeFilter.SHOW_TEXT, null);
+    var sawText = false;
+    var current = walker.nextNode();
+    while (current) {
+      if (
+        current.nodeValue &&
+        current.nodeValue.trim() &&
+        range.intersectsNode(current)
+      ) {
+        sawText = true;
+        var parent = current.parentElement;
+        if (!parent || !spec.isOn(window.getComputedStyle(parent))) {
+          return false;
+        }
+      }
+      current = walker.nextNode();
+    }
+    return sawText ? true : spec.isOn(window.getComputedStyle(rootEl));
+  }
+
   function applyTextEditFormat(key: string): boolean {
     var spec = TEXT_EDIT_FORMATS[key];
     if (!spec) return false;
     var selection = window.getSelection ? window.getSelection() : null;
     if (!selection || selection.rangeCount === 0) return false;
-    var node = selection.getRangeAt(0).commonAncestorContainer;
-    var el =
-      node && node.nodeType === 1
-        ? (node as Element)
-        : node && node.parentElement;
-    var next =
-      el && spec.isOn(window.getComputedStyle(el as Element))
-        ? spec.off
-        : spec.on;
+    var range = selection.getRangeAt(0);
+    // Known gap: applyTextRangeStyle can only SET a property, so an "off"
+    // value cannot beat an inner run that sets the format itself. Toggling off
+    // works for a single covering run, not for a format split across several.
+    var next = rangeFormatIsOn(range, spec) ? spec.off : spec.on;
     return applyTextRangeStyle(spec.property, next);
   }
 

--- a/templates/design/app/components/design/edit-panel/component-section.tsx
+++ b/templates/design/app/components/design/edit-panel/component-section.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -39,6 +40,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 
 import {
   canRebuildAlpineDataLosslessly,
@@ -460,6 +462,9 @@ export function ComponentSection({
   sourceCapabilities?: string[];
 }) {
   const t = useT();
+  const applePlatform = useApplePlatform();
+  const shortcut = (binding: string) =>
+    formatShortcutLabel(binding, applePlatform);
   const queryClient = useQueryClient();
   const detailsParams = { designId, nodeId, ...(fileId ? { fileId } : {}) };
   const detailsKey = ["action", "get-component-details", detailsParams];
@@ -1005,7 +1010,7 @@ export function ComponentSection({
               <TooltipContent>
                 {t("designEditor.componentInstances.detach")}
                 <span className="ms-1.5 text-muted-foreground/70">
-                  {"⌥⌘B" /* i18n-ignore keyboard shortcut */}
+                  {shortcut("$mod+alt+b")}
                 </span>
               </TooltipContent>
             </Tooltip>

--- a/templates/design/app/components/design/edit-panel/position-layout-properties.tsx
+++ b/templates/design/app/components/design/edit-panel/position-layout-properties.tsx
@@ -23,11 +23,13 @@ import {
 } from "@tabler/icons-react";
 import { useCallback, useState } from "react";
 
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import { cn } from "@/lib/utils";
 
 import {
@@ -331,6 +333,9 @@ export function PositionLayoutProperties({
   breakpointOverrideContext?: BreakpointOverrideFieldContext;
 }) {
   const t = useT();
+  const applePlatform = useApplePlatform();
+  const shortcut = (binding: string) =>
+    formatShortcutLabel(binding, applePlatform);
   const styles = element.computedStyles;
   const constrainedPosition =
     styles.position === "absolute" || styles.position === "fixed";
@@ -422,21 +427,21 @@ export function PositionLayoutProperties({
           <InspectorSegment>
             <InspectorIconButton
               label={t("editPanel.textAligns.left")}
-              shortcut="⌥A"
+              shortcut={shortcut("alt+a")}
               onClick={() => handlePositionAlignH("left")}
             >
               <IconLayoutAlignLeft className="size-3.5" />
             </InspectorIconButton>
             <InspectorIconButton
               label={t("editPanel.textAligns.center")}
-              shortcut="⌥H"
+              shortcut={shortcut("alt+h")}
               onClick={() => handlePositionAlignH("center")}
             >
               <IconLayoutAlignCenter className="size-3.5" />
             </InspectorIconButton>
             <InspectorIconButton
               label={t("editPanel.textAligns.right")}
-              shortcut="⌥D"
+              shortcut={shortcut("alt+d")}
               onClick={() => handlePositionAlignH("right")}
             >
               <IconLayoutAlignRight className="size-3.5" />
@@ -445,21 +450,21 @@ export function PositionLayoutProperties({
           <InspectorSegment>
             <InspectorIconButton
               label={t("editPanel.alignSelfOptions.start")}
-              shortcut="⌥W"
+              shortcut={shortcut("alt+w")}
               onClick={() => handlePositionAlignV("top")}
             >
               <IconLayoutAlignTop className="size-3.5" />
             </InspectorIconButton>
             <InspectorIconButton
               label={t("editPanel.alignSelfOptions.center")}
-              shortcut="⌥V"
+              shortcut={shortcut("alt+v")}
               onClick={() => handlePositionAlignV("middle")}
             >
               <IconLayoutAlignMiddle className="size-3.5" />
             </InspectorIconButton>
             <InspectorIconButton
               label={t("editPanel.alignSelfOptions.end")}
-              shortcut="⌥S"
+              shortcut={shortcut("alt+s")}
               onClick={() => handlePositionAlignV("bottom")}
             >
               <IconLayoutAlignBottom className="size-3.5" />

--- a/templates/design/app/components/design/edit-panel/typography-properties.tsx
+++ b/templates/design/app/components/design/edit-panel/typography-properties.tsx
@@ -22,6 +22,7 @@ import {
 } from "@tabler/icons-react";
 import { useState } from "react";
 
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -40,6 +41,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import { cn } from "@/lib/utils";
 
 import { ScrubInput } from "../inspector";
@@ -174,6 +176,9 @@ function TypographyDetailsPopover({
   onTextCaseChange: (value: string) => void;
 }) {
   const t = useT();
+  const applePlatform = useApplePlatform();
+  const shortcut = (binding: string) =>
+    formatShortcutLabel(binding, applePlatform);
   const [open, setOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<TypographyDetailsTab>("basics");
 
@@ -249,7 +254,7 @@ function TypographyDetailsPopover({
               <InspectorSegment>
                 <InspectorIconButton
                   label={t("editPanel.textDecorations.underline")}
-                  shortcut="⌘U"
+                  shortcut={shortcut("$mod+u")}
                   active={underlineActive}
                   onClick={onToggleUnderline}
                 >
@@ -257,7 +262,7 @@ function TypographyDetailsPopover({
                 </InspectorIconButton>
                 <InspectorIconButton
                   label={t("editPanel.textDecorations.strikethrough")}
-                  shortcut="⌘⇧X"
+                  shortcut={shortcut("$mod+shift+x")}
                   active={strikethroughActive}
                   onClick={onToggleStrikethrough}
                 >

--- a/templates/design/app/components/design/editor/DesignBottomToolbar.tsx
+++ b/templates/design/app/components/design/editor/DesignBottomToolbar.tsx
@@ -27,6 +27,8 @@ import {
   DesignToolbarTool,
 } from "@/components/design/editor/toolbar-controls";
 import { IconText } from "@/components/design/inspector/design-icons";
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import {
   MOVE_GROUP_TOOL_PRESENTATIONS,
   getMoveGroupToolPresentation,
@@ -83,6 +85,7 @@ export function DesignBottomToolbar({
   shortcutsPanelOpen: boolean;
 }) {
   const t = useT();
+  const applePlatform = useApplePlatform();
   const shapeTools = new Set<DesignTool>([
     "rect",
     "line",
@@ -132,7 +135,7 @@ export function DesignBottomToolbar({
       key: "arrow",
       label: t("designEditor.tools.arrow"),
       icon: shapeIcon("arrow", "size-4"),
-      shortcut: "⇧L",
+      shortcut: formatShortcutLabel("shift+l", applePlatform),
       active: activeTool === "arrow",
       onSelect: () => onShape("arrow"),
     },

--- a/templates/design/app/components/design/keyboard-shortcuts.test.ts
+++ b/templates/design/app/components/design/keyboard-shortcuts.test.ts
@@ -5,6 +5,7 @@ import {
   DESIGN_SHORTCUT_CATEGORIES,
   DESIGN_SHORTCUTS,
   formatShortcutKeycaps,
+  formatShortcutLabel,
 } from "./keyboard-shortcuts";
 
 describe("keyboard shortcuts catalog", () => {
@@ -70,5 +71,22 @@ describe("keyboard shortcuts catalog", () => {
       "?",
     ]);
     expect(formatShortcutKeycaps("+", true)).toEqual(["+"]);
+  });
+  it("orders Windows modifiers Ctrl, Alt, Shift and never doubles Ctrl", () => {
+    expect(formatShortcutKeycaps("$mod+alt+g", false)).toEqual([
+      "Ctrl",
+      "Alt",
+      "G",
+    ]);
+    expect(formatShortcutKeycaps("$mod+alt+g", true)).toEqual(["⌥", "⌘", "G"]);
+    expect(formatShortcutKeycaps("ctrl+$mod+t", false)).toEqual(["Ctrl", "T"]);
+  });
+
+  it("spells menu hints for the viewer's platform, not the author's Mac", () => {
+    expect(formatShortcutLabel("$mod+shift+r", true)).toBe("⇧⌘R");
+    expect(formatShortcutLabel("$mod+shift+r", false)).toBe("Ctrl+Shift+R");
+    expect(formatShortcutLabel("alt+a", true)).toBe("⌥A");
+    expect(formatShortcutLabel("alt+a", false)).toBe("Alt+A");
+    expect(formatShortcutLabel("", true)).toBe("");
   });
 });

--- a/templates/design/app/components/design/keyboard-shortcuts.ts
+++ b/templates/design/app/components/design/keyboard-shortcuts.ts
@@ -554,11 +554,34 @@ export function formatShortcutKeycaps(
   if (binding === "+") return ["+"];
   const tokens = binding.toLowerCase().split("+");
   const key = tokens.pop() ?? "";
+  const held = (token: string) => tokens.includes(token);
   const keycaps: string[] = [];
-  if (tokens.includes("ctrl")) keycaps.push(applePlatform ? "⌃" : "Ctrl");
-  if (tokens.includes("alt")) keycaps.push(applePlatform ? "⌥" : "Alt");
-  if (tokens.includes("shift")) keycaps.push(applePlatform ? "⇧" : "Shift");
-  if (tokens.includes("$mod")) keycaps.push(applePlatform ? "⌘" : "Ctrl");
+  if (applePlatform) {
+    if (held("ctrl")) keycaps.push("⌃");
+    if (held("alt")) keycaps.push("⌥");
+    if (held("shift")) keycaps.push("⇧");
+    if (held("$mod")) keycaps.push("⌘");
+  } else {
+    // Windows/Linux read Ctrl, Alt, Shift — the reverse of the Mac ⌃⌥⇧⌘ run.
+    // `$mod` and a literal `ctrl` are the same key here, so collapse them or a
+    // ctrl-plus-$mod binding renders "Ctrl+Ctrl".
+    if (held("$mod") || held("ctrl")) keycaps.push("Ctrl");
+    if (held("alt")) keycaps.push("Alt");
+    if (held("shift")) keycaps.push("Shift");
+  }
   keycaps.push(KEY_LABELS[key] ?? (key.length === 1 ? key.toUpperCase() : key));
   return keycaps;
+}
+
+/** One-line menu/tooltip hint, spelled in the viewer's own modifier glyphs.
+ *  Menus must build hints through this — a Mac glyph written into source
+ *  renders verbatim to Windows users. */
+export function formatShortcutLabel(
+  binding: string,
+  applePlatform: boolean,
+): string {
+  if (!binding) return "";
+  return formatShortcutKeycaps(binding, applePlatform).join(
+    applePlatform ? "" : "+",
+  );
 }

--- a/templates/design/app/hooks/use-shortcut-label.ts
+++ b/templates/design/app/hooks/use-shortcut-label.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from "react";
+
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
+import { isApplePlatform } from "@/hooks/useDesignHotkeys";
+
+const subscribe = () => () => {};
+const notApple = () => false;
+
+/**
+ * The SSR shell is one impersonal document cached for every visitor, so the
+ * viewer's platform is unknowable until hydration — read isApplePlatform()
+ * straight from render and a Mac mismatches the server HTML.
+ */
+export function useApplePlatform(): boolean {
+  return useSyncExternalStore(subscribe, isApplePlatform, notApple);
+}
+
+/** Platform-correct menu/tooltip hint for one `$mod+shift+r`-style binding. */
+export function useShortcutLabel(binding: string): string {
+  return formatShortcutLabel(binding, useApplePlatform());
+}

--- a/templates/design/app/hooks/useDesignHotkeys.test.tsx
+++ b/templates/design/app/hooks/useDesignHotkeys.test.tsx
@@ -811,4 +811,61 @@ describe("useDesignHotkeys — minimize UI and show/hide comments", () => {
     expect(onCommentTool).toHaveBeenCalledTimes(1);
     expect(onToggleComments).not.toHaveBeenCalled();
   });
+  it("consumes Cmd+U even with no underline handler so the browser cannot open View Source", async () => {
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({}, () => {
+      event = dispatchKey("u", { metaKey: true, code: "KeyU" });
+    });
+    expect(event?.defaultPrevented).toBe(true);
+  });
+
+  it("consumes Cmd+Shift+R when paste-to-replace is available", async () => {
+    const onPasteToReplace = vi.fn();
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({ onPasteToReplace }, () => {
+      event = dispatchKey("r", { metaKey: true, shiftKey: true, code: "KeyR" });
+    });
+    expect(onPasteToReplace).toHaveBeenCalledTimes(1);
+    expect(event?.defaultPrevented).toBe(true);
+  });
+
+  it("leaves Cmd+Shift+R to the browser on a read-only design", async () => {
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({}, () => {
+      event = dispatchKey("r", { metaKey: true, shiftKey: true, code: "KeyR" });
+    });
+    expect(event?.defaultPrevented).toBe(false);
+  });
+
+  it.each([
+    ["Cmd+D duplicate", "d", { metaKey: true }],
+    ["Cmd+G group", "g", { metaKey: true }],
+    ["Cmd+0 zoom reset", "0", { metaKey: true }],
+    ["Cmd+Alt+B detach instance", "b", { metaKey: true, altKey: true }],
+  ] as const)(
+    "consumes %s with no handler attached",
+    async (_name, key, modifiers) => {
+      let event: KeyboardEvent | undefined;
+      await withHotkeys({}, () => {
+        event = dispatchKey(key, { ...modifiers });
+      });
+      expect(event?.defaultPrevented).toBe(true);
+    },
+  );
+
+  it("leaves Escape to the running app when onEscape is withheld", async () => {
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({}, () => {
+      event = dispatchKey("Escape");
+    });
+    expect(event?.defaultPrevented).toBe(false);
+  });
+
+  it("leaves Cmd+V alone with no paste handler so the native paste event still fires", async () => {
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({}, () => {
+      event = dispatchKey("v", { metaKey: true, code: "KeyV" });
+    });
+    expect(event?.defaultPrevented).toBe(false);
+  });
 });

--- a/templates/design/app/hooks/useDesignHotkeys.test.tsx
+++ b/templates/design/app/hooks/useDesignHotkeys.test.tsx
@@ -853,6 +853,14 @@ describe("useDesignHotkeys — minimize UI and show/hide comments", () => {
     },
   );
 
+  it("leaves bound chords to the browser on a design the viewer cannot edit", async () => {
+    let event: KeyboardEvent | undefined;
+    await withHotkeys({ canClaimBoundChords: false }, () => {
+      event = dispatchKey("d", { metaKey: true, code: "KeyD" });
+    });
+    expect(event?.defaultPrevented).toBe(false);
+  });
+
   it("leaves Escape to the running app when onEscape is withheld", async () => {
     let event: KeyboardEvent | undefined;
     await withHotkeys({}, () => {

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -207,6 +207,12 @@ export interface UseDesignHotkeysProps {
   onAddAutoLayout?: DesignHotkeyHandler;
   /** Figma's Shift+\ "Minimize UI" shortcut, applied here to the full Design
    *  chrome (left rail, right panel, and bottom toolbar). */
+  /**
+   * Whether Design can act on its own chords at all. False on a read-only or
+   * signed-out prototype, where consuming Cmd+Z/Cmd+D/Cmd+G would cost the
+   * viewer their browser defaults in exchange for nothing.
+   */
+  canClaimBoundChords?: boolean;
   onToggleUi?: DesignHotkeyHandler;
   /** Figma's Shift+C — toggle Show/Hide comments (comment pins). */
   onToggleComments?: DesignHotkeyHandler;
@@ -402,10 +408,12 @@ export function handleDesignHotkey(
   };
 
   /** Consume a Design-bound chord even with no handler attached: "bound but
-   *  inapplicable" must not reach the browser (Cmd+U opens View Source,
-   *  Cmd+Shift+R hard-reloads mid-edit). Clipboard chords stay on `run` —
-   *  they need the native copy/cut/paste event. */
+   *  inapplicable" must not reach the browser (Cmd+U opens View Source).
+   *  Clipboard chords stay on `run` — they need the native copy/cut/paste
+   *  event — and a canvas the user cannot edit claims nothing, because there
+   *  is no Design action to trade the browser default for. */
   const claim = (handler: DesignHotkeyHandler | undefined) => {
+    if (!handler && props.canClaimBoundChords === false) return false;
     prevent();
     handler?.(details);
     return true;
@@ -540,7 +548,9 @@ export function handleDesignHotkey(
     !event.shiftKey &&
     key === "f"
   ) {
-    return claim(props.onFind);
+    // `run`, not `claim`: Find is withheld during initial generation, and
+    // browser Find is better than nothing while Design cannot offer its own.
+    return run(props.onFind);
   }
   if (primary && !event.altKey && !event.shiftKey && key === "a") {
     return runSharedCanvasCommand() || run(props.onSelectAll);

--- a/templates/design/app/hooks/useDesignHotkeys.ts
+++ b/templates/design/app/hooks/useDesignHotkeys.ts
@@ -401,6 +401,16 @@ export function handleDesignHotkey(
     return true;
   };
 
+  /** Consume a Design-bound chord even with no handler attached: "bound but
+   *  inapplicable" must not reach the browser (Cmd+U opens View Source,
+   *  Cmd+Shift+R hard-reloads mid-edit). Clipboard chords stay on `run` —
+   *  they need the native copy/cut/paste event. */
+  const claim = (handler: DesignHotkeyHandler | undefined) => {
+    prevent();
+    handler?.(details);
+    return true;
+  };
+
   const runTool = (
     tool: DesignHotkeyTool,
     handler: DesignHotkeyHandler | undefined,
@@ -510,16 +520,16 @@ export function handleDesignHotkey(
   // deletion has been ruled out. Shift+Cmd+G (below, in the Cmd+G family) is
   // a second, equally-supported binding for the same onUngroup handler.
   if (primary && !event.altKey && !event.shiftKey && key === "Backspace") {
-    return run(props.onUngroup);
+    return claim(props.onUngroup);
   }
 
   if (primary && key === "z") {
     return (
       runSharedCanvasCommand() ||
-      (event.shiftKey ? run(props.onRedo) : run(props.onUndo))
+      (event.shiftKey ? claim(props.onRedo) : claim(props.onUndo))
     );
   }
-  if (primary && key === "y") return run(props.onRedo);
+  if (primary && key === "y") return claim(props.onRedo);
   // Figma Find uses the operating system's primary modifier, rather than
   // treating literal Control and Command as interchangeable on macOS. Keep
   // Ctrl+F available for platform/browser behavior on Apple devices while
@@ -530,7 +540,7 @@ export function handleDesignHotkey(
     !event.shiftKey &&
     key === "f"
   ) {
-    return run(props.onFind);
+    return claim(props.onFind);
   }
   if (primary && !event.altKey && !event.shiftKey && key === "a") {
     return runSharedCanvasCommand() || run(props.onSelectAll);
@@ -538,14 +548,14 @@ export function handleDesignHotkey(
   // Figma's Cmd+Shift+X — toggle strikethrough. Must be checked before plain
   // Cmd+X (cut) below, since that check doesn't itself gate on shiftKey.
   if (primary && event.shiftKey && key === "x") {
-    return run(props.onToggleStrikethrough);
+    return claim(props.onToggleStrikethrough);
   }
   if (primary && key === "x" && !hasDocumentTextSelection()) {
     return runSharedCanvasCommand() || run(props.onCut);
   }
   // Figma's Cmd+U — toggle underline. No existing binding claims plain "u".
   if (primary && !event.altKey && !event.shiftKey && key === "u") {
-    return run(props.onToggleUnderline);
+    return claim(props.onToggleUnderline);
   }
 
   // Current Figma: Ctrl+Alt+H / Ctrl+Alt+V — distribute evenly. These use
@@ -587,20 +597,22 @@ export function handleDesignHotkey(
     return runSharedCanvasCommand() || run(props.onPaste);
   }
   if (primary && key === "d") {
-    return runSharedCanvasCommand() || run(props.onDuplicate);
+    return runSharedCanvasCommand() || claim(props.onDuplicate);
   }
   // Keep Shift+Cmd+R available for Figma's "Paste to replace" command. Bare
   // Cmd/Ctrl+R stays native so browser refresh keeps its expected meaning.
+  // Deliberately `run`, not `claim`: with no handler the design is read-only,
+  // and Design has nothing to offer in exchange for a hard reload.
   if (primary && event.shiftKey && key === "r") {
     return run(props.onPasteToReplace);
   }
   // Cmd+Shift+H/L (hide/lock the current selection) must take precedence over
   // the unmodified/shift-only h/l transform and alignment families.
   if (primary && event.shiftKey && key === "h") {
-    return run(props.onToggleHidden);
+    return claim(props.onToggleHidden);
   }
   if (primary && event.shiftKey && key === "l") {
-    return run(props.onToggleLocked);
+    return claim(props.onToggleLocked);
   }
   if (primary && key === "g") {
     // Figma: ⌥⌘G is "Frame selection". Current Figma's primary ungroup chord
@@ -609,14 +621,14 @@ export function handleDesignHotkey(
     // item performs the identical action (handleUngroupSelection) — leaving
     // this chord dead while the menu item works is a regression users hit,
     // not an intentional gap. Support both bindings for ungroup.
-    if (event.altKey) return run(props.onFrameSelection);
-    if (event.shiftKey) return run(props.onUngroup);
-    return run(props.onGroup);
+    if (event.altKey) return claim(props.onFrameSelection);
+    if (event.shiftKey) return claim(props.onUngroup);
+    return claim(props.onGroup);
   }
 
-  if (primary && (key === "=" || key === "+")) return run(props.onZoomIn);
-  if (primary && key === "-") return run(props.onZoomOut);
-  if (primary && key === "0") return run(props.onZoomReset);
+  if (primary && (key === "=" || key === "+")) return claim(props.onZoomIn);
+  if (primary && key === "-") return claim(props.onZoomOut);
+  if (primary && key === "0") return claim(props.onZoomReset);
 
   // Figma: plain +/= and - (no modifiers) also zoom in/out.
   if (!primary && !event.altKey && !event.shiftKey) {
@@ -639,12 +651,12 @@ export function handleDesignHotkey(
 
   // H2: Cmd+Alt+K — create component from the current selection.
   if (primary && event.altKey && key === "k") {
-    return run(props.onCreateComponent);
+    return claim(props.onCreateComponent);
   }
 
   // Figma's Cmd+Alt+B — Detach instance.
   if (primary && event.altKey && key === "b") {
-    return run(props.onDetachInstance);
+    return claim(props.onDetachInstance);
   }
 
   const digit = digitFromEvent(event);

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -243,6 +243,7 @@ import {
   hasEyeDropperSupport,
   type ExportSettingsValue,
 } from "@/components/design/inspector";
+import { formatShortcutLabel } from "@/components/design/keyboard-shortcuts";
 import { KeyboardShortcutsPanel } from "@/components/design/KeyboardShortcutsPanel";
 import {
   LayersPanel,
@@ -353,6 +354,7 @@ import {
   type DesignEditorCommand,
 } from "@/hooks/use-navigation-state";
 import { useQuestionFlow } from "@/hooks/use-question-flow";
+import { useApplePlatform } from "@/hooks/use-shortcut-label";
 import {
   isDesignHotkeyEditableTarget,
   isShowKeyboardShortcutsHotkey,
@@ -822,6 +824,9 @@ export default function DesignEditorRoute() {
 function DesignEditor() {
   // ── Session, route params, design identity ─────────────────────────────────
   const t = useT();
+  const applePlatform = useApplePlatform();
+  const shortcut = (binding: string) =>
+    formatShortcutLabel(binding, applePlatform);
   const { id } = useParams<{ id: string }>();
   const { session, isLoading: sessionLoading } = useSession();
   const isSignedIn = Boolean(session?.email);
@@ -16677,7 +16682,8 @@ function DesignEditor() {
     ],
   );
 
-  // canGroup: 2+ DOM-node layers selected in the active screen (not file rows).
+  // canGroup: 1+ DOM-node layers selected in the active screen (not file
+  // rows). Figma groups a single object too — the wrapper takes its bounds.
   const fileIdSet = new Set(files.map((f) => f.id));
   const selectedDomLayerIds = selectedLayerIds.filter(
     (id) => !id.startsWith("__") && !fileIdSet.has(id),
@@ -16698,7 +16704,7 @@ function DesignEditor() {
     canEditDesign &&
     viewMode === "single" &&
     Boolean(activeFile) &&
-    selectedDomLayerIds.length >= 2 &&
+    selectedDomLayerIds.length >= 1 &&
     selectedLayersUseCompatibleSourceBackend;
   // canUngroup: one or more DOM-node layers selected (L16: handleUngroupSelection
   // loops all selected containers), and EVERY selected layer must be a
@@ -18346,12 +18352,12 @@ function DesignEditor() {
           <DropdownMenuSubContent className="design-editor-app-menu-content w-52">
             <DropdownMenuItem onClick={handleUndo} disabled={!canUndo}>
               {t("designEditor.undo")}
-              <DropdownMenuShortcut>⌘Z</DropdownMenuShortcut>
+              <DropdownMenuShortcut>{shortcut("$mod+z")}</DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={handleRedo} disabled={!canRedo}>
               {t("designEditor.redo")}
               <DropdownMenuShortcut>
-                {"⇧⌘Z" /* i18n-ignore keyboard shortcut */}
+                {shortcut("$mod+shift+z")}
               </DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
@@ -18360,7 +18366,7 @@ function DesignEditor() {
               disabled={!activeFile}
             >
               {"Duplicate" /* i18n-ignore design menu command */}
-              <DropdownMenuShortcut>⌘D</DropdownMenuShortcut>
+              <DropdownMenuShortcut>{shortcut("$mod+d")}</DropdownMenuShortcut>
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={handleDeleteSelection}
@@ -18407,7 +18413,7 @@ function DesignEditor() {
           <DropdownMenuShortcut>
             {/* Control, not Command: ⌘⇧? is the macOS Help-menu shortcut and
                 the browser consumes it before the page ever sees it. */}
-            {"⌃⇧?" /* i18n-ignore keyboard shortcut */}
+            {shortcut("ctrl+shift+?")}
           </DropdownMenuShortcut>
         </DropdownMenuItem>
         {isSignedIn && (
@@ -18523,7 +18529,7 @@ function DesignEditor() {
         >
           <span className="flex-1">{"Zoom in" /* i18n-ignore */}</span>
           <DropdownMenuShortcut className="tracking-normal">
-            {"Cmd Plus" /* i18n-ignore shortcut key label */}
+            {shortcut("$mod+=")}
           </DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -18532,7 +18538,7 @@ function DesignEditor() {
         >
           <span className="flex-1">{"Zoom out" /* i18n-ignore */}</span>
           <DropdownMenuShortcut className="tracking-normal">
-            {"Cmd Minus" /* i18n-ignore shortcut key label */}
+            {shortcut("$mod+-")}
           </DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem
@@ -18541,7 +18547,7 @@ function DesignEditor() {
         >
           <span className="flex-1">{"Zoom to fit" /* i18n-ignore */}</span>
           <DropdownMenuShortcut className="tracking-normal">
-            ⇧1
+            {shortcut("shift+1")}
           </DropdownMenuShortcut>
         </DropdownMenuItem>
         {[50, 100, 200].map((preset) => (
@@ -18565,7 +18571,7 @@ function DesignEditor() {
             </span>
             {preset === 100 ? (
               <DropdownMenuShortcut className="tracking-normal">
-                ⌘0
+                {shortcut("$mod+0")}
               </DropdownMenuShortcut>
             ) : null}
           </DropdownMenuItem>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -13590,6 +13590,7 @@ function DesignEditor() {
       !responsiveInteractActive &&
       !(pendingQuestions && pendingQuestions.length > 0),
     shouldHandleEvent: shouldHandleEditorHotkey,
+    canClaimBoundChords: canEditDesign,
     onMoveTool: canEditDesign ? handleMoveTool : undefined,
     // F always means Frame; without forcing the mode it would reuse whichever
     // sub-tool the dropdown last selected.

--- a/templates/design/app/pages/design-editor/commands/group-selection.ts
+++ b/templates/design/app/pages/design-editor/commands/group-selection.ts
@@ -95,7 +95,7 @@ export function runGroupSelection({
   const nodeIds = selectedLayerIdsState.filter(
     (id) => !id.startsWith("__") && !fileIds.has(id) && activeNodeIdSet.has(id),
   );
-  if (nodeIds.length < 2) return;
+  if (nodeIds.length === 0) return;
   const patch = applyVisualEdit(baseContent, {
     kind: "wrapNodes",
     targetIds: nodeIds,

--- a/templates/design/app/pages/design-editor/commands/paste-to-replace.ts
+++ b/templates/design/app/pages/design-editor/commands/paste-to-replace.ts
@@ -53,6 +53,17 @@ export interface PasteToReplaceArgs {
   t: (key: string, options?: Record<string, unknown>) => string;
 }
 
+/** Pixel lengths only: `10%` or `2rem` parsed loosely would be re-serialized
+ *  as `10px` and visibly move the replacement. */
+function pixelLength(value: string | undefined): number | null {
+  const raw = (value ?? "").trim();
+  if (raw === "0") return 0;
+  const match = /^(-?[\d.]+)px$/.exec(raw);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function runPasteToReplace({
   activeFile,
   applyLocalContentUpdate,
@@ -126,11 +137,11 @@ export function runPasteToReplace({
   // of pixels away from the layer it replaced. The target's own authored
   // offsets are already in the space being written to; the parent-rect
   // subtraction is the fallback for a target positioned by class or transform.
-  const authoredLeft = Number.parseFloat(targetNode.style.left ?? "");
-  const authoredTop = Number.parseFloat(targetNode.style.top ?? "");
+  const authoredLeft = pixelLength(targetNode.style.left);
+  const authoredTop = pixelLength(targetNode.style.top);
   const parentRect = selectedElement?.parentBoundingRect;
   const position =
-    Number.isFinite(authoredLeft) && Number.isFinite(authoredTop)
+    authoredLeft !== null && authoredTop !== null
       ? { x: authoredLeft, y: authoredTop }
       : {
           x: targetPosition.x - (parentRect?.x ?? 0),

--- a/templates/design/app/pages/design-editor/commands/paste-to-replace.ts
+++ b/templates/design/app/pages/design-editor/commands/paste-to-replace.ts
@@ -120,11 +120,27 @@ export function runPasteToReplace({
     targetNode,
   );
   if (!contentWithoutTarget) return;
+  // insertClonedHtmlLayers writes authored, parent-relative left/top, but
+  // targetPosition is iframe-document space. A board surface renders its
+  // content at ~4000,4000, so passing that through drops the copy thousands
+  // of pixels away from the layer it replaced. The target's own authored
+  // offsets are already in the space being written to; the parent-rect
+  // subtraction is the fallback for a target positioned by class or transform.
+  const authoredLeft = Number.parseFloat(targetNode.style.left ?? "");
+  const authoredTop = Number.parseFloat(targetNode.style.top ?? "");
+  const parentRect = selectedElement?.parentBoundingRect;
+  const position =
+    Number.isFinite(authoredLeft) && Number.isFinite(authoredTop)
+      ? { x: authoredLeft, y: authoredTop }
+      : {
+          x: targetPosition.x - (parentRect?.x ?? 0),
+          y: targetPosition.y - (parentRect?.y ?? 0),
+        };
   const result = insertClonedHtmlLayers(
     contentWithoutTarget,
     [entries[0]!.html],
     {
-      positions: [{ x: targetPosition.x, y: targetPosition.y }],
+      positions: [position],
       styleSnapshots: [entries[0]!.portableStyleSnapshot],
       managedStyleSnapshots: [entries[0]!.managedStyleSnapshot],
     },

--- a/templates/design/e2e/canvas-chords.spec.ts
+++ b/templates/design/e2e/canvas-chords.spec.ts
@@ -395,6 +395,7 @@ test.describe("canvas chords", () => {
       expect(tag).toMatch(/underline/i);
     });
   });
+
   test("Cmd+Shift+R drops the replacement where the old layer stood", async ({
     page,
     context,
@@ -586,6 +587,46 @@ test.describe("canvas chords", () => {
       // A layer clone must never end up nested inside a text layer.
       expect(tag).not.toContain("data-agent-native-preserve-styles");
       expect((tag!.match(/klsajfk/g) ?? []).length).toBe(1);
+    });
+  });
+  test("Cmd+U twice in one session leaves the text un-underlined", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Underline Toggle",
+      TEXT_HTML,
+    );
+    await gotoEditor(page, designId);
+
+    const label = designFrame(page)
+      .locator('[data-agent-native-node-id="tx-label"]')
+      .first();
+    await label.waitFor({ state: "visible", timeout: 10_000 });
+    const box = (await label.boundingBox())!;
+    await page.mouse.dblclick(box.x + box.width / 2, box.y + box.height / 2);
+    await expect(
+      designFrame(page).locator("[data-agent-native-text-editing]"),
+    ).toHaveCount(1, { timeout: 10_000 });
+
+    await page.keyboard.press(`${PRIMARY}+A`);
+    await page.keyboard.press(`${PRIMARY}+U`);
+    await page.waitForTimeout(200);
+    await page.keyboard.press(`${PRIMARY}+A`);
+    await page.keyboard.press(`${PRIMARY}+U`);
+    await page.keyboard.press("Escape");
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const tag =
+        /<div[^>]*data-agent-native-node-id="tx-label"[\s\S]*?<\/div>/.exec(
+          html,
+        )?.[0];
+      expect(tag, "tx-label not found").toBeDefined();
+      expect((tag!.match(/klsajfk/g) ?? []).length).toBe(1);
+      expect(tag).not.toMatch(/text-decoration:\s*underline/i);
     });
   });
 });

--- a/templates/design/e2e/canvas-chords.spec.ts
+++ b/templates/design/e2e/canvas-chords.spec.ts
@@ -1,0 +1,591 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { designFrame, gotoEditor } from "./helpers";
+
+/**
+ * Absolutely-positioned rectangles placed well away from the frame origin, so
+ * a wrapper that loses its own left/top shows up as a jump to 0,0 rather than
+ * as a few pixels of drift.
+ */
+const CHORDS_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Canvas Chords</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#0f172a;color:#f8fafc">
+    <main data-agent-native-node-id="ch-root" data-agent-native-layer-name="Root" style="position:relative;width:900px;height:600px">
+      <div data-agent-native-node-id="ch-alpha" data-agent-native-layer-name="Alpha" style="position:absolute;left:240px;top:180px;width:180px;height:90px;background:#38bdf8;color:#082f49">Alpha</div>
+      <div data-agent-native-node-id="ch-bravo" data-agent-native-layer-name="Bravo" style="position:absolute;left:240px;top:340px;width:180px;height:90px;background:#a78bfa;color:#1f1147">Bravo</div>
+      <div data-agent-native-node-id="ch-charlie" data-agent-native-layer-name="Charlie" style="position:absolute;left:600px;top:180px;width:180px;height:90px;background:#fbbf24;color:#451a03">Charlie</div>
+    </main>
+  </body>
+</html>`;
+
+const TEXT_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Canvas Chords Text</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#fff;color:#111">
+    <main data-agent-native-node-id="tx-root" data-agent-native-layer-name="Root" style="position:relative;width:900px;height:600px">
+      <div data-agent-native-node-id="tx-label" data-agent-native-layer-name="Label" style="position:absolute;left:200px;top:200px;font-size:24px">klsajfk</div>
+    </main>
+  </body>
+</html>`;
+
+/** The replace target sits inside an offset frame, so its document-space
+ *  coordinate (frame origin + own offset) differs from its authored left/top.
+ *  A flat body-level fixture makes the two identical and hides the bug. */
+const NESTED_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Canvas Chords Nested</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#fff">
+    <main data-agent-native-node-id="nz-root" data-agent-native-layer-name="Root" style="position:relative;width:900px;height:600px">
+      <div data-agent-native-node-id="nz-source" data-agent-native-layer-name="Source" style="position:absolute;left:40px;top:40px;width:80px;height:60px;background:#22c55e"></div>
+      <div data-agent-native-node-id="nz-frame" data-agent-native-layer-name="Holder" style="position:absolute;left:320px;top:260px;width:400px;height:280px;background:#e2e8f0">
+        <div data-agent-native-node-id="nz-target" data-agent-native-layer-name="Target" style="position:absolute;left:60px;top:50px;width:120px;height:90px;background:#f97316"></div>
+      </div>
+    </main>
+  </body>
+</html>`;
+
+/** A text layer whose content is wrapped in an id-less inline span, inside a
+ *  frame — the exact shape from the report's [dnd:shield:down] log, where the
+ *  click hit `div[...] > span` while the frame was the selected layer. */
+const INLINE_CHILD_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Canvas Chords Inline Child</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,sans-serif;background:#fff;color:#111">
+    <main data-agent-native-node-id="ic-root" data-agent-native-layer-name="Root" style="position:relative;width:900px;height:600px">
+      <div data-agent-native-node-id="ic-frame" data-agent-native-layer-name="Holder" style="position:absolute;left:120px;top:120px;width:500px;height:320px;background:#eef2f7">
+        <div data-agent-native-node-id="ic-text" data-agent-native-layer-name="Caption" style="position:absolute;left:40px;top:60px;font-size:28px"><span style="text-decoration: underline">klsajfk</span></div>
+      </div>
+    </main>
+  </body>
+</html>`;
+
+/** A real board file: absolute children of a transparent, position:relative
+ *  body. The board surface renders its content offset by thousands of pixels
+ *  inside an 8192 iframe, which is why a plain screen fixture cannot stand in
+ *  for it. */
+const BOARD_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { background: transparent; }
+  body { margin: 0; position: relative; overflow: visible; }
+</style>
+</head>
+<body>
+<div data-agent-native-node-id="bd-frame" data-agent-native-layer-name="Holder" data-an-primitive="frame" style="position:absolute;left:240px;top:200px;width:520px;height:340px;background:#eef2f7">
+<div data-agent-native-node-id="bd-text" data-agent-native-layer-name="Caption" style="position:absolute;left:40px;top:60px;font-size:28px"><span style="text-decoration: underline">klsajfk</span></div>
+</div>
+</body>
+</html>`;
+
+const PRIMARY = process.platform === "darwin" ? "Meta" : "Control";
+
+function actionBaseUrl(baseURL: string | undefined): string {
+  return (
+    baseURL ??
+    process.env.E2E_BASE_URL ??
+    `http://127.0.0.1:${process.env.E2E_PORT ?? "9333"}`
+  ).replace(/\/$/, "");
+}
+
+async function postAction(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  name: string,
+  input: Record<string, unknown>,
+): Promise<any> {
+  const res = await request.post(
+    `${actionBaseUrl(baseURL)}/_agent-native/actions/${name}`,
+    { data: input, headers: { "Content-Type": "application/json" } },
+  );
+  if (!res.ok()) {
+    throw new Error(
+      `action ${name} failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+async function createChordsDesign(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  title: string,
+  content: string = CHORDS_HTML,
+): Promise<string> {
+  const created = await postAction(request, baseURL, "create-design", {
+    title,
+    projectType: "prototype",
+  });
+  const id = created?.id ?? created?.data?.id ?? created?.design?.id;
+  if (!id) throw new Error("create-design did not return an id");
+  await postAction(request, baseURL, "create-file", {
+    designId: id,
+    filename: "layout.html",
+    fileType: "html",
+    content,
+  });
+  return id;
+}
+
+function bodyOf(html: string): string {
+  const start = html.indexOf("<body");
+  return start < 0 ? html : html.slice(start, html.indexOf("</body>") + 7);
+}
+
+async function expectFileContent(
+  request: APIRequestContext,
+  baseURL: string | undefined,
+  id: string,
+  assertContent: (html: string) => void,
+) {
+  await expect
+    .poll(
+      async () => {
+        const params = new URLSearchParams({ id });
+        const res = await request.get(
+          `${actionBaseUrl(baseURL)}/_agent-native/actions/get-design?${params}`,
+          { headers: { "Content-Type": "application/json" } },
+        );
+        if (!res.ok()) return `get-design ${res.status()}`;
+        const payload = await res.json();
+        const design = [
+          payload,
+          payload?.result,
+          payload?.design,
+          payload?.data,
+        ].find((candidate) => Array.isArray(candidate?.files));
+        const file = design?.files?.find(
+          (candidate: { filename?: string }) =>
+            candidate.filename === "layout.html",
+        );
+        if (typeof file?.content !== "string") {
+          return "layout.html has no content";
+        }
+        try {
+          assertContent(file.content);
+          return "ok";
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          return `${reason}\n--- layout.html ---\n${bodyOf(file.content)}`;
+        }
+      },
+      { timeout: 20_000 },
+    )
+    .toBe("ok");
+}
+
+function layerTree(page: Page) {
+  return page.getByRole("tree", { name: "Layers" });
+}
+
+async function selectLayerRow(page: Page, name: string): Promise<void> {
+  const input = page.getByPlaceholder("Search layers...");
+  if (!(await input.isVisible().catch(() => false))) {
+    await page
+      .getByRole("button", { name: "Search layers...", exact: true })
+      .click();
+    await expect(input).toBeVisible();
+  }
+  await input.fill(name);
+  const button = layerTree(page)
+    .locator("[data-layer-row-button][data-layer-node-id]")
+    .filter({ has: page.locator(`span[title="${name}"]`) })
+    .first();
+  await expect(button).toBeVisible();
+  await button.click({ force: true });
+  await expect(
+    button.locator('xpath=ancestor::*[@role="treeitem"][1]'),
+  ).toHaveAttribute("aria-selected", "true");
+}
+
+async function pressEditorKey(page: Page, key: string): Promise<void> {
+  await page.evaluate(() => {
+    document.body.setAttribute("tabindex", "-1");
+    document.body.focus();
+  });
+  await page.keyboard.press(key);
+}
+
+function openTagContaining(html: string, needle: string): string | undefined {
+  const tags = html.match(/<div [^>]*>/g) ?? [];
+  return tags.find((tag) => tag.includes(needle));
+}
+
+function inlineOffset(html: string, nodeId: string) {
+  const open = new RegExp(
+    `<[a-z]+[^>]*data-agent-native-node-id="${nodeId}"[^>]*>`,
+    "i",
+  ).exec(html)?.[0];
+  const style = open ? (/style="([^"]*)"/.exec(open)?.[1] ?? "") : "";
+  const px = (prop: string) =>
+    Number(
+      new RegExp(`(?:^|;)\\s*${prop}\\s*:\\s*(-?[\\d.]+)px`).exec(style)?.[1],
+    );
+  return { left: px("left"), top: px("top"), style };
+}
+
+test.describe("canvas chords", () => {
+  let designId = "";
+
+  test.afterEach(async ({ request, baseURL }) => {
+    if (!designId) return;
+    await postAction(request, baseURL, "delete-design", { id: designId }).catch(
+      () => {},
+    );
+    designId = "";
+  });
+
+  test("Shift+A wraps one rectangle where it stands, not at the frame origin", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords AutoLayout",
+    );
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Alpha");
+    await pressEditorKey(page, "Shift+A");
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const wrapper = openTagContaining(html, "display: flex");
+      expect(wrapper, "no auto-layout wrapper was created").toBeTruthy();
+      expect(wrapper).toContain("position: absolute");
+      expect(wrapper).toContain("left: 240px");
+      expect(wrapper).toContain("top: 180px");
+    });
+  });
+
+  test("Cmd+G groups one rectangle at its own bounds", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(request, baseURL, "E2E Chords Group");
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Bravo");
+    await pressEditorKey(page, `${PRIMARY}+G`);
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const wrapper = openTagContaining(html, 'layer-name="Group');
+      expect(wrapper, "no group wrapper was created").toBeTruthy();
+      expect(wrapper).toContain("left: 240px");
+      expect(wrapper).toContain("top: 340px");
+      expect(wrapper).toContain("width: 180px");
+      expect(wrapper).toContain("height: 90px");
+      const child = inlineOffset(html, "ch-bravo");
+      expect(child.left).toBe(0);
+      expect(child.top).toBe(0);
+    });
+  });
+
+  test("Alt+A aligns the selection from the canvas", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(request, baseURL, "E2E Chords Align");
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Charlie");
+    await pressEditorKey(page, "Alt+A");
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      expect(inlineOffset(html, "ch-charlie").left).toBeLessThan(600);
+    });
+  });
+  test("Alt+A still aligns when focus sits inside the preview iframe", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Align Iframe",
+    );
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Charlie");
+    // Clicking a layer leaves focus on the panel; the reported failure is the
+    // one where focus is in the canvas iframe, which is where it lands the
+    // moment you click a frame.
+    await page
+      .locator("iframe[data-design-preview-iframe]")
+      .first()
+      .evaluate((el) => (el as HTMLIFrameElement).contentWindow?.focus());
+    await page.keyboard.press("Alt+A");
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      expect(inlineOffset(html, "ch-charlie").left).toBeLessThan(600);
+    });
+  });
+  test("Cmd+U underlines the text without duplicating it or adding a <u> layer", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Underline",
+      TEXT_HTML,
+    );
+    await gotoEditor(page, designId);
+
+    const label = designFrame(page)
+      .locator('[data-agent-native-node-id="tx-label"]')
+      .first();
+    await label.waitFor({ state: "visible", timeout: 10_000 });
+    const box = await label.boundingBox();
+    if (!box) throw new Error("no bounding box for the text layer");
+
+    // Double-click is the gesture that opens a real contenteditable session —
+    // the state the reported bug needs, and the one Enter-to-drill-in misses.
+    await page.mouse.dblclick(box.x + box.width / 2, box.y + box.height / 2);
+    await expect(
+      designFrame(page).locator("[data-agent-native-text-editing]"),
+    ).toHaveCount(1, { timeout: 10_000 });
+
+    await page.keyboard.press(`${PRIMARY}+A`);
+    await page.keyboard.press(`${PRIMARY}+U`);
+    await page.keyboard.press("Escape");
+
+    // Nudging afterwards is what surfaced the duplication in the report: the
+    // layer now has a child, and the next commit round-trips through it.
+    await selectLayerRow(page, "Label");
+    await pressEditorKey(page, "ArrowRight");
+    await page.waitForTimeout(600);
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const tag =
+        /<div[^>]*data-agent-native-node-id="tx-label"[\s\S]*?<\/div>/.exec(
+          html,
+        )?.[0];
+      expect(tag, "tx-label not found").toBeDefined();
+      // The visible text must survive exactly once.
+      expect((tag!.match(/klsajfk/g) ?? []).length).toBe(1);
+      // Underline must be a style, not a stray <u> element that shows up as
+      // its own layer in the tree.
+      expect(tag).not.toMatch(/<u[\s>]/i);
+      expect(tag).toMatch(/underline/i);
+    });
+  });
+  test("Cmd+Shift+R drops the replacement where the old layer stood", async ({
+    page,
+    context,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords PasteReplace",
+      NESTED_HTML,
+    );
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(actionBaseUrl(baseURL)).origin,
+    });
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Source");
+    await pressEditorKey(page, `${PRIMARY}+C`);
+    await selectLayerRow(page, "Target");
+    await pressEditorKey(page, `${PRIMARY}+Shift+R`);
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      // The target is gone and exactly one copy replaced it.
+      expect(html).not.toContain('data-agent-native-node-id="nz-target"');
+      const copyTag =
+        /<div[^>]*data-agent-native-node-id="copy-[^"]*"[^>]*>/.exec(html)?.[0];
+      expect(copyTag, `no copy node in:\n${html}`).toBeDefined();
+      // Authored, parent-relative offsets — not the 320+60 / 260+50 document
+      // coordinate, and certainly not a board-space ~4000.
+      expect(copyTag).toMatch(/left:\s*60px/);
+      expect(copyTag).toMatch(/top:\s*50px/);
+    });
+  });
+  test("clicking an inline child inside a text layer does not duplicate its text", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Inline Child",
+      INLINE_CHILD_HTML,
+    );
+    await gotoEditor(page, designId);
+
+    // Select the enclosing frame first: selected-layer drag priority is what
+    // retargets the pointerdown, and it is present in the reported log.
+    await selectLayerRow(page, "Holder");
+
+    const span = designFrame(page)
+      .locator('[data-agent-native-node-id="ic-text"] span')
+      .first();
+    await span.waitFor({ state: "visible", timeout: 10_000 });
+    const box = await span.boundingBox();
+    if (!box) throw new Error("no bounding box for the inline span");
+
+    for (let i = 0; i < 3; i += 1) {
+      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+      await page.waitForTimeout(500);
+    }
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const tag =
+        /<div[^>]*data-agent-native-node-id="ic-text"[\s\S]*?<\/div>/.exec(
+          html,
+        )?.[0];
+      expect(tag, "ic-text not found").toBeDefined();
+      expect((tag!.match(/klsajfk/g) ?? []).length).toBe(1);
+      expect((tag!.match(/<span/g) ?? []).length).toBe(1);
+    });
+  });
+  test("clicking an inline child on the board surface leaves its text alone", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Board Click",
+      CHORDS_HTML,
+    );
+    const board = await postAction(request, baseURL, "create-file", {
+      designId,
+      filename: "__board__.html",
+      fileType: "html",
+      content: BOARD_HTML,
+    });
+    const boardFileId = board?.id ?? board?.data?.id ?? board?.file?.id;
+    expect(boardFileId, "board file id").toBeTruthy();
+    await postAction(request, baseURL, "update-design", {
+      id: designId,
+      dataOperations: [
+        { op: "set", path: ["boardFileId"], value: boardFileId },
+      ],
+    });
+
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Holder");
+
+    // The board surface is the preview iframe that deliberately carries no
+    // data-screen-iframe-id (see DesignCanvas boardSurface).
+    const span = page
+      .locator(
+        "iframe[data-design-preview-iframe]:not([data-screen-iframe-id])",
+      )
+      .first()
+      .contentFrame()
+      .locator('[data-agent-native-node-id="bd-text"] span')
+      .first();
+    await span.waitFor({ state: "visible", timeout: 10_000 });
+    const box = await span.boundingBox();
+    if (!box) throw new Error("no bounding box for the board inline span");
+
+    for (let i = 0; i < 3; i += 1) {
+      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+      await page.waitForTimeout(600);
+    }
+
+    await expect
+      .poll(
+        async () => {
+          const params = new URLSearchParams({ id: designId });
+          const res = await request.get(
+            `${actionBaseUrl(baseURL)}/_agent-native/actions/get-design?${params}`,
+          );
+          const payload = await res.json();
+          const design = [
+            payload,
+            payload?.result,
+            payload?.design,
+            payload?.data,
+          ].find((candidate) => Array.isArray(candidate?.files));
+          const file = design?.files?.find(
+            (candidate: { filename?: string }) =>
+              candidate.filename === "__board__.html",
+          );
+          const html = String(file?.content ?? "");
+          const tag =
+            /<div[^>]*data-agent-native-node-id="bd-text"[\s\S]*?<\/div>/.exec(
+              html,
+            )?.[0] ?? "";
+          return `${(tag.match(/klsajfk/g) ?? []).length}|${(tag.match(/<span/g) ?? []).length}`;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe("1|1");
+  });
+  test("Cmd+Shift+R on an underlined text layer does not nest a copy inside it", async ({
+    page,
+    context,
+    request,
+    baseURL,
+  }) => {
+    designId = await createChordsDesign(
+      request,
+      baseURL,
+      "E2E Chords Replace Inline",
+      INLINE_CHILD_HTML,
+    );
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(actionBaseUrl(baseURL)).origin,
+    });
+    await gotoEditor(page, designId);
+
+    await selectLayerRow(page, "Holder");
+    await pressEditorKey(page, `${PRIMARY}+C`);
+
+    // Clicking underlined text selects the inline span, not the text layer —
+    // that is the selection paste-to-replace then acts on.
+    const span = designFrame(page)
+      .locator('[data-agent-native-node-id="ic-text"] span')
+      .first();
+    await span.waitFor({ state: "visible", timeout: 10_000 });
+    const box = (await span.boundingBox())!;
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await page.waitForTimeout(500);
+    await pressEditorKey(page, `${PRIMARY}+Shift+R`);
+
+    await expectFileContent(request, baseURL, designId, (html) => {
+      const tag =
+        /<div[^>]*data-agent-native-node-id="ic-text"[\s\S]*?<\/div>/.exec(
+          html,
+        )?.[0];
+      expect(tag, "ic-text not found").toBeDefined();
+      // A layer clone must never end up nested inside a text layer.
+      expect(tag).not.toContain("data-agent-native-preserve-styles");
+      expect((tag!.match(/klsajfk/g) ?? []).length).toBe(1);
+    });
+  });
+});

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -1120,6 +1120,23 @@ describe("wrapNodes", () => {
     expect(wrapperStyle).not.toContain("height:");
   });
 
+  it("keeps an autoLayout wrapper at the origin even when children have no width/height", () => {
+    const html = `<main><div data-agent-native-node-id="x" style="position: absolute; left: 240px; top: 180px">Hello</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["x"],
+      autoLayout: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    const wrapperStyle = new RegExp(
+      `data-agent-native-node-id="${patch.result.wrapperNodeId}"[^>]*style="([^"]*)"`,
+    ).exec(patch.content)?.[1];
+    expect(wrapperStyle).toContain("left: 240px");
+    expect(wrapperStyle).toContain("top: 180px");
+    expect(wrapperStyle).toContain("display: flex");
+  });
+
   it("wraps a single absolutely-positioned node at its own bounds", () => {
     const html = `<main><div data-agent-native-node-id="x" style="position: absolute; left: 64px; top: 32px; width: 100px; height: 40px">X</div></main>`;
     const patch = applyVisualEdit(html, {

--- a/templates/design/shared/code-layer.test.ts
+++ b/templates/design/shared/code-layer.test.ts
@@ -1099,6 +1099,42 @@ describe("wrapNodes", () => {
     expect(patch.content).not.toContain("right: 5px");
   });
 
+  it("keeps an autoLayout wrapper at the selection's own origin instead of the parent's 0,0", () => {
+    const html = `<main><div data-agent-native-node-id="x" style="position: absolute; left: 240px; top: 180px; width: 120px; height: 60px">X</div><div data-agent-native-node-id="y" style="position: absolute; left: 240px; top: 300px; width: 120px; height: 60px">Y</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["x", "y"],
+      autoLayout: true,
+    });
+
+    expect(patch.result.status).toBe("applied");
+    const wrapperStyle = new RegExp(
+      `data-agent-native-node-id="${patch.result.wrapperNodeId}"[^>]*style="([^"]*)"`,
+    ).exec(patch.content)?.[1];
+    expect(wrapperStyle).toContain("position: absolute");
+    expect(wrapperStyle).toContain("left: 240px");
+    expect(wrapperStyle).toContain("top: 180px");
+    expect(wrapperStyle).toContain("display: flex");
+    // No width/height: an auto-layout frame hugs its children, like Figma's.
+    expect(wrapperStyle).not.toContain("width:");
+    expect(wrapperStyle).not.toContain("height:");
+  });
+
+  it("wraps a single absolutely-positioned node at its own bounds", () => {
+    const html = `<main><div data-agent-native-node-id="x" style="position: absolute; left: 64px; top: 32px; width: 100px; height: 40px">X</div></main>`;
+    const patch = applyVisualEdit(html, {
+      kind: "wrapNodes",
+      targetIds: ["x"],
+    });
+
+    expect(patch.result.status).toBe("applied");
+    expect(patch.content).toContain("left: 64px; top: 32px");
+    expect(patch.content).toContain("width: 100px; height: 40px");
+    // The child is rebased into the wrapper's coordinate space.
+    expect(patch.content).toContain("left: 0px");
+    expect(patch.content).toContain("top: 0px");
+  });
+
   it("returns unsupported when targets don't share a parent", () => {
     const html = `<main><section><div data-agent-native-node-id="a">A</div></section><div data-agent-native-node-id="b">B</div></main>`;
     const patch = applyVisualEdit(html, {

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -3539,6 +3539,30 @@ function computeAbsoluteUnionBounds(
 }
 
 /**
+ * Origin-only variant: an auto-layout wrapper hugs its children, so it needs
+ * where the selection starts but not how big it is. Absolutely positioned text
+ * routinely has left/top and no width/height, and demanding all four sent it
+ * back to the parent's flow origin.
+ */
+function computeAbsoluteUnionOrigin(
+  elements: ParsedElement[],
+): { left: number; top: number } | null {
+  let minLeft = Infinity;
+  let minTop = Infinity;
+  for (const element of elements) {
+    const style = parseStyle(attributeValue(element, "style"));
+    if (style.position !== "absolute") return null;
+    const left = parsePixelLength(style.left);
+    const top = parsePixelLength(style.top);
+    if (left === null || top === null) return null;
+    minLeft = Math.min(minLeft, left);
+    minTop = Math.min(minTop, top);
+  }
+  if (!Number.isFinite(minLeft) || !Number.isFinite(minTop)) return null;
+  return { left: minLeft, top: minTop };
+}
+
+/**
  * GROUP: wrap targetted sibling elements (sharing a common parent) in a new
  * <div> wrapper. Targets must all share the same parent element.
  */
@@ -3648,9 +3672,12 @@ function applyWrapNodes(
   // it hugs its children the way Figma's does. Omitting the origin drops the
   // wrapper at the parent's flow start and teleports the selection to 0,0.
   const autoLayoutStyle = "display: flex; flex-direction: column; gap: 8px";
+  const autoLayoutOrigin = autoLayout
+    ? (targetGeometry ?? computeAbsoluteUnionOrigin(targetElements))
+    : null;
   const wrapperStyle = autoLayout
-    ? targetGeometry
-      ? `position: absolute; left: ${targetGeometry.left}px; top: ${targetGeometry.top}px; ${autoLayoutStyle}`
+    ? autoLayoutOrigin
+      ? `position: absolute; left: ${autoLayoutOrigin.left}px; top: ${autoLayoutOrigin.top}px; ${autoLayoutStyle}`
       : autoLayoutStyle
     : targetGeometry
       ? `position: absolute; left: ${targetGeometry.left}px; top: ${targetGeometry.top}px; width: ${targetGeometry.width}px; height: ${targetGeometry.height}px;`

--- a/templates/design/shared/code-layer.ts
+++ b/templates/design/shared/code-layer.ts
@@ -3613,9 +3613,7 @@ function applyWrapNodes(
   // Falls back to the previous flow/auto-layout wrapper when any child isn't
   // absolutely positioned (there is no meaningful bounding box to compute
   // without a layout pass).
-  const targetGeometry = !autoLayout
-    ? computeAbsoluteUnionBounds(targetElements)
-    : null;
+  const targetGeometry = computeAbsoluteUnionBounds(targetElements);
 
   // Collect the source fragments for all targets.
   const fragments = targetElements.map((el) => {
@@ -3646,8 +3644,14 @@ function applyWrapNodes(
     return frag;
   });
 
+  // An auto-layout wrapper takes the union's origin but no width/height, so
+  // it hugs its children the way Figma's does. Omitting the origin drops the
+  // wrapper at the parent's flow start and teleports the selection to 0,0.
+  const autoLayoutStyle = "display: flex; flex-direction: column; gap: 8px";
   const wrapperStyle = autoLayout
-    ? "display: flex; flex-direction: column; gap: 8px"
+    ? targetGeometry
+      ? `position: absolute; left: ${targetGeometry.left}px; top: ${targetGeometry.top}px; ${autoLayoutStyle}`
+      : autoLayoutStyle
     : targetGeometry
       ? `position: absolute; left: ${targetGeometry.left}px; top: ${targetGeometry.top}px; width: ${targetGeometry.width}px; height: ${targetGeometry.height}px;`
       : null;


### PR DESCRIPTION
- Keyboard shortcuts now work after you click on the canvas. Alt+A to align, Shift+H to flip, the O/L/Y tool keys, number keys for opacity, brackets, zoom keys — 28 shortcuts were silently dead the moment your cursor was over a frame. Also fixed Alt shortcuts failing on Mac but not Windows.
- Cmd+U no longer opens the browser's View Source on top of your design.
- Shift+A stopped flinging the object to the top-left corner. Adding auto layout now leaves it where you put it. Cmd+G on a single object also works instead of doing nothing.
- Windows users see Windows keys. Menus and tooltips said ⌘C and ⇧⌘H on Windows machines; they now say Ctrl+C and Ctrl+Shift+H.
- Underlining text no longer creates a junk layer. Cmd+U/B/I used to leave a stray U layer inside your text layer in the Layers panel. It's now just a style on the text.
- Cmd+Shift+R pastes where you're looking. The replacement was landing thousands of pixels away — off-screen on a board, or jammed into the corner on a screen.