### PR TITLE
fix: locked layers

### DIFF
--- a/templates/design/actions/update-file.ts
+++ b/templates/design/actions/update-file.ts
@@ -269,12 +269,10 @@ export default defineAction({
               fileType ?? persistedFile.fileType ?? file.fileType ?? "html",
           });
         }
-        if (
-          content !== undefined &&
-          context?.caller !== "frontend" &&
-          (fileType === "html" ||
-            liveContent.includes("data-agent-native-locked"))
-        ) {
+        // Applicability belongs to the guard, which cheaply short-circuits
+        // when neither side carries a lock. Gating on the REQUEST's fileType
+        // let a content-only save add a lock the live document never had.
+        if (content !== undefined && context?.caller !== "frontend") {
           assertLockedLayersPreserved(liveContent, content);
         }
         const hasVersionedContentOperation =

--- a/templates/design/e2e/unlock-locked-layer.spec.ts
+++ b/templates/design/e2e/unlock-locked-layer.spec.ts
@@ -1,0 +1,266 @@
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Page,
+} from "@playwright/test";
+
+import { enterDirectMode, gotoEditor } from "./helpers";
+
+const LOCKED_HTML = `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Locked template fixture</title></head>
+  <body style="margin:0">
+    <main class="artboard" data-agent-native-node-id="template-artboard" style="position:relative;width:1080px;height:1080px;overflow:hidden;background:#f3efe6">
+      <div class="backdrop" style="position:absolute;inset:0;background:#eee;pointer-events:none" data-agent-native-node-id="template-background" data-agent-native-layer-name="Background" data-agent-native-locked="true"></div>
+      <div class="brand" style="position:absolute;top:36px;left:42px;z-index:2;display:flex;align-items:center;gap:10px;font-size:13px;font-weight:800" data-agent-native-node-id="template-logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">
+        <span class="brand-mark" style="width:24px;height:24px;border-radius:50%;background:#11110f"></span><span>Northstar</span>
+      </div>
+      <section class="content" data-agent-native-node-id="template-content" style="position:relative;z-index:1;height:100%;display:grid;align-content:end;padding:108px 42px 42px">
+        <h1 data-agent-native-node-id="template-headline" style="margin:0;font-size:82px">Make the work feel lighter.</h1>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+function baseUrl(): string {
+  return (process.env.E2E_BASE_URL ?? "http://127.0.0.1:9333").replace(
+    /\/$/,
+    "",
+  );
+}
+
+async function callAction(
+  request: APIRequestContext,
+  name: string,
+  input: Record<string, unknown>,
+) {
+  const response = await request.post(
+    `${baseUrl()}/_agent-native/actions/${name}`,
+    { data: input },
+  );
+  return {
+    ok: response.ok(),
+    status: response.status(),
+    body: await response.text(),
+  };
+}
+
+async function postAction(
+  request: APIRequestContext,
+  name: string,
+  input: Record<string, unknown>,
+) {
+  const result = await callAction(request, name, input);
+  if (!result.ok) {
+    throw new Error(`${name} failed: ${result.status} ${result.body}`);
+  }
+  return JSON.parse(result.body);
+}
+
+async function readContent(request: APIRequestContext, designId: string) {
+  const response = await request.get(
+    `${baseUrl()}/_agent-native/actions/get-design?id=${designId}`,
+  );
+  const design = await response.json();
+  return (
+    design.files?.find(
+      (file: { filename?: string }) => file.filename === "index.html",
+    )?.content ?? ""
+  );
+}
+
+function lockedNodeIds(html: string): string[] {
+  return Array.from(
+    html.matchAll(
+      /data-agent-native-node-id="([^"]+)"[^>]*data-agent-native-locked="true"/g,
+    ),
+    (match) => match[1]!,
+  );
+}
+
+async function expandAllLayers(page: Page) {
+  const tree = page.getByRole("tree", { name: "Layers" });
+  await expect(tree.getByRole("treeitem").first()).toBeVisible({
+    timeout: 30_000,
+  });
+  for (let depth = 0; depth < 4; depth += 1) {
+    const expanders = tree.getByRole("button", { name: "Expand layer" });
+    const count = await expanders.count();
+    if (count === 0) break;
+    for (let index = count - 1; index >= 0; index -= 1) {
+      await expanders
+        .nth(index)
+        .click()
+        .catch(() => {});
+    }
+  }
+}
+
+async function unlockLayer(page: Page, name: RegExp) {
+  const row = page.getByRole("treeitem", { name }).first();
+  await expect(row).toBeVisible({ timeout: 15_000 });
+  await row.hover();
+  const unlock = row.getByRole("button", { name: "Unlock layer" });
+  await expect(unlock).toBeVisible();
+  await unlock.click();
+}
+
+test("a design whose locked layers were unlocked in the UI accepts an agent edit", async ({
+  page,
+  request,
+}) => {
+  const created = await postAction(request, "create-design", {
+    title: `Unlock locked layer ${Date.now()}`,
+    projectType: "prototype",
+  });
+  const designId = created.id ?? created.data?.id ?? created.design?.id;
+  if (!designId) throw new Error("create-design returned no id");
+
+  try {
+    await postAction(request, "create-file", {
+      designId,
+      filename: "index.html",
+      content: LOCKED_HTML,
+      fileType: "html",
+    });
+    await gotoEditor(page, designId);
+    await enterDirectMode(page);
+    await expandAllLayers(page);
+
+    await unlockLayer(page, /Logo/);
+    await unlockLayer(page, /Background/);
+
+    await expect
+      .poll(async () => lockedNodeIds(await readContent(request, designId)), {
+        timeout: 20_000,
+      })
+      .toEqual([]);
+
+    const edit = await callAction(request, "edit-design", {
+      designId,
+      filename: "index.html",
+      edits: [{ search: "Northstar", replace: "Polestar" }],
+    });
+    expect(
+      `${edit.status} ${edit.body}`,
+      "agent edit after the user unlocked both layers",
+    ).not.toMatch(/locked layer/i);
+    expect(edit.ok).toBe(true);
+
+    expect(await readContent(request, designId)).toContain("Polestar");
+  } finally {
+    await postAction(request, "delete-design", { id: designId }).catch(
+      () => {},
+    );
+  }
+});
+
+test("overview mode: unlocking a template-locked layer persists and unblocks the agent", async ({
+  page,
+  request,
+}) => {
+  const created = await postAction(request, "create-design", {
+    title: `Unlock in overview ${Date.now()}`,
+    projectType: "prototype",
+  });
+  const designId = created.id ?? created.data?.id ?? created.design?.id;
+  if (!designId) throw new Error("create-design returned no id");
+
+  try {
+    await postAction(request, "create-file", {
+      designId,
+      filename: "index.html",
+      content: LOCKED_HTML,
+      fileType: "html",
+    });
+    await gotoEditor(page, designId);
+    await expect(page.locator("[data-screen-shell]").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await expandAllLayers(page);
+
+    await unlockLayer(page, /Logo/);
+    await unlockLayer(page, /Background/);
+
+    await expect
+      .poll(async () => lockedNodeIds(await readContent(request, designId)), {
+        timeout: 20_000,
+      })
+      .toEqual([]);
+
+    const edit = await callAction(request, "edit-design", {
+      designId,
+      filename: "index.html",
+      edits: [{ search: "Northstar", replace: "Polestar" }],
+    });
+    expect(
+      `${edit.status} ${edit.body}`,
+      "agent edit after the user unlocked both layers in overview",
+    ).not.toMatch(/locked layer/i);
+    expect(edit.ok).toBe(true);
+  } finally {
+    await postAction(request, "delete-design", { id: designId }).catch(
+      () => {},
+    );
+  }
+});
+
+test("an agent whole-file write cannot silently re-lock what the user unlocked", async ({
+  page,
+  request,
+}) => {
+  const created = await postAction(request, "create-design", {
+    title: `Relock loop ${Date.now()}`,
+    projectType: "prototype",
+  });
+  const designId = created.id ?? created.data?.id ?? created.design?.id;
+  if (!designId) throw new Error("create-design returned no id");
+
+  try {
+    await postAction(request, "create-file", {
+      designId,
+      filename: "index.html",
+      content: LOCKED_HTML,
+      fileType: "html",
+    });
+    await gotoEditor(page, designId);
+    await enterDirectMode(page);
+    await expandAllLayers(page);
+
+    // The agent reads the design BEFORE the user unlocks anything.
+    const staleSnapshot = await readContent(request, designId);
+    expect(lockedNodeIds(staleSnapshot).sort()).toEqual([
+      "template-background",
+      "template-logo",
+    ]);
+
+    await unlockLayer(page, /Logo/);
+    await unlockLayer(page, /Background/);
+    await expect
+      .poll(async () => lockedNodeIds(await readContent(request, designId)), {
+        timeout: 20_000,
+      })
+      .toEqual([]);
+
+    // The agent now writes a whole file built from that stale snapshot.
+    const replace = await callAction(request, "edit-design", {
+      designId,
+      filename: "index.html",
+      mode: "replace-file",
+      replacementContent: staleSnapshot.replace(
+        "Make the work feel lighter.",
+        "Design at the speed of thought.",
+      ),
+    });
+
+    expect(
+      lockedNodeIds(await readContent(request, designId)),
+      `stale agent write re-locked the layers (status ${replace.status})`,
+    ).toEqual([]);
+  } finally {
+    await postAction(request, "delete-design", { id: designId }).catch(
+      () => {},
+    );
+  }
+});

--- a/templates/design/server/source-workspace.ts
+++ b/templates/design/server/source-workspace.ts
@@ -352,13 +352,7 @@ export async function writeInlineSourceFile(args: {
       };
     }
 
-    if (
-      currentFile.fileType === "html" ||
-      currentFile.fileType === "jsx" ||
-      current.content.includes("data-agent-native-locked")
-    ) {
-      assertLockedLayersPreserved(current.content, args.content);
-    }
+    assertLockedLayersPreserved(current.content, args.content);
     assertDesignHtmlEditIntegrity({
       previousContent: current.content,
       nextContent: args.content,

--- a/templates/design/shared/locked-layers.test.ts
+++ b/templates/design/shared/locked-layers.test.ts
@@ -118,6 +118,49 @@ describe("locked layers", () => {
     ).toThrow(/locks layer/i);
   });
 
+  it("ignores unrelated head edits that shift unstamped ancestor offsets", () => {
+    const page = (title: string) =>
+      `<!doctype html><html><head><title>${title}</title></head><body>
+  <main data-agent-native-node-id="art">
+    <div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">N</div>
+    <h1 data-agent-native-node-id="h">Old</h1>
+  </main>
+</body></html>`;
+    expect(() =>
+      assertLockedLayersPreserved(page("T"), page("A far longer page title")),
+    ).not.toThrow();
+  });
+
+  it("rejects moving a locked layer across an unstamped sibling", () => {
+    const shell = (inner: string) => `<!doctype html><html><body>
+  <main data-agent-native-node-id="art">${inner}
+  </main>
+</body></html>`;
+    const locked =
+      '<div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">N</div>';
+    expect(() =>
+      assertLockedLayersPreserved(
+        shell(`\n    ${locked}\n    <span>plain</span>`),
+        shell(`\n    <span>plain</span>\n    ${locked}`),
+      ),
+    ).toThrow(/locked layer/i);
+  });
+
+  it("allows inserting a sibling that duplicates another sibling's signature", () => {
+    const shell = (inner: string) => `<!doctype html><html><body>
+  <main data-agent-native-node-id="art">${inner}
+  </main>
+</body></html>`;
+    const locked =
+      '<div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">N</div>';
+    expect(() =>
+      assertLockedLayersPreserved(
+        shell(`\n    <span>one</span>\n    ${locked}`),
+        shell(`\n    <span>one</span>\n    <span>two</span>\n    ${locked}`),
+      ),
+    ).not.toThrow();
+  });
+
   it("counts only durable DOM locks across files", () => {
     expect(
       countLockedLayersAcrossFiles([

--- a/templates/design/shared/locked-layers.test.ts
+++ b/templates/design/shared/locked-layers.test.ts
@@ -75,6 +75,49 @@ describe("locked layers", () => {
     );
   });
 
+  it("allows inserting and removing unlocked siblings around a locked layer", () => {
+    const artboard = `<!doctype html><html><body>
+  <main data-agent-native-node-id="artboard">
+    <div data-agent-native-node-id="bg" data-agent-native-layer-name="Background" data-agent-native-locked="true"></div>
+    <div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">Northstar</div>
+    <section data-agent-native-node-id="content"><h1>Old</h1></section>
+  </main>
+</body></html>`;
+
+    for (const next of [
+      artboard.replace(
+        '<div data-agent-native-node-id="bg"',
+        '<div class="glow"></div>\n    <div data-agent-native-node-id="bg"',
+      ),
+      artboard.replace(
+        '<section data-agent-native-node-id="content">',
+        '<div class="rule"></div>\n    <section data-agent-native-node-id="content">',
+      ),
+      artboard.replace(
+        '    <section data-agent-native-node-id="content"><h1>Old</h1></section>\n',
+        "",
+      ),
+    ]) {
+      expect(() => assertLockedLayersPreserved(artboard, next)).not.toThrow();
+    }
+  });
+
+  it("rejects an edit that re-locks a layer the editor unlocked", () => {
+    const unlocked = source.replace(' data-agent-native-locked="true"', "");
+    expect(() => assertLockedLayersPreserved(unlocked, source)).toThrow(
+      /locks layer/i,
+    );
+    expect(() =>
+      assertLockedLayersPreserved(
+        unlocked,
+        unlocked.replace(
+          '<main data-agent-native-node-id="content">',
+          '<main data-agent-native-node-id="content" data-agent-native-locked="true">',
+        ),
+      ),
+    ).toThrow(/locks layer/i);
+  });
+
   it("counts only durable DOM locks across files", () => {
     expect(
       countLockedLayersAcrossFiles([

--- a/templates/design/shared/locked-layers.test.ts
+++ b/templates/design/shared/locked-layers.test.ts
@@ -146,6 +146,63 @@ describe("locked layers", () => {
     ).toThrow(/locked layer/i);
   });
 
+  it("allows an unstamped locked layer when earlier content changes length", () => {
+    const page = (lead: string) =>
+      `<!doctype html><html><body><main data-agent-native-node-id="art">
+  <p>${lead}</p>
+  <div class="bg" data-agent-native-layer-name="BG" data-agent-native-locked="true"></div>
+</main></body></html>`;
+    expect(() =>
+      assertLockedLayersPreserved(page("hi"), page("a much longer lead line")),
+    ).not.toThrow();
+  });
+
+  it("refuses to pass a move it cannot verify past indistinguishable siblings", () => {
+    const shell = (inner: string) =>
+      `<!doctype html><html><body><main data-agent-native-node-id="art">${inner}
+</main></body></html>`;
+    const locked =
+      '<div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">L</div>';
+    expect(() =>
+      assertLockedLayersPreserved(
+        shell(`\n  <span>x</span>\n  <span>x</span>\n  ${locked}`),
+        shell(`\n  ${locked}\n  <span>x</span>\n  <span>x</span>`),
+      ),
+    ).toThrow(/cannot verify/i);
+  });
+
+  it("refuses a duplicated stable id instead of treating the clone as the original", () => {
+    const node =
+      '<div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">A</div>';
+    const shell = (inner: string) =>
+      `<!doctype html><html><body><main data-agent-native-node-id="art">${inner}
+</main></body></html>`;
+    expect(() =>
+      assertLockedLayersPreserved(
+        shell(`\n  ${node}`),
+        shell(`\n  ${node}\n  ${node}`),
+      ),
+    ).toThrow(/cannot verify/i);
+  });
+
+  it("refuses reparenting between containers it cannot tell apart", () => {
+    const locked =
+      '<div data-agent-native-node-id="logo" data-agent-native-layer-name="Logo" data-agent-native-locked="true">L</div>';
+    const shell = (inner: string) =>
+      `<!doctype html><html><body><main data-agent-native-node-id="art">${inner}
+</main></body></html>`;
+    expect(() =>
+      assertLockedLayersPreserved(
+        shell(
+          `\n  <div class="box">${locked}</div>\n  <div class="box"></div>`,
+        ),
+        shell(
+          `\n  <div class="box"></div>\n  <div class="box">${locked}</div>`,
+        ),
+      ),
+    ).toThrow(/cannot verify/i);
+  });
+
   it("allows inserting a sibling that duplicates another sibling's signature", () => {
     const shell = (inner: string) => `<!doctype html><html><body>
   <main data-agent-native-node-id="art">${inner}

