### PR TITLE
Fix Clips meeting notes and Rewind settings

### DIFF
--- a/templates/clips/actions/lib/finalize-ended-meetings.ts
+++ b/templates/clips/actions/lib/finalize-ended-meetings.ts
@@ -1,0 +1,37 @@
+import { and, eq, inArray, isNotNull } from "drizzle-orm";
+
+import { getDb, schema } from "../../server/db/index.js";
+import finalizeMeeting from "../finalize-meeting.js";
+
+/** Finalize meeting notes once a linked recording's transcript is ready. */
+export async function finalizeEndedMeetingsForRecording(
+  db: ReturnType<typeof getDb>,
+  recordingId: string,
+): Promise<void> {
+  const meetings = await db
+    .select({ id: schema.meetings.id })
+    .from(schema.meetings)
+    .where(
+      and(
+        eq(schema.meetings.recordingId, recordingId),
+        isNotNull(schema.meetings.actualEnd),
+        inArray(schema.meetings.transcriptStatus, ["ready", "failed"]),
+        eq(schema.meetings.summaryMd, ""),
+      ),
+    );
+
+  await Promise.all(
+    meetings.map(async (meeting) => {
+      try {
+        await finalizeMeeting.run({ meetingId: meeting.id });
+      } catch (error) {
+        // Transcript delivery must remain successful even when the separate
+        // notes model is unavailable; a later transcript retry can try again.
+        console.warn(
+          `[clips] meeting notes finalization failed for ${meeting.id}:`,
+          (error as Error)?.message ?? String(error),
+        );
+      }
+    }),
+  );
+}

--- a/templates/clips/actions/request-transcript.test.ts
+++ b/templates/clips/actions/request-transcript.test.ts
@@ -45,6 +45,7 @@ const mockAssertAccess = vi.hoisted(() => vi.fn());
 const mockDispatchPostFinalizeJob = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
