### PR TITLE
fix(dispatch): use ACL-aware hosted app links

### DIFF
--- a/.changeset/quiet-hosted-app-access.md
+++ b/.changeset/quiet-hosted-app-access.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Use the authenticated workspace app registry for hosted Dispatch app lists so inaccessible apps do not get an Open app action.

--- a/packages/core/src/client/org/workspace-app-links.spec.ts
+++ b/packages/core/src/client/org/workspace-app-links.spec.ts
@@ -6,6 +6,7 @@ import {
   isWorkspaceAppEnvironment,
   parseWorkspaceAppLinks,
   visibleOrgAppLinks,
+  workspaceAppFetchUrls,
 } from "./workspace-app-links.js";
 
 describe("org switcher app links", () => {
@@ -90,5 +91,21 @@ describe("org switcher app links", () => {
     expect(visible.links).toHaveLength(9);
     expect(visible.links[0]?.id).toBe("dispatch");
     expect(visible.overflowCount).toBe(4);
+  });
+
+  it("uses the authenticated action before any local workspace manifest", () => {
+    const actionUrl =
+      "/_agent-native/actions/list-workspace-apps?includeAgentCards=false";
+
+    expect(
+      workspaceAppFetchUrls({
+        VITE_WORKSPACE_GATEWAY_URL: "https://workspace.example.test",
+      }),
+    ).toEqual([actionUrl]);
+    expect(
+      workspaceAppFetchUrls({
+        VITE_WORKSPACE_GATEWAY_URL: "http://127.0.0.1:8080",
+      }),
+    ).toEqual([actionUrl, "http://127.0.0.1:8080/_workspace/apps"]);
   });
 });

--- a/packages/core/src/client/org/workspace-app-links.ts
+++ b/packages/core/src/client/org/workspace-app-links.ts
@@ -282,42 +282,46 @@ export function visibleOrgAppLinks(
 }
 
 function initialWorkspaceLinks(env: RuntimeEnv): OrgSwitcherAppLink[] {
-  return (
-    parseWorkspaceAppLinksJson(
-      envString(env, "VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON"),
-      env,
-    ) ?? [
-      {
-        id: DISPATCH_ID,
-        name: "Dispatch",
-        href: appendPath(workspaceHref("/dispatch", null, env), "overview"),
-        description: "Workspace hub",
-        icon: getTemplate(DISPATCH_ID)?.icon,
-        isDispatch: true,
-        status: "ready",
-      },
-    ]
-  );
+  return [
+    {
+      id: DISPATCH_ID,
+      name: "Dispatch",
+      href: appendPath(workspaceHref("/dispatch", null, env), "overview"),
+      description: "Workspace hub",
+      icon: getTemplate(DISPATCH_ID)?.icon,
+      isDispatch: true,
+      status: "ready",
+    },
+  ];
 }
 
-function workspaceAppFetchUrls(env: RuntimeEnv): string[] {
-  const urls: string[] = [];
+export function workspaceAppFetchUrls(env: RuntimeEnv): string[] {
+  const urls = [
+    "/_agent-native/actions/list-workspace-apps?includeAgentCards=false",
+  ];
   const gatewayUrl = envString(env, "VITE_WORKSPACE_GATEWAY_URL");
   if (gatewayUrl) {
     try {
-      urls.push(
-        new URL(
-          "/_workspace/apps",
-          `${stripTrailingSlash(gatewayUrl)}/`,
-        ).toString(),
-      );
+      const gateway = new URL(gatewayUrl);
+      const localGateway = [
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+        "::1",
+      ].includes(gateway.hostname.replace(/^\[|\]$/g, "").toLowerCase());
+      if (localGateway) {
+        urls.push(
+          new URL(
+            "/_workspace/apps",
+            `${stripTrailingSlash(gatewayUrl)}/`,
+          ).toString(),
+        );
+      }
     } catch {
-      // Fall through to the same-origin Dispatch action below.
+      // coercion-ok: malformed gateway URL leaves the authenticated action as
+      // the only hosted source.
     }
   }
-  urls.push(
-    "/_agent-native/actions/list-workspace-apps?includeAgentCards=false",
-  );
   return urls;
 }
 

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -372,6 +372,24 @@ describe("listWorkspaceApps", () => {
     expect(apps[0]?.url).toBe("https://agent-workspace.builder.io/atlas");
   });
 
+  it("does not recursively call the hosted registry action", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("A2A_SECRET", "test-a2a-secret");
+    vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://agent-workspace.builder.io");
+
+    const apps = await runWithRequestContext(
+      {
+        userEmail: "dev@example.test",
+        requestOrigin: "https://agent-workspace.builder.io",
+      },
+      () => listWorkspaceApps({ includeAgentCards: false }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(apps.map((app) => app.id)).toEqual(["dispatch"]);
+  });
+
   it("keeps the exact request org in hosted registry tokens", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -321,23 +321,32 @@ describe("listWorkspaceApps", () => {
     ]);
   });
 
-  it("falls back to the authenticated workspace action for hosted gateways", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(new Response("not found", { status: 404 }))
-      .mockResolvedValueOnce(
-        new Response(
+  it("uses the authenticated workspace action for hosted gateways", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).includes("/_workspace/apps")) {
+        return new Response(
           JSON.stringify([
             {
-              id: "atlas",
-              name: "Atlas",
-              path: "/atlas",
-              url: "https://agent-workspace.builder.io/atlas",
+              id: "private-app",
+              name: "Private app",
+              path: "/private-app",
             },
           ]),
           { headers: { "content-type": "application/json" } },
-        ),
+        );
+      }
+      return new Response(
+        JSON.stringify([
+          {
+            id: "atlas",
+            name: "Atlas",
+            path: "/atlas",
+            url: "https://agent-workspace.builder.io/atlas",
+          },
+        ]),
+        { headers: { "content-type": "application/json" } },
       );
+    });
     vi.stubGlobal("fetch", fetchMock);
     vi.stubEnv("A2A_SECRET", "test-a2a-secret");
     vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://agent-workspace.builder.io");
