### PR TITLE
fix(core): stop a rejected provider credential from re-breaking the first prompt

### DIFF
--- a/.changeset/credential-auth-failure-backoff.md
+++ b/.changeset/credential-auth-failure-backoff.md
@@ -1,0 +1,20 @@
+---
+"@agent-native/core": patch
+---
+
+Stop a rejected provider credential from re-breaking the first prompt on a fixed cadence
+
+A 401 pins the rejected credential so the next lane serves everyone after it, but
+two things kept unpinning it and making the next person's first prompt pay to
+rediscover the same rejection:
+
+- `ai-sdk-engine` cleared the auth-failure marker after every stream, error or
+  not, so one unrelated failure (a 500, an overload) re-admitted a credential a
+  401 had just pinned. Clearing asserts the credential works, so only a turn
+  that actually completed does it now.
+- Both auth-failure markers released on a flat 15-minute TTL. The marker is
+  fingerprinted on the credential value, so a rotated credential never matched
+  the old marker anyway — the TTL only ever re-tested a credential that was
+  still wrong. Repeat failures on the same fingerprint now back off
+  exponentially from that base up to 24h, while a first, genuinely transient
+  401 still releases on the original TTL.

--- a/packages/core/docs/content/webmcp.mdx
+++ b/packages/core/docs/content/webmcp.mdx
@@ -13,11 +13,11 @@ discover them, and the browser mediates execution.
 
 The framework supports both directions:
 
-| You want to... | Use |
-| --- | --- |
-| Make selected actions in your app available to a browser agent | `createAgentNativeWebMcpRegistration` |
-| Let Agent-Native chat discover and call WebMCP tools in the current page | `createAgentNativeWebMcpClient` plus `webmcp` on `AgentNativeEmbedded` or `AgentNativeFrame` |
-| Connect a headless or remote agent to an app | [MCP Server](/docs/mcp-protocol), [External Agents](/docs/external-agents), or [A2A](/docs/a2a-protocol) |
+| You want to...                                                           | Use                                                                                                      |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Make selected actions in your app available to a browser agent           | `createAgentNativeWebMcpRegistration`                                                                    |
+| Let Agent-Native chat discover and call WebMCP tools in the current page | `createAgentNativeWebMcpClient` plus `webmcp` on `AgentNativeEmbedded` or `AgentNativeFrame`             |
+| Connect a headless or remote agent to an app                             | [MCP Server](/docs/mcp-protocol), [External Agents](/docs/external-agents), or [A2A](/docs/a2a-protocol) |
 
 WebMCP is not a network MCP server and does not make a closed app globally
 discoverable. A consuming agent needs an open, connected browser page and the

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -380,6 +380,62 @@ describe("AISDKEngine error tagging", () => {
     expect(clearProviderCredentialAuthFailure).not.toHaveBeenCalled();
   });
 
