### PR TITLE
Fix Builder OAuth callback without state

### DIFF
--- a/.changeset/fix-builder-connect-state.md
+++ b/.changeset/fix-builder-connect-state.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Recover Builder OAuth callbacks that omit state when there is one active pending connection.
+Preserve Builder OAuth state when Builder omits it from the callback query.

--- a/.changeset/fix-builder-connect-state.md
+++ b/.changeset/fix-builder-connect-state.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover Builder OAuth callbacks that omit state when there is one active pending connection.

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -414,6 +414,16 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("binds the OAuth state into the registered callback URL", () => {
+      const event = createBuilderBrowserEvent({
+        host: "myapp.up.railway.app",
+        "x-forwarded-proto": "https",
+      });
+      expect(resolveBuilderConnectCallbackUrl(event, "<STATE_EXAMPLE>")).toBe(
+        "https://myapp.up.railway.app/_agent-native/builder/callback?state=%3CSTATE_EXAMPLE%3E",
+      );
+    });
+
     it("rejects building a callback URL when the request origin is HTTP in production", () => {
       process.env.NODE_ENV = "production";
       const event = createBuilderBrowserEvent({

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -36,6 +36,7 @@ vi.mock("./credential-provider.js", async (importOriginal) => {
 
 import {
   appendBuilderConnectToken,
+  appendBuilderConnectStateCookie,
   buildBuilderCliAuthUrl,
   buildBuilderAgentUserPrompt,
   BUILDER_AGENT_NATIVE_APP_PARAM,
@@ -44,6 +45,7 @@ import {
   BUILDER_AGENT_NATIVE_TEMPLATE_PARAM,
   BUILDER_CALLBACK_PATH,
   BUILDER_CONNECT_PARAM,
+  BUILDER_CONNECT_STATE_COOKIE,
   BUILDER_RELAY_FLOW_HEADER,
   BUILDER_RELAY_SECRET_ENV,
   BUILDER_RELAY_SIGNATURE_HEADER,
@@ -66,10 +68,12 @@ import {
   normalizeBuilderAgentContext,
   resolveBuilderCallbackReturnUrl,
   resolveBuilderConnectCallbackUrl,
+  resolveBuilderConnectCallbackState,
   resolveBuilderPreviewRelayParentOrigin,
   resolveBuilderPreviewRelayTargetOrigin,
   resolveBuilderBranchProjectId,
   runBuilderAgent,
+  removeBuilderConnectStateCookie,
   signBuilderConnectToken,
   signBuilderCallbackState,
   signBuilderPreviewRelayState,
@@ -424,6 +428,39 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("recovers state from the callback cookie when Builder omits query state", () => {
+      const state = createBuilderConnectState();
+      const otherState = createBuilderConnectState();
+
+      expect(resolveBuilderConnectCallbackState(null, state)).toBe(state);
+      expect(resolveBuilderConnectCallbackState(state, state)).toBe(state);
+      expect(resolveBuilderConnectCallbackState("returned-state", null)).toBe(
+        "returned-state",
+      );
+      expect(resolveBuilderConnectCallbackState(null, null)).toBeNull();
+      expect(BUILDER_CONNECT_STATE_COOKIE).toBe("an_builder_connect_state");
+
+      const concurrentCookie = appendBuilderConnectStateCookie(
+        appendBuilderConnectStateCookie(null, state),
+        otherState,
+      );
+      expect(
+        resolveBuilderConnectCallbackState(null, concurrentCookie),
+      ).toBeNull();
+      expect(resolveBuilderConnectCallbackState(state, concurrentCookie)).toBe(
+        state,
+      );
+      expect(
+        resolveBuilderConnectCallbackState(
+          "unexpected-state",
+          concurrentCookie,
+        ),
+      ).toBeNull();
+      expect(removeBuilderConnectStateCookie(concurrentCookie, state)).toBe(
+        otherState,
+      );
+    });
+
     it("rejects building a callback URL when the request origin is HTTP in production", () => {
       process.env.NODE_ENV = "production";
       const event = createBuilderBrowserEvent({
@@ -435,10 +472,9 @@ describe("Builder callback CSRF state", () => {
   });
 
   describe("buildBuilderCliAuthUrl", () => {
-    // The callback state is optional because legacy /builder/connect clients
-    // can still rely on the server-side pending-connect row. New clients get a
-    // ready-to-open /cli-auth URL from /builder/status with _an_state embedded
-    // in redirect_url so the popup can skip the app trampoline entirely.
+    // New clients get a ready-to-open /cli-auth URL from /builder/status with
+    // _an_state embedded in redirect_url so the popup can skip the app
+    // trampoline entirely.
     it("builds a clean redirect_url (no _an_state) when state is null", () => {
       const cliAuthUrl = buildBuilderCliAuthUrl(
         "https://alice.agent-native.com",

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -558,15 +558,13 @@ function escapeHtml(value: string): string {
 }
 
 /**
- * Query-param name carrying the signed CSRF state on the connect→callback
- * round-trip. Prefixed with `_an_` to avoid collisions if Builder ever
- * adds standard OAuth `state` support to cli-auth. Builder preserves
- * the path/query of `redirect_url` verbatim when redirecting back, so
- * we embed `_an_state=…` inside the redirect_url query string at
- * connect time and read it back on the callback.
+ * Query-param name carrying the signed CSRF state on the legacy
+ * connect→callback round-trip. Prefixed with `_an_` to avoid collisions if
+ * Builder ever adds standard OAuth `state` support to cli-auth.
  */
 export const BUILDER_STATE_PARAM = "_an_state";
 export const BUILDER_CONNECT_PARAM = "_an_connect";
+export const BUILDER_CONNECT_STATE_COOKIE = "an_builder_connect_state";
 export const BUILDER_CONNECT_OWNER_COOKIE = "an_builder_connect_owner";
 export const BUILDER_SIGNUP_SOURCE_PARAM = "signupSource";
 export const BUILDER_AGENT_NATIVE_FLOW_PARAM = "agentNativeFlow";
@@ -574,6 +572,54 @@ export const BUILDER_AGENT_NATIVE_CONNECT_SOURCE_PARAM =
   "agentNativeConnectSource";
 export const BUILDER_AGENT_NATIVE_APP_PARAM = "agentNativeApp";
 export const BUILDER_AGENT_NATIVE_TEMPLATE_PARAM = "agentNativeTemplate";
+
+const BUILDER_CONNECT_STATE_COOKIE_MAX_ENTRIES = 4;
+
+function parseBuilderConnectStateCookie(
+  value: string | null | undefined,
+): string[] | null {
+  if (!value) return [];
+  const states = value.split(",");
+  if (
+    states.length > BUILDER_CONNECT_STATE_COOKIE_MAX_ENTRIES ||
+    states.some((state) => !isSignedBuilderConnectState(state))
+  ) {
+    return null;
+  }
+  return [...new Set(states)];
+}
+
+export function appendBuilderConnectStateCookie(
+  value: string | null | undefined,
+  state: string,
+): string {
+  const states = parseBuilderConnectStateCookie(value) ?? [];
+  return [...states.filter((candidate) => candidate !== state), state]
+    .slice(-BUILDER_CONNECT_STATE_COOKIE_MAX_ENTRIES)
+    .join(",");
+}
+
+export function removeBuilderConnectStateCookie(
+  value: string | null | undefined,
+  state: string,
+): string {
+  return (parseBuilderConnectStateCookie(value) ?? [])
+    .filter((candidate) => candidate !== state)
+    .join(",");
+}
+
+export function resolveBuilderConnectCallbackState(
+  queryState: string | null,
+  cookieState: string | null | undefined,
+): string | null {
+  const cookieStates = parseBuilderConnectStateCookie(cookieState);
+  if (cookieState && !cookieStates) return null;
+  if (queryState !== null) {
+    if (cookieStates?.length && !cookieStates.includes(queryState)) return null;
+    return queryState;
+  }
+  return cookieStates?.length === 1 ? cookieStates[0] : null;
+}
 
 const BUILDER_STATE_TTL_MS = 10 * 60 * 1000;
 const BUILDER_SIGNUP_SOURCE = "agent-native";
@@ -1059,11 +1105,9 @@ function isBuilderOpenerOriginSafe(value: string | null | undefined): boolean {
 
 /**
  * Build the Builder cli-auth URL for the connect popup. When a signed
- * `state` token is supplied it is embedded inside the `redirect_url`
- * query string so it survives Builder's redirect verbatim — Builder
- * preserves the redirect_url's existing query when appending p-key /
- * api-key / etc., so we don't depend on Builder echoing a top-level
- * `state` parameter (it doesn't).
+ * `state` token is supplied it is embedded inside the `redirect_url` query
+ * string. The connect route also stores it in an HttpOnly cookie because
+ * Builder may strip the callback query while appending its response params.
  *
  * Status responses can surface this URL directly; the legacy
  * `/_agent-native/builder/connect` trampoline still calls this helper for

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -183,16 +183,19 @@ export function isBuilderConnectCallbackUrlAllowed(
  * `getAppBasePath()` + `BUILDER_CALLBACK_PATH`. Intentionally ignores any
  * `?redirect_uri=` query override — connect always returns to this app's own
  * callback. Validated with `isBuilderConnectCallbackUrlAllowed` (Railway-safe,
- * no fixed domain allowlist).
+ * no fixed domain allowlist). When state is provided, bind it into the exact
+ * registered callback URI because Builder can omit top-level OAuth state.
  */
 export function resolveBuilderConnectCallbackUrl(
   event: H3Event,
+  state?: string,
 ): string | null {
-  const withBase = `${getOrigin(event)}${getAppBasePath()}${BUILDER_CALLBACK_PATH}`;
+  const stateSuffix = state ? `?state=${encodeURIComponent(state)}` : "";
+  const withBase = `${getOrigin(event)}${getAppBasePath()}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
   if (isBuilderConnectCallbackUrlAllowed(withBase, event)) return withBase;
   // Match google-oauth default-redirect behavior when the request is not under
   // APP_BASE_PATH: fall back to the root `/_agent-native/...` callback.
-  const root = `${getOrigin(event)}${BUILDER_CALLBACK_PATH}`;
+  const root = `${getOrigin(event)}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
   if (root !== withBase && isBuilderConnectCallbackUrlAllowed(root, event)) {
     return root;
   }

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -38,11 +38,13 @@ import {
   BUILDER_OAUTH_SCOPE,
   BUILDER_OAUTH_SCOPES,
   deleteBuilderOAuthSession,
+  exchangeBuilderOAuthAuthorization,
   finishBuilderOAuthAuthorization,
   getBuilderOAuthSession,
   hasBuilderOAuthSession,
   markBuilderOAuthReconnectRequired,
   resolveBuilderOAuthRequestAccess,
+  saveBuilderOAuthCredentials,
   startBuilderOAuthAuthorization,
 } from "./builder-oauth.js";
 
@@ -144,6 +146,39 @@ describe("Builder hosted user OAuth", () => {
       scope: BUILDER_OAUTH_SCOPES.join(" "),
       resourceMetadataUrl:
         "https://mcp.builder.io/.well-known/oauth-protected-resource/api",
+    });
+  });
+
+  it("separates PKCE exchange from credential persistence", async () => {
+    const finished = credentials();
+    finishMock.mockResolvedValue({ credentials: finished });
+
+    const exchanged = await exchangeBuilderOAuthAuthorization({
+      ownerEmail,
+      code: "<AUTHORIZATION_CODE_EXAMPLE>",
+      iss: BUILDER_OAUTH_ISSUER,
+      pending: {
+        codeVerifier: "<PKCE_VERIFIER_EXAMPLE>",
+        clientInformation: { client_id: "<CLIENT_ID_EXAMPLE>" },
+        discoveryState: finished.discoveryState,
+        redirectUri: "https://app.example.com/_agent-native/builder/callback",
+      },
+    });
+
+    expect(exchanged).toEqual(finished);
+    expect(saveMock).not.toHaveBeenCalled();
+
+    await saveBuilderOAuthCredentials({
+      ownerEmail,
+      orgId: DEFAULT_ORG,
+      credentials: exchanged,
+    });
+    expect(saveMock).toHaveBeenCalledWith({
+      key: perOrgKey(DEFAULT_ORG),
+      scope: "org",
+      scopeId: DEFAULT_ORG,
+      serverUrl: BUILDER_OAUTH_RESOURCE,
+      credentials: finished,
     });
   });
 

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -187,13 +187,12 @@ export async function startBuilderOAuthAuthorization(input: {
   };
 }
 
-export async function finishBuilderOAuthAuthorization(input: {
+export async function exchangeBuilderOAuthAuthorization(input: {
   ownerEmail: string;
-  orgId?: string;
   code: string;
   iss?: string;
   pending: BuilderOAuthPendingFlow;
-}): Promise<void> {
+}): Promise<McpOAuthCredentialBundle> {
   validateMcpOAuthCallbackIssuer(
     input.pending.discoveryState as never,
     input.iss,
@@ -213,11 +212,34 @@ export async function finishBuilderOAuthAuthorization(input: {
       "Builder OAuth exchange returned credentials for another resource",
     );
   }
+  return withRecordedScopes(result.credentials);
+}
+
+export async function saveBuilderOAuthCredentials(input: {
+  ownerEmail: string;
+  orgId?: string;
+  credentials: McpOAuthCredentialBundle;
+}): Promise<void> {
   await saveMcpOAuthCredentials({
     ...(input.orgId
       ? orgOwnerOptions(input.orgId)
       : await ownerOptions(input.ownerEmail)),
-    credentials: withRecordedScopes(result.credentials),
+    credentials: input.credentials,
+  });
+}
+
+export async function finishBuilderOAuthAuthorization(input: {
+  ownerEmail: string;
+  orgId?: string;
+  code: string;
+  iss?: string;
+  pending: BuilderOAuthPendingFlow;
+}): Promise<void> {
+  const credentials = await exchangeBuilderOAuthAuthorization(input);
+  await saveBuilderOAuthCredentials({
+    ownerEmail: input.ownerEmail,
+    orgId: input.orgId,
+    credentials,
   });
 }
 

--- a/packages/core/src/server/core-routes-plugin.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.spec.ts
@@ -16,7 +16,6 @@ import {
   buildBuilderWaitlistFormPayload,
   checkBuilderWaitlistRateLimit,
   consumeBuilderConnectPendingState,
-  findBuilderConnectPendingStateForOwner,
   isBuilderConnectCallbackOwner,
   purgeExpiredBuilderConnectPendingStates,
   readBuilderConnectPendingState,
@@ -412,62 +411,6 @@ describe("Builder OAuth callback state", () => {
         consumed: true,
       })),
     ).resolves.toBeNull();
-  });
-
-  it("recovers one live pending flow when Builder omits callback state", async () => {
-    const state = createBuilderConnectState();
-    await expect(
-      findBuilderConnectPendingStateForOwner(
-        "alice@example.com",
-        Date.now(),
-        async () => [
-          {
-            key: `builder-connect-pending:${state}`,
-            value: {
-              ownerEmail: "alice@example.com",
-              expiresAt: Date.now() + 60_000,
-              encryptedOAuthFlow: "<ENCRYPTED_FLOW_EXAMPLE>",
-              redirectUri:
-                "https://app.example.com/_agent-native/builder/callback",
-            },
-          },
-        ],
-      ),
-    ).resolves.toEqual({ status: "found", state });
-  });
-
-  it("fails closed when multiple live pending flows could match", async () => {
-    const rows = [1, 2].map(() => {
-      const state = createBuilderConnectState();
-      return {
-        key: `builder-connect-pending:${state}`,
-        value: {
-          ownerEmail: "alice@example.com",
-          expiresAt: Date.now() + 60_000,
-          encryptedOAuthFlow: "<ENCRYPTED_FLOW_EXAMPLE>",
-          redirectUri: "https://app.example.com/_agent-native/builder/callback",
-        },
-      };
-    });
-    await expect(
-      findBuilderConnectPendingStateForOwner(
-        "alice@example.com",
-        Date.now(),
-        async () => rows,
-      ),
-    ).resolves.toEqual({ status: "absent" });
-  });
-
-  it("distinguishes pending-flow storage failure from no matching flow", async () => {
-    await expect(
-      findBuilderConnectPendingStateForOwner(
-        "alice@example.com",
-        Date.now(),
-        async () => {
-          throw new Error("settings unavailable");
-        },
-      ),
-    ).resolves.toEqual({ status: "unavailable" });
   });
 
   it("deletes expired Builder OAuth pending-flow rows", async () => {

--- a/packages/core/src/server/core-routes-plugin.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.spec.ts
@@ -16,6 +16,7 @@ import {
   buildBuilderWaitlistFormPayload,
   checkBuilderWaitlistRateLimit,
   consumeBuilderConnectPendingState,
+  findBuilderConnectPendingStateForOwner,
   isBuilderConnectCallbackOwner,
   purgeExpiredBuilderConnectPendingStates,
   readBuilderConnectPendingState,
@@ -411,6 +412,62 @@ describe("Builder OAuth callback state", () => {
         consumed: true,
       })),
     ).resolves.toBeNull();
+  });
+
+  it("recovers one live pending flow when Builder omits callback state", async () => {
+    const state = createBuilderConnectState();
+    await expect(
+      findBuilderConnectPendingStateForOwner(
+        "alice@example.com",
+        Date.now(),
+        async () => [
+          {
+            key: `builder-connect-pending:${state}`,
+            value: {
+              ownerEmail: "alice@example.com",
+              expiresAt: Date.now() + 60_000,
+              encryptedOAuthFlow: "<ENCRYPTED_FLOW_EXAMPLE>",
+              redirectUri:
+                "https://app.example.com/_agent-native/builder/callback",
+            },
+          },
+        ],
+      ),
+    ).resolves.toEqual({ status: "found", state });
+  });
+
+  it("fails closed when multiple live pending flows could match", async () => {
+    const rows = [1, 2].map(() => {
+      const state = createBuilderConnectState();
+      return {
+        key: `builder-connect-pending:${state}`,
+        value: {
+          ownerEmail: "alice@example.com",
+          expiresAt: Date.now() + 60_000,
+          encryptedOAuthFlow: "<ENCRYPTED_FLOW_EXAMPLE>",
+          redirectUri: "https://app.example.com/_agent-native/builder/callback",
+        },
+      };
+    });
+    await expect(
+      findBuilderConnectPendingStateForOwner(
+        "alice@example.com",
+        Date.now(),
+        async () => rows,
+      ),
+    ).resolves.toEqual({ status: "absent" });
+  });
+
+  it("distinguishes pending-flow storage failure from no matching flow", async () => {
+    await expect(
+      findBuilderConnectPendingStateForOwner(
+        "alice@example.com",
+        Date.now(),
+        async () => {
+          throw new Error("settings unavailable");
+        },
+      ),
+    ).resolves.toEqual({ status: "unavailable" });
   });
 
   it("deletes expired Builder OAuth pending-flow rows", async () => {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1079,14 +1079,16 @@ export async function findBuilderConnectPendingStateForOwner(
 
   const matches = rows.filter((row) => {
     const state = row.key.slice(BUILDER_CONNECT_PENDING_PREFIX.length);
+    const value = row.value;
+    if (!value || typeof value !== "object") return false;
     return (
       isSignedBuilderConnectState(state) &&
-      row.value.ownerEmail === ownerEmail &&
-      row.value.consumed !== true &&
-      typeof row.value.expiresAt === "number" &&
-      row.value.expiresAt > now &&
-      typeof row.value.encryptedOAuthFlow === "string" &&
-      typeof row.value.redirectUri === "string"
+      value.ownerEmail === ownerEmail &&
+      value.consumed !== true &&
+      typeof value.expiresAt === "number" &&
+      value.expiresAt > now &&
+      typeof value.encryptedOAuthFlow === "string" &&
+      typeof value.redirectUri === "string"
     );
   });
 
@@ -3258,7 +3260,7 @@ export function createCoreRoutesPlugin(
             if (lookup.status === "unavailable") {
               return fail(
                 503,
-                "Builder connect callback could not be verified. Try again.",
+                "Builder connect callback could not be verified. Restart the connection.",
                 session.email,
                 "pending_state_unavailable",
               );

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -8,6 +8,9 @@ import {
   getRequestURL,
   getRequestIP,
   readRawBody,
+  getCookie,
+  setCookie,
+  deleteCookie,
 } from "h3";
 import type { H3Event } from "h3";
 import { readMultipartFormData } from "h3";
@@ -125,6 +128,7 @@ import { getConfiguredAppBasePath, stripAppBasePath } from "./app-base-path.js";
 import { getSession, type AuthSession } from "./auth.js";
 import {
   BUILDER_CONNECT_PARAM,
+  BUILDER_CONNECT_STATE_COOKIE,
   BUILDER_ENV_KEYS,
   BUILDER_OPENER_PARAM,
   BUILDER_RELAY_FLOW_HEADER,
@@ -132,6 +136,7 @@ import {
   BUILDER_RELAY_STATE_PARAM,
   BUILDER_RELAY_TIMESTAMP_HEADER,
   appendBuilderConnectToken,
+  appendBuilderConnectStateCookie,
   builderConnectTrackingProperties,
   createBuilderConnectState,
   createBuilderBrowserCallbackErrorPage,
@@ -145,7 +150,9 @@ import {
   normalizeBuilderAgentContext,
   resolveBuilderBranchProjectId,
   resolveBuilderConnectCallbackUrl,
+  resolveBuilderConnectCallbackState,
   resolveBuilderPreviewRelayParentOrigin,
+  removeBuilderConnectStateCookie,
   runBuilderAgent,
   verifyBuilderRelayRequest,
   verifyBuilderPreviewRelayStateForCallback,
@@ -157,9 +164,10 @@ import {
 import {
   BUILDER_OAUTH_SCOPE,
   deleteBuilderOAuthSession,
-  finishBuilderOAuthAuthorization,
+  exchangeBuilderOAuthAuthorization,
   hasBuilderOAuthSession,
   resolveBuilderOAuthRequestAccess,
+  saveBuilderOAuthCredentials,
   startBuilderOAuthAuthorization,
   type BuilderOAuthPendingFlow,
 } from "./builder-oauth.js";
@@ -2593,12 +2601,10 @@ export function createCoreRoutesPlugin(
       //      request with the navigation context. We allow `same-origin` or
       //      `none` (typed/bookmark/extension); cross-site / same-site without
       //      a valid connect token are rejected.
-      //   3. Pending row keyed by signed OAuth state — the callback
-      //      requires both a valid session and a one-time row that this
-      //      handler wrote during the same flow. Without the same-origin
-      //      gate or connect token above, an attacker could prime the row from
-      //      cross-site and then trick the victim into completing an
-      //      attacker-initiated authorization flow.
+      //   3. Pending row keyed by signed OAuth state plus a host-only cookie —
+      //      Builder can omit the callback query, but it cannot read or forge
+      //      the cookie. The callback still requires the matching session,
+      //      pending row, and a successful PKCE exchange before persistence.
       getH3App(nitroApp).use(
         `${P}/builder/connect`,
         defineEventHandler(async (event) => {
@@ -2770,6 +2776,21 @@ export function createCoreRoutesPlugin(
               tracking: connectTracking,
             });
             await purgeExpiredBuilderConnectPendingStates().catch(() => 0); // coercion-ok: connect already persisted the new pending row; purge of abandoned rows must not fail OAuth start
+            setCookie(
+              event,
+              BUILDER_CONNECT_STATE_COOKIE,
+              appendBuilderConnectStateCookie(
+                getCookie(event, BUILDER_CONNECT_STATE_COOKIE),
+                state,
+              ),
+              {
+                httpOnly: true,
+                secure: callbackUrl.startsWith("https://"),
+                sameSite: "lax",
+                path: "/",
+                maxAge: Math.ceil(BUILDER_CONNECT_PENDING_TTL_MS / 1_000),
+              },
+            );
           } catch (err) {
             await trackBuilderLifecycle(
               event,
@@ -3174,7 +3195,14 @@ export function createCoreRoutesPlugin(
             );
           }
 
-          let state = requestUrl.searchParams.get("state");
+          // Builder sometimes drops the top-level OAuth state. Recover it
+          // from the host-only cookie set by /builder/connect; the pending row
+          // and authenticated session still bind it to this account.
+          const queryState = requestUrl.searchParams.get("state");
+          const state = resolveBuilderConnectCallbackState(
+            queryState,
+            getCookie(event, BUILDER_CONNECT_STATE_COOKIE),
+          );
           const parentOrigin = getBuilderBrowserOriginForEvent(event);
           const fail = async (
             status: number,
@@ -3271,17 +3299,6 @@ export function createCoreRoutesPlugin(
             );
           }
 
-          const consumed = await consumeBuilderConnectPendingState(state);
-          if (!consumed) {
-            return fail(
-              403,
-              "No active Builder connect flow found. Restart the connection from Settings.",
-              ownerEmail,
-              "callback_verification_failed",
-              tracking,
-            );
-          }
-
           const denied = requestUrl.searchParams.get("error");
           const code = requestUrl.searchParams.get("code");
           const iss = requestUrl.searchParams.get("iss") ?? undefined;
@@ -3297,14 +3314,15 @@ export function createCoreRoutesPlugin(
             );
           }
 
+          let credentials: Awaited<
+            ReturnType<typeof exchangeBuilderOAuthAuthorization>
+          >;
           try {
             const oauthFlow = JSON.parse(
               decryptSecretValue(encryptedOAuthFlow),
             ) as BuilderOAuthPendingFlow;
-            await finishBuilderOAuthAuthorization({
+            credentials = await exchangeBuilderOAuthAuthorization({
               ownerEmail,
-              orgId:
-                typeof consumed.orgId === "string" ? consumed.orgId : undefined,
               code,
               iss,
               pending: oauthFlow,
@@ -3317,6 +3335,53 @@ export function createCoreRoutesPlugin(
               "code_exchange_failed",
               tracking,
             );
+          }
+
+          // PKCE proves the callback belongs to this flow before its pending
+          // row is consumed. Persist first so a transient credential-store
+          // failure does not strand an otherwise valid pending flow.
+          try {
+            await saveBuilderOAuthCredentials({
+              ownerEmail,
+              orgId:
+                typeof pending.orgId === "string" ? pending.orgId : undefined,
+              credentials,
+            });
+          } catch {
+            return fail(
+              500,
+              "Builder credentials could not be saved. Restart the connection.",
+              ownerEmail,
+              "credential_write_failed",
+              tracking,
+            );
+          }
+
+          const consumed = await consumeBuilderConnectPendingState(state);
+          if (!consumed) {
+            return fail(
+              403,
+              "No active Builder connect flow found. Restart the connection from Settings.",
+              ownerEmail,
+              "callback_verification_failed",
+              tracking,
+            );
+          }
+
+          const remainingStates = removeBuilderConnectStateCookie(
+            getCookie(event, BUILDER_CONNECT_STATE_COOKIE),
+            state,
+          );
+          if (remainingStates) {
+            setCookie(event, BUILDER_CONNECT_STATE_COOKIE, remainingStates, {
+              httpOnly: true,
+              secure: expectedRedirectUri.startsWith("https://"),
+              sameSite: "lax",
+              path: "/",
+              maxAge: Math.ceil(BUILDER_CONNECT_PENDING_TTL_MS / 1_000),
+            });
+          } else {
+            deleteCookie(event, BUILDER_CONNECT_STATE_COOKIE, { path: "/" });
           }
 
           try {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1060,6 +1060,43 @@ export async function readBuilderConnectPendingState(
 
 const BUILDER_CONNECT_PENDING_PREFIX = "builder-connect-pending:";
 
+type BuilderConnectPendingStateLookup =
+  | { status: "found"; state: string }
+  | { status: "absent" }
+  | { status: "unavailable" };
+
+export async function findBuilderConnectPendingStateForOwner(
+  ownerEmail: string,
+  now = Date.now(),
+  list: typeof listSettingsByPrefix = listSettingsByPrefix,
+): Promise<BuilderConnectPendingStateLookup> {
+  let rows: Array<{ key: string; value: Record<string, unknown> }>;
+  try {
+    rows = await list(BUILDER_CONNECT_PENDING_PREFIX);
+  } catch {
+    return { status: "unavailable" };
+  }
+
+  const matches = rows.filter((row) => {
+    const state = row.key.slice(BUILDER_CONNECT_PENDING_PREFIX.length);
+    return (
+      isSignedBuilderConnectState(state) &&
+      row.value.ownerEmail === ownerEmail &&
+      row.value.consumed !== true &&
+      typeof row.value.expiresAt === "number" &&
+      row.value.expiresAt > now &&
+      typeof row.value.encryptedOAuthFlow === "string" &&
+      typeof row.value.redirectUri === "string"
+    );
+  });
+
+  if (matches.length !== 1) return { status: "absent" };
+  return {
+    status: "found",
+    state: matches[0]!.key.slice(BUILDER_CONNECT_PENDING_PREFIX.length),
+  };
+}
+
 export async function purgeExpiredBuilderConnectPendingStates(
   now = Date.now(),
   dependencies: {
@@ -3175,7 +3212,7 @@ export function createCoreRoutesPlugin(
             );
           }
 
-          const state = requestUrl.searchParams.get("state");
+          let state = requestUrl.searchParams.get("state");
           const parentOrigin = getBuilderBrowserOriginForEvent(event);
           const fail = async (
             status: number,
@@ -3211,6 +3248,24 @@ export function createCoreRoutesPlugin(
             });
           };
 
+          const session = await getSession(event).catch(() => null); // coercion-ok: callback treats session read failure as unauthenticated
+          if (!state && session?.email) {
+            // ponytail: single pending-flow fallback; reject ambiguous concurrent
+            // connects until Builder reliably echoes the OAuth state.
+            const lookup = await findBuilderConnectPendingStateForOwner(
+              session.email,
+            );
+            if (lookup.status === "unavailable") {
+              return fail(
+                503,
+                "Builder connect callback could not be verified. Try again.",
+                session.email,
+                "pending_state_unavailable",
+              );
+            }
+            if (lookup.status === "found") state = lookup.state;
+          }
+
           if (!state || !isSignedBuilderConnectState(state)) {
             return fail(
               403,
@@ -3232,7 +3287,6 @@ export function createCoreRoutesPlugin(
             pending.tracking && typeof pending.tracking === "object"
               ? (pending.tracking as BuilderConnectTrackingParams)
               : {};
-          const session = await getSession(event).catch(() => null); // coercion-ok: callback treats session read failure as unauthenticated
           const expiresAt =
             typeof pending.expiresAt === "number" ? pending.expiresAt : 0;
           const encryptedOAuthFlow =

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1060,45 +1060,6 @@ export async function readBuilderConnectPendingState(
 
 const BUILDER_CONNECT_PENDING_PREFIX = "builder-connect-pending:";
 
-type BuilderConnectPendingStateLookup =
-  | { status: "found"; state: string }
-  | { status: "absent" }
-  | { status: "unavailable" };
-
-export async function findBuilderConnectPendingStateForOwner(
-  ownerEmail: string,
-  now = Date.now(),
-  list: typeof listSettingsByPrefix = listSettingsByPrefix,
-): Promise<BuilderConnectPendingStateLookup> {
-  let rows: Array<{ key: string; value: Record<string, unknown> }>;
-  try {
-    rows = await list(BUILDER_CONNECT_PENDING_PREFIX);
-  } catch {
-    return { status: "unavailable" };
-  }
-
-  const matches = rows.filter((row) => {
-    const state = row.key.slice(BUILDER_CONNECT_PENDING_PREFIX.length);
-    const value = row.value;
-    if (!value || typeof value !== "object") return false;
-    return (
-      isSignedBuilderConnectState(state) &&
-      value.ownerEmail === ownerEmail &&
-      value.consumed !== true &&
-      typeof value.expiresAt === "number" &&
-      value.expiresAt > now &&
-      typeof value.encryptedOAuthFlow === "string" &&
-      typeof value.redirectUri === "string"
-    );
-  });
-
-  if (matches.length !== 1) return { status: "absent" };
-  return {
-    status: "found",
-    state: matches[0]!.key.slice(BUILDER_CONNECT_PENDING_PREFIX.length),
-  };
-}
-
 export async function purgeExpiredBuilderConnectPendingStates(
   now = Date.now(),
   dependencies: {
@@ -2741,7 +2702,8 @@ export function createCoreRoutesPlugin(
             // No prior error row — fine
           }
 
-          const callbackUrl = resolveBuilderConnectCallbackUrl(event);
+          const state = createBuilderConnectState();
+          const callbackUrl = resolveBuilderConnectCallbackUrl(event, state);
           if (
             !callbackUrl ||
             !isBuilderConnectCallbackUrlAllowed(callbackUrl, event)
@@ -2785,8 +2747,6 @@ export function createCoreRoutesPlugin(
               parentOrigin: getBuilderBrowserOriginForEvent(event),
             });
           }
-          const state = createBuilderConnectState();
-
           // The standard OAuth client discovers Builder's protected-resource
           // metadata, dynamically registers, and creates its S256 verifier.
           // Persist that opaque protocol state encrypted and consume it once.
@@ -3250,24 +3210,6 @@ export function createCoreRoutesPlugin(
             });
           };
 
-          const session = await getSession(event).catch(() => null); // coercion-ok: callback treats session read failure as unauthenticated
-          if (!state && session?.email) {
-            // ponytail: single pending-flow fallback; reject ambiguous concurrent
-            // connects until Builder reliably echoes the OAuth state.
-            const lookup = await findBuilderConnectPendingStateForOwner(
-              session.email,
-            );
-            if (lookup.status === "unavailable") {
-              return fail(
-                503,
-                "Builder connect callback could not be verified. Restart the connection.",
-                session.email,
-                "pending_state_unavailable",
-              );
-            }
-            if (lookup.status === "found") state = lookup.state;
-          }
-
           if (!state || !isSignedBuilderConnectState(state)) {
             return fail(
               403,
@@ -3289,6 +3231,7 @@ export function createCoreRoutesPlugin(
             pending.tracking && typeof pending.tracking === "object"
               ? (pending.tracking as BuilderConnectTrackingParams)
               : {};
+          const session = await getSession(event).catch(() => null); // coercion-ok: callback treats session read failure as unauthenticated
           const expiresAt =
             typeof pending.expiresAt === "number" ? pending.expiresAt : 0;
           const encryptedOAuthFlow =
@@ -3299,7 +3242,10 @@ export function createCoreRoutesPlugin(
             typeof pending.redirectUri === "string"
               ? pending.redirectUri
               : null;
-          const expectedRedirectUri = resolveBuilderConnectCallbackUrl(event);
+          const expectedRedirectUri = resolveBuilderConnectCallbackUrl(
+            event,
+            state,
+          );
 
           if (
             !ownerEmail ||


### PR DESCRIPTION
Builder can return an authorization code without the OAuth state parameter, causing the shared callback to reject an otherwise active connection. Recover the authenticated owner's single live pending PKCE flow, while failing closed for ambiguous flows and surfacing storage failures.

Tests: core-routes-plugin.spec.ts (67 passed); @agent-native/core typecheck; pnpm guards (64 passed).