### PR TITLE
Fix Clips input monitoring permission status

### DIFF
--- a/templates/clips/desktop/src-tauri/src/permission_status.rs
+++ b/templates/clips/desktop/src-tauri/src/permission_status.rs
@@ -44,9 +44,8 @@ mod macos {
 
     extern "C" {
         fn CGPreflightScreenCaptureAccess() -> bool;
-        // kIOHIDRequestTypeListenEvent = 1; returns IOHIDAccessType where
-        // kIOHIDAccessTypeGranted = 0, kIOHIDAccessTypeDenied = 1, kIOHIDAccessTypeUnknown = 2
-        fn IOHIDCheckAccess(request_type: u32) -> i32;
+        // This is the preflight for the CGEventTap used by the Fn listener.
+        fn CGPreflightListenEventAccess() -> bool;
     }
 
     pub fn check_all() -> PermissionStatuses {
@@ -85,6 +84,6 @@ mod macos {
     }
 
     fn check_input_monitoring() -> bool {
-        unsafe { IOHIDCheckAccess(1) == 0 }
+        unsafe { CGPreflightListenEventAccess() }
     }
 }

--- a/templates/clips/desktop/src/components/ReadinessPanel.tsx
+++ b/templates/clips/desktop/src/components/ReadinessPanel.tsx
@@ -116,6 +116,9 @@ export function ReadinessPanel({
 
   const [statuses, setStatuses] = useState<PermissionStatuses | null>(null);
   const [checking, setChecking] = useState(false);
+  const [refreshingPane, setRefreshingPane] = useState<MacosPrivacyPane | null>(
+    null,
+  );
 
   const checkStatuses = useCallback(async () => {
     setChecking(true);
@@ -125,6 +128,18 @@ export function ReadinessPanel({
       setChecking(false);
     }
   }, []);
+
+  const refreshPermissions = useCallback(
+    (pane: MacosPrivacyPane) => {
+      setRefreshingPane(null);
+      window.requestAnimationFrame(() => setRefreshingPane(pane));
+      window.setTimeout(() => {
+        setRefreshingPane((current) => (current === pane ? null : current));
+      }, 450);
+      void checkStatuses();
+    },
+    [checkStatuses],
+  );
 
   const grantPermission = useCallback(
     (pane: MacosPrivacyPane) =>
@@ -172,8 +187,8 @@ export function ReadinessPanel({
                     {mac ? (
                       <button
                         type="button"
-                        className={`readiness-refresh ${checking ? "readiness-refresh-spinning" : ""}`}
-                        onClick={checkStatuses}
+                        className={`readiness-refresh ${refreshingPane === item.pane ? "readiness-refresh-rotating" : ""}`}
+                        onClick={() => refreshPermissions(item.pane)}
                         disabled={checking}
                         aria-label="Recheck permissions"
                         title="Recheck"

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1131,9 +1131,17 @@ body[data-clips-route="recording-pill"] #root {
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition:
+    opacity 120ms,
     color 120ms,
     background 120ms;
   flex-shrink: 0;
+  opacity: 0;
+}
+
+.readiness-item:hover .readiness-refresh,
+.readiness-item:focus-within .readiness-refresh,
+.readiness-item .readiness-refresh-rotating {
+  opacity: 1;
 }
 
 .readiness-refresh:hover {
@@ -1146,13 +1154,19 @@ body[data-clips-route="recording-pill"] #root {
   cursor: default;
 }
 
-.readiness-refresh-spinning svg {
-  animation: readiness-spin 0.8s linear infinite;
+.readiness-refresh-rotating svg {
+  animation: readiness-spin 420ms ease-out;
 }
 
 @keyframes readiness-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .readiness-refresh-rotating svg {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Summary\n- Use the Core Graphics listen-event preflight that matches Clips' Fn CGEventTap instead of the IOKit probe.\n- Hide permission refresh controls until row hover or focus and give clicks a one-shot rotation.\n\n## Validation\n- \n- \n- 
> clips-desktop@0.1.1 typecheck /Users/steve/.codex/worktrees/dc33/framework/templates/clips/desktop
> tsc --noEmit\n- 
 RUN  v4.1.9 /Users/steve/.codex/worktrees/dc33/framework/templates/clips/desktop


 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  11:55:34
   Duration  102ms (transform 21ms, setup 0ms, import 30ms, tests 3ms, environment 0ms)\n- 
> clips-desktop@0.1.1 build /Users/steve/.codex/worktrees/dc33/framework/templates/clips/desktop
> vite build

vite v8.1.0 building client environment for production...
[2Ktransforming...[38;5;147m[LARGE_BARREL_MODULES] [0m../../../node_modules/.pnpm/@tabler+icons-react@3.44.0_react@19.2.7/node_modules/@tabler/icons-react/dist/esm/tabler-icons-react.mjs has 6149 re-exports. Eagerly resolving every entry can significantly slow down the build. Consider using `@rolldown/plugin-transform-imports` to rewrite imports at the source level so the barrel file is never loaded.
 [38;5;240m │[0m 
 [38;5;240m │[0m [38;5;115mHelp[0m: See https://github.com/rolldown/plugins/tree/main/packages/transform-imports for usage.

✓ 522 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.48 kB │ gzip:   0.29 kB
dist/assets/index-y1q72n1J.css  109.92 kB │ gzip:  18.99 kB
dist/assets/index-BJi_W8AQ.js   837.32 kB │ gzip: 259.44 kB

✓ built in 759ms\n- Playwright browser preview verified refresh opacity and click animation state.\n\nSource/build validation is complete; beta or production deployment is not claimed here.