### PR TITLE
Enhance error handling and pricing logic across various templates

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -325,21 +325,46 @@ Constraints that are not visible from the emit site:
   PostHog's schema; a name it does not define today it may define tomorrow with
   a different meaning. Ours are plain (`duration_ms`, `input_truncated`,
   `spans_dropped`), which also keeps them out of PostHog's `$ai_*` aggregation.
-- **Trace-level input/output state lives only on `$ai_trace`.** PostHog reads a
-  trace's input and output from that event and never from its children, so
-  `$ai_input_state` / `$ai_output_state` have to be set there or the trace
-  detail view is empty.
+- **`$ai_trace` carries no `$ai_input_state` / `$ai_output_state`.** Content
+  rides the generations; a trace-level copy repeated the run's prompt and answer
+  on a second event. PostHog reads a trace's input and output from that event
+  and from nowhere else, so the visible cost is that traces list with a null
+  input and a conversation is titled from the first generation's `$ai_input`
+  instead. Measured, not assumed — check whether that title is still wrong
+  before trading the duplication back.
 
-- **One generation per run, not per model round-trip.** The engine layer reports
-  aggregate usage through `onUsage` and exposes no per-step hook, so a multi-step
-  run collapses into a single generation carrying the whole message list.
-  Per-round-trip latency and intermediate turns are unavailable without a new
-  seam in `ai-sdk-engine.ts` / `builder-engine.ts`. Do not describe the current
-  output as per-step.
+- **One generation per model round-trip.** Engines that bracket their calls with
+  `model_stream` get one `$ai_generation` each, with that call's tools as its
+  children. Only an engine that never brackets falls back to a single aggregate
+  generation covering the whole run, and it is reported as one.
+- **Messages are rewritten into PostHog's shape before they ship.**
+  `toPostHogMessages()` in `posthog-ai.ts` maps engine parts onto the
+  OpenAI/Anthropic conventions PostHog reads: `tool-call` becomes `tool_calls`,
+  and a `tool-result` — which the engine has to carry inside a `user` message,
+  because `EngineMessage` has no `tool` role — becomes its own `role: "tool"`
+  message. Skipping this is not cosmetic: PostHog dumps raw JSON for shapes it
+  does not know, and the byte-ceiling rescue in `boundAiContent` keeps "the last
+  user message", which in engine shape is the last tool result rather than the
+  question. Attachment bodies become a marker naming the media type and size —
+  base64 renders as nothing in PostHog and spends the whole ceiling.
+- **A tool call and its result pair on the id the MODEL issued.** The span id is
+  a separate namespace that never appears in the transcript, so emitting it on
+  `tool_calls[].id` leaves PostHog with a call and a result that never match and
+  every tool call renders with no output. Span id is the fallback only for
+  emitters that report no call id.
 - **Disabled capture omits the field rather than sending an empty one.** An
   empty array is indistinguishable from a run that genuinely had no messages.
   Truncated content is marked, and a run over the span cap stamps
-  `spans_dropped` — a truncated run must not read as a complete one.
+  `spans_dropped` — a truncated run must not read as a complete one. The one
+  deliberate exception is a tool span's `$ai_output_state` with
+  `captureToolResults` off: it carries an explicit "withheld" marker, because an
+  absent output state reads as a tool that returned nothing, and the tool did
+  answer.
+- **A tool that RETURNS an error envelope is a success here.** `$ai_is_error`
+  and `failed_tools` follow the tool event's `isError`, which the agent sets
+  when an action throws. An action that returns `{ error: ... }` instead is
+  counted as a healthy call by every rollup on this page. Fix it in the action
+  (`fail()`), not by teaching this layer to sniff payload shapes.
 - **The structural tool-call list ships even when content capture is off.**
   Backends derive their tool tags from tool-call blocks inside the output
   choices and from nothing else, so tool names (without arguments) are always

--- a/.changeset/normalize-input-token-accounting.md
+++ b/.changeset/normalize-input-token-accounting.md
@@ -1,0 +1,31 @@
+---
+"@agent-native/core": patch
+"@agent-native/recap-cli": patch
+---
+
+Stop billing cached prompt tokens twice, and normalize what `inputTokens` means
+across every engine.
+
+Providers disagree: OpenAI's `prompt_tokens` includes cached tokens, Anthropic's
+`input_tokens` excludes them. The `usage` event never said which it carried, so
+both conventions reached `calculateCost`, which charged `inputTokens` at the
+full input rate and then added `cacheReadTokens` / `cacheWriteTokens` on top.
+On a long cached conversation the cache is nearly the whole prompt, so a turn
+that cost $0.0054 was reported as $0.0478 — and every `token_usage` row for an
+OpenAI-family model was inflated the same way.
+
+- The `usage` event now documents one convention: `inputTokens` is the whole
+  prompt and INCLUDES both cache counts, which are a slice of it rather than an
+  addition. This matches the AI SDK's own `inputTokens.total` / `noCache` /
+  `cacheRead` / `cacheWrite` normalization, and the Builder gateway.
+- `anthropic-engine` was the only ENGINE reporting the exclusive form. It now
+  adds the cache counts back, which also fixes its prompt size: a fully cached
+  turn used to report ~3 input tokens instead of the real 42,438.
+- `calculateCost` treats the three counts as a partition and prices each token
+  exactly once. Callers with no prompt caching pass zeroes and are unaffected.
+
+The recap CLI carried all three conventions at once and now shares this one:
+`parseClaudeUsage` adds Anthropic's cache counts back into the prompt,
+`parseCodexUsage` no longer strips OpenAI's cached tokens out of it (it did that
+to compensate for the old pricing formula, so keeping both would have swung the
+error the other way), and `parseOpenAiCompatibleUsage` was already correct.

