### PR TITLE
fix(dispatch): keep integrations available during credential outages

### DIFF
--- a/templates/dispatch/actions/list-workspace-connections.ts
+++ b/templates/dispatch/actions/list-workspace-connections.ts
@@ -9,6 +9,7 @@ import {
   listProviderApiCatalog,
 } from "@agent-native/core/provider-api";
 import {
+  CredentialStoreUnavailableError,
   hasWorkspaceProviderOAuthCredentials,
   isGoogleWorkspaceOAuthProvider,
 } from "@agent-native/core/server";
@@ -50,7 +51,7 @@ type GrantSummary = {
   lastUsedAt?: string | null;
 };
 
-type GoogleOAuthAvailability = "configured" | "unconfigured";
+type GoogleOAuthAvailability = "configured" | "unconfigured" | "unavailable";
 
 function unique(values: string[]) {
   return Array.from(
@@ -129,10 +130,17 @@ export default defineAction({
         | WorkspaceConnectionTemplateUse
         | undefined,
     });
-    const googleOAuthAvailability: GoogleOAuthAvailability =
-      (await hasWorkspaceProviderOAuthCredentials("gmail"))
+    let googleOAuthAvailability: GoogleOAuthAvailability;
+    try {
+      googleOAuthAvailability = (await hasWorkspaceProviderOAuthCredentials(
+        "gmail",
+      ))
         ? "configured"
         : "unconfigured";
+    } catch (error) {
+      if (!(error instanceof CredentialStoreUnavailableError)) throw error;
+      googleOAuthAvailability = "unavailable";
+    }
     const googleOAuthConfigured = googleOAuthAvailability === "configured";
     const providers = catalogProviders.filter(
       (provider) =>
@@ -274,7 +282,7 @@ export default defineAction({
       availability: {
         googleOAuth: {
           status: googleOAuthAvailability,
-          retryable: false,
+          retryable: googleOAuthAvailability === "unavailable",
         },
       },
       providers: providersWithReadiness,

--- a/templates/dispatch/app/routes/integrations.tsx
+++ b/templates/dispatch/app/routes/integrations.tsx
@@ -221,6 +221,12 @@ interface WorkspaceConnectionGrantSummary {
 }
 
 interface WorkspaceConnectionsResponse {
+  availability?: {
+    googleOAuth: {
+      status: "configured" | "unconfigured" | "unavailable";
+      retryable: boolean;
+    };
+  };
   providers: WorkspaceConnectionProvider[];
   connections: WorkspaceConnection[];
   grants: WorkspaceConnectionGrant[];
@@ -2719,6 +2725,9 @@ export default function WorkspaceIntegrationsRoute() {
     EMPTY_RESPONSE) as WorkspaceConnectionsResponse;
   const providers = data.providers;
   const connections = data.connections;
+  const googleOAuthUnavailable =
+    data.availability?.googleOAuth.status === "unavailable" &&
+    data.availability.googleOAuth.retryable;
   const apps = (appsQuery.data ?? []) as WorkspaceAppSummary[];
   const groups = (groupsQuery.data ?? []) as WorkspaceUserGroup[];
   const providersById = useMemo(
@@ -3151,6 +3160,9 @@ export default function WorkspaceIntegrationsRoute() {
               void appsQuery.refetch();
             }}
           />
+        ) : null}
+        {googleOAuthUnavailable ? (
+          <ActionQueryError onRetry={() => void connectionsQuery.refetch()} />
         ) : null}
         {!connectionsQuery.isError && !appsQuery.isError ? (
           <>

--- a/templates/dispatch/server/actions/list-workspace-connections.spec.ts
+++ b/templates/dispatch/server/actions/list-workspace-connections.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class MockCredentialStoreUnavailableError extends Error {
+    constructor() {
+      super("Credential store unavailable");
+      this.name = "CredentialStoreUnavailableError";
+    }
+  }
+
+  return {
+    CredentialStoreUnavailableError: MockCredentialStoreUnavailableError,
+    getWorkspaceConnectionAppAccess: vi.fn(() => ({
+      available: true,
+      mode: "all-apps",
+      grantId: null,
+    })),
+    hasWorkspaceProviderOAuthCredentials: vi.fn(),
+    isProviderApiId: vi.fn(() => false),
+    listProviderApiCatalog: vi.fn(() => []),
+    listWorkspaceConnectionGrants: vi.fn(),
+    listWorkspaceConnectionProviders: vi.fn(),
+    listWorkspaceConnections: vi.fn(),
+    summarizeWorkspaceConnectionProviderReadiness: vi.fn(() => ({
+      status: "ready",
+      connectionCount: 1,
+      activeConnectionCount: 1,
+      readyConnectionCount: 1,
+      requiredCredentialKeys: [],
+      missingRequiredCredentialKeys: [],
+    })),
+  };
+});
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: <T>(options: T) => options,
+}));
+
+vi.mock("@agent-native/core/connections", () => ({
+  listWorkspaceConnectionProviders: mocks.listWorkspaceConnectionProviders,
+}));
+
+vi.mock("@agent-native/core/provider-api", () => ({
+  isProviderApiId: mocks.isProviderApiId,
+  listProviderApiCatalog: mocks.listProviderApiCatalog,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  CredentialStoreUnavailableError: mocks.CredentialStoreUnavailableError,
+  hasWorkspaceProviderOAuthCredentials:
+    mocks.hasWorkspaceProviderOAuthCredentials,
+  isGoogleWorkspaceOAuthProvider: (provider: string) => provider === "gmail",
+}));
+
+vi.mock("@agent-native/core/workspace-connections", () => ({
+  getWorkspaceConnectionAppAccess: mocks.getWorkspaceConnectionAppAccess,
+  listWorkspaceConnectionGrants: mocks.listWorkspaceConnectionGrants,
+  listWorkspaceConnections: mocks.listWorkspaceConnections,
+  summarizeWorkspaceConnectionProviderReadiness:
+    mocks.summarizeWorkspaceConnectionProviderReadiness,
+}));
+
+vi.mock("@agent-native/dispatch/actions", () => ({
+  dispatchActions: {
+    "list-workspace-apps": {
+      run: vi.fn(async () => [
+        { id: "dispatch", name: "Dispatch", status: "ready" },
+      ]),
+    },
+  },
+}));
+
+const action = (await import("../../actions/list-workspace-connections.js"))
+  .default;
+
+describe("list-workspace-connections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasWorkspaceProviderOAuthCredentials.mockRejectedValue(
+      new mocks.CredentialStoreUnavailableError(),
+    );
+    mocks.listWorkspaceConnectionProviders.mockReturnValue([
+      { id: "gmail", label: "Gmail" },
+      { id: "slack", label: "Slack" },
+    ]);
+    mocks.listWorkspaceConnections.mockResolvedValue([
+      { id: "google-1", provider: "gmail", allowedApps: [] },
+      { id: "slack-1", provider: "slack", allowedApps: [] },
+    ]);
+    mocks.listWorkspaceConnectionGrants.mockResolvedValue([
+      {
+        id: "google-grant",
+        connectionId: "google-1",
+        provider: "gmail",
+        appId: "dispatch",
+      },
+      {
+        id: "slack-grant",
+        connectionId: "slack-1",
+        provider: "slack",
+        appId: "dispatch",
+      },
+    ]);
+  });
+
+  it("returns non-Google integrations when the credential store is unavailable", async () => {
+    const result = await action.run({ includeDisabled: true });
+
+    expect(result.availability.googleOAuth).toEqual({
+      status: "unavailable",
+      retryable: true,
+    });
+    expect(result.providers.map((provider) => provider.id)).toEqual(["slack"]);
+    expect(result.connections.map((connection) => connection.id)).toEqual([
+      "slack-1",
+    ]);
+    expect(result.grants.map((grant) => grant.id)).toEqual([
+      "slack-1:all-apps",
+      "slack-grant",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- classify temporary credential-store outages as retryable
- keep non-Google providers, connections, and grants visible while Google entries are filtered
- add a regression test for the partial response

Fixes the reported [Dispatch integrations Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787674714700589).

## Verification
- `corepack pnpm --dir templates/dispatch test -- server/actions/list-workspace-connections.spec.ts` - 5 files, 41 tests passed
- `corepack pnpm guards` - all 64 checks passed
- `corepack pnpm --dir templates/dispatch typecheck` - completed with expected local production-config warnings for deployment-only auth/database variables
