### PR TITLE
fix(calendar): preserve events when Zoom setup fails

### DIFF
--- a/templates/calendar/actions/create-event.test.ts
+++ b/templates/calendar/actions/create-event.test.ts
@@ -83,6 +83,7 @@ describe("create-event recurrence", () => {
       expect(result).toMatchObject({
         id: "google-event-123",
         title: "Customer call",
+        videoConferenceError: "zoom",
       });
       expect(result.meetingLink).toBeUndefined();
     } finally {

--- a/templates/calendar/actions/create-event.test.ts
+++ b/templates/calendar/actions/create-event.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createEventMock, getAuthStatusMock, isConnectedMock } = vi.hoisted(
-  () => ({
-    createEventMock: vi.fn(),
-    getAuthStatusMock: vi.fn(),
-    isConnectedMock: vi.fn(),
-  }),
-);
+const {
+  createEventMock,
+  getAuthStatusMock,
+  isConnectedMock,
+  prepareZoomMeetingPatchMock,
+} = vi.hoisted(() => ({
+  createEventMock: vi.fn(),
+  getAuthStatusMock: vi.fn(),
+  isConnectedMock: vi.fn(),
+  prepareZoomMeetingPatchMock: vi.fn(),
+}));
 
 vi.mock("@agent-native/core/event-bus", () => ({
   emit: vi.fn(),
@@ -20,7 +24,7 @@ vi.mock("@agent-native/core/server", () => ({
 }));
 
 vi.mock("../server/lib/event-video-conferencing.js", () => ({
-  prepareZoomMeetingPatch: vi.fn(),
+  prepareZoomMeetingPatch: prepareZoomMeetingPatchMock,
   shouldAutoAddGoogleMeet: vi.fn(() => false),
 }));
 
@@ -34,6 +38,7 @@ import createEventAction from "./create-event";
 
 describe("create-event recurrence", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     isConnectedMock.mockResolvedValue(true);
     getAuthStatusMock.mockResolvedValue({ accounts: [] });
     createEventMock.mockResolvedValue({ id: "event-123" });
@@ -58,5 +63,30 @@ describe("create-event recurrence", () => {
         },
       }),
     );
+  });
+
+  it("persists the event when Zoom provisioning fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    prepareZoomMeetingPatchMock.mockRejectedValue(new Error("Zoom 401"));
+
+    try {
+      const result = await createEventAction.run({
+        title: "Customer call",
+        start: "2026-08-17T16:00:00.000Z",
+        end: "2026-08-17T16:30:00.000Z",
+        addZoom: true,
+      });
+
+      expect(createEventMock).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        id: "google-event-123",
+        title: "Customer call",
+      });
+      expect(result.meetingLink).toBeUndefined();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -217,9 +217,13 @@ export default defineAction({
 
     let zoomMeetingLink: string | undefined;
     if (args.addZoom) {
-      const zoom = await prepareZoomMeetingPatch(email, calEvent);
-      zoomMeetingLink = zoom.meetingLink;
-      Object.assign(calEvent, zoom.patch);
+      try {
+        const zoom = await prepareZoomMeetingPatch(email, calEvent);
+        zoomMeetingLink = zoom.meetingLink;
+        Object.assign(calEvent, zoom.patch);
+      } catch (error) {
+        console.error("[create-event] Zoom meeting provisioning failed", error);
+      }
     }
 
     const result = await googleCalendar.createEvent(calEvent, {

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -216,12 +216,14 @@ export default defineAction({
     };
 
     let zoomMeetingLink: string | undefined;
+    let videoConferenceError: CalendarEvent["videoConferenceError"];
     if (args.addZoom) {
       try {
         const zoom = await prepareZoomMeetingPatch(email, calEvent);
         zoomMeetingLink = zoom.meetingLink;
         Object.assign(calEvent, zoom.patch);
       } catch (error) {
+        videoConferenceError = "zoom";
         console.error("[create-event] Zoom meeting provisioning failed", error);
       }
     }
@@ -242,6 +244,8 @@ export default defineAction({
     if (result.meetLink) calEvent.hangoutLink = result.meetLink;
     if (result.conferenceData) calEvent.conferenceData = result.conferenceData;
     if (zoomMeetingLink) calEvent.meetingLink = zoomMeetingLink;
+    if (videoConferenceError)
+      calEvent.videoConferenceError = videoConferenceError;
 
     try {
       emit(

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -856,7 +856,7 @@ export function CreateEventPopover({
           deletePersistedDraft(activeDraftId);
           onDraftCreated?.(activeDraftId);
         }
-        if (payload.addZoom && !result?.meetingLink) {
+        if (result?.videoConferenceError === "zoom") {
           toast.error(t("eventForm.zoomAddFailed"));
         }
         const eventId = result?.id;

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -856,6 +856,9 @@ export function CreateEventPopover({
           deletePersistedDraft(activeDraftId);
           onDraftCreated?.(activeDraftId);
         }
+        if (payload.addZoom && !result?.meetingLink) {
+          toast.error(t("eventForm.zoomAddFailed"));
+        }
         const eventId = result?.id;
         const undo = eventId
           ? () => {

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -896,7 +896,7 @@ export default function CalendarView() {
       createEvent.mutate(payload, {
         onSuccess: (result) => {
           discardedCommittingDraftsRef.current.delete(draftId);
-          if (payload.addZoom && !result?.meetingLink) {
+          if (result?.videoConferenceError === "zoom") {
             toast.error(t("eventForm.zoomAddFailed"));
           }
           const createdEventId = result?.id;

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -896,6 +896,9 @@ export default function CalendarView() {
       createEvent.mutate(payload, {
         onSuccess: (result) => {
           discardedCommittingDraftsRef.current.delete(draftId);
+          if (payload.addZoom && !result?.meetingLink) {
+            toast.error(t("eventForm.zoomAddFailed"));
+          }
           const createdEventId = result?.id;
           if (createdEventId) {
             const undo = () => {

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -66,6 +66,8 @@ export interface CalendarEvent {
   hangoutLink?: string; // Google Meet link
   /** Meeting URL stored in location/description for non-Google providers such as Zoom */
   meetingLink?: string;
+  /** Action-result warning when optional video conferencing could not be provisioned. */
+  videoConferenceError?: "zoom";
   conferenceData?: {
     entryPoints?: Array<{
       entryPointType: string;


### PR DESCRIPTION
## Summary\n- let Google Calendar event creation continue when optional Zoom provisioning fails\n- surface the existing localized Zoom warning instead of rolling back the optimistic event\n- cover the failure path with an action test\n\n## Validation\n- Calendar test suite: 486 passed\n- Calendar typecheck: passed\n- oxfmt check: passed\n- repository guards: 64 passed\n\nThe change addresses the reported event flash/disappear behavior caused by Zoom failure before the Google event write.