### PR TITLE
Fix Slides deletion snackbar styling

### DIFF
--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -112,7 +112,6 @@ import {
 } from "@/lib/slide-image-replacement";
 import { TAB_ID } from "@/lib/tab-id";
 import { shouldActivateTextTool } from "@/lib/text-tool-shortcut";
-import { shortcutLabel } from "@/lib/utils";
 
 type EditorSidePanel = "comments" | null;
 
@@ -918,7 +917,7 @@ export default function DeckEditor() {
       })();
       deleteSlide(deckId, slideId);
       toast(`${slideTitle} deleted`, {
-        description: `Press ${shortcutLabel("cmd+z")} or click Undo to restore.`,
+        className: "!bg-background !text-foreground !border-border",
         duration: 6000,
         action: {
           label: "Undo",


### PR DESCRIPTION
## Summary
- remove the secondary restore hint from the slide deletion snackbar
- use the Slides semantic background and foreground tokens for the snackbar

## Checks
- corepack pnpm guards
- corepack pnpm --filter slides typecheck
- corepack pnpm --filter slides build
- corepack pnpm exec vitest --run app/pages/DeckEditor.slide-clipboard.test.ts --config vitest.config.ts