### PR TITLE
fix: harden Electron auth and dev startup

### DIFF
--- a/.changeset/harden-electron-auth-and-dev-startup.md
+++ b/.changeset/harden-electron-auth-and-dev-startup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reset Google sign-in state when an Electron OAuth popup closes and keep Nitro dev startup errors behind the recovery page until the server is ready.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5920,6 +5920,7 @@ describe("server/auth", () => {
       expect(html).toContain("var __anNativeOAuthRequestPending = false;");
       expect(html).toContain("var __anNativeOAuthAbandonGraceMs = 5000;");
       expect(html).toContain("function __anBeginNativeOAuth(flowId)");
+      expect(html).toContain("function __anCancelNativeOAuthAbandonment()");
       expect(html).toContain(
         "function __anScheduleNativeOAuthAbandonment(flowId)",
       );
@@ -5948,6 +5949,12 @@ describe("server/auth", () => {
       expect(html).toContain("__anRecoverGoogleSignInAfterReturn();");
       expect(html).toContain(
         "window.addEventListener('focus', function() {\n        __anRecoverGoogleSignInAfterReturn();\n      });",
+      );
+      expect(html).toContain(
+        "window.addEventListener('blur', function() {\n        __anCancelNativeOAuthAbandonment();\n      });",
+      );
+      expect(html).toContain(
+        "if (document.visibilityState === 'visible') {\n          __anRecoverGoogleSignInAfterReturn();\n        } else {\n          __anCancelNativeOAuthAbandonment();\n        }",
       );
       const recoverStart = html.indexOf(
         "function __anRecoverGoogleSignInAfterReturn(flowId)",

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5833,8 +5833,10 @@ describe("server/auth", () => {
         'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
       );
       expect(html).toContain('var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";');
-      expect(html).toContain("__anStartPopupOAuth(ret, btn, err)");
-      expect(html).toContain("__anStartNativeDesktopOAuth(ret, btn, err)");
+      expect(html).toContain("__anStartPopupOAuth(ret, btn, err, flowId)");
+      expect(html).toContain(
+        "__anStartNativeDesktopOAuth(ret, btn, err, flowId)",
+      );
       expect(html).toContain(
         "__anPath('/_agent-native/auth/desktop-exchange')",
       );
@@ -5909,12 +5911,19 @@ describe("server/auth", () => {
       expect(html).toContain(
         "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier)",
       );
-      expect(html).toContain("function __anWatchOAuthPopupClose(popup)");
+      expect(html).toContain(
+        "function __anWatchOAuthPopupClose(popup, flowId)",
+      );
       expect(html).toContain("closed = popup.closed === true");
-      expect(html).toContain("__anWatchOAuthPopupClose(popup);");
+      expect(html).toContain("__anWatchOAuthPopupClose(popup, flowId);");
+      expect(html).toContain("function __anInvalidateGoogleSignInFlow(flowId)");
+      expect(html).toContain("__anStopOAuthExchangePolling();");
+      expect(html).toContain(
+        "if (!__anIsCurrentGoogleSignInFlow(flowId)) return;",
+      );
       expect(html).toContain("__anRecoverGoogleSignInAfterReturn();");
       const recoverStart = html.indexOf(
-        "function __anRecoverGoogleSignInAfterReturn()",
+        "function __anRecoverGoogleSignInAfterReturn(flowId)",
       );
       const recoverEnd = html.indexOf(
         "function __anBindGoogleRecover()",

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5922,6 +5922,9 @@ describe("server/auth", () => {
         "if (!__anIsCurrentGoogleSignInFlow(flowId)) return;",
       );
       expect(html).toContain("__anRecoverGoogleSignInAfterReturn();");
+      expect(html).toContain(
+        "window.addEventListener('focus', function() {\n        __anRecoverGoogleSignInAfterReturn();\n      });",
+      );
       const recoverStart = html.indexOf(
         "function __anRecoverGoogleSignInAfterReturn(flowId)",
       );

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5926,6 +5926,9 @@ describe("server/auth", () => {
       expect(html).toContain("closed = popup.closed === true");
       expect(html).toContain("__anWatchOAuthPopupClose(popup, flowId);");
       expect(html).toContain("function __anInvalidateGoogleSignInFlow(flowId)");
+      expect(html).toContain(
+        "if (!flowId && (__anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;",
+      );
       expect(html).toContain("__anStopOAuthExchangePolling();");
       expect(html).toContain(
         "if (!__anIsCurrentGoogleSignInFlow(flowId)) return;",

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5916,6 +5916,18 @@ describe("server/auth", () => {
       );
       expect(html).toContain("function __anHandleOAuthPopupClosed(flowId)");
       expect(html).toContain("var __anOAuthPopupCloseGraceMs = 5000;");
+      expect(html).toContain("var __anNativeOAuthFlowId = null;");
+      expect(html).toContain("var __anNativeOAuthRequestPending = false;");
+      expect(html).toContain("var __anNativeOAuthAbandonGraceMs = 5000;");
+      expect(html).toContain("function __anBeginNativeOAuth(flowId)");
+      expect(html).toContain(
+        "function __anScheduleNativeOAuthAbandonment(flowId)",
+      );
+      expect(html).toContain("__anFinalizeNativeOAuthAbandonment(flowId);");
+      expect(html).toContain("__anNativeOAuthRequestPending = true;");
+      expect(html).toContain("__anNativeOAuthRequestPending = false;");
+      expect(html).toContain("__anBeginNativeOAuth(flowId);");
+      expect(html).toContain("__anMarkNativeOAuthPolling(flowId);");
       expect(html).toContain(
         "if (__anOAuthPollTimer) {\n        __anOAuthPopupCloseGraceTimer = setTimeout(function()",
       );
@@ -5927,7 +5939,7 @@ describe("server/auth", () => {
       expect(html).toContain("__anWatchOAuthPopupClose(popup, flowId);");
       expect(html).toContain("function __anInvalidateGoogleSignInFlow(flowId)");
       expect(html).toContain(
-        "if (!flowId && (__anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;",
+        "if (!flowId && (__anNativeOAuthFlowId || __anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;",
       );
       expect(html).toContain("__anStopOAuthExchangePolling();");
       expect(html).toContain(

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5914,6 +5914,15 @@ describe("server/auth", () => {
       expect(html).toContain(
         "function __anWatchOAuthPopupClose(popup, flowId)",
       );
+      expect(html).toContain("function __anHandleOAuthPopupClosed(flowId)");
+      expect(html).toContain("var __anOAuthPopupCloseGraceMs = 5000;");
+      expect(html).toContain(
+        "if (__anOAuthPollTimer) {\n        __anOAuthPopupCloseGraceTimer = setTimeout(function()",
+      );
+      expect(html).toContain(
+        "__anFinalizeOAuthPopupClose(flowId);\n        }, __anOAuthPopupCloseGraceMs);",
+      );
+      expect(html).toContain("__anHandleOAuthPopupClosed(flowId);");
       expect(html).toContain("closed = popup.closed === true");
       expect(html).toContain("__anWatchOAuthPopupClose(popup, flowId);");
       expect(html).toContain("function __anInvalidateGoogleSignInFlow(flowId)");

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5918,6 +5918,7 @@ describe("server/auth", () => {
       expect(html).toContain("var __anOAuthPopupCloseGraceMs = 5000;");
       expect(html).toContain("var __anNativeOAuthFlowId = null;");
       expect(html).toContain("var __anNativeOAuthRequestPending = false;");
+      expect(html).toContain("var __anNativeOAuthReturnObserved = false;");
       expect(html).toContain("var __anNativeOAuthAbandonGraceMs = 5000;");
       expect(html).toContain("function __anBeginNativeOAuth(flowId)");
       expect(html).toContain("function __anCancelNativeOAuthAbandonment()");
@@ -5927,8 +5928,12 @@ describe("server/auth", () => {
       expect(html).toContain("__anFinalizeNativeOAuthAbandonment(flowId);");
       expect(html).toContain("__anNativeOAuthRequestPending = true;");
       expect(html).toContain("__anNativeOAuthRequestPending = false;");
+      expect(html).toContain("__anNativeOAuthReturnObserved = true;");
       expect(html).toContain("__anBeginNativeOAuth(flowId);");
       expect(html).toContain("__anMarkNativeOAuthPolling(flowId);");
+      expect(html).toContain(
+        "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);\n        __anScheduleNativeOAuthAbandonment(flowId);",
+      );
       expect(html).toContain(
         "if (__anOAuthPollTimer) {\n        __anOAuthPopupCloseGraceTimer = setTimeout(function()",
       );

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -5909,6 +5909,10 @@ describe("server/auth", () => {
       expect(html).toContain(
         "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier)",
       );
+      expect(html).toContain("function __anWatchOAuthPopupClose(popup)");
+      expect(html).toContain("closed = popup.closed === true");
+      expect(html).toContain("__anWatchOAuthPopupClose(popup);");
+      expect(html).toContain("__anRecoverGoogleSignInAfterReturn();");
       const recoverStart = html.indexOf(
         "function __anRecoverGoogleSignInAfterReturn()",
       );

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2842,6 +2842,7 @@ ${signInJourneyInlineScript()}
     function __anFinishOAuthExchange(ret, flowId, sessionToken) {
       __anStopOAuthPopupWatch();
       __anGoogleSignInInFlight = false;
+      __anClearGoogleSignInFlow();
       __anMagicLinkInFlight = false;
       if (__anIsBuilderPreview()) {
         if (sessionToken) {
@@ -3114,6 +3115,8 @@ ${identitySsoScript}
     var __anOAuthPopupWatchTimer = null;
     var __anOAuthPollCount = 0;
     var __anGoogleSignInInFlight = false;
+    var __anGoogleSignInFlowId = null;
+    var __anGoogleSignInRecoveryFlowId = null;
     var __anMagicLinkInFlight = false;
     var __anGoogleRecoverBound = false;
     function __anNewOAuthFlowId() {
@@ -3176,10 +3179,36 @@ ${identitySsoScript}
         __anOAuthPopupWatchTimer = null;
       }
     }
-    function __anWatchOAuthPopupClose(popup) {
+    function __anBeginGoogleSignInFlow(flowId) {
+      __anGoogleSignInFlowId = flowId;
+      __anGoogleSignInRecoveryFlowId = null;
+      __anGoogleSignInInFlight = true;
+    }
+    function __anIsCurrentGoogleSignInFlow(flowId) {
+      return __anGoogleSignInInFlight && __anGoogleSignInFlowId === flowId;
+    }
+    function __anClearGoogleSignInFlow() {
+      __anGoogleSignInFlowId = null;
+      __anGoogleSignInRecoveryFlowId = null;
+    }
+    function __anInvalidateGoogleSignInFlow(flowId) {
+      if (!__anIsCurrentGoogleSignInFlow(flowId)) return false;
+      __anGoogleSignInFlowId = null;
+      __anGoogleSignInRecoveryFlowId = flowId;
+      return true;
+    }
+    function __anCanRecoverGoogleSignInFlow(flowId, expectedFlowId) {
+      if (flowId) {
+        return __anGoogleSignInInFlight &&
+          !__anGoogleSignInFlowId &&
+          __anGoogleSignInRecoveryFlowId === flowId;
+      }
+      return __anGoogleSignInInFlight && __anGoogleSignInFlowId === expectedFlowId;
+    }
+    function __anWatchOAuthPopupClose(popup, flowId) {
       __anStopOAuthPopupWatch();
       __anOAuthPopupWatchTimer = setInterval(function() {
-        if (!__anGoogleSignInInFlight) {
+        if (!__anIsCurrentGoogleSignInFlow(flowId)) {
           __anStopOAuthPopupWatch();
           return;
         }
@@ -3188,12 +3217,18 @@ ${identitySsoScript}
           closed = popup.closed === true;
         } catch(e) {
           __anStopOAuthPopupWatch();
-          __anRecoverGoogleSignInAfterReturn();
+          if (__anInvalidateGoogleSignInFlow(flowId)) {
+            __anStopOAuthExchangePolling();
+            __anRecoverGoogleSignInAfterReturn(flowId);
+          }
           return;
         }
         if (!closed) return;
         __anStopOAuthPopupWatch();
-        __anRecoverGoogleSignInAfterReturn();
+        if (__anInvalidateGoogleSignInFlow(flowId)) {
+          __anStopOAuthExchangePolling();
+          __anRecoverGoogleSignInAfterReturn(flowId);
+        }
       }, 500);
     }
     function __anShowAuthExchangeError(err, btn, message, kind) {
@@ -3207,22 +3242,25 @@ ${identitySsoScript}
         showMagicLinkForm();
       } else {
         __anGoogleSignInInFlight = false;
+        __anClearGoogleSignInFlow();
       }
     }
     function __anShowOAuthError(err, btn, message) {
       __anShowAuthExchangeError(err, btn, message, 'google');
     }
-    function __anRecoverGoogleSignInAfterReturn() {
+    function __anRecoverGoogleSignInAfterReturn(flowId) {
       // The user left for the Google sign-in window and came back. If the flow
       // never completed (e.g. they closed the window to switch profiles), the
       // button is stuck disabled with no error path firing for up to 5 minutes.
       // Re-enable it so they can retry. Wait briefly first so a genuinely
       // in-flight exchange can still finish and navigate without a flicker.
-      if (!__anGoogleSignInInFlight) return;
+      var expectedFlowId = flowId || __anGoogleSignInFlowId;
+      if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
       setTimeout(function() {
+        if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
         __anMaybeRedirectSignedIn(__anResumeHref()).then(function(redirected) {
+          if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
           if (redirected) return;
-          if (!__anGoogleSignInInFlight) return;
           var btn = document.getElementById('google-btn');
           if (!btn || !btn.disabled) return;
           // Keep the desktop-exchange poll alive. Agent Native Desktop opens
@@ -3230,6 +3268,7 @@ ${identitySsoScript}
           // callback has stored the session token.
           btn.disabled = false;
           __anGoogleSignInInFlight = false;
+          __anClearGoogleSignInFlow();
         });
       }, 1200);
     }
@@ -3266,6 +3305,7 @@ ${identitySsoScript}
       var isMagicLink = kind === 'magic-link';
       __anOAuthPollCount = 0;
       async function check() {
+        if (!isMagicLink && !__anIsCurrentGoogleSignInFlow(flowId)) return;
         __anOAuthPollCount++;
         try {
           var exchangeParams = '?flow_id=' + encodeURIComponent(flowId);
@@ -3275,6 +3315,7 @@ ${identitySsoScript}
           }
           var res = await fetch(__anPath('/_agent-native/auth/desktop-exchange') + exchangeParams, exchangeOptions);
           var data = await res.json().catch(function() { return {}; });
+          if (!isMagicLink && !__anIsCurrentGoogleSignInFlow(flowId)) return;
           if (data && (data.email || data.token)) {
             if (__anOAuthPollTimer) clearInterval(__anOAuthPollTimer);
             __anOAuthPollTimer = null;
@@ -3338,8 +3379,7 @@ ${identitySsoScript}
       }
       return data.url;
     }
-    function __anStartPopupOAuth(ret, btn, err) {
-      var flowId = __anNewOAuthFlowId();
+    function __anStartPopupOAuth(ret, btn, err, flowId) {
       var verifier = __anNewOAuthVerifier();
       if (!verifier) {
         __anShowOAuthError(err, btn, __anT('failedToConnect'));
@@ -3356,12 +3396,13 @@ ${identitySsoScript}
           return;
         }
         try { popup.opener = null; } catch(e) {}
-        __anWatchOAuthPopupClose(popup);
+        __anWatchOAuthPopupClose(popup, flowId);
       } catch(e) {
         __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect', 'Could not open Google popup.');
         return;
       }
       __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn).then(function(url) {
+        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
         try {
           popup.location.href = url;
           __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
@@ -3370,12 +3411,12 @@ ${identitySsoScript}
           throw e;
         }
       }).catch(function(e) {
+        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
         try { popup.close(); } catch(closeErr) {}
         __anShowOAuthError(err, btn, e && e.message ? e.message : __anT('failedToConnect'));
       });
     }
-    function __anStartNativeDesktopOAuth(ret, btn, err) {
-      var flowId = __anNewOAuthFlowId();
+    function __anStartNativeDesktopOAuth(ret, btn, err, flowId) {
       var verifier = __anNewOAuthVerifier();
       if (!verifier) {
         __anShowOAuthError(err, btn, __anT('failedToConnect'));
@@ -3384,10 +3425,12 @@ ${identitySsoScript}
       var oauthReturn = ret;
       __anSetOAuthDebug('Preparing Google sign-in in system browser', flowId);
       __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn).then(function(url) {
+        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
         __anSetOAuthDebug('Opening Google sign-in in system browser', flowId);
         __anOpenOAuthUrl(url);
         __anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);
       }).catch(function(e) {
+        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
         __anShowOAuthError(err, btn, e && e.message ? e.message : __anT('failedToConnect'));
       });
     }
@@ -4111,20 +4154,20 @@ ${
     var btn = document.getElementById('google-btn');
     var err = document.getElementById('google-err');
     var ret = __anResumeHref();
+    var flowId = __anNewOAuthFlowId();
     btn.disabled = true;
-    __anGoogleSignInInFlight = true;
+    __anBeginGoogleSignInFlow(flowId);
     __anBindGoogleRecover();
     err.classList.remove('show');
     if (__anResolveAuthFlow() === 'popup') {
-      __anStartPopupOAuth(ret, btn, err);
+      __anStartPopupOAuth(ret, btn, err, flowId);
       return;
     }
     if (__anIsAgentNativeDesktop()) {
-      __anStartNativeDesktopOAuth(ret, btn, err);
+      __anStartNativeDesktopOAuth(ret, btn, err, flowId);
       return;
     }
     if (__anIsBuilderPreview()) {
-      var flowId = __anNewOAuthFlowId();
       __anStartRedirectOAuth(ret, btn, err, flowId, 'Opening Google sign-in redirect from Builder preview');
       return;
     }
@@ -4132,6 +4175,7 @@ ${
       var authUrl = __anGoogleAuthUrlPath() + '?return=' + encodeURIComponent(ret);
       var res = await fetch(authUrl);
       var data = await res.json();
+      if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
       if (data.url) {
         __anOpenOAuthUrl(data.url);
       } else {
@@ -4139,12 +4183,14 @@ ${
         err.classList.add('show');
         btn.disabled = false;
         __anGoogleSignInInFlight = false;
+        __anClearGoogleSignInFlow();
       }
     } catch (e) {
       err.textContent = __anT('failedToConnect');
       err.classList.add('show');
       btn.disabled = false;
       __anGoogleSignInInFlight = false;
+      __anClearGoogleSignInFlow();
     }
   }`
     : ""

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -3118,6 +3118,7 @@ ${identitySsoScript}
     var __anOAuthPopupCloseGraceMs = 5000;
     var __anNativeOAuthFlowId = null;
     var __anNativeOAuthRequestPending = false;
+    var __anNativeOAuthReturnObserved = false;
     var __anNativeOAuthAbandonGraceTimer = null;
     var __anNativeOAuthAbandonGraceMs = 5000;
     var __anOAuthPollCount = 0;
@@ -3200,11 +3201,13 @@ ${identitySsoScript}
         clearTimeout(__anNativeOAuthAbandonGraceTimer);
         __anNativeOAuthAbandonGraceTimer = null;
       }
+      __anNativeOAuthReturnObserved = false;
     }
     function __anBeginNativeOAuth(flowId) {
       __anStopNativeOAuthAbandonment();
       __anNativeOAuthFlowId = flowId;
       __anNativeOAuthRequestPending = true;
+      __anNativeOAuthReturnObserved = false;
     }
     function __anMarkNativeOAuthPolling(flowId) {
       if (__anNativeOAuthFlowId !== flowId) return;
@@ -3231,6 +3234,7 @@ ${identitySsoScript}
       if (
         !__anIsCurrentNativeOAuth(flowId) ||
         __anNativeOAuthRequestPending ||
+        !__anNativeOAuthReturnObserved ||
         !__anOAuthPollTimer ||
         __anNativeOAuthAbandonGraceTimer
       ) return;
@@ -3331,6 +3335,7 @@ ${identitySsoScript}
       // Re-enable it so they can retry. Wait briefly first so a genuinely
       // in-flight exchange can still finish and navigate without a flicker.
       if (!flowId && __anNativeOAuthFlowId) {
+        __anNativeOAuthReturnObserved = true;
         __anScheduleNativeOAuthAbandonment(__anNativeOAuthFlowId);
         return;
       }
@@ -3520,6 +3525,7 @@ ${identitySsoScript}
         __anSetOAuthDebug('Opening Google sign-in in system browser', flowId);
         __anOpenOAuthUrl(url);
         __anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);
+        __anScheduleNativeOAuthAbandonment(flowId);
       }).catch(function(e) {
         if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
         __anShowOAuthError(err, btn, e && e.message ? e.message : __anT('failedToConnect'));

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -3275,7 +3275,9 @@ ${identitySsoScript}
     function __anBindGoogleRecover() {
       if (__anGoogleRecoverBound) return;
       __anGoogleRecoverBound = true;
-      window.addEventListener('focus', __anRecoverGoogleSignInAfterReturn);
+      window.addEventListener('focus', function() {
+        __anRecoverGoogleSignInAfterReturn();
+      });
       document.addEventListener('visibilitychange', function() {
         if (document.visibilityState === 'visible') __anRecoverGoogleSignInAfterReturn();
       });

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2840,6 +2840,7 @@ ${signInJourneyInlineScript()}
       }
     }
     function __anFinishOAuthExchange(ret, flowId, sessionToken) {
+      __anStopOAuthPopupWatch();
       __anGoogleSignInInFlight = false;
       __anMagicLinkInFlight = false;
       if (__anIsBuilderPreview()) {
@@ -3110,6 +3111,7 @@ ${identitySsoScript}
       return __anIsAgentNativeDesktop() ? 'redirect' : 'popup';
     }
     var __anOAuthPollTimer = null;
+    var __anOAuthPopupWatchTimer = null;
     var __anOAuthPollCount = 0;
     var __anGoogleSignInInFlight = false;
     var __anMagicLinkInFlight = false;
@@ -3168,8 +3170,35 @@ ${identitySsoScript}
         __anOAuthPollTimer = null;
       }
     }
+    function __anStopOAuthPopupWatch() {
+      if (__anOAuthPopupWatchTimer) {
+        clearInterval(__anOAuthPopupWatchTimer);
+        __anOAuthPopupWatchTimer = null;
+      }
+    }
+    function __anWatchOAuthPopupClose(popup) {
+      __anStopOAuthPopupWatch();
+      __anOAuthPopupWatchTimer = setInterval(function() {
+        if (!__anGoogleSignInInFlight) {
+          __anStopOAuthPopupWatch();
+          return;
+        }
+        var closed = false;
+        try {
+          closed = popup.closed === true;
+        } catch(e) {
+          __anStopOAuthPopupWatch();
+          __anRecoverGoogleSignInAfterReturn();
+          return;
+        }
+        if (!closed) return;
+        __anStopOAuthPopupWatch();
+        __anRecoverGoogleSignInAfterReturn();
+      }, 500);
+    }
     function __anShowAuthExchangeError(err, btn, message, kind) {
       __anStopOAuthExchangePolling();
+      __anStopOAuthPopupWatch();
       err.textContent = message;
       err.classList.add('show', 'error');
       btn.disabled = false;
@@ -3327,6 +3356,7 @@ ${identitySsoScript}
           return;
         }
         try { popup.opener = null; } catch(e) {}
+        __anWatchOAuthPopupClose(popup);
       } catch(e) {
         __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect', 'Could not open Google popup.');
         return;

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -3204,6 +3204,9 @@ ${identitySsoScript}
       return true;
     }
     function __anCanRecoverGoogleSignInFlow(flowId, expectedFlowId) {
+      // Focus can return while either the system-browser exchange or the popup
+      // exchange is still active. Let that exchange finish before recovering.
+      if (!flowId && (__anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;
       if (flowId) {
         return __anGoogleSignInInFlight &&
           !__anGoogleSignInFlowId &&

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -3191,12 +3191,15 @@ ${identitySsoScript}
       }
     }
     function __anStopNativeOAuthAbandonment() {
+      __anCancelNativeOAuthAbandonment();
+      __anNativeOAuthFlowId = null;
+      __anNativeOAuthRequestPending = false;
+    }
+    function __anCancelNativeOAuthAbandonment() {
       if (__anNativeOAuthAbandonGraceTimer) {
         clearTimeout(__anNativeOAuthAbandonGraceTimer);
         __anNativeOAuthAbandonGraceTimer = null;
       }
-      __anNativeOAuthFlowId = null;
-      __anNativeOAuthRequestPending = false;
     }
     function __anBeginNativeOAuth(flowId) {
       __anStopNativeOAuthAbandonment();
@@ -3212,6 +3215,10 @@ ${identitySsoScript}
     }
     function __anFinalizeNativeOAuthAbandonment(flowId) {
       if (!__anIsCurrentNativeOAuth(flowId) || !__anOAuthPollTimer) return;
+      if (document.visibilityState === 'hidden') {
+        __anCancelNativeOAuthAbandonment();
+        return;
+      }
       __anStopNativeOAuthAbandonment();
       if (__anInvalidateGoogleSignInFlow(flowId)) {
         __anStopOAuthExchangePolling();
@@ -3351,8 +3358,15 @@ ${identitySsoScript}
       window.addEventListener('focus', function() {
         __anRecoverGoogleSignInAfterReturn();
       });
+      window.addEventListener('blur', function() {
+        __anCancelNativeOAuthAbandonment();
+      });
       document.addEventListener('visibilitychange', function() {
-        if (document.visibilityState === 'visible') __anRecoverGoogleSignInAfterReturn();
+        if (document.visibilityState === 'visible') {
+          __anRecoverGoogleSignInAfterReturn();
+        } else {
+          __anCancelNativeOAuthAbandonment();
+        }
       });
     }
     function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage) {

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2841,6 +2841,7 @@ ${signInJourneyInlineScript()}
     }
     function __anFinishOAuthExchange(ret, flowId, sessionToken) {
       __anStopOAuthPopupWatch();
+      __anStopNativeOAuthAbandonment();
       __anGoogleSignInInFlight = false;
       __anClearGoogleSignInFlow();
       __anMagicLinkInFlight = false;
@@ -3115,6 +3116,10 @@ ${identitySsoScript}
     var __anOAuthPopupWatchTimer = null;
     var __anOAuthPopupCloseGraceTimer = null;
     var __anOAuthPopupCloseGraceMs = 5000;
+    var __anNativeOAuthFlowId = null;
+    var __anNativeOAuthRequestPending = false;
+    var __anNativeOAuthAbandonGraceTimer = null;
+    var __anNativeOAuthAbandonGraceMs = 5000;
     var __anOAuthPollCount = 0;
     var __anGoogleSignInInFlight = false;
     var __anGoogleSignInFlowId = null;
@@ -3185,6 +3190,48 @@ ${identitySsoScript}
         __anOAuthPopupCloseGraceTimer = null;
       }
     }
+    function __anStopNativeOAuthAbandonment() {
+      if (__anNativeOAuthAbandonGraceTimer) {
+        clearTimeout(__anNativeOAuthAbandonGraceTimer);
+        __anNativeOAuthAbandonGraceTimer = null;
+      }
+      __anNativeOAuthFlowId = null;
+      __anNativeOAuthRequestPending = false;
+    }
+    function __anBeginNativeOAuth(flowId) {
+      __anStopNativeOAuthAbandonment();
+      __anNativeOAuthFlowId = flowId;
+      __anNativeOAuthRequestPending = true;
+    }
+    function __anMarkNativeOAuthPolling(flowId) {
+      if (__anNativeOAuthFlowId !== flowId) return;
+      __anNativeOAuthRequestPending = false;
+    }
+    function __anIsCurrentNativeOAuth(flowId) {
+      return __anNativeOAuthFlowId === flowId && __anIsCurrentGoogleSignInFlow(flowId);
+    }
+    function __anFinalizeNativeOAuthAbandonment(flowId) {
+      if (!__anIsCurrentNativeOAuth(flowId) || !__anOAuthPollTimer) return;
+      __anStopNativeOAuthAbandonment();
+      if (__anInvalidateGoogleSignInFlow(flowId)) {
+        __anStopOAuthExchangePolling();
+        __anRecoverGoogleSignInAfterReturn(flowId);
+      }
+    }
+    function __anScheduleNativeOAuthAbandonment(flowId) {
+      // Returning focus is the only signal that the system-browser ceremony was
+      // abandoned. Preserve the exchange poll briefly for a late deep-link.
+      if (
+        !__anIsCurrentNativeOAuth(flowId) ||
+        __anNativeOAuthRequestPending ||
+        !__anOAuthPollTimer ||
+        __anNativeOAuthAbandonGraceTimer
+      ) return;
+      __anNativeOAuthAbandonGraceTimer = setTimeout(function() {
+        __anNativeOAuthAbandonGraceTimer = null;
+        __anFinalizeNativeOAuthAbandonment(flowId);
+      }, __anNativeOAuthAbandonGraceMs);
+    }
     function __anBeginGoogleSignInFlow(flowId) {
       __anGoogleSignInFlowId = flowId;
       __anGoogleSignInRecoveryFlowId = null;
@@ -3206,7 +3253,7 @@ ${identitySsoScript}
     function __anCanRecoverGoogleSignInFlow(flowId, expectedFlowId) {
       // Focus can return while either the system-browser exchange or the popup
       // exchange is still active. Let that exchange finish before recovering.
-      if (!flowId && (__anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;
+      if (!flowId && (__anNativeOAuthFlowId || __anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;
       if (flowId) {
         return __anGoogleSignInInFlight &&
           !__anGoogleSignInFlowId &&
@@ -3255,6 +3302,7 @@ ${identitySsoScript}
     function __anShowAuthExchangeError(err, btn, message, kind) {
       __anStopOAuthExchangePolling();
       __anStopOAuthPopupWatch();
+      __anStopNativeOAuthAbandonment();
       err.textContent = message;
       err.classList.add('show', 'error');
       btn.disabled = false;
@@ -3275,6 +3323,10 @@ ${identitySsoScript}
       // button is stuck disabled with no error path firing for up to 5 minutes.
       // Re-enable it so they can retry. Wait briefly first so a genuinely
       // in-flight exchange can still finish and navigate without a flicker.
+      if (!flowId && __anNativeOAuthFlowId) {
+        __anScheduleNativeOAuthAbandonment(__anNativeOAuthFlowId);
+        return;
+      }
       var expectedFlowId = flowId || __anGoogleSignInFlowId;
       if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
       setTimeout(function() {
@@ -3446,9 +3498,11 @@ ${identitySsoScript}
         return;
       }
       var oauthReturn = ret;
+      __anBeginNativeOAuth(flowId);
       __anSetOAuthDebug('Preparing Google sign-in in system browser', flowId);
       __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn).then(function(url) {
         if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
+        __anMarkNativeOAuthPolling(flowId);
         __anSetOAuthDebug('Opening Google sign-in in system browser', flowId);
         __anOpenOAuthUrl(url);
         __anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -3113,6 +3113,8 @@ ${identitySsoScript}
     }
     var __anOAuthPollTimer = null;
     var __anOAuthPopupWatchTimer = null;
+    var __anOAuthPopupCloseGraceTimer = null;
+    var __anOAuthPopupCloseGraceMs = 5000;
     var __anOAuthPollCount = 0;
     var __anGoogleSignInInFlight = false;
     var __anGoogleSignInFlowId = null;
@@ -3178,6 +3180,10 @@ ${identitySsoScript}
         clearInterval(__anOAuthPopupWatchTimer);
         __anOAuthPopupWatchTimer = null;
       }
+      if (__anOAuthPopupCloseGraceTimer) {
+        clearTimeout(__anOAuthPopupCloseGraceTimer);
+        __anOAuthPopupCloseGraceTimer = null;
+      }
     }
     function __anBeginGoogleSignInFlow(flowId) {
       __anGoogleSignInFlowId = flowId;
@@ -3205,6 +3211,26 @@ ${identitySsoScript}
       }
       return __anGoogleSignInInFlight && __anGoogleSignInFlowId === expectedFlowId;
     }
+    function __anFinalizeOAuthPopupClose(flowId) {
+      if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
+      __anOAuthPopupCloseGraceTimer = null;
+      if (__anInvalidateGoogleSignInFlow(flowId)) {
+        __anStopOAuthExchangePolling();
+        __anRecoverGoogleSignInAfterReturn(flowId);
+      }
+    }
+    function __anHandleOAuthPopupClosed(flowId) {
+      __anStopOAuthPopupWatch();
+      // The success callback closes its tab 250ms after staging the token, but
+      // the opener polls once per second. Let an active exchange win that race.
+      if (__anOAuthPollTimer) {
+        __anOAuthPopupCloseGraceTimer = setTimeout(function() {
+          __anFinalizeOAuthPopupClose(flowId);
+        }, __anOAuthPopupCloseGraceMs);
+        return;
+      }
+      __anFinalizeOAuthPopupClose(flowId);
+    }
     function __anWatchOAuthPopupClose(popup, flowId) {
       __anStopOAuthPopupWatch();
       __anOAuthPopupWatchTimer = setInterval(function() {
@@ -3216,19 +3242,11 @@ ${identitySsoScript}
         try {
           closed = popup.closed === true;
         } catch(e) {
-          __anStopOAuthPopupWatch();
-          if (__anInvalidateGoogleSignInFlow(flowId)) {
-            __anStopOAuthExchangePolling();
-            __anRecoverGoogleSignInAfterReturn(flowId);
-          }
+          __anHandleOAuthPopupClosed(flowId);
           return;
         }
         if (!closed) return;
-        __anStopOAuthPopupWatch();
-        if (__anInvalidateGoogleSignInFlow(flowId)) {
-          __anStopOAuthExchangePolling();
-          __anRecoverGoogleSignInAfterReturn(flowId);
-        }
+        __anHandleOAuthPopupClosed(flowId);
       }, 500);
     }
     function __anShowAuthExchangeError(err, btn, message, kind) {

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -89,6 +89,45 @@ describe("Nitro dev startup recovery", () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  it("settles readiness before the first document request", () => {
+    vi.useFakeTimers();
+    try {
+      const entry = {
+        id: "/node_modules/nitro/dist/runtime/internal/vite/dev-entry.mjs",
+        transformResult: { code: "entry" },
+      };
+      const environment = {
+        moduleGraph: { idToModuleMap: new Map([[entry.id, entry]]) },
+      };
+      let time = 0;
+      let middleware:
+        | ((req: unknown, res: unknown, next: () => void) => void)
+        | undefined;
+      _nitroStartupGate({ now: () => time, settleMs: 100 }).configureServer?.({
+        environments: { nitro: environment },
+        middlewares: {
+          use: vi.fn((handler) => {
+            middleware = handler;
+          }),
+        },
+      } as never);
+
+      // The interval observes readiness while no browser request is present.
+      time = 150;
+      vi.advanceTimersByTime(100);
+
+      const next = vi.fn();
+      middleware?.(
+        { headers: { accept: "text/html" }, method: "GET" },
+        { end: vi.fn(), setHeader: vi.fn(), statusCode: 200 },
+        next,
+      );
+      expect(next).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("turns a transient document error into a quiet retry page", () => {
     let middleware:
       | ((

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -2869,7 +2869,10 @@ type NitroModuleGraph = {
   idToModuleMap: Map<string, NitroModuleNode>;
 };
 
-const NITRO_STARTUP_SETTLE_MS = 1_000;
+// Nitro's worker can expose a transformed module graph before its entry
+// module has finished importing. Keep the recovery page up for the same
+// cold-start window instead of letting the first poll render a 500 error.
+const NITRO_STARTUP_SETTLE_MS = 3_000;
 const NITRO_STARTUP_TIMEOUT_MS = 30_000;
 const NITRO_STARTUP_RETRY_DELAY_MS = 1_000;
 const NITRO_STARTUP_RETRY_MAX_DELAY_MS = 3_000;

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -2873,6 +2873,7 @@ type NitroModuleGraph = {
 // module has finished importing. Keep the recovery page up for the same
 // cold-start window instead of letting the first poll render a 500 error.
 const NITRO_STARTUP_SETTLE_MS = 3_000;
+const NITRO_STARTUP_POLL_INTERVAL_MS = 100;
 const NITRO_STARTUP_TIMEOUT_MS = 30_000;
 const NITRO_STARTUP_RETRY_DELAY_MS = 1_000;
 const NITRO_STARTUP_RETRY_MAX_DELAY_MS = 3_000;
@@ -2999,17 +3000,26 @@ function nitroStartupGate(
       let graphSignature: string | null = null;
       let graphStableAt: number | undefined;
       let startupComplete = false;
+      let readinessTimer: ReturnType<typeof setInterval> | undefined;
 
-      server.middlewares.use((req, res, next) => {
-        if (startupComplete || !isHtmlDocumentRequest(req)) {
-          next();
-          return;
+      const completeStartup = () => {
+        startupComplete = true;
+        if (readinessTimer) {
+          clearInterval(readinessTimer);
+          readinessTimer = undefined;
         }
+      };
+
+      // Observe the graph independently of the first document request. A
+      // server can finish compiling while the shell is still on its loading
+      // screen; measuring stability only from the first request adds the full
+      // settle window to an otherwise-ready server.
+      const observeStartup = () => {
+        if (startupComplete) return;
 
         const timestamp = now();
         if (timestamp - startedAt >= timeoutMs) {
-          startupComplete = true;
-          next();
+          completeStartup();
           return;
         }
 
@@ -3024,13 +3034,48 @@ function nitroStartupGate(
             graphStableAt !== undefined &&
             timestamp - graphStableAt >= settleMs
           ) {
-            startupComplete = true;
-            next();
-            return;
+            completeStartup();
           }
         } else {
           graphSignature = null;
           graphStableAt = undefined;
+        }
+      };
+
+      // Start watching before any HTML request arrives so readiness time is
+      // measured from server startup, not from the user's first navigation.
+      observeStartup();
+      if (!startupComplete) {
+        readinessTimer = setInterval(
+          observeStartup,
+          NITRO_STARTUP_POLL_INTERVAL_MS,
+        );
+        readinessTimer.unref?.();
+        server.httpServer?.once("close", () => {
+          if (readinessTimer) {
+            clearInterval(readinessTimer);
+            readinessTimer = undefined;
+          }
+        });
+      }
+
+      server.middlewares.use((req, res, next) => {
+        if (startupComplete || !isHtmlDocumentRequest(req)) {
+          next();
+          return;
+        }
+
+        const timestamp = now();
+        if (timestamp - startedAt >= timeoutMs) {
+          completeStartup();
+          next();
+          return;
+        }
+
+        observeStartup();
+        if (startupComplete) {
+          next();
+          return;
         }
 
         sendNitroStartingResponse(req, res);

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -161,9 +161,10 @@ describe("desktop passive-access regressions", () => {
     expect(connectFlow).toContain("hasMissingCredentialSignal(");
     expect(connectFlow).toContain("await host.retryRun({");
     expect(connectFlow).toContain("selectRun(retryResult.run.id)");
-    expect(agent).toContain(
-      "const hasCredentialGap = providerBlocked && hasCredentialHistory",
-    );
+    expect(agent).toContain("shouldShowCodeAgentCredentialCallout({");
+    expect(agent).toContain("providerBlocked,");
+    expect(agent).toContain("hasCredentialHistory,");
+    expect(agent).toContain("phase: run.phase,");
     expect(agent).toContain("hideCredentialMessages={hasCredentialHistory}");
   });
 
@@ -202,7 +203,7 @@ describe("desktop passive-access regressions", () => {
     const providerCheck = between(
       main,
       "function ensureCodeAgentLlmProvider()",
-      "function getLocalCodexCliStatus()",
+      "const CLI_PROBE_TIMEOUT_MS",
     );
 
     expect(providerCheck).toContain(

--- a/scripts/dev-electron-template.ts
+++ b/scripts/dev-electron-template.ts
@@ -29,6 +29,7 @@ const child = spawn(pnpm, ["--dir", `templates/${appName}`, "exec", "vite"], {
     APP_NAME: appName,
     PORT: String(port),
   },
+  shell: process.platform === "win32",
   stdio: "inherit",
 });
 

--- a/scripts/dev-electron-template.ts
+++ b/scripts/dev-electron-template.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+
+const [appName, portText, delayText] = process.argv.slice(2);
+const port = Number(portText);
+const delayMs = Number(delayText);
+
+if (
+  !appName ||
+  !Number.isInteger(port) ||
+  port <= 0 ||
+  !Number.isInteger(delayMs) ||
+  delayMs < 0
+) {
+  console.error(
+    "Usage: node scripts/dev-electron-template.ts <app> <port> <delay-ms>",
+  );
+  process.exit(1);
+}
+
+await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const child = spawn(pnpm, ["--dir", `templates/${appName}`, "exec", "vite"], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    APP_NAME: appName,
+    PORT: String(port),
+  },
+  stdio: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  process.on(signal, () => child.kill(signal));
+}
+
+child.once("error", () => process.exit(1));
+child.once("exit", (code, signal) => process.exit(code ?? (signal ? 1 : 0)));

--- a/scripts/dev-electron-template.ts
+++ b/scripts/dev-electron-template.ts
@@ -33,8 +33,23 @@ const child = spawn(pnpm, ["--dir", `templates/${appName}`, "exec", "vite"], {
   stdio: "inherit",
 });
 
+let stopping = false;
+function stopChild(signal: NodeJS.Signals): void {
+  if (stopping) return;
+  stopping = true;
+  if (process.platform === "win32" && child.pid) {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    killer.once("error", () => child.kill());
+    return;
+  }
+  child.kill(signal);
+}
+
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-  process.on(signal, () => child.kill(signal));
+  process.on(signal, () => stopChild(signal));
 }
 
 child.once("error", () => process.exit(1));

--- a/scripts/dev-electron.ts
+++ b/scripts/dev-electron.ts
@@ -7,7 +7,7 @@
  * By default starts the core template set (mail, calendar, slides, etc.).
  * Pass --apps to override, e.g.: --apps calendar,slides
  */
-import { spawn, execSync } from "child_process";
+import { execFileSync, execSync, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 
@@ -87,14 +87,68 @@ const portsToUse = requestedApps
   .filter(Boolean) as number[];
 portsToUse.push(FRAME_PORT);
 
-function tryKillPort(port: number) {
-  try {
-    const pids = execSync(`lsof -ti :${port}`, { encoding: "utf8" }).trim();
-    if (pids) {
-      execSync(`kill -9 ${pids.split("\n").join(" ")}`, { stdio: "ignore" });
+function listeningPidsForPort(port: number): number[] {
+  if (process.platform === "win32") {
+    const output = execFileSync("netstat", ["-ano", "-p", "tcp"], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const pids = new Set<number>();
+    for (const line of output.split(/\r?\n/)) {
+      const fields = line.trim().split(/\s+/);
+      if (
+        fields[0]?.toUpperCase() !== "TCP" ||
+        fields[3]?.toUpperCase() !== "LISTENING"
+      ) {
+        continue;
+      }
+      const localAddress = fields[1] ?? "";
+      const localPort = localAddress.slice(localAddress.lastIndexOf(":") + 1);
+      const pid = Number(fields[4]);
+      if (localPort === String(port) && Number.isInteger(pid) && pid > 0) {
+        pids.add(pid);
+      }
     }
+    return [...pids];
+  }
+
+  const output = execFileSync("lsof", ["-ti", `:${port}`], {
+    encoding: "utf8",
+  });
+  const pids: number[] = [];
+  for (const value of output.split(/\s+/)) {
+    if (!value) continue;
+    const pid = Number(value);
+    if (Number.isInteger(pid) && pid > 0) pids.push(pid);
+  }
+  return pids;
+}
+
+function tryKillPort(port: number) {
+  let pids: number[];
+  try {
+    pids = listeningPidsForPort(port);
   } catch {
     // Port not in use — fine
+    return;
+  }
+
+  for (const pid of pids) {
+    try {
+      if (process.platform === "win32") {
+        // Vite is launched through pnpm/concurrently, so kill the full tree;
+        // terminating only the listener leaves its wrapper alive for relaunch.
+        execFileSync("taskkill", ["/pid", String(pid), "/t", "/f"], {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+      } else {
+        execFileSync("kill", ["-9", String(pid)], { stdio: "ignore" });
+      }
+    } catch {
+      // coercion-ok: a raced process exit means cleanup already happened.
+      // The process may have exited between discovery and termination.
+    }
   }
 }
 

--- a/scripts/dev-electron.ts
+++ b/scripts/dev-electron.ts
@@ -137,6 +137,11 @@ const colors: string[] = [];
 
 const appColors = ["blue", "green", "cyan", "magenta", "white"];
 
+// Keep cold-start SSR imports from racing one another. Nitro's Vite worker
+// reports a transient 503 while its entry is still being compiled; starting
+// every template at once turns that expected warm-up into a visible app error.
+const STAGGER_DELAY_S = 0.25;
+
 requestedApps.forEach((appName, i) => {
   const port = PORT_MAP[appName];
   if (!port) {
@@ -150,8 +155,10 @@ requestedApps.forEach((appName, i) => {
   // both the frontend and all /api/* routes on the one port.
   // PORT pins the dev server port (Nitro's vite plugin reads process.env.PORT
   // first when resolving the dev server port).
+  const delay = i * STAGGER_DELAY_S;
+  const prefix = delay > 0 ? `sleep ${delay} && ` : "";
   commands.push(
-    `APP_NAME=${appName} PORT=${port} pnpm --dir templates/${appName} exec vite`,
+    `${prefix}APP_NAME=${appName} PORT=${port} pnpm --dir templates/${appName} exec vite`,
   );
   colors.push(appColors[i % appColors.length]);
 });

--- a/scripts/dev-electron.ts
+++ b/scripts/dev-electron.ts
@@ -155,10 +155,9 @@ requestedApps.forEach((appName, i) => {
   // both the frontend and all /api/* routes on the one port.
   // PORT pins the dev server port (Nitro's vite plugin reads process.env.PORT
   // first when resolving the dev server port).
-  const delay = i * STAGGER_DELAY_S;
-  const prefix = delay > 0 ? `sleep ${delay} && ` : "";
+  const delayMs = Math.round(i * STAGGER_DELAY_S * 1000);
   commands.push(
-    `${prefix}APP_NAME=${appName} PORT=${port} pnpm --dir templates/${appName} exec vite`,
+    `node scripts/dev-electron-template.ts ${JSON.stringify(appName)} ${port} ${delayMs}`,
   );
   colors.push(appColors[i % appColors.length]);
 });


### PR DESCRIPTION
## Summary
- reset the Google sign-in flow when an Electron OAuth popup is closed
- hold the Nitro recovery page through the dev cold-start window and stagger Electron app servers
- refresh stale desktop privacy regression expectations

## Validation
- live Electron sweep covered shell boot, Mail, auth failure handling, Settings, Connections, AI providers, Workspace, and production/dev URL restoration
- focused core auth/startup tests: 547 passed
- desktop tests: 536 passed; computer-control/privacy: 58 passed
- dispatch suite: 567 passed
- full workspace prep: all suites passed except one dispatch timeout under parallel load; the full dispatch suite passed in isolation
- guards: 64 passed; workspace typecheck passed

## Notes
- the OAuth popup-close regression was reproduced in the production Mail sign-in flow before the fix
- the Nitro cold-start error was reproduced against local Vite and verified to remain behind the recovery page until the app returned 200
- this PR contains source/test fixes; deployment health is separate from merge validation