### PR TITLE
fix: keep Analytics sidebar rename focused

### DIFF
--- a/.changeset/core-migration-branding.md
+++ b/.changeset/core-migration-branding.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Standardize Agent-Native branding in the migration runner documentation.

--- a/packages/core/docs/content/locales/ar-SA/server-database.mdx
+++ b/packages/core/docs/content/locales/ar-SA/server-database.mdx
@@ -258,7 +258,7 @@ export const getDb = createGetDb(schema);
 
 بالنسبة إلى تغييرات مخطط التطبيق الجديدة، استخدم `pnpm db:generate` لإنشاء SQL
 قابل للمراجعة. ينشئ ذلك `server/db/migrations/<id_name>.sql`، ويحمّل
-`runDrizzleMigrations` هذه الملفات إلى مشغّل Agent Native المشترك في بيئات Node.js
+`runDrizzleMigrations` هذه الملفات إلى مشغّل Agent-Native المشترك في بيئات Node.js
 وبيئات serverless المستندة إلى Node. تبقى خطوة الإصدار هي المسؤولة عن تغييرات
 الإنتاج. احتفظ بـ `runMigrations()` للحالات الخاصة باللهجات أو D1، وعمليات ملء
 البيانات، وخطوات JavaScript المؤجلة.

--- a/packages/core/docs/content/locales/fr-FR/server-database.mdx
+++ b/packages/core/docs/content/locales/fr-FR/server-database.mdx
@@ -261,7 +261,7 @@ de leur numéro de version.
 Pour les nouvelles modifications du schéma de l'application, utilisez
 `pnpm db:generate` afin de créer du SQL révisable. Cela crée
 `server/db/migrations/<id_name>.sql`, que `runDrizzleMigrations` charge
-dans le runner Agent Native partagé sur Node.js et les runtimes serverless basés
+dans le runner Agent-Native partagé sur Node.js et les runtimes serverless basés
 sur Node. L'étape de release reste responsable des modifications de production.
 Conservez `runMigrations()` pour le SQL propre au dialecte, D1, les backfills et
 les étapes JavaScript différées.

--- a/packages/core/docs/content/locales/hi-IN/server-database.mdx
+++ b/packages/core/docs/content/locales/hi-IN/server-database.mdx
@@ -259,7 +259,7 @@ named migrations को version number से स्वतंत्र track क
 ऐप स्कीमा में नए बदलावों के लिए समीक्षा योग्य SQL बनाने हेतु
 `pnpm db:generate` चलाएं। इससे `server/db/migrations/<id_name>.sql`
 बनता है और `runDrizzleMigrations` इन फ़ाइलों को Node.js और Node-आधारित serverless
-रनटाइम में साझा Agent Native रनर में लोड करता है। प्रोडक्शन बदलावों की
+रनटाइम में साझा Agent-Native रनर में लोड करता है। प्रोडक्शन बदलावों की
 जिम्मेदारी release चरण की रहती है। डायलेक्ट-विशिष्ट SQL, D1 व्यवहार, backfill और
 स्थगित JavaScript चरणों के लिए `runMigrations()` का उपयोग जारी रखें।
 

--- a/packages/core/docs/content/locales/ja-JP/server-database.mdx
+++ b/packages/core/docs/content/locales/ja-JP/server-database.mdx
@@ -260,7 +260,7 @@ export const getDb = createGetDb(schema);
 アプリの新しいスキーマ変更には `pnpm db:generate` を使い、レビュー可能な
 SQL を生成します。`server/db/migrations/<id_name>.sql` が作成され、
 `runDrizzleMigrations` がこれらのファイルを Node.js と Node ベースの
-serverless ランタイムで共有 Agent Native ランナーに読み込みます。本番の
+serverless ランタイムで共有 Agent-Native ランナーに読み込みます。本番の
 変更は引き続きリリース手順が担当します。方言固有の SQL、D1 の動作、
 データのバックフィル、遅延 JavaScript ステップには `runMigrations()` を使います。
 

