### PR TITLE
fix: refresh serverless release size baselines

### DIFF
--- a/scripts/serverless-function-baseline.json
+++ b/scripts/serverless-function-baseline.json
@@ -1,8 +1,8 @@
 {
   "@agent-native/docs": {
     "agent-native-recurring-jobs": 1758,
-    "server": 23054523,
-    "server-agent-background": 13204810
+    "server": 30828134,
+    "server-agent-background": 20656947
   },
   "analytics": {
     "agent-native-recurring-jobs": 1758,
@@ -34,13 +34,13 @@
   },
   "calendar": {
     "agent-native-recurring-jobs": 1758,
-    "server": 22139899,
-    "server-agent-background": 15361339
+    "server": 27787264,
+    "server-agent-background": 20761805
   },
   "chat": {
     "agent-native-recurring-jobs": 1758,
-    "server": 19283423,
-    "server-agent-background": 12632830
+    "server": 26633830,
+    "server-agent-background": 20027802
   },
   "clips": {
     "agent-native-recurring-jobs": 1758,
@@ -50,18 +50,18 @@
   },
   "content": {
     "agent-native-recurring-jobs": 1758,
-    "server": 41767636,
-    "server-agent-background": 25753432
+    "server": 49492787,
+    "server-agent-background": 33135002
   },
   "dispatch": {
     "agent-native-recurring-jobs": 1758,
-    "server": 35066699,
-    "server-agent-background": 35071363
+    "server": 41733325,
+    "server-agent-background": 41733325
   },
   "factory": {
     "agent-native-recurring-jobs": 1758,
-    "server": 19830916,
-    "server-agent-background": 19835580
+    "server": 27262976,
+    "server-agent-background": 27367834
   },
   "forms": {
     "agent-native-recurring-jobs": 1758,
@@ -70,8 +70,8 @@
   },
   "macros": {
     "agent-native-recurring-jobs": 1758,
-    "server": 19486875,
-    "server-agent-background": 12898938
+    "server": 26843546,
+    "server-agent-background": 20342374
   },
   "mail": {
     "agent-native-recurring-jobs": 1758,
@@ -80,8 +80,8 @@
   },
   "plan": {
     "agent-native-recurring-jobs": 1758,
-    "server": 25092838,
-    "server-agent-background": 16780809
+    "server": 32715571,
+    "server-agent-background": 24222106
   },
   "slides": {
     "agent-native-recurring-jobs": 1758,


### PR DESCRIPTION
## Summary

- Refresh the production and beta serverless function baselines after the intentional Run evaluator dependency increased emitted payloads.
- Keep the shared size gate intact so future unexpected growth still fails both release lanes.

## Verification

- `corepack pnpm test:package-release-workflow`
- `corepack pnpm test:netlify-prebuilt-workflow`
- `corepack pnpm guard:netlify-prebuilt-workflow`
- Synthetic size-baseline checks for all eight affected sites