### PR TITLE
fix: gate stable package releases and version nightlies

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "snapshot": {
+    "useCalculatedVersion": true
+  },
   "updateInternalDependencies": "patch",
   "ignore": [
     "agent-native",

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -85,16 +85,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
           EVENT_NAME: ${{ github.event_name }}
-          MARKED: ${{ contains(github.event.head_commit.message, '[stable-release]') }}
           REPOSITORY: ${{ github.repository }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           verified=false
+          stable_marker="${{ contains(github.event.head_commit.message, '[stable-release]') }}"
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             verified=true
-          elif [ "$EVENT_NAME" = "push" ] && [ "$MARKED" = "true" ] && [ "$ACTOR" = "builder-io-integration[bot]" ]; then
+          elif [ "$EVENT_NAME" = "push" ] && [ "$stable_marker" = "true" ] && [ "$ACTOR" = "builder-io-integration[bot]" ]; then
             release_prs="$RUNNER_TEMP/stable-release-pull-requests.json"
             gh api --paginate --slurp \
               "repos/$REPOSITORY/commits/$SHA/pulls" > "$release_prs"

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,8 +8,9 @@ name: Publish packages
 #      That creates the normal all-package Version Packages PR. Its marked
 #      merge is the only path that publishes a stable release.
 #
-# Stable release merges produce a `[stable-release]`-marked commit so the
-# nightly job does not publish a duplicate snapshot for that merge.
+# Stable release merges produce a `[stable-release]`-marked commit. The
+# workflow verifies that marker belongs to the bot-owned release PR before
+# stable publication, so an ordinary merge cannot opt into the stable lane.
 #
 # Desktop-app publishing is OUT of changesets - it ships binaries via
 # electron-builder, not npm. Production desktop releases are dispatched from
@@ -69,11 +70,58 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  verify-stable-merge:
+    name: Verify stable release merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      verified: ${{ steps.verify.outputs.verified }}
+    steps:
+      - name: Verify release PR and actor
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTOR: ${{ github.actor }}
+          EVENT_NAME: ${{ github.event_name }}
+          MARKED: ${{ contains(github.event.head_commit.message, '[stable-release]') }}
+          REPOSITORY: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          verified=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            verified=true
+          elif [ "$EVENT_NAME" = "push" ] && [ "$MARKED" = "true" ] && [ "$ACTOR" = "builder-io-integration[bot]" ]; then
+            release_prs="$RUNNER_TEMP/stable-release-pull-requests.json"
+            gh api --paginate --slurp \
+              "repos/$REPOSITORY/commits/$SHA/pulls" > "$release_prs"
+            if jq -e --arg repository "$REPOSITORY" --arg sha "$SHA" '
+              any(.[][];
+                .base.ref == "main" and
+                .head.ref == "changeset-release/main" and
+                .head.repo.full_name == $repository and
+                .user.login == "builder-io-integration[bot]" and
+                .merged_at != null and
+                .merge_commit_sha == $sha and
+                (.title | contains("[stable-release]"))
+              )
+            ' "$release_prs" >/dev/null; then
+              verified=true
+            fi
+          fi
+
+          echo "Stable release merge verified: $verified"
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
+
   publish-nightly:
     name: Publish nightly snapshot
+    needs: [verify-stable-merge]
     # A stable Version Packages merge is intentionally stable-only. All other
     # matching main pushes get the automatic nightly package snapshot.
-    if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, '[stable-release]') }}
+    if: ${{ github.event_name == 'push' && needs.verify-stable-merge.outputs.verified != 'true' }}
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
@@ -194,12 +242,8 @@ jobs:
     # marked Version Packages PR; only that PR's merge can enter stable npm
     # publication. A downstream redispatch only re-sends a notification for
     # versions that are already on npm, so it must not re-enter build/publish.
-    if: |
-      !inputs.redispatchDownstream &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[stable-release]'))
-      )
+    needs: [verify-stable-merge]
+    if: ${{ !inputs.redispatchDownstream && needs.verify-stable-merge.outputs.verified == 'true' }}
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
@@ -291,15 +335,16 @@ jobs:
   # while production stopped receiving releases.
   notify-downstream:
     name: Notify downstream repos
-    needs: [release]
+    needs: [release, verify-stable-merge]
     # A normal main push has no stable release job. Manual dispatches (including
     # redispatch) and marked stable merges still need a written notification
     # result even when the release job fails or is intentionally skipped.
     if: |
       always() &&
       (
+        inputs.redispatchDownstream ||
         github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'push' && contains(github.event.head_commit.message, '[stable-release]'))
+        needs.verify-stable-merge.outputs.verified == 'true'
       )
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,18 +4,12 @@ name: Publish packages
 #
 #   1. Every matching ordinary merge to `main` publishes a `nightly` snapshot.
 #      It never changes the repository or moves npm's `latest` dist-tag.
