### PR TITLE
fix(clips): keep native transcripts readable

### DIFF
--- a/templates/clips/.agents/skills/ai-video-tools/SKILL.md
+++ b/templates/clips/.agents/skills/ai-video-tools/SKILL.md
@@ -141,18 +141,19 @@ removing overlapping duplicate speech and low-speech Whisper hallucinations. Kee
 system audio enabled when the meeting audio comes from another app.
 
 Native transcript first is a hard rule, not a preference: cloud transcription is
-fallback-only for Clips recordings. Cleanup and transcript-backed title/summary
-generation run in the durable post-finalize path, so never hide a usable native
-transcript behind failed metadata work, and keep heuristic titles replaceable
-until the agent refinement lands.
+fallback-only for Clips recordings. Recording transcripts keep the native text as
+captured; `request-transcript` does not run automatic cleanup. Never hide a
+usable native transcript behind failed metadata work, and keep heuristic titles
+replaceable until the agent refinement lands. The standalone `cleanup-transcript`
+action remains available for explicit dictation, meeting, and agent workflows.
 
 Clips never routes recording/meeting audio to OpenAI for transcription. (Groq's endpoint is OpenAI-_compatible_ in request shape only — the audio goes to Groq, not OpenAI.)
 
 If no native transcript exists and no cloud fallback is available (no Builder connection and no Groq key), the action writes `status="failed"` so the UI can show a friendly prompt.
 
-When a transcript becomes ready, `request-transcript` must await native cleanup
-and the metadata handoff before its durable post-finalize worker returns.
-Do not leave title/summary work as an unawaited promise in that worker:
+When a transcript becomes ready, `request-transcript` must await the metadata
+handoff before its durable post-finalize worker returns. Do not leave
+title/summary work as an unawaited promise in that worker:
 serverless runtimes may freeze it immediately. A local heuristic title uses
 `titleSource: "context"` so it remains a temporary UI fallback until the
 `generate-metadata` agent request replaces it with a transcript-backed title.

--- a/templates/clips/actions/request-transcript.test.ts
+++ b/templates/clips/actions/request-transcript.test.ts
@@ -29,11 +29,8 @@ const mockDb = vi.hoisted(() => ({
   })),
 }));
 const mockWriteAppState = vi.hoisted(() => vi.fn());
-const mockGetSetting = vi.hoisted(() => vi.fn());
-const mockGetUserSetting = vi.hoisted(() => vi.fn());
 const mockFetchLoomTranscript = vi.hoisted(() => vi.fn());
 const mockExportToBrainRun = vi.hoisted(() => vi.fn());
-const mockCleanupTranscriptRun = vi.hoisted(() => vi.fn());
 const mockRegenerateTitleRun = vi.hoisted(() => vi.fn());
 const mockRegenerateSummaryRun = vi.hoisted(() => vi.fn());
 const mockQueueTitleRegenerationRequest = vi.hoisted(() => vi.fn());
@@ -56,22 +53,12 @@ vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: (...args: unknown[]) => mockWriteAppState(...args),
 }));
 