+const mockFinalizeEndedMeetingsForRecording = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (options: unknown) => options,
@@ -168,6 +169,11 @@ vi.mock("./lib/audio-only-transcription.js", () => ({
 vi.mock("./lib/loom-transcript.js", () => ({
   fetchLoomTranscript: (...args: unknown[]) => mockFetchLoomTranscript(...args),
   loomTranscriptUnavailableMessage: () => "Loom transcript unavailable.",
+}));
+
+vi.mock("./lib/finalize-ended-meetings.js", () => ({
+  finalizeEndedMeetingsForRecording: (...args: unknown[]) =>
+    mockFinalizeEndedMeetingsForRecording(...args),
 }));
 
 import { PENDING_TRANSCRIPT_HEARTBEAT_MS } from "../shared/transcript-status";

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -80,6 +80,7 @@ import {
   clearBuilderCreditsExhausted,
   noteBuilderCreditsExhausted,
 } from "./lib/builder-credits-state.js";
+import { finalizeEndedMeetingsForRecording } from "./lib/finalize-ended-meetings.js";
 import {
   fetchLoomTranscript,
   loomTranscriptUnavailableMessage,
@@ -739,6 +740,7 @@ export async function importLoomTranscriptForRecording({
           now,
         });
         await writeAppState("refresh-signal", { ts: Date.now() });
+        await finalizeEndedMeetingsForRecording(db, recordingId);
         await queueBrainExport(recordingId);
         return {
           recordingId,
@@ -1177,6 +1179,7 @@ async function completeReadyTranscript({
   // (`transcript-cleanup-${recordingId}`) before its next 2s tick lands —
   // otherwise the "Cleaning up…" badge can lag for one full poll interval.
   await writeAppState("refresh-signal", { ts: Date.now() });
+  await finalizeEndedMeetingsForRecording(db, recordingId);
   await queueBrainExport(recordingId);
 
   return {
@@ -1580,6 +1583,7 @@ const requestTranscriptAction = defineAction({
             now,
           });
           await writeAppState("refresh-signal", { ts: Date.now() });
+          await finalizeEndedMeetingsForRecording(db, args.recordingId);
           await queueBrainExport(args.recordingId);
           await clearBuilderCreditsExhausted();
 

--- a/templates/clips/actions/save-browser-transcript.test.ts
+++ b/templates/clips/actions/save-browser-transcript.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   update: vi.fn(),
   insert: vi.fn(),
   writeAppState: vi.fn(),
+  finalizeEndedMeetingsForRecording: vi.fn(),
 }));
 
 const mockDb = {
@@ -56,6 +57,11 @@ vi.mock("../server/lib/post-finalize-dispatch.js", () => ({
 
 vi.mock("../server/lib/recordings.js", () => ({
   getCurrentOwnerEmail: vi.fn(() => "owner@example.com"),
+}));
+
+vi.mock("./lib/finalize-ended-meetings.js", () => ({
+  finalizeEndedMeetingsForRecording: (...args: unknown[]) =>
+    mocks.finalizeEndedMeetingsForRecording(...args),
 }));
 
 import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js";

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -24,6 +24,7 @@ import { dispatchPostFinalizeJob } from "../server/lib/post-finalize-dispatch.js
 import { getCurrentOwnerEmail } from "../server/lib/recordings.js";
 import { buildCaptionSegmentsFromText } from "../shared/transcript-segments.js";
 import { booleanParam } from "./lib/cli-params.js";
+import { finalizeEndedMeetingsForRecording } from "./lib/finalize-ended-meetings.js";
 import { isAutoTitleReplaceable } from "./lib/title-source.js";
 
 // web-speech and macos-native are both mic-only engines — see
@@ -226,6 +227,9 @@ export default defineAction({
     );
 
     await writeAppState("refresh-signal", { ts: Date.now() });
+    if (savedStatus === "ready") {
+      await finalizeEndedMeetingsForRecording(db, args.recordingId);
+    }
 
     const [rec] = await db
       .select({

--- a/templates/clips/desktop/src-tauri/src/adhoc_meetings_watcher.rs
+++ b/templates/clips/desktop/src-tauri/src/adhoc_meetings_watcher.rs
@@ -17,13 +17,15 @@ use tauri::{AppHandle, Emitter, Manager};
 
 use crate::config::{feature_config, MeetingTranscriptionMode};
 use crate::dlog;
-use crate::meetings_watcher::MeetingsWatcherState;
+use crate::meetings_watcher::{
+    find_matching_calendar_meeting, parse_meetings, MeetingItem, MeetingsWatcherState,
+};
 
 /// How often to sample the frontmost app.
-const POLL_SECS: u64 = 4;
+const POLL_SECS: u64 = 2;
 
 /// Require this many consecutive frontmost seconds before firing.
-const DWELL_SECS: u64 = 9;
+const DWELL_SECS: u64 = 3;
 
 /// After dismiss / fire, suppress re-prompts for this platform until the
 /// cooldown elapses (or the VC app leaves front — see tick logic).
@@ -202,7 +204,7 @@ async fn tick_macos(
     let front = crate::util::frontmost_bundle_id();
     let matched = front.as_deref().and_then(match_vc_bundle);
 
-    let Some((platform, title)) = matched else {
+    let Some((platform, fallback_title)) = matched else {
         // VC app left front — clear session dedupe so a later re-focus can
         // fire again (cooldown still applies).
         clear_session_if_left(app, None);
@@ -294,8 +296,8 @@ async fn tick_macos(
         platform
     );
 
-    let meeting_id = match create_adhoc_meeting(app, client, platform).await {
-        Ok(id) => id,
+    let meeting = match create_adhoc_meeting(app, client, platform).await {
+        Ok(meeting) => meeting,
         Err(err) => {
             // Allow retry on next dwell if create failed.
             if let Some(state) = app.try_state::<AdhocMeetingsWatcherState>() {
@@ -315,22 +317,34 @@ async fn tick_macos(
 
     if show_widget {
         let app_clone = app.clone();
-        let id_clone = meeting_id.clone();
-        let title_clone = title.to_string();
-        let platform_clone = platform.to_string();
-        let scheduled_start = chrono::Utc::now().to_rfc3339();
+        let id_clone = meeting.id.clone();
+        let title_clone = meeting
+            .title
+            .clone()
+            .unwrap_or_else(|| fallback_title.to_string());
+        let platform_clone = meeting
+            .platform
+            .clone()
+            .unwrap_or_else(|| platform.to_string());
+        let scheduled_start = meeting
+            .scheduled_start
+            .clone()
+            .or_else(|| Some(chrono::Utc::now().to_rfc3339()));
+        let scheduled_end = meeting.scheduled_end.clone();
+        let join_url = meeting.join_url.clone();
+        let source = meeting.source.clone().or_else(|| Some("adhoc".to_string()));
         tauri::async_runtime::spawn(async move {
             let _ = crate::notifications::notify_meeting_starting(
                 app_clone,
                 id_clone,
                 title_clone,
                 0,
-                None,
-                Some(scheduled_start),
-                None,
+                join_url,
+                scheduled_start,
+                scheduled_end,
                 Some(platform_clone),
                 Some(auto_start),
-                Some("adhoc".to_string()),
+                source,
             )
             .await;
         });
@@ -340,9 +354,10 @@ async fn tick_macos(
         let _ = app.emit(
             "meetings:start-transcription",
             serde_json::json!({
-                "meetingId": meeting_id,
-                "joinUrl": null,
+                "meetingId": meeting.id,
+                "joinUrl": meeting.join_url,
                 "reason": "adhoc-auto",
+                "scheduledStart": meeting.scheduled_start,
             }),
         );
     }
@@ -472,14 +487,36 @@ async fn create_adhoc_meeting(
     app: &AppHandle,
     client: &reqwest::Client,
     platform: &str,
-) -> Result<String, String> {
+) -> Result<MeetingItem, String> {
     let session = app
         .try_state::<MeetingsWatcherState>()
         .map(|s| s.session_snapshot())
         .unwrap_or_default();
-    let Some(server_url) = session.server_url else {
+    let Some(server_url) = session.server_url.as_deref() else {
         return Err("no server_url for create-meeting".to_string());
     };
+
+    // The native watcher knows which conferencing app is active, but not the
+    // calendar event title. Resolve the nearest joinable event first so a
+    // calendar-backed meeting keeps its title, URL, and scheduled span. A
+    // disconnected calendar only loses that enrichment and still gets an
+    // adhoc meeting below.
+    match find_calendar_meeting(app, client, server_url, &session, platform).await {
+        Ok(Some(meeting)) => {
+            dlog!(
+                "[clips-tray] adhoc matched calendar meeting {} for {}",
+                meeting.id,
+                platform
+            );
+            return Ok(meeting);
+        }
+        Ok(None) => {}
+        Err(error) => dlog!(
+            "[clips-tray] adhoc calendar title lookup skipped for {}: {}",
+            platform,
+            error
+        ),
+    }
 
     let url = format!("{}/_agent-native/actions/create-meeting", server_url);
     let row_title = if platform == "zoom" {
@@ -487,11 +524,12 @@ async fn create_adhoc_meeting(
     } else {
         "Teams meeting"
     };
+    let scheduled_start = chrono::Utc::now().to_rfc3339();
     let body = serde_json::json!({
         "title": row_title,
         "platform": platform,
         "source": "adhoc",
-        "scheduledStart": chrono::Utc::now().to_rfc3339(),
+        "scheduledStart": scheduled_start,
     });
 
     let mut req = client
@@ -524,12 +562,66 @@ async fn create_adhoc_meeting(
         ));
     }
     let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
-    extract_meeting_id(&body).ok_or_else(|| {
+    let id = extract_meeting_id(&body).ok_or_else(|| {
         format!(
             "create-meeting response missing meeting id: {}",
             body.to_string().chars().take(200).collect::<String>()
         )
+    })?;
+    Ok(MeetingItem {
+        id,
+        title: Some(row_title.to_string()),
+        scheduled_start: Some(scheduled_start),
+        scheduled_end: None,
+        join_url: None,
+        platform: Some(platform.to_string()),
+        source: Some("adhoc".to_string()),
     })
+}
+
+async fn find_calendar_meeting(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    server_url: &str,
+    session: &crate::meetings_watcher::MeetingsSessionSnapshot,
+    platform: &str,
+) -> Result<Option<MeetingItem>, String> {
+    let url = format!("{server_url}/_agent-native/actions/list-meetings");
+    let mut req = client.get(url).query(&[
+        ("view", "upcoming"),
+        ("limit", "20"),
+        ("upcomingWithinMin", "5"),
+        ("includeStartedWithinMin", "15"),
+        ("excludePersonalSoloEvents", "true"),
+        ("excludeDeclinedEvents", "true"),
+    ]);
+    req = req.header("X-Request-Source", "clips-desktop");
+    if let Some(cookie) = session.session_cookie.as_deref() {
+        req = req.header("Cookie", cookie);
+    }
+    if let Some(token) = session.auth_token.as_deref() {
+        req = req.bearer_auth(token);
+    }
+    let response = req
+        .send()
+        .await
+        .map_err(|error| format!("list-meetings fetch: {error}"))?;
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        let _ = app.emit("meetings:auth-needed", serde_json::json!({}));
+        return Err("list-meetings http 401".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!("list-meetings http {}", response.status()));
+    }
+    let body: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|error| format!("list-meetings response: {error}"))?;
+    Ok(find_matching_calendar_meeting(
+        &parse_meetings(&body),
+        platform,
+        chrono::Utc::now(),
+    ))
 }
 
 fn extract_meeting_id(body: &serde_json::Value) -> Option<String> {

--- a/templates/clips/desktop/src-tauri/src/adhoc_meetings_watcher.rs
+++ b/templates/clips/desktop/src-tauri/src/adhoc_meetings_watcher.rs
@@ -19,6 +19,7 @@ use crate::config::{feature_config, MeetingTranscriptionMode};
 use crate::dlog;
 use crate::meetings_watcher::{
     find_matching_calendar_meeting, parse_meetings, MeetingItem, MeetingsWatcherState,
+    CALENDAR_MATCH_WINDOW_MINUTES,
 };
 
 /// How often to sample the frontmost app.
@@ -587,10 +588,11 @@ async fn find_calendar_meeting(
     platform: &str,
 ) -> Result<Option<MeetingItem>, String> {
     let url = format!("{server_url}/_agent-native/actions/list-meetings");
+    let upcoming_within_min = CALENDAR_MATCH_WINDOW_MINUTES.to_string();
     let mut req = client.get(url).query(&[
         ("view", "upcoming"),
         ("limit", "20"),
-        ("upcomingWithinMin", "5"),
+        ("upcomingWithinMin", upcoming_within_min.as_str()),
         ("includeStartedWithinMin", "15"),
         ("excludePersonalSoloEvents", "true"),
         ("excludeDeclinedEvents", "true"),

--- a/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
+++ b/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
@@ -149,6 +149,9 @@ pub(crate) struct MeetingItem {
     pub(crate) source: Option<String>,
 }
 
+pub(crate) const CALENDAR_MATCH_WINDOW_MINUTES: i64 = 15;
+const CALENDAR_MATCH_AMBIGUITY_MARGIN_SECS: i64 = 60;
+
 #[derive(Debug, Deserialize)]
 struct ListMeetingsResponse {
     #[serde(default)]
@@ -459,7 +462,7 @@ pub(crate) fn find_matching_calendar_meeting(
     platform: &str,
     started_at: chrono::DateTime<chrono::Utc>,
 ) -> Option<MeetingItem> {
-    meetings
+    let mut candidates: Vec<_> = meetings
         .iter()
         .filter_map(|meeting| {
             if !is_calendar_reminder_candidate(meeting)
@@ -477,10 +480,19 @@ pub(crate) fn find_matching_calendar_meeting(
                 .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())?
                 .with_timezone(&chrono::Utc);
             let distance = (scheduled_start - started_at).num_seconds().abs();
-            (distance <= 15 * 60).then(|| (distance, meeting.clone()))
+            (distance <= CALENDAR_MATCH_WINDOW_MINUTES * 60).then(|| (distance, meeting))
         })
-        .min_by_key(|(distance, _)| *distance)
-        .map(|(_, meeting)| meeting)
+        .collect();
+    candidates.sort_by_key(|(distance, _)| *distance);
+    let Some((distance, meeting)) = candidates.first() else {
+        return None;
+    };
+    if candidates.get(1).is_some_and(|(next_distance, _)| {
+        next_distance - distance <= CALENDAR_MATCH_AMBIGUITY_MARGIN_SECS
+    }) {
+        return None;
+    }
+    Some((*meeting).clone())
 }
 
 pub(crate) fn parse_meetings(body: &serde_json::Value) -> Vec<MeetingItem> {
@@ -589,5 +601,30 @@ mod tests {
             matched.and_then(|meeting| meeting.title),
             Some("Product sync".to_string())
         );
+    }
+
+    #[test]
+    fn avoids_ambiguous_same_platform_calendar_matches() {
+        let meetings = parse_meetings(&serde_json::json!({
+            "meetings": [
+                {
+                    "id": "first",
+                    "scheduledStart": "2026-07-22T19:09:00Z",
+                    "joinUrl": "https://zoom.us/j/1",
+                    "platform": "zoom",
+                    "source": "calendar"
+                },
+                {
+                    "id": "second",
+                    "scheduledStart": "2026-07-22T19:11:00Z",
+                    "joinUrl": "https://zoom.us/j/2",
+                    "platform": "zoom",
+                    "source": "calendar"
+                }
+            ]
+        }));
+
+        let started_at = Utc.with_ymd_and_hms(2026, 7, 22, 19, 10, 0).unwrap();
+        assert!(find_matching_calendar_meeting(&meetings, "zoom", started_at).is_none());
     }
 }

--- a/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
+++ b/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
@@ -1,6 +1,6 @@
 //! Background poller for upcoming meetings.
 //!
-//! Runs as a tokio task spawned from `lib.rs::run` setup. Every 30s it calls
+//! Runs as a tokio task spawned from `lib.rs::run` setup. Every 10s it calls
 //! the backend's `list-meetings` action for the next handful of live Google
 //! Calendar meetings. For any meeting in the Granola-style reminder window
 //! (1 minute before start through 5 minutes after) that we haven't already
@@ -134,19 +134,19 @@ impl MeetingsWatcherState {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-struct MeetingItem {
-    id: String,
-    title: Option<String>,
+pub(crate) struct MeetingItem {
+    pub(crate) id: String,
+    pub(crate) title: Option<String>,
     #[serde(default, alias = "scheduledStart")]
-    scheduled_start: Option<String>,
+    pub(crate) scheduled_start: Option<String>,
     #[serde(default, alias = "scheduledEnd")]
-    scheduled_end: Option<String>,
+    pub(crate) scheduled_end: Option<String>,
     #[serde(default, alias = "joinUrl")]
-    join_url: Option<String>,
+    pub(crate) join_url: Option<String>,
     #[serde(default)]
-    platform: Option<String>,
+    pub(crate) platform: Option<String>,
     #[serde(default)]
-    source: Option<String>,
+    pub(crate) source: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -245,7 +245,7 @@ pub fn spawn_watcher(app: AppHandle) {
 }
 
 async fn run_watcher(app: AppHandle) {
-    let mut interval = tokio::time::interval(Duration::from_secs(30));
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
     // Skip the first tick — gives the frontend time to push us a server URL.
     interval.tick().await;
     let client = match reqwest::Client::builder()
@@ -316,7 +316,7 @@ async fn tick_once(app: &AppHandle, client: &reqwest::Client) -> Result<(), Stri
     let status = resp.status();
     if status == reqwest::StatusCode::UNAUTHORIZED {
         // Tell the renderer to re-push a fresh cookie or surface a
-        // re-login prompt. We keep silently retrying every 30s — once
+        // re-login prompt. We keep silently retrying every 10s - once
         // the renderer pushes a new cookie via
         // `meetings_watcher_set_session` we'll succeed on the next tick.
         let _ = app.emit("meetings:auth-needed", serde_json::json!({}));
@@ -454,8 +454,38 @@ fn is_calendar_reminder_candidate(meeting: &MeetingItem) -> bool {
     meeting.source.as_deref() != Some("adhoc")
 }
 
-fn parse_meetings(body: &serde_json::Value) -> Vec<MeetingItem> {
-    if let Ok(parsed) = serde_json::from_value::<ListMeetingsResponse>(body.clone()) {
+pub(crate) fn find_matching_calendar_meeting(
+    meetings: &[MeetingItem],
+    platform: &str,
+    started_at: chrono::DateTime<chrono::Utc>,
+) -> Option<MeetingItem> {
+    meetings
+        .iter()
+        .filter_map(|meeting| {
+            if !is_calendar_reminder_candidate(meeting)
+                || meeting
+                    .platform
+                    .as_deref()
+                    .is_none_or(|value| !value.eq_ignore_ascii_case(platform))
+                || meeting.join_url.as_deref().is_none_or(str::is_empty)
+            {
+                return None;
+            }
+            let scheduled_start = meeting
+                .scheduled_start
+                .as_deref()
+                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())?
+                .with_timezone(&chrono::Utc);
+            let distance = (scheduled_start - started_at).num_seconds().abs();
+            (distance <= 15 * 60).then(|| (distance, meeting.clone()))
+        })
+        .min_by_key(|(distance, _)| *distance)
+        .map(|(_, meeting)| meeting)
+}
+
+pub(crate) fn parse_meetings(body: &serde_json::Value) -> Vec<MeetingItem> {
+    let payload = body.get("result").unwrap_or(body);
+    if let Ok(parsed) = serde_json::from_value::<ListMeetingsResponse>(payload.clone()) {
         if let Some(v) = parsed.upcoming {
             return v;
         }
@@ -466,7 +496,7 @@ fn parse_meetings(body: &serde_json::Value) -> Vec<MeetingItem> {
             return v;
         }
     }
-    if let Ok(arr) = serde_json::from_value::<Vec<MeetingItem>>(body.clone()) {
+    if let Ok(arr) = serde_json::from_value::<Vec<MeetingItem>>(payload.clone()) {
         return arr;
     }
     Vec::new()
@@ -474,7 +504,9 @@ fn parse_meetings(body: &serde_json::Value) -> Vec<MeetingItem> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_calendar_reminder_candidate, parse_meetings};
+    use chrono::{TimeZone, Utc};
+
+    use super::{find_matching_calendar_meeting, is_calendar_reminder_candidate, parse_meetings};
 
     #[test]
     fn excludes_adhoc_meetings_from_calendar_reminders() {
@@ -511,5 +543,51 @@ mod tests {
 
         assert_eq!(meetings.len(), 1);
         assert!(is_calendar_reminder_candidate(&meetings[0]));
+    }
+
+    #[test]
+    fn finds_the_nearest_joinable_calendar_meeting_for_adhoc_detection() {
+        let meetings = parse_meetings(&serde_json::json!({
+            "result": {
+                "meetings": [
+                    {
+                        "id": "too-far",
+                        "title": "Later Zoom",
+                        "scheduledStart": "2026-07-22T19:40:00Z",
+                        "joinUrl": "https://zoom.us/j/2",
+                        "platform": "zoom",
+                        "source": "calendar"
+                    },
+                    {
+                        "id": "nearest",
+                        "title": "Product sync",
+                        "scheduledStart": "2026-07-22T19:11:00Z",
+                        "joinUrl": "https://zoom.us/j/1",
+                        "platform": "zoom",
+                        "source": "calendar"
+                    },
+                    {
+                        "id": "adhoc",
+                        "title": "Zoom meeting",
+                        "scheduledStart": "2026-07-22T19:10:00Z",
+                        "joinUrl": "https://zoom.us/j/3",
+                        "platform": "zoom",
+                        "source": "adhoc"
+                    }
+                ]
+            }
+        }));
+
+        let started_at = Utc.with_ymd_and_hms(2026, 7, 22, 19, 10, 0).unwrap();
+        let matched = find_matching_calendar_meeting(&meetings, "zoom", started_at);
+
+        assert_eq!(
+            matched.as_ref().map(|meeting| meeting.id.as_str()),
+            Some("nearest")
+        );
+        assert_eq!(
+            matched.and_then(|meeting| meeting.title),
+            Some("Product sync".to_string())
+        );
     }
 }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1177,6 +1177,8 @@ export function App({
   const [meetings, setMeetings] = useState<PopoverMeeting[]>([]);
   const [meetingsLoading, setMeetingsLoading] = useState(false);
   const [meetingsError, setMeetingsError] = useState<string | null>(null);
+  const [meetingsCalendarNeedsReauth, setMeetingsCalendarNeedsReauth] =
+    useState(false);
   const [meetingStartMessage, setMeetingStartMessage] = useState<string | null>(
     null,
   );
@@ -1974,16 +1976,28 @@ export function App({
     if (authStatus !== "authed") {
       setMeetings([]);
       setMeetingsError(null);
+      setMeetingsCalendarNeedsReauth(false);
       return;
     }
 
     setMeetingsLoading(true);
     setMeetingsError(null);
     try {
-      const result = await callClipsAction<{ meetings?: unknown[] }>(
+      const result = await callClipsAction<{
+        meetings?: unknown[];
+        calendarErrors?: Array<{ needsReauth?: boolean }>;
+      }>(
         "list-meetings",
-        { view: "upcoming", limit: 3, upcomingWithinMin: 24 * 60 },
+        {
+          view: "upcoming",
+          limit: 3,
+          upcomingWithinMin: 24 * 60,
+        },
         { method: "GET" },
+      );
+      setMeetingsCalendarNeedsReauth(
+        result.calendarErrors?.some((error) => error.needsReauth === true) ===
+          true,
       );
       const list = Array.isArray(result.meetings) ? result.meetings : [];
       setMeetings(
@@ -2002,6 +2016,7 @@ export function App({
       );
     } catch (err) {
       setMeetings([]);
+      setMeetingsCalendarNeedsReauth(false);
       setMeetingsError(
         err instanceof Error ? err.message : "Could not load meetings.",
       );
@@ -4150,6 +4165,7 @@ export function App({
           onStartNotes={startMeetingNotes}
           onStartNotesAndJoin={startMeetingNotesAndJoin}
           onShowActiveMeeting={showActiveMeetingPill}
+          calendarNeedsReauth={meetingsCalendarNeedsReauth}
         />
       </div>
     );
@@ -5409,6 +5425,7 @@ function MeetingsPopoverView({
   onStartNotes,
   onStartNotesAndJoin,
   onShowActiveMeeting,
+  calendarNeedsReauth,
 }: {
   meetings: PopoverMeeting[];
   loading: boolean;
@@ -5431,23 +5448,8 @@ function MeetingsPopoverView({
     includeFromMeetingStart?: boolean,
   ) => void;
   onShowActiveMeeting: (meetingId: string) => void;
+  calendarNeedsReauth: boolean;
 }) {
-  const [includeHistoryFor, setIncludeHistoryFor] = useState<Set<string>>(
-    () => new Set(),
-  );
-
-  const consumeIncludeHistoryChoice = (meeting: PopoverMeeting): boolean => {
-    const include = includeHistoryFor.has(meeting.id);
-    // This is intentionally a one-shot choice. It never follows the next
-    // meeting, an automatic start, or a tray action around like a lost duck.
-    setIncludeHistoryFor((current) => {
-      const next = new Set(current);
-      next.delete(meeting.id);
-      return next;
-    });
-    return include;
-  };
-
   return (
     <div className="setup popover-view">
       <PopoverSubViewHeader
@@ -5483,9 +5485,21 @@ function MeetingsPopoverView({
         <div className="popover-empty-card">
           <strong>Could not load meetings</strong>
           <p>{error}</p>
+          {calendarNeedsReauth ? (
+            <p>Reconnect your calendar from the Meetings page.</p>
+          ) : null}
           <button type="button" className="secondary" onClick={onRefresh}>
             Try again
           </button>
+          {calendarNeedsReauth ? (
+            <button
+              type="button"
+              className="secondary"
+              onClick={onOpenMeetings}
+            >
+              Open Meetings
+            </button>
+          ) : null}
         </div>
       ) : loading ? (
         <div className="popover-empty-card">
@@ -5494,8 +5508,16 @@ function MeetingsPopoverView({
         </div>
       ) : meetings.length === 0 ? (
         <div className="popover-empty-card">
-          <strong>No meetings ready</strong>
-          <p>Connect Google Calendar or open the Meetings page to see setup.</p>
+          <strong>
+            {calendarNeedsReauth
+              ? "Reconnect your calendar"
+              : "No meetings ready"}
+          </strong>
+          <p>
+            {calendarNeedsReauth
+              ? "Your calendar connection needs attention before Clips can match meeting titles."
+              : "Connect Google Calendar or open the Meetings page to see setup."}
+          </p>
           <button type="button" className="secondary" onClick={onOpenMeetings}>
             Open Meetings
           </button>
@@ -5507,7 +5529,6 @@ function MeetingsPopoverView({
             const hasJoin = Boolean(meeting.joinUrl);
             const isActive = activeMeetingId === meeting.id;
             const rewindHistory = rewindHistoryAvailability[meeting.id];
-            const includeHistory = includeHistoryFor.has(meeting.id);
             return (
               <div className="popover-list-item" key={meeting.id}>
                 <div className="popover-list-icon">
@@ -5519,24 +5540,6 @@ function MeetingsPopoverView({
                     {formatMeetingWhen(meeting)}
                     {meeting.platform ? ` · ${meeting.platform}` : ""}
                   </div>
-                  {canStart && rewindHistory?.available ? (
-                    <label className="popover-list-sub">
-                      <input
-                        type="checkbox"
-                        checked={includeHistory}
-                        onChange={(event) => {
-                          const checked = event.currentTarget.checked;
-                          setIncludeHistoryFor((current) => {
-                            const next = new Set(current);
-                            if (checked) next.add(meeting.id);
-                            else next.delete(meeting.id);
-                            return next;
-                          });
-                        }}
-                      />{" "}
-                      Include from meeting start
-                    </label>
-                  ) : null}
                 </div>
                 {isActive ? (
                   <button
@@ -5556,11 +5559,11 @@ function MeetingsPopoverView({
                       hasJoin
                         ? onStartNotesAndJoin(
                             meeting,
-                            consumeIncludeHistoryChoice(meeting),
+                            rewindHistory?.available === true,
                           )
                         : onStartNotes(
                             meeting,
-                            consumeIncludeHistoryChoice(meeting),
+                            rewindHistory?.available === true,
                           )
                     }
                     title={
@@ -5850,6 +5853,8 @@ function Setup({
     featureConfig?.screenMemory ?? DEFAULT_SCREEN_MEMORY_CONFIG;
   const [screenMemory, setScreenMemory] = useState(observedScreenMemory);
   const [rewindConsentOpen, setRewindConsentOpen] = useState(false);
+  const [rewindManageOpen, setRewindManageOpen] = useState(false);
+  const [rewindShowAdvanced, setRewindShowAdvanced] = useState(false);
   const screenMemoryRef = useRef(observedScreenMemory);
   const screenMemoryMutationRef = useRef(0);
   const screenMemoryMutationVersionRef = useRef(0);
@@ -6969,31 +6974,11 @@ function Setup({
     );
   }
 
-  /**
-   * Rewind's settings, flat. Every one of these used to live behind a Manage
-   * button inside a popover launched from another popover — three layers deep,
-   * with tooltips escaping behind the window. They are ordinary rows now, in
-   * the order a user reasons about them: does it run, what does it keep, who
-   * may see it, where does it live.
-   */
   function renderRewindSettings() {
     const rewindOn = screenMemory.enabled === true;
     return (
       <div className="mx-auto grid w-full max-w-[620px] gap-7 pb-4">
         <SettingsGroup>
-          {/* A confirmation, so a dialog rather than a takeover: the user is
-              answering one question about the screen behind it, not moving to
-              a new place. What it remembers is chosen afterwards, in the row
-              below — asking before they have agreed puts the options in front
-              of the decision.
-
-              The copy names what is captured and what can leave, and nothing
-              else. Two claims are tempting and both are false: this buffer
-              holds screen *video* (hence the GB disk limit below), not app
-              and window notes; and it cannot promise "never leaves this Mac"
-              because the agent-handoff path uploads an approved range. A
-              consent screen is the one place a comforting simplification is
-              indistinguishable from a lie. */}
           <UiAlertDialog
             open={rewindConsentOpen}
             onOpenChange={setRewindConsentOpen}
@@ -7038,24 +7023,397 @@ function Setup({
             label="Rewind"
             description="Keeps a rolling record of your recent screen on this device"
             control={
-              <SettingsSwitch
-                checked={rewindOn}
-                onCheckedChange={(next) => {
-                  // Turning it on starts continuously capturing the screen, so
-                  // it routes through consent rather than flipping silently.
-                  // Turning it off needs no confirmation — stopping is safe.
-                  if (next) {
-                    setRewindConsentOpen(true);
-                    return;
+              <div className="flex items-center gap-2">
+                <SettingsPopover
+                  title="Rewind settings"
+                  open={rewindManageOpen}
+                  onOpenChange={setRewindManageOpen}
+                  className="w-[480px] max-w-[calc(100vw-24px)]"
+                  trigger={
+                    <SettingsActionButton
+                      aria-expanded={rewindManageOpen}
+                      aria-haspopup="dialog"
+                    >
+                      Manage
+                    </SettingsActionButton>
                   }
-                  void setScreenMemoryConfig({ enabled: false });
-                }}
-                /* Rust rejects Rewind capture changes mid-Clip
-                   (config.rs `set_feature_config` guard); disabling here
-                   turns that hard error into a visible lock. */
-                disabled={screenMemoryConfigBusy || captureControlsLocked}
-                label="Rewind"
-              />
+                >
+                  <div className="grid max-h-[min(620px,calc(100vh-80px))] gap-3 overflow-y-auto pr-1">
+                    {rewindOn ? (
+                      <>
+                        <SettingsGroup label="Capture">
+                          <SettingsRow
+                            label="Remember"
+                            description="Choose what Rewind captures"
+                            control={
+                              <SettingsSelect
+                                ariaLabel="What Rewind remembers"
+                                value={screenMemory.captureMode ?? "visuals"}
+                                onValueChange={(value) => {
+                                  void setScreenMemoryConfig({
+                                    captureMode: value as RewindCaptureMode,
+                                  });
+                                }}
+                                disabled={
+                                  screenMemoryConfigBusy ||
+                                  captureControlsLocked
+                                }
+                                options={[
+                                  { value: "visuals", label: "Screen only" },
+                                  {
+                                    value: "visuals-audio",
+                                    label: "Screen + audio",
+                                  },
+                                ]}
+                              />
+                            }
+                          />
+                          <SettingsRow
+                            label="Time limit"
+                            description="Choose how long Rewind keeps your screen history"
+                            control={
+                              <SettingsSelect
+                                ariaLabel="Rewind time limit"
+                                placeholder={`${screenMemory.retentionHours} hours`}
+                                value={String(screenMemory.retentionHours)}
+                                onValueChange={(value) => {
+                                  void setScreenMemoryConfig({
+                                    retentionHours: Number(value),
+                                  });
+                                }}
+                                disabled={screenMemoryConfigBusy}
+                                options={[
+                                  { value: "8", label: "8 hours" },
+                                  { value: "24", label: "24 hours" },
+                                ]}
+                              />
+                            }
+                          />
+                          <SettingsRow
+                            label="Storage limit"
+                            description="Choose how much space Rewind can use on this device"
+                            control={
+                              <SettingsSelect
+                                ariaLabel="Rewind storage limit"
+                                placeholder={formatStorageBytes(
+                                  screenMemory.maxBytes,
+                                )}
+                                value={String(screenMemory.maxBytes)}
+                                onValueChange={(value) => {
+                                  void setScreenMemoryConfig({
+                                    maxBytes: Number(value),
+                                  });
+                                }}
+                                disabled={screenMemoryConfigBusy}
+                                options={[
+                                  {
+                                    value: String(5 * 1024 * 1024 * 1024),
+                                    label: "5 GB",
+                                  },
+                                  {
+                                    value: String(20 * 1024 * 1024 * 1024),
+                                    label: "20 GB",
+                                  },
+                                  {
+                                    value: String(50 * 1024 * 1024 * 1024),
+                                    label: "50 GB",
+                                  },
+                                ]}
+                              />
+                            }
+                          />
+                        </SettingsGroup>
+                        <SettingsActionButton
+                          emphasis="quiet"
+                          className="justify-self-start"
+                          aria-expanded={rewindShowAdvanced}
+                          onClick={() =>
+                            setRewindShowAdvanced((current) => !current)
+                          }
+                        >
+                          {rewindShowAdvanced
+                            ? "Hide advanced"
+                            : "Show advanced"}
+                        </SettingsActionButton>
+                        {rewindShowAdvanced ? (
+                          <>
+                            <SettingsGroup label="Privacy">
+                              <SettingsRow
+                                label="Excluded apps"
+                                description="Apps Rewind never captures"
+                                control={
+                                  <SettingsActionButton
+                                    onClick={() =>
+                                      void chooseExcludedApplications()
+                                    }
+                                    disabled={excludedAppsBusy}
+                                  >
+                                    Choose apps
+                                  </SettingsActionButton>
+                                }
+                              >
+                                {excludedAppGroups.length > 0 ? (
+                                  <div className="grid gap-1">
+                                    {excludedAppGroups.map((app) => (
+                                      <div
+                                        key={app.bundleIds.join(",")}
+                                        className="flex items-center justify-between gap-2"
+                                      >
+                                        <span className="truncate">
+                                          {app.name}
+                                        </span>
+                                        <SettingsActionButton
+                                          emphasis="quiet"
+                                          onClick={() =>
+                                            removeExcludedApplications(
+                                              app.bundleIds,
+                                            )
+                                          }
+                                        >
+                                          Remove
+                                        </SettingsActionButton>
+                                      </div>
+                                    ))}
+                                  </div>
+                                ) : null}
+                              </SettingsRow>
+                              <SettingsRow
+                                label="Review before sending"
+                                description="Approve each visual or audio range before an agent receives it"
+                                control={
+                                  <SettingsSwitch
+                                    checked={
+                                      screenMemory.reviewBeforeSending !== false
+                                    }
+                                    onCheckedChange={(next) => {
+                                      void setScreenMemoryConfig({
+                                        reviewBeforeSending: next,
+                                      });
+                                    }}
+                                    disabled={screenMemoryConfigBusy}
+                                    label="Review before sending"
+                                  />
+                                }
+                              />
+                              <SettingsRow
+                                label="Preview before sending"
+                                description="Open the range locally so you see exactly what is sent"
+                                control={
+                                  <SettingsSwitch
+                                    checked={
+                                      screenMemory.autoPreviewBeforeSending ===
+                                      true
+                                    }
+                                    onCheckedChange={(next) => {
+                                      void setScreenMemoryConfig({
+                                        autoPreviewBeforeSending: next,
+                                      });
+                                    }}
+                                    disabled={screenMemoryConfigBusy}
+                                    label="Preview before sending"
+                                  />
+                                }
+                              />
+                              <SettingsRow
+                                label="Keep agent Clips"
+                                description="Choose how long Clips made for agents stay in your library"
+                                control={
+                                  <SettingsSelect
+                                    ariaLabel="How long agent-created Clips are kept"
+                                    value={screenMemory.agentClipRetention}
+                                    onValueChange={(value) => {
+                                      void setScreenMemoryConfig({
+                                        agentClipRetention:
+                                          value as ScreenMemoryStatus["config"]["agentClipRetention"],
+                                      });
+                                    }}
+                                    disabled={screenMemoryConfigBusy}
+                                    options={[
+                                      {
+                                        value: "forever",
+                                        label: "Forever",
+                                      },
+                                      {
+                                        value: "24-hours",
+                                        label: "24 hours",
+                                      },
+                                      {
+                                        value: "7-days",
+                                        label: "7 days",
+                                      },
+                                      {
+                                        value: "30-days",
+                                        label: "30 days",
+                                      },
+                                    ]}
+                                  />
+                                }
+                              />
+                              <SettingsRow
+                                label="Agent activity"
+                                description="Each time an agent searched this device's memory, newest first"
+                              >
+                                {rewindEgressEvents.length === 0 ? (
+                                  <p>No agent has searched it yet.</p>
+                                ) : (
+                                  <div className="grid gap-1">
+                                    {rewindEgressEvents
+                                      .slice(0, 10)
+                                      .map((event) => (
+                                        <div
+                                          key={`${event.requestId}-${event.state}`}
+                                          className="flex items-center justify-between gap-2"
+                                        >
+                                          <span className="truncate">
+                                            {new Date(
+                                              event.occurredAt,
+                                            ).toLocaleString()}
+                                          </span>
+                                          <span className="shrink-0">
+                                            {event.state} ·{" "}
+                                            {`${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
+                                          </span>
+                                        </div>
+                                      ))}
+                                  </div>
+                                )}
+                              </SettingsRow>
+                            </SettingsGroup>
+
+                            <SettingsGroup label="Agents">
+                              <SettingsRow
+                                label="Setup prompt"
+                                description="Paste it into an agent once to install Rewind's instructions"
+                                control={
+                                  <>
+                                    <SettingsActionButton
+                                      emphasis="quiet"
+                                      onClick={onOpenRewindDocs}
+                                    >
+                                      Learn more
+                                    </SettingsActionButton>
+                                    <SettingsActionButton
+                                      onClick={onCopyRewindAgentPrompt}
+                                    >
+                                      {rewindAgentPromptCopied
+                                        ? "Copied"
+                                        : "Copy"}
+                                    </SettingsActionButton>
+                                  </>
+                                }
+                              />
+                              <SettingsRow
+                                label="Connect an agent"
+                                description="Gives a local agent access to this device's Rewind memory"
+                                control={
+                                  <>
+                                    <SettingsActionButton
+                                      onClick={() =>
+                                        void installRewindAgentConnection(
+                                          "codex",
+                                        )
+                                      }
+                                      disabled={agentConnectionBusy !== null}
+                                    >
+                                      Codex
+                                    </SettingsActionButton>
+                                    <SettingsActionButton
+                                      onClick={() =>
+                                        void installRewindAgentConnection(
+                                          "claude-code",
+                                        )
+                                      }
+                                      disabled={agentConnectionBusy !== null}
+                                    >
+                                      Claude Code
+                                    </SettingsActionButton>
+                                  </>
+                                }
+                              >
+                                {agentConnectionMessage ? (
+                                  <p
+                                    className={
+                                      agentConnectionMessage.kind === "ok"
+                                        ? "text-xs text-success"
+                                        : "text-xs text-destructive"
+                                    }
+                                  >
+                                    {agentConnectionMessage.text}
+                                  </p>
+                                ) : null}
+                              </SettingsRow>
+                            </SettingsGroup>
+
+                            <SettingsGroup label="Storage">
+                              <SettingsRow
+                                label="Search memory"
+                                description="Find and replay a recent moment yourself"
+                                control={
+                                  <SettingsActionButton onClick={onOpenMemory}>
+                                    Search
+                                  </SettingsActionButton>
+                                }
+                              />
+                              <SettingsRow
+                                label="Save last 5 minutes"
+                                description="Exports recent memory as video files on this device. Nothing is uploaded."
+                                control={
+                                  <SettingsActionButton
+                                    onClick={() =>
+                                      void exportScreenMemoryRecent()
+                                    }
+                                    disabled={screenMemoryBusy}
+                                  >
+                                    Save
+                                  </SettingsActionButton>
+                                }
+                              />
+                              <SettingsRow
+                                label="On this device"
+                                description={`${screenMemorySegments.length} ${screenMemorySegments.length === 1 ? "segment" : "segments"} · ${formatStorageBytes(screenMemoryTotalBytes)}`}
+                                control={
+                                  <>
+                                    <SettingsActionButton
+                                      onClick={openScreenMemoryFolder}
+                                    >
+                                      Open folder
+                                    </SettingsActionButton>
+                                    <SettingsActionButton
+                                      emphasis="destructive"
+                                      onClick={() => void clearScreenMemory()}
+                                      disabled={screenMemoryBusy}
+                                    >
+                                      Delete all
+                                    </SettingsActionButton>
+                                  </>
+                                }
+                              />
+                            </SettingsGroup>
+                          </>
+                        ) : null}
+                      </>
+                    ) : (
+                      <SettingsGroup>
+                        <div className="p-3 text-sm text-muted-foreground">
+                          Turn on Rewind to manage what it remembers.
+                        </div>
+                      </SettingsGroup>
+                    )}
+                  </div>
+                </SettingsPopover>
+                <SettingsSwitch
+                  checked={rewindOn}
+                  onCheckedChange={(next) => {
+                    if (next) {
+                      setRewindConsentOpen(true);
+                      return;
+                    }
+                    void setScreenMemoryConfig({ enabled: false });
+                  }}
+                  disabled={screenMemoryConfigBusy || captureControlsLocked}
+                  label="Rewind"
+                />
+              </div>
             }
           >
             {screenMemoryMessage ? (
@@ -7074,294 +7432,7 @@ function Setup({
               </p>
             ) : null}
           </SettingsRow>
-          {rewindOn ? (
-            <>
-              <SettingsRow
-                label="Remember"
-                description="Choose what Rewind captures"
-                control={
-                  <SettingsSelect
-                    ariaLabel="What Rewind remembers"
-                    value={screenMemory.captureMode ?? "visuals"}
-                    onValueChange={(value) => {
-                      void setScreenMemoryConfig({
-                        captureMode: value as RewindCaptureMode,
-                      });
-                    }}
-                    disabled={screenMemoryConfigBusy || captureControlsLocked}
-                    options={[
-                      { value: "visuals", label: "Screen only" },
-                      { value: "visuals-audio", label: "Screen + audio" },
-                    ]}
-                  />
-                }
-              />
-              <SettingsRow
-                label="Time limit"
-                description="Choose how long Rewind keeps your screen history"
-                control={
-                  <SettingsSelect
-                    ariaLabel="Rewind time limit"
-                    placeholder={`${screenMemory.retentionHours} hours`}
-                    value={String(screenMemory.retentionHours)}
-                    onValueChange={(value) => {
-                      void setScreenMemoryConfig({
-                        retentionHours: Number(value),
-                      });
-                    }}
-                    disabled={screenMemoryConfigBusy}
-                    options={[
-                      { value: "8", label: "8 hours" },
-                      { value: "24", label: "24 hours" },
-                    ]}
-                  />
-                }
-              />
-              <SettingsRow
-                label="Storage limit"
-                description="Choose how much space Rewind can use on this device"
-                control={
-                  <SettingsSelect
-                    ariaLabel="Rewind storage limit"
-                    placeholder={formatStorageBytes(screenMemory.maxBytes)}
-                    value={String(screenMemory.maxBytes)}
-                    onValueChange={(value) => {
-                      void setScreenMemoryConfig({ maxBytes: Number(value) });
-                    }}
-                    disabled={screenMemoryConfigBusy}
-                    options={[
-                      { value: String(5 * 1024 * 1024 * 1024), label: "5 GB" },
-                      {
-                        value: String(20 * 1024 * 1024 * 1024),
-                        label: "20 GB",
-                      },
-                      {
-                        value: String(50 * 1024 * 1024 * 1024),
-                        label: "50 GB",
-                      },
-                    ]}
-                  />
-                }
-              />
-            </>
-          ) : null}
         </SettingsGroup>
-
-        {rewindOn ? (
-          <>
-            <SettingsGroup label="Privacy">
-              <SettingsRow
-                label="Excluded apps"
-                description={"Apps Rewind never captures"}
-                control={
-                  <SettingsActionButton
-                    onClick={() => void chooseExcludedApplications()}
-                    disabled={excludedAppsBusy}
-                  >
-                    Choose apps
-                  </SettingsActionButton>
-                }
-              >
-                {excludedAppGroups.length > 0 ? (
-                  <div className="grid gap-1">
-                    {excludedAppGroups.map((app) => (
-                      <div
-                        key={app.bundleIds.join(",")}
-                        className="flex items-center justify-between gap-2"
-                      >
-                        <span className="truncate">{app.name}</span>
-                        <SettingsActionButton
-                          emphasis="quiet"
-                          onClick={() =>
-                            removeExcludedApplications(app.bundleIds)
-                          }
-                        >
-                          Remove
-                        </SettingsActionButton>
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-              </SettingsRow>
-              <SettingsRow
-                label="Review before sending"
-                description="Approve each visual or audio range before an agent receives it"
-                control={
-                  <SettingsSwitch
-                    checked={screenMemory.reviewBeforeSending !== false}
-                    onCheckedChange={(next) => {
-                      void setScreenMemoryConfig({
-                        reviewBeforeSending: next,
-                      });
-                    }}
-                    disabled={screenMemoryConfigBusy}
-                    label="Review before sending"
-                  />
-                }
-              />
-              <SettingsRow
-                label="Preview before sending"
-                description="Open the range locally so you see exactly what is sent"
-                control={
-                  <SettingsSwitch
-                    checked={screenMemory.autoPreviewBeforeSending === true}
-                    onCheckedChange={(next) => {
-                      void setScreenMemoryConfig({
-                        autoPreviewBeforeSending: next,
-                      });
-                    }}
-                    disabled={screenMemoryConfigBusy}
-                    label="Preview before sending"
-                  />
-                }
-              />
-              <SettingsRow
-                label="Keep agent Clips"
-                description="Choose how long Clips made for agents stay in your library"
-                control={
-                  <SettingsSelect
-                    ariaLabel="How long agent-created Clips are kept"
-                    value={screenMemory.agentClipRetention}
-                    onValueChange={(value) => {
-                      void setScreenMemoryConfig({
-                        agentClipRetention:
-                          value as ScreenMemoryStatus["config"]["agentClipRetention"],
-                      });
-                    }}
-                    disabled={screenMemoryConfigBusy}
-                    options={[
-                      { value: "forever", label: "Forever" },
-                      { value: "24-hours", label: "24 hours" },
-                      { value: "7-days", label: "7 days" },
-                      { value: "30-days", label: "30 days" },
-                    ]}
-                  />
-                }
-              />
-              <SettingsRow
-                label="Agent activity"
-                description="Each time an agent searched this device's memory, newest first"
-              >
-                {rewindEgressEvents.length === 0 ? (
-                  <p>No agent has searched it yet.</p>
-                ) : (
-                  <div className="grid gap-1">
-                    {rewindEgressEvents.slice(0, 10).map((event) => (
-                      <div
-                        key={`${event.requestId}-${event.state}`}
-                        className="flex items-center justify-between gap-2"
-                      >
-                        <span className="truncate">
-                          {new Date(event.occurredAt).toLocaleString()}
-                        </span>
-                        <span className="shrink-0">
-                          {event.state} ·{" "}
-                          {`${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </SettingsRow>
-            </SettingsGroup>
-
-            <SettingsGroup label="Agents">
-              <SettingsRow
-                label="Setup prompt"
-                description="Paste it into an agent once to install Rewind's instructions"
-                control={
-                  <>
-                    <SettingsActionButton
-                      emphasis="quiet"
-                      onClick={onOpenRewindDocs}
-                    >
-                      Learn more
-                    </SettingsActionButton>
-                    <SettingsActionButton onClick={onCopyRewindAgentPrompt}>
-                      {rewindAgentPromptCopied ? "Copied" : "Copy"}
-                    </SettingsActionButton>
-                  </>
-                }
-              />
-              <SettingsRow
-                label="Connect an agent"
-                description="Gives a local agent access to this device's Rewind memory"
-                control={
-                  <>
-                    <SettingsActionButton
-                      onClick={() => void installRewindAgentConnection("codex")}
-                      disabled={agentConnectionBusy !== null}
-                    >
-                      Codex
-                    </SettingsActionButton>
-                    <SettingsActionButton
-                      onClick={() =>
-                        void installRewindAgentConnection("claude-code")
-                      }
-                      disabled={agentConnectionBusy !== null}
-                    >
-                      Claude Code
-                    </SettingsActionButton>
-                  </>
-                }
-              >
-                {agentConnectionMessage ? (
-                  <p
-                    className={
-                      agentConnectionMessage.kind === "ok"
-                        ? "text-xs text-success"
-                        : "text-xs text-destructive"
-                    }
-                  >
-                    {agentConnectionMessage.text}
-                  </p>
-                ) : null}
-              </SettingsRow>
-            </SettingsGroup>
-
-            <SettingsGroup label="Storage">
-              <SettingsRow
-                label="Search memory"
-                description="Find and replay a recent moment yourself"
-                control={
-                  <SettingsActionButton onClick={onOpenMemory}>
-                    Search
-                  </SettingsActionButton>
-                }
-              />
-              <SettingsRow
-                label="Save last 5 minutes"
-                description="Exports recent memory as video files on this device. Nothing is uploaded."
-                control={
-                  <SettingsActionButton
-                    onClick={() => void exportScreenMemoryRecent()}
-                    disabled={screenMemoryBusy}
-                  >
-                    Save
-                  </SettingsActionButton>
-                }
-              />
-              <SettingsRow
-                label="On this device"
-                description={`${screenMemorySegments.length} ${screenMemorySegments.length === 1 ? "segment" : "segments"} · ${formatStorageBytes(screenMemoryTotalBytes)}`}
-                control={
-                  <>
-                    <SettingsActionButton onClick={openScreenMemoryFolder}>
-                      Open folder
-                    </SettingsActionButton>
-                    <SettingsActionButton
-                      emphasis="destructive"
-                      onClick={() => void clearScreenMemory()}
-                      disabled={screenMemoryBusy}
-                    >
-                      Delete all
-                    </SettingsActionButton>
-                  </>
-                }
-              />
-            </SettingsGroup>
-          </>
-        ) : null}
       </div>
     );
   }

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -459,7 +459,7 @@ export function useMeetingTranscription({
         const silenceDetectorConfig = {
           silenceThreshold: 0.05,
           silenceMs: 15 * 60 * 1000,
-          callEndedMs: 30 * 1000,
+          callEndedMs: 2 * 60 * 1000,
           callAppBundleIds: callAppBundleIdsForJoinUrl(payload.joinUrl),
           scheduledEndMs,
           watchSleep: true,

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -306,8 +306,27 @@ export function useMeetingTranscription({
           capturedUntil: string;
         } | null;
       } = { current: null };
+      let includeFromMeetingStart = payload.includeFromMeetingStart === true;
       try {
-        if (payload.includeFromMeetingStart) {
+        if (
+          !includeFromMeetingStart &&
+          payload.reason === "user" &&
+          payload.scheduledStart
+        ) {
+          try {
+            const historyStatus = await invoke<{ available: boolean }>(
+              "rewind_meeting_history_status",
+              { scheduledStart: payload.scheduledStart },
+            );
+            includeFromMeetingStart = historyStatus.available === true;
+          } catch (error) {
+            console.warn(
+              "[clips-popover] Rewind meeting history status unavailable:",
+              error,
+            );
+          }
+        }
+        if (includeFromMeetingStart) {
           if (payload.reason !== "user" || !payload.scheduledStart) {
             throw new Error(
               "Include from meeting start is only available when you manually start a scheduled meeting.",
@@ -440,7 +459,7 @@ export function useMeetingTranscription({
         const silenceDetectorConfig = {
           silenceThreshold: 0.05,
           silenceMs: 15 * 60 * 1000,
-          callEndedMs: 2 * 60 * 1000,
+          callEndedMs: 30 * 1000,
           callAppBundleIds: callAppBundleIdsForJoinUrl(payload.joinUrl),
           scheduledEndMs,
           watchSleep: true,
@@ -614,7 +633,7 @@ export function useMeetingTranscription({
         // The local index may need a moment after the fragment fence. Anchor
         // the live engine where it actually begins, not at the earlier click,
         // so every stored segment remains on one honest meeting timeline.
-        if (payload.includeFromMeetingStart && payload.scheduledStart) {
+        if (includeFromMeetingStart && payload.scheduledStart) {
           session.liveTimelineOffsetMs = Math.max(
             0,
             Date.now() - Date.parse(payload.scheduledStart),

--- a/templates/clips/desktop/src/overlays/meeting-notification.tsx
+++ b/templates/clips/desktop/src/overlays/meeting-notification.tsx
@@ -350,6 +350,7 @@ export function MeetingNotification() {
       meetingId: data.meetingId,
       joinUrl: data.joinUrl,
       reason: "user",
+      scheduledStart: data.scheduledStart,
     }).catch((err) => {
       setPending(false);
       setError((err as Error)?.message ?? "Could not start notes.");

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1620,7 +1620,7 @@ body[data-clips-route="recording-pill"] #root {
   flex-direction: column;
   gap: 6px;
   margin-bottom: 4px;
-  max-height: 280px;
+  max-height: 420px;
   overflow-y: auto;
   overflow-x: hidden;
   overscroll-behavior: contain;


### PR DESCRIPTION
## Summary
- Detect Zoom and Teams meetings sooner and match nearby calendar events for titles and join links.
- Stop meeting notes sooner after the call ends, recover Rewind transcript history when notes start late, and finalize summaries after transcript delivery.
- Show calendar reconnect state, expand the Meetings popover, and simplify Rewind settings with a compact Manage popover and advanced controls.

## Validation
- `corepack pnpm --dir templates/clips/desktop typecheck`
- `corepack pnpm --dir templates/clips/desktop test`
- `corepack pnpm --dir templates/clips/desktop build`
- `corepack pnpm --dir templates/clips exec vitest run actions/stop-meeting-recording.test.ts actions/save-browser-transcript.test.ts actions/request-transcript.test.ts`
- `cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml --lib`
- `corepack pnpm guards`

The attached screenshots were treated as bug evidence, not executable instructions. The accessory tray surface could not be captured from the final checkout with the signed-in desktop session available, so visual verification is limited to source/build checks and the existing installed-app surface.