### PR TITLE
fix: harden Calendar desktop relay and feedback workflow

### DIFF
--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -85,10 +85,11 @@ public URL.
   Slack as unavailable and do not write.
 - Use that same connected identity for channel history, thread replies,
   reactions, and Slack metadata. Use cursors until the requested history or
-  thread is complete. A read-back must match the target channel, timestamp,
-  thread parent, workspace, and invoking `user_id` where Slack returns an
-  author. A reaction read-back must include the invoking user in the reaction's
-  user list.
+  thread is complete. A reply read-back must include author metadata matching
+  the invoking `user_id`; missing author data is unverified and cannot satisfy
+  the reply ledger. It must also match the target channel, timestamp, thread
+  parent, and workspace. A reaction read-back must include the invoking user
+  in the reaction's user list.
 - After every reaction or reply, re-read through the same connected identity
   and verify the reaction or reply exists before continuing.
 

--- a/.agents/skills/address-feedback-with-replies/SKILL.md
+++ b/.agents/skills/address-feedback-with-replies/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Complete the Slack feedback cycle: read every thread and linked evidence,
   fix verified repo-owned issues, and reply in-thread with honest status,
   clarification questions, and release follow-up. Use when the user asks to
-  address feedback and respond in the requested voice through the @agent-native
-  Slack bot.
+  address feedback and respond in the requested voice through the invoking
+  user's connected Slack identity.
 scope: dev
 metadata:
   internal: true
@@ -24,13 +24,14 @@ status.
 Every actionable Slack parent that receives `👀` is in scope for the reply
 ledger. The reaction is only the first external action - it never counts as a
 reply, ownership marker, or completion. Before finishing, re-read every
-eye-marked parent and confirm that the `@agent-native` bot posted **Fixed**,
-**In progress**, or **Clarification needed** in that thread. **In progress** is
-valid only when the thread already contains a substantive ownership or
-active-fix signal from `@agent-native` or another participant; it is an open
-state, not a terminal resolution, and the next run must return to it for
-**Fixed** or **Clarification needed**. A generic bot forward, another person's
-reply, or the `👀` reaction alone does not satisfy the ledger.
+eye-marked parent and confirm that the invoking Slack identity posted
+**Fixed**, **In progress**, or **Clarification needed** in that thread.
+**In progress** is valid only when the thread already contains a substantive
+ownership or active-fix signal from the invoking identity, `@agent-native`, or
+another participant; it is an open state, not a terminal resolution, and the
+next run must return to it for **Fixed** or **Clarification needed**. A generic
+bot forward, another person's reply, or the `👀` reaction alone does not
+satisfy the ledger.
 
 ## Prerequisites
 
@@ -66,39 +67,30 @@ reply, or the `👀` reaction alone does not satisfy the ledger.
 - Re-read dirty files before changing them. Preserve the shared checkout and
   never move branches, reset, stash, or overwrite peer work.
 
-## Slack bot identity
+## Slack identity
 
-Every Slack API interaction in this workflow - channel history, reactions,
-thread replies and read-backs, permalinks, and Slack message/user/file
-metadata - must use the Slack Web API with the local, untracked `.env` value
-`SLACK_BOT_TOKEN`. That value must authenticate the `@agent-native` Slack bot.
-Do not use the connected Slack MCP user's OAuth identity, a Steve/ChatGPT
-identity, or a different bot token for any Slack operation in this workflow.
+Every Slack interaction in this workflow - channel history, reactions, thread
+replies and read-backs, permalinks, and Slack message/user/file metadata - uses
+the connected Slack identity of the user who invoked the workflow. Verify that
+identity before the first write and keep its stable `{ team_id, user_id }`
+tuple for all read-backs. Do not silently switch to a bot, another user's
+connector, or a different workspace. Do not load or use `SLACK_BOT_TOKEN`.
 
 Linked external artifacts are not Slack interactions. After extracting their
 reference from Slack, fetch them through the artifact's owning connector or
-public URL; never send the Slack bearer token to an external service.
+public URL.
 
-- Load the value from `.env` without printing it, then call Slack `auth.test`
-  before the first request. Require `ok: true`, `team_id`, `user_id`, and
-  `bot_id`; verify `users.info(user_id)` returns a bot user (`is_bot: true`)
-  whose canonical name or display name is `agent-native`. Keep the stable
-  identity tuple `{ team_id, user_id, bot_id }` for all read-back checks.
-- Use that same bearer token for channel history, thread replies, reactions,
-  and Slack metadata. Use Slack cursors until the requested history or thread
-  is complete. The authenticated `team_id` scopes the request; do not require
-  individual message objects to repeat it. A message read-back must match the
-  target channel, timestamp, and thread parent, compare `team` or `team_id`
-  when Slack returns either field, and match the `bot_id`; if Slack also
-  includes a `user` author, it must match `user_id`, but a missing `user` field
-  is valid for bot messages. A reaction read-back must target the same message
-  and include the same `user_id` in its users list.
-- After every reaction or reply, re-read through the same token and verify the
-  reaction or reply exists and matches that identity tuple.
-- If the token is absent, invalid, or resolves to any identity other than
-  `@agent-native`, do not fall back to a user connector for Slack reads or
-  writes. Record Slack as unavailable, preserve the exact gap, and continue
-  only with non-Slack evidence.
+- Read the current Slack profile and confirm its user ID and display name
+  match the invoking user. If identity or workspace verification fails, record
+  Slack as unavailable and do not write.
+- Use that same connected identity for channel history, thread replies,
+  reactions, and Slack metadata. Use cursors until the requested history or
+  thread is complete. A read-back must match the target channel, timestamp,
+  thread parent, workspace, and invoking `user_id` where Slack returns an
+  author. A reaction read-back must include the invoking user in the reaction's
+  user list.
+- After every reaction or reply, re-read through the same connected identity
+  and verify the reaction or reply exists before continuing.
 
 ## Decision Gate
 
