### PR TITLE
fix(core): persist denied tool approvals across reloads

### DIFF
--- a/.changeset/durable-tool-denials.md
+++ b/.changeset/durable-tool-denials.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Persist denied tool approvals so rejected actions stay blocked after a reload.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -10100,6 +10100,38 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("does not execute or re-ask when an exact approval was already consumed", async () => {
+    const run = vi.fn(async () => "delivered");
+    const onApprovalRequired = vi.fn(async () => "replacement-ask");
+    const events: AgentChatEvent[] = [];
+
+    await runAgentLoop({
+      engine: approvalEngine().engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "send-email": {
+          ...actionEntry({ readOnly: false }),
+          needsApproval: true,
+          run,
+        },
+      },
+      approvedToolCalls: ['send-email:{"to":"a@b.com"}'],
+      consumeApproval: vi.fn(async () => "consumed" as const),
+      onApprovalRequired,
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(onApprovalRequired).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === "approval_required")).toBe(
+      false,
+    );
+  });
+
   it("consumes an approval grant after the first exact tool-call match", async () => {
     const first = approvalEngine();
     const run = vi.fn(async () => "delivered");

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1531,6 +1531,17 @@ describe("resolveAgentOwnerEmail", () => {
 });
 
 describe("resolveAgentApprovalThreadScope", () => {
+  it("returns absent when chat thread sharing is not registered", async () => {
+    await expect(
+      resolveAgentApprovalThreadScope(
+        "owner@example.com",
+        null,
+        "thread-1",
+        "editor",
+      ),
+    ).resolves.toBeNull();
+  });
+
   it("uses the persisted thread owner and org when the active org differs", async () => {
     const resolveAccess = vi.fn(
       async (

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -55,6 +55,7 @@ import {
   lastUnfinishedPreparingActionToolFromEvents,
   markBackgroundContinuationChunkTerminal,
   resolveAgentModelSelection,
+  resolveAgentApprovalThreadScope,
   resolveAgentOwnerEmail,
   resolveBackgroundDispatchOutcome,
   resolveFinalResponseGuardRequestText,
@@ -1526,6 +1527,43 @@ describe("resolveAgentOwnerEmail", () => {
     );
 
     expect(owner).toBe("context@example.com");
+  });
+});
+
+describe("resolveAgentApprovalThreadScope", () => {
+  it("uses the persisted thread owner and org when the active org differs", async () => {
+    const resolveAccess = vi.fn(
+      async (
+        _userEmail: string,
+        _threadId: string,
+        _role: "viewer" | "editor",
+        _ctx: { orgId?: string },
+      ) => ({
+        id: "thread-1",
+        ownerEmail: "owner@example.com",
+        orgId: null,
+      }),
+    );
+
+    await expect(
+      resolveAgentApprovalThreadScope(
+        "owner@example.com",
+        "active-org",
+        "thread-1",
+        "editor",
+        resolveAccess,
+      ),
+    ).resolves.toEqual({
+      ownerEmail: "owner@example.com",
+      orgId: null,
+      threadId: "thread-1",
+    });
+    expect(resolveAccess).toHaveBeenCalledWith(
+      "owner@example.com",
+      "thread-1",
+      "editor",
+      { orgId: "active-org" },
+    );
   });
 });
 
@@ -9986,6 +10024,68 @@ describe("runAgentLoop", () => {
     expect(run).not.toHaveBeenCalled();
     expect(events2).toContainEqual(
       expect.objectContaining({ type: "approval_required" }),
+    );
+  });
+
+  it("never executes a durably denied call after a reload continuation", async () => {
+    const first = approvalEngine();
+    const run = vi.fn(async () => "delivered");
+    const actions = {
+      "send-email": {
+        ...actionEntry({ readOnly: false }),
+        needsApproval: true,
+        run,
+      },
+    };
+    const firstEvents: any[] = [];
+
+    await runAgentLoop({
+      engine: first.engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions,
+      send: (event) => firstEvents.push(event),
+      signal: new AbortController().signal,
+    });
+
+    const approvalKey = firstEvents.find(
+      (event) => event.type === "approval_required",
+    )?.approvalKey as string;
+    expect(approvalKey).toBeTruthy();
+    expect(run).not.toHaveBeenCalled();
+
+    // A reload can replay the stale Approve control, but the durable store is
+    // authoritative: once Deny won, the continuation must not execute or mint
+    // a replacement approval for the same logical call.
+    const consumeApproval = vi.fn(async () => "denied" as const);
+    const onApprovalRequired = vi.fn(async () => "replacement-ask");
+    const replayEvents: any[] = [];
+
+    await runAgentLoop({
+      engine: approvalEngine().engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions,
+      approvedToolCalls: [approvalKey],
+      consumeApproval,
+      onApprovalRequired,
+      send: (event) => replayEvents.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(consumeApproval).toHaveBeenCalledOnce();
+    expect(onApprovalRequired).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
+    expect(replayEvents).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "send-email",
+        result: expect.stringMatching(/denied|did NOT execute/i),
+      }),
     );
   });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -3332,7 +3332,7 @@ export interface ExecuteAgentToolCallOptions {
   ) => Promise<string | void>;
   consumeApproval?: (
     binding: AgentApprovalBinding,
-  ) => Promise<boolean | "denied">;
+  ) => Promise<boolean | "denied" | "consumed">;
   isToolAlwaysAllowed?: (binding: AgentApprovalBinding) => Promise<boolean>;
   send?: (event: AgentChatEvent) => void;
 }
@@ -4680,7 +4680,7 @@ export async function runAgentLoop(opts: {
   ) => Promise<string | void>;
   consumeApproval?: (
     binding: AgentApprovalBinding,
-  ) => Promise<boolean | "denied">;
+  ) => Promise<boolean | "denied" | "consumed">;
   /** User-scoped action-type policy, checked only after needsApproval. */
   isToolAlwaysAllowed?: (binding: AgentApprovalBinding) => Promise<boolean>;
   /**
@@ -5989,14 +5989,19 @@ export async function runAgentLoop(opts: {
           ? await opts.consumeApproval(approvalBinding)
           : requestedApproval;
       const wasApproved = approvalDecision === true;
-      if (approvalDecision === "denied") {
+      if (approvalDecision === "denied" || approvalDecision === "consumed") {
         const result =
-          `Denied by the user: "${toolCall.name}" did NOT execute. ` +
-          "This exact request cannot be approved later.";
+          approvalDecision === "denied"
+            ? `Denied by the user: "${toolCall.name}" did NOT execute. ` +
+              "This exact request cannot be approved later."
+            : `The approved "${toolCall.name}" request already completed and was not run again.`;
         turnYieldedToUser = true;
         requestedActionStop ??= {
           message: result,
-          errorCode: "approval-denied",
+          errorCode:
+            approvalDecision === "denied"
+              ? "approval-denied"
+              : "approval-consumed",
         };
         return declineToolCall(result);
       }
@@ -9561,6 +9566,10 @@ export function createProductionAgentHandler(
             .filter((key: unknown): key is string => typeof key === "string")
             .slice(0, 200)
         : undefined;
+    const requestedApprovalId =
+      typeof body.approvalId === "string" && body.approvalId.trim()
+        ? body.approvalId.trim()
+        : undefined;
     // The durable approval row is the authorization boundary. Do not require
     // the client to reproduce the original structured history exactly: the UI
     // may truncate tool arguments and intentionally assigns fresh replay ids.
@@ -9647,6 +9656,7 @@ export function createProductionAgentHandler(
             threadId,
             requestedTurnId: requestTurnId,
             approvalKeys: requestedApprovedToolCalls,
+            approvalId: requestedApprovalId,
           })
         : null;
     const effectiveTurnId =
@@ -9670,6 +9680,7 @@ export function createProductionAgentHandler(
         orgId: approvalOrgId,
         threadId: effectiveThreadId,
         turnId: effectiveTurnId,
+        ...(requestedApprovalId ? { approvalId: requestedApprovalId } : {}),
         toolName: binding.toolName,
         callId: binding.callId,
         approvalKey: binding.approvalKey,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -203,7 +203,10 @@ import {
   isAgentToolAlwaysAllowed,
   resolveAgentToolApprovalTurnId,
 } from "./tool-approval-store.js";
-import type { AgentToolApprovalBinding } from "./tool-approval-store.js";
+import type {
+  AgentToolApprovalBinding,
+  AgentToolApprovalPolicyBinding,
+} from "./tool-approval-store.js";
 import {
   findCompletedJournalEntry,
   type ToolCallJournal,
@@ -1421,6 +1424,18 @@ export async function resolveAgentApprovalThreadScope(
         threadId: thread.id,
       }
     : null;
+}
+
+export function agentToolApprovalPolicyBindingForThread(
+  actorEmail: string,
+  threadScope: { orgId?: string | null },
+  toolName: string,
+): AgentToolApprovalPolicyBinding {
+  return {
+    ownerEmail: actorEmail,
+    orgId: threadScope.orgId ?? null,
+    toolName,
+  };
 }
 
 const MAX_RETRIES = 3;
@@ -9696,11 +9711,13 @@ export function createProductionAgentHandler(
       },
       isToolAlwaysAllowed: async (binding: AgentApprovalBinding) => {
         if (!ownerEmail) return false;
-        return isAgentToolAlwaysAllowed({
-          ownerEmail,
-          orgId: getRequestOrgId() ?? null,
-          toolName: binding.toolName,
-        });
+        return isAgentToolAlwaysAllowed(
+          agentToolApprovalPolicyBindingForThread(
+            ownerEmail,
+            { orgId: approvalOrgId },
+            binding.toolName,
+          ),
+        );
       },
     };
     const approvedToolCallsForExecution = requestedApprovedToolCalls;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1390,6 +1390,35 @@ export async function resolveAgentOwnerEmail(
   return ownerEmail ?? getRequestUserEmail() ?? null;
 }
 
+type AgentApprovalThreadAccessResolver = (
+  userEmail: string,
+  threadId: string,
+  minRole: "viewer" | "editor",
+  ctx: { orgId?: string },
+) => Promise<{ id: string; ownerEmail: string; orgId: string | null } | null>;
+
+export async function resolveAgentApprovalThreadScope(
+  callerEmail: string,
+  activeOrgId: string | null | undefined,
+  threadId: string,
+  role: "viewer" | "editor",
+  resolveAccess?: AgentApprovalThreadAccessResolver,
+) {
+  const accessResolver =
+    resolveAccess ??
+    (await import("../chat-threads/store.js")).resolveThreadAccessIdentity;
+  const thread = await accessResolver(callerEmail, threadId, role, {
+    orgId: activeOrgId ?? undefined,
+  });
+  return thread
+    ? {
+        ownerEmail: thread.ownerEmail,
+        orgId: thread.orgId,
+        threadId: thread.id,
+      }
+    : null;
+}
+
 const MAX_RETRIES = 3;
 const COMPLETION_DATABASE_RETRY_DELAYS_MS = [250, 750, 1_500] as const;
 
@@ -3297,7 +3326,9 @@ export interface ExecuteAgentToolCallOptions {
   onApprovalRequired?: (
     binding: AgentApprovalBinding,
   ) => Promise<string | void>;
-  consumeApproval?: (binding: AgentApprovalBinding) => Promise<boolean>;
+  consumeApproval?: (
+    binding: AgentApprovalBinding,
+  ) => Promise<boolean | "denied">;
   isToolAlwaysAllowed?: (binding: AgentApprovalBinding) => Promise<boolean>;
   send?: (event: AgentChatEvent) => void;
 }
@@ -4643,7 +4674,9 @@ export async function runAgentLoop(opts: {
   onApprovalRequired?: (
     binding: AgentApprovalBinding,
   ) => Promise<string | void>;
-  consumeApproval?: (binding: AgentApprovalBinding) => Promise<boolean>;
+  consumeApproval?: (
+    binding: AgentApprovalBinding,
+  ) => Promise<boolean | "denied">;
   /** User-scoped action-type policy, checked only after needsApproval. */
   isToolAlwaysAllowed?: (binding: AgentApprovalBinding) => Promise<boolean>;
   /**
@@ -5947,10 +5980,22 @@ export async function runAgentLoop(opts: {
         approvalKey,
       };
       const requestedApproval = approvedToolCallKeys.delete(approvalKey);
-      const wasApproved =
+      const approvalDecision =
         requestedApproval && opts.consumeApproval
           ? await opts.consumeApproval(approvalBinding)
           : requestedApproval;
+      const wasApproved = approvalDecision === true;
+      if (approvalDecision === "denied") {
+        const result =
+          `Denied by the user: "${toolCall.name}" did NOT execute. ` +
+          "This exact request cannot be approved later.";
+        turnYieldedToUser = true;
+        requestedActionStop ??= {
+          message: result,
+          errorCode: "approval-denied",
+        };
+        return declineToolCall(result);
+      }
       if (actionEntry.needsApproval && !wasApproved) {
         let mustApprove = false;
         try {
@@ -9573,14 +9618,28 @@ export function createProductionAgentHandler(
       isBackgroundWorker && backgroundContinuationCount > 0;
     const runId = backgroundRunMarker?.runId ?? generateRunId();
     const effectiveThreadId = threadId ?? runId;
+    const activeApprovalOrgId = getRequestOrgId() ?? null;
+    const persistedApprovalScope =
+      ownerEmail && threadId
+        ? await resolveAgentApprovalThreadScope(
+            ownerEmail,
+            activeApprovalOrgId,
+            threadId,
+            "editor",
+          ).catch(() => null)
+        : null;
+    const approvalOwnerEmail = persistedApprovalScope?.ownerEmail ?? ownerEmail;
+    const approvalOrgId = persistedApprovalScope
+      ? persistedApprovalScope.orgId
+      : activeApprovalOrgId;
     const resolvedApprovalTurnId =
       !isBackgroundWorker &&
-      ownerEmail &&
+      approvalOwnerEmail &&
       threadId &&
       requestedApprovedToolCalls?.length
         ? await resolveAgentToolApprovalTurnId({
-            ownerEmail,
-            orgId: getRequestOrgId() ?? null,
+            ownerEmail: approvalOwnerEmail,
+            orgId: approvalOrgId,
             threadId,
             requestedTurnId: requestTurnId,
             approvalKeys: requestedApprovedToolCalls,
@@ -9597,14 +9656,14 @@ export function createProductionAgentHandler(
     const approvalStoreBinding = (
       binding: AgentApprovalBinding,
     ): AgentToolApprovalBinding => {
-      if (!ownerEmail) {
+      if (!approvalOwnerEmail) {
         throw new Error(
           "Cannot create or consume an approval without an authenticated owner",
         );
       }
       return {
-        ownerEmail,
-        orgId: getRequestOrgId() ?? null,
+        ownerEmail: approvalOwnerEmail,
+        orgId: approvalOrgId,
         threadId: effectiveThreadId,
         turnId: effectiveTurnId,
         toolName: binding.toolName,
@@ -9617,7 +9676,7 @@ export function createProductionAgentHandler(
         return createAgentToolApproval(approvalStoreBinding(binding));
       },
       consumeApproval: async (binding: AgentApprovalBinding) => {
-        if (!ownerEmail) return false;
+        if (!approvalOwnerEmail) return false;
         return consumeAgentToolApproval(approvalStoreBinding(binding));
       },
       isToolAlwaysAllowed: async (binding: AgentApprovalBinding) => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1404,6 +1404,10 @@ export async function resolveAgentApprovalThreadScope(
   role: "viewer" | "editor",
   resolveAccess?: AgentApprovalThreadAccessResolver,
 ) {
+  if (!resolveAccess) {
+    const { getShareableResource } = await import("../sharing/registry.js");
+    if (!getShareableResource("chat_thread")) return null;
+  }
   const accessResolver =
     resolveAccess ??
     (await import("../chat-threads/store.js")).resolveThreadAccessIdentity;
@@ -9626,7 +9630,7 @@ export function createProductionAgentHandler(
             activeApprovalOrgId,
             threadId,
             "editor",
-          ).catch(() => null)
+          )
         : null;
     const approvalOwnerEmail = persistedApprovalScope?.ownerEmail ?? ownerEmail;
     const approvalOrgId = persistedApprovalScope

--- a/packages/core/src/agent/tool-approval-store.spec.ts
+++ b/packages/core/src/agent/tool-approval-store.spec.ts
@@ -385,10 +385,12 @@ describe("agent tool approval store", () => {
       }),
       expect.objectContaining({
         sql: expect.stringMatching(
-          /INSERT INTO agent_tool_approval_policies[\s\S]*WHERE EXISTS[\s\S]*status IN \('approved', 'always_allowed', 'consumed'\)/,
+          /INSERT INTO agent_tool_approval_policies[\s\S]*WHERE EXISTS[\s\S]*status IN \('approved', 'always_allowed', 'consumed'\)[\s\S]*\(status = 'consumed' OR expires_at > \?\)/,
         ),
       }),
     ]);
+    const [approve, policy] = dbMocks.atomicBatch.mock.calls[0]![0];
+    expect(policy.args?.at(-1)).toBe(approve.args?.at(-1));
   });
 
   it("denies one durable ask idempotently without touching matching parallel approvals", async () => {

--- a/packages/core/src/agent/tool-approval-store.spec.ts
+++ b/packages/core/src/agent/tool-approval-store.spec.ts
@@ -29,6 +29,12 @@ const binding = {
   approvalKey: 'send-email:{"to":"recipient@example.com"}',
 };
 
+function queueApprovalTableReady() {
+  for (let index = 0; index < 4; index += 1) {
+    dbMocks.execute.mockResolvedValueOnce({ rows: [], rowsAffected: 0 });
+  }
+}
+
 describe("agent tool approval store", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -60,6 +66,9 @@ describe("agent tool approval store", () => {
     expect(dbMocks.execute.mock.calls[4]?.[0].args).not.toContain(
       binding.approvalKey,
     );
+    expect(dbMocks.execute.mock.calls[5]?.[0].sql).toContain(
+      "status <> 'pending'",
+    );
   });
 
   it("gives a delayed approval click at least 30 minutes before the grant expires", async () => {
@@ -79,7 +88,7 @@ describe("agent tool approval store", () => {
     expect(expiresAt - before).toBeLessThanOrEqual(60 * 60_000 + 1_000);
   });
 
-  it("recovers a unique pending turn when a continuation omits its turn id", async () => {
+  it("recovers only a live pending turn", async () => {
     dbMocks.execute
       .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
       .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
@@ -101,6 +110,9 @@ describe("agent tool approval store", () => {
         approvalKeys: [binding.approvalKey],
       }),
     ).resolves.toBe("turn-1");
+    expect(dbMocks.execute.mock.calls[4]?.[0].sql).not.toContain(
+      "status = 'denied'",
+    );
   });
 
   it("does not guess between pending approvals from different turns", async () => {
@@ -142,7 +154,8 @@ describe("agent tool approval store", () => {
         await import("./tool-approval-store.js");
 
       await expect(consumeAgentToolApproval(binding)).resolves.toBe(expected);
-      expect(dbMocks.execute).toHaveBeenLastCalledWith(
+      expect(dbMocks.execute).toHaveBeenNthCalledWith(
+        5,
         expect.objectContaining({
           sql: expect.stringMatching(
             /status = 'pending'[\s\S]*expires_at > \?/,
@@ -154,7 +167,7 @@ describe("agent tool approval store", () => {
           ]),
         }),
       );
-      const consumeQuery = dbMocks.execute.mock.calls.at(-1)?.[0] as {
+      const consumeQuery = dbMocks.execute.mock.calls[4]?.[0] as {
         sql: string;
         args: unknown[];
       };
@@ -164,6 +177,103 @@ describe("agent tool approval store", () => {
       expect(consumeQuery.args).not.toContain(binding.callId);
     },
   );
+
+  it("returns denied instead of authorizing or re-asking a rejected logical call", async () => {
+    queueApprovalTableReady();
+    dbMocks.execute
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({
+        rows: [{ status: "denied" }],
+        rowsAffected: 0,
+      });
+    const { consumeAgentToolApproval } =
+      await import("./tool-approval-store.js");
+
+    await expect(consumeAgentToolApproval(binding)).resolves.toBe("denied");
+    const consumeQuery = dbMocks.execute.mock.calls[4]?.[0] as {
+      sql: string;
+    };
+    expect(consumeQuery.sql).toContain(
+      "FROM agent_tool_approvals AS candidate",
+    );
+    expect(consumeQuery.sql).toMatch(/NOT EXISTS[\s\S]*status = 'denied'/);
+  });
+
+  it("denies one logical call idempotently without touching parallel approvals", async () => {
+    queueApprovalTableReady();
+    const logical = {
+      turn_id: binding.turnId,
+      tool_name: binding.toolName,
+      approval_key_hash: "approval-hash",
+    };
+    dbMocks.execute
+      .mockResolvedValueOnce({
+        rows: [{ ...logical, status: "pending" }],
+        rowsAffected: 0,
+      })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 2 })
+      .mockResolvedValueOnce({
+        rows: [{ status: "denied" }],
+        rowsAffected: 0,
+      })
+      .mockResolvedValueOnce({
+        rows: [{ ...logical, status: "denied" }],
+        rowsAffected: 0,
+      });
+    const { denyAgentToolApproval } = await import("./tool-approval-store.js");
+
+    await expect(
+      denyAgentToolApproval({
+        approvalId: "ask-1",
+        ownerEmail: binding.ownerEmail,
+        orgId: binding.orgId,
+        threadId: binding.threadId,
+      }),
+    ).resolves.toBe("denied");
+    await expect(
+      denyAgentToolApproval({
+        approvalId: "ask-1",
+        ownerEmail: binding.ownerEmail,
+        orgId: binding.orgId,
+        threadId: binding.threadId,
+      }),
+    ).resolves.toBe("denied");
+
+    const denyQuery = dbMocks.execute.mock.calls[5]?.[0] as {
+      sql: string;
+      args: unknown[];
+    };
+    expect(denyQuery.sql).toMatch(/SET status = 'denied'/);
+    expect(denyQuery.sql).toMatch(
+      /approval_key_hash = \?[\s\S]*status = 'pending'/,
+    );
+    expect(denyQuery.args).toContain("approval-hash");
+    expect(denyQuery.args).not.toContain("parallel-ask");
+  });
+
+  it("returns terminal resolutions used to rehydrate approval cards after reload", async () => {
+    queueApprovalTableReady();
+    dbMocks.execute.mockResolvedValueOnce({
+      rows: [
+        { id: "ask-approved", status: "consumed" },
+        { id: "ask-denied", status: "denied" },
+      ],
+      rowsAffected: 0,
+    });
+    const { listAgentToolApprovalResolutions } =
+      await import("./tool-approval-store.js");
+
+    await expect(
+      listAgentToolApprovalResolutions({
+        ownerEmail: binding.ownerEmail,
+        orgId: binding.orgId,
+        threadId: binding.threadId,
+      }),
+    ).resolves.toEqual({
+      "ask-approved": "approved",
+      "ask-denied": "denied",
+    });
+  });
 
   it("propagates database failures instead of authorizing", async () => {
     dbMocks.execute

--- a/packages/core/src/agent/tool-approval-store.spec.ts
+++ b/packages/core/src/agent/tool-approval-store.spec.ts
@@ -2,11 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbMocks = vi.hoisted(() => ({
   execute: vi.fn(),
+  transaction: vi.fn(),
+  atomicBatch: vi.fn(),
+  getDialect: vi.fn(() => "sqlite"),
   isPostgres: vi.fn(() => false),
 }));
 
 vi.mock("../db/client.js", () => ({
-  getDbExec: () => ({ execute: dbMocks.execute }),
+  getDbExec: () => ({
+    execute: dbMocks.execute,
+    transaction: dbMocks.transaction,
+    atomicBatch: dbMocks.atomicBatch,
+  }),
+  getDialect: dbMocks.getDialect,
   intType: () => "INTEGER",
   isPostgres: dbMocks.isPostgres,
   retryOnDdlRace: async (fn: () => Promise<unknown>) => fn(),
@@ -40,8 +48,16 @@ describe("agent tool approval store", () => {
     vi.resetModules();
     dbMocks.execute.mockReset();
     dbMocks.execute.mockResolvedValue({ rows: [], rowsAffected: 1 });
+    dbMocks.transaction.mockReset();
+    dbMocks.transaction.mockImplementation(async (fn) =>
+      fn({ execute: dbMocks.execute }),
+    );
+    dbMocks.atomicBatch.mockReset();
+    dbMocks.atomicBatch.mockResolvedValue([]);
     dbMocks.isPostgres.mockReset();
     dbMocks.isPostgres.mockReturnValue(false);
+    dbMocks.getDialect.mockReset();
+    dbMocks.getDialect.mockReturnValue("sqlite");
     ddlMocks.ensureIndexExists.mockReset();
     ddlMocks.ensureIndexExists.mockResolvedValue(undefined);
     ddlMocks.ensureTableExists.mockReset();
@@ -66,9 +82,7 @@ describe("agent tool approval store", () => {
     expect(dbMocks.execute.mock.calls[4]?.[0].args).not.toContain(
       binding.approvalKey,
     );
-    expect(dbMocks.execute.mock.calls[5]?.[0].sql).toContain(
-      "status <> 'pending'",
-    );
+    expect(dbMocks.execute).toHaveBeenCalledTimes(5);
   });
 
   it("gives a delayed approval click at least 30 minutes before the grant expires", async () => {
@@ -138,6 +152,30 @@ describe("agent tool approval store", () => {
     ).resolves.toBeNull();
   });
 
+  it("recovers the original turn from the exact ask after Deny wins", async () => {
+    queueApprovalTableReady();
+    dbMocks.execute.mockResolvedValueOnce({
+      rows: [{ turn_id: "turn-1" }],
+      rowsAffected: 0,
+    });
+    const { resolveAgentToolApprovalTurnId } =
+      await import("./tool-approval-store.js");
+
+    await expect(
+      resolveAgentToolApprovalTurnId({
+        ownerEmail: binding.ownerEmail,
+        orgId: binding.orgId,
+        threadId: binding.threadId,
+        approvalId: "ask-1",
+        approvalKeys: [binding.approvalKey],
+      }),
+    ).resolves.toBe("turn-1");
+    expect(dbMocks.execute.mock.calls[4]?.[0]).toMatchObject({
+      sql: expect.stringContaining("id = ?"),
+      args: expect.arrayContaining(["ask-1"]),
+    });
+  });
+
   it.each([
     { rowsAffected: 1, expected: true },
     { rowsAffected: 0, expected: false },
@@ -199,6 +237,114 @@ describe("agent tool approval store", () => {
     expect(consumeQuery.sql).toMatch(/NOT EXISTS[\s\S]*status = 'denied'/);
   });
 
+  it("binds consumption to the exact approval and treats replay as terminal", async () => {
+    const { consumeAgentToolApproval, hashAgentToolApprovalKey } =
+      await import("./tool-approval-store.js");
+    queueApprovalTableReady();
+    dbMocks.execute.mockResolvedValueOnce({
+      rows: [
+        {
+          turn_id: binding.turnId,
+          tool_name: binding.toolName,
+          approval_key_hash: hashAgentToolApprovalKey(binding.approvalKey),
+          status: "consumed",
+          expires_at: Date.now() + 60_000,
+        },
+      ],
+      rowsAffected: 0,
+    });
+    await expect(
+      consumeAgentToolApproval({ ...binding, approvalId: "ask-1" }),
+    ).resolves.toBe("consumed");
+    const consume = dbMocks.execute.mock.calls[4]?.[0] as {
+      sql: string;
+      args: unknown[];
+    };
+    expect(consume.sql).toContain("id = ?");
+    expect(consume.args).toContain("ask-1");
+  });
+
+  it("atomically refuses Always Allow after Deny wins", async () => {
+    queueApprovalTableReady();
+    dbMocks.execute
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [{ status: "denied" }], rowsAffected: 0 });
+    const { alwaysAllowAgentToolApproval } =
+      await import("./tool-approval-store.js");
+
+    await expect(
+      alwaysAllowAgentToolApproval({
+        approval: {
+          approvalId: "ask-1",
+          ownerEmail: binding.ownerEmail,
+          orgId: binding.orgId,
+          threadId: binding.threadId,
+        },
+        policy: {
+          ownerEmail: "editor@example.com",
+          orgId: binding.orgId,
+          toolName: binding.toolName,
+        },
+      }),
+    ).resolves.toBe("denied");
+    expect(dbMocks.transaction).toHaveBeenCalledOnce();
+    expect(
+      dbMocks.execute.mock.calls.some(([statement]) =>
+        String(statement.sql).includes(
+          "INSERT INTO agent_tool_approval_policies",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("uses one conditional atomic batch for Always Allow on D1", async () => {
+    dbMocks.getDialect.mockReturnValue("d1");
+    queueApprovalTableReady();
+    dbMocks.execute
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            status: "always_allowed",
+            expires_at: Date.now() + 60_000,
+          },
+        ],
+        rowsAffected: 0,
+      });
+    const { alwaysAllowAgentToolApproval } =
+      await import("./tool-approval-store.js");
+
+    await expect(
+      alwaysAllowAgentToolApproval({
+        approval: {
+          approvalId: "ask-1",
+          ownerEmail: binding.ownerEmail,
+          orgId: binding.orgId,
+          threadId: binding.threadId,
+        },
+        policy: {
+          ownerEmail: binding.ownerEmail,
+          orgId: binding.orgId,
+          toolName: binding.toolName,
+        },
+      }),
+    ).resolves.toBe("approved");
+    expect(dbMocks.transaction).not.toHaveBeenCalled();
+    expect(dbMocks.atomicBatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        sql: expect.stringContaining("status = 'always_allowed'"),
+      }),
+      expect.objectContaining({
+        sql: expect.stringMatching(
+          /INSERT INTO agent_tool_approval_policies[\s\S]*WHERE EXISTS[\s\S]*status = 'always_allowed'/,
+        ),
+      }),
+    ]);
+  });
+
   it("denies one logical call idempotently without touching parallel approvals", async () => {
     queueApprovalTableReady();
     const logical = {
@@ -257,6 +403,11 @@ describe("agent tool approval store", () => {
       rows: [
         { id: "ask-approved", status: "consumed" },
         { id: "ask-denied", status: "denied" },
+        {
+          id: "ask-inflight",
+          status: "approved",
+          expires_at: Date.now() + 60_000,
+        },
       ],
       rowsAffected: 0,
     });

--- a/packages/core/src/agent/tool-approval-store.spec.ts
+++ b/packages/core/src/agent/tool-approval-store.spec.ts
@@ -473,6 +473,41 @@ describe("agent tool approval store", () => {
     });
   });
 
+  it.each([
+    {
+      orgId: "org-1",
+      orgPredicate: "org_id = ?",
+      expectedArgs: ["owner@example.com", "org-1", "thread-1"],
+    },
+    {
+      orgId: null,
+      orgPredicate: "org_id IS NULL",
+      expectedArgs: ["owner@example.com", "thread-1"],
+    },
+  ])(
+    "uses the full owner/org/thread index prefix when orgId is $orgId",
+    async ({ orgId, orgPredicate, expectedArgs }) => {
+      queueApprovalTableReady();
+      const { listAgentToolApprovalResolutions } =
+        await import("./tool-approval-store.js");
+
+      await listAgentToolApprovalResolutions({
+        ownerEmail: binding.ownerEmail,
+        orgId,
+        threadId: binding.threadId,
+      });
+
+      const query = dbMocks.execute.mock.calls[4]?.[0] as {
+        sql: string;
+        args: unknown[];
+      };
+      expect(query.sql).toContain(orgPredicate);
+      expect(query.sql).not.toContain("CAST(");
+      expect(query.sql).not.toContain(" OR org_id");
+      expect(query.args).toEqual(expectedArgs);
+    },
+  );
+
   it("propagates database failures instead of authorizing", async () => {
     dbMocks.execute
       .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })

--- a/packages/core/src/agent/tool-approval-store.spec.ts
+++ b/packages/core/src/agent/tool-approval-store.spec.ts
@@ -299,6 +299,52 @@ describe("agent tool approval store", () => {
     ).toBe(false);
   });
 
+  it("persists Always Allow when another tab approved the exact ask first", async () => {
+    queueApprovalTableReady();
+    dbMocks.execute
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 0 })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            turn_id: binding.turnId,
+            tool_name: binding.toolName,
+            approval_key_hash: "approval-hash",
+            status: "approved",
+            expires_at: Date.now() + 60_000,
+          },
+        ],
+        rowsAffected: 0,
+      })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 });
+    const { alwaysAllowAgentToolApproval } =
+      await import("./tool-approval-store.js");
+
+    await expect(
+      alwaysAllowAgentToolApproval({
+        approval: {
+          approvalId: "ask-1",
+          ownerEmail: binding.ownerEmail,
+          orgId: binding.orgId,
+          threadId: binding.threadId,
+        },
+        policy: {
+          ownerEmail: binding.ownerEmail,
+          orgId: binding.orgId,
+          toolName: binding.toolName,
+        },
+      }),
+    ).resolves.toBe("approved");
+    expect(
+      dbMocks.execute.mock.calls.some(([statement]) =>
+        String(statement.sql).includes(
+          "INSERT INTO agent_tool_approval_policies",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("uses one conditional atomic batch for Always Allow on D1", async () => {
     dbMocks.getDialect.mockReturnValue("d1");
     queueApprovalTableReady();
@@ -339,13 +385,13 @@ describe("agent tool approval store", () => {
       }),
       expect.objectContaining({
         sql: expect.stringMatching(
-          /INSERT INTO agent_tool_approval_policies[\s\S]*WHERE EXISTS[\s\S]*status = 'always_allowed'/,
+          /INSERT INTO agent_tool_approval_policies[\s\S]*WHERE EXISTS[\s\S]*status IN \('approved', 'always_allowed', 'consumed'\)/,
         ),
       }),
     ]);
   });
 
-  it("denies one logical call idempotently without touching parallel approvals", async () => {
+  it("denies one durable ask idempotently without touching matching parallel approvals", async () => {
     queueApprovalTableReady();
     const logical = {
       turn_id: binding.turnId,
@@ -357,7 +403,7 @@ describe("agent tool approval store", () => {
         rows: [{ ...logical, status: "pending" }],
         rowsAffected: 0,
       })
-      .mockResolvedValueOnce({ rows: [], rowsAffected: 2 })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
       .mockResolvedValueOnce({
         rows: [{ status: "denied" }],
         rowsAffected: 0,
@@ -393,8 +439,9 @@ describe("agent tool approval store", () => {
     expect(denyQuery.sql).toMatch(
       /approval_key_hash = \?[\s\S]*status = 'pending'/,
     );
+    expect(denyQuery.sql).toMatch(/WHERE id = \?/);
+    expect(denyQuery.args).toContain("ask-1");
     expect(denyQuery.args).toContain("approval-hash");
-    expect(denyQuery.args).not.toContain("parallel-ask");
   });
 
   it("returns terminal resolutions used to rehydrate approval cards after reload", async () => {

--- a/packages/core/src/agent/tool-approval-store.ts
+++ b/packages/core/src/agent/tool-approval-store.ts
@@ -561,10 +561,14 @@ export async function alwaysAllowAgentToolApproval(input: {
         await writeAgentToolApprovalPolicy(tx, input.policy, true);
         return "approved";
       }
-      return storedApprovalDecision(
-        await readAgentToolApproval(input.approval, tx),
-        now,
-      );
+      const approval = await readAgentToolApproval(input.approval, tx);
+      const decision = storedApprovalDecision(approval, now);
+      if (decision === "denied") return decision;
+      if (approval?.tool_name !== input.policy.toolName) return null;
+      if (decision === "approved" || decision === "consumed") {
+        await writeAgentToolApprovalPolicy(tx, input.policy, true);
+      }
+      return decision;
     });
   }
   if (!client.atomicBatch) {
@@ -580,7 +584,8 @@ export async function alwaysAllowAgentToolApproval(input: {
         SELECT 1 FROM agent_tool_approvals
         WHERE id = ? AND owner_email = ?
           AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
-          AND thread_id = ? AND tool_name = ? AND status = 'always_allowed'
+          AND thread_id = ? AND tool_name = ?
+          AND status IN ('approved', 'always_allowed', 'consumed')
       )`,
   );
   policy.args = [
@@ -617,6 +622,7 @@ export async function denyAgentToolApproval(
   if (logical.status !== "pending") return null;
 
   const logicalArgs = [
+    input.approvalId,
     input.ownerEmail,
     input.orgId ?? null,
     input.orgId ?? null,
@@ -629,7 +635,7 @@ export async function denyAgentToolApproval(
   await client.execute({
     sql: `UPDATE agent_tool_approvals
       SET status = 'denied', updated_at = ?
-      WHERE owner_email = ?
+      WHERE id = ? AND owner_email = ?
         AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
         AND thread_id = ?
         AND ((turn_id IS NULL AND CAST(? AS TEXT) IS NULL) OR turn_id = ?)

--- a/packages/core/src/agent/tool-approval-store.ts
+++ b/packages/core/src/agent/tool-approval-store.ts
@@ -292,23 +292,36 @@ export async function createAgentToolApproval(
  */
 export async function consumeAgentToolApproval(
   binding: AgentToolApprovalBinding,
-): Promise<boolean> {
+): Promise<boolean | "denied"> {
   await ensureAgentToolApprovalTable();
   const now = Date.now();
   const result = await getDbExec().execute({
     sql: `UPDATE agent_tool_approvals
       SET status = 'consumed', consumed_at = ?, updated_at = ?
       WHERE id = (
-        SELECT id FROM agent_tool_approvals
-        WHERE owner_email = ?
-          AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
-          AND ((thread_id IS NULL AND CAST(? AS TEXT) IS NULL) OR thread_id = ?)
-          AND ((turn_id IS NULL AND CAST(? AS TEXT) IS NULL) OR turn_id = ?)
-          AND tool_name = ?
-          AND approval_key_hash = ?
-          AND status = 'pending'
-          AND expires_at > ?
-        ORDER BY created_at DESC
+        SELECT candidate.id FROM agent_tool_approvals AS candidate
+        WHERE candidate.owner_email = ?
+          AND ((candidate.org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR candidate.org_id = ?)
+          AND ((candidate.thread_id IS NULL AND CAST(? AS TEXT) IS NULL) OR candidate.thread_id = ?)
+          AND ((candidate.turn_id IS NULL AND CAST(? AS TEXT) IS NULL) OR candidate.turn_id = ?)
+          AND candidate.tool_name = ?
+          AND candidate.approval_key_hash = ?
+          AND candidate.status = 'pending'
+          AND candidate.expires_at > ?
+          AND NOT EXISTS (
+            SELECT 1 FROM agent_tool_approvals denied
+            WHERE denied.owner_email = candidate.owner_email
+              AND ((denied.org_id IS NULL AND candidate.org_id IS NULL)
+                OR denied.org_id = candidate.org_id)
+              AND ((denied.thread_id IS NULL AND candidate.thread_id IS NULL)
+                OR denied.thread_id = candidate.thread_id)
+              AND ((denied.turn_id IS NULL AND candidate.turn_id IS NULL)
+                OR denied.turn_id = candidate.turn_id)
+              AND denied.tool_name = candidate.tool_name
+              AND denied.approval_key_hash = candidate.approval_key_hash
+              AND denied.status = 'denied'
+          )
+        ORDER BY candidate.created_at DESC
         LIMIT 1
       )
       AND status = 'pending'`,
@@ -327,5 +340,146 @@ export async function consumeAgentToolApproval(
       now,
     ],
   });
-  return result.rowsAffected === 1;
+  if (result.rowsAffected === 1) return true;
+
+  const denied = await getDbExec().execute({
+    sql: `SELECT status FROM agent_tool_approvals
+      WHERE owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND ((thread_id IS NULL AND CAST(? AS TEXT) IS NULL) OR thread_id = ?)
+        AND ((turn_id IS NULL AND CAST(? AS TEXT) IS NULL) OR turn_id = ?)
+        AND tool_name = ?
+        AND approval_key_hash = ?
+        AND status = 'denied'
+      LIMIT 1`,
+    args: [
+      binding.ownerEmail,
+      binding.orgId ?? null,
+      binding.orgId ?? null,
+      binding.threadId ?? null,
+      binding.threadId ?? null,
+      binding.turnId ?? null,
+      binding.turnId ?? null,
+      binding.toolName,
+      hashAgentToolApprovalKey(binding.approvalKey),
+    ],
+  });
+  return (denied.rows ?? []).length > 0 ? "denied" : false;
+}
+
+export type AgentToolApprovalResolution = "approved" | "denied";
+
+interface AgentToolApprovalThreadScope {
+  ownerEmail: string;
+  orgId?: string | null;
+  threadId: string;
+}
+
+type StoredAgentToolApproval = {
+  turn_id: string | null;
+  tool_name: string;
+  approval_key_hash: string;
+  status: string;
+};
+
+async function readAgentToolApproval(
+  input: AgentToolApprovalThreadScope & { approvalId: string },
+): Promise<StoredAgentToolApproval | undefined> {
+  const result = await getDbExec().execute({
+    sql: `SELECT turn_id, tool_name, approval_key_hash, status
+      FROM agent_tool_approvals
+      WHERE id = ? AND owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ? LIMIT 1`,
+    args: [
+      input.approvalId,
+      input.ownerEmail,
+      input.orgId ?? null,
+      input.orgId ?? null,
+      input.threadId,
+    ],
+  });
+  return (result.rows ?? [])[0] as StoredAgentToolApproval | undefined;
+}
+
+export async function denyAgentToolApproval(
+  input: AgentToolApprovalThreadScope & { approvalId: string },
+): Promise<AgentToolApprovalResolution | null> {
+  await ensureAgentToolApprovalTable();
+  const client = getDbExec();
+  const logical = await readAgentToolApproval(input);
+  if (!logical) return null;
+  if (logical.status === "consumed") return "approved";
+  if (logical.status === "denied") return "denied";
+  if (logical.status !== "pending") return null;
+
+  const logicalArgs = [
+    input.ownerEmail,
+    input.orgId ?? null,
+    input.orgId ?? null,
+    input.threadId,
+    logical.turn_id,
+    logical.turn_id,
+    logical.tool_name,
+    logical.approval_key_hash,
+  ];
+  await client.execute({
+    sql: `UPDATE agent_tool_approvals
+      SET status = 'denied', updated_at = ?
+      WHERE owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ?
+        AND ((turn_id IS NULL AND CAST(? AS TEXT) IS NULL) OR turn_id = ?)
+        AND tool_name = ? AND approval_key_hash = ?
+        AND status = 'pending'`,
+    args: [Date.now(), ...logicalArgs],
+  });
+  const resolution = await client.execute({
+    sql: `SELECT status FROM agent_tool_approvals
+      WHERE id = ? AND owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ?
+        AND status IN ('consumed', 'denied')
+      LIMIT 1`,
+    args: [
+      input.approvalId,
+      input.ownerEmail,
+      input.orgId ?? null,
+      input.orgId ?? null,
+      input.threadId,
+    ],
+  });
+  const status = (resolution.rows ?? [])[0]?.status;
+  return status === "consumed"
+    ? "approved"
+    : status === "denied"
+      ? status
+      : null;
+}
+
+export async function listAgentToolApprovalResolutions(
+  input: AgentToolApprovalThreadScope,
+): Promise<Record<string, AgentToolApprovalResolution>> {
+  await ensureAgentToolApprovalTable();
+  const result = await getDbExec().execute({
+    sql: `SELECT id, status FROM agent_tool_approvals
+      WHERE owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ?
+        AND status IN ('consumed', 'denied')`,
+    args: [
+      input.ownerEmail,
+      input.orgId ?? null,
+      input.orgId ?? null,
+      input.threadId,
+    ],
+  });
+  const resolutions: Record<string, AgentToolApprovalResolution> = {};
+  for (const row of result.rows ?? []) {
+    const { id, status } = row as { id?: unknown; status?: unknown };
+    if (typeof id !== "string") continue;
+    if (status === "consumed") resolutions[id] = "approved";
+    if (status === "denied") resolutions[id] = status;
+  }
+  return resolutions;
 }

--- a/packages/core/src/agent/tool-approval-store.ts
+++ b/packages/core/src/agent/tool-approval-store.ts
@@ -1,6 +1,13 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { getDbExec, isPostgres, retryOnDdlRace } from "../db/client.js";
+import {
+  getDbExec,
+  getDialect,
+  isPostgres,
+  retryOnDdlRace,
+  type DbExec,
+  type DbExecQuery,
+} from "../db/client.js";
 import { ensureIndexExists, ensureTableExists } from "../db/ddl-guard.js";
 import {
   AGENT_TOOL_APPROVAL_INDEX_SQL,
@@ -18,7 +25,6 @@ import {
 // longer matches. An hour gives real human latency room while still bounding
 // how long a stale grant can be replayed.
 const APPROVAL_TTL_MS = 60 * 60_000;
-const APPROVAL_CLEANUP_AGE_MS = 24 * 60 * 60_000;
 
 let initPromise: Promise<void> | undefined;
 let policyInitPromise: Promise<void> | undefined;
@@ -90,6 +96,7 @@ export async function ensureAgentToolApprovalPolicyTable(): Promise<void> {
 }
 
 export interface AgentToolApprovalBinding {
+  approvalId?: string;
   ownerEmail: string;
   orgId?: string | null;
   threadId?: string | null;
@@ -138,9 +145,25 @@ export async function setAgentToolApprovalPolicy(input: {
 }): Promise<void> {
   const binding = normalizeApprovalPolicyBinding(input.binding);
   await ensureAgentToolApprovalPolicyTable();
+  await writeAgentToolApprovalPolicy(getDbExec(), binding, input.enabled);
+}
+
+async function writeAgentToolApprovalPolicy(
+  client: Pick<DbExec, "execute">,
+  binding: AgentToolApprovalPolicyBinding,
+  enabled: boolean,
+): Promise<void> {
+  await client.execute(agentToolApprovalPolicyStatement(binding, enabled));
+}
+
+function agentToolApprovalPolicyStatement(
+  binding: AgentToolApprovalPolicyBinding,
+  enabled: boolean,
+): DbExecQuery {
+  const normalized = normalizeApprovalPolicyBinding(binding);
   const now = Date.now();
-  const id = approvalPolicyId(binding);
-  await getDbExec().execute({
+  const id = approvalPolicyId(normalized);
+  return {
     sql: `INSERT INTO agent_tool_approval_policies
       (id, owner_email, org_id, tool_name, enabled, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -149,14 +172,14 @@ export async function setAgentToolApprovalPolicy(input: {
         updated_at = excluded.updated_at`,
     args: [
       id,
-      binding.ownerEmail,
-      binding.orgId,
-      binding.toolName,
-      input.enabled,
+      normalized.ownerEmail,
+      normalized.orgId,
+      normalized.toolName,
+      enabled,
       now,
       now,
     ],
-  });
+  };
 }
 
 export async function isAgentToolAlwaysAllowed(
@@ -187,6 +210,7 @@ export async function resolveAgentToolApprovalTurnId(binding: {
   threadId?: string | null;
   requestedTurnId?: string | null;
   approvalKeys: readonly string[];
+  approvalId?: string | null;
 }): Promise<string | null> {
   const approvalKeys = [...new Set(binding.approvalKeys)].slice(0, 200);
   if (!binding.threadId || approvalKeys.length === 0) return null;
@@ -195,6 +219,30 @@ export async function resolveAgentToolApprovalTurnId(binding: {
   const now = Date.now();
   const hashes = approvalKeys.map(hashAgentToolApprovalKey);
   const placeholders = hashes.map(() => "?").join(", ");
+  if (binding.approvalId) {
+    const exact = await getDbExec().execute({
+      sql: `SELECT turn_id FROM agent_tool_approvals
+        WHERE id = ?
+          AND owner_email = ?
+          AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+          AND thread_id = ?
+          AND approval_key_hash IN (${placeholders})
+          AND turn_id IS NOT NULL
+        LIMIT 1`,
+      args: [
+        binding.approvalId,
+        binding.ownerEmail,
+        binding.orgId ?? null,
+        binding.orgId ?? null,
+        binding.threadId,
+        ...hashes,
+      ],
+    });
+    const exactTurnId = (exact.rows ?? [])[0]?.turn_id;
+    return typeof exactTurnId === "string" && exactTurnId.trim()
+      ? exactTurnId.trim()
+      : null;
+  }
   const result = await getDbExec().execute({
     sql: `SELECT turn_id FROM agent_tool_approvals
       WHERE owner_email = ?
@@ -264,22 +312,6 @@ export async function createAgentToolApproval(
     ],
   });
 
-  // Cleanup is hygiene only. Expired rows remain unusable because consume uses
-  // an atomic status and expiry predicate, so cleanup failures must not affect
-  // the approval that was just recorded.
-  try {
-    await getDbExec().execute({
-      sql: `DELETE FROM agent_tool_approvals
-        WHERE expires_at < ? AND status <> 'pending'`,
-      args: [now - APPROVAL_CLEANUP_AGE_MS],
-    });
-  } catch (error) {
-    console.warn(
-      "[agent] Could not clean expired tool approval records",
-      error,
-    );
-  }
-
   return id;
 }
 
@@ -292,9 +324,43 @@ export async function createAgentToolApproval(
  */
 export async function consumeAgentToolApproval(
   binding: AgentToolApprovalBinding,
-): Promise<boolean | "denied"> {
+): Promise<boolean | "denied" | "consumed"> {
   await ensureAgentToolApprovalTable();
   const now = Date.now();
+  if (binding.approvalId && binding.threadId) {
+    const scope = {
+      approvalId: binding.approvalId,
+      ownerEmail: binding.ownerEmail,
+      orgId: binding.orgId,
+      threadId: binding.threadId,
+    };
+    let approval = await readAgentToolApproval(scope);
+    if (
+      !approval ||
+      approval.turn_id !== (binding.turnId ?? null) ||
+      approval.tool_name !== binding.toolName ||
+      approval.approval_key_hash !==
+        hashAgentToolApprovalKey(binding.approvalKey)
+    ) {
+      return false;
+    }
+    const decision = storedApprovalDecision(approval, now);
+    if (decision === "consumed" || decision === "denied") return decision;
+    if (decision !== "approved") return false;
+
+    const exact = await getDbExec().execute({
+      sql: `UPDATE agent_tool_approvals
+        SET status = 'consumed', consumed_at = ?, updated_at = ?
+        WHERE id = ? AND status IN ('approved', 'always_allowed')
+          AND expires_at > ?`,
+      args: [now, now, binding.approvalId, now],
+    });
+    if (exact.rowsAffected === 1) return true;
+    approval = await readAgentToolApproval(scope);
+    return storedApprovalDecision(approval, now) === "consumed"
+      ? "consumed"
+      : false;
+  }
   const result = await getDbExec().execute({
     sql: `UPDATE agent_tool_approvals
       SET status = 'consumed', consumed_at = ?, updated_at = ?
@@ -368,6 +434,9 @@ export async function consumeAgentToolApproval(
 }
 
 export type AgentToolApprovalResolution = "approved" | "denied";
+export type AgentToolApprovalDecision =
+  | AgentToolApprovalResolution
+  | "consumed";
 
 interface AgentToolApprovalThreadScope {
   ownerEmail: string;
@@ -380,13 +449,15 @@ type StoredAgentToolApproval = {
   tool_name: string;
   approval_key_hash: string;
   status: string;
+  expires_at: number;
 };
 
 async function readAgentToolApproval(
   input: AgentToolApprovalThreadScope & { approvalId: string },
+  client: Pick<DbExec, "execute"> = getDbExec(),
 ): Promise<StoredAgentToolApproval | undefined> {
-  const result = await getDbExec().execute({
-    sql: `SELECT turn_id, tool_name, approval_key_hash, status
+  const result = await client.execute({
+    sql: `SELECT turn_id, tool_name, approval_key_hash, status, expires_at
       FROM agent_tool_approvals
       WHERE id = ? AND owner_email = ?
         AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
@@ -402,6 +473,132 @@ async function readAgentToolApproval(
   return (result.rows ?? [])[0] as StoredAgentToolApproval | undefined;
 }
 
+function storedApprovalDecision(
+  approval: StoredAgentToolApproval | undefined,
+  now = Date.now(),
+): AgentToolApprovalDecision | null {
+  if (!approval) return null;
+  if (
+    approval.expires_at <= now &&
+    approval.status !== "consumed" &&
+    approval.status !== "denied"
+  ) {
+    return "denied";
+  }
+  if (approval.status === "consumed") return "consumed";
+  if (approval.status === "approved" || approval.status === "always_allowed") {
+    return "approved";
+  }
+  if (approval.status === "denied") {
+    return "denied";
+  }
+  return null;
+}
+
+export async function approveAgentToolApproval(
+  input: AgentToolApprovalThreadScope & { approvalId: string },
+): Promise<AgentToolApprovalDecision | null> {
+  await ensureAgentToolApprovalTable();
+  const now = Date.now();
+  const result = await getDbExec().execute({
+    sql: `UPDATE agent_tool_approvals
+      SET status = 'approved', updated_at = ?
+      WHERE id = ? AND owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ?
+        AND status = 'pending'
+        AND expires_at > ?`,
+    args: [
+      now,
+      input.approvalId,
+      input.ownerEmail,
+      input.orgId ?? null,
+      input.orgId ?? null,
+      input.threadId,
+      now,
+    ],
+  });
+  if (result.rowsAffected === 1) return "approved";
+  return storedApprovalDecision(await readAgentToolApproval(input), now);
+}
+
+export async function alwaysAllowAgentToolApproval(input: {
+  approval: AgentToolApprovalThreadScope & { approvalId: string };
+  policy: AgentToolApprovalPolicyBinding;
+}): Promise<AgentToolApprovalDecision | null> {
+  await ensureAgentToolApprovalTable();
+  await ensureAgentToolApprovalPolicyTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const approve: DbExecQuery = {
+    sql: `UPDATE agent_tool_approvals
+      SET status = 'always_allowed', updated_at = ?
+      WHERE id = ? AND owner_email = ?
+        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+        AND thread_id = ?
+        AND tool_name = ?
+        AND status = 'pending'
+        AND expires_at > ?`,
+    args: [
+      now,
+      input.approval.approvalId,
+      input.approval.ownerEmail,
+      input.approval.orgId ?? null,
+      input.approval.orgId ?? null,
+      input.approval.threadId,
+      input.policy.toolName,
+      now,
+    ],
+  };
+
+  if (getDialect() !== "d1") {
+    if (!client.transaction) {
+      throw new Error("Always Allow requires transaction support.");
+    }
+    return client.transaction(async (tx) => {
+      const claimed = await tx.execute(approve);
+      if (claimed.rowsAffected === 1) {
+        await writeAgentToolApprovalPolicy(tx, input.policy, true);
+        return "approved";
+      }
+      return storedApprovalDecision(
+        await readAgentToolApproval(input.approval, tx),
+        now,
+      );
+    });
+  }
+  if (!client.atomicBatch) {
+    throw new Error("Always Allow requires atomic database support.");
+  }
+
+  const normalizedPolicy = normalizeApprovalPolicyBinding(input.policy);
+  const policy = agentToolApprovalPolicyStatement(normalizedPolicy, true);
+  policy.sql = policy.sql.replace(
+    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+    `SELECT ?, ?, ?, ?, ?, ?, ?
+      WHERE EXISTS (
+        SELECT 1 FROM agent_tool_approvals
+        WHERE id = ? AND owner_email = ?
+          AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
+          AND thread_id = ? AND tool_name = ? AND status = 'always_allowed'
+      )`,
+  );
+  policy.args = [
+    ...(policy.args ?? []),
+    input.approval.approvalId,
+    input.approval.ownerEmail,
+    input.approval.orgId ?? null,
+    input.approval.orgId ?? null,
+    input.approval.threadId,
+    normalizedPolicy.toolName,
+  ];
+  await client.atomicBatch([approve, policy]);
+  return storedApprovalDecision(
+    await readAgentToolApproval(input.approval, client),
+    now,
+  );
+}
+
 export async function denyAgentToolApproval(
   input: AgentToolApprovalThreadScope & { approvalId: string },
 ): Promise<AgentToolApprovalResolution | null> {
@@ -410,7 +607,13 @@ export async function denyAgentToolApproval(
   const logical = await readAgentToolApproval(input);
   if (!logical) return null;
   if (logical.status === "consumed") return "approved";
+  if (logical.status === "approved" || logical.status === "always_allowed") {
+    return "approved";
+  }
   if (logical.status === "denied") return "denied";
+  if (logical.status === "pending" && logical.expires_at <= Date.now()) {
+    return "denied";
+  }
   if (logical.status !== "pending") return null;
 
   const logicalArgs = [
@@ -439,7 +642,7 @@ export async function denyAgentToolApproval(
       WHERE id = ? AND owner_email = ?
         AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
         AND thread_id = ?
-        AND status IN ('consumed', 'denied')
+        AND status IN ('approved', 'always_allowed', 'consumed', 'denied')
       LIMIT 1`,
     args: [
       input.approvalId,
@@ -450,7 +653,9 @@ export async function denyAgentToolApproval(
     ],
   });
   const status = (resolution.rows ?? [])[0]?.status;
-  return status === "consumed"
+  return status === "approved" ||
+    status === "always_allowed" ||
+    status === "consumed"
     ? "approved"
     : status === "denied"
       ? status
@@ -462,11 +667,11 @@ export async function listAgentToolApprovalResolutions(
 ): Promise<Record<string, AgentToolApprovalResolution>> {
   await ensureAgentToolApprovalTable();
   const result = await getDbExec().execute({
-    sql: `SELECT id, status FROM agent_tool_approvals
+    sql: `SELECT id, status, expires_at FROM agent_tool_approvals
       WHERE owner_email = ?
         AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
         AND thread_id = ?
-        AND status IN ('consumed', 'denied')`,
+        AND status IN ('pending', 'approved', 'always_allowed', 'consumed', 'denied')`,
     args: [
       input.ownerEmail,
       input.orgId ?? null,
@@ -475,11 +680,23 @@ export async function listAgentToolApprovalResolutions(
     ],
   });
   const resolutions: Record<string, AgentToolApprovalResolution> = {};
+  const now = Date.now();
   for (const row of result.rows ?? []) {
-    const { id, status } = row as { id?: unknown; status?: unknown };
+    const { id, status, expires_at } = row as {
+      id?: unknown;
+      status?: unknown;
+      expires_at?: unknown;
+    };
     if (typeof id !== "string") continue;
-    if (status === "consumed") resolutions[id] = "approved";
-    if (status === "denied") resolutions[id] = status;
+    if (status === "consumed") {
+      resolutions[id] = "approved";
+    }
+    if (
+      status === "denied" ||
+      (status !== "consumed" && Number(expires_at) <= now)
+    ) {
+      resolutions[id] = "denied";
+    }
   }
   return resolutions;
 }

--- a/packages/core/src/agent/tool-approval-store.ts
+++ b/packages/core/src/agent/tool-approval-store.ts
@@ -444,6 +444,20 @@ interface AgentToolApprovalThreadScope {
   threadId: string;
 }
 
+function agentToolApprovalThreadScopeWhere(
+  input: AgentToolApprovalThreadScope,
+): { sql: string; args: unknown[] } {
+  return input.orgId == null
+    ? {
+        sql: "owner_email = ? AND org_id IS NULL AND thread_id = ?",
+        args: [input.ownerEmail, input.threadId],
+      }
+    : {
+        sql: "owner_email = ? AND org_id = ? AND thread_id = ?",
+        args: [input.ownerEmail, input.orgId, input.threadId],
+      };
+}
+
 type StoredAgentToolApproval = {
   turn_id: string | null;
   tool_name: string;
@@ -672,18 +686,12 @@ export async function listAgentToolApprovalResolutions(
   input: AgentToolApprovalThreadScope,
 ): Promise<Record<string, AgentToolApprovalResolution>> {
   await ensureAgentToolApprovalTable();
+  const scope = agentToolApprovalThreadScopeWhere(input);
   const result = await getDbExec().execute({
     sql: `SELECT id, status, expires_at FROM agent_tool_approvals
-      WHERE owner_email = ?
-        AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
-        AND thread_id = ?
+      WHERE ${scope.sql}
         AND status IN ('pending', 'approved', 'always_allowed', 'consumed', 'denied')`,
-    args: [
-      input.ownerEmail,
-      input.orgId ?? null,
-      input.orgId ?? null,
-      input.threadId,
-    ],
+    args: scope.args,
   });
   const resolutions: Record<string, AgentToolApprovalResolution> = {};
   const now = Date.now();
@@ -705,4 +713,16 @@ export async function listAgentToolApprovalResolutions(
     }
   }
   return resolutions;
+}
+
+export async function deleteAgentToolApprovalsForThread(
+  input: AgentToolApprovalThreadScope,
+): Promise<number> {
+  await ensureAgentToolApprovalTable();
+  const scope = agentToolApprovalThreadScopeWhere(input);
+  const result = await getDbExec().execute({
+    sql: `DELETE FROM agent_tool_approvals WHERE ${scope.sql}`,
+    args: scope.args,
+  });
+  return result.rowsAffected;
 }

--- a/packages/core/src/agent/tool-approval-store.ts
+++ b/packages/core/src/agent/tool-approval-store.ts
@@ -600,6 +600,7 @@ export async function alwaysAllowAgentToolApproval(input: {
           AND ((org_id IS NULL AND CAST(? AS TEXT) IS NULL) OR org_id = ?)
           AND thread_id = ? AND tool_name = ?
           AND status IN ('approved', 'always_allowed', 'consumed')
+          AND (status = 'consumed' OR expires_at > ?)
       )`,
   );
   policy.args = [
@@ -610,6 +611,7 @@ export async function alwaysAllowAgentToolApproval(input: {
     input.approval.orgId ?? null,
     input.approval.threadId,
     normalizedPolicy.toolName,
+    now,
   ];
   await client.atomicBatch([approve, policy]);
   return storedApprovalDecision(

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -298,6 +298,12 @@ export interface AgentChatRequest {
    * durable grant when a transport drops it, but refuses ambiguous matches.
    */
   approvedToolCalls?: string[];
+  /**
+   * Exact durable ask resolved by this continuation. New clients include it
+   * alongside `approvedToolCalls`; older clients remain supported by the
+   * unique-pending-key recovery path.
+   */
+  approvalId?: string;
 }
 
 export type AgentToolInput = Record<string, unknown>;

--- a/packages/core/src/chat-threads/store.access-projection.spec.ts
+++ b/packages/core/src/chat-threads/store.access-projection.spec.ts
@@ -16,7 +16,7 @@ vi.mock("../sharing/access.js", () => ({
 
 vi.mock("./emitter.js", () => ({ emitChatThreadChange: vi.fn() }));
 
-import { resolveThreadAccess } from "./store.js";
+import { resolveThreadAccess, resolveThreadAccessIdentity } from "./store.js";
 
 const THREAD_ROW = {
   id: "t1",
@@ -68,6 +68,29 @@ describe("resolveThreadAccess loads the ACL without the conversation blob", () =
     expect(resolveAccessMock.mock.calls[0][3]).toEqual({
       skipResourceBody: true,
     });
+  });
+
+  it("returns the authorized identity without loading thread data", async () => {
+    resolveAccessMock.mockResolvedValue({
+      role: "editor",
+      resource: {
+        id: "t1",
+        ownerEmail: "owner@example.com",
+        orgId: null,
+        visibility: "private",
+      },
+    });
+
+    await expect(
+      resolveThreadAccessIdentity("editor@example.com", "t1", "editor", {
+        orgId: "active-org",
+      }),
+    ).resolves.toEqual({
+      id: "t1",
+      ownerEmail: "owner@example.com",
+      orgId: null,
+    });
+    expect(executeMock).not.toHaveBeenCalled();
   });
 
   it("still denies a caller whose role does not satisfy the minimum", async () => {

--- a/packages/core/src/chat-threads/store.spec.ts
+++ b/packages/core/src/chat-threads/store.spec.ts
@@ -8,6 +8,7 @@ vi.mock("../db/client.js", () => ({
   getDialect: () => "sqlite",
   intType: () => "INTEGER",
   isPostgres: () => false,
+  retryOnDdlRace: async (fn: () => Promise<unknown>) => fn(),
 }));
 
 vi.mock("./emitter.js", () => ({
@@ -17,6 +18,7 @@ vi.mock("./emitter.js", () => ({
 import {
   adoptThreadScopeIfUnscoped,
   createThreadShareLink,
+  deleteThread,
   forkThread,
   getThreadByShareToken,
   grantThreadUserShare,
@@ -80,6 +82,12 @@ describe("chat thread store", () => {
     role: string;
     created_by: string;
   }>;
+  let approvalRows: Array<{
+    id: string;
+    owner_email: string;
+    org_id: string | null;
+    thread_id: string;
+  }>;
 
   beforeEach(() => {
     row = {
@@ -91,11 +99,26 @@ describe("chat thread store", () => {
       message_count: 1,
       created_at: 1,
       updated_at: 1,
+      org_id: "org-1",
     };
     conflictOnce = null;
     conflictEveryThreadDataUpdate = false;
     transientThreadDataUpdateFailures = 0;
     shareRows = [];
+    approvalRows = [
+      {
+        id: "approval-thread-1",
+        owner_email: "user@example.com",
+        org_id: "org-1",
+        thread_id: "thread-1",
+      },
+      {
+        id: "approval-thread-2",
+        owner_email: "user@example.com",
+        org_id: "org-1",
+        thread_id: "thread-2",
+      },
+    ];
     executeMock.mockReset();
     emitChatThreadChangeMock.mockReset();
     executeMock.mockImplementation(async (query: string | any) => {
@@ -182,6 +205,34 @@ describe("chat thread store", () => {
         row = { ...row, archived_at: args[0] };
         return { rows: [], rowsAffected: 1 };
       }
+      if (/DELETE FROM chat_threads/i.test(sql)) {
+        if (!row || row.id !== args[0]) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        const deleted = row;
+        row = null;
+        return { rows: [deleted], rowsAffected: 1 };
+      }
+      if (/DELETE FROM chat_thread_shares/i.test(sql)) {
+        shareRows = shareRows.filter((share) => share.resource_id !== args[0]);
+        return { rows: [], rowsAffected: 1 };
+      }
+      if (/DELETE FROM agent_tool_approvals/i.test(sql)) {
+        approvalRows = approvalRows.filter((approval) =>
+          /org_id IS NULL/i.test(sql)
+            ? !(
+                approval.owner_email === args[0] &&
+                approval.org_id === null &&
+                approval.thread_id === args[1]
+              )
+            : !(
+                approval.owner_email === args[0] &&
+                approval.org_id === args[1] &&
+                approval.thread_id === args[2]
+              ),
+        );
+        return { rows: [], rowsAffected: 1 };
+      }
       if (/SELECT id, role FROM chat_thread_shares/i.test(sql)) {
         return {
           rows: shareRows.filter(
@@ -229,6 +280,29 @@ describe("chat thread store", () => {
       }),
     ]);
   });
+
+  it.each(["org-1", null])(
+    "removes approval rows only after their owning thread is deleted (orgId: %s)",
+    async (orgId) => {
+      row!.org_id = orgId;
+      approvalRows[0]!.org_id = orgId;
+      shareRows.push({
+        id: "share-1",
+        resource_id: "thread-1",
+        principal_id: "editor@example.com",
+        role: "editor",
+        created_by: "user@example.com",
+      });
+
+      await expect(deleteThread("thread-1")).resolves.toBe(true);
+
+      expect(row).toBeNull();
+      expect(shareRows).toEqual([]);
+      expect(approvalRows.map((approval) => approval.id)).toEqual([
+        "approval-thread-2",
+      ]);
+    },
+  );
 
   it("is idempotent and never downgrades an existing stronger role", async () => {
     await grantThreadUserShare(

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -5,6 +5,7 @@ import {
   normalizeThreadRepository,
   normalizeThreadTitle,
 } from "../agent/thread-data-builder.js";
+import { deleteAgentToolApprovalsForThread } from "../agent/tool-approval-store.js";
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { createGetDb } from "../db/create-get-db.js";
 import {
@@ -1564,7 +1565,7 @@ export async function deleteThread(id: string): Promise<boolean> {
   await ensureTable();
   const client = getDbExec();
   const result = await client.execute({
-    sql: `DELETE FROM chat_threads WHERE id = ?`,
+    sql: `DELETE FROM chat_threads WHERE id = ? RETURNING owner_email, org_id`,
     args: [id],
   });
   if (result.rowsAffected > 0) {
@@ -1574,6 +1575,21 @@ export async function deleteThread(id: string): Promise<boolean> {
         args: [id],
       })
       .catch(() => {});
+    const deleted = result.rows[0] as
+      | { owner_email?: unknown; org_id?: unknown }
+      | undefined;
+    if (typeof deleted?.owner_email === "string") {
+      await deleteAgentToolApprovalsForThread({
+        ownerEmail: deleted.owner_email,
+        orgId: typeof deleted.org_id === "string" ? deleted.org_id : null,
+        threadId: id,
+      }).catch((error) => {
+        console.warn(
+          `[chat-threads] Could not clean tool approvals for deleted thread ${id}`,
+          error,
+        );
+      });
+    }
     emitChatThreadChange(id);
     return true;
   }

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -602,18 +602,14 @@ export async function ensureChatThreadTables(): Promise<void> {
   await ensureTable();
 }
 
-export async function resolveThreadAccess(
+/** Authorize access and return only the durable identity columns. */
+export async function resolveThreadAccessIdentity(
   userEmail: string | null | undefined,
   threadId: string | null | undefined,
   minRole: ShareRole | "owner" = "viewer",
   ctx: Omit<AccessContext, "userEmail"> = {},
-): Promise<ChatThread | null> {
+): Promise<Pick<ChatThread, "id" | "ownerEmail" | "orgId"> | null> {
   if (!userEmail || !threadId) return null;
-  // `skipResourceBody` matters more here than anywhere else: without it the
-  // access load is an unprojected `select()` that pulls `thread_data` — the
-  // whole conversation JSON — and then this function discards the row and reads
-  // it again through `getThread`. Two full-blob reads of the same row per call,
-  // on the agent-chat hot path.
   const access = await resolveAccess(
     "chat_thread",
     threadId,
@@ -621,7 +617,27 @@ export async function resolveThreadAccess(
     { skipResourceBody: true },
   );
   if (!access || !roleSatisfies(access.role, minRole)) return null;
-  return await getThread(threadId);
+  return {
+    id: access.resource.id,
+    ownerEmail: access.resource.ownerEmail,
+    orgId: access.resource.orgId ?? null,
+  };
+}
+
+export async function resolveThreadAccess(
+  userEmail: string | null | undefined,
+  threadId: string | null | undefined,
+  minRole: ShareRole | "owner" = "viewer",
+  ctx: Omit<AccessContext, "userEmail"> = {},
+): Promise<ChatThread | null> {
+  const access = await resolveThreadAccessIdentity(
+    userEmail,
+    threadId,
+    minRole,
+    ctx,
+  );
+  if (!access) return null;
+  return await getThread(access.id);
 }
 
 export async function getThread(id: string): Promise<ChatThread | null> {

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -24,6 +24,7 @@ import { clearActiveRun, getActiveRun } from "./active-run-state.js";
 import {
   AssistantMessageListErrorBoundary,
   AssistantUiStaleIndexErrorBoundary,
+  agentToolApprovalHydrationTarget,
   assistantMessageRunId,
   assistantChatAutoscrollStatusKey,
   assistantUiMessageListStructureKey,
@@ -55,6 +56,34 @@ import {
 } from "./AssistantChat.js";
 
 describe("tool approval resolution", () => {
+  it("waits to hydrate a new thread until an approval card exists", () => {
+    expect(agentToolApprovalHydrationTarget("thread-1", [])).toBeNull();
+    expect(
+      agentToolApprovalHydrationTarget("thread-1", [
+        {
+          content: [{ type: "text", text: "New chat" }],
+        },
+      ]),
+    ).toBeNull();
+
+    expect(
+      agentToolApprovalHydrationTarget("thread-1", [
+        {
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-1",
+              approval: {
+                approvalKey: 'send-email:{"to":"recipient@example.com"}',
+                askId: "ask-1",
+              },
+            },
+          ],
+        },
+      ]),
+    ).toEqual({ threadId: "thread-1", revision: '["ask-1"]' });
+  });
+
   it.each([
     { localScope: "old-thread", local: "approved" as const },
     { localScope: "thread-2", local: "approved" as const },

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -39,6 +39,7 @@ import {
   latestNonRecoveryUserMessageText,
   reconnectActivityFallbackContent,
   reconnectProgressTimedOut,
+  resolveApprovalResolution,
   resolveAssistantChatRunningState,
   resolveAssistantChatRunningStatusLabel,
   resolveAssistantChatComposerPlaceholder,
@@ -52,6 +53,29 @@ import {
   useAutoResumeStatus,
   waitForThreadRunToClear,
 } from "./AssistantChat.js";
+
+describe("tool approval resolution", () => {
+  it.each([
+    { localScope: "old-thread", local: "approved" as const },
+    { localScope: "thread-2", local: "approved" as const },
+  ])("keeps a persisted denial authoritative", ({ localScope, local }) => {
+    expect(
+      resolveApprovalResolution({
+        scope: "thread-2",
+        identity: "call\0key\0ask-1",
+        askId: "ask-1",
+        local: {
+          scope: localScope,
+          byIdentity: new Map([["call\0key\0ask-1", local]]),
+        },
+        persisted: {
+          scope: "thread-2",
+          resolutions: { "ask-1": "denied" },
+        },
+      }),
+    ).toBe("denied");
+  });
+});
 
 describe("shouldShowAssistantChatModelSelector", () => {
   it("keeps the framework selector by default and lets hosts replace only its visual control", () => {

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -81,7 +81,36 @@ describe("tool approval resolution", () => {
           ],
         },
       ]),
-    ).toEqual({ threadId: "thread-1", revision: '["ask-1"]' });
+    ).toEqual({
+      threadId: "thread-1",
+      revision: '[1,"ask-1"]',
+      durable: true,
+    });
+
+    const beforeCompletion = agentToolApprovalHydrationTarget("thread-1", [
+      {
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            approval: { approvalKey: "key-1", askId: "ask-1" },
+          },
+        ],
+      },
+    ]);
+    const afterCompletion = agentToolApprovalHydrationTarget("thread-1", [
+      {
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            approval: { approvalKey: "key-1", askId: "ask-1" },
+          },
+        ],
+      },
+      { content: [{ type: "text", text: "Completed" }] },
+    ]);
+    expect(afterCompletion?.revision).not.toBe(beforeCompletion?.revision);
   });
 
   it.each([
@@ -530,11 +559,16 @@ describe("createUserMessageRunConfig model snapshot", () => {
       undefined,
       ["create-builder-branch:{}"],
       "queued-approval",
+      undefined,
+      undefined,
+      undefined,
+      "ask-1",
     );
 
     expect(options.runConfig?.custom).toMatchObject({
       approvedToolCalls: ["create-builder-branch:{}"],
       agentNativeQueuedMessageId: "queued-approval",
+      approvalId: "ask-1",
     });
   });
 
@@ -1620,7 +1654,9 @@ describe("tool approval continuation", () => {
     const source = readFileSync("src/client/AssistantChat.tsx", {
       encoding: "utf8",
     });
-    const start = source.indexOf("const approveToolCall = useCallback");
+    const start = source.indexOf(
+      "const continueApprovedToolCall = useCallback",
+    );
     const end = source.indexOf("const approvalCtx = useMemo", start);
     const approvalSource = source.slice(start, end);
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -71,10 +71,13 @@ import {
 } from "./agent-chat-adapter.js";
 import {
   appendAgentChatContextToMessage,
+  AgentToolApprovalRequestError,
+  denyAgentToolApproval,
   filterAgentChatContextItems,
   formatAgentChatContextItemsForPrompt,
   getAgentChatContextState,
   isAgentChatSubmitCancelled,
+  loadAgentToolApprovalResolutions,
   normalizeAgentChatContextItem,
   publishAgentChatContextItems,
   refreshAgentChatContext,
@@ -2418,6 +2421,28 @@ function approvalResolutionIdentity(
   askId?: string,
 ): string {
   return `${toolCallId ?? ""}\u0000${approvalKey}\u0000${askId ?? ""}`;
+}
+
+export function resolveApprovalResolution(input: {
+  scope: string;
+  identity: string;
+  askId?: string;
+  local: { scope: string; byIdentity: ReadonlyMap<string, ApprovalResolution> };
+  persisted: {
+    scope: string;
+    resolutions: Readonly<Record<string, ApprovalResolution>>;
+  };
+}): ApprovalResolution | null {
+  const local =
+    input.local.scope === input.scope
+      ? (input.local.byIdentity.get(input.identity) ?? null)
+      : null;
+  const persisted =
+    input.persisted.scope === input.scope && input.askId
+      ? (input.persisted.resolutions[input.askId] ?? null)
+      : null;
+  if (local === "denied" || persisted === "denied") return "denied";
+  return local ?? persisted;
 }
 
 const AssistantChatInner = forwardRef<
@@ -5835,6 +5860,8 @@ const AssistantChatInner = forwardRef<
   );
 
   const approvalResolutionScope = threadId ?? tabId ?? "default";
+  const approvalPersistenceScope = `${apiUrl}\u0000${approvalResolutionScope}`;
+  const defaultApprovalApiUrl = agentNativePath("/_agent-native/agent-chat");
   const [approvalResolutionState, setApprovalResolutionState] = useState<{
     scope: string;
     byIdentity: Map<string, ApprovalResolution>;
@@ -5842,18 +5869,79 @@ const AssistantChatInner = forwardRef<
     scope: approvalResolutionScope,
     byIdentity: new Map(),
   }));
+  const [approvalHydrationRetry, setApprovalHydrationRetry] = useState(0);
+  const [persistedApprovals, setPersistedApprovals] = useState<{
+    scope: string;
+    status: "loading" | "ready" | "error";
+    resolutions: Record<string, ApprovalResolution>;
+  }>(() => ({
+    scope: approvalPersistenceScope,
+    status: threadId ? "loading" : "ready",
+    resolutions: {},
+  }));
+  useEffect(() => {
+    const controller = new AbortController();
+    setPersistedApprovals({
+      scope: approvalPersistenceScope,
+      status: threadId ? "loading" : "ready",
+      resolutions: {},
+    });
+    if (!threadId) return () => controller.abort();
+    void loadAgentToolApprovalResolutions(apiUrl, threadId, controller.signal)
+      .then((resolutions) => {
+        if (!controller.signal.aborted) {
+          setPersistedApprovals({
+            scope: approvalPersistenceScope,
+            status: "ready",
+            resolutions,
+          });
+        }
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        const unsupportedCustomRoute =
+          apiUrl !== defaultApprovalApiUrl &&
+          error instanceof AgentToolApprovalRequestError &&
+          error.status === 404;
+        setPersistedApprovals({
+          scope: approvalPersistenceScope,
+          status: unsupportedCustomRoute ? "ready" : "error",
+          resolutions: {},
+        });
+      });
+    return () => controller.abort();
+  }, [
+    apiUrl,
+    approvalHydrationRetry,
+    approvalPersistenceScope,
+    defaultApprovalApiUrl,
+    threadId,
+  ]);
+  const approvalHydrationStatus =
+    persistedApprovals.scope === approvalPersistenceScope
+      ? persistedApprovals.status
+      : "loading";
   const getApprovalResolution = useCallback(
-    (approvalKey: string, toolCallId?: string, askId?: string) => {
-      if (approvalResolutionState.scope !== approvalResolutionScope) {
-        return null;
-      }
-      return (
-        approvalResolutionState.byIdentity.get(
-          approvalResolutionIdentity(approvalKey, toolCallId, askId),
-        ) ?? null
-      );
-    },
-    [approvalResolutionScope, approvalResolutionState],
+    (approvalKey: string, toolCallId?: string, askId?: string) =>
+      resolveApprovalResolution({
+        scope: approvalResolutionScope,
+        identity: approvalResolutionIdentity(approvalKey, toolCallId, askId),
+        askId,
+        local: approvalResolutionState,
+        persisted: {
+          scope:
+            persistedApprovals.scope === approvalPersistenceScope
+              ? approvalResolutionScope
+              : "",
+          resolutions: persistedApprovals.resolutions,
+        },
+      }),
+    [
+      approvalPersistenceScope,
+      approvalResolutionScope,
+      approvalResolutionState,
+      persistedApprovals,
+    ],
   );
   const recordApprovalResolution = useCallback(
     (
@@ -5883,8 +5971,23 @@ const AssistantChatInner = forwardRef<
   // gate lets that specific call run. Reuses the same append path as recovery /
   // queued messages (no hand-written fetch).
   const approveToolCall = useCallback(
-    (approvalKey: string) => {
-      void addToQueue(
+    async (approvalKey: string, askId?: string) => {
+      if (threadId && askId) {
+        try {
+          const resolutions = await loadAgentToolApprovalResolutions(
+            apiUrl,
+            threadId,
+          );
+          if (resolutions[askId] === "denied") return "denied" as const;
+        } catch (error) {
+          const unsupportedCustomRoute =
+            apiUrl !== defaultApprovalApiUrl &&
+            error instanceof AgentToolApprovalRequestError &&
+            error.status === 404;
+          if (!unsupportedCustomRoute) throw error;
+        }
+      }
+      await addToQueue(
         "Approved. Go ahead and run the requested action.", // i18n-ignore -- stable hidden agent instruction, not UI copy.
         undefined,
         undefined,
@@ -5899,37 +6002,66 @@ const AssistantChatInner = forwardRef<
         undefined,
         [approvalKey],
       );
+      return "approved" as const;
     },
-    [addToQueue],
+    [addToQueue, apiUrl, defaultApprovalApiUrl, threadId],
   );
   const alwaysAllowToolCall = useCallback(
-    (approvalKey: string, toolName: string) => {
+    (approvalKey: string, toolName: string, askId?: string) => {
       if (approvalActions?.onAlwaysAllow) {
         return approvalActions.onAlwaysAllow(approvalKey, toolName);
       }
       return callAction("set-tool-approval-policy", {
         toolName,
         enabled: true,
-      }).then(() => approveToolCall(approvalKey));
+      }).then(() => approveToolCall(approvalKey, askId));
     },
     [approvalActions, approveToolCall],
+  );
+  const denyToolCall = useCallback(
+    async (approvalKey: string, askId?: string) => {
+      let resolution: ApprovalResolution = "denied";
+      if (threadId && askId) {
+        try {
+          resolution = await denyAgentToolApproval(apiUrl, {
+            threadId,
+            approvalId: askId,
+          });
+        } catch (error) {
+          const unsupportedCustomRoute =
+            apiUrl !== defaultApprovalApiUrl &&
+            error instanceof AgentToolApprovalRequestError &&
+            error.status === 404;
+          if (!unsupportedCustomRoute) throw error;
+        }
+      }
+      if (resolution === "denied") {
+        await Promise.resolve(approvalActions?.onDeny?.(approvalKey));
+      }
+      return resolution;
+    },
+    [apiUrl, approvalActions, defaultApprovalApiUrl, threadId],
   );
   const showActionTypeApprovalPolicy =
     approvalActions?.alwaysAllowScope !== "exact-command";
   const approvalCtx = useMemo<ApprovalContextValue>(
     () => ({
       getApprovalResolution,
+      approvalHydrationStatus,
+      onRetryApprovalResolutions: () =>
+        setApprovalHydrationRetry((value) => value + 1),
       onApprovalResolved: recordApprovalResolution,
       onApprove: approveToolCall,
+      onDeny: denyToolCall,
       ...(showActionTypeApprovalPolicy
         ? { onAlwaysAllow: alwaysAllowToolCall }
         : {}),
-      ...(approvalActions?.onDeny ? { onDeny: approvalActions.onDeny } : {}),
     }),
     [
       alwaysAllowToolCall,
-      approvalActions,
+      approvalHydrationStatus,
       approveToolCall,
+      denyToolCall,
       getApprovalResolution,
       recordApprovalResolution,
       showActionTypeApprovalPolicy,

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -70,8 +70,10 @@ import {
   type AgentChatSurfaceKind,
 } from "./agent-chat-adapter.js";
 import {
+  alwaysAllowAgentToolApproval,
   appendAgentChatContextToMessage,
   AgentToolApprovalRequestError,
+  approveAgentToolApproval,
   denyAgentToolApproval,
   filterAgentChatContextItems,
   formatAgentChatContextItemsForPrompt,
@@ -311,6 +313,7 @@ export function createUserMessageRunConfig(
     effort?: ReasoningEffort;
   },
   turnId?: string,
+  approvalId?: string,
 ) {
   const custom: {
     references?: Reference[];
@@ -318,6 +321,7 @@ export function createUserMessageRunConfig(
     trackInRunsTray?: boolean;
     agentNativeQueuedMessageId?: string;
     approvedToolCalls?: string[];
+    approvalId?: string;
     model?: string;
     engine?: string;
     effort?: ReasoningEffort;
@@ -340,6 +344,9 @@ export function createUserMessageRunConfig(
   }
   if (approvedToolCalls && approvedToolCalls.length > 0) {
     custom.approvedToolCalls = approvedToolCalls;
+  }
+  if (approvalId) {
+    custom.approvalId = approvalId;
   }
   if (turnId) {
     custom.turnId = turnId;
@@ -1778,6 +1785,7 @@ type QueuedMessage = {
   trackInRunsTray?: boolean;
   hideUserMessage?: boolean;
   approvedToolCalls?: string[];
+  approvalId?: string;
   /** Preserve the logical turn when a hidden reconnect recovery is re-issued. */
   turnId?: string;
   /**
@@ -2126,7 +2134,8 @@ export interface AssistantChatProps {
     onAlwaysAllow?: (
       approvalKey: string,
       toolName: string,
-    ) => void | Promise<void>;
+      askId?: string,
+    ) => ApprovalResolution | void | Promise<ApprovalResolution | void>;
     alwaysAllowScope?: "action" | "exact-command";
   };
   /**
@@ -2448,9 +2457,10 @@ export function resolveApprovalResolution(input: {
 export function agentToolApprovalHydrationTarget(
   threadId: string | null | undefined,
   messages: readonly { content?: readonly unknown[] }[],
-): { threadId: string; revision: string } | null {
+): { threadId: string; revision: string; durable: boolean } | null {
   if (!threadId) return null;
   const approvals: string[] = [];
+  let durable = true;
   for (const message of messages) {
     for (const part of message.content ?? []) {
       if (!part || typeof part !== "object") continue;
@@ -2466,16 +2476,25 @@ export function agentToolApprovalHydrationTarget(
       ) {
         continue;
       }
-      approvals.push(
+      if (
         typeof toolCall.approval.askId === "string" &&
-          toolCall.approval.askId.length > 0
-          ? toolCall.approval.askId
-          : `${typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : ""}\u0000${toolCall.approval.approvalKey}`,
-      );
+        toolCall.approval.askId.length > 0
+      ) {
+        approvals.push(toolCall.approval.askId);
+      } else {
+        durable = false;
+        approvals.push(
+          `${typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : ""}\u0000${toolCall.approval.approvalKey}`,
+        );
+      }
     }
   }
   return approvals.length > 0
-    ? { threadId, revision: JSON.stringify(approvals) }
+    ? {
+        threadId,
+        revision: JSON.stringify([messages.length, ...approvals]),
+        durable,
+      }
     : null;
 }
 
@@ -4798,6 +4817,7 @@ const AssistantChatInner = forwardRef<
                 effort: next.effort,
               },
               next.turnId,
+              next.approvalId,
             ),
           } as Parameters<typeof threadRuntime.append>[0]);
           appended = true;
@@ -5178,6 +5198,7 @@ const AssistantChatInner = forwardRef<
       submitMessageId?: string,
       approvedToolCalls?: string[],
       continuationTurnId?: string,
+      continuationApprovalId?: string,
     ) => {
       if (isAgentChatSubmitCancelled(submitMessageId)) return;
       if (!preserveReconnectAutoRecoveryBudget) {
@@ -5357,6 +5378,9 @@ const AssistantChatInner = forwardRef<
             trackInRunsTray,
             hideUserMessage,
             approvedToolCalls,
+            ...(continuationApprovalId
+              ? { approvalId: continuationApprovalId }
+              : {}),
             ...(continuationTurnId ? { turnId: continuationTurnId } : {}),
             ...modelSnapshot,
           },
@@ -5380,6 +5404,9 @@ const AssistantChatInner = forwardRef<
             trackInRunsTray,
             hideUserMessage,
             approvedToolCalls,
+            ...(continuationApprovalId
+              ? { approvalId: continuationApprovalId }
+              : {}),
             ...(continuationTurnId ? { turnId: continuationTurnId } : {}),
             ...modelSnapshot,
           },
@@ -5403,6 +5430,7 @@ const AssistantChatInner = forwardRef<
               hideUserMessage,
               undefined,
               continuationTurnId,
+              continuationApprovalId,
             ),
           } as Parameters<typeof threadRuntime.append>[0]);
         } catch (error) {
@@ -5915,10 +5943,12 @@ const AssistantChatInner = forwardRef<
     scope: string;
     status: "loading" | "ready" | "error";
     resolutions: Record<string, ApprovalResolution>;
+    canResolve: boolean;
   }>(() => ({
     scope: approvalHydrationScope,
     status: approvalHydrationThreadId ? "loading" : "ready",
     resolutions: {},
+    canResolve: true,
   }));
   useEffect(() => {
     const controller = new AbortController();
@@ -5926,6 +5956,7 @@ const AssistantChatInner = forwardRef<
       scope: approvalHydrationScope,
       status: approvalHydrationThreadId ? "loading" : "ready",
       resolutions: {},
+      canResolve: true,
     });
     if (!approvalHydrationThreadId) return () => controller.abort();
     void loadAgentToolApprovalResolutions(
@@ -5933,18 +5964,20 @@ const AssistantChatInner = forwardRef<
       approvalHydrationThreadId,
       controller.signal,
     )
-      .then((resolutions) => {
+      .then(({ resolutions, canResolve }) => {
         if (!controller.signal.aborted) {
           setPersistedApprovals({
             scope: approvalHydrationScope,
             status: "ready",
             resolutions,
+            canResolve,
           });
         }
       })
       .catch((error) => {
         if (controller.signal.aborted) return;
         const unsupportedCustomRoute =
+          approvalHydrationTarget?.durable === false &&
           apiUrl !== defaultApprovalApiUrl &&
           error instanceof AgentToolApprovalRequestError &&
           error.status === 404;
@@ -5952,6 +5985,7 @@ const AssistantChatInner = forwardRef<
           scope: approvalHydrationScope,
           status: unsupportedCustomRoute ? "ready" : "error",
           resolutions: {},
+          canResolve: true,
         });
       });
     return () => controller.abort();
@@ -5960,6 +5994,7 @@ const AssistantChatInner = forwardRef<
     approvalHydrationScope,
     approvalHydrationThreadId,
     approvalHydrationRetry,
+    approvalHydrationTarget?.durable,
     defaultApprovalApiUrl,
   ]);
   const approvalHydrationStatus = !approvalHydrationThreadId
@@ -6012,27 +6047,8 @@ const AssistantChatInner = forwardRef<
     [approvalResolutionScope],
   );
 
-  // Human-in-the-loop approvals: when the user approves a paused `needsApproval`
-  // tool call, re-issue the turn carrying the call's approval key so the server
-  // gate lets that specific call run. Reuses the same append path as recovery /
-  // queued messages (no hand-written fetch).
-  const approveToolCall = useCallback(
+  const continueApprovedToolCall = useCallback(
     async (approvalKey: string, askId?: string) => {
-      if (threadId && askId) {
-        try {
-          const resolutions = await loadAgentToolApprovalResolutions(
-            apiUrl,
-            threadId,
-          );
-          if (resolutions[askId] === "denied") return "denied" as const;
-        } catch (error) {
-          const unsupportedCustomRoute =
-            apiUrl !== defaultApprovalApiUrl &&
-            error instanceof AgentToolApprovalRequestError &&
-            error.status === 404;
-          if (!unsupportedCustomRoute) throw error;
-        }
-      }
       await addToQueue(
         "Approved. Go ahead and run the requested action.", // i18n-ignore -- stable hidden agent instruction, not UI copy.
         undefined,
@@ -6047,46 +6063,67 @@ const AssistantChatInner = forwardRef<
         true, // hideUserMessage: this is a protocol continuation, not a new prompt
         undefined,
         [approvalKey],
+        undefined,
+        askId,
       );
       return "approved" as const;
     },
-    [addToQueue, apiUrl, defaultApprovalApiUrl, threadId],
+    [addToQueue],
+  );
+  // Durable asks are resolved before their hidden continuation is queued. The
+  // exact ask row, not client state, decides concurrent Approve/Deny clicks.
+  const approveToolCall = useCallback(
+    async (approvalKey: string, askId?: string) => {
+      if (threadId && askId) {
+        const resolution = await approveAgentToolApproval(apiUrl, {
+          threadId,
+          approvalId: askId,
+        });
+        if (resolution === "denied") return resolution;
+        if (resolution === "consumed") return "approved" as const;
+      }
+      return continueApprovedToolCall(approvalKey, askId);
+    },
+    [apiUrl, continueApprovedToolCall, threadId],
   );
   const alwaysAllowToolCall = useCallback(
-    (approvalKey: string, toolName: string, askId?: string) => {
+    async (approvalKey: string, toolName: string, askId?: string) => {
       if (approvalActions?.onAlwaysAllow) {
-        return approvalActions.onAlwaysAllow(approvalKey, toolName);
+        return approvalActions.onAlwaysAllow(approvalKey, toolName, askId);
       }
-      return callAction("set-tool-approval-policy", {
-        toolName,
-        enabled: true,
-      }).then(() => approveToolCall(approvalKey, askId));
+      if (threadId && askId) {
+        const resolution = await alwaysAllowAgentToolApproval(apiUrl, {
+          threadId,
+          approvalId: askId,
+          toolName,
+        });
+        if (resolution === "denied") return resolution;
+        if (resolution === "consumed") return "approved" as const;
+      } else {
+        await callAction("set-tool-approval-policy", {
+          toolName,
+          enabled: true,
+        });
+      }
+      return continueApprovedToolCall(approvalKey, askId);
     },
-    [approvalActions, approveToolCall],
+    [apiUrl, approvalActions, continueApprovedToolCall, threadId],
   );
   const denyToolCall = useCallback(
     async (approvalKey: string, askId?: string) => {
       let resolution: ApprovalResolution = "denied";
       if (threadId && askId) {
-        try {
-          resolution = await denyAgentToolApproval(apiUrl, {
-            threadId,
-            approvalId: askId,
-          });
-        } catch (error) {
-          const unsupportedCustomRoute =
-            apiUrl !== defaultApprovalApiUrl &&
-            error instanceof AgentToolApprovalRequestError &&
-            error.status === 404;
-          if (!unsupportedCustomRoute) throw error;
-        }
+        resolution = await denyAgentToolApproval(apiUrl, {
+          threadId,
+          approvalId: askId,
+        });
       }
       if (resolution === "denied") {
         await Promise.resolve(approvalActions?.onDeny?.(approvalKey));
       }
       return resolution;
     },
-    [apiUrl, approvalActions, defaultApprovalApiUrl, threadId],
+    [apiUrl, approvalActions, threadId],
   );
   const showActionTypeApprovalPolicy =
     approvalActions?.alwaysAllowScope !== "exact-command";
@@ -6094,6 +6131,10 @@ const AssistantChatInner = forwardRef<
     () => ({
       getApprovalResolution,
       approvalHydrationStatus,
+      canResolveApprovals:
+        persistedApprovals.scope === approvalHydrationScope
+          ? persistedApprovals.canResolve
+          : false,
       onRetryApprovalResolutions: () =>
         setApprovalHydrationRetry((value) => value + 1),
       onApprovalResolved: recordApprovalResolution,
@@ -6106,9 +6147,12 @@ const AssistantChatInner = forwardRef<
     [
       alwaysAllowToolCall,
       approvalHydrationStatus,
+      approvalHydrationScope,
       approveToolCall,
       denyToolCall,
       getApprovalResolution,
+      persistedApprovals.canResolve,
+      persistedApprovals.scope,
       recordApprovalResolution,
       showActionTypeApprovalPolicy,
     ],

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2445,6 +2445,40 @@ export function resolveApprovalResolution(input: {
   return local ?? persisted;
 }
 
+export function agentToolApprovalHydrationTarget(
+  threadId: string | null | undefined,
+  messages: readonly { content?: readonly unknown[] }[],
+): { threadId: string; revision: string } | null {
+  if (!threadId) return null;
+  const approvals: string[] = [];
+  for (const message of messages) {
+    for (const part of message.content ?? []) {
+      if (!part || typeof part !== "object") continue;
+      const toolCall = part as {
+        type?: unknown;
+        toolCallId?: unknown;
+        approval?: { approvalKey?: unknown; askId?: unknown } | null;
+      };
+      if (
+        toolCall.type !== "tool-call" ||
+        typeof toolCall.approval?.approvalKey !== "string" ||
+        toolCall.approval.approvalKey.length === 0
+      ) {
+        continue;
+      }
+      approvals.push(
+        typeof toolCall.approval.askId === "string" &&
+          toolCall.approval.askId.length > 0
+          ? toolCall.approval.askId
+          : `${typeof toolCall.toolCallId === "string" ? toolCall.toolCallId : ""}\u0000${toolCall.approval.approvalKey}`,
+      );
+    }
+  }
+  return approvals.length > 0
+    ? { threadId, revision: JSON.stringify(approvals) }
+    : null;
+}
+
 const AssistantChatInner = forwardRef<
   AssistantChatHandle,
   AssistantChatProps & { apiUrl: string }
@@ -5861,6 +5895,13 @@ const AssistantChatInner = forwardRef<
 
   const approvalResolutionScope = threadId ?? tabId ?? "default";
   const approvalPersistenceScope = `${apiUrl}\u0000${approvalResolutionScope}`;
+  const approvalHydrationTarget = agentToolApprovalHydrationTarget(
+    threadId,
+    messages,
+  );
+  const approvalHydrationThreadId = approvalHydrationTarget?.threadId ?? null;
+  const approvalHydrationRevision = approvalHydrationTarget?.revision ?? null;
+  const approvalHydrationScope = `${approvalPersistenceScope}\u0000${approvalHydrationRevision ?? ""}`;
   const defaultApprovalApiUrl = agentNativePath("/_agent-native/agent-chat");
   const [approvalResolutionState, setApprovalResolutionState] = useState<{
     scope: string;
@@ -5875,23 +5916,27 @@ const AssistantChatInner = forwardRef<
     status: "loading" | "ready" | "error";
     resolutions: Record<string, ApprovalResolution>;
   }>(() => ({
-    scope: approvalPersistenceScope,
-    status: threadId ? "loading" : "ready",
+    scope: approvalHydrationScope,
+    status: approvalHydrationThreadId ? "loading" : "ready",
     resolutions: {},
   }));
   useEffect(() => {
     const controller = new AbortController();
     setPersistedApprovals({
-      scope: approvalPersistenceScope,
-      status: threadId ? "loading" : "ready",
+      scope: approvalHydrationScope,
+      status: approvalHydrationThreadId ? "loading" : "ready",
       resolutions: {},
     });
-    if (!threadId) return () => controller.abort();
-    void loadAgentToolApprovalResolutions(apiUrl, threadId, controller.signal)
+    if (!approvalHydrationThreadId) return () => controller.abort();
+    void loadAgentToolApprovalResolutions(
+      apiUrl,
+      approvalHydrationThreadId,
+      controller.signal,
+    )
       .then((resolutions) => {
         if (!controller.signal.aborted) {
           setPersistedApprovals({
-            scope: approvalPersistenceScope,
+            scope: approvalHydrationScope,
             status: "ready",
             resolutions,
           });
@@ -5904,7 +5949,7 @@ const AssistantChatInner = forwardRef<
           error instanceof AgentToolApprovalRequestError &&
           error.status === 404;
         setPersistedApprovals({
-          scope: approvalPersistenceScope,
+          scope: approvalHydrationScope,
           status: unsupportedCustomRoute ? "ready" : "error",
           resolutions: {},
         });
@@ -5912,13 +5957,14 @@ const AssistantChatInner = forwardRef<
     return () => controller.abort();
   }, [
     apiUrl,
+    approvalHydrationScope,
+    approvalHydrationThreadId,
     approvalHydrationRetry,
-    approvalPersistenceScope,
     defaultApprovalApiUrl,
-    threadId,
   ]);
-  const approvalHydrationStatus =
-    persistedApprovals.scope === approvalPersistenceScope
+  const approvalHydrationStatus = !approvalHydrationThreadId
+    ? "ready"
+    : persistedApprovals.scope === approvalHydrationScope
       ? persistedApprovals.status
       : "loading";
   const getApprovalResolution = useCallback(
@@ -5930,14 +5976,14 @@ const AssistantChatInner = forwardRef<
         local: approvalResolutionState,
         persisted: {
           scope:
-            persistedApprovals.scope === approvalPersistenceScope
+            persistedApprovals.scope === approvalHydrationScope
               ? approvalResolutionScope
               : "",
           resolutions: persistedApprovals.resolutions,
         },
       }),
     [
-      approvalPersistenceScope,
+      approvalHydrationScope,
       approvalResolutionScope,
       approvalResolutionState,
       persistedApprovals,

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -594,13 +594,17 @@ describe("createAgentChatAdapter", () => {
         ],
         abortSignal: new AbortController().signal,
         runConfig: {
-          custom: { approvedToolCalls: ["create-builder-branch:{}"] },
+          custom: {
+            approvedToolCalls: ["create-builder-branch:{}"],
+            approvalId: "ask-1",
+          },
         },
       } as any),
     );
 
     const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
     expect(body.approvedToolCalls).toEqual(["create-builder-branch:{}"]);
+    expect(body.approvalId).toBe("ask-1");
   });
 
   it("falls back to the live picker for queue entries without a model snapshot", async () => {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -2027,6 +2027,13 @@ export function createAgentChatAdapter(
         );
         return keys.length > 0 ? keys : undefined;
       })();
+      const approvalId = (() => {
+        const raw =
+          runConfig?.custom && typeof runConfig.custom === "object"
+            ? (runConfig.custom as { approvalId?: unknown }).approvalId
+            : undefined;
+        return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+      })();
       const requestMode =
         runConfigRequestMode === "act" || runConfigRequestMode === "plan"
           ? runConfigRequestMode
@@ -3898,6 +3905,7 @@ export function createAgentChatAdapter(
                     ? { references: runConfig.custom.references }
                     : {}),
                   ...(approvedToolCalls ? { approvedToolCalls } : {}),
+                  ...(approvalId ? { approvalId } : {}),
                 }),
               },
               STARTUP_RESPONSE_TIMEOUT_MS,

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -63,9 +63,11 @@ vi.stubGlobal("fetch", fetchSpy);
 const {
   _resetAgentChatContextForTests,
   _resetAgentChatSubmitBufferForTests,
+  AgentToolApprovalRequestError,
   addContextToAgentChat,
   claimAgentChatSubmit,
   clearAgentChatContext,
+  denyAgentToolApproval,
   drainBufferedAgentChatSubmits,
   filterAgentChatContextItems,
   formatAgentChatContextItemsForPrompt,
@@ -74,6 +76,7 @@ const {
   listAgentChatContext,
   normalizeAgentComposerReference,
   parseSubmitChatMessage,
+  loadAgentToolApprovalResolutions,
   removeAgentChatContextItem,
   reportAgentChatSubmitResult,
   sendToAgentChat,
@@ -921,5 +924,62 @@ describe("filterAgentChatContextItems", () => {
       items[0],
       items[2],
     ]);
+  });
+});
+
+describe("agent tool approval client", () => {
+  it("preserves HTTP status for transport fallbacks", async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: false, status: 404 } as any);
+
+    await expect(
+      loadAgentToolApprovalResolutions("/custom-chat", "thread-1"),
+    ).rejects.toMatchObject({
+      name: "AgentToolApprovalRequestError",
+      status: 404,
+    } satisfies Partial<InstanceType<typeof AgentToolApprovalRequestError>>);
+  });
+
+  it("loads persisted resolutions for one thread", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        resolutions: { "ask-1": "denied", ignored: "pending" },
+      }),
+    } as any);
+
+    await expect(
+      loadAgentToolApprovalResolutions("/agent-chat", "thread/1"),
+    ).resolves.toEqual({ "ask-1": "denied" });
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "/agent-chat/approvals?threadId=thread%2F1",
+      expect.objectContaining({ method: "GET", cache: "no-store" }),
+    );
+  });
+
+  it("persists a denial through the protected route", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ resolution: "denied" }),
+    } as any);
+
+    await expect(
+      denyAgentToolApproval("/agent-chat", {
+        threadId: "thread-1",
+        approvalId: "ask-1",
+      }),
+    ).resolves.toBe("denied");
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "/agent-chat/approvals",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-Agent-Native-CSRF": "1" }),
+        body: JSON.stringify({
+          threadId: "thread-1",
+          approvalId: "ask-1",
+        }),
+      }),
+    );
   });
 });

--- a/packages/core/src/client/agent-chat.spec.ts
+++ b/packages/core/src/client/agent-chat.spec.ts
@@ -64,6 +64,8 @@ const {
   _resetAgentChatContextForTests,
   _resetAgentChatSubmitBufferForTests,
   AgentToolApprovalRequestError,
+  alwaysAllowAgentToolApproval,
+  approveAgentToolApproval,
   addContextToAgentChat,
   claimAgentChatSubmit,
   clearAgentChatContext,
@@ -945,16 +947,80 @@ describe("agent tool approval client", () => {
       status: 200,
       json: async () => ({
         resolutions: { "ask-1": "denied", ignored: "pending" },
+        canResolve: true,
       }),
     } as any);
 
     await expect(
       loadAgentToolApprovalResolutions("/agent-chat", "thread/1"),
-    ).resolves.toEqual({ "ask-1": "denied" });
+    ).resolves.toEqual({
+      resolutions: { "ask-1": "denied" },
+      canResolve: true,
+    });
     expect(fetchSpy).toHaveBeenLastCalledWith(
       "/agent-chat/approvals?threadId=thread%2F1",
       expect.objectContaining({ method: "GET", cache: "no-store" }),
     );
+  });
+
+  it("rejects a malformed successful resolution payload", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ canResolve: true }),
+    } as any);
+
+    await expect(
+      loadAgentToolApprovalResolutions("/agent-chat", "thread-1"),
+    ).rejects.toMatchObject({
+      name: "AgentToolApprovalRequestError",
+      status: 500,
+    });
+  });
+
+  it.each([
+    ["approve", approveAgentToolApproval, "approved"],
+    ["always_allow", alwaysAllowAgentToolApproval, "approved"],
+  ] as const)(
+    "persists an atomic %s decision before continuing",
+    async (operation, resolveApproval, resolution) => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ resolution }),
+      } as any);
+
+      await expect(
+        resolveApproval("/agent-chat", {
+          threadId: "thread-1",
+          approvalId: "ask-1",
+          ...(operation === "always_allow" ? { toolName: "send-email" } : {}),
+        } as never),
+      ).resolves.toBe("approved");
+      const [url, request] = fetchSpy.mock.calls.at(-1)!;
+      expect(url).toBe("/agent-chat/approvals");
+      expect(JSON.parse(request.body)).toEqual({
+        threadId: "thread-1",
+        approvalId: "ask-1",
+        operation,
+        ...(operation === "always_allow" ? { toolName: "send-email" } : {}),
+      });
+    },
+  );
+
+  it("reports an already consumed approval without replaying it", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ resolution: "approved", consumed: true }),
+    } as any);
+
+    await expect(
+      approveAgentToolApproval("/agent-chat", {
+        threadId: "thread-1",
+        approvalId: "ask-1",
+      }),
+    ).resolves.toBe("consumed");
   });
 
   it("persists a denial through the protected route", async () => {

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -31,6 +31,14 @@ import { sendMcpAppHostMessage } from "./mcp-app-host.js";
 export type AgentChatRequestMode = "act" | "plan";
 
 export type AgentToolApprovalResolution = "approved" | "denied";
+export type AgentToolApprovalDecision =
+  | AgentToolApprovalResolution
+  | "consumed";
+
+export interface AgentToolApprovalState {
+  resolutions: Record<string, AgentToolApprovalResolution>;
+  canResolve: boolean;
+}
 
 export class AgentToolApprovalRequestError extends Error {
   constructor(
@@ -51,14 +59,18 @@ async function approvalJson(
       response.status,
     );
   }
-  return (await response.json()) as Record<string, unknown>;
+  const payload = await response.json();
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new AgentToolApprovalRequestError("Invalid approval response", 500);
+  }
+  return payload as Record<string, unknown>;
 }
 
 export async function loadAgentToolApprovalResolutions(
   apiUrl: string,
   threadId: string,
   signal?: AbortSignal,
-): Promise<Record<string, AgentToolApprovalResolution>> {
+): Promise<AgentToolApprovalState> {
   const payload = await approvalJson(
     await fetch(
       `${apiUrl}/approvals?threadId=${encodeURIComponent(threadId)}`,
@@ -70,13 +82,65 @@ export async function loadAgentToolApprovalResolutions(
     ),
   );
   const resolutions: Record<string, AgentToolApprovalResolution> = {};
-  if (!payload.resolutions || typeof payload.resolutions !== "object") {
-    return resolutions;
+  if (
+    !payload.resolutions ||
+    typeof payload.resolutions !== "object" ||
+    Array.isArray(payload.resolutions)
+  ) {
+    throw new AgentToolApprovalRequestError("Invalid approval response", 500);
   }
   for (const [id, value] of Object.entries(payload.resolutions)) {
     if (value === "approved" || value === "denied") resolutions[id] = value;
   }
-  return resolutions;
+  return {
+    resolutions,
+    canResolve:
+      typeof payload.canResolve === "boolean" ? payload.canResolve : true,
+  };
+}
+
+async function resolveAgentToolApproval(
+  apiUrl: string,
+  input: {
+    threadId: string;
+    approvalId: string;
+    operation: "approve" | "always_allow";
+    toolName?: string;
+  },
+): Promise<AgentToolApprovalDecision> {
+  const payload = await approvalJson(
+    await fetch(`${apiUrl}/approvals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Agent-Native-CSRF": "1",
+      },
+      body: JSON.stringify(input),
+    }),
+  );
+  if (payload.resolution !== "approved" && payload.resolution !== "denied") {
+    throw new AgentToolApprovalRequestError("Invalid approval response", 500);
+  }
+  return payload.resolution === "approved" && payload.consumed === true
+    ? "consumed"
+    : payload.resolution;
+}
+
+export async function approveAgentToolApproval(
+  apiUrl: string,
+  input: { threadId: string; approvalId: string },
+): Promise<AgentToolApprovalDecision> {
+  return resolveAgentToolApproval(apiUrl, { ...input, operation: "approve" });
+}
+
+export async function alwaysAllowAgentToolApproval(
+  apiUrl: string,
+  input: { threadId: string; approvalId: string; toolName: string },
+): Promise<AgentToolApprovalDecision> {
+  return resolveAgentToolApproval(apiUrl, {
+    ...input,
+    operation: "always_allow",
+  });
 }
 
 export async function denyAgentToolApproval(

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -30,6 +30,78 @@ import { sendMcpAppHostMessage } from "./mcp-app-host.js";
 
 export type AgentChatRequestMode = "act" | "plan";
 
+export type AgentToolApprovalResolution = "approved" | "denied";
+
+export class AgentToolApprovalRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "AgentToolApprovalRequestError";
+  }
+}
+
+async function approvalJson(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  if (!response.ok) {
+    throw new AgentToolApprovalRequestError(
+      "Could not resolve tool approval",
+      response.status,
+    );
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+export async function loadAgentToolApprovalResolutions(
+  apiUrl: string,
+  threadId: string,
+  signal?: AbortSignal,
+): Promise<Record<string, AgentToolApprovalResolution>> {
+  const payload = await approvalJson(
+    await fetch(
+      `${apiUrl}/approvals?threadId=${encodeURIComponent(threadId)}`,
+      {
+        method: "GET",
+        cache: "no-store",
+        signal,
+      },
+    ),
+  );
+  const resolutions: Record<string, AgentToolApprovalResolution> = {};
+  if (!payload.resolutions || typeof payload.resolutions !== "object") {
+    return resolutions;
+  }
+  for (const [id, value] of Object.entries(payload.resolutions)) {
+    if (value === "approved" || value === "denied") resolutions[id] = value;
+  }
+  return resolutions;
+}
+
+export async function denyAgentToolApproval(
+  apiUrl: string,
+  input: {
+    threadId: string;
+    approvalId: string;
+  },
+): Promise<AgentToolApprovalResolution> {
+  const payload = await approvalJson(
+    await fetch(`${apiUrl}/approvals`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Agent-Native-CSRF": "1",
+      },
+      body: JSON.stringify(input),
+    }),
+  );
+  if (payload.resolution !== "approved" && payload.resolution !== "denied") {
+    throw new AgentToolApprovalRequestError("Invalid approval response", 500);
+  }
+  return payload.resolution;
+}
+
 export interface AgentChatMessage {
   /** The visible prompt message sent to the chat */
   message: string;

--- a/packages/core/src/client/chat/message-components.spec.tsx
+++ b/packages/core/src/client/chat/message-components.spec.tsx
@@ -36,8 +36,45 @@ import {
   ChatImageAttachmentPreview,
   MISSING_FINAL_RESPONSE_SETTLE_MS,
   resolveAssistantRequestId,
+  displayableApprovalText,
 } from "./message-components.js";
 import { runErrorKey } from "./run-recovery.js";
+
+describe("approval waiting transcript display", () => {
+  it("removes only framework waiting copy represented by a matching approval card", () => {
+    const waiting = "Waiting for your approval to run send-email.";
+    const content = [
+      {
+        type: "tool-call",
+        toolName: "archive-email",
+        approval: { approvalKey: "archive-email:{}" },
+      },
+      {
+        type: "tool-call",
+        toolName: "send-email",
+        approval: { approvalKey: "send-email:{}" },
+      },
+      { type: "text", text: waiting },
+    ];
+
+    expect(displayableApprovalText(waiting, content)).toBe("");
+    expect(displayableApprovalText(`${waiting}Email sent.`, content)).toBe(
+      "Email sent.",
+    );
+    expect(
+      displayableApprovalText(waiting, [{ type: "text", text: waiting }]),
+    ).toBe(waiting);
+    expect(
+      displayableApprovalText(waiting, [
+        {
+          type: "tool-call",
+          toolName: "archive-email",
+          approval: { approvalKey: "archive-email:{}" },
+        },
+      ]),
+    ).toBe(waiting);
+  });
+});
 
 describe("assistant request ID resolution", () => {
   it("prefers the server run ID attached to the message", () => {

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -94,6 +94,7 @@ import {
   MarkdownText,
   renderMarkdownToClipboardHtml,
   SmoothMarkdownText,
+  TextStreamingContext,
 } from "./markdown-renderer.js";
 import { getAssistantRunDurationMs } from "./repo-helpers.js";
 import {
@@ -1057,6 +1058,33 @@ export function messageTextFromContent(content: unknown): string {
     .join("\n");
 }
 
+export function displayableApprovalText(
+  text: string,
+  content: readonly unknown[],
+): string {
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const toolCall = part as {
+      type?: unknown;
+      toolName?: unknown;
+      approval?: { approvalKey?: unknown } | null;
+    };
+    if (
+      toolCall.type !== "tool-call" ||
+      typeof toolCall.toolName !== "string" ||
+      typeof toolCall.approval?.approvalKey !== "string" ||
+      toolCall.approval.approvalKey.length === 0
+    ) {
+      continue;
+    }
+    // Match the server's fallback transcript copy without removing it from
+    // persistence for hosts that do not render the structured approval card.
+    const waitingText = `Waiting for your approval to run ${toolCall.toolName}.`; // i18n-ignore -- protocol copy match, not new UI copy.
+    if (text.startsWith(waitingText)) return text.slice(waitingText.length);
+  }
+  return text;
+}
+
 export function isMissingFinalResponseWarningText(text: string): boolean {
   const normalized = text.trim();
   if (
@@ -1709,6 +1737,7 @@ export function AssistantMessage() {
   const [restoreError, setRestoreError] = useState<string | null>(null);
   const messageRuntime = useMessageRuntime();
   const threadRuntime = useThreadRuntime();
+  const textStreaming = React.useContext(TextStreamingContext);
   const chatRunning = React.useContext(ChatRunningContext);
   const activeRunId = React.useContext(ChatRunningRunIdContext);
   const activeTurnId = React.useContext(ChatRunningTurnIdContext);
@@ -2021,7 +2050,12 @@ export function AssistantMessage() {
                     </WorkedForSummary>
                   );
                 }
-                case "text":
+                case "text": {
+                  const displayText = displayableApprovalText(
+                    part.text,
+                    msgContent ?? [],
+                  );
+                  if (!displayText) return null;
                   if (
                     isUserStoppedRun &&
                     isMissingFinalResponseWarningText(part.text)
@@ -2047,7 +2081,18 @@ export function AssistantMessage() {
                       />
                     );
                   }
+                  if (displayText !== part.text) {
+                    return (
+                      <SmoothMarkdownText
+                        text={localizeKnownChatErrorText(displayText, t)}
+                        streaming={textStreaming && isLast}
+                        resetKey={msg.id}
+                        statusType={msg.status?.type ?? "complete"}
+                      />
+                    );
+                  }
                   return <MarkdownText />;
+                }
                 case "reasoning":
                   return <ReasoningMessagePart />;
                 case "tool-call":

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -2788,6 +2788,30 @@ describe("ApprovalAffordance", () => {
     expect(retry).toHaveBeenCalledOnce();
   });
 
+  it("does not render mutating approval controls for a shared viewer", () => {
+    act(() => {
+      root.render(
+        <ApprovalContext.Provider
+          value={{ onApprove: vi.fn(), canResolveApprovals: false }}
+        >
+          <ToolCallDisplay
+            toolName="bash"
+            args={{}}
+            approval={{ approvalKey: "approval-1", askId: "ask-1" }}
+            isRunning={false}
+          />
+        </ApprovalContext.Provider>,
+      );
+    });
+
+    expect(container.textContent).toContain("Approve to run bash?");
+    expect(
+      Array.from(container.querySelectorAll("button")).map(
+        (button) => button.textContent,
+      ),
+    ).toEqual(["bash"]);
+  });
+
   it("renders Always allow only when onAlwaysAllow is provided, and it approves on click", async () => {
     const onApprove = vi.fn();
     const onAlwaysAllow = vi.fn();

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -2419,7 +2419,7 @@ describe("ApprovalAffordance", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps Deny local-only and hides Approve/Always-allow with no ApprovalContext", () => {
+  it("keeps Deny local-only and hides Approve/Always-allow with no ApprovalContext", async () => {
     act(() => {
       root.render(
         <ToolCallDisplay
@@ -2441,7 +2441,7 @@ describe("ApprovalAffordance", () => {
     const denyButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Deny",
     ) as HTMLButtonElement;
-    act(() => denyButton.click());
+    await act(async () => denyButton.click());
 
     expect(container.textContent).toContain("Denied. bash did not run.");
   });
@@ -2481,7 +2481,7 @@ describe("ApprovalAffordance", () => {
     }
   });
 
-  it("keeps the default two-button layout when only onApprove is provided", () => {
+  it("keeps the default two-button layout when only onApprove is provided", async () => {
     const onApprove = vi.fn();
     act(() => {
       root.render(
@@ -2505,7 +2505,7 @@ describe("ApprovalAffordance", () => {
     const approveButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Approve",
     ) as HTMLButtonElement;
-    act(() => approveButton.click());
+    await act(async () => approveButton.click());
 
     expect(onApprove).toHaveBeenCalledWith("approval-1");
     expect(container.textContent).toContain("Approved. Re-running bash...");
@@ -2542,7 +2542,7 @@ describe("ApprovalAffordance", () => {
     ).toEqual(["send email", "Approve", "Deny"]);
   });
 
-  it("keeps Approved visible when the chat refresh remounts the tool card", () => {
+  it("keeps Approved visible when the chat refresh remounts the tool card", async () => {
     const onApprove = vi.fn();
 
     function RefreshingApproval() {
@@ -2577,7 +2577,7 @@ describe("ApprovalAffordance", () => {
       (button) => button.textContent === "Approve",
     ) as HTMLButtonElement;
 
-    act(() => approveButton.click());
+    await act(async () => approveButton.click());
 
     expect(onApprove).toHaveBeenCalledWith("approval-1");
     expect(container.textContent).toContain("Approved. Re-running bash...");
@@ -2588,7 +2588,35 @@ describe("ApprovalAffordance", () => {
     ).toEqual(["bash"]);
   });
 
-  it("shows Approve/Deny again when the server re-issues approval_required with a new askId for the same toolCallId", () => {
+  it("keeps a server-rehydrated Deny visible when the tool card remounts", () => {
+    const render = (revision: number) =>
+      root.render(
+        <ApprovalContext.Provider
+          value={{
+            onApprove: vi.fn(),
+            getApprovalResolution: (_key, _callId, askId) =>
+              askId === "ask-denied" ? "denied" : null,
+          }}
+        >
+          <ToolCallDisplay
+            key={revision}
+            toolName="bash"
+            toolCallId="call-1"
+            args={{}}
+            approval={{ approvalKey: "approval-1", askId: "ask-denied" }}
+            isRunning={false}
+          />
+        </ApprovalContext.Provider>,
+      );
+
+    act(() => render(1));
+    act(() => render(2));
+
+    expect(container.textContent).toContain("Denied. bash did not run.");
+    expect(container.textContent).not.toContain("Approve to run bash?");
+  });
+
+  it("shows Approve/Deny again when the server re-issues approval_required with a new askId for the same toolCallId", async () => {
     // Mirrors a failed resume: the server's resume never consumed the grant
     // (expired TTL, turn-id mismatch) and re-enters the gate, re-emitting
     // `approval_required` for the SAME toolCallId with a fresh `askId`. The
@@ -2634,9 +2662,9 @@ describe("ApprovalAffordance", () => {
     const approveButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Approve",
     ) as HTMLButtonElement;
-    act(() => approveButton.click());
+    await act(async () => approveButton.click());
 
-    expect(onApprove).toHaveBeenCalledWith("approval-1");
+    expect(onApprove).toHaveBeenCalledWith("approval-1", "ask-1");
     expect(container.textContent).toContain("Approved. Re-running bash...");
 
     // The failed resume re-emits approval_required for the same toolCallId
@@ -2651,9 +2679,15 @@ describe("ApprovalAffordance", () => {
     ).toEqual(["bash", "Approve", "Deny"]);
   });
 
-  it("calls onDeny in addition to the local denied state when provided", () => {
+  it("waits for durable Deny and ignores a double click", async () => {
     const onApprove = vi.fn();
-    const onDeny = vi.fn();
+    let resolveDeny!: (resolution: "denied") => void;
+    const onDeny = vi.fn(
+      () =>
+        new Promise<"denied">((resolve) => {
+          resolveDeny = resolve;
+        }),
+    );
     act(() => {
       root.render(
         <ApprovalContext.Provider value={{ onApprove, onDeny }}>
@@ -2670,10 +2704,88 @@ describe("ApprovalAffordance", () => {
     const denyButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Deny",
     ) as HTMLButtonElement;
-    act(() => denyButton.click());
+    await act(async () => {
+      denyButton.click();
+      denyButton.click();
+    });
 
     expect(onDeny).toHaveBeenCalledWith("approval-1");
+    expect(onDeny).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("Denied. bash did not run.");
+
+    await act(async () => resolveDeny("denied"));
     expect(container.textContent).toContain("Denied. bash did not run.");
+  });
+
+  it("waits for approval resolution and renders a competing denial", async () => {
+    let resolveApproval!: (resolution: "denied") => void;
+    const onApprove = vi.fn(
+      () =>
+        new Promise<"denied">((resolve) => {
+          resolveApproval = resolve;
+        }),
+    );
+    act(() => {
+      root.render(
+        <ApprovalContext.Provider value={{ onApprove }}>
+          <ToolCallDisplay
+            toolName="bash"
+            args={{}}
+            approval={{ approvalKey: "approval-1", askId: "ask-1" }}
+            isRunning={false}
+          />
+        </ApprovalContext.Provider>,
+      );
+    });
+
+    const approve = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Approve",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      approve.click();
+      approve.click();
+    });
+
+    expect(onApprove).toHaveBeenCalledWith("approval-1", "ask-1");
+    expect(onApprove).toHaveBeenCalledOnce();
+    expect(container.textContent).not.toContain("Denied. bash did not run.");
+    await act(async () => resolveApproval("denied"));
+    expect(container.textContent).toContain("Denied. bash did not run.");
+  });
+
+  it("blocks approvals and offers retry when hydration fails", () => {
+    const retry = vi.fn();
+    act(() => {
+      root.render(
+        <ApprovalContext.Provider
+          value={{
+            onApprove: vi.fn(),
+            approvalHydrationStatus: "error",
+            onRetryApprovalResolutions: retry,
+          }}
+        >
+          <ToolCallDisplay
+            toolName="bash"
+            args={{}}
+            approval={{ approvalKey: "approval-1", askId: "ask-1" }}
+            isRunning={false}
+          />
+        </ApprovalContext.Provider>,
+      );
+    });
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    expect(
+      buttons.find((button) => button.textContent === "Approve")?.disabled,
+    ).toBe(true);
+    expect(
+      buttons.find((button) => button.textContent === "Deny")?.disabled,
+    ).toBe(true);
+    const retryButton = buttons.find(
+      (button) => button.textContent === "Retry",
+    ) as HTMLButtonElement;
+    act(() => retryButton.click());
+    expect(retry).toHaveBeenCalledOnce();
   });
 
   it("renders Always allow only when onAlwaysAllow is provided, and it approves on click", async () => {

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -110,15 +110,17 @@ export function ToolCallStackMotion({
  * Human-in-the-loop approval bridge. `AssistantChatInner` provides a value that
  * re-issues the turn approving a specific paused tool call (opt-in
  * `needsApproval` actions). When null, the Approve button is not rendered.
- * Deny defaults to local-only (the action stays un-run) unless `onDeny` is
- * provided. The chevron menu persists an action-type policy before approving
- * the current call.
+ * Deny is persisted by the owning chat when `onDeny` is provided. The chevron
+ * menu persists an action-type policy before approving the current call.
  */
 export type ApprovalResolution = "approved" | "denied";
 
 export type ApprovalContextValue = {
   /** Re-issue the turn so the server runs the approved call. */
-  onApprove: (approvalKey: string) => void;
+  onApprove: (
+    approvalKey: string,
+    askId?: string,
+  ) => ApprovalResolution | void | Promise<ApprovalResolution | void>;
   /**
    * Keep the visible resolution stable while the chat repository refreshes or
    * remounts the message containing this approval card.
@@ -142,11 +144,11 @@ export type ApprovalContextValue = {
     toolCallId?: string,
     askId?: string,
   ) => ApprovalResolution | null;
-  /**
-   * Optional host hook invoked in addition to the local "denied" state, e.g.
-   * so a Code session can also resolve its own pending approval as denied.
-   */
-  onDeny?: (approvalKey: string) => void;
+  /** Persist the rejection before the card displays its terminal state. */
+  onDeny?: (
+    approvalKey: string,
+    askId?: string,
+  ) => ApprovalResolution | void | Promise<ApprovalResolution | void>;
   /**
    * Optional host hook that persists this action type and resolves the current
    * call. The default AssistantChat implementation uses the shared policy.
@@ -154,7 +156,10 @@ export type ApprovalContextValue = {
   onAlwaysAllow?: (
     approvalKey: string,
     toolName: string,
-  ) => void | Promise<void>;
+    askId?: string,
+  ) => ApprovalResolution | void | Promise<ApprovalResolution | void>;
+  approvalHydrationStatus?: "loading" | "ready" | "error";
+  onRetryApprovalResolutions?: () => void;
 };
 export const ApprovalContext = React.createContext<ApprovalContextValue | null>(
   null,
@@ -565,7 +570,7 @@ export function AnimatedCollapse({
 /**
  * Inline Approve/Deny prompt rendered when a `needsApproval` action paused the
  * turn. Approve re-issues the turn with the call's `approvalKey`; Deny dismisses
- * the prompt locally (the action stays un-run).
+ * the prompt after the owning chat has durably rejected the call.
  */
 function ApprovalAffordance({
   toolName,
@@ -585,8 +590,10 @@ function ApprovalAffordance({
   const ctx = React.useContext(ApprovalContext);
   const [localResolution, setLocalResolution] =
     useState<ApprovalResolution | null>(null);
-  const [isAlwaysAllowing, setIsAlwaysAllowing] = useState(false);
-  const [alwaysAllowFailed, setAlwaysAllowFailed] = useState(false);
+  const [isResolving, setIsResolving] = useState(false);
+  const approveInFlight = React.useRef(false);
+  const denyInFlight = React.useRef(false);
+  const [saveFailed, setSaveFailed] = useState(false);
   const onAlwaysAllow =
     approval.allowPersistentApproval === false ? undefined : ctx?.onAlwaysAllow;
   const retainedResolution =
@@ -599,6 +606,9 @@ function ApprovalAffordance({
     retainedResolution ??
     localResolution ??
     (approval.dismissed === true ? "denied" : null);
+  const hydrationBlocked =
+    ctx?.approvalHydrationStatus === "loading" ||
+    ctx?.approvalHydrationStatus === "error";
 
   // Once resolved, collapse to a quiet note so a repository refresh cannot
   // restore the action buttons while the continuation is running.
@@ -609,9 +619,6 @@ function ApprovalAffordance({
       </div>
     );
   }
-  // Deny defaults to local-only (the action simply stays un-run). When the
-  // host also provided `onDeny` (e.g. a Code session resolving its own
-  // pending approval), it fires alongside the local state.
   if (resolution === "denied") {
     return (
       <div className="mt-1.5 text-xs text-muted-foreground">
@@ -620,22 +627,73 @@ function ApprovalAffordance({
     );
   }
   const handleAlwaysAllow = async () => {
-    if (!onAlwaysAllow || isAlwaysAllowing) return;
-    setIsAlwaysAllowing(true);
-    setAlwaysAllowFailed(false);
+    if (!onAlwaysAllow || isResolving || hydrationBlocked) return;
+    setIsResolving(true);
+    setSaveFailed(false);
     try {
-      await onAlwaysAllow(approval.approvalKey, toolName);
-      setLocalResolution("approved");
+      const result = approval.askId
+        ? await onAlwaysAllow(approval.approvalKey, toolName, approval.askId)
+        : await onAlwaysAllow(approval.approvalKey, toolName);
+      const resolution = result ?? "approved";
+      setLocalResolution(resolution);
       ctx?.onApprovalResolved?.(
         approval.approvalKey,
-        "approved",
+        resolution,
         toolCallId,
         approval.askId,
       );
     } catch {
-      setAlwaysAllowFailed(true);
+      setSaveFailed(true);
     } finally {
-      setIsAlwaysAllowing(false);
+      setIsResolving(false);
+    }
+  };
+  const handleApprove = async () => {
+    if (!ctx || approveInFlight.current || hydrationBlocked) return;
+    approveInFlight.current = true;
+    setIsResolving(true);
+    setSaveFailed(false);
+    try {
+      const result = approval.askId
+        ? await ctx.onApprove(approval.approvalKey, approval.askId)
+        : await ctx.onApprove(approval.approvalKey);
+      const resolution = result ?? "approved";
+      setLocalResolution(resolution);
+      ctx.onApprovalResolved?.(
+        approval.approvalKey,
+        resolution,
+        toolCallId,
+        approval.askId,
+      );
+    } catch {
+      setSaveFailed(true);
+    } finally {
+      approveInFlight.current = false;
+      setIsResolving(false);
+    }
+  };
+  const handleDeny = async () => {
+    if (denyInFlight.current || hydrationBlocked) return;
+    denyInFlight.current = true;
+    setIsResolving(true);
+    setSaveFailed(false);
+    try {
+      const result = approval.askId
+        ? await ctx?.onDeny?.(approval.approvalKey, approval.askId)
+        : await ctx?.onDeny?.(approval.approvalKey);
+      const nextResolution = result ?? "denied";
+      setLocalResolution(nextResolution);
+      ctx?.onApprovalResolved?.(
+        approval.approvalKey,
+        nextResolution,
+        toolCallId,
+        approval.askId,
+      );
+    } catch {
+      setSaveFailed(true);
+    } finally {
+      denyInFlight.current = false;
+      setIsResolving(false);
     }
   };
   return (
@@ -648,17 +706,8 @@ function ApprovalAffordance({
         <div className="inline-flex shrink-0 items-stretch">
           <button
             type="button"
-            disabled={isAlwaysAllowing}
-            onClick={() => {
-              setLocalResolution("approved");
-              ctx.onApprovalResolved?.(
-                approval.approvalKey,
-                "approved",
-                toolCallId,
-                approval.askId,
-              );
-              ctx.onApprove(approval.approvalKey);
-            }}
+            disabled={isResolving || hydrationBlocked}
+            onClick={() => void handleApprove()}
             className={cn(
               "inline-flex shrink-0 items-center gap-1 px-2.5 py-1 text-xs font-medium transition-colors",
               "bg-foreground text-background hover:bg-foreground/90",
@@ -674,7 +723,7 @@ function ApprovalAffordance({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  disabled={isAlwaysAllowing}
+                  disabled={isResolving || hydrationBlocked}
                   aria-label={t("agentChat.approval.moreOptions")}
                   title={t("agentChat.approval.moreOptions")}
                   className={cn(
@@ -700,17 +749,8 @@ function ApprovalAffordance({
       )}
       <button
         type="button"
-        disabled={isAlwaysAllowing}
-        onClick={() => {
-          setLocalResolution("denied");
-          ctx?.onApprovalResolved?.(
-            approval.approvalKey,
-            "denied",
-            toolCallId,
-            approval.askId,
-          );
-          ctx?.onDeny?.(approval.approvalKey);
-        }}
+        disabled={isResolving || hydrationBlocked}
+        onClick={() => void handleDeny()}
         className={cn(
           "inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors",
           "text-foreground hover:bg-muted",
@@ -720,9 +760,26 @@ function ApprovalAffordance({
         <IconX className="h-3.5 w-3.5" />
         {t("agentChat.approval.deny")}
       </button>
-      {alwaysAllowFailed && (
+      {saveFailed && (
         <span role="alert" className="basis-full text-xs text-destructive">
           {t("agentChat.common.saveFailed")}
+        </span>
+      )}
+      {ctx?.approvalHydrationStatus === "error" && (
+        <span
+          role="alert"
+          className="flex basis-full gap-2 text-xs text-destructive"
+        >
+          {t("agentChat.common.saveFailed")}
+          {ctx.onRetryApprovalResolutions && (
+            <button
+              type="button"
+              onClick={ctx.onRetryApprovalResolutions}
+              className="font-medium underline underline-offset-2"
+            >
+              {t("agentChat.common.retry")}
+            </button>
+          )}
         </span>
       )}
     </div>

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -158,6 +158,8 @@ export type ApprovalContextValue = {
     toolName: string,
     askId?: string,
   ) => ApprovalResolution | void | Promise<ApprovalResolution | void>;
+  /** Whether this caller has editor access to resolve durable approvals. */
+  canResolveApprovals?: boolean;
   approvalHydrationStatus?: "loading" | "ready" | "error";
   onRetryApprovalResolutions?: () => void;
 };
@@ -594,8 +596,11 @@ function ApprovalAffordance({
   const approveInFlight = React.useRef(false);
   const denyInFlight = React.useRef(false);
   const [saveFailed, setSaveFailed] = useState(false);
+  const canResolveApprovals = ctx?.canResolveApprovals !== false;
   const onAlwaysAllow =
-    approval.allowPersistentApproval === false ? undefined : ctx?.onAlwaysAllow;
+    approval.allowPersistentApproval === false || !canResolveApprovals
+      ? undefined
+      : ctx?.onAlwaysAllow;
   const retainedResolution =
     ctx?.getApprovalResolution?.(
       approval.approvalKey,
@@ -702,7 +707,7 @@ function ApprovalAffordance({
       <span className="min-w-0 flex-1 text-xs text-muted-foreground">
         {t("agentChat.approval.question", { tool: toolName })}
       </span>
-      {ctx && (
+      {ctx && canResolveApprovals && (
         <div className="inline-flex shrink-0 items-stretch">
           <button
             type="button"
@@ -747,19 +752,21 @@ function ApprovalAffordance({
           )}
         </div>
       )}
-      <button
-        type="button"
-        disabled={isResolving || hydrationBlocked}
-        onClick={() => void handleDeny()}
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors",
-          "text-foreground hover:bg-muted",
-          "disabled:pointer-events-none disabled:opacity-50",
-        )}
-      >
-        <IconX className="h-3.5 w-3.5" />
-        {t("agentChat.approval.deny")}
-      </button>
+      {(!ctx || canResolveApprovals) && (
+        <button
+          type="button"
+          disabled={isResolving || hydrationBlocked}
+          onClick={() => void handleDeny()}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2.5 py-1 text-xs font-medium transition-colors",
+            "text-foreground hover:bg-muted",
+            "disabled:pointer-events-none disabled:opacity-50",
+          )}
+        >
+          <IconX className="h-3.5 w-3.5" />
+          {t("agentChat.approval.deny")}
+        </button>
+      )}
       {saveFailed && (
         <span role="alert" className="basis-full text-xs text-destructive">
           {t("agentChat.common.saveFailed")}

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -7,6 +7,7 @@ import {
   finalizeClaimedAgentChatProcessRunFailure,
   handleSharedThreadRequest,
   isNetlifyRecurringJobsRuntime,
+  resolveAgentApprovalThreadScope,
   resolveRecurringJobsBuildMarker,
   scheduledTriggerAvailability,
   shouldDisableRecurringJobsRuntime,
@@ -99,6 +100,34 @@ const run: AgentRunSummary = {
   terminalReason: "done",
   diagStage: null,
 };
+
+describe("approval thread scope", () => {
+  it("uses the persisted owner and org after authorizing a shared editor", async () => {
+    const resolveAccess = vi.fn(async () =>
+      sharedThread({ orgId: "thread-org" }),
+    );
+
+    await expect(
+      resolveAgentApprovalThreadScope(
+        "editor@example.com",
+        "active-org",
+        "thread-1",
+        "editor",
+        resolveAccess,
+      ),
+    ).resolves.toEqual({
+      ownerEmail: "owner@example.com",
+      orgId: "thread-org",
+      threadId: "thread-1",
+    });
+    expect(resolveAccess).toHaveBeenCalledWith(
+      "editor@example.com",
+      "thread-1",
+      "editor",
+      { orgId: "active-org" },
+    );
+  });
+});
 
 describe("recurring jobs runtime startup", () => {
   it("disables background jobs in local development before scheduler and trigger load", () => {

--- a/packages/core/src/server/agent-chat-plugin.shared.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin.shared.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { agentToolApprovalPolicyBindingForThread } from "../agent/production-agent.js";
 import type { AgentRunSummary } from "../agent/run-store.js";
 import { CLAIMED_BACKGROUND_WORKER_FAILED_ERROR_EVENT } from "../agent/run-store.js";
 import type { ChatThread } from "../chat-threads/store.js";
@@ -107,18 +108,28 @@ describe("approval thread scope", () => {
       sharedThread({ orgId: "thread-org" }),
     );
 
-    await expect(
-      resolveAgentApprovalThreadScope(
-        "editor@example.com",
-        "active-org",
-        "thread-1",
-        "editor",
-        resolveAccess,
-      ),
-    ).resolves.toEqual({
+    const scope = await resolveAgentApprovalThreadScope(
+      "editor@example.com",
+      "active-org",
+      "thread-1",
+      "editor",
+      resolveAccess,
+    );
+    expect(scope).toEqual({
       ownerEmail: "owner@example.com",
       orgId: "thread-org",
       threadId: "thread-1",
+    });
+    expect(
+      agentToolApprovalPolicyBindingForThread(
+        "editor@example.com",
+        scope!,
+        "send-email",
+      ),
+    ).toEqual({
+      ownerEmail: "editor@example.com",
+      orgId: "thread-org",
+      toolName: "send-email",
     });
     expect(resolveAccess).toHaveBeenCalledWith(
       "editor@example.com",

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -78,6 +78,7 @@ import {
   filterActionsByAllowedNames,
   normalizeAgentActionSurfaceResolution,
   readPersistedActionSurface,
+  resolveAgentApprovalThreadScope as resolveProductionAgentApprovalThreadScope,
   toolCallCacheKey,
   getActiveRunForThreadAsync,
   abortRunDurably,
@@ -109,6 +110,10 @@ import {
   upsertUserMessage,
 } from "../agent/thread-data-builder.js";
 import { appendThreadDebugHistory } from "../agent/thread-debug-history.js";
+import {
+  denyAgentToolApproval,
+  listAgentToolApprovalResolutions,
+} from "../agent/tool-approval-store.js";
 import { attachToolSearch } from "../agent/tool-search.js";
 import type {
   AgentChatAttachment,
@@ -455,6 +460,22 @@ export function resolveInteractiveAgentRunOptions(
     runNoProgressTimeoutMs: options?.runNoProgressTimeoutMs,
     durableBackgroundRuns: options?.durableBackgroundRuns,
   };
+}
+
+export async function resolveAgentApprovalThreadScope(
+  callerEmail: string,
+  activeOrgId: string | null | undefined,
+  threadId: string,
+  role: "viewer" | "editor",
+  resolveAccess: typeof resolveThreadAccess = resolveThreadAccess,
+) {
+  return resolveProductionAgentApprovalThreadScope(
+    callerEmail,
+    activeOrgId,
+    threadId,
+    role,
+    resolveAccess,
+  );
 }
 
 export function createSerializedA2ATaskStatusWriter(
@@ -5235,6 +5256,53 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       );
 
       // ─── Run management endpoints (for hot-reload resilience) ─────────────
+
+      getH3App(nitroApp).use(
+        `${routePath}/approvals`,
+        withTransientDatabaseFallback(
+          `${routePath}/approvals`,
+          async (event) => {
+            const ownerEmail = await getOwnerFromEvent(event);
+            const orgId = await getOrgIdFromEvent(event);
+            const method = getMethod(event);
+            const body = method === "POST" ? await readBody(event) : null;
+            const threadId = String(
+              method === "GET"
+                ? (getQuery(event).threadId ?? "")
+                : (body?.threadId ?? ""),
+            );
+            const approvalScope = await resolveAgentApprovalThreadScope(
+              ownerEmail,
+              orgId,
+              threadId,
+              method === "GET" ? "viewer" : "editor",
+            );
+            if (!threadId || !approvalScope) {
+              setResponseStatus(event, 404);
+              return { error: "Thread not found" };
+            }
+            if (method === "GET") {
+              return {
+                resolutions:
+                  await listAgentToolApprovalResolutions(approvalScope),
+              };
+            }
+            if (method !== "POST" || typeof body?.approvalId !== "string") {
+              setResponseStatus(event, 400);
+              return { error: "approvalId required" };
+            }
+            const resolution = await denyAgentToolApproval({
+              ...approvalScope,
+              approvalId: body.approvalId,
+            });
+            if (!resolution) {
+              setResponseStatus(event, 404);
+              return { error: "Approval not found" };
+            }
+            return { resolution };
+          },
+        ),
+      );
 
       // GET /runs/active?threadId=X — check if there's an active run for a thread
       getH3App(nitroApp).use(

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -111,6 +111,8 @@ import {
 } from "../agent/thread-data-builder.js";
 import { appendThreadDebugHistory } from "../agent/thread-debug-history.js";
 import {
+  alwaysAllowAgentToolApproval,
+  approveAgentToolApproval,
   denyAgentToolApproval,
   listAgentToolApprovalResolutions,
 } from "../agent/tool-approval-store.js";
@@ -132,6 +134,7 @@ import {
   registerChatThreadsShareable,
   resolveRunThreadScope,
   resolveThreadAccess,
+  resolveThreadAccessIdentity,
   listThreads,
   searchThreads,
   renameThread,
@@ -467,7 +470,7 @@ export async function resolveAgentApprovalThreadScope(
   activeOrgId: string | null | undefined,
   threadId: string,
   role: "viewer" | "editor",
-  resolveAccess: typeof resolveThreadAccess = resolveThreadAccess,
+  resolveAccess: typeof resolveThreadAccessIdentity = resolveThreadAccessIdentity,
 ) {
   return resolveProductionAgentApprovalThreadScope(
     callerEmail,
@@ -5271,12 +5274,22 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                 ? (getQuery(event).threadId ?? "")
                 : (body?.threadId ?? ""),
             );
-            const approvalScope = await resolveAgentApprovalThreadScope(
+            const editorScope = await resolveAgentApprovalThreadScope(
               ownerEmail,
               orgId,
               threadId,
-              method === "GET" ? "viewer" : "editor",
+              "editor",
             );
+            const approvalScope =
+              editorScope ??
+              (method === "GET"
+                ? await resolveAgentApprovalThreadScope(
+                    ownerEmail,
+                    orgId,
+                    threadId,
+                    "viewer",
+                  )
+                : null);
             if (!threadId || !approvalScope) {
               setResponseStatus(event, 404);
               return { error: "Thread not found" };
@@ -5285,21 +5298,53 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
               return {
                 resolutions:
                   await listAgentToolApprovalResolutions(approvalScope),
+                canResolve: Boolean(editorScope),
               };
             }
             if (method !== "POST" || typeof body?.approvalId !== "string") {
               setResponseStatus(event, 400);
               return { error: "approvalId required" };
             }
-            const resolution = await denyAgentToolApproval({
-              ...approvalScope,
-              approvalId: body.approvalId,
-            });
+            const operation = body?.operation ?? "deny";
+            let resolution;
+            if (operation === "approve") {
+              resolution = await approveAgentToolApproval({
+                ...approvalScope,
+                approvalId: body.approvalId,
+              });
+            } else if (operation === "always_allow") {
+              if (typeof body?.toolName !== "string" || !body.toolName.trim()) {
+                setResponseStatus(event, 400);
+                return { error: "toolName required" };
+              }
+              resolution = await alwaysAllowAgentToolApproval({
+                approval: {
+                  ...approvalScope,
+                  approvalId: body.approvalId,
+                },
+                policy: {
+                  ownerEmail,
+                  orgId,
+                  toolName: body.toolName,
+                },
+              });
+            } else if (operation === "deny") {
+              resolution = await denyAgentToolApproval({
+                ...approvalScope,
+                approvalId: body.approvalId,
+              });
+            } else {
+              setResponseStatus(event, 400);
+              return { error: "Invalid approval operation" };
+            }
             if (!resolution) {
               setResponseStatus(event, 404);
               return { error: "Approval not found" };
             }
-            return { resolution };
+            return {
+              resolution: resolution === "consumed" ? "approved" : resolution,
+              ...(resolution === "consumed" ? { consumed: true } : {}),
+            };
           },
         ),
       );

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -73,6 +73,7 @@ import type { EngineMessage } from "../agent/engine/types.js";
 import { hostedHarnessSystemPrompt } from "../agent/harness/hosted.js";
 import {
   createProductionAgentHandler,
+  agentToolApprovalPolicyBindingForThread,
   actionsToEngineTools,
   executeAgentToolCall,
   filterActionsByAllowedNames,
@@ -5322,11 +5323,11 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
                   ...approvalScope,
                   approvalId: body.approvalId,
                 },
-                policy: {
+                policy: agentToolApprovalPolicyBindingForThread(
                   ownerEmail,
-                  orgId,
-                  toolName: body.toolName,
-                },
+                  approvalScope,
+                  body.toolName,
+                ),
               });
             } else if (operation === "deny") {
               resolution = await denyAgentToolApproval({


### PR DESCRIPTION
### Summary

* Persist `needsApproval` decisions in the existing server-side approval store and rehydrate them after reloads/remounts.
* Bind continuations to the exact durable ask so Deny, Approve, Always Allow, retries, and concurrent tabs resolve through one authoritative state machine.
* Keep terminal decisions as durable tombstones so denied calls never execute later and consumed approvals never execute twice.

### Why

`Deny` was previously stored only in local React state. Reloading a thread therefore rendered the same approval as unresolved, while stale or concurrent approval attempts could race the UI and reach the tool gate again.

Approval is a security boundary: the server must authoritatively decide each exact ask, denial must be terminal, and a consumed approval must not be replayable.

### Changes

* Reuse `agent_tool_approvals`; no migration, local-storage fallback, or second persistence source.
* Add backwards-compatible optional `approvalId` transport for exact ask/turn recovery; older clients keep the unique pending-key path.
* Atomically transition pending asks for Approve and Deny. Always Allow claims the ask and writes the caller-scoped policy in the same transaction/atomic batch.
* Treat consumed approvals as terminal and short-circuit duplicate continuations without executing or minting a replacement ask.
* Keep denied/consumed rows as durable tombstones and hydrate only terminal decisions.
* Fail closed on inaccessible durable approval routes or malformed success payloads; retain the legacy custom-route fallback only for transcripts without durable ask IDs.
* Expose editor capability to shared viewers and hide mutating approval controls for viewer-only access.
* Use projected thread-access identity instead of loading full transcript blobs for approval authorization.
* Remove the framework-generated waiting sentence after resolution while preserving unrelated assistant text.
* Preserve optional host hooks, action-type policies, Code Sessions, older threads, multiple pending asks, and the existing public request shape.
* Add a Core patch changeset.

### Tests

* [x] Unit tests: focused approval regression suites
  * Latest focused rerun: 7 files passed; 727 tests passed
  * Full focused matrix: 6 files passed; 463 tests passed
  * Covers Deny/Reload, Approve/Reload, stale races, consumed replay, Always Allow atomicity, double clicks, malformed responses, viewer controls, older clients, and independent pending asks
* [x] Integration/E2E: manual browser verification against the real chat template on isolated port `9287`
  * Deny remains terminal after reload and the marker action does not run
  * Resolved denial no longer shows the stale waiting sentence
  * A later identical request receives a fresh independent approval
  * Approve executes once after a rapid double click and remains resolved after reload
  * No `Save failed` state or browser console errors
* [x] Full Core suite
  * 922 files passed, 1 skipped
  * 13,055 tests passed, 2 skipped
* [x] Lint/format/typecheck
  * Full workspace typecheck passed
  * Core build and dist-import check passed
  * Repository guards: 64/64 passed
  * All changed files pass `oxfmt --check`; repository-wide format check is currently blocked only by pre-existing formatting drift in `packages/core/docs/content/webmcp.mdx`, which this PR does not modify
* [x] Changeset: `pnpm changeset:status`

### Risk / Rollback

* Risk: Moderate-to-high because this is security-sensitive execution gating, but the scope is contained to the existing Core approval path. There is no schema migration, new storage system, app-specific behavior, patch, override, or deep import.
* Mitigations: exact ask binding, atomic server transitions, terminal replay protection, backwards-compatible optional transport, focused race coverage, full Core tests, workspace typecheck/guards/build, and real browser verification.
* Rollback plan: Revert the four approval commits. Existing approval rows remain schema-compatible and require no data cleanup.

### Checklist

* [x] No secrets/credentials added
* [x] Backwards compatible; no migration required
* [x] Docs updated if needed: Core changeset added; no public API documentation change required
* [x] Existing host hooks, approval policies, Code Sessions, and shared-thread access preserved
* [x] No app-specific changes, patches, overrides, deep imports, or `node_modules` modifications
