### PR TITLE
fix: repair duplicate slide IDs in Slides decks

### DIFF
--- a/templates/slides/actions/add-deck.ts
+++ b/templates/slides/actions/add-deck.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { assertHumanReadableDeckTitle } from "../shared/deck-title.js";
+import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
 import {
   assertDesignSystemReadable,
   assertValidAspectRatio,
@@ -37,6 +38,11 @@ export default defineAction({
   agentTool: false,
   run: async (args) => {
     const deck = args.deck as DeckPayload;
+    if (Array.isArray(deck.slides)) {
+      deck.slides = ensureUniqueSlideIds(
+        deck.slides as Array<{ id?: unknown }>,
+      ).slides;
+    }
     const id = deck.id;
     if (typeof id !== "string" || !id) {
       throw deckHttpError(400, "Deck must have an id");

--- a/templates/slides/actions/add-deck.ts
+++ b/templates/slides/actions/add-deck.ts
@@ -17,7 +17,10 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyClients } from "../server/handlers/decks.js";
 import { assertHumanReadableDeckTitle } from "../shared/deck-title.js";
-import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
+import {
+  ensureUniqueSlideIds,
+  repairDeckSlideReferences,
+} from "../shared/slide-ids.js";
 import {
   assertDesignSystemReadable,
   assertValidAspectRatio,
@@ -39,9 +42,20 @@ export default defineAction({
   run: async (args) => {
     const deck = args.deck as DeckPayload;
     if (Array.isArray(deck.slides)) {
-      deck.slides = ensureUniqueSlideIds(
+      const normalized = ensureUniqueSlideIds(
         deck.slides as Array<{ id?: unknown }>,
-      ).slides;
+      );
+      deck.slides = normalized.slides;
+      if (normalized.changed) {
+        Object.assign(
+          deck,
+          repairDeckSlideReferences(
+            deck,
+            normalized.slides,
+            normalized.originalIds,
+          ),
+        );
+      }
     }
     const id = deck.id;
     if (typeof id !== "string" || !id) {

--- a/templates/slides/actions/create-deck.test.ts
+++ b/templates/slides/actions/create-deck.test.ts
@@ -267,4 +267,38 @@ describe("create-deck — aspectRatio", () => {
     expect(result.slides.map((slide) => slide.id)).toEqual(ids);
     expect(data.slides[1].content).toBe("<div>Second</div>");
   });
+
+  it("rebinds slide-scoped Creative Context labels when repairing IDs", async () => {
+    const label = {
+      itemId: "item-1",
+      itemVersionId: "version-1",
+      kind: "slide",
+      label: "Referenced slide",
+      dataRole: "untrusted-reference" as const,
+      elementId: "slide-a",
+    };
+    const result = await action.run({
+      title: "T",
+      slides: [
+        {
+          id: "slide-a",
+          content: "<div>First</div>",
+          creativeContextReuseLabels: [label],
+        },
+        {
+          id: "slide-a",
+          content: "<div>Second</div>",
+          creativeContextReuseLabels: [label],
+        },
+      ],
+    });
+    const ids = result.slides.map((slide) => slide.id);
+
+    expect(result.slides[0].creativeContextReuseLabels?.[0].elementId).toBe(
+      "slide-a",
+    );
+    expect(result.slides[1].creativeContextReuseLabels?.[0].elementId).toBe(
+      ids[1],
+    );
+  });
 });

--- a/templates/slides/actions/create-deck.test.ts
+++ b/templates/slides/actions/create-deck.test.ts
@@ -251,4 +251,20 @@ describe("create-deck — aspectRatio", () => {
     });
     expect(data.slides[0].content).toBe("<div>Slide</div>");
   });
+
+  it("repairs duplicate slide IDs before persisting a deck", async () => {
+    const result = await action.run({
+      title: "T",
+      slides: [
+        { id: "slide-a", content: "<div>First</div>" },
+        { id: "slide-a", content: "<div>Second</div>" },
+      ],
+    });
+    const data = JSON.parse(insertedRow!.data as string);
+    const ids = data.slides.map((slide: { id: string }) => slide.id);
+
+    expect(new Set(ids).size).toBe(2);
+    expect(result.slides.map((slide) => slide.id)).toEqual(ids);
+    expect(data.slides[1].content).toBe("<div>Second</div>");
+  });
 });

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -24,6 +24,7 @@ import {
   assertHumanReadableDeckTitle,
   repairGeneratedDeckTitle,
 } from "../shared/deck-title.js";
+import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
 import { getDeckUrl } from "./_app-url.js";
 
 const ReuseLabelSchema = z
@@ -159,6 +160,12 @@ export default defineAction({
   }) => {
     const db = getDb();
     const now = new Date().toISOString();
+    const { slides } = ensureUniqueSlideIds(
+      rawSlides.map((s) => ({
+        ...s,
+        content: normalizeSlidePadding(s.content),
+      })),
+    );
     const validatedCreativeContext = await validateGenerationCreativeContext({
       contextPackId,
       contextModeOverride,
@@ -166,7 +173,7 @@ export default defineAction({
         new Map(
           [
             ...reuseLabels,
-            ...rawSlides.flatMap(
+            ...slides.flatMap(
               (slide) => slide.creativeContextReuseLabels ?? [],
             ),
           ].map((label) => [`${label.itemId}:${label.itemVersionId}`, label]),
@@ -186,7 +193,7 @@ export default defineAction({
         ...(label.itemVersionId ? { itemVersionId: label.itemVersionId } : {}),
         label: label.label,
       })),
-      ...rawSlides.flatMap((slide) => {
+      ...slides.flatMap((slide) => {
         const labels = slide.creativeContextReuseLabels ?? [];
         return labels.length
           ? labels.map((label) => ({
@@ -206,7 +213,7 @@ export default defineAction({
               },
             ];
       }),
-      ...(reuseLabels.length === 0 && rawSlides.length === 0
+      ...(reuseLabels.length === 0 && slides.length === 0
         ? [
             {
               elementId: "deck",
@@ -217,10 +224,6 @@ export default defineAction({
         : []),
     ];
 
-    const slides = rawSlides.map((s) => ({
-      ...s,
-      content: normalizeSlidePadding(s.content),
-    }));
     const firstSlideContent = slides[0]?.content;
     const resolvedTitle =
       repairGeneratedDeckTitle(title, firstSlideContent) ?? title;

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -24,7 +24,10 @@ import {
   assertHumanReadableDeckTitle,
   repairGeneratedDeckTitle,
 } from "../shared/deck-title.js";
-import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
+import {
+  ensureUniqueSlideIds,
+  rebindCreativeContextSlideLabels,
+} from "../shared/slide-ids.js";
 import { getDeckUrl } from "./_app-url.js";
 
 const ReuseLabelSchema = z
@@ -160,11 +163,15 @@ export default defineAction({
   }) => {
     const db = getDb();
     const now = new Date().toISOString();
-    const { slides } = ensureUniqueSlideIds(
+    const normalizedSlides = ensureUniqueSlideIds(
       rawSlides.map((s) => ({
         ...s,
         content: normalizeSlidePadding(s.content),
       })),
+    );
+    const slides = rebindCreativeContextSlideLabels(
+      normalizedSlides.slides,
+      normalizedSlides.originalIds,
     );
     const validatedCreativeContext = await validateGenerationCreativeContext({
       contextPackId,

--- a/templates/slides/actions/get-deck.test.ts
+++ b/templates/slides/actions/get-deck.test.ts
@@ -3,7 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockResolveAccess = vi.fn();
 const mockNotifyClients = vi.fn();
 let updatedFields: { data?: string; updatedAt?: string } | undefined;
-const mockWhereUpdate = vi.fn(async () => undefined);
+let currentResource:
+  | { data: string; updatedAt: string; [key: string]: unknown }
+  | undefined;
+const mockWhereUpdate = vi.fn(async () => {
+  if (updatedFields && currentResource) {
+    currentResource.data = updatedFields.data ?? currentResource.data;
+    currentResource.updatedAt =
+      updatedFields.updatedAt ?? currentResource.updatedAt;
+  }
+});
 const mockSet = vi.fn((fields: { data?: string; updatedAt?: string }) => {
   updatedFields = fields;
   return { where: mockWhereUpdate };
@@ -21,7 +30,7 @@ vi.mock("@agent-native/core/server/request-context", () => ({
 
 vi.mock("../server/db/index.js", () => ({
   getDb: () => mockDb,
-  schema: { decks: { id: "id_col" } },
+  schema: { decks: { id: "id_col", data: "data_col", updatedAt: "ua_col" } },
 }));
 
 vi.mock("../server/handlers/decks.js", () => ({
@@ -37,32 +46,33 @@ import action from "./get-deck";
 beforeEach(() => {
   vi.clearAllMocks();
   updatedFields = undefined;
-  mockResolveAccess.mockResolvedValue({
-    resource: {
-      id: "deck-1",
+  currentResource = {
+    id: "deck-1",
+    title: "Quarterly Review",
+    visibility: "private",
+    ownerEmail: "Alice@Example.com",
+    designSystemId: null,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-02T00:00:00.000Z",
+    data: JSON.stringify({
       title: "Quarterly Review",
-      visibility: "private",
-      ownerEmail: "Alice@Example.com",
-      designSystemId: null,
-      createdAt: "2026-05-01T00:00:00.000Z",
-      updatedAt: "2026-05-02T00:00:00.000Z",
-      data: JSON.stringify({
-        title: "Quarterly Review",
-        slides: [
-          {
-            id: "slide-a",
-            layout: "title",
-            content: "<h1>Opening</h1>",
-          },
-          {
-            id: "slide-b",
-            layout: "content",
-            content: "<p>Metrics</p>",
-          },
-        ],
-      }),
-    },
-  });
+      slides: [
+        {
+          id: "slide-a",
+          layout: "title",
+          content: "<h1>Opening</h1>",
+        },
+        {
+          id: "slide-b",
+          layout: "content",
+          content: "<p>Metrics</p>",
+        },
+      ],
+    }),
+  };
+  mockResolveAccess.mockImplementation(async () => ({
+    resource: currentResource,
+  }));
 });
 
 describe("get-deck", () => {
@@ -92,22 +102,53 @@ describe("get-deck", () => {
   });
 
   it("repairs duplicate persisted slide IDs before returning the deck", async () => {
-    mockResolveAccess.mockResolvedValue({
-      resource: {
-        id: "deck-1",
+    currentResource = {
+      id: "deck-1",
+      title: "Quarterly Review",
+      visibility: "private",
+      ownerEmail: "Alice@Example.com",
+      updatedAt: "2026-05-02T00:00:00.000Z",
+      data: JSON.stringify({
         title: "Quarterly Review",
-        visibility: "private",
-        ownerEmail: "Alice@Example.com",
-        updatedAt: "2026-05-02T00:00:00.000Z",
-        data: JSON.stringify({
-          title: "Quarterly Review",
+        slides: [
+          {
+            id: "slide-a",
+            content: "<h1>First</h1>",
+            creativeContextReuseLabels: [
+              {
+                itemId: "item-1",
+                itemVersionId: "version-1",
+                kind: "slide",
+                label: "First slide",
+                dataRole: "untrusted-reference",
+                elementId: "slide-a",
+              },
+            ],
+          },
+          {
+            id: "slide-a",
+            content: "<h1>Second</h1>",
+            creativeContextReuseLabels: [
+              {
+                itemId: "item-2",
+                itemVersionId: "version-2",
+                kind: "slide",
+                label: "Second slide",
+                dataRole: "untrusted-reference",
+                elementId: "slide-a",
+              },
+            ],
+          },
+        ],
+        sourceImport: {
+          slideIds: ["slide-a", "slide-a"],
           slides: [
-            { id: "slide-a", content: "<h1>First</h1>" },
-            { id: "slide-a", content: "<h1>Second</h1>" },
+            { id: "slide-a", source: "first" },
+            { id: "slide-a", source: "second" },
           ],
-        }),
-      },
-    });
+        },
+      }),
+    };
 
     const result = (await action.run(
       { id: "deck-1" },
@@ -119,13 +160,27 @@ describe("get-deck", () => {
     expect(new Set(ids).size).toBe(2);
     expect(result.slides[0].id).toBe("slide-a");
     expect(result.slides[1].content).toBe("<h1>Second</h1>");
+    expect(result.slides[1].creativeContextReuseLabels[0].elementId).toBe(
+      ids[1],
+    );
     expect(updatedFields?.data).toBeDefined();
+    const persisted = JSON.parse(updatedFields!.data!);
+    expect(persisted.slides.map((slide: { id: string }) => slide.id)).toEqual(
+      ids,
+    );
+    expect(persisted.sourceImport.slideIds).toEqual(ids);
     expect(
-      JSON.parse(updatedFields!.data!).slides.map(
-        (slide: { id: string }) => slide.id,
-      ),
+      persisted.sourceImport.slides.map((slide: { id: string }) => slide.id),
     ).toEqual(ids);
     expect(mockNotifyClients).toHaveBeenCalledWith("deck-1");
+  });
+
+  it("rejects malformed persisted slide entries explicitly", async () => {
+    currentResource!.data = JSON.stringify({ slides: [null] });
+
+    await expect(
+      action.run({ id: "deck-1" }, { caller: "frontend" }),
+    ).rejects.toThrow("Slide 1 must be an object.");
   });
 
   it("defaults agent calls to compact output so full slide HTML is not retransmitted", async () => {

--- a/templates/slides/actions/get-deck.test.ts
+++ b/templates/slides/actions/get-deck.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockResolveAccess = vi.fn();
+const mockNotifyClients = vi.fn();
+let updatedFields: { data?: string; updatedAt?: string } | undefined;
+const mockWhereUpdate = vi.fn(async () => undefined);
+const mockSet = vi.fn((fields: { data?: string; updatedAt?: string }) => {
+  updatedFields = fields;
+  return { where: mockWhereUpdate };
+});
+const mockUpdate = vi.fn(() => ({ set: mockSet }));
+const mockDb = { update: mockUpdate };
 
 vi.mock("@agent-native/core/sharing", () => ({
   resolveAccess: (...args: unknown[]) => mockResolveAccess(...args),
@@ -10,12 +19,24 @@ vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserEmail: () => "alice@example.com",
 }));
 
-vi.mock("../server/db/index.js", () => ({}));
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema: { decks: { id: "id_col" } },
+}));
+
+vi.mock("../server/handlers/decks.js", () => ({
+  notifyClients: (...args: unknown[]) => mockNotifyClients(...args),
+}));
+
+vi.mock("./patch-deck.js", () => ({
+  withDeckLock: (_deckId: string, run: () => Promise<unknown>) => run(),
+}));
 
 import action from "./get-deck";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  updatedFields = undefined;
   mockResolveAccess.mockResolvedValue({
     resource: {
       id: "deck-1",
@@ -68,6 +89,43 @@ describe("get-deck", () => {
     });
     expect(result.createdByMe).toBe(true);
     expect(result.slides[0]).not.toHaveProperty("index");
+  });
+
+  it("repairs duplicate persisted slide IDs before returning the deck", async () => {
+    mockResolveAccess.mockResolvedValue({
+      resource: {
+        id: "deck-1",
+        title: "Quarterly Review",
+        visibility: "private",
+        ownerEmail: "Alice@Example.com",
+        updatedAt: "2026-05-02T00:00:00.000Z",
+        data: JSON.stringify({
+          title: "Quarterly Review",
+          slides: [
+            { id: "slide-a", content: "<h1>First</h1>" },
+            { id: "slide-a", content: "<h1>Second</h1>" },
+          ],
+        }),
+      },
+    });
+
+    const result = (await action.run(
+      { id: "deck-1" },
+      { caller: "frontend" },
+    )) as any;
+    const ids = result.slides.map((slide: { id: string }) => slide.id);
+
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    expect(result.slides[0].id).toBe("slide-a");
+    expect(result.slides[1].content).toBe("<h1>Second</h1>");
+    expect(updatedFields?.data).toBeDefined();
+    expect(
+      JSON.parse(updatedFields!.data!).slides.map(
+        (slide: { id: string }) => slide.id,
+      ),
+    ).toEqual(ids);
+    expect(mockNotifyClients).toHaveBeenCalledWith("deck-1");
   });
 
   it("defaults agent calls to compact output so full slide HTML is not retransmitted", async () => {

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -2,7 +2,7 @@ import { defineAction, embedApp } from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -11,8 +11,79 @@ import { formatSlideHtml } from "../server/lib/slide-content-patch.js";
 import { summarizeSlideAnimationTargets } from "../server/lib/validate-slide-animations.js";
 import { normalizeOwnerEmail } from "../shared/ownership.js";
 import { hashSlideContent } from "../shared/slide-fit.js";
-import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
+import {
+  ensureUniqueSlideIds,
+  repairDeckSlideReferences,
+} from "../shared/slide-ids.js";
 import { withDeckLock } from "./patch-deck.js";
+
+const MAX_REPAIR_ATTEMPTS = 3;
+
+async function readDeck(deckId: string) {
+  const access = await resolveAccess("deck", deckId);
+  if (!access) {
+    // 404 rather than 403/500 so HTTP callers can't probe for decks they
+    // can't see, and so the slide preview can tell "missing" from "broken".
+    throw Object.assign(new Error("Deck not found"), { statusCode: 404 });
+  }
+
+  const row = access.resource;
+  const data = JSON.parse(row.data);
+  const normalized = ensureUniqueSlideIds(
+    Array.isArray(data?.slides) ? data.slides : [],
+  );
+  return { row, data, ...normalized };
+}
+
+async function loadDeckWithUniqueSlideIds(deckId: string) {
+  for (let attempt = 0; attempt < MAX_REPAIR_ATTEMPTS; attempt += 1) {
+    const snapshot = await readDeck(deckId);
+    if (!snapshot.changed) return { ...snapshot, repaired: false };
+
+    const repaired = await withDeckLock(deckId, async () => {
+      const lockedSnapshot = await readDeck(deckId);
+      if (!lockedSnapshot.changed) {
+        return { ...lockedSnapshot, repaired: false };
+      }
+
+      const repairedData = {
+        ...repairDeckSlideReferences(
+          lockedSnapshot.data,
+          lockedSnapshot.slides,
+          lockedSnapshot.originalIds,
+        ),
+        updatedAt: new Date().toISOString(),
+      };
+      const versionCondition =
+        lockedSnapshot.row.updatedAt == null
+          ? isNull(schema.decks.updatedAt)
+          : eq(schema.decks.updatedAt, lockedSnapshot.row.updatedAt);
+      await getDb()
+        .update(schema.decks)
+        .set({
+          data: JSON.stringify(repairedData),
+          updatedAt: repairedData.updatedAt,
+        })
+        .where(
+          and(
+            eq(schema.decks.id, lockedSnapshot.row.id),
+            versionCondition,
+            eq(schema.decks.data, lockedSnapshot.row.data),
+          ),
+        );
+
+      const confirmed = await readDeck(deckId);
+      return confirmed.changed ? null : { ...confirmed, repaired: true };
+    });
+
+    if (repaired) {
+      if (repaired.repaired) notifyClients(deckId);
+      return repaired;
+    }
+  }
+
+  throw new Error(`Could not repair duplicate slide IDs for deck ${deckId}.`);
+}
 
 function stripHtml(html: string): string {
   return html
@@ -106,137 +177,109 @@ export default defineAction({
       throw new Error("--id is required.");
     }
 
-    return withDeckLock(args.id, async () => {
-      const access = await resolveAccess("deck", args.id!);
-      if (!access) {
-        // 404 rather than 403/500 so HTTP callers can't probe for decks they
-        // can't see, and so the slide preview can tell "missing" from "broken".
-        throw Object.assign(new Error("Deck not found"), { statusCode: 404 });
-      }
+    const { row, data, slides } = await loadDeckWithUniqueSlideIds(args.id);
+    const ownerEmail = getRequestUserEmail();
+    const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);
+    const selectedSlideIndex =
+      args.slideId === undefined
+        ? -1
+        : slides.findIndex((slide: any) => slide?.id === args.slideId);
 
-      const row = access.resource;
-      let data = JSON.parse(row.data);
-      const { slides, changed } = ensureUniqueSlideIds(
-        Array.isArray(data?.slides) ? data.slides : [],
-      );
-      let updatedAt = row.updatedAt;
-      if (changed) {
-        const now = new Date().toISOString();
-        data = {
-          ...(data && typeof data === "object" ? data : {}),
-          slides,
-          updatedAt: now,
-        };
-        await getDb()
-          .update(schema.decks)
-          .set({ data: JSON.stringify(data), updatedAt: now })
-          .where(eq(schema.decks.id, row.id));
-        updatedAt = now;
-        notifyClients(row.id);
-      }
-      const ownerEmail = getRequestUserEmail();
-      const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);
-      const selectedSlideIndex =
-        args.slideId === undefined
-          ? -1
-          : slides.findIndex((slide: any) => slide?.id === args.slideId);
+    if (args.slideId !== undefined && selectedSlideIndex < 0) {
+      throw Object.assign(new Error(`Slide not found: ${args.slideId}`), {
+        statusCode: 404,
+      });
+    }
 
-      if (args.slideId !== undefined && selectedSlideIndex < 0) {
-        throw Object.assign(new Error(`Slide not found: ${args.slideId}`), {
-          statusCode: 404,
-        });
-      }
+    const selectedSlide =
+      selectedSlideIndex >= 0 ? slides[selectedSlideIndex] : null;
+    const slideEntries: Array<{ slide: any; index: number }> =
+      selectedSlideIndex >= 0
+        ? [{ slide: selectedSlide, index: selectedSlideIndex }]
+        : slides.map((slide: any, index: number) => ({ slide, index }));
 
-      const selectedSlide =
-        selectedSlideIndex >= 0 ? slides[selectedSlideIndex] : null;
-      const slideEntries: Array<{ slide: any; index: number }> =
-        selectedSlideIndex >= 0
-          ? [{ slide: selectedSlide, index: selectedSlideIndex }]
-          : slides.map((slide: any, index: number) => ({ slide, index }));
+    const compact =
+      args.compact === "true" ||
+      (args.compact === undefined &&
+        ctx?.caller === "tool" &&
+        selectedSlideIndex < 0);
 
-      const compact =
-        args.compact === "true" ||
-        (args.compact === undefined &&
-          ctx?.caller === "tool" &&
-          selectedSlideIndex < 0);
-
-      if (compact) {
-        return {
-          id: row.id,
-          title: row.title || data?.title,
-          visibility: row.visibility,
-          designSystemId: row.designSystemId ?? null,
-          sourceImport: data?.sourceImport
-            ? {
-                mode: data.sourceImport.mode,
-                format: data.sourceImport.format,
-                fidelity: data.sourceImport.fidelity,
-                slideCount: data.sourceImport.slideCount,
-                slideIds: data.sourceImport.slideIds,
-                ...(typeof data.sourceImport.imagesSkipped === "number"
-                  ? { imagesSkipped: data.sourceImport.imagesSkipped }
-                  : {}),
-              }
-            : null,
-          slideCount: slides.length,
-          slideNumbering:
-            'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
-          deepLink: deckDeepLink(row.id),
-          ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
-          slides: slideEntries.map(({ slide: s, index: i }) => ({
-            slideNumber: i + 1,
-            zeroBasedIndex: i,
-            id: s.id,
-            layout: s.layout ?? null,
-            transition: s.transition ?? null,
-            animations: compactAnimationSummary(
-              s.animations,
-              typeof s.content === "string" ? s.content : "",
-            ),
-            textPreview: stripHtml(s.content || "").slice(0, 120),
-          })),
-        };
-      }
-
-      const deckMetadata = { ...data };
-      delete deckMetadata.slides;
-
-      const formatHtml = args.format === "true";
-      const fullSlides = await Promise.all(
-        slideEntries.map(async ({ slide: s, index: i }) => ({
-          ...s,
+    if (compact) {
+      return {
+        id: row.id,
+        title: row.title || data?.title,
+        visibility: row.visibility,
+        designSystemId: row.designSystemId ?? null,
+        sourceImport: data?.sourceImport
+          ? {
+              mode: data.sourceImport.mode,
+              format: data.sourceImport.format,
+              fidelity: data.sourceImport.fidelity,
+              slideCount: data.sourceImport.slideCount,
+              slideIds: data.sourceImport.slideIds,
+              ...(typeof data.sourceImport.imagesSkipped === "number"
+                ? { imagesSkipped: data.sourceImport.imagesSkipped }
+                : {}),
+            }
+          : null,
+        slideCount: slides.length,
+        slideNumbering:
+          'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
+        deepLink: deckDeepLink(row.id),
+        ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
+        slides: slideEntries.map(({ slide: s, index: i }) => ({
           slideNumber: i + 1,
           zeroBasedIndex: i,
           id: s.id,
           layout: s.layout ?? null,
-          content: formatHtml
-            ? await formatSlideHtml(String(s.content ?? ""))
-            : s.content,
-          contentHash: hashSlideContent(String(s.content ?? "")),
-          notes: s.notes ?? null,
+          transition: s.transition ?? null,
+          animations: compactAnimationSummary(
+            s.animations,
+            typeof s.content === "string" ? s.content : "",
+          ),
+          textPreview: stripHtml(s.content || "").slice(0, 120),
         })),
-      );
-
-      return {
-        ...deckMetadata,
-        id: row.id,
-        title: row.title || data?.title,
-        visibility: row.visibility,
-        createdByMe:
-          normalizedOwnerEmail !== null &&
-          normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
-        designSystemId: row.designSystemId ?? null,
-        slideCount: slides.length,
-        slideNumbering:
-          'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
-        createdAt:
-          typeof data.createdAt === "string" ? data.createdAt : row.createdAt,
-        updatedAt,
-        deepLink: deckDeepLink(row.id),
-        ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
-        slides: fullSlides,
       };
-    });
+    }
+
+    const deckMetadata = { ...data };
+    delete deckMetadata.slides;
+
+    const formatHtml = args.format === "true";
+    const fullSlides = await Promise.all(
+      slideEntries.map(async ({ slide: s, index: i }) => ({
+        ...s,
+        slideNumber: i + 1,
+        zeroBasedIndex: i,
+        id: s.id,
+        layout: s.layout ?? null,
+        content: formatHtml
+          ? await formatSlideHtml(String(s.content ?? ""))
+          : s.content,
+        contentHash: hashSlideContent(String(s.content ?? "")),
+        notes: s.notes ?? null,
+      })),
+    );
+
+    return {
+      ...deckMetadata,
+      id: row.id,
+      title: row.title || data?.title,
+      visibility: row.visibility,
+      createdByMe:
+        normalizedOwnerEmail !== null &&
+        normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
+      designSystemId: row.designSystemId ?? null,
+      slideCount: slides.length,
+      slideNumbering:
+        'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
+      createdAt:
+        typeof data.createdAt === "string" ? data.createdAt : row.createdAt,
+      updatedAt: row.updatedAt,
+      deepLink: deckDeepLink(row.id),
+      ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
+      slides: fullSlides,
+    };
   },
   link: ({ result, args }) => {
     const id =

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -55,7 +55,7 @@ async function loadDeckWithUniqueSlideIds(deckId: string) {
         updatedAt: new Date().toISOString(),
       };
       const versionCondition =
-        lockedSnapshot.row.updatedAt == null
+        typeof lockedSnapshot.row.updatedAt !== "string"
           ? isNull(schema.decks.updatedAt)
           : eq(schema.decks.updatedAt, lockedSnapshot.row.updatedAt);
       await getDb()

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -2,13 +2,17 @@ import { defineAction, embedApp } from "@agent-native/core";
 import { buildDeepLink } from "@agent-native/core/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { resolveAccess } from "@agent-native/core/sharing";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { getDb, schema } from "../server/db/index.js";
+import { notifyClients } from "../server/handlers/decks.js";
 import { formatSlideHtml } from "../server/lib/slide-content-patch.js";
 import { summarizeSlideAnimationTargets } from "../server/lib/validate-slide-animations.js";
 import { normalizeOwnerEmail } from "../shared/ownership.js";
 import { hashSlideContent } from "../shared/slide-fit.js";
-import "../server/db/index.js"; // ensure registerShareableResource runs
+import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
+import { withDeckLock } from "./patch-deck.js";
 
 function stripHtml(html: string): string {
   return html
@@ -102,118 +106,137 @@ export default defineAction({
       throw new Error("--id is required.");
     }
 
-    const access = await resolveAccess("deck", args.id);
-    if (!access) {
-      // 404 rather than 403/500 so HTTP callers can't probe for decks they
-      // can't see, and so the slide preview can tell "missing" from "broken".
-      throw Object.assign(new Error("Deck not found"), { statusCode: 404 });
-    }
+    return withDeckLock(args.id, async () => {
+      const access = await resolveAccess("deck", args.id!);
+      if (!access) {
+        // 404 rather than 403/500 so HTTP callers can't probe for decks they
+        // can't see, and so the slide preview can tell "missing" from "broken".
+        throw Object.assign(new Error("Deck not found"), { statusCode: 404 });
+      }
 
-    const row = access.resource;
-    const data = JSON.parse(row.data);
-    const slides = data?.slides || [];
-    const ownerEmail = getRequestUserEmail();
-    const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);
-    const selectedSlideIndex =
-      args.slideId === undefined
-        ? -1
-        : slides.findIndex((slide: any) => slide?.id === args.slideId);
+      const row = access.resource;
+      let data = JSON.parse(row.data);
+      const { slides, changed } = ensureUniqueSlideIds(
+        Array.isArray(data?.slides) ? data.slides : [],
+      );
+      let updatedAt = row.updatedAt;
+      if (changed) {
+        const now = new Date().toISOString();
+        data = {
+          ...(data && typeof data === "object" ? data : {}),
+          slides,
+          updatedAt: now,
+        };
+        await getDb()
+          .update(schema.decks)
+          .set({ data: JSON.stringify(data), updatedAt: now })
+          .where(eq(schema.decks.id, row.id));
+        updatedAt = now;
+        notifyClients(row.id);
+      }
+      const ownerEmail = getRequestUserEmail();
+      const normalizedOwnerEmail = normalizeOwnerEmail(ownerEmail);
+      const selectedSlideIndex =
+        args.slideId === undefined
+          ? -1
+          : slides.findIndex((slide: any) => slide?.id === args.slideId);
 
-    if (args.slideId !== undefined && selectedSlideIndex < 0) {
-      throw Object.assign(new Error(`Slide not found: ${args.slideId}`), {
-        statusCode: 404,
-      });
-    }
+      if (args.slideId !== undefined && selectedSlideIndex < 0) {
+        throw Object.assign(new Error(`Slide not found: ${args.slideId}`), {
+          statusCode: 404,
+        });
+      }
 
-    const selectedSlide =
-      selectedSlideIndex >= 0 ? slides[selectedSlideIndex] : null;
-    const slideEntries: Array<{ slide: any; index: number }> =
-      selectedSlideIndex >= 0
-        ? [{ slide: selectedSlide, index: selectedSlideIndex }]
-        : slides.map((slide: any, index: number) => ({ slide, index }));
+      const selectedSlide =
+        selectedSlideIndex >= 0 ? slides[selectedSlideIndex] : null;
+      const slideEntries: Array<{ slide: any; index: number }> =
+        selectedSlideIndex >= 0
+          ? [{ slide: selectedSlide, index: selectedSlideIndex }]
+          : slides.map((slide: any, index: number) => ({ slide, index }));
 
-    const compact =
-      args.compact === "true" ||
-      (args.compact === undefined &&
-        ctx?.caller === "tool" &&
-        selectedSlideIndex < 0);
+      const compact =
+        args.compact === "true" ||
+        (args.compact === undefined &&
+          ctx?.caller === "tool" &&
+          selectedSlideIndex < 0);
 
-    if (compact) {
-      return {
-        id: row.id,
-        title: row.title || data?.title,
-        visibility: row.visibility,
-        designSystemId: row.designSystemId ?? null,
-        sourceImport: data?.sourceImport
-          ? {
-              mode: data.sourceImport.mode,
-              format: data.sourceImport.format,
-              fidelity: data.sourceImport.fidelity,
-              slideCount: data.sourceImport.slideCount,
-              slideIds: data.sourceImport.slideIds,
-              ...(typeof data.sourceImport.imagesSkipped === "number"
-                ? { imagesSkipped: data.sourceImport.imagesSkipped }
-                : {}),
-            }
-          : null,
-        slideCount: slides.length,
-        slideNumbering:
-          'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
-        deepLink: deckDeepLink(row.id),
-        ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
-        slides: slideEntries.map(({ slide: s, index: i }) => ({
+      if (compact) {
+        return {
+          id: row.id,
+          title: row.title || data?.title,
+          visibility: row.visibility,
+          designSystemId: row.designSystemId ?? null,
+          sourceImport: data?.sourceImport
+            ? {
+                mode: data.sourceImport.mode,
+                format: data.sourceImport.format,
+                fidelity: data.sourceImport.fidelity,
+                slideCount: data.sourceImport.slideCount,
+                slideIds: data.sourceImport.slideIds,
+                ...(typeof data.sourceImport.imagesSkipped === "number"
+                  ? { imagesSkipped: data.sourceImport.imagesSkipped }
+                  : {}),
+              }
+            : null,
+          slideCount: slides.length,
+          slideNumbering:
+            'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
+          deepLink: deckDeepLink(row.id),
+          ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
+          slides: slideEntries.map(({ slide: s, index: i }) => ({
+            slideNumber: i + 1,
+            zeroBasedIndex: i,
+            id: s.id,
+            layout: s.layout ?? null,
+            transition: s.transition ?? null,
+            animations: compactAnimationSummary(
+              s.animations,
+              typeof s.content === "string" ? s.content : "",
+            ),
+            textPreview: stripHtml(s.content || "").slice(0, 120),
+          })),
+        };
+      }
+
+      const deckMetadata = { ...data };
+      delete deckMetadata.slides;
+
+      const formatHtml = args.format === "true";
+      const fullSlides = await Promise.all(
+        slideEntries.map(async ({ slide: s, index: i }) => ({
+          ...s,
           slideNumber: i + 1,
           zeroBasedIndex: i,
           id: s.id,
           layout: s.layout ?? null,
-          transition: s.transition ?? null,
-          animations: compactAnimationSummary(
-            s.animations,
-            typeof s.content === "string" ? s.content : "",
-          ),
-          textPreview: stripHtml(s.content || "").slice(0, 120),
+          content: formatHtml
+            ? await formatSlideHtml(String(s.content ?? ""))
+            : s.content,
+          contentHash: hashSlideContent(String(s.content ?? "")),
+          notes: s.notes ?? null,
         })),
+      );
+
+      return {
+        ...deckMetadata,
+        id: row.id,
+        title: row.title || data?.title,
+        visibility: row.visibility,
+        createdByMe:
+          normalizedOwnerEmail !== null &&
+          normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
+        designSystemId: row.designSystemId ?? null,
+        slideCount: slides.length,
+        slideNumbering:
+          'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
+        createdAt:
+          typeof data.createdAt === "string" ? data.createdAt : row.createdAt,
+        updatedAt,
+        deepLink: deckDeepLink(row.id),
+        ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
+        slides: fullSlides,
       };
-    }
-
-    const deckMetadata = { ...data };
-    delete deckMetadata.slides;
-
-    const formatHtml = args.format === "true";
-    const fullSlides = await Promise.all(
-      slideEntries.map(async ({ slide: s, index: i }) => ({
-        ...s,
-        slideNumber: i + 1,
-        zeroBasedIndex: i,
-        id: s.id,
-        layout: s.layout ?? null,
-        content: formatHtml
-          ? await formatSlideHtml(String(s.content ?? ""))
-          : s.content,
-        contentHash: hashSlideContent(String(s.content ?? "")),
-        notes: s.notes ?? null,
-      })),
-    );
-
-    return {
-      ...deckMetadata,
-      id: row.id,
-      title: row.title || data?.title,
-      visibility: row.visibility,
-      createdByMe:
-        normalizedOwnerEmail !== null &&
-        normalizeOwnerEmail(row.ownerEmail) === normalizedOwnerEmail,
-      designSystemId: row.designSystemId ?? null,
-      slideCount: slides.length,
-      slideNumbering:
-        'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
-      createdAt:
-        typeof data.createdAt === "string" ? data.createdAt : row.createdAt,
-      updatedAt: row.updatedAt,
-      deepLink: deckDeepLink(row.id),
-      ...(selectedSlide ? { selectedSlideId: selectedSlide.id } : {}),
-      slides: fullSlides,
-    };
+    });
   },
   link: ({ result, args }) => {
     const id =

--- a/templates/slides/actions/save-deck.ts
+++ b/templates/slides/actions/save-deck.ts
@@ -23,7 +23,10 @@ import {
   assertHumanReadableDeckTitle,
   repairGeneratedDeckTitle,
 } from "../shared/deck-title.js";
-import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
+import {
+  ensureUniqueSlideIds,
+  repairDeckSlideReferences,
+} from "../shared/slide-ids.js";
 import {
   assertDesignSystemReadable,
   assertValidAspectRatio,
@@ -70,9 +73,20 @@ export default defineAction({
       const deckId = args.deckId;
       const deck = args.deck as DeckPayload;
       if (Array.isArray(deck.slides)) {
-        deck.slides = ensureUniqueSlideIds(
+        const normalized = ensureUniqueSlideIds(
           deck.slides as Array<{ id?: unknown }>,
-        ).slides;
+        );
+        deck.slides = normalized.slides;
+        if (normalized.changed) {
+          Object.assign(
+            deck,
+            repairDeckSlideReferences(
+              deck,
+              normalized.slides,
+              normalized.originalIds,
+            ),
+          );
+        }
       }
       assertValidAspectRatio(deck);
 

--- a/templates/slides/actions/save-deck.ts
+++ b/templates/slides/actions/save-deck.ts
@@ -23,6 +23,7 @@ import {
   assertHumanReadableDeckTitle,
   repairGeneratedDeckTitle,
 } from "../shared/deck-title.js";
+import { ensureUniqueSlideIds } from "../shared/slide-ids.js";
 import {
   assertDesignSystemReadable,
   assertValidAspectRatio,
@@ -68,6 +69,11 @@ export default defineAction({
     withDeckLock(args.deckId, async () => {
       const deckId = args.deckId;
       const deck = args.deck as DeckPayload;
+      if (Array.isArray(deck.slides)) {
+        deck.slides = ensureUniqueSlideIds(
+          deck.slides as Array<{ id?: unknown }>,
+        ).slides;
+      }
       assertValidAspectRatio(deck);
 
       const db = getDb();

--- a/templates/slides/shared/slide-ids.ts
+++ b/templates/slides/shared/slide-ids.ts
@@ -2,11 +2,20 @@ import { nanoid } from "nanoid";
 
 export function ensureUniqueSlideIds<T extends { id?: unknown }>(
   slides: readonly T[],
-): { slides: T[]; changed: boolean } {
+): {
+  slides: T[];
+  changed: boolean;
+  originalIds: Array<string | null>;
+} {
   const used = new Set<string>();
   let changed = false;
-  const repaired = slides.map((slide) => {
+  const originalIds: Array<string | null> = [];
+  const repaired = slides.map((slide, index) => {
+    if (!slide || typeof slide !== "object" || Array.isArray(slide)) {
+      throw new Error(`Slide ${index + 1} must be an object.`);
+    }
     const id = typeof slide.id === "string" ? slide.id : "";
+    originalIds.push(id || null);
     if (id && !used.has(id)) {
       used.add(id);
       return slide;
@@ -19,5 +28,106 @@ export function ensureUniqueSlideIds<T extends { id?: unknown }>(
     return { ...slide, id: nextId } as T;
   });
 
-  return { slides: repaired, changed };
+  return { slides: repaired, changed, originalIds };
+}
+
+export function rebindCreativeContextSlideLabels<T extends { id?: unknown }>(
+  slides: readonly T[],
+  originalIds: readonly (string | null)[],
+): T[] {
+  return slides.map((slide, index) => {
+    const originalId = originalIds[index];
+    const nextId = typeof slide.id === "string" ? slide.id : null;
+    if (!originalId || !nextId || originalId === nextId) return slide;
+
+    const labels = (slide as unknown as Record<string, unknown>)
+      .creativeContextReuseLabels;
+    if (!Array.isArray(labels)) return slide;
+
+    return {
+      ...slide,
+      creativeContextReuseLabels: labels.map((label) => {
+        if (!label || typeof label !== "object" || Array.isArray(label)) {
+          return label;
+        }
+        const record = label as Record<string, unknown>;
+        return record.elementId === originalId
+          ? { ...record, elementId: nextId }
+          : label;
+      }),
+    } as T;
+  });
+}
+
+export function repairDeckSlideReferences<T extends { id?: unknown }>(
+  data: unknown,
+  slides: readonly T[],
+  originalIds: readonly (string | null)[],
+): Record<string, unknown> {
+  const repairedSlides = rebindCreativeContextSlideLabels(slides, originalIds);
+  const repairedData: Record<string, unknown> = {
+    ...(data && typeof data === "object" && !Array.isArray(data) ? data : {}),
+    slides: repairedSlides,
+  };
+
+  const sourceImport = repairedData.sourceImport;
+  if (
+    !sourceImport ||
+    typeof sourceImport !== "object" ||
+    Array.isArray(sourceImport)
+  ) {
+    return repairedData;
+  }
+
+  const sourceImportRecord = sourceImport as Record<string, unknown>;
+  const idsByOriginalId = new Map<string, string[]>();
+  for (const [index, originalId] of originalIds.entries()) {
+    const nextId = repairedSlides[index]?.id;
+    if (!originalId || typeof nextId !== "string") continue;
+    const ids = idsByOriginalId.get(originalId) ?? [];
+    ids.push(nextId);
+    idsByOriginalId.set(originalId, ids);
+  }
+
+  const mapOccurrences = (
+    values: readonly unknown[],
+    getId: (value: unknown) => unknown,
+    replace: (value: unknown, id: string) => unknown,
+  ) => {
+    const occurrenceById = new Map<string, number>();
+    return values.map((value) => {
+      const originalId = getId(value);
+      if (typeof originalId !== "string") return value;
+      const ids = idsByOriginalId.get(originalId);
+      if (!ids) return value;
+      const occurrence = occurrenceById.get(originalId) ?? 0;
+      occurrenceById.set(originalId, occurrence + 1);
+      const nextId = ids[occurrence];
+      return nextId ? replace(value, nextId) : value;
+    });
+  };
+
+  const repairedSourceImport = { ...sourceImportRecord };
+  if (Array.isArray(sourceImportRecord.slideIds)) {
+    repairedSourceImport.slideIds = mapOccurrences(
+      sourceImportRecord.slideIds,
+      (value) => value,
+      (_value, id) => id,
+    );
+  }
+  if (Array.isArray(sourceImportRecord.slides)) {
+    repairedSourceImport.slides = mapOccurrences(
+      sourceImportRecord.slides,
+      (value) =>
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>).id
+          : undefined,
+      (value, id) =>
+        value && typeof value === "object" && !Array.isArray(value)
+          ? { ...(value as Record<string, unknown>), id }
+          : value,
+    );
+  }
+  repairedData.sourceImport = repairedSourceImport;
+  return repairedData;
 }

--- a/templates/slides/shared/slide-ids.ts
+++ b/templates/slides/shared/slide-ids.ts
@@ -1,0 +1,23 @@
+import { nanoid } from "nanoid";
+
+export function ensureUniqueSlideIds<T extends { id?: unknown }>(
+  slides: readonly T[],
+): { slides: T[]; changed: boolean } {
+  const used = new Set<string>();
+  let changed = false;
+  const repaired = slides.map((slide) => {
+    const id = typeof slide.id === "string" ? slide.id : "";
+    if (id && !used.has(id)) {
+      used.add(id);
+      return slide;
+    }
+
+    let nextId = `slide-${nanoid(8)}`;
+    while (used.has(nextId)) nextId = `slide-${nanoid(8)}`;
+    used.add(nextId);
+    changed = true;
+    return { ...slide, id: nextId } as T;
+  });
+
+  return { slides: repaired, changed };
+}


### PR DESCRIPTION
## Summary
- repair duplicate slide IDs when reading legacy decks so each thumbnail and canvas target remains addressable
- normalize IDs at deck creation and full-payload write boundaries

## Verification
- `corepack pnpm --filter slides test`
- `corepack pnpm --filter slides typecheck`
- `corepack pnpm guards`

The beta deployment is handled by the post-merge prebuilt publisher.