### PR TITLE
fix: prefer workspace credentials for managed MCP OAuth

### DIFF
--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -1,7 +1,7 @@
 import { mockEvent, type H3Event } from "h3";
 import { describe, expect, it, vi } from "vitest";
 
-const resolveSecretPairMock = vi.hoisted(() => vi.fn());
+const resolveSecretPairsMock = vi.hoisted(() => vi.fn());
 const CredentialStoreUnavailableErrorMock = vi.hoisted(
   () =>
     class CredentialStoreUnavailableErrorMock extends Error {
@@ -12,7 +12,7 @@ const CredentialStoreUnavailableErrorMock = vi.hoisted(
 
 vi.mock("../server/credential-provider.js", () => ({
   CredentialStoreUnavailableError: CredentialStoreUnavailableErrorMock,
-  resolveSecretPair: resolveSecretPairMock,
+  resolveSecretPairs: resolveSecretPairsMock,
 }));
 
 import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
@@ -249,8 +249,8 @@ describe("managed MCP OAuth clients", () => {
   });
 
   it("resolves the workspace HubSpot client without exposing its secret to the browser", async () => {
-    resolveSecretPairMock.mockImplementation(
-      async ([clientIdKey, clientSecretKey]: [string, string]) =>
+    resolveSecretPairsMock.mockImplementation(
+      async ([[clientIdKey, clientSecretKey]]) =>
         clientIdKey === "HUBSPOT_MCP_CLIENT_ID" &&
         clientSecretKey === "HUBSPOT_MCP_CLIENT_SECRET"
           ? ["hubspot-client-id", "hubspot-client-secret"]
@@ -267,8 +267,8 @@ describe("managed MCP OAuth clients", () => {
   });
 
   it("resolves the shared Google client for official Workspace MCP servers", async () => {
-    resolveSecretPairMock.mockImplementation(
-      async ([clientIdKey, clientSecretKey]: [string, string]) =>
+    resolveSecretPairsMock.mockImplementation(
+      async ([[clientIdKey, clientSecretKey]]) =>
         clientIdKey === "GOOGLE_CLIENT_ID" &&
         clientSecretKey === "GOOGLE_CLIENT_SECRET"
           ? ["google-client-id", "google-client-secret"]
@@ -295,19 +295,19 @@ describe("managed MCP OAuth clients", () => {
       });
       expect(resolveMcpOAuthScope(new URL(origin), "org")).toBeNull();
     }
-    expect(resolveSecretPairMock).toHaveBeenLastCalledWith(
-      ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
+    expect(resolveSecretPairsMock).toHaveBeenLastCalledWith(
+      [["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]],
       { allowUserScope: false, preferWorkspaceScope: true },
     );
   });
 
   it("does not resolve a managed client for an unrelated MCP server", async () => {
-    resolveSecretPairMock.mockReset();
+    resolveSecretPairsMock.mockReset();
 
     await expect(
       resolveManagedMcpOAuthClient(new URL("https://mcp.example.com")),
     ).resolves.toBeUndefined();
-    expect(resolveSecretPairMock).not.toHaveBeenCalled();
+    expect(resolveSecretPairsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -297,7 +297,7 @@ describe("managed MCP OAuth clients", () => {
     }
     expect(resolveSecretPairMock).toHaveBeenLastCalledWith(
       ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
-      { allowUserScope: false },
+      { allowUserScope: false, preferWorkspaceScope: true },
     );
   });
 

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -18,7 +18,7 @@ import { decryptSecretValue, encryptSecretValue } from "../secrets/crypto.js";
 import { getSession, safeReturnPath } from "../server/auth.js";
 import {
   CredentialStoreUnavailableError,
-  resolveSecretPair,
+  resolveSecretPairs,
 } from "../server/credential-provider.js";
 import { getH3App } from "../server/framework-request-handler.js";
 import {
@@ -372,19 +372,17 @@ export async function resolveManagedMcpOAuthClient(
   );
   if (!client) return undefined;
 
-  for (const [clientIdKey, clientSecretKey] of client.credentialPairs) {
-    const credentials = await resolveSecretPair(
-      [clientIdKey, clientSecretKey],
-      { allowUserScope: false, preferWorkspaceScope: true },
-    );
-    if (credentials) {
-      const [clientId, clientSecret] = credentials;
-      return {
-        client_id: clientId,
-        client_secret: clientSecret,
-        token_endpoint_auth_method: "client_secret_post",
-      } as StoredOAuthClientInformation;
-    }
+  const credentials = await resolveSecretPairs(client.credentialPairs, {
+    allowUserScope: false,
+    preferWorkspaceScope: true,
+  });
+  if (credentials) {
+    const [clientId, clientSecret] = credentials;
+    return {
+      client_id: clientId,
+      client_secret: clientSecret,
+      token_endpoint_auth_method: "client_secret_post",
+    } as StoredOAuthClientInformation;
   }
   return undefined;
 }

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -375,7 +375,7 @@ export async function resolveManagedMcpOAuthClient(
   for (const [clientIdKey, clientSecretKey] of client.credentialPairs) {
     const credentials = await resolveSecretPair(
       [clientIdKey, clientSecretKey],
-      { allowUserScope: false },
+      { allowUserScope: false, preferWorkspaceScope: true },
     );
     if (credentials) {
       const [clientId, clientSecret] = credentials;

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -72,6 +72,7 @@ import {
   resolveHasCompleteBuilderConnection,
   resolveSecret,
   resolveSecretPair,
+  resolveSecretPairs,
   resolveSecretDetailed,
 } from "./credential-provider.js";
 
@@ -1488,6 +1489,88 @@ describe("resolveSecretPair", () => {
         preferWorkspaceScope: true,
       }),
     ).resolves.toEqual(["workspace-client", "workspace-secret"]);
+  });
+
+  it("prefers workspace credentials across managed OAuth aliases", async () => {
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockReadAppSecrets.mockImplementation(
+      async ({ scope, keys }: { scope: string; keys: string[] }) => {
+        if (scope === "org" && keys[0] === "HUBSPOT_MCP_CLIENT_ID") {
+          return new Map([
+            ["HUBSPOT_MCP_CLIENT_ID", { value: "stale-org-client" }],
+            ["HUBSPOT_MCP_CLIENT_SECRET", { value: "stale-org-secret" }],
+          ]);
+        }
+        if (
+          scope === "workspace" &&
+          keys[0] === "HUBSPOT_INTEGRATION_CLIENT_ID"
+        ) {
+          return new Map([
+            ["HUBSPOT_INTEGRATION_CLIENT_ID", { value: "workspace-client" }],
+            [
+              "HUBSPOT_INTEGRATION_CLIENT_SECRET",
+              { value: "workspace-secret" },
+            ],
+          ]);
+        }
+        return new Map();
+      },
+    );
+
+    await expect(
+      resolveSecretPairs(
+        [
+          ["HUBSPOT_MCP_CLIENT_ID", "HUBSPOT_MCP_CLIENT_SECRET"],
+          [
+            "HUBSPOT_INTEGRATION_CLIENT_ID",
+            "HUBSPOT_INTEGRATION_CLIENT_SECRET",
+          ],
+        ],
+        { allowUserScope: false, preferWorkspaceScope: true },
+      ),
+    ).resolves.toEqual(["workspace-client", "workspace-secret"]);
+    expect(
+      mockReadAppSecrets.mock.calls.map(([args]) => [args.scope, args.keys[0]]),
+    ).toEqual([
+      ["workspace", "HUBSPOT_MCP_CLIENT_ID"],
+      ["workspace", "HUBSPOT_INTEGRATION_CLIENT_ID"],
+    ]);
+  });
+
+  it("prefers workspace credentials over a stale designated-vault org pair", async () => {
+    process.env.AGENT_VAULT_ORG_ID = "dispatch-vault";
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    mockGetRequestOrgId.mockReturnValue("app-org");
+    mockReadAppSecrets.mockImplementation(
+      async ({ scope, scopeId }: { scope: string; scopeId: string }) => {
+        if (scopeId === "dispatch-vault" && scope === "org") {
+          return new Map([
+            ["GOOGLE_CLIENT_ID", { value: "stale-org-client" }],
+            ["GOOGLE_CLIENT_SECRET", { value: "stale-org-secret" }],
+          ]);
+        }
+        if (scopeId === "dispatch-vault" && scope === "workspace") {
+          return new Map([
+            ["GOOGLE_CLIENT_ID", { value: "workspace-client" }],
+            ["GOOGLE_CLIENT_SECRET", { value: "workspace-secret" }],
+          ]);
+        }
+        return new Map();
+      },
+    );
+
+    await expect(
+      resolveSecretPairs([["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"]], {
+        allowUserScope: false,
+        preferWorkspaceScope: true,
+      }),
+    ).resolves.toEqual(["workspace-client", "workspace-secret"]);
+    expect(
+      mockReadAppSecrets.mock.calls
+        .filter(([args]) => args.scopeId === "dispatch-vault")
+        .map(([args]) => args.scope),
+    ).toEqual(["workspace"]);
   });
 
   it("skips a stale solo workspace pair for shared OAuth clients", async () => {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -1453,11 +1453,41 @@ describe("resolveSecretPair", () => {
     await expect(
       resolveSecretPair(["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"], {
         allowUserScope: false,
+        preferWorkspaceScope: true,
       }),
     ).resolves.toEqual(["workspace-client", "workspace-secret"]);
     expect(
       mockReadAppSecrets.mock.calls.map(([args]) => args.scope),
     ).not.toContain("user");
+  });
+
+  it("prefers workspace credentials over a stale org pair", async () => {
+    mockGetRequestUserEmail.mockReturnValue("user@b.com");
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockReadAppSecrets.mockImplementation(
+      async ({ scope }: { scope: string }) => {
+        if (scope === "org") {
+          return new Map([
+            ["GOOGLE_CLIENT_ID", { value: "stale-org-client" }],
+            ["GOOGLE_CLIENT_SECRET", { value: "stale-org-secret" }],
+          ]);
+        }
+        if (scope === "workspace") {
+          return new Map([
+            ["GOOGLE_CLIENT_ID", { value: "workspace-client" }],
+            ["GOOGLE_CLIENT_SECRET", { value: "workspace-secret" }],
+          ]);
+        }
+        return new Map();
+      },
+    );
+
+    await expect(
+      resolveSecretPair(["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"], {
+        allowUserScope: false,
+        preferWorkspaceScope: true,
+      }),
+    ).resolves.toEqual(["workspace-client", "workspace-secret"]);
   });
 
   it("skips a stale solo workspace pair for shared OAuth clients", async () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -1698,10 +1698,14 @@ export async function resolveSecret(key: string): Promise<string | null> {
  */
 export async function resolveSecretPair(
   keys: readonly [string, string],
-  options?: { allowUserScope?: boolean },
+  options?: {
+    allowUserScope?: boolean;
+    preferWorkspaceScope?: boolean;
+  },
 ): Promise<[string, string] | null> {
   const [firstKey, secondKey] = keys;
   const allowUserScope = options?.allowUserScope ?? true;
+  const preferWorkspaceScope = options?.preferWorkspaceScope ?? false;
   const readPair = async (
     scope: "user" | "org" | "workspace",
     scopeId: string,
@@ -1752,10 +1756,16 @@ export async function resolveSecretPair(
     }
 
     if (orgId) {
+      if (preferWorkspaceScope) {
+        pair = await readPair("workspace", orgId);
+        if (pair) return pair;
+      }
       pair = await readPair("org", orgId);
       if (pair) return pair;
-      pair = await readPair("workspace", orgId);
-      if (pair) return pair;
+      if (!preferWorkspaceScope) {
+        pair = await readPair("workspace", orgId);
+        if (pair) return pair;
+      }
     }
 
     if (allowUserScope) {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -1692,51 +1692,71 @@ export async function resolveSecret(key: string): Promise<string | null> {
   return null;
 }
 
+type SecretPairKeys = readonly [string, string];
+type ResolveSecretPairOptions = {
+  allowUserScope?: boolean;
+  preferWorkspaceScope?: boolean;
+};
+
 /**
- * Resolve two related secrets from one scope/source. A complete lower-
- * precedence pair wins over mixing a partial override with another source.
+ * Resolve the first complete pair from the requested aliases. A complete
+ * lower-precedence pair wins over mixing a partial override with another
+ * source, and workspace preference applies across every alias before org.
  */
-export async function resolveSecretPair(
-  keys: readonly [string, string],
-  options?: {
-    allowUserScope?: boolean;
-    preferWorkspaceScope?: boolean;
-  },
+export async function resolveSecretPairs(
+  keyPairs: ReadonlyArray<SecretPairKeys>,
+  options?: ResolveSecretPairOptions,
 ): Promise<[string, string] | null> {
-  const [firstKey, secondKey] = keys;
+  if (keyPairs.length === 0) return null;
+
   const allowUserScope = options?.allowUserScope ?? true;
   const preferWorkspaceScope = options?.preferWorkspaceScope ?? false;
   const readPair = async (
+    keys: SecretPairKeys,
     scope: "user" | "org" | "workspace",
     scopeId: string,
   ): Promise<[string, string] | null> => {
     const { readAppSecrets } = await import("../secrets/storage.js");
     const secrets = await readAppSecrets({ keys, scope, scopeId });
+    const [firstKey, secondKey] = keys;
     const first = secrets.get(firstKey)?.value;
     const second = secrets.get(secondKey)?.value;
     return first && second ? [first, second] : null;
   };
-  const readEnvironmentPair = (): [string, string] | null => {
-    if (
-      !canUseDeployCredentialFallbackForRequest(firstKey) ||
-      !canUseDeployCredentialFallbackForRequest(secondKey)
-    ) {
-      return null;
+  const readPairs = async (
+    scope: "user" | "org" | "workspace",
+    scopeId: string,
+  ): Promise<[string, string] | null> => {
+    for (const keys of keyPairs) {
+      const pair = await readPair(keys, scope, scopeId);
+      if (pair) return pair;
     }
-    const first = process.env[firstKey];
-    const second = process.env[secondKey];
-    return first && second ? [first, second] : null;
+    return null;
+  };
+  const readEnvironmentPairs = (): [string, string] | null => {
+    for (const [firstKey, secondKey] of keyPairs) {
+      if (
+        !canUseDeployCredentialFallbackForRequest(firstKey) ||
+        !canUseDeployCredentialFallbackForRequest(secondKey)
+      ) {
+        continue;
+      }
+      const first = process.env[firstKey];
+      const second = process.env[secondKey];
+      if (first && second) return [first, second];
+    }
+    return null;
   };
 
   const email = getRequestUserEmail();
-  if (!email) return readEnvironmentPair();
+  if (!email) return readEnvironmentPairs();
 
   let lookupFailed = false;
   let cause: unknown;
   try {
     let pair: [string, string] | null = null;
     if (allowUserScope) {
-      pair = await readPair("user", email);
+      pair = await readPairs("user", email);
       if (pair) return pair;
     }
 
@@ -1749,7 +1769,7 @@ export async function resolveSecretPair(
     }
 
     if (lookupFailed) {
-      const environmentPair = readEnvironmentPair();
+      const environmentPair = readEnvironmentPairs();
       if (environmentPair) return environmentPair;
       assertCredentialStoreReadable({ lookupFailed, cause });
       return null;
@@ -1757,37 +1777,51 @@ export async function resolveSecretPair(
 
     if (orgId) {
       if (preferWorkspaceScope) {
-        pair = await readPair("workspace", orgId);
+        pair = await readPairs("workspace", orgId);
         if (pair) return pair;
       }
-      pair = await readPair("org", orgId);
+      pair = await readPairs("org", orgId);
       if (pair) return pair;
       if (!preferWorkspaceScope) {
-        pair = await readPair("workspace", orgId);
+        pair = await readPairs("workspace", orgId);
         if (pair) return pair;
       }
     }
 
     if (allowUserScope) {
-      pair = await readPair("workspace", `solo:${email}`);
+      pair = await readPairs("workspace", `solo:${email}`);
       if (pair) return pair;
     }
 
     const vaultOrgId = process.env.AGENT_VAULT_ORG_ID?.trim();
     if (vaultOrgId && vaultOrgId !== orgId) {
-      const access = await Promise.all(
-        keys.map((key) => canReadDesignatedVaultFallback(vaultOrgId, key)),
-      );
-      const unavailable = access.find(
-        (result) => result.status === "unavailable",
-      );
-      if (unavailable?.status === "unavailable") {
-        lookupFailed = true;
-        cause = unavailable.cause;
-      } else if (access.every((result) => result.status === "allowed")) {
-        pair = await readPair("org", vaultOrgId);
-        if (pair) return pair;
-        pair = await readPair("workspace", vaultOrgId);
+      const readDesignatedVaultPairs = async (
+        scope: "org" | "workspace",
+      ): Promise<[string, string] | null> => {
+        for (const keys of keyPairs) {
+          const access = await Promise.all(
+            keys.map((key) => canReadDesignatedVaultFallback(vaultOrgId, key)),
+          );
+          const unavailable = access.find(
+            (result) => result.status === "unavailable",
+          );
+          if (unavailable?.status === "unavailable") {
+            lookupFailed = true;
+            cause = unavailable.cause;
+            continue;
+          }
+          if (access.every((result) => result.status === "allowed")) {
+            const pair = await readPair(keys, scope, vaultOrgId);
+            if (pair) return pair;
+          }
+        }
+        return null;
+      };
+      const designatedScopes: Array<"org" | "workspace"> = preferWorkspaceScope
+        ? ["workspace", "org"]
+        : ["org", "workspace"];
+      for (const scope of designatedScopes) {
+        pair = await readDesignatedVaultPairs(scope);
         if (pair) return pair;
       }
     }
@@ -1796,10 +1830,17 @@ export async function resolveSecretPair(
     cause = error;
   }
 
-  const environmentPair = readEnvironmentPair();
+  const environmentPair = readEnvironmentPairs();
   if (environmentPair) return environmentPair;
   assertCredentialStoreReadable({ lookupFailed, cause });
   return null;
+}
+
+export async function resolveSecretPair(
+  keys: SecretPairKeys,
+  options?: ResolveSecretPairOptions,
+): Promise<[string, string] | null> {
+  return resolveSecretPairs([keys], options);
 }
 
 /**


### PR DESCRIPTION
## Summary
- prefer the registered workspace OAuth client pair over stale org-scoped values
- keep managed MCP OAuth clients out of personal user and solo-workspace overrides
- cover stale org precedence with focused tests

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest run src/server/credential-provider.spec.ts src/mcp-client/oauth-routes.spec.ts`
- `corepack pnpm guards`
