### PR TITLE
Compile PostHog transcript bounding without Array.findLast

### DIFF
--- a/.changeset/es2022-bound-ai-content.md
+++ b/.changeset/es2022-bound-ai-content.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Compile oversized PostHog transcript bounding against ES2022 by walking the last user message instead of using `Array.findLast`.

--- a/packages/core/src/observability/posthog-ai.ts
+++ b/packages/core/src/observability/posthog-ai.ts
@@ -139,12 +139,19 @@ export function boundAiContent(value: unknown): {
     // What was ASKED is the one thing worth rescuing from an oversized
     // transcript: the rest is context the thread itself still holds, and
     // keeping as much of it as fits just ships the ceiling on every event.
-    const lastUser = value.findLast(
-      (entry) =>
+    // `findLast` is ES2023; this package compiles with lib ES2022.
+    let lastUser: unknown;
+    for (let i = value.length - 1; i >= 0; i -= 1) {
+      const entry = value[i];
+      if (
         !!entry &&
         typeof entry === "object" &&
-        (entry as { role?: unknown }).role === "user",
-    );
+        (entry as { role?: unknown }).role === "user"
+      ) {
+        lastUser = entry;
+        break;
+      }
+    }
     const kept =
       lastUser !== undefined &&
       utf8Bytes(JSON.stringify(lastUser) ?? "null") <=


### PR DESCRIPTION
## Summary
- `boundAiContent` now walks the last user message with an ES2022 loop instead of `Array.findLast`, which `packages/core` cannot type-check under `lib: ES2022`.
- This unblocks Netlify `pnpm install` / core `tsc` on PRs that compile `@agent-native/core`.

## Test plan
- [x] `vitest --run packages/core/src/observability/posthog-ai.spec.ts` (17 passed)
- [x] `packages/core` `tsc` succeeds
- [ ] Confirm a Git-connected Netlify preview that builds core no longer fails on `findLast`


Made with [Cursor](https://cursor.com)