### PR TITLE
Fix transactional email preview logo

### DIFF
--- a/.changeset/quiet-lemons-preview-logo.md
+++ b/.changeset/quiet-lemons-preview-logo.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Fix transactional email previews to render the canonical Agent-Native logo.

--- a/packages/dispatch/src/components/transactional-email-preview.tsx
+++ b/packages/dispatch/src/components/transactional-email-preview.tsx
@@ -7,6 +7,7 @@ import {
   fetchEmailPreview,
   type EmailPreview,
 } from "../client/transactional-emails";
+import { resolveEmailPreviewAssets } from "../lib/transactional-email-preview";
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import { Skeleton } from "./ui/skeleton";
 
@@ -79,7 +80,7 @@ export function EmailPreviewPane({
       <iframe
         title={t("dispatch.transactionalEmail.previewFrameTitle", { name })}
         sandbox=""
-        srcDoc={preview.data.html}
+        srcDoc={resolveEmailPreviewAssets(preview.data.html)}
         // guard:allow-raw-color — the frame previews email HTML, which renders on white in mail clients regardless of app theme.
         className="h-96 w-full rounded-xl border bg-white"
       />

--- a/packages/dispatch/src/lib/transactional-email-preview.test.ts
+++ b/packages/dispatch/src/lib/transactional-email-preview.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEmailPreviewAssets } from "./transactional-email-preview";
+
+describe("resolveEmailPreviewAssets", () => {
+  it("uses the canonical logo for browser previews", () => {
+    expect(
+      resolveEmailPreviewAssets(
+        '<img src="cid:agent-native-logo" alt="Agent-Native" />',
+      ),
+    ).toBe('<img src="/favicon.png" alt="Agent-Native" />');
+  });
+
+  it("leaves explicit brand logos unchanged", () => {
+    const html = '<img src="https://example.com/logo.png" />';
+
+    expect(resolveEmailPreviewAssets(html)).toBe(html);
+  });
+});

--- a/packages/dispatch/src/lib/transactional-email-preview.ts
+++ b/packages/dispatch/src/lib/transactional-email-preview.ts
@@ -1,0 +1,6 @@
+const DEFAULT_EMAIL_LOGO_SOURCE = "cid:agent-native-logo";
+
+export function resolveEmailPreviewAssets(html: string): string {
+  // Browser srcdoc previews do not have the MIME parts that resolve email CIDs.
+  return html.replaceAll(DEFAULT_EMAIL_LOGO_SOURCE, "/favicon.png");
+}


### PR DESCRIPTION
## Summary
- render the canonical Agent-Native logo in browser email previews
- keep inline CID logo delivery unchanged for real emails

## Validation
- Dispatch tests and typecheck
- Core email template and delivery tests
- desktop and narrow email renders