+  // Prod, 2026-08-26 (slides): "The saved provider key was rejected" kept
+  // returning to whoever prompted first. A 401 pins the rejected credential so
+  // the next lane serves everyone after it — but this cleanup ran after EVERY
+  // stream, error or not, so one unrelated failure (a 500, an overload, a
+  // context stop) unpinned it and the next person's first prompt paid to
+  // rediscover the same rejection. Clearing asserts the credential works, and
+  // only a turn that completed proves that.
+  it("keeps the auth-failure marker when the turn ends in an unrelated error", async () => {
+    const clearProviderCredentialAuthFailure = vi.fn(async () => {});
+    vi.doMock("../../server/credential-provider.js", () => ({
+      clearProviderCredentialAuthFailure,
+      readDeployCredentialEnv: vi.fn(),
+      recordProviderCredentialAuthFailure: vi.fn(async () => {}),
+    }));
+    const streamText = vi.fn().mockReturnValue({
+      fullStream: (async function* () {
+        yield {
+          type: "error",
+          error: Object.assign(new Error("Internal server error"), {
+            statusCode: 500,
+            isRetryable: true,
+          }),
+        };
+      })(),
+    });
+    vi.doMock("ai", () => ({ streamText, jsonSchema: (s: unknown) => s }));
+    mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", { apiKey: "sk-test" });
+    const events: any[] = [];
+    for await (const e of engine.stream(BASE_STREAM_OPTIONS)) events.push(e);
+
+    expect(events.find((e) => e.type === "stop")?.reason).toBe("error");
+    expect(clearProviderCredentialAuthFailure).not.toHaveBeenCalled();
+  });
+
+  it("still clears the marker when the turn completes normally", async () => {
+    const clearProviderCredentialAuthFailure = vi.fn(async () => {});
+    vi.doMock("../../server/credential-provider.js", () => ({
+      clearProviderCredentialAuthFailure,
+      readDeployCredentialEnv: vi.fn(),
+      recordProviderCredentialAuthFailure: vi.fn(async () => {}),
+    }));
+    mockAiSdk();
+    mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", { apiKey: "sk-test" });
+    await drain(engine.stream(BASE_STREAM_OPTIONS));
+
+    expect(clearProviderCredentialAuthFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "OPENAI_API_KEY" }),
+    );
+  });
+
   it("tags a retry-wrapped Cannot connect to API failure as a provider network error", async () => {
     const lastError = Object.assign(
       new Error(

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -567,7 +567,15 @@ class AISDKEngine implements AgentEngine {
       }
 
       yield { type: "assistant-content", parts: assistantContent };
-      if (!credentialFailureRecorded) {
+      // Clearing the marker asserts "this credential demonstrably works", so
+      // only a turn that actually completed may do it. A turn that ended in
+      // error proves nothing about the credential, and this ran on every one:
+      // a single unrelated 500 re-admitted a credential a 401 had just pinned,
+      // so the next person's first prompt spent itself rediscovering the same
+      // rejection. `credentialFailureRecorded` only covers the 401 path.
+      const stoppedWithError =
+        bufferedStop?.type === "stop" && bufferedStop.reason === "error";
+      if (!credentialFailureRecorded && !stoppedWithError) {
         await clearProviderCredentialAuthFailure({
           key: PROVIDER_ENV_VARS[this.provider][0],
           value: this.apiKey,

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -456,9 +456,71 @@ describe("Builder credential auth failure markers", () => {
     });
 
     expect(failure).toBeNull();
-    expect(mockDeleteSetting).toHaveBeenCalledWith(
-      `builder-auth-failure:${builderCredentialFingerprint("bpk-secret", "pub-secret")}`,
+    // The row deliberately outlives its TTL: deleting it here reset the strike
+    // count, so a credential that is simply wrong was re-admitted on the same
+    // flat cadence forever, spending one real user's turn on a 401 each time.
+    expect(mockDeleteSetting).not.toHaveBeenCalled();
+  });
+
+  // Prod, 2026-08-26 (slides): two users got "The saved provider key was
+  // rejected" minutes apart, each on their first prompt, each followed by the
+  // run succeeding on its own once the marker armed and the next lane served
+  // the turn. 15 minutes later the same credential was re-admitted and the
+  // next person paid for the same rediscovery.
+  it("backs off re-admission for a credential that keeps failing", async () => {
+    const staleByBaseTtl = {
+      message: "Missing Authentication header",
+      status: 401,
+      code: "http_401",
+      at: Date.now() - BUILDER_AUTH_FAILURE_TTL_MS - 1,
+    };
+
+    mockGetSetting.mockResolvedValue({ ...staleByBaseTtl, strikes: 3 });
+    expect(
+      await getBuilderCredentialAuthFailure({
+        privateKey: "bpk-secret",
+        publicKey: "pub-secret",
+      }),
+    ).not.toBeNull();
+
+    // A first-strike marker still releases on the base TTL, so a genuinely
+    // transient 401 is not punished.
+    mockGetSetting.mockResolvedValue({ ...staleByBaseTtl, strikes: 1 });
+    expect(
+      await getBuilderCredentialAuthFailure({
+        privateKey: "bpk-secret",
+        publicKey: "pub-secret",
+      }),
+    ).toBeNull();
+  });
+
+  it("counts a repeat failure on the same credential as another strike", async () => {
+    mockGetSetting.mockImplementation(async (key: string) =>
+      key.startsWith("provider-auth-failure:")
+        ? { strikes: 2, at: Date.now() }
+        : null,
     );
+
+    await recordProviderCredentialAuthFailure({
+      key: "OPENAI_API_KEY",
+      value: "sk-example-invalid",
+      status: 401,
+      code: "http_401",
+      message: "Missing Authentication header",
+    });
+    expect(mockPutSetting.mock.calls.at(-1)?.[1]).toMatchObject({ strikes: 3 });
+
+    // First failure for a credential we have never rejected before starts at 1,
+    // so a one-off transient 401 still releases on the base TTL.
+    mockGetSetting.mockResolvedValue(null);
+    await recordProviderCredentialAuthFailure({
+      key: "OPENAI_API_KEY",
+      value: "sk-example-invalid",
+      status: 401,
+      code: "http_401",
+      message: "Missing Authentication header",
+    });
+    expect(mockPutSetting.mock.calls.at(-1)?.[1]).toMatchObject({ strikes: 1 });
   });
 });
 
@@ -540,9 +602,9 @@ describe("provider credential auth failure markers", () => {
         value: "sk-example-invalid",
       }),
     ).resolves.toBeNull();
-    expect(mockDeleteSetting).toHaveBeenCalledWith(
-      `provider-auth-failure:${fingerprint}`,
-    );
+    // Retained on purpose — see the Builder-side twin: the row carries the
+    // strike count that makes re-admission back off.
+    expect(mockDeleteSetting).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -1174,6 +1174,51 @@ export async function resolveBuilderGatewayAuth(): Promise<BuilderGatewayAuth | 
     : null;
 }
 
+/**
+ * Both auth-failure markers below are fingerprinted on the credential VALUE, so
+ * a rotated or corrected credential never matches the old marker and is usable
+ * immediately — the TTL is not what unpins it. The TTL covers only the case
+ * where the SAME value starts working again: a plan upgrade, a re-enabled
+ * gateway, a transient upstream 401.
+ *
+ * Re-admitting on a flat timer means a credential that is simply wrong is
+ * retested on that cadence forever, and each retest is paid for by whichever
+ * user's turn happens to land first — they get a 401 while the next lane serves
+ * everyone after them. That is the whole shape of the recurring "the saved
+ * provider key was rejected" report. Back off per consecutive strike so a dead
+ * credential stops costing a turn every quarter hour, while one that genuinely
+ * recovers is still retried within the day.
+ */
+const AUTH_FAILURE_MAX_TTL_MS = 24 * 60 * 60 * 1000;
+const AUTH_FAILURE_MAX_STRIKES = 8;
+
+function authFailureStrikes(row: Record<string, unknown> | null): number {
+  const raw = row?.strikes;
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 1
+    ? Math.min(Math.floor(raw), AUTH_FAILURE_MAX_STRIKES)
+    : 1;
+}
+
+function authFailureTtlMs(
+  baseTtlMs: number,
+  row: Record<string, unknown> | null,
+): number {
+  return Math.min(
+    baseTtlMs * 2 ** (authFailureStrikes(row) - 1),
+    AUTH_FAILURE_MAX_TTL_MS,
+  );
+}
+
+/** Next strike count for a marker being (re-)armed on the same fingerprint. */
+async function nextAuthFailureStrikes(settingKey: string): Promise<number> {
+  const { getSetting } = await import("../settings/store.js");
+  const prior = await getSetting(settingKey, { bypassCache: true });
+  return Math.min(
+    authFailureStrikes(prior) + (prior ? 1 : 0),
+    AUTH_FAILURE_MAX_STRIKES,
+  );
+}
+
 const BUILDER_AUTH_FAILURE_SETTING_PREFIX = "builder-auth-failure:";
 /**
  * Stale markers expire so a rejected model or a transient gateway failure
@@ -1227,10 +1272,10 @@ export async function getBuilderCredentialAuthFailure(
     const row = await settings.getSetting(settingKey);
     if (!row) return null;
     const at = typeof row.at === "number" ? row.at : Date.now();
-    if (Date.now() - at > BUILDER_AUTH_FAILURE_TTL_MS) {
-      if (typeof settings.deleteSetting === "function") {
-        await settings.deleteSetting(settingKey).catch(() => {});
-      }
+    // Expired means "usable again", not "never failed": the row stays so the
+    // strike count survives, and a credential that fails on re-admission backs
+    // off further instead of resetting to the base TTL. A success clears it.
+    if (Date.now() - at > authFailureTtlMs(BUILDER_AUTH_FAILURE_TTL_MS, row)) {
       return null;
     }
     return {
@@ -1264,13 +1309,16 @@ export async function recordBuilderCredentialAuthFailure(details?: {
     );
     if (!fingerprint) return;
     const { putSetting } = await import("../settings/store.js");
-    await putSetting(builderAuthFailureSettingKey(fingerprint), {
+    const settingKey = builderAuthFailureSettingKey(fingerprint);
+    const strikes = await nextAuthFailureStrikes(settingKey);
+    await putSetting(settingKey, {
       fingerprint,
       message:
         details?.message ||
         "Builder rejected the connected credentials. Reconnect Builder.io (free tier available).",
       ...(typeof details?.status === "number" && { status: details.status }),
       ...(details?.code && { code: details.code }),
+      strikes,
       at: Date.now(),
       ownerEmail: getRequestUserEmail() ?? null,
       orgId: getRequestOrgId() ?? null,
@@ -1345,10 +1393,9 @@ export async function getProviderCredentialAuthFailure(opts: {
     if (!row) return null;
     if (row.fingerprint !== fingerprint) return null;
     const at = typeof row.at === "number" ? row.at : Date.now();
-    if (Date.now() - at > PROVIDER_AUTH_FAILURE_TTL_MS) {
-      if (typeof settings.deleteSetting === "function") {
-        await settings.deleteSetting(settingKey).catch(() => {});
-      }
+    // See `getBuilderCredentialAuthFailure`: the row outlives its TTL so the
+    // strike count does, and re-admission backs off instead of resetting.
+    if (Date.now() - at > authFailureTtlMs(PROVIDER_AUTH_FAILURE_TTL_MS, row)) {
       return null;
     }
     return {
@@ -1386,12 +1433,15 @@ export async function recordProviderCredentialAuthFailure(opts: {
     const fingerprint = providerCredentialFingerprint(key, value);
     if (!fingerprint) return;
     const { putSetting } = await import("../settings/store.js");
-    await putSetting(providerAuthFailureSettingKey(fingerprint), {
+    const settingKey = providerAuthFailureSettingKey(fingerprint);
+    const strikes = await nextAuthFailureStrikes(settingKey);
+    await putSetting(settingKey, {
       fingerprint,
       key,
       message: opts.message || "The model provider rejected the saved API key.",
       ...(typeof opts.status === "number" && { status: opts.status }),
       ...(opts.code && { code: opts.code }),
+      strikes,
       at: Date.now(),
       ownerEmail: getRequestUserEmail() ?? null,
       orgId: getRequestOrgId() ?? null,


### PR DESCRIPTION
## The report

Two users on `slides` (beta **and** prod, ~20 min apart) got, on their **first prompt**:

> Error: The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.
> `code: http_401` — `Missing Authentication header`

Then the deck built anyway. Taylor's words: *"first prompt --> error but it is now working on something without me retrying"*. This has recurred for two days and previous passes chased provider-key configuration, which is not what is broken.

## What is actually happening

A 401 arms an auth-failure marker fingerprinted on the credential's **value**. While it is armed, credential resolution skips that credential and the next lane serves the turn — which is why the run recovers on its own with no user action.

Two things kept unpinning it, so the deployment re-learned the same rejection over and over, and each re-learn was paid for by whoever prompted first:

1. **`ai-sdk-engine` cleared the marker after every stream, error or not.** The clear ran unconditionally after the stream loop with no check on the buffered stop reason, so a single unrelated failure — a 500, an overload — re-admitted a credential a 401 had just pinned. A failed turn wrote the same state a successful one writes.
2. **Both markers released on a flat 15-minute TTL.** Because the marker is fingerprinted on the credential value, a rotated or corrected credential never matches the old marker and is usable immediately — the TTL was never what unpinned a fixed credential. Its only observable effect was to re-test a credential that was still wrong, every 15 minutes, forever.

Beta and prod share one database, hence one marker row — which is why both were affected at once.

## The fix

- Clearing the marker asserts "this credential demonstrably works", so only a turn that actually completed does it.
- Repeat failures on the same fingerprint back off exponentially from the existing base TTL up to a 24h cap. A first, genuinely transient 401 still releases on the original 15 minutes. The row now outlives its TTL so the strike count survives re-admission; a success still deletes it on both lanes.

Applied at the shared boundary in `credential-provider.ts` so the Builder and provider lanes stay in step. `anthropic-engine`, `builder-engine`, and the save-key route already clear only on success — `ai-sdk-engine` was the sole ungated site.

## Verification

- Both new tests confirmed **failing before** the fix and passing after.
- `packages/core`: 13,062 passed.
- `pnpm guards`: all 64 checks passed.

`prep:urgent` had one unrelated failure: `templates/design > html-integrity > stays linear on large valid documents`, a wall-clock ratio assertion (20.5ms vs a ~19.8ms bound) that only trips under concurrent prep load — it passes in isolation and is in a template this diff does not touch. That failure killed the `packages/core` lane via `--kill-others-on-fail` (exit 143); core was rerun standalone and is conclusively green.

## Not addressed here

The client still renders any `http_401` as "The saved provider key was rejected" and withholds the Retry button. With this change that path is rare, but the copy is misleading when the fault is a shared deployment credential rather than the reader's own key. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)