### PR TITLE
Fix starter template first-run onboarding default

### DIFF
--- a/templates/chat/agent-native.json
+++ b/templates/chat/agent-native.json
@@ -1,10 +1,7 @@
 {
   "version": 1,
   "onboarding": {
-    "firstRun": {
-      "development": "off",
-      "production": "connect-and-integrations"
-    }
+    "firstRun": "off"
   },
   "doctor": {
     "failOnBuild": false


### PR DESCRIPTION
## Summary

- keep first-run Agent-Native onboarding off in the chat starter template
- leave hosted non-chat templates free to opt into the flow

Source feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787835916922259?thread_ts=1787835200.083909&cid=C0ATH3CCZT4

## Validation

- `node -e` assertion confirms the chat template resolves `onboarding.firstRun` to `off`
- `git diff --check`
- focused Vitest command was unavailable in this clean worktree because dependencies are not installed; CI remains the test gate
