### PR TITLE
fix: normalize coded Builder gateway errors

### DIFF
--- a/.changeset/canonicalize-builder-gateway-errors.md
+++ b/.changeset/canonicalize-builder-gateway-errors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Handle coded Builder gateway internal errors consistently across streamed and HTTP responses.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -1644,6 +1644,71 @@ describe("createBuilderEngine", () => {
     expect(stop?.error?.toLowerCase()).toContain("rate_limit");
   });
 
+  it("canonicalizes coded Builder internal-error envelopes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonlResponse([
+          {
+            type: "stop",
+            reason: "error",
+            code: "provider_internal_error",
+            error:
+              "Sorry, we ran into an issue processing your request. ERROR ID: bebaeb5da13441539790834b63ff955a",
+          },
+        ]),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.errorCode).toBe("builder_gateway_internal_error");
+    expect(stop?.providerRetryable).toBe(true);
+  });
+
+  it("canonicalizes coded Builder internal-error HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(500, {
+          code: "provider_internal_error",
+          message:
+            "Sorry, we ran into an issue processing your request. ERROR ID: bebaeb5da13441539790834b63ff955a",
+        }),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.errorCode).toBe("builder_gateway_internal_error");
+    expect(stop?.providerRetryable).toBe(true);
+    expect(stop?.statusCode).toBe(500);
+  });
+
+  it("preserves provider_internal_error for non-envelope messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonlResponse([
+          {
+            type: "stop",
+            reason: "error",
+            code: "provider_internal_error",
+            error: "upstream provider failed",
+          },
+        ]),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.errorCode).toBe("provider_internal_error");
+    expect(stop?.providerRetryable).toBeUndefined();
+  });
+
   it("maps invalid_request stops into a non-retryable error stop preserving the gateway message and code", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -1687,6 +1687,25 @@ describe("createBuilderEngine", () => {
     expect(stop?.statusCode).toBe(500);
   });
 
+  it("canonicalizes message-only Builder internal-error HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(500, {
+          message:
+            "Sorry, we ran into an issue processing your request. ERROR ID: bebaeb5da13441539790834b63ff955a",
+        }),
+      ),
+    );
+
+    const events = await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.errorCode).toBe("builder_gateway_internal_error");
+    expect(stop?.providerRetryable).toBe(true);
+    expect(stop?.statusCode).toBe(500);
+  });
+
   it("preserves provider_internal_error for non-envelope messages", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -49,6 +49,7 @@ import {
 } from "./credential-errors.js";
 import {
   classifyTerminalErrorCode,
+  canonicalizeBuilderGatewayErrorCode,
   describeErrorWithCauses,
   isBuilderGatewayInternalErrorMessage,
   isContextOverflowCode,
@@ -656,8 +657,12 @@ async function* emitHttpError(
       errBody.message = normalizeGatewayErrorText(rawText, status);
     }
   }
-  const code = errBody.code ?? `http_${status}`;
   const message = errBody.message ?? `Builder gateway returned ${status}`;
+  const code =
+    canonicalizeBuilderGatewayErrorCode(
+      errBody.code ?? `http_${status}`,
+      message,
+    ) ?? `http_${status}`;
   const stop = (details: GatewayErrorStopDetails): EngineEvent =>
     gatewayErrorStop(details, opts.creditsLane, opts.requestShape);
 
@@ -990,7 +995,10 @@ async function* parseJsonlStream(
               `Gateway error (no detail; raw event: ${JSON.stringify(event)})`;
             const gatewayRequestId =
               typeof event.requestId === "string" ? event.requestId : undefined;
-            const gatewayErrCode = event.errorCode ?? event.code;
+            const gatewayErrCode = canonicalizeBuilderGatewayErrorCode(
+              event.errorCode ?? event.code,
+              String(errMsg),
+            );
             // The gateway already authenticated this request before streaming,
             // so a bare "Unauthorized" here means the account cannot use this
             // model — not that the connection is broken. Only a message that

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -659,10 +659,8 @@ async function* emitHttpError(
   }
   const message = errBody.message ?? `Builder gateway returned ${status}`;
   const code =
-    canonicalizeBuilderGatewayErrorCode(
-      errBody.code ?? `http_${status}`,
-      message,
-    ) ?? `http_${status}`;
+    canonicalizeBuilderGatewayErrorCode(errBody.code, message) ??
+    `http_${status}`;
   const stop = (details: GatewayErrorStopDetails): EngineEvent =>
     gatewayErrorStop(details, opts.creditsLane, opts.requestShape);
 

--- a/packages/core/src/agent/engine/error-detail.spec.ts
+++ b/packages/core/src/agent/engine/error-detail.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   BUILDER_GATEWAY_INTERNAL_ERROR_CODE,
+  canonicalizeBuilderGatewayErrorCode,
   classifyProviderError,
   classifyTerminalErrorCode,
   describeErrorWithCauses,
@@ -158,6 +159,23 @@ describe("isProviderConnectionErrorMessage", () => {
     expect(isBuilderGatewayInternalErrorMessage("error id: abc")).toBe(false);
     expect(classifyTerminalErrorCode("Bad request, no id at all")).toBe(
       undefined,
+    );
+  });
+
+  it("canonicalizes only provider_internal_error envelopes", () => {
+    const envelope =
+      "Sorry, we ran into an issue processing your request. ERROR ID: bebaeb5da13441539790834b63ff955a";
+    expect(
+      canonicalizeBuilderGatewayErrorCode("provider_internal_error", envelope),
+    ).toBe(BUILDER_GATEWAY_INTERNAL_ERROR_CODE);
+    expect(
+      canonicalizeBuilderGatewayErrorCode(
+        "provider_internal_error",
+        "upstream provider failed",
+      ),
+    ).toBe("provider_internal_error");
+    expect(canonicalizeBuilderGatewayErrorCode("rate_limited", envelope)).toBe(
+      "rate_limited",
     );
   });
 

--- a/packages/core/src/agent/engine/error-detail.spec.ts
+++ b/packages/core/src/agent/engine/error-detail.spec.ts
@@ -174,6 +174,12 @@ describe("isProviderConnectionErrorMessage", () => {
         "upstream provider failed",
       ),
     ).toBe("provider_internal_error");
+    expect(
+      canonicalizeBuilderGatewayErrorCode(
+        "provider_internal_error",
+        "Provider failed. ERROR ID: bebaeb5da13441539790834b63ff955a",
+      ),
+    ).toBe("provider_internal_error");
     expect(canonicalizeBuilderGatewayErrorCode("rate_limited", envelope)).toBe(
       "rate_limited",
     );

--- a/packages/core/src/agent/engine/error-detail.spec.ts
+++ b/packages/core/src/agent/engine/error-detail.spec.ts
@@ -162,12 +162,15 @@ describe("isProviderConnectionErrorMessage", () => {
     );
   });
 
-  it("canonicalizes only provider_internal_error envelopes", () => {
+  it("canonicalizes coded and message-only Builder envelopes", () => {
     const envelope =
       "Sorry, we ran into an issue processing your request. ERROR ID: bebaeb5da13441539790834b63ff955a";
     expect(
       canonicalizeBuilderGatewayErrorCode("provider_internal_error", envelope),
     ).toBe(BUILDER_GATEWAY_INTERNAL_ERROR_CODE);
+    expect(canonicalizeBuilderGatewayErrorCode(undefined, envelope)).toBe(
+      BUILDER_GATEWAY_INTERNAL_ERROR_CODE,
+    );
     expect(
       canonicalizeBuilderGatewayErrorCode(
         "provider_internal_error",

--- a/packages/core/src/agent/engine/error-detail.ts
+++ b/packages/core/src/agent/engine/error-detail.ts
@@ -97,14 +97,16 @@ export function isContextOverflowMessage(message: string): boolean {
 /**
  * The Builder gateway's own 500 envelope, which is the whole message: an
  * apology sentence plus a correlation id, e.g. "Sorry, we ran into an issue
- * processing your request. ERROR ID: 0f3c...". The apology prose varies; the
- * correlation id does not, so that is what the predicate below anchors on.
+ * processing your request. ERROR ID: 0f3c...". Require the known apology
+ * prefix as well as the id so an unrelated provider message cannot match.
  */
 export const BUILDER_GATEWAY_INTERNAL_ERROR_CODE =
   "builder_gateway_internal_error";
 
 const BUILDER_GATEWAY_ERROR_ID_PATTERN = /\berror id:\s*([0-9a-f]+)\b/i;
 const BUILDER_GATEWAY_ERROR_ID_MIN_CHARS = 8;
+const BUILDER_GATEWAY_ERROR_PREFIX_PATTERN =
+  /^sorry,\s+(?:we ran into an issue processing your request|this was caused by an internal error)\b/i;
 
 /**
  * The gateway attaches that envelope to an unhandled 500, and it arrives two
@@ -118,7 +120,9 @@ const BUILDER_GATEWAY_ERROR_ID_MIN_CHARS = 8;
 export function isBuilderGatewayInternalErrorMessage(message: string): boolean {
   const match = BUILDER_GATEWAY_ERROR_ID_PATTERN.exec(message);
   return (
-    match !== null && match[1].length >= BUILDER_GATEWAY_ERROR_ID_MIN_CHARS
+    BUILDER_GATEWAY_ERROR_PREFIX_PATTERN.test(message) &&
+    match !== null &&
+    match[1].length >= BUILDER_GATEWAY_ERROR_ID_MIN_CHARS
   );
 }
 

--- a/packages/core/src/agent/engine/error-detail.ts
+++ b/packages/core/src/agent/engine/error-detail.ts
@@ -122,6 +122,17 @@ export function isBuilderGatewayInternalErrorMessage(message: string): boolean {
   );
 }
 
+/** Preserve the canonical code only for the gateway's generic error envelope. */
+export function canonicalizeBuilderGatewayErrorCode(
+  code: string | undefined,
+  message: string,
+): string | undefined {
+  return code === "provider_internal_error" &&
+    isBuilderGatewayInternalErrorMessage(message)
+    ? BUILDER_GATEWAY_INTERNAL_ERROR_CODE
+    : code;
+}
+
 /** The overflow codes a provider or gateway may report instead of prose. */
 export function isContextOverflowCode(code: string | undefined): boolean {
   const normalized = (code ?? "").toLowerCase();

--- a/packages/core/src/agent/engine/error-detail.ts
+++ b/packages/core/src/agent/engine/error-detail.ts
@@ -131,7 +131,7 @@ export function canonicalizeBuilderGatewayErrorCode(
   code: string | undefined,
   message: string,
 ): string | undefined {
-  return code === "provider_internal_error" &&
+  return (code === undefined || code === "provider_internal_error") &&
     isBuilderGatewayInternalErrorMessage(message)
     ? BUILDER_GATEWAY_INTERNAL_ERROR_CODE
     : code;


### PR DESCRIPTION
## Summary
- canonicalize the generic Builder error-id envelope when responses carry `provider_internal_error`
- apply the same handling to streamed and HTTP responses while preserving other provider codes
- add regression coverage and a core patch changeset

## Validation
- `@agent-native/core` focused Vitest: 145 passed
- `@agent-native/core` typecheck
- `pnpm guards`: 65 passed