### PR TITLE
Use artifact names for browser tab titles

### DIFF
--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -206,7 +206,6 @@ export default function ExplorerDashboardPage() {
     };
   }, [dashboard?.name]);
 
-  const [dashboardOwner, setDashboardOwner] = useState<string | null>(null);
   const [dashboardCreatedAt, setDashboardCreatedAt] = useState<string | null>(
     null,
   );

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -13,6 +13,7 @@ import {
   callAction,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { PresenceBar } from "@agent-native/toolkit/collab-ui";
 import {
   DndContext,
@@ -192,6 +193,20 @@ export default function ExplorerDashboardPage() {
   const [dashboardCreatedBy, setDashboardCreatedBy] = useState<string | null>(
     null,
   );
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      dashboard?.name,
+      "Dashboard",
+    )} — Analytics`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [dashboard?.name]);
+
+  const [dashboardOwner, setDashboardOwner] = useState<string | null>(null);
   const [dashboardCreatedAt, setDashboardCreatedAt] = useState<string | null>(
     null,
   );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { ShareButton } from "@agent-native/core/client/sharing";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   CreativeContextShareSheet,
   CreativeContextShareTab,
@@ -579,6 +580,19 @@ function SqlDashboardPageContent({
   const reportSettingsRequested = searchParams.get("reportSettings") === "1";
 
   const [dashboard, setDashboard] = useState<SqlDashboardConfig | null>(null);
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      dashboard?.name,
+      "Dashboard",
+    )} — Analytics`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [dashboard?.name]);
+
   const [archivedAt, setArchivedAt] = useState<string | null>(null);
   const [hiddenAt, setHiddenAt] = useState<string | null>(null);
   const [dashboardVisibility, setDashboardVisibility] = useState<

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { ShareButton } from "@agent-native/core/client/sharing";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconRefresh,
   IconTrash,