@@ -148,14 +140,14 @@ handoff first.
 
 **Clarification needed** is an open state, not a completed product fix. Asking
 the question creates a standing obligation to come back for the answer. It is
-the bot's terminal disposition for the current cursor, but the next
+the invoking identity's terminal disposition for the current cursor, but the next
 `review-latest-feedback` run must re-read every thread it previously asked in
 before scanning newer messages; when this workflow runs on its own, do the same
 and act on the replies first.
 
 **In progress** is also an open state. It records that the thread already has
-real ownership or an active fix, so the bot must not ask the reporter to repeat
-the issue. Re-read it on the next run, verify the work, and replace the open
+real ownership or an active fix, so the invoking identity must not ask the
+reporter to repeat the issue. Re-read it on the next run, verify the work, and replace the open
 state with **Fixed** when complete or **Clarification needed** only if a
 specific reporter or product input is still missing.
 
@@ -251,15 +243,15 @@ non-repeating question only if one specific required detail still blocks it.
    contains a real ownership or active-fix signal - never as a label for an
    internal tooling gap alone. The run is incomplete while that parent has
    only `👀`.
-6. When the user explicitly asks to reply, call Slack Web API
-   `chat.postMessage` directly in each requested thread with `thread_ts` and
-   the same `SLACK_BOT_TOKEN`. Do not silently turn an authorized write into a
-   draft. Re-read each thread afterward to confirm the reply landed. Before
-   ending the run, mechanically audit the reply ledger: for every `👀` parent,
-   record the `@agent-native` reply timestamp and whether it is **Fixed**,
-   **In progress**, or **Clarification needed**. If any parent has only `👀`, a generic bot
-   forward, or another person's reply, keep working and post the missing reply
-   before finishing.
+6. When the user explicitly asks to reply, post directly in each requested
+   thread with `thread_ts` through the same connected Slack identity. Do not
+   silently turn an authorized write into a draft. Re-read each thread
+   afterward to confirm the reply landed. Before ending the run, mechanically
+   audit the reply ledger: for every `👀` parent, record the invoking user's
+   reply timestamp and whether it is **Fixed**, **In progress**, or
+   **Clarification needed**. If any parent has only `👀`, a generic bot forward,
+   or another person's reply, keep working and post the missing reply before
+   finishing.
    If any participant replies after the post, re-read the entire thread again
    before deciding whether to fix, close, or ask anything else.
 7. If any participant supplies the requested detail or an explicit resolution,
@@ -275,8 +267,8 @@ non-repeating question only if one specific required detail still blocks it.
 
 ## Slack reply voice
 
-Write in Steve's voice, but let `@agent-native` be the sender - do not switch
-to a user-authored Slack identity:
+Write in the invoking user's voice and send from that same connected Slack
+identity:
 
 - Use lowercase, short conversational paragraphs, and clear, conversational
   wording. Keep the tone casual and collaborative - warm without being corny,
@@ -332,7 +324,7 @@ to a user-authored Slack identity:
 - Before finishing the sweep, search every reply authored in that sweep for
   vague unresolved wording and edit or remove it. Re-read the affected threads
   after each edit. Check that skipped subjective/product/policy items still
-  have neither an eye reaction nor an agent-authored reply.
+  have neither an eye reaction nor a reply from the invoking identity.
 
 A useful reply shape is:
 

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -96,13 +96,13 @@ answers already present. A detail found anywhere in that evidence is available
 context - never ask the reporter to repeat it.
 
 Look for resolution or ownership signals before classifying an item as missing
-evidence. A substantive reply from `@agent-native` or any participant that
-identifies the cause, supplies the repro, links a fix, or says the issue is
-fixed, landed, or being fixed is evidence, not a clarification gap. Verify the
-claim when needed and record the item as already owned, fixed, or in progress;
-do not ask a duplicate question while that work is being verified or handed
-off. Ask only when one concrete reporter or product detail still blocks a safe
-fix after this review.
+evidence. A substantive reply from the invoking Slack identity, a legacy
+`@agent-native` message, or any participant that identifies the cause, supplies
+the repro, links a fix, or says the issue is fixed, landed, or being fixed is
+evidence, not a clarification gap. Verify the claim when needed and record the
+item as already owned, fixed, or in progress; do not ask a duplicate question
+while that work is being verified or handed off. Ask only when one concrete
+reporter or product detail still blocks a safe fix after this review.
 
 Every human-facing feedback reply starts with a brief thank-you. When
 clarification is genuinely required, say `thanks for the feedback -` first and
