### PR TITLE
fix(clips): expose agent discovery in shared-page head

### DIFF
--- a/templates/clips/changelog/2026-08-24-shared-clips-now-expose-agent-readable-transcript-and-frame-metadata-from-public-links.md
+++ b/templates/clips/changelog/2026-08-24-shared-clips-now-expose-agent-readable-transcript-and-frame-metadata-from-public-links.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-24
+---
+
+Shared Clips now expose agent-readable transcript and frame metadata from public links.

--- a/templates/clips/server/routes/[...page].get.ts
+++ b/templates/clips/server/routes/[...page].get.ts
@@ -1,21 +1,190 @@
+import { verifyScopedAgentAccessToken } from "@agent-native/core/server";
 import { createH3SSRHandler } from "@agent-native/core/server/ssr-handler";
-import { defineEventHandler, setResponseHeader } from "h3";
+import {
+  injectDocumentMarkup,
+  safeJsonForHtml,
+} from "@agent-native/core/shared";
+import { eq } from "drizzle-orm";
+import {
+  defineEventHandler,
+  getQuery,
+  getRequestURL,
+  setResponseHeader,
+  type H3Event,
+} from "h3";
 
+import {
+  buildAgentApiUrls,
+  buildAgentDiscoveryPayload,
+  CLIP_AGENT_ACCESS_TOKEN_PREFIX,
+  CLIPS_AGENT_ACCESS_PARAM,
+} from "../../shared/agent-context.js";
+import { getDb, schema } from "../db/index.js";
 import {
   MEDIA_CAPTURE_PERMISSIONS_POLICY,
   withMediaCapturePermissions,
 } from "../lib/media-permissions.js";
+import {
+  getServerAppBasePath,
+  queryString,
+} from "../lib/public-agent-context.js";
+import { isRecordingExpired } from "../lib/recording-page-access.js";
 
 const ssrHandler = createH3SSRHandler(
   () => import("virtual:react-router/server-build"),
 );
 
