### PR TITLE
fix: preserve chat drafts and simplify muted mic state

### DIFF
--- a/.changeset/soft-dogs-throw.md
+++ b/.changeset/soft-dogs-throw.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Analytics chat composer drafts to prefer the stable tab identity over a late-arriving thread identity, preventing typed text from disappearing when the draft scope changes.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -157,6 +157,7 @@ describe("AssistantChat thread restore and composer recovery", () => {
     expect(source).toContain(
       "writeAssistantChatComposerDraft(composerDraftScope, text)",
     );
+    expect(source).toContain("const composerDraftScope = tabId || threadId;");
     expect(source).toContain("initialTextKey={composerDraftScope}");
     expect(source).toContain("draftScope={composerDraftScope}");
   });

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2540,7 +2540,7 @@ const AssistantChatInner = forwardRef<
   // Cleared on the next message send.
   const [composerError, setComposerError] = useState<string | null>(null);
   const [composerText, setComposerText] = useState("");
-  const composerDraftScope = threadId || tabId;
+  const composerDraftScope = tabId || threadId;
   const initialComposerText = useMemo(
     () => readAssistantChatComposerDraft(composerDraftScope),
     [composerDraftScope],

--- a/templates/analytics/changelog/2026-08-24-chat-draft-preservation.md
+++ b/templates/analytics/changelog/2026-08-24-chat-draft-preservation.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-24
+---
+Analytics chat drafts now stay in place while a new chat finishes loading.

--- a/templates/clips/changelog/2026-08-24-muted-microphone-start-guidance.md
+++ b/templates/clips/changelog/2026-08-24-muted-microphone-start-guidance.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-24
+---
+Muted microphone alerts now return you to recording setup before recording starts.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -4303,9 +4303,7 @@ export function App({
   return (
     <div className="app app-recorder" ref={appRef}>
       {micOffConfirmOpen ? (
-        <MicOffConfirmation
-          onBack={closeMicOffConfirmation}
-        />
+        <MicOffConfirmation onBack={closeMicOffConfirmation} />
       ) : null}
 
       <div

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1087,8 +1087,6 @@ export function App({
   );
   const [micOn, setMicOn] = useState<boolean>(() => loadBool(MIC_ON_KEY, true));
   const [micOffConfirmOpen, setMicOffConfirmOpen] = useState(false);
-  const pendingStartOptionsRef =
-    useRef<Parameters<typeof handleStartRecording>[0]>(undefined);
   const [systemAudioOn, setSystemAudioOn] = useState<boolean>(() =>
     loadBool(SYSTEM_AUDIO_KEY, true),
   );
@@ -3591,16 +3589,14 @@ export function App({
   }, []);
 
   // Gates every start-recording gesture (button, global shortcut, permission
-  // retry) on the mic toggle. When the mic is off we hold the actual
-  // getDisplayMedia/getUserMedia call until the user confirms in
-  // micOffConfirmOpen — the confirm button's own click supplies the user
-  // activation handleStartRecording needs, same as the direct gesture would.
+  // retry) on the mic toggle. When the mic is off we show the informational
+  // mic-off screen and wait for the user to go back and change that setting
+  // before the actual getDisplayMedia/getUserMedia call runs.
   function beginRecording(
     options?: Parameters<typeof handleStartRecording>[0],
     beginOptions?: { revealPopoverIfMicOff?: boolean },
   ) {
     if (!micOn) {
-      pendingStartOptionsRef.current = options;
       if (beginOptions?.revealPopoverIfMicOff) {
         invoke("show_popover").catch(() => {});
       }
@@ -3611,19 +3607,7 @@ export function App({
   }
 
   function closeMicOffConfirmation() {
-    pendingStartOptionsRef.current = undefined;
     setMicOffConfirmOpen(false);
-  }
-
-  function unmuteFromConfirmation() {
-    setMicOn(true);
-    closeMicOffConfirmation();
-  }
-
-  function continueWithoutMic() {
-    const options = pendingStartOptionsRef.current;
-    closeMicOffConfirmation();
-    void handleStartRecording(options);
   }
 
   recordShortcutHandlerRef.current = () => {
@@ -4321,8 +4305,6 @@ export function App({
       {micOffConfirmOpen ? (
         <MicOffConfirmation
           onBack={closeMicOffConfirmation}
-          onUnmute={unmuteFromConfirmation}
-          onContinue={continueWithoutMic}
         />
       ) : null}
 

--- a/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
@@ -1,0 +1,18 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { MicOffConfirmation } from "./MicOffConfirmation";
+
+describe("MicOffConfirmation", () => {
+  it("only exposes Back in the muted info state", () => {
+    const html = renderToStaticMarkup(
+      <MicOffConfirmation onBack={vi.fn()} />,
+    );
+
+    expect(html).toContain("Back");
+    expect(html).toContain("Your mic is muted");
+    expect(html).toContain("change your microphone setting");
+    expect(html).not.toContain("Unmute");
+    expect(html).not.toContain("Continue");
+  });
+});

--- a/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
@@ -5,9 +5,7 @@ import { MicOffConfirmation } from "./MicOffConfirmation";
 
 describe("MicOffConfirmation", () => {
   it("only exposes Back in the muted info state", () => {
-    const html = renderToStaticMarkup(
-      <MicOffConfirmation onBack={vi.fn()} />,
-    );
+    const html = renderToStaticMarkup(<MicOffConfirmation onBack={vi.fn()} />);
 
     expect(html).toContain("Back");
     expect(html).toContain("Your mic is muted");

--- a/templates/clips/desktop/src/components/MicOffConfirmation.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.tsx
@@ -1,10 +1,6 @@
 import { IconArrowLeft, IconMicrophone2 } from "@tabler/icons-react";
 
-export function MicOffConfirmation({
-  onBack,
-}: {
-  onBack: () => void;
-}) {
+export function MicOffConfirmation({ onBack }: { onBack: () => void }) {
   return (
     <section className="mic-off-confirmation" aria-labelledby="mic-off-title">
       <header className="mic-off-confirmation-header">

--- a/templates/clips/desktop/src/components/MicOffConfirmation.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.tsx
@@ -2,12 +2,8 @@ import { IconArrowLeft, IconMicrophone2 } from "@tabler/icons-react";
 
 export function MicOffConfirmation({
   onBack,
-  onUnmute,
-  onContinue,
 }: {
   onBack: () => void;
-  onUnmute: () => void;
-  onContinue: () => void;
 }) {
   return (
     <section className="mic-off-confirmation" aria-labelledby="mic-off-title">
@@ -29,19 +25,10 @@ export function MicOffConfirmation({
         </div>
         <h2 id="mic-off-title">Your mic is muted</h2>
         <p>
-          To have sound in your video, you&apos;ll need to unmute your
-          microphone.
+          You can change your microphone setting and then come back to start
+          recording.
         </p>
       </div>
-
-      <footer className="mic-off-confirmation-actions">
-        <button type="button" className="secondary" onClick={onUnmute}>
-          Unmute
-        </button>
-        <button type="button" className="primary" onClick={onContinue}>
-          Continue
-        </button>
-      </footer>
     </section>
   );
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2177,26 +2177,6 @@ body[data-clips-route="recording-pill"] #root {
   line-height: 1.55;
 }
 
-.mic-off-confirmation-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  padding: 16px 18px 18px;
-  border-top: 1px solid var(--border);
-  background: var(--surface);
-}
-
-.mic-off-confirmation-actions .primary,
-.mic-off-confirmation-actions .secondary {
-  width: auto;
-  min-width: 0;
-  height: 42px;
-  padding: 0 12px;
-  border-radius: var(--radius);
-  font-size: 13px;
-  white-space: nowrap;
-}
-
 /* ------------------------------------------------------------------------- */
 /* Alert dialog                                                              */
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes two product-feedback regressions:

- Clips desktop muted-microphone start attempts now show a Back-only informational state; removed the misleading Unmute/Continue actions and dead flow.
- Analytics chat drafts prefer the stable client tab identity, so a late thread identity cannot clear typed text.

Added focused coverage and dated app changelog entries.

Feedback:
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787604853135799
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787604969165319