@@ -223,15 +223,17 @@ instead of **Fixed** until verification is complete.
 When this skill is used by `address-feedback-with-replies`, that skill's Slack
 reply states take precedence: a Slack thread must receive **Fixed**, **In
 progress**, or **Clarification needed** for the current run. **In progress** is
-valid only when `@agent-native` or another participant already owns the issue
-or is actively fixing it; it is an open handoff that the next run must resolve
-to **Fixed** or **Clarification needed**. Do not post **Not fixed yet**, **Needs
+valid only when the invoking Slack identity, a legacy `@agent-native` message,
+or another participant already owns the issue or is actively fixing it; it is
+an open handoff that the next run must resolve to **Fixed** or **Clarification
+needed**. Do not post **Not fixed yet**, **Needs
 clarification**, or a bare **Verification pending** status in Slack. Ask one
 concrete, plain-language clarification question only when reporter or product
-input is still missing after the complete-thread and resolution-signal checks. If
-`@agent-native` or another participant already found, fixed, or is fixing the
-issue, do not ask the reporter to restate it - verify the claim or continue the
-existing ownership instead. Start any **In progress** or clarification reply
+input is still missing after the complete-thread and resolution-signal checks.
+If the invoking Slack identity, a legacy `@agent-native` message, or another
+participant already found, fixed, or is fixing the issue, do not ask the
+reporter to restate it - verify the claim or continue the existing ownership
+instead. Start any **In progress** or clarification reply
 with a thank-you. For clarification, ask the question second;
 **Clarification needed** remains an internal ledger state and must not appear as
 the reporter-facing opening. **Clarification needed** is the one timing

--- a/.agents/skills/address-feedback/SKILL.md
+++ b/.agents/skills/address-feedback/SKILL.md
@@ -38,9 +38,9 @@ the right abstraction, not the most general one.
 - If no link or feedback text is provided, ask for it.
 - Read the repo `AGENTS.md` before touching code.
 - Use the relevant connector/plugin/skill for the source when available, instead of scraping authenticated pages.
-- For Slack, use the `SLACK_BOT_TOKEN` / `@agent-native` identity contract in
-  `address-feedback-with-replies`; never mix user OAuth reads or writes into a
-  bot-authenticated feedback workflow.
+- For Slack, use the connected identity contract in
+  `address-feedback-with-replies`; verify the invoking user's profile and use
+  that same identity for all reads, reactions, replies, and read-backs.
 - Before starting work, search available task history and local Git/PR metadata for the exact feedback link or issue identifiers. Reuse existing work instead of creating a duplicate fix.
 
 ## Steps
@@ -53,11 +53,11 @@ the right abstraction, not the most general one.
    | Google Docs/Drive link | Google Drive connector or Google Docs skill |
    | Linear link | Linear connector if installed; otherwise ask for pasted content |
    | GitHub issue or PR | GitHub connector or `gh issue view` / `gh pr view` |
-   | Slack thread | Slack Web API with `SLACK_BOT_TOKEN` / `@agent-native` identity |
+   | Slack thread | Slack connector with the invoking user's identity |
    | Public URL | Web browsing |
    | Pasted text | Read directly |
 
-   Use web browsing only for public URLs. Auth-gated docs usually need their matching connector. For Slack threads, use the bot-authenticated Web API for the parent, replies, reactions, and Slack metadata; fetch linked external artifacts through their owning connector or public URL.
+   Use web browsing only for public URLs. Auth-gated docs usually need their matching connector. For Slack threads, use the invoking user's connected Slack identity for the parent, replies, reactions, and Slack metadata; fetch linked external artifacts through their owning connector or public URL.
 
 2. Check whether this defect has already been reported.
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -21,7 +21,7 @@ This is a reply-producing workflow, not a reaction-only workflow. Apply the
 reply rules in `address-feedback-with-replies` to every actionable Slack item.
 The moment this skill adds `👀` to a Slack parent, that parent enters a
 mandatory reply ledger. Before the run ends, re-read every ledger item and
-confirm that the `@agent-native` bot has posted a concise **Fixed**, **In
+confirm that the invoking Slack identity has posted a concise **Fixed**, **In
 progress**, or **Clarification needed** disposition. **In progress** is valid
 only when the complete thread already contains real ownership or an active-fix
 signal; it is open and must be revisited on the next run. A generic bot
@@ -36,15 +36,17 @@ repository that is currently `#product-agent-native-feedback` (`C0ATH3CCZT4`);
 if the invocation names another channel, use that channel instead.
 
 Scan the channel newest to oldest and choose the most recent parent message
-without a verified `@agent-native` bot-authored disposition - **Fixed**, an
+without a verified disposition from the invoking Slack identity - **Fixed**, an
 open **In progress** ownership reply, or an open **Clarification needed**
-question - from the same token contract. An `👀` reaction is only an
+question. An `👀` reaction is only an
 investigation marker and never suppresses the scan. A thread with only that
 reaction, including a fix waiting for internal verification, remains the next
-work item until it receives the verified bot disposition. **In progress** is
+work item until it receives the invoking identity's verified disposition. **In progress** is
 not terminal and must be revisited before newer work is treated as complete.
