### PR TITLE
fix(core): default fresh chats to configured AI provider

### DIFF
--- a/.changeset/fresh-chat-configured-model.md
+++ b/.changeset/fresh-chat-configured-model.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix fresh chats to use a configured provider instead of an unavailable deployment default

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -234,6 +234,7 @@ vi.mock("./AssistantChat.js", async () => {
         selectedEngine?: string;
         selectedEffort?: string;
         availableModels?: Array<{ engine: string; configured: boolean }>;
+        composerDisabled?: boolean;
         contextScope?: ChatThreadScope | null;
         contextNamespace?: string;
         onThreadRestoreNotFound?: () => void;
@@ -261,6 +262,7 @@ vi.mock("./AssistantChat.js", async () => {
           data-model-catalog={props.availableModels
             ?.map((group) => `${group.engine}:${group.configured}`)
             .join(",")}
+          data-composer-disabled={props.composerDisabled ? "true" : "false"}
           data-context-scope={
             props.contextScope
               ? `${props.contextScope.type}:${props.contextScope.id}`
@@ -394,6 +396,50 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
 
     expect(view.engineOf()).toBe("builder");
     await view.cleanup();
+  });
+
+  it("blocks a fresh chat until the model catalog resolves", async () => {
+    const engines = [
+      {
+        name: "builder",
+        label: "Builder.io Gateway",
+        supportedModels: ["gpt-5-6-luna"],
+        requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+      },
+    ];
+    stubCatalog(engines, [], true);
+    let resolveEngineList!: (value: unknown) => void;
+    actionMocks.callAction.mockImplementation(
+      () => new Promise((resolve) => (resolveEngineList = resolve)) as never,
+    );
+
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const localRoot = createRoot(el);
+    act(() => {
+      localRoot.render(<MultiTabAssistantChat storageKey="pending-catalog" />);
+    });
+
+    expect(
+      el
+        .querySelector("[data-testid='assistant-chat']")
+        ?.getAttribute("data-composer-disabled"),
+    ).toBe("true");
+
+    await act(async () => {
+      resolveEngineList({ engines });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      el
+        .querySelector("[data-testid='assistant-chat']")
+        ?.getAttribute("data-composer-disabled"),
+    ).toBe("false");
+
+    await act(async () => localRoot.unmount());
+    el.remove();
   });
 
   // The engines fetch is still in flight when an app-initiated first turn

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -158,7 +158,11 @@ const actionMocks = vi.hoisted(() => ({ callAction: vi.fn(async () => null) }));
 vi.mock("./use-action.js", () => actionMocks);
 
 /** Serve the three requests refreshEngines makes so the catalog is non-empty. */
-function stubCatalog(engines: unknown[], configuredKeys: string[]) {
+function stubCatalog(
+  engines: unknown[],
+  configuredKeys: string[],
+  builderConfigured = false,
+) {
   invalidateClientStatusRequests();
   actionMocks.callAction.mockResolvedValue({ engines } as never);
   vi.stubGlobal(
@@ -171,7 +175,7 @@ function stubCatalog(engines: unknown[], configuredKeys: string[]) {
         );
       }
       if (url.includes("builder/status")) {
-        return Response.json({ configured: false });
+        return Response.json({ configured: builderConfigured });
       }
       return Response.json({ value: null });
     }),
@@ -182,8 +186,12 @@ function stubCatalog(engines: unknown[], configuredKeys: string[]) {
  * Mounts a fresh instance after stubbing, because `refreshEngines` runs once on
  * mount — the shared root from `beforeEach` has already resolved an empty list.
  */
-async function mountWithCatalog(engines: unknown[], configuredKeys: string[]) {
-  stubCatalog(engines, configuredKeys);
+async function mountWithCatalog(
+  engines: unknown[],
+  configuredKeys: string[],
+  builderConfigured = false,
+) {
+  stubCatalog(engines, configuredKeys, builderConfigured);
   const el = document.createElement("div");
   document.body.appendChild(el);
   const localRoot = createRoot(el);
@@ -368,6 +376,24 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
         .querySelector("[data-testid='assistant-chat']")
         ?.getAttribute("data-reasoning-effort"),
     ).toBe("high");
+  });
+
+  it("defaults a fresh chat to a configured model group", async () => {
+    const view = await mountWithCatalog(
+      [
+        {
+          name: "builder",
+          label: "Builder.io Gateway",
+          supportedModels: ["gpt-5-6-luna"],
+          requiredEnvVars: ["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"],
+        },
+      ],
+      [],
+      true,
+    );
+
+    expect(view.engineOf()).toBe("builder");
+    await view.cleanup();
   });
 
   // The engines fetch is still in flight when an app-initiated first turn

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -2854,6 +2854,8 @@ export function MultiTabAssistantChat({
           )
           .map((tabId) => {
             const modelSelection = resolveThreadModelSelection(tabId);
+            const modelSelectionPending =
+              !hostManagedModels && modelListLoading && !modelSelection;
             const tabDynamicSuggestions =
               tabId === activeThreadId && !contentHidden
                 ? props.dynamicSuggestions
@@ -2943,11 +2945,15 @@ export function MultiTabAssistantChat({
                   // sub-agent tab would start a fresh run on that thread and kill
                   // the in-flight team chunk. Disable the composer and show a
                   // hint so users know to send via the orchestrator chat instead.
-                  composerDisabled={Boolean(parentMap[tabId])}
+                  composerDisabled={
+                    Boolean(parentMap[tabId]) || modelSelectionPending
+                  }
                   composerDisabledPlaceholder={
                     parentMap[tabId]
                       ? translate("agentChat.composer.subAgentReadOnly")
-                      : undefined
+                      : modelSelectionPending
+                        ? translate("agentChat.composer.loadingModels")
+                        : undefined
                   }
                 />
               </div>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -178,7 +178,17 @@ function resolveModelSelection(
   selection: ModelSelection | undefined,
   groups: EngineModelGroup[],
 ): ModelSelection | undefined {
-  if (!selection?.model) return undefined;
+  if (!selection?.model) {
+    const group = groups.find((candidate) => candidate.configured);
+    const model = group?.models[0];
+    return group && model
+      ? {
+          model,
+          engine: group.engine,
+          effort: resolveReasoningEffortSelection(model, undefined),
+        }
+      : undefined;
+  }
   // Engine precedence turns on whether the catalog OFFERS the supplied engine,
   // not on whether that engine advertises this model:
   //   offered      → honor it. A gateway's advertised list is its built-in


### PR DESCRIPTION
## Summary
- default fresh multi-tab chats to the first configured model group
- prevent a deployment model default from overriding an available Builder route
- add regression coverage for a fresh Builder-backed chat

## Verification
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/core exec vitest run src/client/MultiTabAssistantChat.spec.tsx src/client/chat-model-groups.spec.ts src/client/use-chat-models.spec.tsx`
