### PR TITLE
fix(desktop): repair auth, app loading, and runtime error loops

### DIFF
--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -275,6 +275,13 @@ export interface DesktopAppCreationSettings {
   appsRoot: string;
 }
 
+/** `settings` always reflects the current on-disk value, so a rejected update still snaps the UI back to something real. */
+export interface DesktopAppCreationSettingsUpdateResult {
+  ok: boolean;
+  settings: DesktopAppCreationSettings;
+  error?: string;
+}
+
 export interface DesktopCreateAppRequest {
   prompt: string;
   appsRoot?: string;

--- a/packages/desktop-app/src/main/app-store.apps.spec.ts
+++ b/packages/desktop-app/src/main/app-store.apps.spec.ts
@@ -162,3 +162,53 @@ describe("desktop app mode defaults", () => {
     ).toBe(true);
   });
 });
+
+describe("loading a store that cannot be migrated", () => {
+  beforeEach(() => {
+    electronState.userData = fs.mkdtempSync(
+      path.join(os.tmpdir(), "agent-native-app-store-"),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(electronState.userData, { recursive: true, force: true });
+  });
+
+  it("keeps the user's apps when a malformed entry breaks migration", () => {
+    const storePath = path.join(electronState.userData, "app-config.json");
+    const custom = {
+      id: "self-hosted",
+      name: "Self Hosted",
+      icon: "mail",
+      description: "",
+      devPort: 0,
+      url: "https://mail.example.internal",
+      isBuiltIn: false,
+      enabled: true,
+      mode: "prod" as const,
+    };
+    // A single bad element is enough to throw inside migration, which used to
+    // replace the whole file with defaults.
+    fs.writeFileSync(storePath, JSON.stringify([custom, null]));
+
+    const apps = loadApps();
+
+    expect(apps.some((app) => app.id === "self-hosted")).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(
+      onDisk.some(
+        (app: { id?: string } | null) => app && app.id === "self-hosted",
+      ),
+    ).toBe(true);
+  });
+
+  it("seeds defaults when the store is unparseable", () => {
+    const storePath = path.join(electronState.userData, "app-config.json");
+    fs.writeFileSync(storePath, "{ not json");
+
+    const apps = loadApps();
+
+    expect(apps.length).toBeGreaterThan(0);
+    expect(apps.every((app) => app.mode === "prod")).toBe(true);
+  });
+});

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -677,10 +677,28 @@ function getStorePath(): string {
   return path.join(app.getPath("userData"), STORE_FILE);
 }
 
+function seedDefaultApps(): AppConfig[] {
+  const apps = defaultApps();
+  saveApps(apps);
+  saveDesktopAppPreferences({
+    appModeDefaultsVersion: DESKTOP_APP_MODE_DEFAULTS_VERSION,
+  });
+  return apps;
+}
+
 export function loadApps(): AppConfig[] {
+  let parsed: unknown;
   try {
-    const raw = fs.readFileSync(getStorePath(), "utf-8");
-    let apps = JSON.parse(raw) as AppConfig[];
+    parsed = JSON.parse(fs.readFileSync(getStorePath(), "utf-8"));
+  } catch {
+    // Nothing readable is stored yet. A first launch and a file we cannot parse
+    // at all are the only cases where writing defaults over the store is right.
+    return seedDefaultApps();
+  }
+  if (!Array.isArray(parsed)) return seedDefaultApps();
+
+  try {
+    let apps = parsed as AppConfig[];
     // Migrations
     let migrated = false;
 
@@ -771,14 +789,17 @@ export function loadApps(): AppConfig[] {
 
     if (migrated) saveApps(apps);
     return apps;
-  } catch {
-    // First launch or corrupted — seed with defaults
-    const apps = defaultApps();
-    saveApps(apps);
-    saveDesktopAppPreferences({
-      appModeDefaultsVersion: DESKTOP_APP_MODE_DEFAULTS_VERSION,
-    });
-    return apps;
+  } catch (error) {
+    // The store parsed, so anything failing past this point is migration or the
+    // write itself — a malformed entry, or a transient ENOSPC/EACCES. Seeding
+    // defaults here would turn that into permanent loss of the user's custom
+    // and self-hosted apps, so return what was stored and leave the file alone
+    // to be retried on the next launch.
+    console.error(
+      "[app-store] keeping stored apps unmigrated after a load failure",
+      error,
+    );
+    return parsed as AppConfig[];
   }
 }
 

--- a/packages/desktop-app/src/main/codex-subscription.spec.ts
+++ b/packages/desktop-app/src/main/codex-subscription.spec.ts
@@ -631,6 +631,55 @@ describe("CodexSubscriptionAdapter", () => {
     expect(status.telemetry.meters[0]).not.toHaveProperty("label");
   });
 
+  it("keeps retrying respawns across two consecutive failures while stale", async () => {
+    vi.useFakeTimers();
+    try {
+      let initializeCalls = 0;
+      const client = createClient([]);
+      client.request.mockImplementation(async (method: string) => {
+        if (method === "initialize") {
+          initializeCalls += 1;
+          // The first respawn (inside start()) succeeds; every respawn
+          // triggered by a reconnect attempt fails, simulating a
+          // crash-looping app-server or a stale socket/lockfile.
+          if (initializeCalls === 1) return {};
+          throw new Error("app-server failed to respawn");
+        }
+        if (method === "account/read") {
+          return { account: { type: "chatgpt", planType: "plus" } };
+        }
+        return { rateLimits: { primary: { usedPercent: 5 } } };
+      });
+      const adapter = new CodexSubscriptionAdapter({
+        runCommand: signedInCommand,
+        createAppServerClient: () => client,
+        restartDelayMs: () => 100,
+      });
+
+      await adapter.start();
+      expect(adapter.getStatus().telemetry.state).toBe("live");
+
+      client.emitExit();
+      expect(adapter.getStatus().telemetry.state).toBe("stale");
+
+      // First reconnect attempt fires and its respawn fails.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(initializeCalls).toBe(2);
+      expect(adapter.getStatus().telemetry.state).toBe("stale");
+
+      // A second consecutive failure must not kill the loop: cleanup and
+      // scheduleRestart() have to run even though telemetry was already
+      // stale, so a third respawn attempt still fires.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(initializeCalls).toBe(3);
+      expect(adapter.getStatus().telemetry.state).toBe("stale");
+
+      adapter.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("marks telemetry stale and schedules a bounded reconnect after process exit", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/desktop-app/src/main/codex-subscription.ts
+++ b/packages/desktop-app/src/main/codex-subscription.ts
@@ -372,15 +372,22 @@ export class CodexSubscriptionAdapter {
         }
       }
     } catch (error) {
-      if (this.status.telemetry.state === "stale") return this.status;
-      this.publish(
-        unavailableStatus(
-          "Codex subscription telemetry could not be refreshed.",
-          probe,
-          this.plan,
-          "error",
-        ),
-      );
+      // A respawn can keep failing (crash-looping app-server, stale
+      // socket/lockfile, CLI/app-server version mismatch) while telemetry is
+      // already stale. Only the softer "stale" message is worth keeping in
+      // that case, but cleanup and the retry itself must still run every
+      // time, or a second consecutive failure permanently kills the
+      // reconnect loop (and the manual Refresh button with it).
+      if (this.status.telemetry.state !== "stale") {
+        this.publish(
+          unavailableStatus(
+            "Codex subscription telemetry could not be refreshed.",
+            probe,
+            this.plan,
+            "error",
+          ),
+        );
+      }
       this.clearSessionCache();
       this.closeClient();
       this.scheduleRestart();

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -942,6 +942,38 @@ describe("DesktopIdentityBroker", () => {
     expect(broker.getStatus()).toBe("sign-in-required");
   });
 
+  it("announces a status only when it actually changes", async () => {
+    // The renderer refreshes its workspace app list and environment lane on
+    // every status event, and the lane read calls back into refreshStatus().
+    // Re-announcing an unchanged status closed that into a feedback loop that
+    // hammered the dispatch origin at round-trip speed.
+    const authority = authorityFixture();
+    const onStatus = vi.fn();
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: cookieStore([
+          sessionCookie("an_session_dispatch", authority.origin),
+        ]),
+        fetch: vi.fn(async () => sessionResponse()),
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      resolveApp: (id) => (id === authority.id ? authority : null),
+      createWindow: vi.fn() as never,
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+      statusRevalidationIntervalMs: 0,
+      onStatus,
+    });
+
+    await broker.refreshStatus(authority);
+    await broker.refreshStatus(authority);
+    await broker.refreshStatus(authority);
+
+    expect(broker.getStatus()).toBe("signed-in");
+    expect(onStatus).toHaveBeenCalledTimes(1);
+    expect(onStatus).toHaveBeenCalledWith("signed-in");
+  });
+
   it("preserves a verified session across a transient status refresh failure", async () => {
     const authority = authorityFixture();
     const identityFetch = vi

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -3575,6 +3575,15 @@ export class DesktopIdentityBroker {
   }
 
   private setStatus(status: DesktopIdentityStatus): void {
+    // Captured before the assignment below: only a real transition may be
+    // announced. Every listener treats this as an edge — the renderer reloads
+    // its workspace app list and environment lane, and that lane read calls
+    // back into refreshStatus(), which lands here again. Re-announcing an
+    // unchanged status closes that into a main<->renderer loop that re-warms
+    // app origins and rebuilds the menu at round-trip speed. The bookkeeping
+    // below still runs every time, so `statusVerifiedAt` keeps refreshing and
+    // the signed-in freshness check is unaffected.
+    const changed = status !== this.status;
     if (
       status === "signing-in" ||
       status === "sign-in-required" ||
@@ -3588,6 +3597,6 @@ export class DesktopIdentityBroker {
     if (status !== "signed-in") this.verifiedIdentityEmail = null;
     this.statusVerifiedAt = status === "signed-in" ? Date.now() : 0;
     this.statusRevalidationRetryAt = 0;
-    this.options.onStatus?.(status);
+    if (changed) this.options.onStatus?.(status);
   }
 }

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -531,6 +531,19 @@ function handleSecondInstance(_event: Electron.Event, argv: string[]): void {
   }
 }
 
+// Windows/Linux: a cold start (the app was not already running) delivers the
+// deep link as a plain argv entry instead of firing 'open-url' (macOS-only)
+// or 'second-instance' (only reached by an already-running primary
+// instance), so nothing else observes it before the window loads. Queue it
+// into pendingDeepLink the same way the macOS open-url cold-start path below
+// does, for app.whenReady() to drain into handleDeepLink().
+function capturePendingDeepLinkFromArgv(argv: string[]): void {
+  const deepLink = argv.find(isDeepLinkArg);
+  if (deepLink) {
+    pendingDeepLink = deepLink;
+  }
+}
+
 if (IS_DEV) {
   // electron-vite kills the main process and relaunches it on every rebuild
   // (e.g. when the concurrent `@agent-native/core` tsc --watch under
@@ -539,6 +552,7 @@ if (IS_DEV) {
   // and app.quit() — leaving the killed instance's dead Dock tile behind.
   // Skip the lock in dev; keep the deep-link handler for parity.
   app.on("second-instance", handleSecondInstance);
+  capturePendingDeepLinkFromArgv(process.argv);
   // Quit immediately when electron-vite SIGTERMs us so the old process and its
   // Dock tile vanish at once, before the relaunched instance paints its window.
   const exitNow = () => app.exit(0);
@@ -550,6 +564,7 @@ if (IS_DEV) {
     app.quit();
   } else {
     app.on("second-instance", handleSecondInstance);
+    capturePendingDeepLinkFromArgv(process.argv);
   }
 }
 

--- a/packages/desktop-app/src/main/ipc/apps.spec.ts
+++ b/packages/desktop-app/src/main/ipc/apps.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronState = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  return {
+    ipcMain: {
+      handle: vi.fn(
+        (channel: string, handler: (...args: unknown[]) => unknown) => {
+          handlers.set(channel, handler);
+        },
+      ),
+    },
+    handlers,
+  };
+});
+
+vi.mock("electron", () => ({
+  ipcMain: electronState.ipcMain,
+}));
+
+const appStoreState = vi.hoisted(() => ({
+  saveDesktopAppPreferences: vi.fn(),
+}));
+
+vi.mock("../app-store", () => appStoreState);
+
+import { IPC } from "@shared/ipc-channels";
+
+import { registerAppsIpc, type AppsIpcDeps } from "./apps.js";
+
+describe("APPS_UPDATE_CREATION_SETTINGS", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    electronState.handlers.clear();
+  });
+
+  function register(overrides: Partial<AppsIpcDeps> = {}) {
+    const deps: AppsIpcDeps = {
+      getManagedDesktopAppIds: vi.fn(() => []),
+      stopManagedDesktopApp: vi.fn(),
+      refreshDesktopShortcutBindings: vi.fn(),
+      chooseLocalAppFolder: vi.fn(),
+      desktopAppCreationSettings: vi.fn(() => ({
+        appsRoot: "/Users/steve/apps",
+      })),
+      normalizeDesktopAppsRoot: vi.fn(() => null),
+      createDesktopAppFromPrompt: vi.fn(),
+      prepareDesktopAppForLocalCodeChange: vi.fn(),
+      showDesktopAppContextMenu: vi.fn(),
+      ...overrides,
+    };
+    registerAppsIpc(deps);
+    const handler = electronState.handlers.get(
+      IPC.APPS_UPDATE_CREATION_SETTINGS,
+    );
+    if (!handler) throw new Error("handler not registered");
+    return handler;
+  }
+
+  it("returns ok:false with an error when the root is rejected, not the stale settings alone", async () => {
+    const handler = register({
+      desktopAppCreationSettings: vi.fn(() => ({
+        appsRoot: "/Users/steve/apps",
+      })),
+      normalizeDesktopAppsRoot: vi.fn(() => null),
+    });
+
+    const result = await handler({}, { appsRoot: "/" });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.any(String),
+      settings: { appsRoot: "/Users/steve/apps" },
+    });
+    // The rejected input must never surface as the saved root.
+    expect(
+      (result as { settings: { appsRoot: string } }).settings.appsRoot,
+    ).not.toBe("/");
+    expect(appStoreState.saveDesktopAppPreferences).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:true and persists the normalized root when it is accepted", async () => {
+    const handler = register({
+      desktopAppCreationSettings: vi.fn(() => ({
+        appsRoot: "/Users/steve/apps",
+      })),
+      normalizeDesktopAppsRoot: vi.fn(() => "/Users/steve/new-apps"),
+    });
+
+    const result = await handler({}, { appsRoot: "/Users/steve/new-apps" });
+
+    expect(result).toEqual({
+      ok: true,
+      settings: { appsRoot: "/Users/steve/new-apps" },
+    });
+    expect(appStoreState.saveDesktopAppPreferences).toHaveBeenCalledWith({
+      appsRoot: "/Users/steve/new-apps",
+    });
+  });
+});

