### PR TITLE
Improve calendar overlap layout

### DIFF
--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -297,7 +297,7 @@ const DayEventCard = memo(function DayEventCard({
       style={{
         ...posStyle,
         left: `calc(${li.left}% + ${li.indent}px)`,
-        width: `calc(${li.width}% - ${li.indent * 2 + 2}px)`,
+        width: `calc(${li.width}% - ${li.indent + 2}px)`,
         zIndex:
           isBeingDragged && isDragging
             ? 100

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -367,7 +367,7 @@ const WeekEventCard = memo(function WeekEventCard({
       style={{
         ...style,
         left: `calc(${li.left}% + ${li.indent}px)`,
-        width: `calc(${li.width}% - ${li.indent * 2 + 2}px)`,
+        width: `calc(${li.width}% - ${li.indent + 2}px)`,
         zIndex:
           isBeingDragged && isDragging
             ? 100

--- a/templates/calendar/app/lib/event-layout.test.ts
+++ b/templates/calendar/app/lib/event-layout.test.ts
@@ -37,7 +37,7 @@ describe("computeTimedEventLayout", () => {
     });
   });
 
-  it("divides the column width proportionally across overlap layers", () => {
+  it("lets nested later events overlap the earliest card", () => {
     const layout = computeTimedEventLayout(
       [
         event("a", "08:00", "09:00"),
@@ -48,13 +48,33 @@ describe("computeTimedEventLayout", () => {
       DAY,
     );
 
-    expect(layout.get("a")).toMatchObject({ col: 0, left: 0, width: 25 });
-    expect(layout.get("b")).toMatchObject({ col: 1, left: 25, width: 25 });
-    expect(layout.get("c")).toMatchObject({ col: 2, left: 50, width: 25 });
-    expect(layout.get("d")).toMatchObject({ col: 3, left: 75, width: 25 });
+    expect(layout.get("a")).toMatchObject({
+      col: 0,
+      left: 0,
+      width: 100,
+      indent: 0,
+    });
+    expect(layout.get("b")).toMatchObject({
+      col: 1,
+      left: 0,
+      width: 100,
+      indent: 16,
+    });
+    expect(layout.get("c")).toMatchObject({
+      col: 2,
+      left: 0,
+      width: 100,
+      indent: 16,
+    });
+    expect(layout.get("d")).toMatchObject({
+      col: 3,
+      left: 0,
+      width: 100,
+      indent: 16,
+    });
   });
 
-  it("indents the later event while splitting the shared column width", () => {
+  it("overlays a later event across the earlier event", () => {
     const layout = computeTimedEventLayout(
       [event("gym", "16:00", "18:00"), event("friyay", "17:00", "18:00")],
       DAY,
@@ -62,20 +82,20 @@ describe("computeTimedEventLayout", () => {
 
     expect(layout.get("gym")).toMatchObject({
       left: 0,
-      width: 50,
+      width: 100,
       indent: 0,
       col: 0,
     });
     expect(layout.get("friyay")).toMatchObject({
-      left: 50,
-      width: 50,
+      left: 0,
+      width: 100,
       indent: 16,
       col: 1,
       totalCols: 2,
     });
   });
 
-  it("adds another inset layer for simultaneous events", () => {
+  it("overlays a later event that starts inside a longer event", () => {
     const layout = computeTimedEventLayout(
       [event("a", "09:00", "11:00"), event("b", "09:20", "10:00")],
       DAY,
@@ -83,15 +103,37 @@ describe("computeTimedEventLayout", () => {
 
     expect(layout.get("a")).toMatchObject({
       left: 0,
-      width: 50,
+      width: 100,
       indent: 0,
       col: 0,
     });
     expect(layout.get("b")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 16,
+      col: 1,
+    });
+  });
+
+  it("keeps later same-start events in readable lanes", () => {
+    const layout = computeTimedEventLayout(
+      [
+        event("background", "08:00", "12:00"),
+        event("later-a", "09:00", "10:00"),
+        event("later-b", "09:00", "10:00"),
+      ],
+      DAY,
+    );
+
+    expect(layout.get("later-a")).toMatchObject({
+      left: 0,
+      width: 100,
+      indent: 16,
+    });
+    expect(layout.get("later-b")).toMatchObject({
       left: 50,
       width: 50,
       indent: 16,
-      col: 1,
     });
   });
 
@@ -111,8 +153,8 @@ describe("computeTimedEventLayout", () => {
       DAY,
     );
 
-    expect(layout.get("a")).toMatchObject({ left: 0, width: 50, indent: 0 });
-    expect(layout.get("b")).toMatchObject({ left: 50, width: 50, indent: 16 });
+    expect(layout.get("a")).toMatchObject({ left: 0, width: 100, indent: 0 });
+    expect(layout.get("b")).toMatchObject({ left: 0, width: 100, indent: 16 });
   });
 
   it("reuses a free overlap layer after an earlier event ends", () => {
@@ -141,17 +183,23 @@ describe("computeTimedEventLayout", () => {
 
     expect(layout.get("first")).toMatchObject({
       col: 0,
+      left: 0,
+      width: 100,
       indent: 0,
       totalCols: 2,
     });
     expect(layout.get("middle")).toMatchObject({
       col: 1,
+      left: 0,
+      width: 100,
       indent: 16,
       totalCols: 2,
     });
     expect(layout.get("last")).toMatchObject({
       col: 0,
-      indent: 0,
+      left: 0,
+      width: 100,
+      indent: 16,
       totalCols: 2,
     });
   });
@@ -165,12 +213,12 @@ describe("computeTimedEventLayout", () => {
 
     expect(layout.get("overnight")).toMatchObject({
       left: 0,
-      width: 50,
+      width: 100,
       indent: 0,
     });
     expect(layout.get("later")).toMatchObject({
-      left: 50,
-      width: 50,
+      left: 0,
+      width: 100,
       indent: 16,
     });
   });
@@ -187,7 +235,7 @@ describe("computeTimedEventLayout", () => {
 
     expect(layout.get("morning-a")).toMatchObject({
       left: 0,
-      width: 50,
+      width: 100,
       totalCols: 2,
     });
     expect(layout.get("morning-b")).toMatchObject({

--- a/templates/calendar/app/lib/event-layout.ts
+++ b/templates/calendar/app/lib/event-layout.ts
@@ -112,18 +112,33 @@ export function computeTimedEventLayout(
     }
 
     const totalCols = overlapLayers.length;
-    // Give every overlap column a proportional slice of the day column so an
-    // event's right edge stays visible instead of being covered by whichever
-    // card renders on top of it.
-    const width = 100 / totalCols;
+    const sameStartGroups = new Map<number, EventEntry[]>();
+    const sameStartIndexes = new Map<EventEntry, number>();
+    for (const entry of group) {
+      const entries = sameStartGroups.get(entry.bounds.start) ?? [];
+      sameStartIndexes.set(entry, entries.length);
+      entries.push(entry);
+      sameStartGroups.set(entry.bounds.start, entries);
+    }
 
     for (const entry of group) {
       const col = eventColumns.get(entry.event)!;
+      const sameStartEntries = sameStartGroups.get(entry.bounds.start)!;
+      const sameStartIndex = sameStartIndexes.get(entry)!;
+      const sameStartWidth = 100 / sameStartEntries.length;
+      const isGroupStart = entry.bounds.start === group[0].bounds.start;
+      const useStartLanes = sameStartEntries.length > 1;
+
+      // Later events sit over the earlier event instead of forcing both cards
+      // into equal columns. Events with the same start time still get lanes so
+      // their titles remain independently readable.
+      const left = useStartLanes ? sameStartIndex * sameStartWidth : 0;
+      const width = 100 - left;
 
       result.set(entry.event.id, {
-        left: col * width,
+        left,
         width,
-        indent: col * OVERLAP_INDENT_PX,
+        indent: isGroupStart && sameStartIndex === 0 ? 0 : OVERLAP_INDENT_PX,
         col,
         totalCols,
         stackOrder: stackOrder++,

--- a/templates/calendar/changelog/2026-08-24-overlapping-events-use-space-better.md
+++ b/templates/calendar/changelog/2026-08-24-overlapping-events-use-space-better.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-24
+---
+Overlapping calendar events now use more of the available width while keeping same-time meetings readable.


### PR DESCRIPTION
## Summary
- Let later overlapping events use the available day-column width instead of equal-width slices.
- Keep same-start events in readable lanes while later events stack over longer meetings.
- Apply the shared sizing to week and day views and record the calendar improvement.

## Verification
- `corepack pnpm --filter calendar exec vitest --run app/lib/event-layout.test.ts`
- `corepack pnpm --filter calendar typecheck`
- `corepack pnpm guards`
- Verified the seeded local calendar week in the browser with the long and same-start overlap cases.