### PR TITLE
Enable file drag-and-drop for upload surfaces

### DIFF
--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -215,10 +215,8 @@ export default function DesignSystemSetup() {
     [],
   );
 
-  const handleBuilderIndexUpload = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      e.target.value = "";
+  const processBuilderIndexFile = useCallback(
+    async (file: File | undefined) => {
       if (!file) return;
       if (!file.name.toLowerCase().endsWith(".fig")) {
         setBuilderIndexError(t("designSystemSetup.errors.chooseFig"));
@@ -256,6 +254,23 @@ export default function DesignSystemSetup() {
       }
     },
     [companyInfo, t, startDecodePolling, stopDecodePolling],
+  );
+
+  const handleBuilderIndexUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      void processBuilderIndexFile(e.target.files?.[0]);
+      e.target.value = "";
+    },
+    [processBuilderIndexFile],
+  );
+
+  const handleBuilderIndexDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      void processBuilderIndexFile(e.dataTransfer.files?.[0]);
+    },
+    [processBuilderIndexFile],
   );
 
   useEffect(() => {
@@ -406,12 +421,8 @@ export default function DesignSystemSetup() {
     [readTextFiles],
   );
 
-  const handleDesignMdUpload = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const files = e.target.files;
-      if (!files) return;
-      const file = files[0];
-      e.target.value = "";
+  const processDesignMdFile = useCallback(
+    (file: File | undefined) => {
       if (!file) return;
       const uploadGeneration = ++designMdUploadGenerationRef.current;
       setDesignMdFiles([]);
@@ -448,49 +459,102 @@ export default function DesignSystemSetup() {
     [t],
   );
 
-  const handleDocUpload = useCallback(
+  const handleDesignMdUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (!e.target.files) return;
-      const newFiles: UploadedFile[] = Array.from(e.target.files).map((f) => ({
-        id: crypto.randomUUID(),
-        name: f.name,
-        type: f.type || f.name.split(".").pop() || "",
-        size: f.size,
-      }));
-      setDocFiles((prev) => [...prev, ...newFiles]);
+      processDesignMdFile(e.target.files?.[0]);
       e.target.value = "";
     },
-    [],
+    [processDesignMdFile],
   );
+
+  const handleDesignMdDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      processDesignMdFile(e.dataTransfer.files?.[0]);
+    },
+    [processDesignMdFile],
+  );
+
+  const processDocFiles = useCallback((files: FileList) => {
+    const newFiles: UploadedFile[] = Array.from(files).map((f) => ({
+      id: crypto.randomUUID(),
+      name: f.name,
+      type: f.type || f.name.split(".").pop() || "",
+      size: f.size,
+    }));
+    setDocFiles((prev) => [...prev, ...newFiles]);
+  }, []);
+
+  const handleDocUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) processDocFiles(e.target.files);
+      e.target.value = "";
+    },
+    [processDocFiles],
+  );
+
+  const handleDocDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      processDocFiles(e.dataTransfer.files);
+    },
+    [processDocFiles],
+  );
+
+  const processImageFiles = useCallback((files: FileList) => {
+    const newFiles: UploadedFile[] = Array.from(files).map((f) => ({
+      id: crypto.randomUUID(),
+      name: f.name,
+      type: f.type,
+      size: f.size,
+    }));
+    setImageFiles((prev) => [...prev, ...newFiles]);
+  }, []);
 
   const handleImageUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (!e.target.files) return;
-      const newFiles: UploadedFile[] = Array.from(e.target.files).map((f) => ({
-        id: crypto.randomUUID(),
-        name: f.name,
-        type: f.type,
-        size: f.size,
-      }));
-      setImageFiles((prev) => [...prev, ...newFiles]);
+      if (e.target.files) processImageFiles(e.target.files);
       e.target.value = "";
     },
-    [],
+    [processImageFiles],
   );
