### PR TITLE
Clarify personal Jira connection setup

### DIFF
--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -490,7 +490,7 @@ describe("McpIntegrationDialog", () => {
 
     expect(document.body.textContent).toContain("Provider setup required");
     const continueButton = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "I've completed setup",
+      (button) => button.textContent === "Connect my account",
     );
     expect(continueButton).toBeTruthy();
 
@@ -566,11 +566,59 @@ describe("McpIntegrationDialog", () => {
       );
     });
 
-    expect(document.body.textContent).toContain("Who should use this?");
-    expect(document.body.textContent).toContain(
-      "Only personal connections are supported for this integration.",
-    );
+    expect(document.body.textContent).not.toContain("Who should use this?");
     expect(document.body.textContent).not.toContain("Set up for workspace");
+
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect",
+    );
+    act(() => connect?.click());
+    expect(mocks.navigateToMcpOAuthStart).toHaveBeenCalledOnce();
+  });
+
+  it("routes personal-only provider setup directly to a personal connection", () => {
+    const atlassian = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "atlassian",
+    )!;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            quickConnectIntegrationId="atlassian"
+            defaultScope="org"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={vi.fn()}
+            integrations={[atlassian]}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).not.toContain("Who should use this?");
+    expect(document.body.textContent).toContain("Connect Jira");
+    expect(document.body.textContent).toContain("Personal connection");
+    expect(document.body.textContent).toContain(
+      "Only you can use this connection.",
+    );
+    expect(document.body.textContent).toContain("Open setup guide");
+    expect(document.body.querySelectorAll('a[target="_blank"]')).toHaveLength(
+      1,
+    );
+
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect my account",
+    );
+    expect(connect).toBeTruthy();
+    act(() => connect?.click());
+
+    const url = mocks.navigateToMcpOAuthStart.mock.calls[0]?.[0];
+    expect(
+      new URL(url, "https://analytics.example.com").searchParams.get("scope"),
+    ).toBe("user");
   });
 
   it("does not offer an unauthenticated test for setup-gated integrations", () => {
@@ -600,17 +648,17 @@ describe("McpIntegrationDialog", () => {
         (button) => button.textContent === "Test",
       ),
     ).toBeUndefined();
-    expect(document.body.textContent).toContain("Set up Slack");
+    expect(document.body.textContent).toContain("Connect Slack");
     expect(document.body.textContent).toContain("Provider setup required");
-    expect(document.body.textContent).toContain("View setup");
+    expect(document.body.textContent).toContain("Open setup guide");
     expect(
       [...document.body.querySelectorAll("a")]
-        .find((link) => link.textContent?.includes("View setup"))
+        .find((link) => link.textContent?.includes("Open setup guide"))
         ?.getAttribute("href"),
     ).toBe(slack.docsUrl);
 
     const continueButton = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "I've completed setup",
+      (button) => button.textContent === "Connect my account",
     );
     expect(continueButton).toBeTruthy();
 
@@ -640,17 +688,12 @@ describe("McpIntegrationDialog", () => {
     });
 
     const viewSetupButton = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "View setup",
+      (button) => button.textContent === "Open setup guide",
     );
     expect(viewSetupButton).toBeTruthy();
 
     act(() => viewSetupButton?.click());
