### PR TITLE
Allow changing existing share permissions in Clips

### DIFF
--- a/docs/plans/2026-08-25-clips-share-role-design.md
+++ b/docs/plans/2026-08-25-clips-share-role-design.md
@@ -1,0 +1,23 @@
+# Clips Existing Share Role Design
+
+## Goal
+
+Let a recording owner or share administrator change the permission level of an existing user from the Clips share dialog.
+
+## UI and architecture
+
+Keep the existing Clips share surface and styles. Replace each manageable grant's static role label with the same compact role selector used by the invite row. Keep the owner row read-only, keep the remove button separate, and keep static role text for users without permission to manage shares.
+
+The selector exposes the existing Viewer, Commenter, Editor, and Admin roles with the current localized labels and optional recording-specific descriptions.
+
+## Data flow
+
+Selecting a role calls the existing `share-resource` action with the grant's current `principalType`, `principalId`, and new role. The action already updates matching grants. After success, refetch `list-resource-shares` so the server result is authoritative. Disable role controls while the mutation is pending.
+
+## Failure behavior
+
+Do not change the displayed role before the write succeeds. Route failures through the share dialog's existing error callback with a permission-change action type, leaving the prior role visible.
+
+## Verification
+
+Add focused coverage for the existing-grant selector and mutation path. Run formatting, the targeted Clips share-dialog test, Clips type checking, and i18n guards. Exercise the recording share dialog in the running app for manager and read-only states.

