### PR TITLE
Connect pasted Google Slides links in chat

### DIFF
--- a/.changeset/bright-slides-connect.md
+++ b/.changeset/bright-slides-connect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Publish restored composer drafts to host affordances.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -162,6 +162,15 @@ describe("AssistantChat thread restore and composer recovery", () => {
     expect(source).toContain("draftScope={composerDraftScope}");
   });
 
+  it("publishes restored composer drafts to host affordances", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+
+    expect(source).toContain('const restoredText = initialComposerText ?? "";');
+    expect(source).toContain("onComposerTextChange?.(restoredText);");
+  });
+
   it("synchronizes app context before a scope-switch paint", () => {
     const source = readFileSync("src/client/AssistantChat.tsx", {
       encoding: "utf8",

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1993,7 +1993,8 @@ export interface AssistantChatProps {
   /** Optional content rendered just above the composer input */
   composerSlot?: React.ReactNode;
   /**
-   * Called with the active composer's current plain text as it changes.
+   * Called with the active composer's current plain text when it initializes
+   * and as it changes.
    * Host apps can use this to render contextual, non-destructive affordances
    * beside the shared composer without replacing the composer stack.
    */
@@ -2550,12 +2551,18 @@ const AssistantChatInner = forwardRef<
   // (unsupported format, size cap, body-size rejection, drop errors).
   // Cleared on the next message send.
   const [composerError, setComposerError] = useState<string | null>(null);
-  const [composerText, setComposerText] = useState("");
   const composerDraftScope = tabId || threadId;
   const initialComposerText = useMemo(
     () => readAssistantChatComposerDraft(composerDraftScope),
     [composerDraftScope],
   );
+  const [composerText, setComposerText] = useState(initialComposerText ?? "");
+  useEffect(() => {
+    const restoredText = initialComposerText ?? "";
+    setComposerText(restoredText);
+    if (!isActiveComposer) return;
+    onComposerTextChange?.(restoredText);
+  }, [initialComposerText, isActiveComposer, onComposerTextChange]);
   const handleComposerTextChange = useCallback(
     (text: string) => {
       setComposerText(text);

--- a/templates/slides/actions/import-google-slides-reference.test.ts
+++ b/templates/slides/actions/import-google-slides-reference.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { extractGoogleSlidesUrls } from "../shared/google-docs";
 import {
   extractGoogleSlidesPresentationId,
   googleSlidesExportError,
@@ -15,10 +16,37 @@ describe("extractGoogleSlidesPresentationId", () => {
     ).toBe("presentation_123");
   });
 
+  it("accepts account-scoped Google Slides URLs", () => {
+    expect(
+      extractGoogleSlidesPresentationId(
+        "https://docs.google.com/presentation/u/0/d/presentation_123/edit",
+      ),
+    ).toBe("presentation_123");
+  });
+
   it("continues to accept picker file IDs", () => {
     expect(extractGoogleSlidesPresentationId("presentation_123")).toBe(
       "presentation_123",
     );
+  });
+
+  it("extracts Google Slides URLs from text", () => {
+    expect(
+      extractGoogleSlidesUrls(
+        "See https://docs.google.com/presentation/d/presentation_123/edit?slide=id.p1#slide=id.p1, and also https://docs.google.com/presentation/u/0/d/presentation_456/view?usp=sharing.",
+      ),
+    ).toEqual([
+      "https://docs.google.com/presentation/d/presentation_123/edit?slide=id.p1#slide=id.p1",
+      "https://docs.google.com/presentation/u/0/d/presentation_456/view?usp=sharing",
+    ]);
+  });
+
+  it("ignores Docs and arbitrary URLs", () => {
+    expect(
+      extractGoogleSlidesUrls(
+        "https://docs.google.com/document/d/doc_1/edit https://example.com/presentation/d/presentation_123/edit",
+      ),
+    ).toEqual([]);
   });
 
   it("rejects non-Slides URLs", () => {

--- a/templates/slides/actions/import-google-slides-reference.ts
+++ b/templates/slides/actions/import-google-slides-reference.ts
@@ -47,7 +47,7 @@ export function extractGoogleSlidesPresentationId(value: string): string {
     throw new Error("Use a docs.google.com Google Slides presentation URL.");
   }
   const match = url.pathname.match(
-    /^\/presentation\/d\/([a-zA-Z0-9_-]+)(?:\/|$)/,
+    /^\/presentation\/(?:u\/\d+\/)?d\/([a-zA-Z0-9_-]+)(?:\/|$)/,
   );
   if (!match) {
     throw new Error("That URL is not a Google Slides presentation link.");

--- a/templates/slides/actions/import-google-slides-reference.ts
+++ b/templates/slides/actions/import-google-slides-reference.ts
@@ -9,7 +9,7 @@ import {
   parsePptx,
   type ParsedPresentation,
 } from "../server/handlers/import/pptx-parser.js";
-import { getGoogleDocsAccessToken } from "../server/lib/google-docs-oauth.js";
+import { getAvailableGoogleDocsAccessToken } from "../server/lib/google-docs-access.js";
 import {
   importPptxBufferToDeck,
   type ImportedImageFallback,
@@ -345,9 +345,10 @@ export default defineAction({
     const owner = getRequestUserEmail();
     if (!owner) throw new Error("no authenticated user");
 
-    const connection = await getGoogleDocsAccessToken(owner, {
-      requireDriveExportScope: true,
-    });
+    const connection = await getAvailableGoogleDocsAccessToken(
+      owner,
+      presentationUrl ? { requireDriveExportScope: true } : undefined,
+    );
     if (!connection) {
       throw new Error(
         "Google Drive is not connected. Use the Connect Google button in Slides, then try again.",

--- a/templates/slides/actions/import-google-slides-reference.ts
+++ b/templates/slides/actions/import-google-slides-reference.ts
@@ -345,7 +345,9 @@ export default defineAction({
     const owner = getRequestUserEmail();
     if (!owner) throw new Error("no authenticated user");
 
-    const connection = await getGoogleDocsAccessToken(owner);
+    const connection = await getGoogleDocsAccessToken(owner, {
+      requireDriveExportScope: true,
+    });
     if (!connection) {
       throw new Error(
         "Google Drive is not connected. Use the Connect Google button in Slides, then try again.",

--- a/templates/slides/app/components/editor/GoogleDriveConnectionCta.test.tsx
+++ b/templates/slides/app/components/editor/GoogleDriveConnectionCta.test.tsx
@@ -133,6 +133,31 @@ describe("<GoogleDriveConnectionCta>", () => {
     ).toBeTruthy();
   });
 
+  it("keeps the reconnect button available when managed OAuth needs repair", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              configured: true,
+              connected: true,
+              googleSlidesUrlImportReady: false,
+              googleSlidesUrlImportError: "Google authorization expired",
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    render(<GoogleDriveConnectionCta />);
+
+    expect(
+      await screen.findByText("Google authorization expired"),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Connect Google" })).toBeTruthy();
+  });
+
   it("starts the managed Drive OAuth flow", async () => {
     render(<GoogleDriveConnectionCta />);
     fireEvent.click(

--- a/templates/slides/app/components/editor/GoogleDriveConnectionCta.test.tsx
+++ b/templates/slides/app/components/editor/GoogleDriveConnectionCta.test.tsx
@@ -81,6 +81,26 @@ describe("<GoogleDriveConnectionCta>", () => {
     ).toBeTruthy();
   });
 
+  it("stays quiet until a pasted Slides link is detected", async () => {
+    render(<GoogleDriveConnectionCta active={false} />);
+
+    await waitFor(() => {
+      expect(fetch).not.toHaveBeenCalled();
+    });
+    expect(screen.queryByRole("button", { name: "Connect Google" })).toBeNull();
+  });
+
+  it("checks the connection when a pasted Slides link becomes active", async () => {
+    const { rerender } = render(<GoogleDriveConnectionCta active={false} />);
+
+    rerender(<GoogleDriveConnectionCta active />);
+
+    expect(
+      await screen.findByRole("button", { name: "Connect Google" }),
+    ).toBeTruthy();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("can be dismissed without starting OAuth", async () => {
     render(<GoogleDriveConnectionCta />);
 

--- a/templates/slides/app/components/editor/GoogleDriveConnectionCta.tsx
+++ b/templates/slides/app/components/editor/GoogleDriveConnectionCta.tsx
@@ -15,6 +15,7 @@ interface GoogleDocsStatus {
   configured: boolean;
   connected: boolean;
   googleSlidesUrlImportReady?: boolean;
+  googleSlidesUrlImportError?: string;
   error?: string;
   message?: string;
 }
@@ -147,6 +148,11 @@ export function GoogleDriveConnectionCta({
             ? t("home.googleSlidesReferenceConnect")
             : t("raw.googleOAuthNotConfigured")}
         </p>
+        {displayStatus.googleSlidesUrlImportError && (
+          <p className="mt-1 text-[11px] text-destructive">
+            {displayStatus.googleSlidesUrlImportError}
+          </p>
+        )}
         {error && <p className="mt-1 text-[11px] text-destructive">{error}</p>}
       </div>
       {displayStatus.configured && (

--- a/templates/slides/app/components/editor/GoogleDriveConnectionCta.tsx
+++ b/templates/slides/app/components/editor/GoogleDriveConnectionCta.tsx
@@ -19,6 +19,11 @@ interface GoogleDocsStatus {
   message?: string;
 }
 
+interface GoogleDriveConnectionCtaProps {
+  /** Only query and render for a detected pasted-link intent. */
+  active?: boolean;
+}
+
 type JsonReadResult<T> = { ok: true; data: T } | { ok: false; error: Error };
 
 function endpoint(path: string): string {
@@ -48,7 +53,9 @@ function responseError(
   );
 }
 
-export function GoogleDriveConnectionCta() {
+export function GoogleDriveConnectionCta({
+  active = true,
+}: GoogleDriveConnectionCtaProps) {
   const t = useT();
   const [status, setStatus] = useState<GoogleDocsStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -85,8 +92,18 @@ export function GoogleDriveConnectionCta() {
     }, []);
 
   useEffect(() => {
+    if (!active) {
+      setStatus(null);
+      setError(null);
+      setDismissed(false);
+      setConnecting(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setDismissed(false);
     void refreshStatus();
-  }, [refreshStatus]);
+  }, [active, refreshStatus]);
 
   const needsReconnect =
     status?.connected === true && status.googleSlidesUrlImportReady === false;
@@ -101,7 +118,12 @@ export function GoogleDriveConnectionCta() {
     });
   }, [connecting]);
 
-  if (dismissed || loading || (status?.connected && !needsReconnect)) {
+  if (
+    !active ||
+    dismissed ||
+    loading ||
+    (status?.connected && !needsReconnect)
+  ) {
     return null;
   }
 

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -3,6 +3,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { InvitationBanner } from "@agent-native/core/client/org";
 import { CreativeContextComposerChip } from "@agent-native/creative-context/client";
 import { HeaderActionsProvider } from "@agent-native/toolkit/app-shell";
+import { extractGoogleSlidesUrls } from "@shared/google-docs";
 import { IconMenu2 } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
@@ -18,6 +19,7 @@ import {
 import { TAB_ID } from "@/lib/tab-id";
 import { cn } from "@/lib/utils";
 
+import { GoogleDriveConnectionCta } from "../editor/GoogleDriveConnectionCta";
 import { AgentWorkIndicator } from "./AgentWorkIndicator";
 import { Header } from "./Header";
 import {
@@ -51,6 +53,7 @@ export function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const t = useT();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [composerText, setComposerText] = useState("");
   const [slidesSelection, setSlidesSelection] =
     useState<SlidesAgentSelection | null>(() => readPublishedSlidesSelection());
   const [editorSidebarOverride, setEditorSidebarOverride] =
@@ -141,7 +144,15 @@ export function Layout({ children }: LayoutProps) {
         browserTabId={TAB_ID}
         agentPageHref="/settings/agent"
         suppressFirstRunOnboarding={isSlidesEditorRoute(location.pathname)}
-        composerSlot={<CreativeContextComposerChip />}
+        onComposerTextChange={setComposerText}
+        composerSlot={
+          <>
+            <GoogleDriveConnectionCta
+              active={extractGoogleSlidesUrls(composerText).length > 0}
+            />
+            <CreativeContextComposerChip />
+          </>
+        }
       >
         <div className="agent-layout-shell flex h-screen w-full overflow-hidden bg-background text-foreground">
           {!isEmptyDecksState && showAppSidebar && (

--- a/templates/slides/server/handlers/google-docs-auth.test.ts
+++ b/templates/slides/server/handlers/google-docs-auth.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getGooglePickerConfig: vi.fn(),
+  isGoogleDocsOAuthConfigured: vi.fn(),
+  listGoogleDocsAccounts: vi.fn(),
+  resolveManagedGoogleDriveAccount: vi.fn(),
+  setResponseStatus: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  decodeOAuthState: vi.fn(),
+  encodeOAuthState: vi.fn(),
+  getAppUrl: vi.fn(),
+  getSession: mocks.getSession,
+  isElectron: vi.fn(),
+  oauthCallbackResponse: vi.fn(),
+  oauthErrorPage: vi.fn(),
+  resolveOAuthRedirectUri: vi.fn(),
+  safeReturnPath: vi.fn(),
+}));
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getQuery: vi.fn(),
+  setResponseStatus: mocks.setResponseStatus,
+}));
+
+vi.mock("../lib/google-docs-access.js", () => ({
+  getAvailableGoogleDocsAccessToken: vi.fn(),
+  resolveManagedGoogleDriveAccount: mocks.resolveManagedGoogleDriveAccount,
+}));
+
+vi.mock("../lib/google-docs-error.js", () => ({
+  formatGoogleOAuthError: (error: unknown) =>
+    error instanceof Error ? `formatted: ${error.message}` : "formatted",
+}));
+
+vi.mock("../lib/google-docs-oauth.js", () => ({
+  disconnectGoogleDocs: vi.fn(),
+  exchangeGoogleDocsCode: vi.fn(),
+  getGoogleDocsAuthUrl: vi.fn(),
+  getGooglePickerConfig: mocks.getGooglePickerConfig,
+  hasGoogleDriveExportScope: (scope: string) =>
+    scope.includes("drive.readonly"),
+  isGoogleDocsOAuthConfigured: mocks.isGoogleDocsOAuthConfigured,
+  listGoogleDocsAccounts: mocks.listGoogleDocsAccounts,
+}));
+
+vi.mock("./request-auth-context.js", () => ({
+  withSlidesRequestContext: async (_event: unknown, callback: () => unknown) =>
+    callback(),
+}));
+
+import { getGoogleDocsStatus } from "./google-docs-auth";
+
+describe("getGoogleDocsStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({ email: "owner@example.com" });
+    mocks.listGoogleDocsAccounts.mockResolvedValue([
+      {
+        email: "picker@example.com",
+        scope: "https://www.googleapis.com/auth/drive.file",
+      },
+    ]);
+    mocks.resolveManagedGoogleDriveAccount.mockRejectedValue(
+      new Error("invalid_grant"),
+    );
+    mocks.getGooglePickerConfig.mockResolvedValue({});
+    mocks.isGoogleDocsOAuthConfigured.mockResolvedValue(true);
+  });
+
+  it("keeps a local Picker connection reconnectable when managed OAuth is stale", async () => {
+    const result = await getGoogleDocsStatus({} as any);
+
+    expect(mocks.setResponseStatus).not.toHaveBeenCalledWith(
+      expect.anything(),
+      500,
+    );
+    expect(result).toMatchObject({
+      connected: true,
+      googleSlidesUrlImportReady: false,
+      googleSlidesUrlImportError: "formatted: invalid_grant",
+    });
+  });
+});

--- a/templates/slides/server/handlers/google-docs-auth.ts
+++ b/templates/slides/server/handlers/google-docs-auth.ts
@@ -164,18 +164,25 @@ export const getGoogleDocsStatus = defineEventHandler(
 
     try {
       const accounts = await listGoogleDocsAccounts(owner);
+      let googleSlidesUrlImportError: string | undefined;
       if (
         !accounts.some((account) => hasGoogleDriveExportScope(account.scope))
       ) {
-        const managed = await withSlidesRequestContext(event, () =>
-          resolveManagedGoogleDriveAccount(),
-        );
-        if (managed) {
-          accounts.push({
-            email: managed.email,
-            scope: managed.scope,
-            shared: true,
-          });
+        try {
+          const managed = await withSlidesRequestContext(event, () =>
+            resolveManagedGoogleDriveAccount(),
+          );
+          if (managed) {
+            accounts.push({
+              email: managed.email,
+              scope: managed.scope,
+              shared: true,
+            });
+          }
+        } catch (error) {
+          // Keep the status response actionable so a revoked managed token can
+          // still be repaired through the Connect Google CTA.
+          googleSlidesUrlImportError = formatGoogleOAuthError(error);
         }
       }
       const picker = await getGooglePickerConfig(owner);
@@ -185,6 +192,7 @@ export const getGoogleDocsStatus = defineEventHandler(
         googleSlidesUrlImportReady: accounts.some((account) =>
           hasGoogleDriveExportScope(account.scope),
         ),
+        googleSlidesUrlImportError,
         accounts,
         pickerConfigured: !!(picker.apiKey && picker.appId),
         pickerApiKey: picker.apiKey,

--- a/templates/slides/server/handlers/google-docs-auth.ts
+++ b/templates/slides/server/handlers/google-docs-auth.ts
@@ -24,7 +24,6 @@ import { formatGoogleOAuthError } from "../lib/google-docs-error.js";
 import {
   disconnectGoogleDocs,
   exchangeGoogleDocsCode,
-  getGoogleDocsAccessToken,
   getGoogleDocsAuthUrl,
   getGooglePickerConfig,
   hasGoogleDriveExportScope,

--- a/templates/slides/server/handlers/google-docs-auth.ts
+++ b/templates/slides/server/handlers/google-docs-auth.ts
@@ -2,7 +2,6 @@ import {
   decodeOAuthState,
   encodeOAuthState,
   getAppUrl,
-  getCredentialContext,
   getSession,
   isElectron,
   oauthCallbackResponse,
@@ -10,7 +9,6 @@ import {
   resolveOAuthRedirectUri,
   safeReturnPath,
 } from "@agent-native/core/server";
-import { resolveWorkspaceConnectionForApp } from "@agent-native/core/workspace-connections";
 import {
   defineEventHandler,
   getQuery,
@@ -18,6 +16,10 @@ import {
   type H3Event,
 } from "h3";
 
+import {
+  getAvailableGoogleDocsAccessToken,
+  resolveManagedGoogleDriveAccount,
+} from "../lib/google-docs-access.js";
 import { formatGoogleOAuthError } from "../lib/google-docs-error.js";
 import {
   disconnectGoogleDocs,
@@ -29,44 +31,8 @@ import {
   isGoogleDocsOAuthConfigured,
   listGoogleDocsAccounts,
 } from "../lib/google-docs-oauth.js";
-import { getSlidesProviderApiRuntime } from "../lib/provider-api.js";
 import { withSlidesRequestContext } from "./request-auth-context.js";
 const OAUTH_STATE_APP_ID = process.env.APP_NAME || "slides";
-
-async function resolveManagedGoogleDriveAccount() {
-  if (!getCredentialContext()) return null;
-  const connection = await resolveWorkspaceConnectionForApp({
-    appId: "slides",
-    provider: "google_drive",
-    requireConnected: true,
-  });
-  if (!connection.available) return null;
-  const credential =
-    await getSlidesProviderApiRuntime().resolveOAuthAccessToken({
-      provider: "google_drive",
-    });
-  if (!credential.accountId) return null;
-  return {
-    email: credential.accountId,
-    accessToken: credential.accessToken,
-    scope: "https://www.googleapis.com/auth/drive.readonly",
-    shared: true,
-  };
-}
-
-async function getAvailableGoogleDocsAccessToken(
-  event: H3Event,
-  owner: string,
-) {
-  return withSlidesRequestContext(event, async () => {
-    const local = await getGoogleDocsAccessToken(owner);
-    if (local) return local;
-    const managed = await resolveManagedGoogleDriveAccount();
-    return managed
-      ? { accessToken: managed.accessToken, accountEmail: managed.email }
-      : null;
-  });
-}
 
 async function requireSessionEmail(event: H3Event): Promise<string | null> {
   const session = await getSession(event);
@@ -199,7 +165,9 @@ export const getGoogleDocsStatus = defineEventHandler(
 
     try {
       const accounts = await listGoogleDocsAccounts(owner);
-      if (accounts.length === 0) {
+      if (
+        !accounts.some((account) => hasGoogleDriveExportScope(account.scope))
+      ) {
         const managed = await withSlidesRequestContext(event, () =>
           resolveManagedGoogleDriveAccount(),
         );
@@ -257,7 +225,9 @@ export const getGoogleDocsPickerToken = defineEventHandler(
     }
 
     try {
-      const token = await getAvailableGoogleDocsAccessToken(event, owner);
+      const token = await withSlidesRequestContext(event, () =>
+        getAvailableGoogleDocsAccessToken(owner),
+      );
       if (!token) {
         setResponseStatus(event, 401);
         return {

--- a/templates/slides/server/lib/google-docs-access.test.ts
+++ b/templates/slides/server/lib/google-docs-access.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCredentialContext: vi.fn(),
+  getGoogleDocsAccessToken: vi.fn(),
+  getSlidesProviderApiRuntime: vi.fn(),
+  resolveWorkspaceConnectionForApp: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  getCredentialContext: mocks.getCredentialContext,
+}));
+vi.mock("@agent-native/core/workspace-connections", () => ({
+  resolveWorkspaceConnectionForApp: mocks.resolveWorkspaceConnectionForApp,
+}));
+vi.mock("./google-docs-oauth.js", () => ({
+  getGoogleDocsAccessToken: mocks.getGoogleDocsAccessToken,
+}));
+vi.mock("./provider-api.js", () => ({
+  getSlidesProviderApiRuntime: mocks.getSlidesProviderApiRuntime,
+}));
+
+import { getAvailableGoogleDocsAccessToken } from "./google-docs-access.js";
+
+beforeEach(() => {
+  mocks.getCredentialContext.mockReturnValue({
+    userEmail: "owner@example.com",
+    orgId: "org-1",
+  });
+  mocks.getGoogleDocsAccessToken.mockResolvedValue(null);
+  mocks.resolveWorkspaceConnectionForApp.mockResolvedValue({
+    available: true,
+  });
+  mocks.getSlidesProviderApiRuntime.mockReturnValue({
+    resolveOAuthAccessToken: vi.fn().mockResolvedValue({
+      accountId: "managed@example.com",
+      accessToken: "managed-token",
+    }),
+  });
+});
+
+describe("Google Docs access resolution", () => {
+  it("keeps Picker imports on a drive.file local account", async () => {
+    mocks.getGoogleDocsAccessToken.mockResolvedValue({
+      accountEmail: "picker@example.com",
+      accessToken: "picker-token",
+    });
+
+    await expect(
+      getAvailableGoogleDocsAccessToken("owner@example.com"),
+    ).resolves.toMatchObject({ accountEmail: "picker@example.com" });
+    expect(mocks.getGoogleDocsAccessToken).toHaveBeenCalledWith(
+      "owner@example.com",
+      {},
+    );
+    expect(mocks.resolveWorkspaceConnectionForApp).not.toHaveBeenCalled();
+  });
+
+  it("requires export scope for pasted URL imports", async () => {
+    await expect(
+      getAvailableGoogleDocsAccessToken("owner@example.com", {
+        requireDriveExportScope: true,
+      }),
+    ).resolves.toMatchObject({ accountEmail: "managed@example.com" });
+    expect(mocks.getGoogleDocsAccessToken).toHaveBeenCalledWith(
+      "owner@example.com",
+      { requireDriveExportScope: true },
+    );
+  });
+
+  it("falls back to the managed Google Drive connection", async () => {
+    await expect(
+      getAvailableGoogleDocsAccessToken("owner@example.com"),
+    ).resolves.toEqual({
+      accountEmail: "managed@example.com",
+      accessToken: "managed-token",
+    });
+    expect(mocks.resolveWorkspaceConnectionForApp).toHaveBeenCalledWith({
+      appId: "slides",
+      provider: "google_drive",
+      requireConnected: true,
+    });
+  });
+});

--- a/templates/slides/server/lib/google-docs-access.ts
+++ b/templates/slides/server/lib/google-docs-access.ts
@@ -1,0 +1,51 @@
+import { getCredentialContext } from "@agent-native/core/server";
+import { resolveWorkspaceConnectionForApp } from "@agent-native/core/workspace-connections";
+
+import {
+  getGoogleDocsAccessToken,
+  type GoogleDocsAccessTokenOptions,
+} from "./google-docs-oauth.js";
+import { getSlidesProviderApiRuntime } from "./provider-api.js";
+
+export interface GoogleDocsAccessToken {
+  accessToken: string;
+  accountEmail: string;
+}
+
+export async function resolveManagedGoogleDriveAccount(): Promise<{
+  email: string;
+  accessToken: string;
+  scope: string;
+  shared: true;
+} | null> {
+  if (!getCredentialContext()) return null;
+  const connection = await resolveWorkspaceConnectionForApp({
+    appId: "slides",
+    provider: "google_drive",
+    requireConnected: true,
+  });
+  if (!connection.available) return null;
+  const credential =
+    await getSlidesProviderApiRuntime().resolveOAuthAccessToken({
+      provider: "google_drive",
+    });
+  if (!credential.accountId) return null;
+  return {
+    email: credential.accountId,
+    accessToken: credential.accessToken,
+    scope: "https://www.googleapis.com/auth/drive.readonly",
+    shared: true,
+  };
+}
+
+export async function getAvailableGoogleDocsAccessToken(
+  owner: string,
+  options: GoogleDocsAccessTokenOptions = {},
+): Promise<GoogleDocsAccessToken | null> {
+  const local = await getGoogleDocsAccessToken(owner, options);
+  if (local) return local;
+  const managed = await resolveManagedGoogleDriveAccount();
+  return managed
+    ? { accessToken: managed.accessToken, accountEmail: managed.email }
+    : null;
+}

--- a/templates/slides/server/lib/google-docs-oauth.test.ts
+++ b/templates/slides/server/lib/google-docs-oauth.test.ts
@@ -1,10 +1,63 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const oauthMocks = vi.hoisted(() => ({
+  getOAuthTokens: vi.fn(),
+  listOAuthAccountsByOwner: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/oauth-tokens", () => ({
+  deleteOAuthTokens: vi.fn(),
+  getOAuthTokens: oauthMocks.getOAuthTokens,
+  listOAuthAccountsByOwner: oauthMocks.listOAuthAccountsByOwner,
+  saveOAuthTokens: vi.fn(),
+}));
 
 import {
   GOOGLE_DOCS_SCOPES,
   GOOGLE_DRIVE_READONLY_SCOPE,
+  getGoogleDocsAccessToken,
   hasGoogleDriveExportScope,
 } from "./google-docs-oauth.js";
+
+beforeEach(() => {
+  oauthMocks.listOAuthAccountsByOwner.mockImplementation(
+    async (provider: string) =>
+      provider === "google"
+        ? [
+            {
+              accountId: "picker@example.com",
+              tokens: {
+                access_token: "picker-token",
+                expiry_date: Date.now() + 60 * 60 * 1000,
+                scope: "https://www.googleapis.com/auth/drive.file",
+              },
+            },
+            {
+              accountId: "export@example.com",
+              tokens: {
+                access_token: "export-token",
+                expiry_date: Date.now() + 60 * 60 * 1000,
+                scope: GOOGLE_DRIVE_READONLY_SCOPE,
+              },
+            },
+          ]
+        : [],
+  );
+  oauthMocks.getOAuthTokens.mockImplementation(
+    async (_provider: string, accountId: string) =>
+      accountId === "export@example.com"
+        ? {
+            access_token: "export-token",
+            expiry_date: Date.now() + 60 * 60 * 1000,
+            scope: GOOGLE_DRIVE_READONLY_SCOPE,
+          }
+        : {
+            access_token: "picker-token",
+            expiry_date: Date.now() + 60 * 60 * 1000,
+            scope: "https://www.googleapis.com/auth/drive.file",
+          },
+  );
+});
 
 describe("Google Slides URL import OAuth scopes", () => {
   it("requests Drive read access for pasted presentation links", () => {
@@ -20,5 +73,13 @@ describe("Google Slides URL import OAuth scopes", () => {
       hasGoogleDriveExportScope("https://www.googleapis.com/auth/drive.file"),
     ).toBe(false);
     expect(hasGoogleDriveExportScope()).toBe(false);
+  });
+
+  it("selects an export-capable account for pasted Slides imports", async () => {
+    await expect(
+      getGoogleDocsAccessToken("owner@example.com", {
+        requireDriveExportScope: true,
+      }),
+    ).resolves.toMatchObject({ accountEmail: "export@example.com" });
   });
 });

--- a/templates/slides/server/lib/google-docs-oauth.ts
+++ b/templates/slides/server/lib/google-docs-oauth.ts
@@ -326,7 +326,7 @@ export async function disconnectGoogleDocs(owner: string): Promise<void> {
 
 export async function getGoogleDocsAccessToken(
   owner: string,
-  options: { requireDriveExportScope?: boolean } = {},
+  options: GoogleDocsAccessTokenOptions = {},
 ): Promise<{
   accessToken: string;
   accountEmail: string;
@@ -353,6 +353,10 @@ export async function getGoogleDocsAccessToken(
     stored as unknown as GoogleDocsTokens,
   );
   return { accessToken, accountEmail: account.accountId };
+}
+
+export interface GoogleDocsAccessTokenOptions {
+  requireDriveExportScope?: boolean;
 }
 
 async function listGoogleProviderAccounts(owner: string): Promise<

--- a/templates/slides/server/lib/google-docs-oauth.ts
+++ b/templates/slides/server/lib/google-docs-oauth.ts
@@ -324,14 +324,21 @@ export async function disconnectGoogleDocs(owner: string): Promise<void> {
   );
 }
 
-export async function getGoogleDocsAccessToken(owner: string): Promise<{
+export async function getGoogleDocsAccessToken(
+  owner: string,
+  options: { requireDriveExportScope?: boolean } = {},
+): Promise<{
   accessToken: string;
   accountEmail: string;
 } | null> {
   const accounts = await listGoogleProviderAccounts(owner);
-  if (accounts.length === 0) return null;
+  const account = options.requireDriveExportScope
+    ? accounts.find((candidate) =>
+        hasGoogleDriveExportScope(String(candidate.tokens.scope ?? "")),
+      )
+    : accounts[0];
+  if (!account) return null;
 
-  const account = accounts[0];
   const stored = await getOAuthTokens(
     account.provider,
     account.accountId,

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -25,6 +25,7 @@ const INITIAL_TOOL_NAMES = [
   "generate-image-api",
   "import-file",
   "import-google-doc",
+  "import-google-slides-reference",
   "import-pptx",
   "export-pptx",
   "navigate",
@@ -65,6 +66,8 @@ export default createAgentChatPlugin({
   ],
   prepareRequest: prepareSlidesChatAttachments,
   systemPrompt: `You are an AI deck assistant. You create, edit, import, export, style, share, and navigate decks through actions and shared application state. For a newly created presentation, use create-deck with slides: [] only when you are creating the deck yourself, then add-slide sequentially with full rendered HTML. The legacy generate-slides-ai action returns Markdown drafts and is not part of the persisted presentation workflow. When speaker notes are requested, keep presenter-only text in each slide's notes field rather than the slide HTML, and preserve notes during source-preserving edits.
+
+Treat Google Workspace links as authenticated sources, not public web pages. For a Google Slides presentation URL, call import-google-slides-reference with the original presentationUrl before authoring or editing. For a Google Docs URL, call import-google-doc with the original url before using its content. For Google Drive or Sheets links, use the connected Google provider API when the request needs their contents. If the relevant Google connection is unavailable, tell the user to use the Connect Google button in the Slides import step. Do not send Google Workspace URLs to web-request.
 
 When a request includes a public URL as source material, fetch it with web-request before authoring. Inspect the returned page content, links, and agent-readable metadata, then follow any context, transcript, visual/frame, or asset URLs it exposes. Image responses are visual evidence for the deck and should be inspected when available; do not claim to have reviewed visuals that could not be fetched.
 

--- a/templates/slides/shared/google-docs.ts
+++ b/templates/slides/shared/google-docs.ts
@@ -1,4 +1,5 @@
 const GOOGLE_DOC_ID_RE = /^[a-zA-Z0-9_-]{20,}$/;
+const GOOGLE_SLIDES_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
 export function extractGoogleDocId(input: string): string | null {
   const trimmed = input.trim();
@@ -29,6 +30,31 @@ export function extractGoogleDocUrls(text: string): string[] {
   for (const match of text.matchAll(pattern)) {
     const url = match[0].replace(/[.,;:!?]+$/, "");
     if (extractGoogleDocId(url)) urls.add(url);
+  }
+  return [...urls];
+}
+
+export function extractGoogleSlidesUrls(text: string): string[] {
+  const urls = new Set<string>();
+  const pattern =
+    /https:\/\/docs\.google\.com\/presentation(?:\/u\/\d+)?\/d\/[^\s<>"'`),\]]+/gi;
+  for (const match of text.matchAll(pattern)) {
+    const url = match[0].replace(/[.,;:!?]+$/, "");
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      continue;
+    }
+
+    if (!/(\.|^)google\.com$/i.test(parsed.hostname)) continue;
+
+    const presentationMatch = parsed.pathname.match(
+      /\/presentation(?:\/u\/\d+)?\/d\/([a-zA-Z0-9_-]+)/,
+    );
+    if (presentationMatch && GOOGLE_SLIDES_ID_RE.test(presentationMatch[1])) {
+      urls.add(url);
+    }
   }
   return [...urls];
 }


### PR DESCRIPTION
## Summary\n\n- Detect standard and account-scoped Google Slides URLs in the Slides composer.\n- Show the existing Google Drive OAuth CTA only when a Slides link is detected.\n- Route Google Workspace links through authenticated actions and make Slides import available on the first agent turn.\n\n## Validation\n\n- Focused Vitest: 2 files, 15 tests passed\n- Slides typecheck passed\n- pnpm guards: 65 checks passed\n- Slides build passed\n- Live local Playwright smoke showed the CTA and preserved composer text\n\nVisual recap: https://plan.agent-native.com/_agent-native/open?app=plan&view=plan&to=%2Frecaps%2Frecap-74d474d2f8b64e75&planId=recap-74d474d2f8b64e75&agentSidebar=closed