### PR TITLE
fix(dispatch): contain page scrolling

### DIFF
--- a/.changeset/dispatch-scroll-boundary.md
+++ b/.changeset/dispatch-scroll-boundary.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Keep Dispatch page scrolling inside the viewport and replace the global header with a sticky agent-chat control.

--- a/packages/dispatch/src/components/dispatch-shell.tsx
+++ b/packages/dispatch/src/components/dispatch-shell.tsx
@@ -8,10 +8,9 @@ import { useSetPageTitle } from "./layout/HeaderActions";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
 /**
- * DispatchShell renders the per-page title (with an optional click-to-open
- * description popover) into the global header via the HeaderActions store.
- * The actual chrome (sidebar, AgentSidebar, header bar with AgentToggleButton)
- * is provided by `Layout` mounted in `root.tsx`.
+ * DispatchShell registers the per-page title (with an optional click-to-open
+ * description popover) with the HeaderActions store for layouts that expose
+ * that metadata.
  */
 export function DispatchShell({
   title,

--- a/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
+++ b/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
@@ -21,6 +21,8 @@ describe("Dispatch layout scrolling", () => {
       "<RunsTray limit={8} onOpenThread={openRunThread} />",
     );
     expect(layoutSource).toContain("<AgentToggleButton");
+    expect(layoutSource).toContain("useHeaderTitle");
+    expect(layoutSource).toContain("useHeaderActions");
     expect(layoutSource).not.toContain("showHeader ? <Header onOpenMobile");
   });
 });

--- a/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
+++ b/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
@@ -17,6 +17,9 @@ describe("Dispatch layout scrolling", () => {
     expect(layoutSource).toContain(
       'className="pointer-events-none sticky top-0',
     );
+    expect(layoutSource).toContain(
+      "<RunsTray limit={8} onOpenThread={openRunThread} />",
+    );
     expect(layoutSource).toContain("<AgentToggleButton");
     expect(layoutSource).not.toContain("showHeader ? <Header onOpenMobile");
   });

--- a/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
+++ b/packages/dispatch/src/components/layout/Layout.app-chat.spec.ts
@@ -11,6 +11,17 @@ const railSource = readFileSync(
   "utf8",
 );
 
