### PR TITLE
Fix stopped chat runs staying marked as streaming

### DIFF
--- a/.changeset/stopped-chat-run.md
+++ b/.changeset/stopped-chat-run.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep intentionally stopped chat runs from reappearing as missing final responses.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1707,12 +1707,30 @@ describe("resolveAssistantChatRunningState", () => {
 
 describe("matchesUserStoppedRun", () => {
   it("keeps a stop effective across delayed terminal updates", () => {
-    const stopped = { threadId: "thread-1", runId: "run-1" };
+    const stopped = {
+      threadId: "thread-1",
+      runId: "run-1",
+      turnId: "turn-1",
+    };
 
-    expect(matchesUserStoppedRun(stopped, "thread-1", "run-1")).toBe(true);
-    expect(matchesUserStoppedRun(stopped, "thread-1", "run-2")).toBe(false);
-    expect(matchesUserStoppedRun(stopped, "thread-2", "run-1")).toBe(false);
-    expect(matchesUserStoppedRun(null, "thread-1", "run-1")).toBe(false);
+    expect(matchesUserStoppedRun(stopped, "thread-1", "run-1", "turn-1")).toBe(
+      true,
+    );
+    expect(matchesUserStoppedRun(stopped, "thread-1", "run-2", "turn-1")).toBe(
+      true,
+    );
+    expect(matchesUserStoppedRun(stopped, "thread-1", "run-2", "turn-2")).toBe(
+      false,
+    );
+    expect(matchesUserStoppedRun(stopped, "thread-2", "run-1", "turn-1")).toBe(
+      false,
+    );
+    expect(
+      matchesUserStoppedRun({ threadId: "thread-1" }, "thread-1", "run-2"),
+    ).toBe(false);
+    expect(matchesUserStoppedRun(null, "thread-1", "run-1", "turn-1")).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -37,6 +37,7 @@ import {
   isAssistantUiStaleIndexError,
   installAssistantUiMessageRepositoryRecovery,
   latestNonRecoveryUserMessageText,
+  matchesUserStoppedRun,
   reconnectActivityFallbackContent,
   reconnectProgressTimedOut,
   resolveAssistantChatRunningState,
@@ -1701,6 +1702,17 @@ describe("resolveAssistantChatRunningState", () => {
         isAutoResuming: true,
       }),
     ).toEqual({ isRunning: false, showRunningInUI: false });
+  });
+});
+
+describe("matchesUserStoppedRun", () => {
+  it("keeps a stop effective across delayed terminal updates", () => {
+    const stopped = { threadId: "thread-1", runId: "run-1" };
+
+    expect(matchesUserStoppedRun(stopped, "thread-1", "run-1")).toBe(true);
+    expect(matchesUserStoppedRun(stopped, "thread-1", "run-2")).toBe(false);
+    expect(matchesUserStoppedRun(stopped, "thread-2", "run-1")).toBe(false);
+    expect(matchesUserStoppedRun(null, "thread-1", "run-1")).toBe(false);
   });
 });
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -5122,6 +5122,7 @@ const AssistantChatInner = forwardRef<
       continuationTurnId?: string,
     ) => {
       if (isAgentChatSubmitCancelled(submitMessageId)) return;
+      const stoppedRunAtSubmitStart = userStoppedRunRef.current;
       if (!preserveReconnectAutoRecoveryBudget) {
         reconnectAutoRecoveryCountRef.current = 0;
       }
@@ -5132,7 +5133,6 @@ const AssistantChatInner = forwardRef<
       setDismissedRunErrorKey(null);
       setDismissedProviderAuthErrorKey(null);
       setComposerError(null);
-      userStoppedRunRef.current = null;
       // Selection context attached via Cmd+I is one-shot — clear it as soon
       // as the user actually sends a message so it can't be re-used.
       clearPendingSelection();
@@ -5363,6 +5363,11 @@ const AssistantChatInner = forwardRef<
       // hidden reconnect recovery turns must leave the user's viewport alone.
       if (!hideUserMessage) resumeFollowingRef.current();
       reportAgentChatSubmitResult(submitMessageId, true);
+      // A queued immediate submit can abort the previous run after it is
+      // accepted. Preserve that newer stop marker while clearing the old one.
+      if (userStoppedRunRef.current === stoppedRunAtSubmitStart) {
+        userStoppedRunRef.current = null;
+      }
       if (submitted.includesContext) {
         updateComposerContextItems(() => []);
       }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -490,14 +490,15 @@ export function reconnectProgressTimedOut(args: {
 }
 
 export function matchesUserStoppedRun(
-  stopped: { runId?: string; threadId?: string } | null,
+  stopped: { runId?: string; threadId?: string; turnId?: string } | null,
   threadId?: string,
   runId?: string,
+  turnId?: string,
 ): boolean {
+  if (!stopped || stopped.threadId !== threadId) return false;
   return Boolean(
-    stopped &&
-    stopped.threadId === threadId &&
-    (!stopped.runId || !runId || stopped.runId === runId),
+    (stopped.runId && runId && stopped.runId === runId) ||
+    (stopped.turnId && turnId && stopped.turnId === turnId),
   );
 }
 
@@ -2852,6 +2853,7 @@ const AssistantChatInner = forwardRef<
   const userStoppedRunRef = useRef<{
     runId?: string;
     threadId?: string;
+    turnId?: string;
   } | null>(null);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [optimisticRunning, setOptimisticRunning] = useState(false);
@@ -3423,8 +3425,8 @@ const AssistantChatInner = forwardRef<
   }, [cacheCurrentThreadSnapshot]);
 
   const wasUserStoppedRun = useCallback(
-    (runId?: string): boolean =>
-      matchesUserStoppedRun(userStoppedRunRef.current, threadId, runId),
+    (runId?: string, turnId?: string): boolean =>
+      matchesUserStoppedRun(userStoppedRunRef.current, threadId, runId, turnId),
     [threadId],
   );
 
@@ -3439,7 +3441,7 @@ const AssistantChatInner = forwardRef<
         return false;
       }
       const runId = String(runInfo.runId);