-Do not treat a Steve or another person's reply, generic bot acknowledgement or
-forward, or vague status update as terminal.
+Do not treat an unrelated person's reply, generic bot acknowledgement or
+forward, or vague status update as terminal. A prior reply from the invoking
+identity counts only when it is an explicit disposition and its read-back
+matches that identity.
 
 That message is the start cursor. Classify it, record it if it is not
 actionable, then continue toward older messages, processing each actionable
@@ -179,17 +181,16 @@ it through a temporary file plus rename so a killed heartbeat cannot leave a
 partial cursor. The scheduled heartbeat must use the same path and protocol on
 the next run, then append the loaded and updated rows to its recap.
 
-Initialize `owner_identities` with the invoking Slack identity and the
-configured `agent-native` identity. During the required full-thread read,
-inspect **Fixed** and **Clarification needed** replies from every author, not
-only Steve. Scheduled discovery first queries all exact terminal replies in
-the channel, joins them to eye-marked parents, and reads each candidate thread
-without an author filter. If the full thread or assignment establishes a new
-investigator or owner, add that identity and persist it in the ledger before
-applying the owner filter on later scans. A known-owner filter may optimize
-subsequent reads, but it must never gate this bootstrap query. If no recurring
-automation is available, say that the follow-up is manual and do not claim
-scheduled coverage exists.
+Initialize `owner_identities` with the invoking Slack identity. During the
+required full-thread read, inspect **Fixed** and **Clarification needed**
+replies from every author, not only the invoking identity. Scheduled discovery
+first queries all exact terminal replies in the channel, joins them to
+eye-marked parents, and reads each candidate thread without an author filter.
+If the full thread or assignment establishes a new investigator or owner, add
+that identity and persist it in the ledger before applying the owner filter on
+later scans. A known-owner filter may optimize subsequent reads, but it must
+never gate this bootstrap query. If no recurring automation is available, say
+that the follow-up is manual and do not claim scheduled coverage exists.
 
 If there is still no reporter answer after the aging threshold, make one bounded
 source investigation before leaving the item pending. The threshold is exactly
@@ -226,15 +227,16 @@ specific missing reporter or product input.
 ## Resolution and ownership gate
 
 Do not infer missing reporter evidence merely because a thread lacks a
-bot-authored terminal reply. After reading the full thread, treat a substantive
-reply from `@agent-native` or any participant that identifies the cause,
+terminal reply from the invoking identity. After reading the full thread,
+treat a substantive reply from a legacy `@agent-native` message or any
+participant that identifies the cause,
 provides the repro, links a fix, or says the issue is fixed, landed, or being
 fixed as resolution or ownership evidence. It suppresses a duplicate
 clarification request. Verify a claimed fix before recording **Fixed**; if the
 work is in progress, record it as already owned or in progress and continue the
-handoff without asking the reporter to restate the issue. A non-bot resolution
-reply may still need an `@agent-native` ledger reply, but it is not missing
-evidence.
+handoff without asking the reporter to restate the issue. A resolution reply
+from another author may still need an invoking-identity ledger reply, but it
+is not missing evidence.
 
 Only ask for clarification when the evidence ledger still contains one specific
 reporter or product detail that blocks a safe fix and no resolution or
@@ -248,7 +250,7 @@ Before changing code, read `address-feedback`,
 `address-feedback-with-replies`, `concurrent-agents`, and
 `verifying-changes`. Read `ship` when a verified fix is ready to publish.
 
-Use the Slack Web API under the bot-identity contract above. Use the configured
+Use the Slack connector under the invoking-identity contract above. Use the configured
 GitHub and Sentry connectors when available:
 
  - Slack: channel history, reactions, full thread replies, permalinks, and
@@ -259,11 +261,10 @@ GitHub and Sentry connectors when available:
  - Sentry: newest unresolved errors for the repository's projects, stack
    traces, route or component, frequency, affected release, and event links.
 
-For every Slack read or write, follow the `## Slack bot identity` contract in
-`address-feedback-with-replies`: load the local untracked `.env`'s
-`SLACK_BOT_TOKEN`, verify it with `auth.test` as `@agent-native`, and use that
-same bot identity for history, reactions, replies, and read-backs. Never fall
-back to a user/OAuth Slack connector or another bot token for this sweep.
+For every Slack read or write, follow the `## Slack identity` contract in
+`address-feedback-with-replies`: verify the connected Slack profile matches the
+invoking user, then use that same identity for history, reactions, replies, and
+read-backs. Never switch identities during the sweep.
 
 If a connector or permission is missing, continue with the other sources and
 name the exact gap in the final recap. Treat that as unavailable evidence, not
@@ -277,12 +278,15 @@ Do not infer a Sentry “no results” state from an unavailable API.
 Build one checklist per item with its source link, symptom, expected behavior,
 evidence, likely owner, and disposition. Use this order:
 
-1. **Check the existing marker and owner before any Slack write** - after
-   reading the complete parent, replies, reactions, and the linked evidence
-   needed to classify the item, inspect the latest readable parent reaction
-   state. If it already has an `👀` reaction from anyone, preserve that marker
-   and do not add another. If the reaction state is unavailable, record the
-   item as unavailable or unverified and do not guess or add a reaction. GitHub
+1. **Mark before investigating** - after the bounded newest-message search
+   identifies a concrete repo-owned or missing-evidence Slack item, verify the
+   invoking identity and inspect only enough reaction state to avoid duplicating
+   that identity's own marker. If the invoking identity has no `👀`, add it and
+   read it back immediately before reading the full thread, opening linked
+   evidence, delegating, editing code, or asking a clarification. An eye from
+   another identity does not satisfy this run's marker. If reaction state or
+   the write is unavailable, record the item as unavailable or unverified and
+   stop that item's investigation rather than pretending it was marked. GitHub
    and Sentry items have no Slack parent, so apply the same evidence-first
    triage without a reaction.
    - Concrete small Design UI or interaction bugs are in scope. Apply the same
