### PR TITLE
fix: dispatch release workflows from stable tag

### DIFF
--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -266,6 +266,10 @@ jobs:
               releaseSha,
               "templates/clips/desktop/package.json",
             );
+            const corePackage = await readJsonAt(
+              releaseSha,
+              "packages/core/package.json",
+            );
             const sitesManifest = await readJsonAt(
               releaseSha,
               "scripts/netlify-production-sites.json",
@@ -278,6 +282,10 @@ jobs:
             };
             const desktopVersion = stableVersion(desktopPackage.version, "Desktop app");
             const clipsVersion = stableVersion(clipsPackage.version, "Clips desktop app");
+            const coreVersion = stableVersion(corePackage.version, "Core package");
+            // workflow_dispatch accepts a branch or tag, not a raw commit SHA.
+            // The stable core package tag points at the verified release commit.
+            const workflowRef = `@agent-native/core@${coreVersion}`;
             const productionSites = Object.entries(sitesManifest)
               .filter(([, site]) =>
                 typeof site?.host === "string" && site.host.endsWith(".agent-native.com"),
@@ -288,15 +296,15 @@ jobs:
             }
 
             const [desktop, clips, production] = await Promise.all([
-              dispatch("desktop-release.yml", releaseSha, {
+              dispatch("desktop-release.yml", workflowRef, {
                 channel: "production",
                 version: desktopVersion,
               }),
-              dispatch("clips-desktop-release.yml", releaseSha, {
+              dispatch("clips-desktop-release.yml", workflowRef, {
                 channel: "production",
                 version: clipsVersion,
               }),
-              dispatch("deploy-production-sites-prebuilt.yml", releaseSha, {
+              dispatch("deploy-production-sites-prebuilt.yml", workflowRef, {
                 sites: productionSites.join(","),
                 source_ref: releaseSha,
                 beta_e2e: "false",

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -101,6 +101,31 @@ jobs:
               return { id: runId, url };
             }
 
+            async function getPublishedRelease(tag) {
+              try {
+                const response = await github.rest.repos.getReleaseByTag({
+                  owner,
+                  repo,
+                  tag,
+                });
+                return response.data;
+              } catch (error) {
+                if (error.status === 404) return null;
+                throw error;
+              }
+            }
+
+            function hasCompleteClipsRelease(release, version) {
+              if (!release || release.draft || release.prerelease) return false;
+              const assets = new Set(release.assets.map((asset) => asset.name));
+              return [
+                `Clips_${version}_universal.dmg`,
+                `Clips_${version}_x64-setup.exe`,
+                `Clips_${version}_x64_en-US.msi`,
+                "latest.json",
+              ].every((asset) => assets.has(asset));
+            }
+
             async function getRun(runId) {
               return (await github.rest.actions.getWorkflowRun({
                 owner,
@@ -295,15 +320,26 @@ jobs:
               throw new Error("The production site manifest contains no *.agent-native.com sites.");
             }
 
+            const existingClipsRelease = await getPublishedRelease(`clips-v${clipsVersion}`);
+            const clipsAlreadyPublished = hasCompleteClipsRelease(existingClipsRelease, clipsVersion);
+            if (clipsAlreadyPublished) {
+              core.info(`Clips v${clipsVersion} is already published with its required assets; treating it as complete.`);
+            }
+
             const [desktop, clips, production] = await Promise.all([
               dispatch("desktop-release.yml", workflowRef, {
                 channel: "production",
                 version: desktopVersion,
               }),
-              dispatch("clips-desktop-release.yml", workflowRef, {
-                channel: "production",
-                version: clipsVersion,
-              }),
+              clipsAlreadyPublished
+                ? Promise.resolve({
+                    url: existingClipsRelease.html_url,
+                    existing: true,
+                  })
+                : dispatch("clips-desktop-release.yml", workflowRef, {
+                    channel: "production",
+                    version: clipsVersion,
+                  }),
               dispatch("deploy-production-sites-prebuilt.yml", workflowRef, {
                 sites: productionSites.join(","),
                 source_ref: releaseSha,
@@ -314,7 +350,9 @@ jobs:
 
             const downstream = await Promise.allSettled([
               waitForRun(desktop, "Agent Native desktop stable release", 120 * 60_000),
-              waitForRun(clips, "Clips desktop stable release", 120 * 60_000),
+              clipsAlreadyPublished
+                ? Promise.resolve({ status: "completed", conclusion: "success" })
+                : waitForRun(clips, "Clips desktop stable release", 120 * 60_000),
               waitForRun(production, "Production site fleet", 120 * 60_000),
             ]);
             const failures = downstream

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -56,6 +56,11 @@ describe("release everything workflow", () => {
     assert.match(source, /clips-desktop-release\.yml/);
     assert.match(source, /deploy-production-sites-prebuilt\.yml/);
     assert.match(source, /channel: "production"/);
+    assert.match(
+      source,
+      /const workflowRef = `@agent-native\/core@\$\{coreVersion\}`/,
+    );
+    assert.match(source, /dispatch\("desktop-release\.yml", workflowRef/);
     assert.match(source, /source_ref: releaseSha/);
     assert.match(source, /endsWith\("\.agent-native\.com"\)/);
     assert.match(source, /Promise\.allSettled/);

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -61,6 +61,10 @@ describe("release everything workflow", () => {
       /const workflowRef = `@agent-native\/core@\$\{coreVersion\}`/,
     );
     assert.match(source, /dispatch\("desktop-release\.yml", workflowRef/);
+    assert.match(source, /getReleaseByTag/);
+    assert.match(source, /hasCompleteClipsRelease/);
+    assert.match(source, /Clips_\$\{version\}_universal\.dmg/);
+    assert.match(source, /clipsAlreadyPublished/);
     assert.match(source, /source_ref: releaseSha/);
     assert.match(source, /endsWith\("\.agent-native\.com"\)/);
     assert.match(source, /Promise\.allSettled/);

--- a/scripts/serverless-function-baseline.json
+++ b/scripts/serverless-function-baseline.json
@@ -23,8 +23,8 @@
   },
   "assets": {
     "agent-native-recurring-jobs": 1758,
-    "server": 47974585,
-    "server-agent-background": 41401561
+    "server": 53372518,
+    "server-agent-background": 46556774
   },
   "brain": {
     "agent-native-recurring-jobs": 1758,
@@ -44,9 +44,9 @@
   },
   "clips": {
     "agent-native-recurring-jobs": 1758,
-    "clips-brain-export-sweep-background": 37853594,
-    "server": 37853594,
-    "server-agent-background": 17930650
+    "clips-brain-export-sweep-background": 118174515,
+    "server": 118174515,
+    "server-agent-background": 97936998
   },
   "content": {
     "agent-native-recurring-jobs": 1758,


### PR DESCRIPTION
## Summary\n- dispatch desktop and production workflows from the stable core package tag\n- keep the production source SHA explicit for site deploys\n- cover the workflow ref in the release coordinator test\n\n## Validation\n- corepack pnpm test:package-release-workflow