### PR TITLE
Allow changing existing share permissions in Clips

### DIFF
--- a/templates/clips/app/components/meetings/share-meeting-dialog.tsx
+++ b/templates/clips/app/components/meetings/share-meeting-dialog.tsx
@@ -262,7 +262,9 @@ function LinkTab({
               ? err.message
               : action === "invite"
                 ? t("clipsFinalRaw.inviteFailed")
-                : t("clipsFinalRaw.removePersonFailed"),
+                : action === "permission"
+                  ? t("clipsFinalRaw.permissionUpdateFailed")
+                  : t("clipsFinalRaw.removePersonFailed"),
           )
         }
       />

--- a/templates/clips/app/components/player/share-dialog.test.ts
+++ b/templates/clips/app/components/player/share-dialog.test.ts
@@ -129,4 +129,21 @@ describe("recording share popover", () => {
     expect(shareUiSource).toContain('useState<Role>("viewer")');
     expect(meetingDialogSource).not.toContain("roleCopy");
   });
+
+  it("lets managers change an existing share role", () => {
+    const shareUiSource = readSource("../sharing/share-ui.tsx");
+
+    expect(shareUiSource).toContain(
+      "const handleChangeRole = (s: Share, nextRole: Role)",
+    );
+    expect(shareUiSource).toContain("principalType: s.principalType");
+    expect(shareUiSource).toContain("principalId: s.principalId");
+    expect(shareUiSource).toContain("role: nextRole");
+    expect(shareUiSource).toContain('onError?.(err, "permission")');
+    expect(shareUiSource).toContain("value={s.role}");
+    expect(shareUiSource).toContain(
+      "onValueChange={(value) => handleChangeRole(s, value as Role)}",
+    );
+    expect(shareUiSource).toContain("disabled={share.isPending}");
+  });
 });

--- a/templates/clips/app/components/player/share-dialog.tsx
+++ b/templates/clips/app/components/player/share-dialog.tsx
@@ -573,6 +573,17 @@ function LinkTab({
               description: t("shareUi.recordingCommenter.description"),
             },
           }}
+          onError={(err, action) =>
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : action === "invite"
+                  ? t("clipsFinalRaw.inviteFailed")
+                  : action === "permission"
+                    ? t("clipsFinalRaw.permissionUpdateFailed")
+                    : t("clipsFinalRaw.removePersonFailed"),
+            )
+          }
         />
       ) : null}
 

--- a/templates/clips/app/components/player/timestamped-comment-button.tsx
+++ b/templates/clips/app/components/player/timestamped-comment-button.tsx
@@ -1,6 +1,6 @@
 import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { IconMessagePlus, IconAt, IconMoodSmile } from "@tabler/icons-react";
+import { IconMessagePlus } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -74,23 +74,6 @@ export function TimestampedCommentBar({
     requestAnimationFrame(() => textareaRef.current?.focus());
   }, []);
 
-  const insertAtCursor = (text: string) => {
-    const el = textareaRef.current;
-    if (!el) {
-      setDraft(draft + text);
-      return;
-    }
-    const start = el.selectionStart ?? draft.length;
-    const end = el.selectionEnd ?? draft.length;
-    const next = draft.slice(0, start) + text + draft.slice(end);
-    setDraft(next);
-    requestAnimationFrame(() => {
-      el.focus();
-      const pos = start + text.length;
-      el.setSelectionRange(pos, pos);
-    });
-  };
-
   const submit = () => {
     const content = draft.trim();
     if (!content) return;
@@ -130,29 +113,7 @@ export function TimestampedCommentBar({
           rows={2}
           className="min-h-[3rem] resize-none border-0 bg-transparent px-1 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
         />
-        <div className="mt-2 flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground"
-              aria-label={t("commentsPanel.mentionSomeone")}
-              onClick={() => insertAtCursor("@")}
-            >
-              <IconAt className="h-4 w-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-muted-foreground"
-              aria-label={t("commentsPanel.addEmoji")}
-              onClick={() => insertAtCursor("🙂")}
-            >
-              <IconMoodSmile className="h-4 w-4" />
-            </Button>
-          </div>
+        <div className="mt-2 flex items-center justify-end">
           <div className="flex items-center gap-2">
             <Button type="button" variant="ghost" size="sm" onClick={onClose}>
               {t("common.cancel")}

--- a/templates/clips/app/components/sharing/share-ui.tsx
+++ b/templates/clips/app/components/sharing/share-ui.tsx
@@ -341,7 +341,7 @@ export function SharePeopleTab({
   sharesQuery: SharesQuery;
   canManage: boolean;
   roleCopy?: Partial<Record<Role, RoleCopy>>;
-  onError?: (err: unknown, action: "invite" | "remove") => void;
+  onError?: (err: unknown, action: "invite" | "permission" | "remove") => void;
 }) {
   const t = useT();
   const share = useActionMutation("share-resource");
@@ -377,6 +377,24 @@ export function SharePeopleTab({
           sharesQuery.refetch();
         },
         onError: (err: unknown) => onError?.(err, "invite"),
+      },
+    );
+  };
+
+  const handleChangeRole = (s: Share, nextRole: Role) => {
+    if (nextRole === s.role) return;
+    share.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: s.principalType,
+        principalId: s.principalId,
+        role: nextRole,
+        notify: false,
+      } as any,
+      {
+        onSuccess: () => sharesQuery.refetch(),
+        onError: (err: unknown) => onError?.(err, "permission"),
       },
     );
   };