@@ -292,9 +296,10 @@ evidence, likely owner, and disposition. Use this order:
    - All Content app feedback is owned by Alice. Leave those items for Alice;
      do not automatically react, investigate, fix, clarify, reply, or dispatch
      them. Record the source and ownership in the disposition.
-   - For a concrete repo-owned or missing-evidence Slack item that is not
-     already marked, add `👀` as the first external write, before delegating,
-     editing code, or asking a clarification. Do not react to status-only,
+   - For a concrete repo-owned or missing-evidence Slack item, add `👀` from
+     the invoking identity as the first external write, before full-thread
+     investigation, delegating, editing code, or asking a clarification. Do
+     not react to status-only,
      subjective, duplicate, external, or other non-repo-owned items.
 2. **Concrete repo-owned bug** - after the `👀` marker or existing-marker
    check, reproduce or establish it from source, tests, logs, a stack trace, or
@@ -359,13 +364,13 @@ failure modes, surfaces, or owners.
    running surface. For Sentry reports, confirm the affected release and
    distinguish a source fix from deployed and observed-live recovery.
 6. This skill is authorized to react to actionable Slack threads and must post
-   one concise in-thread update through the `@agent-native` bot for every
+   one concise in-thread update through the invoking Slack identity for every
    actionable parent it marked `👀`, not only for items whose code it changed.
    Post only after the fix or
    clarification is ready. A **Fixed** reply says that the fix is complete and
    when it should be live. An **In progress** reply acknowledges existing
-   ownership or active fixing, starts with a thank-you, and says the bot will
-   follow up after verification - it must not ask the reporter to repeat
+   ownership or active fixing, starts with a thank-you, and says we will follow
+   up after verification - it must not ask the reporter to repeat
    details. A **Clarification needed** reply asks one concrete question about
    missing reporter or product input, but only after the
    resolution and ownership gate above passes. Start that reply by thanking
@@ -460,9 +465,9 @@ skipped, duplicated, already owned, blocked by missing evidence, or blocked by
 an unavailable connector. Include direct links to the Slack message or thread,
 GitHub issue, Sentry event, PR, commit, and verification result when present.
 For Slack, include the reply-ledger result for every parent this run marked
-`👀`: `@agent-native` reply timestamp and disposition, or the exact reason the
+`👀`: invoking-user reply timestamp and disposition, or the exact reason the
 item was not marked. Never call a sweep complete while an actionable Slack
-parent in the ledger has no bot-authored reply.
+parent in the ledger has no reply from the invoking identity.
 
 Use this shape:
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -22,12 +22,10 @@ reply rules in `address-feedback-with-replies` to every actionable Slack item.
 The moment this skill adds `👀` to a Slack parent, that parent enters a
 mandatory reply ledger. Before the run ends, re-read every ledger item and
 confirm that the invoking Slack identity has posted a concise **Fixed**, **In
-progress**, or **Clarification needed** disposition. **In progress** is valid
-only when the complete thread already contains real ownership or an active-fix
-signal; it is open and must be revisited on the next run. A generic bot
-acknowledgement or forward, another person's reply, or the `👀` reaction alone
-never satisfies the ledger. Do not finish the sweep or report success while an
-actionable parent that this run marked has only `👀` or an unrelated reply.
+progress**, or **Clarification needed** disposition. **In progress** requires
+thread ownership or an active-fix signal and must be revisited next run. A bot
+forward, another person's reply, or `👀` alone never satisfies the ledger. Do
+not finish while a marked actionable parent has only `👀` or an unrelated reply.
 
 ## Start cursor
 
@@ -38,15 +36,11 @@ if the invocation names another channel, use that channel instead.
 Scan the channel newest to oldest and choose the most recent parent message
 without a verified disposition from the invoking Slack identity - **Fixed**, an
 open **In progress** ownership reply, or an open **Clarification needed**
-question. An `👀` reaction is only an
-investigation marker and never suppresses the scan. A thread with only that
-reaction, including a fix waiting for internal verification, remains the next
-work item until it receives the invoking identity's verified disposition. **In progress** is
-not terminal and must be revisited before newer work is treated as complete.
-Do not treat an unrelated person's reply, generic bot acknowledgement or
-forward, or vague status update as terminal. A prior reply from the invoking
-identity counts only when it is an explicit disposition and its read-back
-matches that identity.
+question. An `👀` reaction is only an investigation marker and never suppresses
+the scan. A thread with only `👀`, or with **In progress**, remains open until
+the invoking identity's disposition is verified. Do not treat an unrelated
+reply, bot forward, or vague status update as terminal; prior replies count
+only when their read-back matches the invoking identity.
 
 That message is the start cursor. Classify it, record it if it is not
 actionable, then continue toward older messages, processing each actionable
