### PR TITLE
fix: address latest product feedback

### DIFF
--- a/.changeset/clear-feedback-controls.md
+++ b/.changeset/clear-feedback-controls.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+---
+
+Keep shared sidebar feedback controls clear of the environment badge.

--- a/.changeset/clear-feedback-controls.md
+++ b/.changeset/clear-feedback-controls.md
@@ -3,4 +3,4 @@
 "@agent-native/toolkit": patch
 ---
 
-Keep shared sidebar feedback controls clear of the environment badge.
+Keep shared feedback controls clear of the environment badge and editor chrome.

--- a/packages/dispatch/src/styles/dispatch-css.spec.ts
+++ b/packages/dispatch/src/styles/dispatch-css.spec.ts
@@ -27,9 +27,6 @@ describe("dispatch Tailwind styles", () => {
       '@source "../components/**/*.{js,mjs,ts,tsx}"',
     );
     expect(stylesheet).toContain('@source "../routes/**/*.{js,mjs,ts,tsx}"');
-    expect(stylesheet).toContain(
-      "body:has(.fixed.bottom-3.left-3) [data-dispatch-sidebar-footer]",
-    );
   });
 
   it("imports package source directives from the Dispatch template", () => {

--- a/packages/dispatch/src/styles/dispatch.css
+++ b/packages/dispatch/src/styles/dispatch.css
@@ -40,11 +40,6 @@
   font-weight: 600;
 }
 
-body:has(.fixed.bottom-3.left-3) [data-dispatch-sidebar-footer] {
-  /* The fixed environment badge only needs this space when it is rendered. */
-  padding-bottom: 2.5rem;
-}
-
 @media (max-width: 767px) {
   .dispatch-chat-first-surface {
     position: relative;

--- a/packages/toolkit/src/canvas-annotations/DrawOverlay.spec.tsx
+++ b/packages/toolkit/src/canvas-annotations/DrawOverlay.spec.tsx
@@ -142,4 +142,13 @@ describe("DrawOverlay clear undo", () => {
     await act(async () => send?.click());
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  it("keeps the toolbar on one row and below editor chrome", () => {
+    const toolbar = document.querySelector<HTMLElement>("[data-draw-toolbar]");
+    const overlay = container.querySelector<HTMLElement>("[data-draw-overlay]");
+
+    expect(toolbar?.className).toContain("flex-nowrap");
+    expect(toolbar?.className).toContain("overflow-x-auto");
+    expect(overlay?.className).toContain("z-[60]");
+  });
 });

--- a/packages/toolkit/src/canvas-annotations/DrawOverlay.spec.tsx
+++ b/packages/toolkit/src/canvas-annotations/DrawOverlay.spec.tsx
@@ -148,6 +148,7 @@ describe("DrawOverlay clear undo", () => {
     const overlay = container.querySelector<HTMLElement>("[data-draw-overlay]");
 
     expect(toolbar?.className).toContain("flex-nowrap");
+    expect(toolbar?.className).toContain("justify-start");
     expect(toolbar?.className).toContain("overflow-x-auto");
     expect(overlay?.className).toContain("z-[60]");
   });

--- a/packages/toolkit/src/canvas-annotations/DrawOverlay.tsx
+++ b/packages/toolkit/src/canvas-annotations/DrawOverlay.tsx
@@ -885,7 +885,7 @@ export function DrawOverlay({
     <TooltipProvider>
       <div
         data-draw-toolbar
-        className="pointer-events-auto fixed bottom-20 left-1/2 z-[110] flex max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-nowrap items-center justify-center gap-2 overflow-x-auto rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="pointer-events-auto fixed bottom-20 left-1/2 z-[110] flex max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-nowrap items-center justify-start gap-2 overflow-x-auto rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {/* Color picker */}
         <div className="flex gap-1">

--- a/packages/toolkit/src/canvas-annotations/DrawOverlay.tsx
+++ b/packages/toolkit/src/canvas-annotations/DrawOverlay.tsx
@@ -885,7 +885,7 @@ export function DrawOverlay({
     <TooltipProvider>
       <div
         data-draw-toolbar
-        className="pointer-events-auto fixed bottom-20 left-1/2 z-[110] flex max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-2 rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl"
+        className="pointer-events-auto fixed bottom-20 left-1/2 z-[110] flex max-w-[calc(100vw-1rem)] -translate-x-1/2 flex-nowrap items-center justify-center gap-2 overflow-x-auto rounded-xl border border-border bg-popover px-3 py-2 shadow-2xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {/* Color picker */}
         <div className="flex gap-1">
@@ -1090,7 +1090,7 @@ export function DrawOverlay({
       data-draw-overlay
       aria-hidden={!visible}
       className={cn(
-        "absolute inset-0 z-[100]",
+        "absolute inset-0 z-[60]",
         visible ? "visible" : "invisible pointer-events-none",
         canvasInteractive && !sending
           ? "pointer-events-auto"

--- a/packages/toolkit/src/styles.css
+++ b/packages/toolkit/src/styles.css
@@ -20,6 +20,11 @@
  */
 @source "./**/*.{js,ts,tsx}";
 
+body:has(.fixed.bottom-3.left-3) [data-sidebar-footer-actions] {
+  /* Keep shared sidebar footers clear of the fixed environment badge. */
+  padding-bottom: 2.5rem;
+}
+
 @property --agent-realtime-voice-angle {
   syntax: "<angle>";
   inherits: true;

--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -541,9 +541,14 @@ describe("VideoPlayer playback", () => {
     expect(video.paused).toBe(false);
   });
 
-  it("suppresses the synthetic click that follows a touch tap instead of double-toggling playback", () => {
+  it("toggles playback on touch taps and suppresses the synthetic follow-up click", () => {
     const surface = getPlayerSurface();
     const video = getVideo();
+
+    act(() => {
+      surface.click();
+    });
+    expect(video.paused).toBe(false);
 
     act(() => {
       surface.dispatchEvent(
@@ -570,10 +575,8 @@ describe("VideoPlayer playback", () => {
       );
     });
 
-    // A touch tap on the surface only reveals controls (matching native
-    // mobile players) — it must not start playback on its own.
     expect(video.paused).toBe(true);
-    expect(onPlay).not.toHaveBeenCalled();
+    expect(onPause).toHaveBeenCalledTimes(1);
 
     // Real browsers fire a synthetic "click" immediately after a touch tap.
     // The component must swallow exactly that one click rather than treating
@@ -585,7 +588,7 @@ describe("VideoPlayer playback", () => {
     });
 
     expect(video.paused).toBe(true);
-    expect(onPlay).not.toHaveBeenCalled();
+    expect(onPlay).toHaveBeenCalledOnce();
 
     // A later, unrelated real click still toggles playback normally — proving
     // the suppression is a one-shot flag consumed by the synthetic click, not
@@ -595,7 +598,7 @@ describe("VideoPlayer playback", () => {
     });
 
     expect(video.paused).toBe(false);
-    expect(onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlay).toHaveBeenCalledTimes(2);
   });
 
   it("uses WebKit video fullscreen when the player container cannot enter fullscreen", () => {

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -999,10 +999,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
 
     const activateVideoSurface = useCallback(
       (input: "mouse" | "touch") => {
-        // Match native mobile players: touching the video reveals the controls
-        // without unexpectedly pausing or resuming it. Embeds that explicitly
-        // hide their chrome keep surface-tap playback so they remain usable.
+        // Touch taps should behave like native mobile players: pause while
+        // playing, resume while paused, and keep the chrome visible long
+        // enough to expose the explicit controls. Embeds that explicitly hide
+        // their chrome keep surface-tap playback so they remain usable.
         if (input === "touch" && !hideChrome) {
+          togglePlayback();
           bumpControls();
           return;
         }

--- a/templates/slides/app/components/editor/EditorSidebar.test.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.test.tsx
@@ -94,6 +94,44 @@ describe("EditorSidebar thumbnail scroll cue", () => {
 });
 
 describe("EditorSidebar arrow navigation", () => {
+  it("moves to the next thumbnail with arrows after a thumbnail click", () => {
+    const slideOne: Slide = {
+      id: "slide-1",
+      content: "<div />",
+      notes: "",
+      layout: "content",
+    };
+    const slideTwo: Slide = {
+      id: "slide-2",
+      content: "<div />",
+      notes: "",
+      layout: "content",
+    };
+    const onSelectSlide = vi.fn();
+    const { container } = render(
+      <EditorSidebar
+        slides={[slideOne, slideTwo]}
+        activeSlideId="slide-1"
+        deckId="deck-1"
+        deckTitle="Test deck"
+        onSelectSlide={onSelectSlide}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+    const thumbnail = container.querySelector<HTMLButtonElement>(
+      '[data-slide-thumbnail-id="slide-1"]',
+    );
+    thumbnail?.focus();
+    onSelectSlide.mockClear();
+
+    fireEvent.keyDown(thumbnail ?? document, { key: "ArrowDown" });
+
+    expect(onSelectSlide).toHaveBeenCalledOnce();
+    expect(onSelectSlide).toHaveBeenCalledWith("slide-2");
+  });
+
   it("does not navigate while a slide text block owns the arrow keys", () => {
     const slideOne: Slide = {
       id: "slide-1",

--- a/templates/slides/app/components/editor/EditorSidebar.test.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Slide } from "@/context/DeckContext";
 
+const sortableKeyDown = vi.hoisted(() => vi.fn());
+
 vi.mock("@agent-native/core/client/api-path", () => ({
   agentNativePath: (path: string) => path,
 }));
@@ -19,6 +21,19 @@ vi.mock("@agent-native/core/client/i18n", () => ({
 
 vi.mock("@agent-native/toolkit/collab-ui", () => ({
   DEFAULT_AGENT_IDENTITY: { email: "agent@example.com" },
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useSortable: () => ({
+    attributes: {},
+    listeners: { onKeyDown: sortableKeyDown },
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+  verticalListSortingStrategy: {},
 }));
 
 vi.mock("@/components/deck/SlideRenderer", () => ({
@@ -46,7 +61,10 @@ vi.stubGlobal(
 
 import EditorSidebar from "./EditorSidebar";
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  sortableKeyDown.mockClear();
+});
 
 describe("EditorSidebar thumbnail scroll cue", () => {
   it("only marks the thumbnail pane as scrolled after it leaves the top", () => {
@@ -94,6 +112,34 @@ describe("EditorSidebar thumbnail scroll cue", () => {
 });
 
 describe("EditorSidebar arrow navigation", () => {
+  it("preserves sortable keyboard activation on the thumbnail", () => {
+    const slide: Slide = {
+      id: "slide-1",
+      content: "<div />",
+      notes: "",
+      layout: "content",
+    };
+    const { container } = render(
+      <EditorSidebar
+        slides={[slide]}
+        activeSlideId="slide-1"
+        deckId="deck-1"
+        deckTitle="Test deck"
+        onSelectSlide={() => {}}
+        describeSlideId={null}
+        onCloseDescribe={() => {}}
+        addSlideAgentSubmit={() => {}}
+      />,
+    );
+    const thumbnail = container.querySelector<HTMLButtonElement>(
+      '[data-slide-thumbnail-id="slide-1"]',
+    );
+
+    fireEvent.keyDown(thumbnail ?? document, { key: "Enter" });
+
+    expect(sortableKeyDown).toHaveBeenCalledOnce();
+  });
+
   it("moves to the next thumbnail with arrows after a thumbnail click", () => {
     const slideOne: Slide = {
       id: "slide-1",

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -299,6 +299,8 @@ function SortableSlideThumb({
             {...(readOnly ? {} : attributes)}
             {...(readOnly ? {} : listeners)}
             onKeyDown={(event) => {
+              listeners?.onKeyDown?.(event);
+              if (event.defaultPrevented) return;
               if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
               event.preventDefault();
               event.stopPropagation();

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -132,6 +132,22 @@ function isAgentPresenceUser(user: CollabUser): boolean {
   );
 }
 
+function getNextSlideId(
+  slides: Slide[],
+  activeSlideId: string,
+  key: "ArrowUp" | "ArrowDown",
+): string | null {
+  const currentIndex = slides.findIndex((s) => s.id === activeSlideId);
+  if (currentIndex === -1) return null;
+
+  const nextIndex =
+    key === "ArrowUp"
+      ? Math.max(0, currentIndex - 1)
+      : Math.min(slides.length - 1, currentIndex + 1);
+
+  return nextIndex === currentIndex ? null : (slides[nextIndex]?.id ?? null);
+}
+
 /** Small presence avatar circle with hover card showing name + email */
 function PresenceAvatarTip({
   user,
@@ -197,6 +213,7 @@ function SortableSlideThumb({
   index,
   isActive,
   onSelect,
+  onArrowNavigate,
   registerButtonRef,
   presenceUsers = [],
   aspectRatio,
@@ -219,6 +236,7 @@ function SortableSlideThumb({
   index: number;
   isActive: boolean;
   onSelect: () => void;
+  onArrowNavigate: (key: "ArrowUp" | "ArrowDown") => void;
   readOnly?: boolean;
   registerButtonRef: (slideId: string, node: HTMLButtonElement | null) => void;
   presenceUsers?: CollabUser[];
@@ -280,6 +298,12 @@ function SortableSlideThumb({
             type="button"
             {...(readOnly ? {} : attributes)}
             {...(readOnly ? {} : listeners)}
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+              event.preventDefault();
+              event.stopPropagation();
+              onArrowNavigate(event.key);
+            }}
             onClick={(event) => {
               // Safari does not focus a button on click, and the slide copy/paste
               // and delete shortcuts are scoped to a focused thumbnail.
@@ -603,6 +627,21 @@ export default function EditorSidebar({
     [describeSlideId],
   );
 
+  const navigateToSlide = useCallback(
+    (fromSlideId: string, key: "ArrowUp" | "ArrowDown") => {
+      const nextSlideId = getNextSlideId(slides, fromSlideId, key);
+      if (!nextSlideId) return;
+
+      onSelectSlide(nextSlideId);
+      requestAnimationFrame(() => {
+        const nextButton = slideButtonRefs.current.get(nextSlideId);
+        nextButton?.focus({ preventScroll: true });
+        nextButton?.scrollIntoView({ block: "nearest" });
+      });
+    },
+    [onSelectSlide, slides],
+  );
+
   const describeSlideIndex = describeSlideId
     ? slides.findIndex((s) => s.id === describeSlideId)
     : -1;
@@ -629,28 +668,12 @@ export default function EditorSidebar({
         return;
 
       e.preventDefault();
-      const currentIndex = slides.findIndex((s) => s.id === activeSlideId);
-      if (currentIndex === -1) return;
-
-      const nextIndex =
-        e.key === "ArrowUp"
-          ? Math.max(0, currentIndex - 1)
-          : Math.min(slides.length - 1, currentIndex + 1);
-
-      if (nextIndex !== currentIndex) {
-        const nextSlideId = slides[nextIndex].id;
-        onSelectSlide(nextSlideId);
-        requestAnimationFrame(() => {
-          const nextButton = slideButtonRefs.current.get(nextSlideId);
-          nextButton?.focus({ preventScroll: true });
-          nextButton?.scrollIntoView({ block: "nearest" });
-        });
-      }
+      navigateToSlide(activeSlideId, e.key as "ArrowUp" | "ArrowDown");
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [slides, activeSlideId, onSelectSlide]);
+  }, [activeSlideId, navigateToSlide]);
 
   return (
     <div className="flex h-full min-h-0 w-48 flex-shrink-0 flex-col bg-background sm:w-52">
@@ -677,6 +700,7 @@ export default function EditorSidebar({
                 index={index}
                 isActive={slide.id === activeSlideId}
                 onSelect={() => onSelectSlide(slide.id)}
+                onArrowNavigate={(key) => navigateToSlide(slide.id, key)}
                 readOnly={readOnly}
                 registerButtonRef={registerSlideButton}
                 presenceUsers={slidePresence?.get(slide.id) ?? []}

--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -37,4 +37,17 @@ describe("SlideEditor render-phase safety", () => {
     });
     expect(offenders.map((m) => m[0])).toEqual([]);
   });
+
+  it("flushes an active inline draft before browser teardown", () => {
+    expect(source).toContain("flushPendingSaves");
+    expect(source).toContain(
+      'window.addEventListener("beforeunload", flushInlineEditDraft',
+    );
+    expect(source).toContain(
+      'window.addEventListener("pagehide", flushInlineEditDraft',
+    );
+    expect(source).toContain(
+      'document.addEventListener("visibilitychange", flushWhenHidden',
+    );
+  });
 });

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -59,7 +59,11 @@ import {
   CanvasCommentPins,
   MultiSelectChip,
 } from "@/components/visual-editor";
-import type { Slide, UpdateSlideOptions } from "@/context/DeckContext";
+import {
+  flushPendingSaves,
+  type Slide,
+  type UpdateSlideOptions,
+} from "@/context/DeckContext";
 import { getAspectRatioDims, type AspectRatio } from "@/lib/aspect-ratios";
 import {
   computeCanvasFitZoom,
@@ -1548,6 +1552,45 @@ export default function SlideEditor({
     null,
   );
   const previousSlideIdRef = useRef(slide.id);
+
+  // Inline editing keeps its latest HTML in the DOM until blur so React does
+  // not rerender the contentEditable on every keystroke. Hand that draft to
+  // the keepalive queue before browser teardown.
+  useEffect(() => {
+    const flushInlineEditDraft = () => {
+      const draft = inlineEditDraftRef.current;
+      if (!draft) return;
+      onUpdateSlideRef.current({ content: draft.content }, draft.slideId, {
+        persistence: "debounced",
+      });
+      inlineEditDraftRef.current = null;
+      flushPendingSaves();
+    };
+    const flushWhenHidden = () => {
+      if (document.visibilityState === "hidden") flushInlineEditDraft();
+    };
+
+    window.addEventListener("beforeunload", flushInlineEditDraft, {
+      capture: true,
+    });
+    window.addEventListener("pagehide", flushInlineEditDraft, {
+      capture: true,
+    });
+    document.addEventListener("visibilitychange", flushWhenHidden, {
+      capture: true,
+    });
+    return () => {
+      window.removeEventListener("beforeunload", flushInlineEditDraft, {
+        capture: true,
+      });
+      window.removeEventListener("pagehide", flushInlineEditDraft, {
+        capture: true,
+      });
+      document.removeEventListener("visibilitychange", flushWhenHidden, {
+        capture: true,
+      });
+    };
+  }, []);
 
   const readCurrentSlideContentHtml = useCallback(() => {
     const slideContent = containerRef.current?.querySelector(

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -17,6 +17,8 @@ vi.mock("@agent-native/core/client/org", () => ({
 
 import {
   DeckProvider,
+  flushPendingSaves,
+  hasUnsavedDeckChanges,
   hasUncommittedDeckChanges,
   mergeServerAddedSlides,
   useDecks,
@@ -268,6 +270,7 @@ describe("DeckContext deck creation persistence", () => {
 
   afterEach(() => {
     cleanup();
+    window.history.pushState({}, "", "/");
     _resetSyncTransportRegistryForTests();
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -317,6 +320,143 @@ describe("DeckContext deck creation persistence", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.decks).toEqual([accessible]);
+  });
+
+  it("keeps an unload flush behind the active save chain", async () => {
+    window.history.pushState({}, "", "/deck/flush-order-deck");
+    const { fetchMock, resolveDeferredPatch, setAccessibleDeck } = setupFetch({
+      deferredPatch: true,
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "flush-order-deck",
+      title: "Flush order deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<h1>Before</h1>",
+          notes: "",
+          layout: "title",
+        },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide(
+        "flush-order-deck",
+        "slide-1",
+        { content: "<h1>First</h1>" },
+        { persistence: "immediate" },
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.updateSlide("flush-order-deck", "slide-1", {
+        content: "<h1>Latest</h1>",
+      });
+      flushPendingSaves();
+    });
+
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("/_agent-native/actions/patch-deck"),
+      ),
+    ).toHaveLength(1);
+
+    resolveDeferredPatch();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(([url]) =>
+      String(url).includes("/_agent-native/actions/patch-deck"),
+    );
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.[1]?.keepalive).toBe(true);
+    expect(actionCallBody(patchCalls[1]?.[1])).toMatchObject({
+      deckId: "flush-order-deck",
+      operations: [
+        {
+          op: "patch-slide",
+          slideId: "slide-1",
+          fields: { content: "<h1>Latest</h1>" },
+        },
+      ],
+    });
+
+    await result.current.flushDeckSave("flush-order-deck");
+  });
+
+  it("requeues a failed keepalive flush for a normal retry", async () => {
+    window.history.pushState({}, "", "/deck/flush-retry-deck");
+    const { fetchMock, setAccessibleDeck, getPatchAttempts } = setupFetch({
+      patchFailures: { deckId: "flush-retry-deck", count: 1 },
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "flush-retry-deck",
+      title: "Flush retry deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<h1>Before</h1>",
+          notes: "",
+          layout: "title",
+        },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide("flush-retry-deck", "slide-1", {
+        content: "<h1>Latest</h1>",
+      });
+      flushPendingSaves();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getPatchAttempts("flush-retry-deck")).toBe(1);
+    expect(hasUnsavedDeckChanges("flush-retry-deck")).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getPatchAttempts("flush-retry-deck")).toBe(2);
+    expect(hasUnsavedDeckChanges("flush-retry-deck")).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          String(url).includes("/_agent-native/actions/patch-deck") &&
+          init?.keepalive === true,
+      ),
+    ).toBe(true);
   });
 
   it("awaits the in-flight create request instead of polling for the new deck", async () => {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -714,7 +714,7 @@ function saveDeckToAPI(deck: Deck) {
  * is fine: granular ops are small, and if a full-replace payload is too large
  * to send keepalive the normal debounce/poll path still catches up on reopen.
  */
-function flushPendingSaves() {
+export function flushPendingSaves() {
   const actionsBase = agentNativePath("/_agent-native/actions");
   const actionUrl = `${actionsBase}/patch-deck`;
   const saveDeckUrl = `${actionsBase}/save-deck`;

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -382,7 +382,7 @@ const inFlightSaves = new Set<string>();
 const inFlightSaveChains = new Map<string, Promise<void>>();
 const inFlightSaveControllers = new Map<string, AbortController>();
 const deckSaveGenerations = new Map<string, number>();
-const immediateFlushRequests = new Set<string>();
+const immediateFlushRequests = new Map<string, boolean>();
 const deckSaveRetryAttempts = new Map<string, number>();
 const failedSaveDecks = new Set<string>();
 const saveStateListeners = new Set<() => void>();
@@ -502,11 +502,64 @@ function deckPayload(deck: Deck): Record<string, unknown> {
  * the `save-deck` action is called first, then any trailing granular ops are
  * sent through `patch-deck`.
  */
+async function sendKeepaliveAction(
+  url: string,
+  method: "POST" | "PUT",
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Agent-Native-Frontend": "1",
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+    keepalive: true,
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Action request failed with status ${response.status}`);
+  }
+}
+
 async function persistDeckOps(
   deckId: string,
   ops: GranularOp[],
   signal?: AbortSignal,
+  options?: { keepalive?: boolean },
 ) {
+  if (options?.keepalive) {
+    const actionsBase = agentNativePath("/_agent-native/actions");
+    if (ops[0].op === "full-replace") {
+      const deck = ops[0].deck;
+      await sendKeepaliveAction(
+        `${actionsBase}/save-deck`,
+        "PUT",
+        { deckId, deck: deckPayload(deck) },
+        signal,
+      );
+      const trailingOps = ops.slice(1) as PatchDeckOp[];
+      if (trailingOps.length > 0) {
+        await sendKeepaliveAction(
+          `${actionsBase}/patch-deck`,
+          "POST",
+          { deckId, operations: trailingOps },
+          signal,
+        );
+      }
+    } else {
+      await sendKeepaliveAction(
+        `${actionsBase}/patch-deck`,
+        "POST",
+        { deckId, operations: ops as PatchDeckOp[] },
+        signal,
+      );
+    }
+    return;
+  }
+
   if (ops[0].op === "full-replace") {
     // Legacy full-deck write — used by undo/redo and setDeckSlides.
     // `callAction` bounds it so a stalled save can't wedge `inFlightSaves`
@@ -547,14 +600,21 @@ async function persistDeckOps(
  * could otherwise complete out of order and let a stale drag overwrite a
  * newer resize.
  */
-function drainPendingDeckOps(deckId: string): Promise<void> {
+function drainPendingDeckOps(
+  deckId: string,
+  options?: { keepalive?: boolean },
+): Promise<void> {
   const timer = pendingSaves.get(deckId);
   if (timer) clearTimeout(timer);
   pendingSaves.delete(deckId);
 
   const active = inFlightSaveChains.get(deckId);
   if (active) {
-    immediateFlushRequests.add(deckId);
+    immediateFlushRequests.set(
+      deckId,
+      (immediateFlushRequests.get(deckId) ?? false) ||
+        options?.keepalive === true,
+    );
     notifySaveListeners();
     return active;
   }
@@ -574,7 +634,7 @@ function drainPendingDeckOps(deckId: string): Promise<void> {
   inFlightOpSlides.set(deckId, ops);
   const isCurrentGeneration = () =>
     (deckSaveGenerations.get(deckId) ?? 0) === generation;
-  const next = persistDeckOps(deckId, ops, controller?.signal)
+  const next = persistDeckOps(deckId, ops, controller?.signal, options)
     .then(() => {
       if (!isCurrentGeneration()) return;
       deckSaveRetryAttempts.delete(deckId);
@@ -613,10 +673,15 @@ function drainPendingDeckOps(deckId: string): Promise<void> {
         }
         inFlightSaves.delete(deckId);
         inFlightOpSlides.delete(deckId);
-        const flushImmediately = immediateFlushRequests.delete(deckId);
+        const requestedFlush = immediateFlushRequests.get(deckId);
+        const flushImmediately = requestedFlush !== undefined;
+        immediateFlushRequests.delete(deckId);
         notifySaveListeners();
         if (flushImmediately) {
-          void drainPendingDeckOps(deckId);
+          void drainPendingDeckOps(
+            deckId,
+            requestedFlush ? { keepalive: true } : undefined,
+          );
         }
       }
     });
@@ -704,10 +769,10 @@ function saveDeckToAPI(deck: Deck) {
 }
 
 /**
- * Synchronously flush every pending (debounced) deck op queue using
- * `fetch(..., { keepalive: true })` so in-flight edits survive a tab
+ * Flush every pending (debounced) deck op through the same per-deck queue used
+ * by normal saves, using keepalive transport so in-flight edits survive a tab
  * close / navigation. Called from a `pagehide` / `visibilitychange(hidden)`
- * handler — without it there is a ~500ms window (the debounce) where the
+ * handler - without it there is a ~500ms window (the debounce) where the
  * user's most recent edits are only in memory and are lost on tab close.
  *
  * keepalive requests are best-effort and capped (~64KB by the browser), which
@@ -715,60 +780,9 @@ function saveDeckToAPI(deck: Deck) {
  * to send keepalive the normal debounce/poll path still catches up on reopen.
  */
 export function flushPendingSaves() {
-  const actionsBase = agentNativePath("/_agent-native/actions");
-  const actionUrl = `${actionsBase}/patch-deck`;
-  const saveDeckUrl = `${actionsBase}/save-deck`;
-  for (const [deckId, timer] of pendingSaves) {
-    clearTimeout(timer);
-    const ops = pendingOpsQueue.get(deckId);
-    pendingOpsQueue.delete(deckId);
-    if (!ops || ops.length === 0) continue;
-    try {
-      if (ops[0].op === "full-replace") {
-        const deck = ops[0].deck;
-        void fetch(saveDeckUrl, {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Agent-Native-Frontend": "1",
-          },
-          body: JSON.stringify({ deckId, deck }),
-          keepalive: true,
-        });
-        const trailingOps = ops.slice(1) as PatchDeckOp[];
-        if (trailingOps.length === 0) continue;
-        void fetch(actionUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Agent-Native-Frontend": "1",
-          },
-          body: JSON.stringify({
-            deckId,
-            operations: trailingOps,
-          }),
-          keepalive: true,
-        });
-      } else {
-        void fetch(actionUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Agent-Native-Frontend": "1",
-          },
-          body: JSON.stringify({
-            deckId,
-            operations: ops as PatchDeckOp[],
-          }),
-          keepalive: true,
-        });
-      }
-    } catch {
-      // Best-effort — nothing more we can do as the page is unloading.
-    }
+  for (const deckId of [...pendingSaves.keys()]) {
+    void drainPendingDeckOps(deckId, { keepalive: true });
   }
-  pendingSaves.clear();
-  notifySaveListeners();
 }
 
 function discardPendingDeckOps(deckId: string) {

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -182,7 +182,9 @@ export default function DeckEditor() {
   const { hasUnsavedChanges: hasUnsavedSave } = useSaveState();
   const hasPendingDeckEdits =
     inlineEditActive || (id ? hasUnsavedDeckChanges(id) : hasUnsavedSave);
-  usePendingDeckUnloadGuard(hasPendingDeckEdits);
+  // Inline drafts flush through SlideEditor keepalive handlers. The native
+  // prompt only needs to cover queued or in-flight writes now.
+  usePendingDeckUnloadGuard(id ? hasUnsavedDeckChanges(id) : hasUnsavedSave);
   const pendingDeckNavigationBlocker = useBlocker(
     useCallback(
       ({ currentLocation, nextLocation }) =>

--- a/templates/slides/changelog/2026-08-26-thumbnail-arrow-keys-now-navigate-slides-after-selection.md
+++ b/templates/slides/changelog/2026-08-26-thumbnail-arrow-keys-now-navigate-slides-after-selection.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-26
+---
+
+Clicking a slide thumbnail now keeps arrow keys on slide navigation instead of scrolling the thumbnail pane.


### PR DESCRIPTION
## Summary

- Keep the shared sidebar feedback action clear of the fixed environment badge.
- Keep ArrowUp and ArrowDown on Slides thumbnail navigation after selection.
- Make touch activation toggle Clips playback while preserving click suppression.
- Keep the Design annotate toolbar on one row and keep other design tools clickable while annotating.
- Persist manual Slides text edits before browser unload or refresh through the serialized keepalive save queue.
- Add the required package changeset and Slides changelog entry.

## Feedback handoff

- Slack sweep started at the newest actionable parent, [beta badge overlap](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787739668508029), and covered the current feedback channel plus older grouped dispositions.
- Accepted fixes: [beta badge](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787739668508029), [Slides thumbnail arrows](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787720853878229), and [Clips mobile pause](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787714197625199). Each has an invoking-identity Slack disposition reply.
- The newest [Clips meeting auto-stop report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787752209580979) is in progress under the active approved [Clips desktop meeting work](https://github.com/BuilderIO/agent-native/pull/3611); it is not duplicated into this PR. Steve's invoking-identity disposition reply is recorded in the thread.
- A later [Clips adhoc Zoom meeting-notes report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787756828664119) is also covered by the active [Clips desktop meeting work](https://github.com/BuilderIO/agent-native/pull/3611); it is not duplicated into this PR. Steve's invoking-identity disposition reply is recorded in the thread.
- The newest [Slides template-import report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787752628581269) shows `redirect_uri_mismatch`, matching the merged source fix; beta Google callback registration remains an external configuration item. Steve's invoking-identity disposition reply is recorded in the thread.
- The newest [Builder blank-screen report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787752871567449) now identifies the Builder Projects/home flow and includes screenshots, but no route, console error, or matching Sentry issue in the last 24 hours. Steve requested clarification and console evidence; it is handed to the Builder app/runtime owner and is not a scoped change in this PR.
- The newest [Slides Generate Image report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787752903611979) reports a permanent Assets setup precondition after three identical failures. The existing source intentionally keeps rejected Assets runs distinct from unavailable transport, so this remains an external setup item. Steve's invoking-identity disposition reply is recorded in the thread.
- The newest [Design annotate-toolbar report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787753581461009) is fixed in the shared DrawOverlay layer; the one-row overflow keeps the close control in line, and the lowered canvas layer leaves other design tools clickable. Steve's invoking-identity disposition reply is recorded in the thread.
- The newest [Dispatch sign-in report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787753749143579) shows Google's exact `redirect_uri_mismatch` page after sign-out. The shared callback source and related fix are already in place; provider callback registration remains external and in progress, not a duplicate sign-out change. Steve's invoking-identity disposition reply is recorded in the thread.
- The newest [Design generation report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787753908136909) reports no output after 10 minutes. The beta route responds, but the thread has no agent error or output evidence and Sentry has no matching generation issue; the current generation lifecycle allows long-running prompts and has recovery states. Steve requested clarification on whether the turn is still running, showing an error, or created any screen; it remains in progress and is not a justified source change from the available evidence.
- The newest [Slides manual text-save report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787754740394719) showed an active inline edit was held only in the editor draft when refresh or unload occurred. Inline drafts now flush through the existing serialized keepalive save queue before browser teardown, retain failed requests for retry, and preserve thumbnail keyboard drag activation. Steve's invoking-identity disposition reply is recorded in the thread.
- The latest [PMM Radar/Dispatch retry-storm report](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787757214858749) requires the Dispatch/environment owner to handle project settings or queued integration tasks; it is an external environment issue, not a source change in this PR. Steve's invoking-identity disposition reply is recorded in the thread.
- Existing ownership was preserved: Desktop sign-out remains in progress under [#3630](https://github.com/BuilderIO/agent-native/pull/3630), and the source portion of [Slides OAuth](https://github.com/BuilderIO/agent-native/pull/3596) is merged while beta Google Cloud callback configuration remains external. Content reports remain with the designated Content owner.
- Sentry was available and reviewed. Current unresolved items were recurring automation, MCP capability, database connection, and provider throttling signals without a deduped Slack report or safe scoped source patch.

## Verification

- Focused regressions pass: toolkit, Dispatch, Slides editor/sidebar/persistence, and Clips video player tests.
- The full Slides suite passes: 171 test files and 1,215 tests.
- Shared package builds and changed template typechecks pass.
- `corepack pnpm guards` passes all 64 checks.
- The repository prep gate observed 37 test suites passing. Its only failures were pre-existing missing workspace artifacts for `@agent-native/code-agents-ui` in desktop-app and `@agent-native/scheduling` in calendar; the accepted fixes have targeted green verification.
- This PR contains source and test verification only. No beta or production live-health claim is made here.
