### PR TITLE
fix: stabilize Builder connect OAuth state

### DIFF
--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -119,6 +119,7 @@ describe("Builder callback CSRF state", () => {
   beforeEach(() => {
     // Pin the secret so signed tokens are stable across calls and the
     // .env.local autogeneration in resolveAuthSecret never fires.
+    delete process.env.OAUTH_STATE_SECRET;
     process.env.BETTER_AUTH_SECRET = "test-secret-9f2a7c";
   });
 
@@ -347,6 +348,24 @@ describe("Builder callback CSRF state", () => {
   });
 
   describe("Builder connect OAuth state", () => {
+    it("uses the stable OAuth state secret when auth secret is absent", () => {
+      delete process.env.BETTER_AUTH_SECRET;
+      process.env.OAUTH_STATE_SECRET = "oauth-state-secret-for-tests";
+
+      const state = createBuilderConnectState();
+
+      delete process.env.OAUTH_STATE_SECRET;
+      process.env.OAUTH_STATE_SECRET = "oauth-state-secret-for-tests";
+      expect(isSignedBuilderConnectState(state)).toBe(true);
+    });
+
+    it("accepts an in-flight state signed with the previous auth secret", () => {
+      const state = createBuilderConnectState();
+      process.env.OAUTH_STATE_SECRET = "oauth-state-secret-for-tests";
+
+      expect(isSignedBuilderConnectState(state)).toBe(true);
+    });
+
     it("creates a signed OAuth state", () => {
       expect(isSignedBuilderConnectState(createBuilderConnectState())).toBe(
         true,

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -14,9 +14,12 @@ import {
   getAuthSecret,
   resolveSignupTrackingIdentity,
 } from "./better-auth-instance.js";
+import { readDeployCredentialEnv } from "./credential-provider.js";
+import { getWorkspaceA2ADerivedSecret } from "./derived-secret.js";
 import {
   getAppBasePath,
   getOrigin,
+  getOAuthStateSigningKey,
   isAllowedOAuthRedirectUri,
 } from "./google-oauth.js";
 import { getRequestOrgId, getRequestUserEmail } from "./request-context.js";
@@ -109,15 +112,25 @@ function safeEqualText(expected: string, actual: string): boolean {
 }
 
 /**
- * Opaque OAuth `state` for Builder connect. Bound to the app auth secret so a
- * pending row cannot be forged from another deployment that shares a database.
+ * Opaque OAuth `state` for Builder connect. Bound to a server-only signing
+ * secret so a pending row cannot be forged from another deployment that shares
+ * a database.
  */
+function builderConnectStateSigningKeys(): string[] {
+  const currentSecret = getOAuthStateSigningKey();
+  const keys = [`builder-connect-state:${currentSecret}`];
+  const legacySecret =
+    readDeployCredentialEnv("BETTER_AUTH_SECRET")?.trim() ||
+    getWorkspaceA2ADerivedSecret("better-auth");
+  if (legacySecret && legacySecret !== currentSecret) {
+    keys.push(`builder-connect-state:${legacySecret}`);
+  }
+  return keys;
+}
+
 export function createBuilderConnectState(): string {
   const stateNonce = randomBytes(32).toString("base64url");
-  const signature = createHmac(
-    "sha256",
-    `builder-connect-state:${getAuthSecret()}`,
-  )
+  const signature = createHmac("sha256", builderConnectStateSigningKeys()[0]!)
     .update(stateNonce)
     .digest("base64url");
   return `${stateNonce}.${signature}`;
@@ -137,13 +150,12 @@ export function isSignedBuilderConnectState(
   ) {
     return false;
   }
-  const expected = createHmac(
-    "sha256",
-    `builder-connect-state:${getAuthSecret()}`,
-  )
-    .update(nonce)
-    .digest("base64url");
-  return safeEqualText(expected, signature);
+  return builderConnectStateSigningKeys().some((key) => {
+    const expected = createHmac("sha256", key)
+      .update(nonce)
+      .digest("base64url");
+    return safeEqualText(expected, signature);
+  });
 }
 
 /**

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -508,7 +508,7 @@ let _devStateSigningKey: string | undefined;
  *
  * In production, throws if no usable server secret is set.
  */
-function getStateSigningKey(): string {
+export function getOAuthStateSigningKey(): string {
   const secret =
     process.env.OAUTH_STATE_SECRET ||
     process.env.BETTER_AUTH_SECRET ||
@@ -641,7 +641,7 @@ export function encodeOAuthState(
   if (signupAnonymousId) payload.ai = signupAnonymousId;
   const data = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const sig = crypto
-    .createHmac("sha256", getStateSigningKey())
+    .createHmac("sha256", getOAuthStateSigningKey())
     .update(data)
     .digest("base64url");
   return `${data}.${sig}`;
@@ -664,7 +664,7 @@ export function decodeOAuthState(
       const data = stateParam.slice(0, dotIdx);
       const sig = stateParam.slice(dotIdx + 1);
       const expected = crypto
-        .createHmac("sha256", getStateSigningKey())
+        .createHmac("sha256", getOAuthStateSigningKey())
         .update(data)
         .digest("base64url");
 

--- a/packages/core/src/server/short-lived-token.ts
+++ b/packages/core/src/server/short-lived-token.ts
@@ -10,7 +10,7 @@
  *   payload = base64url(JSON.stringify({ resourceId, viewerEmail?, exp }))
  *   sig     = base64url(HMAC-SHA256(payload, key))
  *
- * Key resolution mirrors `google-oauth.ts:getStateSigningKey`:
+ * Key resolution mirrors `google-oauth.ts:getOAuthStateSigningKey`:
  *   1. OAUTH_STATE_SECRET (preferred — dedicated to short-lived signing)
  *   2. BETTER_AUTH_SECRET (already used as a server secret)
  *   3. Hosted workspace deploys derive a per-purpose key from A2A_SECRET


### PR DESCRIPTION
## Summary
- use the stable OAuth state signer for Builder connect across serverless instances
- accept the prior configured auth signer during the pending-flow transition window
- cover stable-secret and in-flight compatibility cases

## Validation
- 166 focused core tests passed
- core typecheck passed
- all 64 repository guards passed
- reproduced the production callback failure before this fix

Production promotion will be run from the exact merged commit.