### PR TITLE
fix: do not permanently fail when app is slow to cold-boot

### DIFF
--- a/.changeset/target-embed-cold-boot-timeout.md
+++ b/.changeset/target-embed-cold-boot-timeout.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Give the Dispatch workspace embed handshake a cold-boot connect budget so opening an app whose server is still starting no longer fails as unreachable. `McpClientManager` now accepts a `connectTimeoutMs` option, and the embed session mint spends up to 90s per attempt within a 95s total budget instead of the 5s interactive default, matching the dev gateway's own readiness wait.

--- a/packages/core/src/mcp-client/manager.ts
+++ b/packages/core/src/mcp-client/manager.ts
@@ -88,6 +88,14 @@ export function parseMcpToolName(
 export interface McpClientManagerOptions {
   /** Emit debug logs on startup */
   debug?: boolean;
+  /**
+   * Per-server budget for the connect and tools/list handshake. The default
+   * suits an interactive surface that must not stall on a dead server; raise it
+   * only for a caller whose target is expected to be cold-starting, and stay
+   * under the platform request wall. An explicit
+   * `AGENT_NATIVE_MCP_CLIENT_CONNECT_TIMEOUT_MS` still overrides this.
+   */
+  connectTimeoutMs?: number;
 }
 
 function sameServerConfig(a: McpServerConfig, b: McpServerConfig): boolean {
@@ -149,7 +157,7 @@ type SdkModules = {
 
 const DEFAULT_MCP_CONNECT_TIMEOUT_MS = 5_000;
 
-function mcpConnectTimeoutMs(): number {
+function mcpConnectTimeoutMs(configured?: number): number {
   const raw =
     typeof process !== "undefined"
       ? process.env.AGENT_NATIVE_MCP_CLIENT_CONNECT_TIMEOUT_MS ||
@@ -157,6 +165,9 @@ function mcpConnectTimeoutMs(): number {
       : undefined;
   const parsed = raw ? Number(raw) : NaN;
   if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  if (Number.isFinite(configured) && (configured as number) >= 0) {
+    return configured as number;
+  }
   return DEFAULT_MCP_CONNECT_TIMEOUT_MS;
 }
 
@@ -182,6 +193,7 @@ async function withConnectTimeout<T>(
 export class McpClientManager {
   private readonly servers: Map<string, ServerEntry> = new Map();
   private readonly debug: boolean;
+  private readonly connectTimeoutMs: number | undefined;
   private started = false;
   private config: McpConfig | null;
   private sdk: SdkModules | null = null;
@@ -193,6 +205,7 @@ export class McpClientManager {
   constructor(config: McpConfig | null, options: McpClientManagerOptions = {}) {
     this.config = config;
     this.debug = !!options.debug;
+    this.connectTimeoutMs = options.connectTimeoutMs;
   }
 
   /** True when the manager has any configured servers. */
@@ -467,7 +480,7 @@ export class McpClientManager {
     // process (stdio) or pending HTTP session — otherwise repeated failures
     // leak transports. Assign to the entry only after the handshake succeeds.
     try {
-      const timeoutMs = mcpConnectTimeoutMs();
+      const timeoutMs = mcpConnectTimeoutMs(this.connectTimeoutMs);
       await withConnectTimeout(
         Promise.resolve(client.connect(transport)),
         `MCP server ${entry.id} connect`,

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -45,6 +45,9 @@ const DISPATCH_DESCRIPTION =
 const DISPATCH_COLOR = "#14B8A6";
 const TARGET_EMBED_SESSION_ATTEMPTS = 3;
 const TARGET_EMBED_SESSION_RETRY_BASE_MS = 250;
+// target apps can take a long time to cold-boot, so we give a large timeout here
+const TARGET_EMBED_SESSION_CONNECT_TIMEOUT_MS = 90_000;
+const TARGET_EMBED_SESSION_BUDGET_MS = 95_000;
 const DISPATCH_ASK_APP_DEFAULT_INLINE_WAIT_MS = 20_000;
 const DISPATCH_ASK_APP_MAX_INLINE_WAIT_MS = 25_000;
 const DISPATCH_ASK_APP_POLL_INTERVAL_MS = 1_500;
@@ -1027,6 +1030,12 @@ function targetMcpRequestDetails(input: {
   };
 }
 
+function targetMcpConnectTimeout(deadline: number): number {
+  const remaining = deadline - Date.now();
+  const budget = Math.min(TARGET_EMBED_SESSION_CONNECT_TIMEOUT_MS, remaining);
+  return Math.max(1000, budget);
+}
+
 function targetMcpRetryDelay(attempt: number): number {
   const base =
     TARGET_EMBED_SESSION_RETRY_BASE_MS * Math.pow(2, Math.max(0, attempt - 1));
@@ -1040,18 +1049,22 @@ async function callTargetCreateEmbedSession(input: {
   chrome?: "full" | "minimal";
 }): Promise<unknown> {
   const serverId = "target";
+  const deadline = Date.now() + TARGET_EMBED_SESSION_BUDGET_MS;
   for (let attempt = 1; ; attempt += 1) {
-    const manager = new McpClientManager({
-      servers: {
-        [serverId]: {
-          type: "http",
-          url: `${appBaseUrl(input.app)}/mcp`,
-          headers: {
-            Authorization: `Bearer ${input.token}`,
+    const manager = new McpClientManager(
+      {
+        servers: {
+          [serverId]: {
+            type: "http",
+            url: `${appBaseUrl(input.app)}/mcp`,
+            headers: {
+              Authorization: `Bearer ${input.token}`,
+            },
           },
         },
       },
-    });
+      { connectTimeoutMs: targetMcpConnectTimeout(deadline) },
+    );
     try {
       await manager.start();
       return await manager.callTool(
@@ -1064,7 +1077,8 @@ async function callTargetCreateEmbedSession(input: {
     } catch (error) {
       if (
         attempt >= TARGET_EMBED_SESSION_ATTEMPTS ||
-        !isRetryableTargetMcpError(error)
+        !isRetryableTargetMcpError(error) ||
+        deadline - Date.now() < TARGET_EMBED_SESSION_RETRY_BASE_MS
       ) {
         throw error;
       }


### PR DESCRIPTION
Apps are slow to cold boot when connected against large prod databases. Currently, we wait ~5s when starting an app from Dispatch which is not enough time. This resulted in `MCP server "target" is not connected: Could not reach that MCP server. Check the URL and make sure it is publicly reachable from this app.` errors despite the app being accessible when you open it in another tab.

This PR increases the timeout to avoid this.