### PR TITLE
fix(auth): emit the signup event once, only when someone actually signed up

### DIFF
--- a/.changeset/signup-event-is-an-acquisition.md
+++ b/.changeset/signup-event-is-an-acquisition.md
@@ -1,0 +1,17 @@
+---
+"@agent-native/core": patch
+---
+
+Emit the `signup` event once per real account creation, and stop emitting it for user rows that are not signups.
+
+Better Auth runs its `user.create.after` hook on every `user` row insert, and the hook treated all of them as a person signing up. Two production paths create rows through `internalAdapter` outside any endpoint, where Better Auth's context — and therefore the request, the browser, and its `an_aid` / `an_ft` cookies — is `null`: `ensureCanonicalUserForLegacySession` (backfilling a canonical row for someone who signed up months ago) and `ensureGoogleAuthIdentity` (provisioning the canonical row during the Google callback). Both emitted an unattributable `signup` recorded as `referral_source: "direct"`, which is why ~94% of `better-auth` signups carried no `anonymous_id` and one person provisioned across sibling apps counted as a dozen acquisitions.
+
+Google sign-in was also losing its real event: because `ensureGoogleAuthIdentity` writes the canonical row _before_ `createOAuthSession` runs, the `hasBetterAuthUserEmail` probe there concluded the person was an existing user and skipped the one emitter that carries the browser's anonymous id. Callers now pass the `isNewUser` answer they already hold, and the event carries the canonical Better Auth user id rather than the Google profile id, so it still joins to `referrer_user` in the virality panels.
+
+- A row insert with no request behind it emits nothing at all.
+- Emitted events carry `signup_origin` (`browser_signup` / `google_oauth` / `sso_jit`) so acquisitions are selectable from sibling-app provisioning.
+- `referral_source: "direct"` is no longer fabricated when no browser context was present — "we never saw a visitor" and "a visitor arrived with no campaign" are now different values.
+- The internal `x-agent-native-signup-attribution` handoff header is stripped from every inbound request instead of only being overwritten on email signup. It is unsigned and outranks the request cookie, so an inbound copy let any client write the `anonymous_id` and campaign onto someone else's signup row.
+- The `webhook` tracking provider now sends `anonymousId`, which it silently dropped.
+
+Signup counts will fall to the real number. The removed rows were duplicate and backfilled events, not lost users.