-    expect(document.body.textContent).toContain("Who should use this?");
-    const personal = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent === "Connect for me",
-    );
-    expect(personal).toBeTruthy();
-    act(() => personal?.click());
+    expect(document.body.textContent).not.toContain("Who should use this?");
     expect(document.body.textContent).toContain("Provider setup required");
   });
 

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -398,7 +398,7 @@ export function McpIntegrationDialog({
   };
 
   const quickConnect = (integration: DefaultMcpIntegration) => {
-    if (hasOrg) {
+    if (hasOrg && supportsMcpIntegrationOrganizationScope(integration)) {
       setSelected(integration);
       setMode("choice");
       return;
@@ -427,7 +427,7 @@ export function McpIntegrationDialog({
 
   const selectCatalogConnection = (integration: DefaultMcpIntegration) => {
     if (!mcpServersQuery.isSuccess) return;
-    if (hasOrg) {
+    if (hasOrg && supportsMcpIntegrationOrganizationScope(integration)) {
       setSelected(integration);
       setMode("choice");
       return;
@@ -485,7 +485,7 @@ export function McpIntegrationDialog({
     const attemptKey = `connect:${connectIntegrationId}`;
     if (quickConnectAttemptedRef.current === attemptKey) return;
     quickConnectAttemptedRef.current = attemptKey;
-    if (hasOrg) {
+    if (hasOrg && supportsMcpIntegrationOrganizationScope(integration)) {
       setSelected(integration);
       setMode("choice");
       return;
@@ -870,6 +870,19 @@ export function McpIntegrationDialog({
                         {t(selected.setupNoteKey)}
                       </p>
                     ) : null}
+                    <div className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-foreground">
+                          {t("mcpIntegrations.personalConnection")}
+                        </p>
+                        <p className="text-[11px] leading-relaxed text-muted-foreground">
+                          {t("mcpIntegrations.personalDescription")}
+                        </p>
+                      </div>
+                      <span className="shrink-0 text-[11px] text-muted-foreground">
+                        {t("mcpIntegrations.personal")}
+                      </span>
+                    </div>
                     {selected.docsUrl ? (
                       <a
                         href={selected.docsUrl}
@@ -1064,17 +1077,6 @@ export function McpIntegrationDialog({
               ) : null}
               {selectedRequiresSetup ? (
                 <div className="ms-auto flex items-center gap-2">
-                  {selected?.docsUrl ? (
-                    <a
-                      href={selected.docsUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex min-w-[92px] items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent"
-                    >
-                      {t("mcpIntegrations.viewSetup")}
-                      <IconExternalLink className="h-3 w-3" />
-                    </a>
-                  ) : null}
                   {selected?.authMode === "oauth" && (
                     <button
                       type="button"

--- a/packages/core/src/client/resources/mcp-integration-catalog.ts
+++ b/packages/core/src/client/resources/mcp-integration-catalog.ts
@@ -361,7 +361,7 @@ export const DEFAULT_MCP_INTEGRATIONS: DefaultMcpIntegration[] = [
   },
   {
     id: "atlassian",
-    name: "Atlassian",
+    name: "Jira",
     provider: "atlassian",
     description: "Read and write Jira issues and Confluence content.",
     descriptionKey: "mcpIntegrations.catalog.atlassian.description",

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -1134,12 +1134,13 @@ const messages = {
       "This provider usually requires an OAuth setup. Follow the provider docs, or add an Authorization header if your endpoint supports token-based access.",
     providerSetupRequired: "Provider setup required",
     providerSetupDescription:
-      "Complete the required setup in {{name}} first. Then return here to authorize your account.",
+      "Complete the required setup in {{name}} first. Then return here to connect your account.",
     providerSetupFormDescription:
-      "Review the provider requirements and open the official setup guide before connecting your account.",
-    continueToConnect: "I've completed setup",
-    setupTitle: "Set up {{name}}",
+      "Complete provider setup before connecting your account.",
+    continueToConnect: "Connect my account",
+    setupTitle: "Connect {{name}}",
     personal: "Personal",
+    personalConnection: "Personal connection",
     organization: "Organization",
     scopeQuestion: "Who should be able to use this connection?",
     scopeChoiceTitle: "Who should use this?",
@@ -1167,7 +1168,7 @@ const messages = {
     descriptionPlaceholder: "Description (optional)",
     headersPlaceholder: "Authorization: Bearer <token>",
     openSetupDocs: "Open setup docs",
-    viewSetup: "View setup",
+    viewSetup: "Open setup guide",
     test: "Test",
     toolsAvailable_one: "{{count}} tool available",
     toolsAvailable_other: "{{count}} tools available",
@@ -1261,7 +1262,7 @@ const messages = {
         useCase:
           "Project management, issue tracking, documentation, team collaboration",
         setupNote:
-          "Atlassian admins manage the allowed AI domains and Rovo integration permissions. Use the current Streamable HTTP endpoint, /v1/mcp, and reconnect after policy changes.",
+          "Ask your Atlassian admin to allow the Clips app domain and enable Rovo/MCP with Read, Write, and Search permissions for your Jira site.",
       },
       cloudflare: {
         description:


### PR DESCRIPTION
## Summary
- route personal-only integrations directly to their provider setup form
- make the Jira label and personal connection state explicit
- remove duplicate setup-guide affordances and cover the flow with tests

## Validation
- focused McpIntegrationDialog and catalog Vitest suites
- @agent-native/core typecheck
- clips typecheck
- localization guards and full guards
- local browser verification of Jira catalog, desktop setup, and mobile setup states with no console errors

Post-merge deployment monitoring is not included in this PR.