### PR TITLE
fix(core): stop blaming the reader's provider key for a 401 that was not theirs

### DIFF
--- a/.changeset/provider-credential-rejected-copy.md
+++ b/.changeset/provider-credential-rejected-copy.md
@@ -1,0 +1,20 @@
+---
+"@agent-native/core": patch
+---
+
+Stop telling readers their own provider key was rejected when it was not theirs
+
+A 401 proves the credential a request carried was refused. It does not prove
+whose credential it was, and the reader is often someone with no saved key to
+fix — the rejected credential can be a workspace or deployment one they cannot
+see. The copy named "the saved provider key" as the cause and sent everyone to
+Settings, which is why one shared credential cost two days of chasing key
+configuration.
+
+The message now says only what the 401 proves, and the rejected-credential card
+offers a retry alongside the setup flow. That retry used to be withheld because
+it would "replay the same rejected credential and loop"; that stopped being true
+once a 401 began fingerprinting the credential and skipping it for a backing-off
+window, so the next attempt reaches for a different one or fails closed as
+missing credentials. Previously this rendered a setup panel for a connection
+already marked good, with no action available at all.

--- a/e2e/beta/lib/chat.ts
+++ b/e2e/beta/lib/chat.ts
@@ -213,7 +213,7 @@ export const CHAT_FAILURE_PATTERNS: RegExp[] = [
   /ERROR ID:/i,
   /we ran into an issue processing your request/i,
   /provider_internal_error/i,
-  /The saved provider key was rejected/i,
+  /rejected the credential used for this request/i,
   /Builder rejected the connected credentials/i,
   /Missing Authentication header/i,
   /Authentication is still initializing/i,

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -463,6 +463,54 @@ describe("run recovery surfaces", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
+  // Review feedback on #3721: the restored retry on a rejected-credential card
+  // can hand the reader straight into `missing_credentials` — the rejected
+  // credential is skipped for a backing-off window, so the very next run has
+  // nothing to use. Gating this card's retry on connecting a provider here
+  // assumed that was the only way out, which is false when the fix is an admin
+  // repairing the shared credential or the window simply expiring. That put the
+  // same dead end back, one step later.
+  it("offers retry on the missing-provider card without connecting first", async () => {
+    const onRetry = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <AgentNativeI18nProvider
+          initialLocale="en-US"
+          initialPreference="en-US"
+          persistPreference={false}
+        >
+          <RunErrorRecoveryCard
+            info={{
+              message: "No LLM provider is connected.",
+              errorCode: "missing_credentials",
+            }}
+            onContinue={vi.fn()}
+            onRetry={onRetry}
+            onDismiss={vi.fn()}
+          />
+        </AgentNativeI18nProvider>,
+      );
+    });
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Retry",
+    );
+    expect(retryButton).toBeTruthy();
+
+    await act(async () => {
+      retryButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // Once per card: a retry that is always offered must still not be able to
+    // spam the run.
+    await act(async () => {
+      retryButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
   it("renders missing-provider errors as inline setup and retries on click", async () => {
     const onRetry = vi.fn();
 

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -60,7 +60,7 @@ vi.mock("../i18n.js", () => ({
         "agentChat.recovery.copyDebug": "Copy debug info",
         "agentChat.recovery.copyFailed": "Copy failed",
         "agentChat.recovery.credentialRejected":
-          "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+          "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
         "agentChat.recovery.newChatHint":
           "This run can be continued in a new chat.",
         "agentChat.recovery.reconnectBuilder": "Reconnect Builder.io",
@@ -416,7 +416,19 @@ describe("run recovery surfaces", () => {
     });
   });
 
-  it("shows the AI setup flow without a direct retry button for a rejected provider key", async () => {
+  // Prod, 2026-08-26 (slides): this exact shape — a 401 whose body is the
+  // gateway's absent-credential sentence — reached users whose own key was
+  // fine, because the rejected credential belonged to the workspace. They got
+  // a setup panel for a connection already marked good and no way forward. The
+  // retry premise ("replays the same rejected credential") stopped being true
+  // once a 401 started fingerprinting and skipping that credential, so the
+  // setup flow and a retry now ship together.
+  //
+  // Asserted through `aria-label`: the retry control is an icon-only button, so
+  // the previous `textContent` check read "" and passed no matter what
+  // rendered.
+  it("shows the AI setup flow AND a retry button for a rejected provider key", async () => {
+    const onRetry = vi.fn();
     await act(async () => {
       root.render(
         <AgentNativeI18nProvider
@@ -431,7 +443,7 @@ describe("run recovery surfaces", () => {
               details: '401 {"error":{"type":"authentication_error"}}',
             }}
             onContinue={vi.fn()}
-            onRetry={vi.fn()}
+            onRetry={onRetry}
             onDismiss={vi.fn()}
           />
         </AgentNativeI18nProvider>,
@@ -440,10 +452,15 @@ describe("run recovery surfaces", () => {
 
     expect(container.textContent).toContain("Connect Builder.io");
     expect(container.textContent).toContain("Custom keys");
-    const buttonLabels = Array.from(container.querySelectorAll("button")).map(
-      (button) => button.textContent?.trim() ?? "",
+
+    const retryButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Retry"]',
     );
-    expect(buttonLabels).not.toContain("Retry");
+    expect(retryButton).toBeTruthy();
+    await act(async () => {
+      retryButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it("renders missing-provider errors as inline setup and retries on click", async () => {
@@ -584,7 +601,7 @@ describe("run recovery surfaces", () => {
           <RunErrorRecoveryCard
             info={{
               message:
-                "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+                "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
               errorCode: "authentication_error",
             }}
             onContinue={vi.fn()}

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -504,7 +504,6 @@ export function RunErrorRecoveryCard({
   );
   const [forking, setForking] = useState(false);
   const [forkError, setForkError] = useState<string | null>(null);
-  const [providerConnected, setProviderConnected] = useState(false);
   const retryRequestedRef = useRef(false);
   const [retryRequested, setRetryRequested] = useState(false);
   const builderReconnect = useBuilderConnectFlow({
@@ -576,7 +575,6 @@ export function RunErrorRecoveryCard({
   }, [onDismiss, onProviderConnected, onRetry]);
 
   const handleMissingProviderConnected = useCallback(() => {
-    setProviderConnected(true);
     onProviderConnected?.();
   }, [onProviderConnected]);
   const handleMissingProviderRetry = useCallback(() => {
@@ -616,19 +614,30 @@ export function RunErrorRecoveryCard({
           layout="sidebar"
           onConnected={handleMissingProviderConnected}
         />
-        {providerConnected ? (
-          <div className="flex justify-center px-3 pt-1">
-            <button
-              type="button"
-              onClick={handleMissingProviderRetry}
-              disabled={retryRequested}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
-            >
-              <IconRefresh size={13} />
-              {t("agentChat.common.retry")}
-            </button>
-          </div>
-        ) : null}
+        {/*
+          Deliberately not gated on `providerConnected`. That gate assumed
+          connecting here is the only route out, which is false for the reader
+          this card now most often reaches: a rejected workspace or deployment
+          credential is skipped for a backing-off window, so the next run can
+          report missing credentials while the actual fix is someone else
+          repairing the shared credential, or simply the window expiring.
+          Withholding retry until they connect a provider they may have no
+          permission to add left an already-connected panel with no action —
+          the same dead end the rejected-credential card was just changed to
+          stop producing, one step later. `handleMissingProviderRetry` fires at
+          most once per card, so offering it cannot loop.
+        */}
+        <div className="flex justify-center px-3 pt-1">
+          <button
+            type="button"
+            onClick={handleMissingProviderRetry}
+            disabled={retryRequested}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+          >
+            <IconRefresh size={13} />
+            {t("agentChat.common.retry")}
+          </button>
+        </div>
       </div>
     );
   }

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -524,11 +524,17 @@ export function RunErrorRecoveryCard({
   // replayed.
   const isUnblockableExternally =
     info.errorCode === "email_verification_required";
-  // Rejected provider keys already have a recovery path: update/connect the
-  // credential, then let the setup callback re-run the turn. Exposing a
-  // separate retry button here just replays the same rejected credential and
-  // turns a permanent auth failure into a loop.
-  const canRetry = canRecover || isUnblockableExternally;
+  // Rejected provider keys keep their setup path below — update/connect the
+  // credential and the setup callback re-runs the turn. They ALSO get a retry
+  // now, which the old comment here ruled out because "retry replays the same
+  // rejected credential and turns a permanent auth failure into a loop". That
+  // is no longer true: a 401 fingerprints the credential and skips it for a
+  // backing-off window (`recordProviderCredentialAuthFailure`), so the next
+  // attempt reaches for a different one, or fails closed as missing
+  // credentials. Without this the common case — a rejected workspace or
+  // deployment credential the reader cannot see, let alone edit — rendered a
+  // "Connected ✓" panel with no action at all.
+  const canRetry = canRecover || isUnblockableExternally || isProviderAuthError;
   const builderReconnectResolved =
     shouldShowBuilderReconnect &&
     builderReconnect.hasFetchedStatus &&

--- a/packages/core/src/client/error-format.spec.ts
+++ b/packages/core/src/client/error-format.spec.ts
@@ -236,11 +236,11 @@ describe("formatChatErrorText", () => {
     const normalized = normalizeChatError(raw, "authentication_error");
 
     expect(normalized.message).toBe(
-      "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+      "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
     );
     expect(normalized.details).toBe(raw);
     expect(formatChatErrorText(raw, undefined, "authentication_error")).toBe(
-      "Error: The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+      "Error: The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
     );
   });
 
@@ -248,12 +248,12 @@ describe("formatChatErrorText", () => {
     const normalized = normalizeChatError("401 status code (no body)");
 
     expect(normalized.message).toBe(
-      "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+      "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
     );
     expect(normalized.details).toBe("401 status code (no body)");
     expect(normalized.message).not.toContain("no body");
     expect(formatChatErrorText("401 status code (no body)")).toBe(
-      "Error: The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+      "Error: The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
     );
   });
 
@@ -262,7 +262,7 @@ describe("formatChatErrorText", () => {
       normalizeChatError("The model provider rejected the saved API key."),
     ).toMatchObject({
       message:
-        "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+        "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
     });
   });
 

--- a/packages/core/src/client/error-format.ts
+++ b/packages/core/src/client/error-format.ts
@@ -27,6 +27,28 @@ const UPGRADE_AT_BUILDER_LABEL = "Upgrade at builder.io";
 const BUILDER_AUTHENTICATION_ERROR =
   "Builder rejected the connected credentials. Reconnect Builder.io (free tier available) in Settings, then retry.";
 /**
+ * A 401 says the credential this request carried was refused. It does NOT say
+ * whose credential it was, and the reader is frequently someone with no saved
+ * key to fix: the rejected credential can be a workspace or deployment one they
+ * cannot see. The previous copy named the reader's own "saved provider key" as
+ * the cause and sent everyone to Settings, which is why one shared credential
+ * cost two days of chasing key configuration.
+ *
+ * Say only what the 401 actually proves, and name the recovery that now exists:
+ * a rejected credential is fingerprinted and skipped on the next attempt
+ * (`recordProviderCredentialAuthFailure`), so retrying reaches for a different
+ * one instead of replaying this failure.
+ */
+export const PROVIDER_CREDENTIAL_REJECTED_MESSAGE =
+  "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.";
+/**
+ * Distinctive fragment of the message above. `run-recovery` re-classifies a
+ * message this module already normalized, so the predicate must match its own
+ * output — anchoring both to one constant is what stops them drifting apart.
+ */
+const PROVIDER_CREDENTIAL_REJECTED_FRAGMENT =
+  "rejected the credential used for this request";
+/**
  * The gateway's unhandled-500 envelope is an internal correlation id and an
  * apology: nothing the reader can act on, and nothing that says whether the
  * failure was theirs. Say where it broke and keep the raw sentence in
@@ -136,6 +158,10 @@ const KNOWN_CHAT_ERROR_KEYS = new Map<string, string>([
   [
     "The model provider rejected the saved API key. Update the key in Settings → Integrations → API keys, then retry.",
     "agentChat.errorMessages.providerAuthentication",
+  ],
+  [
+    PROVIDER_CREDENTIAL_REJECTED_MESSAGE,
+    "agentChat.errorMessages.providerCredentialRejected",
   ],
   [
     "The model provider could not be reached. Check your connection and retry.",
@@ -280,7 +306,7 @@ export function isProviderAuthenticationError(
     lower.includes("incorrect api key") ||
     lower.includes("api key is invalid") ||
     lower.includes("rejected the saved api key") ||
-    lower.includes("saved provider key was rejected") ||
+    lower.includes(PROVIDER_CREDENTIAL_REJECTED_FRAGMENT) ||
     (lower.includes("authentication_error") && lower.includes("api"))
   );
 }
@@ -372,8 +398,7 @@ export function normalizeChatError(
 
   if (isProviderAuthenticationError(text, errorCode)) {
     return {
-      message:
-        "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+      message: PROVIDER_CREDENTIAL_REJECTED_MESSAGE,
       details: text,
     };
   }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -2206,7 +2206,7 @@ describe("SSE event processor error classification", () => {
         type: "agent-chat:run-error",
         detail: {
           message:
-            "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+            "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
           details: "401 status code (no body)",
           tabId: "tab-provider-auth",
         },
@@ -2219,7 +2219,7 @@ describe("SSE event processor error classification", () => {
       content: [
         {
           type: "text",
-          text: "Error: The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+          text: "Error: The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
         },
       ],
       status: { type: "incomplete", reason: "error" },
@@ -2227,7 +2227,7 @@ describe("SSE event processor error classification", () => {
         custom: {
           runError: {
             message:
-              "The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.",
+              "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
             details: "401 status code (no body)",
           },
         },

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -496,6 +496,37 @@ describe("Builder credential auth failure markers", () => {
     ).toBeNull();
   });
 
+  // The back-off is exponential, so without a ceiling a credential that failed
+  // enough times would be pinned for weeks and a server-side recovery (plan
+  // upgrade, gateway re-enabled) would never be noticed. A corrupt strike count
+  // must not be a way to pin one forever either.
+  it("never pins a credential beyond the 24h ceiling", async () => {
+    const dayAndAHalfAgo = Date.now() - 36 * 60 * 60 * 1000;
+
+    for (const strikes of [8, 99, Number.MAX_SAFE_INTEGER]) {
+      mockGetSetting.mockResolvedValue({ strikes, at: dayAndAHalfAgo });
+      expect(
+        await getBuilderCredentialAuthFailure({
+          privateKey: "bpk-secret",
+          publicKey: "pub-secret",
+        }),
+      ).toBeNull();
+    }
+
+    // Still armed just inside the ceiling, so the ceiling is real rather than
+    // the back-off silently collapsing to "always expired".
+    mockGetSetting.mockResolvedValue({
+      strikes: 8,
+      at: Date.now() - 23 * 60 * 60 * 1000,
+    });
+    expect(
+      await getBuilderCredentialAuthFailure({
+        privateKey: "bpk-secret",
+        publicKey: "pub-secret",
+      }),
+    ).not.toBeNull();
+  });
+
   it("counts a repeat failure on the same credential as another strike", async () => {
     mockGetSetting.mockImplementation(async (key: string) =>
       key.startsWith("provider-auth-failure:")

--- a/scripts/guard-help-icon-scale.mjs
+++ b/scripts/guard-help-icon-scale.mjs
@@ -20,8 +20,13 @@ const REPO_ROOT = path.resolve(
 
 const SOURCE_ROOTS = ["packages", "templates"];
 const SOURCE_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
+// `.tmp*` covers the scratch directories test workers create and delete while
+// they run — `packages/core/.tmp-worker-test-*` among them. Without it this
+// walk races them and dies on ENOENT partway through, which reads as a guard
+// violation rather than as the unrelated concurrency it is. `pnpm prep` runs
+// guards and tests together, so the race is the normal case, not a rare one.
 const EXCLUDED_PATH =
-  /(^|\/)(node_modules|dist|build|\.next|\.nuxt|\.output|\.cache|\.turbo|\.netlify|\.vercel|\.wrangler|\.react-router|\.generated|coverage|corpus)(\/|$)/;
+  /(^|\/)(node_modules|dist|build|\.next|\.nuxt|\.output|\.cache|\.turbo|\.netlify|\.vercel|\.wrangler|\.react-router|\.generated|coverage|corpus|\.tmp[^/]*)(\/|$)/;
 const HELP_ELEMENT_RE = /<Icon(?:HelpCircle|CircleHelp|Help)\b[\s\S]*?\/>/g;
 const LOCAL_HELP_GLYPH_RE = /\.local-dev-help-glyph\s*\{[\s\S]*?\}/g;
 const LARGE_GLYPH_RE =


### PR DESCRIPTION
Follow-up to [#3668](https://github.com/BuilderIO/agent-native/pull/3668), which stopped a rejected credential from being re-admitted on a flat timer. This fixes the sentence that made that bug cost two days.

## The problem

A 401 proves the credential a request carried was refused. It does **not** prove whose credential it was. The copy said:

> The saved provider key was rejected. Connect Builder.io for managed AI, or update your provider key, then retry.

and the recovery card withheld Retry, routing the reader to a setup flow instead. For the common case — a rejected *workspace or deployment* credential the reader cannot see, let alone edit — that rendered a setup panel for a connection already marked "Connected ✓", with no action available at all. Two users hit this on `slides` and both runs recovered on their own; the message still told them to go fix a key that was fine.

## Changes

**Copy** — say only what the 401 proves, and name the recovery that now exists:

> The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.

Accurate whether the credential was the reader's or the workspace's.

**Retry restored.** The old comment ruled it out because retrying would "replay the same rejected credential and turn a permanent auth failure into a loop." That premise stopped being true in #3668: a 401 now fingerprints the credential and skips it for a backing-off window, so the next attempt reaches for a different one, or fails closed as `missing_credentials` — which is the honest message. The setup flow still ships alongside it.

**One constant, not two strings.** `run-recovery` re-classifies a message this module already normalized, so `isProviderAuthenticationError` must match its own output. Both now anchor to `PROVIDER_CREDENTIAL_REJECTED_MESSAGE` so they cannot drift.

## Two things worth a reviewer's eye

**The test that guarded this was vacuous.** `run-recovery.spec.tsx` asserted `buttonLabels).not.toContain("Retry")` — but the retry control is an icon-only button, so `textContent` was `""` and the assertion passed no matter what rendered. It never tested its claim. It now queries `aria-label` and asserts the retry actually fires. Confirmed failing before this change, passing after.

**No locale sweep needed.** `agentChat.errorMessages.*` keys are inline `defaultValue`s in `error-format.ts`; no locale catalog defines any `agentChat` key. `guard:i18n-catalogs` and `guard:i18n-changed-copy` both pass.

## Also here

- `test(core)`: pins the 24h ceiling on the #3668 back-off. Without a ceiling the exponential would pin a credential for weeks and a server-side recovery would never be noticed. Covers the cap, a corrupt strike count, and that the ceiling has not collapsed into "always expired".
- `fix(guards)`: `guard-help-icon-scale` walked into `packages/core/.tmp-worker-test-*` directories that test workers delete mid-scan and died on ENOENT. Since `pnpm prep` runs guards and tests concurrently, that race is the normal case — it failed for me on a clean tree. Excluded `.tmp*` alongside the other scratch paths.

## Verification

`packages/core` full suite: **13,171 passed, 2 skipped, 0 failed.** `pnpm guards`: all 65 pass.

`pnpm prep` exits 1 on this machine, and I am not claiming otherwise. Every failing lane was rerun in isolation and passed:

| Lane | Isolated result | Cause |
|---|---|---|
| `guard:help-icon-scale` | OK | the race fixed here |
| `core src/scripts/runner.spec.ts` | 13 passed | exit 143 (SIGTERM) at 30s under load |
| `templates/design html-integrity` | 117 passed | wall-clock ratio assertion, 28.7ms vs a ~19.1ms bound |

The design assertion is load-sensitive and lives in a template this diff does not touch. Separately, a stale `node_modules/.cache/tsbuildinfo` made `packages/dispatch` fail to build against a core that genuinely had the symbols; clearing it resolved that and is not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)