--- a/packages/core/src/server/attribution.spec.ts
+++ b/packages/core/src/server/attribution.spec.ts
@@ -7,6 +7,7 @@ import {
   deriveSignupAttribution,
   encodeSignupAttributionContext,
   parseCookieHeader,
+  SIGNUP_ATTRIBUTION_HEADER_NAME,
   readAnalyticsAnonymousId,
   readFirstTouchAttribution,
   signupAttributionContextFromCookieHeader,
@@ -253,8 +254,30 @@ describe("signupAttributionContextFromCookieHeader", () => {
   it("keeps malformed browser identity input out of the context", () => {
     expect(
       signupAttributionContextFromCookieHeader("an_aid=has%20space"),
+    ).toBeUndefined();
+  });
+
+  // A browser that ran our client script always has `an_ft`, so no cookies at
+  // all means no browser. Reporting that as "direct" is what made an
+  // unattributable server-side row indistinguishable from a real visitor who
+  // arrived with no campaign — and it is why 94% of `better-auth` signups read
+  // as direct traffic nobody could trace.
+  it("reports no browser context rather than direct attribution", () => {
+    expect(signupAttributionContextFromCookieHeader(null)).toBeUndefined();
+    expect(signupAttributionContextFromCookieHeader("")).toBeUndefined();
+    expect(
+      signupAttributionContextFromCookieHeader("other=1; session=abc"),
+    ).toBeUndefined();
+  });
+
+  it("still reports direct for a real visitor carrying no campaign", () => {
+    expect(
+      signupAttributionContextFromCookieHeader(
+        `${ftCookie({ landing_path: "/" })}; an_aid=anon_1`,
+      ),
     ).toEqual({
-      attribution: { referral_source: "direct" },
+      attribution: { referral_source: "direct", first_touch_path: "/" },
+      anonymousId: "anon_1",
     });
   });
 });
@@ -279,5 +302,23 @@ describe("signup attribution request handoff", () => {
   it("distinguishes malformed handoffs from direct attribution", () => {
     expect(decodeSignupAttributionContext("not-json")).toBeUndefined();
     expect(signupAttributionContextFromHeaders(new Headers())).toBeUndefined();
+  });
+
+  // The handoff header is unsigned and outranks the request cookie in the
+  // user-create hook, so an inbound copy lets a stranger write the
+  // `anonymous_id` and campaign onto somebody else's signup row.
+  it("drops an inbound handoff when there is nothing of ours to stamp", () => {
+    const spoofed = addSignupAttributionHeader(
+      {
+        [SIGNUP_ATTRIBUTION_HEADER_NAME]: encodeSignupAttributionContext({
+          attribution: { utm_campaign: "attacker" },
+          anonymousId: "anon_attacker",
+        }),
+      },
+      undefined,
+    );
+
+    expect(spoofed.get(SIGNUP_ATTRIBUTION_HEADER_NAME)).toBeNull();
+    expect(signupAttributionContextFromHeaders(spoofed)).toBeUndefined();
   });
 });

--- a/packages/core/src/server/attribution.ts
+++ b/packages/core/src/server/attribution.ts
@@ -43,6 +43,22 @@ export interface FirstTouchAttribution {
 }
 
 /**
+ * Which flow created the account, as opposed to which credential it uses.
+ *
+ * Better Auth fires its `user.create.after` hook on every `user` row insert,
+ * but only some inserts are a person signing up in a browser. Every emitted
+ * `signup` event names its origin so a campaign report can select the ones
+ * that are acquisitions instead of counting row inserts.
+ */
+export type SignupOrigin =
+  /** A person completed a signup form or magic link in a browser. */
+  | "browser_signup"
+  /** The framework's Google OAuth callback owns this event. */
+  | "google_oauth"
+  /** Federated SSO provisioning an identity into a sibling app. */
+  | "sso_jit";
+
+/**
  * Request-scoped browser attribution captured at the signup boundary.
  * Better Auth may create the user in a later async callback where the
  * original request headers are no longer available, so the values must be
@@ -255,13 +271,22 @@ export function signupAttributionFromCookieHeader(
  * Capture all browser attribution needed by the server-side signup event.
  * Keep this as one boundary helper so every signup entry point carries the
  * same values into Better Auth's user-create hook.
+ *
+ * Returns `undefined` when the request carried neither cookie. A browser that
+ * ran our client script always has `an_ft`, so "no cookies at all" means no
+ * browser — a server-side backfill or provisioning call. Reporting that as
+ * `referral_source: "direct"` is the coercion that made this metric unusable:
+ * it renders "we never saw a visitor" identical to "a visitor arrived with no
+ * campaign", and only the second one is direct traffic.
  */
 export function signupAttributionContextFromCookieHeader(
   cookieHeader: string | null | undefined,
-): SignupAttributionContext {
+): SignupAttributionContext | undefined {
+  const firstTouch = readFirstTouchAttribution(cookieHeader);
   const anonymousId = readAnalyticsAnonymousId(cookieHeader);
+  if (!firstTouch && !anonymousId) return undefined;
   return {
-    attribution: signupAttributionFromCookieHeader(cookieHeader),
+    attribution: deriveSignupAttribution(firstTouch),
     ...(anonymousId ? { anonymousId } : {}),
   };
 }
@@ -320,12 +345,24 @@ export function decodeSignupAttributionContext(
   }
 }
 
