### PR TITLE
fix: preserve Analytics dashboard creator metadata

### DIFF
--- a/templates/analytics/actions/get-explorer-dashboard.ts
+++ b/templates/analytics/actions/get-explorer-dashboard.ts
@@ -34,6 +34,7 @@ export default defineAction({
       orgId: dash.orgId,
       visibility: dash.visibility,
       createdAt: dash.createdAt,
+      createdBy: dash.createdBy,
       updatedAt: dash.updatedAt,
       updatedBy: dash.updatedBy,
       role: dash.role,

--- a/templates/analytics/actions/get-sql-dashboard.spec.ts
+++ b/templates/analytics/actions/get-sql-dashboard.spec.ts
@@ -89,7 +89,11 @@ describe("get-sql-dashboard seed fallback", () => {
   it("returns a saved empty dashboard instead of rehydrating its seed", async () => {
     mocks.getDashboard.mockResolvedValue({
       kind: "sql",
-      config: { name: "Blank", panels: [] },
+      config: {
+        name: "Blank",
+        panels: [],
+        createdBy: "spoof@example.com",
+      },
       ownerEmail: "alice@example.com",
       orgId: null,
       visibility: "private",
@@ -100,6 +104,7 @@ describe("get-sql-dashboard seed fallback", () => {
       hiddenAt: null,
       hiddenBy: null,
       createdAt: "2026-06-24T00:00:00.000Z",
+      createdBy: "alice@example.com",
       updatedAt: "2026-06-24T00:00:00.000Z",
     });
     mocks.loadDashboardSeed.mockReturnValue({
@@ -112,12 +117,14 @@ describe("get-sql-dashboard seed fallback", () => {
       layout: { panelOrder: string[] };
       name: string;
       ownerEmail: string | null;
+      createdBy: string | null;
     };
 
     expect(result.name).toBe("Blank");
     expect(result.panels).toEqual([]);
     expect(result.layout.panelOrder).toEqual([]);
     expect(result.ownerEmail).toBe("alice@example.com");
+    expect(result.createdBy).toBe("alice@example.com");
   });
 
   it("repairs legacy SQL when reading the persisted first-party dashboard", async () => {

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -118,8 +118,8 @@ const TAB_ID = generateTabId();
 
 type FetchedExplorerDashboard = {
   data: ExplorerDashboardData;
-  ownerEmail: string | null;
   createdAt: string | null;
+  createdBy: string | null;
   updatedAt: string | null;
   updatedBy: string | null;
   archivedAt: string | null;
@@ -152,8 +152,8 @@ async function fetchDashboard(
       name: raw.name ?? "Untitled Dashboard",
       charts: raw.charts ?? [],
     },
-    ownerEmail: typeof raw.ownerEmail === "string" ? raw.ownerEmail : null,
     createdAt: typeof raw.createdAt === "string" ? raw.createdAt : null,
+    createdBy: typeof raw.createdBy === "string" ? raw.createdBy : null,
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : null,
     updatedBy: typeof raw.updatedBy === "string" ? raw.updatedBy : null,
     archivedAt: typeof raw.archivedAt === "string" ? raw.archivedAt : null,
@@ -189,7 +189,9 @@ export default function ExplorerDashboardPage() {
   const [dashboard, setDashboard] = useState<ExplorerDashboardData | null>(
     null,
   );
-  const [dashboardOwner, setDashboardOwner] = useState<string | null>(null);
+  const [dashboardCreatedBy, setDashboardCreatedBy] = useState<string | null>(
+    null,
+  );
   const [dashboardCreatedAt, setDashboardCreatedAt] = useState<string | null>(
     null,
   );
@@ -345,7 +347,7 @@ export default function ExplorerDashboardPage() {
     if (!dashboardId) return;
     setLoaded(false);
     setDashboard(null);
-    setDashboardOwner(null);
+    setDashboardCreatedBy(null);
     setDashboardCreatedAt(null);
     setDashboardUpdatedAt(null);
     setDashboardUpdatedBy(null);
@@ -360,7 +362,7 @@ export default function ExplorerDashboardPage() {
     const d = dashboardQuery.data;
     if (d) {
       setDashboard(d.data);
-      setDashboardOwner(d.ownerEmail);
+      setDashboardCreatedBy(d.createdBy);
       setDashboardCreatedAt(d.createdAt);
       setDashboardUpdatedAt(d.updatedAt);
       setDashboardUpdatedBy(d.updatedBy);
@@ -377,7 +379,7 @@ export default function ExplorerDashboardPage() {
         name: t("explorerDashboard.untitledDashboard"),
         charts: [],
       });
-      setDashboardOwner(null);
+      setDashboardCreatedBy(null);
       setDashboardCreatedAt(null);
       setDashboardUpdatedAt(null);
       setDashboardUpdatedBy(null);
@@ -701,7 +703,7 @@ export default function ExplorerDashboardPage() {
                     <DropdownMenuLabel className="font-normal">
                       <DashboardMetadata
                         createdAt={dashboardCreatedAt}
-                        createdBy={dashboardOwner}
+                        createdBy={dashboardCreatedBy}
                         updatedAt={dashboardUpdatedAt}
                         updatedBy={dashboardUpdatedBy}
                       />

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -407,8 +407,8 @@ type FetchedDashboard = {
   hiddenAt: string | null;
   hiddenBy: string | null;
   visibility: "private" | "org" | "public";
-  ownerEmail: string | null;
   createdAt: string | null;
+  createdBy: string | null;
   updatedAt: string | null;
   updatedBy: string | null;
 } & ResourceAccess;
@@ -494,8 +494,8 @@ async function fetchDashboard(
         data.visibility === "org" || data.visibility === "public"
           ? data.visibility
           : "private",
-      ownerEmail: typeof data.ownerEmail === "string" ? data.ownerEmail : null,
       createdAt: typeof data.createdAt === "string" ? data.createdAt : null,
+      createdBy: typeof data.createdBy === "string" ? data.createdBy : null,
       updatedAt: typeof data.updatedAt === "string" ? data.updatedAt : null,
       updatedBy: typeof data.updatedBy === "string" ? data.updatedBy : null,
       role: typeof data.role === "string" ? data.role : undefined,
@@ -584,7 +584,9 @@ function SqlDashboardPageContent({
   const [dashboardVisibility, setDashboardVisibility] = useState<
     "private" | "org" | "public" | null
   >(null);
-  const [dashboardOwner, setDashboardOwner] = useState<string | null>(null);
+  const [dashboardCreatedBy, setDashboardCreatedBy] = useState<string | null>(
+    null,
+  );
   const [dashboardCreatedAt, setDashboardCreatedAt] = useState<string | null>(
     null,
   );
@@ -875,7 +877,7 @@ function SqlDashboardPageContent({
     setArchivedAt(null);
     setHiddenAt(null);
     setDashboardVisibility(null);
-    setDashboardOwner(null);
+    setDashboardCreatedBy(null);
     setDashboardCreatedAt(null);
     setDashboardUpdatedAt(null);
     setDashboardUpdatedBy(null);
@@ -922,7 +924,7 @@ function SqlDashboardPageContent({
     setArchivedAt(fetched?.archivedAt ?? null);
     setHiddenAt(fetched?.hiddenAt ?? null);
     setDashboardVisibility(fetchedVisibility);
-    setDashboardOwner(fetched?.ownerEmail ?? null);
+    setDashboardCreatedBy(fetched?.createdBy ?? null);
     setDashboardCreatedAt(fetched?.createdAt ?? null);
     setDashboardUpdatedAt(fetched?.updatedAt ?? null);
     setDashboardUpdatedBy(fetched?.updatedBy ?? null);
@@ -1682,14 +1684,11 @@ function SqlDashboardPageContent({
   const handleUnhide = useCallback(async () => {
     if (!dashboardId) return;
     try {
-      const result = (await hideDashboardAction({
+      await hideDashboardAction({
         id: dashboardId,
         hidden: false,
-      })) as { ownerEmail?: string | null } | undefined;
+      });
       setHiddenAt(null);
-      if (typeof result?.ownerEmail === "string") {
-        setDashboardOwner(result.ownerEmail);
-      }
       queryClient.invalidateQueries({
         queryKey: ["sql-dashboards-sidebar", dashboardScope],
       });
@@ -1952,7 +1951,7 @@ function SqlDashboardPageContent({
             <DropdownMenuLabel className="font-normal">
               <DashboardMetadata
                 createdAt={dashboardCreatedAt}
-                createdBy={dashboardOwner}
+                createdBy={dashboardCreatedBy}
                 updatedAt={dashboardUpdatedAt}
                 updatedBy={dashboardUpdatedBy}
               />

--- a/templates/analytics/changelog/2026-08-26-dashboard-metadata-now-shows-the-original-creator-separately.md
+++ b/templates/analytics/changelog/2026-08-26-dashboard-metadata-now-shows-the-original-creator-separately.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-26
+---
+
+Dashboard metadata now shows the original creator separately from the current owner

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -31,6 +31,8 @@ export const dashboards = table("dashboards", {
   /** Full dashboard config (SqlDashboardConfig or Explorer state) as JSON. */
   config: text("config").notNull(),
   createdAt: text("created_at").notNull().default(now()),
+  /** Original authenticated creator. Null when historical provenance is unknown. */
+  createdBy: text("created_by"),
   updatedAt: text("updated_at").notNull().default(now()),
   /** Archive timestamp. Null = active. Archived rows are hidden from
    *  default list responses but remain accessible by id and can be restored. */

--- a/templates/analytics/server/lib/agent-readable-resource-context.ts
+++ b/templates/analytics/server/lib/agent-readable-resource-context.ts
@@ -104,11 +104,14 @@ export function buildDashboardAgentContext(
     hiddenAt: dashboard.hiddenAt,
     hiddenBy: dashboard.hiddenBy,
     createdAt: dashboard.createdAt,
+    createdBy: dashboard.createdBy,
     updatedAt: dashboard.updatedAt,
     updatedBy: dashboard.updatedBy,
     url: `/dashboards/${dashboard.id}`,
   };
-  return options.includeConfig === false ? base : { ...base, ...config };
+  return options.includeConfig === false
+    ? base
+    : { ...base, ...config, createdBy: base.createdBy };
 }
 
 export function buildDashboardSeedAgentContext(
@@ -135,9 +138,12 @@ export function buildDashboardSeedAgentContext(
     archivedAt: null,
     hiddenAt: null,
     hiddenBy: null,
+    createdBy: null,
     url: `/dashboards/${id}`,
   };
-  return options.includeConfig === false ? base : { ...base, ...seed };
+  return options.includeConfig === false
+    ? base
+    : { ...base, ...seed, createdBy: base.createdBy };
 }
 
 export function buildAnalysisAgentContext(

--- a/templates/analytics/server/lib/dashboards-store.interleave.spec.ts
+++ b/templates/analytics/server/lib/dashboards-store.interleave.spec.ts
@@ -24,6 +24,7 @@ type DashboardRow = {
   orgId: string | null;
   visibility: string;
   createdAt: string;
+  createdBy: string | null;
   updatedAt: string;
   updatedBy: string | null;
   archivedAt: string | null;
@@ -52,6 +53,7 @@ function baseDashboard(): DashboardRow {
     orgId: null,
     visibility: "private",
     createdAt: "2026-07-09T00:00:00.000Z",
+    createdBy: "alice@example.com" as string | null,
     updatedAt: "2026-07-09T00:00:00.000Z",
     updatedBy: null,
     archivedAt: null,
@@ -70,6 +72,7 @@ const state = vi.hoisted(() => ({
     orgId: null as string | null,
     visibility: "private",
     createdAt: "2026-07-09T00:00:00.000Z",
+    createdBy: "alice@example.com" as string | null,
     updatedAt: "2026-07-09T00:00:00.000Z",
     updatedBy: null as string | null,
     archivedAt: null as string | null,
@@ -175,6 +178,7 @@ vi.mock("../db/index.js", () => {
       orgId: { name: "orgId" },
       visibility: { name: "visibility" },
       createdAt: { name: "createdAt" },
+      createdBy: { name: "createdBy" },
       updatedAt: { name: "updatedAt" },
       updatedBy: { name: "updatedBy" },
       archivedAt: { name: "archivedAt" },
@@ -232,6 +236,18 @@ vi.mock("../db/index.js", () => {
     }),
     insert: (table: unknown) => ({
       values: (row: any) => {
+        if (table === schema.dashboards) {
+          const timestamp = "2026-07-09T00:00:00.000Z";
+          state.otherDashboards.push({
+            archivedAt: null,
+            createdAt: timestamp,
+            createdBy: row.createdBy ?? null,
+            hiddenAt: null,
+            hiddenBy: null,
+            updatedAt: timestamp,
+            ...row,
+          });
+        }
         if (table === schema.dashboardRevisions) {
           state.revisions.push({ ...row });
         }
@@ -462,6 +478,30 @@ describe("dashboards-store concurrency", () => {
     ).resolves.toBeDefined();
     expect(existing).not.toBeNull();
     expect(readPanelIds()).toEqual(["a", "legacy"]);
+  });
+
+  it("keeps the original creator unchanged when another user edits the dashboard", async () => {
+    await upsertDashboard(
+      "traffic",
+      "sql",
+      { name: "Traffic", panels: [panel("a"), panel("editor")] },
+      { email: "bob@example.com", orgId: null },
+    );
+
+    expect(state.dashboard.createdBy).toBe("alice@example.com");
+    expect(state.dashboard.updatedBy).toBe("bob@example.com");
+  });
+
+  it("records the authenticated user as creator on dashboard creation", async () => {
+    const saved = await upsertDashboard(
+      "new-dashboard",
+      "sql",
+      { name: "New dashboard", panels: [] },
+      { email: "bob@example.com", orgId: null },
+    );
+
+    expect(saved.createdBy).toBe("bob@example.com");
+    expect(state.otherDashboards[0]?.createdBy).toBe("bob@example.com");
   });
 
   it("upsertDashboardWithRetry re-reads and re-applies the mutation after losing the race, landing both writers' panels", async () => {

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -53,6 +53,7 @@ export interface DashboardRecord {
   orgId: string | null;
   visibility: "private" | "org" | "public";
   createdAt: string;
+  createdBy: string | null;
   updatedAt: string;
   updatedBy: string | null;
   /** ISO timestamp set when the dashboard is archived. Null = active. */
@@ -467,6 +468,7 @@ function rowToDashboard(row: any, role?: AccessRole): DashboardRecord {
     orgId: row.orgId ?? null,
     visibility: row.visibility,
     createdAt: row.createdAt,
+    createdBy: row.createdBy ?? null,
     updatedAt: row.updatedAt,
     updatedBy: row.updatedBy ?? null,
     archivedAt: row.archivedAt ?? null,
@@ -546,6 +548,7 @@ async function migrateDashboardFromSettings(
     (typeof (settingsValue as any).updatedAt === "string" &&
       (settingsValue as any).updatedAt) ||
     createdAt;
+  const createdBy = visibility === "private" ? ownerEmail : null;
   await db
     .insert(schema.dashboards)
     .values({
@@ -557,6 +560,7 @@ async function migrateDashboardFromSettings(
       orgId,
       visibility,
       createdAt,
+      createdBy,
       updatedAt,
       updatedBy: ownerEmail,
     })
@@ -1389,6 +1393,7 @@ export async function upsertDashboard(
         ownerEmail: ctx.email,
         orgId: ctx.orgId,
         visibility: "private",
+        createdBy: ctx.email,
         updatedBy: ctx.email,
       });
     }

--- a/templates/analytics/server/lib/migrate-analytics-artifacts.ts
+++ b/templates/analytics/server/lib/migrate-analytics-artifacts.ts
@@ -761,7 +761,7 @@ export async function migrateAnalyticsArtifacts(
           orgId: row.orgId,
           visibility: row.visibility,
           createdAt: row.createdAt,
-          createdBy: null,
+          createdBy: row.visibility === "private" ? row.ownerEmail : null,
           updatedAt: row.updatedAt,
           updatedBy: ctx.userEmail,
           archivedAt: row.archivedAt,
@@ -931,6 +931,8 @@ export async function migrateAnalyticsArtifacts(
           orgId: analysis.orgId,
           visibility: analysis.visibility,
           createdAt: analysis.createdAt,
+          createdBy:
+            analysis.visibility === "private" ? analysis.ownerEmail : null,
           updatedAt: now,
           updatedBy: ctx.userEmail,
           hiddenAt: analysis.hiddenAt,
@@ -995,6 +997,8 @@ export async function migrateAnalyticsArtifacts(
           orgId: extension.orgId,
           visibility: extension.visibility,
           createdAt: extension.createdAt,
+          createdBy:
+            extension.visibility === "private" ? extension.ownerEmail : null,
           updatedAt: now,
           updatedBy: ctx.userEmail,
           hiddenAt: extension.hiddenAt,

--- a/templates/analytics/server/lib/migrate-analytics-artifacts.ts
+++ b/templates/analytics/server/lib/migrate-analytics-artifacts.ts
@@ -761,6 +761,7 @@ export async function migrateAnalyticsArtifacts(
           orgId: row.orgId,
           visibility: row.visibility,
           createdAt: row.createdAt,
+          createdBy: null,
           updatedAt: row.updatedAt,
           updatedBy: ctx.userEmail,
           archivedAt: row.archivedAt,

--- a/templates/analytics/server/lib/migrate-analytics-artifacts.ts
+++ b/templates/analytics/server/lib/migrate-analytics-artifacts.ts
@@ -8,7 +8,7 @@ import {
 } from "@agent-native/core/db/schema";
 import { recordChange } from "@agent-native/core/server";
 import { listOrgSettings } from "@agent-native/core/settings";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -750,6 +750,7 @@ export async function migrateAnalyticsArtifacts(
   }
   await db.transaction(async (tx: any) => {
     for (const row of state.dashboards) {
+      const createdBy = row.visibility === "private" ? row.ownerEmail : null;
       await tx
         .insert(schema.dashboards)
         .values({
@@ -761,7 +762,7 @@ export async function migrateAnalyticsArtifacts(
           orgId: row.orgId,
           visibility: row.visibility,
           createdAt: row.createdAt,
-          createdBy: row.visibility === "private" ? row.ownerEmail : null,
+          createdBy,
           updatedAt: row.updatedAt,
           updatedBy: ctx.userEmail,
           archivedAt: row.archivedAt,
@@ -769,6 +770,18 @@ export async function migrateAnalyticsArtifacts(
           hiddenBy: null,
         })
         .onConflictDoNothing();
+      if (createdBy) {
+        await tx
+          .update(schema.dashboards)
+          .set({ createdBy })
+          .where(
+            and(
+              eq(schema.dashboards.id, row.id),
+              eq(schema.dashboards.orgId, row.orgId),
+              isNull(schema.dashboards.createdBy),
+            ),
+          );
+      }
     }
     for (const row of state.analyses) {
       await tx

--- a/templates/analytics/server/plugins/db.spec.ts
+++ b/templates/analytics/server/plugins/db.spec.ts
@@ -312,7 +312,6 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
     expect(migration).toContain(
       "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
     );
-    expect(migration).not.toContain("UPDATE dashboards");
   });
 
   it("stores BigQuery backfill progress in additive PostgreSQL and SQLite shard tables", () => {

--- a/templates/analytics/server/plugins/db.spec.ts
+++ b/templates/analytics/server/plugins/db.spec.ts
@@ -301,6 +301,20 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
     expect(repairEntry).toContain("repairAnalyticsEventCursorIndexes");
   });
 
+  it("adds nullable dashboard creator provenance without rewriting existing rows", () => {
+    const migrationStart = dbTsSource.indexOf("version: 147,");
+    const migrationEnd = dbTsSource.indexOf("\n    },", migrationStart);
+    const migration = dbTsSource.slice(migrationStart, migrationEnd);
+
+    expect(migrationStart).toBeGreaterThan(-1);
+    expect(migrationEnd).toBeGreaterThan(migrationStart);
+    expect(migration).toContain('name: "analytics-dashboard-created-by"');
+    expect(migration).toContain(
+      "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
+    );
+    expect(migration).not.toContain("UPDATE dashboards");
+  });
+
   it("stores BigQuery backfill progress in additive PostgreSQL and SQLite shard tables", () => {
     const shardStart = dbTsSource.indexOf("version: 142,");
     const shardEnd = dbTsSource.indexOf("\n    },", shardStart);

--- a/templates/analytics/server/plugins/db.spec.ts
+++ b/templates/analytics/server/plugins/db.spec.ts
@@ -312,6 +312,9 @@ describe("analytics db.ts wires ensureAdditiveColumns after runMigrations", () =
     expect(migration).toContain(
       "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
     );
+    expect(migration).toContain(
+      'sqlite: "ALTER TABLE dashboards ADD COLUMN created_by TEXT"',
+    );
   });
 
   it("stores BigQuery backfill progress in additive PostgreSQL and SQLite shard tables", () => {

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -1806,8 +1806,7 @@ export const runAnalyticsMigrations = runMigrations(
       sql: {
         postgres:
           "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
-        sqlite:
-          "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
+        sqlite: "ALTER TABLE dashboards ADD COLUMN created_by TEXT",
       },
     },
   ],

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -163,6 +163,7 @@ export const runAnalyticsMigrations = runMigrations(
       title TEXT NOT NULL DEFAULT 'Untitled',
       config TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_by TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       owner_email TEXT NOT NULL DEFAULT 'local@localhost',
       org_id TEXT,
@@ -1797,6 +1798,16 @@ export const runAnalyticsMigrations = runMigrations(
       sql: {
         postgres: "SELECT 1",
         sqlite: "SELECT 1",
+      },
+    },
+    {
+      version: 147,
+      name: "analytics-dashboard-created-by",
+      sql: {
+        postgres:
+          "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
+        sqlite:
+          "ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS created_by TEXT",
       },
     },
   ],

--- a/templates/analytics/server/routes/api/dashboard-agent-context.json.get.ts
+++ b/templates/analytics/server/routes/api/dashboard-agent-context.json.get.ts
@@ -52,6 +52,7 @@ function rowToDashboard(row: any): DashboardRecord {
     orgId: row.orgId ?? null,
     visibility: row.visibility,
     createdAt: row.createdAt,
+    createdBy: row.createdBy ?? null,
     updatedAt: row.updatedAt,
     updatedBy: row.updatedBy ?? null,
     archivedAt: row.archivedAt ?? null,


### PR DESCRIPTION
## Summary

- store immutable Analytics dashboard creator provenance separately from owner and editor metadata
- preserve creator data through dashboard actions, agent context, API context, and both dashboard pages
- keep legacy org-scoped rows untracked when historical creator provenance is unavailable
- add the additive migration, focused regressions, and a user-facing changelog entry

## Feedback followup

| Item | Disposition |
| --- | --- |
| [Analytics Created by](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p178759125761?thread_ts=1787591257.089749&cid=C0ATH3CCZT4) | Fixed in this PR. Saya confirmed the label means original creator. |
| [Analytics prompt mix-up](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787696808018829) | Prior fix is in beta. Production still needs manual promotion. |
| [Analytics list markers](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787694041790599) | Prior fix is in beta. Production still needs manual promotion. |
| [Desktop sign out](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787695732412159) | Prior fix is in the latest nightly build. |
| Content blank body | Owned by Alice per the feedback workflow. |

## Verification

- corepack pnpm exec vitest run server/lib/dashboards-store.interleave.spec.ts actions/get-sql-dashboard.spec.ts server/plugins/db.spec.ts
- 68 tests passed
- corepack pnpm typecheck passed
- corepack pnpm guard:agent-native-brand passed
- source and beta evidence are separate from production live state; beta Analytics run 33025945045 passed, while production still serves pre-fix Analytics bundles