### PR TITLE
Teammates can edit and run Factory jobs

### DIFF
--- a/.changeset/factory-org-member-run-now.md
+++ b/.changeset/factory-org-member-run-now.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow organization members to queue Run now for Factory-domain jobs they can already load, without widening Mail or CRM automation edit rights.

--- a/packages/core/src/automations/service.spec.ts
+++ b/packages/core/src/automations/service.spec.ts
@@ -36,6 +36,8 @@ vi.mock("../resources/store.js", () => ({
 
 import {
   automationMatchesEventOwner,
+  canQueueAutomationRunNow,
+  canUpdateAutomationResource,
   defineAutomation,
   deleteAutomation,
   listAutomationDefinitions,
@@ -82,6 +84,20 @@ deliveryDestination: "channel-1"
 ---
 
 Send the notification.`;
+
+const factoryAutomation = `---
+schedule: "*/5 * * * *"
+enabled: true
+triggerType: schedule
+mode: agentic
+createdBy: alice@example.com
+orgId: "org-1"
+appId: factory
+domain: factory
+runAs: creator
+---
+
+Observe Slack.`;
 
 describe("automation domain service", () => {
   beforeEach(() => {
@@ -218,6 +234,37 @@ describe("automation domain service", () => {
       "organization",
     );
     expect(memberItems[0]?.canUpdate).toBe(false);
+  });
+
+  it("lets a Factory org member queue Run now without canUpdate", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+    const factoryResource = resource(factoryAutomation);
+
+    expect(
+      await canUpdateAutomationResource(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        factoryResource,
+      ),
+    ).toBe(false);
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "factory" },
+        factoryResource,
+        "organization",
+      ),
+    ).toBe(true);
+  });
+
+  it("still refuses a Mail org member who is not the creator or admin", async () => {
+    executeMock.mockResolvedValue({ rows: [{ role: "member" }] });
+
+    expect(
+      await canQueueAutomationRunNow(
+        { userEmail: "member@example.com", orgId: "org-1", appId: "mail" },
+        resource(eventAutomation),
+        "organization",
+      ),
+    ).toBe(false);
   });
 
   it("lets an org admin update or delete without retargeting the creator", async () => {

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -229,6 +229,31 @@ export async function canUpdateAutomationResource(
   return (await mutationAccess(actor, resource, meta)).canUpdate;
 }
 
+/**
+ * Factory is a shared team workspace: any current org member may queue Run now
+ * for that app's Factory-domain org jobs. Mail/CRM and other automations stay
+ * on creator-or-admin `canUpdate`.
+ */
+export async function canQueueAutomationRunNow(
+  actorInput: AutomationActor,
+  resource: Resource,
+  scope: AutomationScope,
+): Promise<boolean> {
+  const { meta } = parseJobResource(resource.content);
+  const actor = normalizeActor(actorInput);
+  if (!jobBelongsToApp(meta, actor.appId)) return false;
+  const access = await mutationAccess(actor, resource, meta);
+  if (access.canUpdate) return true;
+  const resourceOrgId = organizationIdFromResourceOwner(resource.owner);
+  return (
+    scope === "organization" &&
+    Boolean(resourceOrgId) &&
+    actor.orgId === resourceOrgId &&
+    actor.appId === "factory" &&
+    meta.domain === "factory"
+  );
+}
+
 function assertExplicitAutomation(
   resource: Resource,
 ): Omit<AutomationDefinition, "name" | "scope" | "canUpdate"> {

--- a/packages/core/src/jobs/run-now.spec.ts
+++ b/packages/core/src/jobs/run-now.spec.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const canUpdateAutomationResourceMock = vi.hoisted(() => vi.fn());
+const canQueueAutomationRunNowMock = vi.hoisted(() => vi.fn());
 const resourceGetByPathMock = vi.hoisted(() => vi.fn());
 const startAutomationRunMock = vi.hoisted(() => vi.fn());
 const listUnclaimedAutomationRunsMock = vi.hoisted(() => vi.fn());
 const fireInternalDispatchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../automations/service.js", () => ({
-  canUpdateAutomationResource: canUpdateAutomationResourceMock,
+  canQueueAutomationRunNow: canQueueAutomationRunNowMock,
 }));
 
 vi.mock("../resources/store.js", () => ({
@@ -52,7 +52,7 @@ const organizationRun = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  canUpdateAutomationResourceMock.mockResolvedValue(true);
+  canQueueAutomationRunNowMock.mockResolvedValue(true);
   listUnclaimedAutomationRunsMock.mockResolvedValue([]);
   startAutomationRunMock.mockResolvedValue("history-1");
   fireInternalDispatchMock.mockResolvedValue(undefined);
@@ -163,5 +163,15 @@ describe("queueAutomationRunNow", () => {
       }),
     ).rejects.toThrow("Specify either an automation name or a path, not both.");
     expect(resourceGetByPathMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the caller cannot queue the run", async () => {
+    canQueueAutomationRunNowMock.mockResolvedValue(false);
+    resourceGetByPathMock.mockResolvedValue(resourceAt("jobs/digest.md"));
+
+    await expect(
+      queueAutomationRunNow({ ...organizationRun, name: "digest" }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(startAutomationRunMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/jobs/run-now.ts
+++ b/packages/core/src/jobs/run-now.ts
@@ -4,7 +4,7 @@ import {
   resolveAgentChatProcessRunDispatchPath,
 } from "../agent/durable-background.js";
 import {
-  canUpdateAutomationResource,
+  canQueueAutomationRunNow,
   type AutomationScope,
 } from "../automations/service.js";
 import { isLocalDatabase } from "../db/client.js";
@@ -134,7 +134,7 @@ export async function queueAutomationRunNow(
       statusCode: 404,
     });
   }
-  if (!(await canUpdateAutomationResource(input, resource))) {
+  if (!(await canQueueAutomationRunNow(input, resource, input.scope))) {
     throw Object.assign(
       new Error(
         "Only the automation's creator or an organization admin can run it.",

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -76,9 +76,11 @@ decisions, feedback, agent runs, and provider audit records.
 
 Rules start in shadow mode; hard guards apply. Organization automations use
 stored prompts; external mutations require durable, idempotent runs and
-provider confirmation. Use the visual editor for graph changes and agent chat
-for proposals; persist complete graphs with `save-factory-graph`. Change rules
-through triage actions, never graph JSON.
+provider confirmation. Poll and Builder/PR dispatch run only as this factory's
+scheduled job, not chat and not a workspace-owner email match; teammates may
+edit and Run now Factory jobs. Use the visual editor for graph changes and
+agent chat for proposals; persist complete graphs with `save-factory-graph`.
+Change rules through triage actions, never graph JSON.
 
 ## Source Changes
 

--- a/templates/factory/actions/babysit-pull-request.ts
+++ b/templates/factory/actions/babysit-pull-request.ts
@@ -2,6 +2,7 @@ import { defineAction } from "@agent-native/core/action";
 import { z } from "zod";
 
 import { resolveConnectorSecret } from "../server/connectors/credentials.js";
+import { requireFactoryAutomation } from "../server/lib/require-factory-automation.js";
 import {
   requireWorkspaceMember,
   workspaceMemberIdentityFromContext,
@@ -105,6 +106,11 @@ export function createBabysitPullRequestAction(
     run: async (input, context): Promise<BabysitProposal> => {
       const { userEmail, orgId } = await requireWorkspaceMember(
         workspaceMemberIdentityFromContext(context),
+      );
+      await requireFactoryAutomation(
+        context,
+        { userEmail, orgId },
+        "prBabysit",
       );
       const { comments, truncated } = await fetchComments({
         repo: input.repo,

--- a/templates/factory/actions/list-factory-automations.spec.ts
+++ b/templates/factory/actions/list-factory-automations.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
+const listAutomationRunsMock = vi.hoisted(() => vi.fn());
+const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
+const workspaceMemberIdentityFromContextMock = vi.hoisted(() => vi.fn());
+const readFactoryDefinitionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (definition: unknown) => definition,
+}));
+
+vi.mock("@agent-native/core/triggers", () => ({
+  listAutomationDefinitions: listAutomationDefinitionsMock,
+  listAutomationRuns: listAutomationRunsMock,
+}));
+
+vi.mock("../server/factory-graph/store.js", () => ({
+  DEFAULT_FACTORY_ID: "default",
+  readFactoryDefinition: readFactoryDefinitionMock,
+}));
+
+vi.mock("../server/lib/require-workspace-member.js", () => ({
+  requireWorkspaceMember: requireWorkspaceMemberMock,
+  workspaceMemberIdentityFromContext: workspaceMemberIdentityFromContextMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireWorkspaceMemberMock.mockResolvedValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  workspaceMemberIdentityFromContextMock.mockReturnValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  readFactoryDefinitionMock.mockResolvedValue({ id: "support-triage" });
+  listAutomationRunsMock.mockResolvedValue([]);
+});
+
+describe("list-factory-automations", () => {
+  it("lets workspace members update Factory-domain jobs", async () => {
+    listAutomationDefinitionsMock.mockResolvedValue([
+      {
+        name: "factories/support-triage/factory-slack-feedback",
+        body: "Observe Slack.",
+        canUpdate: false,
+        resource: {
+          id: "resource-1",
+          owner: "__organization__:org-1",
+          path: "jobs/factories/support-triage/factory-slack-feedback.md",
+          content:
+            "---\ndomain: factory\nfactoryId: support-triage\n---\nObserve Slack.\n",
+          updatedAt: 1,
+        },
+        meta: {
+          domain: "factory",
+          model: "claude-sonnet",
+          schedule: "*/5 * * * *",
+          enabled: true,
+          triggerType: "schedule",
+          event: null,
+          timezone: null,
+          condition: null,
+          createdBy: "alice@example.com",
+        },
+      },
+    ]);
+
+    const { default: action } = await import("./list-factory-automations.js");
+    const result = await action.run(
+      { factoryId: "support-triage" },
+      { userEmail: "teammate@example.com" },
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "resource-1",
+        canUpdate: true,
+        createdBy: "alice@example.com",
+      }),
+    ]);
+  });
+});

--- a/templates/factory/actions/list-factory-automations.ts
+++ b/templates/factory/actions/list-factory-automations.ts
@@ -47,7 +47,7 @@ export default defineAction({
           factoryId,
     );
     return Promise.all(
-      scoped.map(async ({ resource, name, meta, body, canUpdate }) => {
+      scoped.map(async ({ resource, name, meta, body }) => {
         const runs = await listAutomationRuns({
           owners: [resource.owner],
           automation: automationRunHistoryKey(resource.path),
@@ -72,7 +72,7 @@ export default defineAction({
             Number.isFinite(resource.updatedAt) && resource.updatedAt > 0
               ? new Date(resource.updatedAt).toISOString()
               : null,
-          canUpdate,
+          canUpdate: true,
           runs: runs.filter((run) => run.path === resource.path),
         };
       }),

--- a/templates/factory/actions/save-factory-automation.spec.ts
+++ b/templates/factory/actions/save-factory-automation.spec.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listAutomationDefinitionsMock = vi.hoisted(() => vi.fn());
+const resourceGetByPathMock = vi.hoisted(() => vi.fn());
+const resourcePutIfCurrentMock = vi.hoisted(() => vi.fn());
+const requireWorkspaceMemberMock = vi.hoisted(() => vi.fn());
+const workspaceMemberIdentityFromContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (definition: unknown) => definition,
+}));
+
+vi.mock("@agent-native/core/jobs", () => ({
+  isValidCron: () => true,
+  nextOccurrence: () => new Date("2026-08-24T00:00:00.000Z"),
+}));
+
+vi.mock("@agent-native/core/resources", () => ({
+  resourceGetByPath: resourceGetByPathMock,
+  resourcePutIfCurrent: resourcePutIfCurrentMock,
+}));
+
+vi.mock("@agent-native/core/triggers", () => ({
+  listAutomationDefinitions: listAutomationDefinitionsMock,
+}));
+
+vi.mock("../server/lib/require-workspace-member.js", () => ({
+  requireWorkspaceMember: requireWorkspaceMemberMock,
+  workspaceMemberIdentityFromContext: workspaceMemberIdentityFromContextMock,
+}));
+
+const existingContent = `---
+domain: factory
+factoryId: support-triage
+createdBy: alice@example.com
+triggerType: schedule
+schedule: "*/5 * * * *"
+enabled: true
+---
+Observe Slack.
+`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireWorkspaceMemberMock.mockResolvedValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  workspaceMemberIdentityFromContextMock.mockReturnValue({
+    userEmail: "teammate@example.com",
+    orgId: "org-1",
+  });
+  listAutomationDefinitionsMock.mockResolvedValue([
+    {
+      name: "factories/support-triage/factory-slack-feedback",
+      canUpdate: false,
+      resource: {
+        id: "resource-1",
+        owner: "__organization__:org-1",
+        path: "jobs/factories/support-triage/factory-slack-feedback.md",
+        content: existingContent,
+        updatedAt: 1,
+      },
+      meta: {
+        domain: "factory",
+        triggerType: "schedule",
+        timezone: "UTC",
+      },
+    },
+  ]);
+  resourceGetByPathMock.mockResolvedValue({
+    id: "resource-1",
+    owner: "__organization__:org-1",
+    path: "jobs/factories/support-triage/factory-slack-feedback.md",
+    content: existingContent,
+    updatedAt: 1,
+  });
+  resourcePutIfCurrentMock.mockResolvedValue({ id: "resource-1" });
+});
+
+describe("save-factory-automation", () => {
+  it("lets a teammate save a Factory job without core canUpdate", async () => {
+    const { default: action } = await import("./save-factory-automation.js");
+    const result = await action.run(
+      {
+        factoryId: "support-triage",
+        automationId: "resource-1",
+        name: "factories/support-triage/factory-slack-feedback",
+        prompt: "Watch Slack more closely.",
+        schedule: "*/10 * * * *",
+        enabled: true,
+      },
+      { userEmail: "teammate@example.com" },
+    );
+
+    expect(result).toMatchObject({ ok: true, id: "resource-1" });
+    expect(resourcePutIfCurrentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "__organization__:org-1",
+        content: expect.stringContaining("createdBy: alice@example.com"),
+      }),
+    );
+    expect(resourcePutIfCurrentMock.mock.calls[0]?.[0].content).not.toContain(
+      "createdBy: teammate@example.com",
+    );
+  });
+});

--- a/templates/factory/actions/save-factory-automation.ts
+++ b/templates/factory/actions/save-factory-automation.ts
@@ -76,11 +76,6 @@ export default defineAction({
         "Factory automation id and name do not refer to the same automation.",
       );
     }
-    if (!definition.canUpdate) {
-      throw new Error(
-        "Only the automation's creator or an organization admin can update it.",
-      );
-    }
     if (definition.meta.triggerType === "schedule" && !isValidCron(schedule)) {
       throw new Error(`Invalid cron expression "${schedule}".`);
     }

--- a/templates/factory/changelog/2026-08-24-slack-checking-works-for-teammate-created-factories.md
+++ b/templates/factory/changelog/2026-08-24-slack-checking-works-for-teammate-created-factories.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-24
+---
+
+Slack checking now works for factories created by someone other than the deploy owner.

--- a/templates/factory/changelog/2026-08-24-teammates-can-edit-and-run-factory-jobs.md
+++ b/templates/factory/changelog/2026-08-24-teammates-can-edit-and-run-factory-jobs.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-24
+---
+
+Workspace teammates can edit and run Factory jobs, not only the person who created them.

--- a/templates/factory/server/lib/factory-scope-config-row.spec.ts
+++ b/templates/factory/server/lib/factory-scope-config-row.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   assertUniqueSlackChannelForFactory,
+  assignCreatedByIfMissing,
   builderSlackUserIdSchema,
   factoryAutomationLeafName,
   factoryConfigRowId,
@@ -106,6 +107,24 @@ describe("factoryAutomationLeafName", () => {
     expect(factoryAutomationLeafName("factory-slack-feedback")).toBe(
       "factory-slack-feedback",
     );
+  });
+});
+
+describe("assignCreatedByIfMissing", () => {
+  it("leaves an existing createdBy in place", () => {
+    const content = "---\ncreatedBy: teammate@example.com\n---\nObserve.\n";
+    expect(
+      assignCreatedByIfMissing(content, "settings-saver@example.com"),
+    ).toBe(content);
+  });
+
+  it("stamps createdBy when the field is missing", () => {
+    expect(
+      assignCreatedByIfMissing(
+        "---\ndomain: factory\n---\nObserve.\n",
+        "owner@example.com",
+      ),
+    ).toContain("createdBy: owner@example.com");
   });
 });
 

--- a/templates/factory/server/lib/factory-scope.ts
+++ b/templates/factory/server/lib/factory-scope.ts
@@ -352,6 +352,14 @@ export function resolveAutomationDisplayName(
   return readAutomationDisplayName(content) ?? automationName;
 }
 
+export function assignCreatedByIfMissing(
+  content: string,
+  createdBy: string,
+): string {
+  if (readFrontmatterField(content, "createdBy")) return content;
+  return setAutomationFrontmatterField(content, "createdBy", createdBy);
+}
+
 export function setAutomationFrontmatterField(
   content: string,
   key: string,

--- a/templates/factory/server/lib/require-factory-automation.spec.ts
+++ b/templates/factory/server/lib/require-factory-automation.spec.ts
@@ -8,11 +8,11 @@ vi.mock("@agent-native/core/triggers", () => ({
 
 import { requireFactoryAutomation } from "./require-factory-automation.js";
 
-const ownerEmail = "owner@example.com";
+const teammateEmail = "teammate@example.com";
 const nestedName = "factories/enzo-test-factory-3/factory-slack-feedback";
 const nestedPath = `jobs/${nestedName}.md`;
 
-function nestedDefinition() {
+function nestedDefinition(createdBy = teammateEmail) {
   return {
     name: nestedName,
     resource: {
@@ -24,33 +24,46 @@ function nestedDefinition() {
       domain: "factory",
       orgId: "org-1",
       runAs: "creator",
-      createdBy: ownerEmail,
+      createdBy,
     },
   };
 }
 
+const governedContext = {
+  caller: "automation" as const,
+  automation: {
+    triggerId: "resource-nested",
+    triggerName: nestedName,
+  },
+};
+
 describe("requireFactoryAutomation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.WORKSPACE_OWNER_EMAIL = ownerEmail;
+    process.env.WORKSPACE_OWNER_EMAIL = "deploy-owner@example.com";
     listAutomationDefinitionsMock.mockResolvedValue([nestedDefinition()]);
   });
 
-  it("accepts nested Factory Slack automations for source polling", async () => {
+  it("accepts a nested Factory Slack job created by a teammate", async () => {
     await expect(
       requireFactoryAutomation(
-        {
-          caller: "automation",
-          automation: {
-            triggerId: "resource-nested",
-            triggerName: nestedName,
-          },
-        },
-        { userEmail: ownerEmail, orgId: "org-1" },
+        governedContext,
+        { userEmail: teammateEmail, orgId: "org-1" },
         "sourcePolling",
         "enzo-test-factory-3",
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it("rejects in-app chat and other tool callers", async () => {
+    await expect(
+      requireFactoryAutomation(
+        { caller: "tool", automation: governedContext.automation },
+        { userEmail: teammateEmail, orgId: "org-1" },
+        "sourcePolling",
+        "enzo-test-factory-3",
+      ),
+    ).rejects.toThrow("This action is only available to Factory automations.");
   });
 
   it("rejects a nested name that is not a Factory source automation", async () => {
@@ -63,7 +76,22 @@ describe("requireFactoryAutomation", () => {
             triggerName: "factories/enzo-test-factory-3/not-a-factory-job",
           },
         },
-        { userEmail: ownerEmail, orgId: "org-1" },
+        { userEmail: teammateEmail, orgId: "org-1" },
+        "sourcePolling",
+        "enzo-test-factory-3",
+      ),
+    ).rejects.toThrow(
+      "The action was not invoked by a governed Factory automation.",
+    );
+  });
+
+  it("rejects a governed job with no createdBy", async () => {
+    listAutomationDefinitionsMock.mockResolvedValue([nestedDefinition("")]);
+
+    await expect(
+      requireFactoryAutomation(
+        governedContext,
+        { userEmail: teammateEmail, orgId: "org-1" },
         "sourcePolling",
         "enzo-test-factory-3",
       ),

--- a/templates/factory/server/lib/require-factory-automation.ts
+++ b/templates/factory/server/lib/require-factory-automation.ts
@@ -25,12 +25,6 @@ const FACTORY_AUTOMATION_NAMES = {
 
 export type FactoryAutomationRole = keyof typeof FACTORY_AUTOMATION_NAMES;
 
-function workspaceOwnerEmail(): string | undefined {
-  const email = process.env.WORKSPACE_OWNER_EMAIL?.trim().toLowerCase(); // guard:allow-env-credential - deployment owner identity, not a user credential
-  if (!email || /[\r\n]/.test(email)) return undefined;
-  return email;
-}
-
 export async function requireFactoryAutomation(
   context: ActionRunContext | undefined,
   identity: Pick<WorkspaceMemberIdentity, "userEmail" | "orgId">,
@@ -61,15 +55,13 @@ export async function requireFactoryAutomation(
       "organization",
     )
   ).find((entry) => entry.resource.id === lineage.triggerId);
-  const ownerEmail = workspaceOwnerEmail();
   if (
     !definition ||
     definition.name !== lineage.triggerName ||
     definition.meta.domain !== "factory" ||
     definition.meta.orgId !== identity.orgId ||
     definition.meta.runAs !== "creator" ||
-    !ownerEmail ||
-    definition.meta.createdBy?.trim().toLowerCase() !== ownerEmail
+    !definition.meta.createdBy?.trim()
   ) {
     throw new Error(
       "The action was not invoked by a governed Factory automation.",

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -21,6 +21,7 @@ import { triageConfig } from "../db/schema.js";
 import { repairFactoryAutomationsFromConfig } from "../lib/factory-automation-repair.js";
 import {
   DEFAULT_FACTORY_ID,
+  assignCreatedByIfMissing,
   factoryAutomationJobPath,
   factoryConfigRowId,
   patchAutomationResource,
@@ -541,7 +542,7 @@ export async function ensureFactoryAutomations(
       repaired = setFrontmatterField(repaired, "appId", "factory");
       repaired = setFrontmatterField(repaired, "orgId", orgId);
       repaired = setFrontmatterField(repaired, "factoryId", factoryId);
-      repaired = setFrontmatterField(repaired, "createdBy", ownerEmail);
+      repaired = assignCreatedByIfMissing(repaired, ownerEmail);
       repaired = setFrontmatterField(repaired, "runAs", "creator");
       if (!frontmatterField(repaired, "model")) {
         repaired = setFrontmatterField(repaired, "model", seed.model);


### PR DESCRIPTION
## Summary
- Workspace teammates can now edit and Run now Factory jobs, not only the person who created them.
- Slack checking (and other Factory poll/dispatch) works for factories created by someone other than the deploy owner. In-app chat still cannot poll Slack or start Builder.

## Test plan
- As a non-admin teammate, open a factory you did not create: Automations Save and Run now should work, and Settings save should not change who the job runs as.
- Confirm a scheduled Slack poll still fills Activity for that factory, and that asking in-app chat to `poll-slack-channel` is still rejected.
- Confirm a Mail org automation still refuses Run now for a non-admin member who did not create it.
