### PR TITLE
fix(forms): retry rejected field edits

### DIFF
--- a/templates/forms/.agents/skills/form-building/SKILL.md
+++ b/templates/forms/.agents/skills/form-building/SKILL.md
@@ -68,6 +68,10 @@ Each field is a JSON object:
 - `label` — display label
 - `required` — boolean
 
+Always pass fields as these complete objects. Never encode a field as shorthand
+text such as `text: Enter a name`; `patch-form-fields` upserts also require the
+field `id` so they cannot be ambiguous.
+
 ### Optional properties
 - `placeholder` — input placeholder text
 - `description` — help text below the field

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -49,7 +49,9 @@ export default defineAction({
     fields: z
       .union([z.string(), z.array(z.any())])
       .optional()
-      .describe("Array of form fields (or JSON string of the same)"),
+      .describe(
+        "Array of complete field objects with id, type, label, and required (or JSON string of the same); never use shorthand strings such as 'text: Enter a name'.",
+      ),
     settings: z
       .union([z.string(), z.record(z.string(), z.any())])
       .optional()

--- a/templates/forms/actions/patch-form-fields.concurrency.test.ts
+++ b/templates/forms/actions/patch-form-fields.concurrency.test.ts
@@ -148,4 +148,25 @@ describe("patch-form-fields concurrent writes", () => {
     expect(resultA.fields).toHaveLength(2);
     expect(resultB.fields).toHaveLength(2);
   });
+
+  it("repairs legacy fields before applying a granular edit", async () => {
+    store.set("form-legacy", {
+      id: "form-legacy",
+      status: "draft",
+      fields: JSON.stringify([
+        { id: "legacy-a", type: "dropdown", label: "A" },
+        { id: "legacy-b", type: "text", label: "B" },
+      ]),
+    });
+
+    const result = await patchFormFields.run({
+      id: "form-legacy",
+      ops: [{ op: "reorder", ids: ["legacy-b", "legacy-a"] }],
+    });
+
+    expect(result.fields).toEqual([
+      { id: "legacy-b", type: "text", label: "B", required: false },
+      { id: "legacy-a", type: "text", label: "A", required: false },
+    ]);
+  });
 });

--- a/templates/forms/actions/patch-form-fields.concurrency.test.ts
+++ b/templates/forms/actions/patch-form-fields.concurrency.test.ts
@@ -93,8 +93,8 @@ describe("patch-form-fields concurrent writes", () => {
       id: "form-race",
       status: "draft",
       fields: JSON.stringify([
-        { id: "field-a", type: "text", label: "A" },
-        { id: "field-b", type: "text", label: "B" },
+        { id: "field-a", type: "text", label: "A", required: false },
+        { id: "field-b", type: "text", label: "B", required: false },
       ]),
     });
   });
@@ -108,7 +108,12 @@ describe("patch-form-fields concurrent writes", () => {
         ops: [
           {
             op: "upsert",
-            field: { id: "field-a", type: "text", label: "A updated" },
+            field: {
+              id: "field-a",
+              type: "text",
+              label: "A updated",
+              required: false,
+            },
           },
         ],
       }),
@@ -117,7 +122,12 @@ describe("patch-form-fields concurrent writes", () => {
         ops: [
           {
             op: "upsert",
-            field: { id: "field-b", type: "text", label: "B updated" },
+            field: {
+              id: "field-b",
+              type: "text",
+              label: "B updated",
+              required: false,
+            },
           },
         ],
       }),

--- a/templates/forms/actions/patch-form-fields.ts
+++ b/templates/forms/actions/patch-form-fields.ts
@@ -24,7 +24,10 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { applyFieldOps } from "../server/lib/merge-fields.js";
 import { invalidatePublicFormCache } from "../server/lib/public-form-ssr.js";
-import { assertValidFields } from "../server/lib/validate-fields.js";
+import {
+  assertValidFields,
+  normalizePersistedFields,
+} from "../server/lib/validate-fields.js";
 import type { FormField } from "../shared/types.js";
 import { assertPublishableForm } from "./lib/assert-publishable-form.js";
 