-      if (wasUserStoppedRun(runId)) return false;
+      if (wasUserStoppedRun(runId, runInfo.turnId)) return false;
       if (reconnectRunIdRef.current === runId) return true;
       // SINGLE-READER OWNERSHIP: never start a second reader while the
       // adapter's own stream is live (or mid auto-continuation) for this
@@ -4229,7 +4231,10 @@ const AssistantChatInner = forwardRef<
       forceStopped ||
       isReconnecting ||
       runErrorInfo ||
-      wasUserStoppedRun()
+      wasUserStoppedRun(
+        activeChatRunId ?? undefined,
+        activeChatTurnId ?? undefined,
+      )
     ) {
       return;
     }
@@ -4551,7 +4556,9 @@ const AssistantChatInner = forwardRef<
         return;
       }
       const stopped = userStoppedRunRef.current;
-      if (matchesUserStoppedRun(stopped, threadId, detail.runId)) {
+      if (
+        matchesUserStoppedRun(stopped, threadId, detail.runId, detail.turnId)
+      ) {
         return;
       }
       // A terminal adapter error wins over any read-only reconnect reader that
@@ -5008,9 +5015,14 @@ const AssistantChatInner = forwardRef<
       const activeRun = getActiveRun();
       const runIdToAbort = reconnectRunIdRef.current ?? activeRun?.runId;
       const pendingTurn = threadId ? getPendingTurn(threadId) : null;
+      const turnIdToAbort =
+        pendingTurn?.turnId ??
+        reconnectTurnIdRef.current ??
+        (activeRun?.runId === runIdToAbort ? activeRun?.turnId : undefined);
       userStoppedRunRef.current = {
         ...(threadId ? { threadId } : {}),
         ...(runIdToAbort ? { runId: runIdToAbort } : {}),
+        ...(turnIdToAbort ? { turnId: turnIdToAbort } : {}),
       };
       trackStoppedRun(runIdToAbort);
       setRunErrorInfo(null);
@@ -5707,6 +5719,7 @@ const AssistantChatInner = forwardRef<
       userStoppedRunRef.current,
       threadId,
       visibleRunError.runId,
+      visibleRunError.turnId,
     );
   const providerAuthErrorKey =
     visibleRunError &&

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -489,6 +489,18 @@ export function reconnectProgressTimedOut(args: {
   return args.now - args.lastProgressAt >= threshold;
 }
 
+export function matchesUserStoppedRun(
+  stopped: { runId?: string; threadId?: string } | null,
+  threadId?: string,
+  runId?: string,
+): boolean {
+  return Boolean(
+    stopped &&
+    stopped.threadId === threadId &&
+    (!stopped.runId || !runId || stopped.runId === runId),
+  );
+}
+
 function activeRunMatchesThread(
   state: ActiveRunState | null,
   threadId: string | undefined,
@@ -2835,9 +2847,11 @@ const AssistantChatInner = forwardRef<
   >(null);
   const [dismissedProviderAuthErrorKey, setDismissedProviderAuthErrorKey] =
     useState<string | null>(null);
+  // Keep an intentional stop until the next explicit submission. The server
+  // may replay the terminal snapshot well after the client cancellation.
   const userStoppedRunRef = useRef<{
-    at: number;
     runId?: string;
+    threadId?: string;
   } | null>(null);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [optimisticRunning, setOptimisticRunning] = useState(false);
@@ -3408,14 +3422,11 @@ const AssistantChatInner = forwardRef<
     };
   }, [cacheCurrentThreadSnapshot]);
 
