### PR TITLE
fix: keep Clips todo requests in chat

### DIFF
--- a/.changeset/clips-a2a-tool-names.md
+++ b/.changeset/clips-a2a-tool-names.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep ordinary cross-app todo requests in chat and make oversized provider tool names safe for A2A handoffs.

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -37,6 +37,7 @@ import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
 } from "./output-tokens.js";
+import { createProviderToolNameMap } from "./tool-name.js";
 import {
   engineToolsToAISDK,
   engineMessagesToAISDK,
@@ -309,15 +310,17 @@ class AISDKEngine implements AgentEngine {
       return;
     }
 
+    const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
     const aiSdkTools =
       opts.tools.length > 0
-        ? engineToolsToAISDK(opts.tools, jsonSchema)
+        ? engineToolsToAISDK(opts.tools, jsonSchema, toolNameMap)
         : undefined;
     const messages = engineMessagesToAISDK(opts.messages, {
       // Vision-capable provider translators (anthropic/openai/google/
       // openrouter) map image parts to native blocks; the rest stringify
       // tool-result content arrays, so images degrade to their text notes.
       toolResultImages: this.capabilities.vision,
+      toolNameMap,
     });
 
     // Resolved once so both `maxOutputTokens` (below, in the streamText call)
@@ -481,7 +484,7 @@ class AISDKEngine implements AgentEngine {
           : {}),
         abortSignal: firstEventAbort.signal,
         onStepFinish: (step: any) => {
-          assistantContent = aiSdkStepToAssistantContent(step);
+          assistantContent = aiSdkStepToAssistantContent(step, toolNameMap);
         },
         ...(Object.keys(providerOpts).length > 0
           ? { providerOptions: providerOpts }
@@ -504,7 +507,7 @@ class AISDKEngine implements AgentEngine {
           sawFirstEvent = true;
           firstEventAbort.markFirstEvent();
         }
-        for (const event of aiSdkPartToEngineEvents(part)) {
+        for (const event of aiSdkPartToEngineEvents(part, toolNameMap)) {
           observeStreamedToolInput(toolInputs, event);
           if (
             event.type === "stop" &&

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -34,6 +34,7 @@ import {
   splitSystemPromptForCache,
   stablePrefixCacheControl,
 } from "./prompt-cache.js";
+import { createProviderToolNameMap } from "./tool-name.js";
 import {
   engineToolsToAnthropic,
   engineMessagesToAnthropic,
@@ -83,8 +84,9 @@ class AnthropicEngine implements AgentEngine {
     // multiplies the two layers into ~12 HTTP requests per failed run.
     const client = new Anthropic({ apiKey: this.apiKey, maxRetries: 1 });
 
-    const tools = engineToolsToAnthropic(opts.tools);
-    const messages = engineMessagesToAnthropic(opts.messages);
+    const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
+    const tools = engineToolsToAnthropic(opts.tools, toolNameMap);
+    const messages = engineMessagesToAnthropic(opts.messages, toolNameMap);
     const anthropicOpts = opts.providerOptions?.anthropic;
 
     // Resolved once so both max_tokens and the thinking-budget headroom
@@ -234,7 +236,11 @@ class AnthropicEngine implements AgentEngine {
         // The SDK's SSE parsing already drops `ping` keepalives before they
         // reach this loop, so any chunk here is real provider progress.
         firstEventAbort.markFirstEvent();
-        const events = anthropicChunkToEngineEvents(chunk, chunkState);
+        const events = anthropicChunkToEngineEvents(
+          chunk,
+          chunkState,
+          toolNameMap,
+        );
         for (const event of events) {
           observeStreamedToolInput(toolInputs, event);
           yield event;
@@ -242,7 +248,10 @@ class AnthropicEngine implements AgentEngine {
       }
 
       const finalMessage = await apiStream.finalMessage();
-      const assistantContent = anthropicContentToEngine(finalMessage.content);
+      const assistantContent = anthropicContentToEngine(
+        finalMessage.content,
+        toolNameMap,
+      );
 
       // The final content can carry the same tool call with an empty input
       // even though the stream already delivered complete argument deltas.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -599,6 +599,39 @@ describe("createBuilderEngine", () => {
     });
   });
 
+  it("aliases oversized tool names on the gateway wire and restores them", async () => {
+    const longName = `mcp__${"server_".repeat(8)}__get_meetings`;
+    let providerName = "";
+    const fetchSpy = vi.fn().mockImplementation(async (_url, init) => {
+      const body = JSON.parse(init.body as string);
+      providerName = body.tools[0].name;
+      return jsonlResponse([
+        { type: "tool-call", id: "toolu_01", name: providerName, input: {} },
+        { type: "stop", reason: "tool_use", requestId: "req_1" },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const events = await collectEvents(
+      createBuilderEngine().stream({
+        ...BASE_OPTS,
+        tools: [
+          {
+            name: longName,
+            description: "Get meetings",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    );
+
+    expect(providerName).not.toBe(longName);
+    expect(providerName.length).toBeLessThanOrEqual(64);
+    expect(events.find((event) => event.type === "tool-call")).toMatchObject({
+      name: longName,
+    });
+  });
+
   it("assembles a tool call whose arguments arrive across multiple deltas without a terminal tool-call frame", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -62,6 +62,11 @@ import {
   stablePrefixCacheControl,
 } from "./prompt-cache.js";
 import {
+  createProviderToolNameMap,
+  toEngineToolName,
+  type ProviderToolNameMap,
+} from "./tool-name.js";
+import {
   createStreamedToolInputState,
   engineMessagesToBuilderGatewayAnthropic,
   engineToolsToAnthropic,
@@ -258,8 +263,12 @@ class BuilderEngine implements AgentEngine {
       requestedModel.length === 0 || requestedModel === "auto"
         ? BUILDER_DEFAULT_MODEL
         : requestedModel;
-    const messages = engineMessagesToBuilderGatewayAnthropic(opts.messages);
-    const tools = engineToolsToAnthropic(opts.tools);
+    const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
+    const messages = engineMessagesToBuilderGatewayAnthropic(
+      opts.messages,
+      toolNameMap,
+    );
+    const tools = engineToolsToAnthropic(opts.tools, toolNameMap);
     const thinkingBudget =
       opts.providerOptions?.anthropic?.thinking?.budgetTokens;
     const reasoningEffort = normalizeReasoningEffortForModel(
@@ -519,6 +528,7 @@ class BuilderEngine implements AgentEngine {
       }
 
       yield* parseJsonlStream(reader, model, {
+        toolNameMap,
         creditsLane,
         abortSignal: gatewayAbort.signal,
         didGatewayTimeout: gatewayAbort.didTimeout,
@@ -759,6 +769,7 @@ async function* parseJsonlStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   model: string,
   captureContext: {
+    toolNameMap?: ProviderToolNameMap;
     abortSignal?: AbortSignal;
     didGatewayTimeout?: () => boolean;
     getGatewayTimeoutMs?: () => number;
@@ -880,7 +891,10 @@ async function* parseJsonlStream(
           const delta: EngineEvent = {
             type: "tool-input-delta",
             id: event.id,
-            name: event.name,
+            name:
+              typeof event.name === "string"
+                ? toEngineToolName(event.name, captureContext.toolNameMap)
+                : event.name,
             text:
               typeof event.argsTextDelta === "string"
                 ? event.argsTextDelta
@@ -902,7 +916,10 @@ async function* parseJsonlStream(
           const call = {
             type: "tool-call" as const,
             id: event.id,
-            name: event.name,
+            name:
+              typeof event.name === "string"
+                ? toEngineToolName(event.name, captureContext.toolNameMap)
+                : event.name,
             input: event.input,
           };
           parts.push(call);

--- a/packages/core/src/agent/engine/tool-name.ts
+++ b/packages/core/src/agent/engine/tool-name.ts
@@ -1,0 +1,82 @@
+import type { EngineMessage, EngineTool } from "./types.js";
+
+export const PROVIDER_TOOL_NAME_MAX_LENGTH = 64;
+
+export interface ProviderToolNameMap {
+  toEngine: ReadonlyMap<string, string>;
+  toProvider: ReadonlyMap<string, string>;
+}
+
+function hashToolName(value: string, seed: number): string {
+  let hash = seed;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function providerToolAlias(name: string): string {
+  return `tool_${hashToolName(name, 2166136261)}_${hashToolName(name, 16777619)}`;
+}
+
+function toolNamesFromMessages(messages: readonly EngineMessage[]): string[] {
+  return messages.flatMap((message) =>
+    message.content.flatMap((part) => {
+      if (part.type === "tool-call") return [part.name];
+      if (part.type === "tool-result") return [part.toolName];
+      return [];
+    }),
+  );
+}
+
+export function createProviderToolNameMap(
+  tools: readonly EngineTool[],
+  messages: readonly EngineMessage[] = [],
+): ProviderToolNameMap {
+  const names = new Set([
+    ...tools.map((tool) => tool.name),
+    ...toolNamesFromMessages(messages),
+  ]);
+  const usedProviderNames = new Set(
+    [...names].filter((name) => name.length <= PROVIDER_TOOL_NAME_MAX_LENGTH),
+  );
+  const toProvider = new Map<string, string>();
+  const toEngine = new Map<string, string>();
+
+  for (const name of names) {
+    if (name.length <= PROVIDER_TOOL_NAME_MAX_LENGTH) {
+      toProvider.set(name, name);
+      toEngine.set(name, name);
+      continue;
+    }
+
+    const base = providerToolAlias(name);
+    let alias = base;
+    let suffix = 1;
+    while (usedProviderNames.has(alias)) {
+      alias = `${base}_${suffix}`;
+      suffix += 1;
+    }
+    usedProviderNames.add(alias);
+    toProvider.set(name, alias);
+    toEngine.set(alias, name);
+  }
+
+  return { toEngine, toProvider };
+}
+
+export function toProviderToolName(
+  name: string,
+  map?: ProviderToolNameMap,
+): string {
+  if (name.length <= PROVIDER_TOOL_NAME_MAX_LENGTH) return name;
+  return map?.toProvider.get(name) ?? providerToolAlias(name);
+}
+
+export function toEngineToolName(
+  name: string,
+  map?: ProviderToolNameMap,
+): string {
+  return map?.toEngine.get(name) ?? name;
+}

--- a/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  createProviderToolNameMap,
+  PROVIDER_TOOL_NAME_MAX_LENGTH,
+} from "./tool-name.js";
+import {
   engineToolsToAISDK,
   engineMessagesToAISDK,
   aiSdkPartToEngineEvents,
@@ -79,6 +83,51 @@ describe("engineToolsToAISDK", () => {
     });
     expect(result.write.inputSchema.properties.sql.minLength).toBe(1);
     expect(result.write.inputSchema.properties.statements.pattern).toBe("^\\[");
+  });
+
+  it("aliases oversized provider names and restores them on tool events", () => {
+    const longName = `mcp__${"server_".repeat(8)}__get_meetings`;
+    const tools: EngineTool[] = [
+      {
+        name: longName,
+        description: "Get meetings",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    const toolNameMap = createProviderToolNameMap(tools);
+    const providerName = Object.keys(
+      engineToolsToAISDK(tools, undefined, toolNameMap),
+    )[0];
+
+    expect(providerName).toBeDefined();
+    expect(providerName).not.toBe(longName);
+    expect(providerName!.length).toBeLessThanOrEqual(
+      PROVIDER_TOOL_NAME_MAX_LENGTH,
+    );
+
+    const assistant = engineMessagesToAISDK(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", id: "tc-1", name: longName, input: {} },
+          ],
+        },
+      ],
+      { toolNameMap },
+    ).find((message) => message.role === "assistant");
+    expect(assistant?.content[0].toolName).toBe(providerName);
+    expect(
+      aiSdkPartToEngineEvents(
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: providerName,
+          input: {},
+        },
+        toolNameMap,
+      ),
+    ).toEqual([{ type: "tool-call", id: "tc-1", name: longName, input: {} }]);
   });
 });
 

--- a/packages/core/src/agent/engine/translate-ai-sdk.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.ts
@@ -11,6 +11,12 @@ import {
   classifyProviderError,
   describeErrorWithCauses,
 } from "./error-detail.js";
+import {
+  createProviderToolNameMap,
+  toEngineToolName,
+  toProviderToolName,
+  type ProviderToolNameMap,
+} from "./tool-name.js";
 import { backfillEngineMessagesToolResults } from "./translate-anthropic.js";
 import type {
   EngineTool,
@@ -34,6 +40,7 @@ import type {
 export function engineToolsToAISDK(
   tools: EngineTool[],
   jsonSchema?: (schema: Record<string, unknown>) => unknown,
+  toolNameMap = createProviderToolNameMap(tools),
 ): Record<string, any> {
   const result: Record<string, any> = {};
   for (const tool of tools) {
@@ -43,7 +50,8 @@ export function engineToolsToAISDK(
       properties: tool.inputSchema.properties ?? {},
       required: tool.inputSchema.required ?? [],
     };
-    result[tool.name] = {
+    const providerName = toProviderToolName(tool.name, toolNameMap);
+    result[providerName] = {
       description: tool.description,
       inputSchema: jsonSchema ? jsonSchema(rawSchema) : rawSchema,
     };
@@ -75,6 +83,7 @@ export interface EngineToAISDKOptions {
    * string keep the model informed of what it cannot see.
    */
   toolResultImages?: boolean;
+  toolNameMap?: ProviderToolNameMap;
 }
 
 /** AI SDK tool-result `output` for one engine tool-result part. */
@@ -137,7 +146,7 @@ export function engineMessageToAISDK(
         toolResultParts.push({
           type: "tool-result",
           toolCallId: part.toolCallId,
-          toolName: part.toolName,
+          toolName: toProviderToolName(part.toolName, opts?.toolNameMap),
           output: toolResultOutputToAISDK(part, opts),
         });
       }
@@ -168,7 +177,7 @@ export function engineMessageToAISDK(
         content.push({
           type: "tool-call",
           toolCallId: part.id,
-          toolName: part.name,
+          toolName: toProviderToolName(part.name, opts?.toolNameMap),
           input: part.input,
         });
       } else if (part.type === "thinking") {
@@ -204,8 +213,10 @@ export function engineMessagesToAISDK(
   messages: EngineMessage[],
   opts?: EngineToAISDKOptions,
 ): any[] {
+  const toolNameMap =
+    opts?.toolNameMap ?? createProviderToolNameMap([], messages);
   return backfillEngineMessagesToolResults(messages).flatMap((msg) =>
-    engineMessageToAISDK(msg, opts),
+    engineMessageToAISDK(msg, { ...opts, toolNameMap }),
   );
 }
 
@@ -222,7 +233,10 @@ export function engineMessagesToAISDK(
  * We absorb text/reasoning boundaries, forward text/reasoning/tool-input
  * deltas, and keep the terminal `tool-call`, `finish-step`, and `finish` parts.
  */
-export function aiSdkPartToEngineEvents(part: any): EngineEvent[] {
+export function aiSdkPartToEngineEvents(
+  part: any,
+  toolNameMap?: ProviderToolNameMap,
+): EngineEvent[] {
   const events: EngineEvent[] = [];
 
   switch (part?.type) {
@@ -244,14 +258,14 @@ export function aiSdkPartToEngineEvents(part: any): EngineEvent[] {
       events.push({
         type: "tool-input-start",
         id: part.id ?? part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
       });
       break;
     case "tool-input-delta":
       events.push({
         type: "tool-input-delta",
         id: part.id ?? part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
         text:
           typeof part.delta === "string"
             ? part.delta
@@ -268,7 +282,7 @@ export function aiSdkPartToEngineEvents(part: any): EngineEvent[] {
       events.push({
         type: "tool-call",
         id: part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
         input: part.input ?? {},
       });
       break;
@@ -278,7 +292,7 @@ export function aiSdkPartToEngineEvents(part: any): EngineEvent[] {
       events.push({
         type: "tool-call-error",
         id: part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
         input: part.input ?? {},
         error:
           part.errorText ??
@@ -389,7 +403,10 @@ function usageEventFromLanguageModelUsage(usage: any): EngineEvent {
  * Reconstruct the assistant message content from an AI SDK v6 `StepResult`.
  * `step.content` is the canonical structured form — iterate it.
  */
-export function aiSdkStepToAssistantContent(step: any): EngineContentPart[] {
+export function aiSdkStepToAssistantContent(
+  step: any,
+  toolNameMap?: ProviderToolNameMap,
+): EngineContentPart[] {
   const parts: EngineContentPart[] = [];
   for (const part of step?.content ?? []) {
     if (part.type === "text" && part.text) {
@@ -406,14 +423,14 @@ export function aiSdkStepToAssistantContent(step: any): EngineContentPart[] {
       parts.push({
         type: "tool-call",
         id: part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
         input: part.input,
       });
     } else if (part.type === "tool-input-error" || part.type === "tool-error") {
       parts.push({
         type: "tool-call",
         id: part.toolCallId,
-        name: part.toolName,
+        name: toEngineToolName(part.toolName, toolNameMap),
         input: part.input ?? {},
       });
     }

--- a/packages/core/src/agent/engine/translate-anthropic.spec.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.spec.ts
@@ -3,6 +3,10 @@ import { describe, it, expect } from "vitest";
 
 import { dbExecToolParameters } from "../../scripts/db/tool-schemas.js";
 import {
+  createProviderToolNameMap,
+  PROVIDER_TOOL_NAME_MAX_LENGTH,
+} from "./tool-name.js";
+import {
   anthropicChunkToEngineEvents,
   createAnthropicChunkStreamState,
   engineToolsToAnthropic,
@@ -109,6 +113,30 @@ describe("engineToolsToAnthropic", () => {
     ).toBe(false);
     expect(inputSchema).toHaveProperty("oneOf");
     expect(inputSchema.properties).toHaveProperty("sql");
+  });
+
+  it("aliases oversized provider names while keeping engine names intact", () => {
+    const longName = `mcp__${"server_".repeat(8)}__get_meetings`;
+    const tools: EngineTool[] = [
+      {
+        name: longName,
+        description: "Get meetings",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    const toolNameMap = createProviderToolNameMap(tools);
+    const providerName = engineToolsToAnthropic(tools, toolNameMap)[0].name;
+
+    expect(providerName).not.toBe(longName);
+    expect(providerName.length).toBeLessThanOrEqual(
+      PROVIDER_TOOL_NAME_MAX_LENGTH,
+    );
+    expect(
+      anthropicContentToEngine(
+        [{ type: "tool_use", id: "tu-1", name: providerName, input: {} }],
+        toolNameMap,
+      ),
+    ).toEqual([{ type: "tool-call", id: "tu-1", name: longName, input: {} }]);
   });
 });
 

--- a/packages/core/src/agent/engine/translate-anthropic.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.ts
@@ -15,6 +15,12 @@
 
 import type Anthropic from "@anthropic-ai/sdk";
 
+import {
+  createProviderToolNameMap,
+  toEngineToolName,
+  toProviderToolName,
+  type ProviderToolNameMap,
+} from "./tool-name.js";
 import type {
   EngineTool,
   EngineMessage,
@@ -90,16 +96,23 @@ function normalizeAnthropicInputSchema(
   return normalized as Anthropic.Tool["input_schema"];
 }
 
-export function engineToolToAnthropic(tool: EngineTool): Anthropic.Tool {
+export function engineToolToAnthropic(
+  tool: EngineTool,
+  toolNameMap?: ProviderToolNameMap,
+): Anthropic.Tool {
+  const providerName = toProviderToolName(tool.name, toolNameMap);
   return {
-    name: tool.name,
+    name: providerName,
     description: tool.description,
     input_schema: normalizeAnthropicInputSchema(tool.name, tool.inputSchema),
   };
 }
 
-export function engineToolsToAnthropic(tools: EngineTool[]): Anthropic.Tool[] {
-  return tools.map(engineToolToAnthropic);
+export function engineToolsToAnthropic(
+  tools: EngineTool[],
+  toolNameMap = createProviderToolNameMap(tools),
+): Anthropic.Tool[] {
+  return tools.map((tool) => engineToolToAnthropic(tool, toolNameMap));
 }
 
 // ---------------------------------------------------------------------------
@@ -345,7 +358,10 @@ function replayableAnthropicPart(part: EngineContentPart): boolean {
 
 export function engineMessageToAnthropic(
   msg: EngineMessage,
-  opts?: { builderGateway?: boolean },
+  opts?: {
+    builderGateway?: boolean;
+    toolNameMap?: ProviderToolNameMap;
+  },
 ): Anthropic.MessageParam {
   const builderGateway = opts?.builderGateway === true;
   const content = builderGateway
@@ -353,17 +369,20 @@ export function engineMessageToAnthropic(
     : msg.content.filter(replayableAnthropicPart);
   return {
     role: msg.role,
-    content: content.map((p) => enginePartToAnthropic(p, builderGateway)),
+    content: content.map((p) =>
+      enginePartToAnthropic(p, builderGateway, opts?.toolNameMap),
+    ),
   };
 }
 
 /** Messages for the Anthropic HTTP API (strict schema — no extra tool_result fields). */
 export function engineMessagesToAnthropic(
   messages: EngineMessage[],
+  toolNameMap = createProviderToolNameMap([], messages),
 ): Anthropic.MessageParam[] {
   const normalized = backfillEngineMessagesToolResults(messages);
   return normalized.flatMap((m) => {
-    const translated = engineMessageToAnthropic(m);
+    const translated = engineMessageToAnthropic(m, { toolNameMap });
     return translated.content.length > 0 ? [translated] : [];
   });
 }
@@ -374,16 +393,18 @@ export function engineMessagesToAnthropic(
  */
 export function engineMessagesToBuilderGatewayAnthropic(
   messages: EngineMessage[],
+  toolNameMap = createProviderToolNameMap([], messages),
 ): Anthropic.MessageParam[] {
   const normalized = backfillEngineMessagesToolResults(messages);
   return normalized.map((m) =>
-    engineMessageToAnthropic(m, { builderGateway: true }),
+    engineMessageToAnthropic(m, { builderGateway: true, toolNameMap }),
   );
 }
 
 function enginePartToAnthropic(
   part: EngineContentPart,
   builderGateway: boolean,
+  toolNameMap?: ProviderToolNameMap,
 ): Anthropic.ContentBlockParam {
   switch (part.type) {
     case "text":
@@ -420,13 +441,13 @@ function enginePartToAnthropic(
       return {
         type: "tool_use",
         id: part.id,
-        name: part.name,
+        name: toProviderToolName(part.name, toolNameMap),
         input: part.input as Record<string, unknown>,
       } as any; // tool_use is a ContentBlockParam in Anthropic SDK
 
     case "tool-result": {
       if (builderGateway) {
-        const tool_name = part.toolName.trim();
+        const tool_name = toProviderToolName(part.toolName.trim(), toolNameMap);
         const tool_input = part.toolInput;
         // Gateway degrade: the Builder gateway multiplexes to non-Anthropic
         // models whose tool_result handling is string-only, so images are
@@ -505,6 +526,7 @@ function toolResultContentToAnthropic(
 
 export function anthropicContentToEngine(
   content: Anthropic.ContentBlock[],
+  toolNameMap?: ProviderToolNameMap,
 ): EngineContentPart[] {
   return content
     .map((block) => {
@@ -515,7 +537,7 @@ export function anthropicContentToEngine(
         return {
           type: "tool-call" as const,
           id: block.id,
-          name: block.name,
+          name: toEngineToolName(block.name, toolNameMap),
           input: block.input,
         };
       }
@@ -582,6 +604,7 @@ export function createAnthropicChunkStreamState(): AnthropicChunkStreamState {
 export function anthropicChunkToEngineEvents(
   chunk: any,
   state?: AnthropicChunkStreamState,
+  toolNameMap?: ProviderToolNameMap,
 ): EngineEvent[] {
   const events: EngineEvent[] = [];
 
@@ -589,7 +612,10 @@ export function anthropicChunkToEngineEvents(
     const block = chunk.content_block;
     if (block?.type === "tool_use") {
       const id = typeof block.id === "string" ? block.id : undefined;
-      const name = typeof block.name === "string" ? block.name : undefined;
+      const name =
+        typeof block.name === "string"
+          ? toEngineToolName(block.name, toolNameMap)
+          : undefined;
       if (state && typeof chunk.index === "number" && id && name) {
         state.toolUseByIndex.set(chunk.index, { id, name });
       }

--- a/packages/core/src/server/agent-chat/context-tools.ts
+++ b/packages/core/src/server/agent-chat/context-tools.ts
@@ -158,6 +158,11 @@ Use a natural-language \`message\` by default. The receiving app owns interpreta
 - Call your own app by name
 - Perform tasks you can accomplish with your own registered tools
 
+Written todo lists, checklists, summaries, action-item lists, and prose plans
+belong in the current chat. Do not route those ordinary outputs to Plan. Call
+Plan only when the user explicitly asks for a visual or structured
+Agent-Native Plan, a Plan artifact, or the Plans app.
+
 **ONLY use \`call-agent\` when:**
 - The user explicitly asks you to communicate with a different app
 - You need data that only another deployed app can provide

--- a/templates/clips/server/plugins/agent-chat.ts
+++ b/templates/clips/server/plugins/agent-chat.ts
@@ -49,6 +49,9 @@ export default createAgentChatPlugin({
     `<clips-transcript-guidance>
 The transcript in view-screen and get-recording-player-data are bounded previews when called by the agent. When previewTruncated is true, the text is expected to end mid-sentence and is never evidence that transcription stopped early. Use the bounded payload for a concise summary and do not request or reconstruct the omitted transcript by searching other recordings. For a failed or pending transcript, use request-transcript with force=true. For an explicit fresh retry of an existing ready transcript, also pass regenerate=true. Agent-triggered retries are queued for the durable worker and return pending while processing.
 </clips-transcript-guidance>
+<clips-agent-routing>
+For summaries, action-item lists, follow-up lists, and todo lists based on the recording in view, use Clips' recording/transcript actions and answer directly in this chat. Do not call Plan or another app for a generic written list. Only delegate to Plan when the user explicitly asks for a visual or structured Agent-Native Plan, a Plan artifact, or the Plans app.
+</clips-agent-routing>
 <clips-recording-discovery>
 Clips public recordings are unlisted-by-link, not a searchable public catalog. Treat a recording as known only when it is owned by the current user, already appears in the current screen, or the current user has already viewed it. Do not use list-recordings or search-recordings to discover someone else's clips, recover from a failed direct lookup, answer a date/time question, or search by a title that was not supplied by the user. A question such as when this clip was created refers to the clip already in context; answer it from current-screen or get-recording-player-data. If a direct recording lookup fails, report the failure and stop instead of broadening the search. Only inspect another clip when the user provides its share URL or recording id in the request.
 </clips-recording-discovery>`,


### PR DESCRIPTION
## Summary
- Keep ordinary Clips transcript todo and action-item requests in the current chat instead of routing them to Plan.
- Alias provider tool names longer than 64 characters at the engine wire boundary and restore the original action names on responses.
- Preserve explicit Plan handoffs and Analytics eager cross-app routing.

## Validation
- 202 tests passed across the affected engine suites.
- Focused formatting and import guards passed.
- Full guard run is environment-blocked by missing generated workspace artifacts and existing i18n baseline debt.