### PR TITLE
Fix mobile header, footer feedback, and hero polish

### DIFF
--- a/packages/docs/app/components/website-redesign/ds/icon-button.tsx
+++ b/packages/docs/app/components/website-redesign/ds/icon-button.tsx
@@ -10,6 +10,11 @@ import { useDocsTheme } from "../../ThemeToggle";
 const interactiveClassName =
   "hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]";
 
+// Everything but the 40x40 sizing, so a text control in the footer can sit
+// beside these icon buttons and read as the same surface.
+export const controlSurfaceClassName =
+  "inline-flex h-10 shrink-0 cursor-pointer items-center justify-center rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-transparent text-[var(--b-text-primary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]";
+
 const baseClassName =
   "inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-[var(--b-radius)] border border-solid bg-transparent text-[var(--b-text-primary)] outline-none transition-[background,border-color] duration-150 ease-[ease]";
 
@@ -30,7 +35,7 @@ export function IconButton({
         interactiveClassName,
         dimBorder
           ? "border-[var(--b-action-secondary-border-dim)]"
-          : "border-[var(--b-action-secondary-border)]",
+          : "border-[var(--b-border-default)]",
         className,
       ]
         .filter(Boolean)

--- a/packages/docs/app/components/website-redesign/ds/icon-button.tsx
+++ b/packages/docs/app/components/website-redesign/ds/icon-button.tsx
@@ -42,12 +42,17 @@ export function IconButton({
   );
 }
 
-export function ThemeIconButton() {
+export function ThemeIconButton({ dimBorder }: { dimBorder?: boolean }) {
   const t = useT();
   const { theme, toggleTheme } = useDocsTheme();
   const label = t("theme.toggle");
   return (
-    <IconButton onClick={toggleTheme} aria-label={label} title={label}>
+    <IconButton
+      dimBorder={dimBorder}
+      onClick={toggleTheme}
+      aria-label={label}
+      title={label}
+    >
       {theme === "light" ? (
         <IconSun size={18} stroke={1.5} />
       ) : (

--- a/packages/docs/app/components/website-redesign/ds/kbd.tsx
+++ b/packages/docs/app/components/website-redesign/ds/kbd.tsx
@@ -6,7 +6,7 @@ interface KbdProps {
 
 export function Kbd({ children }: KbdProps) {
   return (
-    <kbd className="rounded-[var(--b-radius-sm)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-prominent)] px-[6px] py-[2px] font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] text-[var(--b-text-secondary)]">
+    <kbd className="rounded-[var(--b-radius-sm)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-elevated)] px-[6px] py-[2px] font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] text-[var(--b-text-secondary)]">
       {children}
     </kbd>
   );

--- a/packages/docs/app/components/website-redesign/ds/language-picker.tsx
+++ b/packages/docs/app/components/website-redesign/ds/language-picker.tsx
@@ -19,6 +19,7 @@ import {
 
 interface LanguagePickerProps {
   openUpward?: boolean;
+  dimBorder?: boolean;
 }
 
 function preferenceLabel(preference: string) {
@@ -122,7 +123,12 @@ export function LanguagePicker(props: LanguagePickerProps) {
         aria-expanded={open}
         aria-controls={listId}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-[var(--b-radius)] border border-solid bg-transparent text-[var(--b-text-primary)] outline-none transition-[background,border-color] duration-150 ease-[ease] border-[var(--b-action-secondary-border)] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]"
+        className={[
+          "inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-[var(--b-radius)] border border-solid bg-transparent text-[var(--b-text-primary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]",
+          props.dimBorder
+            ? "border-[var(--b-action-secondary-border-dim)]"
+            : "border-[var(--b-action-secondary-border)]",
+        ].join(" ")}
       >
         <IconLanguage size={18} stroke={1.5} />
         <span className="sr-only">{label}</span>

--- a/packages/docs/app/components/website-redesign/ds/language-picker.tsx
+++ b/packages/docs/app/components/website-redesign/ds/language-picker.tsx
@@ -127,7 +127,7 @@ export function LanguagePicker(props: LanguagePickerProps) {
           "inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center rounded-[var(--b-radius)] border border-solid bg-transparent text-[var(--b-text-primary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]",
           props.dimBorder
             ? "border-[var(--b-action-secondary-border-dim)]"
-            : "border-[var(--b-action-secondary-border)]",
+            : "border-[var(--b-border-default)]",
         ].join(" ")}
       >
         <IconLanguage size={18} stroke={1.5} />

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -1,10 +1,6 @@
 import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { FeedbackButton } from "@agent-native/core/client/ui";
-import {
-  IconBrandDiscord,
-  IconBrandGithub,
-  IconSpeakerphone,
-} from "@tabler/icons-react";
+import { IconBrandDiscord, IconBrandGithub } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 
@@ -208,9 +204,8 @@ export function Footer() {
             trigger={
               <button
                 type="button"
-                className={`${controlSurfaceClassName} gap-[var(--spacing-2)] px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
+                className={`${controlSurfaceClassName} px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
               >
-                <IconSpeakerphone size={18} stroke={1.5} />
                 {t("feedback.label")}
               </button>
             }

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -173,12 +173,15 @@ export function Footer() {
       </div>
 
       <GridInner className="flex flex-wrap items-center justify-between gap-[var(--spacing-6)] px-[var(--spacing-20)] py-[var(--spacing-6)]">
-        <span className="font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-medium tracking-[0.04em] text-[var(--b-text-primary)]">
-          {/* i18n-ignore: a year and the wordmark, nothing translatable */}©
-          2026 AGENT-NATIVE
-        </span>
-
         <div className="flex items-center gap-[var(--spacing-6)]">
+          <span className="font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-medium tracking-[0.04em] text-[var(--b-text-primary)]">
+            {/* i18n-ignore: a year and the wordmark, nothing translatable */}©
+            2026 AGENT-NATIVE
+          </span>
+          <div
+            aria-hidden
+            className="h-[13px] w-px bg-[var(--b-border-default)]"
+          />
           <div className="flex items-center gap-4">
             {SOCIAL_LINKS.map((social) => (
               <a
@@ -193,30 +196,27 @@ export function Footer() {
               </a>
             ))}
           </div>
-          <div
-            aria-hidden
-            className="h-[13px] w-px bg-[var(--b-border-default)]"
+        </div>
+
+        <div className="flex items-center gap-[var(--spacing-2)]">
+          <FeedbackButton
+            url={DOCS_FEEDBACK_URL}
+            label={t("feedback.label")}
+            placeholder={t("feedback.placeholder")}
+            align="end"
+            side="top"
+            trigger={
+              <button
+                type="button"
+                className={`${controlSurfaceClassName} gap-[var(--spacing-2)] px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
+              >
+                <IconSpeakerphone size={18} stroke={1.5} />
+                {t("feedback.label")}
+              </button>
+            }
           />
-          <div className="flex items-center gap-[var(--spacing-2)]">
-            <FeedbackButton
-              url={DOCS_FEEDBACK_URL}
-              label={t("feedback.label")}
-              placeholder={t("feedback.placeholder")}
-              align="end"
-              side="top"
-              trigger={
-                <button
-                  type="button"
-                  className={`${controlSurfaceClassName} gap-[var(--spacing-2)] px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
-                >
-                  <IconSpeakerphone size={18} stroke={1.5} />
-                  {t("feedback.label")}
-                </button>
-              }
-            />
-            <LanguagePicker openUpward />
-            <ThemeIconButton />
-          </div>
+          <LanguagePicker openUpward />
+          <ThemeIconButton />
         </div>
       </GridInner>
     </PageSection>

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -1,6 +1,10 @@
 import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { FeedbackButton } from "@agent-native/core/client/ui";
-import { IconBrandDiscord, IconBrandGithub } from "@tabler/icons-react";
+import {
+  IconBrandDiscord,
+  IconBrandGithub,
+  IconSpeakerphone,
+} from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
 
@@ -203,8 +207,9 @@ export function Footer() {
               trigger={
                 <button
                   type="button"
-                  className={`${controlSurfaceClassName} px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
+                  className={`${controlSurfaceClassName} gap-[var(--spacing-2)] px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
                 >
+                  <IconSpeakerphone size={18} stroke={1.5} />
                   {t("feedback.label")}
                 </button>
               }

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router";
 
 import { sitePathForLocale } from "../docs-locale";
-import { ThemeIconButton } from "./ds/icon-button";
+import { controlSurfaceClassName, ThemeIconButton } from "./ds/icon-button";
 import { LanguagePicker } from "./ds/language-picker";
 import { Logo } from "./ds/logo";
 import { GridInner, PageSection } from "./page-grid";
@@ -169,26 +169,26 @@ export function Footer() {
       </div>
 
       <GridInner className="flex flex-wrap items-center justify-between gap-[var(--spacing-6)] px-[var(--spacing-20)] py-[var(--spacing-6)]">
-        <div className="flex items-center gap-4">
-          {SOCIAL_LINKS.map((social) => (
-            <a
-              key={social.label}
-              href={social.href}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={social.label}
-              className="flex text-[var(--b-text-primary)] opacity-80 hover:opacity-100"
-            >
-              {social.icon}
-            </a>
-          ))}
-        </div>
+        <span className="font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-medium tracking-[0.04em] text-[var(--b-text-primary)]">
+          {/* i18n-ignore: a year and the wordmark, nothing translatable */}©
+          2026 AGENT-NATIVE
+        </span>
 
         <div className="flex items-center gap-[var(--spacing-6)]">
-          <span className="font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-medium tracking-[0.04em] text-[var(--b-text-primary)]">
-            {/* i18n-ignore: a year and the wordmark, nothing translatable */}©
-            2026 AGENT-NATIVE
-          </span>
+          <div className="flex items-center gap-4">
+            {SOCIAL_LINKS.map((social) => (
+              <a
+                key={social.label}
+                href={social.href}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={social.label}
+                className="flex text-[var(--b-text-primary)] opacity-80 hover:opacity-100"
+              >
+                {social.icon}
+              </a>
+            ))}
+          </div>
           <div
             aria-hidden
             className="h-[13px] w-px bg-[var(--b-border-default)]"
@@ -203,7 +203,7 @@ export function Footer() {
               trigger={
                 <button
                   type="button"
-                  className={`${linkClassName} cursor-pointer border-none bg-transparent p-0`}
+                  className={`${controlSurfaceClassName} px-[var(--spacing-3)] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)]`}
                 >
                   {t("feedback.label")}
                 </button>

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -182,21 +182,6 @@ export function Footer() {
               {social.icon}
             </a>
           ))}
-          <FeedbackButton
-            url={DOCS_FEEDBACK_URL}
-            label={t("feedback.label")}
-            placeholder={t("feedback.placeholder")}
-            align="start"
-            side="top"
-            trigger={
-              <button
-                type="button"
-                className={`${linkClassName} cursor-pointer border-none bg-transparent p-0 lowercase`}
-              >
-                {t("feedback.label")}
-              </button>
-            }
-          />
         </div>
 
         <div className="flex items-center gap-[var(--spacing-6)]">
@@ -209,6 +194,21 @@ export function Footer() {
             className="h-[13px] w-px bg-[var(--b-border-default)]"
           />
           <div className="flex items-center gap-[var(--spacing-2)]">
+            <FeedbackButton
+              url={DOCS_FEEDBACK_URL}
+              label={t("feedback.label")}
+              placeholder={t("feedback.placeholder")}
+              align="end"
+              side="top"
+              trigger={
+                <button
+                  type="button"
+                  className={`${linkClassName} cursor-pointer border-none bg-transparent p-0`}
+                >
+                  {t("feedback.label")}
+                </button>
+              }
+            />
             <LanguagePicker openUpward />
             <ThemeIconButton />
           </div>

--- a/packages/docs/app/components/website-redesign/footer.tsx
+++ b/packages/docs/app/components/website-redesign/footer.tsx
@@ -1,4 +1,5 @@
 import { useLocale, useT } from "@agent-native/core/client/i18n";
+import { FeedbackButton } from "@agent-native/core/client/ui";
 import { IconBrandDiscord, IconBrandGithub } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router";
@@ -95,6 +96,11 @@ const SOCIAL_LINKS: Array<{
   },
 ];
 
+// Docs, legal, and app routes all render this footer, so it is the one
+// in-site way to report a problem now that the header no longer carries it.
+const DOCS_FEEDBACK_URL =
+  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
+
 const linkClassName =
   "font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)] text-[var(--b-text-secondary)] no-underline hover:text-[var(--b-text-primary)]";
 
@@ -176,6 +182,21 @@ export function Footer() {
               {social.icon}
             </a>
           ))}
+          <FeedbackButton
+            url={DOCS_FEEDBACK_URL}
+            label={t("feedback.label")}
+            placeholder={t("feedback.placeholder")}
+            align="start"
+            side="top"
+            trigger={
+              <button
+                type="button"
+                className={`${linkClassName} cursor-pointer border-none bg-transparent p-0 lowercase`}
+              >
+                {t("feedback.label")}
+              </button>
+            }
+          />
         </div>
 
         <div className="flex items-center gap-[var(--spacing-6)]">

--- a/packages/docs/app/components/website-redesign/hero-shader-background.tsx
+++ b/packages/docs/app/components/website-redesign/hero-shader-background.tsx
@@ -351,6 +351,9 @@ export function HeroShaderBackground({
         pointerX = targetX = canvas.width * 0.5;
         pointerY = targetY = canvas.height * 0.5;
       }
+      // Under reduced motion there is no next frame to pick the new size up,
+      // so the buffer would stay blank until something else redraws.
+      if (reducedMotion) draw(20, false);
     }
 
     function handlePointerMove(event: PointerEvent | MouseEvent) {
@@ -372,7 +375,11 @@ export function HeroShaderBackground({
     }
 
     resize();
-    window.addEventListener("resize", resize);
+    // Observes the box, not the window: the hero's height comes from padding
+    // tokens and its own content, so it changes without the viewport changing
+    // and the buffer would otherwise keep the size it had on mount.
+    const sizeObserver = new ResizeObserver(resize);
+    sizeObserver.observe(container);
     window.addEventListener("pointermove", handlePointerMove, {
       passive: true,
     });
@@ -464,7 +471,7 @@ export function HeroShaderBackground({
       }
       observer.disconnect();
       visibilityObserver.disconnect();
-      window.removeEventListener("resize", resize);
+      sizeObserver.disconnect();
       window.removeEventListener("pointermove", handlePointerMove);
       window.removeEventListener("mousemove", handlePointerMove);
       document.removeEventListener("pointerleave", fadePointer);

--- a/packages/docs/app/components/website-redesign/hero.tsx
+++ b/packages/docs/app/components/website-redesign/hero.tsx
@@ -17,7 +17,7 @@ export function Hero() {
       {/* No top border on the GridInner below: the sticky SiteHeader already
           draws the border directly above this section, so a second one would
           double the line. */}
-      <GridInner className="flex flex-col items-center gap-[var(--spacing-12)] px-[var(--spacing-10)] pt-[var(--spacing-50)] pb-[var(--spacing-40)]">
+      <GridInner className="flex flex-col items-center gap-[var(--spacing-12)] px-[var(--spacing-10)] pt-[var(--spacing-60)] pb-[var(--spacing-40)]">
         <div className="flex w-full max-w-[875px] flex-col items-center gap-[var(--spacing-6)]">
           <h1 className="m-0 text-center font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-1)] font-medium leading-[1.05] tracking-[-0.02em] text-[var(--b-text-primary)] mobile:leading-[1.2]">
             {t("homepage.hero.title")}

--- a/packages/docs/app/components/website-redesign/install-command.tsx
+++ b/packages/docs/app/components/website-redesign/install-command.tsx
@@ -47,7 +47,10 @@ async function copyText(text: string): Promise<boolean> {
 const CLASSES = [
   // The two properties have different durations, so this keeps the shorthand
   // verbatim rather than flattening both onto one `duration-*`.
-  "inline-flex cursor-pointer items-center gap-[var(--spacing-2)] rounded-[var(--b-radius)] px-[var(--spacing-3)] py-[9px] font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-1)] leading-none text-[var(--b-text-secondary)] [transition:color_0.15s,background_0.2s_ease]",
+  // The command is one unbreakable token to a reader, so it scales with the
+  // viewport instead of wrapping mid-command: 2.6vw is the widest size that
+  // still fits inside the get-started dialog's padding at 390px.
+  "inline-flex cursor-pointer items-center gap-[var(--spacing-2)] rounded-[var(--b-radius)] px-[var(--spacing-3)] py-[9px] font-[family-name:var(--b-font-mono)] text-[length:min(var(--b-t-label-1),2.6vw)] leading-none whitespace-nowrap text-[var(--b-text-secondary)] [transition:color_0.15s,background_0.2s_ease]",
   "border border-transparent bg-origin-border [background-clip:padding-box,border-box]",
   "bg-[image:linear-gradient(var(--b-bg-inset),var(--b-bg-inset)),linear-gradient(140deg,var(--b-stroke-gradient-start),var(--b-stroke-gradient-end))]",
   "hover:bg-[image:linear-gradient(var(--b-bg-prominent),var(--b-bg-prominent)),linear-gradient(140deg,var(--b-stroke-gradient-start),var(--b-stroke-gradient-end))]",

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -1,8 +1,6 @@
 import { useLocale, useT } from "@agent-native/core/client/i18n";
-import { FeedbackButton } from "@agent-native/core/client/ui";
 import {
   IconBrandGithub,
-  IconSpeakerphone,
   IconMenu2,
   IconMessage,
   IconSearch,
@@ -26,11 +24,6 @@ const SearchModal = lazy(() =>
 );
 
 const DISCORD_URL = "https://discord.gg/qm82StQ2NC";
-
-// Same form as the header this one replaced: dropping it would leave docs,
-// legal, and app routes with no in-site way to report a problem.
-const DOCS_FEEDBACK_URL =
-  "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
 
 const GITHUB_REPO_URL = "https://github.com/BuilderIO/agent-native";
 
@@ -56,27 +49,6 @@ function AskAiIconButton() {
     >
       <IconMessage size={18} stroke={1.5} />
     </IconButton>
-  );
-}
-
-function FeedbackIconButton({ align }: { align: "start" | "end" }) {
-  const t = useT();
-  const label = t("feedback.label");
-  return (
-    <FeedbackButton
-      url={DOCS_FEEDBACK_URL}
-      label={label}
-      placeholder={t("feedback.placeholder")}
-      align={align}
-      side="bottom"
-      trigger={
-        <IconButton dimBorder aria-label={label} title={label}>
-          {/* Not a speech bubble: Ask AI beside it already owns that shape,
-              and two bubbles read as one control duplicated. */}
-          <IconSpeakerphone size={18} stroke={1.5} />
-        </IconButton>
-      }
-    />
   );
 }
 
@@ -220,7 +192,6 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
           <div className="hidden items-stretch gap-3 lg:flex">
             <SearchTrigger onClick={openSearch} label={searchLabel} />
             <GithubStarsButton starCount={starCount} />
-            <FeedbackIconButton align="end" />
             <AskAiIconButton />
           </div>
 
@@ -260,7 +231,6 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
             <GithubStarsButton starCount={starCount} className="h-10" />
             <LanguagePicker dimBorder />
             <ThemeIconButton dimBorder />
-            <FeedbackIconButton align="start" />
             <AskAiIconButton />
           </div>
         </div>

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -93,7 +93,7 @@ function SearchTrigger({
       aria-label={label}
       // The fixed width is on purpose: with `justify-between` it is what
       // opens the gap between the label and the ⌘K hint.
-      className="inline-flex h-10 w-[280px] shrink-0 cursor-pointer items-center justify-between gap-[var(--spacing-2)] rounded-[var(--b-radius)] border border-solid border-[var(--b-action-secondary-border-dim)] bg-transparent px-[var(--spacing-3)] py-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-1)] text-[var(--b-text-secondary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]"
+      className="inline-flex h-10 w-[280px] shrink-0 cursor-pointer items-center justify-between gap-[var(--spacing-2)] rounded-[var(--b-radius)] border border-solid border-[var(--b-action-secondary-border-dim)] bg-[var(--b-bg-raised)] px-[var(--spacing-3)] py-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-1)] text-[var(--b-text-secondary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]"
     >
       <span className="inline-flex items-center gap-[var(--spacing-2)]">
         <IconSearch size={16} stroke={1.75} />

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -80,11 +80,17 @@ function FeedbackIconButton({ align }: { align: "start" | "end" }) {
   );
 }
 
-function GithubStarsButton({ starCount }: { starCount: number | null }) {
+interface GithubStarsButtonProps {
+  starCount: number | null;
+  className?: string;
+}
+
+function GithubStarsButton({ starCount, className }: GithubStarsButtonProps) {
   return (
     <Button
       variant="secondary"
       dimBorder
+      className={className}
       href={GITHUB_REPO_URL}
       target="_blank"
       rel="noreferrer"
@@ -250,8 +256,8 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
               {link.label}
             </NavLink>
           ))}
-          <div className="mt-[var(--spacing-2)] flex items-center gap-[var(--spacing-3)]">
-            <GithubStarsButton starCount={starCount} />
+          <div className="mt-[var(--spacing-2)] flex items-center justify-between gap-[var(--spacing-3)]">
+            <GithubStarsButton starCount={starCount} className="grow" />
             <LanguagePicker dimBorder />
             <ThemeIconButton dimBorder />
             <FeedbackIconButton align="start" />

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -256,7 +256,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
               {link.label}
             </NavLink>
           ))}
-          <div className="mt-[var(--spacing-2)] flex items-center justify-between gap-[var(--spacing-3)]">
+          <div className="mt-[var(--spacing-2)] flex items-center gap-[var(--spacing-3)]">
             <GithubStarsButton starCount={starCount} className="h-10" />
             <LanguagePicker dimBorder />
             <ThemeIconButton dimBorder />

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -257,7 +257,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
             </NavLink>
           ))}
           <div className="mt-[var(--spacing-2)] flex items-center justify-between gap-[var(--spacing-3)]">
-            <GithubStarsButton starCount={starCount} className="grow" />
+            <GithubStarsButton starCount={starCount} className="h-10" />
             <LanguagePicker dimBorder />
             <ThemeIconButton dimBorder />
             <FeedbackIconButton align="start" />

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -91,9 +91,9 @@ function SearchTrigger({
       type="button"
       onClick={onClick}
       aria-label={label}
-      // The 320px width is fixed on purpose: with `justify-between` it is what
+      // The fixed width is on purpose: with `justify-between` it is what
       // opens the gap between the label and the ⌘K hint.
-      className="inline-flex h-10 w-[320px] shrink-0 cursor-pointer items-center justify-between gap-[var(--spacing-2)] rounded-[var(--b-radius)] border border-solid border-[var(--b-action-secondary-border-dim)] bg-transparent px-[var(--spacing-3)] py-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-1)] text-[var(--b-text-secondary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]"
+      className="inline-flex h-10 w-[280px] shrink-0 cursor-pointer items-center justify-between gap-[var(--spacing-2)] rounded-[var(--b-radius)] border border-solid border-[var(--b-action-secondary-border-dim)] bg-transparent px-[var(--spacing-3)] py-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-1)] text-[var(--b-text-secondary)] outline-none transition-[background,border-color] duration-150 ease-[ease] hover:bg-[var(--b-action-secondary-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]"
     >
       <span className="inline-flex items-center gap-[var(--spacing-2)]">
         <IconSearch size={16} stroke={1.75} />

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -234,7 +234,10 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
       </div>
 
       {mobileOpen && (
-        <div className="absolute top-full right-0 left-0 flex flex-col gap-[var(--spacing-3)] border-t border-solid border-[var(--b-border-default)] bg-[var(--b-bg-translucent)] px-[var(--spacing-10)] py-[var(--spacing-4)] backdrop-blur-[12px] lg:hidden">
+        // Opaque, not the header's translucent fill: this panel is a child of
+        // the blurred header, so its own backdrop-filter samples the header
+        // rather than the page and leaves the content behind it fully legible.
+        <div className="absolute top-full right-0 left-0 flex flex-col gap-[var(--spacing-3)] border-t border-solid border-[var(--b-border-default)] bg-[var(--b-bg-page)] px-[var(--spacing-10)] py-[var(--spacing-4)] lg:hidden">
           {navLinks.map((link) => (
             <NavLink
               key={link.label}

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -2,9 +2,9 @@ import { useLocale, useT } from "@agent-native/core/client/i18n";
 import { FeedbackButton } from "@agent-native/core/client/ui";
 import {
   IconBrandGithub,
+  IconSpeakerphone,
   IconMenu2,
   IconMessage,
-  IconMessage2,
   IconSearch,
   IconX,
 } from "@tabler/icons-react";
@@ -71,7 +71,9 @@ function FeedbackIconButton({ align }: { align: "start" | "end" }) {
       side="bottom"
       trigger={
         <IconButton dimBorder aria-label={label} title={label}>
-          <IconMessage2 size={18} stroke={1.5} />
+          {/* Not a speech bubble: Ask AI beside it already owns that shape,
+              and two bubbles read as one control duplicated. */}
+          <IconSpeakerphone size={18} stroke={1.5} />
         </IconButton>
       }
     />
@@ -217,7 +219,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
           </div>
 
           <div className="flex items-center gap-2 lg:hidden">
-            <IconButton onClick={openSearch} aria-label={searchLabel}>
+            <IconButton dimBorder onClick={openSearch} aria-label={searchLabel}>
               <IconSearch size={18} stroke={1.5} />
             </IconButton>
             <button
@@ -250,8 +252,8 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
           ))}
           <div className="mt-[var(--spacing-2)] flex items-center gap-[var(--spacing-3)]">
             <GithubStarsButton starCount={starCount} />
-            <LanguagePicker />
-            <ThemeIconButton />
+            <LanguagePicker dimBorder />
+            <ThemeIconButton dimBorder />
             <FeedbackIconButton align="start" />
             <AskAiIconButton />
           </div>

--- a/packages/docs/app/components/website-redesign/tokens.css
+++ b/packages/docs/app/components/website-redesign/tokens.css
@@ -190,6 +190,7 @@
   --spacing-35: 150px;
   --spacing-40: 160px;
   --spacing-50: 200px;
+  --spacing-60: 240px;
 
   /* Typography scale */
   --b-t-heading-1: 56px;
@@ -310,6 +311,7 @@
     --spacing-35: 88px;
     --spacing-40: 88px;
     --spacing-50: 80px;
+    --spacing-60: 96px;
 
     --b-t-heading-1: 32px;
     --b-t-heading-2: 28px;

--- a/packages/docs/app/components/website-redesign/tokens.css
+++ b/packages/docs/app/components/website-redesign/tokens.css
@@ -51,6 +51,12 @@
   --b-bg-surface: #0a0a0a;
   --b-bg-raised: #0f0f0f;
   --b-bg-prominent: #1a1a1a;
+  /* One stop past --b-bg-prominent, for a chip that has to read as lifted off
+     a surface which is itself already lifted (the ⌘K badge inside the header
+     search box). Indirect on purpose: the light theme overrides
+     --c-neutral-800, so this follows the neutral ramp one stop in whichever
+     direction that theme separates, instead of needing a second literal. */
+  --b-bg-elevated: var(--c-neutral-800);
   --b-bg-translucent: #0a0a0ae6;
   --b-bg-alternative: #00161b;
   /* Surface for terminal/code chrome. In dark mode it drops below the page


### PR DESCRIPTION
### Summary
Fixes several mobile navigation and header/footer styling issues, including a solid background for the mobile menu, a non-wrapping install command, a single feedback control relocated to the footer, and small brightness/sizing tweaks to the header search and hero section.

### Problem
On mobile, the terminal install command wrapped awkwardly, and the mobile menu had no background so page content was visible behind it. Additionally, there were duplicate chat/feedback icons in the header and mobile menu, inconsistent border colors between controls (theme toggle, language picker, search button), and the search box and command-k badge didn't stand out enough from the page background. The hero section was also requested to be slightly taller.

### Solution
- Replaced the mobile menu's translucent background with an opaque one so content behind it is no longer visible.
- Made the install command text scale with viewport width and prevented it from wrapping.
- Removed the duplicate feedback icon button from the header and mobile menu, and added a single text-based "Feedback" control to the footer styled to match the theme/language toggles.
- Unified border colors across icon buttons, the language picker, and the search trigger using a shared `--b-border-default` / dim-border pattern.
- Introduced a new elevated background token for surfaces that need to read as "one stop brighter" than already-raised surfaces, and applied it to the search box and command-k badge.
- Increased hero top padding via a new spacing token and made the hero shader background resize with its container (not just the window) using a `ResizeObserver`.

### Key Changes
- `icon-button.tsx`: added `controlSurfaceClassName` export (icon-button styling without fixed width) for reuse in the footer feedback button; updated `ThemeIconButton` to accept a `dimBorder` prop; standardized non-dim border to `--b-border-default`.
- `kbd.tsx`: updated `Kbd` background to the new `--b-bg-elevated` token.
- `language-picker.tsx`: added `dimBorder` prop to control border color, matching other header/footer controls.
- `footer.tsx`: moved the feedback trigger into the footer next to the language and theme toggles, swapped the order of copyright text and social links (copyright left, socials right), using the new `controlSurfaceClassName`.
- `hero-shader-background.tsx`: replaced the `window` resize listener with a `ResizeObserver` on the container, and force a redraw under reduced motion so the canvas isn't left blank after a resize.
- `hero.tsx`: increased top padding from `--spacing-50` to the new `--spacing-60` token.
- `install-command.tsx`: constrained the command text size with `min(var(--b-t-label-1), 2.6vw)` and added `whitespace-nowrap` to prevent wrapping on small screens.
- `site-header.tsx`: removed the separate `FeedbackIconButton` (now handled by the footer), added `dimBorder` to the mobile search icon button, adjusted `GithubStarsButton` to accept a `className`, reduced the search trigger width, and gave it the new `--b-bg-raised` background; changed the mobile menu container to use `--b-bg-page` instead of a translucent fill.
- `tokens.css`: added `--b-bg-elevated` token (mapped to `--c-neutral-800`) and a new `--spacing-60` spacing token (with a responsive/mobile override).


---

<a href="https://builder.io/app/projects/57b23034acbe47cdabc7/circle-matrix-loo4l16a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://57b23034acbe47cdabc7-circle-matrix-loo4l16a.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3743`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>57b23034acbe47cdabc7</projectId>-->
<!--<branchName>circle-matrix-loo4l16a</branchName>-->