### PR TITLE
fix(clips): keep paused video progress seekable

### DIFF
--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -127,6 +127,17 @@ describe("VideoPlayer playback", () => {
     return video;
   }
 
+  function getPlayerControls(): HTMLDivElement {
+    const scrubber = container.querySelector<HTMLElement>(
+      "[data-player-scrubber]",
+    );
+    const controls = scrubber?.parentElement?.parentElement;
+    if (!(controls instanceof HTMLDivElement)) {
+      throw new Error("player controls did not render");
+    }
+    return controls;
+  }
+
   it("toggles play/pause on the real video element when the surface is clicked", () => {
     const surface = getPlayerSurface();
     const video = getVideo();
@@ -172,6 +183,16 @@ describe("VideoPlayer playback", () => {
 
     expect(video.paused).toBe(false);
     expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps paused progress visible and interactive after the idle timeout", () => {
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    const controls = getPlayerControls();
+    expect(controls.className).toContain("opacity-100");
+    expect(controls.className).not.toContain("pointer-events-none");
   });
 
   it("keeps owner playback on the same-origin media request path", () => {
@@ -438,6 +459,14 @@ describe("VideoPlayer playback", () => {
     expect(playSpy).toHaveBeenCalledTimes(1);
     expect(container.textContent).toContain("Buffering");
     expect(container.textContent).not.toContain("Starting playback");
+
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+
+    const controls = getPlayerControls();
+    expect(controls.className).toContain("opacity-100");
+    expect(controls.className).not.toContain("pointer-events-none");
   });
 
   it.each(["AbortError", "NotAllowedError"])(

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -1629,6 +1629,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const fullscreenMenuContainer = isFullscreen ? containerRef.current : null;
 
     const showThroughoutCta = cta && cta.placement === "throughout";
+    const controlsVisible =
+      showControls || !isPlaying || isPlayPending || isBuffering;
     // Mobile Safari may defer loadeddata/canplay until playback starts. Keep
     // the paused state actionable even when those readiness events have not
     // fired yet; once the user asks to play, the pending/buffering states give
@@ -2067,7 +2069,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           <div
             className={cn(
               "absolute inset-x-0 bottom-0 z-20 transition-opacity duration-200",
-              showControls ? "opacity-100" : "opacity-0 pointer-events-none",
+              controlsVisible ? "opacity-100" : "opacity-0 pointer-events-none",
             )}
           >
             <PlayerControls


### PR DESCRIPTION
## Summary
- keep the existing player progress control visible and interactive while paused, play-pending, or buffering
- preserve the existing desktop hover-hide behavior during playback
- add focused coverage for the idle-timeout regression

## Validation
- oxfmt completed on the changed files
- git diff --check passed
- focused Vitest is pending because this clean worktree has no installed workspace dependencies