-#   2. Stable releases ride changesets. A matching merge with pending
-#      changesets opens or updates the Version Packages PR (auto-merged by
-#      `auto-merge-version-packages.yml`); that PR's merge consumes the
-#      changesets and publishes to `latest`. A maintainer can also dispatch
-#      this workflow with a patch/minor/major choice to force an all-package
-#      release without waiting for a changeset to arrive.
+#   2. A maintainer dispatches this workflow with a patch/minor/major choice.
+#      That creates the normal all-package Version Packages PR. Its marked
+#      merge is the only path that publishes a stable release.
 #
-# Both stable paths produce a `[stable-release]`-marked merge commit. That
-# marker exists to keep the nightly job off the release merge — it is not a
-# gate on stable publishing, and gating the release job on it deadlocks the
-# train, because the marker can only ever appear on a PR the release job
-# itself opens.
+# Stable release merges produce a `[stable-release]`-marked commit so the
+# nightly job does not publish a duplicate snapshot for that merge.
 #
 # Desktop-app publishing is OUT of changesets - it ships binaries via
 # electron-builder, not npm. Production desktop releases are dispatched from
@@ -196,18 +190,16 @@ jobs:
 
   release:
     name: Prepare or publish stable npm packages
-    # Runs on every matching main push, which is what keeps the changeset train
-    # moving: with pending changesets `changesets/action` opens or updates the
-    # Version Packages PR, and with none it publishes whatever that PR's merge
-    # bumped. Gating this job on `[stable-release]` (or on a dispatch) stops the
-    # PR from ever being opened, so no merge can ever carry the marker: stable
-    # publishing stalls silently while nightly keeps going green, and changesets
-    # pile up unconsumed. That is not hypothetical — it held npm `latest` at
-    # 0.169.1 for three days behind 43 unreleased changesets.
-    #
-    # A downstream redispatch only re-sends a notification for versions that are
-    # already on npm, so it must not re-enter build/publish.
-    if: ${{ !inputs.redispatchDownstream }}
+    # Ordinary main pushes are nightly-only. A manual dispatch creates the
+    # marked Version Packages PR; only that PR's merge can enter stable npm
+    # publication. A downstream redispatch only re-sends a notification for
+    # versions that are already on npm, so it must not re-enter build/publish.
+    if: |
+      !inputs.redispatchDownstream &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'push' && contains(github.event.head_commit.message, '[stable-release]'))
+      )
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
@@ -300,14 +292,15 @@ jobs:
   notify-downstream:
     name: Notify downstream repos
     needs: [release]
-    # always(): `release` is skipped on a redispatch and may fail on a bad
-    # publish; both cases still need a written answer about the notification.
-    # Do not narrow this to marked pushes either — `release` publishes whenever
-    # no changesets are pending, which is not always a merge carrying the
-    # marker, and a notification job that skips on the run that published is
-    # the exact silent failure the paragraph above describes. The body already
-    # writes "published nothing" and exits 0, so an ordinary push is cheap.
-    if: always()
+    # A normal main push has no stable release job. Manual dispatches (including
+    # redispatch) and marked stable merges still need a written notification
+    # result even when the release job fails or is intentionally skipped.
+    if: |
+      always() &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'push' && contains(github.event.head_commit.message, '[stable-release]'))
+      )
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -46,14 +46,28 @@ describe("npm package release workflow", () => {
     assert.doesNotMatch(source, /AGENT_NATIVE_NPM_DIST_TAG: beta/);
   });
 
