### PR TITLE
Preserve static docs with Markdown negotiation

### DIFF
--- a/packages/docs/app/vite-sitemap-plugin.ts
+++ b/packages/docs/app/vite-sitemap-plugin.ts
@@ -151,10 +151,11 @@ export function buildSitemapPaths(rootDir: string): string[] {
  *   `<meta http-equiv="refresh">` 200 page;
  * - draft docs, hidden by `VITE_SHOW_DRAFTS` — including every translation of a
  *   canonically-draft slug, matching `loadDocRespectingDraftVisibility`.
- * - docs pages, which must reach the SSR handler so `Accept: text/markdown`
- *   can select the Markdown representation before a CDN serves HTML.
  *
- * Both keep falling through to the SSR function, which still answers 301/404.
+ * Redirected and draft paths keep falling through to the SSR function, which
+ * still answers 301/404. Published docs stay prerendered because the Netlify
+ * edge negotiation hook rewrites Markdown requests to the SSR function before
+ * static routing can serve the HTML file.
  */
 export function buildPrerenderPaths(): string[] {
   const pages = buildDocsSitePages(path.resolve(__dirname, ".."));
@@ -164,17 +165,9 @@ export function buildPrerenderPaths(): string[] {
   return pages
     .filter(
       (page) =>
-        !draftSlugs.has(page.docSlug) &&
-        !isRedirectedDocsPath(page.path) &&
-        !isDocsPagePath(page.path),
+        !draftSlugs.has(page.docSlug) && !isRedirectedDocsPath(page.path),
     )
     .map((page) => page.path);
-}
-
-function isDocsPagePath(pagePath: string): boolean {
-  const segments = pagePath.split("/").filter(Boolean);
-  const docsIndex = segments[0] === "docs" ? 0 : 1;
-  return segments[docsIndex] === "docs";
 }
 
 export function buildAgentWebPages(rootDir: string): AgentWebPage[] {

--- a/packages/docs/netlify.toml
+++ b/packages/docs/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter @agent-native/docs build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter @agent-native/docs migrate:production; fi"
 publish = "packages/docs/dist"
+edge_functions = "packages/docs/netlify/edge-functions"
 
 # React Router prerendered pages bypass the framework SSR handler because
 # Netlify serves them from its static backing store. The shared Core Netlify

--- a/packages/docs/netlify/edge-functions/markdown-negotiation.ts
+++ b/packages/docs/netlify/edge-functions/markdown-negotiation.ts
@@ -1,0 +1,46 @@
+const MARKDOWN_REWRITE_PREFIX = "/__agent-native-markdown";
+
+export function acceptsMarkdown(header: string | null): boolean {
+  return (header ?? "").split(",").some((range) => {
+    const [mediaType, ...parameters] = range.split(";");
+    if (mediaType?.trim().toLowerCase() !== "text/markdown") return false;
+    const quality = parameters
+      .map((parameter) => parameter.trim().split("=", 2))
+      .find(([name]) => name?.toLowerCase() === "q")?.[1];
+    return quality === undefined || Number(quality) > 0;
+  });
+}
+
+function isStaticAsset(pathname: string): boolean {
+  return /\.(?:css|gif|ico|jpeg|jpg|js|json|map|md|png|svg|txt|webp|xml)$/i.test(
+    pathname,
+  );
+}
+
+export default function markdownNegotiation(request: Request): URL | undefined {
+  const url = new URL(request.url);
+  if (
+    !acceptsMarkdown(request.headers.get("accept")) ||
+    url.pathname.startsWith(`${MARKDOWN_REWRITE_PREFIX}/`) ||
+    isStaticAsset(url.pathname)
+  ) {
+    return undefined;
+  }
+
+  return new URL(
+    `${MARKDOWN_REWRITE_PREFIX}${url.pathname}${url.search}`,
+    request.url,
+  );
+}
+
+export const config = {
+  path: "/*",
+  excludedPath: [
+    "/.netlify/*",
+    "/.well-known/*",
+    "/_agent-native/*",
+    "/__agent-native-markdown/*",
+    "/api/*",
+    "/assets/*",
+  ],
+};

--- a/packages/docs/netlify/edge-functions/markdown-negotiation.ts
+++ b/packages/docs/netlify/edge-functions/markdown-negotiation.ts
@@ -12,8 +12,11 @@ export function acceptsMarkdown(header: string | null): boolean {
 }
 
 function isStaticAsset(pathname: string): boolean {
-  return /\.(?:css|gif|ico|jpeg|jpg|js|json|map|md|png|svg|txt|webp|xml)$/i.test(
-    pathname,
+  return (
+    pathname.endsWith("/Dockerfile") ||
+    /\.(?:avif|css|data|dockerignore|eot|example|gif|html|ico|jpe?g|js|json|map|md|png|svg|txt|ttf|wasm|webmanifest|webp|woff2?|xml|ya?ml)$/i.test(
+      pathname,
+    )
   );
 }
 
@@ -21,6 +24,7 @@ export default function markdownNegotiation(request: Request): URL | undefined {
   const url = new URL(request.url);
   if (
     !acceptsMarkdown(request.headers.get("accept")) ||
+    url.pathname === MARKDOWN_REWRITE_PREFIX ||
     url.pathname.startsWith(`${MARKDOWN_REWRITE_PREFIX}/`) ||
     isStaticAsset(url.pathname)
   ) {
@@ -39,8 +43,22 @@ export const config = {
     "/.netlify/*",
     "/.well-known/*",
     "/_agent-native/*",
+    "/__agent-native-markdown",
     "/__agent-native-markdown/*",
     "/api/*",
     "/assets/*",
+    "/examples/self-hosted-chat/Dockerfile",
+    "/templates",
+    "/templates/",
+    "/templates/*",
+    "/:locale/templates",
+    "/:locale/templates/",
+    "/:locale/templates/*",
+    "/docs/getting-started",
+    "/:locale/docs/getting-started",
+    "/docs/resources",
+    "/docs/workspace",
+    "/:locale/docs/workspace",
+    "/docs/:locale/workspace",
   ],
 };

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -26,6 +26,7 @@ import {
 import { fetchMarkdownMirror } from "../lib/markdown-mirror";
 
 const SITE_URL = "https://www.agent-native.com";
+const MARKDOWN_REWRITE_PREFIX = "/__agent-native-markdown";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ssrHandler = createH3SSRHandler(
@@ -63,7 +64,7 @@ export default async function docsPageHandler(event: H3Event) {
     return markdown.content;
   }
 
-  if (getRequestURL(event).pathname.endsWith(".md")) {
+  if (markdownRequestPath(event).endsWith(".md")) {
     throw createError({ statusCode: 404, statusMessage: "Markdown not found" });
   }
 
@@ -133,9 +134,8 @@ async function readMarkdownForRequest(
 ): Promise<
   { content: string; pagePath: string; relativePath: string } | undefined
 > {
-  const requestUrl = getRequestURL(event);
   const wantsMarkdown = acceptsMarkdown(getRequestHeader(event, "accept"));
-  const pathname = requestUrl.pathname.replace(/\/+$/, "") || "/";
+  const pathname = markdownRequestPath(event).replace(/\/+$/, "") || "/";
   const isMarkdownPath = pathname.endsWith(".md");
   if (!isMarkdownPath && !wantsMarkdown) return undefined;
 
@@ -150,6 +150,15 @@ async function readMarkdownForRequest(
     pagePath: pagePathForMarkdownRequest(pathname, relativePath),
     relativePath,
   };
+}
+
+function markdownRequestPath(event: H3Event): string {
+  const pathname = getRequestURL(event).pathname;
+  if (pathname === MARKDOWN_REWRITE_PREFIX) return "/";
+  if (pathname.startsWith(`${MARKDOWN_REWRITE_PREFIX}/`)) {
+    return pathname.slice(MARKDOWN_REWRITE_PREFIX.length) || "/";
+  }
+  return pathname;
 }
 
 async function readMarkdownContent(

--- a/packages/docs/server/routes/[...page].head.ts
+++ b/packages/docs/server/routes/[...page].head.ts
@@ -21,6 +21,7 @@ import { acceptsMarkdown, appendVary } from "../lib/agent-web-responses";
 import { fetchMarkdownMirror } from "../lib/markdown-mirror";
 
 const SITE_URL = "https://www.agent-native.com";
+const MARKDOWN_REWRITE_PREFIX = "/__agent-native-markdown";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ssrHandler = createH3SSRHandler(
@@ -77,7 +78,7 @@ function setSsrCacheHeaders(event: H3Event) {
 async function readHeadAssetForRequest(
   event: H3Event,
 ): Promise<{ content: string; contentType: string } | undefined> {
-  const pathname = getRequestURL(event).pathname.replace(/\/+$/, "") || "/";
+  const pathname = markdownRequestPath(event).replace(/\/+$/, "") || "/";
   const wantsMarkdown = acceptsMarkdown(getRequestHeader(event, "accept"));
   const contentTypeByPath: Record<string, string> = {
     "/llms.txt": "text/plain; charset=utf-8",
@@ -107,6 +108,15 @@ async function readHeadAssetForRequest(
     content,
     contentType: contentType ?? "text/markdown; charset=utf-8",
   };
+}
+
+function markdownRequestPath(event: H3Event): string {
+  const pathname = getRequestURL(event).pathname;
+  if (pathname === MARKDOWN_REWRITE_PREFIX) return "/";
+  if (pathname.startsWith(`${MARKDOWN_REWRITE_PREFIX}/`)) {
+    return pathname.slice(MARKDOWN_REWRITE_PREFIX.length) || "/";
+  }
+  return pathname;
 }
 
 function markdownRelativePathForRequest(pathname: string): string {

--- a/packages/docs/tests/markdown-negotiation.test.ts
+++ b/packages/docs/tests/markdown-negotiation.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import markdownNegotiation, {
+  acceptsMarkdown,
+} from "../netlify/edge-functions/markdown-negotiation";
+
+describe("markdown negotiation edge function", () => {
+  it("recognizes a positive Markdown media range and respects q=0", () => {
+    expect(acceptsMarkdown("text/markdown, text/html;q=0.9")).toBe(true);
+    expect(acceptsMarkdown("text/markdown;q=0, text/html;q=0.9")).toBe(false);
+  });
+
+  it("rewrites extensionless pages to the SSR markdown path", () => {
+    const rewrite = markdownNegotiation(
+      new Request(
+        "https://www.agent-native.com/docs/agent-web-surfaces?tab=api",
+        {
+          headers: { Accept: "text/markdown" },
+        },
+      ),
+    );
+    expect(rewrite?.pathname).toBe(
+      "/__agent-native-markdown/docs/agent-web-surfaces",
+    );
+    expect(rewrite?.search).toBe("?tab=api");
+  });
+
+  it("leaves static Markdown assets and ordinary browser requests alone", () => {
+    expect(
+      markdownNegotiation(
+        new Request("https://www.agent-native.com/docs/agent-web-surfaces.md", {
+          headers: { Accept: "text/markdown" },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(
+      markdownNegotiation(
+        new Request("https://www.agent-native.com/docs/agent-web-surfaces", {
+          headers: { Accept: "text/html" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("declares the package edge directory for root-based prebuilt builds", () => {
+    const config = readFileSync(
+      new URL("../netlify.toml", import.meta.url),
+      "utf8",
+    );
+
+    expect(config).toContain(
+      'edge_functions = "packages/docs/netlify/edge-functions"',
+    );
+  });
+});

--- a/packages/docs/tests/markdown-negotiation.test.ts
+++ b/packages/docs/tests/markdown-negotiation.test.ts
@@ -37,8 +37,40 @@ describe("markdown negotiation edge function", () => {
     ).toBeUndefined();
     expect(
       markdownNegotiation(
+        new Request("https://www.agent-native.com/assets/font.woff2", {
+          headers: { Accept: "text/markdown" },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(
+      markdownNegotiation(
+        new Request("https://www.agent-native.com/docs/page.data", {
+          headers: { Accept: "text/markdown" },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(
+      markdownNegotiation(
+        new Request(
+          "https://www.agent-native.com/examples/self-hosted-chat/Dockerfile",
+          { headers: { Accept: "text/markdown" } },
+        ),
+      ),
+    ).toBeUndefined();
+    expect(
+      markdownNegotiation(
         new Request("https://www.agent-native.com/docs/agent-web-surfaces", {
           headers: { Accept: "text/html" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not rewrite the internal root path a second time", () => {
+    expect(
+      markdownNegotiation(
+        new Request("https://www.agent-native.com/__agent-native-markdown", {
+          headers: { Accept: "text/markdown" },
         }),
       ),
     ).toBeUndefined();
@@ -53,5 +85,19 @@ describe("markdown negotiation edge function", () => {
     expect(config).toContain(
       'edge_functions = "packages/docs/netlify/edge-functions"',
     );
+    for (const redirectPath of [
+      "/examples/self-hosted-chat/Dockerfile",
+      "/templates",
+      "/templates/*",
+      "/:locale/templates/*",
+      "/docs/getting-started",
+      "/:locale/docs/getting-started",
+      "/docs/resources",
+      "/docs/workspace",
+      "/:locale/docs/workspace",
+      "/docs/:locale/workspace",
+    ]) {
+      expect(config).toContain(`"${redirectPath}"`);
+    }
   });
 });

--- a/packages/docs/tests/prerender-paths.test.ts
+++ b/packages/docs/tests/prerender-paths.test.ts
@@ -25,12 +25,12 @@ describe("isRedirectedDocsPath", () => {
 describe("buildPrerenderPaths", () => {
   const paths = buildPrerenderPaths();
 
-  it("keeps content-negotiated docs on SSR and prerenders marketing pages", () => {
+  it("prerenders published docs and marketing pages", () => {
     expect(paths).toContain("/");
-    expect(paths).not.toContain("/docs");
-    expect(paths).not.toContain("/docs/actions-overview");
-    expect(paths).not.toContain("/docs/what-is-agent-native");
-    expect(paths).not.toContain("/ja-JP/docs/actions-overview");
+    expect(paths).toContain("/docs");
+    expect(paths).toContain("/docs/actions-overview");
+    expect(paths).toContain("/docs/what-is-agent-native");
+    expect(paths).toContain("/ja-JP/docs/actions-overview");
     expect(paths).toContain("/about");
     expect(paths).toContain("/apps/calendar");
     expect(paths.every((page) => !isRedirectedDocsPath(page))).toBe(true);


### PR DESCRIPTION
## Summary
- Keep published docs prerendered so the production serverless pruning guard can remove translated doc chunks.
- Add the package edge-function directory to the root-based prebuilt Netlify configuration.
- Route positive `Accept: text/markdown` requests through the SSR Markdown handler before static routing.

## Verification
- Focused docs tests: 11 passed
- Docs typecheck passed
- Oxfmt and `git diff --check` passed
- `NITRO_PRESET=netlify pnpm --filter @agent-native/docs build` passed, including the 1,241-chunk pruning guard

The production deployment still owns the final live edge-function and endpoint smoke verification.