--- a/packages/desktop-app/src/main/ipc/apps.ts
+++ b/packages/desktop-app/src/main/ipc/apps.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   type DesktopAppContextAction,
   type DesktopAppCreationSettings,
+  type DesktopAppCreationSettingsUpdateResult,
   type DesktopCreateAppRequest,
   type DesktopCreateAppResult,
   type DesktopPrepareLocalCodeChangeRequest,
@@ -124,11 +125,17 @@ export function registerAppsIpc(deps: AppsIpcDeps): void {
     (
       _event: IpcMainInvokeEvent,
       settings: Partial<DesktopAppCreationSettings>,
-    ): DesktopAppCreationSettings => {
+    ): DesktopAppCreationSettingsUpdateResult => {
       const appsRoot = normalizeDesktopAppsRoot(settings?.appsRoot);
-      if (!appsRoot) return desktopAppCreationSettings();
+      if (!appsRoot) {
+        return {
+          ok: false,
+          error: "Choose a valid folder for new apps.",
+          settings: desktopAppCreationSettings(),
+        };
+      }
       AppStore.saveDesktopAppPreferences({ appsRoot });
-      return { appsRoot };
+      return { ok: true, settings: { appsRoot } };
     },
   );
 

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -328,4 +328,44 @@ describe("desktop passive-access regressions", () => {
     expect(guardIndex).toBeLessThan(quittingIndex);
     expect(guardIndex).toBeLessThan(stopServicesIndex);
   });
