### PR TITLE
fix(slides): restore deck previews and move sharing to overflow

### DIFF
--- a/templates/slides/actions/list-decks.test.ts
+++ b/templates/slides/actions/list-decks.test.ts
@@ -32,6 +32,7 @@ vi.mock("../server/db/index.js", () => ({
       createdAt: "created_at_col",
       updatedAt: "updated_at_col",
       visibility: "visibility_col",
+      data: "data_col",
     },
     deckShares: {},
   },
@@ -120,6 +121,27 @@ describe("list-decks", () => {
     });
     expect(result.decks[0]).not.toHaveProperty("ownerEmail");
     expect(result.count).toBe(1);
+  });
+
+  it("can include only the first slide as a light-mode preview", async () => {
+    const result = await action.run({
+      light: "true",
+      includePreview: "true",
+    });
+
+    expect(selectFn).toHaveBeenCalledWith({
+      id: "id_col",
+      title: "title_col",
+      updatedAt: "updated_at_col",
+      visibility: "visibility_col",
+      ownerEmail: "owner_email_col",
+      data: "data_col",
+    });
+    expect(result.decks[0]).toMatchObject({
+      id: "deck_123",
+      previewSlide: { id: "slide-1" },
+    });
+    expect(result.decks[0]).not.toHaveProperty("slides");
   });
 
   it("can limit results to decks created by the current user", async () => {

--- a/templates/slides/actions/list-decks.test.ts
+++ b/templates/slides/actions/list-decks.test.ts
@@ -5,6 +5,8 @@ const deckRows = [
     id: "deck_123",
     title: "Roadmap",
     data: JSON.stringify({ slides: [{ id: "slide-1" }] }),
+    previewSlide: JSON.stringify({ id: "slide-1" }),
+    aspectRatio: "4:3",
     visibility: "private",
     designSystemId: null,
     ownerEmail: "Alice@Example.com",
@@ -40,6 +42,10 @@ vi.mock("../server/db/index.js", () => ({
 
 vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserEmail: () => requestUserEmail,
+}));
+
+vi.mock("@agent-native/core/db", () => ({
+  isPostgres: () => false,
 }));
 
 vi.mock("@agent-native/core/sharing", () => ({
@@ -135,11 +141,17 @@ describe("list-decks", () => {
       updatedAt: "updated_at_col",
       visibility: "visibility_col",
       ownerEmail: "owner_email_col",
-      data: "data_col",
+      previewSlide: expect.objectContaining({
+        strings: expect.arrayContaining(["json_extract("]),
+      }),
+      aspectRatio: expect.objectContaining({
+        strings: expect.arrayContaining(["json_extract("]),
+      }),
     });
     expect(result.decks[0]).toMatchObject({
       id: "deck_123",
       previewSlide: { id: "slide-1" },
+      aspectRatio: "4:3",
     });
     expect(result.decks[0]).not.toHaveProperty("slides");
   });

--- a/templates/slides/actions/list-decks.ts
+++ b/templates/slides/actions/list-decks.ts
@@ -26,13 +26,20 @@ export default defineAction({
       .describe(
         "Set to 'true' for full frontend deck payloads; omitted returns metadata only",
       ),
+    includePreview: z
+      .enum(["true", "false"])
+      .optional()
+      .describe(
+        "Set to 'true' with light mode to include only the first slide preview",
+      ),
     light: z
       .enum(["true", "false"])
       .optional()
       .describe(
         "Set to 'true' for a minimal id/title/updatedAt/visibility listing " +
           "used for cheap add/remove diffing (e.g. background polling). " +
-          "Never reads the deck body — no slides, no slideCount.",
+          "By default never reads the deck body — no slides, no slideCount. " +
+          "Use includePreview for the first slide only.",
       ),
     createdBy: z
       .enum(["all", "me"])
@@ -50,7 +57,7 @@ export default defineAction({
     const ownerEmail = getRequestUserEmail();
     const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);
     if (
-      args.includeSlides === "true" &&
+      (args.includeSlides === "true" || args.includePreview === "true") &&
       ctx?.caller === "frontend" &&
       normalizedOwnerEmail === null
     ) {
@@ -75,9 +82,44 @@ export default defineAction({
     if (args.light === "true") {
       // Column-projected listing for cheap add/remove diffing (the client's
       // background poll and SSE-reconnect resync). The `data` column holds
-      // each deck's entire slide JSON and can be large — never select it
-      // here. Callers that need slide content use `includeSlides: "true"` or
-      // fetch the specific deck via `get-deck`.
+      // each deck's entire slide JSON and can be large. The home grid opts
+      // into the separate preview projection; polling keeps the metadata-only
+      // path below.
+      if (args.includePreview === "true") {
+        const rows = await db
+          .select({
+            id: schema.decks.id,
+            title: schema.decks.title,
+            updatedAt: schema.decks.updatedAt,
+            visibility: schema.decks.visibility,
+            ownerEmail: schema.decks.ownerEmail,
+            data: schema.decks.data,
+          })
+          .from(schema.decks)
+          .where(where)
+          .orderBy(desc(schema.decks.updatedAt));
+
+        return {
+          count: rows.length,
+          decks: rows.map((row) => {
+            const data = JSON.parse(row.data);
+            const previewSlide = Array.isArray(data?.slides)
+              ? data.slides[0]
+              : undefined;
+            return {
+              id: row.id,
+              title: row.title,
+              updatedAt: row.updatedAt,
+              visibility: row.visibility,
+              createdByMe:
+                normalizedOwnerEmail !== null &&
+                normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
+              ...(previewSlide ? { previewSlide } : {}),
+            };
+          }),
+        };
+      }
+
       const rows = await db
         .select({
           id: schema.decks.id,

--- a/templates/slides/actions/list-decks.ts
+++ b/templates/slides/actions/list-decks.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { isPostgres } from "@agent-native/core/db";
 import { buildDeepLink } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { accessFilter } from "@agent-native/core/sharing";
@@ -11,6 +12,16 @@ import { getDeckUrl } from "./_app-url.js";
 
 function slidesDeepLink(): string {
   return buildDeepLink({ app: "slides", view: "list" });
+}
+
+function parseJsonProjection(value: unknown, label: string): unknown {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`Invalid ${label} JSON projection`, { cause: error });
+  }
 }
 
 export default defineAction({
@@ -86,6 +97,21 @@ export default defineAction({
       // into the separate preview projection; polling keeps the metadata-only
       // path below.
       if (args.includePreview === "true") {
+        // Keep the list bounded at the database boundary. `data` is an opaque
+        // full-deck blob, so selecting it and parsing it here scales with every
+        // slide even though the caller only needs the first one.
+        const previewSlideProjection = isPostgres()
+          ? sql<
+              string | null
+            >`(${schema.decks.data}::jsonb -> 'slides' -> 0)::text`
+          : sql<
+              string | null
+            >`json_extract(${schema.decks.data}, '$.slides[0]')`;
+        const aspectRatioProjection = isPostgres()
+          ? sql<string | null>`(${schema.decks.data}::jsonb ->> 'aspectRatio')`
+          : sql<
+              string | null
+            >`json_extract(${schema.decks.data}, '$.aspectRatio')`;
         const rows = await db
           .select({
             id: schema.decks.id,
@@ -93,7 +119,8 @@ export default defineAction({
             updatedAt: schema.decks.updatedAt,
             visibility: schema.decks.visibility,
             ownerEmail: schema.decks.ownerEmail,
-            data: schema.decks.data,
+            previewSlide: previewSlideProjection,
+            aspectRatio: aspectRatioProjection,
           })
           .from(schema.decks)
           .where(where)
@@ -102,10 +129,10 @@ export default defineAction({
         return {
           count: rows.length,
           decks: rows.map((row) => {
-            const data = JSON.parse(row.data);
-            const previewSlide = Array.isArray(data?.slides)
-              ? data.slides[0]
-              : undefined;
+            const previewSlide = parseJsonProjection(
+              row.previewSlide,
+              "first slide preview",
+            );
             return {
               id: row.id,
               title: row.title,
@@ -114,7 +141,12 @@ export default defineAction({
               createdByMe:
                 normalizedOwnerEmail !== null &&
                 normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
-              ...(previewSlide ? { previewSlide } : {}),
+              ...(previewSlide && typeof previewSlide === "object"
+                ? { previewSlide }
+                : {}),
+              ...(typeof row.aspectRatio === "string"
+                ? { aspectRatio: row.aspectRatio }
+                : {}),
             };
           }),
         };

--- a/templates/slides/app/components/deck/DeckCard.delete.lifecycle.test.tsx
+++ b/templates/slides/app/components/deck/DeckCard.delete.lifecycle.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@tabler/icons-react", () => ({
   IconPalette: () => <span />,
   IconPencil: () => <span />,
   IconPlus: () => <span />,
+  IconShare2: () => <span />,
   IconStar: () => <span />,
   IconStarFilled: () => <span />,
   IconTrash: () => <span />,
@@ -52,6 +53,10 @@ vi.mock("@/lib/deck-preview-frame", () => ({
 
 vi.mock("./SlideRenderer", () => ({
   default: () => <div />,
+}));
+
+vi.mock("../editor/ShareDialog", () => ({
+  default: () => null,
 }));
 
 import {

--- a/templates/slides/app/components/deck/DeckCard.delete.test.tsx
+++ b/templates/slides/app/components/deck/DeckCard.delete.test.tsx
@@ -1,12 +1,19 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   closeAutoFocus: null as
     | ((event: { preventDefault: () => void }) => void)
     | null,
+  renderSlide: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/client/i18n", () => ({
@@ -28,6 +35,7 @@ vi.mock("@tabler/icons-react", () => ({
   IconPalette: () => <span />,
   IconPencil: () => <span />,
   IconPlus: () => <span />,
+  IconShare2: () => <span />,
   IconStar: () => <span />,
   IconStarFilled: () => <span />,
   IconTrash: () => <span />,
@@ -47,7 +55,16 @@ vi.mock("@/lib/deck-preview-frame", () => ({
 }));
 
 vi.mock("./SlideRenderer", () => ({
-  default: () => <div />,
+  default: (props: unknown) => {
+    mocks.renderSlide(props);
+    return <div data-testid="slide-renderer" />;
+  },
+}));
+
+vi.mock("../editor/ShareDialog", () => ({
+  default: ({ open }: { open?: boolean }) => (
+    <div data-testid="share-dialog" data-open={String(Boolean(open))} />
+  ),
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
@@ -103,6 +120,7 @@ const deck: Deck = {
 afterEach(() => {
   cleanup();
   mocks.closeAutoFocus = null;
+  mocks.renderSlide.mockClear();
   vi.useRealTimers();
 });
 
@@ -132,5 +150,48 @@ describe("DeckCard delete flow", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(onDelete).toHaveBeenCalledOnce();
     expect(onDelete).toHaveBeenCalledWith("deck-1");
+  });
+
+  it("renders the first-slide preview returned by the light deck listing", () => {
+    render(
+      <DeckCard
+        deck={{ ...deck, slides: [], previewSlide: deck.slides[0] }}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onDuplicate={vi.fn()}
+        onToggleStar={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("slide-renderer")).toBeTruthy();
+    expect(mocks.renderSlide).toHaveBeenCalledWith(
+      expect.objectContaining({ slide: deck.slides[0] }),
+    );
+  });
+
+  it("opens sharing after the overflow menu finishes closing", async () => {
+    render(
+      <DeckCard
+        deck={deck}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onDuplicate={vi.fn()}
+        onToggleStar={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "share.title" }));
+    expect(screen.getByTestId("share-dialog").getAttribute("data-open")).toBe(
+      "false",
+    );
+    const closeEvent = { preventDefault: vi.fn() };
+    mocks.closeAutoFocus?.(closeEvent);
+    expect(closeEvent.preventDefault).toHaveBeenCalledOnce();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("share-dialog").getAttribute("data-open")).toBe(
+        "true",
+      ),
+    );
   });
 });

--- a/templates/slides/app/components/deck/DeckCard.tsx
+++ b/templates/slides/app/components/deck/DeckCard.tsx
@@ -8,6 +8,7 @@ import {
   IconCopy,
   IconPencil,
   IconPlus,
+  IconShare2,
   IconStar,
   IconStarFilled,
 } from "@tabler/icons-react";
@@ -24,6 +25,7 @@ import {
 import type { Deck } from "@/context/DeckContext";
 import { getDeckListingPreviewFrameStyle } from "@/lib/deck-preview-frame";
 
+import ShareDialog from "../editor/ShareDialog";
 import SlideRenderer from "./SlideRenderer";
 
 interface DeckCardProps {
@@ -48,16 +50,18 @@ export default function DeckCard({
   onSetWorkspaceDefault,
 }: DeckCardProps) {
   const t = useT();
-  const firstSlide = deck.slides?.[0];
+  const firstSlide = deck.previewSlide ?? deck.slides?.[0];
   const previewFrameStyle = getDeckListingPreviewFrameStyle(deck.aspectRatio);
   const [isRenaming, setIsRenaming] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(deck.title);
   const [contextOpen, setContextOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const pendingRenameRef = useRef(false);
   const pendingDeleteRef = useRef(false);
   const pendingWorkspaceDefaultRef = useRef(false);
+  const pendingShareRef = useRef(false);
 
   useEffect(() => {
     if (isRenaming) {
@@ -206,6 +210,11 @@ export default function DeckCard({
                 pendingWorkspaceDefaultRef.current = false;
                 onSetWorkspaceDefault?.(deck.id, !isWorkspaceDefault);
               }
+              if (pendingShareRef.current) {
+                e.preventDefault();
+                pendingShareRef.current = false;
+                setTimeout(() => setShareOpen(true), 0);
+              }
               if (pendingDeleteRef.current) {
                 e.preventDefault();
                 pendingDeleteRef.current = false;
@@ -225,6 +234,16 @@ export default function DeckCard({
             <DropdownMenuItem onSelect={() => onDuplicate(deck.id)}>
               <IconCopy className="w-3.5 h-3.5 me-2" />
               Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                pendingShareRef.current = true;
+                setMenuOpen(false);
+              }}
+            >
+              <IconShare2 className="w-3.5 h-3.5 me-2" />
+              {t("share.title")}
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={(event) => {
@@ -279,6 +298,7 @@ export default function DeckCard({
         }}
         canManage={deck.createdByMe}
       />
+      <ShareDialog deck={deck} open={shareOpen} onOpenChange={setShareOpen} />
     </div>
   );
 }

--- a/templates/slides/app/components/editor/ShareDialog.tsx
+++ b/templates/slides/app/components/editor/ShareDialog.tsx
@@ -7,6 +7,7 @@ import {
   cloneElement,
   isValidElement,
   useCallback,
+  useEffect,
   useState,
   type MouseEvent,
   type ReactElement,
@@ -22,7 +23,10 @@ import { getDeckShareLinkOrder } from "@/lib/deck-share-links";
 interface ShareDialogProps {
   deck: Deck;
   /** Trigger element rendered as the dialog anchor (usually the Share button). */
-  children: ReactNode;
+  children?: ReactNode;
+  /** Controlled opening for menu items that must wait for their parent to close. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 function getShareUrls(deckId: string) {
@@ -40,7 +44,12 @@ function getShareUrls(deckId: string) {
   };
 }
 
-export default function ShareDialog({ deck, children }: ShareDialogProps) {
+export default function ShareDialog({
+  deck,
+  children,
+  open: requestedOpen,
+  onOpenChange,
+}: ShareDialogProps) {
   const t = useT();
   const { isLocal } = useDbStatus();
   const [open, setOpen] = useState(false);
@@ -49,6 +58,14 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
     token: string;
   } | null>(null);
   const [creatingLink, setCreatingLink] = useState(false);
+
+  const setDialogOpen = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
 
   const shareUrls = getShareUrls(deck.id);
   const shareLinkOrder = getDeckShareLinkOrder(deck.visibility);
@@ -61,11 +78,11 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
 
   const openShareDialog = useCallback(async () => {
     if (isLocal) {
-      setOpen(true);
+      setDialogOpen(true);
       return;
     }
     if (shareToken) {
-      setOpen(true);
+      setDialogOpen(true);
       return;
     }
     if (creatingLink) return;
@@ -97,29 +114,40 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
         throw new Error(t("share.createFailed"));
       }
       setShareLink({ deckId: deck.id, token: payload.shareToken });
-      setOpen(true);
+      setDialogOpen(true);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : t("share.createFailed"),
       );
+      if (requestedOpen !== undefined) setDialogOpen(false);
     } finally {
       setCreatingLink(false);
     }
-  }, [creatingLink, deck, isLocal, shareToken, t]);
+  }, [creatingLink, deck, isLocal, setDialogOpen, shareToken, t]);
 
-  const trigger = isValidElement(children)
-    ? (() => {
-        const triggerElement = children as ReactElement<{
-          onClick?: (event: MouseEvent) => void;
-        }>;
-        return cloneElement(triggerElement, {
-          onClick: (event) => {
-            triggerElement.props.onClick?.(event);
-            if (!event.defaultPrevented) void openShareDialog();
-          },
-        });
-      })()
-    : children;
+  useEffect(() => {
+    if (requestedOpen === undefined) return;
+    if (!requestedOpen) {
+      setOpen(false);
+      return;
+    }
+    if (!open) void openShareDialog();
+  }, [open, openShareDialog, requestedOpen]);
+
+  const trigger =
+    children && isValidElement(children)
+      ? (() => {
+          const triggerElement = children as ReactElement<{
+            onClick?: (event: MouseEvent) => void;
+          }>;
+          return cloneElement(triggerElement, {
+            onClick: (event) => {
+              triggerElement.props.onClick?.(event);
+              if (!event.defaultPrevented) void openShareDialog();
+            },
+          });
+        })()
+      : children;
 
   return (
     <>
@@ -128,12 +156,12 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
         <CloudUpgrade
           title={t("share.title")}
           description={t("share.cloudUpgradeDescription")}
-          onClose={() => setOpen(false)}
+          onClose={() => setDialogOpen(false)}
         />
       ) : null}
       <CoreShareDialog
         open={open && !isLocal}
-        onClose={() => setOpen(false)}
+        onClose={() => setDialogOpen(false)}
         resourceType="deck"
         resourceId={deck.id}
         resourceTitle={deck.title}

--- a/templates/slides/app/context/DeckContext.test.ts
+++ b/templates/slides/app/context/DeckContext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   changedDeckIds,
   deckIdFromPathname,
+  getDuplicateSourceSlides,
   hasUncommittedDeckChanges,
   includeOpenDeckIfMissing,
   type Deck,
@@ -49,6 +50,22 @@ describe("DeckContext route hydration helpers", () => {
     const after = [deck("a"), { ...deck("b"), title: "Updated" }, deck("c")];
 
     expect(changedDeckIds(before, after)).toEqual(["b", "c"]);
+  });
+
+  it("uses a preview slide while hydrating a listing deck for duplication", () => {
+    const preview = {
+      id: "preview-slide",
+      content: "<h1>Preview</h1>",
+      notes: "",
+      layout: "title" as const,
+    };
+
+    expect(
+      getDuplicateSourceSlides({
+        ...deck("preview-only"),
+        previewSlide: preview,
+      }),
+    ).toEqual([preview]);
   });
 
   it("treats dirty decks as uncommitted before the debounced save is registered", () => {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -201,19 +201,18 @@ interface DeckContextType {
   ) => Deck;
   ensureDeckPersisted: (id: string) => Promise<DeckPersistenceResult>;
   /**
-   * Optimistically duplicate a deck. Inserts a copy into local state with the
-   * supplied `newId` immediately so the UI can navigate without awaiting the
-   * server, then fires the duplicate-deck action in the background. On error,
-   * the optimistic deck is rolled back.
+   * Duplicate a deck, hydrating a preview-only source before creating the
+   * optimistic copy. On error, the optimistic deck is rolled back.
    *
-   * Returns the optimistic deck (or `null` if the source deck isn't found).
+   * Returns the optimistic deck (or `null` if the source deck isn't found or
+   * could not be hydrated).
    */
   duplicateDeck: (
     sourceDeckId: string,
     newId: string,
     title?: string,
     onFailure?: () => void,
-  ) => Deck | null;
+  ) => Promise<Deck | null>;
   deleteDeck: (id: string) => void;
   updateDeck: (
     id: string,
@@ -364,6 +363,14 @@ function normalizeActionDeck(value: unknown): Deck | null {
       ? { previewSlide: previewSlide as Slide }
       : {}),
   } as Deck;
+}
+
+export function getDuplicateSourceSlides(deck: Deck): Slide[] {
+  return deck.slides.length > 0
+    ? deck.slides
+    : deck.previewSlide
+      ? [deck.previewSlide]
+      : [];
 }
 
 // Debounced save to API + save-state listeners (so the toolbar indicator
@@ -2150,15 +2157,27 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   );
 
   const duplicateDeck = useCallback(
-    (
+    async (
       sourceDeckId: string,
       newId: string,
       title?: string,
       onFailure?: () => void,
-    ): Deck | null => {
+    ): Promise<Deck | null> => {
       if (pendingDuplicateSourceIdsRef.current.has(sourceDeckId)) return null;
-      const source = decks.find((d) => d.id === sourceDeckId);
-      if (!source) return null;
+      pendingDuplicateSourceIdsRef.current.add(sourceDeckId);
+      let source = decks.find((d) => d.id === sourceDeckId);
+      if (!source) {
+        pendingDuplicateSourceIdsRef.current.delete(sourceDeckId);
+        return null;
+      }
+      if (source.slides.length === 0 && source.previewSlide) {
+        const hydrated = await fetchDeckFromAPI(sourceDeckId);
+        if (!hydrated) {
+          pendingDuplicateSourceIdsRef.current.delete(sourceDeckId);
+          return null;
+        }
+        source = hydrated;
+      }
 
       const now = new Date().toISOString();
       const newTitle = title || `Copy of ${source.title}`;
@@ -2179,7 +2198,8 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         createdByMe: true,
         shareToken: undefined,
       };
-      optimistic.slides = optimistic.slides.map((s) => ({
+      delete optimistic.previewSlide;
+      optimistic.slides = getDuplicateSourceSlides(source).map((s) => ({
         ...s,
         id: `slide-${nanoid(8)}`,
       }));
@@ -2188,7 +2208,6 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // the duplicate-deck action's INSERT lands.
       pendingCreateIdsRef.current.add(newId);
       noteLocalCreate(newId);
-      pendingDuplicateSourceIdsRef.current.add(sourceDeckId);
 
       // Fire the action in the background. On error, roll back.
       const duplicatePromise = callAction<DuplicateDeckActionResult>(
@@ -2197,10 +2216,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           deckId: sourceDeckId,
           newId,
           title,
-          // The user can start editing the copy before this resolves, so the
-          // persisted slides must carry the ids the optimistic ones already
-          // have — otherwise those edits address slides the server never had.
-          slideIds: optimistic.slides.map((s) => s.id),
+          // Preview-only sources were hydrated above. An empty array is not
+          // a valid optimistic slide-id projection, so omit it for empty
+          // decks and let the server generate ids for any uncovered slides.
+          ...(optimistic.slides.length > 0
+            ? { slideIds: optimistic.slides.map((s) => s.id) }
+            : {}),
         },
       ).then(() => undefined);
       pendingCreatePromisesRef.current.set(newId, duplicatePromise);
@@ -2220,9 +2241,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           }
           console.error("Duplicate failed:", err);
           // Roll back: drop the optimistic deck from local state. The caller
-          // (via onFailure) is responsible for navigating away if the user is
-          // still sitting on this now-gone deck's route — otherwise they're
-          // stranded on a "Deck unavailable" screen with no way back.
+          // (via onFailure) is responsible for navigating away if the user
+          // is still sitting on this now-gone deck's route — otherwise
+          // they're stranded on a "Deck unavailable" screen with no way back.
           setDecks((prev) => prev.filter((d) => d.id !== newId));
           onFailure?.();
         })

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -147,6 +147,8 @@ export interface Deck {
   starred?: boolean;
   /** Slide aspect ratio (defaults to 16:9 when absent for backwards compat) */
   aspectRatio?: AspectRatio;
+  /** First slide returned by the light deck listing for home-page previews. */
+  previewSlide?: Slide;
 }
 
 export type DeckPersistenceResult =
@@ -325,6 +327,8 @@ function normalizeActionDeck(value: unknown): Deck | null {
   const deckRecord = deck as unknown as Record<string, unknown>;
   const cleanedDeck = { ...deckRecord };
   for (const field of GET_DECK_ONLY_DECK_FIELDS) delete cleanedDeck[field];
+  const previewSlide = deckRecord.previewSlide;
+  delete cleanedDeck.previewSlide;
 
   // Strip the same decorative fields from every slide, so a deck fetched from
   // `get-deck` is structurally identical to one built by local mutations —
@@ -356,6 +360,9 @@ function normalizeActionDeck(value: unknown): Deck | null {
         ? deck.updatedAt
         : deck.createdAt || "",
     slides,
+    ...(previewSlide && typeof previewSlide === "object"
+      ? { previewSlide: previewSlide as Slide }
+      : {}),
   } as Deck;
 }
 
@@ -1040,7 +1047,7 @@ async function fetchDecksFromAPI(): Promise<Deck[] | null> {
   try {
     const result = await callAction<DeckListActionResult>(
       "list-decks",
-      { light: "true" },
+      { light: "true", includePreview: "true" },
       { method: "GET" },
     );
     if (!Array.isArray(result?.decks)) {
@@ -1172,7 +1179,7 @@ async function fetchDecksForCurrentRoute(): Promise<Deck[] | null> {
   }
   if (!currentOpenDeckId) return loaded;
 
-  // The list is intentionally metadata-only. Hydrate just the deck the user
+  // The list has only first-slide previews. Hydrate just the deck the user
   // opened so the editor gets full slide content without making the home page
   // download every deck body.
   const directDeck = await fetchDeckFromAPI(currentOpenDeckId);

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1545,9 +1545,9 @@ export default function DeckEditor() {
         onTogglePinMode={togglePinMode}
         textBoxMode={textBoxMode}
         onToggleTextBoxMode={toggleTextBoxMode}
-        onDuplicateDeck={() => {
+        onDuplicateDeck={async () => {
           const newId = `deck-${nanoid()}`;
-          const optimistic = duplicateDeck(id, newId, undefined, () => {
+          const optimistic = await duplicateDeck(id, newId, undefined, () => {
             // The background duplicate-deck action failed after we already
             // navigated to the optimistic copy. If the user is still there,
             // send them back instead of stranding them on a "Deck

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1289,19 +1289,17 @@ export default function Index() {
   // first (the same path the editor's own Duplicate uses) and navigate to
   // that; the background action reconciles or rolls the copy back.
   const handleDuplicate = useCallback(
-    (id: string) => {
-      let copy: ReturnType<typeof duplicateDeck> | undefined;
-      flushSync(() => {
-        copy = duplicateDeck(id, `deck-${nanoid()}`, undefined, () => {
-          // The background duplicate-deck action failed after we already
-          // navigated to the optimistic copy's route. If the user is still
-          // there, send them back to the deck list instead of stranding them
-          // on a "Deck unavailable" screen for a deck that no longer exists.
-          if (deckIdFromPathname(window.location.pathname) === copy?.id) {
-            navigate("/");
-          }
-          toast.error(t("home.duplicateFailed"));
-        });
+    async (id: string) => {
+      const newId = `deck-${nanoid()}`;
+      const copy = await duplicateDeck(id, newId, undefined, () => {
+        // The background duplicate-deck action failed after we already
+        // navigated to the optimistic copy's route. If the user is still
+        // there, send them back to the deck list instead of stranding them
+        // on a "Deck unavailable" screen for a deck that no longer exists.
+        if (deckIdFromPathname(window.location.pathname) === newId) {
+          navigate("/");
+        }
+        toast.error(t("home.duplicateFailed"));
       });
       // The context refuses a second copy of the same deck while the first
       // one's action is still in flight.

--- a/templates/slides/changelog/2026-08-24-deck-previews-and-sharing-live-in-the-overflow-menu.md
+++ b/templates/slides/changelog/2026-08-24-deck-previews-and-sharing-live-in-the-overflow-menu.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-24
+---
+Decks now show a first-slide preview and keep sharing controls in the overflow menu.


### PR DESCRIPTION
## Summary
- Restore first-slide previews in the home deck grid without downloading full deck bodies.
- Add the existing Slides sharing dialog to the deck card overflow menu, with menu-close sequencing so the dialog does not leave the page inert.
- Add focused action and UI regression coverage plus a user-facing changelog entry.

## Feedback handoff
- [Slides feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787595885078609): fixed missing preview and moved sharing into hover overflow menu. Parent re-read; no replies before work.
- Latest feedback sweep re-read recent Slack threads/replies. Content reports Alice-owned; Clips/Analytics active owners or follow-up; subjective/informational deferred.
- GitHub connector search found no matching open Slides, thumbnail, or sharing issue.
- Sentry unresolved Slides results include a separate dynamic-import issue, not the thumbnail path; outside this change.

## Validation
- Focused Vitest: 4 files, 12 tests passed.
- Slides typecheck passed.
- Slides production build passed.
- `corepack pnpm guards` passed all 64 checks.
- Browser verification passed: home card first-slide canvas, hover overflow Share Presentation, and sharing dialog General access controls. Temporary deck deleted.

Deployment/beta health is not claimed.