+
+  const handleImageDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      processImageFiles(e.dataTransfer.files);
+    },
+    [processImageFiles],
+  );
+
+  const processAssetFiles = useCallback((files: FileList) => {
+    const newAssets: UploadedFile[] = Array.from(files).map((f) => ({
+      id: crypto.randomUUID(),
+      name: f.name,
+      type: f.type,
+      size: f.size,
+    }));
+    setAssets((prev) => [...prev, ...newAssets]);
+  }, []);
 
   const handleAssetUpload = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (!e.target.files) return;
-      const newAssets: UploadedFile[] = Array.from(e.target.files).map((f) => ({
-        id: crypto.randomUUID(),
-        name: f.name,
-        type: f.type,
-        size: f.size,
-      }));
-      setAssets((prev) => [...prev, ...newAssets]);
+      if (e.target.files) processAssetFiles(e.target.files);
       e.target.value = "";
     },
-    [],
+    [processAssetFiles],
+  );
+
+  const handleAssetDrop = useCallback(
+    (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      processAssetFiles(e.dataTransfer.files);
+    },
+    [processAssetFiles],
   );
 
   const handleFolderDrop = useCallback(
@@ -962,6 +1026,8 @@ export default function DesignSystemSetup() {
                   <button
                     type="button"
                     onClick={() => realFigInputRef.current?.click()}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={handleBuilderIndexDrop}
                     disabled={builderIndexing}
                     className="w-full rounded-xl border border-dashed border-border bg-card p-8 text-center hover:border-[#609FF8]/40 cursor-pointer disabled:cursor-wait disabled:opacity-70"
                   >
@@ -1256,6 +1322,8 @@ export default function DesignSystemSetup() {
               <button
                 type="button"
                 onClick={() => designMdInputRef.current?.click()}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={handleDesignMdDrop}
                 className="w-full rounded-xl border border-dashed border-border bg-card p-8 text-center hover:border-foreground/15 cursor-pointer"
               >
                 <div className="flex flex-col items-center gap-2">
@@ -1307,6 +1375,8 @@ export default function DesignSystemSetup() {
                 </div>
                 <button
                   onClick={() => docInputRef.current?.click()}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={handleDocDrop}
                   className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
                   <p className="text-xs text-muted-foreground/70">
@@ -1339,6 +1409,8 @@ export default function DesignSystemSetup() {
                 </div>
                 <button
                   onClick={() => imageInputRef.current?.click()}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={handleImageDrop}
                   className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
                   <p className="text-xs text-muted-foreground/70">
@@ -1371,6 +1443,8 @@ export default function DesignSystemSetup() {
                 </div>
                 <button
                   onClick={() => assetInputRef.current?.click()}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={handleAssetDrop}
                   className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
                   <p className="text-xs text-muted-foreground/70">

--- a/templates/design/e2e/design-system-design-md-import.spec.ts
+++ b/templates/design/e2e/design-system-design-md-import.spec.ts
@@ -66,11 +66,46 @@ test("imports design.md guidance through Builder DSI", async ({ page }) => {
     .getByRole("button", { name: "Continue to generation", exact: true })
     .click();
 
-  await expect(page).toHaveURL(/\/design-systems$/);
+  await expect(page.getByRole("heading", { name: "Acme" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Open in Builder" }),
+  ).toHaveAttribute("href", /design-system-intelligence\/ds-design-md-e2e/);
   expect(capturedInput).toMatchObject({
     designMd:
       "# Acme Design System\n\nUse cobalt accents and compact controls.",
   });
+});
+
+test("imports a dropped design.md file", async ({ page }) => {
+  await page.goto("/design-systems/setup");
+  await page
+    .getByRole("button", { name: "Import design.md", exact: true })
+    .click();
+
+  await page
+    .locator("#design-system-design-md-source > button")
+    .evaluate((button) => {
+      const file = new File(
+        ["# Dropped Design System\n\nUse cobalt accents."],
+        "design.md",
+        { type: "text/markdown" },
+      );
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      button.dispatchEvent(
+        new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+    });
+
+  await expect(
+    page.locator("#design-system-design-md-source").getByText("design.md", {
+      exact: true,
+    }),
+  ).toBeVisible();
 });
 
 test("rejects design.md files larger than the inline Builder limit", async ({

--- a/templates/slides/app/components/design-system/DesignSystemSetup.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemSetup.tsx
@@ -417,10 +417,8 @@ export function DesignSystemSetup({
     [t],
   );
 
-  const handleBuilderIndexUpload = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      event.target.value = "";
+  const processBuilderIndexFile = useCallback(
+    async (file: File | undefined) => {
       if (!file) return;
       if (!file.name.toLowerCase().endsWith(".fig")) {
         setBuilderIndexError(t("designSystemSetup.figFileRequired"));
@@ -466,6 +464,33 @@ export function DesignSystemSetup({
     },
     [companyName, t, startDecodePolling, stopDecodePolling],
   );
+
+  const handleBuilderIndexUpload = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      void processBuilderIndexFile(event.target.files?.[0]);
+      event.target.value = "";
+    },
+    [processBuilderIndexFile],
+  );
+
+  const handleBuilderIndexDrop = useCallback(
+    (event: React.DragEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void processBuilderIndexFile(event.dataTransfer.files?.[0]);
+    },
+    [processBuilderIndexFile],
+  );
+
+  const addImageFiles = useCallback((files: FileList) => {
+    const newFiles = Array.from(files).map((file) => ({
+      id: crypto.randomUUID(),
+      name: file.name,
+      type: file.type,
+      size: file.size,
+    }));
+    setImageFiles((previous) => [...previous, ...newFiles]);
+  }, []);
 
   const handleEditSave = async () => {
     if (!editingId || !existingDs) return;
@@ -808,6 +833,8 @@ export function DesignSystemSetup({
                         <button
                           type="button"
                           onClick={() => figInputRef.current?.click()}
+                          onDragOver={(event) => event.preventDefault()}
+                          onDrop={handleBuilderIndexDrop}
                           disabled={builderIndexing}
                           className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/20 cursor-pointer disabled:cursor-wait disabled:opacity-70"
                         >
@@ -1153,6 +1180,12 @@ export function DesignSystemSetup({
                     </Label>
                     <button
                       onClick={() => imageInputRef.current?.click()}
+                      onDragOver={(event) => event.preventDefault()}
+                      onDrop={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        addImageFiles(event.dataTransfer.files);
+                      }}
                       className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/20 cursor-pointer"
                     >
                       <p className="text-xs text-muted-foreground">
@@ -1165,16 +1198,7 @@ export function DesignSystemSetup({
                       accept="image/*,.svg"
                       multiple
                       onChange={(e) => {
-                        if (!e.target.files) return;
-                        const newFiles = Array.from(e.target.files).map(
-                          (f) => ({
-                            id: crypto.randomUUID(),
-                            name: f.name,
-                            type: f.type,
-                            size: f.size,
-                          }),
-                        );
-                        setImageFiles((p) => [...p, ...newFiles]);
+                        if (e.target.files) addImageFiles(e.target.files);
                         e.target.value = "";
                       }}
                       className="hidden"


### PR DESCRIPTION
## Summary

- Accept native file drops on the Design and Slides design-system upload cards, including Figma, design.md, documents, visual references, and brand assets.
- Preserve the existing picker validation and processing paths for dropped files.
- Add Design E2E coverage for dropping design.md and align the existing Builder DSI assertion with its current preview flow.
- Verify the shared chat composer drop path, which already supports native file drops.

## Validation

- `corepack pnpm --filter design exec playwright test e2e/design-system-design-md-import.spec.ts` (3 passed)
- `corepack pnpm --filter @agent-native/toolkit exec vitest --run src/composer/TiptapComposer.spec.ts --config vitest.config.ts` (31 passed)
- Design and Slides typechecks passed
- oxfmt and diff checks passed
- `corepack pnpm guards` reached one pre-existing `guard:agent-native-brand` failure outside the changed files scope; all other reported guards passed