### PR TITLE
fix(slides): align AI editing presence with right-side actions

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
+++ b/templates/slides/app/components/editor/EditorToolbar.layout.test.ts
@@ -32,14 +32,26 @@ describe("EditorToolbar layout contract", () => {
 
   it("pushes the top-right actions to the row edge when the style toolbar moves below", () => {
     expect(editorToolbarSource).toContain(
-      '<div className="ml-auto flex-shrink-0">',
+      '<div className="ml-auto flex shrink-0 items-center gap-1">',
     );
   });
 
-  it("keeps the AI presence indicator adjacent to the editor actions", () => {
-    expect(editorToolbarSource).toContain(
-      'className="flex-shrink-0 mr-0.5 pl-2"',
+  it("keeps the AI presence indicator beside the top-right editor actions", () => {
+    const presenceIndex = editorToolbarSource.indexOf("<PresenceBar");
+    const actionClusterIndex = editorToolbarSource.indexOf(
+      '<div className="ml-auto flex shrink-0 items-center gap-1">',
     );
+    const menuIndex = editorToolbarSource.indexOf("<DropdownMenu>");
+    const shareIndex = editorToolbarSource.indexOf("{/* Framework share");
+
+    expect(presenceIndex).toBeGreaterThan(actionClusterIndex);
+    expect(presenceIndex).toBeLessThan(menuIndex);
+    expect(menuIndex).toBeLessThan(shareIndex);
+    expect(actionClusterIndex).toBeGreaterThan(-1);
+    expect(presenceIndex).toBeGreaterThan(-1);
+    expect(menuIndex).toBeGreaterThan(-1);
+    expect(shareIndex).toBeGreaterThan(-1);
+    expect(editorToolbarSource).toContain('className="flex-shrink-0 pl-2"');
   });
 
   it("lets the overflow menu use most of the viewport height", () => {

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -597,18 +597,19 @@ export default function EditorToolbar({
         />
       )}
 
-      {/* Presence avatars — shared PresenceBar (agent + collaborators) */}
-      <PresenceBar
-        activeUsers={activeUsers ?? []}
-        agentPresent={agentPresent}
-        agentActive={agentActive}
-        showAgentEditingDot={false}
-        currentUserEmail={currentUserEmail}
-        className="flex-shrink-0 mr-0.5 pl-2"
-      />
+      {/* Top-right editor actions */}
+      <div className="ml-auto flex shrink-0 items-center gap-1">
+        {/* Presence avatars — shared PresenceBar (agent + collaborators) */}
+        <PresenceBar
+          activeUsers={activeUsers ?? []}
+          agentPresent={agentPresent}
+          agentActive={agentActive}
+          showAgentEditingDot={false}
+          currentUserEmail={currentUserEmail}
+          className="flex-shrink-0 pl-2"
+        />
 
-      {/* Consolidated editor menu */}
-      <div className="ml-auto flex-shrink-0">
+        {/* Consolidated editor menu */}
         <DropdownMenu>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/templates/slides/changelog/2026-08-27-ai-editing-presence-sits-with-right-side-sharing-controls.md
+++ b/templates/slides/changelog/2026-08-27-ai-editing-presence-sits-with-right-side-sharing-controls.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-08-27
+---
+AI editing presence now sits with the editor's right-side sharing controls.


### PR DESCRIPTION
## Summary
- Move the Slides AI editing and collaborator presence bar into the right-side editor action cluster.
- Keep the overflow menu, Share, and Present controls together at the top-right.
- Add a layout contract test and a user-facing changelog entry.

## Validation
- `pnpm --filter slides exec vitest --run app/components/editor/EditorToolbar.layout.test.ts app/components/editor/EditorToolbar.test.tsx` (2 files, 9 tests)
- `pnpm exec oxfmt --check templates/slides/app/components/editor/EditorToolbar.tsx templates/slides/app/components/editor/EditorToolbar.layout.test.ts`
- `git diff --check`
- Local dev server started successfully, but the editor route could not hydrate because local deck actions returned `Unauthorized`; no hydrated screenshot is available.