--- a/docs/plans/2026-08-25-clips-share-role.md
+++ b/docs/plans/2026-08-25-clips-share-role.md
@@ -1,0 +1,77 @@
+# Clips Existing Share Role Implementation Plan
+
+> **For the Fusion agent:** Execute this plan task-by-task. Each step is one action. Do not skip steps. Verify after each task. Commit after each task.
+
+**Goal:** Allow Clips owners and share administrators to change an existing user's recording permission from the share dialog.
+
+**Architecture:** Extend the template-owned `SharePeopleTab` to render the existing role `Select` for manageable grants. Reuse the framework `share-resource` upsert action and refetch the existing shares query after a successful update; no new action or API route is needed.
+
+**Tech Stack:** React, TypeScript, shadcn Select, Agent Native action hooks, Vitest.
+
+### Task 1: Add existing-grant role updates
+
+**Files:**
+- Modify: `templates/clips/app/components/sharing/share-ui.tsx`
+
+**Step 1: Extend the error action type**
+
+Allow `onError` to receive `"permission"` in addition to `"invite"` and `"remove"`.
+
+**Step 2: Add the role-change handler**
+
+Call `share-resource` with the existing grant's resource, principal type, principal id, and selected role. Refetch `sharesQuery` on success and report `"permission"` on failure.
+
+**Step 3: Render the manager selector**
+
+For manageable grants, replace static role text with the existing compact `Select`, using `ROLE_OPTIONS`, localized labels, role descriptions, and a disabled state while the share mutation is pending. Preserve static role text for non-managers.
+
+**Step 4: Format**
+
+Run: `pnpm exec oxfmt templates/clips/app/components/sharing/share-ui.tsx`
+
+Expected: command exits 0 and only formats the modified file.
+
+### Task 2: Add focused regression coverage
+
+**Files:**
+- Modify: `templates/clips/app/components/player/share-dialog.test.ts`
+
+**Step 1: Add the assertion**
+
+Add a focused test asserting that existing manageable grants use the role selector, role changes call the share mutation with the existing principal, and failures use the permission error path.
+
+**Step 2: Format**
+
+Run: `pnpm exec oxfmt templates/clips/app/components/player/share-dialog.test.ts`
+
+Expected: command exits 0.
+
+**Step 3: Run the targeted test**
+
+Run the Clips package's existing Vitest command for `app/components/player/share-dialog.test.ts` as defined in `templates/clips/package.json`.
+
+Expected: all tests in the file pass.
+
+### Task 3: Verify the feature
+
+**Files:**
+- Verify: `templates/clips/app/components/sharing/share-ui.tsx`
+- Verify: `templates/clips/app/components/player/share-dialog.test.ts`
+
+**Step 1: Run Clips type checking**
+
+Run the typecheck command defined by `templates/clips/package.json`.
+
+Expected: command exits 0.
+
+**Step 2: Run localization guards**
+
+Run: `pnpm guard:i18n-catalogs && pnpm guard:i18n-changed-copy`
+
+Expected: both guards exit 0 and all configured locale catalogs stay aligned.
+
+**Step 3: Exercise the UI**
+
+Open an owned recording's share dialog in the running Clips app. Change an existing grant between Viewer, Commenter, Editor, and Admin; confirm the saved role survives refetch. Confirm a non-manager sees static role text.
+
+Expected: manager changes persist, controls disable during the write, and read-only users cannot edit roles.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1281,31 +1281,43 @@ describe("AgentEngine registry", () => {
         "BUILDER_GATEWAY_TOKEN",
         rejectedToken,
       );
-      vi.doMock("../../settings/store.js", () => ({
-        getSetting: vi.fn(async (key: string) =>
-          key === `provider-auth-failure:${fingerprint}`
-            ? {
-                fingerprint,
-                key: "BUILDER_GATEWAY_TOKEN",
-                message: "401 status code (no body)",
-                status: 401,
-                at: Date.now(),
-              }
-            : null,
-        ),
-        deleteSetting: vi.fn(),
-      }));
-      // The enclosing beforeEach already registered an always-null
-      // settings/store factory and imported through it. `doMock` only governs
-      // the NEXT import, so without this reset the module instance built there
-      // keeps answering and this failure marker is never seen.
+      vi.doMock("../../server/credential-provider.js", async () => {
+        const actual = await vi.importActual<
+          typeof import("../../server/credential-provider.js")
+        >("../../server/credential-provider.js");
+        return {
+          ...actual,
+          getProviderCredentialAuthFailure: vi.fn(
+            async ({ key, value }: { key?: string; value?: string }) =>
+              key === "BUILDER_GATEWAY_TOKEN" && value === rejectedToken
+                ? {
+                    fingerprint,
+                    key,
+                    message: "401 status code (no body)",
+                    status: 401,
+                    at: Date.now(),
+                  }
+                : null,
+          ),
+        };
+      });
       vi.resetModules();
 
-      const { registerAgentEngine, detectEngineFromEnvForRequest } =
-        await import("./registry.js");
+      const {
+        registerAgentEngine,
+        detectEngineFromEnvForRequest,
+        detectEngineFromEnv,
+      } = await import("./registry.js");
+      const { getProviderCredentialAuthFailure } =
+        await import("../../server/credential-provider.js");
       registerBuilderAndAnthropic(registerAgentEngine);
 
+      expect(detectEngineFromEnv()?.name).toBe("builder");
       expect(await detectEngineFromEnvForRequest()).toBeNull();
+      expect(getProviderCredentialAuthFailure).toHaveBeenCalledWith({
+        key: "BUILDER_GATEWAY_TOKEN",
+        value: rejectedToken,
+      });
     });
 
     it("captures the Builder-credits pair as the engine's credentials", async () => {

--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -262,7 +262,9 @@ function LinkTab({
               ? err.message
               : action === "invite"
                 ? t("clipsFinalRaw.inviteFailed")
-                : t("clipsFinalRaw.removePersonFailed"),
+                : action === "permission"
+                  ? t("clipsFinalRaw.permissionUpdateFailed")
+                  : t("clipsFinalRaw.removePersonFailed"),
           )
         }
       />

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -119,4 +119,21 @@ describe("recording share popover", () => {
     expect(shareUiSource).toContain('useState<Role>("viewer")');
     expect(meetingDialogSource).not.toContain("roleCopy");
   });
+
+  it("lets managers change an existing share role", () => {
+    const shareUiSource = readSource("../sharing/share-ui.tsx");
+
+    expect(shareUiSource).toContain(
+      "const handleChangeRole = (s: Share, nextRole: Role)",
+    );
+    expect(shareUiSource).toContain("principalType: s.principalType");
+    expect(shareUiSource).toContain("principalId: s.principalId");
+    expect(shareUiSource).toContain("role: nextRole");
+    expect(shareUiSource).toContain('onError?.(err, "permission")');
+    expect(shareUiSource).toContain("value={s.role}");
+    expect(shareUiSource).toContain(
+      "onValueChange={(value) => handleChangeRole(s, value as Role)}",
+    );
+    expect(shareUiSource).toContain("disabled={share.isPending}");
+  });
 });

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -539,6 +539,17 @@ function LinkTab({
               description: t("shareUi.recordingCommenter.description"),
             },
           }}
