### PR TITLE
Polish Clips timeline comment and reaction markers

### DIFF
--- a/templates/clips/app/components/player/scrubber.test.tsx
+++ b/templates/clips/app/components/player/scrubber.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tabler/icons-react", () => ({
-  IconMessage2Filled: () => <span data-icon-comment />,
+  IconMessage2: () => <span data-icon-comment />,
 }));
 
 vi.mock("@/lib/utils", () => ({
@@ -58,5 +58,36 @@ describe("Scrubber reaction markers", () => {
       (markers[0] as HTMLButtonElement).click();
     });
     expect(onSeek).toHaveBeenCalledWith(1_000);
+  });
+
+  it("keeps comments and reactions above the track without marker bubbles", () => {
+    act(() => {
+      root.render(
+        <Scrubber
+          currentMs={2_000}
+          durationMs={10_000}
+          onSeek={vi.fn()}
+          comments={[
+            { id: "comment-1", content: "Nice", videoTimestampMs: 1_000 },
+          ]}
+          reactions={[
+            { id: "reaction-1", emoji: "👍", videoTimestampMs: 1_000 },
+          ]}
+        />,
+      );
+    });
+
+    const comment = container.querySelector<HTMLButtonElement>(
+      '[aria-label="1 comment"]',
+    );
+    const reaction = container.querySelector<HTMLButtonElement>(
+      "[data-player-reaction-marker]",
+    );
+
+    expect(comment?.className).toContain("-top-10");
+    expect(comment?.className).not.toContain("rounded-full");
+    expect(comment?.querySelector("[data-icon-comment]")).not.toBeNull();
+    expect(reaction?.className).toContain("-top-8");
+    expect(reaction?.className).not.toContain("rounded-full");
   });
 });

--- a/templates/clips/app/components/player/scrubber.test.tsx
+++ b/templates/clips/app/components/player/scrubber.test.tsx
@@ -61,12 +61,14 @@ describe("Scrubber reaction markers", () => {
   });
 
   it("keeps comments and reactions above the track without marker bubbles", () => {
+    const onSeek = vi.fn();
+
     act(() => {
       root.render(
         <Scrubber
           currentMs={2_000}
           durationMs={10_000}
-          onSeek={vi.fn()}
+          onSeek={onSeek}
           comments={[
             { id: "comment-1", content: "Nice", videoTimestampMs: 1_000 },
           ]}
@@ -84,10 +86,17 @@ describe("Scrubber reaction markers", () => {
       "[data-player-reaction-marker]",
     );
 
-    expect(comment?.className).toContain("-top-10");
+    expect(comment?.className).toContain("-top-14");
     expect(comment?.className).not.toContain("rounded-full");
     expect(comment?.querySelector("[data-icon-comment]")).not.toBeNull();
-    expect(reaction?.className).toContain("-top-8");
+    expect(reaction?.className).toContain("-top-7");
     expect(reaction?.className).not.toContain("rounded-full");
+
+    act(() => {
+      comment?.click();
+      reaction?.click();
+    });
+    expect(onSeek).toHaveBeenNthCalledWith(1, 1_000);
+    expect(onSeek).toHaveBeenNthCalledWith(2, 1_000);
   });
 });

--- a/templates/clips/app/components/player/scrubber.tsx
+++ b/templates/clips/app/components/player/scrubber.tsx
@@ -1,4 +1,4 @@
-import { IconMessage2Filled } from "@tabler/icons-react";
+import { IconMessage2 } from "@tabler/icons-react";
 import { useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -209,13 +209,13 @@ export function Scrubber(props: ScrubberProps) {
               e.stopPropagation();
               onSeek(ms);
             }}
-            className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md ring-2 ring-background transition-transform hover:scale-125"
+            className="absolute -top-10 flex h-8 w-8 -translate-x-1/2 items-center justify-center text-background dark:text-foreground drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:focus-visible:ring-foreground/80"
             style={{ left: (ms / Math.max(1, durationMs)) * 100 + "%" }}
             aria-label={`${list.length} comment${list.length > 1 ? "s" : ""}`}
           >
-            <IconMessage2Filled className="h-2.5 w-2.5" />
+            <IconMessage2 className="h-7 w-7 stroke-[1.5]" />
             {list.length > 1 && (
-              <span className="absolute -top-1.5 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[8px] font-bold leading-none text-primary-foreground ring-2 ring-background">
+              <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-foreground/75 px-0.5 text-[8px] font-bold leading-none text-background shadow-sm dark:bg-background/75 dark:text-foreground">
                 {list.length}
               </span>
             )}
@@ -241,13 +241,13 @@ export function Scrubber(props: ScrubberProps) {
               event.stopPropagation();
               onSeek(ms);
             }}
-            className="absolute -bottom-5 flex h-5 min-w-5 -translate-x-1/2 items-center justify-center rounded-full bg-background/95 px-1 text-sm shadow-md ring-1 ring-primary/40 transition-transform hover:scale-125"
+            className="absolute -top-8 flex h-7 min-w-7 -translate-x-1/2 items-center justify-center px-0.5 text-2xl leading-none text-background drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:text-foreground dark:focus-visible:ring-foreground/80"
             style={{ left: (ms / Math.max(1, durationMs)) * 100 + "%" }}
             aria-label={`${list.length} reaction${list.length === 1 ? "" : "s"} at ${msToClock(ms)}`}
           >
             {list[0].emoji}
             {list.length > 1 ? (
-              <span className="absolute -right-1.5 -top-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[8px] font-bold leading-none text-primary-foreground ring-1 ring-background">
+              <span className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-foreground/75 px-0.5 text-[8px] font-bold leading-none text-background shadow-sm dark:bg-background/75 dark:text-foreground">
                 {list.length}
               </span>
             ) : null}

--- a/templates/clips/app/components/player/scrubber.tsx
+++ b/templates/clips/app/components/player/scrubber.tsx
@@ -209,7 +209,7 @@ export function Scrubber(props: ScrubberProps) {
               e.stopPropagation();
               onSeek(ms);
             }}