@@ -121,7 +124,9 @@ export default defineAction({
       // Parse current fields from the DB row.
       let currentFields: FormField[] = [];
       try {
-        currentFields = JSON.parse(existing.fields) as FormField[];
+        currentFields = normalizePersistedFields(
+          JSON.parse(existing.fields),
+        ) as FormField[];
       } catch {
         currentFields = [];
       }

--- a/templates/forms/actions/patch-form-fields.ts
+++ b/templates/forms/actions/patch-form-fields.ts
@@ -61,7 +61,11 @@ export function withFormLock<T>(
 const fieldOpSchema = z.union([
   z.object({
     op: z.literal("upsert"),
-    field: z.record(z.string(), z.any()),
+    field: z
+      .record(z.string(), z.any())
+      .describe(
+        "Complete field object with id, type, label, and required; never use shorthand strings.",
+      ),
   }),
   z.object({
     op: z.literal("remove"),

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -35,7 +35,9 @@ export default defineAction({
     fields: z
       .union([z.string(), z.array(z.any())])
       .optional()
-      .describe("Array of form fields (or JSON string of the same)"),
+      .describe(
+        "Array of complete field objects with id, type, label, and required (or JSON string of the same); never use shorthand strings such as 'text: Enter a name'.",
+      ),
     settings: z
       .union([z.string(), z.record(z.string(), z.any())])
       .optional()

--- a/templates/forms/changelog/2026-08-25-forms-agents-retry-invalid-field-edits.md
+++ b/templates/forms/changelog/2026-08-25-forms-agents-retry-invalid-field-edits.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-25
+---
+Forms agents now retry rejected field edits with valid field objects.

--- a/templates/forms/server/lib/validate-fields.spec.ts
+++ b/templates/forms/server/lib/validate-fields.spec.ts
@@ -18,7 +18,7 @@ describe("normalizeFieldIds", () => {
 
   it("leaves an already-valid id untouched", () => {
     const [field] = normalizeFieldIds([
-      { id: "email", type: "text", label: "Email" },
+      { id: "email", type: "text", label: "Email", required: false },
     ]) as Array<{ id: string }>;
 
     expect(field.id).toBe("email");
@@ -26,8 +26,8 @@ describe("normalizeFieldIds", () => {
 
   it("disambiguates generated ids so two fields never collide", () => {
     const fields = normalizeFieldIds([
-      { type: "text", label: "Name" },
-      { type: "text", label: "Name" },
+      { type: "text", label: "Name", required: false },
+      { type: "text", label: "Name", required: false },
     ]) as Array<{ id: string }>;
 
     expect(fields[0].id).not.toBe(fields[1].id);
@@ -35,9 +35,9 @@ describe("normalizeFieldIds", () => {
   });
 
   it("falls back to a generic id when the label is empty or unusable", () => {
-    const [field] = normalizeFieldIds([{ type: "text", label: "" }]) as Array<{
-      id: string;
-    }>;
+    const [field] = normalizeFieldIds([
+      { type: "text", label: "", required: false },
+    ]) as Array<{ id: string }>;
 
     expect(field.id).toMatch(FIELD_ID_PATTERN);
   });
@@ -47,9 +47,26 @@ describe("normalizeFieldIds", () => {
     // helper only fills in MISSING ids, it must never launder an attacker
     // -controlled string into looking "generated".
     const fields = normalizeFieldIds([
-      { id: 'x" onfocus="alert(1)', type: "text", label: "Name" },
+      {
+        id: 'x" onfocus="alert(1)',
+        type: "text",
+        label: "Name",
+        required: false,
+      },
     ]) as Array<{ id: string }>;
     expect(fields[0].id).toMatch(FIELD_ID_PATTERN);
     expect(fields[0].id).not.toContain("onfocus");
+  });
+
+  it("rejects incomplete field objects before they can be persisted", () => {
+    expect(() => assertValidFields([{ id: "name" }])).toThrow(
+      "field #1 has an invalid type",
+    );
+    expect(() =>
+      assertValidFields([{ id: "name", type: "text", required: false }]),
+    ).toThrow("field #1 label must be a string");
+    expect(() =>
+      assertValidFields([{ id: "name", type: "text", label: "Name" }]),
+    ).toThrow("field #1 required must be a boolean");
   });
 });

--- a/templates/forms/server/lib/validate-fields.spec.ts
+++ b/templates/forms/server/lib/validate-fields.spec.ts
@@ -4,6 +4,7 @@ import {
   assertValidFields,
   FIELD_ID_PATTERN,
   normalizeFieldIds,
+  normalizePersistedFields,
 } from "./validate-fields.js";
 
 describe("normalizeFieldIds", () => {
@@ -68,5 +69,30 @@ describe("normalizeFieldIds", () => {
     expect(() =>
       assertValidFields([{ id: "name", type: "text", label: "Name" }]),
     ).toThrow("field #1 required must be a boolean");
+  });
+});
+
+describe("normalizePersistedFields", () => {
+  it("keeps legacy granular edits compatible with the current field contract", () => {
+    const fields = normalizePersistedFields([
+      { id: "legacy", type: "dropdown", label: "Legacy" },
+      { id: "known", type: "text", label: "Known" },
+    ]) as Array<Record<string, unknown>>;
+
+    expect(fields).toEqual([
+      {
+        id: "legacy",
+        type: "text",
+        label: "Legacy",
+        required: false,
+      },
+      {
+        id: "known",
+        type: "text",
+        label: "Known",
+        required: false,
+      },
+    ]);
+    expect(() => assertValidFields(fields)).not.toThrow();
   });
 });

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -62,6 +62,28 @@ export function normalizeFieldIds(fields: unknown): unknown {
   });
 }
 
+/**
+ * Keeps granular edits compatible with fields written before the current
+ * schema. The UI already renders unknown types as text and treats a missing
+ * required flag as false, so patch reads must make the same repair before the
+ * strict persistence check runs.
+ */
+export function normalizePersistedFields(fields: unknown): unknown {
+  if (!Array.isArray(fields)) return fields;
+  return fields.map((field) => {
+    if (field == null || typeof field !== "object" || Array.isArray(field)) {
+      return field;
+    }
+    const f = field as Record<string, unknown>;
+    return {
+      ...f,
+      type:
+        typeof f.type === "string" && FIELD_TYPES.has(f.type) ? f.type : "text",
+      required: f.required === undefined ? false : f.required,
+    };
+  });
+}
+
 export function assertValidFields(fields: unknown): void {
   if (!Array.isArray(fields)) {
     throw new Error("fields must be an array");

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -4,6 +4,19 @@
 // runtime — an unrestricted id like `x" onfocus="alert(1)` would otherwise
 // stored-XSS every anonymous submitter of a published form.
 export const FIELD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const FIELD_TYPES = new Set([
+  "text",
+  "email",
+  "number",
+  "textarea",
+  "select",
+  "multiselect",
+  "checkbox",
+  "radio",
+  "date",
+  "rating",
+  "scale",
+]);
 const CONDITIONAL_OPERATORS = new Set(["equals", "not_equals", "contains"]);
 
 /**
@@ -70,6 +83,18 @@ export function assertValidFields(fields: unknown): void {
       throw new Error(`duplicate field id "${id}" at position #${idx + 1}`);
     }
     seenIds.add(id);
+
+    if (typeof f.type !== "string" || !FIELD_TYPES.has(f.type)) {
+      throw new Error(
+        `field #${idx + 1} has an invalid type ${JSON.stringify(f.type)}`,
+      );
+    }
+    if (typeof f.label !== "string") {
+      throw new Error(`field #${idx + 1} label must be a string`);
+    }
+    if (typeof f.required !== "boolean") {
+      throw new Error(`field #${idx + 1} required must be a boolean`);
+    }
 
     const cond = f.conditional;
     if (cond !== undefined) {

--- a/templates/forms/server/plugins/agent-chat.spec.ts
+++ b/templates/forms/server/plugins/agent-chat.spec.ts
@@ -26,4 +26,17 @@ describe("Forms agent public form links", () => {
       "Do not invent SQL or query another app's database",
     );
   });
+
+  it("repairs rejected field payloads instead of stopping at the diagnosis", () => {
+    expect(FORMS_SYSTEM_PROMPT).toContain(
+      "complete object with id, type, label, and required",
+    );
+    expect(FORMS_SYSTEM_PROMPT).toContain("never send shorthand strings");
+    expect(FORMS_SYSTEM_PROMPT).toContain(
+      "correct the arguments and retry in the same turn",
+    );
+    expect(FORMS_SYSTEM_PROMPT).toContain(
+      "repair that draft instead of explaining the fix and stopping",
+    );
+  });
 });

--- a/templates/forms/server/plugins/agent-chat.ts
+++ b/templates/forms/server/plugins/agent-chat.ts
@@ -11,6 +11,7 @@ export const FORMS_SYSTEM_PROMPT = `## Agent-Native Forms
 You are the in-app agent for Agent-Native Forms, a chat-first form builder and response workspace. Help users create, edit, publish, share, and analyze forms through the registered actions. The actions are the source of truth for database access, validation, permissions, UI sync, and business logic.
 
 Core rules:
+- Build every field as a complete object with id, type, label, and required; never send shorthand strings such as "text: Enter a name". If a form or field action rejects its payload, correct the arguments and retry in the same turn, then verify the saved fields. If a draft was created before the failure, repair that draft instead of explaining the fix and stopping.
 - Use Forms actions instead of raw database access. Raw database tools are not available in this app.
 - Never hardcode API keys, tokens, webhook URLs, signing secrets, customer data, or credential-looking literals. Use placeholders or configured integrations.
 - Inspect the current state when it matters. Use \`view-screen\` when the active form, selected field, publish state, response table, or current route is unclear.


### PR DESCRIPTION
## Summary
- teach Forms to send complete field objects and retry corrected payloads after validation failures
- preserve and repair drafts instead of stopping at a diagnosis
- add a focused regression assertion and changelog entry

## Verification
- `corepack pnpm --filter forms test -- server/plugins/agent-chat.spec.ts actions/create-form.link.spec.ts actions/patch-form-fields.spec.ts actions/patch-form-fields.concurrency.test.ts actions/update-form.spec.ts server/lib/validate-fields.spec.ts`
- 28 test files, 112 tests passed
- `git diff --check`