@@ -280,15 +274,12 @@ evidence, likely owner, and disposition. Use this order:
 
 1. **Mark before investigating** - after the bounded newest-message search
    identifies a concrete repo-owned or missing-evidence Slack item, verify the
-   invoking identity and inspect only enough reaction state to avoid duplicating
-   that identity's own marker. If the invoking identity has no `👀`, add it and
-   read it back immediately before reading the full thread, opening linked
-   evidence, delegating, editing code, or asking a clarification. An eye from
-   another identity does not satisfy this run's marker. If reaction state or
-   the write is unavailable, record the item as unavailable or unverified and
-   stop that item's investigation rather than pretending it was marked. GitHub
-   and Sentry items have no Slack parent, so apply the same evidence-first
-   triage without a reaction.
+   invoking identity and reaction state. If it has no own `👀`, add it as the
+   first external write and read it back before the full thread, linked
+   evidence, delegation, code, or clarification. Another identity's eye does
+   not satisfy this run. If reaction state or the write is unavailable, record
+   unavailable or unverified and stop that item. GitHub and Sentry items have
+   no Slack parent, so use the same evidence-first triage without a reaction.
    - Concrete small Design UI or interaction bugs are in scope. Apply the same
      evidence, reaction, fix, verification, and reply gates without narrowing
      the sweep to Design; route broad redesigns, subjective suggestions, or
@@ -296,11 +287,6 @@ evidence, likely owner, and disposition. Use this order:
    - All Content app feedback is owned by Alice. Leave those items for Alice;
      do not automatically react, investigate, fix, clarify, reply, or dispatch
      them. Record the source and ownership in the disposition.
-   - For a concrete repo-owned or missing-evidence Slack item, add `👀` from
-     the invoking identity as the first external write, before full-thread
-     investigation, delegating, editing code, or asking a clarification. Do
-     not react to status-only,
-     subjective, duplicate, external, or other non-repo-owned items.
 2. **Concrete repo-owned bug** - after the `👀` marker or existing-marker
    check, reproduce or establish it from source, tests, logs, a stack trace, or
    a linked run. Fix it and keep working until the smallest meaningful

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -163,7 +163,7 @@ derive `<codex_task_id>` from a fresh per-tick run id. If the scheduler cannot
 expose a stable id, require the external persistence mechanism to provide one
 before claiming scheduled coverage. This is local Codex state, not a recap and
 not a file committed to
-a worktree. The ledger has `schema_version`, `codex_task_id`,
+a worktree. The ledger has `schema_version`, `codex_task_id`, `slack_identity`,
 `owner_identities`, and an `items` map keyed by
 `<slack_channel_id>:<parent_ts>`. Each item has
 `parent_ts`, `clarification_ts`, `last_recheck_at`, `next_recheck_at`,
@@ -175,13 +175,17 @@ it through a temporary file plus rename so a killed heartbeat cannot leave a
 partial cursor. The scheduled heartbeat must use the same path and protocol on
 the next run, then append the loaded and updated rows to its recap.
 
-Initialize `owner_identities` with the invoking Slack identity. During the
-required full-thread read, inspect **Fixed** and **Clarification needed**
-replies from every author, not only the invoking identity. Scheduled discovery
-first queries all exact terminal replies in the channel, joins them to
-eye-marked parents, and reads each candidate thread without an author filter.
-If the full thread or assignment establishes a new investigator or owner, add
-that identity and persist it in the ledger before applying the owner filter on
+For a fresh manual run, verify and persist the invoking Slack profile as
+`slack_identity`. A scheduled run must load that stable `{ team_id, user_id }`
+identity from the ledger and require the current connected profile to match it
+before reading or writing. If it is missing or mismatched, record Slack as
+unavailable and do not claim scheduled coverage or initialize a new owner.
+Initialize `owner_identities` from the persisted identity. During the required
+full-thread read, inspect **Fixed** and **Clarification needed** replies from
+every author. Scheduled discovery first queries all exact terminal replies,
+joins them to eye-marked parents, and reads each candidate thread without an
+author filter. If the full thread or assignment establishes a new investigator
+or owner, add that identity and persist it before applying the owner filter on
 later scans. A known-owner filter may optimize subsequent reads, but it must
 never gate this bootstrap query. If no recurring automation is available, say
 that the follow-up is manual and do not claim scheduled coverage exists.

--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -110,11 +110,11 @@ owner's UX changes, refactors, failed or pending checks, and ordinary unresolved
 human or bot feedback. The owner exception overrides the normal UX-owner,
 narrow-refactor, check, and review-resolution gates.
 
-For a verified PR authored by Sid, or by Enzo when the PR is Factory-specific,
-auto-approve by default, including that owner's UX changes, refactors, failed
-or pending checks, and ordinary unresolved human or bot feedback. The owner
-exception overrides the normal UX-owner, narrow-refactor, check, and
-review-resolution gates.
+For a verified PR authored by Sid, or by Enzo (`enzoames`) when the PR is
+Factory-specific, auto-approve by default, including that owner's UX changes,
+refactors, failed or pending checks, and ordinary unresolved human or bot
+feedback. The owner exception overrides the normal UX-owner, narrow-refactor,
+check, and review-resolution gates.
 
 For a verified PR authored by Manu (`manucorporat`), auto-approve by default
 regardless of app scope, UX implications, refactors, failed or pending checks,

