### PR TITLE
fix: align Slides editing presence badges

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
+++ b/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
@@ -36,9 +36,9 @@ describe("EditorToolbar layout contract", () => {
     );
   });
 
-  it("right-aligns the AI presence indicator with the editor actions", () => {
+  it("keeps the AI presence indicator adjacent to the editor actions", () => {
     expect(editorToolbarSource).toContain(
-      'className="ml-auto flex-shrink-0 mr-0.5 pl-2"',
+      'className="flex-shrink-0 mr-0.5 pl-2"',
     );
   });
 

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -615,7 +615,7 @@ export default function EditorToolbar({
         agentActive={agentActive}
         showAgentEditingDot={false}
         currentUserEmail={currentUserEmail}
-        className="ml-auto flex-shrink-0 mr-0.5 pl-2"
+        className="flex-shrink-0 mr-0.5 pl-2"
       />
 
       {/* Consolidated editor menu */}


### PR DESCRIPTION
Aligns the Slides AI editing and collaborator presence badges directly before the overflow menu by removing the competing auto margin.

Validation:
- corepack pnpm --dir templates/slides exec vitest --run app/components/editor/EditorToolbar.layout.test.ts app/components/editor/EditorToolbar.test.tsx
- git diff --check