### PR TITLE
fix(desktop): preserve workspace app SSO eligibility

### DIFF
--- a/packages/desktop-app/src/main/workspace-apps.spec.ts
+++ b/packages/desktop-app/src/main/workspace-apps.spec.ts
@@ -46,6 +46,7 @@ describe("loadDesktopWorkspaceApps", () => {
               name: "Alpha",
               description: "Workspace tool",
               path: "/alpha",
+              workspaceSso: true,
               status: "ready",
             },
             { id: "pending", path: "/pending", status: "pending" },
@@ -77,6 +78,42 @@ describe("loadDesktopWorkspaceApps", () => {
     expect(fetch.mock.calls[1]?.[0]).toContain(
       "includeAgentCards=false&audience=all",
     );
+  });
+
+  it("preserves the server's workspace SSO eligibility per app", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(response({ [WORKSPACE_APP_LIST_FLAG_KEY]: true }))
+      .mockResolvedValueOnce(
+        response({
+          apps: [
+            {
+              id: "registered",
+              name: "Registered",
+              path: "/registered",
+              workspaceSso: true,
+              status: "ready",
+            },
+            {
+              id: "unregistered",
+              name: "Unregistered",
+              path: "/unregistered",
+              workspaceSso: false,
+              status: "ready",
+            },
+          ],
+        }),
+      );
+
+    const result = await loadDesktopWorkspaceApps({
+      identitySession: sessionFor(fetch),
+      dispatchOrigin: "https://dispatch.example.com",
+    });
+
+    expect(result.apps).toEqual([
+      expect.objectContaining({ id: "registered", workspaceSso: true }),
+      expect.objectContaining({ id: "unregistered", workspaceSso: false }),
+    ]);
   });
 
   it("passes the authenticated session cookies to the rollout and inventory requests", async () => {

--- a/packages/desktop-app/src/main/workspace-apps.ts
+++ b/packages/desktop-app/src/main/workspace-apps.ts
@@ -133,7 +133,7 @@ export async function loadDesktopWorkspaceApps(options: {
     const apps = normalizeWorkspaceAppConfigs(inventory, { baseUrl: origin });
     return {
       enabled: true,
-      apps: apps.map((app) => ({ ...app, workspaceSso: true })),
+      apps,
     };
   } catch (error) {
     // Native shells fail closed while the rollout or session is unavailable.

--- a/packages/shared-app-config/index.ts
+++ b/packages/shared-app-config/index.ts
@@ -151,6 +151,9 @@ export function normalizeWorkspaceAppConfigs(
       enabled: true,
       mode: "prod",
       ...(color ? { color } : {}),
+      ...(typeof record.workspaceSso === "boolean"
+        ? { workspaceSso: record.workspaceSso }
+        : {}),
     });
   }
 


### PR DESCRIPTION
## Summary
- preserve Dispatch's per-app `workspaceSso` eligibility in the native workspace-app inventory
- stop Desktop from treating every workspace app as SSO-eligible
- add regression coverage for registered and unregistered apps in the same inventory

## Feedback evidence
Sentry issue [AGENT-NATIVE-BROWSER-FH](https://bridge-tm.sentry.io/issues/7688887915/) recorded 22 production failures for `3dot0-faq`: Desktop forced the app through the workspace SSO action even though Dispatch did not register it for workspace sign-in.

## Validation
- `git diff --check`
- Focused local tests were attempted but this worktree has no installed `node_modules`; CI is the dependency-backed validation gate.