+describe("Dispatch layout scrolling", () => {
+  it("keeps page scrolling inside the viewport with a sticky chat control", () => {
+    expect(layoutSource).toMatch(/<main\s+className=\{cn\(\s*"min-h-0 flex-1"/);
+    expect(layoutSource).toContain(
+      'className="pointer-events-none sticky top-0',
+    );
+    expect(layoutSource).toContain("<AgentToggleButton");
+    expect(layoutSource).not.toContain("showHeader ? <Header onOpenMobile");
+  });
+});
+
 describe("Dispatch workspace app chat rail", () => {
   it("routes the open-app rail through the shared app-chat component", () => {
     // Both app surfaces must share one rail: a second inlined AgentSidebar is

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import {
   CHAT_FIRST_MODE_CHANGED_EVENT,
   AgentChatSurface,
+  AgentToggleButton,
   chatFirstSurfaceTabId,
   AgentSidebar,
   ChatFirstSurfacePanelToggle,
@@ -76,6 +77,7 @@ import {
   IconHierarchy2,
   IconMessageQuestion,
   IconBroadcast,
+  IconLayoutSidebar,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
   IconSettings,
@@ -116,6 +118,7 @@ import {
 import { CHAT_FIRST_PANE_STATE_KEY } from "../../shared/chat-first-pane";
 import { AppIcon } from "../app-icon";
 import { CreateAppPopover } from "../create-app-popover";
+import { Button } from "../ui/button";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "../ui/sheet";
 import { Skeleton } from "../ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
@@ -256,9 +259,8 @@ export function useDispatchExtensions(): DispatchExtensionConfig | undefined {
   return useContext(DispatchExtensionsContext);
 }
 
-// Routes whose page renders its own toolbar.
-// Layout still mounts the sidebar + AgentSidebar, but skips its own Header so
-// there's no double-header.
+// Routes whose page renders its own toolbar. Layout skips its sticky chat
+// control so there's no duplicate page chrome.
 function pageOwnsToolbar(pathname: string): boolean {
   if (pathname === "/tools" || pathname.startsWith("/tools/")) return true;
   if (pathname === "/extensions" || pathname.startsWith("/extensions/"))
@@ -2283,7 +2285,7 @@ export function Layout({
     );
   }
 
-  const showHeader = !isChatRoute && !pageOwnsToolbar(localPathname);
+  const showAgentControls = !isChatRoute && !pageOwnsToolbar(localPathname);
   function openAskAgentFullscreen() {
     focusAgentChat();
     navigateWithAgentChatViewTransition(
@@ -2297,8 +2299,7 @@ export function Layout({
     t("dispatch.sidebar.suggestionGrantKey"),
   ];
   const appContent = (
-    <div className="relative flex h-full min-w-0 flex-1 flex-col overflow-hidden">
-      {showHeader ? <Header onOpenMobile={() => setMobileOpen(true)} /> : null}
+    <div className="relative flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       <InvitationBanner />
       {isChatRoute && chatFirstMode && chatFirstHasActiveChat ? (
         <ChatFirstSurfacePanelToggle
@@ -2325,16 +2326,30 @@ export function Layout({
       ) : null}
       <main
         className={cn(
-          "flex-1",
+          "min-h-0 flex-1",
           isChatRoute || isWorkspaceAppRoute
-            ? "min-h-0 overflow-hidden"
+            ? "overflow-hidden"
             : "overflow-y-auto",
         )}
       >
-        {showHeader ? (
-          <div className="mx-auto max-w-7xl space-y-10 px-4 py-6 sm:px-6">
-            {children}
-          </div>
+        {showAgentControls ? (
+          <>
+            <div className="pointer-events-none sticky top-0 z-10 flex justify-end px-4 pt-2 lg:px-6">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="pointer-events-auto absolute start-4 top-2 h-8 w-8 lg:hidden"
+                onClick={() => setMobileOpen(true)}
+                aria-label="Open navigation"
+              >
+                <IconLayoutSidebar className="h-4 w-4" />
+              </Button>
+              <AgentToggleButton className="pointer-events-auto h-8 w-8 rounded-md bg-background/80 hover:bg-accent" />
+            </div>
+            <div className="mx-auto max-w-7xl space-y-10 px-4 py-6 sm:px-6">
+              {children}
+            </div>
+          </>
         ) : (
           children
         )}

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -62,6 +62,7 @@ import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { InvitationBanner, OrgSwitcher } from "@agent-native/core/client/org";
+import { RunsTray } from "@agent-native/core/client/progress";
 import { FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
@@ -2293,6 +2294,23 @@ export function Layout({
       dispatchNavLinkTarget("/chat"),
     );
   }
+  function openRunThread(threadId: string) {
+    navigate("/chat", {
+      state: {
+        dispatchThread: {
+          id: `${Date.now()}-${threadId}`,
+          threadId,
+        },
+      },
+    });
+    window.requestAnimationFrame(() => {
+      window.dispatchEvent(
+        new CustomEvent("agent-chat:open-thread", {
+          detail: { threadId },
+        }),
+      );
+    });
+  }
   const sidebarSuggestions = [
     t("dispatch.sidebar.suggestionBuildApp"),
     t("dispatch.sidebar.suggestionRouteSlack"),
@@ -2344,7 +2362,10 @@ export function Layout({
               >
                 <IconLayoutSidebar className="h-4 w-4" />
               </Button>
-              <AgentToggleButton className="pointer-events-auto h-8 w-8 rounded-md bg-background/80 hover:bg-accent" />
+              <div className="pointer-events-auto flex items-center gap-1">
+                <RunsTray limit={8} onOpenThread={openRunThread} />
+                <AgentToggleButton className="h-8 w-8 rounded-md bg-background/80 hover:bg-accent" />
+              </div>
             </div>
             <div className="mx-auto max-w-7xl space-y-10 px-4 py-6 sm:px-6">
               {children}

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -129,7 +129,11 @@ import {
   WorkspaceAppKeepAlive,
 } from "../workspace-app-host";
 import { Header } from "./Header";
-import { HeaderActionsProvider } from "./HeaderActions";
+import {
+  HeaderActionsProvider,
+  useHeaderActions,
+  useHeaderTitle,
+} from "./HeaderActions";
 
 export { buildChatFirstEmbedSessionInput } from "../workspace-app-host";
 
@@ -1403,6 +1407,8 @@ export function Layout({
   const t = useT();
   const location = useLocation();
   const navigate = useNavigate();
+  const pageTitle = useHeaderTitle();
+  const headerActions = useHeaderActions();
   const [mobileOpen, setMobileOpen] = useState(false);
   // Drives renderChatFirstSurfaceTab's app-tab chatSidebar decision below —
   // the chat-first surface panel is already a full-screen overlay at this
@@ -2368,6 +2374,16 @@ export function Layout({
               </div>
             </div>
             <div className="mx-auto max-w-7xl space-y-10 px-4 py-6 sm:px-6">
+              {localPathname !== "/overview" && (pageTitle || headerActions) ? (
+                <div className="flex min-w-0 items-center justify-between gap-3">
+                  <div className="min-w-0 flex-1">{pageTitle}</div>
+                  {headerActions ? (
+                    <div className="flex shrink-0 items-center gap-2">
+                      {headerActions}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
               {children}
             </div>
           </>


### PR DESCRIPTION
## Summary
- Keep standard Dispatch page scrolling inside the viewport.
- Replace the shared page header with a transparent sticky agent-chat control and retain mobile navigation.

## Validation
- Focused layout tests: 30 passed.
- Dispatch typecheck passed.
- All 64 repository guards passed.
- Standalone Dispatch browser check: document scroll stayed at viewport height, main scrolled independently, and the sticky toggle remained at top: 0 after scrolling.