--- a/.changeset/openai-5-6-pricing-rates.md
+++ b/.changeset/openai-5-6-pricing-rates.md
@@ -1,0 +1,26 @@
+---
+"@agent-native/core": patch
+---
+
+Correct the GPT-5.6 pricing rates, which matched no published tier.
+
+The `sol` / `terra` / `luna` entries carried input and output rates that appear
+in neither column of OpenAI's table (luna was $1.00/$6.00 per MTok against a
+real $0.20/$1.20), and set `cacheWrite: 0` on the belief that OpenAI does not
+bill cache writes — it does, at above the full input rate. All three now track
+the published short-context rates:
+
+|       | input | cached | cache write | output |
+|-------|-------|--------|-------------|--------|
+| sol   | $4.00 | $0.40  | $5.00       | $20.00 |
+| terra | $2.00 | $0.20  | $2.50       | $12.00 |
+| luna  | $0.20 | $0.02  | $0.25       | $1.20  |
+
+Short context on purpose: each model has a long-context tier at roughly 2x, and
+a usage row does not preserve the request's context size, so the tier cannot be
+recovered at pricing time.
+
+Together with the cached-token double-billing fix, a real 11-call run drops from
+a reported $0.8524 to $0.0358 — 24x. Pricing that run's cache writes at the
+input rate instead reproduces PostHog's independently derived $0.0328 to the
+cent, which is what confirms the rates.

--- a/.changeset/openai-5-6-pricing-rates.md
+++ b/.changeset/openai-5-6-pricing-rates.md
@@ -11,7 +11,7 @@ bill cache writes — it does, at above the full input rate. All three now track
 the published short-context rates:
 
 |       | input | cached | cache write | output |
-|-------|-------|--------|-------------|--------|
+| ----- | ----- | ------ | ----------- | ------ |
 | sol   | $4.00 | $0.40  | $5.00       | $20.00 |
 | terra | $2.00 | $0.20  | $2.50       | $12.00 |
 | luna  | $0.20 | $0.02  | $0.25       | $1.20  |

--- a/.changeset/posthog-tool-call-rendering.md
+++ b/.changeset/posthog-tool-call-rendering.md
@@ -1,0 +1,24 @@
+---
+"@agent-native/core": patch
+---
+
+Fix tool calls rendering without their output in PostHog LLM analytics.
+
+Engine messages shipped verbatim as `$ai_input`, in a shape PostHog does not
+read: `tool-call` / `tool-result` parts with camelCase ids, and tool results
+carried inside a `user` message because `EngineMessage` has no `tool` role.
+PostHog dumps raw JSON for shapes it does not recognize, so a tool call rendered
+as an escaped blob with its result nowhere in sight. Messages now normalize to
+the OpenAI/Anthropic conventions PostHog reads, and attachment bodies become a
+marker naming the media type and size instead of inlining base64.
+
+- `tool_calls[].id` now carries the id the model issued rather than our span id,
+  so a call and its result actually pair. Span id remains the fallback for
+  emitters that report no call id.
+- The byte-ceiling rescue in `boundAiContent` keeps "the last user message",
+  which in engine shape was the last tool result — so the user's question was
+  dropped from every oversized generation. Normalizing first fixes it.
+- A tool span with `captureToolResults` off now carries an explicit "withheld"
+  marker in `$ai_output_state` instead of omitting it, matching what the error
+  path already did. An absent output state reads as a tool that returned
+  nothing, and the tool did answer.

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -134,6 +134,56 @@ describe("createAnthropicEngine", () => {
     vi.doUnmock("@anthropic-ai/sdk");
   });
 