-  const wasRecentlyStoppedRun = useCallback((runId?: string): boolean => {
-    const stopped = userStoppedRunRef.current;
-    return Boolean(
-      stopped &&
-      Date.now() - stopped.at < 10_000 &&
-      (!stopped.runId || !runId || stopped.runId === runId),
-    );
-  }, []);
+  const wasUserStoppedRun = useCallback(
+    (runId?: string): boolean =>
+      matchesUserStoppedRun(userStoppedRunRef.current, threadId, runId),
+    [threadId],
+  );
 
   const startReconnectToRun = useCallback(
     (runInfo: ActiveRunLookup): boolean => {
@@ -3428,7 +3439,7 @@ const AssistantChatInner = forwardRef<
         return false;
       }
       const runId = String(runInfo.runId);
-      if (wasRecentlyStoppedRun(runId)) return false;
+      if (wasUserStoppedRun(runId)) return false;
       if (reconnectRunIdRef.current === runId) return true;
       // SINGLE-READER OWNERSHIP: never start a second reader while the
       // adapter's own stream is live (or mid auto-continuation) for this
@@ -3920,14 +3931,7 @@ const AssistantChatInner = forwardRef<
       void streamReconnect();
       return true;
     },
-    [
-      apiUrl,
-      refreshThreadFromServer,
-      t,
-      tabId,
-      threadId,
-      wasRecentlyStoppedRun,
-    ],
+    [apiUrl, refreshThreadFromServer, t, tabId, threadId, wasUserStoppedRun],
   );
 
   const reconnectActiveRunForThread =
@@ -4225,7 +4229,7 @@ const AssistantChatInner = forwardRef<
       forceStopped ||
       isReconnecting ||
       runErrorInfo ||
-      wasRecentlyStoppedRun()
+      wasUserStoppedRun()
     ) {
       return;
     }
@@ -4247,7 +4251,7 @@ const AssistantChatInner = forwardRef<
     reconnectActiveRunForThread,
     runErrorInfo,
     threadId,
