### PR TITLE
fix(core): stop replayed provider auth failures from looping

### DIFF
--- a/.changeset/replay-auth-failure.md
+++ b/.changeset/replay-auth-failure.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop SQL-replayed provider authentication failures from self-continuing.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -10933,6 +10933,20 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
         continuationCount: 0,
       }),
     ).toBe(true);
+
+    expect(
+      shouldChainBackgroundContinuation({
+        isBackgroundWorker: true,
+        run: makeRun([
+          {
+            type: "error",
+            error: "Missing Authentication header",
+            errorCode: "http_401",
+          },
+        ]),
+        continuationCount: 0,
+      }),
+    ).toBe(false);
   });
 
   it("preserves the specific continuation reason for recoverable background errors", () => {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -62,7 +62,6 @@ vi.mock("./run-store.js", () => ({
           type: "error",
           error: detail || "The agent run failed.",
           ...(code && code !== "unknown" ? { errorCode: code } : {}),
-          recoverable: true,
         },
         shouldPersist: true,
       };
@@ -3607,7 +3606,6 @@ describe("run manager soft timeout", () => {
       expect.objectContaining({
         type: "error",
         error: "Connection error.",
-        recoverable: true,
       }),
     );
   });

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -242,6 +242,7 @@ const {
   BACKGROUND_PROCESSING_RUN_STALE_MS,
   BACKGROUND_RUN_STALE_MS,
   RUN_STALE_MS,
+  resolveErroredRunTerminalEvent,
 } = await import("./run-store.js");
 
 // Mock storage for ledger SELECT responses, keyed by toolKey
@@ -271,6 +272,20 @@ describe("run store", () => {
     abortRowsAffected = 1;
     __resetNoRunningRunsProbeForTests();
     vi.clearAllMocks();
+  });
+
+  it("does not mark replayed provider auth failures recoverable", () => {
+    const resolved = resolveErroredRunTerminalEvent({
+      errorCode: "http_401",
+      errorDetail: "Missing Authentication header",
+    });
+
+    expect(resolved.event).toEqual({
+      type: "error",
+      error: "Missing Authentication header",
+      errorCode: "http_401",
+    });
+    expect(resolved.event).not.toHaveProperty("recoverable");
   });
 
   it("readBackgroundRunClaim parses dispatch_mode + status + diag_stage + liveness, or null when missing", async () => {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -2616,7 +2616,6 @@ export function resolveErroredRunTerminalEvent(run: {
         type: "error",
         error: detail || "The agent run failed.",
         ...(code && code !== "unknown" ? { errorCode: code } : {}),
-        recoverable: true,
       },
       shouldPersist: true,
     };


### PR DESCRIPTION
## Summary
- Stop the SQL/SSE replay fallback from fabricating recoverable=true for stored errors, which could turn a persisted provider 401 into a background continuation.
- Add regressions for replayed http_401 payloads and background-chain decisions.
- Fixes the linked Slack report: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787671716160729

## Verification
- Focused Core suites: 506 passed; the two remaining handler failures are local better-sqlite3 binding setup failures.
- Focused regression selection: 5 passed.
- pnpm guards: only pre-existing i18n baseline/dependency-import and migration-manifest inventory failures remain.