--- a/packages/core/docs/content/locales/ko-KR/server-database.mdx
+++ b/packages/core/docs/content/locales/ko-KR/server-database.mdx
@@ -259,7 +259,7 @@ export const getDb = createGetDb(schema);
 새 앱 스키마 변경에는 `pnpm db:generate`를 사용해 검토 가능한 SQL을
 생성하세요. 이 명령은 `server/db/migrations/<id_name>.sql`을 만들고,
 `runDrizzleMigrations`가 Node.js 및 Node 기반 serverless 런타임에서 이 파일들을
-공유 Agent Native 러너에 로드합니다. 운영 변경의 책임은 계속 릴리스 단계에
+공유 Agent-Native 러너에 로드합니다. 운영 변경의 책임은 계속 릴리스 단계에
 있습니다. 방언별 SQL, D1 동작, backfill 및 지연된 JavaScript 단계에는
 `runMigrations()`를 계속 사용하세요.
 

--- a/packages/core/docs/content/locales/zh-CN/server-database.mdx
+++ b/packages/core/docs/content/locales/zh-CN/server-database.mdx
@@ -253,7 +253,7 @@ export const getDb = createGetDb(schema);
 对于新的应用 schema 变更，请使用 `pnpm db:generate` 生成可审查的 SQL。
 它会创建 `server/db/migrations/<id_name>.sql`，并由
 `runDrizzleMigrations` 在 Node.js 和基于 Node 的 serverless runtime 中将这些
-文件加载到共享的 Agent Native runner。生产变更仍由发布步骤负责。方言专用
+文件加载到共享的 Agent-Native runner。生产变更仍由发布步骤负责。方言专用
 SQL、D1 行为、数据回填和延迟 JavaScript 步骤继续使用 `runMigrations()`。
 
 基于文件系统的 loader 不适用于 Cloudflare Workers/Pages 或其他没有可部署

--- a/packages/core/docs/content/locales/zh-TW/server-database.mdx
+++ b/packages/core/docs/content/locales/zh-TW/server-database.mdx
@@ -252,7 +252,7 @@ export const getDb = createGetDb(schema);
 對於新的應用程式架構變更，請使用 `pnpm db:generate` 產生可供審查的 SQL。
 這會建立 `server/db/migrations/<id_name>.sql`，並由
 `runDrizzleMigrations` 在 Node.js 與以 Node 為基礎的 serverless runtime 中將
-這些檔案載入共用的 Agent Native runner。正式環境的變更仍由發佈步驟負責。
+這些檔案載入共用的 Agent-Native runner。正式環境的變更仍由發佈步驟負責。
 方言專用 SQL、D1 行為、資料回填與延遲的 JavaScript 步驟，請繼續使用
 `runMigrations()`。
 

--- a/packages/core/docs/content/server-database.mdx
+++ b/packages/core/docs/content/server-database.mdx
@@ -5,7 +5,7 @@ description: "Connect a portable SQL database to your agent-native app: schema h
 
 # Database
 
