### PR TITLE
Improve Calendar people search responsiveness

### DIFF
--- a/templates/calendar/app/components/calendar/AddCalendarDialog.tsx
+++ b/templates/calendar/app/components/calendar/AddCalendarDialog.tsx
@@ -1,4 +1,3 @@
-import { callAction } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconSearch,
@@ -8,7 +7,7 @@ import {
   IconLink,
   IconCalendarPlus,
 } from "@tabler/icons-react";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -31,17 +30,12 @@ import {
   useAddOverlayPerson,
   useRemoveOverlayPerson,
 } from "@/hooks/use-overlay-people";
-
-interface SearchResult {
-  name: string;
-  email: string;
-  photoUrl?: string;
-}
-
-interface SearchResponse {
-  results: SearchResult[];
-  scopeRequired?: boolean;
-}
+import {
+  filterPeopleResults,
+  mergePeopleResults,
+  usePeopleContacts,
+  usePeopleSearch,
+} from "@/hooks/use-people";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const URL_REGEX = /^(https?|webcal):\/\/.+/i;
@@ -67,7 +61,7 @@ export function AddCalendarDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[440px] gap-0 p-0 top-[8%] translate-y-0">
+      <DialogContent className="sm:max-w-[440px] gap-0 p-0 top-[15vh] !translate-y-0">
         <DialogHeader className="px-4 pt-4 pb-0">
           <DialogTitle className="text-base">
             {t("eventForm.addCalendar")}