--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -81,6 +81,8 @@ The verified owner exceptions are:
 
  - Alice (`3mdistal`) - Content
  - Nick (`NKoech123`) - Slides
+ - Shomix (`shomix`) - Clips, only when the PR is specific to the Clips
+   app
  - Enzo (`enzoames`) - Factory, only when the PR is specific to the Factory
    app
  - Sid (`sidmohanty11`) - Design
@@ -100,6 +102,13 @@ Treat a PR as Factory-specific only when the changed behavior is limited to
 Factory app paths and Factory-owned actions, instructions, locales, or tests.
 Shared framework changes that materially affect other apps, Slack ingestion,
 core runtime, or deployment remain on the standard gate.
+
+For a verified PR authored by Shomix (`shomix`) and limited to Clips app or
+template behavior, including supporting shared framework or Desktop plumbing
+required by that Clips feature, auto-approve by default. This includes that
+owner's UX changes, refactors, failed or pending checks, and ordinary unresolved
+human or bot feedback. The owner exception overrides the normal UX-owner,
+narrow-refactor, check, and review-resolution gates.
 
 For a verified PR authored by Sid, or by Enzo when the PR is Factory-specific,
 auto-approve by default, including that owner's UX changes, refactors, failed
@@ -160,7 +169,7 @@ loading states, accessibility behavior, and user-facing defaults.
 The current app-owner map is:
 
  - Alice (`3mdistal`) - Content
- - Milos - Clips
+ - Shomix (`shomix`) - Clips
  - Nick (`NKoech123`) - Slides
  - Nicholas - Analytics
  - Enzo (`enzoames`) - Factory

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -98,9 +98,10 @@ Honor the feedback ownership and reaction gates from `/review-latest-feedback`:
   already has an `👀` reaction from anyone, preserve that fact as an existing
   investigation marker, but do not treat it as a disposition or suppression
   signal. After classifying the parent, re-read the complete thread and, for
-  an actionable in-scope item, require a verified `@agent-native` **Fixed**,
-  **In progress**, or **Clarification needed** disposition; an eye-only or
-  stale eye-only item remains actionable for that handoff check. For items
+  an actionable in-scope item, require a verified disposition from the
+  invoking Slack identity - **Fixed**, **In progress**, or **Clarification
+  needed**; an eye-only or stale eye-only item remains actionable for that
+  handoff check. For items
   routed to Sid or Alice, or classified as external, duplicate, deferred, or
   informational, honor that owning disposition and do not turn the eye into a
   merge blocker. If the reaction state is unavailable, record the item as
@@ -133,7 +134,8 @@ external, or unavailable/unverified - always re-read the complete source thread
 and current handoff and reconcile them for new replies, reactions, linked
 evidence, resolution, or ownership signals. The handoff is a prior record, not
 the source of truth. After that refresh, if
-`@agent-native` or another participant already supplied the needed details,
+the invoking Slack identity, a legacy `@agent-native` message, or another
+participant already supplied the needed details,
 identified the cause, linked a fix, or said the issue is fixed, landed, or being
 fixed, do not reopen it as a clarification request or ask for duplicate
 information. Carry it as fixed pending verification, already owned, or in
@@ -170,7 +172,8 @@ workflow's ownership. External, duplicate, deferred, and informational items
 also follow their recorded disposition rather than blocking this workflow. A
 parent marked with `👀` is not thereby complete or non-actionable: preserve the
 reaction without duplicating it, and for actionable in-scope items do not merge
