### PR TITLE
Run weekday production release train at noon PT

### DIFF
--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -5,7 +5,7 @@ name: 🚀 Release everything
 # *.agent-native.com site from that exact post-release commit.
 on:
   schedule:
-    - cron: "17 12 * * 1-4"
+    - cron: "0 12 * * 1-4"
       timezone: "America/Los_Angeles"
   workflow_dispatch:
     inputs:

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -24,7 +24,7 @@ describe("release everything workflow", () => {
   it("runs a DST-aware Monday-Thursday noon Pacific patch release", () => {
     assert.equal(workflow.name, "🚀 Release everything");
     assert.deepEqual(schedules, [
-      { cron: "17 12 * * 1-4", timezone: "America/Los_Angeles" },
+      { cron: "0 12 * * 1-4", timezone: "America/Los_Angeles" },
     ]);
     assert.match(
       String((job.env as Workflow).RELEASE_TYPE),


### PR DESCRIPTION
## Summary
- run the Monday-Thursday production release train at exactly 12:00 PM Pacific
- keep the DST-aware America/Los_Angeles timezone and patch default
- update the focused workflow assertion

## Validation
- corepack pnpm test:package-release-workflow
- corepack pnpm exec oxfmt --write scripts/release-everything-workflow.test.ts
- git diff --check