### PR TITLE
fix: preserve Slides object and slide ordering on deletion

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -59,4 +59,14 @@ describe("SlideEditor render-phase safety", () => {
     expect(flushBody).not.toContain("inlineEditDraftRef.current = null");
     expect(flushBody).not.toContain("onUpdateSlideRef.current");
   });
+
+  it("selects persisted text boxes on plain click while keeping double-click editing", () => {
+    const clickStart = source.indexOf("// For editable text");
+    const clickEnd = source.indexOf("// Non-text elements", clickStart);
+    const clickBody = source.slice(clickStart, clickEnd);
+    expect(clickBody).toContain("includeTextBoxes: false");
+    expect(source).toContain(
+      "const block = findSmartBlock(target, slideContent);",
+    );
+  });
 });

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -4983,7 +4983,9 @@ export default function SlideEditor({
       // highlighting, shortcuts, and Enter-to-add-bullet all work, and the
       // style dock targets the same block being edited.
       if (!readOnly && slideContent) {
-        const block = findSmartBlock(target, slideContent);
+        const block = findSmartBlock(target, slideContent, {
+          includeTextBoxes: false,
+        });
         if (
           block &&
           slidesCanvasInteractionCore.textActivation({

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2850,6 +2850,12 @@ export default function SlideEditor({
           el = el.parentElement;
           continue;
         }
+        const textBox = el.closest<HTMLElement>(
+          ".fmd-text-box[data-slide-object-id]",
+        );
+        if (textBox && slideContent.contains(textBox)) {
+          return textBox.getAttribute("data-builder-id");
+        }
         const id = el.getAttribute("data-builder-id");
         if (id) return id;
         el = el.parentElement;

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2879,6 +2879,10 @@ export default function SlideEditor({
           el = el.parentElement;
           continue;
         }
+        const textBox = el.closest<HTMLElement>(
+          ".fmd-text-box[data-slide-object-id]",
+        );
+        if (textBox && slideContent.contains(textBox)) return textBox;
         if (el.getAttribute("data-builder-id")) return el;
         el = el.parentElement;
       }

--- a/templates/slides/app/components/editor/slide-text-targets.test.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.test.ts
@@ -46,15 +46,23 @@ describe("slide text targets", () => {
       <div class="fmd-slide">
         <div class="fmd-text-box" data-slide-object-id="text-box-1">
           Existing text box
+          <div>Nested text box content</div>
         </div>
       </div>
     `;
 
     const textBox = root.querySelector(".fmd-text-box") as HTMLElement;
+    const nestedText = textBox.querySelector("div") as HTMLElement;
 
     expect(findSmartBlock(textBox, root)).toBe(textBox);
     expect(
       findSmartBlock(textBox, root, {
+        includeTextBoxes: false,
+      }),
+    ).toBeNull();
+    expect(findSmartBlock(nestedText, root)).toBe(nestedText);
+    expect(
+      findSmartBlock(nestedText, root, {
         includeTextBoxes: false,
       }),
     ).toBeNull();

--- a/templates/slides/app/components/editor/slide-text-targets.test.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.test.ts
@@ -39,4 +39,24 @@ describe("slide text targets", () => {
       true,
     );
   });
+
+  it("keeps persisted text boxes selectable on single click while preserving explicit edit targets", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <div class="fmd-slide">
+        <div class="fmd-text-box" data-slide-object-id="text-box-1">
+          Existing text box
+        </div>
+      </div>
+    `;
+
+    const textBox = root.querySelector(".fmd-text-box") as HTMLElement;
+
+    expect(findSmartBlock(textBox, root)).toBe(textBox);
+    expect(
+      findSmartBlock(textBox, root, {
+        includeTextBoxes: false,
+      }),
+    ).toBeNull();
+  });
 });

--- a/templates/slides/app/components/editor/slide-text-targets.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.ts
@@ -94,9 +94,18 @@ export function isSmartGroup(element: HTMLElement): boolean {
 export function findSmartBlock(
   target: HTMLElement,
   root: HTMLElement,
+  options?: { includeTextBoxes?: boolean },
 ): HTMLElement | null {
+  const includeTextBoxes = options?.includeTextBoxes ?? true;
   let element: HTMLElement | null = target;
   while (element && root.contains(element)) {
+    if (
+      !includeTextBoxes &&
+      element.classList.contains("fmd-text-box") &&
+      element.hasAttribute("data-slide-object-id")
+    ) {
+      return null;
+    }
     if (isTextLeaf(element)) {
       const list = findEnclosingList(element, root);
       if (list) return list;

--- a/templates/slides/app/components/editor/slide-text-targets.ts
+++ b/templates/slides/app/components/editor/slide-text-targets.ts
@@ -101,8 +101,7 @@ export function findSmartBlock(
   while (element && root.contains(element)) {
     if (
       !includeTextBoxes &&
-      element.classList.contains("fmd-text-box") &&
-      element.hasAttribute("data-slide-object-id")
+      element.closest(".fmd-text-box[data-slide-object-id]")
     ) {
       return null;
     }

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -1791,6 +1791,168 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("reorders by slide id after a thumbnail delete and keeps the granular op and undo", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const original: Deck = {
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+        {
+          id: "slide-3",
+          content: "<h1>Three</h1>",
+          notes: "",
+          layout: "content",
+        },
+        {
+          id: "slide-4",
+          content: "<h1>Four</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { fetchMock, setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await waitFor(() =>
+      expect(result.current.getDeck("shared-deck")?.slides).toHaveLength(4),
+    );
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("shared-deck", "slide-2");
+      result.current.reorderSlides("shared-deck", "slide-4", "slide-1");
+      result.current.reorderSlides("shared-deck", "slide-1", "slide-3");
+    });
+
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-4", "slide-3", "slide-1"]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    const patchCall = fetchMock.mock.calls.find(([url, init]) => {
+      return (
+        String(url).includes("/_agent-native/actions/patch-deck") &&
+        actionCallBody(init).deckId === "shared-deck"
+      );
+    });
+    expect(patchCall).toBeTruthy();
+    expect(actionCallBody(patchCall?.[1])).toMatchObject({
+      deckId: "shared-deck",
+      operations: [
+        {
+          op: "delete-slide",
+          slideId: "slide-2",
+        },
+        {
+          op: "reorder-slides",
+          orderedIds: ["slide-4", "slide-1", "slide-3"],
+        },
+        {
+          op: "reorder-slides",
+          orderedIds: ["slide-4", "slide-3", "slide-1"],
+        },
+      ],
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    act(() => {
+      result.current.undo();
+    });
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-4", "slide-1", "slide-3"]);
+
+    vi.useRealTimers();
+  });
+
+  it("does not resurrect a locally deleted slide from a stale open-deck refetch", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const original: Deck = {
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+        {
+          id: "slide-3",
+          content: "<h1>Three</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck, getFirstPatchSignal, resolveDeferredPatch } =
+      setupFetch({ deferredPatch: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await waitFor(() =>
+      expect(result.current.getDeck("shared-deck")?.slides).toHaveLength(3),
+    );
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("shared-deck", "slide-2");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPatchSignal()).toBeDefined();
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-3"]);
+    expect(hasUncommittedDeckChanges("shared-deck", new Set())).toBe(true);
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.refreshOpenDeck("shared-deck");
+    });
+
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-3"]);
+
+    resolveDeferredPatch();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-3"]);
+    vi.useRealTimers();
+  });
+
   it("waits for an in-flight granular save before restoring an authoritative version", async () => {
     window.history.pushState({}, "", "/deck/restore-patch-race-deck");
     const initial: Deck = {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -94,6 +94,8 @@ function setupFetch(options?: {
   let firstPatchSignal: AbortSignal | undefined;
   let deferNextGetDeck = false;
   let resolveDeferredGetDeck: (() => void) | null = null;
+  let deferNextDeckList = false;
+  let resolveDeferredDeckList: (() => void) | null = null;
   let accessibleDeck: Deck | null = null;
   const patchAttempts = new Map<string, number>();
   const putAttempts = new Map<string, number>();
@@ -170,11 +172,17 @@ function setupFetch(options?: {
         );
       }
       const decks = accessibleDeck ? [accessibleDeck] : [];
-      return Promise.resolve(
-        new Response(JSON.stringify({ count: decks.length, decks }), {
-          status: 200,
-        }),
+      const response = new Response(
+        JSON.stringify({ count: decks.length, decks }),
+        { status: 200 },
       );
+      if (deferNextDeckList) {
+        deferNextDeckList = false;
+        return new Promise<Response>((resolve) => {
+          resolveDeferredDeckList = () => resolve(response);
+        });
+      }
+      return Promise.resolve(response);
     }
 
     if (href.includes("/_agent-native/actions/get-deck")) {
@@ -245,7 +253,15 @@ function setupFetch(options?: {
       resolveDeferredGetDeck?.();
       resolveDeferredGetDeck = null;
     },
-    setAccessibleDeck: (deck: Deck) => {
+    deferNextDeckList: () => {
+      deferNextDeckList = true;
+    },
+    hasDeferredDeckList: () => resolveDeferredDeckList !== null,
+    resolveDeferredDeckList: () => {
+      resolveDeferredDeckList?.();
+      resolveDeferredDeckList = null;
+    },
+    setAccessibleDeck: (deck: Deck | null) => {
       accessibleDeck = deck;
     },
     getPatchAttempts: (deckId: string) => patchAttempts.get(deckId) ?? 0,
@@ -2110,6 +2126,50 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("ignores an in-flight deck-list diff after a baseline reload", async () => {
+    window.history.pushState({}, "", "/");
+    const deck: Deck = {
+      id: "baseline-list-deck",
+      title: "Baseline list deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [],
+    };
+    const {
+      setAccessibleDeck,
+      deferNextDeckList,
+      hasDeferredDeckList,
+      resolveDeferredDeckList,
+    } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(deck);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    expect(result.current.getDeck(deck.id)?.title).toBe(deck.title);
+
+    setAccessibleDeck(null);
+    deferNextDeckList();
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(hasDeferredDeckList()).toBe(true));
+
+    setAccessibleDeck(deck);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    resolveDeferredDeckList();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.getDeck(deck.id)?.title).toBe(deck.title);
+  });
+
   it("shows a deleted slide again after its save permanently fails", async () => {
     window.history.pushState({}, "", "/deck/failed-delete-deck");
     const original: Deck = {
@@ -2335,6 +2395,95 @@ describe("DeckContext deck creation persistence", () => {
     expect(
       result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
     ).toEqual(["slide-3"]);
+    vi.useRealTimers();
+  });
+
+  it("retries the newest replacement after an older replacement fails", async () => {
+    window.history.pushState({}, "", "/deck/replacement-retry-deck");
+    const initial: Deck = {
+      id: "replacement-retry-deck",
+      title: "Replacement retry deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+        {
+          id: "slide-3",
+          content: "<h1>Three</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const {
+      fetchMock,
+      setAccessibleDeck,
+      getFirstPutSignal,
+      rejectDeferredPut,
+    } = setupFetch({ deferredPut: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-1");
+      result.current.setDeckSlides(initial.id, [
+        initial.slides[0]!,
+        initial.slides[1]!,
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPutSignal()).toBeDefined();
+
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-2");
+      result.current.setDeckSlides(initial.id, [
+        initial.slides[1]!,
+        initial.slides[2]!,
+      ]);
+    });
+    rejectDeferredPut();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(250);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.flushDeckSave(initial.id);
+    });
+    const saveCalls = fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url).includes("/_agent-native/actions/save-deck") &&
+        actionCallBody(init).deckId === initial.id,
+    );
+    expect(saveCalls).toHaveLength(2);
+
+    setAccessibleDeck({
+      ...initial,
+      updatedAt: "2026-05-12T00:02:00.000Z",
+    });
+    await act(async () => {
+      await result.current.refreshOpenDeck(initial.id);
+    });
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-2", "slide-3"]);
     vi.useRealTimers();
   });
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -2671,6 +2671,110 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("does not merge a slide omitted by a pending replacement", async () => {
+    window.history.pushState({}, "", "/deck/pending-replacement-deck");
+    const initial: Deck = {
+      id: "pending-replacement-deck",
+      title: "Pending replacement deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.setDeckSlides(initial.id, [initial.slides[0]!]);
+    });
+    await act(async () => {
+      await result.current.refreshOpenDeck(initial.id);
+    });
+
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1"]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    vi.useRealTimers();
+  });
+
+  it("allows a later authoritative re-add after a successful replacement omission", async () => {
+    window.history.pushState({}, "", "/deck/replacement-omission-readd-deck");
+    const initial: Deck = {
+      id: "replacement-omission-readd-deck",
+      title: "Replacement omission re-add deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck } = setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-2");
+    });
+    act(() => {
+      result.current.setDeckSlides(initial.id, [
+        { ...initial.slides[0]!, content: "<h1>Replacement one</h1>" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    await act(async () => {
+      await result.current.flushDeckSave(initial.id);
+    });
+
+    setAccessibleDeck({
+      ...initial,
+      updatedAt: "2099-01-01T00:00:00.000Z",
+      slides: [
+        initial.slides[0]!,
+        { ...initial.slides[1]!, content: "<h1>Re-added</h1>" },
+      ],
+    });
+    await act(async () => {
+      await result.current.refreshOpenDeck(initial.id);
+    });
+
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-2"]);
+    vi.useRealTimers();
+  });
+
   it("waits for an in-flight granular save before restoring an authoritative version", async () => {
     window.history.pushState({}, "", "/deck/restore-patch-race-deck");
     const initial: Deck = {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -85,6 +85,7 @@ function setupFetch(options?: {
   failDeckList?: boolean;
   deleteDeckNotFound?: boolean;
   patchFailures?: { deckId: string; count: number };
+  putFailures?: { deckId: string; count: number };
 }) {
   let resolveCreate: (response: Response) => void = () => {};
   let resolveDeferredPut: (() => void) | null = null;
@@ -140,6 +141,12 @@ function setupFetch(options?: {
             });
           }
         });
+      }
+      if (
+        deckId === options?.putFailures?.deckId &&
+        attempts <= options.putFailures.count
+      ) {
+        return Promise.reject(new Error("save-deck failed"));
       }
       return Promise.resolve(
         new Response(JSON.stringify({ ok: true }), { status: 200 }),
@@ -243,6 +250,7 @@ function setupFetch(options?: {
     rejectDeferredPut: (error: unknown = new Error("late save failure")) =>
       rejectDeferredPut?.(error),
     getFirstPutSignal: () => firstPutSignal,
+    getPutAttempts: (deckId: string) => putAttempts.get(deckId) ?? 0,
     resolveDeferredPatch: () => resolveDeferredPatch?.(),
     getFirstPatchSignal: () => firstPatchSignal,
     deferNextGetDeck: () => {
@@ -2398,6 +2406,69 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("does not clear a newer delete when a replacement save succeeds", async () => {
+    window.history.pushState({}, "", "/deck/replacement-same-slide-deck");
+    const initial: Deck = {
+      id: "replacement-same-slide-deck",
+      title: "Replacement same slide deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck, resolveDeferredPut, getFirstPutSignal } =
+      setupFetch({ deferredPut: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-1");
+    });
+    act(() => {
+      result.current.setDeckSlides(initial.id, [
+        initial.slides[0]!,
+        { ...initial.slides[1]!, content: "<h1>Replaced two</h1>" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPutSignal()).toBeDefined();
+
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-1");
+    });
+    resolveDeferredPut();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    await act(async () => {
+      await result.current.refreshOpenDeck(initial.id);
+    });
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-2"]);
+    vi.useRealTimers();
+  });
+
   it("retries the newest replacement after an older replacement fails", async () => {
     window.history.pushState({}, "", "/deck/replacement-retry-deck");
     const initial: Deck = {
@@ -2484,6 +2555,119 @@ describe("DeckContext deck creation persistence", () => {
     expect(
       result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
     ).toEqual(["slide-2", "slide-3"]);
+    vi.useRealTimers();
+  });
+
+  it("resets the retry budget for a newer replacement", async () => {
+    window.history.pushState({}, "", "/deck/replacement-retry-budget-deck");
+    const initial: Deck = {
+      id: "replacement-retry-budget-deck",
+      title: "Replacement retry budget deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck, getPutAttempts } = setupFetch({
+      putFailures: { deckId: initial.id, count: 3 },
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.setDeckSlides(initial.id, [
+        { ...initial.slides[0]!, content: "<h1>Replacement one</h1>" },
+        initial.slides[1]!,
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(getPutAttempts(initial.id)).toBe(2);
+
+    act(() => {
+      result.current.setDeckSlides(initial.id, [
+        initial.slides[0]!,
+        { ...initial.slides[1]!, content: "<h1>Replacement two</h1>" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    await act(async () => {
+      await result.current.flushDeckSave(initial.id);
+    });
+
+    expect(getPutAttempts(initial.id)).toBe(4);
+    expect(hasUnsavedDeckChanges(initial.id)).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("clears tombstones omitted by a permanently failed replacement", async () => {
+    window.history.pushState({}, "", "/deck/failed-replacement-deck");
+    const initial: Deck = {
+      id: "failed-replacement-deck",
+      title: "Failed replacement deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck, getPutAttempts } = setupFetch({
+      putFailures: { deckId: initial.id, count: 3 },
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-1");
+    });
+    act(() => {
+      result.current.setDeckSlides(initial.id, [
+        { ...initial.slides[1]!, content: "<h1>Replacement two</h1>" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getPutAttempts(initial.id)).toBe(3);
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-2"]);
     vi.useRealTimers();
   });
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -2162,6 +2162,88 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("re-establishes delete protection when a later edit retries a failed delete", async () => {
+    window.history.pushState({}, "", "/deck/retry-delete-deck");
+    const original: Deck = {
+      id: "retry-delete-deck",
+      title: "Retry delete deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const {
+      setAccessibleDeck,
+      getPatchAttempts,
+      deferNextGetDeck,
+      hasDeferredGetDeck,
+      resolveDeferredGetDeck,
+    } = setupFetch({
+      patchFailures: { deckId: "retry-delete-deck", count: 3 },
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("retry-delete-deck", "slide-2");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_250);
+    });
+    expect(getPatchAttempts("retry-delete-deck")).toBe(3);
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    expect(
+      result.current
+        .getDeck("retry-delete-deck")
+        ?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-2"]);
+
+    act(() => {
+      result.current.updateSlide("retry-delete-deck", "slide-1", {
+        content: "<h1>Edited after retry</h1>",
+      });
+    });
+
+    deferNextGetDeck();
+    const delayedRefresh = result.current.refreshOpenDeck("retry-delete-deck");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hasDeferredGetDeck()).toBe(true);
+
+    resolveDeferredGetDeck();
+    await act(async () => {
+      await delayedRefresh;
+    });
+    expect(
+      result.current
+        .getDeck("retry-delete-deck")
+        ?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-2"]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getPatchAttempts("retry-delete-deck")).toBe(4);
+    vi.useRealTimers();
+  });
+
   it("waits for an in-flight granular save before restoring an authoritative version", async () => {
     window.history.pushState({}, "", "/deck/restore-patch-race-deck");
     const initial: Deck = {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -92,6 +92,8 @@ function setupFetch(options?: {
   let firstPutSignal: AbortSignal | undefined;
   let resolveDeferredPatch: (() => void) | null = null;
   let firstPatchSignal: AbortSignal | undefined;
+  let deferNextGetDeck = false;
+  let resolveDeferredGetDeck: (() => void) | null = null;
   let accessibleDeck: Deck | null = null;
   const patchAttempts = new Map<string, number>();
   const putAttempts = new Map<string, number>();
@@ -177,6 +179,15 @@ function setupFetch(options?: {
 
     if (href.includes("/_agent-native/actions/get-deck")) {
       if (accessibleDeck) {
+        if (deferNextGetDeck) {
+          deferNextGetDeck = false;
+          return new Promise<Response>((resolve) => {
+            resolveDeferredGetDeck = () =>
+              resolve(
+                new Response(JSON.stringify(accessibleDeck), { status: 200 }),
+              );
+          });
+        }
         return Promise.resolve(
           new Response(JSON.stringify(accessibleDeck), { status: 200 }),
         );
@@ -225,6 +236,14 @@ function setupFetch(options?: {
     getFirstPutSignal: () => firstPutSignal,
     resolveDeferredPatch: () => resolveDeferredPatch?.(),
     getFirstPatchSignal: () => firstPatchSignal,
+    deferNextGetDeck: () => {
+      deferNextGetDeck = true;
+    },
+    hasDeferredGetDeck: () => resolveDeferredGetDeck !== null,
+    resolveDeferredGetDeck: () => {
+      resolveDeferredGetDeck?.();
+      resolveDeferredGetDeck = null;
+    },
     setAccessibleDeck: (deck: Deck) => {
       accessibleDeck = deck;
     },
@@ -1950,6 +1969,73 @@ describe("DeckContext deck creation persistence", () => {
     expect(
       result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
     ).toEqual(["slide-1", "slide-3"]);
+    vi.useRealTimers();
+  });
+
+  it("keeps a stale refetch from resurrecting a delete after the save settles", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const original: Deck = {
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const {
+      setAccessibleDeck,
+      deferNextGetDeck,
+      hasDeferredGetDeck,
+      resolveDeferredGetDeck,
+      getFirstPatchSignal,
+      resolveDeferredPatch,
+    } = setupFetch({ deferredPatch: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await waitFor(() =>
+      expect(result.current.getDeck("shared-deck")?.slides).toHaveLength(2),
+    );
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("shared-deck", "slide-2");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPatchSignal()).toBeDefined();
+
+    deferNextGetDeck();
+    const staleRefresh = result.current.refreshOpenDeck("shared-deck");
+    expect(hasDeferredGetDeck()).toBe(true);
+
+    resolveDeferredPatch();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(hasUncommittedDeckChanges("shared-deck", new Set())).toBe(false);
+
+    resolveDeferredGetDeck();
+    await act(async () => {
+      await staleRefresh;
+    });
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1"]);
     vi.useRealTimers();
   });
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -2244,6 +2244,100 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("preserves newer delete tombstones after a replacement save", async () => {
+    window.history.pushState({}, "", "/deck/replacement-delete-race-deck");
+    const initial: Deck = {
+      id: "replacement-delete-race-deck",
+      title: "Replacement delete race deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+        {
+          id: "slide-3",
+          content: "<h1>Three</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const {
+      setAccessibleDeck,
+      resolveDeferredPut,
+      deferNextGetDeck,
+      hasDeferredGetDeck,
+      resolveDeferredGetDeck,
+      resolveDeferredPatch,
+      getPatchAttempts,
+      getFirstPutSignal,
+    } = setupFetch({ deferredPut: true, deferredPatch: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(initial);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    const replacementSlides = [
+      initial.slides[1]!,
+      { ...initial.slides[2]!, content: "<h1>Replaced three</h1>" },
+    ];
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-1");
+      result.current.setDeckSlides(initial.id, replacementSlides);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPutSignal()).toBeDefined();
+
+    act(() => {
+      result.current.deleteSlide(initial.id, "slide-2");
+    });
+    setAccessibleDeck({
+      ...initial,
+      updatedAt: "2026-05-12T00:02:00.000Z",
+    });
+    deferNextGetDeck();
+    const staleRefresh = result.current.refreshOpenDeck(initial.id);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hasDeferredGetDeck()).toBe(true);
+
+    resolveDeferredPut();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getPatchAttempts(initial.id)).toBe(1);
+
+    resolveDeferredPatch();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    resolveDeferredGetDeck();
+    await act(async () => {
+      await staleRefresh;
+    });
+
+    expect(
+      result.current.getDeck(initial.id)?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-3"]);
+    vi.useRealTimers();
+  });
+
   it("waits for an in-flight granular save before restoring an authoritative version", async () => {
     window.history.pushState({}, "", "/deck/restore-patch-race-deck");
     const initial: Deck = {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -181,10 +181,11 @@ function setupFetch(options?: {
       if (accessibleDeck) {
         if (deferNextGetDeck) {
           deferNextGetDeck = false;
+          const deferredDeck = accessibleDeck;
           return new Promise<Response>((resolve) => {
             resolveDeferredGetDeck = () =>
               resolve(
-                new Response(JSON.stringify(accessibleDeck), { status: 200 }),
+                new Response(JSON.stringify(deferredDeck), { status: 200 }),
               );
           });
         }
@@ -2036,6 +2037,128 @@ describe("DeckContext deck creation persistence", () => {
     expect(
       result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
     ).toEqual(["slide-1"]);
+    vi.useRealTimers();
+  });
+
+  it("does not let a stale baseline reload resurrect a deleted slide", async () => {
+    window.history.pushState({}, "", "/deck/shared-deck");
+    const original: Deck = {
+      id: "shared-deck",
+      title: "Shared Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const {
+      setAccessibleDeck,
+      deferNextGetDeck,
+      hasDeferredGetDeck,
+      resolveDeferredGetDeck,
+      getFirstPatchSignal,
+      resolveDeferredPatch,
+    } = setupFetch({ deferredPatch: true });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("shared-deck", "slide-2");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(getFirstPatchSignal()).toBeDefined();
+
+    deferNextGetDeck();
+    const staleReload = result.current.reloadDecks();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(hasDeferredGetDeck()).toBe(true);
+
+    resolveDeferredPatch();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(hasUncommittedDeckChanges("shared-deck", new Set())).toBe(false);
+
+    setAccessibleDeck({ ...original, slides: [original.slides[0]!] });
+    resolveDeferredGetDeck();
+    await act(async () => {
+      await staleReload;
+    });
+
+    expect(
+      result.current.getDeck("shared-deck")?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1"]);
+    vi.useRealTimers();
+  });
+
+  it("shows a deleted slide again after its save permanently fails", async () => {
+    window.history.pushState({}, "", "/deck/failed-delete-deck");
+    const original: Deck = {
+      id: "failed-delete-deck",
+      title: "Failed delete deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        { id: "slide-1", content: "<h1>One</h1>", notes: "", layout: "title" },
+        {
+          id: "slide-2",
+          content: "<h1>Two</h1>",
+          notes: "",
+          layout: "content",
+        },
+      ],
+    };
+    const { setAccessibleDeck, getPatchAttempts } = setupFetch({
+      patchFailures: { deckId: "failed-delete-deck", count: 3 },
+    });
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    vi.useFakeTimers();
+    act(() => {
+      result.current.deleteSlide("failed-delete-deck", "slide-2");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_250);
+    });
+    expect(getPatchAttempts("failed-delete-deck")).toBe(3);
+    expect(hasUncommittedDeckChanges("failed-delete-deck", new Set())).toBe(
+      true,
+    );
+
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+
+    expect(
+      result.current
+        .getDeck("failed-delete-deck")
+        ?.slides.map((slide) => slide.id),
+    ).toEqual(["slide-1", "slide-2"]);
     vi.useRealTimers();
   });
 

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1593,13 +1593,27 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const clearReplacedSlideDeleteTombstones = useCallback(
-    (ops: GranularOp[]) => {
-      for (const op of ops) {
-        if (op.op !== "full-replace") continue;
-        clearDeckDeleteTombstones(op.deck.id);
-      }
+    (deckId: string, capturedTombstones: ReadonlySet<string>) => {
+      const tombstones = deletedSlideTombstonesRef.current.get(deckId);
+      if (!tombstones) return;
+      for (const slideId of capturedTombstones) tombstones.delete(slideId);
+      if (tombstones.size === 0) clearDeckDeleteTombstones(deckId);
     },
     [clearDeckDeleteTombstones],
+  );
+
+  const captureReplacedSlideDeleteTombstones = useCallback(
+    (deck: Deck) => {
+      const tombstones = deletedSlideTombstonesRef.current.get(deck.id);
+      const capturedTombstones = new Set(
+        deck.slides
+          .map((slide) => slide.id)
+          .filter((slideId) => tombstones?.has(slideId) ?? false),
+      );
+      return () =>
+        clearReplacedSlideDeleteTombstones(deck.id, capturedTombstones);
+    },
+    [clearReplacedSlideDeleteTombstones],
   );
 
   const nextOpenDeckRequestId = useCallback((deckId: string) => {
@@ -1695,7 +1709,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             enqueueDeckOp(
               op.deckId,
               { op: "full-replace", deck: op.deck },
-              { onSaveSuccess: clearReplacedSlideDeleteTombstones },
+              {
+                onSaveSuccess: captureReplacedSlideDeleteTombstones(op.deck),
+              },
             );
           } else {
             const { deckId, ...granular } = op;
@@ -2893,7 +2909,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           enqueueDeckOp(
             deckId,
             { op: "full-replace", deck: next },
-            { onSaveSuccess: clearReplacedSlideDeleteTombstones },
+            { onSaveSuccess: captureReplacedSlideDeleteTombstones(next) },
           );
           return next;
         }),
@@ -2906,7 +2922,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         });
       }
     },
-    [clearReplacedSlideDeleteTombstones, markDeckDirty, setDecksLocal],
+    [captureReplacedSlideDeleteTombstones, markDeckDirty, setDecksLocal],
   );
 
   return (

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -808,8 +808,11 @@ function enqueueDeckOp(
  * creation path which already inserts via `add-deck` — it is NOT called for
  * edits any more.
  */
-function saveDeckToAPI(deck: Deck) {
-  enqueueDeckOp(deck.id, { op: "full-replace", deck });
+function saveDeckToAPI(
+  deck: Deck,
+  onSaveSuccess?: (ops: GranularOp[]) => void,
+) {
+  enqueueDeckOp(deck.id, { op: "full-replace", deck }, { onSaveSuccess });
 }
 
 /**
@@ -1439,10 +1442,12 @@ export function mergeServerSlideUpdate(
   server: Deck,
   changedSlideId: string | undefined,
   deckId: string,
+  options?: { shouldMergeServerOnlySlide?: (slide: Slide) => boolean },
 ): Deck {
   const merged = mergeServerAddedSlides(local, server, {
     shouldMergeServerOnlySlide: (slide) =>
-      !hasPendingDeleteForSlide(deckId, slide.id),
+      !hasPendingDeleteForSlide(deckId, slide.id) &&
+      (options?.shouldMergeServerOnlySlide?.(slide) ?? true),
   });
   if (!changedSlideId || hasPendingWriteForSlide(deckId, changedSlideId)) {
     return merged;
@@ -1534,6 +1539,13 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const slideDeleteGenerationsRef = useRef<Map<string, Map<string, number>>>(
     new Map(),
   );
+  const successfulReplacementTombstoneBoundariesRef = useRef<
+    Map<
+      string,
+      Map<string, { generation: number; omitted: boolean; updatedAt: string }>
+    >
+  >(new Map());
+  const serverSnapshotGenerationRef = useRef(0);
   const deckBaselineRequestIdRef = useRef(0);
   const deckListRequestIdRef = useRef(0);
   const openDeckRequestIdByDeckRef = useRef<Map<string, number>>(new Map());
@@ -1568,12 +1580,30 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         new Map<string, number>();
       generations.set(slideId, (generations.get(slideId) ?? 0) + 1);
       slideDeleteGenerationsRef.current.set(deckId, generations);
+      successfulReplacementTombstoneBoundariesRef.current
+        .get(deckId)
+        ?.delete(slideId);
       const tombstones =
         deletedSlideTombstonesRef.current.get(deckId) ?? new Set<string>();
       tombstones.add(slideId);
       deletedSlideTombstonesRef.current.set(deckId, tombstones);
     },
     [],
+  );
+
+  const markReplacedSlideOmissions = useCallback(
+    (current: Deck | undefined, replacement: Deck) => {
+      if (!current) return;
+      const replacementIds = new Set(
+        replacement.slides.map((slide) => slide.id),
+      );
+      for (const slide of current.slides) {
+        if (!replacementIds.has(slide.id)) {
+          markSlideDeleteTombstone(replacement.id, slide.id);
+        }
+      }
+    },
+    [markSlideDeleteTombstone],
   );
 
   const markDeckDirty = useCallback(
@@ -1594,35 +1624,61 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const clearSlideDeleteTombstone = useCallback(
     (deckId: string, slideId: string) => {
       const tombstones = deletedSlideTombstonesRef.current.get(deckId);
-      if (!tombstones) return;
-      tombstones.delete(slideId);
-      if (tombstones.size === 0) {
-        deletedSlideTombstonesRef.current.delete(deckId);
+      if (tombstones) {
+        tombstones.delete(slideId);
+        if (tombstones.size === 0) {
+          deletedSlideTombstonesRef.current.delete(deckId);
+        }
       }
+      successfulReplacementTombstoneBoundariesRef.current
+        .get(deckId)
+        ?.delete(slideId);
     },
     [],
   );
 
   const clearDeckDeleteTombstones = useCallback((deckId: string) => {
     deletedSlideTombstonesRef.current.delete(deckId);
+    successfulReplacementTombstoneBoundariesRef.current.delete(deckId);
   }, []);
 
-  const clearReplacedSlideDeleteTombstones = useCallback(
-    (deckId: string, capturedTombstones: ReadonlyMap<string, number>) => {
+  const recordReplacedSlideDeleteTombstones = useCallback(
+    (
+      deckId: string,
+      capturedTombstones: ReadonlyMap<string, number>,
+      replacementUpdatedAt: string,
+      replacementSlideIds: ReadonlySet<string>,
+    ) => {
       const tombstones = deletedSlideTombstonesRef.current.get(deckId);
-      if (!tombstones) return;
+      if (!tombstones || capturedTombstones.size === 0) return;
       const generations = slideDeleteGenerationsRef.current.get(deckId);
+      const boundary = ++serverSnapshotGenerationRef.current;
+      const boundaries =
+        successfulReplacementTombstoneBoundariesRef.current.get(deckId) ??
+        new Map<
+          string,
+          { generation: number; omitted: boolean; updatedAt: string }
+        >();
       for (const [slideId, generation] of capturedTombstones) {
         if (
           tombstones.has(slideId) &&
           generations?.get(slideId) === generation
         ) {
-          tombstones.delete(slideId);
+          boundaries.set(slideId, {
+            generation: boundary,
+            omitted: !replacementSlideIds.has(slideId),
+            updatedAt: replacementUpdatedAt,
+          });
         }
       }
-      if (tombstones.size === 0) clearDeckDeleteTombstones(deckId);
+      if (boundaries.size > 0) {
+        successfulReplacementTombstoneBoundariesRef.current.set(
+          deckId,
+          boundaries,
+        );
+      }
     },
-    [clearDeckDeleteTombstones],
+    [],
   );
 
   const captureReplacedSlideDeleteTombstones = useCallback(
@@ -1630,16 +1686,21 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const tombstones = deletedSlideTombstonesRef.current.get(deck.id);
       const generations = slideDeleteGenerationsRef.current.get(deck.id);
       const capturedTombstones = new Map<string, number>();
-      for (const slide of deck.slides) {
-        const generation = generations?.get(slide.id);
-        if (tombstones?.has(slide.id) && generation !== undefined) {
-          capturedTombstones.set(slide.id, generation);
+      for (const slideId of tombstones ?? []) {
+        const generation = generations?.get(slideId);
+        if (generation !== undefined) {
+          capturedTombstones.set(slideId, generation);
         }
       }
       return () =>
-        clearReplacedSlideDeleteTombstones(deck.id, capturedTombstones);
+        recordReplacedSlideDeleteTombstones(
+          deck.id,
+          capturedTombstones,
+          deck.updatedAt,
+          new Set(deck.slides.map((slide) => slide.id)),
+        );
     },
-    [clearReplacedSlideDeleteTombstones],
+    [recordReplacedSlideDeleteTombstones],
   );
 
   const nextOpenDeckRequestId = useCallback((deckId: string) => {
@@ -1649,11 +1710,16 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const reconcileServerDeckWithDeleteTombstones = useCallback(
-    (server: Deck): Deck => {
+    (
+      server: Deck,
+      snapshotGeneration = serverSnapshotGenerationRef.current,
+    ): Deck => {
       const tombstones = deletedSlideTombstonesRef.current.get(server.id);
       if (!tombstones?.size) return server;
 
       const serverSlideIds = new Set(server.slides.map((slide) => slide.id));
+      const replacementBoundaries =
+        successfulReplacementTombstoneBoundariesRef.current.get(server.id);
       const failedOps = failedSaveDecks.has(server.id)
         ? (pendingOpsQueue.get(server.id) ?? [])
         : [];
@@ -1670,17 +1736,26 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         ? new Set(failedFullReplace.deck.slides.map((slide) => slide.id))
         : null;
       for (const slideId of tombstones) {
+        const replacementBoundary = replacementBoundaries?.get(slideId);
+        const replacementSnapshotIsCurrent =
+          replacementBoundary &&
+          replacementBoundary.generation <= snapshotGeneration &&
+          (!replacementBoundary.omitted ||
+            server.updatedAt > replacementBoundary.updatedAt);
         if (
           failedDeleteSlideIds.has(slideId) ||
           (failedFullReplaceSlideIds &&
             !failedFullReplaceSlideIds.has(slideId)) ||
-          !serverSlideIds.has(slideId)
+          !serverSlideIds.has(slideId) ||
+          replacementSnapshotIsCurrent
         ) {
           tombstones.delete(slideId);
+          replacementBoundaries?.delete(slideId);
         }
       }
       if (tombstones.size === 0) {
         deletedSlideTombstonesRef.current.delete(server.id);
+        successfulReplacementTombstoneBoundariesRef.current.delete(server.id);
         return server;
       }
 
@@ -1745,6 +1820,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             discardPendingDeckOps(op.deckId);
             deleteDeckAfterPendingCreate(op.deckId);
           } else if (op.op === "restore-deck" || op.op === "replace-deck") {
+            markReplacedSlideOmissions(
+              decksRef.current.find((deck) => deck.id === op.deckId),
+              op.deck,
+            );
             enqueueDeckOp(
               op.deckId,
               { op: "full-replace", deck: op.deck },
@@ -1911,6 +1990,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       currentOpenId: string,
       options?: { clearPendingWrites?: boolean; changedSlideId?: string },
     ): Promise<Deck | null> => {
+      const snapshotGeneration = serverSnapshotGenerationRef.current;
       const requestId = nextOpenDeckRequestId(currentOpenId);
       const fetchedServerDeck = await fetchDeckFromAPI(currentOpenId);
       if (openDeckRequestIdByDeckRef.current.get(currentOpenId) !== requestId) {
@@ -1922,8 +2002,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       if (options?.clearPendingWrites) {
         clearDeckDeleteTombstones(currentOpenId);
       }
-      const serverDeck =
-        reconcileServerDeckWithDeleteTombstones(fetchedServerDeck);
+      const serverDeck = reconcileServerDeckWithDeleteTombstones(
+        fetchedServerDeck,
+        snapshotGeneration,
+      );
       const clientDeck = decksRef.current.find((d) => d.id === currentOpenId);
       if (options?.clearPendingWrites) {
         lastExternalUpdateRef.current = Date.now();
@@ -1945,6 +2027,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           serverDeck,
           options?.changedSlideId,
           currentOpenId,
+          {
+            shouldMergeServerOnlySlide: (slide) =>
+              !deletedSlideTombstonesRef.current
+                .get(currentOpenId)
+                ?.has(slide.id),
+          },
         );
         if (merged === clientDeck) return serverDeck; // nothing new to surface
         lastExternalUpdateRef.current = Date.now();
@@ -1996,14 +2084,18 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, [refetchDeckListIfChanged, refetchOpenDeckIfChanged]);
 
   const resetDeckBaseline = useCallback(
-    (nextDecks: Deck[], createSeqAtRequest: number) => {
+    (
+      nextDecks: Deck[],
+      createSeqAtRequest: number,
+      snapshotGeneration = serverSnapshotGenerationRef.current,
+    ) => {
       // A baseline snapshot supersedes any in-flight light-list membership
       // diff before it replaces local state.
       ++deckListRequestIdRef.current;
       const reconciledDecks = nextDecks.map((deck) =>
         deck.previewSlide
           ? deck
-          : reconcileServerDeckWithDeleteTombstones(deck),
+          : reconcileServerDeckWithDeleteTombstones(deck, snapshotGeneration),
       );
       const nextIds = new Set(reconciledDecks.map((d) => d.id));
       setDecks((prev) => {
@@ -2032,6 +2124,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     useCallback(async (): Promise<DeckReloadStatus> => {
       const requestId = ++deckBaselineRequestIdRef.current;
       const createSeqAtRequest = localCreateSeqRef.current;
+      const snapshotGeneration = serverSnapshotGenerationRef.current;
       const requestedOpenDeckId = currentOpenDeckIdFromWindow();
       const openDeckRequestId = requestedOpenDeckId
         ? nextOpenDeckRequestId(requestedOpenDeckId)
@@ -2054,7 +2147,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         return "failed";
       }
       lastExternalUpdateRef.current = Date.now();
-      resetDeckBaseline(loaded, createSeqAtRequest);
+      resetDeckBaseline(loaded, createSeqAtRequest, snapshotGeneration);
       setLoadError(false);
       setLoading(false);
       return "loaded";
@@ -2072,6 +2165,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     if (orgLoading) return;
     const requestId = ++deckBaselineRequestIdRef.current;
     const createSeqAtRequest = localCreateSeqRef.current;
+    const snapshotGeneration = serverSnapshotGenerationRef.current;
     const requestedOpenDeckId = currentOpenDeckIdFromWindow();
     const openDeckRequestId = requestedOpenDeckId
       ? nextOpenDeckRequestId(requestedOpenDeckId)
@@ -2092,7 +2186,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // triggering the save effect (lastExternalUpdateRef is bumped).
       const initial = loaded ?? [];
       lastExternalUpdateRef.current = Date.now(); // Don't save initial load back
-      resetDeckBaseline(initial, createSeqAtRequest);
+      resetDeckBaseline(initial, createSeqAtRequest, snapshotGeneration);
       setLoadError(loaded === null);
       setLoading(false);
     });
@@ -2227,10 +2321,19 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       ) {
         const deck = decks.find((d) => d.id === id);
         if (!deck) continue;
-        saveDeckToAPI(deck);
+        markReplacedSlideOmissions(
+          decksRef.current.find((d) => d.id === id),
+          deck,
+        );
+        saveDeckToAPI(deck, captureReplacedSlideDeleteTombstones(deck));
       }
     }
-  }, [decks, loading]);
+  }, [
+    captureReplacedSlideDeleteTombstones,
+    decks,
+    loading,
+    markReplacedSlideOmissions,
+  ]);
 
   // Listen for deck changes through the shared framework sync transport. A
   // separate deck EventSource used to consume another long-lived browser
@@ -2936,6 +3039,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       ) {
         return;
       }
+      if (before && after) {
+        markReplacedSlideOmissions(before, after);
+      }
+      const onSaveSuccess = after
+        ? captureReplacedSlideDeleteTombstones(after)
+        : undefined;
       markDeckDirty(deckId);
       // setDeckSlides replaces ALL slides wholesale (used by AI generation and
       // imports), so its undo entry is a deck-level full replacement instead of
@@ -2951,7 +3060,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           enqueueDeckOp(
             deckId,
             { op: "full-replace", deck: next },
-            { onSaveSuccess: captureReplacedSlideDeleteTombstones(next) },
+            { onSaveSuccess },
           );
           return next;
         }),
@@ -2964,7 +3073,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         });
       }
     },
-    [captureReplacedSlideDeleteTombstones, markDeckDirty, setDecksLocal],
+    [
+      captureReplacedSlideDeleteTombstones,
+      markDeckDirty,
+      markReplacedSlideOmissions,
+      setDecksLocal,
+    ],
   );
 
   return (

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1510,6 +1510,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   );
   const pendingDuplicateSourceIdsRef = useRef<Set<string>>(new Set());
   const dirtyDeckIdsRef = useRef<Set<string>>(new Set());
+  const deletedSlideTombstonesRef = useRef<Map<string, Set<string>>>(new Map());
   const deckBaselineRequestIdRef = useRef(0);
   const openDeckRequestIdByDeckRef = useRef<Map<string, number>>(new Map());
   // True only while the SSE channel is actually open. Stays false when SSE is
@@ -1540,6 +1541,54 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     lastExternalUpdateRef.current = 0;
     dirtyDeckIdsRef.current.add(deckId);
   }, []);
+
+  const markSlideDeleteTombstone = useCallback(
+    (deckId: string, slideId: string) => {
+      const tombstones =
+        deletedSlideTombstonesRef.current.get(deckId) ?? new Set<string>();
+      tombstones.add(slideId);
+      deletedSlideTombstonesRef.current.set(deckId, tombstones);
+    },
+    [],
+  );
+
+  const clearSlideDeleteTombstone = useCallback(
+    (deckId: string, slideId: string) => {
+      const tombstones = deletedSlideTombstonesRef.current.get(deckId);
+      if (!tombstones) return;
+      tombstones.delete(slideId);
+      if (tombstones.size === 0) {
+        deletedSlideTombstonesRef.current.delete(deckId);
+      }
+    },
+    [],
+  );
+
+  const clearDeckDeleteTombstones = useCallback((deckId: string) => {
+    deletedSlideTombstonesRef.current.delete(deckId);
+  }, []);
+
+  const reconcileServerDeckWithDeleteTombstones = useCallback(
+    (server: Deck): Deck => {
+      const tombstones = deletedSlideTombstonesRef.current.get(server.id);
+      if (!tombstones?.size) return server;
+
+      const serverSlideIds = new Set(server.slides.map((slide) => slide.id));
+      for (const slideId of tombstones) {
+        if (!serverSlideIds.has(slideId)) tombstones.delete(slideId);
+      }
+      if (tombstones.size === 0) {
+        deletedSlideTombstonesRef.current.delete(server.id);
+        return server;
+      }
+
+      const slides = server.slides.filter((slide) => !tombstones.has(slide.id));
+      return slides.length === server.slides.length
+        ? server
+        : { ...server, slides };
+    },
+    [],
+  );
 
   const deleteDeckAfterPendingCreate = useCallback(
     (deckId: string, onFailure?: () => void) => {
@@ -1597,6 +1646,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             enqueueDeckOp(op.deckId, { op: "full-replace", deck: op.deck });
           } else {
             const { deckId, ...granular } = op;
+            if (granular.op === "delete-slide") {
+              markSlideDeleteTombstone(deckId, granular.slideId);
+            } else if (granular.op === "add-slide") {
+              clearSlideDeleteTombstone(deckId, granular.slideId);
+            }
             enqueueDeckOp(deckId, granular);
           }
         }
@@ -1648,6 +1702,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       if (options?.clearPendingWrites) {
         discardPendingDeckOps(updated.id);
         dirtyDeckIdsRef.current.delete(updated.id);
+        clearDeckDeleteTombstones(updated.id);
       }
       const before = decksRef.current.find((d) => d.id === updated.id);
       if (
@@ -1670,7 +1725,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         return [...prev, updated];
       });
     },
-    [],
+    [clearDeckDeleteTombstones],
   );
 
   // Re-fetch the deck list and diff it against local state (added/removed
@@ -1748,13 +1803,18 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const requestId =
         (openDeckRequestIdByDeckRef.current.get(currentOpenId) ?? 0) + 1;
       openDeckRequestIdByDeckRef.current.set(currentOpenId, requestId);
-      const serverDeck = await fetchDeckFromAPI(currentOpenId);
+      const fetchedServerDeck = await fetchDeckFromAPI(currentOpenId);
       if (openDeckRequestIdByDeckRef.current.get(currentOpenId) !== requestId) {
         return null;
       }
       // Null means 404 (row not created yet), a transient failure, or a
       // still-pending create — nothing authoritative to reconcile.
-      if (!serverDeck) return null;
+      if (!fetchedServerDeck) return null;
+      if (options?.clearPendingWrites) {
+        clearDeckDeleteTombstones(currentOpenId);
+      }
+      const serverDeck =
+        reconcileServerDeckWithDeleteTombstones(fetchedServerDeck);
       const clientDeck = decksRef.current.find((d) => d.id === currentOpenId);
       if (options?.clearPendingWrites) {
         lastExternalUpdateRef.current = Date.now();
@@ -1798,7 +1858,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       applyRemoteDeckUpdate(serverDeck);
       return serverDeck;
     },
-    [applyRemoteDeckUpdate],
+    [
+      applyRemoteDeckUpdate,
+      clearDeckDeleteTombstones,
+      reconcileServerDeckWithDeleteTombstones,
+    ],
   );
 
   /**
@@ -2589,6 +2653,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     (deckId: string, slideId: string) => {
       markDeckDirty(deckId);
       const before = decksRef.current.find((d) => d.id === deckId);
+      if (before?.slides.some((slide) => slide.id === slideId)) {
+        markSlideDeleteTombstone(deckId, slideId);
+      }
       setDecksLocal((prev) =>
         prev.map((d) => {
           if (d.id !== deckId) return d;
@@ -2612,7 +2679,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // behind the "Undo delete" toast in DeckEditor.)
       if (before) recordUndo(before, op, { label: "Delete slide" });
     },
-    [markDeckDirty, recordUndo, setDecksLocal],
+    [markDeckDirty, markSlideDeleteTombstone, recordUndo, setDecksLocal],
   );
 
   const duplicateSlide = useCallback(
@@ -2726,6 +2793,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const setDeckSlides = useCallback(
     (deckId: string, slides: Slide[]) => {
       const before = decksRef.current.find((deck) => deck.id === deckId);
+      for (const slide of slides) {
+        clearSlideDeleteTombstone(deckId, slide.id);
+      }
       const after = before
         ? { ...before, slides, updatedAt: new Date().toISOString() }
         : null;
@@ -2760,7 +2830,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         });
       }
     },
-    [markDeckDirty, setDecksLocal],
+    [clearSlideDeleteTombstone, markDeckDirty, setDecksLocal],
   );
 
   return (

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1896,8 +1896,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
   const resetDeckBaseline = useCallback(
     (nextDecks: Deck[], createSeqAtRequest: number) => {
-      const reconciledDecks = nextDecks.map(
-        reconcileServerDeckWithDeleteTombstones,
+      const reconciledDecks = nextDecks.map((deck) =>
+        deck.previewSlide
+          ? deck
+          : reconcileServerDeckWithDeleteTombstones(deck),
       );
       const nextIds = new Set(reconciledDecks.map((d) => d.id));
       setDecks((prev) => {

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -400,6 +400,7 @@ const DECK_SAVE_RETRY_BASE_MS = 250;
 // Per-deck queue of granular ops waiting to be flushed. Keys are deck IDs.
 // Ops are appended by enqueueDeckOp and drained when the debounce fires.
 const pendingOpsQueue = new Map<string, GranularOp[]>();
+const deckSaveSuccessHandlers = new Map<string, (ops: GranularOp[]) => void>();
 
 // The ops a deck's current in-flight save actually sent, so a slide-scoped
 // check can tell "this slide's save is in flight" from "some other slide in
@@ -629,9 +630,13 @@ function drainPendingDeckOps(
   const ops = pendingOpsQueue.get(deckId) ?? [];
   pendingOpsQueue.delete(deckId);
   if (ops.length === 0) {
+    deckSaveSuccessHandlers.delete(deckId);
     notifySaveListeners();
     return Promise.resolve();
   }
+
+  const onSaveSuccess = deckSaveSuccessHandlers.get(deckId);
+  deckSaveSuccessHandlers.delete(deckId);
 
   const generation = deckSaveGenerations.get(deckId) ?? 0;
   const controller =
@@ -644,6 +649,7 @@ function drainPendingDeckOps(
   const next = persistDeckOps(deckId, ops, controller?.signal, options)
     .then(() => {
       if (!isCurrentGeneration()) return;
+      onSaveSuccess?.(ops);
       deckSaveRetryAttempts.delete(deckId);
       failedSaveDecks.delete(deckId);
     })
@@ -652,6 +658,7 @@ function drainPendingDeckOps(
       // resurrect the old queue or schedule a retry after the boundary.
       if (!isCurrentGeneration()) return;
       console.error(`Failed to save deck ${deckId}:`, err);
+      if (onSaveSuccess) deckSaveSuccessHandlers.set(deckId, onSaveSuccess);
       const pending = pendingOpsQueue.get(deckId) ?? [];
       pendingOpsQueue.set(deckId, [...ops, ...pending]);
       const attempt = (deckSaveRetryAttempts.get(deckId) ?? 0) + 1;
@@ -736,8 +743,12 @@ function enqueueDeckOp(
   options?: {
     persistence?: "debounced" | "immediate";
     coalesceContent?: boolean;
+    onSaveSuccess?: (ops: GranularOp[]) => void;
   },
 ) {
+  if (options?.onSaveSuccess) {
+    deckSaveSuccessHandlers.set(deckId, options.onSaveSuccess);
+  }
   const existing = pendingSaves.get(deckId);
   if (existing) clearTimeout(existing);
   if (
@@ -749,6 +760,7 @@ function enqueueDeckOp(
   }
 
   if (op.op === "full-replace") {
+    if (!options?.onSaveSuccess) deckSaveSuccessHandlers.delete(deckId);
     // Discard any accumulated granular ops — this is a wholesale replacement
     pendingOpsQueue.set(deckId, [op]);
   } else {
@@ -816,6 +828,7 @@ function discardPendingDeckOps(deckId: string) {
   if (timer) clearTimeout(timer);
   pendingSaves.delete(deckId);
   pendingOpsQueue.delete(deckId);
+  deckSaveSuccessHandlers.delete(deckId);
   deckSaveRetryAttempts.delete(deckId);
   failedSaveDecks.delete(deckId);
   immediateFlushRequests.delete(deckId);
@@ -1512,6 +1525,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const dirtyDeckIdsRef = useRef<Set<string>>(new Set());
   const deletedSlideTombstonesRef = useRef<Map<string, Set<string>>>(new Map());
   const deckBaselineRequestIdRef = useRef(0);
+  const deckListRequestIdRef = useRef(0);
   const openDeckRequestIdByDeckRef = useRef<Map<string, number>>(new Map());
   // True only while the SSE channel is actually open. Stays false when SSE is
   // never started (embed auth), so the poll keeps its fast intervals there.
@@ -1540,6 +1554,16 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const markDeckDirty = useCallback((deckId: string) => {
     lastExternalUpdateRef.current = 0;
     dirtyDeckIdsRef.current.add(deckId);
+    if (failedSaveDecks.has(deckId)) {
+      const tombstones =
+        deletedSlideTombstonesRef.current.get(deckId) ?? new Set<string>();
+      for (const op of pendingOpsQueue.get(deckId) ?? []) {
+        if (op.op === "delete-slide") tombstones.add(op.slideId);
+      }
+      if (tombstones.size > 0) {
+        deletedSlideTombstonesRef.current.set(deckId, tombstones);
+      }
+    }
   }, []);
 
   const markSlideDeleteTombstone = useCallback(
@@ -1566,6 +1590,22 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
   const clearDeckDeleteTombstones = useCallback((deckId: string) => {
     deletedSlideTombstonesRef.current.delete(deckId);
+  }, []);
+
+  const clearReplacedSlideDeleteTombstones = useCallback(
+    (ops: GranularOp[]) => {
+      for (const op of ops) {
+        if (op.op !== "full-replace") continue;
+        clearDeckDeleteTombstones(op.deck.id);
+      }
+    },
+    [clearDeckDeleteTombstones],
+  );
+
+  const nextOpenDeckRequestId = useCallback((deckId: string) => {
+    const requestId = (openDeckRequestIdByDeckRef.current.get(deckId) ?? 0) + 1;
+    openDeckRequestIdByDeckRef.current.set(deckId, requestId);
+    return requestId;
   }, []);
 
   const reconcileServerDeckWithDeleteTombstones = useCallback(
@@ -1652,7 +1692,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             discardPendingDeckOps(op.deckId);
             deleteDeckAfterPendingCreate(op.deckId);
           } else if (op.op === "restore-deck" || op.op === "replace-deck") {
-            enqueueDeckOp(op.deckId, { op: "full-replace", deck: op.deck });
+            enqueueDeckOp(
+              op.deckId,
+              { op: "full-replace", deck: op.deck },
+              { onSaveSuccess: clearReplacedSlideDeleteTombstones },
+            );
           } else {
             const { deckId, ...granular } = op;
             if (granular.op === "delete-slide") {
@@ -1747,8 +1791,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   // (rare — usually zero per poll) get a follow-up full fetch so DeckCard can
   // still render an immediate preview for them.
   const refetchDeckListIfChanged = useCallback(async () => {
+    const requestId = ++deckListRequestIdRef.current;
     const createSeqAtRequest = localCreateSeqRef.current;
     const fresh = await fetchDeckListLightFromAPI();
+    if (requestId !== deckListRequestIdRef.current) return;
     // A null result means the fetch failed (network error or non-2xx). Skip
     // the diff so we don't wipe local state on a transient failure.
     if (fresh === null) return;
@@ -1774,6 +1820,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     const addedDecks = (
       await Promise.all(addedIds.map((id) => fetchDeckFromAPI(id)))
     ).filter((d): d is Deck => d !== null);
+    if (requestId !== deckListRequestIdRef.current) return;
 
     lastExternalUpdateRef.current = Date.now();
     const removedIds = new Set(removed.map((d) => d.id));
@@ -1809,9 +1856,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       currentOpenId: string,
       options?: { clearPendingWrites?: boolean; changedSlideId?: string },
     ): Promise<Deck | null> => {
-      const requestId =
-        (openDeckRequestIdByDeckRef.current.get(currentOpenId) ?? 0) + 1;
-      openDeckRequestIdByDeckRef.current.set(currentOpenId, requestId);
+      const requestId = nextOpenDeckRequestId(currentOpenId);
       const fetchedServerDeck = await fetchDeckFromAPI(currentOpenId);
       if (openDeckRequestIdByDeckRef.current.get(currentOpenId) !== requestId) {
         return null;
@@ -1870,6 +1915,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     [
       applyRemoteDeckUpdate,
       clearDeckDeleteTombstones,
+      nextOpenDeckRequestId,
       reconcileServerDeckWithDeleteTombstones,
     ],
   );
@@ -1929,12 +1975,19 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const requestId = ++deckBaselineRequestIdRef.current;
       const createSeqAtRequest = localCreateSeqRef.current;
       const requestedOpenDeckId = currentOpenDeckIdFromWindow();
+      const openDeckRequestId = requestedOpenDeckId
+        ? nextOpenDeckRequestId(requestedOpenDeckId)
+        : null;
       setLoading(true);
       const loaded = await fetchDecksForCurrentRoute();
       if (
         requestId !== deckBaselineRequestIdRef.current ||
-        requestedOpenDeckId !== currentOpenDeckIdFromWindow()
+        requestedOpenDeckId !== currentOpenDeckIdFromWindow() ||
+        (requestedOpenDeckId !== null &&
+          openDeckRequestId !==
+            openDeckRequestIdByDeckRef.current.get(requestedOpenDeckId))
       ) {
+        setLoading(false);
         return "stale";
       }
       if (loaded === null) {
@@ -1947,7 +2000,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       setLoadError(false);
       setLoading(false);
       return "loaded";
-    }, [resetDeckBaseline]);
+    }, [nextOpenDeckRequestId, resetDeckBaseline]);
 
   const reloadDecks = useCallback(async () => {
     await reloadDecksWithStatus();
@@ -1962,10 +2015,16 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     const requestId = ++deckBaselineRequestIdRef.current;
     const createSeqAtRequest = localCreateSeqRef.current;
     const requestedOpenDeckId = currentOpenDeckIdFromWindow();
+    const openDeckRequestId = requestedOpenDeckId
+      ? nextOpenDeckRequestId(requestedOpenDeckId)
+      : null;
     fetchDecksForCurrentRoute().then(async (loaded) => {
       if (
         requestId !== deckBaselineRequestIdRef.current ||
-        requestedOpenDeckId !== currentOpenDeckIdFromWindow()
+        requestedOpenDeckId !== currentOpenDeckIdFromWindow() ||
+        (requestedOpenDeckId !== null &&
+          openDeckRequestId !==
+            openDeckRequestIdByDeckRef.current.get(requestedOpenDeckId))
       ) {
         setLoading(false);
         return;
@@ -1979,7 +2038,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       setLoadError(loaded === null);
       setLoading(false);
     });
-  }, [orgLoading, resetDeckBaseline]);
+  }, [nextOpenDeckRequestId, orgLoading, resetDeckBaseline]);
 
   // Switching orgs re-scopes list-decks server-side but leaves this context's
   // in-memory list untouched, so the previous org's decks linger. Reload when
@@ -2628,7 +2687,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         }
         return;
       }
-      if (!options?.preserveLocalState) markDeckDirty(deckId);
+      markDeckDirty(deckId);
       if (!options?.preserveLocalState) {
         setDecksLocal((prev: Deck[]) =>
           prev.map((d) => {
@@ -2787,7 +2846,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         prev.map((d) => {
           if (d.id !== deckId) return d;
           const slides = reorderSlidesById(
-            d.slides,
+            d.slides.filter(
+              (slide) => !hasPendingDeleteForSlide(deckId, slide.id),
+            ),
             activeSlideId,
             overSlideId,
           );
@@ -2807,9 +2868,6 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const setDeckSlides = useCallback(
     (deckId: string, slides: Slide[]) => {
       const before = decksRef.current.find((deck) => deck.id === deckId);
-      for (const slide of slides) {
-        clearSlideDeleteTombstone(deckId, slide.id);
-      }
       const after = before
         ? { ...before, slides, updatedAt: new Date().toISOString() }
         : null;
@@ -2832,7 +2890,11 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             slides,
             updatedAt: new Date().toISOString(),
           };
-          enqueueDeckOp(deckId, { op: "full-replace", deck: next });
+          enqueueDeckOp(
+            deckId,
+            { op: "full-replace", deck: next },
+            { onSaveSuccess: clearReplacedSlideDeleteTombstones },
+          );
           return next;
         }),
       );
@@ -2844,7 +2906,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         });
       }
     },
-    [clearSlideDeleteTombstone, markDeckDirty, setDecksLocal],
+    [clearReplacedSlideDeleteTombstones, markDeckDirty, setDecksLocal],
   );
 
   return (

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -252,7 +252,11 @@ interface DeckContextType {
     afterSlideId: string,
     slideFields: Omit<Slide, "id">,
   ) => string | undefined;
-  reorderSlides: (deckId: string, oldIndex: number, newIndex: number) => void;
+  reorderSlides: (
+    deckId: string,
+    activeSlideId: string,
+    overSlideId: string,
+  ) => void;
   setDeckSlides: (deckId: string, slides: Slide[]) => void;
   /**
    * Mark a deck as having uncommitted local changes without modifying its data.
@@ -831,6 +835,23 @@ type PatchDeckFields = Extract<
   { op: "patch-deck-fields" }
 >["fields"];
 
+/** Reorders the current slide list by stable IDs, or returns null for a no-op. */
+function reorderSlidesById(
+  slides: Slide[],
+  activeSlideId: string,
+  overSlideId: string,
+): Slide[] | null {
+  const oldIndex = slides.findIndex((slide) => slide.id === activeSlideId);
+  const newIndex = slides.findIndex((slide) => slide.id === overSlideId);
+  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return null;
+
+  const reordered = [...slides];
+  const [moved] = reordered.splice(oldIndex, 1);
+  if (!moved) return null;
+  reordered.splice(newIndex, 0, moved);
+  return reordered;
+}
+
 /**
  * Apply a single granular op to a deck's slides/fields, returning the updated
  * Deck. Unknown/no-op cases (slide already gone, etc.) return the deck
@@ -1301,9 +1322,17 @@ export function hasUncommittedDeckChanges(
  * Returns the same `local` reference when nothing was added, so callers can
  * cheaply detect "no change".
  */
-export function mergeServerAddedSlides(local: Deck, server: Deck): Deck {
+export function mergeServerAddedSlides(
+  local: Deck,
+  server: Deck,
+  options?: { shouldMergeServerOnlySlide?: (slide: Slide) => boolean },
+): Deck {
+  const shouldMergeServerOnlySlide =
+    options?.shouldMergeServerOnlySlide ?? (() => true);
   const localIds = new Set(local.slides.map((s) => s.id));
-  const additions = server.slides.filter((s) => !localIds.has(s.id));
+  const additions = server.slides.filter(
+    (s) => !localIds.has(s.id) && shouldMergeServerOnlySlide(s),
+  );
   if (additions.length === 0) return local;
 
   // Walk the server order, emitting local slides with their local (possibly
@@ -1315,7 +1344,13 @@ export function mergeServerAddedSlides(local: Deck, server: Deck): Deck {
   const merged: Slide[] = [];
   for (const s of server.slides) {
     const localSlide = localById.get(s.id);
-    merged.push(localSlide ?? s);
+    if (localSlide) {
+      merged.push(localSlide);
+    } else if (shouldMergeServerOnlySlide(s)) {
+      merged.push(s);
+    } else {
+      continue;
+    }
     emitted.add(s.id);
   }
   for (const s of local.slides) {
@@ -1357,6 +1392,20 @@ function hasPendingWriteForSlide(deckId: string, slideId: string): boolean {
   return queue.some((op) => opTargetsSlide(op, slideId));
 }
 
+function hasPendingDeleteForSlide(deckId: string, slideId: string): boolean {
+  const inFlightOps = inFlightOpSlides.get(deckId);
+  if (
+    inFlightOps?.some(
+      (op) => op.op === "delete-slide" && op.slideId === slideId,
+    )
+  ) {
+    return true;
+  }
+  const queue = pendingOpsQueue.get(deckId);
+  if (!queue) return false;
+  return queue.some((op) => op.op === "delete-slide" && op.slideId === slideId);
+}
+
 /**
  * Same additive merge as `mergeServerAddedSlides`, but additionally adopts
  * the server's content for `changedSlideId` when no local write is pending
@@ -1371,7 +1420,10 @@ export function mergeServerSlideUpdate(
   changedSlideId: string | undefined,
   deckId: string,
 ): Deck {
-  const merged = mergeServerAddedSlides(local, server);
+  const merged = mergeServerAddedSlides(local, server, {
+    shouldMergeServerOnlySlide: (slide) =>
+      !hasPendingDeleteForSlide(deckId, slide.id),
+  });
   if (!changedSlideId || hasPendingWriteForSlide(deckId, changedSlideId)) {
     return merged;
   }
@@ -2630,27 +2682,43 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   );
 
   const reorderSlides = useCallback(
-    (deckId: string, oldIndex: number, newIndex: number) => {
-      markDeckDirty(deckId);
+    (deckId: string, activeSlideId: string, overSlideId: string) => {
       const before = decksRef.current.find((d) => d.id === deckId);
-      let orderedIds: string[] | undefined;
+      if (!before) return;
+
+      const currentSlides = before.slides.filter(
+        (slide) => !hasPendingDeleteForSlide(deckId, slide.id),
+      );
+      const orderedSlides = reorderSlidesById(
+        currentSlides,
+        activeSlideId,
+        overSlideId,
+      );
+      if (!orderedSlides) return;
+      const orderedIds = orderedSlides.map((slide) => slide.id);
+      const updatedAt = new Date().toISOString();
+
+      markDeckDirty(deckId);
+      decksRef.current = decksRef.current.map((d) =>
+        d.id === deckId ? { ...d, slides: orderedSlides, updatedAt } : d,
+      );
       setDecksLocal((prev) =>
         prev.map((d) => {
           if (d.id !== deckId) return d;
-          const slides = [...d.slides];
-          const [moved] = slides.splice(oldIndex, 1);
-          slides.splice(newIndex, 0, moved);
-          orderedIds = slides.map((s) => s.id);
-          return { ...d, slides, updatedAt: new Date().toISOString() };
+          const slides = reorderSlidesById(
+            d.slides,
+            activeSlideId,
+            overSlideId,
+          );
+          return slides ? { ...d, slides, updatedAt } : d;
         }),
       );
-      if (orderedIds) {
-        // Granular op — server reorders by slide ID rather than by index,
-        // so concurrent adds from other writers don't get dropped.
-        const op: PatchDeckOp = { op: "reorder-slides", orderedIds };
-        enqueueDeckOp(deckId, op);
-        if (before) recordUndo(before, op, { label: "Reorder slides" });
-      }
+
+      // Granular op — server reorders by slide ID rather than by index,
+      // so concurrent adds from other writers don't get dropped.
+      const op: PatchDeckOp = { op: "reorder-slides", orderedIds };
+      enqueueDeckOp(deckId, op);
+      recordUndo(before, op, { label: "Reorder slides" });
     },
     [markDeckDirty, recordUndo, setDecksLocal],
   );

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1574,8 +1574,17 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       if (!tombstones?.size) return server;
 
       const serverSlideIds = new Set(server.slides.map((slide) => slide.id));
+      const failedDeleteSlideIds = new Set(
+        failedSaveDecks.has(server.id)
+          ? (pendingOpsQueue.get(server.id) ?? [])
+              .filter((op) => op.op === "delete-slide")
+              .map((op) => op.slideId)
+          : [],
+      );
       for (const slideId of tombstones) {
-        if (!serverSlideIds.has(slideId)) tombstones.delete(slideId);
+        if (failedDeleteSlideIds.has(slideId) || !serverSlideIds.has(slideId)) {
+          tombstones.delete(slideId);
+        }
       }
       if (tombstones.size === 0) {
         deletedSlideTombstonesRef.current.delete(server.id);
@@ -1887,7 +1896,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
   const resetDeckBaseline = useCallback(
     (nextDecks: Deck[], createSeqAtRequest: number) => {
-      const nextIds = new Set(nextDecks.map((d) => d.id));
+      const reconciledDecks = nextDecks.map(
+        reconcileServerDeckWithDeleteTombstones,
+      );
+      const nextIds = new Set(reconciledDecks.map((d) => d.id));
       setDecks((prev) => {
         // A wholesale replace still can't discard state the snapshot never saw:
         // a deck created here after the fetch started is missing from
@@ -1897,8 +1909,8 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             !nextIds.has(d.id) && isNewerThanSnapshot(d.id, createSeqAtRequest),
         );
         return preserved.length === 0
-          ? nextDecks
-          : [...nextDecks, ...preserved];
+          ? reconciledDecks
+          : [...reconciledDecks, ...preserved];
       });
       for (const id of nextIds) localCreateSeqByIdRef.current.delete(id);
       // A baseline reset (initial mount, route change, or access reload) starts a
@@ -1907,7 +1919,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // intact so a collaborator's edit doesn't wipe your local undo history.
       undoControllerRef.current?.clear();
     },
-    [isNewerThanSnapshot],
+    [isNewerThanSnapshot, reconcileServerDeckWithDeleteTombstones],
   );
 
   const reloadDecksWithStatus =

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -52,7 +52,11 @@ type GranularOp =
       >;
     }
   /** Sentinel: discard all accumulated ops and do a full PUT instead. */
-  | { op: "full-replace"; deck: Deck };
+  | {
+      op: "full-replace";
+      deck: Deck;
+      onSaveSuccess?: (ops: GranularOp[]) => void;
+    };
 
 export type PatchDeckOp = Exclude<GranularOp, { op: "full-replace" }>;
 
@@ -400,7 +404,6 @@ const DECK_SAVE_RETRY_BASE_MS = 250;
 // Per-deck queue of granular ops waiting to be flushed. Keys are deck IDs.
 // Ops are appended by enqueueDeckOp and drained when the debounce fires.
 const pendingOpsQueue = new Map<string, GranularOp[]>();
-const deckSaveSuccessHandlers = new Map<string, (ops: GranularOp[]) => void>();
 
 // The ops a deck's current in-flight save actually sent, so a slide-scoped
 // check can tell "this slide's save is in flight" from "some other slide in
@@ -630,13 +633,12 @@ function drainPendingDeckOps(
   const ops = pendingOpsQueue.get(deckId) ?? [];
   pendingOpsQueue.delete(deckId);
   if (ops.length === 0) {
-    deckSaveSuccessHandlers.delete(deckId);
     notifySaveListeners();
     return Promise.resolve();
   }
 
-  const onSaveSuccess = deckSaveSuccessHandlers.get(deckId);
-  deckSaveSuccessHandlers.delete(deckId);
+  const onSaveSuccess =
+    ops[0]?.op === "full-replace" ? ops[0].onSaveSuccess : undefined;
 
   const generation = deckSaveGenerations.get(deckId) ?? 0;
   const controller =
@@ -658,9 +660,13 @@ function drainPendingDeckOps(
       // resurrect the old queue or schedule a retry after the boundary.
       if (!isCurrentGeneration()) return;
       console.error(`Failed to save deck ${deckId}:`, err);
-      if (onSaveSuccess) deckSaveSuccessHandlers.set(deckId, onSaveSuccess);
       const pending = pendingOpsQueue.get(deckId) ?? [];
-      pendingOpsQueue.set(deckId, [...ops, ...pending]);
+      // A queued full replacement already includes the latest local snapshot,
+      // so retry it instead of sending an older replacement as a patch op.
+      pendingOpsQueue.set(
+        deckId,
+        pending[0]?.op === "full-replace" ? pending : [...ops, ...pending],
+      );
       const attempt = (deckSaveRetryAttempts.get(deckId) ?? 0) + 1;
       deckSaveRetryAttempts.set(deckId, attempt);
       immediateFlushRequests.delete(deckId);
@@ -746,9 +752,6 @@ function enqueueDeckOp(
     onSaveSuccess?: (ops: GranularOp[]) => void;
   },
 ) {
-  if (options?.onSaveSuccess) {
-    deckSaveSuccessHandlers.set(deckId, options.onSaveSuccess);
-  }
   const existing = pendingSaves.get(deckId);
   if (existing) clearTimeout(existing);
   if (
@@ -760,9 +763,11 @@ function enqueueDeckOp(
   }
 
   if (op.op === "full-replace") {
-    if (!options?.onSaveSuccess) deckSaveSuccessHandlers.delete(deckId);
+    const queuedOp = options?.onSaveSuccess
+      ? { ...op, onSaveSuccess: options.onSaveSuccess }
+      : op;
     // Discard any accumulated granular ops — this is a wholesale replacement
-    pendingOpsQueue.set(deckId, [op]);
+    pendingOpsQueue.set(deckId, [queuedOp]);
   } else {
     const queue = pendingOpsQueue.get(deckId) ?? [];
     const previous = queue[queue.length - 1];
@@ -828,7 +833,6 @@ function discardPendingDeckOps(deckId: string) {
   if (timer) clearTimeout(timer);
   pendingSaves.delete(deckId);
   pendingOpsQueue.delete(deckId);
-  deckSaveSuccessHandlers.delete(deckId);
   deckSaveRetryAttempts.delete(deckId);
   failedSaveDecks.delete(deckId);
   immediateFlushRequests.delete(deckId);
@@ -1958,6 +1962,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
 
   const resetDeckBaseline = useCallback(
     (nextDecks: Deck[], createSeqAtRequest: number) => {
+      // A baseline snapshot supersedes any in-flight light-list membership
+      // diff before it replaces local state.
+      ++deckListRequestIdRef.current;
       const reconciledDecks = nextDecks.map((deck) =>
         deck.previewSlide
           ? deck

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -763,6 +763,9 @@ function enqueueDeckOp(
   }
 
   if (op.op === "full-replace") {
+    // A newer snapshot supersedes any retry budget from the older write.
+    deckSaveRetryAttempts.delete(deckId);
+    failedSaveDecks.delete(deckId);
     const queuedOp = options?.onSaveSuccess
       ? { ...op, onSaveSuccess: options.onSaveSuccess }
       : op;
@@ -1528,6 +1531,9 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const pendingDuplicateSourceIdsRef = useRef<Set<string>>(new Set());
   const dirtyDeckIdsRef = useRef<Set<string>>(new Set());
   const deletedSlideTombstonesRef = useRef<Map<string, Set<string>>>(new Map());
+  const slideDeleteGenerationsRef = useRef<Map<string, Map<string, number>>>(
+    new Map(),
+  );
   const deckBaselineRequestIdRef = useRef(0);
   const deckListRequestIdRef = useRef(0);
   const openDeckRequestIdByDeckRef = useRef<Map<string, number>>(new Map());
@@ -1555,29 +1561,34 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     );
   }, []);
 
-  const markDeckDirty = useCallback((deckId: string) => {
-    lastExternalUpdateRef.current = 0;
-    dirtyDeckIdsRef.current.add(deckId);
-    if (failedSaveDecks.has(deckId)) {
-      const tombstones =
-        deletedSlideTombstonesRef.current.get(deckId) ?? new Set<string>();
-      for (const op of pendingOpsQueue.get(deckId) ?? []) {
-        if (op.op === "delete-slide") tombstones.add(op.slideId);
-      }
-      if (tombstones.size > 0) {
-        deletedSlideTombstonesRef.current.set(deckId, tombstones);
-      }
-    }
-  }, []);
-
   const markSlideDeleteTombstone = useCallback(
     (deckId: string, slideId: string) => {
+      const generations =
+        slideDeleteGenerationsRef.current.get(deckId) ??
+        new Map<string, number>();
+      generations.set(slideId, (generations.get(slideId) ?? 0) + 1);
+      slideDeleteGenerationsRef.current.set(deckId, generations);
       const tombstones =
         deletedSlideTombstonesRef.current.get(deckId) ?? new Set<string>();
       tombstones.add(slideId);
       deletedSlideTombstonesRef.current.set(deckId, tombstones);
     },
     [],
+  );
+
+  const markDeckDirty = useCallback(
+    (deckId: string) => {
+      lastExternalUpdateRef.current = 0;
+      dirtyDeckIdsRef.current.add(deckId);
+      if (failedSaveDecks.has(deckId)) {
+        for (const op of pendingOpsQueue.get(deckId) ?? []) {
+          if (op.op === "delete-slide") {
+            markSlideDeleteTombstone(deckId, op.slideId);
+          }
+        }
+      }
+    },
+    [markSlideDeleteTombstone],
   );
 
   const clearSlideDeleteTombstone = useCallback(
@@ -1597,10 +1608,18 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const clearReplacedSlideDeleteTombstones = useCallback(
-    (deckId: string, capturedTombstones: ReadonlySet<string>) => {
+    (deckId: string, capturedTombstones: ReadonlyMap<string, number>) => {
       const tombstones = deletedSlideTombstonesRef.current.get(deckId);
       if (!tombstones) return;
-      for (const slideId of capturedTombstones) tombstones.delete(slideId);
+      const generations = slideDeleteGenerationsRef.current.get(deckId);
+      for (const [slideId, generation] of capturedTombstones) {
+        if (
+          tombstones.has(slideId) &&
+          generations?.get(slideId) === generation
+        ) {
+          tombstones.delete(slideId);
+        }
+      }
       if (tombstones.size === 0) clearDeckDeleteTombstones(deckId);
     },
     [clearDeckDeleteTombstones],
@@ -1609,11 +1628,14 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   const captureReplacedSlideDeleteTombstones = useCallback(
     (deck: Deck) => {
       const tombstones = deletedSlideTombstonesRef.current.get(deck.id);
-      const capturedTombstones = new Set(
-        deck.slides
-          .map((slide) => slide.id)
-          .filter((slideId) => tombstones?.has(slideId) ?? false),
-      );
+      const generations = slideDeleteGenerationsRef.current.get(deck.id);
+      const capturedTombstones = new Map<string, number>();
+      for (const slide of deck.slides) {
+        const generation = generations?.get(slide.id);
+        if (tombstones?.has(slide.id) && generation !== undefined) {
+          capturedTombstones.set(slide.id, generation);
+        }
+      }
       return () =>
         clearReplacedSlideDeleteTombstones(deck.id, capturedTombstones);
     },
@@ -1632,15 +1654,28 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       if (!tombstones?.size) return server;
 
       const serverSlideIds = new Set(server.slides.map((slide) => slide.id));
+      const failedOps = failedSaveDecks.has(server.id)
+        ? (pendingOpsQueue.get(server.id) ?? [])
+        : [];
       const failedDeleteSlideIds = new Set(
-        failedSaveDecks.has(server.id)
-          ? (pendingOpsQueue.get(server.id) ?? [])
-              .filter((op) => op.op === "delete-slide")
-              .map((op) => op.slideId)
-          : [],
+        failedOps
+          .filter((op) => op.op === "delete-slide")
+          .map((op) => op.slideId),
       );
+      const failedFullReplace = failedOps.find(
+        (op): op is Extract<GranularOp, { op: "full-replace" }> =>
+          op.op === "full-replace",
+      );
+      const failedFullReplaceSlideIds = failedFullReplace
+        ? new Set(failedFullReplace.deck.slides.map((slide) => slide.id))
+        : null;
       for (const slideId of tombstones) {
-        if (failedDeleteSlideIds.has(slideId) || !serverSlideIds.has(slideId)) {
+        if (
+          failedDeleteSlideIds.has(slideId) ||
+          (failedFullReplaceSlideIds &&
+            !failedFullReplaceSlideIds.has(slideId)) ||
+          !serverSlideIds.has(slideId)
+        ) {
           tombstones.delete(slideId);
         }
       }

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -694,11 +694,7 @@ export default function DeckEditor() {
       if (!deck || !id) return;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      const oldIndex = deck.slides.findIndex((s) => s.id === active.id);
-      const newIndex = deck.slides.findIndex((s) => s.id === over.id);
-      if (oldIndex !== -1 && newIndex !== -1) {
-        reorderSlides(id, oldIndex, newIndex);
-      }
+      reorderSlides(id, String(active.id), String(over.id));
     },
     [deck, id, reorderSlides],
   );


### PR DESCRIPTION
## Summary
- Keep persisted text boxes in object selection on plain click while preserving double-click inline editing.
- Reorder slides by stable IDs and keep pending deletions out of stale reconciliation and reorder payloads.
- Preserve functional React state updates while projecting rapid reorder calls correctly.

## Verification
- Slides test suite: 171 files, 1,227 tests passed with the Node local-storage shim.
- Slides typecheck passed.
- Focused regressions passed: 5 files, 115 tests.
- Formatting and diff checks passed.
- `pnpm guards` has one pre-existing `guard:agent-native-brand` baseline failure in core docs/migrations; all other guards passed.
- Local browser verification confirmed persisted text-box plain-click selection, double-click editing, and thumbnail reorder surviving reload.

## Feedback
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787777765859189
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787777973509119