### PR TITLE
fix(content): preserve semantic Builder body diffs

### DIFF
--- a/templates/content/shared/builder-mdx.test.ts
+++ b/templates/content/shared/builder-mdx.test.ts
@@ -2028,6 +2028,221 @@ describe("Builder MDX conversion", () => {
     });
   });
 
+  it("keeps a compact two-word edit semantic across readable block boundaries", async () => {
+    const blocks = [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "heading-1",
+        component: {
+          name: "Text",
+          options: { text: "<h2>BS-QA-R40</h2>" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "paragraph-1",
+        component: {
+          name: "Text",
+          options: { text: "<p>R40 rich fixture paragraph.</p>" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "list-1",
+        component: {
+          name: "Text",
+          options: { text: "<ul><li>One</li><li>Two</li></ul>" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "code-1",
+        component: {
+          name: "Code Block",
+          options: { code: "const answer = 42;", language: "ts" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "embed-1",
+        component: {
+          name: "Embed",
+          options: { url: "https://example.com/embed" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "quote-1",
+        component: {
+          name: "Text",
+          options: { text: "<blockquote><p>A quote.</p></blockquote>" },
+        },
+      },
+    ];
+    const article: BuilderContentEntry = {
+      id: "article-compact-two-word-edit",
+      model: "blog-article",
+      name: "Article Compact Two Word Edit",
+      data: { title: "Article Compact Two Word Edit", blocks },
+    };
+    const [readable, lossless] = await Promise.all([
+      builderEntryToReadableMdxBundle(article),
+      builderEntryToMdxBundle(article),
+    ]);
+    const sidecars = Object.fromEntries(
+      Object.entries(lossless.files).filter(
+        ([path]) => path !== lossless.mdx.path,
+      ),
+    );
+
+    const result = await builderReadableBodyToBuilderBlocks({
+      localContent: readable.mdx.body
+        .replace(/\n\n/g, "\n")
+        .replace("rich fixture", "semantic sample"),
+      losslessContent: lossless.mdx.body,
+      sidecars,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(
+      result.blocks?.map((block) => (block as { id?: string }).id),
+    ).toEqual(blocks.map((block) => block.id));
+    expect(result.blocks?.[1]).toMatchObject({
+      component: {
+        name: "Text",
+        options: { text: "<p>R40 semantic sample paragraph.</p>" },
+      },
+    });
+    expect(result.blocks?.[0]).toEqual(lossless.blocks[0]);
+    expect(result.blocks?.[2]).toEqual(lossless.blocks[2]);
+    expect(result.blocks?.[3]).toEqual(lossless.blocks[3]);
+    expect(result.blocks?.[4]).toEqual(lossless.blocks[4]);
+    expect(result.blocks?.[5]).toEqual(lossless.blocks[5]);
+  });
+
+  it.each([
+    ["heading", "## Heading", "Heading"],
+    ["list", "- One\n- Two", "One\nTwo"],
+    ["quote", "> A quote.", "A quote."],
+    ["fence", "```ts\nconst answer = 42;\n```", "const answer = 42;"],
+  ])("rejects a real %s node-kind change", async (_kind, before, after) => {
+    const blocks = [
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "heading-1",
+        component: { name: "Text", options: { text: "<h2>Heading</h2>" } },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "list-1",
+        component: {
+          name: "Text",
+          options: { text: "<ul><li>One</li><li>Two</li></ul>" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "quote-1",
+        component: {
+          name: "Text",
+          options: { text: "<blockquote><p>A quote.</p></blockquote>" },
+        },
+      },
+      {
+        "@type": "@builder.io/sdk:Element",
+        "@version": 2,
+        id: "code-1",
+        component: {
+          name: "Code Block",
+          options: { code: "const answer = 42;", language: "ts" },
+        },
+      },
+    ];
+    const article: BuilderContentEntry = {
+      id: `article-real-${_kind}-change`,
+      model: "blog-article",
+      data: { title: "Article Real Structure Change", blocks },
+    };
+    const [readable, lossless] = await Promise.all([
+      builderEntryToReadableMdxBundle(article),
+      builderEntryToMdxBundle(article),
+    ]);
+    const sidecars = Object.fromEntries(
+      Object.entries(lossless.files).filter(
+        ([path]) => path !== lossless.mdx.path,
+      ),
+    );
+
+    const result = await builderReadableBodyToBuilderBlocks({
+      localContent: readable.mdx.body.replace(before, after),
+      losslessContent: lossless.mdx.body,
+      sidecars,
+    });
+
+    expect(result.blocks).toBeNull();
+    expect(result.warnings[0]).toContain("moved or restructured");
+  });
+
+  it("rejects movement between same-kind editable nodes", async () => {
+    const article: BuilderContentEntry = {
+      id: "article-same-kind-move",
+      model: "blog-article",
+      data: {
+        title: "Article Same-kind Move",
+        blocks: [
+          {
+            "@type": "@builder.io/sdk:Element",
+            "@version": 2,
+            id: "paragraph-1",
+            component: {
+              name: "Text",
+              options: { text: "<p>First unique paragraph.</p>" },
+            },
+          },
+          {
+            "@type": "@builder.io/sdk:Element",
+            "@version": 2,
+            id: "paragraph-2",
+            component: {
+              name: "Text",
+              options: { text: "<p>Second unique paragraph.</p>" },
+            },
+          },
+        ],
+      },
+    };
+    const [readable, lossless] = await Promise.all([
+      builderEntryToReadableMdxBundle(article),
+      builderEntryToMdxBundle(article),
+    ]);
+    const sidecars = Object.fromEntries(
+      Object.entries(lossless.files).filter(
+        ([path]) => path !== lossless.mdx.path,
+      ),
+    );
+
+    const result = await builderReadableBodyToBuilderBlocks({
+      localContent: readable.mdx.body.replace(
+        "First unique paragraph.\n\nSecond unique paragraph.",
+        "Second unique paragraph.\n\nFirst unique paragraph.",
+      ),
+      losslessContent: lossless.mdx.body,
+      sidecars,
+    });
+
+    expect(result.blocks).toBeNull();
+    expect(result.warnings[0]).toContain("moved existing semantic blocks");
+  });
+
   it("blocks readable merge when a source component marker is moved", async () => {
     const article: BuilderContentEntry = {
       id: "article-marker-move",

--- a/templates/content/shared/builder-mdx.ts
+++ b/templates/content/shared/builder-mdx.ts
@@ -90,6 +90,8 @@ type MdxNode = {
   type: string;
   name?: string;
   value?: string;
+  depth?: number;
+  ordered?: boolean | null;
   children?: MdxNode[];
   attributes?: Array<{
     type: string;
@@ -146,6 +148,34 @@ export function stableHash(value: unknown): string {
 
 export function stableJson(value: unknown): string {
   return `${JSON.stringify(sortJson(value), null, 2)}\n`;
+}
+
+function hasMovedUniqueSemanticUnit(
+  baselineUnits: string[],
+  currentUnits: string[],
+): boolean {
+  const baselineIndexes = new Map<string, number>();
+  const baselineCounts = new Map<string, number>();
+  const currentCounts = new Map<string, number>();
+  for (const [index, unit] of baselineUnits.entries()) {
+    baselineIndexes.set(unit, index);
+    baselineCounts.set(unit, (baselineCounts.get(unit) ?? 0) + 1);
+  }
+  for (const unit of currentUnits) {
+    currentCounts.set(unit, (currentCounts.get(unit) ?? 0) + 1);
+  }
+
+  let previousBaselineIndex = -1;
+  for (const unit of currentUnits) {
+    if (baselineCounts.get(unit) !== 1 || currentCounts.get(unit) !== 1) {
+      continue;
+    }
+    const baselineIndex = baselineIndexes.get(unit);
+    if (baselineIndex === undefined) continue;
+    if (baselineIndex < previousBaselineIndex) return true;
+    previousBaselineIndex = baselineIndex;
+  }
+  return false;
 }
 
 function sortJson(value: unknown): unknown {
@@ -489,9 +519,10 @@ function isReadableUnsupportedBuilderPlaceholder(value: string) {
   );
 }
 
-function countReadableSourceComponentMarkers(markdown: string) {
-  return markdownUnits(markdown).filter(isReadableUnsupportedBuilderPlaceholder)
-    .length;
+async function countReadableSourceComponentMarkers(markdown: string) {
+  return (await readableSemanticUnits(markdown)).filter(
+    isReadableUnsupportedBuilderPlaceholder,
+  ).length;
 }
 
 function sourceComponentMarkerIdForBlock(block: unknown) {
@@ -544,20 +575,21 @@ function parseMarkdownImage(markdown: string) {
 }
 
 async function readableLayoutFingerprint(markdown: string) {
-  const units = markdownUnits(markdown);
   const fingerprint: string[] = [];
-  for (const unit of units) {
-    if (/^>\s*Builder .+ component preserved from source\.$/.test(unit)) {
+  for (const unit of await readableSemanticNodes(markdown)) {
+    if (
+      /^>\s*Builder .+ component preserved from source\.$/.test(unit.markdown)
+    ) {
       fingerprint.push("source:legacy");
       continue;
     }
-    if (/^<SourceComponent\b/.test(unit.trim())) {
-      const parsed = await parseRegistryBlockData(unit);
+    if (/^<SourceComponent\b/.test(unit.markdown.trim())) {
+      const parsed = await parseRegistryBlockData(unit.markdown);
       const id = parsed?.base.id || "missing-id";
       fingerprint.push(`source:${id}`);
       continue;
     }
-    fingerprint.push("prose");
+    fingerprint.push(readableSemanticNodeKind(unit.node));
   }
   return fingerprint;
 }
@@ -571,26 +603,34 @@ async function expectedReadableLayoutFingerprint(blocks: unknown[]) {
     if (name === "Text") {
       const table = possibleNativeTableHtml(String(options.text ?? ""));
       if (table) {
-        fingerprint.push("prose");
+        fingerprint.push(...(await readableLayoutFingerprint(table)));
         continue;
       }
-      for (const unit of markdownUnits(
-        htmlToMarkdown(String(options.text ?? "")),
-      )) {
-        if (unit) fingerprint.push("prose");
-      }
+      fingerprint.push(
+        ...(await readableLayoutFingerprint(
+          htmlToMarkdown(String(options.text ?? "")),
+        )),
+      );
       continue;
     }
     if (name === "Code Block" || name === "Blog Code Block") {
-      if (readableCodeBlockMarkdown(options).trim()) fingerprint.push("prose");
+      fingerprint.push(
+        ...(await readableLayoutFingerprint(
+          readableCodeBlockMarkdown(options),
+        )),
+      );
       continue;
     }
     if (name === "Image") {
-      if (builderImageMarkdown(options)) fingerprint.push("prose");
+      fingerprint.push(
+        ...(await readableLayoutFingerprint(builderImageMarkdown(options))),
+      );
       continue;
     }
     if (name === "Video") {
-      if (builderVideoMdx(options)) fingerprint.push("prose");
+      fingerprint.push(
+        ...(await readableLayoutFingerprint(builderVideoMdx(options))),
+      );
       continue;
     }
     if (name === "Tabbed Content") {
@@ -599,7 +639,11 @@ async function expectedReadableLayoutFingerprint(blocks: unknown[]) {
         const content =
           isRecord(tab) && Array.isArray(tab.content) ? tab.content : [];
         if (content.some(builderBlockHasReadableOutput)) {
-          fingerprint.push("prose");
+          const label =
+            isRecord(tab) && typeof tab.label === "string" ? tab.label : "Tab";
+          fingerprint.push(
+            ...(await readableLayoutFingerprint(`### ${label}`)),
+          );
           fingerprint.push(
             ...(await expectedReadableLayoutFingerprint(content)),
           );
@@ -622,7 +666,7 @@ async function validateReadableSourceComponentMarkers(
   sidecars: Record<string, string>,
 ) {
   const warnings: string[] = [];
-  const markers = markdownUnits(markdown).filter((unit) =>
+  const markers = (await readableSemanticUnits(markdown)).filter((unit) =>
     /^<SourceComponent\b/.test(unit.trim()),
   );
   for (const marker of markers) {
@@ -1322,37 +1366,27 @@ async function builderBlockToReadableMdx(
   return serializeRegistryBlockToMdx("source-component", { id, data });
 }
 
-function markdownUnits(markdown: string) {
-  const units: string[] = [];
-  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
-  let current: string[] = [];
-  let fence: string | null = null;
-  const flush = () => {
-    const value = current.join("\n").trim();
-    if (value) units.push(value);
-    current = [];
-  };
+async function readableSemanticUnits(markdown: string) {
+  return (await readableSemanticNodes(markdown)).map((unit) => unit.markdown);
+}
 
-  for (const line of lines) {
-    const fenceMatch = line.match(/^(```|~~~)/);
-    if (fenceMatch) {
-      current.push(line);
-      fence = fence ? null : fenceMatch[1];
-      if (!fence) flush();
-      continue;
-    }
-    if (fence) {
-      current.push(line);
-      continue;
-    }
-    if (!line.trim()) {
-      flush();
-      continue;
-    }
-    current.push(line);
+async function readableSemanticNodes(markdown: string) {
+  const normalized = markdown.replace(/\r\n?/g, "\n");
+  const root = await parseMdxRoot(normalized);
+  return (root.children ?? [])
+    .map((node) => ({ node, markdown: nodeSlice(normalized, node) }))
+    .filter((unit) => unit.markdown);
+}
+
+function readableSemanticNodeKind(node: MdxNode) {
+  if (node.type === "heading") return `heading:${node.depth ?? "unknown"}`;
+  if (node.type === "list") {
+    return node.ordered ? "list:ordered" : "list:unordered";
   }
-  flush();
-  return units;
+  if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+    return `mdx:${node.name || "unknown"}`;
+  }
+  return node.type;
 }
 
 function fencedCodeFromMarkdown(markdown: string) {
@@ -1518,7 +1552,7 @@ export async function builderReadableBodyToBuilderBlocks(args: {
   const segments = collectReadableEditableSegments(baselineBlocks);
   const expectedSourceMarkerCount =
     countExpectedReadableSourceComponentMarkers(baselineBlocks);
-  const currentSourceMarkerCount = countReadableSourceComponentMarkers(
+  const currentSourceMarkerCount = await countReadableSourceComponentMarkers(
     args.localContent,
   );
   if (expectedSourceMarkerCount !== currentSourceMarkerCount) {
@@ -1555,10 +1589,14 @@ export async function builderReadableBodyToBuilderBlocks(args: {
     return { blocks: baselineBlocks, warnings: [] };
   }
 
-  const baselineUnitCounts = segments.map(
-    (segment) => markdownUnits(segment.baseline).length,
+  const baselineUnitsBySegment = await Promise.all(
+    segments.map(async (segment) => readableSemanticUnits(segment.baseline)),
   );
-  const currentUnits = markdownUnits(args.localContent).filter(
+  const baselineUnitCounts = baselineUnitsBySegment.map(
+    (units) => units.length,
+  );
+  const baselineUnits = baselineUnitsBySegment.flat();
+  const currentUnits = (await readableSemanticUnits(args.localContent)).filter(
     (unit) => !isReadableUnsupportedBuilderPlaceholder(unit),
   );
   const expectedUnitCount = baselineUnitCounts.reduce(
@@ -1570,6 +1608,14 @@ export async function builderReadableBodyToBuilderBlocks(args: {
       blocks: null,
       warnings: [
         `Readable Builder body changed structure from ${expectedUnitCount} markdown blocks to ${currentUnits.length}; review in Builder before pushing.`,
+      ],
+    };
+  }
+  if (hasMovedUniqueSemanticUnit(baselineUnits, currentUnits)) {
+    return {
+      blocks: null,
+      warnings: [
+        "Readable Builder body moved existing semantic blocks; refresh or review in Builder before pushing.",
       ],
     };
   }


### PR DESCRIPTION
## Problem

Content users can make a small text-only edit to a Builder-backed document and still receive a structural-change warning during review. The editor preserves its block identities and order, but its Markdown save may normalize blank lines between adjacent constructs. The Builder readable-body codec previously treated those formatting differences as semantic block boundaries, so it rejected the edit before producing proposed Builder blocks.

## Approach

Parse the readable Markdown/MDX into top-level semantic units at the Builder codec boundary. The same unitization now drives layout comparison, baseline distribution, and edited-block reconstruction. SourceComponent identifiers and order remain structural fences, and distinct node kinds remain part of the layout fingerprint.

The change deliberately leaves editor serialization, hydration, sync policy, write preparation, approval, staging, execution, and generic Markdown behavior unchanged.

## What changed

- Replace blank-line unitization with codec-local top-level MDX node extraction.
- Fingerprint headings, lists, quotes, fenced code, MDX elements, and SourceComponent markers by semantic kind.
- Reject reordered unique semantic units before positional redistribution, including movement between two paragraph blocks.
- Add the exact compacted-whitespace `rich fixture` to `semantic sample` regression and structural sibling cases.

## Safety and operations

This is a pure codec change with no migration, credential, deployment-configuration, or provider-write implication. Builder review and write controls are unchanged. The safe rollback is reverting this commit.

## Verification

- The focused Builder MDX suite passes 69 tests, demonstrating the exact two-word edit produces proposed blocks while true kind and marker changes still reject.
- Content typecheck passes.
- All 64 repository guards pass.
- Independent bounded review found a same-kind movement gap; the follow-up order fence and regression resolved it with no material repair regression.

Post-patch real-interface acceptance is still pending. The authenticated beta surface confirmed the Golden Wren fixture and read-only model, but beta does not contain this branch.

## Review focus

- Does top-level semantic parsing preserve every existing SourceComponent and structural fence?
- Is the unique-unit order check appropriately conservative before positional distribution?
- Do the regressions cover the intended difference between formatting normalization and real structural change?