### PR TITLE
test: protect automatic package release train

### DIFF
--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -46,15 +46,16 @@ describe("npm package release workflow", () => {
     assert.doesNotMatch(source, /AGENT_NATIVE_NPM_DIST_TAG: beta/);
   });
 
-  it("does not run stable publication on an ordinary main push", () => {
+  it("keeps stable changesets flowing on main pushes", () => {
     const release = jobs.release as Workflow;
     const condition = String(release.if);
 
-    assert.match(condition, /workflow_dispatch/);
-    assert.match(condition, /\[stable-release\]/);
-    assert.match(
+    assert.match(condition, /!inputs\.redispatchDownstream/);
+    assert.doesNotMatch(condition, /github\.event_name/);
+    assert.doesNotMatch(condition, /stable-release/);
+    assert.equal(
       String((jobs["notify-downstream"] as Workflow).if),
-      /github\.event_name == 'workflow_dispatch'/,
+      "always()",
     );
   });
 

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -49,14 +49,11 @@ describe("npm package release workflow", () => {
   it("keeps stable changesets flowing on main pushes", () => {
     const release = jobs.release as Workflow;
     const condition = String(release.if);
+    const notify = jobs["notify-downstream"] as Workflow;
 
-    assert.match(condition, /!inputs\.redispatchDownstream/);
-    assert.doesNotMatch(condition, /github\.event_name/);
-    assert.doesNotMatch(condition, /stable-release/);
-    assert.equal(
-      String((jobs["notify-downstream"] as Workflow).if),
-      "always()",
-    );
+    assert.equal(condition, "${{ !inputs.redispatchDownstream }}");
+    assert.deepEqual(notify.needs, ["release"]);
+    assert.equal(String(notify.if), "always()");
   });
 
   it("keeps the release changeset package list aligned with the publisher", () => {


### PR DESCRIPTION
## Summary
- align the package release workflow regression test with the restored automatic changeset release train
- keep the test asserting that ordinary main pushes run stable preparation/publication and downstream notification always reports

## Verification
- `corepack pnpm test:package-release-workflow`
- `corepack pnpm exec oxfmt --check scripts/package-release-workflow.test.ts`
- `git diff --check`

The underlying workflow repair is already on main in `ddcb8ce981`; this follow-up prevents the stale test from rejecting that fix.