### PR TITLE
fix: stabilize desktop app auth and app rail

### DIFF
--- a/.changeset/calm-app-rail-actions.md
+++ b/.changeset/calm-app-rail-actions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add pin, reorder, and reload actions to workspace app rail context menus.

--- a/packages/core/src/client/chat-first/apps-rail.spec.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.spec.tsx
@@ -322,6 +322,53 @@ describe("ChatFirstAppsRail", () => {
     ).toEqual(defaultAppIds);
   });
 
+  it("opens collapsed app actions and reloads the selected app", async () => {
+    const onReloadApp = vi.fn();
+    const app = { id: "calendar", name: "Calendar" };
+
+    act(() => {
+      root.render(
+        <ChatFirstAppsRail
+          apps={[app]}
+          collapsed
+          onOpenApp={vi.fn()}
+          onReloadApp={onReloadApp}
+          renderIcon={(item) => <span>{item.name}</span>}
+        />,
+      );
+    });
+
+    const appButton = container.querySelector<HTMLButtonElement>(
+      '[data-app-id="calendar"]',
+    );
+    expect(appButton).not.toBeNull();
+
+    await act(async () => {
+      appButton?.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          button: 2,
+          clientX: 40,
+          clientY: 40,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const reloadItem = [
+      ...document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ].find((item) => item.textContent?.trim() === "Reload app");
+    expect(reloadItem).not.toBeUndefined();
+
+    act(() => {
+      reloadItem?.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true }),
+      );
+      reloadItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onReloadApp).toHaveBeenCalledWith(app);
+  });
+
   it("persists the expanded rail state across remounts", () => {
     const apps = Array.from({ length: 7 }, (_, index) => ({
       id: `app-${index}`,

--- a/packages/core/src/client/chat-first/apps-rail.tsx
+++ b/packages/core/src/client/chat-first/apps-rail.tsx
@@ -16,6 +16,7 @@ import {
   IconChevronUp,
   IconPin,
   IconPlus,
+  IconRefresh,
   IconTrash,
 } from "@tabler/icons-react";
 import { memo, useEffect, useMemo, useState, type ReactNode } from "react";
@@ -89,6 +90,70 @@ function ChatFirstRailAppIcon({
   );
 }
 
+function AppContextMenuContent({
+  app,
+  copy,
+  index,
+  onMove,
+  onReloadApp,
+  onRemoveApp,
+  onTogglePinned,
+  pinned,
+  total,
+}: {
+  app: ChatFirstAppItem;
+  copy: ChatFirstCopy;
+  index: number;
+  onMove: (id: string, direction: -1 | 1) => void;
+  onReloadApp?: (app: ChatFirstAppItem) => void;
+  onRemoveApp?: (app: ChatFirstAppItem) => void;
+  onTogglePinned: (id: string) => void;
+  pinned: boolean;
+  total: number;
+}) {
+  return (
+    <ContextMenuContent>
+      <ContextMenuItem onSelect={() => onTogglePinned(app.id)}>
+        <IconPin size={14} aria-hidden="true" />
+        {pinned ? copy("removePinned") : copy("pinTop")}
+      </ContextMenuItem>
+      {onReloadApp ? (
+        <ContextMenuItem onSelect={() => onReloadApp(app)}>
+          <IconRefresh size={14} aria-hidden="true" />
+          {copy("reloadApp")}
+        </ContextMenuItem>
+      ) : null}
+      <ContextMenuSeparator />
+      <ContextMenuItem
+        disabled={index === 0}
+        onSelect={() => onMove(app.id, -1)}
+      >
+        <IconChevronUp size={14} aria-hidden="true" />
+        {copy("moveUp")}
+      </ContextMenuItem>
+      <ContextMenuItem
+        disabled={index === total - 1}
+        onSelect={() => onMove(app.id, 1)}
+      >
+        <IconChevronDown size={14} aria-hidden="true" />
+        {copy("moveDown")}
+      </ContextMenuItem>
+      {onRemoveApp ? (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() => onRemoveApp(app)}
+            className="text-destructive focus:text-destructive"
+          >
+            <IconTrash size={14} aria-hidden="true" />
+            {copy("removeApp")}
+          </ContextMenuItem>
+        </>
+      ) : null}
+    </ContextMenuContent>
+  );
+}
+
 function AppRows({
   apps,
   defaultAppIds,
@@ -98,6 +163,7 @@ function AppRows({
   onDrop,
   onDragEnd,
   onOpenApp,
+  onReloadApp,
   onRemoveApp,
   onTogglePinned,
   onMove,
@@ -112,6 +178,7 @@ function AppRows({
   onDrop: (id: string) => void;
   onDragEnd: () => void;
   onOpenApp: (app: ChatFirstAppItem) => void;
+  onReloadApp?: (app: ChatFirstAppItem) => void;
   onRemoveApp?: (app: ChatFirstAppItem) => void;
   onTogglePinned: (id: string) => void;
   onMove: (id: string, direction: -1 | 1) => void;
@@ -205,39 +272,17 @@ function AppRows({
                 </span>
               </li>
             </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ContextMenuItem onSelect={() => onTogglePinned(app.id)}>
-                <IconPin size={14} aria-hidden="true" />
-                {pinned ? copy("removePinned") : copy("pinTop")}
-              </ContextMenuItem>
-              <ContextMenuSeparator />
-              <ContextMenuItem
-                disabled={index === 0}
-                onSelect={() => onMove(app.id, -1)}
-              >
-                <IconChevronUp size={14} aria-hidden="true" />
-                {copy("moveUp")}
-              </ContextMenuItem>
-              <ContextMenuItem
-                disabled={index === orderedApps.length - 1}
-                onSelect={() => onMove(app.id, 1)}
-              >
-                <IconChevronDown size={14} aria-hidden="true" />
-                {copy("moveDown")}
-              </ContextMenuItem>
-              {onRemoveApp ? (
-                <>
-                  <ContextMenuSeparator />
-                  <ContextMenuItem
-                    onSelect={() => onRemoveApp(app)}
-                    className="text-destructive focus:text-destructive"
-                  >
-                    <IconTrash size={14} aria-hidden="true" />
-                    {copy("removeApp")}
-                  </ContextMenuItem>
-                </>
-              ) : null}
-            </ContextMenuContent>
+            <AppContextMenuContent
+              app={app}
+              copy={copy}
+              index={index}
+              onMove={onMove}
+              onReloadApp={onReloadApp}
+              onRemoveApp={onRemoveApp}
+              onTogglePinned={onTogglePinned}
+              pinned={pinned}
+              total={orderedApps.length}
+            />
           </ContextMenu>
         );
       })}
@@ -257,6 +302,7 @@ export const ChatFirstAppsRail = memo(function ChatFirstAppsRail({
   onLayoutError,
   onRetry,
   onOpenApp,
+  onReloadApp,
   onRemoveApp,
   onOpenAllApps,
   onCreateApp,
@@ -378,30 +424,45 @@ export const ChatFirstAppsRail = memo(function ChatFirstAppsRail({
                 <Skeleton key={index} className="size-9 rounded-md" />
               ))
             : visibleApps.map((app) => (
-                <Tooltip key={app.id} delayDuration={0}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      data-chat-first-app
-                      data-app-id={app.id}
-                      className={cn(
-                        "flex size-9 items-center justify-center rounded-md",
-                        activeAppId === app.id
-                          ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                          : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                      )}
-                      onClick={() => onOpenApp(app)}
-                      aria-label={copy("openApp", { name: app.name })}
-                    >
-                      <ChatFirstRailAppIcon
-                        app={app}
-                        activeAppId={activeAppId}
-                        renderIcon={renderIcon}
-                      />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">{app.name}</TooltipContent>
-                </Tooltip>
+                <ContextMenu key={app.id}>
+                  <Tooltip delayDuration={0}>
+                    <TooltipTrigger asChild>
+                      <ContextMenuTrigger asChild>
+                        <button
+                          type="button"
+                          data-chat-first-app
+                          data-app-id={app.id}
+                          className={cn(
+                            "flex size-9 items-center justify-center rounded-md",
+                            activeAppId === app.id
+                              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                              : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                          )}
+                          onClick={() => onOpenApp(app)}
+                          aria-label={copy("openApp", { name: app.name })}
+                        >
+                          <ChatFirstRailAppIcon
+                            app={app}
+                            activeAppId={activeAppId}
+                            renderIcon={renderIcon}
+                          />
+                        </button>
+                      </ContextMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">{app.name}</TooltipContent>
+                  </Tooltip>
+                  <AppContextMenuContent
+                    app={app}
+                    copy={copy}
+                    index={orderedApps.indexOf(app)}
+                    onMove={moveApp}
+                    onReloadApp={onReloadApp}
+                    onRemoveApp={onRemoveApp}
+                    onTogglePinned={togglePinned}
+                    pinned={layout.pinnedIds.includes(app.id)}
+                    total={orderedApps.length}
+                  />
+                </ContextMenu>
               ))}
           {onOpenAllApps ? (
             <Tooltip delayDuration={0}>
@@ -477,6 +538,7 @@ export const ChatFirstAppsRail = memo(function ChatFirstAppsRail({
           onDrop={reorderApps}
           onDragEnd={() => setDraggedAppId(null)}
           onOpenApp={onOpenApp}
+          onReloadApp={onReloadApp}
           onRemoveApp={onRemoveApp}
           onTogglePinned={togglePinned}
           onMove={moveApp}

--- a/packages/core/src/client/chat-first/copy.ts
+++ b/packages/core/src/client/chat-first/copy.ts
@@ -17,6 +17,7 @@ const DEFAULT_COPY: Record<string, string> = {
   dismiss: "Dismiss",
   unpinApp: "Unpin this app",
   pinApp: "Pin this app",
+  reloadApp: "Reload app",
   removePinned: "Remove from pinned apps",
   pinTop: "Pin app to the top",
   moveUp: "Move up",

--- a/packages/core/src/client/chat-first/types.ts
+++ b/packages/core/src/client/chat-first/types.ts
@@ -74,6 +74,7 @@ export interface ChatFirstAppRailProps {
   onLayoutError?: (reason: "unavailable" | "write-failed") => void;
   onRetry?: () => void;
   onOpenApp: (app: ChatFirstAppItem) => void;
+  onReloadApp?: (app: ChatFirstAppItem) => void;
   onRemoveApp?: (app: ChatFirstAppItem) => void;
   onOpenAllApps?: () => void;
   onCreateApp?: () => void;

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -2184,7 +2184,7 @@ describe("DesktopIdentityBroker", () => {
         "/_agent-native/actions/create-workspace-app-embed-session",
     ).length;
 
-    await expect(broker.ensureAppSession(mail.id)).resolves.toBe(true);
+    await expect(broker.ensureAppSession(mail.id)).resolves.toBe(false);
 
     expect(
       identityFetch.mock.calls.filter(
@@ -2194,6 +2194,18 @@ describe("DesktopIdentityBroker", () => {
       ),
     ).toHaveLength(embedSessionRequestCount);
     expect(reloadApp).toHaveBeenCalledTimes(1);
+
+    mailCookies.get.mockRejectedValueOnce(
+      new Error("cookie store unavailable"),
+    );
+    await expect(broker.ensureAppSession(mail.id)).resolves.toBe(false);
+    expect(
+      identityFetch.mock.calls.filter(
+        ([input]) =>
+          new URL(String(input)).pathname ===
+          "/_agent-native/actions/create-workspace-app-embed-session",
+      ),
+    ).toHaveLength(embedSessionRequestCount);
   });
 
   it("dedupes a completed workspace embed session", async () => {

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -802,7 +802,7 @@ export class DesktopIdentityBroker {
           if (sessionState === "matching") return true;
           // A transient session-check failure must not turn a known-good
           // completed handoff into an unnecessary sign-in ceremony.
-          if (sessionState === "unavailable") return this.hasAppSession(app);
+          if (sessionState === "unavailable") return false;
           this.completedModernAppSessions.delete(pendingKey);
           return this.ensureModernAppSessionDeduped(
             appId,
@@ -2734,16 +2734,24 @@ export class DesktopIdentityBroker {
   }
 
   private async hasAppSession(app: DesktopIdentityApp): Promise<boolean> {
+    return (await this.inspectAppSession(app)) === "present";
+  }
+
+  private async inspectAppSession(
+    app: DesktopIdentityApp,
+  ): Promise<"present" | "absent" | "unavailable"> {
     try {
       const cookies = await app.session.cookies.get({});
       const allowed = new Set(app.cookieNames);
       return cookies.some(
         (cookie) =>
           cookieMatchesOrigin(cookie, app.origin) && allowed.has(cookie.name),
-      );
+      )
+        ? "present"
+        : "absent";
     } catch (error) {
       void error;
-      return false;
+      return "unavailable";
     }
   }
 
@@ -2857,7 +2865,14 @@ export class DesktopIdentityBroker {
     expectedIdentityEmail?: string,
   ): Promise<boolean> {
     const authority = this.resolveIdentityAuthority();
-    if (!authority || !(await this.hasAppSession(app))) return false;
+    if (!authority) return false;
+    const appSessionState = await this.inspectAppSession(app);
+    if (appSessionState === "unavailable") {
+      throw new Error(
+        `[desktop identity] app session cookie check unavailable for ${app.id}`,
+      );
+    }
+    if (appSessionState === "absent") return false;
 
     const [authorityEmail, appEmail] = await Promise.all([
       expectedIdentityEmail ?? this.verifyIdentitySession(authority),

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -797,16 +797,21 @@ export class DesktopIdentityBroker {
     if (this.completedModernAppSessions.has(pendingKey)) {
       const app = this.options.resolveApp(appId);
       if (!app) return Promise.resolve(false);
-      return this.hasAppSession(app).then((hasSession) => {
-        if (hasSession) return true;
-        this.completedModernAppSessions.delete(pendingKey);
-        return this.ensureModernAppSessionDeduped(
-          appId,
-          generation,
-          expectedEmail,
-          options,
-        );
-      });
+      return this.inspectCachedModernAppSession(app, expectedEmail).then(
+        (sessionState) => {
+          if (sessionState === "matching") return true;
+          // A transient session-check failure must not turn a known-good
+          // completed handoff into an unnecessary sign-in ceremony.
+          if (sessionState === "unavailable") return this.hasAppSession(app);
+          this.completedModernAppSessions.delete(pendingKey);
+          return this.ensureModernAppSessionDeduped(
+            appId,
+            generation,
+            expectedEmail,
+            options,
+          );
+        },
+      );
     }
     const existing = this.pendingModernAppSessions.get(pendingKey);
     if (existing) return existing;
@@ -2864,6 +2869,19 @@ export class DesktopIdentityBroker {
       normalizeIdentityEmail(authorityEmail) ===
         normalizeIdentityEmail(appEmail),
     );
+  }
+
+  private async inspectCachedModernAppSession(
+    app: DesktopIdentityApp,
+    expectedIdentityEmail?: string,
+  ): Promise<"matching" | "mismatch" | "unavailable"> {
+    try {
+      return (await this.hasMatchingIdentitySession(app, expectedIdentityEmail))
+        ? "matching"
+        : "mismatch";
+    } catch {
+      return "unavailable";
+    }
   }
 
   private async pollDesktopOAuthExchange(

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -13505,7 +13505,7 @@ app.on("web-contents-created", (_event, contents) => {
 
     // Cmd+R reloads the guest that received the key instead of asking the
     // shell renderer to rediscover the active tab.
-    if (key === "r" && !input.alt && !input.shift) {
+    if (key === "r" && !input.alt) {
       event.preventDefault();
       reloadWebviewContents(contents);
       return;
@@ -14241,7 +14241,7 @@ app.whenReady().then(async () => {
     }
 
     // Cmd+R — refresh active webview, not the shell
-    if (key === "r" && !input.alt && !input.shift) {
+    if (key === "r" && !input.alt) {
       _event.preventDefault();
       reloadActiveWebview();
       return;

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -2017,6 +2017,26 @@ function getActiveWebviewContents() {
   );
 }
 
+function reloadWebviewContents(contents?: Electron.WebContents): boolean {
+  if (!contents) return false;
+  try {
+    if (contents.isDestroyed() || contents.getType() !== "webview") {
+      return false;
+    }
+    contents.reloadIgnoringCache();
+    return true;
+  } catch (error) {
+    console.debug("[desktop] webview reload skipped", {
+      reason: error instanceof Error ? error.message : "unknown error",
+    });
+    return false;
+  }
+}
+
+function reloadActiveWebview(): boolean {
+  return reloadWebviewContents(getActiveWebviewContents());
+}
+
 function getDesktopShortcutSettings(): DesktopShortcutSettings {
   const bindings = AppStore.loadDesktopShortcutBindings();
   return {
@@ -13483,6 +13503,14 @@ app.on("web-contents-created", (_event, contents) => {
       return;
     }
 
+    // Cmd+R reloads the guest that received the key instead of asking the
+    // shell renderer to rediscover the active tab.
+    if (key === "r" && !input.alt && !input.shift) {
+      event.preventDefault();
+      reloadWebviewContents(contents);
+      return;
+    }
+
     // Cmd+Option+Up/Down — previous/next app
     if (input.alt && (key === "arrowup" || key === "arrowdown")) {
       event.preventDefault();
@@ -13517,13 +13545,9 @@ app.on("web-contents-created", (_event, contents) => {
 
     const isAgentSidebarToggleShortcut = isDesktopChatToggleShortcut(input);
 
-    // Forward other Cmd+ shortcuts: F, L, R, T, Shift+T, \
+    // Forward other Cmd+ shortcuts: F, L, T, Shift+T, \
     const isShortcut =
-      key === "f" ||
-      key === "l" ||
-      key === "r" ||
-      key === "t" ||
-      isAgentSidebarToggleShortcut;
+      key === "f" || key === "l" || key === "t" || isAgentSidebarToggleShortcut;
 
     if (isShortcut) {
       event.preventDefault();
@@ -14217,13 +14241,9 @@ app.whenReady().then(async () => {
     }
 
     // Cmd+R — refresh active webview, not the shell
-    if (key === "r") {
+    if (key === "r" && !input.alt && !input.shift) {
       _event.preventDefault();
-      win.webContents.send("shortcut:keydown", {
-        key: "r",
-        shiftKey: input.shift,
-        ctrlKey: input.control,
-      });
+      reloadActiveWebview();
       return;
     }
 

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -325,7 +325,7 @@ describe("Desktop identity activation", () => {
     ).toHaveLength(initialSourceAssignmentCount);
   });
 
-  it("reconciles a loaded app without replacing its session on activation", async () => {
+  it("reconciles a loaded app session on activation", async () => {
     const ensureAppSession = vi
       .fn<() => Promise<boolean>>()
       .mockResolvedValueOnce(true)
@@ -410,9 +410,7 @@ describe("Desktop identity activation", () => {
       await Promise.resolve();
     });
     expect(ensureAppSession).toHaveBeenCalledTimes(2);
-    expect(ensureAppSession).toHaveBeenNthCalledWith(2, "mail", {
-      preserveExistingSession: true,
-    });
+    expect(ensureAppSession).toHaveBeenNthCalledWith(2, "mail");
 
     act(() => {
       root.render(
@@ -436,9 +434,7 @@ describe("Desktop identity activation", () => {
     });
 
     await vi.waitFor(() => expect(ensureAppSession).toHaveBeenCalledTimes(3));
-    expect(ensureAppSession).toHaveBeenNthCalledWith(3, "mail", {
-      preserveExistingSession: true,
-    });
+    expect(ensureAppSession).toHaveBeenNthCalledWith(3, "mail");
   });
 
   it("keeps a remembered session gated until child synchronization completes", async () => {

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -757,6 +757,43 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       active: isActive,
       enabled: desktopIdentityEnabled,
     });
+    const desktopIdentityRepairRef = useRef<Promise<boolean> | null>(null);
+    const repairDesktopIdentitySession = useCallback(() => {
+      if (
+        !isActive ||
+        !desktopIdentityGateEligible ||
+        desktopIdentityEnabled !== true ||
+        desktopIdentityStatus !== "signed-in"
+      ) {
+        return Promise.resolve(false);
+      }
+      const existingRepair = desktopIdentityRepairRef.current;
+      if (existingRepair) return existingRepair;
+      const identity = window.electronAPI?.identity;
+      if (!identity) return Promise.resolve(false);
+      const repair = identity
+        .ensureAppSession(app.id)
+        .catch((error) => {
+          console.warn("[desktop-identity] app session repair failed", {
+            appId: app.id,
+            reason: error instanceof Error ? error.message : "unknown error",
+          });
+          return false;
+        })
+        .finally(() => {
+          if (desktopIdentityRepairRef.current === repair) {
+            desktopIdentityRepairRef.current = null;
+          }
+        });
+      desktopIdentityRepairRef.current = repair;
+      return repair;
+    }, [
+      app.id,
+      desktopIdentityEnabled,
+      desktopIdentityGateEligible,
+      desktopIdentityStatus,
+      isActive,
+    ]);
     const deferDesktopWebviewLoad = shouldDeferDesktopAppWebviewLoad({
       eligible: desktopIdentityGateEligible,
       enabled: desktopIdentityEnabled,
@@ -961,11 +998,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           }
           let synchronized: boolean | null;
           try {
-            synchronized = preserveLoadedSession
-              ? await identity.ensureAppSession(app.id, {
-                  preserveExistingSession: true,
-                })
-              : await identity.ensureAppSession(app.id);
+            synchronized = await identity.ensureAppSession(app.id);
           } catch (error) {
             console.warn("[desktop-identity] lazy app synchronization failed", {
               appId: app.id,
@@ -1279,7 +1312,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         onAuthStateChangeRef.current?.("unknown");
         void readAppWebviewAuthState(wv).then((state) => {
           if (disposed || sequence !== authProbeSequenceRef.current) return;
-          onAuthStateChangeRef.current?.(state);
+          const repair =
+            state === "unauthenticated"
+              ? repairDesktopIdentitySession()
+              : Promise.resolve(false);
+          void repair.then((repaired) => {
+            if (disposed || sequence !== authProbeSequenceRef.current) return;
+            onAuthStateChangeRef.current?.(repaired ? "authenticated" : state);
+          });
         });
       };
 
@@ -1400,6 +1440,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       applyGuestTheme,
       applyGuestSurfaceVisibility,
       executeGuestScript,
+      repairDesktopIdentitySession,
       syncGuestAppChatSidebar,
       deferDesktopWebviewLoad,
     ]);
@@ -1458,7 +1499,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       }
       void readAppWebviewAuthState(wv).then((state) => {
         if (!active || sequence !== authProbeSequenceRef.current) return;
-        onAuthStateChangeRef.current?.(state);
+        const repair =
+          state === "unauthenticated"
+            ? repairDesktopIdentitySession()
+            : Promise.resolve(false);
+        void repair.then((repaired) => {
+          if (!active || sequence !== authProbeSequenceRef.current) return;
+          onAuthStateChangeRef.current?.(repaired ? "authenticated" : state);
+        });
       });
       return () => {
         active = false;
@@ -1468,6 +1516,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       desktopIdentitySessionReady,
       desktopIdentityStatus,
       isActive,
+      repairDesktopIdentitySession,
       url,
     ]);
 

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -129,6 +129,7 @@ import AppWebview, {
   isDesktopIdentityGateUnauthenticated,
   resolveAppWebviewUrl,
   type AppWebviewAuthState,
+  type AppWebviewHandle,
 } from "./AppWebview.js";
 import CodeAgentsAppIcon from "./CodeAgentsAppIcon.js";
 import CodeAgentSchedulesPanel from "./CodeAgentSchedulesPanel.js";
@@ -731,6 +732,7 @@ export default function CodeAgentsHub({
   const [webContentsIdByTab, setWebContentsIdByTab] = useState<
     Record<string, number>
   >({});
+  const appWebviewRefs = useRef<Record<string, AppWebviewHandle | null>>({});
   const [nativeOAuthActiveByTab, setNativeOAuthActiveByTab] = useState<
     Record<string, boolean>
   >({});
@@ -1173,6 +1175,20 @@ export default function CodeAgentsHub({
       ),
     [openChatFirstApp, terminalPreferences.enabled],
   );
+  const reloadChatFirstApp = useCallback(
+    (app: ChatFirstAppItem) => {
+      let reloaded = false;
+      for (const tab of chatFirstSurfaceTabs.tabs) {
+        if (tab.kind !== "app" || tab.appId !== app.id) continue;
+        const webview = appWebviewRefs.current[tab.id];
+        if (!webview) continue;
+        webview.reload();
+        reloaded = true;
+      }
+      if (!reloaded) openChatFirstAppFromRail(app);
+    },
+    [chatFirstSurfaceTabs.tabs, openChatFirstAppFromRail],
+  );
   const openChatFirstAppFromGrid = useCallback(
     (app: AppConfig) =>
       openChatFirstApp(
@@ -1291,6 +1307,7 @@ export default function CodeAgentsHub({
             setChatFirstAppLayout(layout);
           }}
           onRemoveApp={onChatFirstAppRemove}
+          onReloadApp={reloadChatFirstApp}
           onOpenAllApps={openChatFirstAllApps}
           onOpenApp={openChatFirstAppFromRail}
           renderIcon={renderChatFirstAppIcon}
@@ -1309,6 +1326,7 @@ export default function CodeAgentsHub({
     onCreateApp,
     openChatFirstAllApps,
     openChatFirstAppFromRail,
+    reloadChatFirstApp,
     renderChatFirstAppIcon,
   ]);
 
@@ -2701,6 +2719,10 @@ export default function CodeAgentsHub({
                     aria-hidden={!showNativeIntegrationsGuest}
                   >
                     <AppWebview
+                      ref={(webview) => {
+                        if (webview) appWebviewRefs.current[tab.id] = webview;
+                        else delete appWebviewRefs.current[tab.id];
+                      }}
                       app={toAppDefinition(surfaceApp)}
                       appConfig={surfaceApp}
                       isActive={isTabActive}

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -954,7 +954,8 @@ body {
 }
 
 .code-agents-rail-footer {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1px;
   border-top: 1px solid hsl(var(--sidebar-border));
   padding: 8px;


### PR DESCRIPTION
## Summary
- Repair stale Mail and Calendar app sessions from the verified desktop identity instead of preserving expired cookies.
- Reload the focused app webview for Cmd+R from both the guest and Electron shell.
- Add app context menus for pinning, reordering, removing, and reloading, and tighten the Settings/Feedback footer layout.

## Verification
- Focused Vitest suites: 195 tests passed
- Desktop build passed
- Core and desktop typechecks passed
- All 64 repository guards passed

Beta and production deployment verification is not included in this PR.