-    wasRecentlyStoppedRun,
+    wasUserStoppedRun,
   ]);
 
   // Generate a title when the first user message is sent
@@ -4547,11 +4551,7 @@ const AssistantChatInner = forwardRef<
         return;
       }
       const stopped = userStoppedRunRef.current;
-      if (
-        stopped &&
-        Date.now() - stopped.at < 10_000 &&
-        (!stopped.runId || !detail.runId || stopped.runId === detail.runId)
-      ) {
+      if (matchesUserStoppedRun(stopped, threadId, detail.runId)) {
         return;
       }
       // A terminal adapter error wins over any read-only reconnect reader that
@@ -5009,7 +5009,7 @@ const AssistantChatInner = forwardRef<
       const runIdToAbort = reconnectRunIdRef.current ?? activeRun?.runId;
       const pendingTurn = threadId ? getPendingTurn(threadId) : null;
       userStoppedRunRef.current = {
-        at: Date.now(),
+        ...(threadId ? { threadId } : {}),
         ...(runIdToAbort ? { runId: runIdToAbort } : {}),
       };
       trackStoppedRun(runIdToAbort);
@@ -5698,12 +5698,10 @@ const AssistantChatInner = forwardRef<
     !!visibleRunError &&
     !showRunningInUI &&
     visibleRunErrorKey !== dismissedRunErrorKey &&
-    !(
-      userStoppedRunRef.current &&
-      Date.now() - userStoppedRunRef.current.at < 10_000 &&
-      (!userStoppedRunRef.current.runId ||
-        !visibleRunError.runId ||
-        userStoppedRunRef.current.runId === visibleRunError.runId)
+    !matchesUserStoppedRun(
+      userStoppedRunRef.current,
+      threadId,
+      visibleRunError.runId,
     );
   const providerAuthErrorKey =
     visibleRunError &&
@@ -6181,7 +6179,7 @@ const AssistantChatInner = forwardRef<
                                       resetKey={messageListResetKey}
                                     >
                                       <UserStoppedRunContext.Provider
-                                        value={wasRecentlyStoppedRun}
+                                        value={wasUserStoppedRun}
                                       >
                                         <ThreadPrimitive.Messages
                                           // Deliberately NOT keyed on part structure. Doing that

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -1784,7 +1784,10 @@ export function AssistantMessage() {
           ? t("agentChat.message.missingFinal")
           : null));
   const animateMissingFinalResponse = Boolean(
-    isLast && missingFinalResponseNoticeText && wasLiveRef.current,
+    !isUserStoppedRun &&
+    isLast &&
+    missingFinalResponseNoticeText &&
+    wasLiveRef.current,
   );
   const missingFinalResponseAnimationKey = animateMissingFinalResponse
     ? missingFinalResponseNoticeText

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -1346,7 +1346,7 @@ export function shouldShowAssistantMessageFooter({
  */
 export const ServerRunActiveContext = React.createContext(false);
 export const UserStoppedRunContext = React.createContext<
-  (runId?: string) => boolean
+  (runId?: string, turnId?: string) => boolean
 >(() => false);
 
 export function shouldShowMissingFinalResponse({
@@ -1727,7 +1727,8 @@ export function AssistantMessage() {
   const messageTurnId = assistantMessageTurnId(msg);
   const userStoppedRun = React.useContext(UserStoppedRunContext);
   const isUserStoppedRun =
-    assistantMessageWasUserStopped(msg) || userStoppedRun(messageRunId);
+    assistantMessageWasUserStopped(msg) ||
+    userStoppedRun(messageRunId, messageTurnId);
   const thinkingDisplay = useThinkingDisplay();
   const groupWorkParts = useCallback(
     (


### PR DESCRIPTION
Summary:
- Keep an intentional stop effective after delayed terminal updates.
- Render the stopped-run notice without the streaming caret.

Verification:
- Focused core Vitest suites: 470 passed.
- Core typecheck passed.
- pnpm guards: all 65 checks passed.