### PR TITLE
Polish agent recovery card action spacing

### DIFF
--- a/.changeset/recovery-card-action-spacing.md
+++ b/.changeset/recovery-card-action-spacing.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Polish the agent recovery card action spacing.

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -718,13 +718,13 @@ export function RunErrorRecoveryCard({
           <button
             type="button"
             onClick={onContinue}
-            className="inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90"
+            className="inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md bg-foreground px-3 py-2 text-xs font-medium text-background hover:opacity-90"
           >
             <IconPlayerPlay size={13} />
             <span className="truncate">{t("agentChat.common.continue")}</span>
           </button>
         )}
-        <div className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/70 bg-background/60 p-0.5">
+        <div className="flex shrink-0 items-center gap-0.5">
           {canRetry && (
             <button
               type="button"


### PR DESCRIPTION
Polish the agent recovery card actions based on the linked Slides feedback.

- add vertical padding to Continue
- remove the enclosing box around right-side icon actions

Checks: core run recovery tests (11 passed), git diff --check

Feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787765987002749