-vi.mock("@agent-native/core/settings", () => ({
-  getSetting: (...args: unknown[]) => mockGetSetting(...args),
-  getUserSetting: (...args: unknown[]) => mockGetUserSetting(...args),
-}));
-
 vi.mock("@agent-native/core/credentials", () => ({
   resolveCredential: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/extensions/url-safety", () => ({
   ssrfSafeFetch: (...args: unknown[]) => mockSsrfSafeFetch(...args),
-}));
-
-vi.mock("@agent-native/core/server/request-context", () => ({
-  getRequestUserEmail: vi.fn(() => "owner@example.com"),
-  getCredentialContext: vi.fn(() => null),
 }));
 
 vi.mock("@agent-native/core/server", () => ({
@@ -147,14 +134,6 @@ vi.mock("./regenerate-summary.js", () => ({
 
 vi.mock("./export-to-brain.js", () => ({
   default: { run: (...args: unknown[]) => mockExportToBrainRun(...args) },
-}));
-
-vi.mock("./cleanup-transcript.js", () => ({
-  default: { run: (...args: unknown[]) => mockCleanupTranscriptRun(...args) },
-}));
-
-vi.mock("./lib/agents-md-context.js", () => ({
-  loadAgentsMdContext: vi.fn(async () => ""),
 }));
 
 vi.mock("./lib/audio-only-transcription.js", () => ({
@@ -474,9 +453,6 @@ describe("requestTranscript regeneration", () => {
   });
 
   it("completes transcript-backed title and summary handoff before returning", async () => {
-    mockGetUserSetting.mockResolvedValue({
-      transcriptCleanupEnabled: false,
-    });
     mockRegenerateTitleRun.mockResolvedValue({
       updated: true,
       summaryQueued: true,
@@ -523,6 +499,37 @@ describe("requestTranscript regeneration", () => {
       cleanupQueued: false,
       titleQueued: true,
       summaryQueued: true,
+    });
+  });
+
+  it("does not run automatic transcript cleanup", async () => {
+    mockSelectRows.queue = [
+      [
+        {
+          status: "ready",
+          fullText: "Saved transcript.",
+          segmentsJson: existingSegments,
+          updatedAt: "2026-07-09T00:00:00.000Z",
+          language: "en",
+          retryCount: 0,
+        },
+      ],
+      [
+        {
+          title: "Human title",
+          titleSource: "manual",
+          description: "Saved",
+          durationMs: 1200,
+        },
+      ],
+    ];
+
+    const result = await requestTranscript.run({ recordingId: "rec_native" });
+
+    expect(result).toMatchObject({
+      recordingId: "rec_native",
+      status: "ready",
+      cleanupQueued: false,
     });
   });
 
@@ -840,16 +847,10 @@ describe("importLoomTranscriptForRecording", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSelectRows.queue = [];
-    mockGetSetting.mockResolvedValue({ transcriptCleanupEnabled: true });
-    mockGetUserSetting.mockResolvedValue({ transcriptCleanupEnabled: false });
     mockFetchLoomTranscript.mockRejectedValue(
       new Error("temporary Loom error"),
     );
     mockExportToBrainRun.mockResolvedValue({ status: "skipped" });
-    mockCleanupTranscriptRun.mockResolvedValue({
-      cleanedText: "Saved transcript.",
-      provider: "test",
-    });
   });
 
   it("preserves an existing ready transcript when Loom refresh fails", async () => {
@@ -893,14 +894,6 @@ describe("importLoomTranscriptForRecording", () => {
       shareUrl: "https://www.loom.com/share/abcDEF_123456",
       durationMs: 1200,
     });
-    await vi.waitFor(() =>
-      expect(mockGetUserSetting).toHaveBeenCalledWith(
-        "owner@example.com",
-        "clips-user-prefs",
-      ),
-    );
-    expect(mockGetSetting).not.toHaveBeenCalled();
-    expect(mockCleanupTranscriptRun).not.toHaveBeenCalled();
     expect(mockInsertValues).not.toHaveBeenCalled();
     expect(mockUpdateSet).not.toHaveBeenCalled();
   });

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -38,8 +38,6 @@ import {
 } from "@agent-native/core/application-state";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
-import { getRequestUserEmail } from "@agent-native/core/server/request-context";
-import { getSetting, getUserSetting } from "@agent-native/core/settings";
 import { assertAccess } from "@agent-native/core/sharing";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
 import { and, eq } from "drizzle-orm";
@@ -66,8 +64,6 @@ import {
   type TranscriptSegment,
 } from "../shared/transcript-segments.js";
 import { PENDING_TRANSCRIPT_HEARTBEAT_MS } from "../shared/transcript-status.js";
-import cleanupTranscript from "./cleanup-transcript.js";
-import { loadAgentsMdContext } from "./lib/agents-md-context.js";
 import {
   AudioOnlyExtractionError,
   assertAudioHasAudibleSignal,
@@ -107,7 +103,6 @@ type RecordingMediaRow = {
 const BUILDER_GEMINI_TRANSCRIPTION_MODEL = "gemini-3-1-flash-lite";
 const SPEECH_ONLY_TRANSCRIPTION_INSTRUCTIONS =
   "Auto-detect the spoken language from the audio. Transcribe only words spoken in the audio, in the same language they were spoken. Do not translate. Do not infer language from screen text, filenames, account settings, browser locale, or these instructions. Do not describe screen activity, UI changes, silence, music, or non-speech sounds. Return an empty transcript when there are no spoken words.";
-const CLIPS_USER_PREFS_KEY = "clips-user-prefs";
 const RECENT_PENDING_TRANSCRIPT_MS = 2 * 60 * 1000;
 const BUILDER_TRANSCRIPTION_MIN_TIMEOUT_MS = 45_000;
 const BUILDER_TRANSCRIPTION_MAX_TIMEOUT_MS = 65_000;
@@ -856,27 +851,11 @@ async function failAudioOnlyPreparation({
   throw new Error(reason);
 }
 
-async function transcriptCleanupEnabled(): Promise<boolean> {
-  const userEmail = getRequestUserEmail();
-  if (userEmail) {
-    const userSettings = await getUserSetting(
-      userEmail,
-      CLIPS_USER_PREFS_KEY,
-    ).catch(() => null);
-    if (userSettings && "transcriptCleanupEnabled" in userSettings) {
-      return userSettings.transcriptCleanupEnabled !== false;
-    }
-  }
-
-  const settings = await getSetting(CLIPS_USER_PREFS_KEY).catch(() => null);
-  return settings?.transcriptCleanupEnabled !== false;
-}
-
 /**
  * Read the language already detected/stored on this recording's transcript row.
- * Cleanup and renormalization must preserve a detected non-English language
- * rather than clobbering it back to "en". Falls back to "en" only when no row
- * (or no language) exists yet.
+ * Renormalization must preserve a detected non-English language rather than
+ * clobbering it back to "en". Falls back to "en" only when no row (or no
+ * language) exists yet.
  */
 async function resolveStoredLanguage(
   db: ReturnType<typeof getDb>,
@@ -888,140 +867,6 @@ async function resolveStoredLanguage(
     .where(eq(schema.recordingTranscripts.recordingId, recordingId))
     .limit(1);
   return row?.language?.trim() || "en";
-}
-
-async function cleanupNativeTranscript({
-  db,
-  recordingId,
-  ownerEmail,
-  fullText,
-  durationMs,
-  segmentsJson,
-}: {
-  db: ReturnType<typeof getDb>;
-  recordingId: string;
-  ownerEmail: string;
-  fullText: string;
-  durationMs: number | null | undefined;
-  segmentsJson?: string | null;
-}): Promise<{ cleaned: boolean; provider?: string }> {
-  const sourceText = fullText.trim();
-  if (!sourceText) return { cleaned: false };
-
-  if (!(await transcriptCleanupEnabled())) {
-    await writeTranscriptCleanupState(recordingId, {
-      status: "disabled",
-    });
-    return { cleaned: false };
-  }
-
-  await writeTranscriptCleanupState(recordingId, {
-    status: "running",
-    provider: BUILDER_GEMINI_TRANSCRIPTION_MODEL,
-    startedAt: new Date().toISOString(),
-  });
-
-  try {
-    const agentsContext = await loadAgentsMdContext({
-      ownerEmail,
-      purpose: "cleanup",
-    });
-    const result = await cleanupTranscript.run({
-      transcript: sourceText,
-      task: "cleanup",
-      context: agentsContext,
-    });
-    const cleanedText = result.cleanedText?.trim();
-    if (!cleanedText || cleanedText === sourceText) {
-      await writeTranscriptCleanupState(recordingId, {
-        status: "unchanged",
-        provider: result.provider,
-      });
-      return { cleaned: false, provider: result.provider };
-    }
-    if (!isSafeTranscriptCleanupReplacement(sourceText, cleanedText)) {
-      await writeTranscriptCleanupState(recordingId, {
-        status: "failed",
-        provider: result.provider,
-        failureReason:
-          "Cleanup output was incomplete; the original transcript was kept.",
-        sourceChars: sourceText.length,
-        cleanedChars: cleanedText.length,
-      });
-      return { cleaned: false, provider: result.provider };
-    }
-
-    const cleanupSegmentsJson = resolveCleanupSegmentsJson(
-      segmentsJson,
-      cleanedText,
-      durationMs,
-    );
-    if (!cleanupSegmentsJson) {
-      await writeTranscriptCleanupState(recordingId, {
-        status: "unchanged",
-        provider: result.provider,
-        failureReason:
-          "Cleanup output could not be aligned with measured speaker cues; the original transcript was kept.",
-      });
-      return { cleaned: false, provider: result.provider };
-    }
-
-    const now = new Date().toISOString();
-    const language = await resolveStoredLanguage(db, recordingId);
-    const updated = await db
-      .update(schema.recordingTranscripts)
-      .set({
-        ownerEmail,
-        status: "ready",
-        failureReason: null,
-        language,
-        segmentsJson: cleanupSegmentsJson,
-        fullText: cleanedText,
-        retryCount: 0,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(schema.recordingTranscripts.recordingId, recordingId),
-          eq(schema.recordingTranscripts.status, "ready"),
-          eq(schema.recordingTranscripts.fullText, sourceText),
-        ),
-      )
-      .returning({ recordingId: schema.recordingTranscripts.recordingId });
-    if (!updated.length) {
-      await writeTranscriptCleanupState(recordingId, {
-        status: "failed",
-        provider: result.provider,
-        failureReason:
-          "Transcript changed during cleanup; the newer transcript was kept.",
-      });
-      return { cleaned: false, provider: result.provider };
-    }
-    await writeTranscriptCleanupState(recordingId, {
-      status: "ready",
-      provider: result.provider,
-    });
-
-    return { cleaned: true, provider: result.provider };
-  } catch (err) {
-    const details = serializeError(err);
-    console.warn(
-      `[clips] native transcript cleanup skipped for ${recordingId}: ${summarizeError(err)}`,
-    );
-    if (verboseTranscriptErrors()) {
-      console.warn(
-        "[clips] native transcript cleanup error details",
-        serializeError(err, { includeStack: true }),
-      );
-    }
-    await writeTranscriptCleanupState(recordingId, {
-      status: "failed",
-      provider: BUILDER_GEMINI_TRANSCRIPTION_MODEL,
-      failureReason: (err as Error)?.message ?? String(err),
-      details,
-    });
-    return { cleaned: false };
-  }
 }
 
 async function generateRecordingMetadata({
@@ -1120,21 +965,6 @@ async function completeReadyTranscript({
     }
   }
 
-  const cleanupPromise = cleanupNativeTranscript({
-    db,
-    recordingId,
-    ownerEmail,
-    fullText,
-    durationMs: recForTitle?.durationMs,
-    segmentsJson,
-  }).catch((err) => {
-    console.warn(
-      `[clips] native transcript cleanup failed for ${recordingId}:`,
-      (err as Error)?.message ?? String(err),
-    );
-    return { cleaned: false };
-  });
-
   const metadataPromise = recForTitle
     ? generateRecordingMetadata({
         recordingId,
@@ -1151,12 +981,7 @@ async function completeReadyTranscript({
       })
     : Promise.resolve({ titleQueued: false, summaryQueued: false });
 
-  // Both calls are independent. Await them together so the durable worker stays
-  // alive without serially stacking two model-call timeouts.
-  const [cleanupResult, metadataResult] = await Promise.all([
-    cleanupPromise,
-    metadataPromise,
-  ]);
+  const metadataResult = await metadataPromise;
 
   if (!recForTitle) {
     console.warn(
@@ -1175,9 +1000,7 @@ async function completeReadyTranscript({
     );
   }
 
-  // Wake the player polling so it picks up the queued cleanup state row
-  // (`transcript-cleanup-${recordingId}`) before its next 2s tick lands —
-  // otherwise the "Cleaning up…" badge can lag for one full poll interval.
+  // Wake the player polling after transcript metadata generation completes.
   await writeAppState("refresh-signal", { ts: Date.now() });
   await finalizeEndedMeetingsForRecording(db, recordingId);
   await queueBrainExport(recordingId);
@@ -1185,7 +1008,7 @@ async function completeReadyTranscript({
   return {
     recordingId,
     status: "ready",
-    cleaned: cleanupResult.cleaned,
+    cleaned: false,
     provider: segmentsJson && segmentsJson !== "[]" ? "existing" : "native",
     cleanupQueued: false,
     titleQueued: metadataResult.titleQueued,

--- a/templates/clips/app/components/player/transcript-panel.test.tsx
+++ b/templates/clips/app/components/player/transcript-panel.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getTranscriptSeekMs,
   mergeTranscriptSegmentsForDisplay,
   TranscriptPanel,
 } from "./transcript-panel";
@@ -112,5 +113,17 @@ describe("mergeTranscriptSegmentsForDisplay", () => {
         text: "What's up, Sean? So in terms of users and audience, not too different, the big thing here is basically like, the builder audience is just big enough.",
       },
     ]);
+  });
+
+  it("seeks to the matching raw cue when a paragraph is searched", () => {
+    const segments = [
+      { startMs: 0, endMs: 2_000, text: "First thought." },
+      { startMs: 2_000, endMs: 4_000, text: "The matching phrase." },
+    ];
+    const [displaySegment] = mergeTranscriptSegmentsForDisplay(segments);
+
+    expect(
+      getTranscriptSeekMs(displaySegment, "matching phrase", segments),
+    ).toBe(2_000);
   });
 });

--- a/templates/clips/app/components/player/transcript-panel.test.tsx
+++ b/templates/clips/app/components/player/transcript-panel.test.tsx
@@ -4,7 +4,10 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { TranscriptPanel } from "./transcript-panel";
+import {
+  mergeTranscriptSegmentsForDisplay,
+  TranscriptPanel,
+} from "./transcript-panel";
 
 vi.mock("@agent-native/core/client/api-path", () => ({
   agentNativePath: (path: string) => path,
@@ -77,5 +80,37 @@ describe("TranscriptPanel no-audio failures", () => {
     });
 
     expect(container.querySelector(".text-destructive")).not.toBeNull();
+  });
+});
+
+describe("mergeTranscriptSegmentsForDisplay", () => {
+  it("groups short adjacent cues into readable paragraphs", () => {
+    const result = mergeTranscriptSegmentsForDisplay([
+      { startMs: 0, endMs: 2_000, text: "What's up, Sean?" },
+      {
+        startMs: 2_000,
+        endMs: 4_000,
+        text: "So in terms of users and audience,",
+      },
+      { startMs: 4_000, endMs: 5_000, text: "not too different," },
+      {
+        startMs: 5_000,
+        endMs: 10_000,
+        text: "the big thing here is basically like,",
+      },
+      {
+        startMs: 10_000,
+        endMs: 12_000,
+        text: "the builder audience is just big enough.",
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        startMs: 0,
+        endMs: 12_000,
+        text: "What's up, Sean? So in terms of users and audience, not too different, the big thing here is basically like, the builder audience is just big enough.",
+      },
+    ]);
   });
 });

--- a/templates/clips/app/components/player/transcript-panel.test.tsx
+++ b/templates/clips/app/components/player/transcript-panel.test.tsx
@@ -126,4 +126,14 @@ describe("mergeTranscriptSegmentsForDisplay", () => {
       getTranscriptSeekMs(displaySegment, "matching phrase", segments),
     ).toBe(2_000);
   });
+
+  it("seeks to the first cue when a search phrase spans cues", () => {
+    const segments = [
+      { startMs: 0, endMs: 2_000, text: "Please ship" },
+      { startMs: 2_000, endMs: 4_000, text: "this." },
+    ];
+    const [displaySegment] = mergeTranscriptSegmentsForDisplay(segments);
+
+    expect(getTranscriptSeekMs(displaySegment, "ship this", segments)).toBe(0);
+  });
 });

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -112,14 +112,25 @@ export function getTranscriptSeekMs(
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery || segments.length === 0) return displaySegment.startMs;
 
-  return (
-    segments.find(
-      (segment) =>
-        segment.startMs >= displaySegment.startMs &&
-        segment.endMs <= displaySegment.endMs &&
-        segment.text.toLowerCase().includes(normalizedQuery),
-    )?.startMs ?? displaySegment.startMs
+  const displaySegments = segments.filter(
+    (segment) =>
+      segment.startMs >= displaySegment.startMs &&
+      segment.endMs <= displaySegment.endMs,
   );
+  const searchableText = displaySegments
+    .map((segment) => segment.text)
+    .join(" ")
+    .toLowerCase();
+  const matchIndex = searchableText.indexOf(normalizedQuery);
+  if (matchIndex < 0) return displaySegment.startMs;
+
+  let offset = 0;
+  for (const segment of displaySegments) {
+    if (matchIndex < offset + segment.text.length) return segment.startMs;
+    offset += segment.text.length + 1;
+  }
+
+  return displaySegment.startMs;
 }
 
 export function TranscriptPanel(props: TranscriptPanelProps) {

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -157,7 +157,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
   }
 
   function downloadSrt() {
-    const srt = toSrt(displaySegments);
+    const srt = toSrt(segments.length > 0 ? segments : displaySegments);
     const blob = new Blob([srt], { type: "text/srt;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -32,6 +32,8 @@ export interface TranscriptSegment {
   startMs: number;
   endMs: number;
   text: string;
+  source?: "mic" | "system";
+  speaker?: string | null;
 }
 
 export interface TranscriptPanelProps {
@@ -42,18 +44,64 @@ export interface TranscriptPanelProps {
   onSeek: (ms: number) => void;
   status?: "pending" | "ready" | "failed";
   failureReason?: string | null;
-  cleanup?: {
-    status?: string | null;
-    provider?: string | null;
-    failureReason?: string | null;
-    updatedAt?: string | null;
-  } | null;
   recordingTitle?: string;
   /** Called when the user asks us to retry transcription after fixing an error. */
   onRetry?: () => void;
   /** Called when the user asks for a fresh transcript from the recording media. */
   onRegenerate?: () => void;
   isRegenerating?: boolean;
+}
+
+const DISPLAY_MAX_WORDS = 36;
+const DISPLAY_MIN_WORDS_BEFORE_SENTENCE_BREAK = 18;
+const DISPLAY_MAX_GAP_MS = 3_500;
+
+export function mergeTranscriptSegmentsForDisplay(
+  segments: TranscriptSegment[],
+): TranscriptSegment[] {
+  const merged: TranscriptSegment[] = [];
+  let current: TranscriptSegment | null = null;
+
+  for (const segment of segments) {
+    if (!current) {
+      current = { ...segment };
+      continue;
+    }
+
+    const currentWords = countWords(current.text);
+    const segmentWords = countWords(segment.text);
+    const sameSpeaker =
+      current.source === segment.source && current.speaker === segment.speaker;
+    const shouldBreak =
+      !sameSpeaker ||
+      segment.startMs - current.endMs > DISPLAY_MAX_GAP_MS ||
+      (currentWords >= DISPLAY_MIN_WORDS_BEFORE_SENTENCE_BREAK &&
+        endsSentence(current.text)) ||
+      currentWords + segmentWords > DISPLAY_MAX_WORDS;
+
+    if (shouldBreak) {
+      merged.push(current);
+      current = { ...segment };
+      continue;
+    }
+
+    current = {
+      ...current,
+      endMs: segment.endMs,
+      text: `${current.text} ${segment.text}`,
+    };
+  }
+
+  if (current) merged.push(current);
+  return merged;
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function endsSentence(text: string): boolean {
+  return /[.!?]["')\]}]*$/.test(text.trim());
 }
 
 export function TranscriptPanel(props: TranscriptPanelProps) {
@@ -66,7 +114,6 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
     onSeek,
     status,
     failureReason,
-    cleanup,
     recordingTitle,
     onRetry,
     onRegenerate,
@@ -76,7 +123,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
   const [copied, setCopied] = useState(false);
 
   const displaySegments = useMemo<TranscriptSegment[]>(() => {
-    if (segments.length > 0) return segments;
+    if (segments.length > 0) return mergeTranscriptSegmentsForDisplay(segments);
     const text = fullText?.trim();
     if (!text) return [];
     return [
@@ -133,7 +180,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
   if (status === "failed" && builderCreditsPaused) {
     return (
       <div className="p-4">
-        <BuilderCreditsPausedNotice mode="transcription" onRetry={onRetry} />
+        <BuilderCreditsPausedNotice onRetry={onRetry} />
       </div>
     );
   }
@@ -219,7 +266,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-2 p-3 border-b border-border">
+      <div className="flex items-center gap-2 border-b border-border p-3">
         <div className="relative flex-1">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
@@ -229,62 +276,49 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
             className="pl-8 h-8 text-xs"
           />
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={copyAll}>
-              {copied ? (
-                <IconCheck className="h-4 w-4 text-green-600" />
-              ) : (
-                <IconCopy className="h-4 w-4" />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{t("transcriptPanel.copyTranscript")}</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={downloadSrt}>
-              <IconDownload className="h-4 w-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{t("transcriptPanel.downloadSrt")}</TooltipContent>
-        </Tooltip>
-        {onRegenerate ? (
+        <div className="flex items-center gap-0.5">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onRegenerate}
-                disabled={isRegenerating}
-                aria-label={t("transcriptPanel.regenerate")}
-              >
-                <IconRefresh
-                  className={cn("h-4 w-4", isRegenerating && "animate-spin")}
-                />
+              <Button variant="ghost" size="icon" onClick={copyAll}>
+                {copied ? (
+                  <IconCheck className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <IconCopy className="h-4 w-4" />
+                )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{t("transcriptPanel.regenerate")}</TooltipContent>
+            <TooltipContent>
+              {t("transcriptPanel.copyTranscript")}
+            </TooltipContent>
           </Tooltip>
-        ) : null}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon" onClick={downloadSrt}>
+                <IconDownload className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{t("transcriptPanel.downloadSrt")}</TooltipContent>
+          </Tooltip>
+          {onRegenerate ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onRegenerate}
+                  disabled={isRegenerating}
+                  aria-label={t("transcriptPanel.regenerate")}
+                >
+                  <IconRefresh
+                    className={cn("h-4 w-4", isRegenerating && "animate-spin")}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t("transcriptPanel.regenerate")}</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
       </div>
-
-      {cleanup?.status === "running" ? (
-        <div className="mx-3 mt-3 rounded-md border border-border bg-accent/30 px-3 py-2 text-xs text-muted-foreground flex items-center gap-2">
-          <IconLoader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
-          <span>{t("transcriptPanel.cleanupRunning")}</span>
-        </div>
-      ) : null}
-
-      {cleanup?.status === "failed" &&
-      isBuilderCreditsExhaustedMessage(cleanup.failureReason) ? (
-        <BuilderCreditsPausedNotice mode="cleanup" className="mx-3 mt-3" />
-      ) : cleanup?.status === "failed" ? (
-        <div className="mx-3 mt-3 rounded-md border border-border bg-accent/30 px-3 py-2 text-xs text-muted-foreground flex items-start gap-2">
-          <IconBolt className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          <span>{friendlyCleanupFailure(cleanup.failureReason, t)}</span>
-        </div>
-      ) : null}
 
       <div className="flex-1 overflow-y-auto">
         {filtered.length === 0 ? (
@@ -382,17 +416,14 @@ function sanitizeFilename(s: string): string {
 
 const BUILDER_CREDITS_FEATURE_LABELS = [
   "builderCredits.featureBackupTranscription",
-  "builderCredits.featureCleanup",
   "builderCredits.featureSummaries",
   "builderCredits.featureTitles",
 ] as const;
 
 function BuilderCreditsPausedNotice({
-  mode,
   onRetry,
   className,
 }: {
-  mode: "transcription" | "cleanup";
   onRetry?: () => void;
   className?: string;
 }) {
@@ -414,9 +445,7 @@ function BuilderCreditsPausedNotice({
               {t("builderCredits.pausedTitle")}
             </p>
             <p className="mt-1 text-xs leading-relaxed text-amber-900/80 dark:text-amber-100/80">
-              {mode === "cleanup"
-                ? t("builderCredits.cleanupDescription")
-                : t("builderCredits.transcriptionDescription")}
+              {t("builderCredits.transcriptionDescription")}
             </p>
           </div>
           <div className="flex flex-wrap gap-1.5">
@@ -541,31 +570,6 @@ function friendlyTranscriptFailure(
     return t("transcriptPanel.backupNotSetup");
   }
   return reason;
-}
-
-function friendlyCleanupFailure(
-  reason: string | null | undefined,
-  t: ReturnType<typeof useT>,
-): string {
-  if (!reason) return t("transcriptPanel.cleanupKept");
-  const normalized = reason.toLowerCase();
-  if (
-    normalized.includes("is connected, but") ||
-    normalized.includes("returned no text") ||
-    normalized.includes("service failed")
-  ) {
-    return t("transcriptPanel.cleanupBuilderFailed");
-  }
-  if (
-    normalized.includes("incomplete") ||
-    isBuilderCreditsExhaustedMessage(reason) ||
-    normalized.includes("connect builder") ||
-    normalized.includes("not configured") ||
-    normalized.includes("api key")
-  ) {
-    return t("transcriptPanel.cleanupPaused");
-  }
-  return t("transcriptPanel.cleanupKept");
 }
 
 /**

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -104,6 +104,24 @@ function endsSentence(text: string): boolean {
   return /[.!?]["')\]}]*$/.test(text.trim());
 }
 
+export function getTranscriptSeekMs(
+  displaySegment: TranscriptSegment,
+  query: string,
+  segments: TranscriptSegment[],
+): number {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery || segments.length === 0) return displaySegment.startMs;
+
+  return (
+    segments.find(
+      (segment) =>
+        segment.startMs >= displaySegment.startMs &&
+        segment.endMs <= displaySegment.endMs &&
+        segment.text.toLowerCase().includes(normalizedQuery),
+    )?.startMs ?? displaySegment.startMs
+  );
+}
+
 export function TranscriptPanel(props: TranscriptPanelProps) {
   const t = useT();
   const {
@@ -331,6 +349,7 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
           <ul className="py-1">
             {filtered.map((seg) => {
               const isActive = displaySegments[activeIndex] === seg;
+              const seekMs = getTranscriptSeekMs(seg, query, segments);
               return (
                 <li key={seg.startMs}>
                   <TranscriptSegmentRow
@@ -339,12 +358,12 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
                     gutter="panel"
                     onClick={(event) => {
                       if (hasSelectionWithin(event.currentTarget)) return;
-                      onSeek(seg.startMs);
+                      onSeek(seekMs);
                     }}
                     onKeyDown={(event) => {
                       if (event.key !== "Enter" && event.key !== " ") return;
                       event.preventDefault();
-                      onSeek(seg.startMs);
+                      onSeek(seekMs);
                     }}
                   >
                     <span

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -48,7 +48,6 @@ const SPEEDS = ["1", "1.2", "1.5", "1.75", "2"];
 interface ClipsUserSettings {
   defaultPlaybackSpeed?: string;
   emailNotifications?: boolean;
-  transcriptCleanupEnabled?: boolean;
   includeFullVideoInAi?: boolean;
   defaultRecordingVisibility?: ClipsDefaultVisibility;
 }
@@ -133,9 +132,6 @@ export default function SettingsIndexRoute() {
   const [emailNotifications, setEmailNotifications] = useState(true);
   const [defaultVisibility, setDefaultVisibility] =
     useState<ClipsDefaultVisibility>(DEFAULT_CLIPS_RECORDING_VISIBILITY);
-  const [transcriptCleanupEnabled, setTranscriptCleanupEnabled] =
-    useState(true);
-
   useEffect(() => {
     let cancelled = false;
     loadSettings().then((v) => {
@@ -145,7 +141,6 @@ export default function SettingsIndexRoute() {
       setDefaultVisibility(
         v.defaultRecordingVisibility ?? DEFAULT_CLIPS_RECORDING_VISIBILITY,
       );
-      setTranscriptCleanupEnabled(v.transcriptCleanupEnabled !== false);
       setLoading(false);
     });
     return () => {
@@ -194,7 +189,6 @@ export default function SettingsIndexRoute() {
       await saveSettings({
         defaultPlaybackSpeed: defaultSpeed,
         emailNotifications,
-        transcriptCleanupEnabled,
         defaultRecordingVisibility: defaultVisibility,
       });
       toast.success(t("settings.saved"));
@@ -354,20 +348,6 @@ export default function SettingsIndexRoute() {
                         </SelectItem>
                       </SelectContent>
                     </Select>
-                  }
-                />
-                <SettingsRow
-                  id="transcript"
-                  label={t("settings.transcriptCleanup")}
-                  description={t("settings.transcriptCleanupDescription")}
-                  control={
-                    <Switch
-                      id="transcript-cleanup"
-                      aria-label={t("settings.transcriptCleanup")}
-                      checked={transcriptCleanupEnabled}
-                      onCheckedChange={setTranscriptCleanupEnabled}
-                      disabled={loading}
-                    />
                   }
                 />
                 <SettingsRow

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -244,12 +244,6 @@ export default function SettingsIndexRoute() {
         hash: "playback",
       },
       {
-        id: "clips-transcript",
-        label: t("settings.transcript"),
-        keywords: "transcript cleanup captions",
-        hash: "transcript",
-      },
-      {
         id: "clips-sharing",
         label: t("settings.sharing"),
         keywords: "sharing visibility private public organization default",

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -388,7 +388,6 @@ export default function RecordingPage() {
         // Also keep polling while a transcript is pending so "Transcribing…"
         // auto-flips to the ready transcript (or to the failure card).
         if (data?.transcript?.status === "pending") return 3000;
-        if (data?.transcript?.cleanup?.status === "running") return 2000;
         // And keep polling while the title is still the server-seeded
         // default — the agent will land a generated title via
         // `update-recording` and we want the skeleton to swap in promptly.
@@ -460,7 +459,6 @@ export default function RecordingPage() {
   const transcriptFullText = playerDataQ.data?.transcript?.fullText ?? null;
   const transcriptStatus = playerDataQ.data?.transcript?.status;
   const transcriptFailureReason = playerDataQ.data?.transcript?.failureReason;
-  const transcriptCleanup = playerDataQ.data?.transcript?.cleanup ?? null;
   const ctas = playerDataQ.data?.ctas ?? [];
   const canEdit = role === "owner" || role === "admin" || role === "editor";
   // Reaching this page already requires a signed-in session with at least
@@ -1265,7 +1263,7 @@ export default function RecordingPage() {
         </TabsContent>
         <TabsContent
           value="transcript"
-          className="flex-1 min-h-0 mt-3 data-[state=inactive]:hidden"
+          className="mt-0 flex-1 min-h-0 data-[state=inactive]:hidden"
         >
           <TranscriptPanel
             segments={transcriptSegments}
@@ -1279,7 +1277,6 @@ export default function RecordingPage() {
                 : transcriptStatus
             }
             failureReason={transcriptFailureReason}
-            cleanup={transcriptCleanup}
             recordingTitle={recording.title}
             onRetry={
               canEdit

--- a/templates/clips/shared/clips-ai-prefs.ts
+++ b/templates/clips/shared/clips-ai-prefs.ts
@@ -29,7 +29,6 @@ export type ClipsUserPrefs = ClipsAiPrefs & {
   defaultPlaybackSpeed?: string;
   /** Activity emails (comments, replies, reactions) only — never share invites. */
   emailNotifications?: boolean;
-  transcriptCleanupEnabled?: boolean;
   /** Overrides the organization default visibility for new recordings. */
   defaultRecordingVisibility?: ClipsDefaultVisibility;
 };


### PR DESCRIPTION
Removes automatic native-transcript cleanup so ready transcripts stay as captured and stale cleanup warnings stop appearing. Groups adjacent cues into readable paragraph-sized rows while preserving stored timing data, and tightens the transcript header spacing.\n\nChecks: 38 focused tests, Clips typecheck, and all 64 repository guards.