### PR TITLE
Pause the whole turn while an action waits for approval

### DIFF
--- a/.changeset/approval-pauses-whole-turn.md
+++ b/.changeset/approval-pauses-whole-turn.md
@@ -13,3 +13,10 @@ delete(no approval)]` in one message, the human saw an approval card for the
 first while the second had already executed. The approval branch now yields the
 turn like any other action that hands control to the user, and the message shown
 for a suppressed call names the approval case as well as the ends-turn case.
+
+A gated call is also no longer eligible for parallel batching. `flushParallelBatch`
+dispatches a batch through `Promise.all`, so a gated call and its siblings all
+start before the gate is reached and the suppression lands too late to stop a
+sibling that already ran. Any action declaring `needsApproval` or `endsTurn` is
+now serialized, which is what makes the suppression meaningful for the calls
+after it.

--- a/.changeset/approval-pauses-whole-turn.md
+++ b/.changeset/approval-pauses-whole-turn.md
@@ -1,0 +1,15 @@
+---
+"@agent-native/core": patch
+---
+
+Stop later tool calls in the same assistant message from running while an action
+waits for human approval.
+
+The approval gate told the model "the turn is paused" and set
+`requestedActionStop`, but that flag is only read after the tool loop finishes.
+The flag that actually suppresses the remaining calls is `turnYieldedToUser`,
+which the approval path never set — so on `[write(needs approval),
+delete(no approval)]` in one message, the human saw an approval card for the
+first while the second had already executed. The approval branch now yields the
+turn like any other action that hands control to the user, and the message shown
+for a suppressed call names the approval case as well as the ends-turn case.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -9442,6 +9442,89 @@ describe("runAgentLoop", () => {
     ]);
   });
 
+  // The paused tool result tells the model "the turn is paused". That has to be
+  // true for the REST of the same assistant message too: a second call emitted
+  // alongside the gated one previously still executed while the human was
+  // looking at the approval card.
+  it("does not run later tool calls in the same message while approval is pending", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "approval-call-1",
+                name: "send-email",
+                input: { to: "a@b.com" },
+              },
+              {
+                type: "tool-call" as const,
+                id: "follow-up-call-1",
+                name: "delete-records",
+                input: { id: "42" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield { type: "assistant-content", parts: [] };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+
+    const sendEmail = vi.fn(async () => "delivered");
+    const deleteRecords = vi.fn(async () => "deleted");
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: true,
+          run: sendEmail,
+        },
+        "delete-records": {
+          ...actionEntry({ readOnly: false }),
+          run: deleteRecords,
+        },
+      },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    // The whole point: the un-gated sibling must not fire either.
+    expect(deleteRecords).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "delete-records",
+        result: expect.stringContaining("Not executed"),
+      }),
+    );
+  });
+
   it("re-running with approvedToolCalls:[approvalKey] DOES run the action", async () => {
     // Phase 1: capture the approvalKey from the pause.
     const phase1 = approvalEngine();

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -9525,6 +9525,84 @@ describe("runAgentLoop", () => {
     );
   });
 
+  // Same guarantee, but through the parallel path. A batch is dispatched with
+  // `Promise.all`, so if a gated call were batchable its siblings would already
+  // be running by the time the gate is reached — including a mutating
+  // `parallelSafe` one.
+  it("does not run parallelSafe siblings batched alongside a gated call", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "gated-1",
+                name: "send-email",
+                input: { to: "a@b.com" },
+              },
+              {
+                type: "tool-call" as const,
+                id: "sibling-1",
+                name: "bulk-write",
+                input: { id: "42" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield { type: "assistant-content", parts: [] };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+
+    const sendEmail = vi.fn(async () => "delivered");
+    const bulkWrite = vi.fn(async () => "written");
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        // Declares BOTH parallelSafe and needsApproval — without serializing
+        // gated calls this lands in a write batch with its sibling.
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          parallelSafe: true,
+          needsApproval: true,
+          run: sendEmail,
+        },
+        "bulk-write": {
+          ...actionEntry({ readOnly: false }),
+          parallelSafe: true,
+          run: bulkWrite,
+        },
+      },
+      send: () => {},
+      signal: new AbortController().signal,
+    });
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(bulkWrite).not.toHaveBeenCalled();
+  });
+
   it("re-running with approvedToolCalls:[approvalKey] DOES run the action", async () => {
     // Phase 1: capture the approvalKey from the pause.
     const phase1 = approvalEngine();

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -6740,6 +6740,16 @@ export async function runAgentLoop(opts: {
       // alongside genuine reads, which can reorder it ahead of a later mutating
       // call and break the model's intended sequencing.
       if (!entry) return null;
+      // A call that can pause the turn must not share a batch. `flushParallelBatch`
+      // dispatches through `Promise.all`, so a gated call and its siblings all
+      // start before the gate is reached, and `turnYieldedToUser` would then be
+      // set too late to stop a sibling that already ran. Serializing here is what
+      // makes that flag mean anything for the calls after it. `needsApproval` may
+      // be an async predicate, so this cannot resolve whether approval is truly
+      // required — declaring it at all is enough to serialize.
+      if (entry.needsApproval !== undefined || entry.endsTurn === true) {
+        return null;
+      }
       if (entry.readOnly === true) return "read";
       if (entry.parallelSafe === true) return "parallel-write";
       return null;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -6035,6 +6035,12 @@ export async function runAgentLoop(opts: {
             completedSideEffect: false,
           });
           recordToolResult(result, false);
+          // Control is genuinely handed to the user here — the result above
+          // tells the model "the turn is paused". `requestedActionStop` alone
+          // does not stop anything until after the tool loop drains, so
+          // without this the *rest* of this assistant message still executes
+          // while the human is still looking at the approval card.
+          turnYieldedToUser = true;
           requestedActionStop ??= {
             message: `Waiting for your approval to run ${toolCall.name}.`,
             errorCode: "needs-approval",
@@ -6763,7 +6769,8 @@ export async function runAgentLoop(opts: {
       toolCall: import("./engine/types.js").EngineToolCallPart,
     ): EngineContentPart => {
       const result =
-        `Not executed: ${toolCall.name} was called after an action that ends the turn. ` +
+        `Not executed: ${toolCall.name} was called after an action that paused the turn ` +
+        `(an action that ends the turn, or one waiting on the user's approval). ` +
         `The turn is paused for the user's answer — call it again on a later turn if still needed.`;
       send({
         type: "tool_start",

--- a/templates/calendar/changelog/2026-08-24-overlapping-events-use-space-better.md
+++ b/templates/calendar/changelog/2026-08-24-overlapping-events-use-space-better.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-24
 ---
+
 Overlapping calendar events now use more of the available width while keeping same-time meetings readable.


### PR DESCRIPTION
Follow-up to #3501. That PR deliberately left this one out because a concurrent session was rewriting the same approval branch for the always-allow policy work; that landed in #3491, so this is now safe to touch.

## The approval gate did not actually pause the turn

The gate tells the model, in the tool result it writes:

> `Awaiting human approval to run "X". This action did NOT execute — a human must approve this specific call before it can run. The turn is paused; do not retry.`

That last sentence was not true for the rest of the message. The branch set `requestedActionStop`, which is only read *after* the whole tool loop drains. The flag that actually suppresses the remaining tool calls is `turnYieldedToUser`, and the approval path never set it — the loop's own comment spells out the distinction:

```ts
// An `endsTurn` action ran and handed control to the user. Distinct from
// `requestedActionStop`, which also covers failure stops that must not
// suppress the remaining tool calls.
let turnYieldedToUser = false;
```

So on `[send-email(needs approval), delete-records(no approval)]` in one assistant message, the human saw an approval card for the first while the second had **already executed**.

An approval pause is a hand-off of control to the user, not a failure stop, so the branch now yields the turn like any other action that does that.

Also tightened the message a suppressed call receives — it said "was called after an action that ends the turn", which reads wrong when the cause is a pending approval. It now names both cases.

## Verification

Regression test added to `production-agent.spec.ts`: two tool calls in one assistant message, the first `needsApproval`, asserting neither `run` fires and the second gets a "Not executed" result.

Confirmed in both directions — with the one-line fix reverted, the test fails with:

```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
  9518|     expect(deleteRecords).not.toHaveBeenCalled();
```

`production-agent.spec.ts` is 254 passing. `pnpm prep:urgent` green on all three lanes: typecheck 0, 64/64 guards, tests 0.

Source-tested and built only — no beta or production deployment claimed.

Note: the branch snapshot also carries `templates/calendar/changelog/2026-08-24-overlapping-events-use-space-better.md` from a concurrent session, included per the ship flow's whole-snapshot rule rather than reverted.
