### PR TITLE
Fix Notion OAuth client resolving as missing on hosted deploys

### DIFF
--- a/.changeset/notion-oauth-client-deploy-env.md
+++ b/.changeset/notion-oauth-client-deploy-env.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Let deployment-provided `NOTION_CLIENT_ID` / `NOTION_CLIENT_SECRET` back signed-in requests on hosted deploys, so Notion OAuth can be started from a hosted app instead of reporting the client as unconfigured.

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -139,6 +139,8 @@ beforeEach(() => {
   delete process.env.RESEND_API_KEY;
   delete process.env.SENDGRID_API_KEY;
   delete process.env.GOOGLE_CLIENT_SECRET;
+  delete process.env.NOTION_CLIENT_ID;
+  delete process.env.NOTION_CLIENT_SECRET;
   delete process.env.GITHUB_TOKEN;
   mockReadAppSecret.mockResolvedValue(null);
   mockReadAppSecrets.mockImplementation(
@@ -1374,6 +1376,28 @@ describe("resolveSecret (generic)", () => {
     );
     expect(
       canUseDeployCredentialFallbackForRequest("GOOGLE_CLIENT_SECRET"),
+    ).toBe(true);
+  });
+
+  it("uses app-provided Notion OAuth client env in a signed-in production shared-database request", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.NOTION_CLIENT_ID = "notion-deploy-client-id";
+    process.env.NOTION_CLIENT_SECRET = "notion-deploy-secret";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(await resolveSecret("NOTION_CLIENT_ID")).toBe(
+      "notion-deploy-client-id",
+    );
+    expect(await resolveSecret("NOTION_CLIENT_SECRET")).toBe(
+      "notion-deploy-secret",
+    );
+    expect(canUseDeployCredentialFallbackForRequest("NOTION_CLIENT_ID")).toBe(
+      true,
+    );
+    expect(
+      canUseDeployCredentialFallbackForRequest("NOTION_CLIENT_SECRET"),
     ).toBe(true);
   });
 

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -194,6 +194,14 @@ const APP_PROVIDED_DEPLOY_CREDENTIAL_KEYS = new Set([
   "OPENROUTER_API_KEY",
   "GOOGLE_CLIENT_ID",
   "GOOGLE_CLIENT_SECRET",
+  // Same class as the Google pair above: an OAuth *client* identifies the
+  // deployment to the provider, and the per-user identity stays in the scoped
+  // `oauth_tokens` row the consent flow writes. `guards/no-env-credentials`
+  // already classifies these two as deployment configuration; omitting them
+  // here made every signed-in hosted request resolve them as null, so the
+  // consent flow could never start and status reported "missing_credentials".
+  "NOTION_CLIENT_ID",
+  "NOTION_CLIENT_SECRET",
   "GOOGLE_GENERATIVE_AI_API_KEY",
   "GROQ_API_KEY",
   "MISTRAL_API_KEY",

--- a/templates/content/actions/connect-notion-status.test.ts
+++ b/templates/content/actions/connect-notion-status.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentNotionOwner: vi.fn(),
+  getNotionConnectionForOwner: vi.fn(),
+  resolveSecret: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  resolveSecret: mocks.resolveSecret,
+}));
+
+vi.mock("../server/lib/notion.js", () => ({
+  getNotionConnectionForOwner: mocks.getNotionConnectionForOwner,
+}));
+
+vi.mock("./_notion-action-utils.js", () => ({
+  getCurrentNotionOwner: mocks.getCurrentNotionOwner,
+}));
+
+import connectNotionStatus from "./connect-notion-status";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getCurrentNotionOwner.mockReturnValue("owner@example.com");
+  mocks.getNotionConnectionForOwner.mockResolvedValue(null);
+  mocks.resolveSecret.mockResolvedValue(null);
+});
+
+describe("connect-notion-status", () => {
+  it("reports connected for the owner's stored Notion OAuth account", async () => {
+    mocks.getNotionConnectionForOwner.mockResolvedValue({
+      accountId: "workspace-1",
+      accessToken: "secret",
+      workspaceName: "Docs",
+      workspaceId: "workspace-1",
+    });
+
+    await expect(connectNotionStatus.run({})).resolves.toMatchObject({
+      connected: true,
+      workspaceName: "Docs",
+      mode: "oauth",
+      error: undefined,
+    });
+  });
+
+  // The reported bug: a deployment that DOES have a Notion OAuth client
+  // reported `missing_credentials`, which the UI and the agent both read as
+  // "this app cannot talk to Notion" instead of "you have not connected yet".
+  // The cause was `resolveSecret` refusing the deploy env fallback for these
+  // two keys on a hosted signed-in request; keep the not-connected-but-
+  // connectable state distinct from the unconfigured one.
+  it("does not report missing_credentials when the OAuth client resolves", async () => {
+    mocks.resolveSecret.mockImplementation(async (key: string) =>
+      key === "NOTION_CLIENT_ID" || key === "NOTION_CLIENT_SECRET"
+        ? `deploy-${key}`
+        : null,
+    );
+
+    await expect(connectNotionStatus.run({})).resolves.toMatchObject({
+      connected: false,
+      error: undefined,
+    });
+  });
+
+  it("reports missing_credentials only when no client and no connection exist", async () => {
+    await expect(connectNotionStatus.run({})).resolves.toMatchObject({
+      connected: false,
+      error: "missing_credentials",
+    });
+  });
+
+  it("requires both halves of the OAuth client before offering to connect", async () => {
+    mocks.resolveSecret.mockImplementation(async (key: string) =>
+      key === "NOTION_CLIENT_ID" ? "deploy-id" : null,
+    );
+
+    await expect(connectNotionStatus.run({})).resolves.toMatchObject({
+      connected: false,
+      error: "missing_credentials",
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes `connect-notion-status` incorrectly reporting `missing_credentials` on hosted deploys even when a Notion OAuth client (`NOTION_CLIENT_ID`/`NOTION_CLIENT_SECRET`) was configured.

### Problem
Users reported inconsistent Notion connection status in the Content app: the UI sometimes said Notion was "connected," while the agent chat and `connect-notion-status` reported `missing_credentials`, even though the direct Notion OAuth integration worked. Root cause: `resolveSecret` in `@agent-native/core` did not treat `NOTION_CLIENT_ID`/`NOTION_CLIENT_SECRET` as deployment-provided credentials, so signed-in requests on hosted (shared-database) deploys resolved them as `null`. This blocked the OAuth consent flow from ever starting and caused the status check to report the client itself as unconfigured, conflating "not yet connected" with "cannot connect at all."

### Solution
Add `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET` to the set of app-provided deploy credential keys in `credential-provider.ts`, matching the existing treatment of `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` — the OAuth client identifies the deployment to the provider, while per-user identity remains scoped via the `oauth_tokens` row written by the consent flow.

### Key Changes
- `packages/core/src/server/credential-provider.ts`: added `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET` to `APP_PROVIDED_DEPLOY_CREDENTIAL_KEYS` with explanatory comment.
- `packages/core/src/server/credential-provider.spec.ts`: added test verifying `resolveSecret` and `canUseDeployCredentialFallbackForRequest` allow the deploy-provided Notion OAuth client env vars for signed-in production shared-database requests.
- `templates/content/actions/connect-notion-status.test.ts`: new tests covering connected/not-connected/missing-credentials states, including the regression case where a resolvable OAuth client should not surface `missing_credentials`.
- `.changeset/notion-oauth-client-deploy-env.md`: changeset documenting the patch to `@agent-native/core`.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/pearl-coin-7w1aywef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-pearl-coin-7w1aywef.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<i>This PR was created by Alice Moore (alice@builder.io)</i>
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3565`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>pearl-coin-7w1aywef</branchName>-->