### PR TITLE
Schedule weekday production release train

### DIFF
--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -5,7 +5,7 @@ name: 🚀 Release everything
 # *.agent-native.com site from that exact post-release commit.
 on:
   schedule:
-    - cron: "0 12 * * 1-4"
+    - cron: "17 12 * * 1-4"
       timezone: "America/Los_Angeles"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -1,9 +1,12 @@
 name: 🚀 Release everything
 
-# This is the deliberate stable-release button. It completes the package
-# changeset release first, then releases both desktop apps and promotes every
-# configured *.agent-native.com site from that exact post-release commit.
+# This is the stable release train. It completes the package changeset release
+# first, then releases both desktop apps and promotes every configured
+# *.agent-native.com site from that exact post-release commit.
 on:
+  schedule:
+    - cron: "0 12 * * 1-4"
+      timezone: "America/Los_Angeles"
   workflow_dispatch:
     inputs:
       releaseType:
@@ -31,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     env:
-      RELEASE_TYPE: ${{ inputs.releaseType }}
+      RELEASE_TYPE: ${{ inputs.releaseType || 'patch' }}
     steps:
       - name: Release packages, then desktop apps and production sites
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -10,6 +10,7 @@ const workflow = parse(
   readFileSync(".github/workflows/release-everything.yml", "utf8"),
 ) as Workflow;
 const trigger = workflow.on as Workflow;
+const schedules = trigger.schedule as Workflow[];
 const dispatch = trigger.workflow_dispatch as Workflow;
 const inputs = dispatch.inputs as Workflow;
 const job = (workflow.jobs as Workflow)["release-everything"] as Workflow;
@@ -20,8 +21,15 @@ const coordinator = steps.find(
 ) as Workflow;
 
 describe("release everything workflow", () => {
-  it("is a manually triggered, patch-default stable release button", () => {
+  it("runs a DST-aware Monday-Thursday noon Pacific patch release", () => {
     assert.equal(workflow.name, "🚀 Release everything");
+    assert.deepEqual(schedules, [
+      { cron: "0 12 * * 1-4", timezone: "America/Los_Angeles" },
+    ]);
+    assert.match(
+      String((job.env as Workflow).RELEASE_TYPE),
+      /inputs\.releaseType \|\| 'patch'/,
+    );
     assert.deepEqual(inputs.releaseType, {
       description: "Stable npm release bump",
       required: true,

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -24,7 +24,7 @@ describe("release everything workflow", () => {
   it("runs a DST-aware Monday-Thursday noon Pacific patch release", () => {
     assert.equal(workflow.name, "🚀 Release everything");
     assert.deepEqual(schedules, [
-      { cron: "0 12 * * 1-4", timezone: "America/Los_Angeles" },
+      { cron: "17 12 * * 1-4", timezone: "America/Los_Angeles" },
     ]);
     assert.match(
       String((job.env as Workflow).RELEASE_TYPE),


### PR DESCRIPTION
## Summary\n- schedule the existing release coordinator for Monday through Thursday at 12:00 PM Pacific\n- use patch bumps automatically for scheduled runs while preserving manual bump choices\n- keep package publication, both desktop releases, and the configured production-site fleet serialized from the exact release commit\n\n## Validation\n- corepack pnpm test:package-release-workflow\n- corepack pnpm exec oxfmt --check scripts/release-everything-workflow.test.ts\n- corepack pnpm guards