### PR TITLE
fix: stabilize Google Slides OAuth export

### DIFF
--- a/.changeset/google-oauth-redirect-cookie.md
+++ b/.changeset/google-oauth-redirect-cookie.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve shared OAuth flow cookies across redirects.

--- a/packages/core/src/server/workspace-provider-oauth.ts
+++ b/packages/core/src/server/workspace-provider-oauth.ts
@@ -25,7 +25,11 @@ import {
   upsertWorkspaceConnection,
   upsertWorkspaceConnectionGrant,
 } from "../workspace-connections/store.js";
-import { getSession, safeReturnPath } from "./auth.js";
+import {
+  getSession,
+  redirectWithStagedCookies,
+  safeReturnPath,
+} from "./auth.js";
 import { resolveSecret } from "./credential-provider.js";
 import {
   decodeOAuthState,
@@ -253,7 +257,7 @@ export async function handleWorkspaceProviderOAuthStart(
             }
           : {}),
       });
-      return Response.redirect(authorizationUrl, 302);
+      return redirectWithStagedCookies(event, authorizationUrl);
     },
   );
 }
@@ -433,7 +437,7 @@ export async function handleWorkspaceProviderOAuthCallback(
       const returnPath =
         state.returnUrl ??
         `/settings/integrations?connected=${encodeURIComponent(providerId)}`;
-      return Response.redirect(getAppUrl(event, returnPath), 302);
+      return redirectWithStagedCookies(event, getAppUrl(event, returnPath));
     },
   );
 }

--- a/templates/slides/app/lib/export-google-slides-client.test.ts
+++ b/templates/slides/app/lib/export-google-slides-client.test.ts
@@ -7,6 +7,7 @@ const { buildDeckPptxBlobMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@agent-native/core/client/api-path", () => ({
+  agentNativePath: (path: string) => `/slides${path}`,
   appBasePath: () => "/slides",
 }));
 
@@ -49,7 +50,12 @@ beforeEach(() => {
     filename: "quarterly-review.pptx",
   });
   vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:pptx");
