### PR TITLE
fix: include Agent-Native in about page metadata

### DIFF
--- a/packages/docs/app/routes/about.spec.ts
+++ b/packages/docs/app/routes/about.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { meta } from "./about";
+
+describe("about page metadata", () => {
+  it("includes the product name in the page title", () => {
+    expect(meta()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: expect.stringContaining("Agent-Native"),
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/docs/app/routes/about.tsx
+++ b/packages/docs/app/routes/about.tsx
@@ -4,7 +4,7 @@ import { withDefaultSocialImage } from "../seo";
 
 export const meta = () =>
   withDefaultSocialImage([
-    { title: enUS.legal.about.title },
+    { title: `Agent-Native - ${enUS.legal.about.title}` },
     { name: "description", content: enUS.legal.about.intro },
   ]);
 


### PR DESCRIPTION
Ensure the about page title remains discoverable by product name in search and agent previews. Adds a focused metadata test.