+          onError={(err, action) =>
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : action === "invite"
+                  ? t("clipsFinalRaw.inviteFailed")
+                  : action === "permission"
+                    ? t("clipsFinalRaw.permissionUpdateFailed")
+                    : t("clipsFinalRaw.removePersonFailed"),
+            )
+          }
         />
       ) : null}
 

--- a/templates/clips/app/components/player/timestamped-comment-button.tsx
+++ b/templates/clips/app/components/player/timestamped-comment-button.tsx
@@ -1,6 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconMessagePlus, IconMoodSmile } from "@tabler/icons-react";
+import { IconMessagePlus } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -74,23 +74,6 @@ export function TimestampedCommentBar({
     requestAnimationFrame(() => textareaRef.current?.focus());
   }, []);
 
-  const insertAtCursor = (text: string) => {
-    const el = textareaRef.current;
-    if (!el) {
-      setDraft(draft + text);
-      return;
-    }
-    const start = el.selectionStart ?? draft.length;
-    const end = el.selectionEnd ?? draft.length;
-    const next = draft.slice(0, start) + text + draft.slice(end);
-    setDraft(next);
-    requestAnimationFrame(() => {
-      el.focus();
-      const pos = start + text.length;
-      el.setSelectionRange(pos, pos);
-    });
-  };
-
   const submit = () => {
     const content = draft.trim();
     if (!content) return;
@@ -130,19 +113,7 @@ export function TimestampedCommentBar({
           rows={2}
           className="min-h-[3rem] resize-none border-0 bg-transparent px-1 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
         />
-        <div className="mt-2 flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground"
-              aria-label={t("commentsPanel.addEmoji")}
-              onClick={() => insertAtCursor("🙂")}
-            >
-              <IconMoodSmile className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="mt-2 flex items-center justify-end">
           <div className="flex items-center gap-2">
             <Button type="button" variant="ghost" size="sm" onClick={onClose}>
               {t("common.cancel")}

--- a/templates/clips/app/components/player/timestamped-comment-button.tsx
+++ b/templates/clips/app/components/player/timestamped-comment-button.tsx
@@ -1,6 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconMessagePlus, IconAt, IconMoodSmile } from "@tabler/icons-react";
+import { IconMessagePlus, IconMoodSmile } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -132,16 +132,6 @@ export function TimestampedCommentBar({
         />
         <div className="mt-2 flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground"
-              aria-label={t("commentsPanel.mentionSomeone")}
-              onClick={() => insertAtCursor("@")}
-            >
-              <IconAt className="h-4 w-4" />
-            </Button>
             <Button
               type="button"
               variant="ghost"

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -341,7 +341,7 @@ export function SharePeopleTab({
   sharesQuery: SharesQuery;
   canManage: boolean;
   roleCopy?: Partial<Record<Role, RoleCopy>>;
-  onError?: (err: unknown, action: "invite" | "remove") => void;
+  onError?: (err: unknown, action: "invite" | "permission" | "remove") => void;
 }) {
   const t = useT();
   const share = useActionMutation("share-resource");
@@ -377,6 +377,24 @@ export function SharePeopleTab({
           sharesQuery.refetch();
         },
         onError: (err: unknown) => onError?.(err, "invite"),
+      },
+    );
+  };
+
+  const handleChangeRole = (s: Share, nextRole: Role) => {
+    if (nextRole === s.role) return;
+    share.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: s.principalType,
+        principalId: s.principalId,
+        role: nextRole,
+        notify: false,
+      } as any,
+      {
+        onSuccess: () => sharesQuery.refetch(),
+        onError: (err: unknown) => onError?.(err, "permission"),
       },
     );
   };
@@ -476,9 +494,35 @@ export function SharePeopleTab({
             >
               <Avatar label={s.principalId} org={s.principalType === "org"} />
               <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
-              <span className="text-xs text-muted-foreground">
-                {getRoleLabel(s.role)}
-              </span>
+              {canManage ? (
+                <Select
+                  value={s.role}
+                  onValueChange={(value) => handleChangeRole(s, value as Role)}
+                  disabled={share.isPending}
+                >
+                  <SelectTrigger className="h-7 w-[110px] text-xs">
+                    <SelectValue>{getRoleLabel(s.role)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ROLE_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        <div className="flex flex-col">
+                          <span>{getRoleLabel(opt.value)}</span>
+                          {getRoleCopy(opt.value)?.description ? (
+                            <span className="text-xs text-muted-foreground">
+                              {getRoleCopy(opt.value)?.description}
+                            </span>
+                          ) : null}
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  {getRoleLabel(s.role)}
+                </span>
+              )}
               {canManage ? (
                 <Button
                   type="button"

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1001,7 +1001,6 @@ const messages = {
     editComment: "تحرير التعليق",
     commentButton: "تعليق",
     composerPlaceholder: "أضف تعليقًا…",
-    mentionSomeone: "أذكر شخصًا",
     addEmoji: "أضف رمزًا تعبيريًا",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1544,6 +1544,7 @@ const messages = {
     invite: "دعوة",
     inviteFailed: "تعذرت دعوة الشخص",
     removePersonFailed: "تعذرت إزالة الشخص",
+    permissionUpdateFailed: "تعذر تحديث الإذن",
     passwordProtectedDescription:
       "هذا الفيديو محمي. أدخل كلمة المرور للمشاهدة.",
     password: "كلمة المرور",

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1001,7 +1001,6 @@ const messages = {
     editComment: "تحرير التعليق",
     commentButton: "تعليق",
     composerPlaceholder: "أضف تعليقًا…",
-    addEmoji: "أضف رمزًا تعبيريًا",
   },
   shareMeeting: {
     pageTitle: "ملاحظات الاجتماع · Clips",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1026,7 +1026,6 @@ const messages = {
     editComment: "Kommentar bearbeiten",
     commentButton: "Kommentar",
     composerPlaceholder: "Kommentar hinzufügen…",
-    mentionSomeone: "Jemanden erwähnen",
     addEmoji: "Emoji hinzufügen",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1026,7 +1026,6 @@ const messages = {
     editComment: "Kommentar bearbeiten",
     commentButton: "Kommentar",
     composerPlaceholder: "Kommentar hinzufügen…",
-    addEmoji: "Emoji hinzufügen",
   },
   shareMeeting: {
     pageTitle: "Meeting-Notizen · Clips",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1575,6 +1575,7 @@ const messages = {
     invite: "Einladen",
     inviteFailed: "Person konnte nicht eingeladen werden",
     removePersonFailed: "Person konnte nicht entfernt werden",
+    permissionUpdateFailed: "Berechtigung konnte nicht aktualisiert werden",
     passwordProtectedDescription:
       "Dieses Video ist geschützt. Passwort eingeben, um es anzusehen.",
     password: "Passwort",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -988,7 +988,6 @@ const messages = {
     editComment: "Edit comment",
     commentButton: "Comment",
     composerPlaceholder: "Add a comment…",
-    addEmoji: "Add emoji",
   },
   shareMeeting: {
     pageTitle: "Meeting notes · Clips",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -1526,6 +1526,7 @@ const messages = {
     invite: "Invite",
     inviteFailed: "Couldn't invite person",
     removePersonFailed: "Couldn't remove person",
+    permissionUpdateFailed: "Couldn't update permission",
     passwordProtectedDescription:
       "This video is protected. Enter the password to watch.",
     password: "Password",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -988,7 +988,6 @@ const messages = {
     editComment: "Edit comment",
     commentButton: "Comment",
     composerPlaceholder: "Add a comment…",
-    mentionSomeone: "Mention someone",
     addEmoji: "Add emoji",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1560,6 +1560,7 @@ const messages = {
     invite: "Invitar",
     inviteFailed: "No se pudo invitar a la persona",
     removePersonFailed: "No se pudo eliminar a la persona",
+    permissionUpdateFailed: "No se pudo actualizar el permiso",
     passwordProtectedDescription:
       "Este video está protegido. Introduce la contraseña para verlo.",
     password: "Contraseña",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1018,7 +1018,6 @@ const messages = {
     editComment: "Editar comentario",
     commentButton: "Comentar",
     composerPlaceholder: "Añadir un comentario…",
-    mentionSomeone: "Mencionar a alguien",
     addEmoji: "Añadir emoji",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1018,7 +1018,6 @@ const messages = {
     editComment: "Editar comentario",
     commentButton: "Comentar",
     composerPlaceholder: "Añadir un comentario…",
-    addEmoji: "Añadir emoji",
   },
   shareMeeting: {
     pageTitle: "Notas de reunión · Clips",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1017,7 +1017,6 @@ const messages = {
     editComment: "Modifier le commentaire",
     commentButton: "Commenter",
     composerPlaceholder: "Ajouter un commentaire…",
-    addEmoji: "Ajouter un emoji",
   },
   shareMeeting: {
     pageTitle: "Notes de réunion · Clips",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1566,6 +1566,7 @@ const messages = {
     invite: "Inviter",
     inviteFailed: "Impossible d’inviter la personne",
     removePersonFailed: "Impossible de supprimer la personne",
+    permissionUpdateFailed: "Impossible de mettre à jour l’autorisation",
     passwordProtectedDescription:
       "Cette vidéo est protégée. Saisissez le mot de passe pour la regarder.",
     password: "Mot de passe",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1017,7 +1017,6 @@ const messages = {
     editComment: "Modifier le commentaire",
     commentButton: "Commenter",
     composerPlaceholder: "Ajouter un commentaire…",
-    mentionSomeone: "Mentionner quelqu'un",
     addEmoji: "Ajouter un emoji",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -982,7 +982,6 @@ const messages = {
     editComment: "टिप्पणी संपादित करें",
     commentButton: "टिप्पणी",
     composerPlaceholder: "टिप्पणी जोड़ें…",
-    mentionSomeone: "किसी का उल्लेख करें",
     addEmoji: "इमोजी जोड़ें",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -982,7 +982,6 @@ const messages = {
     editComment: "टिप्पणी संपादित करें",
     commentButton: "टिप्पणी",
     composerPlaceholder: "टिप्पणी जोड़ें…",
-    addEmoji: "इमोजी जोड़ें",
   },
   shareMeeting: {
     pageTitle: "मीटिंग नोट्स · Clips",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -1523,6 +1523,7 @@ const messages = {
     invite: "आमंत्रित करें",
     inviteFailed: "व्यक्ति को आमंत्रित नहीं कर सके",
     removePersonFailed: "व्यक्ति को हटा नहीं सके",
+    permissionUpdateFailed: "अनुमति अपडेट नहीं की जा सकी",
     passwordProtectedDescription:
       "यह वीडियो सुरक्षित है। देखने के लिए पासवर्ड दर्ज करें।",
     password: "पासवर्ड",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1005,7 +1005,6 @@ const messages = {
     editComment: "コメントを編集",
     commentButton: "コメント",
     composerPlaceholder: "コメントを追加…",
-    addEmoji: "絵文字を追加",
   },
   shareMeeting: {
     pageTitle: "会議メモ · Clips",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1558,6 +1558,7 @@ const messages = {
     invite: "招待",
     inviteFailed: "招待できませんでした",
     removePersonFailed: "削除できませんでした",
+    permissionUpdateFailed: "権限を更新できませんでした",
     passwordProtectedDescription:
       "この動画は保護されています。視聴するにはパスワードを入力してください。",
     password: "パスワード",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1005,7 +1005,6 @@ const messages = {
     editComment: "コメントを編集",
     commentButton: "コメント",
     composerPlaceholder: "コメントを追加…",
-    mentionSomeone: "メンバーをメンション",
     addEmoji: "絵文字を追加",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -991,7 +991,6 @@ const messages = {
     editComment: "댓글 편집",
     commentButton: "댓글",
     composerPlaceholder: "댓글 추가…",
-    addEmoji: "이모지 추가",
   },
   shareMeeting: {
     pageTitle: "회의 노트 · Clips",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -1536,6 +1536,7 @@ const messages = {
     invite: "초대",
     inviteFailed: "사용자를 초대할 수 없습니다",
     removePersonFailed: "사용자를 제거할 수 없습니다",
+    permissionUpdateFailed: "권한을 업데이트할 수 없습니다",
     passwordProtectedDescription:
       "이 동영상은 보호되어 있습니다. 보려면 비밀번호를 입력하세요.",
     password: "비밀번호",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -991,7 +991,6 @@ const messages = {
     editComment: "댓글 편집",
     commentButton: "댓글",
     composerPlaceholder: "댓글 추가…",
-    mentionSomeone: "멘션하기",
     addEmoji: "이모지 추가",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1013,7 +1013,6 @@ const messages = {
     editComment: "Editar comentário",
     commentButton: "Comentar",
     composerPlaceholder: "Adicionar um comentário…",
-    addEmoji: "Adicionar emoji",
   },
   shareMeeting: {
     pageTitle: "Notas da reunião · Clips",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1013,7 +1013,6 @@ const messages = {
     editComment: "Editar comentário",
     commentButton: "Comentar",
     composerPlaceholder: "Adicionar um comentário…",
-    mentionSomeone: "Mencionar alguém",
     addEmoji: "Adicionar emoji",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1554,6 +1554,7 @@ const messages = {
     invite: "Convidar",
     inviteFailed: "Não foi possível convidar a pessoa",
     removePersonFailed: "Não foi possível remover a pessoa",
+    permissionUpdateFailed: "Não foi possível atualizar a permissão",
     passwordProtectedDescription:
       "Este vídeo está protegido. Digite a senha para assistir.",
     password: "Senha",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -950,7 +950,6 @@ const messages = {
     editComment: "编辑评论",
     commentButton: "评论",
     composerPlaceholder: "添加评论…",
-    addEmoji: "添加表情",
   },
   shareMeeting: {
     pageTitle: "会议笔记 · Clips",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -950,7 +950,6 @@ const messages = {
     editComment: "编辑评论",
     commentButton: "评论",
     composerPlaceholder: "添加评论…",
-    mentionSomeone: "提及某人",
     addEmoji: "添加表情",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -1487,6 +1487,7 @@ const messages = {
     invite: "邀请",
     inviteFailed: "无法邀请此人",
     removePersonFailed: "无法移除此人",
+    permissionUpdateFailed: "无法更新权限",
     passwordProtectedDescription: "此视频受密码保护。请输入密码观看。",
     password: "密码",
     unlock: "解锁",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -949,7 +949,6 @@ const messages = {
     editComment: "編輯評論",
     commentButton: "留言",
     composerPlaceholder: "新增留言…",
-    addEmoji: "新增表情符號",
   },
   shareMeeting: {
     pageTitle: "會議筆記 · Clips",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -949,7 +949,6 @@ const messages = {
     editComment: "編輯評論",
     commentButton: "留言",
     composerPlaceholder: "新增留言…",
-    mentionSomeone: "提及某人",
     addEmoji: "新增表情符號",
   },
   shareMeeting: {

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -1470,6 +1470,7 @@ const messages = {
     invite: "邀請",
     inviteFailed: "無法邀請此人",
     removePersonFailed: "無法移除此人",
+    permissionUpdateFailed: "無法更新權限",
     passwordProtectedDescription: "此影片受密碼保護。請輸入密碼觀看。",
     password: "密碼",
     unlock: "解鎖",


### PR DESCRIPTION
### Summary
Adds the ability to change an existing collaborator's permission level directly from the Clips share dialog, and removes the non-functional `@` mention and emoji buttons from the timestamped comment composer.

### Problem
In Clips, once a recording was shared with someone, the share dialog only showed a static role label for existing collaborators—there was no way for an owner or share administrator to change that person's permission level without removing and re-inviting them. Additionally, the comment composer exposed `@` mention and emoji icons that had no real picker support behind them.

<img width="484" height="161" alt="image" src="https://github.com/user-attachments/assets/81f8a57e-8713-4bb4-81a4-758ab0f2cbd2" />


### Solution
The Clips `SharePeopleTab` now renders an editable role selector for manageable grants, reusing the existing `share-resource` action to update the role and refetching shares on success. Non-manager users still see static role text. The unused mention and emoji buttons were removed from the comment composer along with their now-unused i18n strings.

### Key Changes
- `share-ui.tsx`: Added `handleChangeRole` to call `share-resource` with the grant's `principalType`/`principalId` and new role, refetching `sharesQuery` on success and reporting a `"permission"` error on failure.
- `share-ui.tsx`: Replaced the static role label with a `Select` control (using `ROLE_OPTIONS` and role descriptions) for grants the current user can manage; disabled while a mutation is pending.
- Extended the `onError` action type across `share-ui.tsx`, `share-dialog.tsx`, and `share-meeting-dialog.tsx` to include `"permission"`, wiring up a new `permissionUpdateFailed` toast message.
- Added a new `permissionUpdateFailed` localized string across all supported locales.
- Removed the `@` mention and emoji-insert buttons and their handler (`insertAtCursor`) from `timestamped-comment-button.tsx`, along with the now-unused `mentionSomeone`/`addEmoji` i18n strings.
- Added regression coverage in `share-dialog.test.ts` asserting the role selector wiring, mutation call shape, and error path.
- Added design/implementation planning docs under `docs/plans/` describing the share-role change feature.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/sentinel-unit-mjxtmq4t"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-sentinel-unit-mjxtmq4t.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3559`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>sentinel-unit-mjxtmq4t</branchName>-->