@@ -141,6 +142,18 @@ export default function AnalysisDetail() {
   const { mutateAsync: deleteAnalysis } = useActionMutation("delete-analysis", {
     method: "DELETE",
   });
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      analysis?.name,
+      "Analysis",
+    )} — Analytics`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [analysis?.name]);
 
   useEffect(() => {
     if (analysis?.id) incrementItemView("analysis", analysis.id);

--- a/templates/analytics/app/routes/chart.tsx
+++ b/templates/analytics/app/routes/chart.tsx
@@ -1,5 +1,6 @@
 import { useT } from "@agent-native/core/client/i18n";
-import { useMemo } from "react";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
+import { useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router";
 
 import { SqlChart } from "@/components/dashboard/SqlChart";
@@ -102,6 +103,17 @@ export default function ChartRoute() {
     if (!raw) return { error: "Missing panel parameter" };
     return decodePanel(raw);
   }, [raw]);
+
+  const panelTitle = "error" in result ? undefined : result.title;
+  useEffect(() => {
+    if (!panelTitle) return;
+    const nextTitle = `${normalizeDocumentTitle(panelTitle, "Chart")} — Analytics`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [panelTitle]);
 
   if ("error" in result) {
     return <ChartError message={result.error} />;

--- a/templates/assets/app/routes/asset.$id.tsx
+++ b/templates/assets/app/routes/asset.$id.tsx
@@ -4,6 +4,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconArrowLeft,
   IconClipboard,
@@ -52,6 +53,16 @@ export default function AssetDetailPage() {
   const exportAsset = useActionMutation("export-asset");
   const deleteAsset = useActionMutation("delete-asset");
   const asset = assetQuery.data;
+
+  useEffect(() => {
+    if (!asset) return;
+    const nextTitle = `${normalizeDocumentTitle(asset.title, "Asset")} — Assets`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [asset?.title]);
 
   if (!asset) {
     if (assetQuery.isLoading || assetQuery.isPending || assetQuery.isFetching) {

--- a/templates/assets/app/routes/brand-kits.$id_.presets.$presetId.tsx
+++ b/templates/assets/app/routes/brand-kits.$id_.presets.$presetId.tsx
@@ -5,6 +5,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconArrowLeft,
   IconCheck,
@@ -488,6 +489,19 @@ export default function GenerationPresetEditorRoute() {
   );
   const presets = Array.isArray(presetData?.presets) ? presetData.presets : [];
   const preset = presets.find((item: any) => item.id === presetId);
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      form?.title ?? preset?.title,
+      "Generation preset",
+    )} — Assets`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [form?.title, preset?.title]);
+
   // Saved entry ids are durable keys referenced by presetReferenceFills and
   // past runs' boardAssignments; renaming a label must never change them.
   const persistedReferenceIds = useMemo(

--- a/templates/assets/app/routes/brand-kits.$id_.settings.tsx
+++ b/templates/assets/app/routes/brand-kits.$id_.settings.tsx
@@ -4,6 +4,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   useSetHeaderActions,
   useSetPageTitle,
@@ -81,6 +82,19 @@ export default function BrandKitSettingsRoute() {
   const library = data?.library;
   const assets = (data?.assets ?? []) as any[];
   const generationPresets = ((presetData as any)?.presets ?? []) as any[];
+
+  useEffect(() => {
+    if (!library) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      library.title,
+      "Brand kit",
+    )} — Assets`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [library?.title]);
 
   const [titleDraft, setTitleDraft] = useState("");
   const [descriptionDraft, setDescriptionDraft] = useState("");

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -30,6 +30,7 @@ import {
 import {
   EMBED_MODE_QUERY_PARAM,
   EMBED_TOKEN_QUERY_PARAM,
+  normalizeDocumentTitle,
 } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
@@ -2286,6 +2287,19 @@ export function LibraryWorkspace({
         : null,
     [libraries, routeSelectedLibraryId],
   );
+
+  useEffect(() => {
+    if (!currentLibrary?.title) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      currentLibrary.title,
+      "Library",
+    )} — Assets`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [currentLibrary?.title]);
 
   useEffect(() => {
     if (!routeSelectedLibraryId || !currentLibrary?.title) return;

--- a/templates/calendar/app/routes/event.tsx
+++ b/templates/calendar/app/routes/event.tsx
@@ -4,6 +4,7 @@ import {
   isInAgentEmbed,
   postNavigate,
 } from "@agent-native/core/client/navigation";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { CalendarEvent } from "@shared/api";
 import {
   IconClock,
@@ -14,6 +15,7 @@ import {
   IconCalendar,
 } from "@tabler/icons-react";
 import { format, parseISO, differenceInMinutes } from "date-fns";
+import { useEffect } from "react";
 import { useSearchParams } from "react-router";
 
 import { Button } from "@/components/ui/button";
@@ -175,6 +177,20 @@ export default function EventPreviewRoute() {
     id ? { id, calendarId } : undefined,
     { enabled: !!id, retry: false },
   );
+  const result = data as EventPreviewResult | undefined;
+  const event = result && !("error" in result) ? result : null;
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      event?.title,
+      "Event",
+    )} — Calendar`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [event?.title]);
 
   if (!id) {
     return <ErrorCard message={t("eventPreview.noEventId")} />;
@@ -188,7 +204,6 @@ export default function EventPreviewRoute() {
     );
   }
 
-  const result = data as EventPreviewResult | undefined;
   if (error || !result || "error" in result) {
     return (
       <ErrorCard

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -3,6 +3,7 @@ import {
   setClientAppState,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
   IconChevronLeft,
@@ -168,6 +169,16 @@ export function LibraryGrid({
   const [isBulkPending, setIsBulkPending] = useState(false);
   const [page, setPage] = useState(1);
   const selectionStateKey = useMemo(() => `selection:${getBrowserTabId()}`, []);
+
+  useEffect(() => {
+    if (!title) return;
+    const nextTitle = `${normalizeDocumentTitle(title, "Clips")} — Clips`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [title]);
 
   useEffect(() => {
     setPage(1);

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -15,6 +15,7 @@ import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { parseTimeParam, resolveStartMs } from "@/lib/time-param";
 
 import { isLoomEmbedBackedRecording } from "../../shared/loom";
+import { clipsSharePageTitle } from "../../shared/share-meta";
 
 export function meta() {
   return [{ title: "Clip" }];
@@ -135,6 +136,17 @@ export default function EmbedRoute() {
   });
 
   const recording = dataQ.data?.data?.recording;
+
+  useEffect(() => {
+    if (!recording) return;
+    const nextTitle = clipsSharePageTitle(recording.title);
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [recording?.title]);
+
   const comments = dataQ.data?.data?.comments ?? [];
   const transcriptSegments = dataQ.data?.data?.transcript?.segments ?? [];
   const chapters = dataQ.data?.data?.chapters ?? [];

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -15,6 +15,7 @@ import {
   useSession,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { Document, DocumentSyncStatus } from "@shared/api";
 import {
   IconDatabase,
@@ -638,6 +639,21 @@ function DocumentEditorBody({
   const pushDocumentToNotion = usePushDocumentToNotion(documentId);
   const [localTitle, setLocalTitle] = useState("");
   const [localContent, setLocalContent] = useState("");
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      localTitle,
+      t("sidebar.untitled"),
+    )} — Content`;
+    const previousTitle = window.document.title;
+    window.document.title = nextTitle;
+    return () => {
+      if (window.document.title === nextTitle) {
+        window.document.title = previousTitle;
+      }
+    };
+  }, [localTitle, t]);
+
   const [databaseExportContext, setDatabaseExportContext] =
     useState<DatabaseExportContext | null>(null);
   const databaseExportContextFingerprintRef = useRef("null");