@@ -347,11 +356,11 @@ describe("listWorkspaceApps", () => {
       () => listWorkspaceApps({ includeAgentCards: false }),
     );
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
       "https://agent-workspace.builder.io/_agent-native/actions/list-workspace-apps?includeAgentCards=false&audience=all",
     );
-    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         headers: expect.objectContaining({
           accept: "application/json",
@@ -381,7 +390,7 @@ describe("listWorkspaceApps", () => {
       () => listWorkspaceApps({ includeAgentCards: false }),
     );
 
-    const authorization = fetchMock.mock.calls[1]?.[1]?.headers
+    const authorization = fetchMock.mock.calls[0]?.[1]?.headers
       ?.Authorization as string;
     const tokenPayload = JSON.parse(
       Buffer.from(

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -1557,7 +1557,18 @@ async function readWorkspaceAppsFromGateway(): Promise<
       }
     }
 
-    if (!authHeaders.Authorization) return null;
+    const requestOrigin = requestContext?.requestOrigin;
+    const isSameOriginGateway = requestOrigin
+      ? (() => {
+          try {
+            return new URL(requestOrigin).origin === baseUrl.origin;
+          } catch {
+            // coercion-ok: an invalid request origin cannot prove a self-fetch.
+            return false;
+          }
+        })()
+      : false;
+    if (isSameOriginGateway || !authHeaders.Authorization) return null;
     const actionUrl = gatewayUrl(WORKSPACE_APPS_ACTION_PATH);
     actionUrl.searchParams.set("includeAgentCards", "false");
     actionUrl.searchParams.set("audience", "all");

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -475,6 +475,16 @@ function workspaceAppUrl(appPath: string): string | null {
   }
 }
 
+function isLocalWorkspaceGateway(url: URL): boolean {
+  const hostname = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1"
+  );
+}
+
 function workspaceAppLink(
   appPath: string,
   explicitUrl?: unknown,
@@ -1530,16 +1540,21 @@ async function readWorkspaceAppsFromGateway(): Promise<
   };
 
   try {
-    const localResponse = await fetch(gatewayUrl(WORKSPACE_APPS_GATEWAY_PATH), {
-      headers,
-      signal: controller.signal,
-    });
-    if (localResponse.ok) {
-      return parseWorkspaceAppsManifest(
-        // coercion-ok: malformed gateway JSON is an unavailable registry and
-        // must fall through to the local manifest sources.
-        await localResponse.json().catch(() => null),
+    if (isLocalWorkspaceGateway(baseUrl)) {
+      const localResponse = await fetch(
+        gatewayUrl(WORKSPACE_APPS_GATEWAY_PATH),
+        {
+          headers,
+          signal: controller.signal,
+        },
       );
+      if (localResponse.ok) {
+        return parseWorkspaceAppsManifest(
+          // coercion-ok: malformed gateway JSON is an unavailable registry and
+          // must fall through to the local manifest sources.
+          await localResponse.json().catch(() => null),
+        );
+      }
     }
 
     if (!authHeaders.Authorization) return null;


### PR DESCRIPTION
## Summary

- Use the authenticated `list-workspace-apps` registry for hosted Dispatch app cards so inaccessible apps do not expose an Open app action.
- Keep the public workspace manifest fallback only for localhost development.
- Prevent the authenticated org switcher from seeding hosted app links from the unfiltered static manifest.

This covers the two Dispatch feedback reports:

- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787608720725909
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787608685440589

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest run src/client/org/workspace-app-links.spec.ts` - 5 passed
- `corepack pnpm --filter @agent-native/dispatch exec vitest run src/server/lib/app-creation-store.spec.ts` - 40 passed
- `corepack pnpm guards` - all 64 checks passed
- Inspected the authenticated beta Dispatch `/dispatch/overview` route in normal Chrome; the live app menu and workspace app cards render through the expected path.
