### PR TITLE
fix: reset docs scroll on app navigation

### DIFF
--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -7,7 +7,14 @@ import {
 import { recoverFromStaleChunkError } from "@agent-native/core/client/route-chunk-recovery";
 import { ErrorReportActions } from "@agent-native/core/client/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { lazy, Suspense, useState, useEffect, useRef } from "react";
+import {
+  lazy,
+  Suspense,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 import {
   Links,
   Meta,
@@ -205,6 +212,8 @@ function DocsI18nProvider({ children }: { children: React.ReactNode }) {
 }
 
 const SCROLL_MANAGER_MARKER = "docs-scroll-manager-marker";
+const useBrowserLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 function SeoLinks() {
   const location = useLocation();
@@ -304,7 +313,7 @@ function ScrollManager() {
   const ref = useRef<HTMLSpanElement>(null);
   const isInitialEffectRef = useRef(true);
 
-  useEffect(() => {
+  useBrowserLayoutEffect(() => {
     const isInitialEffect = isInitialEffectRef.current;
     isInitialEffectRef.current = false;
 


### PR DESCRIPTION
## Summary

- Run the docs scroll manager in an SSR-safe layout effect so app navigation resets the destination scroll position before it paints.
- Cover both the window scroller and the nested sidebar scroller without adding per-link behavior.

## Verification

- `corepack pnpm --filter @agent-native/docs exec vitest run app/root.spec.ts` - 4 passed
- `corepack pnpm --filter @agent-native/docs typecheck` - passed; only the expected missing production config warnings were printed
- Playwright browser checks for `/` and `/apps` to `/apps/clips`, including the open-sidebar nested scroll mode
- `git diff --check` - passed
