### PR TITLE
Fix Clips uploads for new Builder connections

### DIFF
--- a/.changeset/builder-oauth-asset-uploads.md
+++ b/.changeset/builder-oauth-asset-uploads.md
@@ -1,0 +1,16 @@
+---
+"@agent-native/core": patch
+---
+
+Fix file uploads for Builder connections made through OAuth. New connections
+store only an OAuth grant, but the upload provider and the storage capability
+gates still looked for a legacy `bpk-` private key, so uploads failed for every
+newly connected user.
+
+Builder OAuth now also requests `builder:assets:write`, the scope its
+`/api/v1/upload/*` endpoints enforce, and the upload provider sends the OAuth
+token when the request's owner has a grant — falling back to a private key only
+when there is no grant at all.
+
+Already-connected users must authorize Builder once more to pick up the new
+scope.

--- a/packages/core/src/file-upload/builder.oauth.spec.ts
+++ b/packages/core/src/file-upload/builder.oauth.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * The Builder upload provider was private-key-only long after new Builder
+ * connections stopped issuing one, so an OAuth-connected user could not store a
+ * file at all. These cases pin which credential actually reaches Builder.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { builderFileUploadProvider } from "./builder.js";
+
+const resolveBuilderApiAuthorizationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/builder-api-auth.js", () => ({
+  resolveBuilderApiAuthorization: resolveBuilderApiAuthorizationMock,
+}));
+
+const ASSETS_WRITE = "builder:assets:write";
+const OAUTH_HEADER = "Bearer <OAUTH_TOKEN_EXAMPLE>";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: new Headers(),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("builderFileUploadProvider over Builder OAuth", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveBuilderApiAuthorizationMock.mockResolvedValue(OAUTH_HEADER);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("uploads a small file with the OAuth token and the asset scope", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ url: "https://cdn.builder.io/abc", id: "abc" }),
+    );
+
+    await expect(
+      builderFileUploadProvider.upload({
+        data: new Uint8Array([1, 2, 3]),
+        filename: "a.png",
+        mimeType: "image/png",
+      }),
+    ).resolves.toMatchObject({ url: "https://cdn.builder.io/abc" });
+
+    expect(resolveBuilderApiAuthorizationMock).toHaveBeenCalledWith(
+      ASSETS_WRITE,
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe(OAUTH_HEADER);
+  });
+
+  it("opens a resumable session with the OAuth token", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uploadUrl: "https://storage.googleapis.com/signed",
+          assetId: "asset-1",
+          requiredHeaders: {},
+        }),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({
+          location: "https://storage.googleapis.com/session",
+        }),
+        text: async () => "",
+      } as unknown as Response);
+
+    await expect(
+      builderFileUploadProvider.resumable!.startSession(
+        "clip.webm",
+        "video/webm",
+        1024,
+      ),
+    ).resolves.toMatchObject({
+      sessionId: "https://storage.googleapis.com/session",
+      meta: { assetId: "asset-1" },
+    });
+
+    const [signedUrlCall] = fetchMock.mock.calls;
+    expect(signedUrlCall[1].headers.Authorization).toBe(OAUTH_HEADER);
+  });
+
+  it("completes a resumable session with the OAuth token", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ url: "https://cdn.builder.io/clip.webm" }),
+    );
+
+    await expect(
+      builderFileUploadProvider.resumable!.completeSession(
+        { sessionId: "https://storage.googleapis.com/session", meta: {} },
+        "clip.webm",
+      ),
+    ).resolves.toBe("https://cdn.builder.io/clip.webm");
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe(OAUTH_HEADER);
+  });
+
+  it("never sends a request when the grant cannot authorize the call", async () => {
+    const reconnect = new Error(
+      "Builder.io access needs re-authorizing to grant builder:assets:write.",
+    );
+    resolveBuilderApiAuthorizationMock.mockRejectedValue(reconnect);
+
+    await expect(
+      builderFileUploadProvider.resumable!.startSession(
+        "clip.webm",
+        "video/webm",
+        1024,
+      ),
+    ).rejects.toBe(reconnect);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/file-upload/builder.spec.ts
+++ b/packages/core/src/file-upload/builder.spec.ts
@@ -4,6 +4,11 @@ import { builderFileUploadProvider } from "./builder.js";
 
 const resolveBuilderCredentialsMock = vi.hoisted(() => vi.fn());
 const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
+const resolveBuilderApiAuthorizationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/builder-api-auth.js", () => ({
+  resolveBuilderApiAuthorization: resolveBuilderApiAuthorizationMock,
+}));
 
 vi.mock("../server/credential-provider.js", () => ({
   resolveBuilderCredentials: resolveBuilderCredentialsMock,
@@ -46,6 +51,7 @@ describe("builderFileUploadProvider", () => {
       publicKey: "public-key",
     });
     resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-secret");
+    resolveBuilderApiAuthorizationMock.mockResolvedValue("Bearer bpk-secret");
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
   });
@@ -87,7 +93,9 @@ describe("builderFileUploadProvider", () => {
   });
 
   it("throws when no Builder credential resolves", async () => {
-    resolveBuilderPrivateKeyMock.mockResolvedValue(null);
+    resolveBuilderApiAuthorizationMock.mockRejectedValue(
+      new Error("Builder.io is not connected."),
+    );
     await expect(
       builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
     ).rejects.toThrow(/Builder\.io is not connected/);

--- a/packages/core/src/file-upload/builder.spec.ts
+++ b/packages/core/src/file-upload/builder.spec.ts
@@ -86,11 +86,11 @@ describe("builderFileUploadProvider", () => {
     });
   });
 
-  it("throws when no private key resolves", async () => {
+  it("throws when no Builder credential resolves", async () => {
     resolveBuilderPrivateKeyMock.mockResolvedValue(null);
     await expect(
       builderFileUploadProvider.upload({ data: new Uint8Array([1]) }),
-    ).rejects.toThrow(/BUILDER_PRIVATE_KEY is not set/);
+    ).rejects.toThrow(/Builder\.io is not connected/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -252,11 +252,6 @@ export const builderFileUploadProvider: FileUploadProvider = {
   id: "builder",
   name: "Builder.io",
   isConfigured: () => !!process.env.BUILDER_PRIVATE_KEY,
-  // isConfiguredForRequest: async () => {
-  //   const { hasBuilderApiCredentialCustody } =
-  //     await import("../server/builder-api-auth.js");
-  //   return hasBuilderApiCredentialCustody();
-  // },
   upload: async (input: FileUploadInput) => {
     const { data, filename, mimeType } = input;
     const authorization = await assetAuthorization();

--- a/packages/core/src/file-upload/builder.ts
+++ b/packages/core/src/file-upload/builder.ts
@@ -67,7 +67,7 @@ async function assertOk(res: Response, label: string): Promise<void> {
 
 async function uploadLargeFileViaSignedUrl(
   input: FileUploadInput,
-  privateKey: string,
+  authorization: string,
   bareMimeType: string,
   bytes: Uint8Array,
 ): Promise<FileUploadResult> {
@@ -81,7 +81,7 @@ async function uploadLargeFileViaSignedUrl(
   // Step 1 — request a signed URL.
   console.log(`[builder-upload] step 1: requesting signed URL`);
   const { uploadUrl, assetId, requiredHeaders } = await requestBuilderSignedUrl(
-    privateKey,
+    authorization,
     name,
     bareMimeType,
     bytes.byteLength,
@@ -106,7 +106,7 @@ async function uploadLargeFileViaSignedUrl(
     `[builder-upload] step 3: registering asset - ${assetId}, ${input.filename}`,
   );
   const { url, id } = await completeBuilderUpload(
-    privateKey,
+    authorization,
     assetId,
     input.filename,
     {
@@ -119,7 +119,7 @@ async function uploadLargeFileViaSignedUrl(
 }
 
 async function requestBuilderSignedUrl(
-  privateKey: string,
+  authorization: string,
   filename: string,
   mimeType: string,
   size: number,
@@ -134,7 +134,7 @@ async function requestBuilderSignedUrl(
   const res = await fetchWithTimeout(url.toString(), {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${privateKey}`,
+      Authorization: authorization,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -163,7 +163,7 @@ async function requestBuilderSignedUrl(
 }
 
 async function completeBuilderUpload(
-  privateKey: string,
+  authorization: string,
   assetId: string,
   filename: string | undefined,
   options?: { stableUrl?: boolean; recordAsset?: boolean },
@@ -177,7 +177,7 @@ async function completeBuilderUpload(
   const res = await fetchWithTimeout(url.toString(), {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${privateKey}`,
+      Authorization: authorization,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -227,9 +227,23 @@ async function uploadSmallFile(url: URL, init: RequestInit): Promise<Response> {
 }
 
 /**
+ * Builder gates every `/api/v1/upload/*` endpoint on `builder:assets:write`.
+ * Legacy `bpk-` keys skip that check, which is why uploads kept working for
+ * older connections while OAuth-only ones could not upload at all.
+ */
+async function assetAuthorization(): Promise<string> {
+  const [{ resolveBuilderApiAuthorization }, { BUILDER_ASSETS_WRITE_SCOPE }] =
+    await Promise.all([
+      import("../server/builder-api-auth.js"),
+      import("../server/builder-oauth.js"),
+    ]);
+  return resolveBuilderApiAuthorization(BUILDER_ASSETS_WRITE_SCOPE);
+}
+
+/**
  * Built-in Builder.io file upload provider.
- * Uses the same BUILDER_PRIVATE_KEY as the browser/background-agent flows,
- * so connecting Builder once (via the sidebar "Connect Builder" action)
+ * Uses the same Builder connection as the browser/background-agent flows, so
+ * connecting Builder once (via the sidebar "Connect Builder" action)
  * automatically enables file uploads.
  *
  * Upload API: https://www.builder.io/c/docs/upload-api
@@ -238,14 +252,14 @@ export const builderFileUploadProvider: FileUploadProvider = {
   id: "builder",
   name: "Builder.io",
   isConfigured: () => !!process.env.BUILDER_PRIVATE_KEY,
+  // isConfiguredForRequest: async () => {
+  //   const { hasBuilderApiCredentialCustody } =
+  //     await import("../server/builder-api-auth.js");
+  //   return hasBuilderApiCredentialCustody();
+  // },
   upload: async (input: FileUploadInput) => {
     const { data, filename, mimeType } = input;
-    const { resolveBuilderPrivateKey } =
-      await import("../server/credential-provider.js");
-    const privateKey = await resolveBuilderPrivateKey();
-    if (!privateKey) {
-      throw new Error("BUILDER_PRIVATE_KEY is not set");
-    }
+    const authorization = await assetAuthorization();
 
     // Strip any media-type parameters (e.g. `;codecs=avc1,opus` from
     // MediaRecorder blobs) — Builder's upload API parses the body as raw
@@ -264,7 +278,7 @@ export const builderFileUploadProvider: FileUploadProvider = {
     if (shouldUseSignedUrlUpload(bytes, bareMimeType)) {
       return uploadLargeFileViaSignedUrl(
         input,
-        privateKey,
+        authorization,
         bareMimeType,
         bytes,
       );
@@ -284,7 +298,7 @@ export const builderFileUploadProvider: FileUploadProvider = {
     const response = await uploadSmallFile(url, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${privateKey}`,
+        Authorization: authorization,
         "Content-Type": bareMimeType,
       },
       body: makeBody(bytes, bareMimeType),
@@ -329,17 +343,14 @@ export const builderFileUploadProvider: FileUploadProvider = {
 
   resumable: {
     async startSession(filename, mimeType, maxBytes) {
-      const { resolveBuilderPrivateKey } =
-        await import("../server/credential-provider.js");
-      const privateKey = await resolveBuilderPrivateKey();
-      if (!privateKey) throw new Error("BUILDER_PRIVATE_KEY is not set");
+      const authorization = await assetAuthorization();
 
       console.log(
         `[builder-resumable] starting session: ${filename} ${mimeType} ${maxBytes} bytes`,
       );
       const { uploadUrl, assetId, requiredHeaders } =
         await requestBuilderSignedUrl(
-          privateKey,
+          authorization,
           filename,
           mimeType,
           maxBytes,
@@ -433,15 +444,12 @@ export const builderFileUploadProvider: FileUploadProvider = {
     },
 
     async completeSession(session, filename, options) {
-      const { resolveBuilderPrivateKey } =
-        await import("../server/credential-provider.js");
-      const privateKey = await resolveBuilderPrivateKey();
-      if (!privateKey) throw new Error("BUILDER_PRIVATE_KEY is not set");
+      const authorization = await assetAuthorization();
 
       const assetId = session.meta.assetId as string;
       console.log(`[builder-resumable] completing upload: assetId=${assetId}`);
       const { url } = await completeBuilderUpload(
-        privateKey,
+        authorization,
         assetId,
         filename,
         {

--- a/packages/core/src/file-upload/registry.spec.ts
+++ b/packages/core/src/file-upload/registry.spec.ts
@@ -12,11 +12,9 @@ import {
 import type { FileUploadProvider } from "./types.js";
 
 const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
-const resolveHasBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../server/credential-provider.js", () => ({
   resolveBuilderPrivateKey: resolveBuilderPrivateKeyMock,
-  resolveHasBuilderPrivateKey: resolveHasBuilderPrivateKeyMock,
 }));
 
 function makeProvider(
@@ -133,12 +131,12 @@ describe("file-upload registry", () => {
     });
 
     it("resolves a request-scoped Builder connection", async () => {
-      resolveHasBuilderPrivateKeyMock.mockResolvedValue(true);
+      resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-secret");
 
       await expect(getActiveFileUploadProviderForRequest()).resolves.toBe(
         builderFileUploadProvider,
       );
-      expect(resolveHasBuilderPrivateKeyMock).toHaveBeenCalled();
+      expect(resolveBuilderPrivateKeyMock).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/file-upload/registry.ts
+++ b/packages/core/src/file-upload/registry.ts
@@ -66,9 +66,11 @@ export async function getActiveFileUploadProviderForRequest(): Promise<FileUploa
     return builderFileUploadProvider;
   }
   try {
-    const { resolveHasBuilderPrivateKey } =
-      await import("../server/credential-provider.js");
-    if (await resolveHasBuilderPrivateKey()) {
+    // Either Builder credential kind counts. Checking only the private key
+    // reported every OAuth-only connection as having no upload provider.
+    const { hasBuilderApiCredentialCustody } =
+      await import("../server/builder-api-auth.js");
+    if (await hasBuilderApiCredentialCustody()) {
       return builderFileUploadProvider;
     }
   } catch {
@@ -109,21 +111,22 @@ export async function uploadFile(
   // via runWithRequestContext — actions always have one via action-routes.ts).
   // Two separate try-catch blocks ensure a real upload failure is never
   // silently swallowed as a "no credentials" case.
-  let builderKey: string | null = null;
+  let hasBuilderCredential = false;
   try {
-    const { resolveBuilderPrivateKey } =
-      await import("../server/credential-provider.js");
-    builderKey = await resolveBuilderPrivateKey();
+    const { hasBuilderApiCredentialCustody } =
+      await import("../server/builder-api-auth.js");
+    hasBuilderCredential = await hasBuilderApiCredentialCustody();
   } catch (err) {
-    // DB unavailable or credential store not ready — can't resolve key.
-    // Return an unavailable-provider state below; never fall back to SQL.
+    // DB unavailable or credential store not ready — can't resolve a
+    // credential. Return an unavailable-provider state below; never fall back
+    // to SQL.
     console.warn(
       "[agent-native] Builder credential check failed:",
       err instanceof Error ? err.message : String(err),
     );
   }
 
-  if (builderKey) {
+  if (hasBuilderCredential) {
     // Credentials confirmed — attempt the upload. Real errors (network,
     // API, rate-limit) propagate to the caller; do NOT catch them here.
     return await builderFileUploadProvider.upload(input);

--- a/packages/core/src/server/builder-api-auth.spec.ts
+++ b/packages/core/src/server/builder-api-auth.spec.ts
@@ -9,6 +9,7 @@ const getBuilderOAuthSessionMock = vi.hoisted(() => vi.fn());
 const hasBuilderOAuthSessionMock = vi.hoisted(() => vi.fn());
 const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
 const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
+const getRequestOrgIdMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./builder-oauth.js", () => ({
   getBuilderOAuthSession: getBuilderOAuthSessionMock,
@@ -19,6 +20,7 @@ vi.mock("./credential-provider.js", () => ({
 }));
 vi.mock("./request-context.js", () => ({
   getRequestUserEmail: getRequestUserEmailMock,
+  getRequestOrgId: getRequestOrgIdMock,
 }));
 
 const ASSETS_WRITE = "builder:assets:write";
@@ -26,6 +28,7 @@ const ASSETS_WRITE = "builder:assets:write";
 beforeEach(() => {
   vi.clearAllMocks();
   getRequestUserEmailMock.mockReturnValue("user@example.com");
+  getRequestOrgIdMock.mockReturnValue(undefined);
   hasBuilderOAuthSessionMock.mockResolvedValue(false);
   getBuilderOAuthSessionMock.mockResolvedValue(null);
   resolveBuilderPrivateKeyMock.mockResolvedValue(null);
@@ -84,6 +87,28 @@ describe("resolveBuilderApiAuthorization", () => {
   it("reports not connected when neither credential kind answers", async () => {
     await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).rejects.toThrow(
       /not connected/,
+    );
+  });
+
+  // The grant is org-scoped, so a recording that finalizes after the user
+  // switched active org must still authorize against its own org.
+  it("binds the lookup to the request organization, not the active one", async () => {
+    getRequestOrgIdMock.mockReturnValue("org-recording");
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+    getBuilderOAuthSessionMock.mockResolvedValue({
+      accessToken: "<OAUTH_TOKEN_EXAMPLE>",
+      scopes: ["builder:ai:invoke", ASSETS_WRITE],
+    });
+
+    await resolveBuilderApiAuthorization(ASSETS_WRITE);
+
+    expect(hasBuilderOAuthSessionMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "org-recording",
+    );
+    expect(getBuilderOAuthSessionMock).toHaveBeenCalledWith(
+      "user@example.com",
+      "org-recording",
     );
   });
 

--- a/packages/core/src/server/builder-api-auth.spec.ts
+++ b/packages/core/src/server/builder-api-auth.spec.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  hasBuilderApiCredentialCustody,
+  resolveBuilderApiAuthorization,
+} from "./builder-api-auth.js";
+
+const getBuilderOAuthSessionMock = vi.hoisted(() => vi.fn());
+const hasBuilderOAuthSessionMock = vi.hoisted(() => vi.fn());
+const resolveBuilderPrivateKeyMock = vi.hoisted(() => vi.fn());
+const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./builder-oauth.js", () => ({
+  getBuilderOAuthSession: getBuilderOAuthSessionMock,
+  hasBuilderOAuthSession: hasBuilderOAuthSessionMock,
+}));
+vi.mock("./credential-provider.js", () => ({
+  resolveBuilderPrivateKey: resolveBuilderPrivateKeyMock,
+}));
+vi.mock("./request-context.js", () => ({
+  getRequestUserEmail: getRequestUserEmailMock,
+}));
+
+const ASSETS_WRITE = "builder:assets:write";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRequestUserEmailMock.mockReturnValue("user@example.com");
+  hasBuilderOAuthSessionMock.mockResolvedValue(false);
+  getBuilderOAuthSessionMock.mockResolvedValue(null);
+  resolveBuilderPrivateKeyMock.mockResolvedValue(null);
+});
+
+describe("resolveBuilderApiAuthorization", () => {
+  it("uses the OAuth token when the grant carries the required scope", async () => {
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+    getBuilderOAuthSessionMock.mockResolvedValue({
+      accessToken: "<OAUTH_TOKEN_EXAMPLE>",
+      scopes: ["builder:ai:invoke", ASSETS_WRITE],
+    });
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-legacy");
+
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).resolves.toBe(
+      "Bearer <OAUTH_TOKEN_EXAMPLE>",
+    );
+    // OAuth wins outright — the legacy key is never even consulted.
+    expect(resolveBuilderPrivateKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("names the missing scope instead of falling back to a legacy key", async () => {
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+    getBuilderOAuthSessionMock.mockResolvedValue({
+      accessToken: "<OAUTH_TOKEN_EXAMPLE>",
+      scopes: ["builder:ai:invoke"],
+    });
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-legacy");
+
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).rejects.toThrow(
+      /needs re-authorizing to grant builder:assets:write/,
+    );
+    // Falling back here would let a deploy-level key act for a user who never
+    // authorized it.
+    expect(resolveBuilderPrivateKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("asks for re-authorization when custody exists but no session resolves", async () => {
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+    getBuilderOAuthSessionMock.mockResolvedValue(null);
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-legacy");
+
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).rejects.toThrow(
+      /access expired/,
+    );
+  });
+
+  it("uses the legacy private key when there is no OAuth grant", async () => {
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-legacy");
+
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).resolves.toBe(
+      "Bearer bpk-legacy",
+    );
+  });
+
+  it("reports not connected when neither credential kind answers", async () => {
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).rejects.toThrow(
+      /not connected/,
+    );
+  });
+
+  it("skips the OAuth lookup with no request owner", async () => {
+    getRequestUserEmailMock.mockReturnValue(undefined);
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-deploy");
+
+    await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).resolves.toBe(
+      "Bearer bpk-deploy",
+    );
+    expect(hasBuilderOAuthSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("hasBuilderApiCredentialCustody", () => {
+  // The reported bug: storage gates only knew about private keys, so every
+  // OAuth-only connection was treated as having no storage at all.
+  it("counts an OAuth grant with no private key as connected", async () => {
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+    resolveBuilderPrivateKeyMock.mockResolvedValue(null);
+
+    await expect(hasBuilderApiCredentialCustody()).resolves.toBe(true);
+  });
+
+  it("counts a narrow OAuth grant as connected so the upload path can explain", async () => {
+    hasBuilderOAuthSessionMock.mockResolvedValue(true);
+
+    await expect(hasBuilderApiCredentialCustody()).resolves.toBe(true);
+    expect(resolveBuilderPrivateKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("counts a legacy private key as connected", async () => {
+    resolveBuilderPrivateKeyMock.mockResolvedValue("bpk-legacy");
+
+    await expect(hasBuilderApiCredentialCustody()).resolves.toBe(true);
+  });
+
+  it("is false when nothing is connected", async () => {
+    await expect(hasBuilderApiCredentialCustody()).resolves.toBe(false);
+  });
+});

--- a/packages/core/src/server/builder-api-auth.ts
+++ b/packages/core/src/server/builder-api-auth.ts
@@ -13,7 +13,7 @@ import {
   hasBuilderOAuthSession,
 } from "./builder-oauth.js";
 import { resolveBuilderPrivateKey } from "./credential-provider.js";
-import { getRequestUserEmail } from "./request-context.js";
+import { getRequestOrgId, getRequestUserEmail } from "./request-context.js";
 
 /**
  * Resolve the `Authorization` header for a Builder asset API call.
@@ -29,9 +29,14 @@ export async function resolveBuilderApiAuthorization(
   requiredScope?: string,
 ): Promise<string> {
   const ownerEmail = getRequestUserEmail();
+  // Bind to the request's organization, not the user's currently active one:
+  // the grant is org-scoped, and a recording that finalizes after the user
+  // switched org must still authorize against the org it belongs to. The
+  // legacy private-key path already resolves this way.
+  const orgId = getRequestOrgId();
 
-  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) {
-    const session = await getBuilderOAuthSession(ownerEmail);
+  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail, orgId))) {
+    const session = await getBuilderOAuthSession(ownerEmail, orgId);
     if (!session) {
       throw new Error(
         "Builder.io access expired. Re-authorize Builder.io in Settings to continue.",
@@ -62,6 +67,11 @@ export async function resolveBuilderApiAuthorization(
  */
 export async function hasBuilderApiCredentialCustody(): Promise<boolean> {
   const ownerEmail = getRequestUserEmail();
-  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) return true;
+  if (
+    ownerEmail &&
+    (await hasBuilderOAuthSession(ownerEmail, getRequestOrgId()))
+  ) {
+    return true;
+  }
   return !!(await resolveBuilderPrivateKey());
 }

--- a/packages/core/src/server/builder-api-auth.ts
+++ b/packages/core/src/server/builder-api-auth.ts
@@ -1,0 +1,67 @@
+/**
+ * Authorization for Builder.io REST asset calls (`/api/v1/upload/*`).
+ *
+ * Two credential kinds reach those endpoints and they are not interchangeable:
+ * a legacy `bpk-` private key bypasses Builder's OAuth scope middleware
+ * entirely, while an OAuth access token is checked against the scopes its
+ * grant was issued with. New Builder connections store only an OAuth grant, so
+ * a caller that knows about private keys alone cannot upload for them at all.
+ */
+
+import {
+  getBuilderOAuthSession,
+  hasBuilderOAuthSession,
+} from "./builder-oauth.js";
+import { resolveBuilderPrivateKey } from "./credential-provider.js";
+import { getRequestUserEmail } from "./request-context.js";
+
+/**
+ * Resolve the `Authorization` header for a Builder asset API call.
+ *
+ * OAuth wins whenever the request's owner has a grant. An unusable grant
+ * throws rather than falling back to a private key: falling back would let a
+ * deploy-level or stale `bpk-` key act for a user who never authorized it.
+ *
+ * @param requiredScope OAuth scope the endpoint enforces. Omit for endpoints
+ * with no scope gate.
+ */
+export async function resolveBuilderApiAuthorization(
+  requiredScope?: string,
+): Promise<string> {
+  const ownerEmail = getRequestUserEmail();
+
+  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) {
+    const session = await getBuilderOAuthSession(ownerEmail);
+    if (!session) {
+      throw new Error(
+        "Builder.io access expired. Re-authorize Builder.io in Settings to continue.",
+      );
+    }
+    if (requiredScope && !session.scopes.includes(requiredScope)) {
+      throw new Error(
+        `Builder.io access needs re-authorizing to grant ${requiredScope}. Open Settings and authorize Builder.io again.`,
+      );
+    }
+    return `Bearer ${session.accessToken}`;
+  }
+
+  const privateKey = await resolveBuilderPrivateKey();
+  if (!privateKey) throw new Error("Builder.io is not connected.");
+  return `Bearer ${privateKey}`;
+}
+
+/**
+ * Whether Builder.io can authenticate an asset call for this request — an
+ * OAuth grant, or a legacy private key.
+ *
+ * Storage gates and provider selection use this. It intentionally does not
+ * verify the grant is usable: answering `false` for a connected user whose
+ * grant needs re-authorizing would report storage as unconfigured and send
+ * them to set up something they already have, instead of letting the upload
+ * path say what is actually wrong.
+ */
+export async function hasBuilderApiCredentialCustody(): Promise<boolean> {
+  const ownerEmail = getRequestUserEmail();
+  if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail))) return true;
+  return !!(await resolveBuilderPrivateKey());
+}

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
 });
 
 describe("Builder hosted user OAuth", () => {
-  it("uses the exact fixed Builder contract and one least-privilege scope", () => {
+  it("uses the exact fixed Builder contract and least-privilege scopes", () => {
     expect({
       issuer: BUILDER_OAUTH_ISSUER,
       resource: BUILDER_OAUTH_RESOURCE,
@@ -105,10 +105,12 @@ describe("Builder hosted user OAuth", () => {
     }).toEqual({
       issuer: "https://mcp.builder.io",
       resource: "https://api.builder.io",
-      scopes: ["builder:ai:invoke"],
+      // Uploads need the asset scope: Builder's /api/v1/upload/* endpoints
+      // enforce it, so without it a connected user cannot store a file.
+      scopes: ["builder:ai:invoke", "builder:assets:write"],
     });
     expect(BUILDER_OAUTH_SCOPES.join(" ")).not.toMatch(
-      /offline_access|project|design|browser|agent|assets/,
+      /offline_access|project|design|browser|agent/,
     );
   });
 
@@ -139,7 +141,7 @@ describe("Builder hosted user OAuth", () => {
       serverUrl: BUILDER_OAUTH_RESOURCE,
       redirectUrl: "https://app.example.com/_agent-native/builder/callback",
       state: "<STATE_EXAMPLE>",
-      scope: BUILDER_OAUTH_SCOPE,
+      scope: BUILDER_OAUTH_SCOPES.join(" "),
       resourceMetadataUrl:
         "https://mcp.builder.io/.well-known/oauth-protected-resource/api",
     });

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -376,6 +376,31 @@ describe("Builder hosted user OAuth", () => {
     ).rejects.toThrow("does not grant builder:assets:write");
   });
 
+  // A token response may omit `scope` when the grant matches the request
+  // (RFC 6749 §5.1). Assuming a narrower set there would tell the user to
+  // reconnect, hand them the identical grant, and loop forever.
+  it("assumes the requested scopes when the token response omits scope", async () => {
+    getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
+    readMock.mockResolvedValue(
+      credentials({
+        tokens: {
+          access_token: "<ACCESS_TOKEN_EXAMPLE>",
+          issuer: BUILDER_OAUTH_ISSUER,
+        },
+      }),
+    );
+
+    await expect(getBuilderOAuthSession(ownerEmail)).resolves.toMatchObject({
+      scopes: [...BUILDER_OAUTH_SCOPES],
+    });
+    await expect(
+      resolveBuilderOAuthRequestAccess({
+        ownerEmail,
+        requiredScope: "builder:assets:write",
+      }),
+    ).resolves.toMatchObject({ ownerEmail });
+  });
+
   it("fails closed for a credential whose issuer or resource binding changed", async () => {
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -179,6 +179,67 @@ describe("Builder hosted user OAuth", () => {
     );
   });
 
+  // Without this the grant's scopes would have to be guessed on every later
+  // read, and a new two-scope grant is indistinguishable from a legacy one.
+  it("records the requested scopes when the token response omits them", async () => {
+    const finished = credentials({
+      tokens: {
+        access_token: "<ACCESS_TOKEN_EXAMPLE>",
+        issuer: BUILDER_OAUTH_ISSUER,
+      },
+    });
+    finishMock.mockResolvedValue({ credentials: finished });
+
+    await finishBuilderOAuthAuthorization({
+      ownerEmail,
+      code: "<AUTHORIZATION_CODE_EXAMPLE>",
+      iss: BUILDER_OAUTH_ISSUER,
+      pending: {
+        codeVerifier: "<PKCE_VERIFIER_EXAMPLE>",
+        clientInformation: { client_id: "<CLIENT_ID_EXAMPLE>" },
+        discoveryState: finished.discoveryState,
+        redirectUri: "https://app.example.com/_agent-native/builder/callback",
+      },
+    });
+
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: expect.objectContaining({
+          tokens: expect.objectContaining({
+            scope: BUILDER_OAUTH_SCOPES.join(" "),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("leaves a declared scope claim untouched", async () => {
+    const finished = credentials({
+      tokens: {
+        access_token: "<ACCESS_TOKEN_EXAMPLE>",
+        scope: BUILDER_OAUTH_SCOPE,
+        issuer: BUILDER_OAUTH_ISSUER,
+      },
+    });
+    finishMock.mockResolvedValue({ credentials: finished });
+
+    await finishBuilderOAuthAuthorization({
+      ownerEmail,
+      code: "<AUTHORIZATION_CODE_EXAMPLE>",
+      iss: BUILDER_OAUTH_ISSUER,
+      pending: {
+        codeVerifier: "<PKCE_VERIFIER_EXAMPLE>",
+        clientInformation: { client_id: "<CLIENT_ID_EXAMPLE>" },
+        discoveryState: finished.discoveryState,
+        redirectUri: "https://app.example.com/_agent-native/builder/callback",
+      },
+    });
+
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.objectContaining({ credentials: finished }),
+    );
+  });
+
   it("does not accept a completed exchange bound to another resource", async () => {
     const finished = credentials({
       serverUrl: "https://unrelated.example.com",
@@ -376,10 +437,11 @@ describe("Builder hosted user OAuth", () => {
     ).rejects.toThrow("does not grant builder:assets:write");
   });
 
-  // A token response may omit `scope` when the grant matches the request
-  // (RFC 6749 §5.1). Assuming a narrower set there would tell the user to
-  // reconnect, hand them the identical grant, and loop forever.
-  it("assumes the requested scopes when the token response omits scope", async () => {
+  // A stored credential with no `scope` claim predates both Builder always
+  // setting one and this flow recording it, so it can only be an AI-only grant.
+  // Crediting it with the upload scope would trade a clear local error for an
+  // opaque 403 from Builder.
+  it("keeps a scope-less legacy credential AI-only", async () => {
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(
       credentials({
@@ -391,14 +453,14 @@ describe("Builder hosted user OAuth", () => {
     );
 
     await expect(getBuilderOAuthSession(ownerEmail)).resolves.toMatchObject({
-      scopes: [...BUILDER_OAUTH_SCOPES],
+      scopes: [BUILDER_OAUTH_SCOPE],
     });
     await expect(
       resolveBuilderOAuthRequestAccess({
         ownerEmail,
         requiredScope: "builder:assets:write",
       }),
-    ).resolves.toMatchObject({ ownerEmail });
+    ).rejects.toThrow("does not grant builder:assets:write");
   });
 
   it("fails closed for a credential whose issuer or resource binding changed", async () => {

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -17,7 +17,12 @@ import { resolveOrgIdForEmail } from "../org/context.js";
 export const BUILDER_OAUTH_ISSUER = "https://mcp.builder.io";
 export const BUILDER_OAUTH_RESOURCE = "https://api.builder.io";
 export const BUILDER_OAUTH_SCOPE = "builder:ai:invoke";
-export const BUILDER_OAUTH_SCOPES = [BUILDER_OAUTH_SCOPE] as const;
+/** Enforced by Builder's `/api/v1/upload/*` endpoints; without it, no uploads. */
+export const BUILDER_ASSETS_WRITE_SCOPE = "builder:assets:write";
+export const BUILDER_OAUTH_SCOPES = [
+  BUILDER_OAUTH_SCOPE,
+  BUILDER_ASSETS_WRITE_SCOPE,
+] as const;
 
 // Folded with the owner so each owner gets their own (provider, account_id)
 // row; a bare shared key would let only the first connector hold a grant.
@@ -94,7 +99,7 @@ function builderOAuthKey(orgId: string): string {
 
 function scopesFrom(credentials: McpOAuthCredentialBundle): string[] {
   const declared = credentials.tokens.scope;
-  if (typeof declared !== "string") return [...BUILDER_OAUTH_SCOPES];
+  if (typeof declared !== "string") return [BUILDER_OAUTH_SCOPE];
   return declared.split(/\s+/).filter(Boolean);
 }
 
@@ -143,7 +148,7 @@ export async function startBuilderOAuthAuthorization(input: {
     serverUrl: BUILDER_OAUTH_RESOURCE,
     redirectUrl: input.redirectUri,
     state: input.state,
-    scope: BUILDER_OAUTH_SCOPE,
+    scope: BUILDER_OAUTH_SCOPES.join(" "),
     resourceMetadataUrl: BUILDER_OAUTH_PROTECTED_RESOURCE_METADATA,
   });
   return {

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -99,7 +99,7 @@ function builderOAuthKey(orgId: string): string {
 
 function scopesFrom(credentials: McpOAuthCredentialBundle): string[] {
   const declared = credentials.tokens.scope;
-  if (typeof declared !== "string") return [BUILDER_OAUTH_SCOPE];
+  if (typeof declared !== "string") return [...BUILDER_OAUTH_SCOPES];
   return declared.split(/\s+/).filter(Boolean);
 }
 

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -64,11 +64,16 @@ function normalizeOwnerEmail(ownerEmail: string): string {
 
 // Read paths use this: a caller with no org simply has no Builder session, so
 // engine detection and status checks get null instead of an exception.
-async function resolveOwnerOptions(ownerEmail: string) {
+//
+// An explicit orgId wins over the user's active org. The grant is org-scoped,
+// so work that carries its own organization — a recording finalizing after the
+// user switched active org, a background run — must authorize against that org
+// rather than whichever one the user happens to be looking at now.
+async function resolveOwnerOptions(ownerEmail: string, orgId?: string | null) {
   const email = normalizeOwnerEmail(ownerEmail);
-  const orgId = await resolveOrgIdForEmail(email);
-  if (!orgId) return null;
-  return orgOwnerOptions(orgId);
+  const resolvedOrgId = orgId?.trim() || (await resolveOrgIdForEmail(email));
+  if (!resolvedOrgId) return null;
+  return orgOwnerOptions(resolvedOrgId);
 }
 
 // Write paths use this: storing a Builder credential without an org is a broken
@@ -97,9 +102,29 @@ function builderOAuthKey(orgId: string): string {
   return `${BUILDER_OAUTH_KEY}:o:${digest}`;
 }
 
+/**
+ * RFC 6749 §5.1 lets a token response omit `scope` when the grant matches what
+ * was requested. Record what this flow asked for, so a stored credential always
+ * states its own scopes: inferring them later cannot tell a new two-scope grant
+ * from a pre-change AI-only one, and either guess is wrong for the other.
+ */
+function withRecordedScopes(
+  credentials: McpOAuthCredentialBundle,
+): McpOAuthCredentialBundle {
+  if (typeof credentials.tokens.scope === "string") return credentials;
+  return {
+    ...credentials,
+    tokens: { ...credentials.tokens, scope: BUILDER_OAUTH_SCOPES.join(" ") },
+  };
+}
+
+// Builder's token endpoint always sets `scope`, and `withRecordedScopes` backs
+// that up for anything this flow stores, so an absent claim can only be a grant
+// predating both. Those were AI-only and must not be credited with an upload
+// scope the user never consented to.
 function scopesFrom(credentials: McpOAuthCredentialBundle): string[] {
   const declared = credentials.tokens.scope;
-  if (typeof declared !== "string") return [...BUILDER_OAUTH_SCOPES];
+  if (typeof declared !== "string") return [BUILDER_OAUTH_SCOPE];
   return declared.split(/\s+/).filter(Boolean);
 }
 
@@ -192,7 +217,7 @@ export async function finishBuilderOAuthAuthorization(input: {
     ...(input.orgId
       ? orgOwnerOptions(input.orgId)
       : await ownerOptions(input.ownerEmail)),
-    credentials: result.credentials,
+    credentials: withRecordedScopes(result.credentials),
   });
 }
 
@@ -206,8 +231,9 @@ export async function markBuilderOAuthReconnectRequired(
 
 export async function getBuilderOAuthSession(
   ownerEmail: string,
+  orgId?: string | null,
 ): Promise<BuilderOAuthSession | null> {
-  const options = await resolveOwnerOptions(ownerEmail);
+  const options = await resolveOwnerOptions(ownerEmail, orgId);
   if (!options) return null;
   // Delegates refresh single-flight and reconnect latching to the shared
   // credential lifecycle; a null token covers missing, expired-unrefreshable,
@@ -225,8 +251,9 @@ export async function getBuilderOAuthSession(
 
 export async function hasBuilderOAuthSession(
   ownerEmail: string,
+  orgId?: string | null,
 ): Promise<boolean> {
-  const options = await resolveOwnerOptions(ownerEmail);
+  const options = await resolveOwnerOptions(ownerEmail, orgId);
   if (!options) return false;
   const stored = await getOAuthTokens(
     "mcp",

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -3878,11 +3878,12 @@ export function createCoreRoutesPlugin(
             const active = await getActiveFileUploadProviderForRequest();
             let builderConfigured = !!process.env.BUILDER_PRIVATE_KEY;
             try {
-              const { resolveBuilderPrivateKey } =
-                await import("./credential-provider.js");
-              builderConfigured = await resolveBuilderPrivateKey().then(
-                (k) => !!k,
-              );
+              // Must match what provider selection asks, or this reports
+              // storage as unconfigured for an OAuth-only connection whose
+              // uploads actually work.
+              const { hasBuilderApiCredentialCustody } =
+                await import("./builder-api-auth.js");
+              builderConfigured = await hasBuilderApiCredentialCustody();
             } catch {
               // fall back to env check above
             }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -571,6 +571,11 @@ export {
   type BuilderCredentialsDetailed,
 } from "./credential-provider.js";
 export {
+  hasBuilderApiCredentialCustody,
+  resolveBuilderApiAuthorization,
+} from "./builder-api-auth.js";
+export { BUILDER_ASSETS_WRITE_SCOPE } from "./builder-oauth.js";
+export {
   builderDesignSystemUrl,
   builderProjectBranchUrl,
   buildBuilderDesignSystemIndexFiles,

--- a/templates/clips/actions/create-recording.ts
+++ b/templates/clips/actions/create-recording.ts
@@ -172,8 +172,15 @@ export default defineAction({
         );
       } catch (err) {
         if (streamingRequired) {
+          // Keep the underlying reason. A Builder connection that needs
+          // re-authorizing is not fixed by refreshing, and replacing its
+          // message with a retry prompt is why that case looked like a
+          // random failure.
+          const reason = err instanceof Error ? err.message.trim() : "";
           await failUploadSetup(
-            "Video storage could not start a resumable upload session. Refresh and try again.",
+            reason
+              ? `Video storage could not start an upload: ${reason}`
+              : "Video storage could not start a resumable upload session. Refresh and try again.",
           );
         }
         console.warn(

--- a/templates/clips/server/lib/resumable-upload-provider.test.ts
+++ b/templates/clips/server/lib/resumable-upload-provider.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getActive: vi.fn(),
   list: vi.fn(),
-  resolveHasBuilderPrivateKey: vi.fn(),
+  hasBuilderApiCredentialCustody: vi.fn(),
   builder: {
     id: "builder",
     name: "Builder.io",
@@ -21,8 +21,8 @@ vi.mock("@agent-native/core/file-upload", () => ({
 }));
 
 vi.mock("@agent-native/core/server", () => ({
-  resolveHasBuilderPrivateKey: (...args: unknown[]) =>
-    mocks.resolveHasBuilderPrivateKey(...args),
+  hasBuilderApiCredentialCustody: (...args: unknown[]) =>
+    mocks.hasBuilderApiCredentialCustody(...args),
 }));
 
 import { resolveResumableUploadProvider } from "./resumable-upload-provider.js";
@@ -32,7 +32,7 @@ describe("resolveResumableUploadProvider", () => {
     vi.clearAllMocks();
     mocks.getActive.mockResolvedValue(null);
     mocks.list.mockReturnValue([]);
-    mocks.resolveHasBuilderPrivateKey.mockResolvedValue(false);
+    mocks.hasBuilderApiCredentialCustody.mockResolvedValue(false);
   });
 
   it("returns the request-scoped provider that owns the session", async () => {
@@ -73,7 +73,7 @@ describe("resolveResumableUploadProvider", () => {
   });
 
   it("resolves Builder sessions from request-scoped credentials", async () => {
-    mocks.resolveHasBuilderPrivateKey.mockResolvedValue(true);
+    mocks.hasBuilderApiCredentialCustody.mockResolvedValue(true);
 
     await expect(resolveResumableUploadProvider("builder")).resolves.toBe(
       mocks.builder,

--- a/templates/clips/server/lib/resumable-upload-provider.ts
+++ b/templates/clips/server/lib/resumable-upload-provider.ts
@@ -4,7 +4,7 @@ import {
   listFileUploadProviders,
   type FileUploadProvider,
 } from "@agent-native/core/file-upload";
-import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
+import { hasBuilderApiCredentialCustody } from "@agent-native/core/server";
 
 async function isConfiguredForRequest(
   provider: FileUploadProvider,
@@ -34,7 +34,7 @@ export async function resolveResumableUploadProvider(
 
   if (providerId === builderFileUploadProvider.id) {
     try {
-      if (await resolveHasBuilderPrivateKey()) {
+      if (await hasBuilderApiCredentialCustody()) {
         return builderFileUploadProvider;
       }
     } catch {

--- a/templates/clips/server/lib/video-storage.spec.ts
+++ b/templates/clips/server/lib/video-storage.spec.ts
@@ -5,7 +5,7 @@ vi.mock("@agent-native/core/file-upload", () => ({
 }));
 
 vi.mock("@agent-native/core/server", () => ({
-  resolveHasBuilderPrivateKey: async () => false,
+  hasBuilderApiCredentialCustody: async () => false,
   runWithRequestContext: async (
     _context: unknown,
     fn: () => Promise<unknown>,

--- a/templates/clips/server/lib/video-storage.ts
+++ b/templates/clips/server/lib/video-storage.ts
@@ -1,6 +1,6 @@
 import { listFileUploadProviders } from "@agent-native/core/file-upload";
 import {
-  resolveHasBuilderPrivateKey,
+  hasBuilderApiCredentialCustody,
   runWithRequestContext,
 } from "@agent-native/core/server";
 
@@ -51,7 +51,7 @@ export async function hasRequestVideoStorage(
     }
 
     try {
-      return await resolveHasBuilderPrivateKey();
+      return await hasBuilderApiCredentialCustody();
     } catch {
       return false;
     }


### PR DESCRIPTION

New users could not upload clips. Recording failed at the start with "Video storage could not start a resumable upload session." This fixes the upload path for anyone who connected Builder recently.

## The problem

Builder connections used to be stored as an API key. They are now stored as an OAuth connection instead. The upload code was never updated, so it still looked for the old API key and found nothing.

Anyone who connected Builder before the switch kept working, because they still have an old key. Anyone who connected after it could not upload at all. Settings still showed Builder as connected, which made the failure look random.

## What changed

Uploads now work with an OAuth connection as well as with an old API key. When both exist, the user's own OAuth connection is used.

The Builder connection now also asks for permission to write files. Builder requires this for uploads and we were not requesting it, so even a valid connection was rejected.

The checks that decide whether video storage is available now recognise an OAuth connection. Previously they only looked for the old API key, so they reported "no storage" and blocked the upload before it started.

Upload errors now say what is actually wrong instead of asking the user to refresh.