### PR TITLE
fix: refine Electron app chat shell states

### DIFF
--- a/.changeset/quiet-scopes-toggle.md
+++ b/.changeset/quiet-scopes-toggle.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Scope sidebar toggle events to the matching app chat surface.

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -260,19 +260,20 @@ describe("AgentPanel shortcut hints", () => {
 describe("AgentSidebar toggle routing", () => {
   it("routes a scoped toggle only to the matching mounted sidebar", () => {
     const event = new CustomEvent("agent-panel:toggle", {
-      detail: { scopeId: "mail" },
+      detail: { scopeId: "mail-tab-1" },
     });
-    const mountedScopes = [{ id: "mail" }, { id: "calendar" }];
+    const mountedScopes = ["mail-tab-1", "mail-tab-2"];
 
     expect(
       mountedScopes.filter((scope) =>
         shouldHandleAgentSidebarToggle(event, scope),
       ),
-    ).toEqual([{ id: "mail" }]);
+    ).toEqual(["mail-tab-1"]);
     expect(
-      shouldHandleAgentSidebarToggle(new Event("agent-panel:toggle"), {
-        id: "calendar",
-      }),
+      shouldHandleAgentSidebarToggle(
+        new Event("agent-panel:toggle"),
+        "mail-tab-2",
+      ),
     ).toBe(true);
   });
 });

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentPanelChatSurface,
   shouldAllowAgentChatSurfaceSettingsMode,
   shouldDefaultAgentChatSurfacePageNewChatButton,
+  shouldHandleAgentSidebarToggle,
   shouldShowAgentPanelFullViewAction,
   shouldShowAgentPanelPageNewChatButton,
   shouldShowAgentPanelChatTabBar,
@@ -253,6 +254,26 @@ describe("AgentPanel shortcut hints", () => {
       toggleSidebar: "^\\",
       widenChat: "^⇧\\",
     });
+  });
+});
+
+describe("AgentSidebar toggle routing", () => {
+  it("routes a scoped toggle only to the matching mounted sidebar", () => {
+    const event = new CustomEvent("agent-panel:toggle", {
+      detail: { scopeId: "mail" },
+    });
+    const mountedScopes = [{ id: "mail" }, { id: "calendar" }];
+
+    expect(
+      mountedScopes.filter((scope) =>
+        shouldHandleAgentSidebarToggle(event, scope),
+      ),
+    ).toEqual([{ id: "mail" }]);
+    expect(
+      shouldHandleAgentSidebarToggle(new Event("agent-panel:toggle"), {
+        id: "calendar",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -154,6 +154,15 @@ const AGENT_PANEL_PREPARE_EVENT = "agent-panel:prepare";
 const AGENT_PANEL_SET_MODE_EVENT = "agent-panel:set-mode";
 const AGENT_PANEL_OPEN_SETTINGS_EVENT = "agent-panel:open-settings";
 
+export function shouldHandleAgentSidebarToggle(
+  event: Event,
+  scope?: { id: string } | null,
+): boolean {
+  const detail = (event as CustomEvent<{ scopeId?: unknown }>).detail;
+  if (!detail || detail.scopeId === undefined) return true;
+  return typeof detail.scopeId === "string" && detail.scopeId === scope?.id;
+}
+
 function postPerAppChatSidebarStateToEmbeddedFrames(open: boolean): void {
   const message = buildAppChatSidebarStateMessage(open);
   for (const frame of document.querySelectorAll("iframe")) {
@@ -3544,7 +3553,8 @@ export function AgentSidebar({
   }, [setOpenPersisted]);
 
   useEffect(() => {
-    const toggleHandler = () => {
+    const toggleHandler = (event: Event) => {
+      if (!shouldHandleAgentSidebarToggle(event, scope)) return;
       if (isPerAppChatHosted) {
         requestPerAppChatCommand("toggle");
         return;

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -156,11 +156,11 @@ const AGENT_PANEL_OPEN_SETTINGS_EVENT = "agent-panel:open-settings";
 
 export function shouldHandleAgentSidebarToggle(
   event: Event,
-  scope?: { id: string } | null,
+  toggleScopeId?: string | null,
 ): boolean {
   const detail = (event as CustomEvent<{ scopeId?: unknown }>).detail;
   if (!detail || detail.scopeId === undefined) return true;
-  return typeof detail.scopeId === "string" && detail.scopeId === scope?.id;
+  return typeof detail.scopeId === "string" && detail.scopeId === toggleScopeId;
 }
 
 function postPerAppChatSidebarStateToEmbeddedFrames(open: boolean): void {
@@ -3122,6 +3122,8 @@ export interface AgentSidebarProps {
   onFullscreenRequest?: () => void;
   /** Ambient resource context rendered as a composer chip. */
   scope?: import("./use-chat-threads.js").ChatThreadScope | null;
+  /** Identity used to route host-scoped sidebar toggle events. */
+  toggleScopeId?: string;
   /** Keep app-owned chat history isolated to the supplied scope. */
   isolateHistoryByScope?: boolean;
   /** @deprecated Scope context now appears inside the composer. */
@@ -3186,6 +3188,7 @@ export function AgentSidebar({
   openOnChatRunning = false,
   onFullscreenRequest,
   scope,
+  toggleScopeId,
   isolateHistoryByScope = false,
   showScopeBadge,
   browserTabId,
@@ -3554,7 +3557,7 @@ export function AgentSidebar({
 
   useEffect(() => {
     const toggleHandler = (event: Event) => {
-      if (!shouldHandleAgentSidebarToggle(event, scope)) return;
+      if (!shouldHandleAgentSidebarToggle(event, toggleScopeId)) return;
       if (isPerAppChatHosted) {
         requestPerAppChatCommand("toggle");
         return;
@@ -3605,7 +3608,7 @@ export function AgentSidebar({
       window.removeEventListener("agent-panel:open", openHandler);
       window.removeEventListener("agent-panel:close", closeHandler);
     };
-  }, [setOpenPersisted, frameCodeMode, isPerAppChatHosted]);
+  }, [setOpenPersisted, frameCodeMode, isPerAppChatHosted, toggleScopeId]);
 
   // Listen for sidebar mode commands from the frame parent.
   // When frame is in "code" mode, hide the app sidebar.

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -311,9 +311,8 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("<IconSettings");
     expect(hubSource).toContain("desktop-chat-first-rail-chat");
     expect(hubSource).toContain('aria-label="Toggle chat sidebar"');
-    expect(hubSource).toContain(
-      'window.dispatchEvent(new Event("agent-panel:toggle"))',
-    );
+    expect(hubSource).toContain('new CustomEvent("agent-panel:toggle"');
+    expect(hubSource).toContain("scopeId: activeChatFirstSurfaceTab?.appId");
     expect(hubSource).toContain("<TooltipProvider delayDuration={0}>");
     expect(hubSource).toContain("IconLayoutSidebarLeftCollapse");
     expect(hubSource).toContain("desktop-chat-first-rail-collapse");

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -312,7 +312,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("desktop-chat-first-rail-chat");
     expect(hubSource).toContain('aria-label="Toggle chat sidebar"');
     expect(hubSource).toContain('new CustomEvent("agent-panel:toggle"');
-    expect(hubSource).toContain("scopeId: activeChatFirstSurfaceTab?.appId");
+    expect(hubSource).toContain("scopeId: activeChatFirstSurfaceTab?.id");
     expect(hubSource).toContain("<TooltipProvider delayDuration={0}>");
     expect(hubSource).toContain("IconLayoutSidebarLeftCollapse");
     expect(hubSource).toContain("desktop-chat-first-rail-collapse");

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -309,6 +309,11 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain('<DesktopRailTooltip label="Settings">');
     expect(hubSource).toContain("onClick={() => onOpenSettings()}");
     expect(hubSource).toContain("<IconSettings");
+    expect(hubSource).toContain("desktop-chat-first-rail-chat");
+    expect(hubSource).toContain('aria-label="Toggle chat sidebar"');
+    expect(hubSource).toContain(
+      'window.dispatchEvent(new Event("agent-panel:toggle"))',
+    );
     expect(hubSource).toContain("<TooltipProvider delayDuration={0}>");
     expect(hubSource).toContain("IconLayoutSidebarLeftCollapse");
     expect(hubSource).toContain("desktop-chat-first-rail-collapse");
@@ -338,6 +343,8 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(shellCss).toContain("min-height: 0;");
     expect(shellCss).toContain("z-index: 1;");
     expect(shellCss).toContain("[data-chat-first-rail-collapse]");
+    expect(shellCss).toContain("[data-chat-first-app][data-app-id]:hover");
+    expect(shellCss).toContain("background-color: transparent;");
   });
 
   it("routes Electron-forwarded Cmd+backslash to the chat sidebar", () => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2687,6 +2687,7 @@ export default function CodeAgentsHub({
                 appAuthState={appAuthState}
                 isActive={isTabActive}
                 chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
+                toggleScopeId={tab.id}
                 onLocalCodeChangeStarted={onLocalCodeChangeStarted}
               >
                 <div
@@ -2937,7 +2938,7 @@ export default function CodeAgentsHub({
                         window.dispatchEvent(
                           new CustomEvent("agent-panel:toggle", {
                             detail: {
-                              scopeId: activeChatFirstSurfaceTab?.appId,
+                              scopeId: activeChatFirstSurfaceTab?.id,
                             },
                           }),
                         )

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -89,6 +89,7 @@ import {
   IconGripVertical,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
+  IconMessageCircle,
   IconPlus,
   IconPin,
   IconSearch,
@@ -869,6 +870,9 @@ export default function CodeAgentsHub({
     activeChatFirstSurfaceTab?.kind === "app" &&
     activeChatFirstSurfaceTab.placement === "main";
   const chatFirstAppSelected = activeChatFirstSurfaceTab?.kind === "app";
+  const chatFirstAppChatEnabled =
+    chatFirstAppSelected &&
+    shouldUseDesktopAppChatShell(activeChatFirstSurfaceTab?.path);
   const [scheduledTasksOpen, setScheduledTasksOpen] = useState(false);
   const activeChatFirstPrimaryTab = useMemo<
     ChatFirstPrimaryTab | undefined
@@ -2923,6 +2927,27 @@ export default function CodeAgentsHub({
           railFooterSlot={
             <TooltipProvider delayDuration={0}>
               <>
+                {chatFirstAppChatEnabled ? (
+                  <DesktopRailTooltip label="Toggle chat sidebar">
+                    <button
+                      type="button"
+                      className="code-agents-nav-link desktop-chat-first-rail-chat"
+                      data-chat-first-rail-chat
+                      onClick={() =>
+                        window.dispatchEvent(new Event("agent-panel:toggle"))
+                      }
+                      aria-label="Toggle chat sidebar"
+                      title="Toggle chat sidebar"
+                    >
+                      <IconMessageCircle
+                        size={15}
+                        strokeWidth={1.8}
+                        aria-hidden="true"
+                      />
+                      <span>Chat</span>
+                    </button>
+                  </DesktopRailTooltip>
+                ) : null}
                 <UpdatePrompt />
                 <UpdateIndicator />
                 {onOpenSettings ? (

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2934,7 +2934,13 @@ export default function CodeAgentsHub({
                       className="code-agents-nav-link desktop-chat-first-rail-chat"
                       data-chat-first-rail-chat
                       onClick={() =>
-                        window.dispatchEvent(new Event("agent-panel:toggle"))
+                        window.dispatchEvent(
+                          new CustomEvent("agent-panel:toggle", {
+                            detail: {
+                              scopeId: activeChatFirstSurfaceTab?.appId,
+                            },
+                          }),
+                        )
                       }
                       aria-label="Toggle chat sidebar"
                       title="Toggle chat sidebar"

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -46,6 +46,7 @@ describe("desktop app chat shell", () => {
     expect(source).toContain("storageKey={`desktop-app-chat:${appId}`}");
     expect(source).toContain('position="left"');
     expect(source).toContain('agentChatSurface="desktop"');
+    expect(source).toContain("toggleScopeId={toggleScopeId}");
     expect(source).toContain("restoreActiveThread={false}");
     expect(source).toContain("enabled={showChatSidebar}");
     expect(source).not.toContain(

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -78,7 +78,7 @@ describe("desktop app chat shell", () => {
     );
 
     expect(shellCss).toMatch(
-      /\.desktop-app-webview-surface,\s*\.code-agents-embedded-app-surface\s*\{\s*border-left: 1px solid hsl\(var\(--border\)\);\s*\}/,
+      /\.desktop-app-webview-surface,\s*\.code-agents-embedded-app-surface\s*\{[\s\S]*?border-radius: var\(--agent-native-raised-radius, 8px\) 0 0\s+var\(--agent-native-raised-radius, 8px\);[\s\S]*?border-left: 0;[\s\S]*?box-shadow: 0 0 0 1px hsl\(var\(--border\)\);[\s\S]*?\}/,
     );
   });
 

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -82,6 +82,7 @@ export interface DesktopAppChatShellProps {
   appAuthState?: AppWebviewAuthState;
   isActive?: boolean;
   chatEnabled?: boolean;
+  toggleScopeId?: string;
   onLocalCodeChangeStarted?: (
     result: DesktopPrepareLocalCodeChangeResult,
   ) => void;
@@ -150,6 +151,7 @@ export default function DesktopAppChatShell({
   appAuthState,
   isActive = true,
   chatEnabled = true,
+  toggleScopeId,
   onLocalCodeChangeStarted,
 }: DesktopAppChatShellProps) {
   const shellRootRef = useRef<HTMLDivElement>(null);
@@ -534,6 +536,7 @@ export default function DesktopAppChatShell({
                 label: appName,
                 contextKey: `desktop-app:${appId}`,
               }}
+              toggleScopeId={toggleScopeId}
               apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
               isolateHistoryByScope
               agentChatSurface="desktop"

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -477,6 +477,10 @@ body {
   span,
 .desktop-chat-first-hub
   .code-agents-rail--collapsed
+  .desktop-chat-first-rail-chat
+  span,
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
   .desktop-chat-first-rail-settings
   span,
 .desktop-chat-first-hub
@@ -1028,6 +1032,14 @@ body {
 
 .desktop-chat-first-hub
   .code-agents-rail--collapsed
+  .desktop-chat-first-rail-chat {
+  width: 40px;
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
   [data-chat-first-rail-collapse] {
   background: hsl(var(--sidebar-accent));
   color: hsl(var(--sidebar-accent-foreground));
@@ -1038,6 +1050,18 @@ body {
   [data-chat-first-rail-collapse]:hover {
   background: hsl(var(--sidebar-accent) / 0.85);
   color: hsl(var(--sidebar-accent-foreground));
+}
+
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
+  [data-chat-first-app][data-app-id] {
+  background-color: transparent;
+}
+
+.desktop-chat-first-hub
+  .code-agents-rail--collapsed
+  [data-chat-first-app][data-app-id]:hover {
+  background-color: hsl(var(--sidebar-accent));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1081,7 +1105,10 @@ body {
 
 .desktop-app-webview-surface,
 .code-agents-embedded-app-surface {
-  border-left: 1px solid hsl(var(--border));
+  border-radius: var(--agent-native-raised-radius, 8px) 0 0
+    var(--agent-native-raised-radius, 8px);
+  border-left: 0;
+  box-shadow: 0 0 0 1px hsl(var(--border));
 }
 
 .code-agents-primary-app-surface {


### PR DESCRIPTION
## Summary
- Remove the selected app background from the collapsed Electron rail while preserving the expanded selection.
- Add a per-app Chat toggle above Settings and update controls.
- Use a zero-blur outline and explicit left radius so the webview boundary follows rounded corners with chat open or closed.

## Validation
- `corepack pnpm --dir packages/desktop-app test`
- `corepack pnpm --dir packages/desktop-app typecheck`
- `corepack pnpm guards`
- Live isolated Electron verification with collapsed, expanded, chat-open, and chat-closed screenshots.