### PR TITLE
Keep the Clips pause button available during mobile video playback.

### DIFF
--- a/templates/clips/app/components/player/video-player.test.tsx
+++ b/templates/clips/app/components/player/video-player.test.tsx
@@ -195,6 +195,26 @@ describe("VideoPlayer playback", () => {
     expect(controls.className).not.toContain("pointer-events-none");
   });
 
+  it("keeps the pause control visible on mobile after the idle timeout", () => {
+    const video = getVideo();
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      value: false,
+    });
+
+    act(() => {
+      video.dispatchEvent(new Event("play"));
+      vi.advanceTimersByTime(2_000);
+    });
+
+    const controls = getPlayerControls();
+    expect(controls.className).toContain("opacity-100");
+    expect(controls.className).toContain("sm:pointer-events-none");
+    expect(
+      container.querySelector('button[aria-label="Pause"]'),
+    ).not.toBeNull();
+  });
+
   it("keeps owner playback on the same-origin media request path", () => {
     act(() => {
       root.render(

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -2070,8 +2070,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         {!hideChrome && !isLoomEmbed ? (
           <div
             className={cn(
-              "absolute inset-x-0 bottom-0 z-20 transition-opacity duration-200",
-              controlsVisible ? "opacity-100" : "opacity-0 pointer-events-none",
+              "absolute inset-x-0 bottom-0 z-20 opacity-100 transition-opacity duration-200",
+              controlsVisible ? "" : "sm:opacity-0 sm:pointer-events-none",
             )}
           >
             <PlayerControls


### PR DESCRIPTION
- Keep video controls visible on mobile after playback becomes idle.
- Preserve the existing desktop control fade behavior.