+
+  it("captures a cold-start deep link from argv on Windows/Linux instead of dropping it", () => {
+    const main = source("./index.ts");
+    const singleInstanceSetup = between(
+      main,
+      "function capturePendingDeepLinkFromArgv(argv: string[]): void {",
+      "interface OAuthInjectionTarget {",
+    );
+
+    // Reuses the same isDeepLinkArg/pendingDeepLink path as the macOS
+    // open-url cold start, instead of a parallel deep-link path.
+    expect(singleInstanceSetup).toContain("argv.find(isDeepLinkArg)");
+    expect(singleInstanceSetup).toContain("pendingDeepLink = deepLink;");
+
+    // Both the dev (no single-instance lock) and packaged (lock acquired)
+    // startup paths must capture it — a cold start can happen either way.
+    const devBranch = between(singleInstanceSetup, "if (IS_DEV) {", "} else {");
+    const lockAcquiredBranch = between(
+      singleInstanceSetup,
+      'app.on("second-instance", handleSecondInstance);\n    capturePendingDeepLinkFromArgv(process.argv);',
+      "}\n}",
+    );
+
+    expect(devBranch).toContain(
+      "capturePendingDeepLinkFromArgv(process.argv);",
+    );
+    expect(lockAcquiredBranch).toContain(
+      "capturePendingDeepLinkFromArgv(process.argv);",
+    );
+
+    // app.whenReady() must be the only place pendingDeepLink is dispatched,
+    // so a cold-start link isn't handled before dependent startup steps run.
+    const whenReady = between(
+      main,
+      "app.whenReady().then(async () => {",
+      "// Webviews now run in per-app persisted partitions",
+    );
+    expect(whenReady).toContain("if (pendingDeepLink) {");
+    expect(whenReady).toContain("handleDeepLink(pendingDeepLink);");
+  });
 });

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -63,6 +63,7 @@ import {
   type DesktopOpenRequest,
   type DesktopAppContextAction,
   type DesktopAppCreationSettings,
+  type DesktopAppCreationSettingsUpdateResult,
   type DesktopAppRuntimeStatus,
   type DesktopIdentityAuthRequest,
   type DesktopIdentityAuthResult,
@@ -228,7 +229,7 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.APPS_GET_CREATION_SETTINGS),
     updateCreationSettings: (
       settings: Partial<DesktopAppCreationSettings>,
-    ): Promise<DesktopAppCreationSettings> =>
+    ): Promise<DesktopAppCreationSettingsUpdateResult> =>
       ipcRenderer.invoke(IPC.APPS_UPDATE_CREATION_SETTINGS, settings),
     createFromPrompt: (
       request: DesktopCreateAppRequest,

--- a/packages/desktop-app/src/renderer/App.spec.ts
+++ b/packages/desktop-app/src/renderer/App.spec.ts
@@ -15,4 +15,24 @@ describe("desktop chat-first shell", () => {
     expect(appSource).not.toContain("Sidebar");
     expect(appSource).not.toContain("TabBar");
   });
+
+  it("reports a failed app removal instead of leaving it unhandled", () => {
+    const appSource = readFileSync(
+      new URL("./App.tsx", import.meta.url),
+      "utf8",
+    );
+
+    const handlerStart = appSource.indexOf("const handleAppRemoval");
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerEnd = appSource.indexOf("[apps],\n  );", handlerStart);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+    const handlerSource = appSource.slice(handlerStart, handlerEnd);
+
+    // api.update/api.remove IPC-invoke the main process and can reject
+    // (disk full, permission denied); that rejection must be caught and
+    // surfaced, not left as an unhandled promise rejection.
+    expect(handlerSource).toContain("try {");
+    expect(handlerSource).toContain("catch");
+    expect(handlerSource).toContain("toast.error(");
+  });
 });

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -239,17 +239,28 @@ export default function App() {
       const app = apps.find((candidate) => candidate.id === appId);
       if (!api || !app) return;
 
-      const updated = app.isBuiltIn
-        ? await api.update(appId, { enabled: false })
-        : await api.remove(appId);
-      setApps(updated);
-      setActiveChatFirstAppId((current) => (current === appId ? "" : current));
-      setChatFirstPreviewRequest((current) =>
-        current?.appId === appId ? undefined : current,
-      );
-      setChatFirstPreviewStatus((current) =>
-        current?.appId === appId ? undefined : current,
-      );
+      try {
+        const updated = app.isBuiltIn
+          ? await api.update(appId, { enabled: false })
+          : await api.remove(appId);
+        setApps(updated);
+        setActiveChatFirstAppId((current) =>
+          current === appId ? "" : current,
+        );
+        setChatFirstPreviewRequest((current) =>
+          current?.appId === appId ? undefined : current,
+        );
+        setChatFirstPreviewStatus((current) =>
+          current?.appId === appId ? undefined : current,
+        );
+      } catch {
+        // The main process failed to persist the change (e.g. userData is
+        // unwritable), so local state must stay untouched and the failure
+        // must be visible instead of leaving a silently-reverted rail.
+        toast.error(`Couldn't remove ${app.name}`, {
+          description: "Please try again.",
+        });
+      }
     },
     [apps],
   );