-export default defineEventHandler(async (event) => {
-  const response = (await ssrHandler(event)) as Response;
+function stripAppBasePath(pathname: string): string {
+  const basePath = getServerAppBasePath();
+  if (!basePath) return pathname;
+  if (pathname === basePath) return "/";
+  return pathname.startsWith(`${basePath}/`)
+    ? pathname.slice(basePath.length) || "/"
+    : pathname;
+}
+
+function clipIdFromPath(pathname: string): string | null {
+  const match = stripAppBasePath(pathname).match(/^\/(?:share|r)\/([^/]+)\/?$/);
+  if (!match?.[1]) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value.replace(/[&<>\"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '\"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return character;
+    }
+  });
+}
+
+async function buildClipAgentDiscovery(event: H3Event): Promise<{
+  markup: string;
+  noReferrer: boolean;
+} | null> {
+  const requestUrl = getRequestURL(event);
+  const recordingId = clipIdFromPath(requestUrl.pathname);
+  if (!recordingId) return null;
+
+  const [recording] = await getDb()
+    .select({
+      id: schema.recordings.id,
+      title: schema.recordings.title,
+      status: schema.recordings.status,
+      visibility: schema.recordings.visibility,
+      password: schema.recordings.password,
+      expiresAt: schema.recordings.expiresAt,
+      archivedAt: schema.recordings.archivedAt,
+      trashedAt: schema.recordings.trashedAt,
+    })
+    .from(schema.recordings)
+    .where(eq(schema.recordings.id, recordingId))
+    .limit(1);
+
+  if (
+    !recording ||
+    recording.archivedAt ||
+    recording.trashedAt ||
+    isRecordingExpired(recording.expiresAt)
+  ) {
+    return null;
+  }
+
+  const query = getQuery(event);
+  const suppliedToken =
+    queryString(query[CLIPS_AGENT_ACCESS_PARAM]) || queryString(query.t);
+  const tokenGrantsAgentAccess = suppliedToken
+    ? verifyScopedAgentAccessToken(suppliedToken, {
+        resourceKind: CLIP_AGENT_ACCESS_TOKEN_PREFIX,
+        resourceId: recording.id,
+      }).ok
+    : false;
+  const anonymousAccess =
+    recording.visibility === "public" && !recording.password;
+  if (!anonymousAccess && !tokenGrantsAgentAccess) return null;
+
+  const token = tokenGrantsAgentAccess ? suppliedToken : undefined;
+  const agentContextUrl = buildAgentApiUrls(recording.id, {
+    origin: requestUrl.origin,
+    basePath: getServerAppBasePath(),
+    token,
+  }).contextUrl;
+  const discovery = buildAgentDiscoveryPayload({
+    recordingId: recording.id,
+    title: recording.title,
+    status: recording.status,
+    agentContextUrl,
+  });
+  const contextHref = escapeHtmlAttribute(agentContextUrl);
+
+  return {
+    markup: `<link rel="alternate" type="application/json" href="${contextHref}" title="Agent-readable clip context"><script type="application/agent-native+json" id="clips-agent-context">${safeJsonForHtml(discovery)}</script>`,
+    noReferrer: tokenGrantsAgentAccess,
+  };
+}
+
+function injectClipAgentDiscovery(html: string, markup: string): string {
+  const scriptId = 'id="clips-agent-context"';
+  const scriptMarkup = html.includes(scriptId)
+    ? ""
+    : markup.slice(markup.indexOf("<script"));
+  const linkMarkup = markup.slice(0, markup.indexOf("<script"));
+  const injection = `${html.includes(linkMarkup) ? "" : linkMarkup}${scriptMarkup}`;
+  return injectDocumentMarkup(html, injection, { target: "head" });
+}
+
+function withClipsResponseHeaders(
+  event: H3Event,
+  response: Response,
+): Response {
   setResponseHeader(
     event,
     "Permissions-Policy",
     MEDIA_CAPTURE_PERMISSIONS_POLICY,
   );
   return withMediaCapturePermissions(response);
+}
+
+export default defineEventHandler(async (event) => {
+  const response = (await ssrHandler(event)) as Response;
+  const discovery = await buildClipAgentDiscovery(event);
+  if (!discovery || !response.ok)
+    return withClipsResponseHeaders(event, response);
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) {
+    return withClipsResponseHeaders(event, response);
+  }
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  if (discovery.noReferrer) {
+    headers.set("Referrer-Policy", "no-referrer");
+    setResponseHeader(event, "Referrer-Policy", "no-referrer");
+  }
+
+  const html = await response.text();
+  const discoveredResponse = new Response(
+    injectClipAgentDiscovery(html, discovery.markup),
+    {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    },
+  );
+  return withClipsResponseHeaders(event, discoveredResponse);
 });