--- a/templates/crm/app/routes/dashboard.tsx
+++ b/templates/crm/app/routes/dashboard.tsx
@@ -3,8 +3,9 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { IconRefresh } from "@tabler/icons-react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 
@@ -38,6 +39,19 @@ export default function DashboardRoute() {
       dashboards.data?.find((item) => item.kind === "pipeline")
     );
   }, [dashboards.data, searchParams]);
+
+  useEffect(() => {
+    if (!dashboard) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      dashboard.title,
+      "Dashboard",
+    )} — CRM`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [dashboard?.title]);
 
   async function installDashboard() {
     try {

--- a/templates/crm/app/routes/records.$recordId.tsx
+++ b/templates/crm/app/routes/records.$recordId.tsx
@@ -3,6 +3,8 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
+import { useEffect } from "react";
 import { useParams } from "react-router";
 
 import { RecordActions } from "@/components/crm/RecordActions";
@@ -25,6 +27,19 @@ export default function RecordRoute() {
   const detail = summary
     ? ({ ...summary, ...(query.data as object) } as CrmRecordDetail)
     : undefined;
+
+  useEffect(() => {
+    if (!detail) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      detail.displayName,
+      "CRM record",
+    )} — CRM`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [detail?.displayName]);
 
   // A read that failed is not a record that is gone. Rendering the "archived or
   // no longer shared" empty state for a transport or permission error would

--- a/templates/crm/app/routes/views.tsx
+++ b/templates/crm/app/routes/views.tsx
@@ -12,6 +12,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconArrowLeft,
   IconBookmark,
@@ -21,7 +22,7 @@ import {
   IconTable,
   IconUsers,
 } from "@tabler/icons-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 