@@ -89,7 +83,7 @@ export function AddCalendarDialog({
           </TabsList>
 
           <TabsContent value="people" className="mt-0">
-            <PeopleTab onClose={() => onOpenChange(false)} />
+            <PeopleTab open={open} />
           </TabsContent>
 
           <TabsContent value="url" className="mt-0 px-4 pb-4 pt-3">
@@ -103,15 +97,12 @@ export function AddCalendarDialog({
 
 // ─── People tab ──────────────────────────────────────────────────────────────
 
-function PeopleTab({ onClose: _ }: { onClose: () => void }) {
+function PeopleTab({ open }: { open: boolean }) {
   const t = useT();
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [scopeRequired, setScopeRequired] = useState(false);
-  const [searching, setSearching] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const listRef = useRef<HTMLDivElement>(null);
   const shouldScrollActiveResultRef = useRef(false);
 
@@ -119,46 +110,57 @@ function PeopleTab({ onClose: _ }: { onClose: () => void }) {
   const overlayPeople = Array.isArray(rawOverlayPeople) ? rawOverlayPeople : [];
   const addPerson = useAddOverlayPerson();
   const removePerson = useRemoveOverlayPerson();
+  const contacts = usePeopleContacts("directory", open);
+  const directorySearch = usePeopleSearch(searchQuery, open, "directory");
 
-  const overlayEmails = new Set(overlayPeople.map((p) => p.email));
-  const selectableResults = results.filter((r) => !overlayEmails.has(r.email));
+  const overlayEmails = useMemo(
+    () => new Set(overlayPeople.map((p) => p.email.toLowerCase())),
+    [overlayPeople],
+  );
 
-  const search = useCallback(async (q: string) => {
-    setSearching(true);
-    try {
-      const data = await callAction<SearchResponse>(
-        "search-people",
-        q ? { q, scope: "directory" } : { scope: "directory" },
-        { method: "GET" },
-      );
-      setResults(data.results ?? []);
-      setScopeRequired(data.scopeRequired ?? false);
-    } catch {
-      // ignore
-    } finally {
-      setSearching(false);
-    }
-  }, []);
+  const results = useMemo(
+    () =>
+      filterPeopleResults(
+        mergePeopleResults(
+          contacts.data?.results,
+          directorySearch.data?.results,
+        ),
+        query,
+        new Set(),
+      ),
+    [contacts.data?.results, directorySearch.data?.results, query],
+  );
+  const selectableResults = results.filter(
+    (r) => !overlayEmails.has(r.email.toLowerCase()),
+  );
+
+  const searching =
+    contacts.isLoading ||
+    contacts.isFetching ||
+    directorySearch.isLoading ||
+    directorySearch.isFetching;
+  const scopeRequired = Boolean(
+    contacts.data?.scopeRequired || directorySearch.data?.scopeRequired,
+  );
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => search(query), query ? 300 : 0);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [query, search]);
+    const timeout = window.setTimeout(
+      () => setSearchQuery(query),
+      query.trim() ? 300 : 0,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [query]);
 
   useEffect(() => {
     setActiveIndex(results.length > 0 ? 0 : -1);
   }, [results]);
 
   useEffect(() => {
+    if (!open) return;
     setQuery("");
-    setResults([]);
-    setScopeRequired(false);
+    setSearchQuery("");
     setActiveIndex(-1);
-    search("");
-  }, [search]);
+  }, [open]);
 
   useEffect(() => {
     if (
@@ -198,7 +200,10 @@ function PeopleTab({ onClose: _ }: { onClose: () => void }) {
         return;
       }
       const trimmed = query.trim();
-      if (EMAIL_REGEX.test(trimmed) && !overlayEmails.has(trimmed)) {
+      if (
+        EMAIL_REGEX.test(trimmed) &&
+        !overlayEmails.has(trimmed.toLowerCase())
+      ) {
         handleAdd(trimmed);
         setQuery("");
       }
@@ -229,7 +234,7 @@ function PeopleTab({ onClose: _ }: { onClose: () => void }) {
           className="max-h-48 overflow-y-auto border-t border-border"
         >
           {results.map((person) => {
-            const alreadyAdded = overlayEmails.has(person.email);
+            const alreadyAdded = overlayEmails.has(person.email.toLowerCase());
             const selectableIdx = selectableResults.indexOf(person);
             const isActive = !alreadyAdded && selectableIdx === activeIndex;
             return (

--- a/templates/calendar/app/components/calendar/AddCalendarDialog.tsx
+++ b/templates/calendar/app/components/calendar/AddCalendarDialog.tsx
@@ -61,7 +61,7 @@ export function AddCalendarDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[440px] gap-0 p-0 top-[15vh] !translate-y-0">
+      <DialogContent className="sm:max-w-[440px] max-h-[calc(85vh-1rem)] gap-0 overflow-y-auto p-0 top-[15vh] !translate-y-0">
         <DialogHeader className="px-4 pt-4 pb-0">
           <DialogTitle className="text-base">
             {t("eventForm.addCalendar")}

--- a/templates/calendar/app/components/calendar/PeopleSearchDialog.tsx
+++ b/templates/calendar/app/components/calendar/PeopleSearchDialog.tsx
@@ -156,7 +156,7 @@ export function PeopleSearchDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[440px] gap-0 p-0 top-[15vh] !translate-y-0">
+      <DialogContent className="sm:max-w-[440px] max-h-[calc(85vh-1rem)] gap-0 overflow-y-auto p-0 top-[15vh] !translate-y-0">
         <DialogHeader className="px-4 pt-4 pb-0">
           <DialogTitle className="text-base">
             {t("eventForm.people")}

--- a/templates/calendar/app/components/calendar/PeopleSearchDialog.tsx
+++ b/templates/calendar/app/components/calendar/PeopleSearchDialog.tsx
@@ -1,4 +1,3 @@
-import { callAction } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   IconSearch,
@@ -6,7 +5,7 @@ import {
   IconUserPlus,
   IconLoader2,
 } from "@tabler/icons-react";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 
 import {
   Dialog,
@@ -19,17 +18,12 @@ import {
   useAddOverlayPerson,
   useRemoveOverlayPerson,
 } from "@/hooks/use-overlay-people";
-
-interface SearchResult {
-  name: string;
-  email: string;
-  photoUrl?: string;
-}
-
-interface SearchResponse {
-  results: SearchResult[];
-  scopeRequired?: boolean;
-}
+import {
+  filterPeopleResults,
+  mergePeopleResults,
+  usePeopleContacts,
+  usePeopleSearch,
+} from "@/hooks/use-people";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -44,12 +38,8 @@ export function PeopleSearchDialog({
 }: PeopleSearchDialogProps) {
   const t = useT();
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
-  const [scopeRequired, setScopeRequired] = useState(false);
-  const [searching, setSearching] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(-1);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const listRef = useRef<HTMLDivElement>(null);
   const shouldScrollActiveResultRef = useRef(false);
 
@@ -57,52 +47,61 @@ export function PeopleSearchDialog({
   const overlayPeople = Array.isArray(rawOverlayPeople) ? rawOverlayPeople : [];
   const addPerson = useAddOverlayPerson();
   const removePerson = useRemoveOverlayPerson();
+  const contacts = usePeopleContacts("directory", open);
+  const directorySearch = usePeopleSearch(searchQuery, open, "directory");
 
-  const overlayEmails = new Set(overlayPeople.map((p) => p.email));
+  const overlayEmails = useMemo(
+    () => new Set(overlayPeople.map((p) => p.email.toLowerCase())),
+    [overlayPeople],
+  );
+
+  const results = useMemo(
+    () =>
+      filterPeopleResults(
+        mergePeopleResults(
+          contacts.data?.results,
+          directorySearch.data?.results,
+        ),
+        query,
+        new Set(),
+      ),
+    [contacts.data?.results, directorySearch.data?.results, query],
+  );
 
   // Selectable results (exclude already-added)
-  const selectableResults = results.filter((r) => !overlayEmails.has(r.email));
+  const selectableResults = results.filter(
+    (r) => !overlayEmails.has(r.email.toLowerCase()),
+  );
 
-  const search = useCallback(async (q: string) => {
-    setSearching(true);
-    try {
-      const data = await callAction<SearchResponse>(
-        "search-people",
-        q ? { q, scope: "directory" } : { scope: "directory" },
-        { method: "GET" },
-      );
-      setResults(data.results ?? []);
-      setScopeRequired(data.scopeRequired ?? false);
-    } catch {
-      // ignore
-    } finally {
-      setSearching(false);
-    }
-  }, []);
+  const searching =
+    contacts.isLoading ||
+    contacts.isFetching ||
+    directorySearch.isLoading ||
+    directorySearch.isFetching;
+  const scopeRequired = Boolean(
+    contacts.data?.scopeRequired || directorySearch.data?.scopeRequired,
+  );
 
   useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => search(query), query ? 300 : 0);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [query, search]);
+    const timeout = window.setTimeout(
+      () => setSearchQuery(query),
+      query.trim() ? 300 : 0,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [query]);
 
   // Reset active index when results change
   useEffect(() => {
     setActiveIndex(results.length > 0 ? 0 : -1);
   }, [results]);
 
-  // Load org contacts when dialog opens
   useEffect(() => {
     if (open) {
       setQuery("");
-      setResults([]);
-      setScopeRequired(false);
+      setSearchQuery("");
       setActiveIndex(-1);
-      search("");
     }
-  }, [open, search]);
+  }, [open]);
 
   function handleAdd(email: string, name?: string) {
     addPerson.mutate({ email, name });
@@ -145,7 +144,10 @@ export function PeopleSearchDialog({
       }
       // Otherwise, try adding as a typed email
       const trimmed = query.trim();
-      if (EMAIL_REGEX.test(trimmed) && !overlayEmails.has(trimmed)) {
+      if (
+        EMAIL_REGEX.test(trimmed) &&
+        !overlayEmails.has(trimmed.toLowerCase())
+      ) {
         handleAdd(trimmed);
         setQuery("");
       }
@@ -154,7 +156,7 @@ export function PeopleSearchDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[440px] gap-0 p-0">
+      <DialogContent className="sm:max-w-[440px] gap-0 p-0 top-[15vh] !translate-y-0">
         <DialogHeader className="px-4 pt-4 pb-0">
           <DialogTitle className="text-base">
             {t("eventForm.people")}
@@ -165,7 +167,6 @@ export function PeopleSearchDialog({
         <div className="relative px-4 pt-3 pb-2">
           <IconSearch className="absolute left-7 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
-            ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
@@ -185,7 +186,9 @@ export function PeopleSearchDialog({
             className="max-h-48 overflow-y-auto border-t border-border"
           >
             {results.map((person) => {
-              const alreadyAdded = overlayEmails.has(person.email);
+              const alreadyAdded = overlayEmails.has(
+                person.email.toLowerCase(),
+              );
               const selectableIdx = selectableResults.indexOf(person);
               const isActive = !alreadyAdded && selectableIdx === activeIndex;
               return (

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -272,7 +272,10 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   useEffect(() => {
     if (!hasAccounts) return;
-    void prefetchPeopleContacts(queryClient);
+    void Promise.all([
+      prefetchPeopleContacts(queryClient),
+      prefetchPeopleContacts(queryClient, "directory"),
+    ]);
   }, [hasAccounts, queryClient]);
 
   useEffect(() => {

--- a/templates/calendar/app/hooks/use-people.ts
+++ b/templates/calendar/app/hooks/use-people.ts
@@ -13,16 +13,18 @@ export interface PeopleSearchResponse {
   scopeRequired?: boolean;
 }
 
+export type PeopleSearchScope = "all" | "directory";
+
 const PEOPLE_CONTACTS_STALE_TIME = 10 * 60_000;
 const PEOPLE_CONTACTS_GC_TIME = 30 * 60_000;
 const PEOPLE_SEARCH_STALE_TIME = 60_000;
 const PEOPLE_SEARCH_GC_TIME = 5 * 60_000;
 
-export const PEOPLE_CONTACTS_QUERY_KEY = [
-  "action",
-  "search-people",
-  { scope: "all" },
-] as const;
+export function peopleContactsQueryKey(scope: PeopleSearchScope = "all") {
+  return ["action", "search-people", { scope }] as const;
+}
+
+export const PEOPLE_CONTACTS_QUERY_KEY = peopleContactsQueryKey();
 
 function sourceRank(source?: PeopleSearchResult["source"]) {
   switch (source) {
@@ -115,13 +117,14 @@ export function filterPeopleResults(
 
 export function prefetchPeopleContacts(
   queryClient: ReturnType<typeof useQueryClient>,
+  scope: PeopleSearchScope = "all",
 ) {
   return queryClient.prefetchQuery({
-    queryKey: PEOPLE_CONTACTS_QUERY_KEY,
+    queryKey: peopleContactsQueryKey(scope),
     queryFn: () =>
       callAction<PeopleSearchResponse>(
         "search-people",
-        { scope: "all" },
+        { scope },
         { method: "GET" },
       ),
     staleTime: PEOPLE_CONTACTS_STALE_TIME,
@@ -129,13 +132,16 @@ export function prefetchPeopleContacts(
   });
 }
 
-export function usePeopleContacts(enabled = true) {
+export function usePeopleContacts(
+  scope: PeopleSearchScope = "all",
+  enabled = true,
+) {
   return useQuery({
-    queryKey: PEOPLE_CONTACTS_QUERY_KEY,
+    queryKey: peopleContactsQueryKey(scope),
     queryFn: () =>
       callAction<PeopleSearchResponse>(
         "search-people",
-        { scope: "all" },
+        { scope },
         { method: "GET" },
       ),
     enabled,
@@ -145,14 +151,18 @@ export function usePeopleContacts(enabled = true) {
   });
 }
 
-export function usePeopleSearch(query: string, enabled = true) {
+export function usePeopleSearch(
+  query: string,
+  enabled = true,
+  scope: PeopleSearchScope = "all",
+) {
   const q = query.trim();
   return useQuery({
-    queryKey: ["action", "search-people", { q, scope: "all" }],
+    queryKey: ["action", "search-people", { q, scope }],
     queryFn: () =>
       callAction<PeopleSearchResponse>(
         "search-people",
-        { q, scope: "all" },
+        { q, scope },
         { method: "GET" },
       ),
     enabled: enabled && q.length > 0,

--- a/templates/calendar/server/lib/people-search.ts
+++ b/templates/calendar/server/lib/people-search.ts
@@ -36,6 +36,7 @@ interface ContactCacheEntry {
 
 const CONTACT_CACHE_TTL = 10 * 60 * 1000;
 const contactCache = new Map<string, ContactCacheEntry>();
+const contactCacheLoads = new Map<string, Promise<ContactCacheEntry>>();
 
 const GENERIC_EMAIL_DOMAINS = new Set([
   "gmail.com",
@@ -255,36 +256,50 @@ async function loadCachedContactPeople(
     return cached;
   }
 
-  const people = new Map<string, PersonResult>();
-  let contactsLimited = false;
+  const pending = contactCacheLoads.get(cacheKey);
+  if (pending) return pending;
 
-  await Promise.all(
-    clients.map(async (client) => {
-      try {
-        const [connections, otherContacts] = await Promise.all([
-          listConnectionPages(client.accessToken, "connections"),
-          listConnectionPages(client.accessToken, "otherContacts"),
-        ]);
+  const load = (async () => {
+    const people = new Map<string, PersonResult>();
+    let contactsLimited = false;
 
-        for (const person of extractPeople(connections, "contact")) {
-          mergeCachedContact(people, person);
+    await Promise.all(
+      clients.map(async (client) => {
+        try {
+          const [connections, otherContacts] = await Promise.all([
+            listConnectionPages(client.accessToken, "connections"),
+            listConnectionPages(client.accessToken, "otherContacts"),
+          ]);
+
+          for (const person of extractPeople(connections, "contact")) {
+            mergeCachedContact(people, person);
+          }
+          for (const person of extractPeople(otherContacts, "otherContact")) {
+            mergeCachedContact(people, person);
+          }
+        } catch (error) {
+          if (permissionLimited(error)) contactsLimited = true;
         }
-        for (const person of extractPeople(otherContacts, "otherContact")) {
-          mergeCachedContact(people, person);
-        }
-      } catch (error) {
-        if (permissionLimited(error)) contactsLimited = true;
-      }
-    }),
-  );
+      }),
+    );
 
-  const entry: ContactCacheEntry = {
-    people: Array.from(people.values()),
-    contactsLimited,
-    expiresAt: Date.now() + CONTACT_CACHE_TTL,
-  };
-  contactCache.set(cacheKey, entry);
-  return entry;
+    const entry: ContactCacheEntry = {
+      people: Array.from(people.values()),
+      contactsLimited,
+      expiresAt: Date.now() + CONTACT_CACHE_TTL,
+    };
+    contactCache.set(cacheKey, entry);
+    return entry;
+  })();
+
+  contactCacheLoads.set(cacheKey, load);
+  try {
+    return await load;
+  } finally {
+    if (contactCacheLoads.get(cacheKey) === load) {
+      contactCacheLoads.delete(cacheKey);
+    }
+  }
 }
 
 export async function searchPeopleForUser(


### PR DESCRIPTION
## Summary
- Prefetch both contact and directory scopes after Google accounts are available.
- Filter warmed people locally in attendee and other-calendar search, keeping debounced directory lookup as a fallback.
- Pin the people-calendar dialogs at the same top offset as the command menu.

## Validation
- `corepack pnpm --filter calendar exec vitest --run` - 69 files, 485 tests passed
- `NODE_ENV=development corepack pnpm --filter calendar typecheck` - passed
- `corepack pnpm exec oxfmt --check` on changed files - passed
- Local dev server served Calendar root with HTTP 200

The protected Google status endpoint was not exercised without an authenticated session.