--- a/templates/clips/server/routes/page-agent-discovery.test.ts
+++ b/templates/clips/server/routes/page-agent-discovery.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSsrHandler = vi.hoisted(() => vi.fn());
+const mockVerifyScopedAgentAccessToken = vi.hoisted(() => vi.fn());
+const mockRecording = vi.hoisted(() => ({
+  value: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@agent-native/core/server/ssr-handler", () => ({
+  createH3SSRHandler: () => mockSsrHandler,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  verifyScopedAgentAccessToken: (...args: unknown[]) =>
+    mockVerifyScopedAgentAccessToken(...args),
+}));
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getQuery: (event: { query?: Record<string, unknown> }) => event.query ?? {},
+  getRequestURL: (event: { url: string }) => new URL(event.url),
+  setResponseHeader: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: () => ({
+    select: () => {
+      const builder: any = {
+        from: () => builder,
+        where: () => builder,
+        limit: async () => (mockRecording.value ? [mockRecording.value] : []),
+      };
+      return builder;
+    },
+  }),
+  schema: {
+    recordings: {
+      id: "recordings.id",
+      title: "recordings.title",
+      status: "recordings.status",
+      visibility: "recordings.visibility",
+      password: "recordings.password",
+      expiresAt: "recordings.expiresAt",
+      archivedAt: "recordings.archivedAt",
+      trashedAt: "recordings.trashedAt",
+    },
+  },
+}));
+
+vi.mock("../lib/media-permissions.js", () => ({
+  MEDIA_CAPTURE_PERMISSIONS_POLICY: "camera=*, microphone=(self)",
+  withMediaCapturePermissions: (response: Response) => response,
+}));
+
+vi.mock("../lib/public-agent-context.js", () => ({
+  getServerAppBasePath: () => "",
+  queryString: (value: unknown) =>
+    typeof value === "string"
+      ? value
+      : Array.isArray(value) && typeof value[0] === "string"
+        ? value[0]
+        : "",
+}));
+
+import handler from "./[...page].get";
+
+function recording(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "rec-1",
+    title: "Public clip",
+    status: "ready",
+    visibility: "public",
+    password: null,
+    expiresAt: null,
+    archivedAt: null,
+    trashedAt: null,
+    ...overrides,
+  };
+}
+
+function htmlResponse(body = "<html><head></head><body>ok</body></html>") {
+  return new Response(body, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "public, max-age=60",
+      "content-length": String(body.length),
+    },
+  });
+}
+
+describe("Clips page agent discovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecording.value = recording();
+    mockVerifyScopedAgentAccessToken.mockReturnValue({ ok: false });
+    mockSsrHandler.mockImplementation(() => htmlResponse());
+  });
+
+  it("puts transcript discovery metadata in the head of legacy /r links", async () => {
+    const response = (await (handler as any)({
+      url: "https://clips.example.com/r/rec-1",
+      query: {},
+    })) as Response;
+    const html = await response.text();
+
+    expect(html).toContain(
+      '<link rel="alternate" type="application/json" href="https://clips.example.com/api/agent-context.json?id=rec-1"',
+    );
+    expect(html.indexOf("agent-context.json")).toBeLessThan(
+      html.indexOf("<body>"),
+    );
+    expect(html).toContain('id="clips-agent-context"');
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    expect(response.headers.get("content-length")).toBeNull();
+  });
+
+  it("does not duplicate the discovery script already rendered by /share", async () => {
+    mockSsrHandler.mockResolvedValue(
+      htmlResponse(
+        '<html><head></head><body><script type="application/agent-native+json" id="clips-agent-context">existing</script></body></html>',
+      ),
+    );
+
+    const response = (await (handler as any)({
+      url: "https://clips.example.com/share/rec-1",
+      query: {},
+    })) as Response;
+    const html = await response.text();
+
+    expect(html.match(/id="clips-agent-context"/g)).toHaveLength(1);
+    expect(html.match(/rel="alternate"/g)).toHaveLength(1);
+  });
+
+  it("only exposes private clips through a valid scoped agent token", async () => {
+    mockRecording.value = recording({ visibility: "private" });
+    const publicResponse = (await (handler as any)({
+      url: "https://clips.example.com/r/rec-1",
+      query: {},
+    })) as Response;
+    expect(await publicResponse.text()).not.toContain("agent-context.json");
+
+    mockVerifyScopedAgentAccessToken.mockReturnValue({ ok: true });
+    const tokenResponse = (await (handler as any)({
+      url: "https://clips.example.com/r/rec-1?agent_access=tok%2B1",
+      query: { agent_access: "tok+1" },
+    })) as Response;
+    const html = await tokenResponse.text();
+
+    expect(html).toContain("agent_access=tok%2B1");
+    expect(tokenResponse.headers.get("cache-control")).toBe(
+      "public, max-age=60",
+    );
+    expect(tokenResponse.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+});


### PR DESCRIPTION
## Summary
- add a standard head-level JSON alternate link for public Clips share pages and legacy /r links
- preserve the existing agent-native discovery payload and scoped-token validation
- add SSR regression coverage and a Clips changelog entry

## Verification
- corepack pnpm exec vitest run templates/clips/server/routes/page-agent-discovery.test.ts
- corepack pnpm --dir templates/clips typecheck
- corepack pnpm guards
- corepack pnpm --dir templates/clips build