### PR TITLE
feat(composer): support custom mention item media

### DIFF
--- a/.changeset/tidy-mention-item-media.md
+++ b/.changeset/tidy-mention-item-media.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": minor
+"@agent-native/toolkit": minor
+---
+
+Allow mention providers to show custom text or images with optional background
+colors, or to omit leading media, while preserving the existing icon fallback.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -22,6 +22,7 @@ export {
   type AgentChatAttachment,
   type AgentChatReference,
   type MentionProvider,
+  type MentionItemMedia,
   type MentionProviderItem,
 } from "./types.js";
 export {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -80,11 +80,32 @@ export interface AgentChatReference {
   metadata?: Record<string, unknown>;
 }
 
+export type MentionItemMedia =
+  | {
+      type: "text";
+      /** Short text shown inside the media frame, such as an emoji or initials. */
+      text: string;
+      /** Optional CSS color used behind the text. */
+      backgroundColor?: string;
+    }
+  | {
+      type: "image";
+      /** Image URL shown inside the media frame. Relative URLs are supported. */
+      src: string;
+      /** How the image fits the frame. Defaults to contain. */
+      fit?: "contain" | "cover";
+      /** Optional CSS color visible behind contained images. */
+      backgroundColor?: string;
+    }
+  | { type: "none" };
+
 export interface MentionProviderItem {
   id: string;
   label: string;
   description?: string;
   icon?: string;
+  /** Optional presentation that takes precedence over the legacy icon. */
+  media?: MentionItemMedia;
   refType: string;
   refId?: string;
   refPath?: string;
@@ -98,6 +119,8 @@ export interface MentionProviderItem {
 export interface MentionProviderReference {
   label: string;
   icon?: string;
+  /** Optional presentation that takes precedence over the legacy icon. */
+  media?: MentionItemMedia;
   source?: string;
   refType: string;
   refId?: string | null;

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -656,6 +656,11 @@ describe("sendToAgentChat", () => {
       normalizeAgentComposerReference({
         label: " Product shots ",
         icon: "folder",
+        media: {
+          type: "text",
+          text: " 📷 ",
+          backgroundColor: " #0f766e ",
+        },
         source: "assets",
         refType: " brand-kit ",
         refId: " lib_123 ",
@@ -676,6 +681,11 @@ describe("sendToAgentChat", () => {
     ).toEqual({
       label: "Product shots",
       icon: "folder",
+      media: {
+        type: "text",
+        text: "📷",
+        backgroundColor: "#0f766e",
+      },
       source: "assets",
       refType: "brand-kit",
       refId: "lib_123",
@@ -697,6 +707,33 @@ describe("sendToAgentChat", () => {
     expect(
       normalizeAgentComposerReference({ label: "", refType: "preset" }),
     ).toBeNull();
+    expect(
+      normalizeAgentComposerReference({
+        label: "No icon",
+        refType: "agent",
+        media: { type: "none" },
+      }),
+    ).toMatchObject({ media: { type: "none" } });
+    expect(
+      normalizeAgentComposerReference({
+        label: "Invalid media",
+        refType: "agent",
+        media: { type: "text", text: "" },
+      }),
+    ).not.toHaveProperty("media");
+    expect(
+      normalizeAgentComposerReference({
+        label: "Logo",
+        refType: "agent",
+        media: {
+          type: "image",
+          src: " /agents/logo.png ",
+          fit: "cover",
+        },
+      }),
+    ).toMatchObject({
+      media: { type: "image", src: "/agents/logo.png", fit: "cover" },
+    });
   });
 
   it("posts composer references without submitting", () => {

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -7,6 +7,7 @@
  * stay inside the embedded app so its own AgentSidebar can receive them.
  */
 
+import type { MentionItemMedia } from "../agent/types.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import { agentNativePath } from "./api-path.js";
 import { readClientAppState } from "./application-state.js";
@@ -172,6 +173,7 @@ export type BufferedAgentChatOpenRequest = {
 export interface AgentComposerReference {
   label: string;
   icon?: string;
+  media?: MentionItemMedia;
   source?: string;
   refType: string;
   refId?: string | null;
@@ -673,6 +675,42 @@ function normalizeMetadata(
   return value as Record<string, unknown>;
 }
 
+function normalizeMentionItemMedia(
+  value: unknown,
+): AgentComposerReference["media"] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type === "none") return { type: "none" };
+  const backgroundColor =
+    typeof candidate.backgroundColor === "string"
+      ? candidate.backgroundColor.trim()
+      : "";
+  if (candidate.type === "text") {
+    const text =
+      typeof candidate.text === "string" ? candidate.text.trim() : "";
+    if (!text) return undefined;
+    return {
+      type: "text",
+      text,
+      ...(backgroundColor ? { backgroundColor } : {}),
+    };
+  }
+  if (candidate.type === "image") {
+    const src = typeof candidate.src === "string" ? candidate.src.trim() : "";
+    if (!src) return undefined;
+    const fit = candidate.fit === "cover" ? "cover" : "contain";
+    return {
+      type: "image",
+      src,
+      fit,
+      ...(backgroundColor ? { backgroundColor } : {}),
+    };
+  }
+  return undefined;
+}
+
 function normalizeAgentComposerReferenceInternal(
   value: unknown,
   depth: number,
@@ -710,6 +748,8 @@ function normalizeAgentComposerReferenceInternal(
   const slotLabel =
     typeof candidate.slotLabel === "string" ? candidate.slotLabel.trim() : "";
   if (slotLabel) normalized.slotLabel = slotLabel;
+  const media = normalizeMentionItemMedia(candidate.media);
+  if (media) normalized.media = media;
   const metadata = normalizeMetadata(candidate.metadata);
   if (metadata) normalized.metadata = metadata;
   const clearsSlots = normalizeStringArray(candidate.clearsSlots);

--- a/packages/core/src/client/composer/runtime-adapters.tsx
+++ b/packages/core/src/client/composer/runtime-adapters.tsx
@@ -19,7 +19,7 @@ import {
   setAgentChatContextItem,
 } from "../agent-chat.js";
 import { SIDEBAR_STATE_CHANGE_EVENT } from "../agent-sidebar-state.js";
-import { agentNativePath } from "../api-path.js";
+import { appPath } from "../api-path.js";
 import { readClientAppState, setClientAppState } from "../application-state.js";
 import { AssistantUiStaleIndexErrorBoundary } from "../assistant-ui-recovery.js";
 import { getBrowserTabId } from "../browser-tab-id.js";
@@ -57,7 +57,7 @@ function subscribeSidebarState(
 }
 
 const coreComposerAdapters: Omit<ComposerRuntimeAdapters, "translate"> = {
-  resolvePath: agentNativePath,
+  resolvePath: (path) => appPath(path),
   models: {
     useChatModels,
     useAgentEngineConfigured,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -112,6 +112,7 @@ import { attachToolSearch } from "../agent/tool-search.js";
 import type {
   AgentChatAttachment,
   AgentChatEvent,
+  MentionItemMedia,
   MentionProvider,
 } from "../agent/types.js";
 import { getAppConfig } from "../app-config/index.js";
@@ -4857,6 +4858,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
             label: string;
             description?: string;
             icon?: string;
+            media?: MentionItemMedia;
             source: string;
             refType: string;
             refPath?: string;
@@ -5010,6 +5012,7 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                         label: item.label,
                         description: item.description,
                         icon: item.icon || provider.icon || "file",
+                        media: item.media,
                         source: key,
                         refType: item.refType,
                         refPath: item.refPath,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -134,6 +134,7 @@ export {
   type AgentChatAttachment,
   type AgentChatReference,
   type MentionProvider,
+  type MentionItemMedia,
   type MentionProviderItem,
   type AgentLoopFinalResponseGuard,
   type AgentLoopFinalResponseGuardContext,

--- a/packages/toolkit/src/composer/MentionItemMedia.spec.tsx
+++ b/packages/toolkit/src/composer/MentionItemMedia.spec.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MentionItemMedia } from "./MentionItemMedia.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("MentionItemMedia", () => {
+  it("keeps the legacy icon when no media is configured", () => {
+    act(() => root.render(<MentionItemMedia icon="agent" />));
+
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders provider-defined text and background", () => {
+    act(() =>
+      root.render(
+        <MentionItemMedia
+          icon="agent"
+          media={{
+            type: "text",
+            text: "🏠",
+            backgroundColor: "rgb(15, 118, 110)",
+          }}
+        />,
+      ),
+    );
+
+    expect(container.textContent).toBe("🏠");
+    expect(container.querySelector("svg")).toBeNull();
+    const frame = container.querySelector("span");
+    expect(frame?.className).toContain("size-5");
+    expect(frame?.firstElementChild?.className).toContain("size-3");
+    expect(frame?.firstElementChild?.className).toContain("text-[9px]");
+    expect(frame?.style.backgroundColor).toBe("rgb(15, 118, 110)");
+  });
+
+  it("allows providers to omit leading media explicitly", () => {
+    act(() =>
+      root.render(<MentionItemMedia icon="agent" media={{ type: "none" }} />),
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("falls back to the legacy icon for empty text media", () => {
+    act(() =>
+      root.render(
+        <MentionItemMedia icon="agent" media={{ type: "text", text: " " }} />,
+      ),
+    );
+
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders a contained image without leaking a referrer", () => {
+    act(() =>
+      root.render(
+        <MentionItemMedia
+          icon="agent"
+          media={{ type: "image", src: "/agent.png" }}
+        />,
+      ),
+    );
+
+    const image = container.querySelector("img");
+    expect(image?.getAttribute("src")).toBe("/agent.png");
+    expect(image?.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(image?.className).toContain("size-3");
+    expect(image?.className).toContain("object-contain");
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/packages/toolkit/src/composer/MentionItemMedia.spec.tsx
+++ b/packages/toolkit/src/composer/MentionItemMedia.spec.tsx
@@ -5,6 +5,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { MentionItemMedia } from "./MentionItemMedia.js";
+import { ComposerRuntimeAdaptersProvider } from "./runtime-adapters.js";
+import type { MentionItemMedia as MentionItemMediaValue } from "./types.js";
 
 let container: HTMLDivElement;
 let root: Root;
@@ -84,5 +86,65 @@ describe("MentionItemMedia", () => {
     expect(image?.className).toContain("size-3");
     expect(image?.className).toContain("object-contain");
     expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("resolves root-relative images against the app mount", () => {
+    act(() =>
+      root.render(
+        <ComposerRuntimeAdaptersProvider
+          adapters={{ resolvePath: (path) => `/assets${path}` }}
+        >
+          <MentionItemMedia media={{ type: "image", src: "/agent.png" }} />
+        </ComposerRuntimeAdaptersProvider>,
+      ),
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "/assets/agent.png",
+    );
+  });
+
+  it("leaves absolute image URLs unchanged", () => {
+    act(() =>
+      root.render(
+        <ComposerRuntimeAdaptersProvider
+          adapters={{ resolvePath: (path) => `/assets${path}` }}
+        >
+          <MentionItemMedia
+            media={{ type: "image", src: "https://example.com/agent.png" }}
+          />
+        </ComposerRuntimeAdaptersProvider>,
+      ),
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.com/agent.png",
+    );
+  });
+
+  it.each([{ type: "text" }, { type: "image", src: null }])(
+    "falls back safely for malformed media",
+    (media) => {
+      act(() =>
+        root.render(
+          <MentionItemMedia
+            icon="agent"
+            media={media as unknown as MentionItemMediaValue}
+          />,
+        ),
+      );
+
+      expect(container.querySelector("svg")).not.toBeNull();
+    },
+  );
+
+  it("preserves the compact clipboard fallback for slot references", () => {
+    act(() =>
+      root.render(<MentionItemMedia size="sm" fallbackIcon="clipboard" />),
+    );
+
+    expect(container.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-3",
+    );
   });
 });

--- a/packages/toolkit/src/composer/MentionItemMedia.tsx
+++ b/packages/toolkit/src/composer/MentionItemMedia.tsx
@@ -1,0 +1,116 @@
+import {
+  IconCheckbox,
+  IconFile,
+  IconFileText,
+  IconFolder,
+  IconMail,
+  IconMessageChatbot,
+  IconPresentation,
+  IconStack2,
+  IconUser,
+} from "@tabler/icons-react";
+
+import type { MentionItemMedia as MentionItemMediaValue } from "./types.js";
+
+const iconProps = { size: 14, className: "shrink-0 text-muted-foreground" };
+
+export interface MentionItemMediaProps {
+  icon?: string;
+  media?: MentionItemMediaValue | null;
+  size?: "sm" | "md";
+  fallbackIcon?: "file" | "stack";
+}
+
+function LegacyMentionIcon({
+  icon,
+  fallbackIcon = "file",
+}: Pick<MentionItemMediaProps, "icon" | "fallbackIcon">) {
+  switch (icon) {
+    case "folder":
+      return <IconFolder {...iconProps} />;
+    case "document":
+      return <IconFileText {...iconProps} />;
+    case "form":
+      return <IconCheckbox {...iconProps} />;
+    case "email":
+      return <IconMail {...iconProps} />;
+    case "user":
+      return <IconUser {...iconProps} />;
+    case "deck":
+      return <IconPresentation {...iconProps} />;
+    case "agent":
+      return <IconMessageChatbot {...iconProps} />;
+    case "file":
+      return <IconFile {...iconProps} />;
+    default:
+      return fallbackIcon === "stack" ? (
+        <IconStack2 {...iconProps} />
+      ) : (
+        <IconFile {...iconProps} />
+      );
+  }
+}
+
+export function MentionItemMedia({
+  icon,
+  media,
+  size = "md",
+  fallbackIcon = "file",
+}: MentionItemMediaProps) {
+  if (media?.type === "none") return null;
+  if (media?.type === "text" && media.text.trim()) {
+    return (
+      <span
+        aria-hidden="true"
+        className={`inline-grid shrink-0 place-items-center overflow-hidden rounded-full ${
+          size === "sm" ? "size-4" : "size-5"
+        }`}
+        style={
+          media.backgroundColor
+            ? { backgroundColor: media.backgroundColor }
+            : undefined
+        }
+      >
+        <span
+          className={`inline-grid place-items-center whitespace-nowrap leading-none ${
+            size === "sm" ? "size-2 text-[8px]" : "size-3 text-[9px]"
+          }`}
+        >
+          {media.text}
+        </span>
+      </span>
+    );
+  }
+  if (media?.type === "image" && media.src.trim()) {
+    const coversFrame = media.fit === "cover";
+    return (
+      <span
+        aria-hidden="true"
+        className={`inline-grid shrink-0 place-items-center overflow-hidden rounded-full ${
+          size === "sm" ? "size-4" : "size-5"
+        }`}
+        style={
+          media.backgroundColor
+            ? { backgroundColor: media.backgroundColor }
+            : undefined
+        }
+      >
+        <img
+          alt=""
+          src={media.src}
+          decoding="async"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className={
+            coversFrame
+              ? "size-full object-cover"
+              : size === "sm"
+                ? "size-2 object-contain"
+                : "size-3 object-contain"
+          }
+        />
+      </span>
+    );
+  }
+  return <LegacyMentionIcon icon={icon} fallbackIcon={fallbackIcon} />;
+}

--- a/packages/toolkit/src/composer/MentionItemMedia.tsx
+++ b/packages/toolkit/src/composer/MentionItemMedia.tsx
@@ -1,5 +1,6 @@
 import {
   IconCheckbox,
+  IconClipboardList,
   IconFile,
   IconFileText,
   IconFolder,
@@ -10,6 +11,7 @@ import {
   IconUser,
 } from "@tabler/icons-react";
 
+import { useComposerRuntimeAdapters } from "./runtime-adapters.js";
 import type { MentionItemMedia as MentionItemMediaValue } from "./types.js";
 
 const iconProps = { size: 14, className: "shrink-0 text-muted-foreground" };
@@ -18,13 +20,18 @@ export interface MentionItemMediaProps {
   icon?: string;
   media?: MentionItemMediaValue | null;
   size?: "sm" | "md";
-  fallbackIcon?: "file" | "stack";
+  fallbackIcon?: "clipboard" | "file" | "stack";
 }
 
 function LegacyMentionIcon({
   icon,
   fallbackIcon = "file",
 }: Pick<MentionItemMediaProps, "icon" | "fallbackIcon">) {
+  if (!icon && fallbackIcon === "clipboard") {
+    return (
+      <IconClipboardList className="size-3 shrink-0 text-muted-foreground" />
+    );
+  }
   switch (icon) {
     case "folder":
       return <IconFolder {...iconProps} />;
@@ -57,47 +64,54 @@ export function MentionItemMedia({
   size = "md",
   fallbackIcon = "file",
 }: MentionItemMediaProps) {
+  const { resolvePath = (path) => path } = useComposerRuntimeAdapters();
   if (media?.type === "none") return null;
-  if (media?.type === "text" && media.text.trim()) {
+  const backgroundColor =
+    typeof media?.backgroundColor === "string"
+      ? media.backgroundColor
+      : undefined;
+  const text =
+    media?.type === "text" && typeof media.text === "string"
+      ? media.text.trim()
+      : "";
+  if (text) {
     return (
       <span
         aria-hidden="true"
         className={`inline-grid shrink-0 place-items-center overflow-hidden rounded-full ${
           size === "sm" ? "size-4" : "size-5"
         }`}
-        style={
-          media.backgroundColor
-            ? { backgroundColor: media.backgroundColor }
-            : undefined
-        }
+        style={backgroundColor ? { backgroundColor } : undefined}
       >
         <span
           className={`inline-grid place-items-center whitespace-nowrap leading-none ${
             size === "sm" ? "size-2 text-[8px]" : "size-3 text-[9px]"
           }`}
         >
-          {media.text}
+          {text}
         </span>
       </span>
     );
   }
-  if (media?.type === "image" && media.src.trim()) {
-    const coversFrame = media.fit === "cover";
+  const src =
+    media?.type === "image" && typeof media.src === "string"
+      ? media.src.trim()
+      : "";
+  if (src) {
+    const coversFrame = media?.type === "image" && media.fit === "cover";
+    const resolvedSrc =
+      src.startsWith("/") && !src.startsWith("//") ? resolvePath(src) : src;
     return (
       <span
         aria-hidden="true"
         className={`inline-grid shrink-0 place-items-center overflow-hidden rounded-full ${
           size === "sm" ? "size-4" : "size-5"
         }`}
-        style={
-          media.backgroundColor
-            ? { backgroundColor: media.backgroundColor }
-            : undefined
-        }
+        style={backgroundColor ? { backgroundColor } : undefined}
       >
         <img
           alt=""
-          src={media.src}
+          src={resolvedSrc}
           decoding="async"
           loading="lazy"
           referrerPolicy="no-referrer"

--- a/packages/toolkit/src/composer/MentionPopover.tsx
+++ b/packages/toolkit/src/composer/MentionPopover.tsx
@@ -1,13 +1,5 @@
 import {
-  IconFile,
-  IconFolder,
   IconStack2,
-  IconFileText,
-  IconCheckbox,
-  IconMail,
-  IconUser,
-  IconPresentation,
-  IconMessageChatbot,
   IconTrash,
   IconPlus,
   IconHelp,
@@ -31,6 +23,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip.js";
+import { MentionItemMedia } from "./MentionItemMedia.js";
 import { useComposerRuntimeAdapters } from "./runtime-adapters.js";
 import type { MentionItem, SkillResult, SlashCommand } from "./types.js";
 
@@ -58,29 +51,6 @@ interface MentionPopoverProps {
 }
 
 const iconProps = { size: 14, className: "shrink-0 text-muted-foreground" };
-
-function MentionItemIcon({ icon }: { icon?: string }) {
-  switch (icon) {
-    case "folder":
-      return <IconFolder {...iconProps} />;
-    case "document":
-      return <IconFileText {...iconProps} />;
-    case "form":
-      return <IconCheckbox {...iconProps} />;
-    case "email":
-      return <IconMail {...iconProps} />;
-    case "user":
-      return <IconUser {...iconProps} />;
-    case "deck":
-      return <IconPresentation {...iconProps} />;
-    case "agent":
-      return <IconMessageChatbot {...iconProps} />;
-    case "file":
-      return <IconFile {...iconProps} />;
-    default:
-      return <IconFile {...iconProps} />;
-  }
-}
 
 function CommandIcon({ icon }: { icon?: string }) {
   switch (icon) {
@@ -369,7 +339,10 @@ export const MentionPopover = forwardRef<
                             onMouseEnter={() => setSelectedIndex(idx)}
                             onClick={() => onSelectMention(item)}
                           >
-                            <MentionItemIcon icon={item.icon} />
+                            <MentionItemMedia
+                              icon={item.icon}
+                              media={item.media}
+                            />
                             <span className="truncate text-sm">
                               {item.label}
                             </span>

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -188,6 +188,69 @@ describe("createTiptapComposerExtensions", () => {
     editor.destroy();
   });
 
+  it.each([
+    [
+      "text",
+      {
+        type: "text",
+        text: "PK",
+        backgroundColor: "#4f46e5",
+      },
+    ],
+    [
+      "image",
+      {
+        type: "image",
+        src: "/agents/property.png",
+        fit: "cover",
+        backgroundColor: "#ffffff",
+      },
+    ],
+    ["none", { type: "none" }],
+  ] as const)(
+    "preserves %s mention media through HTML drafts",
+    (_type, media) => {
+      const first = new Editor({
+        element: document.createElement("div"),
+        extensions: createTiptapComposerExtensions(() => "Message agent..."),
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "mentionReference",
+                  attrs: {
+                    label: "Property agent",
+                    media,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const html = first.getHTML();
+      first.destroy();
+
+      expect(html).toContain("data-media=");
+      expect(html).not.toContain("[object Object]");
+
+      const restored = new Editor({
+        element: document.createElement("div"),
+        extensions: createTiptapComposerExtensions(() => "Message agent..."),
+        content: html,
+      });
+      const mentionNode = restored.getJSON().content?.[0]?.content?.[0] as
+        | { attrs?: Record<string, unknown> }
+        | undefined;
+      restored.destroy();
+
+      expect(mentionNode?.attrs?.media).toEqual(media);
+    },
+  );
+
   it("allows sending an attachment-only prompt", () => {
     expect(
       canSubmitComposerContent({

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -179,6 +179,7 @@ function composerReferenceFromMentionItem(
   return {
     label: item.label,
     icon: item.icon || "file",
+    media: item.media,
     source: item.source,
     refType: item.refType,
     refId: item.refId || null,
@@ -195,6 +196,7 @@ function mentionReferenceAttrs(ref: AgentComposerReference) {
   return {
     label: ref.label,
     icon: ref.icon || "file",
+    media: ref.media || null,
     source: ref.source,
     refType: ref.refType,
     refId: ref.refId || null,

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -44,6 +44,7 @@ import { getComposerDraftKey } from "./draft-key.js";
 import { FileReference } from "./extensions/FileReference.js";
 import { MentionReference } from "./extensions/MentionReference.js";
 import { SkillReference } from "./extensions/SkillReference.js";
+import { MentionItemMedia } from "./MentionItemMedia.js";
 import { MentionPopover, type MentionPopoverRef } from "./MentionPopover.js";
 import {
   isClaudeCodeAgentId,
@@ -3695,7 +3696,11 @@ export function TiptapComposer({
               key={ref.slotKey}
               className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-[11px] font-medium text-foreground shadow-sm"
             >
-              <IconClipboardList className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <MentionItemMedia
+                media={ref.media}
+                size="sm"
+                fallbackIcon="clipboard"
+              />
               {ref.slotLabel && (
                 <span className="shrink-0 text-muted-foreground">
                   {ref.slotLabel}

--- a/packages/toolkit/src/composer/extensions/MentionReference.tsx
+++ b/packages/toolkit/src/composer/extensions/MentionReference.tsx
@@ -1,41 +1,7 @@
-import {
-  IconFile,
-  IconFolder,
-  IconFileText,
-  IconCheckbox,
-  IconMail,
-  IconUser,
-  IconPresentation,
-  IconStack2,
-  IconMessageChatbot,
-} from "@tabler/icons-react";
 import { mergeAttributes, Node } from "@tiptap/core";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 
-const iconProps = { size: 14, className: "shrink-0 text-muted-foreground" };
-
-function MentionIcon({ icon }: { icon?: string }) {
-  switch (icon) {
-    case "folder":
-      return <IconFolder {...iconProps} />;
-    case "document":
-      return <IconFileText {...iconProps} />;
-    case "form":
-      return <IconCheckbox {...iconProps} />;
-    case "email":
-      return <IconMail {...iconProps} />;
-    case "user":
-      return <IconUser {...iconProps} />;
-    case "deck":
-      return <IconPresentation {...iconProps} />;
-    case "agent":
-      return <IconMessageChatbot {...iconProps} />;
-    case "file":
-      return <IconFile {...iconProps} />;
-    default:
-      return <IconStack2 {...iconProps} />;
-  }
-}
+import { MentionItemMedia } from "../MentionItemMedia.js";
 
 const MentionReferenceComponent = ({ node }: { node: any }) => {
   return (
@@ -44,7 +10,12 @@ const MentionReferenceComponent = ({ node }: { node: any }) => {
         className="inline-flex items-center gap-1 rounded-md border border-input bg-muted/50 px-1.5 py-0.5 text-xs font-medium text-foreground align-middle mx-0.5 max-w-[200px] select-none"
         title={node.attrs.refPath || node.attrs.refId || node.attrs.label}
       >
-        <MentionIcon icon={node.attrs.icon} />
+        <MentionItemMedia
+          icon={node.attrs.icon}
+          media={node.attrs.media}
+          size="sm"
+          fallbackIcon="stack"
+        />
         <span className="truncate">{node.attrs.label}</span>
       </span>
     </NodeViewWrapper>
@@ -62,6 +33,7 @@ export const MentionReference = Node.create({
     return {
       label: { default: null },
       icon: { default: "file" },
+      media: { default: null },
       source: { default: "" },
       refType: { default: "file" },
       refId: { default: null },

--- a/packages/toolkit/src/composer/extensions/MentionReference.tsx
+++ b/packages/toolkit/src/composer/extensions/MentionReference.tsx
@@ -2,6 +2,46 @@ import { mergeAttributes, Node } from "@tiptap/core";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 
 import { MentionItemMedia } from "../MentionItemMedia.js";
+import type { MentionItemMedia as MentionItemMediaValue } from "../types.js";
+
+function parseMentionItemMedia(
+  value: string | null,
+): MentionItemMediaValue | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    const backgroundColor =
+      typeof candidate.backgroundColor === "string"
+        ? candidate.backgroundColor
+        : undefined;
+    if (candidate.type === "none") return { type: "none" };
+    if (candidate.type === "text" && typeof candidate.text === "string") {
+      return {
+        type: "text",
+        text: candidate.text,
+        ...(backgroundColor ? { backgroundColor } : {}),
+      };
+    }
+    if (candidate.type === "image" && typeof candidate.src === "string") {
+      return {
+        type: "image",
+        src: candidate.src,
+        ...(candidate.fit === "cover" ? { fit: "cover" } : {}),
+        ...(backgroundColor ? { backgroundColor } : {}),
+      };
+    }
+    // coercion-ok: Malformed optional media must preserve legacy draft rendering.
+  } catch {}
+  return null;
+}
 
 const MentionReferenceComponent = ({ node }: { node: any }) => {
   return (
@@ -33,7 +73,15 @@ export const MentionReference = Node.create({
     return {
       label: { default: null },
       icon: { default: "file" },
-      media: { default: null },
+      media: {
+        default: null,
+        parseHTML: (element) =>
+          parseMentionItemMedia(element.getAttribute("data-media")),
+        renderHTML: (attributes) =>
+          attributes.media
+            ? { "data-media": JSON.stringify(attributes.media) }
+            : {},
+      },
       source: { default: "" },
       refType: { default: "file" },
       refId: { default: null },

--- a/packages/toolkit/src/composer/index.ts
+++ b/packages/toolkit/src/composer/index.ts
@@ -81,6 +81,8 @@ export type {
   FileResult,
   SkillResult,
   MentionItem,
+  MentionItemMedia,
+  MentionReferenceInsert,
   Reference,
   SlashCommand,
 } from "./types.js";

--- a/packages/toolkit/src/composer/runtime-adapters.tsx
+++ b/packages/toolkit/src/composer/runtime-adapters.tsx
@@ -6,6 +6,8 @@ import {
   type ReactNode,
 } from "react";
 
+import type { MentionItemMedia } from "./types.js";
+
 export type ComposerTranslate = (
   key: string,
   options?: Record<string, unknown>,
@@ -86,6 +88,7 @@ export interface ComposerBuilderConnectFlowOptions {
 export interface AgentComposerReference {
   label: string;
   icon?: string;
+  media?: MentionItemMedia;
   source?: string;
   refType: string;
   refId?: string | null;

--- a/packages/toolkit/src/composer/types.ts
+++ b/packages/toolkit/src/composer/types.ts
@@ -12,11 +12,32 @@ export interface SkillResult {
   source: "codebase" | "resource";
 }
 
+export type MentionItemMedia =
+  | {
+      type: "text";
+      /** Short text shown inside the media frame, such as an emoji or initials. */
+      text: string;
+      /** Optional CSS color used behind the text. */
+      backgroundColor?: string;
+    }
+  | {
+      type: "image";
+      /** Image URL shown inside the media frame. Relative URLs are supported. */
+      src: string;
+      /** How the image fits the frame. Defaults to contain. */
+      fit?: "contain" | "cover";
+      /** Optional CSS color visible behind contained images. */
+      backgroundColor?: string;
+    }
+  | { type: "none" };
+
 export interface MentionItem {
   id: string;
   label: string;
   description?: string;
   icon?: string;
+  /** Optional presentation that takes precedence over the legacy icon. */
+  media?: MentionItemMedia;
   source: string;
   refType: string;
   refPath?: string;
@@ -44,6 +65,8 @@ export interface Reference {
 export interface MentionReferenceInsert {
   label: string;
   icon?: string;
+  /** Optional presentation that takes precedence over the legacy icon. */
+  media?: MentionItemMedia;
   source?: string;
   refType: string;
   refId?: string | null;


### PR DESCRIPTION
### Summary

* Let mention providers show custom text, images, or no leading media.
* Render custom media consistently in the mention picker and inline composer references.
* Preserve the existing icon rendering for providers that do not opt in.

### Why

Custom mention providers can currently only choose from the framework's fixed icons. This makes different resources harder to identify and leaves apps to fork the shared composer when they need custom presentation.

Providers can now supply their own text or image, or omit leading media entirely, while existing providers keep the same UI without any changes.

### Changes

* Add a public `MentionItemMedia` contract for text, image, and icon-free variants.
* Carry mention media through the server and client mention contracts.
* Add a shared Toolkit renderer for the mention picker and inline references.
* Validate incoming values and preserve the existing icon fallback for absent or invalid media.
* Preserve mention media when HTML composer drafts are saved and restored.
* Add focused regression coverage and package changesets.

### UI

<img width="1200" height="720" alt="image" src="https://github.com/user-attachments/assets/1513e8e7-2ec3-4420-9fc3-d6d20f4c42e7" />


### Tests

* [x] Unit tests: `pnpm --filter @agent-native/toolkit test -- --run` — 422 passed
* [x] Core tests: `pnpm --filter @agent-native/core exec vitest --run src/client/agent-chat.spec.ts` — 39 passed
* [x] Integration/E2E: `pnpm qa:standalone-chat-dev` — passed
* [x] Typecheck: Core and Toolkit passed
* [x] Build: Core and Toolkit passed
* [x] Lint/format: `oxfmt`, `oxlint`, and `git diff --check` passed
* [x] Relevant architecture and package guards passed

The standalone Chat smoke covered scaffold, install, dev startup, auto-login, `/agent`, and the normal Chat surface without SSR or browser errors.

### Risk / Rollback

* Risk: Low. Custom media is opt-in, and existing mention providers retain their previous icon rendering.
* No database or data migration is required.
* Rollback plan: revert this pull request.

### Checklist

* [x] No secrets or credentials added
* [x] Backwards compatible
* [x] Public types and package changesets updated
* [x] Existing Chat composer behavior preserved