### PR TITLE
Simplify shared-resource email notifications

### DIFF
--- a/.changeset/share-notification-email.md
+++ b/.changeset/share-notification-email.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve shared-resource notification emails with sender context, a resource-name block, and a focused call to action.

--- a/packages/core/src/server/email-template.spec.ts
+++ b/packages/core/src/server/email-template.spec.ts
@@ -120,6 +120,24 @@ describe("renderEmail", () => {
     expect(text).toContain("Reply to reach alice@example.com directly.");
   });
 
+  it("renders the resource block before the CTA", () => {
+    const { html, text } = renderEmail({
+      heading: "Alice shared a document",
+      paragraphs: [
+        "Alice (alice@example.com) has invited you to view the following document:",
+      ],
+      resourceBlock: { name: "Project plan" },
+      cta: { label: "Open", url: "https://example.com/doc/1" },
+    });
+
+    expect(html).toContain(">Project plan</td>");
+    expect(html.indexOf("Project plan")).toBeLessThan(
+      html.indexOf(">\n              Open\n"),
+    );
+    expect(text).toContain("Project plan\n\nOpen: https://example.com/doc/1");
+    expect(text).not.toContain("Use the button below to open it");
+  });
+
   it("renders a safe treated link block after the CTA", () => {
     const url = "https://clips.example/r/rec-1?view=agent&mode=summary";
     const { html, text } = renderEmail({

--- a/packages/core/src/server/email-template.ts
+++ b/packages/core/src/server/email-template.ts
@@ -32,6 +32,10 @@ export interface EmailLinkBlock {
   placement?: "before-cta" | "after-cta";
 }
 
+export interface EmailResourceBlock {
+  name: string;
+}
+
 export interface RenderEmailArgs {
   /** Short preview text shown by email clients next to the subject. */
   preheader?: string;
@@ -45,6 +49,8 @@ export interface RenderEmailArgs {
   secondaryCta?: EmailCta;
   /** A treated, copyable URL shown before or after the CTA. */
   linkBlock?: EmailLinkBlock;
+  /** Styled resource name shown before the primary CTA. */
+  resourceBlock?: EmailResourceBlock;
   /**
    * Optional trusted HTML injected above the CTA — e.g. a template-owned video
    * thumbnail with a play badge. Injected verbatim, so only pass markup built
@@ -125,6 +131,9 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
   const ctaBg = brand ?? "#fafafa";
   const ctaFg = brand ? "#ffffff" : "#0a0a0c";
   const linkColor = brand ?? "#a1a1aa";
+  const resourceBorder = "#3f3f46"; // guard:allow-raw-color — email markup must inline colors for clients.
+  const resourceBackground = "#0a0a0c"; // guard:allow-raw-color — email markup must inline colors for clients.
+  const resourceText = "#fafafa"; // guard:allow-raw-color — email markup must inline colors for clients.
 
   // Trusted markup supplied by the caller (template code, not user input),
   // injected as-is so a template can own app-specific previews (e.g. a video
@@ -156,6 +165,12 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
         </tr>
       </table>
     `
+    : "";
+
+  const resourceBlockHtml = args.resourceBlock
+    ? `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin:24px 0 0 0; border:1px solid ${resourceBorder}; border-radius:10px; background:${resourceBackground};">
+        <tr><td style="padding:14px 16px; font-size:15px; line-height:1.5; font-weight:600; color:${resourceText};">${escapeHtml(args.resourceBlock.name)}</td></tr>
+      </table>`
     : "";
 
   const ctaButtonCell = (
@@ -228,8 +243,9 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
                   ${escapeHtml(args.heading)}
                 </h1>
                 ${paragraphsHtml}
-                ${heroHtml}
                 ${args.linkBlock?.placement !== "after-cta" ? linkBlockHtml : ""}
+                ${resourceBlockHtml}
+                ${heroHtml}
                 ${ctaHtml}
                 ${args.linkBlock?.placement === "after-cta" ? linkBlockHtml : ""}
                 ${closingParagraphsHtml}
@@ -253,6 +269,10 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
   if (args.linkBlock && args.linkBlock.placement !== "after-cta") {
     textLines.push(args.linkBlock.intro);
     textLines.push(args.linkBlock.url);
+    textLines.push("");
+  }
+  if (args.resourceBlock) {
+    textLines.push(args.resourceBlock.name);
     textLines.push("");
   }
   if (args.cta) {

--- a/packages/core/src/sharing/actions/share-resource.ts
+++ b/packages/core/src/sharing/actions/share-resource.ts
@@ -447,7 +447,7 @@ export default defineAction({
         }
         const resourceLabel = reg.displayName.toLowerCase();
         const article = /^[aeiou]/i.test(resourceLabel) ? "an" : "a";
-        const subject = `${reg.displayName} shared with you: "${resourceTitle}"`;
+        const subject = `${senderDisplayName} shared with you: "${resourceTitle}"`;
         const messageParagraph = args.message?.trim()
           ? emailQuote(args.message)
           : null;
@@ -456,7 +456,9 @@ export default defineAction({
             ? "view"
             : args.role === "commenter"
               ? "comment on"
-              : "edit";
+              : args.role === "admin"
+                ? "edit and manage access to"
+                : "edit";
         const defaultParagraphs = [
           `${emailStrong(senderDisplayName)} (${emailStrong(actor)}) has invited you to ${roleVerb} the following ${resourceLabel}:`,
           ...(messageParagraph ? [messageParagraph] : []),

--- a/packages/core/src/sharing/actions/share-resource.ts
+++ b/packages/core/src/sharing/actions/share-resource.ts
@@ -445,31 +445,38 @@ export default defineAction({
             );
           }
         }
-        const subject = `${actor} shared "${resourceTitle}" with you on ${appName}`;
+        const resourceLabel = reg.displayName.toLowerCase();
+        const article = /^[aeiou]/i.test(resourceLabel) ? "an" : "a";
+        const subject = `${reg.displayName} shared with you: "${resourceTitle}"`;
         const messageParagraph = args.message?.trim()
           ? emailQuote(args.message)
           : null;
+        const roleVerb =
+          args.role === "viewer"
+            ? "view"
+            : args.role === "commenter"
+              ? "comment on"
+              : "edit";
         const defaultParagraphs = [
-          `${emailStrong(actor)} has shared the ${reg.displayName} ${emailStrong(resourceTitle)} with you as a ${emailStrong(args.role)}.`,
+          `${emailStrong(senderDisplayName)} (${emailStrong(actor)}) has invited you to ${roleVerb} the following ${resourceLabel}:`,
           ...(messageParagraph ? [messageParagraph] : []),
-          `Use the button below to open it. If prompted, sign in with ${emailStrong(principalId)}.`,
         ];
         const { html, text } = renderEmail({
           brandName,
           brandLogoUrl,
           preheader: subject,
-          heading: `${senderDisplayName} shared "${resourceTitle}" with you`,
+          heading: `${senderDisplayName} shared ${article} ${resourceLabel}`,
           paragraphs: extras?.paragraphs
             ? messageParagraph
               ? [messageParagraph, ...extras.paragraphs]
               : extras.paragraphs
             : defaultParagraphs,
+          resourceBlock: { name: resourceTitle },
           heroHtml,
-          cta: { label: `Open ${reg.displayName}`, url: notificationUrl },
+          cta: { label: "Open", url: notificationUrl },
           secondaryCta: extras?.secondaryCta,
           linkBlock: extras?.linkBlock,
           closingParagraphs: extras?.closingParagraphs,
-          footer: `You received this because ${actor} granted you ${args.role} access.`,
         });
         await sendEmail({
           to: principalId,

--- a/templates/clips/server/lib/share-email-hero.ts
+++ b/templates/clips/server/lib/share-email-hero.ts
@@ -66,9 +66,6 @@ export function recordingShareEmailExtras(ctx: {
   const summarizeUrl = new URL(ctx.href);
   summarizeUrl.searchParams.set("panel", "agent");
   return {
-    // The heading already says who shared what, so the clip thumbnail follows
-    // it directly.
-    paragraphs: [],
     secondaryCta: { label: "Summarize with AI", url: summarizeUrl.toString() },
     linkBlock: {
       intro: "Copy and paste this link for your own AI agent to summarize:",


### PR DESCRIPTION
Update the shared notification email used across registered apps to mirror Google's information hierarchy while preserving Agent-Native styling.

- Remove redundant copy, the sign-in instruction, and the generic access footer.
- Show the sender, recipient action, and resource name in a concise structure.
- Use one focused Open CTA and preserve Clips-specific AI/link content.

Validation: Core email-template tests, Core sharing access tests, Core typecheck, Clips typecheck, formatting, raw-color guard, and desktop/narrow visual checks.