-/** Add the explicit handoff to a Better Auth request/API header set. */
+/**
+ * Stamp the explicit handoff onto a Better Auth request/API header set.
+ *
+ * This is the only writer of the handoff header, and it always writes: with a
+ * context it sets ours, without one it deletes whatever was there. The header
+ * is unsigned and outranks the request cookie when the hook reads it, so an
+ * inbound copy from the public internet is an attacker-supplied `anonymous_id`
+ * and campaign for someone else's signup row. Never merge — replace.
+ */
 export function addSignupAttributionHeader(
   headers: HeadersInit | undefined,
-  context: SignupAttributionContext,
+  context: SignupAttributionContext | undefined,
 ): Headers {
   const result = new Headers(headers);
+  if (!context) {
+    result.delete(SIGNUP_ATTRIBUTION_HEADER_NAME);
+    return result;
+  }
   result.set(
     SIGNUP_ATTRIBUTION_HEADER_NAME,
     encodeSignupAttributionContext(context),

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -6285,6 +6285,7 @@ describe("server/auth", () => {
       expect(hasBetterAuthUserEmail).toHaveBeenCalledWith("user@gmail.com");
       expect(trackSignupEvent).toHaveBeenCalledWith({
         authProvider: "google",
+        origin: "google_oauth",
         authUserId: "google-user-1",
         email: "user@gmail.com",
         name: "Google User",
@@ -6351,6 +6352,7 @@ describe("server/auth", () => {
 
       expect(trackSignupEvent).toHaveBeenCalledWith({
         authProvider: "google",
+        origin: "google_oauth",
         authUserId: "google-user-1",
         email: "user@gmail.com",
         name: "Google User",

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -140,6 +140,7 @@ import { injectBetaOptOutPersistence } from "./beta-opt-out-html.js";
 import {
   createBetterAuthSessionForEmail,
   ensureGoogleAuthIdentity,
+  getBetterAuthUserIdForEmail,
   getAuthSecret,
   getBetterAuth,
   getBetterAuthSync,
@@ -234,9 +235,16 @@ function withSignupAttributionContext<T>(
   );
 }
 
+/**
+ * Replace the internal attribution handoff on a request bound for Better
+ * Auth. Call this on every such request, including the ones with no
+ * attribution to add — the header is unsigned and outranks the request cookie
+ * inside the user-create hook, so an inbound copy is a stranger writing the
+ * `anonymous_id` and campaign of somebody else's signup.
+ */
 function requestWithSignupAttribution(
   request: Request,
-  signupAttribution: SignupAttributionContext,
+  signupAttribution: SignupAttributionContext | undefined,
 ): Request {
   return new Request(request, {
     headers: addSignupAttributionHeader(request.headers, signupAttribution),
@@ -4395,10 +4403,20 @@ async function mountBetterAuthRoutes(
             mobile,
             trackSignup: {
               authProvider: "google",
-              authUserId: typeof user.id === "string" ? user.id : undefined,
+              // The signup event joins to `referrer_user` in the virality
+              // panels, which is always a Better Auth id — the Google profile
+              // id that used to go here joined to nothing. Only looked up when
+              // the event will actually be emitted.
+              authUserId: isNewGoogleUser
+                ? await getBetterAuthUserIdForEmail(email)
+                : undefined,
               name: typeof user.name === "string" ? user.name : undefined,
               attribution: signupAttribution,
               signupAnonymousId,
+              // `ensureGoogleAuthIdentity` above already wrote the canonical
+              // row, so this callback is the only thing that still knows
+              // whether the person is new.
+              isNewUser: isNewGoogleUser,
             },
           });
           logGoogleOAuthDebug(event, "callback-session-created", {
@@ -5003,12 +5021,10 @@ async function mountBetterAuthRoutes(
         }
       }
 
-      if (signupAttribution) {
-        requestForAuth = requestWithSignupAttribution(
-          requestForAuth,
-          signupAttribution,
-        );
-      }
+      requestForAuth = requestWithSignupAttribution(
+        requestForAuth,
+        signupAttribution,
+      );
 
       let response: Response;
       try {

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -70,6 +70,7 @@ import {
 import { flushTracking, identify, track } from "../tracking/index.js";
 import { getAppProductionUrl } from "./app-url.js";
 import {
+  type SignupOrigin,
   signupAttributionContextFromCookieHeader,
   signupAttributionContextFromHeaders,
 } from "./attribution.js";
@@ -118,6 +119,113 @@ export async function hasBetterAuthUserEmail(email: string): Promise<boolean> {
   return !!existing?.user?.email;
 }
 
+/**
+ * The canonical Better Auth user id for an email, or `undefined` when there
+ * is no row (or the adapter is unavailable).
+ *
+ * Signup events must carry this id, not the identity provider's subject id:
+ * the virality panels self-join `auth_user_id` against `referrer_user`, and
+ * `referrer_user` is always a Better Auth id, so a Google profile id in that
+ * column silently joins to nothing.
+ */
+export async function getBetterAuthUserIdForEmail(
+  email: string,
+): Promise<string | undefined> {
+  const adapter = await getBetterAuthInternalAdapter();
+  if (!adapter) return undefined;
+  try {
+    const existing = await adapter.findUserByEmail(email.trim().toLowerCase(), {
+      includeAccounts: false,
+    });
+    return existing?.user?.id || undefined;
+  } catch (error) {
+    // coercion-ok: this is analytics enrichment on the sign-in path. Failing
+    // the sign-in over it would be worse, and the only consequence is one
+    // event missing `auth_user_id` — never a wrong id. Logged, not swallowed.
+    console.error(
+      "[auth] failed to resolve the canonical user id for a signup event",
+      error,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * The endpoint context Better Auth (1.6.x) hands to `user.create.after`. It is
+ * `null` for any row created through `internalAdapter` outside an endpoint —
+ * see `emitSignupEventForCreatedUser`.
+ */
+export interface BetterAuthUserCreateContext {
+  headers?: Headers | null;
+  request?: { headers?: Headers | null; url?: string } | null;
+}
+
+/**
+ * Emit the `signup` event for a freshly created Better Auth `user` row — but
+ * only when that row is an actual person signing up.
+ *
+ * Better Auth runs its create hook on every `user` insert. Only inserts made
+ * through one of its HTTP endpoints carry the originating request; everything
+ * that reaches the row through `internalAdapter` directly gets a null context,
+ * because `getCurrentAuthContext()` throws outside an endpoint. Two production
+ * paths do exactly that, and neither is an acquisition:
+ *
+ *   - `ensureCanonicalUserForLegacySession` backfills a canonical row for
+ *     someone who signed up long ago, on an ordinary authenticated request.
+ *   - `ensureGoogleAuthIdentity` provisions the canonical row during the Google
+ *     callback, whose own attributed event `createOAuthSession` emits.
+ *
+ * Emitting for those is what broke campaign reporting: they arrived with no
+ * browser context and were recorded as `referral_source: "direct"`, so ~94% of
+ * `better-auth` signups were unattributable rows that were never signups, and
+ * one person provisioned across sibling apps counted as a dozen. A row insert
+ * is not an acquisition, so a context-free insert emits nothing at all.
+ */
+export async function emitSignupEventForCreatedUser(
+  user: { id?: string; email?: string; name?: string | null },
+  context?: BetterAuthUserCreateContext | null,
+): Promise<void> {
+  const email = user?.email;
+  if (!email) return;
+
+  const requestHeaders = context?.headers ?? context?.request?.headers ?? null;
+  if (!requestHeaders) return;
+
+  const scoped = hasContinuationLocalRequestContext()
+    ? getRequestContext()
+    : undefined;
+  let attribution: Record<string, string> | undefined;
+  let anonymousId: string | undefined;
+  try {
+    const browser =
+      // The signed magic-link token is the only source that survives the link
+      // being opened in a different browser than the one that requested it.
+      (context?.request?.url?.includes("newUserCallbackURL")
+        ? readMagicLinkSignupAttribution(context.request.url, getAuthSecret())
+        : undefined) ??
+      scoped?.signupAttribution ??
+      signupAttributionContextFromHeaders(requestHeaders) ??
+      signupAttributionContextFromCookieHeader(requestHeaders.get("cookie"));
+    attribution = browser?.attribution;
+    anonymousId = browser?.anonymousId;
+  } catch (err) {
+    // Analytics must never block signup, but a parse failure is not "this
+    // visitor came direct" — leave both unset so the event shows the gap
+    // instead of inventing a source for it.
+    console.error("[auth] failed to derive signup attribution", err);
+  }
+
+  await trackSignupEvent({
+    authProvider: "better-auth",
+    origin: scoped?.signupOrigin ?? "browser_signup",
+    authUserId: user.id,
+    email,
+    name: user.name,
+    attribution,
+    anonymousId,
+  });
+}
+
 /** Return whether the canonical user has a verified Google account link. */
 export async function hasGoogleAuthIdentity(
   email: string,
@@ -135,6 +243,7 @@ export async function hasGoogleAuthIdentity(
 
 export async function trackSignupEvent({
   authProvider,
+  origin,
   authUserId,
   email,
   name,
@@ -142,6 +251,7 @@ export async function trackSignupEvent({
   anonymousId,
 }: {
   authProvider: string;
+  origin: SignupOrigin;
   authUserId?: string;
   email: string;
   name?: string | null;
@@ -150,7 +260,9 @@ export async function trackSignupEvent({
    * cookie (see `server/attribution.ts`). Snake_case keys such as
    * `referral_source`, `referrer_user`, and the UTM passthrough are merged
    * into the `signup` event so we can measure where new users came from.
-   * `undefined` values are dropped; a missing object is a clean no-op.
+   * `undefined` values are dropped; a missing object is a clean no-op — and
+   * it must stay a no-op rather than defaulting to `direct`, so a signup we
+   * could not attribute stays visibly different from an unattributed visit.
    */
   attribution?: Record<string, string | undefined>;
   anonymousId?: string;
@@ -173,6 +285,7 @@ export async function trackSignupEvent({
     {
       ...resolveSignupTrackingProperties(),
       auth_provider: authProvider,
+      signup_origin: origin,
       ...(authUserId ? { auth_user_id: authUserId } : {}),
       ...cleanAttribution,
     },
@@ -1469,61 +1582,13 @@ async function createBetterAuthInstance(
               request?: { headers?: Headers | null; url?: string } | null;
             } | null,
           ) => {
-            // When a newly-created user's email has pending org invitations
-            // (common when someone is invited *before* they've signed up),
-            // auto-accept them so the user lands in the org on their very
-            // first page load instead of a blank-slate workspace.
             const email = user?.email;
             if (!email) return;
-            // Derive first-touch referral attribution from the request's
-            // cookie header. Never let attribution parsing throw or block
-            // signup — on any error fall back to `direct`.
-            let attribution: Record<string, string> | undefined;
-            let anonymousId: string | undefined;
-            try {
-              const cookieHeader =
-                context?.headers?.get("cookie") ??
-                context?.request?.headers?.get("cookie") ??
-                null;
-              const scopedSignupAttribution =
-                hasContinuationLocalRequestContext()
-                  ? getRequestContext()?.signupAttribution
-                  : undefined;
-              const requestSignupAttribution =
-                signupAttributionContextFromCookieHeader(cookieHeader);
-              const headerSignupAttribution =
-                signupAttributionContextFromHeaders(context?.headers) ??
-                signupAttributionContextFromHeaders(context?.request?.headers);
-              const magicLinkAttribution = context?.request?.url?.includes(
-                "newUserCallbackURL",
-              )
-                ? readMagicLinkSignupAttribution(
-                    context.request.url,
-                    getAuthSecret(),
-                  )
-                : undefined;
-              attribution =
-                magicLinkAttribution?.attribution ??
-                scopedSignupAttribution?.attribution ??
-                headerSignupAttribution?.attribution ??
-                requestSignupAttribution.attribution;
-              anonymousId =
-                magicLinkAttribution?.anonymousId ??
-                scopedSignupAttribution?.anonymousId ??
-                headerSignupAttribution?.anonymousId ??
-                requestSignupAttribution.anonymousId;
-            } catch (err) {
-              console.error("[auth] failed to derive signup attribution", err);
-              attribution = undefined;
-            }
-            await trackSignupEvent({
-              authProvider: "better-auth",
-              authUserId: user.id,
-              email,
-              name: user.name,
-              attribution,
-              anonymousId,
-            });
+
+            await emitSignupEventForCreatedUser(user, context);
+
+            // Invitations and domain auto-join are about the row existing, not
+            // about how it got here, so they run for backfills too.
             try {
               await acceptPendingInvitationsForEmail(email);
             } catch (err) {

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -753,6 +753,15 @@ export async function createOAuthSession(
       name?: string | null;
       attribution?: Record<string, string | undefined>;
       signupAnonymousId?: string;
+      /**
+       * Whether this callback created the account, decided by the caller at
+       * the moment it created it. Callers that provision the canonical user
+       * before getting here MUST pass this: the `hasBetterAuthUserEmail`
+       * probe below then reads the row they just wrote and concludes the
+       * person is an existing user, which silently deleted the only
+       * attributed signup event Google sign-in produces.
+       */
+      isNewUser?: boolean;
     };
   },
 ): Promise<OAuthSessionResult> {
@@ -767,11 +776,14 @@ export async function createOAuthSession(
   let shouldTrackSignup = false;
   if (!opts.hasProductionSession || needsDeepLink) {
     if (opts.trackSignup && !opts.hasProductionSession) {
-      const [hasLegacySession, hasBetterAuthUser] = await Promise.all([
-        hasLegacySessionForEmail(email).catch(() => true),
-        hasBetterAuthUserEmail(email).catch(() => true),
-      ]);
-      shouldTrackSignup = !hasLegacySession && !hasBetterAuthUser;
+      shouldTrackSignup =
+        opts.trackSignup.isNewUser ??
+        (await Promise.all([
+          hasLegacySessionForEmail(email).catch(() => true),
+          hasBetterAuthUserEmail(email).catch(() => true),
+        ]).then(
+          ([hasLegacySession, hasUser]) => !hasLegacySession && !hasUser,
+        ));
     }
 
     sessionToken = crypto.randomBytes(32).toString("hex");
@@ -786,6 +798,7 @@ export async function createOAuthSession(
         readAnalyticsAnonymousId(getHeader(event, "cookie") ?? null);
       await trackSignupEvent({
         authProvider: opts.trackSignup.authProvider,
+        origin: "google_oauth",
         authUserId: opts.trackSignup.authUserId,
         email,
         name: opts.trackSignup.name,

--- a/packages/core/src/server/identity-sso.ts
+++ b/packages/core/src/server/identity-sso.ts
@@ -611,6 +611,10 @@ export async function handleIdentitySso(
             {
               ...(getRequestContext() ?? {}),
               signupAttribution,
+              // This person already signed up somewhere; we are provisioning
+              // them into this app. Counting it as an acquisition is how one
+              // human became a dozen "signups" across sibling apps.
+              signupOrigin: "sso_jit",
             },
             linkIdentity,
           )

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -167,6 +167,12 @@ export interface RequestContext {
    * async user-create hook. Analytics-only; never used for authorization.
    */
   signupAttribution?: SignupAttributionContext;
+  /**
+   * Which flow is creating a user row on this request. Set by callers that
+   * provision an identity rather than acquire a new person, so the signup
+   * event they trigger says so instead of impersonating a browser signup.
+   */
+  signupOrigin?: import("./attribution.js").SignupOrigin;
   /** Canonical client surface for analytics attribution. */
   clientPlatform?: import("../shared/analytics-platform.js").AnalyticsClientPlatform;
   /**

--- a/packages/core/src/server/signup-event-origin.spec.ts
+++ b/packages/core/src/server/signup-event-origin.spec.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { encodeMagicLinkSignupAttribution } from "./magic-link-attribution.js";
+
+/**
+ * The contract this file pins:
+ *
+ *   a `user` row insert is only a signup when a request created it.
+ *
+ * Better Auth calls `user.create.after` for every insert and hands it a null
+ * context for anything created through `internalAdapter` outside an HTTP
+ * endpoint. In production that is the legacy-session backfill and Google's
+ * canonical-identity provisioning — neither of which is a person signing up.
+ * Emitting for them is what put ~94% of `better-auth` signups into the
+ * warehouse with no `anonymous_id` and a fabricated `referral_source: direct`.
+ *
+ * Every previous attempt at this bug added another attribution source to the
+ * hook and shipped green, because no test ever drove the hook with the context
+ * shape production actually produces. These do.
+ */
+
+const tracked: Array<{
+  name: string;
+  properties: Record<string, unknown>;
+  source?: { userId?: string; anonymousId?: string };
+}> = [];
+
+vi.mock("../tracking/index.js", () => ({
+  track: (
+    name: string,
+    properties: Record<string, unknown>,
+    source?: { userId?: string; anonymousId?: string },
+  ) => {
+    tracked.push({ name, properties, source });
+  },
+  identify: () => {},
+  flushTracking: async () => {},
+}));
+
+const AUTH_SECRET = "test-secret-for-magic-link-attribution";
+vi.mock("./app-url.js", () => ({ getAppProductionUrl: () => undefined }));
+
+let requestContext: Record<string, unknown> | undefined;
+vi.mock("./request-context.js", () => ({
+  getRequestContext: () => requestContext,
+  hasContinuationLocalRequestContext: () => true,
+  runWithRequestContext: (ctx: Record<string, unknown>, fn: () => unknown) =>
+    fn(),
+}));
+
+const { emitSignupEventForCreatedUser, getAuthSecret } =
+  await import("./better-auth-instance.js");
+
+const USER = { id: "user_1", email: "new@example.com", name: "New" };
+
+function firstTouchCookie(value: Record<string, string>): string {
+  return `an_ft=${encodeURIComponent(JSON.stringify(value))}`;
+}
+
+function headersWithCookie(cookie: string): Headers {
+  return new Headers({ cookie });
+}
+
+beforeEach(() => {
+  tracked.length = 0;
+  requestContext = undefined;
+  process.env.BETTER_AUTH_SECRET = AUTH_SECRET;
+});
+
+describe("emitSignupEventForCreatedUser", () => {
+  it("emits an attributed signup for a browser that reached an endpoint", async () => {
+    await emitSignupEventForCreatedUser(USER, {
+      headers: headersWithCookie(
+        `an_aid=anon_browser_1; ${firstTouchCookie({
+          utm_source: "google",
+          utm_campaign: "launch",
+          landing_path: "/",
+        })}`,
+      ),
+    });
+
+    expect(tracked).toHaveLength(1);
+    expect(tracked[0].name).toBe("signup");
+    expect(tracked[0].source?.anonymousId).toBe("anon_browser_1");
+    expect(tracked[0].properties).toMatchObject({
+      auth_provider: "better-auth",
+      signup_origin: "browser_signup",
+      utm_source: "google",
+      utm_campaign: "launch",
+    });
+  });
+
+  // The regression. `ensureGoogleAuthIdentity` and the legacy-session backfill
+  // both land here with no context; each used to mint an unattributable row.
+  it("emits nothing for a row created outside any request", async () => {
+    await emitSignupEventForCreatedUser(USER, null);
+    await emitSignupEventForCreatedUser(USER, undefined);
+    await emitSignupEventForCreatedUser(USER, {});
+    await emitSignupEventForCreatedUser(USER, { request: { url: "/x" } });
+
+    expect(tracked).toEqual([]);
+  });
+
+  // "No browser" and "a browser with no campaign" must not look alike: only
+  // the second one is direct traffic a marketer can act on.
+  it("omits referral_source entirely when the request carried no cookies", async () => {
+    await emitSignupEventForCreatedUser(USER, { headers: new Headers() });
+
+    expect(tracked).toHaveLength(1);
+    expect(tracked[0].properties).not.toHaveProperty("referral_source");
+    expect(tracked[0].source?.anonymousId).toBeUndefined();
+  });
+
+  it("still records direct for a real visitor who arrived with no campaign", async () => {
+    await emitSignupEventForCreatedUser(USER, {
+      headers: headersWithCookie(
+        `an_aid=anon_2; ${firstTouchCookie({ landing_path: "/" })}`,
+      ),
+    });
+
+    expect(tracked[0].properties).toMatchObject({
+      referral_source: "direct",
+      signup_origin: "browser_signup",
+    });
+  });
+
+  it("labels SSO provisioning so one person across sibling apps is not a dozen acquisitions", async () => {
+    requestContext = { signupOrigin: "sso_jit" };
+
+    await emitSignupEventForCreatedUser(USER, {
+      headers: headersWithCookie("an_aid=anon_3"),
+    });
+
+    expect(tracked[0].properties).toMatchObject({ signup_origin: "sso_jit" });
+  });
+
+  it("recovers attribution from the signed magic-link token across browsers", async () => {
+    const token = encodeMagicLinkSignupAttribution(
+      {
+        attribution: { referral_source: "external", utm_source: "newsletter" },
+        anonymousId: "anon_magic_1",
+      },
+      getAuthSecret(),
+    );
+    const callback = `/_agent-native/auth/magic-link/new-user?signup_attribution=${encodeURIComponent(
+      token as string,
+    )}`;
+
+    await emitSignupEventForCreatedUser(USER, {
+      // No cookie: the link was opened in a different browser than the one
+      // that requested it, which is the case the token exists for.
+      headers: new Headers(),
+      request: {
+        url: `https://app.example.com/_agent-native/auth/ba/magic-link/verify?token=t&newUserCallbackURL=${encodeURIComponent(
+          callback,
+        )}`,
+      },
+    });
+
+    expect(tracked[0].source?.anonymousId).toBe("anon_magic_1");
+    expect(tracked[0].properties).toMatchObject({ utm_source: "newsletter" });
+  });
+
+  // The handoff header is unsigned and outranks the cookie, so a request that
+  // arrives carrying one must not be able to author somebody's attribution.
+  it("prefers the request-scoped context over an inbound handoff header", async () => {
+    requestContext = {
+      signupAttribution: {
+        attribution: { utm_source: "real" },
+        anonymousId: "anon_real",
+      },
+    };
+
+    await emitSignupEventForCreatedUser(USER, {
+      headers: new Headers({
+        "x-agent-native-signup-attribution": encodeURIComponent(
+          JSON.stringify({
+            attribution: { utm_source: "spoofed" },
+            anonymousId: "anon_spoofed",
+          }),
+        ),
+      }),
+    });
+
+    expect(tracked[0].source?.anonymousId).toBe("anon_real");
+    expect(tracked[0].properties).toMatchObject({ utm_source: "real" });
+  });
+});

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -417,6 +417,9 @@ function createWebhookProvider(
           event: event.name,
           properties: event.properties,
           userId: event.userId,
+          // Without this a webhook consumer cannot join a signup back to the
+          // anonymous pageviews that preceded it — the whole point of the id.
+          anonymousId: event.anonymousId,
           sessionId: event.sessionId,
           timestamp: event.timestamp,
         }),


### PR DESCRIPTION
## The report

[Slack](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787255399470939): `anonymous_id` is present on ~96% of Google signups but ~4% of Better Auth ones, and Better Auth is 87% of signups. Marketing can't attribute paid campaigns. A previous fix ([#3277](https://github.com/BuilderIO/builder-agent-native-workspace/pull/3277), merged 8/20, live in production since 8/21) did not move the number.

## What the production data actually shows

Queried `builder-3b0a2.analytics.first_party_analytics_events_raw`. In the last 21 days, **2,500 of 2,664** `better-auth` signup rows have no `anonymous_id` — and no `first_touch_path` either, so the whole browser context is absent, not just the id. Better Auth signup volume went from ~20/day to ~250/day on **2026-08-04** while Google's fell from ~1000/day to ~10/day.

Classifying every unattributed row:

| bucket | rows | share |
| --- | ---: | ---: |
| duplicate of a Google signup seconds earlier | 305 | 12% |
| same person, another sibling app | 1,552 | 62% |
| single unattributed row | 632 | 25% |

The signature, same user and app 1.7s apart:

```
2023nitsgr245@nitsri.ac.in | google      | clips | 10:34:42.695Z | anonymous_id: yes
2023nitsgr245@nitsri.ac.in | better-auth | clips | 10:34:44.404Z | anonymous_id: NO
```

468 users have rows under both providers. **Most of these were never signups.**

## Root cause

Better Auth runs `user.create.after` on every `user` row insert, and the hook treated all of them as an acquisition. Verified against `better-auth@1.6.28`: `getCurrentAuthContext()` throws outside an endpoint, so anything created through `internalAdapter` gets `context === null` — no request, no browser, no cookies:

| how the row is created | hook context |
| --- | --- |
| `auth.api.signUpEmail({ headers })` | headers present |
| `auth.handler(Request)` | headers present |
| `internalAdapter.createUser` / `createOAuthUser` | **null** |

Two production paths take the null-context route, and neither is a signup:

1. `ensureCanonicalUserForLegacySession` backfills a canonical row for someone who signed up months ago, on an ordinary authenticated request — once per app, which is the 62% bucket.
2. `ensureGoogleAuthIdentity` provisions the row during the Google callback.

And Google was *also* losing its real event: `ensureGoogleAuthIdentity` (`auth.ts:4373`) writes the row **before** `createOAuthSession` (`auth.ts:4392`) computes `shouldTrackSignup = !hasLegacySession && !hasBetterAuthUser`. That probe reads the row just written, concludes the person already exists, and skips the one emitter carrying the browser's anonymous id. `createOAuthUser` was introduced 2026-08-03; the step change is 2026-08-04.

Every prior fix added another attribution *source* to the hook. None could help: when `context` is null there is nothing to read from.

## The change

- A row insert with no request behind it **emits nothing**. That is one rule replacing two special cases.
- Google's callback passes the `isNewUser` answer it already holds instead of re-deriving it from a now-stale probe, and carries the canonical Better Auth user id (the Google profile id it used to send never joined to `referrer_user` in the virality panels).
- Emitted events carry `signup_origin`: `browser_signup` / `google_oauth` / `sso_jit`, so acquisitions are selectable from sibling-app provisioning.
- `referral_source: "direct"` is no longer fabricated when no browser context was present. "We never saw a visitor" and "a visitor arrived with no campaign" are now different values — that coercion is why this was invisible for three weeks.
- The unsigned `x-agent-native-signup-attribution` handoff is stripped from **every** inbound request, not just overwritten on email signup. It outranks the request cookie in the hook, so an inbound copy let any client write the `anonymous_id` and campaign onto someone else's signup row.
- The `webhook` tracking provider now sends `anonymousId`, which it silently dropped.

## Verification

Ran a real signup in a browser against a locally served template, capturing what the provider that feeds BigQuery actually sends:

```json
{ "event": "signup",
  "properties": { "auth_provider": "better-auth", "signup_origin": "browser_signup",
    "referral_source": "external", "utm_source": "google", "utm_medium": "cpc",
    "utm_campaign": "paid_launch_v2", "first_touch_path": "/sign-in" },
  "userId": "paid-campaign-e2e@example.test",
  "anonymousId": "3563b4eb-bab5-495e-b606-ceb24d2de733" }
```

`anonymousId` is exactly the `an_aid` cookie read in the browser before submitting. One event, full campaign attribution.

Negative case, same running app: with the local dev auto-account enabled (a context-less `signUpEmail`, the same shape as Google provisioning and the legacy backfill), the user row is created and **zero** signup events are emitted.

`signup-event-origin.spec.ts` pins the contract and was checked against the old behavior — it fails there, so it is not vacuous. Core typecheck and full core suite green; the 3 remaining core failures and the `i18n-catalogs` guard failure reproduce on clean `origin/main`.

## Expected impact

**Signup counts will drop to the real number.** The removed rows were duplicates and backfills, not lost users. Existing dashboards count `COUNT(*)` on signup events, so their numbers become truthful rather than inflated; anything needing acquisitions-only can now filter `signup_origin`. Attribution accrues forward from deploy — historical rows are not backfilled.