-<!-- i18n-copy-ignore: Agent-Native is a proper name; punctuation is locale-invariant. -->
+<!-- i18n-copy-ignore: Agent-Native is a proper name; punctuation is locale-invariant, including migration runner references. -->
 
 Every agent-native app stores its state in SQL. The UI and the agent both read and write the same tables through the same actions, using the same [Drizzle ORM](https://orm.drizzle.team) client. Live sync uses SSE with polling fallback, so changes appear in the other surface without a manual refresh.
 
@@ -259,7 +259,7 @@ pnpm db:generate
 
 This creates `server/db/migrations/<id_name>.sql`. Commit the generated file and
 review its SQL before shipping it. `runDrizzleMigrations`
-loads those files into the shared Agent Native runner on Node.js and Node-based
+loads those files into the shared Agent-Native runner on Node.js and Node-based
 serverless runtimes, so release authorization, dialect handling, and bookkeeping
 stay in one place:
 

--- a/packages/core/src/db/drizzle-migrations.ts
+++ b/packages/core/src/db/drizzle-migrations.ts
@@ -21,9 +21,9 @@ function isMissingPath(error: unknown): boolean {
 }
 
 /**
- * Read Drizzle Kit's generated migration files as Agent Native migrations.
+ * Read Drizzle Kit's generated migration files as Agent-Native migrations.
  *
- * Drizzle Kit owns SQL generation. The Agent Native runner remains the runtime
+ * Drizzle Kit owns SQL generation. The Agent-Native runner remains the runtime
  * owner, so release authorization, dialect adaptation, and bookkeeping stay in
  * one place. The file name becomes the stable migration name.
  *

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -148,6 +148,7 @@ import { useUserPref } from "@/hooks/use-user-pref";
 import { shouldRenderDashboardList } from "@/lib/dashboard-list-loading";
 import { usePopularity, popularityOf } from "@/lib/item-popularity";
 import {
+  DASHBOARD_SESSION_LOADING_SCOPE,
   dashboardCacheScope,
   preserveScopedDashboardPlaceholder,
   sqlDashboardPrefetchKey,
@@ -1526,8 +1527,10 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
   const t = useT();
   const queryClient = useQueryClient();
   const { setTheme } = useTheme();
-  const { auth } = useAuth();
-  const dashboardScope = dashboardCacheScope(auth);
+  const { auth, isLoading: authLoading } = useAuth();
+  const dashboardScope = authLoading
+    ? DASHBOARD_SESSION_LOADING_SCOPE
+    : dashboardCacheScope(auth);
 
   const isAskRoute = location.pathname === "/ask";
   const activeDashboardId = useMemo(() => {
@@ -1713,6 +1716,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
   } = useQuery({
     queryKey: ["sql-dashboards-sidebar", dashboardScope, dashboardsSync],
     queryFn: () => fetchSqlDashboards(t),
+    enabled: !authLoading,
     staleTime: 30_000,
     placeholderData: (prev, previousQuery) =>
       preserveScopedDashboardPlaceholder(prev, previousQuery, dashboardScope),

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -516,6 +516,7 @@ function SortableRow({
     useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(name);
+  const pendingRenameRef = useRef(false);
   const renameInputRef = useAutoFocusSelect<HTMLInputElement>(isRenaming);
 
   useEffect(() => {
@@ -749,11 +750,22 @@ function SortableRow({
                 {t("sidebar.itemActions", { name })}
               </TooltipContent>
             </Tooltip>
-            <DropdownMenuContent side="right" align="start" className="w-44">
+            <DropdownMenuContent
+              side="right"
+              align="start"
+              className="w-44"
+              onCloseAutoFocus={(event) => {
+                if (!pendingRenameRef.current) return;
+                event.preventDefault();
+                pendingRenameRef.current = false;
+                setIsRenaming(true);
+              }}
+            >
               <DropdownMenuItem
                 onSelect={() => {
                   setRenameValue(name);
-                  setIsRenaming(true);
+                  pendingRenameRef.current = true;
+                  setMenuOpen(false);
                 }}
               >
                 <IconPencil className="me-2 h-3.5 w-3.5" />
@@ -1701,6 +1713,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
     queryKey: ["sql-dashboards-sidebar", dashboardScope, dashboardsSync],
     queryFn: () => fetchSqlDashboards(t),
     staleTime: 30_000,
+    placeholderData: (prev) => prev,
   });
 
   const {

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -149,6 +149,7 @@ import { shouldRenderDashboardList } from "@/lib/dashboard-list-loading";
 import { usePopularity, popularityOf } from "@/lib/item-popularity";
 import {
   dashboardCacheScope,
+  preserveScopedDashboardPlaceholder,
   sqlDashboardPrefetchKey,
   type PrefetchSnapshot,
 } from "@/lib/prefetch-keys";
@@ -1713,7 +1714,8 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
     queryKey: ["sql-dashboards-sidebar", dashboardScope, dashboardsSync],
     queryFn: () => fetchSqlDashboards(t),
     staleTime: 30_000,
-    placeholderData: (prev) => prev,
+    placeholderData: (prev, previousQuery) =>
+      preserveScopedDashboardPlaceholder(prev, previousQuery, dashboardScope),
   });
 
   const {

--- a/templates/analytics/app/lib/prefetch-keys.spec.ts
+++ b/templates/analytics/app/lib/prefetch-keys.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DASHBOARD_SESSION_LOADING_SCOPE,
   dashboardCacheScope,
   preserveScopedDashboardPlaceholder,
   sqlDashboardPrefetchKey,
@@ -60,6 +61,17 @@ describe("dashboard cache scope", () => {
         previous,
         previousQuery,
         aliceOtherOrg,
+      ),
+    ).toBeUndefined();
+
+    const loadingQuery = {
+      queryKey: ["sql-dashboards-sidebar", DASHBOARD_SESSION_LOADING_SCOPE, 1],
+    };
+    expect(
+      preserveScopedDashboardPlaceholder(
+        previous,
+        loadingQuery,
+        dashboardCacheScope(null),
       ),
     ).toBeUndefined();
   });

--- a/templates/analytics/app/lib/prefetch-keys.spec.ts
+++ b/templates/analytics/app/lib/prefetch-keys.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { dashboardCacheScope, sqlDashboardPrefetchKey } from "./prefetch-keys";
+import {
+  dashboardCacheScope,
+  preserveScopedDashboardPlaceholder,
+  sqlDashboardPrefetchKey,
+} from "./prefetch-keys";
 
 describe("dashboard cache scope", () => {
   it("separates principals and active organizations", () => {
@@ -25,5 +29,38 @@ describe("dashboard cache scope", () => {
     expect(sqlDashboardPrefetchKey("dashboard-1", alice)).not.toEqual(
       sqlDashboardPrefetchKey("dashboard-1", bob),
     );
+  });
+
+  it("does not preserve a dashboard list across a scope change", () => {
+    const alice = dashboardCacheScope({
+      userId: "alice",
+      orgId: "org-1",
+    });
+    const bob = dashboardCacheScope({
+      userId: "bob",
+      orgId: "org-1",
+    });
+    const aliceOtherOrg = dashboardCacheScope({
+      userId: "alice",
+      orgId: "org-2",
+    });
+    const previous = [{ id: "private-dashboard" }];
+    const previousQuery = {
+      queryKey: ["sql-dashboards-sidebar", alice, 1],
+    };
+
+    expect(
+      preserveScopedDashboardPlaceholder(previous, previousQuery, alice),
+    ).toBe(previous);
+    expect(
+      preserveScopedDashboardPlaceholder(previous, previousQuery, bob),
+    ).toBeUndefined();
+    expect(
+      preserveScopedDashboardPlaceholder(
+        previous,
+        previousQuery,
+        aliceOtherOrg,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/templates/analytics/app/lib/prefetch-keys.ts
+++ b/templates/analytics/app/lib/prefetch-keys.ts
@@ -9,6 +9,8 @@ export type DashboardCacheSession = {
   orgId?: string | null;
 };
 
+export const DASHBOARD_SESSION_LOADING_SCOPE = "session-loading";
+
 /**
  * Dashboard payloads are access-scoped. Keep the principal and active org in
  * every client cache key so a session change cannot adopt another caller's

--- a/templates/analytics/app/lib/prefetch-keys.ts
+++ b/templates/analytics/app/lib/prefetch-keys.ts
@@ -22,6 +22,14 @@ export function dashboardCacheScope(
   return `${encodeURIComponent(principal)}:${encodeURIComponent(org)}`;
 }
 
+export function preserveScopedDashboardPlaceholder<T>(
+  previous: T | undefined,
+  previousQuery: { queryKey: readonly unknown[] } | undefined,
+  scope: string,
+): T | undefined {
+  return previousQuery?.queryKey[1] === scope ? previous : undefined;
+}
+
 export const sqlDashboardPrefetchKey = (
   id: string,
   scope = "anonymous:personal",

--- a/templates/analytics/changelog/2026-08-26-dashboard-names-stay-editable-when-the-analytics-sidebar-ref.md
+++ b/templates/analytics/changelog/2026-08-26-dashboard-names-stay-editable-when-the-analytics-sidebar-ref.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-26
+---
+
+Dashboard names stay editable when the Analytics sidebar refreshes


### PR DESCRIPTION
Fix Analytics sidebar dashboard renames losing focus during the settled list refresh.

The sidebar now preserves prior SQL dashboard data during refreshes and defers rename mode until the dropdown menu has finished restoring focus.

Checks: Analytics focused Vitest suite, Analytics typecheck, runtime Playwright flow, formatting, guards (one unrelated pre-existing agent-native-brand failure).