--- a/packages/desktop-app/src/renderer/components/AppSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/AppSettings.tsx
@@ -1645,11 +1645,12 @@ export function AddAppDialog({
   async function saveAppsRoot(nextRoot: string) {
     const trimmed = nextRoot.trim();
     if (!trimmed) return;
-    const settings =
-      await window.electronAPI?.appConfig?.updateCreationSettings({
-        appsRoot: trimmed,
-      });
-    if (settings?.appsRoot) setAppsRoot(settings.appsRoot);
+    const result = await window.electronAPI?.appConfig?.updateCreationSettings({
+      appsRoot: trimmed,
+    });
+    if (!result) return;
+    setAppsRoot(result.settings.appsRoot);
+    setBuildError(result.error ?? "");
   }
 
   async function chooseAppsRoot() {

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -1221,6 +1221,52 @@ describe("Returning to an already loaded app tab", () => {
     ).toBe(true);
   });
 
+  it("re-gates a loaded tab whose session ended while it was hidden", () => {
+    // Sign-out reloads hidden webviews too, so the preserved page is already
+    // showing the signed-out screen. Preserving it here is what flashed that
+    // page with no gate over it.
+    expect(
+      shouldClearDesktopIdentitySessionOnActivation({
+        hasLoadedGuestPage: true,
+        sessionReady: true,
+        rememberedStatus: "sign-in-required",
+      }),
+    ).toBe(true);
+    expect(
+      shouldClearDesktopIdentitySessionOnActivation({
+        hasLoadedGuestPage: true,
+        sessionReady: true,
+        rememberedStatus: "failed",
+      }),
+    ).toBe(true);
+  });
+
+  it("still preserves a loaded tab when workspace SSO is simply off", () => {
+    // "idle" is SSO disabled, not a sign-out. Re-gating here would put every
+    // tab switch back behind the loading screen for anyone not using SSO.
+    expect(
+      shouldClearDesktopIdentitySessionOnActivation({
+        hasLoadedGuestPage: true,
+        sessionReady: true,
+        rememberedStatus: "idle",
+      }),
+    ).toBe(false);
+    expect(
+      shouldClearDesktopIdentitySessionOnActivation({
+        hasLoadedGuestPage: true,
+        sessionReady: true,
+        rememberedStatus: "signed-in",
+      }),
+    ).toBe(false);
+    expect(
+      shouldClearDesktopIdentitySessionOnActivation({
+        hasLoadedGuestPage: true,
+        sessionReady: true,
+        rememberedStatus: null,
+      }),
+    ).toBe(false);
+  });
+
   it("leaves a preserved page unblocked for loading", () => {
     // The reactivation path must not reintroduce the deferral that keeps the
     // webview on about:blank.
@@ -1232,5 +1278,98 @@ describe("Returning to an already loaded app tab", () => {
         status: "signed-in",
       }),
     ).toBe(false);
+  });
+});
+
+describe("Recovering from a slow app load", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        disconnect() {}
+        observe() {}
+      },
+    );
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    Object.defineProperty(HTMLElement.prototype, "executeJavaScript", {
+      configurable: true,
+      value: () => Promise.resolve(),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    act(() => root.unmount());
+    container.remove();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    invalidateRememberedDesktopIdentityStatus();
+  });
+
+  it("clears the load-timeout error when the app finally arrives", async () => {
+    root = createRoot(container);
+    const app = {
+      id: "custom-mail",
+      name: "Mail",
+      icon: "mail",
+      description: "",
+      devPort: 3000,
+    };
+    const appConfig = {
+      ...app,
+      url: "https://mail.agent-native.com",
+      isBuiltIn: false,
+      enabled: true,
+      mode: "prod" as const,
+    };
+
+    act(() => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: true,
+          theme: "dark" as const,
+        }),
+      );
+    });
+
+    const webview = container.querySelector("webview");
+    expect(webview).not.toBeNull();
+    Object.defineProperties(webview!, {
+      getTitle: { configurable: true, value: () => "" },
+      getURL: {
+        configurable: true,
+        value: () => webview!.getAttribute("src") ?? "",
+      },
+    });
+
+    // The origin is slow: nothing failed, the client just stopped waiting.
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+    expect(container.textContent).toContain("Mail isn't loading");
+    expect((webview!.parentElement as HTMLElement).style.display).toBe("none");
+
+    // The same navigation completes afterwards. A timeout is not a failure, so
+    // the real page must replace the error screen instead of staying hidden
+    // behind it until the user hits Retry.
+    await act(async () => {
+      webview?.dispatchEvent(new Event("dom-ready"));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("Mail isn't loading");
+    expect((webview!.parentElement as HTMLElement).style.display).toBe("flex");
   });
 });

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -350,8 +350,29 @@ export function shouldDeferDesktopAppWebviewLoad(input: {
 export function shouldClearDesktopIdentitySessionOnActivation(input: {
   hasLoadedGuestPage: boolean;
   sessionReady: boolean;
+  rememberedStatus?: DesktopIdentityStatus | null;
 }): boolean {
+  // A page loaded under a session the shell has since watched end is not
+  // "usable to preserve": sign-out reloads every app webview including the
+  // hidden ones, so preserving it reveals that app's own signed-out page with
+  // no gate over it until the status round trip lands.
+  if (isDesktopIdentitySignedOutStatus(input.rememberedStatus ?? null)) {
+    return true;
+  }
   return !(input.hasLoadedGuestPage && input.sessionReady);
+}
+
+/**
+ * Whether a status the shell already observed means a loaded guest page can no
+ * longer be treated as signed in. Sign-out publishes "sign-in-required", so
+ * that and a hard "failed" are the only statuses that invalidate a loaded page.
+ * "idle" is excluded deliberately — that is workspace SSO switched off, where
+ * there is no session to gate and re-gating would stall every tab switch.
+ */
+export function isDesktopIdentitySignedOutStatus(
+  status: DesktopIdentityStatus | null,
+): boolean {
+  return status === "sign-in-required" || status === "failed";
 }
 
 const DESKTOP_IDENTITY_STATUS_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -959,7 +980,9 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         rememberedDesktopIdentityStatusAt,
       );
       const preserveLoadedSession =
-        hasLoadedGuestPageRef.current && desktopIdentitySessionReadyRef.current;
+        hasLoadedGuestPageRef.current &&
+        desktopIdentitySessionReadyRef.current &&
+        !isDesktopIdentitySignedOutStatus(rememberedDesktopIdentityStatus);
       setDesktopIdentityEnabled(rememberedSignedIn ? true : null);
       setDesktopIdentityStatus(
         rememberedSignedIn || preserveLoadedSession ? "signed-in" : "idle",
@@ -973,6 +996,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         shouldClearDesktopIdentitySessionOnActivation({
           hasLoadedGuestPage: hasLoadedGuestPageRef.current,
           sessionReady: desktopIdentitySessionReadyRef.current,
+          rememberedStatus: rememberedDesktopIdentityStatus,
         })
       ) {
         updateDesktopIdentitySessionReady(false);
@@ -1626,7 +1650,12 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       const failT = setTimeout(
         () => {
           if (isLoading) {
-            loadFailureRef.current = true;
+            // Deliberately not `loadFailureRef`: Chromium never reported a
+            // failure here, we only stopped waiting. The navigation is still in
+            // flight, so a later dom-ready is the real app arriving rather than
+            // the error document that flag exists to suppress — latching it
+            // would strand the user on this screen with the app loaded and
+            // hidden behind it.
             authProbeSequenceRef.current += 1;
             setError(true);
             setIsLoading(false);

--- a/packages/desktop-app/src/renderer/components/RendererErrorBoundary.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/RendererErrorBoundary.spec.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureException = vi.fn();
+vi.mock("@sentry/electron/renderer", () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+import { RendererErrorBoundary } from "./RendererErrorBoundary.js";
+
+function Thrower(): never {
+  throw new Error("boom");
+}
+
+describe("RendererErrorBoundary", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    captureException.mockClear();
+    // React logs the caught error to console.error itself; silence that noise
+    // without hiding an assertion failure from this test's own expectations.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    consoleError.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the fallback instead of unmounting when a child throws", () => {
+    act(() => {
+      root.render(
+        <RendererErrorBoundary>
+          <Thrower />
+        </RendererErrorBoundary>,
+      );
+    });
+
+    expect(
+      container.querySelector("[data-renderer-error-boundary]"),
+    ).not.toBeNull();
+    expect(container.textContent).toContain("Something went wrong");
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+
+  it("renders children normally when nothing throws", () => {
+    act(() => {
+      root.render(
+        <RendererErrorBoundary>
+          <p>All good</p>
+        </RendererErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain("All good");
+    expect(
+      container.querySelector("[data-renderer-error-boundary]"),
+    ).toBeNull();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("lets 'Try again' re-render the children without a full reload", () => {
+    let shouldThrow = true;
+    function MaybeThrow() {
+      if (shouldThrow) throw new Error("boom");
+      return <p>Recovered</p>;
+    }
+
+    act(() => {
+      root.render(
+        <RendererErrorBoundary>
+          <MaybeThrow />
+        </RendererErrorBoundary>,
+      );
+    });
+    expect(
+      container.querySelector("[data-renderer-error-boundary]"),
+    ).not.toBeNull();
+
+    shouldThrow = false;
+    const tryAgain = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Try again",
+    );
+    expect(tryAgain).toBeDefined();
+    act(() => tryAgain?.click());
+
+    expect(container.textContent).toContain("Recovered");
+  });
+});

--- a/packages/desktop-app/src/renderer/components/RendererErrorBoundary.tsx
+++ b/packages/desktop-app/src/renderer/components/RendererErrorBoundary.tsx
@@ -1,0 +1,106 @@
+import * as Sentry from "@sentry/electron/renderer";
+import {
+  Component,
+  type CSSProperties,
+  type ErrorInfo,
+  type ReactNode,
+} from "react";
+
+interface RendererErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface RendererErrorBoundaryState {
+  error: Error | null;
+}
+
+// Inline styles (not a class in shell.css) so the fallback still renders
+// correctly even if the crash happened before/during stylesheet application.
+// Colors reuse the same tokens shell.css defines, so light/dark still match.
+const overlayStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 16,
+  height: "100%",
+  padding: 24,
+  textAlign: "center",
+  color: "var(--shell-fg)",
+  background: "var(--shell-bg)",
+};
+
+const actionsStyle: CSSProperties = {
+  display: "flex",
+  gap: 8,
+};
+
+const buttonStyle: CSSProperties = {
+  minHeight: 32,
+  padding: "6px 14px",
+  border: "1px solid var(--separator)",
+  borderRadius: 6,
+  color: "var(--shell-fg)",
+  background: "var(--surface-active-bg)",
+  font: "inherit",
+  fontSize: 13,
+  cursor: "pointer",
+};
+
+const primaryButtonStyle: CSSProperties = {
+  ...buttonStyle,
+  borderColor: "var(--label-active)",
+  color: "var(--shell-bg)",
+  background: "var(--label-active)",
+};
+
+/**
+ * Catches render-time and commit-phase-effect throws from anywhere under
+ * `<App />`. Without this, React unmounts the whole tree on any such throw
+ * and the window goes blank with no recovery short of quitting and
+ * relaunching. Only a class component can implement getDerivedStateFromError
+ * / componentDidCatch.
+ */
+export class RendererErrorBoundary extends Component<
+  RendererErrorBoundaryProps,
+  RendererErrorBoundaryState
+> {
+  state: RendererErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): RendererErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    console.error("[desktop-renderer] Unhandled render error", error, info);
+    Sentry.captureException(error, {
+      contexts: { react: { componentStack: info.componentStack } },
+    });
+  }
+
+  private reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <div style={overlayStyle} data-renderer-error-boundary>
+        <p>Something went wrong. You can try again or reload the app.</p>
+        <div style={actionsStyle}>
+          <button type="button" style={buttonStyle} onClick={this.reset}>
+            Try again
+          </button>
+          <button
+            type="button"
+            style={primaryButtonStyle}
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -780,6 +780,13 @@ type DesktopAppCreationSettings = {
   appsRoot: string;
 };
 
+/** `settings` always reflects the current on-disk value, so a rejected update still snaps the UI back to something real. */
+type DesktopAppCreationSettingsUpdateResult = {
+  ok: boolean;
+  settings: DesktopAppCreationSettings;
+  error?: string;
+};
+
 type DesktopCreateAppRequest = {
   prompt: string;
   appsRoot?: string;
@@ -1092,7 +1099,7 @@ interface ElectronAPI {
     getCreationSettings(): Promise<DesktopAppCreationSettings>;
     updateCreationSettings(
       settings: Partial<DesktopAppCreationSettings>,
-    ): Promise<DesktopAppCreationSettings>;
+    ): Promise<DesktopAppCreationSettingsUpdateResult>;
     createFromPrompt(
       request: DesktopCreateAppRequest,
     ): Promise<DesktopCreateAppResult>;

--- a/packages/desktop-app/src/renderer/main.tsx
+++ b/packages/desktop-app/src/renderer/main.tsx
@@ -1,9 +1,11 @@
 import { configureTracking } from "@agent-native/core/client/analytics";
+import { AgentNativeI18nProvider } from "@agent-native/core/client/i18n";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 import App from "./App.js";
 import QuickPromptOverlay from "./components/QuickPromptOverlay.js";
+import { RendererErrorBoundary } from "./components/RendererErrorBoundary.js";
 import { initRendererTheme } from "./lib/theme.js";
 import { initializeDesktopRendererSentry } from "./sentry.js";
 
@@ -47,6 +49,23 @@ const quickPromptSurface = isQuickPromptSurface ? (
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    {isQuickPromptSurface ? quickPromptSurface : <App />}
+    <RendererErrorBoundary>
+      {/*
+        The shell renders core client components directly rather than inside a
+        webview, so they call useTranslation() here. Without a provider
+        react-i18next hands back a fresh `t` on every render, which cascades
+        through useT() into the composer's memoized adapters and re-fires
+        effects keyed on them in a loop. Copy is unchanged either way — useT()
+        falls back to the same English table when a key is missing.
+      */}
+      {/*
+        persistPreference reads and writes the locale through origin-relative
+        endpoints. The shell is served from file://, so those can only ever
+        fail here — there is no hosted origin behind this window to persist to.
+      */}
+      <AgentNativeI18nProvider persistPreference={false}>
+        {isQuickPromptSurface ? quickPromptSurface : <App />}
+      </AgentNativeI18nProvider>
+    </RendererErrorBoundary>
   </React.StrictMode>,
 );

--- a/scripts/dev-electron.ts
+++ b/scripts/dev-electron.ts
@@ -183,6 +183,19 @@ if (dryRun) {
 }
 
 ensureElectronBinary();
+
+// The desktop shell resolves @agent-native/core, /shared-app-config, /toolkit,
+// and /code-agents-ui through their built `dist/`, not their source. A dist left
+// behind by an older checkout still loads, so the shell boots against last
+// week's code and fails in ways that look like app bugs — a missing export
+// reads as `undefined` at the call site (a dropped `workspaceSso` turns into a
+// re-login prompt; a missing host map throws on every app URL it resolves).
+// dev-lazy already prebuilds for this reason; this entry point must too.
+console.log(`\x1b[36m[dev-electron]\x1b[0m Prebuilding workspace packages...`);
+execSync("node scripts/prebuild-workspace-packages.ts dev", {
+  stdio: "inherit",
+});
+
 portsToUse.forEach(tryKillPort);
 
 console.log(`\x1b[36m[dev-electron]\x1b[0m Starting: ${names.join(", ")}`);


### PR DESCRIPTION
The desktop app was reported as "super buggy — auth issues, errors in apps." This is a testing pass over the Electron shell plus fixes for what it turned up. Everything below was found by auditing the shell and by driving the built app with Playwright, then verified by reverting each fix and confirming its test fails.

## Root cause behind most of it: the shell booted against stale `dist/`

`packages/desktop-app` resolves `@agent-native/core`, `/shared-app-config`, `/toolkit`, and `/code-agents-ui` through their built `dist/`, never their source. `dev-lazy` prebuilds those; `dev:electron` did not. A `dist/` left by an older checkout still loads, so the shell ran week-old code and failed in ways that look like app bugs:

- `ENVIRONMENT_BETA_HOSTS` resolved to `undefined`, so `withDesktopEnvironmentLane` threw a `TypeError` on **every app URL the shell resolved**.
- `workspaceSso` was silently dropped from workspace app metadata, which turns into a re-login prompt.

On a stale checkout this alone failed **22 of the desktop suite's tests**; all 22 pass on a fresh build. `dev:electron` now prebuilds the same way `dev-lazy` does (~23s steady state).

## Runtime loops, measured on the built app

Driving the shell with Playwright over an identical scripted session, before → after:

| | before | after |
|---|---|---|
| failed requests | 543 | 30 |
| console errors | 652 | 149 |
| workspace inventory reloads | 543 | 1 |

- **Identity status was announced on every check, not on transitions.** Every listener treats it as an edge — the renderer reloads its workspace app list and environment lane, and that lane read calls back into `refreshStatus()`, which announced again. That closed a main↔renderer loop that re-warmed app origins and rebuilt the menu at round-trip speed.
- **The renderer never mounted `AgentNativeI18nProvider`.** The shell renders core client components directly, so they call `useTranslation()` here; with no instance react-i18next returns a fresh `t` every render, which cascades through `useT()` into the composer's memoized adapters and re-fires effects keyed on them. Visible copy is unchanged — `useT()` falls back to the same English table either way.

## Other fixes

- **A load timeout was latched as a load failure.** An app that responded after the 15s timeout stayed hidden behind "isn't loading" with the page fully loaded underneath, recoverable only via Retry. A timeout is not a failure — nothing was reported, we only stopped waiting.
- **A tab loaded before sign-out stayed marked signed-in.** Sign-out reloads hidden webviews too, so reactivating one briefly showed its signed-out page with no gate. `"idle"` is deliberately excluded — that is SSO switched off, and re-gating it would stall every tab switch.
- **`loadApps()` replaced the user's config with defaults on any failure**, including a transient write error, so one bad element or a full disk permanently destroyed custom and self-hosted apps. Only an unreadable store resets now.
- **`APPS_UPDATE_CREATION_SETTINGS` returned current settings for a rejected path**, indistinguishable from a save; the folder input silently reverted. It now returns a discriminated result and the dialog shows the error.
- **A failed app removal was dropped** as an unhandled rejection, leaving the app in the rail with no error.
- **The Codex reconnect loop died permanently** after two consecutive failures while telemetry was stale, skipping `scheduleRestart()` — manual Refresh could not recover it either.
- **Cold-start deep links were dropped on Windows/Linux**: `open-url` is macOS-only and `second-instance` needs a running instance, so an OAuth return that cold-launched the app went nowhere.
- **No error boundary anywhere in the renderer** — one render-time throw blanked the whole window with no recovery but quitting.

## Verification

549 tests pass (12 added), 64 guards pass, typecheck and oxfmt clean. Each fix was verified by reverting it and confirming the new test fails for the stated reason.

## Known, not fixed

Two pre-existing issues are diagnosed but left alone — both need cross-cutting work outside this change:

1. The shell issues origin-relative `/_agent-native/*` calls (`auth/session`, `org/me`, `poll`, `events`, …) that resolve against `file://` and always fail. `agentNativePath()` only ever returns a path, which is correct for a hosted page but not for the shell. Needs an injectable base origin or IPC routing.
2. `ERR_CONTENT_DECODING_FAILED` on the desktop-chat relay's `auth/session` proxy — the body does not match its `Content-Encoding`.

These account for most of the remaining 30 failed requests.
