### PR TITLE
Make Plans the default home

### DIFF
--- a/templates/plan/app/components/layout/Header.tsx
+++ b/templates/plan/app/components/layout/Header.tsx
@@ -10,7 +10,7 @@ import { useLocation } from "react-router";
 import { APP_TITLE } from "@/lib/app-config";
 
 const pageTitleKeys: Record<string, string> = {
-  "/": "header.plan",
+  "/chat": "header.plan",
   "/plans": "header.plan",
   "/agent": "settings.agentTitle",
   "/settings": "header.settings",

--- a/templates/plan/app/components/layout/Layout.tsx
+++ b/templates/plan/app/components/layout/Layout.tsx
@@ -48,6 +48,7 @@ function isPlanDetailRoute(pathname: string): boolean {
 
 export function Layout({ children }: LayoutProps) {
   const location = useLocation();
+  const pathname = location.pathname.replace(/\/+$/, "") || "/";
   const t = useT();
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
@@ -88,11 +89,11 @@ export function Layout({ children }: LayoutProps) {
 
   const ownsToolbar = routeOwnsToolbar(location.pathname);
   const planDetailRoute = isPlanDetailRoute(location.pathname);
-  const chatRoute = location.pathname === "/chat";
+  const chatRoute = pathname === "/chat";
   const { session, isLoading: sessionLoading } = useSession();
   const chatHomeHandoffActive = useAgentChatHomeHandoff({
     storageKey: "plans",
-    activePath: location.pathname,
+    activePath: pathname,
     enabled: !chatRoute,
   });
   const chatHomeHandoffPending = isAgentChatHomeHandoffActive("plans");
@@ -102,8 +103,7 @@ export function Layout({ children }: LayoutProps) {
     requireActiveHandoff: true,
   });
   const hideAppNavigation = planDetailRoute && planReaderImmersive;
-  const hideAppHeader =
-    location.pathname === "/plans" && !sessionLoading && !session;
+  const hideAppHeader = pathname === "/plans" && !sessionLoading && !session;
   const effectiveSidebarCollapsed = chatRoute
     ? chatSidebarCollapsed
     : sidebarCollapsed;

--- a/templates/plan/app/components/layout/Layout.tsx
+++ b/templates/plan/app/components/layout/Layout.tsx
@@ -100,6 +100,7 @@ export function Layout({ children }: LayoutProps) {
   useAgentChatHomeHandoffLinks({
     storageKey: "plans",
     chatPath: "/chat",
+    isChatPath: (path) => (path.replace(/\/+$/, "") || "/") === "/chat",
     requireActiveHandoff: true,
   });
   const hideAppNavigation = planDetailRoute && planReaderImmersive;

--- a/templates/plan/app/components/layout/Layout.tsx
+++ b/templates/plan/app/components/layout/Layout.tsx
@@ -173,7 +173,18 @@ export function Layout({ children }: LayoutProps) {
             </button>
           </div>
         )
-      ) : hideAppHeader ? null : (
+      ) : hideAppHeader ? (
+        <div className="flex h-12 items-center border-b border-border px-4 md:hidden shrink-0">
+          <button
+            type="button"
+            onClick={() => setMobileSidebarOpen(true)}
+            aria-label={t("sidebar.openNavigation")}
+            className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
+          >
+            <IconMenu2 className="h-4 w-4" />
+          </button>
+        </div>
+      ) : (
         <Header onOpenMobileSidebar={() => setMobileSidebarOpen(true)} />
       )}
       <main className="agent-native-app-main flex-1 overflow-y-auto">

--- a/templates/plan/app/components/layout/Layout.tsx
+++ b/templates/plan/app/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import {
   useAgentChatHomeHandoff,
   useAgentChatHomeHandoffLinks,
 } from "@agent-native/core/client/agent-chat";
+import { useSession } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { HeaderActionsProvider } from "@agent-native/toolkit/app-shell";
 import { IconMenu2 } from "@tabler/icons-react";
@@ -87,7 +88,8 @@ export function Layout({ children }: LayoutProps) {
 
   const ownsToolbar = routeOwnsToolbar(location.pathname);
   const planDetailRoute = isPlanDetailRoute(location.pathname);
-  const chatRoute = location.pathname === "/";
+  const chatRoute = location.pathname === "/chat";
+  const { session, isLoading: sessionLoading } = useSession();
   const chatHomeHandoffActive = useAgentChatHomeHandoff({
     storageKey: "plans",
     activePath: location.pathname,
@@ -96,10 +98,12 @@ export function Layout({ children }: LayoutProps) {
   const chatHomeHandoffPending = isAgentChatHomeHandoffActive("plans");
   useAgentChatHomeHandoffLinks({
     storageKey: "plans",
-    chatPath: "/",
+    chatPath: "/chat",
     requireActiveHandoff: true,
   });
   const hideAppNavigation = planDetailRoute && planReaderImmersive;
+  const hideAppHeader =
+    location.pathname === "/plans" && !sessionLoading && !session;
   const effectiveSidebarCollapsed = chatRoute
     ? chatSidebarCollapsed
     : sidebarCollapsed;
@@ -168,7 +172,7 @@ export function Layout({ children }: LayoutProps) {
             </button>
           </div>
         )
-      ) : (
+      ) : hideAppHeader ? null : (
         <Header onOpenMobileSidebar={() => setMobileSidebarOpen(true)} />
       )}
       <main className="agent-native-app-main flex-1 overflow-y-auto">

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -536,6 +536,7 @@ export function Sidebar({
   onCollapsedChange,
 }: SidebarProps) {
   const location = useLocation();
+  const pathname = location.pathname.replace(/\/+$/, "") || "/";
   const { session, isLoading: sessionLoading } = useSession();
   const t = useT();
   const returnPath = planReturnPathFromLocation(location);
@@ -653,12 +654,12 @@ export function Sidebar({
           const Icon = item.icon;
           const isActive =
             item.href === "/chat"
-              ? location.pathname === "/chat"
+              ? pathname === "/chat"
               : item.href === "/plans"
-                ? location.pathname.startsWith("/plans") ||
-                  location.pathname.startsWith("/recaps") ||
-                  location.pathname.startsWith("/local-plans")
-                : location.pathname.startsWith(item.href);
+                ? pathname.startsWith("/plans") ||
+                  pathname.startsWith("/recaps") ||
+                  pathname.startsWith("/local-plans")
+                : pathname.startsWith(item.href);
           const link = (
             <Link
               to={item.href}
@@ -695,7 +696,7 @@ export function Sidebar({
       <nav className="grid shrink-0 gap-1 px-2 py-1">
         {bottomNavItems.map((item) => {
           const Icon = item.icon;
-          const isActive = location.pathname.startsWith(item.href);
+          const isActive = pathname.startsWith(item.href);
           const link = (
             <Link
               to={item.href}

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -72,7 +72,7 @@ function buildBrandingCustomizationMessage(request: string) {
 }
 
 const navItems = [
-  { icon: IconMessageCircle, labelKey: "navigation.ask", href: "/" },
+  { icon: IconMessageCircle, labelKey: "navigation.ask", href: "/chat" },
   { icon: IconClipboardCheck, labelKey: "navigation.plan", href: "/plans" },
 ];
 
@@ -216,7 +216,7 @@ function PlanChatsSection({
 
   function openThread(threadId: string, options?: { isNew?: boolean }) {
     switchThread(threadId);
-    navigateWithAgentChatViewTransition(navigate, "/");
+    navigateWithAgentChatViewTransition(navigate, "/chat");
     window.requestAnimationFrame(() => {
       window.dispatchEvent(
         new CustomEvent("agent-chat:open-thread", {
@@ -652,8 +652,8 @@ export function Sidebar({
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive =
-            item.href === "/"
-              ? location.pathname === "/"
+            item.href === "/chat"
+              ? location.pathname === "/chat"
               : item.href === "/plans"
                 ? location.pathname.startsWith("/plans") ||
                   location.pathname.startsWith("/recaps") ||
@@ -681,7 +681,7 @@ export function Sidebar({
           return (
             <div key={item.href}>
               {link}
-              {item.href === "/" ? (
+              {item.href === "/chat" ? (
                 <PlanChatsSection collapsed={collapsed} open={isActive} />
               ) : null}
               {item.href === "/plans" && isActive ? (

--- a/templates/plan/app/hooks/use-navigation-state.ts
+++ b/templates/plan/app/hooks/use-navigation-state.ts
@@ -122,22 +122,23 @@ export function useNavigationState() {
 }
 
 function viewForPath(pathname: string): string {
+  const normalizedPathname = pathname.replace(/\/+$/, "") || "/";
   // Recaps are a kind of plan; both detail routes map to the "plan" view so the
   // agent's navigation/selection state is the same surface regardless of route.
   if (
-    pathname.startsWith("/plans/") ||
-    pathname.startsWith("/recaps/") ||
-    pathname.startsWith("/local-plans/")
+    normalizedPathname.startsWith("/plans/") ||
+    normalizedPathname.startsWith("/recaps/") ||
+    normalizedPathname.startsWith("/local-plans/")
   ) {
     return "plan";
   }
-  if (pathname === "/chat") {
+  if (normalizedPathname === "/chat") {
     return "chat";
   }
   if (
-    pathname.startsWith("/plans") ||
-    pathname.startsWith("/recaps") ||
-    pathname.startsWith("/local-plans")
+    normalizedPathname.startsWith("/plans") ||
+    normalizedPathname.startsWith("/recaps") ||
+    normalizedPathname.startsWith("/local-plans")
   ) {
     return "plans";
   }

--- a/templates/plan/app/hooks/use-navigation-state.ts
+++ b/templates/plan/app/hooks/use-navigation-state.ts
@@ -131,7 +131,7 @@ function viewForPath(pathname: string): string {
   ) {
     return "plan";
   }
-  if (pathname === "/") {
+  if (pathname === "/chat") {
     return "chat";
   }
   if (
@@ -187,7 +187,7 @@ function localPathFromCommandPath(value: unknown): string | null {
 function pathForView(view?: string): string {
   switch (view) {
     case "chat":
-      return "/";
+      return "/chat";
     case "plan":
     case "plans":
       return "/plans";
@@ -198,7 +198,7 @@ function pathForView(view?: string): string {
     case "team":
       return "/settings/organization";
     default:
-      return "/";
+      return "/chat";
   }
 }
 

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -7448,7 +7448,7 @@ function LoggedOutEmptyPlan() {
   }, []);
 
   return (
-    <div className="flex min-h-full items-center justify-center overflow-auto p-4 sm:p-8">
+    <div className="flex min-h-full -translate-y-[10vh] items-center justify-center overflow-auto p-4 sm:p-8">
       <div className="flex w-full max-w-4xl flex-col items-center gap-3 py-8 text-center">
         <h2 className="text-2xl font-semibold tracking-tight">
           {t("plansPage.loggedOut.title")}

--- a/templates/plan/app/root.tsx
+++ b/templates/plan/app/root.tsx
@@ -223,14 +223,15 @@ function AppContent() {
 export default function Root() {
   const [queryClient] = useState(() => createAgentNativeQueryClient());
   const location = useLocation();
+  const pathname = location.pathname.replace(/\/+$/, "") || "/";
   const sessionBypass =
-    location.pathname === "/chat" ||
-    location.pathname === "/plans" ||
-    location.pathname.startsWith("/plans/") ||
-    location.pathname === "/recaps" ||
-    location.pathname.startsWith("/recaps/") ||
-    location.pathname === "/local-plans" ||
-    location.pathname.startsWith("/local-plans/");
+    pathname === "/chat" ||
+    pathname === "/plans" ||
+    pathname.startsWith("/plans/") ||
+    pathname === "/recaps" ||
+    pathname.startsWith("/recaps/") ||
+    pathname === "/local-plans" ||
+    pathname.startsWith("/local-plans/");
   const localPlanPrivacyRoute = !shouldCapturePlanContent(location.pathname);
   return (
     // Pass the plan-specific styled Toaster via `toaster` so only one sonner

--- a/templates/plan/app/root.tsx
+++ b/templates/plan/app/root.tsx
@@ -166,7 +166,7 @@ function AppContent() {
         changelogKey="plan"
       >
         <CommandMenu.Group heading={t("root.commandActions")}>
-          <CommandMenu.Item onSelect={() => go("/")}>
+          <CommandMenu.Item onSelect={() => go("/chat")}>
             {t("root.askPlan")}
           </CommandMenu.Item>
           <CommandMenu.Item onSelect={() => go("/plans")}>
@@ -224,7 +224,7 @@ export default function Root() {
   const [queryClient] = useState(() => createAgentNativeQueryClient());
   const location = useLocation();
   const sessionBypass =
-    location.pathname === "/" ||
+    location.pathname === "/chat" ||
     location.pathname === "/plans" ||
     location.pathname.startsWith("/plans/") ||
     location.pathname === "/recaps" ||

--- a/templates/plan/app/routes/_index.tsx
+++ b/templates/plan/app/routes/_index.tsx
@@ -1,34 +1,10 @@
-import { Spinner } from "@/components/ui/spinner";
-import { APP_TITLE } from "@/lib/app-config";
-import { PlanChatPage } from "@/pages/PlanChatPage";
+import { withSsrHtmlContentType } from "@agent-native/core/shared";
+import { redirect } from "react-router";
 
-const SEO_TITLE = `${APP_TITLE} - Open Source visual planning and PR recaps for coding agents`;
-const SEO_DESCRIPTION =
-  "Open Source planning workspace for coding agents with visual plans, PR recaps, diagrams, wireframes, API specs, and prototypes.";
-
-export function meta() {
-  return [
-    { title: SEO_TITLE },
-    {
-      name: "description",
-      content: SEO_DESCRIPTION,
-    },
-    { property: "og:title", content: SEO_TITLE },
-    { property: "og:description", content: SEO_DESCRIPTION },
-    { name: "twitter:card", content: "summary" },
-    { name: "twitter:title", content: SEO_TITLE },
-    { name: "twitter:description", content: SEO_DESCRIPTION },
-  ];
+export function loader() {
+  return withSsrHtmlContentType(redirect("/plans"));
 }
 
-export function HydrateFallback() {
-  return (
-    <div className="flex items-center justify-center h-screen w-full">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
-}
-
-export default function IndexPage() {
-  return <PlanChatPage />;
+export default function IndexRedirect() {
+  return null;
 }

--- a/templates/plan/app/routes/chat.tsx
+++ b/templates/plan/app/routes/chat.tsx
@@ -1,0 +1,34 @@
+import { Spinner } from "@/components/ui/spinner";
+import { APP_TITLE } from "@/lib/app-config";
+import { PlanChatPage } from "@/pages/PlanChatPage";
+
+const SEO_TITLE = `${APP_TITLE} - Open Source visual planning and PR recaps for coding agents`;
+const SEO_DESCRIPTION =
+  "Open Source planning workspace for coding agents with visual plans, PR recaps, diagrams, wireframes, API specs, and prototypes.";
+
+export function meta() {
+  return [
+    { title: SEO_TITLE },
+    {
+      name: "description",
+      content: SEO_DESCRIPTION,
+    },
+    { property: "og:title", content: SEO_TITLE },
+    { property: "og:description", content: SEO_DESCRIPTION },
+    { name: "twitter:card", content: "summary" },
+    { name: "twitter:title", content: SEO_TITLE },
+    { name: "twitter:description", content: SEO_DESCRIPTION },
+  ];
+}
+
+export function HydrateFallback() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <Spinner className="size-8 text-foreground" />
+    </div>
+  );
+}
+
+export default function ChatRoute() {
+  return <PlanChatPage />;
+}

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -139,6 +139,19 @@ test.describe("guest mode + claim", () => {
     await expect(page.getByText("Start with /visual-plan")).toBeVisible();
   });
 
+  test("logged-out chat route loads directly", async ({ page }) => {
+    await clearAuth(page);
+    const response = await page.goto("/chat");
+
+    expect(response?.ok(), `guest /chat response ${response?.status()}`).toBe(
+      true,
+    );
+    await expect(page).toHaveURL(/\/chat\/?$/);
+    await expect(
+      page.getByRole("heading", { name: /ask plan/i }),
+    ).toBeVisible();
+  });
+
   test("anonymous create-visual-plan is rejected with a clean message (no plan minted)", async ({
     page,
   }) => {

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -152,6 +152,19 @@ test.describe("guest mode + claim", () => {
     ).toBeVisible();
   });
 
+  test("trailing-slash public routes keep their shells", async ({ page }) => {
+    await clearAuth(page);
+
+    await page.goto("/chat/");
+    await expect(
+      page.getByRole("heading", { name: /ask plan/i }),
+    ).toBeVisible();
+
+    await page.goto("/plans/");
+    await expect(page.locator("header")).toHaveCount(0);
+    await expect(page.getByText("Start with /visual-plan")).toBeVisible();
+  });
+
   test("anonymous create-visual-plan is rejected with a clean message (no plan minted)", async ({
     page,
   }) => {
@@ -312,9 +325,6 @@ test.describe("guest mode + claim", () => {
       timeout: 15_000,
     });
     await expect(page.getByText(/viewing as a guest/i)).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: /^sign in$/i }).first(),
-    ).toBeVisible();
 
     // Register + login same-origin (verification-free path the framework uses
     // for programmatic auth), exactly as global-setup does. This is the moment a

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -101,9 +101,10 @@ test.describe("guest mode + claim", () => {
     await page.waitForLoadState("domcontentloaded");
 
     await expect(page.getByText(/viewing as a guest/i)).toHaveCount(0);
-    await expect(
-      page.getByRole("button", { name: /^sign in$/i }).first(),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /^plan$/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^sign in$/i })).toHaveCount(
+      0,
+    );
 
     // Create must NOT be offered as a real create to a guest.
     await expect(
@@ -129,25 +130,13 @@ test.describe("guest mode + claim", () => {
     await expect(page.getByText(/no cli yet/i)).toHaveCount(0);
   });
 
-  test("guest clicking the header sign-in action is sent to sign-in", async ({
-    page,
-  }) => {
+  test("logged-out plans page omits the app header", async ({ page }) => {
     await clearAuth(page);
     await page.goto("/plans");
     await page.waitForLoadState("domcontentloaded");
 
-    const signInButton = page.getByRole("button", { name: /^sign in$/i });
-    await expect(signInButton).toBeVisible({ timeout: 15_000 });
-    await signInButton.click();
-
-    // Must land on the framework sign-in surface.
-    await page.waitForURL(/\/sign-in\?c=/i, { timeout: 15_000 });
-    expect(page.url()).toMatch(/sign-in/i);
-    expect(new URL(page.url()).searchParams.get("c")).toBeTruthy();
-    // The sign-in page offers account creation (the only way to author plans).
-    await expect(page.getByText(/create account/i).first()).toBeVisible({
-      timeout: 15_000,
-    });
+    await expect(page.locator("header")).toHaveCount(0);
+    await expect(page.getByText("Start with /visual-plan")).toBeVisible();
   });
 
   test("anonymous create-visual-plan is rejected with a clean message (no plan minted)", async ({

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -160,6 +160,31 @@ test.describe("guest mode + claim", () => {
       page.getByRole("heading", { name: /ask plan/i }),
     ).toBeVisible();
 
+    await page.evaluate(() => {
+      sessionStorage.setItem(
+        "agent-native.plans.chat-home-handoff",
+        String(Date.now()),
+      );
+      (
+        window as typeof window & { handoffTransitions?: number }
+      ).handoffTransitions = 0;
+      window.addEventListener("agentNative.chatViewTransitionPrepare", () => {
+        window.handoffTransitions = (window.handoffTransitions ?? 0) + 1;
+      });
+    });
+    await page
+      .getByRole("link", { name: /^plan$/i })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/plans\/?$/);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as typeof window & { handoffTransitions?: number })
+            .handoffTransitions,
+      ),
+    ).toBe(1);
+
     await page.goto("/plans/");
     await expect(page.locator("header")).toHaveCount(0);
     await expect(page.getByText("Start with /visual-plan")).toBeVisible();

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -139,6 +139,18 @@ test.describe("guest mode + claim", () => {
     await expect(page.getByText("Start with /visual-plan")).toBeVisible();
   });
 
+  test("logged-out mobile plans keeps navigation available", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await clearAuth(page);
+    await page.goto("/plans");
+
+    await page.getByRole("button", { name: /open navigation/i }).click();
+    await page.getByRole("link", { name: /^ask$/i }).click();
+    await expect(page).toHaveURL(/\/chat\/?$/);
+  });
+
   test("logged-out chat route loads directly", async ({ page }) => {
     await clearAuth(page);
     const response = await page.goto("/chat");

--- a/templates/plan/server/plugins/auth.ts
+++ b/templates/plan/server/plugins/auth.ts
@@ -48,6 +48,7 @@ export default createAuthPlugin({
   // auth so the UI does not create placeholder plans for signed-out visitors.
   workspaceAppPublicPaths: [
     "/",
+    "/chat",
     "/plans",
     "/plans/plan_",
     "/recaps",


### PR DESCRIPTION
## Summary
- Redirect `/` to `/plans` and move the Plan chat surface to `/chat`.
- Hide the logged-out Plans app header and shift the `/visual-plan` empty state upward.
- Update Plan navigation, handoff state, and guest coverage.

## Validation
- `corepack pnpm --filter plan typecheck`
- `corepack pnpm --filter plan exec vitest --run app/hooks/use-navigation-state.test.ts app/hooks/use-navigation-state.spec.ts`
- `corepack pnpm --filter plan build`
- Browser smoke: `/` -> `/plans`, logged-out header absence, `/chat` render, no local app console errors.