### PR TITLE
Fix Permission dismissed in the Chrome extension

### DIFF
--- a/templates/clips/changelog/2026-08-24-chrome-recording-recovers-a-dropped-mic-grant.md
+++ b/templates/clips/changelog/2026-08-24-chrome-recording-recovers-a-dropped-mic-grant.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-24
+---
+
+Recording from the Chrome extension no longer dead-ends on "Permission dismissed" when Chrome has quietly dropped the extension's microphone or camera access: Clips now reopens the permission page and starts the recording once you allow it again.

--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1,6 +1,13 @@
 import { buildRecordingShareUrl } from "@shared/recording-link";
 
 import {
+  MediaPermissionRequiredError,
+  mediaPermissionErrorFromResponse,
+  mediaPermissionRequirements,
+  permissionPageUrl,
+  writeCachedMediaPermission,
+} from "./media-permission";
+import {
   restartUploadModeFromResponse,
   restartUploadResetBody,
   shouldReconcilePersistedRecording,
@@ -1060,21 +1067,56 @@ async function ensureOffscreenDocument(): Promise<void> {
   });
 }
 
+type OffscreenErrorResponse = {
+  error?: string;
+  errorCode?: string;
+  errorDevice?: string;
+};
+
+// The offscreen document can only answer with plain data, so rebuild the typed
+// error here — callers branch on the class, not on a message string.
+function offscreenError(response: OffscreenErrorResponse): Error {
+  return (
+    mediaPermissionErrorFromResponse(response) ?? new Error(response.error)
+  );
+}
+
 function sendOffscreenMessage<T>(message: Record<string, unknown>): Promise<T> {
   return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(message, (response: T & { error?: string }) => {
-      const error = chromeLastError();
-      if (error) {
-        reject(error);
-        return;
-      }
-      if (response && typeof response.error === "string") {
-        reject(new Error(response.error));
-        return;
-      }
-      resolve(response);
-    });
+    chrome.runtime.sendMessage(
+      message,
+      (response: T & OffscreenErrorResponse) => {
+        const error = chromeLastError();
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (response && typeof response.error === "string") {
+          reject(offscreenError(response));
+          return;
+        }
+        resolve(response);
+      },
+    );
   });
+}
+
+// MV3 suspends an idle worker after ~30 seconds. The native picker routinely
+// stays open longer than that, and a worker that dies mid-acquire takes the
+// popup's pending sendResponse channel with it ("the message channel closed
+// before a response was received"). Any extension API call resets the idle
+// timer, so ping while the user is still choosing.
+const WORKER_KEEPALIVE_INTERVAL_MS = 20_000;
+
+async function withWorkerKeepAlive<T>(run: () => Promise<T>): Promise<T> {
+  const timer = setInterval(() => {
+    void chrome.runtime.getPlatformInfo().catch(() => undefined);
+  }, WORKER_KEEPALIVE_INTERVAL_MS);
+  try {
+    return await run();
+  } finally {
+    clearInterval(timer);
+  }
 }
 
 // The author's own dashboard. Fine to OPEN for the person who just recorded;
