### PR TITLE
feat(core): support per-tool approval policies for connected MCP tools

### DIFF
--- a/.changeset/calm-tools-approve.md
+++ b/.changeset/calm-tools-approve.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow apps to configure approval requirements for individual MCP tools and require a fresh approval on every call when persistent approval is disabled.

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -342,6 +342,18 @@ describe("defineAction", () => {
     expect(action.needsApproval).toBe(gate);
   });
 
+  it("preserves a per-call-only approval policy on the returned entry", () => {
+    const action = defineAction({
+      description: "send an email",
+      parameters: { to: { type: "string" } },
+      needsApproval: true,
+      allowPersistentApproval: false,
+      run: async () => "sent",
+    });
+
+    expect(action.allowPersistentApproval).toBe(false);
+  });
+
   it("leaves needsApproval undefined when not specified (default off)", () => {
     const action = defineAction({
       description: "send an email",

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -649,6 +649,8 @@ interface DefineActionWithSchema<
         args: StandardSchemaV1.InferOutput<TSchema>,
         ctx?: ActionRunContext,
       ) => boolean | Promise<boolean>);
+  /** Allow a saved user preference to satisfy `needsApproval`. Defaults true. */
+  allowPersistentApproval?: boolean;
   /**
    * Authorization gate that runs before `run()` on **every** caller — agent
    * tool, HTTP, frontend, MCP, A2A, and CLI. It wraps `run` itself rather than
@@ -778,6 +780,8 @@ interface DefineActionWithParams<
         args: InferParams<TParams>,
         ctx?: ActionRunContext,
       ) => boolean | Promise<boolean>);
+  /** Allow a saved user preference to satisfy `needsApproval`. Defaults true. */
+  allowPersistentApproval?: boolean;
   /** Pre-run authorization gate applied to every caller. See the schema
    *  overload above for full semantics. */
   authorize?: ActionAuthorize<InferParams<TParams>>;
@@ -849,6 +853,8 @@ export interface ActionDefinition<TInput, TReturn> {
   readonly needsApproval?:
     | boolean
     | ((args: TInput, ctx?: ActionRunContext) => boolean | Promise<boolean>);
+  /** Allow a saved user preference to satisfy `needsApproval`. Defaults true. */
+  readonly allowPersistentApproval?: boolean;
   /** Resolved audit-log configuration. Present only when the caller passed
    *  `audit`. The audit capture wrapper is baked into `run`; this field is for
    *  introspection. */
@@ -1137,6 +1143,9 @@ export function defineAction(options: any) {
     ...(typeof options.needsApproval === "boolean" ||
     typeof options.needsApproval === "function"
       ? { needsApproval: options.needsApproval }
+      : {}),
+    ...(typeof options.allowPersistentApproval === "boolean"
+      ? { allowPersistentApproval: options.allowPersistentApproval }
       : {}),
     ...(auditConfig ? { audit: auditConfig } : {}),
   };

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -9603,6 +9603,73 @@ describe("runAgentLoop", () => {
     expect(bulkWrite).not.toHaveBeenCalled();
   });
 
+  it("requires a fresh approval when persistent approval is disabled", async () => {
+    const { engine } = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const isToolAlwaysAllowed = vi.fn(async () => true);
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: true,
+          allowPersistentApproval: false,
+          run,
+        },
+      },
+      isToolAlwaysAllowed,
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(isToolAlwaysAllowed).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "approval_required",
+        tool: "send-email",
+        allowPersistentApproval: false,
+      }),
+    );
+  });
+
+  it("honors persistent approval by default", async () => {
+    const { engine } = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const isToolAlwaysAllowed = vi.fn(async () => true);
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: true,
+          run,
+        },
+      },
+      isToolAlwaysAllowed,
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(isToolAlwaysAllowed).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledOnce();
+    expect(events.some((event) => event.type === "approval_required")).toBe(
+      false,
+    );
+  });
+
   it("re-running with approvedToolCalls:[approvalKey] DOES run the action", async () => {
     // Phase 1: capture the approvalKey from the pause.
     const phase1 = approvalEngine();

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -782,6 +782,11 @@ export interface ActionEntry {
         ctx?: import("../action.js").ActionRunContext,
       ) => boolean | Promise<boolean>);
   /**
+   * Whether a user-scoped action preference may satisfy `needsApproval`
+   * without prompting for this call. Defaults to true.
+   */
+  allowPersistentApproval?: boolean;
+  /**
    * The action hands control back to the user: once it succeeds the loop stops
    * the turn instead of asking the model for another step, and any remaining
    * tool calls in the same assistant message do not execute. Only for actions
@@ -5964,7 +5969,11 @@ export async function runAgentLoop(opts: {
           // than silently running a high-consequence action.
           mustApprove = true;
         }
-        if (mustApprove && opts.isToolAlwaysAllowed) {
+        if (
+          mustApprove &&
+          actionEntry.allowPersistentApproval !== false &&
+          opts.isToolAlwaysAllowed
+        ) {
           try {
             mustApprove = !(await opts.isToolAlwaysAllowed(approvalBinding));
           } catch {
@@ -5994,6 +6003,9 @@ export async function runAgentLoop(opts: {
             tool: toolCall.name,
             input: toolCall.input as Record<string, string>,
             approvalKey,
+            ...(actionEntry.allowPersistentApproval === false
+              ? { allowPersistentApproval: false }
+              : {}),
             ...(askId ? { askId } : {}),
             ...(toolCall.id ? { toolCallId: toolCall.id } : {}),
           });

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -448,6 +448,44 @@ describe("buildAssistantMessage", () => {
     ]);
   });
 
+  it("persists per-call-only approval policy when rebuilding thread history", () => {
+    const message = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: {
+            type: "tool_start",
+            id: "send-email-call",
+            tool: "send-email",
+            input: { to: "person@example.com" },
+          },
+        },
+        {
+          seq: 1,
+          event: {
+            type: "approval_required",
+            tool: "send-email",
+            toolCallId: "send-email-call",
+            approvalKey: "send-email:approval",
+            allowPersistentApproval: false,
+          },
+        },
+      ],
+      "run-send-email-approval",
+    );
+
+    expect(message?.content).toEqual([
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "send-email",
+        approval: {
+          approvalKey: "send-email:approval",
+          allowPersistentApproval: false,
+        },
+      }),
+    ]);
+  });
+
   it("falls back to legacy name matching when a done id has no matching start", () => {
     const message = buildAssistantMessage(
       [

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -33,7 +33,12 @@ interface ContentPart {
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
   activity?: boolean;
-  approval?: { approvalKey: string; dismissed?: boolean; askId?: string };
+  approval?: {
+    approvalKey: string;
+    dismissed?: boolean;
+    askId?: string;
+    allowPersistentApproval?: false;
+  };
 }
 
 interface BuildAssistantMessageOptions {
@@ -238,6 +243,9 @@ export function buildAssistantMessage(
         part.approval = {
           approvalKey: event.approvalKey,
           ...(event.askId ? { askId: event.askId } : {}),
+          ...(event.allowPersistentApproval === false
+            ? { allowPersistentApproval: false }
+            : {}),
         };
       }
       continue;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -345,6 +345,8 @@ export type AgentChatEvent =
       input: Record<string, string>;
       /** Stable key the client echoes back in `approvedToolCalls` to approve. */
       approvalKey: string;
+      /** False when this action requires a fresh approval for every call. */
+      allowPersistentApproval?: false;
       /** The model-side tool-call id for this paused call, when available. */
       toolCallId?: string;
       /**

--- a/packages/core/src/client/chat/runtime.spec.ts
+++ b/packages/core/src/client/chat/runtime.spec.ts
@@ -338,6 +338,7 @@ describe("createAgentNativeChatRuntime", () => {
           input: {},
           approvalKey: "start-prospect-run:{}",
           toolCallId: "call-1",
+          allowPersistentApproval: false,
         },
         { type: "done" },
       ]),
@@ -359,6 +360,7 @@ describe("createAgentNativeChatRuntime", () => {
       approvalId: "start-prospect-run:{}",
       toolCallId: "call-1",
       toolName: "start-prospect-run",
+      allowPersistentApproval: false,
     });
   });
 });
@@ -503,6 +505,7 @@ describe("createAgentChatRuntimeAdapter", () => {
                 toolCallId: "call-1",
                 toolName: "start-prospect-run",
                 message: "Approve this tool call?",
+                allowPersistentApproval: false,
               };
               yield { type: "done", reason: "complete" };
             }
@@ -532,7 +535,10 @@ describe("createAgentChatRuntimeAdapter", () => {
     expect(toolCalls).toHaveLength(2);
     expect(toolCalls[0]).toMatchObject({
       toolCallId: "call-1",
-      approval: { approvalKey: "start-prospect-run:call-1" },
+      approval: {
+        approvalKey: "start-prospect-run:call-1",
+        allowPersistentApproval: false,
+      },
     });
     expect(toolCalls[1].approval).toBeUndefined();
   });

--- a/packages/core/src/client/chat/runtime.ts
+++ b/packages/core/src/client/chat/runtime.ts
@@ -374,6 +374,7 @@ export interface AgentChatRuntimeApprovalRequestEvent extends AgentChatRuntimeEv
   readonly toolName?: string;
   readonly message: string;
   readonly input?: unknown;
+  readonly allowPersistentApproval?: false;
 }
 
 export interface AgentChatRuntimeApprovalResolvedEvent extends AgentChatRuntimeEventBase<"approval-resolved"> {
@@ -1371,6 +1372,9 @@ function mapAgentNativeEvent(
         toolName: ev.tool,
         message: ev.label ?? "Approve this tool call?",
         input: ev.input,
+        ...(ev.allowPersistentApproval === false
+          ? { allowPersistentApproval: false }
+          : {}),
       },
     ];
   }
@@ -1658,7 +1662,12 @@ function applyRuntimeEventToContent(
             isToolCall(candidate) && candidate.toolName === typed.toolName,
         );
     if (part && part.type === "tool-call") {
-      part.approval = { approvalKey: typed.approvalId };
+      part.approval = {
+        approvalKey: typed.approvalId,
+        ...(typed.allowPersistentApproval === false
+          ? { allowPersistentApproval: false }
+          : {}),
+      };
     } else if (!typed.toolCallId) {
       // Only runtimes that never announced the call (no id) get a synthesized
       // card. An id that matches nothing means the call was never observed or
@@ -1670,7 +1679,12 @@ function applyRuntimeEventToContent(
         toolName: typed.toolName ?? "approval",
         argsText: typed.input ? JSON.stringify(typed.input) : "",
         args: toContentPartInput(typed.input),
-        approval: { approvalKey: typed.approvalId },
+        approval: {
+          approvalKey: typed.approvalId,
+          ...(typed.allowPersistentApproval === false
+            ? { allowPersistentApproval: false }
+            : {}),
+        },
       });
     }
     return { content: [...content] } as ChatModelRunResult;

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -2258,6 +2258,7 @@ describe("ApprovalAffordance", () => {
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    builderHandoffMocks.useAgentChatContext.mockReturnValue({ items: [] });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -2365,6 +2366,32 @@ describe("ApprovalAffordance", () => {
         (button) => button.textContent,
       ),
     ).toEqual(["bash"]);
+  });
+
+  it("hides the persistent approval option for per-call-only actions", () => {
+    act(() => {
+      root.render(
+        <ApprovalContext.Provider
+          value={{ onApprove: vi.fn(), onAlwaysAllow: vi.fn() }}
+        >
+          <ToolCallDisplay
+            toolName="send-email"
+            args={{}}
+            approval={{
+              approvalKey: "approval-1",
+              allowPersistentApproval: false,
+            }}
+            isRunning={false}
+          />
+        </ApprovalContext.Provider>,
+      );
+    });
+
+    expect(
+      Array.from(container.querySelectorAll("button")).map(
+        (button) => button.textContent,
+      ),
+    ).toEqual(["send email", "Approve", "Deny"]);
   });
 
   it("keeps Approved visible when the chat refresh remounts the tool card", () => {

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -573,7 +573,12 @@ function ApprovalAffordance({
 }: {
   toolName: string;
   toolCallId?: string;
-  approval: { approvalKey: string; dismissed?: boolean; askId?: string };
+  approval: {
+    approvalKey: string;
+    dismissed?: boolean;
+    askId?: string;
+    allowPersistentApproval?: false;
+  };
 }) {
   const t = useT();
   const ctx = React.useContext(ApprovalContext);
@@ -581,6 +586,8 @@ function ApprovalAffordance({
     useState<ApprovalResolution | null>(null);
   const [isAlwaysAllowing, setIsAlwaysAllowing] = useState(false);
   const [alwaysAllowFailed, setAlwaysAllowFailed] = useState(false);
+  const onAlwaysAllow =
+    approval.allowPersistentApproval === false ? undefined : ctx?.onAlwaysAllow;
   const retainedResolution =
     ctx?.getApprovalResolution?.(
       approval.approvalKey,
@@ -612,13 +619,13 @@ function ApprovalAffordance({
     );
   }
   const handleAlwaysAllow = async () => {
-    if (!ctx?.onAlwaysAllow || isAlwaysAllowing) return;
+    if (!onAlwaysAllow || isAlwaysAllowing) return;
     setIsAlwaysAllowing(true);
     setAlwaysAllowFailed(false);
     try {
-      await ctx.onAlwaysAllow(approval.approvalKey, toolName);
+      await onAlwaysAllow(approval.approvalKey, toolName);
       setLocalResolution("approved");
-      ctx.onApprovalResolved?.(
+      ctx?.onApprovalResolved?.(
         approval.approvalKey,
         "approved",
         toolCallId,
@@ -654,14 +661,14 @@ function ApprovalAffordance({
             className={cn(
               "inline-flex shrink-0 items-center gap-1 px-2.5 py-1 text-xs font-medium transition-colors",
               "bg-foreground text-background hover:bg-foreground/90",
-              ctx.onAlwaysAllow ? "rounded-s-md rounded-e-none" : "rounded-md",
+              onAlwaysAllow ? "rounded-s-md rounded-e-none" : "rounded-md",
               "disabled:pointer-events-none disabled:opacity-50",
             )}
           >
             <IconCheck className="h-3.5 w-3.5" />
             {t("agentChat.approval.approve")}
           </button>
-          {ctx.onAlwaysAllow && (
+          {onAlwaysAllow && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -752,7 +759,12 @@ export function ToolCallDisplay({
   outcome?: "unknown";
   structuredMeta?: Record<string, unknown>;
   activity?: boolean;
-  approval?: { approvalKey: string; dismissed?: boolean; askId?: string };
+  approval?: {
+    approvalKey: string;
+    dismissed?: boolean;
+    askId?: string;
+    allowPersistentApproval?: false;
+  };
   repeatCount?: number;
   /** The latest tool shown while the overall chat turn is still active. */
   isActiveTail?: boolean;
@@ -874,7 +886,12 @@ function ToolCallDisplayGeneric({
   outcome?: "unknown";
   isActiveTail: boolean;
   structuredMeta?: Record<string, unknown>;
-  approval?: { approvalKey: string; dismissed?: boolean; askId?: string };
+  approval?: {
+    approvalKey: string;
+    dismissed?: boolean;
+    askId?: string;
+    allowPersistentApproval?: false;
+  };
   repeatCount?: number;
   context?: string;
 }) {
@@ -1383,7 +1400,12 @@ export function ToolCallFallback({
   structuredMeta?: Record<string, unknown>;
   activity?: boolean;
   outcome?: "unknown";
-  approval?: { approvalKey: string; dismissed?: boolean; askId?: string };
+  approval?: {
+    approvalKey: string;
+    dismissed?: boolean;
+    askId?: string;
+    allowPersistentApproval?: false;
+  };
   repeatCount?: number;
   isLatestRunning?: boolean;
   isActiveTail?: boolean;

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -4058,6 +4058,7 @@ describe("SSE event processor tool id matching", () => {
             tool: "send-email",
             id: "approve-1",
             approvalKey: 'send-email:{"to":"a@b.com"}',
+            allowPersistentApproval: false,
             input: { to: "a@b.com" },
           },
           {
@@ -4079,6 +4080,7 @@ describe("SSE event processor tool id matching", () => {
     );
     expect(part?.approval).toEqual({
       approvalKey: 'send-email:{"to":"a@b.com"}',
+      allowPersistentApproval: false,
     });
   });
 

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -59,7 +59,12 @@ export type ContentPart =
        * tells that apart from the same ask simply re-rendering (see
        * `ApprovalAffordance` in chat/tool-call-display.tsx).
        */
-      approval?: { approvalKey: string; dismissed?: boolean; askId?: string };
+      approval?: {
+        approvalKey: string;
+        dismissed?: boolean;
+        askId?: string;
+        allowPersistentApproval?: false;
+      };
       /**
        * Structured metadata from the coding-tools executor side-channel.
        * Present only on code-agent tool calls from executors new enough to
@@ -89,6 +94,8 @@ export interface SSEEvent {
   toolCallId?: string;
   /** Identifies this `approval_required` gate hit (mirrors AgentChatEvent). */
   askId?: string;
+  /** False when this action requires a fresh approval for every call. */
+  allowPersistentApproval?: false;
   error?: string;
   seq?: number;
   agent?: string;
@@ -1649,6 +1656,9 @@ export function processEvent(
           part.approval = {
             approvalKey,
             ...(ev.askId ? { askId: ev.askId } : {}),
+            ...(ev.allowPersistentApproval === false
+              ? { allowPersistentApproval: false }
+              : {}),
           };
         }
       }

--- a/packages/core/src/mcp-client/index.spec.ts
+++ b/packages/core/src/mcp-client/index.spec.ts
@@ -198,6 +198,30 @@ describe("mcpToolsToActionEntries", () => {
     expect(entries["mcp__x__mutate"].readOnly).toBeUndefined();
   });
 
+  it("decorates discovered MCP actions with app-provided approval metadata", async () => {
+    serverFixtures["x-bin"] = {
+      tools: [{ name: "mutate", description: "Mutate state" }],
+      callImpl: () => ({ content: [{ type: "text", text: "ok" }] }),
+    };
+    const mgr = new McpClientManager({
+      servers: { x: { command: "x-bin" } },
+    });
+    await mgr.start();
+    const needsApproval = (args: Record<string, unknown>) =>
+      args.confirmed !== true;
+
+    const entries = mcpToolsToActionEntries(mgr, {
+      resolveActionEntry: (tool) => {
+        expect(tool.name).toBe("mcp__x__mutate");
+        expect(tool.originalName).toBe("mutate");
+        return { needsApproval, allowPersistentApproval: false };
+      },
+    });
+
+    expect(entries["mcp__x__mutate"].needsApproval).toBe(needsApproval);
+    expect(entries["mcp__x__mutate"].allowPersistentApproval).toBe(false);
+  });
+
   it("updates existing MCP ActionEntry metadata when the manager tool set changes", () => {
     const target: Record<string, ActionEntry> = {
       mcp__x__inspect: {
@@ -229,7 +253,12 @@ describe("mcpToolsToActionEntries", () => {
       readResourceForTool: vi.fn(),
     } as unknown as McpClientManager;
 
-    syncMcpActionEntries(manager, target);
+    syncMcpActionEntries(manager, target, {
+      resolveActionEntry: () => ({
+        needsApproval: true,
+        allowPersistentApproval: false,
+      }),
+    });
 
     expect(target["mcp__x__inspect"].tool).toEqual({
       description: "New description",
@@ -240,6 +269,8 @@ describe("mcpToolsToActionEntries", () => {
       },
     });
     expect(target["mcp__x__inspect"].readOnly).toBe(true);
+    expect(target["mcp__x__inspect"].needsApproval).toBe(true);
+    expect(target["mcp__x__inspect"].allowPersistentApproval).toBe(false);
   });
 
   it("prefixes error-flagged results with 'Error:'", async () => {

--- a/packages/core/src/mcp-client/index.ts
+++ b/packages/core/src/mcp-client/index.ts
@@ -169,6 +169,12 @@ export interface McpActionEntryOptions {
   invocationPolicy?: McpToolInvocationPolicy;
   /** Restrict the generated entries to an explicit background capability set. */
   toolNames?: readonly string[];
+  /** Add app-owned approval metadata without replacing the MCP runtime wrapper. */
+  resolveActionEntry?: (
+    tool: McpTool,
+  ) =>
+    | Partial<Pick<ActionEntry, "needsApproval" | "allowPersistentApproval">>
+    | undefined;
 }
 
 export function mcpToolsToActionEntries(
@@ -198,11 +204,12 @@ export function mcpToolsToActionEntries(
 export function syncMcpActionEntries(
   manager: McpClientManager,
   target: Record<string, ActionEntry>,
+  options: McpActionEntryOptions = {},
 ): void {
   const current = new Set<string>();
   for (const tool of manager.getTools().filter(isVisibleToModel)) {
     current.add(tool.name);
-    target[tool.name] = mcpToolToActionEntry(manager, tool);
+    target[tool.name] = mcpToolToActionEntry(manager, tool, options);
   }
   for (const key of Object.keys(target)) {
     if (key.startsWith("mcp__") && !current.has(key)) {
@@ -216,6 +223,7 @@ function mcpToolToActionEntry(
   tool: McpTool,
   options: McpActionEntryOptions = {},
 ): ActionEntry {
+  const resolvedEntry = options.resolveActionEntry?.(tool);
   return {
     tool: {
       description: tool.description,
@@ -229,6 +237,7 @@ function mcpToolToActionEntry(
         "Plan mode allows MCP calls classified as read-only from annotations, operation names, and runtime arguments.",
     },
     ...(tool.annotations?.readOnlyHint === true ? { readOnly: true } : {}),
+    ...resolvedEntry,
     run: async (args: Record<string, unknown>) => {
       // Defense-in-depth: even if a cross-scope MCP tool somehow makes it
       // into the LLM's visible tool list, reject invocation here so we never

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -291,6 +291,21 @@ describe("action discovery", () => {
     expect(registry["send-email-named"].needsApproval).toBe(gate);
   });
 
+  it("preserves a per-call-only approval policy through discovery", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "send-email": {
+        default: {
+          tool: { description: "Send email", parameters: {} },
+          needsApproval: true,
+          allowPersistentApproval: false,
+          run: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    expect(registry["send-email"].allowPersistentApproval).toBe(false);
+  });
+
   it("threads the http config through named and default static entries", () => {
     const registry = loadActionsFromStaticRegistry({
       "named-get": {

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -273,6 +273,9 @@ function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
   ) {
     out.needsApproval = entry.needsApproval;
   }
+  if (typeof entry.allowPersistentApproval === "boolean") {
+    out.allowPersistentApproval = entry.allowPersistentApproval;
+  }
   return out;
 }
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -176,6 +176,7 @@ import {
   startMcpConfigRefresh,
   getHubStatus,
   isHubServeEnabled,
+  type McpActionEntryOptions,
 } from "../mcp-client/index.js";
 import { declaredMcpToolNames } from "../mcp/build-server.js";
 import { setProgressPreListHook } from "../progress/store.js";
@@ -708,6 +709,10 @@ export function createAgentChatPlugin(
       // connector policy cannot diverge between the two external surfaces.
       const mcpOptions = resolveAgentChatMcpOptions(options);
       const backgroundMcpTools = options?.backgroundMcpTools ?? "requested";
+      const mcpActionEntryOptions: McpActionEntryOptions =
+        options?.resolveMcpActionEntry
+          ? { resolveActionEntry: options.resolveMcpActionEntry }
+          : {};
 
       // Build the four assembled system prompt strings. These are static for the
       // lifetime of this plugin instance — examples come from options once at
@@ -775,7 +780,9 @@ export function createAgentChatPlugin(
         await ensureMcpInitialized();
         const entries = mcpToolsToActionEntries(
           mcpManager,
-          backgroundMcpTools === "all" ? {} : { toolNames: requested },
+          backgroundMcpTools === "all"
+            ? mcpActionEntryOptions
+            : { ...mcpActionEntryOptions, toolNames: requested },
         );
         const missing = requested.filter((toolName) => !entries[toolName]);
         if (missing.length > 0) {
@@ -3314,8 +3321,12 @@ export function createAgentChatPlugin(
       // through the settings UI). getEngineTools() in production-agent re-reads
       // the registry per request, so updates here propagate without restart.
       mcpManager.onChange(() => {
-        syncMcpActionEntries(mcpManager, mcpActionEntries);
-        syncMcpActionEntries(mcpManager, prodActions);
+        syncMcpActionEntries(
+          mcpManager,
+          mcpActionEntries,
+          mcpActionEntryOptions,
+        );
+        syncMcpActionEntries(mcpManager, prodActions, mcpActionEntryOptions);
       });
 
       // Always build the production handler (includes resource tools + call-agent + team tools)
@@ -3932,7 +3943,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
         // === prodActions so the prod listener already covers it.
         if (devActions !== prodActions && devActions !== leanActions) {
           mcpManager.onChange(() => {
-            syncMcpActionEntries(mcpManager, devActions);
+            syncMcpActionEntries(mcpManager, devActions, mcpActionEntryOptions);
           });
         }
         devHandler = createProductionAgentHandler({

--- a/packages/core/src/server/agent-chat/plugin-options.ts
+++ b/packages/core/src/server/agent-chat/plugin-options.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../agent/types.js";
 import type { FeatureFlagDefinition } from "../../feature-flags/registry.js";
 import type { FrameworkToolsConfig } from "../../framework-tools.js";
+import type { McpActionEntryOptions } from "../../mcp-client/index.js";
 import type { ExternalAgentPolicy } from "../../mcp/external-agent-policy.js";
 import type { DatabaseToolsOption } from "../../scripts/db/tool-mode.js";
 import type { PromptExamples } from "../prompts/index.js";
@@ -81,6 +82,12 @@ export interface AgentChatPluginOptions {
    * the per-request scope gate when a tool is called.
    */
   backgroundMcpTools?: "requested" | "all";
+  /**
+   * Resolve approval metadata for connected MCP tools as they enter the agent
+   * action registry. This can require approval for selected tools and disable
+   * persistent approval for actions that must be confirmed on every call.
+   */
+  resolveMcpActionEntry?: McpActionEntryOptions["resolveActionEntry"];
   /**
    * Everything about this app's MCP mount — whether it is mounted, which tools
    * external callers see, and the branding sent during the `initialize`


### PR DESCRIPTION
### Summary

- Allow apps to attach approval metadata to dynamically discovered MCP tools.
- Support actions that require fresh human approval on every call, even when a persistent approval preference exists.
- Keep server enforcement and the shared approval UI consistent across discovery, reconnects, and registry refreshes.

### Why

Connected MCP servers expose dynamic tool catalogs, but apps currently have no supported Core seam for assigning approval requirements to individual discovered tools.

Some integration actions may run automatically, while higher-consequence actions must be approved on every invocation. For those actions, an existing “Always allow this action” preference must not bypass the current policy. The policy also needs to remain attached when Agent Native rebuilds MCP action entries during background setup, reconnects, development refreshes, or production synchronization.

### Changes

- Add `McpActionEntryOptions.resolveActionEntry` for attaching app-owned approval metadata to discovered MCP tools.
- Expose the resolver through `AgentChatPluginOptions.resolveMcpActionEntry`.
- Apply the resolver during initial discovery, background action creation, and production or development registry synchronization.
- Add `allowPersistentApproval` to action definitions and preserve it through static action discovery.
- Make `allowPersistentApproval: false` skip stored persistent approval preferences and require a new decision for every invocation.
- Propagate the per-call-only restriction through approval events, SSE normalization, and the generic chat runtime.
- Hide “Always allow this action” in the shared tool-call UI when persistent approval is not permitted.
- Add focused MCP, server, action-discovery, agent-runtime, SSE, and UI tests plus a patch changeset.

### Tests

- [x] Focused Core regression suites: 581 tests passed
- [x] Agent Chat plugin suites: 97 tests passed
- [x] Full Core suite before the final upstream rebase: 12,871 tests passed
- [x] Affected suites rerun successfully after the final rebase
- [x] Focused approval acceptance smoke: 5 tests passed
- [x] `corepack pnpm --filter @agent-native/core typecheck`
- [x] `corepack pnpm --filter @agent-native/core build`, including dist import validation
- [x] `corepack pnpm guards`: 64/64 passed
- [x] Changed-file formatting, `git diff --check`, and changeset validation

A full workspace `corepack pnpm prep` run completed workspace typecheck, all 64 guards, and Core’s 12,771 fast tests before unrelated remaining package suites exhausted the local macOS temporary volume with `ENOSPC`. Upstream CI should rerun the complete workspace matrix.

A browser-only smoke test was not run because this introduces no new visual surface. The focused acceptance smoke renders the real shared `ToolCallDisplay` and covers the per-call-only button state, server enforcement, and MCP registry refresh behavior.

### Risk / Rollback

- Risk: Approval metadata crosses MCP discovery, server events, and client normalization paths.
- Mitigation: Only the explicit value `allowPersistentApproval: false` changes behavior, and the server remains the enforcement boundary.
- Backwards compatibility: Existing apps and actions remain unchanged when the new resolver and field are omitted. Older clients may still display the persistent option, but the server ignores it for per-call-only actions.
- Rollback plan: Revert the single feature commit. There are no migrations, new dependencies, environment variables, credential changes, or persisted-data changes.

### Checklist

- [x] Backwards compatible
- [x] No migration required
- [x] No secrets or credentials added
- [x] Public API comments added
- [x] Patch changeset included