### PR TITLE
chore: update review policy and Google OAuth account selection

### DIFF
--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -84,6 +84,7 @@ The verified owner exceptions are:
  - Enzo (`enzoames`) - Factory, only when the PR is specific to the Factory
    app
  - Sid (`sidmohanty11`) - Design
+ - Manu (`manucorporat`) - any app or framework area
 
 For a verified PR authored by Alice and limited to Content app or template
 behavior, including supporting shared framework or Desktop plumbing required
@@ -105,6 +106,11 @@ auto-approve by default, including that owner's UX changes, refactors, failed
 or pending checks, and ordinary unresolved human or bot feedback. The owner
 exception overrides the normal UX-owner, narrow-refactor, check, and
 review-resolution gates.
+
+For a verified PR authored by Manu (`manucorporat`), auto-approve by default
+regardless of app scope, UX implications, refactors, failed or pending checks,
+or ordinary unresolved human or bot feedback. This exception does not waive the
+ultra-scary safety gate or the external-author prohibition.
 
 For a verified PR authored by `kapunahelewong` or Wes (`bwreid`), auto-approve
 by default when the PR is docs-only. Docs-only means documentation content,

--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -110,7 +110,10 @@ review-resolution gates.
 For a verified PR authored by Manu (`manucorporat`), auto-approve by default
 regardless of app scope, UX implications, refactors, failed or pending checks,
 or ordinary unresolved human or bot feedback. This exception does not waive the
-ultra-scary safety gate or the external-author prohibition.
+ultra-scary safety gate or the external-author prohibition. Changes to review or
+approval policy, agent safety instructions, membership verification, or
+CI/deployment security controls require independent review and are not eligible
+for this exception.
 
 For a verified PR authored by `kapunahelewong` or Wes (`bwreid`), auto-approve
 by default when the PR is docs-only. Docs-only means documentation content,

--- a/.changeset/google-connection-account-chooser.md
+++ b/.changeset/google-connection-account-chooser.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the Google account chooser when connecting a managed workspace connection and preselect the signed-in identity.

--- a/packages/core/src/server/workspace-provider-oauth.spec.ts
+++ b/packages/core/src/server/workspace-provider-oauth.spec.ts
@@ -316,7 +316,7 @@ describe("workspace provider OAuth", () => {
     );
     expect(url.searchParams.get("access_type")).toBe("offline");
     expect(url.searchParams.get("include_granted_scopes")).toBe("true");
-    expect(url.searchParams.get("prompt")).toBe("consent");
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
     expect(url.searchParams.get("scope")?.split(" ")).toEqual(
       expect.arrayContaining([
         "openid",
@@ -325,6 +325,41 @@ describe("workspace provider OAuth", () => {
         "https://www.googleapis.com/auth/drive.file",
       ]),
     );
+  });
+
+  it("keeps the Google account chooser and preselects the signed-in identity", () => {
+    const provider = getWorkspaceConnectionProvider("google_calendar")!;
+    const url = new URL(
+      buildWorkspaceProviderAuthorizationUrl({
+        provider,
+        clientId: "google-client",
+        redirectUri:
+          "https://beta.calendar.agent-native.com/_agent-native/connections/oauth/google_calendar/callback",
+        state: "signed-state",
+        challenge: "unused-challenge",
+        loginHint: "work@example.com",
+      }),
+    );
+
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
+    expect(url.searchParams.get("login_hint")).toBe("work@example.com");
+  });
+
+  it("omits login_hint when no signed-in identity is available", () => {
+    const provider = getWorkspaceConnectionProvider("google_calendar")!;
+    const url = new URL(
+      buildWorkspaceProviderAuthorizationUrl({
+        provider,
+        clientId: "google-client",
+        redirectUri:
+          "https://beta.calendar.agent-native.com/_agent-native/connections/oauth/google_calendar/callback",
+        state: "signed-state",
+        challenge: "unused-challenge",
+      }),
+    );
+
+    expect(url.searchParams.has("login_hint")).toBe(false);
+    expect(url.searchParams.get("prompt")).toBe("consent select_account");
   });
 
   it("exchanges Figma codes at the current token endpoint without exposing credentials", async () => {

--- a/packages/core/src/server/workspace-provider-oauth.ts
+++ b/packages/core/src/server/workspace-provider-oauth.ts
@@ -243,6 +243,7 @@ export async function handleWorkspaceProviderOAuthStart(
         redirectUri,
         state,
         challenge,
+        loginHint: session.email,
         ...(salesforceLoginUrl
           ? {
               authorizationUrl: salesforceOAuthEndpoint(
@@ -444,6 +445,7 @@ export function buildWorkspaceProviderAuthorizationUrl(input: {
   state: string;
   challenge: string;
   authorizationUrl?: string;
+  loginHint?: string;
 }): string {
   if (!input.provider.oauth)
     throw new Error("Provider does not support OAuth.");
@@ -468,7 +470,8 @@ export function buildWorkspaceProviderAuthorizationUrl(input: {
   if (isGoogleWorkspaceOAuthProvider(input.provider.id)) {
     url.searchParams.set("access_type", "offline");
     url.searchParams.set("include_granted_scopes", "true");
-    url.searchParams.set("prompt", "consent");
+    url.searchParams.set("prompt", "consent select_account");
+    if (input.loginHint) url.searchParams.set("login_hint", input.loginHint);
   }
   if (input.provider.oauth.scopes.length) {
     url.searchParams.set("scope", input.provider.oauth.scopes.join(" "));


### PR DESCRIPTION
## Summary

- recognize verified BuilderIO member `manucorporat` as an owner exception for any app or framework PR
- allow auto-approval across ordinary UX, refactor, check, and feedback gates while retaining the ultra-scary safety gate and membership requirement
- keep the Google account chooser for managed workspace connections and preselect the signed-in app identity

## Beta Calendar feedback

The live beta flow was reproduced in authenticated Chrome. Google rejects the managed Calendar callback with `redirect_uri_mismatch` for `https://beta.calendar.agent-native.com/_agent-native/connections/oauth/google_calendar/callback`. A direct Google probe confirmed the client accepts the legacy `/_agent-native/google/callback` paths but rejects the new managed-connection path on both beta and production. This is an external Google OAuth client registration gap; the repository change cannot alter Google Cloud Console configuration.

Sentry also has unresolved beta issue `erriss_c834d8eca88cca6c282229f2`, an `invalid_client` refresh failure from `/api/people/photos`; it is separate from the reproduced redirect mismatch and needs credential/config follow-up.

Slack lookup is unavailable in this checkout because the required `SLACK_BOT_TOKEN` is not present, so no Slack reaction or reply is being claimed.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/server/workspace-provider-oauth.spec.ts` - 30 passed
- `corepack pnpm guard:google-auth-redirects` - passed
- `corepack pnpm guard:no-env-credentials` - passed
- `corepack pnpm guard:no-silent-coercion` - passed
- full guards remain blocked by pre-existing i18n baseline/import debt and missing built `recap-cli` artifacts
- full core typecheck remains blocked by pre-existing toolkit UI declaration errors