-            className="absolute -top-10 flex h-8 w-8 -translate-x-1/2 items-center justify-center text-background dark:text-foreground drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:focus-visible:ring-foreground/80"
+            className="absolute -top-14 flex h-8 w-8 -translate-x-1/2 items-center justify-center text-background dark:text-foreground drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:focus-visible:ring-foreground/80"
             style={{ left: (ms / Math.max(1, durationMs)) * 100 + "%" }}
             aria-label={`${list.length} comment${list.length > 1 ? "s" : ""}`}
           >
@@ -241,7 +241,7 @@ export function Scrubber(props: ScrubberProps) {
               event.stopPropagation();
               onSeek(ms);
             }}
-            className="absolute -top-8 flex h-7 min-w-7 -translate-x-1/2 items-center justify-center px-0.5 text-2xl leading-none text-background drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:text-foreground dark:focus-visible:ring-foreground/80"
+            className="absolute -top-7 flex h-7 min-w-7 -translate-x-1/2 items-center justify-center px-0.5 text-2xl leading-none text-background drop-shadow-sm transition-transform hover:scale-110 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background/80 dark:text-foreground dark:focus-visible:ring-foreground/80"
             style={{ left: (ms / Math.max(1, durationMs)) * 100 + "%" }}
             aria-label={`${list.length} reaction${list.length === 1 ? "" : "s"} at ${msToClock(ms)}`}
           >


### PR DESCRIPTION
## Summary
- Move comment markers above the progress track and use the outline message icon without a circular button background.
- Move reaction markers above the track as bare emojis while preserving counts, grouping, and seeking.
- Add focused scrubber regression coverage.

## Verification
- Live Clips player screenshot captured from /r/vTd7I6VKjvoF
- HAR media request returned HTTP 206
- Clips typecheck
- Focused scrubber and video-player tests
- All 65 repository guards