### PR TITLE
fix(slides): reduce editor toolbar height

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -515,7 +515,7 @@ export default function EditorToolbar({
   useEffect(() => registerEditorCommands(() => editorCommandsRef.current), []);
 
   return (
-    <div className="deck-editor-toolbar flex h-14 shrink-0 items-center gap-1 overflow-x-auto whitespace-nowrap bg-background px-2 sm:px-3">
+    <div className="deck-editor-toolbar flex h-12 shrink-0 items-center gap-1 overflow-x-auto whitespace-nowrap bg-background px-2 sm:px-3">
       {/* Back button */}
       <Tooltip>
         <TooltipTrigger asChild>


### PR DESCRIPTION
Reduce the Slides editor toolbar from h-14 to h-12.

Tests:
- corepack pnpm --dir templates/slides test -- app/components/editor/EditorToolbar.layout.test.ts
- 173 test files, 1,233 tests passed