### PR TITLE
fix(core): support Google Workspace MCP OAuth clients

### DIFF
--- a/.changeset/google-workspace-mcp-oauth.md
+++ b/.changeset/google-workspace-mcp-oauth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use the configured Google OAuth client for official Google Workspace MCP servers.

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -2,16 +2,26 @@ import { mockEvent, type H3Event } from "h3";
 import { describe, expect, it, vi } from "vitest";
 
 const resolveSecretPairMock = vi.hoisted(() => vi.fn());
+const CredentialStoreUnavailableErrorMock = vi.hoisted(
+  () =>
+    class CredentialStoreUnavailableErrorMock extends Error {
+      readonly errorCode = "credential_store_unavailable";
+      readonly retryable = true;
+    },
+);
 
 vi.mock("../server/credential-provider.js", () => ({
+  CredentialStoreUnavailableError: CredentialStoreUnavailableErrorMock,
   resolveSecretPair: resolveSecretPairMock,
 }));
 
+import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
 import {
   clearMcpOAuthFlowCookies,
   isValidMcpOAuthFlow,
   readMcpOAuthFlowCookie,
   redirectWithStagedCookies,
+  resolveMcpOAuthStartError,
   resolveMcpOAuthScope,
   resolveManagedMcpOAuthClient,
   setMcpOAuthFlowCookie,
@@ -293,6 +303,33 @@ describe("managed MCP OAuth clients", () => {
       resolveManagedMcpOAuthClient(new URL("https://mcp.example.com")),
     ).resolves.toBeUndefined();
     expect(resolveSecretPairMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("MCP OAuth start failures", () => {
+  it("preserves credential-store outages as retryable service errors", () => {
+    const result = resolveMcpOAuthStartError(
+      new CredentialStoreUnavailableError("database timeout"),
+    );
+
+    expect(result).toEqual({
+      status: 503,
+      body: {
+        error: "database timeout",
+        errorCode: "credential_store_unavailable",
+        retryable: true,
+      },
+    });
+  });
+
+  it("keeps remote OAuth failures as client errors", () => {
+    expect(resolveMcpOAuthStartError(new Error("discovery failed"))).toEqual({
+      status: 400,
+      body: {
+        error:
+          "This MCP server could not start OAuth. It may not support standard MCP OAuth discovery or dynamic client registration.",
+      },
+    });
   });
 });
 

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -244,6 +244,31 @@ describe("managed MCP OAuth clients", () => {
     });
   });
 
+  it("resolves the shared Google client for official Workspace MCP servers", async () => {
+    resolveSecretMock.mockImplementation(async (key: string) => {
+      if (key === "GOOGLE_CLIENT_ID") return "google-client-id";
+      if (key === "GOOGLE_CLIENT_SECRET") return "google-client-secret";
+      return null;
+    });
+
+    for (const origin of [
+      "https://gmailmcp.googleapis.com",
+      "https://drivemcp.googleapis.com",
+      "https://calendarmcp.googleapis.com",
+      "https://chatmcp.googleapis.com",
+      "https://people.googleapis.com",
+    ]) {
+      await expect(
+        resolveManagedMcpOAuthClient(new URL(`${origin}/mcp/v1`)),
+      ).resolves.toEqual({
+        client_id: "google-client-id",
+        client_secret: "google-client-secret",
+        token_endpoint_auth_method: "client_secret_post",
+      });
+      expect(resolveMcpOAuthScope(new URL(origin), "org")).toBeNull();
+    }
+  });
+
   it("does not resolve a managed client for an unrelated MCP server", async () => {
     resolveSecretMock.mockReset();
 

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -1,10 +1,10 @@
 import { mockEvent, type H3Event } from "h3";
 import { describe, expect, it, vi } from "vitest";
 
-const resolveSecretMock = vi.hoisted(() => vi.fn());
+const resolveSecretPairMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../server/credential-provider.js", () => ({
-  resolveSecret: resolveSecretMock,
+  resolveSecretPair: resolveSecretPairMock,
 }));
 
 import {
@@ -221,6 +221,16 @@ describe("managed MCP OAuth clients", () => {
       resolveMcpOAuthScope(new URL("https://mcp.hubspot.com"), "org"),
     ).toBeNull();
     expect(
+      resolveMcpOAuthScope(new URL("https://mcp.hubspot.com"), "org", {
+        allowManagedOrgReconnect: true,
+      }),
+    ).toBe("org");
+    expect(
+      resolveMcpOAuthScope(new URL("https://drivemcp.googleapis.com"), "org", {
+        allowManagedOrgReconnect: true,
+      }),
+    ).toBe("org");
+    expect(
       resolveMcpOAuthScope(new URL("https://mcp.hubspot.com"), "user"),
     ).toBe("user");
     expect(
@@ -229,11 +239,13 @@ describe("managed MCP OAuth clients", () => {
   });
 
   it("resolves the workspace HubSpot client without exposing its secret to the browser", async () => {
-    resolveSecretMock.mockImplementation(async (key: string) => {
-      if (key === "HUBSPOT_MCP_CLIENT_ID") return "hubspot-client-id";
-      if (key === "HUBSPOT_MCP_CLIENT_SECRET") return "hubspot-client-secret";
-      return null;
-    });
+    resolveSecretPairMock.mockImplementation(
+      async ([clientIdKey, clientSecretKey]: [string, string]) =>
+        clientIdKey === "HUBSPOT_MCP_CLIENT_ID" &&
+        clientSecretKey === "HUBSPOT_MCP_CLIENT_SECRET"
+          ? ["hubspot-client-id", "hubspot-client-secret"]
+          : null,
+    );
 
     await expect(
       resolveManagedMcpOAuthClient(new URL("https://mcp.hubspot.com")),
@@ -245,15 +257,20 @@ describe("managed MCP OAuth clients", () => {
   });
 
   it("resolves the shared Google client for official Workspace MCP servers", async () => {
-    resolveSecretMock.mockImplementation(async (key: string) => {
-      if (key === "GOOGLE_CLIENT_ID") return "google-client-id";
-      if (key === "GOOGLE_CLIENT_SECRET") return "google-client-secret";
-      return null;
-    });
+    resolveSecretPairMock.mockImplementation(
+      async ([clientIdKey, clientSecretKey]: [string, string]) =>
+        clientIdKey === "GOOGLE_CLIENT_ID" &&
+        clientSecretKey === "GOOGLE_CLIENT_SECRET"
+          ? ["google-client-id", "google-client-secret"]
+          : null,
+    );
 
     for (const origin of [
       "https://gmailmcp.googleapis.com",
       "https://drivemcp.googleapis.com",
+      "https://docsmcp.googleapis.com",
+      "https://sheetsmcp.googleapis.com",
+      "https://slidesmcp.googleapis.com",
       "https://calendarmcp.googleapis.com",
       "https://chatmcp.googleapis.com",
       "https://people.googleapis.com",
@@ -270,12 +287,12 @@ describe("managed MCP OAuth clients", () => {
   });
 
   it("does not resolve a managed client for an unrelated MCP server", async () => {
-    resolveSecretMock.mockReset();
+    resolveSecretPairMock.mockReset();
 
     await expect(
       resolveManagedMcpOAuthClient(new URL("https://mcp.example.com")),
     ).resolves.toBeUndefined();
-    expect(resolveSecretMock).not.toHaveBeenCalled();
+    expect(resolveSecretPairMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -267,7 +267,7 @@ async function handleMcpOAuthStart(
       setResponseStatus(event, 400);
       return {
         error:
-          "HubSpot personal MCP connect is not configured for this workspace. A workspace owner must register the HubSpot MCP Auth App once; after that, any workspace member can connect a personal account.",
+          "Managed MCP OAuth is not configured for this workspace. A workspace owner must register the OAuth client once; after that, any workspace member can connect a personal account.",
       };
     }
     const flow: McpOAuthFlow = {

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -16,7 +16,7 @@ import {
 import { getOrgContext } from "../org/context.js";
 import { decryptSecretValue, encryptSecretValue } from "../secrets/crypto.js";
 import { getSession, safeReturnPath } from "../server/auth.js";
-import { resolveSecret } from "../server/credential-provider.js";
+import { resolveSecretPair } from "../server/credential-provider.js";
 import { getH3App } from "../server/framework-request-handler.js";
 import {
   getAppBasePath,
@@ -47,32 +47,28 @@ const CHUNKED_COOKIE_PREFIX = "__chunked__";
 
 const MANAGED_MCP_OAUTH_CLIENTS: ReadonlyArray<{
   serverOrigins: ReadonlyArray<string>;
-  clientIdKeys: ReadonlyArray<string>;
-  clientSecretKeys: ReadonlyArray<string>;
+  credentialPairs: ReadonlyArray<readonly [string, string]>;
 }> = [
   {
     serverOrigins: ["https://mcp.hubspot.com"],
-    clientIdKeys: [
-      "HUBSPOT_MCP_CLIENT_ID",
-      "HUBSPOT_INTEGRATION_CLIENT_ID",
-      "HUBSPOT_CLIENT_ID",
-    ],
-    clientSecretKeys: [
-      "HUBSPOT_MCP_CLIENT_SECRET",
-      "HUBSPOT_INTEGRATION_CLIENT_SECRET",
-      "HUBSPOT_CLIENT_SECRET",
+    credentialPairs: [
+      ["HUBSPOT_MCP_CLIENT_ID", "HUBSPOT_MCP_CLIENT_SECRET"],
+      ["HUBSPOT_INTEGRATION_CLIENT_ID", "HUBSPOT_INTEGRATION_CLIENT_SECRET"],
+      ["HUBSPOT_CLIENT_ID", "HUBSPOT_CLIENT_SECRET"],
     ],
   },
   {
     serverOrigins: [
       "https://gmailmcp.googleapis.com",
       "https://drivemcp.googleapis.com",
+      "https://docsmcp.googleapis.com",
+      "https://sheetsmcp.googleapis.com",
+      "https://slidesmcp.googleapis.com",
       "https://calendarmcp.googleapis.com",
       "https://chatmcp.googleapis.com",
       "https://people.googleapis.com",
     ],
-    clientIdKeys: ["GOOGLE_CLIENT_ID"],
-    clientSecretKeys: ["GOOGLE_CLIENT_SECRET"],
+    credentialPairs: [["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]],
   },
 ];
 
@@ -205,7 +201,10 @@ async function handleMcpOAuthStart(
     return { error: "MCP server name is invalid." };
   }
 
-  const requestedScope = resolveMcpOAuthScope(urlCheck.url!, query.scope);
+  const requestedScope = resolveMcpOAuthScope(urlCheck.url!, query.scope, {
+    allowManagedOrgReconnect:
+      reconnectScope === "org" && Boolean(reconnectServer),
+  });
   if (!requestedScope) {
     setResponseStatus(event, 400);
     return {
@@ -310,8 +309,13 @@ function isManagedMcpOAuthServer(serverUrl: URL): boolean {
 export function resolveMcpOAuthScope(
   serverUrl: URL,
   requestedScope: unknown,
+  options?: { allowManagedOrgReconnect?: boolean },
 ): RemoteMcpScope | null {
-  if (isManagedMcpOAuthServer(serverUrl) && requestedScope === "org") {
+  if (
+    isManagedMcpOAuthServer(serverUrl) &&
+    requestedScope === "org" &&
+    !options?.allowManagedOrgReconnect
+  ) {
     return null;
   }
   return requestedScope === "org" ? "org" : "user";
@@ -340,12 +344,10 @@ export async function resolveManagedMcpOAuthClient(
   );
   if (!client) return undefined;
 
-  for (let index = 0; index < client.clientIdKeys.length; index += 1) {
-    const [clientId, clientSecret] = await Promise.all([
-      resolveSecret(client.clientIdKeys[index]),
-      resolveSecret(client.clientSecretKeys[index]),
-    ]);
-    if (clientId && clientSecret) {
+  for (const [clientIdKey, clientSecretKey] of client.credentialPairs) {
+    const credentials = await resolveSecretPair([clientIdKey, clientSecretKey]);
+    if (credentials) {
+      const [clientId, clientSecret] = credentials;
       return {
         client_id: clientId,
         client_secret: clientSecret,

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -16,7 +16,10 @@ import {
 import { getOrgContext } from "../org/context.js";
 import { decryptSecretValue, encryptSecretValue } from "../secrets/crypto.js";
 import { getSession, safeReturnPath } from "../server/auth.js";
-import { resolveSecretPair } from "../server/credential-provider.js";
+import {
+  CredentialStoreUnavailableError,
+  resolveSecretPair,
+} from "../server/credential-provider.js";
 import { getH3App } from "../server/framework-request-handler.js";
 import {
   getAppBasePath,
@@ -291,13 +294,34 @@ async function handleMcpOAuthStart(
     };
     setMcpOAuthFlowCookie(event, flow, redirectUri.startsWith("https://"));
     return redirectWithStagedCookies(event, started.authorizationUrl.href);
-  } catch {
-    setResponseStatus(event, 400);
+  } catch (error) {
+    const failure = resolveMcpOAuthStartError(error);
+    setResponseStatus(event, failure.status);
+    return failure.body;
+  }
+}
+
+export function resolveMcpOAuthStartError(error: unknown): {
+  status: 400 | 503;
+  body: { error: string; errorCode?: string; retryable?: boolean };
+} {
+  if (error instanceof CredentialStoreUnavailableError) {
     return {
-      error:
-        "This MCP server could not start OAuth. It may not support standard MCP OAuth discovery or dynamic client registration.",
+      status: 503,
+      body: {
+        error: error.message,
+        errorCode: error.errorCode,
+        retryable: error.retryable,
+      },
     };
   }
+  return {
+    status: 400,
+    body: {
+      error:
+        "This MCP server could not start OAuth. It may not support standard MCP OAuth discovery or dynamic client registration.",
+    },
+  };
 }
 
 function isManagedMcpOAuthServer(serverUrl: URL): boolean {

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -45,9 +45,13 @@ const FLOW_COOKIE_CHUNK_SIZE = 2_800;
 const FLOW_COOKIE_MAX_CHUNKS = 8;
 const CHUNKED_COOKIE_PREFIX = "__chunked__";
 
-const MANAGED_MCP_OAUTH_CLIENTS = [
+const MANAGED_MCP_OAUTH_CLIENTS: ReadonlyArray<{
+  serverOrigins: ReadonlyArray<string>;
+  clientIdKeys: ReadonlyArray<string>;
+  clientSecretKeys: ReadonlyArray<string>;
+}> = [
   {
-    serverOrigin: "https://mcp.hubspot.com",
+    serverOrigins: ["https://mcp.hubspot.com"],
     clientIdKeys: [
       "HUBSPOT_MCP_CLIENT_ID",
       "HUBSPOT_INTEGRATION_CLIENT_ID",
@@ -59,7 +63,18 @@ const MANAGED_MCP_OAUTH_CLIENTS = [
       "HUBSPOT_CLIENT_SECRET",
     ],
   },
-] as const;
+  {
+    serverOrigins: [
+      "https://gmailmcp.googleapis.com",
+      "https://drivemcp.googleapis.com",
+      "https://calendarmcp.googleapis.com",
+      "https://chatmcp.googleapis.com",
+      "https://people.googleapis.com",
+    ],
+    clientIdKeys: ["GOOGLE_CLIENT_ID"],
+    clientSecretKeys: ["GOOGLE_CLIENT_SECRET"],
+  },
+];
 
 export interface McpOAuthFlow {
   name: string;
@@ -287,8 +302,8 @@ async function handleMcpOAuthStart(
 }
 
 function isManagedMcpOAuthServer(serverUrl: URL): boolean {
-  return MANAGED_MCP_OAUTH_CLIENTS.some(
-    (client) => client.serverOrigin === serverUrl.origin,
+  return MANAGED_MCP_OAUTH_CLIENTS.some((client) =>
+    client.serverOrigins.includes(serverUrl.origin),
   );
 }
 
@@ -320,8 +335,8 @@ export function stripMcpOAuthAppBasePath(
 export async function resolveManagedMcpOAuthClient(
   serverUrl: URL,
 ): Promise<StoredOAuthClientInformation | undefined> {
-  const client = MANAGED_MCP_OAUTH_CLIENTS.find(
-    (candidate) => candidate.serverOrigin === serverUrl.origin,
+  const client = MANAGED_MCP_OAUTH_CLIENTS.find((candidate) =>
+    candidate.serverOrigins.includes(serverUrl.origin),
   );
   if (!client) return undefined;
 

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -71,6 +71,7 @@ import {
   resolveHasBuilderPrivateKey,
   resolveHasCompleteBuilderConnection,
   resolveSecret,
+  resolveSecretPair,
   resolveSecretDetailed,
 } from "./credential-provider.js";
 
@@ -138,6 +139,7 @@ beforeEach(() => {
   delete process.env.EMAIL_INBOUND_WEBHOOK_SECRET;
   delete process.env.RESEND_API_KEY;
   delete process.env.SENDGRID_API_KEY;
+  delete process.env.GOOGLE_CLIENT_ID;
   delete process.env.GOOGLE_CLIENT_SECRET;
   delete process.env.GITHUB_TOKEN;
   mockReadAppSecret.mockResolvedValue(null);
@@ -1407,6 +1409,53 @@ describe("resolveSecret (generic)", () => {
     mockGetRequestUserEmail.mockReturnValue(undefined);
     expect(await resolveSecret("SOME_KEY")).toBe("v");
     delete process.env.SOME_KEY;
+  });
+});
+
+describe("resolveSecretPair", () => {
+  it("uses a complete pair from the highest-precedence scope", async () => {
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    mockReadAppSecrets.mockImplementation(async ({ scope }: any) =>
+      scope === "user"
+        ? new Map([
+            ["GOOGLE_CLIENT_ID", { value: "user-client" }],
+            ["GOOGLE_CLIENT_SECRET", { value: "user-secret" }],
+          ])
+        : new Map(),
+    );
+
+    await expect(
+      resolveSecretPair(["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]),
+    ).resolves.toEqual(["user-client", "user-secret"]);
+  });
+
+  it("falls back to a complete environment pair instead of mixing sources", async () => {
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    process.env.GOOGLE_CLIENT_ID = "environment-client";
+    process.env.GOOGLE_CLIENT_SECRET = "environment-secret";
+    mockReadAppSecrets.mockImplementation(async ({ scope }: any) =>
+      scope === "user"
+        ? new Map([["GOOGLE_CLIENT_ID", { value: "scoped-client" }]])
+        : new Map(),
+    );
+
+    await expect(
+      resolveSecretPair(["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]),
+    ).resolves.toEqual(["environment-client", "environment-secret"]);
+  });
+
+  it("rejects an incomplete mixed-source pair", async () => {
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    process.env.GOOGLE_CLIENT_SECRET = "environment-secret";
+    mockReadAppSecrets.mockImplementation(async ({ scope }: any) =>
+      scope === "user"
+        ? new Map([["GOOGLE_CLIENT_ID", { value: "scoped-client" }]])
+        : new Map(),
+    );
+
+    await expect(
+      resolveSecretPair(["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]),
+    ).resolves.toBeNull();
   });
 });
 

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -1693,6 +1693,99 @@ export async function resolveSecret(key: string): Promise<string | null> {
 }
 
 /**
+ * Resolve two related secrets from one scope/source. A complete lower-
+ * precedence pair wins over mixing a partial override with another source.
+ */
+export async function resolveSecretPair(
+  keys: readonly [string, string],
+): Promise<[string, string] | null> {
+  const [firstKey, secondKey] = keys;
+  const readPair = async (
+    scope: "user" | "org" | "workspace",
+    scopeId: string,
+  ): Promise<[string, string] | null> => {
+    const { readAppSecrets } = await import("../secrets/storage.js");
+    const secrets = await readAppSecrets({ keys, scope, scopeId });
+    const first = secrets.get(firstKey)?.value;
+    const second = secrets.get(secondKey)?.value;
+    return first && second ? [first, second] : null;
+  };
+  const readEnvironmentPair = (): [string, string] | null => {
+    if (
+      !canUseDeployCredentialFallbackForRequest(firstKey) ||
+      !canUseDeployCredentialFallbackForRequest(secondKey)
+    ) {
+      return null;
+    }
+    const first = process.env[firstKey];
+    const second = process.env[secondKey];
+    return first && second ? [first, second] : null;
+  };
+
+  const email = getRequestUserEmail();
+  if (!email) return readEnvironmentPair();
+
+  let lookupFailed = false;
+  let cause: unknown;
+  try {
+    let pair = await readPair("user", email);
+    if (pair) return pair;
+
+    let orgId: string | null | undefined = getRequestOrgId();
+    if (!orgId) {
+      const resolved = await resolveOrgIdForRequestEmail(email);
+      cause = resolved.cause;
+      lookupFailed = cause !== undefined;
+      orgId = resolved.orgId;
+    }
+
+    if (lookupFailed) {
+      const environmentPair = readEnvironmentPair();
+      if (environmentPair) return environmentPair;
+      assertCredentialStoreReadable({ lookupFailed, cause });
+      return null;
+    }
+
+    if (orgId) {
+      pair = await readPair("org", orgId);
+      if (pair) return pair;
+      pair = await readPair("workspace", orgId);
+      if (pair) return pair;
+    }
+
+    pair = await readPair("workspace", `solo:${email}`);
+    if (pair) return pair;
+
+    const vaultOrgId = process.env.AGENT_VAULT_ORG_ID?.trim();
+    if (vaultOrgId && vaultOrgId !== orgId) {
+      const access = await Promise.all(
+        keys.map((key) => canReadDesignatedVaultFallback(vaultOrgId, key)),
+      );
+      const unavailable = access.find(
+        (result) => result.status === "unavailable",
+      );
+      if (unavailable?.status === "unavailable") {
+        lookupFailed = true;
+        cause = unavailable.cause;
+      } else if (access.every((result) => result.status === "allowed")) {
+        pair = await readPair("org", vaultOrgId);
+        if (pair) return pair;
+        pair = await readPair("workspace", vaultOrgId);
+        if (pair) return pair;
+      }
+    }
+  } catch (error) {
+    lookupFailed = true;
+    cause = error;
+  }
+
+  const environmentPair = readEnvironmentPair();
+  if (environmentPair) return environmentPair;
+  assertCredentialStoreReadable({ lookupFailed, cause });
+  return null;
+}
+
+/**
  * `resolveSecret` without the throw: reports whether the miss is definitive
  * (`lookupFailed: false` — no such row anywhere the caller can reach) or just
  * unknown (`lookupFailed: true` — the store or the org membership behind it


### PR DESCRIPTION
## Summary

- resolve the existing Google OAuth client for official Google Workspace MCP server origins
- keep new managed Google MCP connections personal-scoped while allowing authorized reconnects of existing org-scoped records
- resolve OAuth client ID and secret as an atomic pair at one credential scope
- add focused coverage for Gmail, Drive, Docs, Sheets, Slides, Calendar, Chat, and People MCP servers

## Validation

- corepack pnpm --filter @agent-native/core exec vitest run src/mcp-client/oauth-routes.spec.ts
- corepack pnpm --filter @agent-native/core exec vitest run src/server/credential-provider.spec.ts
- corepack pnpm --filter @agent-native/core typecheck
- corepack pnpm guards
- npx agent-native doctor --only no-env-credentials from apps/3dot0-faq

Source report: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787674636609879
