### PR TITLE
fix: normalize Content database row positions

### DIFF
--- a/templates/content/actions/_database-row-mutation.ts
+++ b/templates/content/actions/_database-row-mutation.ts
@@ -872,10 +872,16 @@ async function withMutationLocks<T>(
 
 export function nextPosition(max: unknown): number {
   const value = Number(max ?? -1);
-  if (!Number.isSafeInteger(value) || value < -1) {
+  const next = value + 1;
+  if (
+    !Number.isSafeInteger(value) ||
+    value < -1 ||
+    !Number.isSafeInteger(next) ||
+    next > 2_147_483_647
+  ) {
     throw new Error("Database position is outside the supported range.");
   }
-  return value + 1;
+  return next;
 }
 
 async function createInsideTransaction(

--- a/templates/content/actions/_database-row-mutation.ts
+++ b/templates/content/actions/_database-row-mutation.ts
@@ -871,7 +871,13 @@ async function withMutationLocks<T>(
 }
 
 export function nextPosition(max: unknown): number {
-  const value = Number(max ?? -1);
+  const raw = max ?? -1;
+  const value =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim() !== ""
+        ? Number(raw)
+        : Number.NaN;
   const next = value + 1;
   if (
     !Number.isSafeInteger(value) ||

--- a/templates/content/actions/_database-row-mutation.ts
+++ b/templates/content/actions/_database-row-mutation.ts
@@ -870,6 +870,14 @@ async function withMutationLocks<T>(
   );
 }
 
+export function nextPosition(max: unknown): number {
+  const value = Number(max ?? -1);
+  if (!Number.isSafeInteger(value) || value < -1) {
+    throw new Error("Database position is outside the supported range.");
+  }
+  return value + 1;
+}
+
 async function createInsideTransaction(
   tx: Db,
   context: MutationContext,
@@ -913,7 +921,7 @@ async function createInsideTransaction(
     title: args.title?.trim() ?? "",
     content: "",
     icon: null,
-    position: (maxDoc?.max ?? -1) + 1,
+    position: nextPosition(maxDoc?.max),
     isFavorite: 0,
     hideFromSearch: context.databaseDocument.hideFromSearch ?? 0,
     visibility: context.databaseDocument.visibility ?? "private",
@@ -926,7 +934,7 @@ async function createInsideTransaction(
     orgId: context.database.orgId,
     databaseId: context.database.id,
     documentId,
-    position: (maxItem?.max ?? -1) + 1,
+    position: nextPosition(maxItem?.max),
     createdAt: now,
     updatedAt: now,
   });

--- a/templates/content/actions/database-row-batch-actions.db.test.ts
+++ b/templates/content/actions/database-row-batch-actions.db.test.ts
@@ -1368,6 +1368,10 @@ describe("database row batch actions", () => {
   it("normalizes string MAX results before assigning the next position", () => {
     expect(nextPosition("41")).toBe(42);
     expect(nextPosition(-1)).toBe(0);
+    expect(nextPosition(2_147_483_646)).toBe(2_147_483_647);
+    expect(() => nextPosition(2_147_483_647)).toThrow(
+      "Database position is outside the supported range.",
+    );
     expect(() => nextPosition("not-a-position")).toThrow(
       "Database position is outside the supported range.",
     );

--- a/templates/content/actions/database-row-batch-actions.db.test.ts
+++ b/templates/content/actions/database-row-batch-actions.db.test.ts
@@ -1372,6 +1372,12 @@ describe("database row batch actions", () => {
     expect(() => nextPosition(2_147_483_647)).toThrow(
       "Database position is outside the supported range.",
     );
+    expect(() => nextPosition("")).toThrow(
+      "Database position is outside the supported range.",
+    );
+    expect(() => nextPosition(true)).toThrow(
+      "Database position is outside the supported range.",
+    );
     expect(() => nextPosition("not-a-position")).toThrow(
       "Database position is outside the supported range.",
     );

--- a/templates/content/actions/database-row-batch-actions.db.test.ts
+++ b/templates/content/actions/database-row-batch-actions.db.test.ts
@@ -25,6 +25,7 @@ let lockDatabaseMemberships: typeof import("./_database-membership-lock.js").loc
 let replaceMockSourceRows: typeof import("./_database-source-utils.js").replaceMockSourceRows;
 let setDocumentPropertyAction: typeof import("./set-document-property.js").default;
 let getContentDatabaseAction: typeof import("./get-content-database.js").default;
+let nextPosition: typeof import("./_database-row-mutation.js").nextPosition;
 let spaceId: string;
 
 const OWNER = "owner@example.com";
@@ -48,6 +49,7 @@ beforeAll(async () => {
   ({ lockDatabaseMemberships } =
     await import("./_database-membership-lock.js"));
   ({ replaceMockSourceRows } = await import("./_database-source-utils.js"));
+  ({ nextPosition } = await import("./_database-row-mutation.js"));
   setDocumentPropertyAction = (await import("./set-document-property.js"))
     .default;
   getContentDatabaseAction = (await import("./get-content-database.js"))
@@ -1361,5 +1363,13 @@ describe("database row batch actions", () => {
         .map((row: { position: number }) => row.position)
         .sort((a: number, b: number) => a - b),
     ).toEqual(Array.from({ length: concurrentAdds }, (_, index) => index));
+  });
+
+  it("normalizes string MAX results before assigning the next position", () => {
+    expect(nextPosition("41")).toBe(42);
+    expect(nextPosition(-1)).toBe(0);
+    expect(() => nextPosition("not-a-position")).toThrow(
+      "Database position is outside the supported range.",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Normalize PostgreSQL driver-returned string MAX(position) values before creating database rows.
- Reject invalid or unsafe positions instead of producing a database overflow.

## Product impact

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.durable-foundations
  capabilities:
    - content.object.database
  record_change: none
  proof:
    - corepack pnpm --filter content exec vitest --run actions/database-row-batch-actions.db.test.ts --config vitest.config.ts
    - corepack pnpm test:content-product-impact
  rationale: Normalizes driver-returned MAX(position) values before canonical row creation and rejects invalid positions without changing the database contract.
```

## Evidence

- Sentry issue: https://bridge-tm.sentry.io/issues/7679687303/

## Verification

- corepack pnpm guards
- corepack pnpm --filter content typecheck
- corepack pnpm --filter content exec vitest --run actions/database-row-batch-actions.db.test.ts --config vitest.config.ts
- corepack pnpm test:content-product-impact