-  globalThis.fetch = vi.fn(async () => {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).endsWith("/_agent-native/google-docs/status")) {
+      return new Response(JSON.stringify({ connected: false }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     return new Response(
       JSON.stringify({
         code: "google-not-connected",
@@ -65,7 +71,7 @@ afterEach(() => {
 });
 
 describe("exportDeckToGoogleSlides", () => {
-  it("returns a connection requirement without downloading a fallback PPTX", async () => {
+  it("checks the connection before building or uploading a PPTX", async () => {
     await expect(
       exportDeckToGoogleSlides("Quarterly Review", [{ id: "slide-1" }]),
     ).resolves.toEqual({
@@ -75,17 +81,24 @@ describe("exportDeckToGoogleSlides", () => {
     });
 
     expect(URL.createObjectURL).not.toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledWith(
-      "/slides/api/exports/google-slides",
-      expect.objectContaining({ method: "POST" }),
+    expect(buildDeckPptxBlobMock).not.toHaveBeenCalled();
+    const [statusUrl, statusInit] = vi.mocked(fetch).mock.calls[0];
+    expect(String(statusUrl)).toBe(
+      "http://localhost:3000/slides/_agent-native/google-docs/status",
     );
+    expect(statusInit).toEqual({ credentials: "same-origin" });
   });
 
   it("uploads the browser-rendered PPTX for an editor-authored deck", async () => {
-    vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ url: "https://docs.google.com/d/new" }), {
-        headers: { "Content-Type": "application/json" },
-      }),
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) =>
+      String(input).endsWith("/_agent-native/google-docs/status")
+        ? new Response(JSON.stringify({ connected: true }))
+        : new Response(
+            JSON.stringify({ url: "https://docs.google.com/d/new" }),
+            {
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
     );
 
     await expect(
@@ -99,15 +112,19 @@ describe("exportDeckToGoogleSlides", () => {
   it("uploads the server-built PPTX when the caller supplies one", async () => {
     // dom-to-pptx rasterizes every custGeom shape, so a source-imported deck
     // must reach Drive as the server's vector build, not the browser's.
-    vi.mocked(fetch).mockImplementation((async (url: string) =>
-      url.endsWith("/api/exports/pptx")
-        ? serverPptxResponse()
-        : new Response(
-            JSON.stringify({ url: "https://docs.google.com/d/new" }),
-            {
-              headers: { "Content-Type": "application/json" },
-            },
-          )) as unknown as typeof fetch);
+    vi.mocked(fetch).mockImplementation((async (input: RequestInfo | URL) => {
+      const url = String(input);
+      return url.endsWith("/_agent-native/google-docs/status")
+        ? new Response(JSON.stringify({ connected: true }))
+        : url.endsWith("/api/exports/pptx")
+          ? serverPptxResponse()
+          : new Response(
+              JSON.stringify({ url: "https://docs.google.com/d/new" }),
+              {
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+    }) as unknown as typeof fetch);
 
     await expect(
       exportDeckToGoogleSlides(
@@ -129,12 +146,15 @@ describe("exportDeckToGoogleSlides", () => {
   it("propagates the server's positioned-object guard without uploading", async () => {
     const guard =
       "Slide 3 contains freeform positioned objects. Export this deck from the Slides editor with Export > PowerPoint so browser-rendered geometry is preserved.";
-    vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ error: guard }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
+    vi.mocked(fetch).mockImplementation((async (input: RequestInfo | URL) => {
+      const url = String(input);
+      return url.endsWith("/_agent-native/google-docs/status")
+        ? new Response(JSON.stringify({ connected: true }))
+        : new Response(JSON.stringify({ error: guard }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+    }) as unknown as typeof fetch);
 
     await expect(
       exportDeckToGoogleSlides(
@@ -148,6 +168,6 @@ describe("exportDeckToGoogleSlides", () => {
     // No silent downgrade: neither the browser exporter nor Drive was reached.
     expect(buildDeckPptxBlobMock).not.toHaveBeenCalled();
     expect(URL.createObjectURL).not.toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/templates/slides/app/lib/export-google-slides-client.ts
+++ b/templates/slides/app/lib/export-google-slides-client.ts
@@ -1,4 +1,7 @@
-import { appBasePath } from "@agent-native/core/client/api-path";
+import {
+  agentNativePath,
+  appBasePath,
+} from "@agent-native/core/client/api-path";
 
 import type { AspectRatio } from "./aspect-ratios";
 import { buildDeckPptxBlob } from "./export-pptx-client";
@@ -18,6 +21,29 @@ export type GoogleSlidesExportResult =
 export interface DeckPptxFile {
   blob: Blob;
   filename: string;
+}
+
+async function googleDriveIsConnected(): Promise<boolean> {
+  const response = await fetch(
+    new URL(
+      agentNativePath("/_agent-native/google-docs/status"),
+      window.location.origin,
+    ),
+    { credentials: "same-origin" },
+  );
+  const payload = (await response.json()) as {
+    connected?: boolean;
+    error?: string;
+    message?: string;
+  } | null;
+  if (!response.ok || !payload || typeof payload.connected !== "boolean") {
+    throw new Error(
+      payload?.message ||
+        payload?.error ||
+        `Could not check Google Drive (${response.status})`,
+    );
+  }
+  return payload.connected === true;
 }
 
 /**
@@ -79,6 +105,14 @@ export async function exportDeckToGoogleSlides(
    */
   buildPptx?: () => Promise<DeckPptxFile>,
 ): Promise<GoogleSlidesExportResult> {
+  if (!(await googleDriveIsConnected())) {
+    return {
+      url: null,
+      requiresConnection: true,
+      reason: "No connected Google account.",
+    };
+  }
+
   const { blob, filename } = await (buildPptx
     ? buildPptx()
     : buildDeckPptxBlob(deckTitle, slides, aspectRatio));


### PR DESCRIPTION
## Summary

- preserve the shared OAuth flow cookie on both provider and completion redirects
- check the existing Google Drive connection before building or uploading a PPTX
- record the core package release note

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest run src/server/workspace-provider-oauth.spec.ts --config vitest.config.ts`
- `corepack pnpm --filter slides exec vitest run app/lib/export-google-slides-client.test.ts app/components/editor/ExportMenu.test.tsx --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `NODE_ENV=development corepack pnpm --filter slides typecheck`
- `corepack pnpm guards`

## Live investigation

- production currently drops the staged OAuth flow cookie on the native 302, which produces the invalid-or-expired state after Google consent
- beta's configured Google OAuth client currently rejects both tested beta callback URI shapes; that remains an external Google Cloud configuration issue