@@ -476,9 +494,35 @@ export function SharePeopleTab({
             >
               <Avatar label={s.principalId} org={s.principalType === "org"} />
               <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
-              <span className="text-xs text-muted-foreground">
-                {getRoleLabel(s.role)}
-              </span>
+              {canManage ? (
+                <Select
+                  value={s.role}
+                  onValueChange={(value) => handleChangeRole(s, value as Role)}
+                  disabled={share.isPending}
+                >
+                  <SelectTrigger className="h-7 w-[110px] text-xs">
+                    <SelectValue>{getRoleLabel(s.role)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ROLE_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        <div className="flex flex-col">
+                          <span>{getRoleLabel(opt.value)}</span>
+                          {getRoleCopy(opt.value)?.description ? (
+                            <span className="text-xs text-muted-foreground">
+                              {getRoleCopy(opt.value)?.description}
+                            </span>
+                          ) : null}
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  {getRoleLabel(s.role)}
+                </span>
+              )}
               {canManage ? (
                 <Button
                   type="button"

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -1003,8 +1003,6 @@ const messages = {
     editComment: "تحرير التعليق",
     commentButton: "تعليق",
     composerPlaceholder: "أضف تعليقًا…",
-    mentionSomeone: "أذكر شخصًا",
-    addEmoji: "أضف رمزًا تعبيريًا",
   },
   shareMeeting: {
     pageTitle: "ملاحظات الاجتماع · Clips",
@@ -1546,6 +1544,7 @@ const messages = {
     invite: "دعوة",
     inviteFailed: "تعذرت دعوة الشخص",
     removePersonFailed: "تعذرت إزالة الشخص",
+    permissionUpdateFailed: "تعذر تحديث الإذن",
     passwordProtectedDescription:
       "هذا الفيديو محمي. أدخل كلمة المرور للمشاهدة.",
     password: "كلمة المرور",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -1028,8 +1028,6 @@ const messages = {
     editComment: "Kommentar bearbeiten",
     commentButton: "Kommentar",
     composerPlaceholder: "Kommentar hinzufügen…",
-    mentionSomeone: "Jemanden erwähnen",
-    addEmoji: "Emoji hinzufügen",
   },
   shareMeeting: {
     pageTitle: "Meeting-Notizen · Clips",
@@ -1577,6 +1575,7 @@ const messages = {
     invite: "Einladen",
     inviteFailed: "Person konnte nicht eingeladen werden",
     removePersonFailed: "Person konnte nicht entfernt werden",
+    permissionUpdateFailed: "Berechtigung konnte nicht aktualisiert werden",
     passwordProtectedDescription:
       "Dieses Video ist geschützt. Passwort eingeben, um es anzusehen.",
     password: "Passwort",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -990,8 +990,6 @@ const messages = {
     editComment: "Edit comment",
     commentButton: "Comment",
     composerPlaceholder: "Add a comment…",
-    mentionSomeone: "Mention someone",
-    addEmoji: "Add emoji",
   },
   shareMeeting: {
     pageTitle: "Meeting notes · Clips",
@@ -1528,6 +1526,7 @@ const messages = {
     invite: "Invite",
     inviteFailed: "Couldn't invite person",
     removePersonFailed: "Couldn't remove person",
+    permissionUpdateFailed: "Couldn't update permission",
     passwordProtectedDescription:
       "This video is protected. Enter the password to watch.",
     password: "Password",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -1020,8 +1020,6 @@ const messages = {
     editComment: "Editar comentario",
     commentButton: "Comentar",
     composerPlaceholder: "Añadir un comentario…",
-    mentionSomeone: "Mencionar a alguien",
-    addEmoji: "Añadir emoji",
   },
   shareMeeting: {
     pageTitle: "Notas de reunión · Clips",
@@ -1562,6 +1560,7 @@ const messages = {
     invite: "Invitar",
     inviteFailed: "No se pudo invitar a la persona",
     removePersonFailed: "No se pudo eliminar a la persona",
+    permissionUpdateFailed: "No se pudo actualizar el permiso",
     passwordProtectedDescription:
       "Este video está protegido. Introduce la contraseña para verlo.",
     password: "Contraseña",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -1019,8 +1019,6 @@ const messages = {
     editComment: "Modifier le commentaire",
     commentButton: "Commenter",
     composerPlaceholder: "Ajouter un commentaire…",
-    mentionSomeone: "Mentionner quelqu'un",
-    addEmoji: "Ajouter un emoji",
   },
   shareMeeting: {
     pageTitle: "Notes de réunion · Clips",
@@ -1568,6 +1566,7 @@ const messages = {
     invite: "Inviter",
     inviteFailed: "Impossible d’inviter la personne",
     removePersonFailed: "Impossible de supprimer la personne",
+    permissionUpdateFailed: "Impossible de mettre à jour l’autorisation",
     passwordProtectedDescription:
       "Cette vidéo est protégée. Saisissez le mot de passe pour la regarder.",
     password: "Mot de passe",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -984,8 +984,6 @@ const messages = {
     editComment: "टिप्पणी संपादित करें",
     commentButton: "टिप्पणी",
     composerPlaceholder: "टिप्पणी जोड़ें…",
-    mentionSomeone: "किसी का उल्लेख करें",
-    addEmoji: "इमोजी जोड़ें",
   },
   shareMeeting: {
     pageTitle: "मीटिंग नोट्स · Clips",
@@ -1525,6 +1523,7 @@ const messages = {
     invite: "आमंत्रित करें",
     inviteFailed: "व्यक्ति को आमंत्रित नहीं कर सके",
     removePersonFailed: "व्यक्ति को हटा नहीं सके",
+    permissionUpdateFailed: "अनुमति अपडेट नहीं की जा सकी",
     passwordProtectedDescription:
       "यह वीडियो सुरक्षित है। देखने के लिए पासवर्ड दर्ज करें।",
     password: "पासवर्ड",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -1007,8 +1007,6 @@ const messages = {
     editComment: "コメントを編集",
     commentButton: "コメント",
     composerPlaceholder: "コメントを追加…",
-    mentionSomeone: "メンバーをメンション",
-    addEmoji: "絵文字を追加",
   },
   shareMeeting: {
     pageTitle: "会議メモ · Clips",
@@ -1560,6 +1558,7 @@ const messages = {
     invite: "招待",
     inviteFailed: "招待できませんでした",
     removePersonFailed: "削除できませんでした",
+    permissionUpdateFailed: "権限を更新できませんでした",
     passwordProtectedDescription:
       "この動画は保護されています。視聴するにはパスワードを入力してください。",
     password: "パスワード",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -993,8 +993,6 @@ const messages = {
     editComment: "댓글 편집",
     commentButton: "댓글",
     composerPlaceholder: "댓글 추가…",
-    mentionSomeone: "멘션하기",
-    addEmoji: "이모지 추가",
   },
   shareMeeting: {
     pageTitle: "회의 노트 · Clips",
@@ -1538,6 +1536,7 @@ const messages = {
     invite: "초대",
     inviteFailed: "사용자를 초대할 수 없습니다",
     removePersonFailed: "사용자를 제거할 수 없습니다",
+    permissionUpdateFailed: "권한을 업데이트할 수 없습니다",
     passwordProtectedDescription:
       "이 동영상은 보호되어 있습니다. 보려면 비밀번호를 입력하세요.",
     password: "비밀번호",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -1015,8 +1015,6 @@ const messages = {
     editComment: "Editar comentário",
     commentButton: "Comentar",
     composerPlaceholder: "Adicionar um comentário…",
-    mentionSomeone: "Mencionar alguém",
-    addEmoji: "Adicionar emoji",
   },
   shareMeeting: {
     pageTitle: "Notas da reunião · Clips",
@@ -1556,6 +1554,7 @@ const messages = {
     invite: "Convidar",
     inviteFailed: "Não foi possível convidar a pessoa",
     removePersonFailed: "Não foi possível remover a pessoa",
+    permissionUpdateFailed: "Não foi possível atualizar a permissão",
     passwordProtectedDescription:
       "Este vídeo está protegido. Digite a senha para assistir.",
     password: "Senha",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -952,8 +952,6 @@ const messages = {
     editComment: "编辑评论",
     commentButton: "评论",
     composerPlaceholder: "添加评论…",
-    mentionSomeone: "提及某人",
-    addEmoji: "添加表情",
   },
   shareMeeting: {
     pageTitle: "会议笔记 · Clips",
@@ -1489,6 +1487,7 @@ const messages = {
     invite: "邀请",
     inviteFailed: "无法邀请此人",
     removePersonFailed: "无法移除此人",
+    permissionUpdateFailed: "无法更新权限",
     passwordProtectedDescription: "此视频受密码保护。请输入密码观看。",
     password: "密码",
     unlock: "解锁",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -951,8 +951,6 @@ const messages = {
     editComment: "編輯評論",
     commentButton: "留言",
     composerPlaceholder: "新增留言…",
-    mentionSomeone: "提及某人",
-    addEmoji: "新增表情符號",
   },
   shareMeeting: {
     pageTitle: "會議筆記 · Clips",
@@ -1472,6 +1470,7 @@ const messages = {
     invite: "邀請",
     inviteFailed: "無法邀請此人",
     removePersonFailed: "無法移除此人",
+    permissionUpdateFailed: "無法更新權限",
     passwordProtectedDescription: "此影片受密碼保護。請輸入密碼觀看。",
     password: "密碼",
     unlock: "解鎖",


### PR DESCRIPTION
### Summary
Adds the ability to change an existing collaborator's permission level directly from the Clips share dialog, and removes the non-functional `@` mention and emoji buttons from the timestamped comment composer.

### Problem
In Clips, once a recording was shared with someone, the share dialog only showed a static role label for existing collaborators—there was no way for an owner or share administrator to change that person's permission level without removing and re-inviting them. Additionally, the comment composer exposed `@` mention and emoji icons that had no real picker support behind them.

<img width="484" height="161" alt="image" src="https://github.com/user-attachments/assets/81f8a57e-8713-4bb4-81a4-758ab0f2cbd2" />


### Solution
The Clips `SharePeopleTab` now renders an editable role selector for manageable grants, reusing the existing `share-resource` action to update the role and refetching shares on success. Non-manager users still see static role text. The unused mention and emoji buttons were removed from the comment composer along with their now-unused i18n strings.

### Key Changes
- `share-ui.tsx`: Added `handleChangeRole` to call `share-resource` with the grant's `principalType`/`principalId` and new role, refetching `sharesQuery` on success and reporting a `"permission"` error on failure.
- `share-ui.tsx`: Replaced the static role label with a `Select` control (using `ROLE_OPTIONS` and role descriptions) for grants the current user can manage; disabled while a mutation is pending.
- Extended the `onError` action type across `share-ui.tsx`, `share-dialog.tsx`, and `share-meeting-dialog.tsx` to include `"permission"`, wiring up a new `permissionUpdateFailed` toast message.
- Added a new `permissionUpdateFailed` localized string across all supported locales.
- Removed the `@` mention and emoji-insert buttons and their handler (`insertAtCursor`) from `timestamped-comment-button.tsx`, along with the now-unused `mentionSomeone`/`addEmoji` i18n strings.
- Added regression coverage in `share-dialog.test.ts` asserting the role selector wiring, mutation call shape, and error path.
