### PR TITLE
fix: gate LLM engine tests until a provider is configured

### DIFF
--- a/.changeset/gentle-llm-test.md
+++ b/.changeset/gentle-llm-test.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent unconfigured LLM engine tests from reporting a false pass.

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -69,6 +69,10 @@ import {
 import { agentNativePath } from "../api-path.js";
 import { BuilderBMark } from "../builder-mark.js";
 import {
+  fetchAgentEngineStatus,
+  fetchEnvironmentStatus,
+} from "../client-status-requests.js";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -776,11 +780,21 @@ function friendlyModelName(model: string): string {
   return model;
 }
 
+type SettingsSource = "env" | "settings" | "app_secrets";
+
 type SettingsStatus = {
   engine: string;
-  source: "env" | "settings" | "app_secrets";
+  source: SettingsSource;
   envVar: string | null;
 } | null;
+
+type AgentEngineStatusResponse = {
+  configured?: boolean;
+  engine?: string;
+  source?: SettingsSource;
+  envVar?: string | null;
+  openAiBaseUrlConfigured?: boolean;
+};
 
 function computeSourceBadge(args: {
   settingsConfigured: boolean;
@@ -972,28 +986,37 @@ function LLMSectionInner({
   const [settingsStatus, setSettingsStatus] = useState<SettingsStatus>(null);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [envLoaded, setEnvLoaded] = useState(false);
+  const [envProbeAvailable, setEnvProbeAvailable] = useState(false);
   const [enginesLoaded, setEnginesLoaded] = useState(false);
   const [statusLoaded, setStatusLoaded] = useState(false);
+  const [statusProbeAvailable, setStatusProbeAvailable] = useState(false);
 
   const initialLoading =
     !envLoaded || !enginesLoaded || !statusLoaded || !!builderLoading;
 
-  useEffect(() => {
-    fetch(agentNativePath("/_agent-native/env-status"))
-      .then((r) => (r.ok ? r.json() : []))
-      .then(setEnvKeys)
-      .catch(() => {})
+  const refreshEnvKeys = useCallback(() => {
+    setEnvProbeAvailable(false);
+    void fetchEnvironmentStatus<Array<{ key: string; configured: boolean }>>()
+      .then((result) => {
+        if (result.state !== "available" || !Array.isArray(result.value)) {
+          return;
+        }
+        setEnvKeys(result.value);
+        setEnvProbeAvailable(true);
+      })
       .finally(() => setEnvLoaded(true));
-  }, [saved]);
+  }, []);
 
   const notifyConfigChanged = useCallback(() => {
     window.dispatchEvent(new CustomEvent("agent-engine:configured-changed"));
   }, []);
 
   const refreshSettingsStatus = useCallback(() => {
-    fetch(agentNativePath("/_agent-native/agent-engine/status"))
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
+    setStatusProbeAvailable(false);
+    void fetchAgentEngineStatus<AgentEngineStatusResponse>()
+      .then((result) => {
+        if (result.state !== "available") return;
+        const data = result.value;
         setBaseUrlConfigured(Boolean(data?.openAiBaseUrlConfigured));
         if (
           data?.configured &&
@@ -1010,14 +1033,32 @@ function LLMSectionInner({
         } else {
           setSettingsStatus(null);
         }
+        setStatusProbeAvailable(true);
       })
       .catch(() => {})
       .finally(() => setStatusLoaded(true));
   }, []);
 
   useEffect(() => {
+    refreshEnvKeys();
+  }, [refreshEnvKeys]);
+
+  useEffect(() => {
     refreshSettingsStatus();
   }, [refreshSettingsStatus]);
+
+  useEffect(() => {
+    const refresh = () => {
+      refreshEnvKeys();
+      refreshSettingsStatus();
+    };
+    window.addEventListener("agent-engine:configured-changed", refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.removeEventListener("agent-engine:configured-changed", refresh);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [refreshEnvKeys, refreshSettingsStatus]);
 
   useEffect(() => {
     callAction("manage-agent-engine" as any, { action: "list" } as any)
@@ -1074,14 +1115,16 @@ function LLMSectionInner({
     return configured;
   }, [envKeys, settingsStatus]);
   const builderConnected = connected || builderFlow.configured;
+  const configurationKnown = envProbeAvailable && statusProbeAvailable;
   const anyKeyConfigured =
     builderConnected ||
-    (selectedEnginePackageInstalled &&
-      (envConfigured || settingsConfigured || configuredProviderIds.size > 0));
+    (configurationKnown &&
+      selectedEnginePackageInstalled &&
+      (envConfigured || settingsConfigured));
   const sourceBadge = computeSourceBadge({
-    settingsConfigured,
-    settingsStatus,
-    envConfigured,
+    settingsConfigured: configurationKnown && settingsConfigured,
+    settingsStatus: configurationKnown ? settingsStatus : null,
+    envConfigured: configurationKnown && envConfigured,
     envVar,
     builderConnected,
   });
@@ -1116,7 +1159,6 @@ function LLMSectionInner({
       setClearBaseUrl(false);
       if (nextBaseUrl) setBaseUrlConfigured(true);
       if (clearBaseUrl) setBaseUrlConfigured(false);
-      refreshSettingsStatus();
       notifyConfigChanged();
       setTimeout(() => setSaved(false), 2000);
     } finally {
@@ -1136,7 +1178,6 @@ function LLMSectionInner({
       if (res.ok) {
         setTestResult(null);
         setApplyNote(false);
-        refreshSettingsStatus();
         notifyConfigChanged();
         return;
       }
@@ -1206,7 +1247,6 @@ function LLMSectionInner({
       setCurrentEngine(selectedEngine);
       setCurrentModel(selectedModel);
       setApplyNote(true);
-      refreshSettingsStatus();
       notifyConfigChanged();
       setTimeout(() => setApplyNote(false), 4000);
     } catch (err) {
@@ -1220,7 +1260,9 @@ function LLMSectionInner({
       icon={<IconBrain size={14} />}
       title="LLM"
       required
-      connected={initialLoading ? undefined : anyKeyConfigured}
+      connected={
+        initialLoading || !configurationKnown ? undefined : anyKeyConfigured
+      }
       subtitle={
         isPage
           ? undefined
@@ -1253,7 +1295,7 @@ function LLMSectionInner({
             </div>
           )}
           <div className={cn("flex flex-wrap items-center justify-end gap-2")}>
-            {!anyKeyConfigured && (
+            {configurationKnown && !anyKeyConfigured && (
               <UseBuilderCard
                 builderFlow={builderFlow}
                 connectUrl={connectUrl}
@@ -1282,7 +1324,7 @@ function LLMSectionInner({
                     })
               }
               summaryContent={
-                anyKeyConfigured ? (
+                configurationKnown && anyKeyConfigured ? (
                   <UseBuilderCard
                     builderFlow={builderFlow}
                     connectUrl={connectUrl}
@@ -1300,7 +1342,9 @@ function LLMSectionInner({
               <div className="space-y-2 mb-1">
                 <AgentProviderPicker
                   value={selectedProvider}
-                  configuredProviders={configuredProviderIds}
+                  configuredProviders={
+                    configurationKnown ? configuredProviderIds : undefined
+                  }
                   layout={isPage ? "page" : "compact"}
                   onChange={(provider) => {
                     const option = getAgentProviderOption(provider);
@@ -1490,7 +1534,9 @@ function LLMSectionInner({
                     intent="neutral"
                     emphasis="outline"
                     onClick={handleTest}
-                    disabled={testing || !anyKeyConfigured}
+                    disabled={
+                      testing || !configurationKnown || !anyKeyConfigured
+                    }
                     className={pillButtonClass(isPage, "outline")}
                   >
                     {testing ? (

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -938,6 +938,7 @@ const PROVIDER_DOCS: Record<string, string> = {
 function LLMSectionInner({
   builderFlow,
   builderLoading,
+  builderStatusAvailable,
   connectUrl,
   connected,
   orgName,
@@ -949,6 +950,7 @@ function LLMSectionInner({
 }: {
   builderFlow: BuilderConnectFlow;
   builderLoading?: boolean;
+  builderStatusAvailable: boolean;
   connectUrl?: string;
   connected: boolean;
   orgName?: string;
@@ -990,21 +992,27 @@ function LLMSectionInner({
   const [enginesLoaded, setEnginesLoaded] = useState(false);
   const [statusLoaded, setStatusLoaded] = useState(false);
   const [statusProbeAvailable, setStatusProbeAvailable] = useState(false);
+  const probeGenerationRef = useRef({ env: 0, status: 0 });
 
   const initialLoading =
     !envLoaded || !enginesLoaded || !statusLoaded || !!builderLoading;
 
   const refreshEnvKeys = useCallback(() => {
+    const generation = ++probeGenerationRef.current.env;
     setEnvProbeAvailable(false);
+    setEnvKeys([]);
     void fetchEnvironmentStatus<Array<{ key: string; configured: boolean }>>()
       .then((result) => {
+        if (generation !== probeGenerationRef.current.env) return;
         if (result.state !== "available" || !Array.isArray(result.value)) {
           return;
         }
         setEnvKeys(result.value);
         setEnvProbeAvailable(true);
       })
-      .finally(() => setEnvLoaded(true));
+      .finally(() => {
+        if (generation === probeGenerationRef.current.env) setEnvLoaded(true);
+      });
   }, []);
 
   const notifyConfigChanged = useCallback(() => {
@@ -1012,9 +1020,13 @@ function LLMSectionInner({
   }, []);
 
   const refreshSettingsStatus = useCallback(() => {
+    const generation = ++probeGenerationRef.current.status;
     setStatusProbeAvailable(false);
+    setSettingsStatus(null);
+    setBaseUrlConfigured(false);
     void fetchAgentEngineStatus<AgentEngineStatusResponse>()
       .then((result) => {
+        if (generation !== probeGenerationRef.current.status) return;
         if (result.state !== "available") return;
         const data = result.value;
         setBaseUrlConfigured(Boolean(data?.openAiBaseUrlConfigured));
@@ -1036,7 +1048,11 @@ function LLMSectionInner({
         setStatusProbeAvailable(true);
       })
       .catch(() => {})
-      .finally(() => setStatusLoaded(true));
+      .finally(() => {
+        if (generation === probeGenerationRef.current.status) {
+          setStatusLoaded(true);
+        }
+      });
   }, []);
 
   useEffect(() => {
@@ -1119,9 +1135,13 @@ function LLMSectionInner({
     }
     return configured;
   }, [envKeys, settingsStatus]);
-  const builderConnected = connected || builderFlow.configured;
+  const builderConnected =
+    builderStatusAvailable && (connected || builderFlow.configured);
   const configurationKnown = envProbeAvailable && statusProbeAvailable;
   const builderEngineSelected = selectedEngine === "builder";
+  const selectedConfigurationKnown = builderEngineSelected
+    ? builderStatusAvailable
+    : configurationKnown;
   const anyKeyConfigured =
     (builderEngineSelected && builderConnected) ||
     (!builderEngineSelected &&
@@ -1268,7 +1288,9 @@ function LLMSectionInner({
       title="LLM"
       required
       connected={
-        initialLoading || !configurationKnown ? undefined : anyKeyConfigured
+        initialLoading || !selectedConfigurationKnown
+          ? undefined
+          : anyKeyConfigured
       }
       subtitle={
         isPage
@@ -1302,11 +1324,11 @@ function LLMSectionInner({
             </div>
           )}
           <div className={cn("flex flex-wrap items-center justify-end gap-2")}>
-            {configurationKnown && !anyKeyConfigured && (
+            {selectedConfigurationKnown && !anyKeyConfigured && (
               <UseBuilderCard
                 builderFlow={builderFlow}
                 connectUrl={connectUrl}
-                connected={connected}
+                connected={builderConnected}
                 orgName={orgName}
                 envManaged={envManaged}
                 credentialSource={credentialSource}
@@ -1331,11 +1353,11 @@ function LLMSectionInner({
                     })
               }
               summaryContent={
-                configurationKnown && anyKeyConfigured ? (
+                selectedConfigurationKnown && anyKeyConfigured ? (
                   <UseBuilderCard
                     builderFlow={builderFlow}
                     connectUrl={connectUrl}
-                    connected={connected}
+                    connected={builderConnected}
                     orgName={orgName}
                     envManaged={envManaged}
                     credentialSource={credentialSource}
@@ -1542,7 +1564,9 @@ function LLMSectionInner({
                     emphasis="outline"
                     onClick={handleTest}
                     disabled={
-                      testing || !configurationKnown || !anyKeyConfigured
+                      testing ||
+                      !selectedConfigurationKnown ||
+                      !anyKeyConfigured
                     }
                     className={pillButtonClass(isPage, "outline")}
                   >
@@ -3016,10 +3040,16 @@ function SettingsPanelContent({
   builderConnectionOwnedExternally = false,
   agentAdditionalContent,
 }: SettingsPanelContentProps) {
-  const { status: builder, loading: builderLoading } = useBuilderStatus({
+  const {
+    status: builder,
+    loading: builderLoading,
+    stale: builderStatusStale,
+  } = useBuilderStatus({
     enabled: !builderConnectionOwnedExternally,
   });
   const connected = builder?.configured ?? false;
+  const builderStatusAvailable =
+    !builderLoading && !builderStatusStale && builder != null;
   const connectUrl = builder?.connectUrl;
   const orgName = builder?.orgName;
   const envManaged = !!builder?.envManaged;
@@ -3088,6 +3118,7 @@ function SettingsPanelContent({
                 <LLMSectionInner
                   builderFlow={builderFlow}
                   builderLoading={builderLoading}
+                  builderStatusAvailable={builderStatusAvailable}
                   connectUrl={connectUrl}
                   connected={connected}
                   orgName={orgName}
@@ -3419,6 +3450,7 @@ function SettingsPanelContent({
           <LLMSectionInner
             builderFlow={builderFlow}
             builderLoading={builderLoading}
+            builderStatusAvailable={builderStatusAvailable}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -1490,7 +1490,7 @@ function LLMSectionInner({
                     intent="neutral"
                     emphasis="outline"
                     onClick={handleTest}
-                    disabled={testing}
+                    disabled={testing || !anyKeyConfigured}
                     className={pillButtonClass(isPage, "outline")}
                   >
                     {testing ? (

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -987,32 +987,27 @@ function LLMSectionInner({
   >(null);
   const [settingsStatus, setSettingsStatus] = useState<SettingsStatus>(null);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
-  const [envLoaded, setEnvLoaded] = useState(false);
   const [envProbeAvailable, setEnvProbeAvailable] = useState(false);
   const [enginesLoaded, setEnginesLoaded] = useState(false);
-  const [statusLoaded, setStatusLoaded] = useState(false);
   const [statusProbeAvailable, setStatusProbeAvailable] = useState(false);
   const probeGenerationRef = useRef({ env: 0, status: 0 });
 
-  const initialLoading =
-    !envLoaded || !enginesLoaded || !statusLoaded || !!builderLoading;
+  const initialLoading = !enginesLoaded || !!builderLoading;
 
   const refreshEnvKeys = useCallback(() => {
     const generation = ++probeGenerationRef.current.env;
     setEnvProbeAvailable(false);
     setEnvKeys([]);
-    void fetchEnvironmentStatus<Array<{ key: string; configured: boolean }>>()
-      .then((result) => {
-        if (generation !== probeGenerationRef.current.env) return;
-        if (result.state !== "available" || !Array.isArray(result.value)) {
-          return;
-        }
-        setEnvKeys(result.value);
-        setEnvProbeAvailable(true);
-      })
-      .finally(() => {
-        if (generation === probeGenerationRef.current.env) setEnvLoaded(true);
-      });
+    void fetchEnvironmentStatus<
+      Array<{ key: string; configured: boolean }>
+    >().then((result) => {
+      if (generation !== probeGenerationRef.current.env) return;
+      if (result.state !== "available" || !Array.isArray(result.value)) {
+        return;
+      }
+      setEnvKeys(result.value);
+      setEnvProbeAvailable(true);
+    });
   }, []);
 
   const notifyConfigChanged = useCallback(() => {
@@ -1047,12 +1042,7 @@ function LLMSectionInner({
         }
         setStatusProbeAvailable(true);
       })
-      .catch(() => {})
-      .finally(() => {
-        if (generation === probeGenerationRef.current.status) {
-          setStatusLoaded(true);
-        }
-      });
+      .catch(() => {});
   }, []);
 
   useEffect(() => {

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -1054,9 +1054,14 @@ function LLMSectionInner({
     };
     window.addEventListener("agent-engine:configured-changed", refresh);
     window.addEventListener("focus", refresh);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       window.removeEventListener("agent-engine:configured-changed", refresh);
       window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [refreshEnvKeys, refreshSettingsStatus]);
 
@@ -1116,9 +1121,11 @@ function LLMSectionInner({
   }, [envKeys, settingsStatus]);
   const builderConnected = connected || builderFlow.configured;
   const configurationKnown = envProbeAvailable && statusProbeAvailable;
+  const builderEngineSelected = selectedEngine === "builder";
   const anyKeyConfigured =
-    builderConnected ||
-    (configurationKnown &&
+    (builderEngineSelected && builderConnected) ||
+    (!builderEngineSelected &&
+      configurationKnown &&
       selectedEnginePackageInstalled &&
       (envConfigured || settingsConfigured));
   const sourceBadge = computeSourceBadge({


### PR DESCRIPTION
## Summary

- disable the LLM engine Test action until Builder or a saved provider configuration exists
- prevent a deploy-level credential from producing a misleading pass for an unconfigured custom-key flow

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/agent-engine-key.spec.ts src/server/core-routes-plugin.agent-engine-status.spec.ts src/client/use-agent-engine-configured.spec.tsx`
- `corepack pnpm --filter @agent-native/dispatch exec vitest --run src/server/lib/workspace-app-chat-proxy.spec.ts src/server/plugins/core-routes.spec.ts src/components/workspace-app-chat-rail.spec.tsx`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`