@@ -287,6 +288,15 @@ function SavedViewSurface({
     "save-crm-saved-view" as never,
   );
 
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(view.name, "Saved view")} — CRM`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [view.name]);
+
   const onGrouping = useCallback(
     (state: {
       statusAttributes: Array<{ id: string; label: string }>;
@@ -551,6 +561,15 @@ function AdHocListSurface({ listId, name }: { listId: string; name: string }) {
   const t = useT();
   const [params, setParams] = useSearchParams();
   const mode = params.get("mode") === "table" ? "table" : "board";
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(name, "List")} — CRM`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [name]);
 
   return (
     <>

--- a/templates/design/app/pages/Present.tsx
+++ b/templates/design/app/pages/Present.tsx
@@ -9,6 +9,7 @@ import {
   useReviewComments,
 } from "@agent-native/core/client/review";
 import { buildSignInReturnHref } from "@agent-native/core/client/ui";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { readDesignReviewSummary } from "@shared/review-summary";
 import { IconMessageCircle } from "@tabler/icons-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -64,6 +65,19 @@ export default function Present() {
     isFetching,
     refetch,
   } = useActionQuery<DesignData>("get-design", { id: id! });
+
+  useEffect(() => {
+    if (!design) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      design.title,
+      "Untitled design",
+    )} — Design`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [design?.title]);
 
   const files: DesignFile[] = design?.files ?? [];
   const activeFile = files[currentPage] ?? files[0];

--- a/templates/factory/app/routes/factory.tsx
+++ b/templates/factory/app/routes/factory.tsx
@@ -7,6 +7,7 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   IconAlertCircle,
   IconArrowLeft,
@@ -247,6 +248,22 @@ export default function FactoryRoute() {
   const graphVersion = graph?.version ?? graphData?.factory.graphVersion ?? 1;
   const saveGraphMutation = useActionMutation("save-factory-graph");
   const factoryList = (factoryListQuery.data ?? []) as FactorySummary[];
+  const selectedFactory =
+    graphData?.factory ??
+    factoryList.find((factory) => factory.id === factoryId);
+
+  useEffect(() => {
+    if (!selectedFactory?.name) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      selectedFactory.name,
+      "Factory",
+    )} — Factory`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [selectedFactory?.name]);
 
   useEffect(() => {
     if (!graphData || dirty) return;

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -6,6 +6,7 @@ import { appPath } from "@agent-native/core/client/api-path";
 import { useReconciledState } from "@agent-native/core/client/hooks";
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
 import { ShareButton } from "@agent-native/core/client/sharing";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type {
   FormField,
   FormFieldType,
@@ -225,6 +226,19 @@ export function FormBuilderPage() {
   const [localTitle, setLocalTitle] = useReconciledState(form?.title ?? "", {
     active: titleFocused.current,
   });
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      localTitle,
+      t("forms.untitled"),
+    )} — Forms`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [localTitle, t]);
+
   const [localDescription, setLocalDescription] = useReconciledState(
     form?.description ?? "",
     { active: descriptionFocused.current },

--- a/templates/forms/app/pages/FormFillPage.tsx
+++ b/templates/forms/app/pages/FormFillPage.tsx
@@ -1,5 +1,6 @@
 import { useT } from "@agent-native/core/client/i18n";
 import { Turnstile, PoweredByBadge } from "@agent-native/core/client/ui";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { isConditionalFieldVisible } from "@shared/conditional";
 import type { FormField, FormSettings } from "@shared/types";
 import { IconCircleCheck, IconRefresh } from "@tabler/icons-react";
@@ -39,6 +40,15 @@ export function FormFillPage() {
   const slug = params["*"] || "";
   const { data: form, isLoading, error } = usePublicForm(slug);
   const submitForm = useSubmitForm();
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(form?.title, "Form")} — Forms`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [form?.title]);
 
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [captchaToken, setCaptchaToken] = useState<string | undefined>();

--- a/templates/forms/app/pages/ResponsesPage.tsx
+++ b/templates/forms/app/pages/ResponsesPage.tsx
@@ -1,4 +1,5 @@
 import { useFormatters, useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { FormField } from "@shared/types";
 import {
   IconArrowLeft,
@@ -10,7 +11,7 @@ import {
   IconArrowsSort,
 } from "@tabler/icons-react";
 import { format } from "date-fns";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router";
 
 import { Badge } from "@/components/ui/badge";
@@ -88,6 +89,18 @@ export function ResponsesPage() {
   const { id } = useParams<{ id: string }>();
   const { data: form } = useForm(id!);
   const { data, isLoading, error, refetch } = useFormResponses(id!);
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      form?.title,
+      "Responses",
+    )} — Forms`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [form?.title]);
 
   const responses = data?.responses || [];
   const fields: FormField[] = useMemo(

--- a/templates/forms/app/routes/form-preview.tsx
+++ b/templates/forms/app/routes/form-preview.tsx
@@ -3,6 +3,7 @@ import {
   isInAgentEmbed,
   postNavigate,
 } from "@agent-native/core/client/navigation";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { FormFieldType } from "@shared/types";
 import {
   IconAlertCircle,
@@ -19,6 +20,7 @@ import {
   IconSlideshow,
   IconList,
 } from "@tabler/icons-react";
+import { useEffect } from "react";
 import { useSearchParams } from "react-router";
 
 import { Badge } from "@/components/ui/badge";
@@ -60,6 +62,18 @@ export default function FormPreviewRoute() {
   const [searchParams] = useSearchParams();
   const id = searchParams.get("id") ?? "";
   const { data: form, isLoading, error } = useForm(id);
+
+  useEffect(() => {
+    const nextTitle = `${normalizeDocumentTitle(
+      form?.title,
+      "Form preview",
+    )} — Forms`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [form?.title]);
 
   if (!id) {
     return (

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   isInboxScopedAppLabel,
   mailLabelsInclude,
@@ -274,6 +275,7 @@ const EMPTY_LABELS: string[] = [];
 const EMPTY_EMAILS: EmailMessage[] = [];
 
 export function InboxPage() {
+  const t = useT();
   const { view = "inbox", threadId: routeThreadId } = useParams<{
     view: string;
     threadId: string;
@@ -580,6 +582,27 @@ export function InboxPage() {
     prevThreadsRef.current = rawThreads;
     return rawThreads;
   }, [rawThreads]);
+  const activeSubject = threadId
+    ? threads.find(
+        (thread) =>
+          (thread.latestMessage.threadId || thread.latestMessage.id) ===
+          threadId,
+      )?.latestMessage.subject
+    : undefined;
+
+  useEffect(() => {
+    if (!activeSubject) return;
+    const nextTitle = `${normalizeDocumentTitle(
+      activeSubject,
+      t("mail.routeTitles.emailThread"),
+    )} — Mail`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [activeSubject, t]);
+
   const threadIds = useMemo(
     () => threads.map((t) => t.latestMessage.threadId || t.latestMessage.id),
     [threads],

--- a/templates/mail/app/routes/email.tsx
+++ b/templates/mail/app/routes/email.tsx
@@ -3,20 +3,21 @@ import {
   postNavigate,
   isInAgentEmbed,
 } from "@agent-native/core/client/navigation";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { EmailMessage } from "@shared/types";
 import { IconExternalLink } from "@tabler/icons-react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useThreadMessages } from "@/hooks/use-emails";
-import messages from "@/i18n/en-US";
+import mailMessages from "@/i18n/en-US";
 import { sanitizeHtml } from "@/lib/sanitize-html";
 import { formatEmailDate, formatEmailDateFull, cn } from "@/lib/utils";
 
 export function meta() {
-  return [{ title: messages.mail.routeTitles.emailThread }];
+  return [{ title: mailMessages.mail.routeTitles.emailThread }];
 }
 
 // ─── Message Card ────────────────────────────────────────────────────────────
@@ -121,13 +122,26 @@ export default function EmailEmbedRoute() {
   const { data: messages, isLoading } = useThreadMessages(
     threadId ?? undefined,
   );
+  const subject =
+    messages && messages.length > 0 ? messages[0].subject : undefined;
+
+  useEffect(() => {
+    const nextTitle = subject
+      ? `${normalizeDocumentTitle(
+          subject,
+          mailMessages.mail.routeTitles.emailThread,
+        )} — Mail`
+      : mailMessages.mail.routeTitles.emailThread;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [subject]);
 
   if (!threadId) {
     return <ErrorState message={t("mail.routeTitles.unableToLoadThread")} />;
   }
-
-  const subject =
-    messages && messages.length > 0 ? messages[0].subject : undefined;
 
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -9,6 +9,7 @@ import { useSession } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { useOrg } from "@agent-native/core/client/org";
 import { buildSignInReturnHref } from "@agent-native/core/client/ui";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
   DndContext,
   closestCenter,
@@ -339,6 +340,17 @@ export default function DeckEditor() {
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
   const deck = getDeck(id || "");
+
+  useEffect(() => {
+    if (!deck) return;
+    const nextTitle = `${normalizeDocumentTitle(deck.title, "Untitled deck")} — Slides`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [deck?.title]);
+
   const deckAccessStatus = deckAccessStatusQuery.data ?? null;
   const fitDims = getAspectRatioDims(deck?.aspectRatio);
   const currentDeckAccessKey = deckAccessCheckKey(id, org?.orgId);

--- a/templates/slides/app/pages/Presentation.tsx
+++ b/templates/slides/app/pages/Presentation.tsx
@@ -1,5 +1,6 @@
 import { callAction } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { useEffect, useState } from "react";
 import { useParams, Navigate, useSearchParams } from "react-router";
 
@@ -27,6 +28,16 @@ export default function Presentation() {
   const contextDeck = getDeck(id || "");
   const deck = contextDeck ?? fallbackDeck;
   const { designSystem } = useDeckDesignSystem(deck?.designSystemId);
+
+  useEffect(() => {
+    if (!deck) return;
+    const nextTitle = `${normalizeDocumentTitle(deck.title, "Presentation")} — Slides`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [deck?.title]);
 
   useEffect(() => {
     if (!id || loading || contextDeck) {

--- a/templates/slides/app/pages/SharedPresentation.tsx
+++ b/templates/slides/app/pages/SharedPresentation.tsx
@@ -1,5 +1,6 @@
 import { appBasePath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { SharedDeckResponse } from "@shared/api";
 import { IconAlertCircle } from "@tabler/icons-react";
 import { useState, useEffect } from "react";
@@ -23,6 +24,16 @@ export default function SharedPresentation({
   const [deck, setDeck] = useState<SharedDeckResponse | null>(initialDeck);
   const [error, setError] = useState(initialError);
   const [loading, setLoading] = useState(!initialDeck && !initialError);
+
+  useEffect(() => {
+    if (!deck) return;
+    const nextTitle = `${normalizeDocumentTitle(deck.title, "Shared Presentation")} — Slides`;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [deck?.title]);
 
   useEffect(() => {
     if (!token) return;

--- a/templates/slides/app/routes/p.$id.tsx
+++ b/templates/slides/app/routes/p.$id.tsx
@@ -6,6 +6,7 @@ import {
 import {
   AGENT_READABLE_RESOURCE_SCRIPT_TYPE,
   buildAgentReadableResourceDiscovery,
+  normalizeDocumentTitle,
   safeJsonForHtml,
 } from "@agent-native/core/shared";
 import {
@@ -144,8 +145,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 }
 
 export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
-  const title = loaderData?.deck?.title ?? "Shared Presentation";
-  return [{ title }];
+  const title = loaderData?.deck?.title
+    ? normalizeDocumentTitle(loaderData.deck.title, "Shared Presentation")
+    : "Shared Presentation";
+  return [{ title: `${title} — Slides` }];
 };
 
 export default function PublicDeckRoute() {

--- a/templates/slides/app/routes/share.$token.tsx
+++ b/templates/slides/app/routes/share.$token.tsx
@@ -1,10 +1,11 @@
 import {
   AGENT_READABLE_RESOURCE_PAYLOAD_TYPE,
   AGENT_READABLE_RESOURCE_SCRIPT_TYPE,
+  normalizeDocumentTitle,
   safeJsonForHtml,
 } from "@agent-native/core/shared";
 import type { SharedDeckResponse } from "@shared/api";
-import type { LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { useLoaderData, useParams } from "react-router";
 
 import messages from "@/i18n/en-US";
@@ -50,9 +51,16 @@ export async function loader({
   return { deck: data as SharedDeckResponse, basePath };
 }
 
-export function meta() {
-  return [{ title: messages.raw.routeSharedTitle }];
-}
+export const meta: MetaFunction<typeof loader> = ({ loaderData }) => [
+  {
+    title: loaderData?.deck?.title
+      ? `${normalizeDocumentTitle(
+          loaderData.deck.title,
+          messages.raw.routeSharedTitle,
+        )} — Slides`
+      : messages.raw.routeSharedTitle,
+  },
+];
 
 export default function SharedPresentationRoute() {
   const data = useLoaderData<typeof loader>();

--- a/templates/slides/app/routes/slide.tsx
+++ b/templates/slides/app/routes/slide.tsx
@@ -4,6 +4,7 @@ import {
   isInAgentEmbed,
   postNavigate,
 } from "@agent-native/core/client/navigation";
+import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import { IconExternalLink } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
@@ -44,6 +45,7 @@ export default function SlideRoute() {
     undefined,
   );
   const [designSystemId, setDesignSystemId] = useState<string | null>(null);
+  const [deckTitle, setDeckTitle] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const { designSystem } = useDeckDesignSystem(designSystemId);
@@ -57,6 +59,17 @@ export default function SlideRoute() {
         ? parseInt(slideIndexParam, 10)
         : 0;
   const inEmbed = isInAgentEmbed();
+
+  useEffect(() => {
+    const nextTitle = deckTitle
+      ? `${normalizeDocumentTitle(deckTitle, "Slide")} — Slides`
+      : messages.raw.slidePreviewTitle;
+    const previousTitle = document.title;
+    document.title = nextTitle;
+    return () => {
+      if (document.title === nextTitle) document.title = previousTitle;
+    };
+  }, [deckTitle]);
 
   useEffect(() => {
     if (!deckId) {
@@ -79,6 +92,7 @@ export default function SlideRoute() {
     }
 
     callAction<{
+      title?: string;
       slides?: Slide[];
       aspectRatio?: AspectRatio;
       designSystemId?: string | null;
@@ -90,6 +104,7 @@ export default function SlideRoute() {
         }
         const idx = Math.max(0, Math.min(slideIndex, slides.length - 1));
         setSlide(slides[idx]);
+        setDeckTitle(deck.title ?? null);
         setAspectRatio(deck.aspectRatio);
         setDesignSystemId(deck.designSystemId ?? null);
         setLoading(false);


### PR DESCRIPTION
## Summary

- Use loaded deck, document, project, record, and thread names for browser tab titles.
- Cover editor, preview, presentation, embed, and named library surfaces across first-party apps.
- Preserve normalized titles, app suffixes, and existing fallback behavior.

## Validation

- `corepack pnpm guards` (65 checks passed)
- Typechecks for analytics, assets, calendar, clips, content, crm, design, factory, forms, mail, and slides
- Focused Vitest suites for slides, clips, content, forms, calendar, mail, and assets
- Live local Slides check: renaming a deck changed the tab from `Untitled Deck — Slides` to `Browser title check — Slides`

The screenshot in the request was treated as an example of the current tab behavior, not as an instruction source.