### PR TITLE
fix(clips): show stored profile avatars

### DIFF
--- a/.changeset/profile-avatars.md
+++ b/.changeset/profile-avatars.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/toolkit": patch
+---
+
+Preserve Google profile avatars across shared identity and collaboration surfaces.

--- a/packages/core/src/client/review/ReviewThreadPanel.tsx
+++ b/packages/core/src/client/review/ReviewThreadPanel.tsx
@@ -1,4 +1,8 @@
-import { Avatar, AvatarFallback } from "@agent-native/toolkit/ui/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@agent-native/toolkit/ui/avatar";
 import { Button } from "@agent-native/toolkit/ui/button";
 import {
   DropdownMenu,
@@ -25,6 +29,7 @@ import type {
 } from "../../review/types.js";
 import { useFormatters } from "../i18n.js";
 import { InlineMarkdown } from "../markdown/index.js";
+import { useAvatarUrl } from "../use-avatar.js";
 import { cn } from "../utils.js";
 import { ReviewCommentComposer } from "./ReviewCommentComposer.js";
 import { ReviewStatusBadge } from "./ReviewStatusBadge.js";
@@ -480,6 +485,7 @@ function CommentBubble({
   formatDate: ReturnType<typeof useFormatters>["formatDate"];
 }) {
   const author = comment.authorName ?? comment.authorEmail ?? reviewerLabel;
+  const avatarUrl = useAvatarUrl(comment.authorEmail);
   const resolutionNote =
     comment.status === "resolved" ? getReviewResolutionNote(comment) : null;
   const bodyIsResolutionNote =
@@ -489,6 +495,7 @@ function CommentBubble({
   return (
     <div className="flex min-w-0 items-start gap-2.5">
       <Avatar className={compact ? "size-5" : "size-7"}>
+        {avatarUrl ? <AvatarImage src={avatarUrl} alt={author} /> : null}
         <AvatarFallback className="text-[10px] font-semibold text-muted-foreground">
           {authorInitials(author)}
         </AvatarFallback>

--- a/packages/core/src/collab/client.registry.spec.tsx
+++ b/packages/core/src/collab/client.registry.spec.tsx
@@ -23,6 +23,7 @@ import {
   useCollaborativeDoc,
   _collabDocRegistrySizeForTests,
   _resetCollabDocRegistryForTests,
+  type CollabUser,
   type UseCollaborativeDocResult,
 } from "./client.js";
 
@@ -75,7 +76,7 @@ function Probe({
 }: {
   docId: string | null;
   onResult: (result: UseCollaborativeDocResult) => void;
-  user?: { name: string; email: string; color: string };
+  user?: CollabUser;
 }) {
   const result = useCollaborativeDoc({ docId, user });
   onResult(result);
@@ -261,6 +262,57 @@ describe("useCollaborativeDoc connection registry", () => {
     });
     expect(_collabDocRegistrySizeForTests()).toBe(1);
     expect(result?.ydoc?.isDestroyed).toBe(false);
+  });
+
+  it("publishes and updates the local avatar in awareness identity", async () => {
+    const { mock } = makeFetchMock();
+    vi.stubGlobal("fetch", mock);
+
+    let result: UseCollaborativeDocResult | undefined;
+    const root = mount(
+      <Probe
+        docId="doc-avatar"
+        onResult={(next) => (result = next)}
+        user={{
+          name: "Local",
+          email: "local@example.com",
+          color: "local-color",
+          avatarUrl: "https://example.com/first.jpg",
+        }}
+      />,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result?.awareness?.getLocalState()?.user).toEqual({
+      name: "Local",
+      email: "local@example.com",
+      color: "local-color",
+      avatarUrl: "https://example.com/first.jpg",
+    });
+
+    act(() => {
+      root.render(
+        <Probe
+          docId="doc-avatar"
+          onResult={(next) => (result = next)}
+          user={{
+            name: "Local",
+            email: "local@example.com",
+            color: "local-color",
+            avatarUrl: "https://example.com/second.jpg",
+          }}
+        />,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result?.awareness?.getLocalState()?.user).toMatchObject({
+      avatarUrl: "https://example.com/second.jpg",
+    });
   });
 
   it("does not re-broadcast local awareness state when a REMOTE awareness event arrives (no storm)", async () => {

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -44,6 +44,7 @@ import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
 
 import { agentNativePath } from "../client/api-path.js";
+import { useAvatarUrl } from "../client/use-avatar.js";
 import { subscribeSyncEvents, type SyncEvent } from "../client/use-db-sync.js";
 import { REALTIME_CAP_NO_AWARENESS } from "../realtime-protocol.js";
 export {
@@ -540,19 +541,26 @@ class CollabDocConnection {
       prev &&
       prev.name === user.name &&
       prev.email === user.email &&
-      prev.color === user.color
+      prev.color === user.color &&
+      prev.avatarUrl === user.avatarUrl
     ) {
       return;
     }
+    const avatarUrl =
+      typeof user.avatarUrl === "string" && user.avatarUrl.trim()
+        ? user.avatarUrl
+        : undefined;
     this.lastSetUser = {
       name: user.name,
       email: user.email,
       color: user.color,
+      ...(avatarUrl ? { avatarUrl } : {}),
     };
     this.awareness.setLocalStateField("user", {
       name: user.name,
       email: user.email,
       color: user.color,
+      ...(avatarUrl ? { avatarUrl } : {}),
     });
     // Also publish this tab's visibility so peers can elect a VISIBLE client
     // to apply external snapshots (see isReconcileLeadClient) — a backgrounded
@@ -1180,6 +1188,13 @@ export function useCollaborativeDoc(
     requestSource,
     user,
   } = options;
+  const storedAvatarUrl = useAvatarUrl(user?.email);
+  const resolvedUser = useMemo(() => {
+    if (!user || !storedAvatarUrl || storedAvatarUrl === user.avatarUrl) {
+      return user;
+    }
+    return { ...user, avatarUrl: storedAvatarUrl };
+  }, [storedAvatarUrl, user]);
 
   // Bumped when the effect finds the memoized connection was disposed in the
   // render→effect gap (rare: a suspended transition outliving the linger
@@ -1239,9 +1254,9 @@ export function useCollaborativeDoc(
   // Publish local user identity for cursor labels (set once per tab; the
   // connection dedupes repeated identical identities across subscribers).
   useEffect(() => {
-    if (!conn || conn.detached || !user) return;
-    conn.setUser({ name: user.name, email: user.email, color: user.color });
-  }, [conn, user?.name, user?.email, user?.color]);
+    if (!conn || conn.detached || !resolvedUser) return;
+    conn.setUser(resolvedUser);
+  }, [conn, resolvedUser]);
 
   return {
     ydoc: conn ? conn.ydoc : null,

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -111,7 +111,8 @@ function collabUsersEqual(a: CollabUser[], b: CollabUser[]): boolean {
     if (
       left.email !== right.email ||
       left.name !== right.name ||
-      left.color !== right.color
+      left.color !== right.color ||
+      left.avatarUrl !== right.avatarUrl
     ) {
       return false;
     }

--- a/packages/core/src/collab/presence.spec.ts
+++ b/packages/core/src/collab/presence.spec.ts
@@ -4,7 +4,12 @@ import { AGENT_CLIENT_ID } from "./agent-identity.js";
 // ---------------------------------------------------------------------------
 // Pure logic tests — no React rendering needed
 // ---------------------------------------------------------------------------
-import { toNormalized, fromNormalized } from "./presence.js";
+import {
+  deriveCollabUser,
+  shallowEqualOthers,
+  toNormalized,
+  fromNormalized,
+} from "./presence.js";
 
 describe("toNormalized", () => {
   const container: DOMRect = {
@@ -143,6 +148,47 @@ function deriveOthers(
 }
 
 describe("usePresence — derivation logic", () => {
+  it("preserves valid avatars and ignores malformed avatar data", () => {
+    expect(
+      deriveCollabUser(
+        {
+          user: {
+            name: "Alice",
+            email: "alice@ex.com",
+            color: "#f00",
+            avatarUrl: "https://example.com/alice.jpg",
+          },
+        },
+        2,
+      ),
+    ).toMatchObject({ avatarUrl: "https://example.com/alice.jpg" });
+    expect(
+      deriveCollabUser(
+        { user: { name: "Bob", email: "bob@ex.com", avatarUrl: "  " } },
+        3,
+      ),
+    ).not.toHaveProperty("avatarUrl");
+    expect(deriveCollabUser({ user: { avatarUrl: 42 } }, 4)).not.toHaveProperty(
+      "avatarUrl",
+    );
+  });
+
+  it("treats avatar changes as a meaningful remote-user change", () => {
+    const base = {
+      clientId: 2,
+      user: { name: "Alice", email: "alice@ex.com", color: "#f00" },
+      presence: {},
+      isAgent: false,
+    };
+    expect(shallowEqualOthers([base], [{ ...base }])).toBe(true);
+    expect(
+      shallowEqualOthers(
+        [base],
+        [{ ...base, user: { ...base.user, avatarUrl: "avatar.jpg" } }],
+      ),
+    ).toBe(false);
+  });
+
   it("excludes the local client from others", () => {
     const awareness = makeAwareness(
       new Map([

--- a/packages/core/src/collab/presence.ts
+++ b/packages/core/src/collab/presence.ts
@@ -39,7 +39,8 @@ export function deriveCollabUser(
 
   return {
     name: userState?.name ?? (isAgent ? "AI Assistant" : "Unknown"),
-    email: userState?.email ?? (isAgent ? "agent@system" : `client-${clientId}`),
+    email:
+      userState?.email ?? (isAgent ? "agent@system" : `client-${clientId}`),
     color: userState?.color ?? (isAgent ? "#00B5FF" : "#94a3b8"),
     ...(avatarUrl ? { avatarUrl } : {}),
   };

--- a/packages/core/src/collab/presence.ts
+++ b/packages/core/src/collab/presence.ts
@@ -41,6 +41,7 @@ export function deriveCollabUser(
     name: userState?.name ?? (isAgent ? "AI Assistant" : "Unknown"),
     email:
       userState?.email ?? (isAgent ? "agent@system" : `client-${clientId}`),
+    // guard:allow-raw-color — collaboration protocol default, not theme UI
     color: userState?.color ?? (isAgent ? "#00B5FF" : "#94a3b8"),
     ...(avatarUrl ? { avatarUrl } : {}),
   };

--- a/packages/core/src/collab/presence.ts
+++ b/packages/core/src/collab/presence.ts
@@ -26,6 +26,55 @@ export type {
   PresencePayload,
 } from "@agent-native/toolkit/collab-ui";
 
+export function deriveCollabUser(
+  state: Record<string, unknown>,
+  clientId: number,
+): CollabUser {
+  const isAgent = clientId === AGENT_CLIENT_ID;
+  const userState = state.user as Partial<CollabUser> | undefined;
+  const avatarUrl =
+    typeof userState?.avatarUrl === "string" && userState.avatarUrl.trim()
+      ? userState.avatarUrl
+      : undefined;
+
+  return {
+    name: userState?.name ?? (isAgent ? "AI Assistant" : "Unknown"),
+    email: userState?.email ?? (isAgent ? "agent@system" : `client-${clientId}`),
+    color: userState?.color ?? (isAgent ? "#00B5FF" : "#94a3b8"),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
+export function shallowEqualOthers(
+  a: readonly OtherPresence[],
+  b: readonly OtherPresence[],
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    const left = a[i]!;
+    const right = b[i]!;
+    if (left === right) continue;
+    if (
+      left.clientId !== right.clientId ||
+      left.isAgent !== right.isAgent ||
+      left.user.name !== right.user.name ||
+      left.user.email !== right.user.email ||
+      left.user.color !== right.user.color ||
+      left.user.avatarUrl !== right.user.avatarUrl
+    ) {
+      return false;
+    }
+    // Compare presence payloads with a stable JSON.stringify — presence
+    // fields (cursor/selection/viewport) are small JSON-safe records, so
+    // this is cheap and avoids a re-render when nothing actually changed.
+    if (JSON.stringify(left.presence) !== JSON.stringify(right.presence)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export interface UsePresenceResult {
   /** All remote participants (excludes local client). */
   others: OtherPresence[];
@@ -64,58 +113,13 @@ export function usePresence(
     // can bail out without triggering a subscriber re-render.
     let lastOthers: OtherPresence[] = [];
 
-    function shallowEqualOthers(
-      a: readonly OtherPresence[],
-      b: readonly OtherPresence[],
-    ): boolean {
-      if (a === b) return true;
-      if (a.length !== b.length) return false;
-      for (let i = 0; i < a.length; i += 1) {
-        const left = a[i]!;
-        const right = b[i]!;
-        if (left === right) continue;
-        if (
-          left.clientId !== right.clientId ||
-          left.isAgent !== right.isAgent ||
-          left.user.name !== right.user.name ||
-          left.user.email !== right.user.email ||
-          left.user.color !== right.user.color
-        ) {
-          return false;
-        }
-        // Compare presence payloads with a stable JSON.stringify — presence
-        // fields (cursor/selection/viewport) are small JSON-safe records, so
-        // this is cheap and avoids a re-render when nothing actually changed.
-        if (JSON.stringify(left.presence) !== JSON.stringify(right.presence)) {
-          return false;
-        }
-      }
-      return true;
-    }
-
     function derive(): OtherPresence[] {
       const result: OtherPresence[] = [];
       awareness!.getStates().forEach((state, clientId) => {
         if (clientId === localClientId) return; // skip self
         const s = state as Record<string, unknown>;
-        const isAgent = clientId === AGENT_CLIENT_ID;
 
-        // User identity — fall back to agent defaults or anonymous.
-        let user: CollabUser;
-        if (isAgent) {
-          user = {
-            name: (s.user as CollabUser)?.name ?? "AI Assistant",
-            email: (s.user as CollabUser)?.email ?? "agent@system",
-            color: (s.user as CollabUser)?.color ?? "#00B5FF",
-          };
-        } else {
-          const u = s.user as CollabUser | undefined;
-          user = {
-            name: u?.name ?? "Unknown",
-            email: u?.email ?? `client-${clientId}`,
-            color: u?.color ?? "#94a3b8",
-          };
-        }
+        const user = deriveCollabUser(s, clientId);
 
         // Everything that isn't `user` or `visible` is presence payload.
         const presence: PresencePayload = {};
@@ -125,7 +129,12 @@ export function usePresence(
           }
         }
 
-        result.push({ clientId, user, presence, isAgent });
+        result.push({
+          clientId,
+          user,
+          presence,
+          isAgent: clientId === AGENT_CLIENT_ID,
+        });
       });
       return result;
     }

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -22,6 +22,7 @@ import {
   FIRST_RUN_ONBOARDING_COOKIE,
   FIRST_RUN_ONBOARDING_MAX_AGE,
 } from "../shared/first-run-onboarding.js";
+import { isGoogleProfileImageUrl } from "../shared/google-profile-image.js";
 import {
   EMBED_TRANSPLANT_HEADER,
   isMcpEmbedCorsOrigin,
@@ -4386,9 +4387,9 @@ async function mountBetterAuthRoutes(
           if (isNewGoogleUser === true) {
             setFirstRunOnboardingCookie(event);
           }
-          if (typeof user.picture === "string" && user.picture.trim()) {
+          if (isGoogleProfileImageUrl(user.picture)) {
             await putSetting(`avatar:${email}`, {
-              image: user.picture,
+              image: user.picture.trim(),
             }).catch((error) => {
               console.warn(
                 "[auth] failed to store Google profile image:",

--- a/packages/core/src/shared/google-profile-image.spec.ts
+++ b/packages/core/src/shared/google-profile-image.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { isGoogleProfileImageUrl } from "./google-profile-image.js";
+
+describe("isGoogleProfileImageUrl", () => {
+  it("accepts Google profile image CDN URLs", () => {
+    expect(
+      isGoogleProfileImageUrl("https://lh3.googleusercontent.com/a/photo"),
+    ).toBe(true);
+    expect(isGoogleProfileImageUrl("https://googleusercontent.com/photo")).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    "http://lh3.googleusercontent.com/photo",
+    "https://googleusercontent.com.evil.example/photo",
+    "https://user:pass@lh3.googleusercontent.com/photo",
+    "https://lh3.googleusercontent.com:8443/photo",
+    "data:image/png;base64,abc",
+    "not-a-url",
+    "",
+  ])("rejects unsafe profile image URL %s", (value) => {
+    expect(isGoogleProfileImageUrl(value)).toBe(false);
+  });
+});

--- a/packages/core/src/shared/google-profile-image.ts
+++ b/packages/core/src/shared/google-profile-image.ts
@@ -1,0 +1,26 @@
+const GOOGLE_PROFILE_IMAGE_HOST = "googleusercontent.com";
+
+/** Accept only HTTPS images served from Google's profile-image CDN. */
+export function isGoogleProfileImageUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const candidate = value.trim();
+  if (!candidate) return false;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    // coercion-ok: malformed profile URLs are invalid input, not a successful value
+    return false;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  return (
+    url.protocol === "https:" &&
+    !url.username &&
+    !url.password &&
+    !url.port &&
+    (hostname === GOOGLE_PROFILE_IMAGE_HOST ||
+      hostname.endsWith(`.${GOOGLE_PROFILE_IMAGE_HOST}`))
+  );
+}

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./agent-chat.js";
 export { agentEnv, type EnvVar } from "./agent-env.js";
 export { extractOAuthStateAppId } from "./oauth-state.js";
+export { isGoogleProfileImageUrl } from "./google-profile-image.js";
 export {
   SIGN_IN_CONTINUATION_MAX_LENGTH,
   SIGN_IN_CONTINUATION_PARAM,

--- a/packages/toolkit/src/collab-ui/types.spec.ts
+++ b/packages/toolkit/src/collab-ui/types.spec.ts
@@ -15,4 +15,43 @@ describe("dedupeCollabUsersByEmail", () => {
       ]),
     ).toEqual([{ name: "Real", email: "real@example.com", color: "#000" }]);
   });
+
+  it("preserves valid avatars and ignores malformed avatar data", () => {
+    expect(
+      dedupeCollabUsersByEmail([
+        {
+          name: "Real",
+          email: "REAL@example.com",
+          color: "#000",
+          avatarUrl: "https://example.com/real.jpg",
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "Real",
+        email: "real@example.com",
+        color: "#000",
+        avatarUrl: "https://example.com/real.jpg",
+      },
+    ]);
+    expect(
+      dedupeCollabUsersByEmail([
+        {
+          name: "Broken",
+          email: "broken@example.com",
+          color: "#fff",
+          avatarUrl: "  " as string,
+        },
+        {
+          name: "Also broken",
+          email: "also@example.com",
+          color: "#000",
+          avatarUrl: 42 as unknown as string,
+        },
+      ]),
+    ).toEqual([
+      { name: "Broken", email: "broken@example.com", color: "#fff" },
+      { name: "Also broken", email: "also@example.com", color: "#000" },
+    ]);
+  });
 });

--- a/packages/toolkit/src/collab-ui/types.ts
+++ b/packages/toolkit/src/collab-ui/types.ts
@@ -90,6 +90,9 @@ export function dedupeCollabUsersByEmail(users: CollabUser[]): CollabUser[] {
         typeof user.color === "string" && user.color.trim()
           ? user.color
           : emailToColor(email),
+      ...(typeof user.avatarUrl === "string" && user.avatarUrl.trim()
+        ? { avatarUrl: user.avatarUrl }
+        : {}),
     });
   }
   return Array.from(byEmail.values());

--- a/templates/clips/app/components/clips-avatar.tsx
+++ b/templates/clips/app/components/clips-avatar.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useVisibleAvatarUrl } from "@/lib/use-visible-avatar-url";
+
+interface ClipsAvatarProps {
+  email: string | null | undefined;
+  alt: string;
+  fallback: ReactNode;
+  className?: string;
+  fallbackClassName?: string;
+  title?: string;
+}
+
+export function ClipsAvatar({
+  email,
+  alt,
+  fallback,
+  className,
+  fallbackClassName,
+  title,
+}: ClipsAvatarProps) {
+  const { avatarRef, avatarUrl } = useVisibleAvatarUrl(email);
+
+  return (
+    <Avatar ref={avatarRef} className={className} title={title}>
+      {avatarUrl ? <AvatarImage src={avatarUrl} alt={alt} /> : null}
+      <AvatarFallback className={fallbackClassName}>{fallback}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/templates/clips/app/components/clips-avatar.tsx
+++ b/templates/clips/app/components/clips-avatar.tsx
@@ -1,31 +1,46 @@
-import type { ReactNode } from "react";
+import {
+  forwardRef,
+  useCallback,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useVisibleAvatarUrl } from "@/lib/use-visible-avatar-url";
 
-interface ClipsAvatarProps {
+interface ClipsAvatarProps extends Omit<
+  ComponentPropsWithoutRef<typeof Avatar>,
+  "children"
+> {
   email: string | null | undefined;
   alt: string;
   fallback: ReactNode;
-  className?: string;
   fallbackClassName?: string;
-  title?: string;
 }
 
-export function ClipsAvatar({
-  email,
-  alt,
-  fallback,
-  className,
-  fallbackClassName,
-  title,
-}: ClipsAvatarProps) {
-  const { avatarRef, avatarUrl } = useVisibleAvatarUrl(email);
+export const ClipsAvatar = forwardRef<HTMLSpanElement, ClipsAvatarProps>(
+  function ClipsAvatar(
+    { email, alt, fallback, fallbackClassName, ...avatarProps },
+    forwardedRef,
+  ) {
+    const { avatarRef, avatarUrl } = useVisibleAvatarUrl(email);
+    const setAvatarRef = useCallback(
+      (element: HTMLSpanElement | null) => {
+        avatarRef.current = element;
+        if (typeof forwardedRef === "function") forwardedRef(element);
+        else if (forwardedRef) forwardedRef.current = element;
+      },
+      [avatarRef, forwardedRef],
+    );
 
-  return (
-    <Avatar ref={avatarRef} className={className} title={title}>
-      {avatarUrl ? <AvatarImage src={avatarUrl} alt={alt} /> : null}
-      <AvatarFallback className={fallbackClassName}>{fallback}</AvatarFallback>
-    </Avatar>
-  );
-}
+    return (
+      <Avatar {...avatarProps} ref={setAvatarRef}>
+        {avatarUrl ? <AvatarImage src={avatarUrl} alt={alt} /> : null}
+        <AvatarFallback className={fallbackClassName}>
+          {fallback}
+        </AvatarFallback>
+      </Avatar>
+    );
+  },
+);
+ClipsAvatar.displayName = "ClipsAvatar";

--- a/templates/clips/app/components/library/recording-card.tsx
+++ b/templates/clips/app/components/library/recording-card.tsx
@@ -19,7 +19,7 @@ import { Link } from "react-router";
 
 import { AgentViewCount } from "@/components/player/recording-views-badge";
 import { ViewedByPopover } from "@/components/sharing/viewed-by-popover";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -340,12 +340,13 @@ export function RecordingCard({
               </div>
             )}
             <div className="mt-1 flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-              <Avatar className="h-4 w-4 shrink-0">
-                <AvatarImage src="" alt={recording.ownerEmail} />
-                <AvatarFallback className="bg-primary/15 text-[8px] text-primary">
-                  {ownerInitials}
-                </AvatarFallback>
-              </Avatar>
+              <ClipsAvatar
+                email={recording.ownerEmail}
+                alt={recording.ownerEmail}
+                fallback={ownerInitials}
+                className="h-4 w-4 shrink-0"
+                fallbackClassName="bg-primary/15 text-[8px] text-primary"
+              />
               <span className="min-w-0 truncate">{recording.ownerEmail}</span>
               <span aria-hidden>•</span>
               <span className="shrink-0">{relative}</span>

--- a/templates/clips/app/components/library/recording-card.tsx
+++ b/templates/clips/app/components/library/recording-card.tsx
@@ -17,9 +17,9 @@ import {
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 
+import { ClipsAvatar } from "@/components/clips-avatar";
 import { AgentViewCount } from "@/components/player/recording-views-badge";
 import { ViewedByPopover } from "@/components/sharing/viewed-by-popover";
-import { ClipsAvatar } from "@/components/clips-avatar";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,

--- a/templates/clips/app/components/library/space-card.tsx
+++ b/templates/clips/app/components/library/space-card.tsx
@@ -9,13 +9,13 @@ import {
 import { useState } from "react";
 import { Link } from "react-router";
 
+import { ClipsAvatar } from "@/components/clips-avatar";
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { ClipsAvatar } from "@/components/clips-avatar";
 import { cn } from "@/lib/utils";
 
 import { SpaceDialogs } from "./space-dialogs";

--- a/templates/clips/app/components/library/space-card.tsx
+++ b/templates/clips/app/components/library/space-card.tsx
@@ -15,6 +15,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import { cn } from "@/lib/utils";
 
 import { SpaceDialogs } from "./space-dialogs";
@@ -104,13 +105,15 @@ export function SpaceCard({
                       .slice(0, 2)
                       .toUpperCase();
                     return (
-                      <div
+                      <ClipsAvatar
                         key={email}
+                        email={email}
+                        alt={email}
+                        fallback={initials}
+                        className="h-5 w-5 border border-background"
+                        fallbackClassName="bg-primary/15 text-[9px] font-medium text-primary"
                         title={email}
-                        className="flex h-5 w-5 items-center justify-center rounded-full border border-background bg-primary/15 text-[9px] font-medium text-primary"
-                      >
-                        {initials}
-                      </div>
+                      />
                     );
                   })}
                   {members.length > 5 && (

--- a/templates/clips/app/components/meetings/attendee-stack.tsx
+++ b/templates/clips/app/components/meetings/attendee-stack.tsx
@@ -5,7 +5,7 @@
  * gets a shadcn Tooltip showing name/email. Used on both list cards and
  * detail headers.
  */
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -58,14 +58,13 @@ export function AttendeeStack({
         {visible.map((p, i) => (
           <Tooltip key={`${p.email}-${i}`}>
             <TooltipTrigger asChild>
-              <Avatar
+              <ClipsAvatar
+                email={p.email}
+                alt={p.name || p.email}
+                fallback={attendeeInitials(p)}
+                fallbackClassName="font-medium"
                 className={`${sizeClass} ring-2 ring-background cursor-default`}
-              >
-                <AvatarImage alt={p.name || p.email} />
-                <AvatarFallback className="font-medium">
-                  {attendeeInitials(p)}
-                </AvatarFallback>
-              </Avatar>
+              />
             </TooltipTrigger>
             <TooltipContent side="top" className="text-xs">
               <div className="font-medium">{p.name || p.email}</div>

--- a/templates/clips/app/components/meetings/transcript-bubbles.tsx
+++ b/templates/clips/app/components/meetings/transcript-bubbles.tsx
@@ -9,7 +9,7 @@ import {
 import type { KeyboardEvent, ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -59,6 +59,7 @@ export interface SpeakerIdentity {
   key: string;
   label: string | null;
   initialsSource: AttendeeStackParticipant | string;
+  email?: string | null;
   isOwner: boolean;
   accentClass: string;
   /** The capture could not tell speakers apart, so this transcript names
@@ -291,6 +292,7 @@ export function resolveSpeaker(
     key,
     label,
     initialsSource: participant ?? label ?? (source === "mic" ? "Me" : "Them"),
+    email: participant?.email ?? (source === "mic" ? ownerEmail : null),
     isOwner: source === "mic",
     accentClass: accentForSpeaker(key, source === "mic"),
   };
@@ -641,21 +643,24 @@ export function TranscriptBubbles({
                 >
                   {!group.speaker.unattributed && (
                     <div className="flex h-6 items-center gap-2">
-                      <Avatar
+                      <ClipsAvatar
+                        email={group.speaker.email}
+                        alt={
+                          group.speaker.label ||
+                          (group.speaker.isOwner
+                            ? t("transcriptBubbles.me")
+                            : t("transcriptBubbles.them"))
+                        }
+                        fallback={attendeeInitials(group.speaker.initialsSource)}
                         className={cn(
                           "size-6 shrink-0",
                           group.speaker.accentClass,
                         )}
-                      >
-                        <AvatarFallback
-                          className={cn(
-                            "text-[9px] font-semibold",
-                            group.speaker.accentClass,
-                          )}
-                        >
-                          {attendeeInitials(group.speaker.initialsSource)}
-                        </AvatarFallback>
-                      </Avatar>
+                        fallbackClassName={cn(
+                          "text-[9px] font-semibold",
+                          group.speaker.accentClass,
+                        )}
+                      />
                       <div className="flex min-h-6 items-center">
                         <span
                           className={cn(

--- a/templates/clips/app/components/meetings/transcript-bubbles.tsx
+++ b/templates/clips/app/components/meetings/transcript-bubbles.tsx
@@ -651,7 +651,9 @@ export function TranscriptBubbles({
                             ? t("transcriptBubbles.me")
                             : t("transcriptBubbles.them"))
                         }
-                        fallback={attendeeInitials(group.speaker.initialsSource)}
+                        fallback={attendeeInitials(
+                          group.speaker.initialsSource,
+                        )}
                         className={cn(
                           "size-6 shrink-0",
                           group.speaker.accentClass,

--- a/templates/clips/app/components/sharing/avatar-rendering.test.tsx
+++ b/templates/clips/app/components/sharing/avatar-rendering.test.tsx
@@ -4,6 +4,7 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ClipsAvatar } from "../clips-avatar";
 import { Avatar as ShareAvatar } from "./share-ui";
 import { ViewerAvatar } from "./viewed-by-popover";
 
@@ -146,5 +147,21 @@ describe("sharing avatar rendering", () => {
     const image = container.querySelector("img");
     expect(image?.getAttribute("src")).toBe(avatarMocks.url);
     expect(image?.getAttribute("alt")).toBe("Viewer Name");
+  });
+
+  it("forwards trigger props and refs through the shared avatar", () => {
+    const ref = React.createRef<HTMLSpanElement>();
+
+    render(
+      <ClipsAvatar
+        ref={ref}
+        email="person@example.com"
+        alt="Person"
+        fallback="PE"
+        data-testid="avatar-trigger"
+      />,
+    );
+
+    expect(ref.current).toBe(container.querySelector("[data-testid]"));
   });
 });

--- a/templates/clips/app/components/workspace/members-list.tsx
+++ b/templates/clips/app/components/workspace/members-list.tsx
@@ -15,7 +15,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,6 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { ClipsAvatar } from "@/components/clips-avatar";
 
 export type MemberRole = "owner" | "admin" | "member";
 
@@ -152,11 +152,13 @@ export function MembersList({
                 <TableRow key={m.id}>
                   <TableCell>
                     <div className="flex items-center gap-2 min-w-0">
-                      <Avatar className="h-8 w-8 flex-shrink-0">
-                        <AvatarFallback className="text-xs bg-primary text-primary-foreground">
-                          {initials(m.email)}
-                        </AvatarFallback>
-                      </Avatar>
+                      <ClipsAvatar
+                        email={m.email}
+                        alt={m.email}
+                        fallback={initials(m.email)}
+                        className="h-8 w-8 flex-shrink-0"
+                        fallbackClassName="text-xs bg-primary text-primary-foreground"
+                      />
                       <div className="min-w-0">
                         <div className="truncate font-medium flex items-center gap-1.5">
                           {m.email}

--- a/templates/clips/app/components/workspace/members-list.tsx
+++ b/templates/clips/app/components/workspace/members-list.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { ClipsAvatar } from "@/components/clips-avatar";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,7 +33,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ClipsAvatar } from "@/components/clips-avatar";
 
 export type MemberRole = "owner" | "admin" | "member";
 

--- a/templates/clips/app/components/workspace/notifications-list.tsx
+++ b/templates/clips/app/components/workspace/notifications-list.tsx
@@ -9,7 +9,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "react-router";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ClipsAvatar } from "@/components/clips-avatar";
 
 export type NotificationKind = "comment" | "reaction" | "mention" | "share";
 
@@ -62,11 +62,13 @@ export function NotificationsList({ items, onReply }: NotificationsListProps) {
     <ul className="divide-y">
       {items.map((item) => (
         <li key={item.id} className="py-3 flex items-start gap-3">
-          <Avatar className="h-9 w-9 flex-shrink-0">
-            <AvatarFallback className="text-xs bg-primary text-primary-foreground">
-              {initials(item.authorEmail)}
-            </AvatarFallback>
-          </Avatar>
+          <ClipsAvatar
+            email={item.authorEmail}
+            alt={item.authorEmail ?? t("clipsFinalRaw.someone")}
+            fallback={initials(item.authorEmail)}
+            className="h-9 w-9 flex-shrink-0"
+            fallbackClassName="text-xs bg-primary text-primary-foreground"
+          />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 text-sm">
               <KindIcon kind={item.kind} />

--- a/templates/clips/app/components/workspace/top-creators-table.tsx
+++ b/templates/clips/app/components/workspace/top-creators-table.tsx
@@ -1,6 +1,6 @@
 import { useT } from "@agent-native/core/client/i18n";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import {
   Table,
   TableBody,
@@ -58,11 +58,13 @@ export function TopCreatorsTable({ rows }: TopCreatorsTableProps) {
             <TableRow key={row.email}>
               <TableCell>
                 <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="h-7 w-7 flex-shrink-0">
-                    <AvatarFallback className="text-xs bg-primary text-primary-foreground">
-                      {initials(row.email)}
-                    </AvatarFallback>
-                  </Avatar>
+                  <ClipsAvatar
+                    email={row.email}
+                    alt={row.email}
+                    fallback={initials(row.email)}
+                    className="h-7 w-7 flex-shrink-0"
+                    fallbackClassName="text-xs bg-primary text-primary-foreground"
+                  />
                   <span className="truncate">{row.email}</span>
                 </div>
               </TableCell>

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -28,8 +28,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { NavLink, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
-import { PageHeader } from "@/components/library/page-header";
 import { ClipsAvatar } from "@/components/clips-avatar";
+import { PageHeader } from "@/components/library/page-header";
 import {
   AttendeeStack,
   attendeeInitials,

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -29,6 +29,7 @@ import { NavLink, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/library/page-header";
+import { ClipsAvatar } from "@/components/clips-avatar";
 import {
   AttendeeStack,
   attendeeInitials,
@@ -52,7 +53,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -258,12 +258,13 @@ function ActionItemsByPerson({
       {grouped.map(([who, list]) => (
         <div key={who} className="space-y-1.5">
           <div className="flex items-center gap-2">
-            <Avatar className="h-5 w-5">
-              <AvatarImage alt={who} />
-              <AvatarFallback className="text-[9px]">
-                {attendeeInitials(who || t("meetingDetail.unassigned"))}
-              </AvatarFallback>
-            </Avatar>
+            <ClipsAvatar
+              email={who || null}
+              alt={who || t("meetingDetail.unassigned")}
+              fallback={attendeeInitials(who || t("meetingDetail.unassigned"))}
+              className="h-5 w-5"
+              fallbackClassName="text-[9px]"
+            />
             <span className="text-xs font-medium">
               {who || t("meetingDetail.unassigned")}
             </span>

--- a/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
@@ -44,12 +44,25 @@ describe("persistGoogleProfileImage", () => {
   it("stores a non-empty Google profile image under the email avatar key", async () => {
     await persistGoogleProfileImage(
       "vishwas@example.com",
-      "https://example.com/avatar.jpg",
+      "https://lh3.googleusercontent.com/a/avatar.jpg",
     );
 
     expect(putSetting).toHaveBeenCalledWith("avatar:vishwas@example.com", {
-      image: "https://example.com/avatar.jpg",
+      image: "https://lh3.googleusercontent.com/a/avatar.jpg",
     });
+  });
+
+  it.each([
+    "",
+    "not-a-url",
+    "http://lh3.googleusercontent.com/avatar.jpg",
+    "data:image/png;base64,abc",
+    "javascript:alert(1)",
+    "https://googleusercontent.com.evil.example/avatar.jpg",
+  ])("ignores an unsafe Google profile image URL: %s", async (picture) => {
+    await persistGoogleProfileImage("vishwas@example.com", picture);
+
+    expect(putSetting).not.toHaveBeenCalled();
   });
 
   it("keeps sign-in non-fatal when avatar storage fails", async () => {
@@ -59,7 +72,7 @@ describe("persistGoogleProfileImage", () => {
     await expect(
       persistGoogleProfileImage(
         "logan@example.com",
-        "https://example.com/avatar.jpg",
+        "https://lh3.googleusercontent.com/a/avatar.jpg",
       ),
     ).resolves.toBeUndefined();
     expect(warning).toHaveBeenCalledWith(

--- a/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
@@ -37,6 +37,7 @@ import { persistGoogleProfileImage } from "./callback.get.js";
 describe("persistGoogleProfileImage", () => {
   beforeEach(() => {
     putSetting.mockReset();
+    putSetting.mockResolvedValue(undefined);
     vi.restoreAllMocks();
   });
 

--- a/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const putSetting = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/server", () => ({
+  createOAuthSession: vi.fn(),
+  decodeOAuthState: vi.fn(),
+  getAppUrl: vi.fn(),
+  matchesDesktopOAuthBrowserBinding: vi.fn(),
+  oauthCallbackResponse: vi.fn(),
+  oauthErrorPage: vi.fn(),
+  resolveGoogleSignInCredentials: vi.fn(),
+  resolveOAuthOwner: vi.fn(),
+  setDesktopExchange: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/settings", () => ({ putSetting }));
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getQuery: vi.fn(),
+  setResponseStatus: vi.fn(),
+}));
+
+vi.mock("../../../lib/google-calendar-client.js", () => ({
+  GOOGLE_TOKEN_URL: "https://example.com/token",
+  GOOGLE_USERINFO_URL: "https://example.com/userinfo",
+}));
+
+vi.mock("../../../lib/google-calendar-oauth.js", () => ({
+  handleGoogleCalendarCallback: vi.fn(),
+  isCalendarConnectState: vi.fn(() => false),
+}));
+
+import { persistGoogleProfileImage } from "./callback.get.js";
+
+describe("persistGoogleProfileImage", () => {
+  beforeEach(() => {
+    putSetting.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("stores a non-empty Google profile image under the email avatar key", async () => {
+    await persistGoogleProfileImage(
+      "vishwas@example.com",
+      "https://example.com/avatar.jpg",
+    );
+
+    expect(putSetting).toHaveBeenCalledWith("avatar:vishwas@example.com", {
+      image: "https://example.com/avatar.jpg",
+    });
+  });
+
+  it("keeps sign-in non-fatal when avatar storage fails", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    putSetting.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(
+      persistGoogleProfileImage(
+        "logan@example.com",
+        "https://example.com/avatar.jpg",
+      ),
+    ).resolves.toBeUndefined();
+    expect(warning).toHaveBeenCalledWith(
+      "[auth] failed to store Google profile image:",
+      expect.any(Error),
+    );
+  });
+});

--- a/templates/clips/server/routes/_agent-native/google/callback.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.ts
@@ -10,6 +10,7 @@ import {
   setDesktopExchange,
   type OAuthStatePayload,
 } from "@agent-native/core/server";
+import { putSetting } from "@agent-native/core/settings";
 import {
   defineEventHandler,
   getQuery,
@@ -25,6 +26,17 @@ import {
   handleGoogleCalendarCallback,
   isCalendarConnectState,
 } from "../../../lib/google-calendar-oauth.js";
+
+export async function persistGoogleProfileImage(
+  email: string,
+  picture: unknown,
+) {
+  if (typeof picture !== "string" || !picture.trim()) return;
+
+  await putSetting(`avatar:${email}`, { image: picture }).catch((error) => {
+    console.warn("[auth] failed to store Google profile image:", error);
+  });
+}
 
 async function handleGoogleSignInCallback(
   event: H3Event,
@@ -104,6 +116,7 @@ async function handleGoogleSignInCallback(
         "Google account email is not verified. Please verify your email with Google and try again.",
       );
     }
+    await persistGoogleProfileImage(email, user.picture);
 
     const { hasProductionSession } = await resolveOAuthOwner(
       event,

--- a/templates/clips/server/routes/_agent-native/google/callback.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/callback.get.ts
@@ -11,6 +11,7 @@ import {
   type OAuthStatePayload,
 } from "@agent-native/core/server";
 import { putSetting } from "@agent-native/core/settings";
+import { isGoogleProfileImageUrl } from "@agent-native/core/shared";
 import {
   defineEventHandler,
   getQuery,
@@ -31,11 +32,13 @@ export async function persistGoogleProfileImage(
   email: string,
   picture: unknown,
 ) {
-  if (typeof picture !== "string" || !picture.trim()) return;
+  if (!isGoogleProfileImageUrl(picture)) return;
 
-  await putSetting(`avatar:${email}`, { image: picture }).catch((error) => {
-    console.warn("[auth] failed to store Google profile image:", error);
-  });
+  await putSetting(`avatar:${email}`, { image: picture.trim() }).catch(
+    (error) => {
+      console.warn("[auth] failed to store Google profile image:", error);
+    },
+  );
 }
 
 async function handleGoogleSignInCallback(

--- a/templates/content/app/components/editor/CommentsSidebar.tsx
+++ b/templates/content/app/components/editor/CommentsSidebar.tsx
@@ -1,5 +1,6 @@
 import { sendToAgentChat } from "@agent-native/core/client/agent-chat";
 import { emailToName } from "@agent-native/core/client/collab";
+import { useAvatarUrl } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   InlineMarkdown,
@@ -23,6 +24,11 @@ import {
 } from "react";
 import { toast } from "sonner";
 
+import {
+  Avatar as UserAvatar,
+  AvatarFallback as UserAvatarFallback,
+  AvatarImage as UserAvatarImage,
+} from "@/components/ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -93,6 +99,30 @@ function emailToAvatarColor(email: string) {
   }
   const hue = Math.abs(hash) % 360;
   return `hsl(${hue}, 55%, 55%)`;
+}
+
+function CommentAvatar({
+  email,
+  name,
+  className = "h-6 w-6",
+}: {
+  email?: string | null;
+  name?: string | null;
+  className?: string;
+}) {
+  const avatarUrl = useAvatarUrl(email);
+  const label = name ?? email ?? "";
+  return (
+    <UserAvatar className={className} title={label}>
+      {avatarUrl ? <UserAvatarImage src={avatarUrl} alt={label} /> : null}
+      <UserAvatarFallback
+        className="text-[11px] font-medium text-primary-foreground"
+        style={{ backgroundColor: emailToAvatarColor(email ?? "user") }}
+      >
+        {emailToInitial(label)}
+      </UserAvatarFallback>
+    </UserAvatar>
+  );
 }
 
 function formatDate(dateStr: string) {
@@ -938,12 +968,10 @@ function ThreadView({
         {thread.comments.map((c) => (
           <div key={c.id} className="mb-3 last:mb-0">
             <div className="flex items-center gap-2 mb-0.5">
-              <div
-                className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-medium text-white shrink-0"
-                style={{ backgroundColor: emailToAvatarColor(c.author_email) }}
-              >
-                {emailToInitial(c.author_name ?? c.author_email)}
-              </div>
+              <CommentAvatar
+                email={c.author_email}
+                name={c.author_name ?? c.author_email}
+              />
               <span className="text-[13px] font-semibold text-foreground">
                 {c.author_name ?? c.author_email.split("@")[0]}
               </span>
@@ -964,16 +992,11 @@ function ThreadView({
           className="flex items-center gap-2 px-3 pb-3 pt-1"
           onClick={(e) => e.stopPropagation()}
         >
-          <div
-            className="w-6 h-6 rounded-full flex items-center justify-center text-[11px] font-medium text-white shrink-0 opacity-40"
-            style={{
-              backgroundColor: emailToAvatarColor(
-                thread.comments[0]?.author_email ?? "user",
-              ),
-            }}
-          >
-            {emailToInitial(thread.comments[0]?.author_name ?? "user")}
-          </div>
+          <CommentAvatar
+            email={thread.comments[0]?.author_email}
+            name={thread.comments[0]?.author_name ?? "user"}
+            className="h-6 w-6 shrink-0 opacity-40"
+          />
           <div className="flex-1 relative">
             <CommentComposer
               ref={replyInputRef}
@@ -1024,12 +1047,11 @@ function ResolvedThreadView({
         </p>
       )}
       <div className="flex items-center gap-2">
-        <div
-          className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-medium text-white shrink-0 opacity-80"
-          style={{ backgroundColor: emailToAvatarColor(first.author_email) }}
-        >
-          {emailToInitial(first.author_name ?? first.author_email)}
-        </div>
+        <CommentAvatar
+          email={first.author_email}
+          name={first.author_name ?? first.author_email}
+          className="h-5 w-5 shrink-0 opacity-80"
+        />
         <span className="flex-1 truncate text-[13px] text-muted-foreground">
           {renderCommentBody(first.content, first.mentions)}
         </span>

--- a/templates/content/app/components/ui/avatar.tsx
+++ b/templates/content/app/components/ui/avatar.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/avatar";

--- a/templates/design/app/components/visual-editor/ReviewCanvasPins.spec.tsx
+++ b/templates/design/app/components/visual-editor/ReviewCanvasPins.spec.tsx
@@ -49,6 +49,7 @@ const comment = vi.hoisted(
 vi.mock("@agent-native/core/client/hooks", () => ({
   callAction: mocks.callAction,
   setClientAppState: mocks.setClientAppState,
+  useAvatarUrl: () => null,
 }));
 
 vi.mock("@agent-native/core/client/review", () => ({

--- a/templates/design/app/components/visual-editor/ReviewCanvasPins.tsx
+++ b/templates/design/app/components/visual-editor/ReviewCanvasPins.tsx
@@ -1,4 +1,5 @@
 import { callAction } from "@agent-native/core/client/hooks";
+import { useAvatarUrl } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   buildReviewThreads,
@@ -30,7 +31,7 @@ import {
 } from "react";
 import { toast } from "sonner";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -1407,6 +1408,7 @@ function ReviewThreadPopover({
 }) {
   const t = useT();
   const rootAuthor = reviewAuthorLabel(thread.root, t("review.reviewer"));
+  const avatarUrl = useAvatarUrl(thread.root.authorEmail);
   return (
     <div
       data-review-popover
@@ -1419,6 +1421,7 @@ function ReviewThreadPopover({
     >
       <div className="flex items-start gap-2.5 p-3">
         <Avatar className="size-7 shrink-0">
+          {avatarUrl ? <AvatarImage src={avatarUrl} alt={rootAuthor} /> : null}
           <AvatarFallback className="text-[10px] font-semibold text-muted-foreground">
             {reviewAuthorInitials(rootAuthor)}
           </AvatarFallback>

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -10,7 +10,11 @@ import { appPath, agentNativePath } from "@agent-native/core/client/api-path";
 import { writeClipboardText } from "@agent-native/core/client/clipboard";
 import { emailToColor, emailToName } from "@agent-native/core/client/collab";
 import { PromptComposer } from "@agent-native/core/client/composer";
-import { useActionQuery, useSession } from "@agent-native/core/client/hooks";
+import {
+  useActionQuery,
+  useAvatarUrl,
+  useSession,
+} from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
   InlineMarkdown,
@@ -7505,6 +7509,23 @@ function LoggedOutEmptyPlan() {
 
 type OverviewFilter = "all" | "plans" | "recaps" | "archived" | "deleted";
 
+function PlanOwnerAvatar({ email }: { email: string }) {
+  const avatarUrl = useAvatarUrl(email);
+  const name = emailToName(email);
+
+  return (
+    <Avatar className="size-5">
+      {avatarUrl ? <AvatarImage src={avatarUrl} alt={name} /> : null}
+      <AvatarFallback
+        className="text-[9px] font-semibold text-primary-foreground"
+        style={{ backgroundColor: emailToColor(email) }}
+      >
+        {commentAuthorInitials(name)}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
 function PlansOverview({
   plans,
   isLoading,
@@ -7785,20 +7806,7 @@ function PlansOverview({
                             className="flex min-w-0 items-center gap-1.5"
                             title={plan.ownerEmail}
                           >
-                            <Avatar className="size-5">
-                              <AvatarFallback
-                                className="text-[9px] font-semibold text-white"
-                                style={{
-                                  backgroundColor: emailToColor(
-                                    plan.ownerEmail,
-                                  ),
-                                }}
-                              >
-                                {commentAuthorInitials(
-                                  emailToName(plan.ownerEmail),
-                                )}
-                              </AvatarFallback>
-                            </Avatar>
+                            <PlanOwnerAvatar email={plan.ownerEmail} />
                             <span className="truncate">
                               {emailToName(plan.ownerEmail)}
                             </span>

--- a/templates/slides/app/components/comments/SlideCommentsPanel.tsx
+++ b/templates/slides/app/components/comments/SlideCommentsPanel.tsx
@@ -1,3 +1,4 @@
+import { useAvatarUrl } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { InlineMarkdown } from "@agent-native/core/client/markdown";
 import {
@@ -11,6 +12,11 @@ import {
 } from "@tabler/icons-react";
 import { useState, useRef, useEffect } from "react";
 
+import {
+  Avatar as UserAvatar,
+  AvatarFallback as UserAvatarFallback,
+  AvatarImage as UserAvatarImage,
+} from "@/components/ui/avatar";
 import {
   Tooltip,
   TooltipContent,
@@ -39,6 +45,7 @@ interface SlideCommentsPanelProps {
 /** Initials avatar */
 function Avatar({ email, name }: { email: string; name?: string | null }) {
   const color = emailToColor(email);
+  const avatarUrl = useAvatarUrl(email);
   const initials = (name || email)
     .split(/[@.\s]/)
     .filter(Boolean)
@@ -47,13 +54,17 @@ function Avatar({ email, name }: { email: string; name?: string | null }) {
     .join("")
     .slice(0, 2);
   return (
-    <div
-      className="w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-bold text-white flex-shrink-0"
-      style={{ backgroundColor: color }}
-      title={name || email}
-    >
-      {initials}
-    </div>
+    <UserAvatar className="h-5 w-5 shrink-0" title={name || email}>
+      {avatarUrl ? (
+        <UserAvatarImage src={avatarUrl} alt={name || email} />
+      ) : null}
+      <UserAvatarFallback
+        className="text-[9px] font-bold text-primary-foreground"
+        style={{ backgroundColor: color }}
+      >
+        {initials}
+      </UserAvatarFallback>
+    </UserAvatar>
   );
 }
 

--- a/templates/slides/app/components/ui/avatar.tsx
+++ b/templates/slides/app/components/ui/avatar.tsx
@@ -1,0 +1,1 @@
+export * from "@agent-native/toolkit/ui/avatar";


### PR DESCRIPTION
## Summary
- persist and propagate stored avatar URLs across Clips identity surfaces
- render lazy profile images with existing fallback avatars
- preserve collaboration avatar data through presence updates

## Verification
- git diff --check
- Clips test command could not run because this worktree has no node_modules/vitest