+  // Anthropic's `input_tokens` EXCLUDES both cache fields; every other engine
+  // reports the whole prompt. Passing it through under-reported the prompt and
+  // made `calculateCost` charge the cached tokens a second time.
+  it("reports the whole prompt in inputTokens, cache included", async () => {
+    const finalMsg = {
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 3,
+        output_tokens: 285,
+        cache_read_input_tokens: 36_734,
+        cache_creation_input_tokens: 5_701,
+      },
+    };
+    const mockStream = {
+      [Symbol.asyncIterator]: async function* () {},
+      finalMessage: vi.fn().mockResolvedValue(finalMsg),
+    };
+    vi.doMock("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = { stream: vi.fn().mockReturnValue(mockStream) };
+      },
+    }));
+    vi.resetModules();
+    const { createAnthropicEngine: freshCreate } =
+      await import("./anthropic-engine.js");
+
+    const events = await collectEvents(
+      freshCreate({ apiKey: "test" }).stream({
+        model: "claude-haiku-4-5-20251001",
+        systemPrompt: "You are helpful.",
+        messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        tools: [],
+        abortSignal: new AbortController().signal,
+      }),
+    );
+
+    const usage = events.find((e) => e.type === "usage");
+    // 3 fresh + 36,734 read + 5,701 written — not the bare 3 the API returns.
+    expect(usage?.inputTokens).toBe(42_438);
+    expect(usage?.cacheReadTokens).toBe(36_734);
+    expect(usage?.cacheWriteTokens).toBe(5_701);
+    // The partition holds, which is what makes the cost math correct.
+    expect(
+      usage.inputTokens - usage.cacheReadTokens - usage.cacheWriteTokens,
+    ).toBe(3);
+
+    vi.doUnmock("@anthropic-ai/sdk");
+  });
+
   it("adds a moving cache breakpoint on the last user message's last content block", async () => {
     const requestParams = await captureRequestParams({
       model: "claude-haiku-4-5-20251001",

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -275,14 +275,24 @@ class AnthropicEngine implements AgentEngine {
 
       // Emit usage
       if (finalMessage.usage) {
+        // Anthropic reports `input_tokens` EXCLUDING both cache fields — the
+        // opposite of OpenAI, and the opposite of what the `usage` event
+        // means. Passing it through under-reported the prompt (a fully cached
+        // turn read as ~3 tokens) and made `calculateCost` charge the cached
+        // tokens twice. Add them back so every engine emits one convention;
+        // `@ai-sdk/anthropic` normalizes its `inputTokens.total` the same way.
+        const cacheReadTokens = finalMessage.usage.cache_read_input_tokens ?? 0;
+        const cacheWriteTokens =
+          finalMessage.usage.cache_creation_input_tokens ?? 0;
         yield {
           type: "usage",
-          inputTokens: finalMessage.usage.input_tokens ?? 0,
+          inputTokens:
+            (finalMessage.usage.input_tokens ?? 0) +
+            cacheReadTokens +
+            cacheWriteTokens,
           outputTokens: finalMessage.usage.output_tokens ?? 0,
-          cacheReadTokens:
-            (finalMessage.usage as any).cache_read_input_tokens ?? 0,
-          cacheWriteTokens:
-            (finalMessage.usage as any).cache_creation_input_tokens ?? 0,
+          cacheReadTokens,
+          cacheWriteTokens,
         };
       }
 

--- a/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
@@ -485,6 +485,16 @@ describe("aiSdkPartToEngineEvents (v6 stream protocol)", () => {
       cacheReadTokens: 50,
       cacheWriteTokens: 10,
     });
+    // `inputTokens` is the whole prompt and the cache counts are a slice of it,
+    // never an addition — `ai`'s `asLanguageModelUsage` maps `inputTokens.total`
+    // with `noCache` / `cacheRead` / `cacheWrite` beneath it. `calculateCost`
+    // subtracts to price each token once, so an exclusive value here would bill
+    // the cached tokens twice.
+    expect(
+      (usage as any).inputTokens -
+        (usage as any).cacheReadTokens -
+        (usage as any).cacheWriteTokens,
+    ).toBe(40);
   });
 
   it("falls back to deprecated cachedInputTokens on pre-v6 usage shapes", () => {

--- a/packages/core/src/agent/engine/types.ts
+++ b/packages/core/src/agent/engine/types.ts
@@ -192,6 +192,21 @@ export type EngineEvent =
       error: string;
     }
   | {
+      /**
+       * Token usage for one model call.
+       *
+       * `inputTokens` is the WHOLE prompt and INCLUDES `cacheReadTokens` and
+       * `cacheWriteTokens` — the cache fields say how that total splits, they
+       * do not add to it. Providers disagree here (OpenAI's `prompt_tokens`
+       * includes cached tokens, Anthropic's `input_tokens` excludes them), so
+       * every engine converts to this one convention before emitting. The AI
+       * SDK settled on the same shape: `inputTokens.total` with `noCache` /
+       * `cacheRead` / `cacheWrite` underneath it.
+       *
+       * Emitting the exclusive form instead is not a rounding difference: it
+       * makes `calculateCost` bill the cached tokens twice, once at the full
+       * input rate and again at the cache rate.
+       */
       type: "usage";
       inputTokens: number;
       outputTokens: number;

--- a/packages/core/src/cli/recap.spec.ts
+++ b/packages/core/src/cli/recap.spec.ts
@@ -2220,7 +2220,9 @@ describe("recap image public readiness", () => {
 });
 
 describe("recap usage parsing", () => {
-  it("reads Claude Code's usage + reported cost (input already cache-exclusive)", () => {
+  // Anthropic reports input_tokens EXCLUDING cache; the parser adds them back
+  // so inputTokens is the whole prompt, matching every other usage source.
+  it("reads Claude Code's usage + reported cost, folding cache into the prompt", () => {
     const stdout = JSON.stringify({
       type: "result",
       model: "claude-opus-4",
@@ -2233,7 +2235,7 @@ describe("recap usage parsing", () => {
       },
     });
     expect(parseClaudeUsage(stdout)).toEqual({
-      inputTokens: 1000,
+      inputTokens: 6300, // 1000 fresh + 5000 read + 300 written
       outputTokens: 200,
       cacheReadTokens: 5000,
       cacheWriteTokens: 300,
@@ -2255,9 +2257,10 @@ describe("recap usage parsing", () => {
     });
   });
 
-  it("strips Codex cached tokens out of input and folds reasoning into output", () => {
-    // OpenAI input_tokens INCLUDES cached_input_tokens, and reasoning is billed
-    // separately — both must be normalized so calculateCost is not double-billed.
+  it("keeps Codex cached tokens inside input and folds reasoning into output", () => {
+    // OpenAI's input_tokens INCLUDES cached_input_tokens, which is already the
+    // shared convention — `calculateCost` subtracts to price each token once.
+    // Reasoning is billed at the output rate and would otherwise be dropped.
     const jsonl = [
       JSON.stringify({ type: "turn.started" }),
       JSON.stringify({
@@ -2271,7 +2274,7 @@ describe("recap usage parsing", () => {
       }),
     ].join("\n");
     expect(parseCodexUsage(jsonl)).toEqual({
-      inputTokens: 2000, // 8000 - 6000 cached
+      inputTokens: 8000, // the whole prompt; 6000 of it served from cache
       outputTokens: 1900, // 400 + 1500 reasoning
       cacheReadTokens: 6000,
       cacheWriteTokens: 0,

--- a/packages/core/src/observability/posthog-ai.spec.ts
+++ b/packages/core/src/observability/posthog-ai.spec.ts
@@ -10,6 +10,7 @@ import {
   boundAiContent,
   emitAiFeedbackSurveyEvent,
   toAiErrorDetail,
+  toPostHogMessages,
 } from "./posthog-ai.js";
 
 function captureEvents(): TrackingEvent[] {
@@ -242,5 +243,152 @@ describe("toAiErrorDetail", () => {
     const detail = toAiErrorDetail("failed with authorization: Bearer abc123");
 
     expect(detail?.message).not.toContain("abc123");
+  });
+});
+
+describe("toPostHogMessages", () => {
+  // The engine has no `tool` role, so a tool result rides inside a `user`
+  // message. PostHog reads OpenAI/Anthropic conventions and recognized none of
+  // this shape — it rendered the raw JSON, which is what a tool call showing an
+  // escaped blob and no output looks like.
+  it("lifts engine tool results out of the user turn into `tool` messages", () => {
+    const normalized = toPostHogMessages([
+      { role: "user", content: [{ type: "text", text: "make the report" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Writing it." },
+          {
+            type: "tool-call",
+            id: "call_abc",
+            name: "write-report",
+            input: { slug: "gold" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_abc",
+            toolName: "write-report",
+            toolInput: '{"slug":"gold"}',
+            content: '{"error":"invalid_blocks"}',
+          },
+        ],
+      },
+    ]);
+
+    expect(normalized).toEqual([
+      { role: "user", content: "make the report" },
+      {
+        role: "assistant",
+        content: "Writing it.",
+        tool_calls: [
+          {
+            id: "call_abc",
+            type: "function",
+            function: { name: "write-report", arguments: { slug: "gold" } },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_abc",
+        name: "write-report",
+        content: '{"error":"invalid_blocks"}',
+      },
+    ]);
+  });
+
+  // The whole point of pairing: the id on the call is the id on the result.
+  it("keeps the model's call id on both halves of a tool call", () => {
+    const [, call, result] = toPostHogMessages([
+      { role: "user", content: [{ type: "text", text: "go" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", id: "call_xyz", name: "run", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_xyz",
+            toolName: "run",
+            toolInput: "{}",
+            content: "ok",
+          },
+        ],
+      },
+    ]) as Array<Record<string, any>>;
+
+    expect(call.tool_calls[0].id).toBe(result.tool_call_id);
+    expect(call.content).toBe("");
+  });
+
+  // A base64 attachment is megabytes and renders as nothing in PostHog, but it
+  // spends the byte ceiling that keeps the rest of the conversation visible.
+  it("replaces attachment bodies with a marker naming what was there", () => {
+    const [message] = toPostHogMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this?" },
+          { type: "image", data: "A".repeat(4000), mediaType: "image/png" },
+        ],
+      },
+    ]) as Array<{ content: Array<{ type: string; text: string }> }>;
+
+    expect(message.content[1].text).toContain("image/png");
+    expect(JSON.stringify(message)).not.toContain("AAAA");
+  });
+
+  it("passes through shapes it does not recognize instead of dropping them", () => {
+    const already = [{ role: "user", content: "plain string content" }];
+    expect(toPostHogMessages(already)).toEqual(already);
+    expect(toPostHogMessages("not a list")).toBe("not a list");
+
+    const unknownPart = [
+      { role: "assistant", content: [{ type: "future-part", payload: 1 }] },
+    ];
+    expect(toPostHogMessages(unknownPart)).toEqual([
+      { role: "assistant", content: [{ type: "future-part", payload: 1 }] },
+    ]);
+  });
+
+  // Normalizing is what makes the byte-ceiling rescue in `boundAiContent` find
+  // the question: before it, every tool result was a `user` message, so the
+  // "last user message" it kept was the last tool result and the question was
+  // dropped from every oversized generation.
+  it("lets the truncation rescue keep the question, not the last tool result", () => {
+    const filler = Array.from({ length: 100 }, () => ({
+      role: "user",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "run-query",
+          toolInput: "{}",
+          content: `rows ${"x".repeat(2000)}`,
+        },
+      ],
+    }));
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "why is it slow?" }] },
+      ...filler,
+    ];
+
+    const result = boundAiContent(toPostHogMessages(messages));
+    const kept = result.value as Array<{ role: string; content: string }>;
+
+    expect(result.truncated).toBe(true);
+    expect(kept[kept.length - 1]).toEqual({
+      role: "user",
+      content: "why is it slow?",
+    });
   });
 });

--- a/packages/core/src/observability/posthog-ai.ts
+++ b/packages/core/src/observability/posthog-ai.ts
@@ -111,6 +111,11 @@ const OMISSION_MARKER_BYTES = 512;
  * small. Replacing the whole conversation with a placeholder, which is what
  * this did, left nothing at all.
  *
+ * Run `toPostHogMessages` FIRST. In engine shape a tool result is a `user`
+ * message, so the rescue below picked the last tool result — the one thing it
+ * is documented not to keep — and the user's question was dropped from every
+ * oversized generation. Normalizing moves those to `role: "tool"`.
+ *
  * Anything else (a string, an object) still becomes a placeholder: there is no
  * message to keep. Either way `truncated` is true, so a cut payload can never
  * be read as a complete one.
@@ -164,6 +169,142 @@ export function boundAiContent(value: unknown): {
   };
 }
 
+interface PostHogToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments?: unknown };
+}
+
+interface PostHogMessage {
+  role: unknown;
+  content?: unknown;
+  tool_calls?: PostHogToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+/** Engine parts are read structurally, not by importing the agent's type
+ *  graph into the tracking boundary. */
+function contentParts(value: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  return value.every(
+    (part) => !!part && typeof part === "object" && !Array.isArray(part),
+  )
+    ? (value as Record<string, unknown>[])
+    : null;
+}
+
+/**
+ * Attachment bodies are base64 and routinely megabytes. PostHog renders an
+ * `image` part only from a URL it can fetch, so inlining the payload would
+ * render nothing while spending the whole byte ceiling — and the ceiling is
+ * what collapses the rest of the conversation into a marker.
+ */
+function mediaPlaceholder(part: Record<string, unknown>): unknown {
+  const mediaType =
+    typeof part.mediaType === "string" ? part.mediaType : "unknown";
+  const data = typeof part.data === "string" ? part.data : "";
+  const bytes = Math.floor((data.length * 3) / 4);
+  const filename = typeof part.filename === "string" ? ` ${part.filename}` : "";
+  const label = part.type === "image" ? "image" : `file${filename}`;
+  return { type: "text", text: `[${label}: ${mediaType}, ~${bytes} bytes]` };
+}
+
+/**
+ * Rewrite an engine message list into the shape PostHog's LLM analytics reads.
+ *
+ * PostHog normalizes on OpenAI/Anthropic conventions. This framework's engine
+ * messages are a near-miss of the Vercel AI SDK's: `type: "tool-call"` /
+ * `"tool-result"` with hyphens, `toolCallId` in camelCase, and — the one that
+ * actually breaks — tool results carried inside a `user` message, because
+ * `EngineMessage` has no `tool` role. PostHog recognizes none of that and falls
+ * back to dumping the raw JSON, which is what a tool call rendering as an
+ * escaped blob with its output nowhere in sight looks like.
+ *
+ * Anything unrecognized is passed through untouched: a shape we cannot map is
+ * still better shipped as-is than dropped, and a future part type must not
+ * silently vanish from traces.
+ */
+export function toPostHogMessages(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+
+  const out: PostHogMessage[] = [];
+  for (const message of value) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      out.push(message as PostHogMessage);
+      continue;
+    }
+    const { role, content } = message as PostHogMessage;
+    const parts = contentParts(content);
+    if (!parts) {
+      out.push(message as PostHogMessage);
+      continue;
+    }
+
+    const toolResults: PostHogMessage[] = [];
+    const toolCalls: PostHogToolCall[] = [];
+    const kept: unknown[] = [];
+    const text: string[] = [];
+    // Text collapses to a plain string, which is what PostHog renders; any
+    // other part forces the array form so nothing is silently flattened away.
+    let textOnly = true;
+
+    for (const part of parts) {
+      switch (part.type) {
+        case "tool-result":
+          toolResults.push({
+            role: "tool",
+            tool_call_id:
+              typeof part.toolCallId === "string" ? part.toolCallId : "",
+            ...(typeof part.toolName === "string"
+              ? { name: part.toolName }
+              : {}),
+            content: part.content,
+          });
+          break;
+        case "tool-call":
+          toolCalls.push({
+            id: typeof part.id === "string" ? part.id : "",
+            type: "function",
+            function: {
+              name: typeof part.name === "string" ? part.name : "",
+              ...(part.input !== undefined ? { arguments: part.input } : {}),
+            },
+          });
+          break;
+        case "text":
+          text.push(typeof part.text === "string" ? part.text : "");
+          kept.push({ type: "text", text: part.text });
+          break;
+        case "thinking":
+          textOnly = false;
+          kept.push({ type: "thinking", thinking: part.text ?? "" });
+          break;
+        case "image":
+        case "file":
+          textOnly = false;
+          kept.push(mediaPlaceholder(part));
+          break;
+        default:
+          textOnly = false;
+          kept.push(part);
+      }
+    }
+
+    // Results answer the assistant turn before them, so they lead — otherwise
+    // PostHog draws this turn's question above the answer to the last one.
+    out.push(...toolResults);
+    if (kept.length > 0 || toolCalls.length > 0) {
+      out.push({
+        role,
+        content: textOnly ? text.join("\n") : kept,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      });
+    }
+  }
+  return out;
+}
+
 export interface AiTraceEventInput {
   runId: string;
   threadId: string | null;
@@ -197,6 +338,10 @@ export interface AiTraceEventInput {
  * copy repeated the first call's prompt and the last call's answer on a second
  * event. The trace owns what only it knows: the run's name, failure, metadata
  * and totals.
+ *
+ * The visible cost is that PostHog reads a trace's input and output from this
+ * event and from nowhere else: traces list with a null input, and a
+ * conversation is titled from the first generation's `$ai_input` instead.
  */
 export function emitAiTraceEvent(input: AiTraceEventInput): void {
   trackAiEvent(

--- a/packages/core/src/observability/traces.spec.ts
+++ b/packages/core/src/observability/traces.spec.ts
@@ -898,7 +898,10 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
       (events[0]?.properties?.["$ai_error"] as { message: string })?.message,
     ).toContain("withheld");
     expect(JSON.stringify(events[0])).not.toContain("abcdef123456");
-    expect(events[0]?.properties).not.toHaveProperty("$ai_output_state");
+    // The output side says withheld rather than going absent: an empty
+    // `$ai_output_state` reads as a tool that returned nothing, which is a
+    // different fact about the run than one whose answer we chose not to ship.
+    expect(events[0]?.properties?.["$ai_output_state"]).toContain("withheld");
 
     events.length = 0;
     await run(true);
@@ -1097,6 +1100,106 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     // The call is still visible — that it happened is not the secret.
     expect(call?.function.name).toBe("search");
     expect(call?.function).not.toHaveProperty("arguments");
+  });
+
+  // A backend pairs a tool call with its result by id. Emitting our span id on
+  // the call while the transcript carries the model's meant they never matched,
+  // so every tool call in PostHog rendered with its output nowhere in sight.
+  it("pairs a tool call with its result by the id the model issued", async () => {
+    const events: TrackingEvent[] = [];
+    registerTrackingProvider({
+      name: "qa-ai-generation",
+      track(event) {
+        if (event.name === "$ai_generation") events.push(event);
+      },
+    });
+
+    const loopOpts: any = {
+      engine: { name: "anthropic" },
+      model: "claude-test",
+      systemPrompt: "",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+      actions: {},
+      send: () => {},
+      signal: new AbortController().signal,
+    };
+
+    await instrumentAgentLoop({
+      runAgentLoop: async ({ send, messages }) => {
+        send({ type: "model_stream", status: "start" });
+        send({
+          type: "tool_start",
+          id: "call_abc",
+          tool: "search",
+          input: { query: "gold" },
+        });
+        send({ type: "model_stream", status: "end" });
+        send({
+          type: "tool_done",
+          id: "call_abc",
+          tool: "search",
+          result: "no rows",
+        });
+        // What the engine appends for the next round-trip: a tool result has
+        // no `tool` role to live in, so it rides inside a `user` message.
+        messages.push({
+          role: "user",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_abc",
+              toolName: "search",
+              toolInput: '{"query":"gold"}',
+              content: "no rows",
+            },
+          ],
+        });
+        send({ type: "model_stream", status: "start" });
+        send({ type: "text", text: "Nothing found." });
+        send({ type: "model_stream", status: "end" });
+        return {
+          inputTokens: 5,
+          outputTokens: 3,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "claude-test",
+          usageReported: true,
+        };
+      },
+      loopOpts,
+      runId: "run-callid-pairing",
+      threadId: null,
+      userId: null,
+      config: {
+        ...DEFAULT_OBSERVABILITY_CONFIG,
+        enabled: true,
+        capturePrompts: true,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const choices = events[0]?.properties?.["$ai_output_choices"] as Array<{
+      tool_calls?: Array<{ id: string }>;
+    }>;
+    const callId = choices?.[0]?.tool_calls?.[0]?.id;
+    expect(callId).toBe("call_abc");
+    // The span id namespace never reaches the transcript, so it can never pair.
+    expect(callId).not.toMatch(/^span-/);
+
+    // The second round-trip saw the result, normalized into a `tool` message
+    // carrying the same id — which is what makes the two halves one call.
+    const laterInput = events
+      .flatMap((event) => (event.properties?.["$ai_input"] as unknown[]) ?? [])
+      .find(
+        (message) =>
+          !!message &&
+          typeof message === "object" &&
+          (message as { role?: string }).role === "tool",
+      ) as { tool_call_id?: string; content?: string } | undefined;
+    expect(laterInput?.tool_call_id).toBe("call_abc");
+    expect(laterInput?.content).toBe("no rows");
   });
 
   it("keeps tool detail in invocation order and pairs parallel calls by id", async () => {
@@ -3069,7 +3172,10 @@ describe("instrumentAgentLoop OpenTelemetry export", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(events).toHaveLength(1);
     expect(events[0]?.properties?.["$ai_is_error"]).toBe(false);
-    expect(events[0]?.properties).not.toHaveProperty("$ai_output_state");
+    // Withheld, not absent — the tool answered, this app just does not export
+    // what it said. The real result never appears either way.
+    expect(events[0]?.properties?.["$ai_output_state"]).toContain("withheld");
+    expect(JSON.stringify(events[0])).not.toContain("three matching rows");
 
     events.length = 0;
     await run(true);

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -13,6 +13,7 @@ import {
   emitAiTraceEvent,
   resolveAiError,
   toAiErrorDetail,
+  toPostHogMessages,
 } from "./posthog-ai.js";
 import { type AgentSpan, endAgentSpan, startAgentSpan } from "./tracing.js";
 import { trackingIdentityProperties } from "./tracking-identity.js";
@@ -391,11 +392,14 @@ function emitLlmGenerationTrackingEvent(args: {
  * on every call — tens of kilobytes of descriptions — and a call is already
  * identified by its name in `tool_calls` and by its own span.
  */
+
 function buildGenerationContent(args: {
   config: ObservabilityConfig;
   messages: unknown;
   assistantText: string;
   toolSpans: TraceSpan[];
+  /** Tool span id → the id the MODEL used for that call. See below. */
+  toolCallIds: Map<string, string>;
 }): {
   aiInput?: unknown;
   aiOutputChoices?: unknown;
@@ -408,15 +412,23 @@ function buildGenerationContent(args: {
   // `system` role, but the prompt is app configuration rather than content and
   // is near-identical on every run — shipping it would repeat kilobytes on each
   // generation for no analytical gain.
+  //
+  // Normalized before bounding: the byte ceiling rescues the last `user`
+  // message, and in engine shape every tool result is one.
   const input = config.capturePrompts
-    ? boundAiContent(redactSensitiveFields(args.messages))
+    ? boundAiContent(toPostHogMessages(redactSensitiveFields(args.messages)))
     : undefined;
 
   const toolCalls = args.toolSpans
     .slice(0, MAX_TRACKED_GENERATION_TOOL_CALLS)
     .map((span) => ({
       type: "function" as const,
-      id: span.id,
+      // The id the MODEL issued, which is what the matching `tool` message in
+      // `$ai_input` carries as `tool_call_id`. Our span id is a different
+      // namespace: emitting it here left PostHog with a call and a result that
+      // never paired, so every tool call rendered with no output. The span id
+      // remains the fallback for engines that report no call id.
+      id: args.toolCallIds.get(span.id) ?? span.id,
       function: {
         name: span.name,
         // Already redacted at span construction, and only present when
@@ -692,6 +704,11 @@ export async function instrumentAgentLoop(opts: {
   /** Tool span id → how it failed. A class, not the tool's output, so it
    *  travels even when `captureToolResults` withholds the message. */
   const toolSpanErrorClass = new Map<string, string>();
+  /** Tool span id → the id the MODEL gave that call. The two namespaces are
+   *  separate, and only the model's appears in the transcript — so it is the
+   *  one that pairs a `tool_calls` entry with its `tool` message. Empty for
+   *  legacy emitters that send no call id. */
+  const toolSpanCallId = new Map<string, string>();
 
   // Track in-flight OTel tool spans so they're all ended even if the loop
   // throws before a matching `tool_done` arrives.
@@ -981,6 +998,8 @@ export async function instrumentAgentLoop(opts: {
           : null;
 
         const toolSpanId = pending?.spanId ?? spanId();
+        const modelCallId = pending?.callId ?? event.id;
+        if (modelCallId) toolSpanCallId.set(toolSpanId, modelCallId);
         // The model_stream bracket closes before the turn's tools start, so the
         // last recorded round-trip is the call that requested this one.
         if (isError) {
@@ -1351,6 +1370,7 @@ export async function instrumentAgentLoop(opts: {
             messages: generation.input,
             assistantText: generation.assistantText,
             toolSpans: generation.toolSpans,
+            toolCallIds: toolSpanCallId,
           });
 
           spans.push({
@@ -1567,6 +1587,15 @@ export async function instrumentAgentLoop(opts: {
                         "error text withheld: captureToolResults is off for this app",
                     }
                   : undefined;
+          // The same distinction on the output side, which had no marker at
+          // all: a span with no `$ai_output_state` reads in PostHog as a tool
+          // that returned nothing, and that is what "the tool output is
+          // missing" looks like to a reader who has not seen this config. The
+          // tool DID answer — this app does not export what it said.
+          const toolOutputState = config.captureToolResults
+            ? (toolErrorMessage ??
+              (span.metadata as { output?: unknown } | null)?.output)
+            : "[tool result withheld: captureToolResults is off for this app]";
 
           const requestingGeneration = toolSpanRoundTrip.get(span.id);
           emitAiSpanEvent({
@@ -1593,9 +1622,7 @@ export async function instrumentAgentLoop(opts: {
             // only present when `captureToolArgs` / `captureToolResults` are
             // on; absent stays absent.
             inputState: (span.metadata as { input?: unknown } | null)?.input,
-            outputState:
-              toolErrorMessage ??
-              (span.metadata as { output?: unknown } | null)?.output,
+            outputState: toolOutputState,
             extraProperties: {
               ...trackingIdentityProperties(),
               source: "agent_observability",

--- a/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/packages/core/src/templates/headless/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/headless/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/packages/core/src/usage/store.spec.ts
+++ b/packages/core/src/usage/store.spec.ts
@@ -148,6 +148,54 @@ describe("calculateCost pricing tiers", () => {
     expect(write).toBe(37_500);
     expect(write).toBeGreaterThan(read);
   });
+
+  // `inputTokens` is the whole prompt and INCLUDES the cache counts, so the
+  // three are a partition. Charging the full total AND the cache counts on top
+  // billed every cached token twice — on a long cached conversation the cache
+  // is nearly the whole prompt, so the error was ~9x, not a rounding artifact.
+  it("prices each input token once when most of the prompt was cached", () => {
+    // A real turn: 42,438-token prompt, all but 3 tokens served from cache.
+    const cost = calculateCost(42_438, 285, "gpt-5.6-luna", 36_734, 5_701);
+
+    // luna, short context: $0.20 input / $0.02 cached / $0.25 cache write /
+    // $1.20 output per MTok, in this table's cents-per-MTok units.
+    const uncached = (3 / 1_000_000) * 20 * 100;
+    const output = (285 / 1_000_000) * 120 * 100;
+    const cacheRead = (36_734 / 1_000_000) * 2 * 100;
+    const cacheWrite = (5_701 / 1_000_000) * 25 * 100;
+    expect(cost).toBe(Math.round(uncached + output + cacheRead + cacheWrite));
+
+    // The shape of the old bug: the whole prompt charged at the full input
+    // rate, on top of the cache counts rather than net of them.
+    const doubleCounted =
+      (42_438 / 1_000_000) * 20 * 100 + output + cacheRead + cacheWrite;
+    expect(cost).toBeLessThan(doubleCounted);
+  });
+
+  // Cache writes cost MORE than uncached input, not less and not nothing —
+  // the one rate in OpenAI's table that is easy to assume away, and the one
+  // this table previously had at zero.
+  it("prices an OpenAI cache write above the full input rate", () => {
+    const write = calculateCost(1_000_000, 0, "gpt-5.6-luna", 0, 1_000_000);
+    const fresh = calculateCost(1_000_000, 0, "gpt-5.6-luna", 0, 0);
+    expect(write).toBe(2_500); // $0.25/MTok
+    expect(fresh).toBe(2_000); // $0.20/MTok
+    expect(write).toBeGreaterThan(fresh);
+  });
+
+  it("never credits the bill when cache counts exceed the prompt", () => {
+    // An engine still emitting the exclusive convention. Clamped, not negative
+    // — a wrong-signed charge is worse than a low one.
+    expect(
+      calculateCost(3, 0, "claude-sonnet-4-5", 36_734, 5_701),
+    ).toBeGreaterThan(0);
+  });
+
+  // A provider without prompt caching passes 0s and must still pay full rate
+  // on the whole prompt — the partition degrades to "all of it is uncached".
+  it("charges the full rate throughout when there is no caching", () => {
+    expect(calculateCost(1_000_000, 0, "claude-sonnet-4-5", 0, 0)).toBe(30_000);
+  });
 });
 
 describe("recordUsage", () => {

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -98,21 +98,33 @@ const PRICING: Array<{ match: RegExp; pricing: ModelPricing }> = [
     pricing: { input: 100, output: 500, cacheRead: 10, cacheWrite: 125 },
   },
   // ── OpenAI / Codex ──────────────────────────────────────────────────────────
-  // Published rates as of 2026-07; OpenAI bills cached input at a discount
-  // and has no separate cache-write token charge, so cacheWrite is 0. Sol and
-  // Terra have higher large-context rates after 272K tokens; this table tracks
-  // the standard rate because usage rows do not preserve request context size.
+  // Short-context rates from OpenAI's published table (read 2026-08-25):
+  // https://developers.openai.com/api/docs/pricing#text-tokens
+  //
+  //            input   cached   cache write   output    (USD per MTok)
+  //   sol      $4.00   $0.40    $5.00         $20.00
+  //   terra    $2.00   $0.20    $2.50         $12.00
+  //   luna     $0.20   $0.02    $0.25         $1.20
+  //
+  // All three also have a long-context tier at roughly 2x these rates. This
+  // table tracks short context because a usage row does not preserve the
+  // request's context size, so the tier cannot be recovered at pricing time.
+  //
+  // Cache WRITES are billed, and above the full input rate. The previous
+  // version of this block set cacheWrite to 0 on the belief that OpenAI does
+  // not charge for them, and carried input/output rates matching neither
+  // column of the table above.
   {
     match: /gpt-5[.-]6-sol/i,
-    pricing: { input: 500, output: 3000, cacheRead: 50, cacheWrite: 0 },
+    pricing: { input: 400, output: 2000, cacheRead: 40, cacheWrite: 500 },
   },
   {
     match: /gpt-5[.-]6-terra/i,
-    pricing: { input: 250, output: 1500, cacheRead: 25, cacheWrite: 0 },
+    pricing: { input: 200, output: 1200, cacheRead: 20, cacheWrite: 250 },
   },
   {
     match: /gpt-5[.-]6-luna/i,
-    pricing: { input: 100, output: 600, cacheRead: 10, cacheWrite: 0 },
+    pricing: { input: 20, output: 120, cacheRead: 2, cacheWrite: 25 },
   },
   {
     match: /gpt-5/i,
@@ -347,8 +359,20 @@ export async function ensureUsageTable(): Promise<void> {
 
 /**
  * Calculate cost in centicents (1/100th of a cent).
- * Accepts cache tokens so callers that use prompt caching are priced
- * correctly. Non-cache-aware callers can pass 0 for the cache fields.
+ *
+ * `inputTokens` is the WHOLE prompt and INCLUDES the two cache counts — the
+ * convention every engine emits, documented on the `usage` event in
+ * `agent/engine/types.ts`. So the three are a PARTITION and each token is
+ * priced exactly once: what was not cached at the full rate, what was read
+ * from cache at the cache-read rate, what was written at the cache-write rate.
+ *
+ * Charging `inputTokens` at the full rate and then adding the cache counts on
+ * top billed every cached token twice. On a long cached conversation that is
+ * not a rounding error — the cache is most of the prompt, so a turn whose real
+ * cost was $0.0054 was reported as $0.0478.
+ *
+ * Non-cache-aware callers pass 0 for the cache fields and get the full rate on
+ * everything, which is correct for a provider with no prompt caching.
  */
 export function calculateCost(
   inputTokens: number,
@@ -358,8 +382,15 @@ export function calculateCost(
   cacheWriteTokens = 0,
 ): number {
   const p = pricingFor(model);
+  // An engine that still emits the exclusive convention would drive this
+  // negative and credit the bill. Clamping keeps the partition non-negative;
+  // the fix for a caller that trips it is that engine, not a wider clamp here.
+  const uncachedInputTokens = Math.max(
+    0,
+    inputTokens - cacheReadTokens - cacheWriteTokens,
+  );
   const rawCenticents =
-    (inputTokens / 1_000_000) * p.input * 100 +
+    (uncachedInputTokens / 1_000_000) * p.input * 100 +
     (outputTokens / 1_000_000) * p.output * 100 +
     (cacheReadTokens / 1_000_000) * p.cacheRead * 100 +
     (cacheWriteTokens / 1_000_000) * p.cacheWrite * 100;

--- a/packages/recap-cli/src/recap.ts
+++ b/packages/recap-cli/src/recap.ts
@@ -4754,8 +4754,10 @@ function parseLastJsonObject(text: string): Record<string, any> | null {
 
 /**
  * Claude Code `-p --output-format json` prints one final result object with a
- * `usage` block and `total_cost_usd`. Anthropic's `input_tokens` already
- * EXCLUDES cache tokens, so no normalization is needed here.
+ * `usage` block and `total_cost_usd`. Anthropic's `input_tokens` EXCLUDES cache
+ * tokens, so the cache counts are added back: `inputTokens` reports the whole
+ * prompt, with the cache counts a slice of it. That is the one convention
+ * `calculateCost` and the engine `usage` event share.
  */
 export function parseClaudeUsage(stdout: string): ParsedUsage | null {
   const obj = parseLastJsonObject(stdout);
@@ -4767,11 +4769,14 @@ export function parseClaudeUsage(stdout: string): ParsedUsage | null {
       : obj?.modelUsage && typeof obj.modelUsage === "object"
         ? Object.keys(obj.modelUsage)[0]
         : undefined;
+  const cacheReadTokens = Number(u.cache_read_input_tokens ?? 0);
+  const cacheWriteTokens = Number(u.cache_creation_input_tokens ?? 0);
   return {
-    inputTokens: Number(u.input_tokens ?? 0),
+    inputTokens:
+      Number(u.input_tokens ?? 0) + cacheReadTokens + cacheWriteTokens,
     outputTokens: Number(u.output_tokens ?? 0),
-    cacheReadTokens: Number(u.cache_read_input_tokens ?? 0),
-    cacheWriteTokens: Number(u.cache_creation_input_tokens ?? 0),
+    cacheReadTokens,
+    cacheWriteTokens,
     model,
     reportedCostUsd:
       typeof obj?.total_cost_usd === "number" ? obj.total_cost_usd : undefined,
@@ -4805,21 +4810,23 @@ function lastCodexUsage(jsonl: string): Record<string, any> | undefined {
 
 /**
  * Codex `exec --json` reports `input_tokens` INCLUSIVE of `cached_input_tokens`
- * (OpenAI counts cached as a subset of prompt tokens) and bills
- * `reasoning_output_tokens` separately. Normalize to the cache-exclusive shape
- * `calculateCost` expects: strip cached out of input, fold reasoning into
- * output. Without this, cached tokens are billed twice and reasoning is dropped.
+ * (OpenAI counts cached as a subset of prompt tokens), which is already the
+ * convention `calculateCost` and the engine `usage` event share — so input
+ * passes through untouched and `calculateCost` subtracts to price each token
+ * once. This used to strip the cached tokens out here instead, back when
+ * pricing added the cache counts on top; doing both now bills them twice.
+ *
+ * `reasoning_output_tokens` is still folded into output — it is billed at the
+ * output rate and would otherwise be dropped.
  */
 export function parseCodexUsage(jsonl: string): ParsedUsage | null {
   const u = lastCodexUsage(jsonl);
   if (!u) return null;
-  const cached = Number(u.cached_input_tokens ?? 0);
-  const input = Number(u.input_tokens ?? 0) - cached;
   return {
-    inputTokens: Math.max(0, input),
+    inputTokens: Number(u.input_tokens ?? 0),
     outputTokens:
       Number(u.output_tokens ?? 0) + Number(u.reasoning_output_tokens ?? 0),
-    cacheReadTokens: cached,
+    cacheReadTokens: Number(u.cached_input_tokens ?? 0),
     cacheWriteTokens: 0, // Codex has no separate cache-write token charge
     model: typeof u.model === "string" ? u.model : undefined,
   };

--- a/templates/analytics/.agents/skills/actions/SKILL.md
+++ b/templates/analytics/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/assets/.agents/skills/actions/SKILL.md
+++ b/templates/assets/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/brain/.agents/skills/actions/SKILL.md
+++ b/templates/brain/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/calendar/.agents/skills/actions/SKILL.md
+++ b/templates/calendar/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/chat/.agents/skills/actions/SKILL.md
+++ b/templates/chat/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/clips/.agents/skills/actions/SKILL.md
+++ b/templates/clips/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/content/.agents/skills/actions/SKILL.md
+++ b/templates/content/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/crm/.agents/skills/actions/SKILL.md
+++ b/templates/crm/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/design/.agents/skills/actions/SKILL.md
+++ b/templates/design/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/dispatch/.agents/skills/actions/SKILL.md
+++ b/templates/dispatch/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/factory/.agents/skills/actions/SKILL.md
+++ b/templates/factory/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/forms/.agents/skills/actions/SKILL.md
+++ b/templates/forms/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/mail/.agents/skills/actions/SKILL.md
+++ b/templates/mail/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/plan/.agents/skills/actions/SKILL.md
+++ b/templates/plan/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/slides/.agents/skills/actions/SKILL.md
+++ b/templates/slides/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 

--- a/templates/tasks/.agents/skills/actions/SKILL.md
+++ b/templates/tasks/.agents/skills/actions/SKILL.md
@@ -121,6 +121,7 @@ Everything else — CRUD, settings, search, list/detail reads, auth state, anyth
 
 - **Do** keep one action, one job; document a reusable action (when to use it, key args, return fields to preserve) in `AGENTS.md` once it's called from outside one narrow screen; promote workflow-heavy actions (provider-backed, cross-app, MCP/A2A, multi-step) into a skill.
 - **Do** use `fail()` for user-friendly errors and import primitives from `@agent-native/core`(`/action`) instead of redefining them; use the core `upload-image` action or `uploadFile()` for durable images/files — never base64 into SQL, markdown, or action results.
+- **Do** signal failure by throwing (`fail()`), never by returning `{ error: ... }`. A returned envelope is a successful return everywhere the framework looks: the retry breakers (`MAX_IDENTICAL_TOOL_ERRORS`, `MAX_SAME_ERROR_ACROSS_ARGUMENTS`) never count it, the call is recorded `completedSideEffect: true` even though nothing was written, and `failed_tools` / `$ai_is_error` stay clean while the model keeps guessing. One production run spent 32% of its cost on three rejected writes that every dashboard reported as successes.
 - **Don't** re-export actions as REST — `/_agent-native/actions/:name` is already the REST surface; duplicating it under `/api/*` hides the operation from agents.
 - **Don't** reach for provider integrations, `outputSchema`, `authorize`, `needsApproval`, or `_agentImages` without checking `references/` first — each has sharp edges covered there, not here.
 


### PR DESCRIPTION
- Updated SKILL.md files in multiple templates to emphasize the importance of signaling failure by throwing `fail()` instead of returning an error object. This change aims to improve the accuracy of error reporting and reduce misleading success indicators in the framework.
- Revised pricing calculations in store.ts to ensure that input tokens are charged correctly, particularly when cache tokens are involved. Adjusted the pricing structure for OpenAI models to reflect accurate costs for input, output, cache reads, and cache writes.
- Improved usage parsing functions in recap.ts to correctly account for cache tokens in input token calculations, ensuring that costs are accurately reflected in usage reports.