### PR TITLE
Simplify Clips recording page surfaces

### DIFF
--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -417,7 +417,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
   );
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col bg-transparent">
       <div
         className={cn(
           "flex-1 overflow-y-auto",
@@ -431,12 +431,12 @@ export function CommentsPanel(props: CommentsPanelProps) {
             isSharePresentation={isSharePresentation}
           />
         ) : (
-          <ul className="divide-y divide-border">
+          <ul className="space-y-3">
             {sortedThreads.map((thread) => {
               const root = thread[0];
               const replies = thread.slice(1);
               return (
-                <li key={root.threadId} className="p-3 space-y-2">
+                <li key={root.threadId} className="space-y-2 px-3 pt-3">
                   <CommentCard
                     comment={root}
                     currentUserEmail={currentUserEmail}
@@ -459,7 +459,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
                     onUnauthenticated={onUnauthenticated}
                   />
                   {replies.length ? (
-                    <ul className="pl-8 space-y-2 border-l-2 border-border ml-3">
+                    <ul className="ml-3 space-y-2 pl-8">
                       {replies.map((r) => (
                         <li key={r.id}>
                           <CommentCard
@@ -508,7 +508,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       </div>
 
       {isSharePresentation && enableComments ? (
-        <div className="border-t border-border px-4 py-4">{composer}</div>
+        <div className="px-4 py-4">{composer}</div>
       ) : !isSharePresentation ? (
         composer
       ) : null}
@@ -608,7 +608,7 @@ function CommentComposer({
   const t = useT();
   if (!enableComments) {
     return (
-      <div className="border-t border-border p-3 text-xs text-muted-foreground">
+      <div className="p-3 text-xs text-muted-foreground">
         {t("commentsPanel.disabled")}
       </div>
     );
@@ -622,7 +622,7 @@ function CommentComposer({
         <button
           type="button"
           onClick={() => onUnauthenticated("comment")}
-          className="flex min-h-16 w-full items-center gap-3 rounded-md border border-border bg-background px-3 py-2.5 text-left text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-h-16 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 py-2.5 text-left text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <Avatar className="size-7 shrink-0">
             <AvatarFallback className="bg-primary/15 text-xs text-primary">
@@ -638,7 +638,7 @@ function CommentComposer({
     }
 
     return (
-      <div className="flex items-center justify-between gap-3 border-t border-border bg-background p-3">
+      <div className="flex items-center justify-between gap-3 px-3 py-3">
         <span className="text-xs text-muted-foreground">
           {t("commentsPanel.signInToComment")}
         </span>
@@ -654,14 +654,7 @@ function CommentComposer({
   }
 
   return (
-    <div
-      className={cn(
-        "bg-background",
-        isSharePresentation
-          ? "space-y-2"
-          : "space-y-2 border-t border-border p-3",
-      )}
-    >
+    <div className={cn(isSharePresentation ? "space-y-2" : "space-y-2 p-3")}>
       {!isSharePresentation ? (
         <div className="px-1 text-[11px] text-muted-foreground">
           {t("commentsPanel.commentAt")}{" "}
@@ -671,8 +664,7 @@ function CommentComposer({
       <div
         className={cn(
           "flex gap-2",
-          isSharePresentation &&
-            "items-start rounded-md border border-border bg-background p-3 shadow-sm",
+          isSharePresentation && "items-start rounded-md p-3 shadow-sm",
         )}
       >
         {isSharePresentation ? (
@@ -687,9 +679,9 @@ function CommentComposer({
           onChange={(e) => onDraftChange(e.target.value)}
           placeholder={t("commentsPanel.leaveComment")}
           className={cn(
-            "resize-none text-sm",
+            "resize-none border-0 bg-background text-sm",
             isSharePresentation
-              ? "min-h-10 flex-1 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              ? "min-h-10 flex-1 border-0 p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               : "min-h-[60px]",
           )}
           onKeyDown={(e) => {
@@ -731,14 +723,14 @@ function InlineReplyComposer({
   const t = useT();
 
   return (
-    <div className="ml-9 mt-2 rounded-lg border border-border bg-muted/20 p-2">
+    <div className="ml-9 mt-2 rounded-lg p-2">
       <Textarea
         ref={textareaRef}
         autoFocus
         value={draft}
         onChange={(event) => onDraftChange(event.target.value)}
         placeholder={t("commentsPanel.writeReply")}
-        className="min-h-16 resize-none bg-background text-sm"
+        className="min-h-16 resize-none border-0 bg-background text-sm"
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();
@@ -787,13 +779,13 @@ function InlineEditComposer({
   const normalizedDraft = draft.trim();
 
   return (
-    <div className="mt-2 rounded-lg border border-border bg-muted/20 p-2">
+    <div className="mt-2 rounded-lg p-2">
       <Textarea
         autoFocus
         value={draft}
         onChange={(event) => onDraftChange(event.target.value)}
         aria-label={t("commentsPanel.editComment")}
-        className="min-h-16 resize-none bg-background text-sm"
+        className="min-h-16 resize-none border-0 bg-background text-sm"
         onKeyDown={(event) => {
           if (event.key === "Escape") {
             event.preventDefault();

--- a/templates/clips/app/components/player/reactions-tray.tsx
+++ b/templates/clips/app/components/player/reactions-tray.tsx
@@ -23,6 +23,7 @@ export interface ReactionsTrayProps {
   onReact: ReactionHandler;
   reactions?: Pick<ReactionSummary, "emoji">[];
   disabled?: boolean;
+  className?: string;
 }
 
 interface Float {
@@ -37,6 +38,7 @@ export function ReactionsTray({
   onReact,
   reactions,
   disabled,
+  className,
 }: ReactionsTrayProps) {
   const [floats, setFloats] = useState<Float[]>([]);
   const [savingEmoji, setSavingEmoji] = useState<string | null>(null);
@@ -92,7 +94,12 @@ export function ReactionsTray({
   }
 
   return (
-    <div className="relative flex w-fit max-w-full items-center gap-0.5 rounded-full border border-border bg-card px-1.5 py-1 shadow-sm sm:gap-1 sm:px-2">
+    <div
+      className={cn(
+        "relative flex w-fit max-w-full items-center gap-0.5 rounded-full border border-border bg-card px-1.5 py-1 shadow-sm sm:gap-1 sm:px-2",
+        className,
+      )}
+    >
       {REACTION_EMOJIS.map((emoji) => (
         <Tooltip key={emoji}>
           <TooltipTrigger asChild>

--- a/templates/clips/app/components/player/settings-panel.tsx
+++ b/templates/clips/app/components/player/settings-panel.tsx
@@ -24,7 +24,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 
 import { SPEED_OPTIONS } from "./player-controls";
@@ -103,9 +102,9 @@ export function SettingsPanel(props: SettingsPanelProps) {
   }
 
   return (
-    <div className="flex flex-col h-full bg-background">
+    <div className="flex h-full flex-col bg-transparent">
       {showHeader ? (
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center justify-between px-4 py-3">
           <h2 className="text-sm font-medium">{t("playerSettings.title")}</h2>
           <Button variant="ghost" size="icon" onClick={onClose}>
             <IconX className="h-4 w-4" />
@@ -229,8 +228,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
           </div>
         </section>
 
-        <Separator />
-
         {/* Toggles */}
         <section className="space-y-3">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -262,8 +259,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
           />
         </section>
 
-        <Separator />
-
         {/* Default speed */}
         <section className="space-y-2">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -285,8 +280,6 @@ export function SettingsPanel(props: SettingsPanelProps) {
             </SelectContent>
           </Select>
         </section>
-
-        <Separator />
 
         {/* CTA editor */}
         <section className="space-y-3">
@@ -395,7 +388,7 @@ function CtaEditor({
 
   return (
     <div
-      className="rounded-lg border border-border bg-card p-3 space-y-2"
+      className="rounded-lg bg-card p-3 space-y-2"
       onFocusCapture={() => {
         editing.current = true;
       }}

--- a/templates/clips/app/components/player/timestamped-comment-button.tsx
+++ b/templates/clips/app/components/player/timestamped-comment-button.tsx
@@ -111,7 +111,7 @@ export function TimestampedCommentBar({
       data-player-ui
       className={cn("absolute inset-x-0 bottom-0 z-30 p-3", className)}
     >
-      <div className="rounded-xl border border-border bg-background/95 p-3 shadow-lg backdrop-blur">
+      <div className="rounded-xl border-0 bg-background/95 p-3 shadow-lg backdrop-blur">
         <Textarea
           ref={textareaRef}
           value={draft}

--- a/templates/clips/app/routes/r.$recordingId.test.ts
+++ b/templates/clips/app/routes/r.$recordingId.test.ts
@@ -32,7 +32,7 @@ describe("direct recording route shell cue", () => {
   it("keeps the main header return control icon-only and shared", () => {
     const route = readRoute("r.$recordingId.tsx");
     const headerStart = route.indexOf(
-      'className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2',
+      'className="flex min-w-0 shrink-0 items-center gap-2 px-3 py-2',
     );
     expect(headerStart).toBeGreaterThan(-1);
 

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -1033,7 +1033,7 @@ export default function RecordingPage() {
     if (!showRecoveryState) {
       return (
         <div className="flex min-h-screen w-full flex-col bg-background">
-          <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3">
+          <header className="flex min-w-0 shrink-0 items-center gap-2 px-3 py-2 sm:px-4 sm:py-3">
             <BackButton
               onBack={() => navigate("/library", { replace: true })}
             />
@@ -1354,10 +1354,10 @@ export default function RecordingPage() {
   };
 
   return (
-    <div className="flex min-h-screen w-full max-w-full flex-col overflow-x-hidden bg-background xl:h-screen xl:flex-row xl:overflow-hidden">
+    <div className="clips-recording-view flex min-h-screen w-full max-w-full flex-col overflow-x-hidden bg-background xl:h-screen xl:flex-row xl:overflow-hidden [&_.agent-composer-root]:!bg-background [&_.agent-composer-root]:!border-0">
       {/* Main video column */}
       <div className="flex w-full min-w-0 flex-col xl:flex-1">
-        <header className="flex min-w-0 shrink-0 items-center gap-2 border-b border-border px-3 py-2 sm:px-4 sm:py-3">
+        <header className="flex min-w-0 shrink-0 items-center gap-2 px-3 py-2 sm:px-4 sm:py-3">
           <BackButton
             onBack={
               editing
@@ -1426,7 +1426,7 @@ export default function RecordingPage() {
               agentViewCount={playerDataQ.data?.agentViewCount ?? 0}
               canViewDetails={canEdit}
               onOpenInsights={openInsightsPanel}
-              className="shrink-0"
+              className="shrink-0 border-0 shadow-none"
             />
           ) : null}
 
@@ -1434,7 +1434,10 @@ export default function RecordingPage() {
             <Button
               variant={editing ? "secondary" : "outline"}
               size="sm"
-              className={cn("gap-1.5", !editing && "hidden sm:inline-flex")}
+              className={cn(
+                "gap-1.5 border-0 shadow-none",
+                !editing && "hidden sm:inline-flex",
+              )}
               onClick={() => setEditing((v) => !v)}
             >
               <IconScissors className="h-4 w-4" />
@@ -1448,7 +1451,7 @@ export default function RecordingPage() {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="hidden gap-1.5 sm:inline-flex"
+                  className="hidden gap-1.5 border-0 shadow-none sm:inline-flex"
                 >
                   {t("recordingPage.aiTools")}
                   <IconChevronDown className="h-4 w-4" />
@@ -1608,7 +1611,10 @@ export default function RecordingPage() {
                 hasPassword={Boolean(recording.hasPassword)}
                 viewerReshareOnly={viewerReshareOnly}
               >
-                <ClipsShareTrigger label={t("recordingPage.share")} />
+                <ClipsShareTrigger
+                  label={t("recordingPage.share")}
+                  className="border-0 shadow-none"
+                />
               </ShareRecordingPopover>
             )
           ) : null}
@@ -1765,7 +1771,7 @@ export default function RecordingPage() {
                   {playerDataQ.data?.meeting ? (
                     <NavLink
                       to={`/meetings/${playerDataQ.data.meeting.id}`}
-                      className="inline-flex items-center gap-1.5 mb-1 rounded-full border border-border bg-accent/40 px-2 py-0.5 text-[11px] text-foreground hover:bg-accent/70 cursor-pointer"
+                      className="inline-flex items-center gap-1.5 mb-1 rounded-full bg-accent/40 px-2 py-0.5 text-[11px] text-foreground hover:bg-accent/70 cursor-pointer"
                     >
                       <IconCalendar className="h-3 w-3" />
                       <span className="text-muted-foreground">
@@ -1782,7 +1788,7 @@ export default function RecordingPage() {
                       <TimestampedCommentButton
                         enableComments={recording.enableComments}
                         canComment={canComment}
-                        className="shrink-0"
+                        className="shrink-0 border-0 shadow-none"
                         onOpen={() => {
                           if (isCompactLayout) {
                             openCommentsPanel();
@@ -1797,6 +1803,7 @@ export default function RecordingPage() {
                       <ReactionsTray
                         reactions={reactions}
                         disabled={!recording.enableReactions || !canComment}
+                        className="border-0 shadow-none"
                         onReact={(emoji) => {
                           tracking.reportReaction(emoji);
                           const liveMs = resolvePlaybackMs();
@@ -1880,13 +1887,13 @@ export default function RecordingPage() {
           {isCompactLayout ? (
             <aside
               id="clip-activity-panel"
-              className="flex min-h-[420px] w-full min-w-0 flex-col border-t border-border bg-background xl:hidden"
+              className="flex min-h-[420px] w-full min-w-0 flex-col bg-muted xl:hidden"
             >
               {renderSidePanel("inline")}
             </aside>
           ) : null}
           {!isCompactLayout ? (
-            <aside className="hidden w-[380px] shrink-0 flex-col border-s border-border bg-background xl:flex">
+            <aside className="hidden w-[380px] shrink-0 flex-col bg-muted xl:flex">
               {renderSidePanel()}
             </aside>
           ) : null}
@@ -1923,10 +1930,10 @@ function GeneratedWorkflowNotice({
 
   return (
     <div className="bg-background px-3 py-2.5">
-      <div className="overflow-hidden rounded-md border border-border bg-muted/20">
-        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+      <div className="overflow-hidden rounded-md bg-muted/20 shadow-sm">
+        <div className="flex items-center justify-between gap-2 px-3 py-2">
           <div className="flex min-w-0 items-center gap-2">
-            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
               {isReady ? (
                 <IconFileText className="h-3.5 w-3.5" />
               ) : (


### PR DESCRIPTION
## Summary
- remove structural divider lines and decorative borders from the Clips recording view
- use a muted right rail and keep the comment textarea background on the textarea itself
- give the agent composer its background surface and let Settings inherit the rail surface

## Validation
- `corepack pnpm --filter clips typecheck`
- `corepack pnpm --filter clips exec vitest run app/components/player/reactions-tray.test.tsx app/components/player/recording-views-badge.test.tsx`
- browser-verified the local recording route in Activity, Agent, and Settings tabs

The typecheck command exits successfully and emits the repository's existing production configuration warnings for deployment-only auth/database settings.