### PR TITLE
fix(core): preserve app base paths in connected-agent settings links

### DIFF
--- a/.changeset/mounted-agent-settings-links.md
+++ b/.changeset/mounted-agent-settings-links.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve mounted app base paths in Connected Agents organization settings links.

--- a/packages/core/src/client/settings/AgentsSection.spec.tsx
+++ b/packages/core/src/client/settings/AgentsSection.spec.tsx
@@ -8,11 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "../components/ui/tooltip.js";
 import { AgentsSection } from "./AgentsSection.js";
 
-vi.mock("../api-path.js", () => ({
-  agentNativePath: (path: string) => path,
-  appBasePath: () => "",
-}));
-
 function renderSection(root: Root) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -79,6 +74,7 @@ describe("AgentsSection", () => {
     act(() => root.unmount());
     container.remove();
     document.body.innerHTML = "";
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 
@@ -127,6 +123,42 @@ describe("AgentsSection", () => {
     const text = container.textContent ?? "";
     expect(text.toLowerCase()).not.toContain("not set");
     expect(text.toLowerCase()).toContain("workspace owner");
+  });
+
+  it("keeps the organization settings link inside the active app base path", async () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/dispatch");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/_agent-native/org/me")) {
+          return Response.json({
+            email: "owner@acme.com",
+            orgId: "org-1",
+            orgName: "Acme",
+            role: "owner",
+            orgs: [],
+            pendingInvitations: [],
+            domainMatches: [],
+            allowedDomain: "acme.com",
+            a2aSecretSet: false,
+          });
+        }
+        if (url.includes("/_agent-native/agents/probe")) {
+          return Response.json({ results: [] });
+        }
+        const detail = url.match(/\/resources\/([^?]+)$/);
+        if (detail) return Response.json({ content: contentById[detail[1]] });
+        return Response.json({ resources });
+      }),
+    );
+
+    await renderSection(root);
+
+    const link = Array.from(container.querySelectorAll("a")).find((anchor) =>
+      anchor.textContent?.includes("Set one on the Team page"),
+    );
+    expect(link?.getAttribute("href")).toBe("/dispatch/settings/organization");
   });
 
   it("does not expose shared-agent mutations to organization members", async () => {

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -24,7 +24,7 @@ import {
   REMOTE_AGENT_RESOURCE_PREFIX,
   remoteAgentResourcePath,
 } from "../../resources/metadata.js";
-import { agentNativePath, appBasePath } from "../api-path.js";
+import { agentNativePath, appBasePath, appPath } from "../api-path.js";
 import {
   Tooltip,
   TooltipContent,
@@ -447,7 +447,9 @@ function AgentAddPopover({
                 <>
                   No shared secret set yet —{" "}
                   <a
-                    href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+                    href={appPath(
+                      buildSettingsRoute(STANDARD_SETTINGS_TABS.team),
+                    )}
                     className="underline underline-offset-2 hover:text-foreground"
                   >
                     set one on the Team page
@@ -527,7 +529,7 @@ function A2ASecretStatusRow({
       <div className="mb-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[10px] text-amber-600 dark:text-amber-400">
         No shared secret set — connected apps will reject calls in production.{" "}
         <a
-          href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+          href={appPath(buildSettingsRoute(STANDARD_SETTINGS_TABS.team))}
           className="underline underline-offset-2 hover:text-amber-500"
         >
           Set one on the Team page
@@ -585,7 +587,7 @@ function A2ASecretStatusRow({
             <>
               {" "}
               <a
-                href={buildSettingsRoute(STANDARD_SETTINGS_TABS.team)}
+                href={appPath(buildSettingsRoute(STANDARD_SETTINGS_TABS.team))}
                 className="underline underline-offset-2"
               >
                 Set the domain


### PR DESCRIPTION
## Summary
- preserve the active app mount when Connected Agents links to organization settings
- cover missing-secret, add-agent, and missing-domain Team links through the shared `appPath` helper
- add a regression test using `VITE_APP_BASE_PATH=/dispatch`
