### PR TITLE
Fix mobile Clips comment composer padding

### DIFF
--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -133,6 +133,14 @@ describe("CommentsPanel reply composer", () => {
     expect(container.textContent).toContain("www.example.org/help.");
   });
 
+  it("keeps the compact comment composer text inset", () => {
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="commentsPanel.leaveComment"]',
+    );
+
+    expect(composer?.className).toContain("px-3 py-2");
+  });
+
   it("renders inline Markdown while flattening headings", () => {
     renderPanel("viewer@example.com", [
       {

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -681,7 +681,7 @@ function CommentComposer({
           className={cn(
             "resize-none border-0 bg-background text-sm",
             isSharePresentation
-              ? "min-h-10 flex-1 border-0 p-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              ? "min-h-10 flex-1 border-0 px-3 py-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               : "min-h-[60px]",
           )}
           onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
- restore padding inside the compact Clips comment composer
- keep the desktop composer layout unchanged
- add a regression assertion for the compact textarea inset

## Validation
- `corepack pnpm --filter clips exec vitest --run app/components/player/comments-panel.test.tsx`
- `corepack pnpm --filter clips typecheck`
- `corepack pnpm guards`
