### PR TITLE
Keep Google account chooser for workspace connections

### DIFF
--- a/.changeset/google-connection-account-chooser.md
+++ b/.changeset/google-connection-account-chooser.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the Google account chooser when connecting a managed workspace connection, and pre-select the signed-in identity. Previously the flow sent `prompt=consent` alone, so Google silently reused whichever Google session the browser already had — a user signed in as their work account could grant a Calendar or Gmail connection from a personal account with no picker and no way to switch.

--- a/packages/core/src/server/workspace-provider-oauth.spec.ts
+++ b/packages/core/src/server/workspace-provider-oauth.spec.ts
@@ -316,7 +316,7 @@ describe("workspace provider OAuth", () => {
     );
     expect(url.searchParams.get("access_type")).toBe("offline");
     expect(url.searchParams.get("include_granted_scopes")).toBe("true");
-    expect(url.searchParams.get("prompt")).toBe("consent");
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
     expect(url.searchParams.get("scope")?.split(" ")).toEqual(
       expect.arrayContaining([
         "openid",
@@ -325,6 +325,41 @@ describe("workspace provider OAuth", () => {
         "https://www.googleapis.com/auth/drive.file",
       ]),
     );
+  });
+
+  it("keeps the Google account chooser and pre-selects the signed-in identity", () => {
+    const provider = getWorkspaceConnectionProvider("google_calendar")!;
+    const url = new URL(
+      buildWorkspaceProviderAuthorizationUrl({
+        provider,
+        clientId: "google-client",
+        redirectUri:
+          "https://beta.calendar.agent-native.com/_agent-native/connections/oauth/google_calendar/callback",
+        state: "signed-state",
+        challenge: "unused-challenge",
+        loginHint: "work@example.com",
+      }),
+    );
+
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
+    expect(url.searchParams.get("login_hint")).toBe("work@example.com");
+  });
+
+  it("omits login_hint when no signed-in identity is available", () => {
+    const provider = getWorkspaceConnectionProvider("google_calendar")!;
+    const url = new URL(
+      buildWorkspaceProviderAuthorizationUrl({
+        provider,
+        clientId: "google-client",
+        redirectUri:
+          "https://beta.calendar.agent-native.com/_agent-native/connections/oauth/google_calendar/callback",
+        state: "signed-state",
+        challenge: "unused-challenge",
+      }),
+    );
+
+    expect(url.searchParams.has("login_hint")).toBe(false);
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
   });
 
   it("exchanges Figma codes at the current token endpoint without exposing credentials", async () => {

--- a/packages/core/src/server/workspace-provider-oauth.ts
+++ b/packages/core/src/server/workspace-provider-oauth.ts
@@ -243,6 +243,7 @@ export async function handleWorkspaceProviderOAuthStart(
         redirectUri,
         state,
         challenge,
+        loginHint: session.email,
         ...(salesforceLoginUrl
           ? {
               authorizationUrl: salesforceOAuthEndpoint(
@@ -444,6 +445,7 @@ export function buildWorkspaceProviderAuthorizationUrl(input: {
   state: string;
   challenge: string;
   authorizationUrl?: string;
+  loginHint?: string;
 }): string {
   if (!input.provider.oauth)
     throw new Error("Provider does not support OAuth.");
@@ -468,7 +470,13 @@ export function buildWorkspaceProviderAuthorizationUrl(input: {
   if (isGoogleWorkspaceOAuthProvider(input.provider.id)) {
     url.searchParams.set("access_type", "offline");
     url.searchParams.set("include_granted_scopes", "true");
-    url.searchParams.set("prompt", "consent");
+    // `consent` alone lets Google silently reuse whichever Google session the
+    // browser already has, so a user signed into the app as work@ can grant a
+    // connection from personal@ with no chooser and no way back. Asking for
+    // `select_account` keeps the picker, and `login_hint` pre-selects the
+    // identity the app session is actually for.
+    url.searchParams.set("prompt", "consent select_account");
+    if (input.loginHint) url.searchParams.set("login_hint", input.loginHint);
   }
   if (input.provider.oauth.scopes.length) {
     url.searchParams.set("scope", input.provider.oauth.scopes.join(" "));

--- a/scripts/probe-google-redirect-uris.ts
+++ b/scripts/probe-google-redirect-uris.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env tsx
+/**
+ * Diagnostic: ask Google which redirect URIs a client actually has registered.
+ *
+ * Google only validates `redirect_uri` after it has resolved a sign-in page, so
+ * an unauthenticated request must follow redirects and carry a browser
+ * user-agent before `redirect_uri_mismatch` appears in the body. A HEAD or
+ * non-following GET returns 302 for registered and unregistered URIs alike,
+ * which reads as "everything is fine" — hence the explicit control probe.
+ */
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0 Safari/537.36";
+
+export type ProbeVerdict = "registered" | "not-registered" | "indeterminate";
+
+export function classifyProbeBody(body: string): ProbeVerdict {
+  if (/redirect_uri_mismatch/i.test(body)) return "not-registered";
+  // A real consent/sign-in page is large and never mentions the mismatch.
+  if (body.length > 50_000) return "registered";
+  return "indeterminate";
+}
+
+export async function probeRedirectUri(
+  clientId: string,
+  redirectUri: string,
+): Promise<ProbeVerdict> {
+  const url = new URL(AUTH_ENDPOINT);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", "openid email");
+  const response = await fetch(url, {
+    redirect: "follow",
+    headers: { "User-Agent": BROWSER_UA },
+  });
+  return classifyProbeBody(await response.text());
+}
+
+function usage(): string {
+  return `Usage:
+  pnpm exec tsx scripts/probe-google-redirect-uris.ts --client <client-id> --uri <uri> [--uri <uri> ...]
+
+Always probes a deliberately unregistered control URI first. If the control
+does not report "not-registered", the probe is not trustworthy and the run
+fails rather than reporting a clean bill of health.
+`;
+}
+
+export default async function main(argv: string[]): Promise<void> {
+  if (argv.includes("--help")) {
+    console.log(usage());
+    return;
+  }
+  let clientId = "";
+  const uris: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--client") clientId = argv[++i] ?? "";
+    else if (argv[i] === "--uri") uris.push(argv[++i] ?? "");
+  }
+  if (!clientId || !uris.length) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+
+  const control = await probeRedirectUri(
+    clientId,
+    "https://control-not-registered.example.com/cb",
+  );
+  console.log(`control (expect not-registered): ${control}`);
+  if (control !== "not-registered") {
+    console.error(
+      "Probe is not trustworthy: the control URI was not rejected. Aborting.",
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  for (const uri of uris) {
+    const verdict = await probeRedirectUri(clientId, uri);
+    console.log(`${verdict.padEnd(16)} ${uri}`);
+  }
+}
+
+const isDirectRun =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectRun) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
### Summary
Fixes the Google OAuth connection flow (Calendar, Gmail, etc.) so it always shows the account chooser and pre-selects the signed-in user's identity, instead of silently reusing whatever Google session the browser already had.

### Problem
Users reported issues connecting Google Calendar on the beta subdomain, including a `redirect_uri_mismatch` error and a confusing flow where, after signing in with their work account, the "connect a calendar" step would silently default to a personal Google account with no way to switch. Investigation traced the account-mixup behavior to the OAuth authorization request only sending `prompt=consent`, which lets Google reuse an existing browser session rather than surfacing a picker.

### Solution
Update the workspace provider OAuth authorization URL builder to request `select_account` in addition to `consent`, forcing Google to always show the account chooser, and pass a `login_hint` derived from the signed-in session's email so the correct account is pre-selected.

### Key Changes
- `buildWorkspaceProviderAuthorizationUrl` now sets `prompt` to `"consent select_account"` for Google workspace OAuth providers and accepts an optional `loginHint` parameter, added as `login_hint` when provided.
- `handleWorkspaceProviderOAuthStart` passes the current session's `email` as `loginHint` when starting the OAuth flow.
- Added/updated tests covering the new `prompt` value, `login_hint` pre-selection, and omission of `login_hint` when no signed-in identity is available.
- Added `scripts/probe-google-redirect-uris.ts`, a diagnostic script to determine which redirect URIs are actually registered for a Google OAuth client, using a control probe to validate trustworthiness of results.
- Added a changeset documenting the fix.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/ultimate-road-q7grgmfs"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-ultimate-road-q7grgmfs.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<i>This PR was created by Alice Moore (alice@builder.io)</i>
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3566`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>ultimate-road-q7grgmfs</branchName>-->