-while an eye-only or stale eye-only item lacks a verified bot disposition.
+while an eye-only or stale eye-only item lacks a verified disposition from the
+invoking Slack identity.
 
 ## Worktree and branch setup
 

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -51,5 +51,12 @@ describe("desktop chat relay target URLs", () => {
     expect(
       shouldForwardRequestHeader("x-agent-native-surface", "desktop"),
     ).toBe(true);
+    expect(
+      shouldForwardRequestHeader(
+        "x-internal",
+        "secret",
+        new Set(["connection", "x-internal"]),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -10,7 +10,10 @@ vi.mock("../app-store", () => ({
   loadApps: vi.fn(() => []),
 }));
 
-import { resolveTargetUrl } from "./desktop-chat.js";
+import {
+  resolveTargetUrl,
+  shouldForwardRequestHeader,
+} from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
   it("rejects dot-segment traversal after URL normalization", () => {
@@ -37,5 +40,16 @@ describe("desktop chat relay target URLs", () => {
     ).toBe(
       "https://mail.example.com/app/_agent-native/agent-chat?surface=desktop",
     );
+  });
+
+  it("does not forward Electron-restricted browser headers", () => {
+    expect(shouldForwardRequestHeader("content-length", "42")).toBe(false);
+    expect(shouldForwardRequestHeader("cookie2", "legacy")).toBe(false);
+    expect(shouldForwardRequestHeader("transfer-encoding", "chunked")).toBe(
+      false,
+    );
+    expect(
+      shouldForwardRequestHeader("x-agent-native-surface", "desktop"),
+    ).toBe(true);
   });
 });

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -136,11 +136,12 @@ function requestHeaderValue(
 export function shouldForwardRequestHeader(
   name: string,
   value: string | string[] | undefined,
+  blockedHeaders: ReadonlySet<string> = RESTRICTED_REQUEST_HEADERS,
 ): boolean {
   const normalizedName = name.toLowerCase();
   return (
     value !== undefined &&
-    !RESTRICTED_REQUEST_HEADERS.has(normalizedName) &&
+    !blockedHeaders.has(normalizedName) &&
     normalizedName !== "host" &&
     normalizedName !== "origin" &&
     normalizedName !== "referer" &&
@@ -230,8 +231,16 @@ async function proxyRequest(
     upstream.chunkedEncoding = true;
   }
 
+  const blockedHeaders = new Set(RESTRICTED_REQUEST_HEADERS);
+  for (const connectionToken of (
+    requestHeaderValue(request.headers.connection) ?? ""
+  ).split(",")) {
+    const normalizedToken = connectionToken.trim().toLowerCase();
+    if (normalizedToken) blockedHeaders.add(normalizedToken);
+  }
+
   for (const [name, value] of Object.entries(request.headers)) {
-    if (!shouldForwardRequestHeader(name, value)) continue;
+    if (!shouldForwardRequestHeader(name, value, blockedHeaders)) continue;
     const headerValue = requestHeaderValue(value);
     if (headerValue !== undefined) upstream.setHeader(name, headerValue);
   }

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -28,6 +28,11 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ]);
+const RESTRICTED_REQUEST_HEADERS = new Set([
+  ...HOP_BY_HOP_HEADERS,
+  "content-length",
+  "cookie2",
+]);
 
 interface RelayState {
   port: number;
@@ -128,6 +133,21 @@ function requestHeaderValue(
   return value;
 }
 
+export function shouldForwardRequestHeader(
+  name: string,
+  value: string | string[] | undefined,
+): boolean {
+  const normalizedName = name.toLowerCase();
+  return (
+    value !== undefined &&
+    !RESTRICTED_REQUEST_HEADERS.has(normalizedName) &&
+    normalizedName !== "host" &&
+    normalizedName !== "origin" &&
+    normalizedName !== "referer" &&
+    normalizedName !== "cookie"
+  );
+}
+
 function corsHeaders(request: IncomingMessage): Record<string, string> {
   const origin = requestHeaderValue(request.headers.origin) ?? "*";
   const requestedHeaders =
@@ -203,17 +223,15 @@ async function proxyRequest(
   upstream.setHeader("Referer", `${targetUrl.origin}/`);
   if (cookieHeader) upstream.setHeader("Cookie", cookieHeader);
 
+  if (
+    request.headers["content-length"] !== undefined ||
+    request.headers["transfer-encoding"] !== undefined
+  ) {
+    upstream.chunkedEncoding = true;
+  }
+
   for (const [name, value] of Object.entries(request.headers)) {
-    if (
-      HOP_BY_HOP_HEADERS.has(name) ||
-      name === "host" ||
-      name === "origin" ||
-      name === "referer" ||
-      name === "cookie" ||
-      value === undefined
-    ) {
-      continue;
-    }
+    if (!shouldForwardRequestHeader(name, value)) continue;
     const headerValue = requestHeaderValue(value);
     if (headerValue !== undefined) upstream.setHeader(name, headerValue);
   }


### PR DESCRIPTION
## Summary\n\n- Harden the Electron Calendar desktop relay by filtering restricted request headers and preserving chunked POST forwarding. This addresses Damian report: net::ERR_INVALID_ARGUMENT on provider-settings save.\n- Update feedback workflows so concrete Slack items receive the invoking identity 👀 as the first external action, and all Slack reads, reactions, replies, and read-backs use that same connected identity. SLACK_BOT_TOKEN is explicitly prohibited.\n- Verify the beta Zoom OAuth callback now reaches the permission screen after the external allow-list update.\n\n## Feedback handoff\n\n| Report | Disposition |\n| --- | --- |\n| [Stephane Zoom report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787648903383419) | Fixed. Beta Zoom accepts the Calendar callback again. |\n| [Damian provider-settings report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787664343119599) | Fixed in source. The desktop relay fix is in the next desktop ship. |\n| [Akash missing-events report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787657759422969) | Clarification needed. The linked clip did not show the Calendar desktop error, so a fresh clip or screenshot with the Unauthorized message was requested. |\n| [Saee beta login report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787584936427299) | In progress. The account-selection source fix is merged, but Google still needs the beta OAuth callback registered before live verification. |\n| [Alice beta login report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787594170818689) | In progress for the same external Google OAuth registration blocker. |\n\nEach actionable parent has an 👀 reaction from the invoking identity and a read-back Slack disposition from Steve.\n\n## Validation\n\n- corepack pnpm desktop focused Vitest: 2 files, 6 tests passed.\n- corepack pnpm exec oxfmt --check on the changed TypeScript files: passed.\n- git diff --check: passed.\n- The earlier Google OAuth source fix is merged in PR #3567, and its beta publisher run succeeded.\n- guard:workspace-skills remains unavailable in this checkout because the pre-existing templates/tasks/.agents/skills/portability/SKILL.md file is missing.\n- Desktop typecheck remains blocked by pre-existing missing workspace declaration packages; no changed-file-specific type error surfaced.\n