### PR TITLE
Fix false background run loss after terminal handoff

### DIFF
--- a/.changeset/quiet-runs-replay.md
+++ b/.changeset/quiet-runs-replay.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prevent background chat recovery from reporting completed runs as lost.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2949,14 +2949,23 @@ const AssistantChatInner = forwardRef<
       ? storedActiveRun?.turnId
       : undefined) ?? (showRunningInUI ? reconnectTurnIdRef.current : null);
   const chatRunStartedAtRef = useRef<number | null>(null);
+  const chatRunTurnIdRef = useRef<string | null>(null);
   const [lastChatRunDurationMs, setLastChatRunDurationMs] = useState<
     number | null
   >(null);
   useEffect(() => {
     if (showRunningInUI) {
-      if (chatRunStartedAtRef.current == null) {
+      const startedForDifferentTurn =
+        chatRunStartedAtRef.current != null &&
+        chatRunTurnIdRef.current != null &&
+        activeChatTurnId != null &&
+        activeChatTurnId !== chatRunTurnIdRef.current;
+      if (chatRunStartedAtRef.current == null || startedForDifferentTurn) {
         chatRunStartedAtRef.current = Date.now();
+        chatRunTurnIdRef.current = activeChatTurnId ?? null;
         setLastChatRunDurationMs(null);
+      } else if (chatRunTurnIdRef.current == null && activeChatTurnId != null) {
+        chatRunTurnIdRef.current = activeChatTurnId;
       }
       return;
     }
@@ -2965,8 +2974,9 @@ const AssistantChatInner = forwardRef<
         Math.max(0, Date.now() - chatRunStartedAtRef.current),
       );
       chatRunStartedAtRef.current = null;
+      chatRunTurnIdRef.current = null;
     }
-  }, [showRunningInUI]);
+  }, [activeChatTurnId, showRunningInUI]);
   // A revealed activity label wins; otherwise keep recovery states calm and
   // product-facing. Reconnect is transport machinery, so normal replay reads as
   // ongoing work instead of exposing "Reconnecting" mid-chat.
@@ -5903,7 +5913,9 @@ const AssistantChatInner = forwardRef<
       <CheckpointContext.Provider value={checkpointCtx}>
         <MessageActionsContext.Provider value={messageActionsCtx}>
           <ApprovalContext.Provider value={approvalCtx}>
-            <ChatRunDurationContext.Provider value={lastChatRunDurationMs}>
+            <ChatRunDurationContext.Provider
+              value={showRunningInUI ? null : lastChatRunDurationMs}
+            >
               <ServerRunActiveContext.Provider value={serverRunActive}>
                 <ChatRunningRunIdContext.Provider value={activeChatRunId}>
                   <ChatRunningTurnIdContext.Provider value={activeChatTurnId}>

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -7904,6 +7904,84 @@ describe("createAgentChatAdapter", () => {
     );
   });
 
+  it("replays a terminal snapshot even when the active flag has already cleared", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let requestTurnId = "";
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "/_agent-native/agent-chat" && init?.method === "POST") {
+        requestTurnId = JSON.parse(init.body as string).turnId;
+        return backgroundSseResponse(
+          [
+            { type: "text", text: "Started " },
+            { type: "auto_continue", reason: "run_timeout" },
+          ],
+          "run-terminal-after-release",
+        );
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: false,
+          runId: "run-terminal-after-release",
+          threadId: "thread-terminal-after-release",
+          turnId: requestTurnId,
+          status: "completed",
+          terminalReason: "done",
+          dispatchMode: "background-processing",
+        });
+      }
+      if (url.includes("/runs/run-terminal-after-release/events")) {
+        return backgroundSseResponse(
+          [{ type: "text", text: "finished" }, { type: "done" }],
+          "run-terminal-after-release",
+        );
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-terminal-after-release",
+      threadId: "thread-terminal-after-release",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "finish this background task" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const results = await promise;
+    const last = results.at(-1) as any;
+
+    expect(last.status).toEqual({ type: "complete", reason: "stop" });
+    expect(last.content.map((part: any) => part.text).join(" ")).toContain(
+      "finished",
+    );
+    expect(last.content.map((part: any) => part.text).join(" ")).not.toContain(
+      "no continuation appeared",
+    );
+  });
+
   it("never condemns a run because the /runs/active poll itself failed", async () => {
     // "The poll failed" is not "the run is gone". A 5xx from this route used
     // to coerce to active=false, fall into the no-active-run branch, and drive

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3302,14 +3302,29 @@ export function createAgentChatAdapter(
               continue;
             }
 
-            const activeRunId =
-              active?.active === true && active.runId
-                ? String(active.runId)
-                : null;
             const activeTurnId =
               typeof active?.turnId === "string" ? active.turnId : "";
             const activeStatus =
               typeof active?.status === "string" ? active.status : "";
+            const reportedRunId = active?.runId ? String(active.runId) : null;
+            // Some deployed readers report a terminal snapshot with
+            // `active: false` while the row is being released. It is still
+            // authoritative when it names this turn or a run we already
+            // claimed; dropping it creates a false idle gap and eventually
+            // reports a completed run as lost.
+            const isTerminalSnapshot =
+              reportedRunId !== null &&
+              (activeStatus === "completed" ||
+                activeStatus === "errored" ||
+                activeStatus === "aborted" ||
+                activeStatus === "truncated") &&
+              (activeTurnId === turnId ||
+                attemptedRunIds.includes(reportedRunId));
+            const activeRunId =
+              reportedRunId !== null &&
+              (active?.active === true || isTerminalSnapshot)
+                ? reportedRunId
+                : null;
             // Only follow runs belonging to THIS turn (server-chained
             // successors reuse the turnId) or runs we already attached to.
             const isOurRun =


### PR DESCRIPTION
## Summary

- Preserve a matching terminal `/runs/active` snapshot even when its `active` flag has cleared during release, so the client does not turn a completed run into a generic lost-run error.
- Reset chat timing when the logical turn changes and avoid showing the previous turn's duration while a new turn is active.
- Add a focused replay regression test and a patch changeset.

## Production investigation

- The reported run `run-1787664815463-q2owxa` is `completed` in production with `terminal_reason=done`, 584 durable events, and a 127.5-second event span. It has no error code or error detail.
- The screenshot's 1h15m failure is therefore a client-side handoff/replay state bug, not the worker's persisted outcome.
- The recent production cohort also contains six `background_run_lost` abort rows with zero events and one `background_worker_never_started` row, which are distinct failure modes. No matching Sentry issues were found in the last 14 days.

## Checks

- Focused Vitest: 294 tests passed across 3 files.
- `oxfmt` and `git diff --check` passed.
- Relevant guards passed. The full guard run still reports the pre-existing `guard:i18n-catalogs` baseline debt.
- Core typecheck is currently blocked by the pre-existing `posthog-ai.ts` `Array.findLast`/ES2022 baseline error under the installed TypeScript 7 toolchain; this diff does not touch that file.
