### PR TITLE
fix(core): support static Google Workspace MCP OAuth

### DIFF
--- a/.changeset/google-workspace-mcp-static-oauth.md
+++ b/.changeset/google-workspace-mcp-static-oauth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Support Google Workspace MCP OAuth clients that use Google's fixed OAuth endpoints instead of MCP discovery.

--- a/packages/core/src/mcp-client/oauth-client.spec.ts
+++ b/packages/core/src/mcp-client/oauth-client.spec.ts
@@ -126,6 +126,7 @@ beforeEach(() => {
       return true;
     },
   );
+  ssrfSafeFetchMock.mockReset();
   ssrfSafeFetchMock.mockImplementation((url: string, init?: RequestInit) =>
     fetch(url, init),
   );
@@ -133,6 +134,86 @@ beforeEach(() => {
 });
 
 describe("MCP OAuth client", () => {
+  it("starts Google Workspace OAuth without MCP discovery", async () => {
+    const result = await startMcpOAuthAuthorization({
+      serverUrl: "https://workspacemcp.googleapis.com/mcp/v1",
+      redirectUrl: "https://app.example.com/callback",
+      state: "<STATE>",
+      clientInformation: {
+        client_id: "google-client-id",
+        client_secret: "google-client-secret",
+        token_endpoint_auth_method: "client_secret_post",
+      },
+    });
+    const authorizationUrl = result.authorizationUrl;
+
+    expect(authMock).not.toHaveBeenCalled();
+    expect(authorizationUrl.origin).toBe("https://accounts.google.com");
+    expect(authorizationUrl.pathname).toBe("/o/oauth2/v2/auth");
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      "google-client-id",
+    );
+    expect(authorizationUrl.searchParams.get("state")).toBe("<STATE>");
+    expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+      "S256",
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toContain(
+      "https://www.googleapis.com/auth/drive.readonly",
+    );
+    expect(result.discoveryState).toMatchObject({
+      authorizationServerUrl: "https://accounts.google.com",
+      authorizationServerMetadata: {
+        token_endpoint: "https://oauth2.googleapis.com/token",
+      },
+      resourceMetadata: {
+        resource: "https://workspacemcp.googleapis.com/mcp/v1",
+      },
+    });
+  });
+
+  it("exchanges Google Workspace OAuth codes at Google's token endpoint", async () => {
+    ssrfSafeFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "<ACCESS_TOKEN>",
+          refresh_token: "<REFRESH_TOKEN>",
+          token_type: "Bearer",
+          expires_in: 3_600,
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await finishMcpOAuthAuthorization({
+      serverUrl: "https://drivemcp.googleapis.com/mcp/v1",
+      redirectUrl: "https://app.example.com/callback",
+      state: "<STATE>",
+      codeVerifier: "<CODE_VERIFIER>",
+      clientInformation: {
+        client_id: "google-client-id",
+        client_secret: "google-client-secret",
+        token_endpoint_auth_method: "client_secret_post",
+      },
+      authorizationCode: "<AUTHORIZATION_CODE>",
+    });
+
+    expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({ method: "POST" }),
+      expect.anything(),
+    );
+    const request = ssrfSafeFetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = request.body as URLSearchParams;
+    expect(body.get("client_id")).toBe("google-client-id");
+    expect(body.get("client_secret")).toBe("google-client-secret");
+    expect(body.get("code_verifier")).toBe("<CODE_VERIFIER>");
+    expect(result.credentials.tokens).toMatchObject({
+      access_token: "<ACCESS_TOKEN>",
+      refresh_token: "<REFRESH_TOKEN>",
+      issuer: "https://accounts.google.com",
+    });
+  });
+
   it("starts a standard MCP authorization flow and preserves PKCE state", async () => {
     authMock.mockImplementationOnce(
       async (provider: McpOAuthClientProvider) => {

--- a/packages/core/src/mcp-client/oauth-client.ts
+++ b/packages/core/src/mcp-client/oauth-client.ts
@@ -7,6 +7,8 @@
  * and refresh boundary.
  */
 
+import crypto from "node:crypto";
+
 import {
   auth,
   refreshAuthorization,
@@ -38,7 +40,65 @@ import { validateRemoteUrl } from "./remote-url.js";
 
 const TOKEN_EXPIRY_SKEW_MS = 60_000;
 const MAX_OAUTH_REDIRECTS = 5;
+const MAX_OAUTH_RESPONSE_BYTES = 256 * 1024;
 const MCP_OAUTH_PRIVATE_ORIGINS_ENV = "AGENT_NATIVE_MCP_OAUTH_PRIVATE_ORIGINS";
+
+const GOOGLE_MCP_ISSUER = "https://accounts.google.com";
+const GOOGLE_MCP_AUTHORIZATION_ENDPOINT =
+  "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_MCP_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_MCP_SCOPES_BY_ORIGIN: Readonly<Record<string, readonly string[]>> =
+  {
+    "https://workspacemcp.googleapis.com": [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/calendar.readonly",
+      "https://www.googleapis.com/auth/chat.messages.readonly",
+    ],
+    "https://gmailmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.compose",
+    ],
+    "https://drivemcp.googleapis.com": [
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/drive.file",
+    ],
+    "https://docsmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/documents.readonly",
+      "https://www.googleapis.com/auth/documents",
+    ],
+    "https://sheetsmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/spreadsheets.readonly",
+      "https://www.googleapis.com/auth/spreadsheets",
+    ],
+    "https://slidesmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/drive.readonly",
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/presentations.readonly",
+      "https://www.googleapis.com/auth/presentations",
+    ],
+    "https://calendarmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
+      "https://www.googleapis.com/auth/calendar.events.freebusy",
+      "https://www.googleapis.com/auth/calendar.events.readonly",
+    ],
+    "https://chatmcp.googleapis.com": [
+      "https://www.googleapis.com/auth/chat.spaces.readonly",
+      "https://www.googleapis.com/auth/chat.memberships.readonly",
+      "https://www.googleapis.com/auth/chat.messages.readonly",
+      "https://www.googleapis.com/auth/chat.messages.create",
+      "https://www.googleapis.com/auth/chat.users.readstate.readonly",
+    ],
+    "https://people.googleapis.com": [
+      "https://www.googleapis.com/auth/directory.readonly",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/contacts.readonly",
+    ],
+  };
 
 type GuardedFetch = (
   url: string | URL,
@@ -57,6 +117,175 @@ function checkedRemoteUrl(value: string | URL, label: string): URL {
 
 function canonicalServerUrl(value: string): string {
   return checkedRemoteUrl(value, "server").toString();
+}
+
+function googleMcpScopes(serverUrl: string): readonly string[] | undefined {
+  try {
+    return GOOGLE_MCP_SCOPES_BY_ORIGIN[new URL(serverUrl).origin];
+  } catch {
+    // coercion-ok: an invalid URL is absent from the managed-server allowlist.
+    return undefined;
+  }
+}
+
+export function isGoogleWorkspaceMcpServer(value: string | URL): boolean {
+  return Boolean(
+    googleMcpScopes(typeof value === "string" ? value : value.toString()),
+  );
+}
+
+function googleMcpDiscoveryState(
+  serverUrl: string,
+  scopes: readonly string[],
+): McpOAuthDiscoveryState {
+  return {
+    authorizationServerUrl: GOOGLE_MCP_ISSUER,
+    authorizationServerMetadata: {
+      issuer: GOOGLE_MCP_ISSUER,
+      authorization_endpoint: GOOGLE_MCP_AUTHORIZATION_ENDPOINT,
+      token_endpoint: GOOGLE_MCP_TOKEN_ENDPOINT,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      token_endpoint_auth_methods_supported: ["client_secret_post"],
+      code_challenge_methods_supported: ["S256"],
+    },
+    resourceMetadata: {
+      resource: serverUrl,
+      authorization_servers: [GOOGLE_MCP_ISSUER],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [...scopes],
+    },
+  };
+}
+
+function googleMcpClientInformation(
+  value: StoredOAuthClientInformation | undefined,
+): StoredOAuthClientInformation & { client_id: string; client_secret: string } {
+  const clientId = value?.client_id;
+  const clientSecret = value?.client_secret;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Google Workspace MCP OAuth client credentials are not configured.",
+    );
+  }
+  if (value.issuer && value.issuer !== GOOGLE_MCP_ISSUER) {
+    throw new Error("Google Workspace MCP OAuth issuer is invalid.");
+  }
+  return {
+    ...value,
+    client_id: clientId,
+    client_secret: clientSecret,
+    issuer: GOOGLE_MCP_ISSUER,
+  };
+}
+
+function startGoogleMcpOAuthAuthorization(
+  options: McpOAuthProviderOptions,
+  scopes: readonly string[],
+): McpOAuthStartResult {
+  const clientInformation = googleMcpClientInformation(
+    options.clientInformation,
+  );
+  const codeVerifier =
+    options.codeVerifier ?? crypto.randomBytes(48).toString("base64url");
+  const codeChallenge = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  const authorizationUrl = new URL(GOOGLE_MCP_AUTHORIZATION_ENDPOINT);
+  authorizationUrl.searchParams.set("client_id", clientInformation.client_id);
+  authorizationUrl.searchParams.set("redirect_uri", options.redirectUrl);
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("scope", scopes.join(" "));
+  authorizationUrl.searchParams.set("state", options.state);
+  authorizationUrl.searchParams.set("access_type", "offline");
+  authorizationUrl.searchParams.set("prompt", "consent");
+  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizationUrl.searchParams.set("code_challenge_method", "S256");
+
+  return {
+    authorizationUrl: checkedRemoteUrl(
+      authorizationUrl,
+      "authorization redirect",
+    ),
+    codeVerifier,
+    state: options.state,
+    clientInformation,
+    discoveryState: googleMcpDiscoveryState(options.serverUrl, scopes),
+  };
+}
+
+async function readOAuthResponseJson(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  if (Buffer.byteLength(text) > MAX_OAUTH_RESPONSE_BYTES) {
+    throw new Error("MCP OAuth response exceeded the size limit.");
+  }
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("MCP OAuth response was not an object.");
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    throw new Error("MCP OAuth response was not valid JSON.");
+  }
+}
+
+async function finishGoogleMcpOAuthAuthorization(
+  options: McpOAuthProviderOptions & { authorizationCode: string },
+  scopes: readonly string[],
+): Promise<McpOAuthCallbackResult> {
+  const clientInformation = googleMcpClientInformation(
+    options.clientInformation,
+  );
+  if (!options.codeVerifier) {
+    throw new Error("Google Workspace MCP OAuth code verifier is missing.");
+  }
+  const response = await guardedOAuthFetch()(GOOGLE_MCP_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code: options.authorizationCode,
+      client_id: clientInformation.client_id,
+      client_secret: clientInformation.client_secret,
+      redirect_uri: options.redirectUrl,
+      grant_type: "authorization_code",
+      code_verifier: options.codeVerifier,
+    }),
+  });
+  const body = await readOAuthResponseJson(response);
+  const accessToken =
+    typeof body.access_token === "string" ? body.access_token : undefined;
+  const tokenType =
+    typeof body.token_type === "string" ? body.token_type : undefined;
+  if (!response.ok || !accessToken || !tokenType) {
+    throw new Error("Google Workspace MCP OAuth token exchange failed.");
+  }
+  const expiresIn = Number(body.expires_in);
+  const tokens: StoredOAuthTokens = {
+    access_token: accessToken,
+    token_type: tokenType,
+    ...(Number.isFinite(expiresIn) && expiresIn > 0
+      ? { expires_in: expiresIn }
+      : {}),
+    ...(typeof body.refresh_token === "string"
+      ? { refresh_token: body.refresh_token }
+      : {}),
+    ...(typeof body.scope === "string" ? { scope: body.scope } : {}),
+    ...(typeof body.id_token === "string" ? { id_token: body.id_token } : {}),
+    issuer: GOOGLE_MCP_ISSUER,
+  };
+  return {
+    credentials: {
+      serverUrl: options.serverUrl,
+      clientInformation,
+      discoveryState: googleMcpDiscoveryState(options.serverUrl, scopes),
+      tokens,
+      tokenExpiresAt: tokenExpiresAt(tokens),
+    },
+  };
 }
 
 /**
@@ -474,7 +703,14 @@ export async function startMcpOAuthAuthorization(
     resourceMetadataUrl?: string;
   },
 ): Promise<McpOAuthStartResult> {
-  checkedRemoteUrl(options.serverUrl, "server");
+  const serverUrl = checkedRemoteUrl(options.serverUrl, "server");
+  const googleScopes = googleMcpScopes(serverUrl.toString());
+  if (googleScopes) {
+    return startGoogleMcpOAuthAuthorization(
+      { ...options, serverUrl: serverUrl.toString() },
+      googleScopes,
+    );
+  }
   const provider = new McpOAuthClientProvider(options);
   const result = await auth(provider, {
     serverUrl: options.serverUrl,
@@ -506,7 +742,14 @@ export async function finishMcpOAuthAuthorization(
     iss?: string;
   },
 ): Promise<McpOAuthCallbackResult> {
-  checkedRemoteUrl(options.serverUrl, "server");
+  const serverUrl = checkedRemoteUrl(options.serverUrl, "server");
+  const googleScopes = googleMcpScopes(serverUrl.toString());
+  if (googleScopes) {
+    return finishGoogleMcpOAuthAuthorization(
+      { ...options, serverUrl: serverUrl.toString() },
+      googleScopes,
+    );
+  }
   const provider = new McpOAuthClientProvider(options);
   const result = await auth(provider, {
     serverUrl: options.serverUrl,

--- a/packages/core/src/mcp-client/oauth-client.ts
+++ b/packages/core/src/mcp-client/oauth-client.ts
@@ -386,7 +386,7 @@ function guardedOAuthFetch(): GuardedFetch {
         nextHeaders.delete("proxy-authorization");
         if (
           (response.status === 307 || response.status === 308) &&
-          currentInit.body != null
+          currentInit.body !== null
         ) {
           throw new Error(
             "MCP OAuth redirect cannot forward a request body across origins.",

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -284,6 +284,7 @@ describe("managed MCP OAuth clients", () => {
       "https://calendarmcp.googleapis.com",
       "https://chatmcp.googleapis.com",
       "https://people.googleapis.com",
+      "https://workspacemcp.googleapis.com",
     ]) {
       await expect(
         resolveManagedMcpOAuthClient(new URL(`${origin}/mcp/v1`)),

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -73,6 +73,10 @@ const MANAGED_MCP_OAUTH_CLIENTS: ReadonlyArray<{
     ],
     credentialPairs: [["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]],
   },
+  {
+    serverOrigins: ["https://workspacemcp.googleapis.com"],
+    credentialPairs: [["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]],
+  },
 ];
 
 export interface McpOAuthFlow {


### PR DESCRIPTION
Google Workspace MCP servers use a pre-registered Google OAuth client and do not expose the standard MCP discovery/DCR flow.

This adds the managed static Google authorization-code + PKCE path for the official product servers and Universal Search endpoint, with refresh metadata and focused coverage.

Checks:
- core OAuth focused tests
- core typecheck
- diff-scoped guards