--- a/templates/design/shared/locked-layers.ts
+++ b/templates/design/shared/locked-layers.ts
@@ -10,84 +10,110 @@ export interface LockedLayerSnapshot {
   id: string;
   label: string;
   source: string;
-  ancestorIds: string[];
-  parentId: string | null;
-  /** Durable identities of every sibling, in document order, including self. */
-  siblingIds: string[];
-  selfId: string;
+  /** Null when nothing tells this node apart from another one. */
+  token: string | null;
+  ancestorTokens: (string | null)[];
+  siblingTokens: (string | null)[];
 }
 
-/**
- * Never fall back to `node.id`: it hashes the element's byte offset, so an
- * unstamped ancestor changes identity whenever anything earlier in the
- * document changes length, and a sibling that merely moved reads as a
- * different node.
- */
-function durableNodeIdentity(node: CodeLayerNode): string {
+function explicitIdentity(node: CodeLayerNode): string | null {
   const stableId = node.dataAttributes["data-agent-native-node-id"];
   if (stableId) return `node:${stableId}`;
   const htmlId = node.attributes.id;
   if (typeof htmlId === "string" && htmlId.length > 0) return `id:${htmlId}`;
+  return null;
+}
+
+function signature(node: CodeLayerNode): string {
   return `sig:${node.tag}|${node.classes.join(".")}`;
+}
+
+function countBy<T>(items: readonly T[], key: (item: T) => string | null) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const value = key(item);
+    if (value !== null) counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * One identity per node, or null when nothing distinguishes it. Never derive
+ * it from a byte offset: unrelated edits move offsets, and a node that merely
+ * moved keeps its markup.
+ */
+function buildTokens(
+  projection: CodeLayerProjection,
+): Map<string, string | null> {
+  const nodesById = new Map(projection.nodes.map((node) => [node.id, node]));
+  const globalCounts = countBy(projection.nodes, explicitIdentity);
+  const tokens = new Map<string, string | null>();
+
+  const assignSiblingGroup = (childIds: readonly string[]) => {
+    const group = childIds.flatMap((id) => {
+      const node = nodesById.get(id);
+      return node ? [node] : [];
+    });
+    const signatureCounts = countBy(group, (node) =>
+      explicitIdentity(node) ? null : signature(node),
+    );
+    for (const node of group) {
+      const explicit = explicitIdentity(node);
+      if (explicit) {
+        tokens.set(node.id, globalCounts.get(explicit) === 1 ? explicit : null);
+        continue;
+      }
+      const sig = signature(node);
+      tokens.set(node.id, signatureCounts.get(sig) === 1 ? sig : null);
+    }
+  };
+
+  assignSiblingGroup(projection.rootNodeIds);
+  for (const node of projection.nodes) assignSiblingGroup(node.children);
+  return tokens;
 }
 
 function lockedLayerPlacement(
   projection: CodeLayerProjection,
+  tokens: Map<string, string | null>,
   node: CodeLayerNode,
-): Omit<LockedLayerSnapshot, "id" | "label" | "source"> {
+): Pick<LockedLayerSnapshot, "token" | "ancestorTokens" | "siblingTokens"> {
   const nodesById = new Map(
     projection.nodes.map((candidate) => [candidate.id, candidate]),
   );
-  const ancestors: CodeLayerNode[] = [];
+  const ancestorTokens: (string | null)[] = [];
   let parent = node.parentId ? nodesById.get(node.parentId) : undefined;
   while (parent) {
-    ancestors.unshift(parent);
+    ancestorTokens.unshift(tokens.get(parent.id) ?? null);
     parent = parent.parentId ? nodesById.get(parent.parentId) : undefined;
   }
 
-  const siblingIds = (
-    node.parentId
-      ? (nodesById.get(node.parentId)?.children ?? [])
-      : projection.rootNodeIds
-  ).flatMap((siblingId) => {
-    const sibling = nodesById.get(siblingId);
-    return sibling ? [durableNodeIdentity(sibling)] : [];
-  });
+  const siblingIds = node.parentId
+    ? (nodesById.get(node.parentId)?.children ?? [])
+    : projection.rootNodeIds;
 
   return {
-    ancestorIds: ancestors.map(durableNodeIdentity),
-    parentId:
-      ancestors.length > 0
-        ? durableNodeIdentity(ancestors[ancestors.length - 1]!)
-        : null,
-    siblingIds,
-    selfId: durableNodeIdentity(node),
+    token: tokens.get(node.id) ?? null,
+    ancestorTokens,
+    siblingTokens: siblingIds.map((id) => tokens.get(id) ?? null),
   };
 }
 
-/** Identities appearing exactly once, so a repeated one anchors nothing. */
-function unambiguous(ids: readonly string[]): Set<string> {
-  const seen = new Map<string, number>();
-  for (const id of ids) seen.set(id, (seen.get(id) ?? 0) + 1);
-  return new Set(
-    Array.from(seen).flatMap(([id, count]) => (count === 1 ? [id] : [])),
+function lockedNodes(projection: CodeLayerProjection): CodeLayerNode[] {
+  return projection.nodes.filter(
+    (node) => node.dataAttributes[LOCKED_ATTRIBUTE] === "true" && node.source,
   );
 }
 
-/**
- * Order among the siblings that anchor on BOTH sides. A raw position would
- * make any insert earlier in the parent read as "the locked layer moved".
- */
-function orderAmongSurvivingSiblings(
-  siblingIds: string[],
-  selfId: string,
-  otherSiblingIds: readonly string[],
+/** Position among the siblings both documents can name, self included. */
+function orderAmongSharedSiblings(
+  side: Pick<LockedLayerSnapshot, "token" | "siblingTokens">,
+  other: Pick<LockedLayerSnapshot, "siblingTokens">,
 ): number {
-  const mine = unambiguous(siblingIds);
-  const theirs = unambiguous(otherSiblingIds);
-  return siblingIds
-    .filter((id) => mine.has(id) && theirs.has(id))
-    .indexOf(selfId);
+  const shared = new Set(other.siblingTokens.filter((token) => token !== null));
+  return side.siblingTokens
+    .filter((token) => token !== null && shared.has(token))
+    .indexOf(side.token);
 }
 
 /**
@@ -97,19 +123,13 @@ function orderAmongSurvivingSiblings(
  */
 export function lockedLayerSnapshots(html: string): LockedLayerSnapshot[] {
   const projection = buildCodeLayerProjection(html);
-  return projection.nodes.flatMap((node) => {
-    if (node.dataAttributes[LOCKED_ATTRIBUTE] !== "true" || !node.source) {
-      return [];
-    }
-    return [
-      {
-        id: node.id,
-        label: node.layerName,
-        source: html.slice(node.source.start, node.source.end),
-        ...lockedLayerPlacement(projection, node),
-      },
-    ];
-  });
+  const tokens = buildTokens(projection);
+  return lockedNodes(projection).map((node) => ({
+    id: node.id,
+    label: node.layerName,
+    source: html.slice(node.source!.start, node.source!.end),
+    ...lockedLayerPlacement(projection, tokens, node),
+  }));
 }
 
 export function countLockedLayers(html: string): number {
@@ -127,72 +147,109 @@ export function countLockedLayersAcrossFiles(
   );
 }
 
-function namesFor(labels: string[]): string {
+function namesFor(labels: readonly string[]): string {
   return Array.from(new Set(labels)).slice(0, 5).join(", ");
 }
 
+function plural(count: number): string {
+  return count === 1 ? "" : "s";
+}
+
+function unverifiable(labels: string[]): Error {
+  return new Error(
+    `Cannot verify locked layer${plural(labels.length)}: ${namesFor(labels)}. ` +
+      "The layer, its parent, or a sibling has no unique " +
+      "data-agent-native-node-id, so this edit cannot be checked. Re-read the " +
+      "file and keep its stamped ids.",
+  );
+}
+
 /**
- * Locked layers are immutable for agent-authored whole-file or text edits, in
- * BOTH directions: an agent that re-adds the flag undoes the human's unlock
- * and re-blocks itself forever. The human editor's own layer control writes as
- * `caller: "frontend"`, which does not reach this guard.
+ * Locked layers are agent-immutable in BOTH directions: re-adding the flag
+ * undoes the human's unlock and re-blocks the agent forever. Ambiguous
+ * identity never passes. The human editor's layer control writes as
+ * `caller: "frontend"` and does not reach this guard.
  */
 export function assertLockedLayersPreserved(
   before: string,
   after: string,
 ): void {
-  // Comparing lock sets needs BOTH sides projected, and most designs carry no
+  // Both sides need projecting to compare lock sets, and most designs carry no
   // locked layer. Keep that case off the parser on every guarded write.
   if (!before.includes(LOCKED_ATTRIBUTE) && !after.includes(LOCKED_ATTRIBUTE)) {
     return;
   }
+
+  const afterProjection = buildCodeLayerProjection(after);
+  const afterTokens = buildTokens(afterProjection);
   const locked = lockedLayerSnapshots(before);
-  const nextProjection = buildCodeLayerProjection(after);
-  const lockedBeforeIds = new Set(locked.map((snapshot) => snapshot.id));
-  const nowLocked = nextProjection.nodes.filter(
-    (node) =>
-      node.dataAttributes[LOCKED_ATTRIBUTE] === "true" &&
-      !lockedBeforeIds.has(node.id),
+  const nowLocked = lockedNodes(afterProjection).map((node) => ({
+    node,
+    token: afterTokens.get(node.id) ?? null,
+  }));
+
+  const nameless = [
+    ...locked
+      .filter((snapshot) => snapshot.token === null)
+      .map((snapshot) => snapshot.label),
+    ...nowLocked
+      .filter((entry) => entry.token === null)
+      .map((entry) => entry.node.layerName),
+  ];
+  if (nameless.length > 0) throw unverifiable(nameless);
+
+  const lockedBeforeTokens = new Set(locked.map((snapshot) => snapshot.token!));
+  const added = nowLocked.filter(
+    (entry) => !lockedBeforeTokens.has(entry.token!),
   );
-  if (nowLocked.length > 0) {
+  if (added.length > 0) {
     throw new Error(
-      `This edit locks layer${nowLocked.length === 1 ? "" : "s"} the editor had unlocked: ` +
-        `${namesFor(nowLocked.map((node) => node.layerName))}. ` +
+      `This edit locks layer${plural(added.length)} the editor had unlocked: ` +
+        `${namesFor(added.map((entry) => entry.node.layerName))}. ` +
         "Only the human editor sets data-agent-native-locked. Re-read the " +
         "file and rebuild the edit from its current content.",
     );
   }
-  if (locked.length === 0) return;
 
-  const nextById = new Map(nextProjection.nodes.map((node) => [node.id, node]));
+  const afterByToken = new Map(nowLocked.map((entry) => [entry.token!, entry]));
   const changed: string[] = [];
+  const unchecked: string[] = [];
 
   for (const snapshot of locked) {
-    const next = nextById.get(snapshot.id);
-    if (!next?.source) {
+    const next = afterByToken.get(snapshot.token!);
+    if (!next) {
       changed.push(snapshot.label);
       continue;
     }
-    const nextSource = after.slice(next.source.start, next.source.end);
-    const nextPlacement = lockedLayerPlacement(nextProjection, next);
     if (
-      nextSource !== snapshot.source ||
-      nextPlacement.parentId !== snapshot.parentId ||
-      nextPlacement.selfId !== snapshot.selfId ||
-      orderAmongSurvivingSiblings(
-        nextPlacement.siblingIds,
-        nextPlacement.selfId,
-        snapshot.siblingIds,
-      ) !==
-        orderAmongSurvivingSiblings(
-          snapshot.siblingIds,
-          snapshot.selfId,
-          nextPlacement.siblingIds,
-        ) ||
-      nextPlacement.ancestorIds.length !== snapshot.ancestorIds.length ||
-      nextPlacement.ancestorIds.some(
-        (ancestorId, index) => ancestorId !== snapshot.ancestorIds[index],
-      )
+      after.slice(next.node.source!.start, next.node.source!.end) !==
+      snapshot.source
+    ) {
+      changed.push(snapshot.label);
+      continue;
+    }
+    const placement = lockedLayerPlacement(
+      afterProjection,
+      afterTokens,
+      next.node,
+    );
+    // A null anchor on the BEFORE side could be hiding the move we are looking
+    // for. Nulls only in AFTER are newly inserted siblings.
+    if (
+      snapshot.ancestorTokens.includes(null) ||
+      placement.ancestorTokens.includes(null) ||
+      snapshot.siblingTokens.includes(null)
+    ) {
+      unchecked.push(snapshot.label);
+      continue;
+    }
+    if (
+      placement.ancestorTokens.length !== snapshot.ancestorTokens.length ||
+      placement.ancestorTokens.some(
+        (token, index) => token !== snapshot.ancestorTokens[index],
+      ) ||
+      orderAmongSharedSiblings(snapshot, placement) !==
+        orderAmongSharedSiblings(placement, snapshot)
     ) {
       changed.push(snapshot.label);
     }
@@ -200,8 +257,9 @@ export function assertLockedLayersPreserved(
 
   if (changed.length > 0) {
     throw new Error(
-      `This edit changes locked layer${changed.length === 1 ? "" : "s"}: ${namesFor(changed)}. ` +
+      `This edit changes locked layer${plural(changed.length)}: ${namesFor(changed)}. ` +
         "Preserve locked layers exactly, or ask the user to unlock them first.",
     );
   }
+  if (unchecked.length > 0) throw unverifiable(unchecked);
 }

--- a/templates/design/shared/locked-layers.ts
+++ b/templates/design/shared/locked-layers.ts
@@ -17,12 +17,18 @@ export interface LockedLayerSnapshot {
   selfId: string;
 }
 
+/**
+ * Never fall back to `node.id`: it hashes the element's byte offset, so an
+ * unstamped ancestor changes identity whenever anything earlier in the
+ * document changes length, and a sibling that merely moved reads as a
+ * different node.
+ */
 function durableNodeIdentity(node: CodeLayerNode): string {
   const stableId = node.dataAttributes["data-agent-native-node-id"];
   if (stableId) return `node:${stableId}`;
   const htmlId = node.attributes.id;
   if (typeof htmlId === "string" && htmlId.length > 0) return `id:${htmlId}`;
-  return node.id;
+  return `sig:${node.tag}|${node.classes.join(".")}`;
 }
 
 function lockedLayerPlacement(
@@ -59,17 +65,29 @@ function lockedLayerPlacement(
   };
 }
 
+/** Identities appearing exactly once, so a repeated one anchors nothing. */
+function unambiguous(ids: readonly string[]): Set<string> {
+  const seen = new Map<string, number>();
+  for (const id of ids) seen.set(id, (seen.get(id) ?? 0) + 1);
+  return new Set(
+    Array.from(seen).flatMap(([id, count]) => (count === 1 ? [id] : [])),
+  );
+}
+
 /**
- * Order among the siblings present on BOTH sides. A raw position would make
- * any insert earlier in the parent read as "the locked layer moved".
+ * Order among the siblings that anchor on BOTH sides. A raw position would
+ * make any insert earlier in the parent read as "the locked layer moved".
  */
 function orderAmongSurvivingSiblings(
   siblingIds: string[],
   selfId: string,
   otherSiblingIds: readonly string[],
 ): number {
-  const shared = new Set(otherSiblingIds);
-  return siblingIds.filter((id) => shared.has(id)).indexOf(selfId);
+  const mine = unambiguous(siblingIds);
+  const theirs = unambiguous(otherSiblingIds);
+  return siblingIds
+    .filter((id) => mine.has(id) && theirs.has(id))
+    .indexOf(selfId);
 }
 
 /**

--- a/templates/design/shared/locked-layers.ts
+++ b/templates/design/shared/locked-layers.ts
@@ -4,15 +4,17 @@ import {
   type CodeLayerProjection,
 } from "./code-layer.js";
 
+const LOCKED_ATTRIBUTE = "data-agent-native-locked";
+
 export interface LockedLayerSnapshot {
   id: string;
   label: string;
   source: string;
   ancestorIds: string[];
   parentId: string | null;
-  siblingIndex: number;
-  previousSiblingId: string | null;
-  nextSiblingId: string | null;
+  /** Durable identities of every sibling, in document order, including self. */
+  siblingIds: string[];
+  selfId: string;
 }
 
 function durableNodeIdentity(node: CodeLayerNode): string {
@@ -37,16 +39,14 @@ function lockedLayerPlacement(
     parent = parent.parentId ? nodesById.get(parent.parentId) : undefined;
   }
 
-  const siblingIds = node.parentId
-    ? (nodesById.get(node.parentId)?.children ?? [])
-    : projection.rootNodeIds;
-  const siblingIndex = siblingIds.indexOf(node.id);
-  const previousSibling =
-    siblingIndex > 0 ? nodesById.get(siblingIds[siblingIndex - 1]!) : undefined;
-  const nextSibling =
-    siblingIndex >= 0 && siblingIndex < siblingIds.length - 1
-      ? nodesById.get(siblingIds[siblingIndex + 1]!)
-      : undefined;
+  const siblingIds = (
+    node.parentId
+      ? (nodesById.get(node.parentId)?.children ?? [])
+      : projection.rootNodeIds
+  ).flatMap((siblingId) => {
+    const sibling = nodesById.get(siblingId);
+    return sibling ? [durableNodeIdentity(sibling)] : [];
+  });
 
   return {
     ancestorIds: ancestors.map(durableNodeIdentity),
@@ -54,12 +54,22 @@ function lockedLayerPlacement(
       ancestors.length > 0
         ? durableNodeIdentity(ancestors[ancestors.length - 1]!)
         : null,
-    siblingIndex,
-    previousSiblingId: previousSibling
-      ? durableNodeIdentity(previousSibling)
-      : null,
-    nextSiblingId: nextSibling ? durableNodeIdentity(nextSibling) : null,
+    siblingIds,
+    selfId: durableNodeIdentity(node),
   };
+}
+
+/**
+ * Order among the siblings present on BOTH sides. A raw position would make
+ * any insert earlier in the parent read as "the locked layer moved".
+ */
+function orderAmongSurvivingSiblings(
+  siblingIds: string[],
+  selfId: string,
+  otherSiblingIds: readonly string[],
+): number {
+  const shared = new Set(otherSiblingIds);
+  return siblingIds.filter((id) => shared.has(id)).indexOf(selfId);
 }
 
 /**
@@ -70,10 +80,7 @@ function lockedLayerPlacement(
 export function lockedLayerSnapshots(html: string): LockedLayerSnapshot[] {
   const projection = buildCodeLayerProjection(html);
   return projection.nodes.flatMap((node) => {
-    if (
-      node.dataAttributes["data-agent-native-locked"] !== "true" ||
-      !node.source
-    ) {
+    if (node.dataAttributes[LOCKED_ATTRIBUTE] !== "true" || !node.source) {
       return [];
     }
     return [
@@ -102,19 +109,43 @@ export function countLockedLayersAcrossFiles(
   );
 }
 
+function namesFor(labels: string[]): string {
+  return Array.from(new Set(labels)).slice(0, 5).join(", ");
+}
+
 /**
- * Locked layers are immutable for agent-authored whole-file or text edits.
- * The human editor can still unlock a layer through its dedicated layer
- * control; that direct UI path does not call this guard.
+ * Locked layers are immutable for agent-authored whole-file or text edits, in
+ * BOTH directions: an agent that re-adds the flag undoes the human's unlock
+ * and re-blocks itself forever. The human editor's own layer control writes as
+ * `caller: "frontend"`, which does not reach this guard.
  */
 export function assertLockedLayersPreserved(
   before: string,
   after: string,
 ): void {
+  // Comparing lock sets needs BOTH sides projected, and most designs carry no
+  // locked layer. Keep that case off the parser on every guarded write.
+  if (!before.includes(LOCKED_ATTRIBUTE) && !after.includes(LOCKED_ATTRIBUTE)) {
+    return;
+  }
   const locked = lockedLayerSnapshots(before);
+  const nextProjection = buildCodeLayerProjection(after);
+  const lockedBeforeIds = new Set(locked.map((snapshot) => snapshot.id));
+  const nowLocked = nextProjection.nodes.filter(
+    (node) =>
+      node.dataAttributes[LOCKED_ATTRIBUTE] === "true" &&
+      !lockedBeforeIds.has(node.id),
+  );
+  if (nowLocked.length > 0) {
+    throw new Error(
+      `This edit locks layer${nowLocked.length === 1 ? "" : "s"} the editor had unlocked: ` +
+        `${namesFor(nowLocked.map((node) => node.layerName))}. ` +
+        "Only the human editor sets data-agent-native-locked. Re-read the " +
+        "file and rebuild the edit from its current content.",
+    );
+  }
   if (locked.length === 0) return;
 
-  const nextProjection = buildCodeLayerProjection(after);
   const nextById = new Map(nextProjection.nodes.map((node) => [node.id, node]));
   const changed: string[] = [];
 
@@ -129,9 +160,17 @@ export function assertLockedLayersPreserved(
     if (
       nextSource !== snapshot.source ||
       nextPlacement.parentId !== snapshot.parentId ||
-      nextPlacement.siblingIndex !== snapshot.siblingIndex ||
-      nextPlacement.previousSiblingId !== snapshot.previousSiblingId ||
-      nextPlacement.nextSiblingId !== snapshot.nextSiblingId ||
+      nextPlacement.selfId !== snapshot.selfId ||
+      orderAmongSurvivingSiblings(
+        nextPlacement.siblingIds,
+        nextPlacement.selfId,
+        snapshot.siblingIds,
+      ) !==
+        orderAmongSurvivingSiblings(
+          snapshot.siblingIds,
+          snapshot.selfId,
+          nextPlacement.siblingIds,
+        ) ||
       nextPlacement.ancestorIds.length !== snapshot.ancestorIds.length ||
       nextPlacement.ancestorIds.some(
         (ancestorId, index) => ancestorId !== snapshot.ancestorIds[index],
@@ -142,9 +181,8 @@ export function assertLockedLayersPreserved(
   }
 
   if (changed.length > 0) {
-    const names = Array.from(new Set(changed)).slice(0, 5).join(", ");
     throw new Error(
-      `This edit changes locked layer${changed.length === 1 ? "" : "s"}: ${names}. ` +
+      `This edit changes locked layer${changed.length === 1 ? "" : "s"}: ${namesFor(changed)}. ` +
         "Preserve locked layers exactly, or ask the user to unlock them first.",
     );
   }


### PR DESCRIPTION
Unlocking a template layer now sticks the agent can no longer silently re-lock it, and edits beside a locked layer are no longer wrongly rejected