-  it("keeps stable changesets flowing on main pushes", () => {
+  it("keeps stable releases behind a manual dispatch or marked merge", () => {
     const release = jobs.release as Workflow;
     const condition = String(release.if);
     const notify = jobs["notify-downstream"] as Workflow;
 
-    assert.equal(condition, "${{ !inputs.redispatchDownstream }}");
+    assert.match(condition, /^!inputs\.redispatchDownstream\s*&&/);
+    assert.match(condition, /github\.event_name == 'workflow_dispatch'/);
+    assert.match(
+      condition,
+      /github\.event_name == 'push' && contains\(github\.event\.head_commit\.message, '\[stable-release\]'\)/,
+    );
+    assert.doesNotMatch(condition, /\$\{\{ !inputs\.redispatchDownstream \}\}/);
     assert.deepEqual(notify.needs, ["release"]);
-    assert.equal(String(notify.if), "always()");
+    assert.match(String(notify.if), /github\.event_name == 'workflow_dispatch'/);
+  });
+
+  it("uses calculated semver bases for nightly snapshots", () => {
+    const config = JSON.parse(
+      readFileSync(".changeset/config.json", "utf8"),
+    ) as { snapshot?: { useCalculatedVersion?: boolean } };
+
+    assert.equal(config.snapshot?.useCalculatedVersion, true);
   });
 
   it("keeps the release changeset package list aligned with the publisher", () => {

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -62,6 +62,7 @@ describe("npm package release workflow", () => {
       String(release.if),
       /needs\.verify-stable-merge\.outputs\.verified == 'true'/,
     );
+    assert.match(JSON.stringify(verifier), /stable_marker/);
     assert.match(JSON.stringify(verifier), /ACTOR/);
     assert.match(JSON.stringify(verifier), /commits\/\$SHA\/pulls/);
   });

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -36,7 +36,14 @@ describe("npm package release workflow", () => {
     assert(publishStep);
 
     assert.match(String(nightly.if), /github\.event_name == 'push'/);
-    assert.match(String(nightly.if), /\[stable-release\]/);
+    assert.match(
+      String(nightly.if),
+      /needs\.verify-stable-merge\.outputs\.verified != 'true'/,
+    );
+    assert.doesNotMatch(
+      String(nightly.if),
+      /contains\(github\.event\.head_commit\.message/,
+    );
     assert.match(source, /--snapshot nightly/);
     assert.equal(
       (publishStep.env as Workflow).AGENT_NATIVE_NPM_DIST_TAG,
@@ -46,22 +53,42 @@ describe("npm package release workflow", () => {
     assert.doesNotMatch(source, /AGENT_NATIVE_NPM_DIST_TAG: beta/);
   });
 
+  it("rejects a marked ordinary push from the stable lane", () => {
+    const verifier = jobs["verify-stable-merge"] as Workflow;
+    const release = jobs.release as Workflow;
+
+    assert.doesNotMatch(String(release.if), /head_commit\.message/);
+    assert.match(
+      String(release.if),
+      /needs\.verify-stable-merge\.outputs\.verified == 'true'/,
+    );
+    assert.match(JSON.stringify(verifier), /ACTOR/);
+    assert.match(JSON.stringify(verifier), /commits\/\$SHA\/pulls/);
+  });
+
   it("keeps stable releases behind a manual dispatch or marked merge", () => {
+    const verifier = jobs["verify-stable-merge"] as Workflow;
+    const verifierSource = JSON.stringify(verifier);
     const release = jobs.release as Workflow;
     const condition = String(release.if);
     const notify = jobs["notify-downstream"] as Workflow;
 
-    assert.match(condition, /^!inputs\.redispatchDownstream\s*&&/);
-    assert.match(condition, /github\.event_name == 'workflow_dispatch'/);
     assert.match(
       condition,
-      /github\.event_name == 'push' && contains\(github\.event\.head_commit\.message, '\[stable-release\]'\)/,
+      /needs\.verify-stable-merge\.outputs\.verified == 'true'/,
     );
-    assert.doesNotMatch(condition, /\$\{\{ !inputs\.redispatchDownstream \}\}/);
-    assert.deepEqual(notify.needs, ["release"]);
+    assert.match(verifierSource, /commits\/\$SHA\/pulls/);
+    assert.match(verifierSource, /changeset-release\/main/);
+    assert.match(verifierSource, /builder-io-integration\[bot\]/);
+    assert.match(verifierSource, /merge_commit_sha == \$sha/);
+    assert.deepEqual(notify.needs, ["release", "verify-stable-merge"]);
     assert.match(
       String(notify.if),
       /github\.event_name == 'workflow_dispatch'/,
+    );
+    assert.match(
+      String(notify.if),
+      /needs\.verify-stable-merge\.outputs\.verified == 'true'/,
     );
   });
 

--- a/scripts/package-release-workflow.test.ts
+++ b/scripts/package-release-workflow.test.ts
@@ -59,7 +59,10 @@ describe("npm package release workflow", () => {
     );
     assert.doesNotMatch(condition, /\$\{\{ !inputs\.redispatchDownstream \}\}/);
     assert.deepEqual(notify.needs, ["release"]);
-    assert.match(String(notify.if), /github\.event_name == 'workflow_dispatch'/);
+    assert.match(
+      String(notify.if),
+      /github\.event_name == 'workflow_dispatch'/,
+    );
   });
 
   it("uses calculated semver bases for nightly snapshots", () => {

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -55,11 +55,6 @@ async function fetchEventsForRange(
   }
 }
 
-function dateKeyFromParts(date: Date): string {
-  const pad = (value: number) => String(value).padStart(2, "0");
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-}
-
 export default defineAction({
   description:
     "See what the user is currently looking at on screen. Returns the current view, date range, and visible events. Always call this first before taking any action.",

--- a/templates/calendar/app/components/calendar/CommandPalette.tsx
+++ b/templates/calendar/app/components/calendar/CommandPalette.tsx
@@ -13,7 +13,7 @@ import {
   IconExternalLink,
 } from "@tabler/icons-react";
 import * as chrono from "chrono-node";
-import { format, parseISO, parse, isValid } from "date-fns";
+import { format, parse, isValid } from "date-fns";
 
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
## Summary
- keep stable npm releases behind the Publish packages workflow button or a marked release merge
- base nightly snapshot versions on the calculated package semver
- add regression coverage for both release contracts

## Validation
- JSON config parse and git diff check passed
- focused workflow test pending dependency install