### PR TITLE
fix(slides): persist inline text edits

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -50,4 +50,13 @@ describe("SlideEditor render-phase safety", () => {
       'document.addEventListener("visibilitychange", flushWhenHidden',
     );
   });
+
+  it("keeps the live draft ref across lifecycle flushes", () => {
+    const start = source.indexOf("const flushInlineEditDraft");
+    const end = source.indexOf("const flushWhenHidden", start);
+    const flushBody = source.slice(start, end);
+    expect(flushBody).toContain("flushPendingSaves();");
+    expect(flushBody).not.toContain("inlineEditDraftRef.current = null");
+    expect(flushBody).not.toContain("onUpdateSlideRef.current");
+  });
 });

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1927,14 +1927,18 @@ export default function SlideEditor({
 
     const html = selected ? readCurrentSlideContentHtml() : null;
     const initial = inlineEditInitialContentRef.current;
-    if (
-      html !== null &&
-      shouldPersistInlineEditContent(initial, {
-        slideId: slide.id,
-        content: html,
-      })
-    ) {
-      onUpdateSlideRef.current({ content: html });
+    if (html !== null) {
+      const current = { slideId: slide.id, content: html };
+      if (shouldPersistInlineEditContent(initial, current)) {
+        const latestDraft = inlineEditDraftRef.current;
+        onUpdateSlideRef.current(
+          { content: html },
+          slide.id,
+          shouldPersistInlineEditContent(latestDraft, current)
+            ? undefined
+            : { recordUndoOnly: true },
+        );
+      }
     }
     onInlineEditEnd?.(slide.id);
     inlineEditDraftRef.current = null;
@@ -2016,10 +2020,12 @@ export default function SlideEditor({
       draft?.slideId === previousSlideId &&
       shouldPersistInlineEditContent(initial, draft)
     ) {
-      onUpdateSlideRef.current({ content: draft.content }, previousSlideId);
-      inlineEditDraftRef.current = null;
+      onUpdateSlideRef.current({ content: draft.content }, previousSlideId, {
+        recordUndoOnly: true,
+      });
     }
     if (editing || draft) onInlineEditEnd?.(previousSlideId);
+    inlineEditDraftRef.current = null;
     inlineEditInitialContentRef.current = null;
 
     previousSlideIdRef.current = slide.id;
@@ -2033,7 +2039,9 @@ export default function SlideEditor({
       const draft = inlineEditDraftRef.current;
       const initial = inlineEditInitialContentRef.current;
       if (shouldPersistInlineEditContent(initial, draft) && draft) {
-        onUpdateSlideRef.current({ content: draft.content }, draft.slideId);
+        onUpdateSlideRef.current({ content: draft.content }, draft.slideId, {
+          recordUndoOnly: true,
+        });
       }
       if (editingElRef.current || draft) {
         onInlineEditEndRef.current?.(

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1557,12 +1557,10 @@ export default function SlideEditor({
   // the keepalive queue before browser teardown.
   useEffect(() => {
     const flushInlineEditDraft = () => {
-      const draft = inlineEditDraftRef.current;
-      if (!draft) return;
-      onUpdateSlideRef.current({ content: draft.content }, draft.slideId, {
-        persistence: "debounced",
-      });
-      inlineEditDraftRef.current = null;
+      // Input captures already enqueue the current draft. Keep the ref while
+      // the editor remains mounted so the first edit after tab restore queues
+      // against the previous snapshot instead of being mistaken for setup.
+      if (!inlineEditDraftRef.current) return;
       flushPendingSaves();
     };
     const flushWhenHidden = () => {

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1930,9 +1930,9 @@ export default function SlideEditor({
       // resize and auto-fit again on the second click.
       setSelectedElementMeasurement(null);
       captureInlineEditDraft(slide.id);
-      // Mark the deck dirty immediately so SSE/poll refreshes do not replace
-      // the deck under an active contentEditable edit, even before the user
-      // types and triggers an onUpdateSlide flush.
+      // Mark the slide active immediately so SSE/poll refreshes do not replace
+      // the live DOM under an active contentEditable edit, even before the
+      // user types and triggers an onUpdateSlide flush.
       onInlineEditStart?.(slide.id);
       // Don't override the selection. The browser's native double-click
       // word-select (or single-click caret) is already on the element from the

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1605,13 +1605,20 @@ export default function SlideEditor({
     (slideId = slide.id) => {
       const html = readCurrentSlideContentHtml();
       if (html !== null) {
-        if (
-          !inlineEditInitialContentRef.current ||
-          inlineEditInitialContentRef.current.slideId !== slideId
-        ) {
-          inlineEditInitialContentRef.current = { slideId, content: html };
+        const next = { slideId, content: html };
+        const initial = inlineEditInitialContentRef.current;
+        if (!initial || initial.slideId !== slideId) {
+          inlineEditInitialContentRef.current = next;
         }
-        inlineEditDraftRef.current = { slideId, content: html };
+        if (
+          initial?.slideId === slideId &&
+          shouldPersistInlineEditContent(initial, next)
+        ) {
+          onUpdateSlideRef.current({ content: html }, slideId, {
+            preserveLocalState: true,
+          });
+        }
+        inlineEditDraftRef.current = next;
       }
     },
     [readCurrentSlideContentHtml, slide.id],
@@ -1980,9 +1987,18 @@ export default function SlideEditor({
   // otherwise never clear and permanently block live sync for that slide.
   useEffect(() => {
     return () => {
-      if (editingElRef.current || inlineEditDraftRef.current) {
-        onInlineEditEndRef.current?.(previousSlideIdRef.current);
+      const draft = inlineEditDraftRef.current;
+      const initial = inlineEditInitialContentRef.current;
+      if (shouldPersistInlineEditContent(initial, draft) && draft) {
+        onUpdateSlideRef.current({ content: draft.content }, draft.slideId);
       }
+      if (editingElRef.current || draft) {
+        onInlineEditEndRef.current?.(
+          draft?.slideId ?? previousSlideIdRef.current,
+        );
+      }
+      inlineEditDraftRef.current = null;
+      inlineEditInitialContentRef.current = null;
     };
   }, []);
 

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -658,9 +658,8 @@ interface SlideEditorProps {
   deckId?: string;
   /**
    * Called the moment the user enters contentEditable inline edit mode.
-   * The parent should call `markDeckDirty(deckId)` here so the SSE/poll
-   * reconcile path knows not to replace the deck under an active in-progress
-   * edit, even before a `content` update has been flushed.
+   * The parent should mark the slide as actively edited so the SSE/poll
+   * reconcile path knows not to replace it before a `content` update is queued.
    */
   onInlineEditStart?: (slideId: string) => void;
   /** Called after inline edit mode exits and its draft has been handed off.
@@ -1606,13 +1605,14 @@ export default function SlideEditor({
       const html = readCurrentSlideContentHtml();
       if (html !== null) {
         const next = { slideId, content: html };
+        const previous = inlineEditDraftRef.current;
         const initial = inlineEditInitialContentRef.current;
         if (!initial || initial.slideId !== slideId) {
           inlineEditInitialContentRef.current = next;
         }
         if (
-          initial?.slideId === slideId &&
-          shouldPersistInlineEditContent(initial, next)
+          previous?.slideId === slideId &&
+          previous.content !== next.content
         ) {
           onUpdateSlideRef.current({ content: html }, slideId, {
             preserveLocalState: true,

--- a/templates/slides/app/components/editor/inline-edit-session.test.ts
+++ b/templates/slides/app/components/editor/inline-edit-session.test.ts
@@ -15,6 +15,13 @@ describe("inline edit session", () => {
     expect(shouldPersistInlineEditContent(initial, { ...initial })).toBe(false);
   });
 
+  it("does not replay content already captured by the latest draft", () => {
+    const latestDraft = { ...initial, content: "<h1>Latest</h1>" };
+    expect(shouldPersistInlineEditContent(latestDraft, latestDraft)).toBe(
+      false,
+    );
+  });
+
   it("persists changed content", () => {
     expect(
       shouldPersistInlineEditContent(initial, {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -827,7 +827,7 @@ describe("DeckContext deck creation persistence", () => {
 
   it("records one undo entry when an inline draft commits", async () => {
     window.history.pushState({}, "", "/deck/inline-undo-deck");
-    const { setAccessibleDeck } = setupFetch();
+    const { fetchMock, setAccessibleDeck } = setupFetch();
     const { result } = renderHook(() => useDecks(), { wrapper });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -850,6 +850,7 @@ describe("DeckContext deck creation persistence", () => {
       await result.current.reloadDecks();
     });
 
+    vi.useFakeTimers();
     act(() => {
       result.current.updateSlide(
         "inline-undo-deck",
@@ -857,12 +858,26 @@ describe("DeckContext deck creation persistence", () => {
         { content: "<div>Draft</div>" },
         { preserveLocalState: true },
       );
-      // The editor's exit path commits the live DOM through the normal update
-      // path, which records the one deck-level undo entry for the session.
-      result.current.updateSlide("inline-undo-deck", "slide-1", {
-        content: "<div>Draft</div>",
-      });
+      // The editor's exit path updates local state and records the one
+      // deck-level undo entry without replaying an already-queued server op.
+      result.current.updateSlide(
+        "inline-undo-deck",
+        "slide-1",
+        {
+          content: "<div>Draft</div>",
+        },
+        { recordUndoOnly: true },
+      );
     });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("/_agent-native/actions/patch-deck"),
+      ),
+    ).toHaveLength(1);
 
     expect(result.current.getDeck("inline-undo-deck")?.slides[0]?.content).toBe(
       "<div>Draft</div>",
@@ -870,10 +885,8 @@ describe("DeckContext deck creation persistence", () => {
     expect(result.current.canUndo).toBe(true);
 
     act(() => result.current.undo());
-    await waitFor(() =>
-      expect(
-        result.current.getDeck("inline-undo-deck")?.slides[0]?.content,
-      ).toBe("<div>Original</div>"),
+    expect(result.current.getDeck("inline-undo-deck")?.slides[0]?.content).toBe(
+      "<div>Original</div>",
     );
   });
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -547,6 +547,81 @@ describe("DeckContext deck creation persistence", () => {
     );
   });
 
+  it("persists inline drafts without replacing the local editor state", async () => {
+    window.history.pushState({}, "", "/deck/inline-draft-deck");
+    const { fetchMock, setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const initial: Deck = {
+      id: "inline-draft-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<div>Original</div>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide(
+        "inline-draft-deck",
+        "slide-1",
+        { content: "<div>First draft</div>" },
+        { preserveLocalState: true },
+      );
+      result.current.updateSlide(
+        "inline-draft-deck",
+        "slide-1",
+        { content: "<div>Final draft</div>" },
+        { preserveLocalState: true },
+      );
+    });
+
+    expect(
+      result.current.getDeck("inline-draft-deck")?.slides[0]?.content,
+    ).toBe("<div>Original</div>");
+    expect(hasUncommittedDeckChanges("inline-draft-deck", new Set())).toBe(
+      true,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(([url, init]) => {
+      if (!String(url).includes("/_agent-native/actions/patch-deck")) {
+        return false;
+      }
+      return actionCallBody(init).deckId === "inline-draft-deck";
+    });
+    expect(patchCalls).toHaveLength(1);
+    expect(actionCallBody(patchCalls[0]?.[1])).toMatchObject({
+      deckId: "inline-draft-deck",
+      operations: [
+        {
+          op: "patch-slide",
+          slideId: "slide-1",
+          fields: { content: "<div>Final draft</div>" },
+        },
+      ],
+    });
+    expect(hasUncommittedDeckChanges("inline-draft-deck", new Set())).toBe(
+      false,
+    );
+  });
+
   it("persists a duplicated slide after the optimistic insert", async () => {
     window.history.pushState({}, "", "/");
     const { fetchMock, resolveCreate } = setupFetch();

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -17,7 +17,9 @@ vi.mock("@agent-native/core/client/org", () => ({
 
 import {
   DeckProvider,
+  clearSlideEditingActive,
   hasUncommittedDeckChanges,
+  markSlideEditingActive,
   mergeServerAddedSlides,
   useDecks,
   type Deck,
@@ -787,6 +789,63 @@ describe("DeckContext deck creation persistence", () => {
       );
     });
     expect(fullSaveCalls).toHaveLength(0);
+  });
+
+  it("protects an active inline draft after its autosave drains", async () => {
+    window.history.pushState({}, "", "/deck/inline-active-deck");
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const original = {
+      id: "inline-active-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<div>Original</div>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    } satisfies Deck;
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    markSlideEditingActive("inline-active-deck", "slide-1");
+    try {
+      vi.useFakeTimers();
+      act(() => {
+        result.current.updateSlide(
+          "inline-active-deck",
+          "slide-1",
+          { content: "<div>Draft</div>" },
+          { preserveLocalState: true },
+        );
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      setAccessibleDeck({
+        ...original,
+        slides: [{ ...original.slides[0], content: "<div>Agent</div>" }],
+      });
+      await act(async () => {
+        await result.current.refreshOpenDeck("inline-active-deck");
+      });
+
+      expect(
+        result.current.getDeck("inline-active-deck")?.slides[0]?.content,
+      ).toBe("<div>Original</div>");
+    } finally {
+      clearSlideEditingActive("inline-active-deck", "slide-1");
+    }
   });
 
   it("persists a duplicated slide after the optimistic insert", async () => {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -622,6 +622,173 @@ describe("DeckContext deck creation persistence", () => {
     );
   });
 
+  it("persists the latest inline draft when the user reverts before debounce", async () => {
+    window.history.pushState({}, "", "/deck/inline-revert-deck");
+    const { fetchMock, setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "inline-revert-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<div>Original</div>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide(
+        "inline-revert-deck",
+        "slide-1",
+        { content: "<div>Draft</div>" },
+        { preserveLocalState: true },
+      );
+      result.current.updateSlide(
+        "inline-revert-deck",
+        "slide-1",
+        { content: "<div>Original</div>" },
+        { preserveLocalState: true },
+      );
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const patchCalls = fetchMock.mock.calls.filter(([url, init]) => {
+      if (!String(url).includes("/_agent-native/actions/patch-deck")) {
+        return false;
+      }
+      return actionCallBody(init).deckId === "inline-revert-deck";
+    });
+    expect(patchCalls).toHaveLength(1);
+    expect(actionCallBody(patchCalls[0]?.[1])).toMatchObject({
+      operations: [
+        {
+          fields: { content: "<div>Original</div>" },
+        },
+      ],
+    });
+  });
+
+  it("records one undo entry when an inline draft commits", async () => {
+    window.history.pushState({}, "", "/deck/inline-undo-deck");
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "inline-undo-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<div>Original</div>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    act(() => {
+      result.current.updateSlide(
+        "inline-undo-deck",
+        "slide-1",
+        { content: "<div>Draft</div>" },
+        { preserveLocalState: true },
+      );
+      // The editor's exit path commits the live DOM through the normal update
+      // path, which records the one deck-level undo entry for the session.
+      result.current.updateSlide("inline-undo-deck", "slide-1", {
+        content: "<div>Draft</div>",
+      });
+    });
+
+    expect(result.current.getDeck("inline-undo-deck")?.slides[0]?.content).toBe(
+      "<div>Draft</div>",
+    );
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => result.current.undo());
+    await waitFor(() =>
+      expect(
+        result.current.getDeck("inline-undo-deck")?.slides[0]?.content,
+      ).toBe("<div>Original</div>"),
+    );
+  });
+
+  it("does not full-replace after an inline draft save and later deck render", async () => {
+    window.history.pushState({}, "", "/deck/inline-render-deck");
+    const { fetchMock, setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck({
+      id: "inline-render-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<div>Original</div>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide(
+        "inline-render-deck",
+        "slide-1",
+        { content: "<div>Draft</div>" },
+        { preserveLocalState: true },
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const fullSaveCalls = fetchMock.mock.calls.filter(([url, init]) => {
+      return (
+        String(url).includes("/_agent-native/actions/save-deck") &&
+        actionCallBody(init).deckId === "inline-render-deck"
+      );
+    });
+    expect(fullSaveCalls).toHaveLength(0);
+  });
+
   it("persists a duplicated slide after the optimistic insert", async () => {
     window.history.pushState({}, "", "/");
     const { fetchMock, resolveCreate } = setupFetch();

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -68,6 +68,8 @@ function addSlideFields(
 export type DeckReloadStatus = "loaded" | "failed" | "stale";
 export interface UpdateSlideOptions {
   persistence?: "debounced" | "immediate";
+  /** Queue a draft without replacing the active contentEditable DOM. */
+  preserveLocalState?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -661,7 +663,10 @@ async function flushDeckSave(deckId: string): Promise<void> {
 function enqueueDeckOp(
   deckId: string,
   op: GranularOp,
-  options?: { persistence?: "debounced" | "immediate" },
+  options?: {
+    persistence?: "debounced" | "immediate";
+    coalesceContent?: boolean;
+  },
 ) {
   const existing = pendingSaves.get(deckId);
   if (existing) clearTimeout(existing);
@@ -678,7 +683,21 @@ function enqueueDeckOp(
     pendingOpsQueue.set(deckId, [op]);
   } else {
     const queue = pendingOpsQueue.get(deckId) ?? [];
-    queue.push(op);
+    const previous = queue[queue.length - 1];
+    if (
+      options?.coalesceContent &&
+      previous?.op === "patch-slide" &&
+      op.op === "patch-slide" &&
+      previous.slideId === op.slideId &&
+      Object.keys(previous.fields).length === 1 &&
+      Object.keys(op.fields).length === 1 &&
+      "content" in previous.fields &&
+      "content" in op.fields
+    ) {
+      queue[queue.length - 1] = op;
+    } else {
+      queue.push(op);
+    }
     pendingOpsQueue.set(deckId, queue);
   }
 
@@ -2435,21 +2454,26 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const op: PatchDeckOp = { op: "patch-slide", slideId, fields: updates };
       if (before && !deriveInverseOp(before, op)) return;
       markDeckDirty(deckId);
-      setDecksLocal((prev: Deck[]) =>
-        prev.map((d) => {
-          if (d.id !== deckId) return d;
-          return {
-            ...d,
-            slides: d.slides.map((s) =>
-              s.id === slideId ? { ...s, ...updates } : s,
-            ),
-            updatedAt: new Date().toISOString(),
-          };
-        }),
-      );
+      if (!options?.preserveLocalState) {
+        setDecksLocal((prev: Deck[]) =>
+          prev.map((d) => {
+            if (d.id !== deckId) return d;
+            return {
+              ...d,
+              slides: d.slides.map((s) =>
+                s.id === slideId ? { ...s, ...updates } : s,
+              ),
+              updatedAt: new Date().toISOString(),
+            };
+          }),
+        );
+      }
       // Granular op — only this slide's changed fields reach the server.
-      enqueueDeckOp(deckId, op, options);
-      if (before) {
+      enqueueDeckOp(deckId, op, {
+        persistence: options?.persistence,
+        coalesceContent: options?.preserveLocalState,
+      });
+      if (before && !options?.preserveLocalState) {
         // Coalesce a burst of edits to the SAME slide's SAME field-set into one
         // undo step (e.g. typing characters into inline text). Distinct
         // field-sets (content vs background vs layout) get distinct undo steps.

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -402,10 +402,9 @@ const pendingOpsQueue = new Map<string, GranularOp[]>();
 // whole request duration, starving unrelated agent writes of live sync.
 const inFlightOpSlides = new Map<string, GranularOp[]>();
 
-// Slides currently mid inline-edit (contentEditable open, keystrokes not yet
-// committed to a "patch-slide" op). `onInlineEditStart`/`onInlineEditEnd`
-// keep this current; a slide only reaches `pendingOpsQueue` when editing
-// ends, so this is the only signal that catches live, uncommitted typing.
+// Slides currently mid inline-edit (contentEditable open). `onInlineEditStart`
+// /`onInlineEditEnd` keep this current while content captures queue granular
+// ops without replacing the live DOM.
 const activeInlineEditSlides = new Map<string, Set<string>>();
 
 /** Mark `slideId` as mid inline-edit so a concurrent agent write to the same
@@ -2452,8 +2451,14 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             : "Edit slide";
       const before = decksRef.current.find((d) => d.id === deckId);
       const op: PatchDeckOp = { op: "patch-slide", slideId, fields: updates };
-      if (before && !deriveInverseOp(before, op)) return;
-      markDeckDirty(deckId);
+      if (
+        before &&
+        !deriveInverseOp(before, op) &&
+        !options?.preserveLocalState
+      ) {
+        return;
+      }
+      if (!options?.preserveLocalState) markDeckDirty(deckId);
       if (!options?.preserveLocalState) {
         setDecksLocal((prev: Deck[]) =>
           prev.map((d) => {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -70,6 +70,8 @@ export interface UpdateSlideOptions {
   persistence?: "debounced" | "immediate";
   /** Queue a draft without replacing the active contentEditable DOM. */
   preserveLocalState?: boolean;
+  /** Record the edit for undo without enqueueing a duplicate server write. */
+  recordUndoOnly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -2471,6 +2473,29 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         !deriveInverseOp(before, op) &&
         !options?.preserveLocalState
       ) {
+        return;
+      }
+      if (options?.recordUndoOnly) {
+        if (before) {
+          setDecksLocal((prev: Deck[]) =>
+            prev.map((d) => {
+              if (d.id !== deckId) return d;
+              return {
+                ...d,
+                slides: d.slides.map((s) =>
+                  s.id === slideId ? { ...s, ...updates } : s,
+                ),
+                updatedAt: new Date().toISOString(),
+              };
+            }),
+          );
+          recordUndo(before, op, {
+            label,
+            coalesceKey: `${deckId}:${slideId}:${Object.keys(updates)
+              .sort()
+              .join(",")}`,
+          });
+        }
         return;
       }
       if (!options?.preserveLocalState) markDeckDirty(deckId);

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1698,7 +1698,8 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
       const hasLocalEdits =
         pendingCreateIdsRef.current.has(currentOpenId) ||
-        hasUncommittedDeckChanges(currentOpenId, dirtyDeckIdsRef.current);
+        hasUncommittedDeckChanges(currentOpenId, dirtyDeckIdsRef.current) ||
+        (activeInlineEditSlides.get(currentOpenId)?.size ?? 0) > 0;
 
       if (hasLocalEdits && clientDeck) {
         // Content-preserving: only ADD server slides missing locally.

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -160,7 +160,6 @@ export default function DeckEditor() {
     addSlide,
     flushDeckSave,
     reorderSlides,
-    markDeckDirty,
     undo,
     loading,
     loadError,
@@ -1770,7 +1769,6 @@ export default function DeckEditor() {
               )
             }
             onInlineEditStart={(slideId) => {
-              markDeckDirty(id);
               if (id) markSlideEditingActive(id, slideId);
             }}
             onInlineEditEnd={(slideId) => {

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -168,7 +168,6 @@ export default function DeckEditor() {
   const deckAccessStatusQuery = useDeckAccessStatus(id);
   const requestDeckAccessMutation = useRequestDeckAccess();
   const [activeSlideId, setActiveSlideId] = useState<string | null>(null);
-  const [inlineEditActive, setInlineEditActive] = useState(false);
   const [addSlideGenerating, setAddSlideGenerating] = useState(false);
   // The blank placeholder the agent was asked to fill in place. The rail must
   // light THAT row up as AI-active instead of appending a synthetic generating
@@ -180,8 +179,7 @@ export default function DeckEditor() {
   }, []);
   const [generatingSlideSelected, setGeneratingSlideSelected] = useState(false);
   const { hasUnsavedChanges: hasUnsavedSave } = useSaveState();
-  const hasPendingDeckEdits =
-    inlineEditActive || (id ? hasUnsavedDeckChanges(id) : hasUnsavedSave);
+  const hasPendingDeckEdits = id ? hasUnsavedDeckChanges(id) : hasUnsavedSave;
   usePendingDeckUnloadGuard(hasPendingDeckEdits);
   const pendingDeckNavigationBlocker = useBlocker(
     useCallback(
@@ -1772,12 +1770,10 @@ export default function DeckEditor() {
               )
             }
             onInlineEditStart={(slideId) => {
-              setInlineEditActive(true);
               markDeckDirty(id);
               if (id) markSlideEditingActive(id, slideId);
             }}
             onInlineEditEnd={(slideId) => {
-              setInlineEditActive(false);
               if (id) clearSlideEditingActive(id, slideId);
             }}
             onGenerateImage={() => setImageGenOpen(true)}

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -179,11 +179,13 @@ export default function DeckEditor() {
   }, []);
   const [generatingSlideSelected, setGeneratingSlideSelected] = useState(false);
   const { hasUnsavedChanges: hasUnsavedSave } = useSaveState();
-  const hasPendingDeckEdits =
-    inlineEditActive || (id ? hasUnsavedDeckChanges(id) : hasUnsavedSave);
+  // useSaveState re-renders this component when a preserved inline draft enters
+  // or leaves the shared save queue, so the deck-specific read stays current.
+  const hasPendingDeckWrites = id ? hasUnsavedDeckChanges(id) : hasUnsavedSave;
+  const hasPendingDeckEdits = inlineEditActive || hasPendingDeckWrites;
   // Inline drafts flush through SlideEditor keepalive handlers. The native
   // prompt only needs to cover queued or in-flight writes now.
-  usePendingDeckUnloadGuard(id ? hasUnsavedDeckChanges(id) : hasUnsavedSave);
+  usePendingDeckUnloadGuard(hasPendingDeckWrites);
   const pendingDeckNavigationBlocker = useBlocker(
     useCallback(
       ({ currentLocation, nextLocation }) =>


### PR DESCRIPTION
Fixes the Slides report from Oliver: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787754740394719

Inline contentEditable drafts now queue autosaves without replacing the active DOM, coalesce draft content writes, flush on refresh, and no longer mark an active editor as unsaved by itself. Added focused persistence coverage.

Verification:
- Local browser: typed an edit, opened the agent panel, refreshed immediately, and confirmed the edit survived with no beforeunload dialog.
- 43 focused Slides tests passed
- 64 repository guards passed
- Slides typecheck passed