@@ -1172,8 +1214,13 @@ async function handlePopupStart(message: PopupStartMessage) {
 async function startRecordingFromTab(args: {
   tab: ChromeTab;
   settings: ExtensionSettings;
+  // False for the start that the permission page itself triggered: sending that
+  // one back to a fresh permission tab on failure would open a new tab per
+  // round, so it reports the failure instead.
+  allowPermissionRecovery?: boolean;
 }) {
   const { tab, settings } = args;
+  const allowPermissionRecovery = args.allowPermissionRecovery !== false;
   await reconcilePersistedNativeRecording();
   // The persisted value is authoritative (survives a worker suspension during
   // arming); the in-memory var is only a same-tick fast path on top of it.
@@ -1201,7 +1248,12 @@ async function startRecordingFromTab(args: {
   await setArmingGuard(sessionId);
   try {
     await storageSet(settings);
-    return await armRecording({ sessionId, tab, settings });
+    return await armRecording({
+      sessionId,
+      tab,
+      settings,
+      allowPermissionRecovery,
+    });
   } finally {
     if (armingNativeRecordingSessionId === sessionId) {
       await setArmingGuard(null);
@@ -1243,7 +1295,52 @@ async function handlePermissionStartAfterGrant() {
     return { ok: false, error: "The original tab is no longer available." };
   }
   await activateTab(tab);
-  return startRecordingFromTab({ tab, settings: pending.settings });
+  return startRecordingFromTab({
+    tab,
+    settings: pending.settings,
+    allowPermissionRecovery: false,
+  });
+}
+
+// The popup's gate let this start because the cached grant said the device was
+// allowed, and Chrome then refused a prompt the offscreen recorder could not
+// show. Drop the stale cache entry so the gate stops trusting it, and send the
+// user through the permission page — the only surface Chrome will prompt from —
+// with the recording queued to resume once the grant lands.
+async function recoverMissingMediaPermission(args: {
+  error: MediaPermissionRequiredError;
+  tab: ChromeTab;
+  settings: ExtensionSettings;
+  openPermissionPage: boolean;
+}): Promise<{ ok: false; error: string }> {
+  const { error, tab, settings, openPermissionPage } = args;
+  captureExtensionError(error, {
+    tags: {
+      surface: "background",
+      recordingStep: "offscreen-acquire",
+      permission: error.device,
+    },
+  });
+  await writeCachedMediaPermission({ [error.device]: false });
+  if (!openPermissionPage) {
+    return {
+      ok: false,
+      error: `Chrome still has not granted Clips ${error.device} access. Allow it from Chrome's address-bar icon, then start the recording again.`,
+    };
+  }
+  if (typeof tab.id === "number") {
+    await writePendingPermissionStart({
+      settings,
+      targetTabId: tab.id,
+      createdAtMs: Date.now(),
+    });
+  }
+  await createTab(
+    permissionPageUrl(mediaPermissionRequirements(settings), {
+      startAfterGrant: typeof tab.id === "number",
+    }),
+  ).catch(() => undefined);
+  return { ok: false, error: error.message };
 }
 
 // Arm a Loom-style in-page recording: show the native picker, create the row,
@@ -1254,8 +1351,9 @@ async function armRecording(args: {
   sessionId: string;
   tab: ChromeTab;
   settings: ExtensionSettings;
+  allowPermissionRecovery: boolean;
 }) {
-  const { sessionId, tab, settings } = args;
+  const { sessionId, tab, settings, allowPermissionRecovery } = args;
   const mode: CaptureMode =
     settings.captureSurface === "camera" ? "camera" : "screen";
   const surface: "browser" | "window" | "monitor" =
@@ -1268,20 +1366,31 @@ async function armRecording(args: {
 
   // 1) Native "Choose what to share" picker. Do this before any network round
   //    trip so the picker stays tied to the user gesture. Throws if cancelled.
-  const acq = await sendOffscreenMessage<{
-    ok: boolean;
-    width: number;
-    height: number;
-  }>({
-    type: "CLIPS_OFFSCREEN_ACQUIRE",
-    sessionId,
-    mode,
-    surface,
-    includeMicrophone: settings.includeMicrophone,
-    includeCamera: settings.includeCamera,
-    videoDeviceId: settings.videoDeviceId,
-    audioDeviceId: settings.audioDeviceId,
-  });
+  let acq: { ok: boolean; width: number; height: number };
+  try {
+    acq = await withWorkerKeepAlive(() =>
+      sendOffscreenMessage<{ ok: boolean; width: number; height: number }>({
+        type: "CLIPS_OFFSCREEN_ACQUIRE",
+        sessionId,
+        mode,
+        surface,
+        includeMicrophone: settings.includeMicrophone,
+        includeCamera: settings.includeCamera,
+        videoDeviceId: settings.videoDeviceId,
+        audioDeviceId: settings.audioDeviceId,
+      }),
+    );
+  } catch (err) {
+    if (err instanceof MediaPermissionRequiredError) {
+      return recoverMissingMediaPermission({
+        error: err,
+        tab,
+        settings,
+        openPermissionPage: allowPermissionRecovery,
+      });
+    }
+    throw err;
+  }
   console.log("[clips-bg] arm: acquired stream", acq);
 
   // 2) Show the countdown overlay IMMEDIATELY — before the network round-trip —

--- a/templates/clips/chrome-extension/src/media-permission.test.ts
+++ b/templates/clips/chrome-extension/src/media-permission.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MEDIA_PERMISSION_REQUIRED_CODE,
+  MediaPermissionRequiredError,
+  hasGrantedDeviceLabels,
+  isMediaPermissionDeniedError,
+  mediaPermissionErrorFromResponse,
+  mediaPermissionRequirements,
+  permissionPageUrl,
+  readCachedMediaPermission,
+  requireMediaPermission,
+  writeCachedMediaPermission,
+} from "./media-permission";
+
+type StorageArea = Record<string, unknown>;
+
+let storage: StorageArea = {};
+let enumerated: (() => Promise<MediaDeviceInfo[]>) | null = null;
+
+function mediaError(name: string, message: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+beforeEach(() => {
+  storage = {};
+  enumerated = null;
+  (globalThis as { chrome?: unknown }).chrome = {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://clips-test/${path}`,
+    },
+    storage: {
+      local: {
+        get: (key: string, done: (value: StorageArea) => void) =>
+          done(key in storage ? { [key]: storage[key] } : {}),
+        set: (value: StorageArea, done: () => void) => {
+          Object.assign(storage, value);
+          done();
+        },
+      },
+    },
+  };
+  // `navigator` is a getter-only global under Node, so stub the one member the
+  // module reads instead of replacing the object.
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      enumerateDevices: () =>
+        enumerated ? enumerated() : Promise.resolve([] as MediaDeviceInfo[]),
+    },
+  });
+});
+
+describe("isMediaPermissionDeniedError", () => {
+  it("matches the dismissal Chrome reports where it cannot prompt", () => {
+    expect(
+      isMediaPermissionDeniedError(
+        mediaError("NotAllowedError", "Permission dismissed"),
+      ),
+    ).toBe(true);
+    expect(
+      isMediaPermissionDeniedError(
+        mediaError("NotAllowedError", "Permission denied"),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores a system-level denial the permission page cannot fix", () => {
+    expect(
+      isMediaPermissionDeniedError(
+        mediaError("NotAllowedError", "Permission denied by system"),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores missing or busy devices", () => {
+    expect(
+      isMediaPermissionDeniedError(
+        mediaError("NotFoundError", "Requested device not found"),
+      ),
+    ).toBe(false);
+    expect(
+      isMediaPermissionDeniedError(
+        mediaError("NotReadableError", "Could not start audio source"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("requireMediaPermission", () => {
+  it("types a dismissal as a missing grant for the failing device", async () => {
+    const error = await requireMediaPermission("microphone", () =>
+      Promise.reject(mediaError("NotAllowedError", "Permission dismissed")),
+    ).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(MediaPermissionRequiredError);
+    expect((error as MediaPermissionRequiredError).device).toBe("microphone");
+  });
+
+  it("passes other capture failures through untouched", async () => {
+    const original = mediaError("NotFoundError", "Requested device not found");
+    const error = await requireMediaPermission("camera", () =>
+      Promise.reject(original),
+    ).catch((err: unknown) => err);
+
+    expect(error).toBe(original);
+  });
+});
+
+describe("mediaPermissionRequirements", () => {
+  it("needs the camera for camera capture or a camera bubble", () => {
+    expect(
+      mediaPermissionRequirements({
+        captureSurface: "camera",
+        includeCamera: false,
+        includeMicrophone: false,
+      }),
+    ).toEqual({ camera: true, microphone: false });
+    expect(
+      mediaPermissionRequirements({
+        captureSurface: "browser",
+        includeCamera: true,
+        includeMicrophone: true,
+      }),
+    ).toEqual({ camera: true, microphone: true });
+    expect(
+      mediaPermissionRequirements({
+        captureSurface: "monitor",
+        includeCamera: false,
+        includeMicrophone: false,
+      }),
+    ).toEqual({ camera: false, microphone: false });
+  });
+});
+
+describe("permissionPageUrl", () => {
+  it("asks only for the devices this recording needs", () => {
+    const url = new URL(
+      permissionPageUrl(
+        { camera: false, microphone: true },
+        { startAfterGrant: true },
+      ),
+    );
+
+    expect(url.pathname.endsWith("src/permission.html")).toBe(true);
+    expect(url.searchParams.get("needsCamera")).toBe("false");
+    expect(url.searchParams.get("needsMicrophone")).toBe("true");
+    expect(url.searchParams.get("startAfterGrant")).toBe("1");
+  });
+
+  it("omits the auto-start flag when there is no queued recording", () => {
+    const url = new URL(permissionPageUrl({ camera: true, microphone: true }));
+
+    expect(url.searchParams.has("startAfterGrant")).toBe(false);
+  });
+});
+
+describe("mediaPermissionErrorFromResponse", () => {
+  it("rebuilds the typed error the offscreen recorder replied with", () => {
+    const error = mediaPermissionErrorFromResponse({
+      errorCode: MEDIA_PERMISSION_REQUIRED_CODE,
+      errorDevice: "camera",
+    });
+
+    expect(error).toBeInstanceOf(MediaPermissionRequiredError);
+    expect(error?.device).toBe("camera");
+  });
+
+  it("leaves an ordinary failure for the caller to report as-is", () => {
+    expect(mediaPermissionErrorFromResponse({ errorCode: undefined })).toBe(
+      null,
+    );
+    expect(
+      mediaPermissionErrorFromResponse({
+        errorCode: MEDIA_PERMISSION_REQUIRED_CODE,
+        errorDevice: "speaker",
+      }),
+    ).toBe(null);
+  });
+});
+
+describe("cached grants", () => {
+  it("revokes one device without dropping the other", async () => {
+    await writeCachedMediaPermission({ camera: true, microphone: true });
+    await writeCachedMediaPermission({ microphone: false });
+
+    expect(await readCachedMediaPermission()).toEqual({
+      camera: true,
+      microphone: false,
+    });
+  });
+
+  it("reads an unset cache as no grants rather than as granted", async () => {
+    expect(await readCachedMediaPermission()).toEqual({});
+  });
+});
+
+describe("hasGrantedDeviceLabels", () => {
+  it("treats labelled devices of that kind as a live grant", async () => {
+    enumerated = async () =>
+      [
+        { kind: "audioinput", deviceId: "mic", label: "Built-in Microphone" },
+        { kind: "videoinput", deviceId: "cam", label: "" },
+      ] as MediaDeviceInfo[];
+
+    expect(await hasGrantedDeviceLabels("microphone")).toBe(true);
+    expect(await hasGrantedDeviceLabels("camera")).toBe(false);
+  });
+
+  it("treats an unreadable device list as unproven", async () => {
+    enumerated = async () => {
+      throw new Error("enumerateDevices blocked");
+    };
+
+    expect(await hasGrantedDeviceLabels("microphone")).toBe(false);
+  });
+});

--- a/templates/clips/chrome-extension/src/media-permission.ts
+++ b/templates/clips/chrome-extension/src/media-permission.ts
@@ -156,8 +156,8 @@ export async function hasGrantedDeviceLabels(
     const devices = await navigator.mediaDevices.enumerateDevices();
     return devices.some((entry) => entry.kind === kind && Boolean(entry.label));
   } catch {
-    // Unreadable, not "revoked" — but the only caller uses this to decide
-    // whether to route through the permission page, which recovers either way.
+    // coercion-ok: unreadable is not "revoked", but the only caller treats both
+    // the same — it routes through the permission page either way, which recovers.
     return false;
   }
 }

--- a/templates/clips/chrome-extension/src/media-permission.ts
+++ b/templates/clips/chrome-extension/src/media-permission.ts
@@ -1,0 +1,163 @@
+// Camera/microphone grants for the chrome-extension:// origin, and the one
+// failure they produce that does not mean "the user cancelled".
+//
+// Chrome only shows the permission prompt for a real extension page, so the
+// headless offscreen recorder can never answer one: an ungranted getUserMedia()
+// there rejects immediately with NotAllowedError "Permission dismissed". The
+// cached grant below is what lets a recording get that far — it can outlive the
+// real grant (Chrome revokes permissions for origins it considers unused, and
+// clearing site data drops them), and nothing but reinstalling the extension
+// used to clear it. So a dismissal from a headless context is a missing grant to
+// recover from, never a cancellation to report back as-is.
+
+const CACHE_KEY = "clipsMediaPermission";
+
+export const MEDIA_PERMISSION_REQUIRED_CODE = "CLIPS_MEDIA_PERMISSION_REQUIRED";
+
+export const MEDIA_PERMISSION_DEVICES = ["camera", "microphone"] as const;
+
+export type MediaPermissionDevice = (typeof MEDIA_PERMISSION_DEVICES)[number];
+
+export type MediaPermissionRequirements = Record<
+  MediaPermissionDevice,
+  boolean
+>;
+
+export type CachedMediaPermission = Partial<MediaPermissionRequirements>;
+
+export type MediaPermissionSettings = {
+  captureSurface: "browser" | "window" | "monitor" | "camera";
+  includeCamera: boolean;
+  includeMicrophone: boolean;
+};
+
+export function mediaPermissionRequirements(
+  settings: MediaPermissionSettings,
+): MediaPermissionRequirements {
+  return {
+    camera: settings.captureSurface === "camera" || settings.includeCamera,
+    microphone: settings.includeMicrophone,
+  };
+}
+
+export function mediaPermissionRequiredMessage(
+  device: MediaPermissionDevice,
+): string {
+  return `Chrome has not granted Clips ${device} access. Allow it in the tab that just opened, then start the recording again.`;
+}
+
+export function toMediaPermissionDevice(
+  value: unknown,
+): MediaPermissionDevice | null {
+  return value === "camera" || value === "microphone" ? value : null;
+}
+
+export class MediaPermissionRequiredError extends Error {
+  readonly code = MEDIA_PERMISSION_REQUIRED_CODE;
+  readonly device: MediaPermissionDevice;
+
+  constructor(device: MediaPermissionDevice, options?: { cause?: unknown }) {
+    super(mediaPermissionRequiredMessage(device));
+    this.name = "MediaPermissionRequiredError";
+    this.device = device;
+    // `cause` is set here rather than through the Error options bag: the
+    // extension's TS lib target predates it, and the original NotAllowedError
+    // is what makes the Sentry report diagnosable.
+    if (options && "cause" in options) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+// True only for the "Chrome would have to ask, and nobody can answer" family. A
+// system-level denial (macOS/Windows privacy settings) reads the same to the
+// page but cannot be fixed from the permission page, so it stays a raw failure.
+export function isMediaPermissionDeniedError(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : String(error ?? "");
+  if (/\bdenied by system\b/i.test(text)) return false;
+  return (
+    /\bNotAllowedError\b/.test(text) ||
+    /\bPermission (?:denied|dismissed)\b/i.test(text)
+  );
+}
+
+// Wraps a getUserMedia() call made where Chrome cannot prompt.
+export async function requireMediaPermission<T>(
+  device: MediaPermissionDevice,
+  request: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (!isMediaPermissionDeniedError(error)) throw error;
+    throw new MediaPermissionRequiredError(device, { cause: error });
+  }
+}
+
+// Rebuilds the typed error on the receiving side of a message reply, so a
+// missing grant stays branchable instead of decaying into a message string.
+export function mediaPermissionErrorFromResponse(response: {
+  errorCode?: string;
+  errorDevice?: string;
+}): MediaPermissionRequiredError | null {
+  const device = toMediaPermissionDevice(response.errorDevice);
+  if (response.errorCode !== MEDIA_PERMISSION_REQUIRED_CODE || !device) {
+    return null;
+  }
+  return new MediaPermissionRequiredError(device);
+}
+
+export function permissionPageUrl(
+  requirements: MediaPermissionRequirements,
+  options?: { startAfterGrant?: boolean },
+): string {
+  const url = new URL(chrome.runtime.getURL("src/permission.html"));
+  if (options?.startAfterGrant) url.searchParams.set("startAfterGrant", "1");
+  url.searchParams.set("needsCamera", String(requirements.camera));
+  url.searchParams.set("needsMicrophone", String(requirements.microphone));
+  return url.toString();
+}
+
+export function readCachedMediaPermission(): Promise<CachedMediaPermission> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(CACHE_KEY, (value) => {
+      const cached = value?.[CACHE_KEY];
+      resolve(
+        cached && typeof cached === "object"
+          ? (cached as CachedMediaPermission)
+          : {},
+      );
+    });
+  });
+}
+
+export async function writeCachedMediaPermission(
+  patch: CachedMediaPermission,
+): Promise<void> {
+  const current = await readCachedMediaPermission();
+  await new Promise<void>((resolve) => {
+    chrome.storage.local.set({ [CACHE_KEY]: { ...current, ...patch } }, () =>
+      resolve(),
+    );
+  });
+}
+
+// Device labels are exposed only while the origin holds a live grant, so this
+// separates a cached grant Chrome still honors from one it revoked — without the
+// prompt that neither the popup nor the offscreen document can show.
+export async function hasGrantedDeviceLabels(
+  device: MediaPermissionDevice,
+): Promise<boolean> {
+  const kind = device === "camera" ? "videoinput" : "audioinput";
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.some((entry) => entry.kind === kind && Boolean(entry.label));
+  } catch {
+    // Unreadable, not "revoked" — but the only caller uses this to decide
+    // whether to route through the permission page, which recovers either way.
+    return false;
+  }
+}

--- a/templates/clips/chrome-extension/src/offscreen.test.ts
+++ b/templates/clips/chrome-extension/src/offscreen.test.ts
@@ -1,6 +1,11 @@
 import type { ScreenCaptureSurface } from "@shared/recording-capture";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import {
+  MEDIA_PERMISSION_REQUIRED_CODE,
+  MediaPermissionRequiredError,
+} from "./media-permission";
+
 // The offscreen document registers a chrome.runtime.onMessage listener as
 // soon as the module loads, so the chrome stub must be in place before
 // offscreen.ts is imported — a dynamic import() (rather than a static one,
@@ -10,6 +15,12 @@ let displayConstraints: (
   surface: ScreenCaptureSurface,
   wantsMic: boolean,
 ) => MediaStreamConstraints;
+let errorResponse: (error: unknown) => {
+  ok: false;
+  error: string;
+  errorCode?: string;
+  errorDevice?: string;
+};
 
 beforeAll(async () => {
   (globalThis as { chrome?: unknown }).chrome = {
@@ -21,7 +32,25 @@ beforeAll(async () => {
       sync: { get: async () => ({}) },
     },
   };
-  ({ displayConstraints } = await import("./offscreen"));
+  ({ displayConstraints, errorResponse } = await import("./offscreen"));
+});
+
+describe("offscreen error replies", () => {
+  it("carries a missing grant across the message boundary as a code", () => {
+    const response = errorResponse(
+      new MediaPermissionRequiredError("microphone"),
+    );
+
+    expect(response.errorCode).toBe(MEDIA_PERMISSION_REQUIRED_CODE);
+    expect(response.errorDevice).toBe("microphone");
+  });
+
+  it("reports every other capture failure as a plain message", () => {
+    const response = errorResponse(new Error("No chunks found"));
+
+    expect(response.error).toBe("No chunks found");
+    expect(response.errorCode).toBeUndefined();
+  });
 });
 
 describe("offscreen display capture audio policy", () => {

--- a/templates/clips/chrome-extension/src/offscreen.ts
+++ b/templates/clips/chrome-extension/src/offscreen.ts
@@ -37,6 +37,10 @@ import { MAX_UPLOAD_BYTES } from "@shared/upload-limits";
 
 import { waitForAcceptedRecordingAfterFinalizeError } from "./finalize-recovery";
 import {
+  MediaPermissionRequiredError,
+  requireMediaPermission,
+} from "./media-permission";
+import {
   createNativeTranscriptionCapture,
   type NativeTranscriptionCapture,
 } from "./native-transcription";
@@ -1123,12 +1127,24 @@ async function acquire(message: AcquireMessage): Promise<{
     audio: message.audioDeviceId,
   });
 
+  // Chrome cannot prompt for camera/mic in this headless document, so an
+  // ungranted device rejects as a dismissal. requireMediaPermission types that
+  // apart from a real cancellation; the worker sends the user to the permission
+  // page instead of surfacing Chrome's "Permission dismissed" as a dead end.
+  const acquireMicStream = async (): Promise<MediaStream> => {
+    const audioLabel = await lookupAudioDeviceLabel(devices.audio);
+    return requireMediaPermission("microphone", () =>
+      getMicStream(devices.audio, audioLabel),
+    );
+  };
+
   try {
     if (message.mode === "camera") {
-      cameraStream = await getCameraStream(devices.video);
+      cameraStream = await requireMediaPermission("camera", () =>
+        getCameraStream(devices.video),
+      );
       if (message.includeMicrophone) {
-        const audioLabel = await lookupAudioDeviceLabel(devices.audio);
-        micStream = await getMicStream(devices.audio, audioLabel);
+        micStream = await acquireMicStream();
       }
     } else {
       // Native "Choose what to share" picker. This is the screenshot Steve showed.
@@ -1136,8 +1152,7 @@ async function acquire(message: AcquireMessage): Promise<{
         displayConstraints(message.surface, message.includeMicrophone),
       );
       if (message.includeMicrophone) {
-        const audioLabel = await lookupAudioDeviceLabel(devices.audio);
-        micStream = await getMicStream(devices.audio, audioLabel);
+        micStream = await acquireMicStream();
       }
       // The screen+camera face comes from the on-page bubble (captured in the
       // display pixels), NOT composited here: canvas/requestAnimationFrame does
@@ -1876,11 +1891,28 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       return false;
   }
 
-  void task.then(sendResponse).catch((err) =>
-    sendResponse({
-      ok: false,
-      error: err instanceof Error ? err.message : "Recording failed.",
-    }),
-  );
+  void task.then(sendResponse).catch((err) => sendResponse(errorResponse(err)));
   return true;
 });
+
+// Errors cross the message boundary as plain data, so a missing grant has to
+// carry its code with it — the worker cannot recover from a bare message.
+export function errorResponse(error: unknown): {
+  ok: false;
+  error: string;
+  errorCode?: string;
+  errorDevice?: string;
+} {
+  if (error instanceof MediaPermissionRequiredError) {
+    return {
+      ok: false,
+      error: error.message,
+      errorCode: error.code,
+      errorDevice: error.device,
+    };
+  }
+  return {
+    ok: false,
+    error: error instanceof Error ? error.message : "Recording failed.",
+  };
+}

--- a/templates/clips/chrome-extension/src/permission.ts
+++ b/templates/clips/chrome-extension/src/permission.ts
@@ -5,6 +5,7 @@
 // the grant for the whole chrome-extension:// origin — so the offscreen recorder
 // (mic) and the camera-bubble iframe both work afterward.
 
+import { writeCachedMediaPermission } from "./media-permission";
 import { captureExtensionError, initExtensionSentry } from "./sentry";
 
 initExtensionSentry("permission");
@@ -96,23 +97,9 @@ function requiredPermissionsReady(camOk: boolean, micOk: boolean): boolean {
 }
 
 function writePermissionCache(camOk: boolean, micOk: boolean): Promise<void> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get("clipsMediaPermission", (value) => {
-      const current =
-        value.clipsMediaPermission &&
-        typeof value.clipsMediaPermission === "object"
-          ? (value.clipsMediaPermission as {
-              camera?: boolean;
-              microphone?: boolean;
-            })
-          : {};
-      const next = {
-        ...current,
-        ...(shouldRequestCamera ? { camera: camOk } : {}),
-        ...(shouldRequestMicrophone ? { microphone: micOk } : {}),
-      };
-      chrome.storage.local.set({ clipsMediaPermission: next }, () => resolve());
-    });
+  return writeCachedMediaPermission({
+    ...(shouldRequestCamera ? { camera: camOk } : {}),
+    ...(shouldRequestMicrophone ? { microphone: micOk } : {}),
   });
 }
 

--- a/templates/clips/chrome-extension/src/popup.ts
+++ b/templates/clips/chrome-extension/src/popup.ts
@@ -1,5 +1,13 @@
 import { isSelectableAudioInputDevice } from "@shared/media-device-selection";
 
+import {
+  MEDIA_PERMISSION_DEVICES,
+  hasGrantedDeviceLabels,
+  mediaPermissionRequirements,
+  permissionPageUrl,
+  readCachedMediaPermission,
+  writeCachedMediaPermission,
+} from "./media-permission";
 import { captureExtensionError, initExtensionSentry } from "./sentry";
 
 initExtensionSentry("popup");
@@ -65,11 +73,6 @@ type PopupStatusResponse = {
 };
 
 type AuthStatus = "checking" | "signed-in" | "signed-out";
-
-type CachedMediaPermission = {
-  camera?: boolean;
-  microphone?: boolean;
-};
 
 type StoredAuth = {
   token: string;
@@ -411,17 +414,6 @@ function createTab(url: string): Promise<void> {
   });
 }
 
-function permissionPageUrl(settings: ExtensionSettings): string {
-  const url = new URL(chrome.runtime.getURL("src/permission.html"));
-  url.searchParams.set("startAfterGrant", "1");
-  url.searchParams.set(
-    "needsCamera",
-    String(settings.captureSurface === "camera" || settings.includeCamera),
-  );
-  url.searchParams.set("needsMicrophone", String(settings.includeMicrophone));
-  return url.toString();
-}
-
 async function mediaPermissionState(
   name: "camera" | "microphone",
 ): Promise<PermissionState | "unknown"> {
@@ -435,35 +427,27 @@ async function mediaPermissionState(
   }
 }
 
-function readCachedMediaPermission(): Promise<CachedMediaPermission> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get("clipsMediaPermission", (value) => {
-      const cached = value.clipsMediaPermission as
-        | CachedMediaPermission
-        | undefined;
-      resolve(cached && typeof cached === "object" ? cached : {});
-    });
-  });
-}
-
 // True when every device the chosen mode needs is already granted to the
 // extension. If not, the caller routes the user to the permission page.
 async function ensureMediaPermission(
   settings: ExtensionSettings,
 ): Promise<boolean> {
-  const needsCamera =
-    settings.captureSurface === "camera" || settings.includeCamera;
-  const needsMic = settings.includeMicrophone;
+  const needs = mediaPermissionRequirements(settings);
   const cached = await readCachedMediaPermission();
-  if (needsCamera) {
-    const state = await mediaPermissionState("camera");
+  for (const device of MEDIA_PERMISSION_DEVICES) {
+    if (!needs[device]) continue;
+    const state = await mediaPermissionState(device);
+    if (state === "granted") continue;
     if (state === "denied") return false;
-    if (state !== "granted" && cached.camera !== true) return false;
-  }
-  if (needsMic) {
-    const state = await mediaPermissionState("microphone");
-    if (state === "denied") return false;
-    if (state !== "granted" && cached.microphone !== true) return false;
+    if (cached[device] !== true) return false;
+    // "prompt" plus a cached grant is the ambiguous case: Chrome reports
+    // "prompt" for some granted extension origins, but also after it revokes a
+    // grant it considers unused. Device labels tell those apart, and a cache
+    // Chrome no longer backs would otherwise send the recording into the
+    // offscreen document, where no prompt can ever be shown.
+    if (await hasGrantedDeviceLabels(device)) continue;
+    await writeCachedMediaPermission({ [device]: false });
+    return false;
   }
   return true;
 }
@@ -1269,7 +1253,11 @@ async function init(): Promise<void> {
         }
         start.disabled = false;
         setStatus("Allow camera & microphone, then start recording.", "error");
-        await createTab(permissionPageUrl(settings));
+        await createTab(
+          permissionPageUrl(mediaPermissionRequirements(settings), {
+            startAfterGrant: true,
+          }),
+        );
         window.close();
         return;
       }


### PR DESCRIPTION
Recording could fail with "Permission dismissed" and stay broken until the user reinstalled the extension. This fixes the cause and lets the extension recover on its own.

## Why it happened

The extension remembered that Chrome had granted it microphone and camera access and never checked again. Chrome can drop that access later, for example when it revokes permissions it thinks you no longer use. After that the extension still believed it had access, so it started recordings that could never work, and nothing cleared the stale memory.

## What changed

Before starting, the extension now confirms that Chrome still grants access, and sends the user to the permission page when it does not.

If a recording still hits a missing permission, it is treated as fixable instead of a dead end: the extension forgets the stale permission, opens the permission page, and starts the recording once the user allows access. The popup now explains what to do rather than showing Chrome's raw error.

The extension also stays awake while Chrome's share picker is open, fixing a second error some users saw when picking slowly.
