### PR TITLE
Show Analytics its own feature flags

### DIFF
--- a/templates/analytics/actions/set-workspace-feature-flag.spec.ts
+++ b/templates/analytics/actions/set-workspace-feature-flag.spec.ts
@@ -32,10 +32,16 @@ describe("set-workspace-feature-flag", () => {
   });
 
   it("delegates the mutation for an authorized Analytics operator", async () => {
-    await expect(action.run(input, { caller: "frontend" })).resolves.toEqual({
+    const context = {
+      caller: "tool" as const,
+      threadId: "thread-1",
+      runId: "run-1",
+      turnId: "turn-1",
+    };
+    await expect(action.run(input, context)).resolves.toEqual({
       key: input.key,
     });
-    expect(setWorkspaceFeatureFlag).toHaveBeenCalledWith(admin, input);
+    expect(setWorkspaceFeatureFlag).toHaveBeenCalledWith(admin, input, context);
   });
 
   it("rejects decimal rollout percentages before delegating a write", () => {

--- a/templates/analytics/actions/set-workspace-feature-flag.ts
+++ b/templates/analytics/actions/set-workspace-feature-flag.ts
@@ -30,7 +30,7 @@ const schema = z.discriminatedUnion("operation", [
 ]);
 export default defineAction({
   description:
-    "Persist one feature-flag change on a trusted organization app. The app target is resolved only through the organization directory.",
+    "Persist one feature-flag change on Analytics or a trusted organization app. Analytics uses its local flag action; peer targets are resolved through the organization directory.",
   schema,
   agentInputSchema: z.object({
     appId: z.string(),

--- a/templates/analytics/actions/set-workspace-feature-flag.ts
+++ b/templates/analytics/actions/set-workspace-feature-flag.ts
@@ -40,6 +40,6 @@ export default defineAction({
   }),
   run: async (args, ctx) => {
     const admin = await requireAnalyticsAdminContext(ctx);
-    return setWorkspaceFeatureFlag(admin, args);
+    return setWorkspaceFeatureFlag(admin, args, ctx);
   },
 });

--- a/templates/analytics/app/components/agents/FeatureFlagsFleetPanel.spec.ts
+++ b/templates/analytics/app/components/agents/FeatureFlagsFleetPanel.spec.ts
@@ -2,10 +2,25 @@ import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  hasFleetApps,
   qualifyFleetMutation,
   recoverFleetMutationFailure,
   reconcileVerifiedFleetMutation,
 } from "./FeatureFlagsFleetPanel";
+
+describe("hasFleetApps", () => {
+  it("keeps a local Analytics entry usable when the peer directory is unavailable", () => {
+    expect(
+      hasFleetApps({
+        directoryStatus: "unavailable",
+        apps: [{ appId: "analytics", state: "ready" }],
+      }),
+    ).toBe(true);
+    expect(hasFleetApps({ directoryStatus: "unavailable", apps: [] })).toBe(
+      false,
+    );
+  });
+});
 
 describe("qualifyFleetMutation", () => {
   it("preserves Core rollout rules while qualifying the target app", () => {

--- a/templates/analytics/app/components/agents/FeatureFlagsFleetPanel.tsx
+++ b/templates/analytics/app/components/agents/FeatureFlagsFleetPanel.tsx
@@ -89,6 +89,10 @@ function asDirectory(value: unknown): FlagDirectory {
   return value && typeof value === "object" ? (value as FlagDirectory) : {};
 }
 
+export function hasFleetApps(value: unknown): boolean {
+  return (asDirectory(value).apps?.length ?? 0) > 0;
+}
+
 function isReady(app: FlagApp) {
   return app.state === "ready" || app.status === "ready";
 }
@@ -188,7 +192,10 @@ export function FeatureFlagsFleetPanel() {
   const directory = asDirectory(flags.data);
   const apps = directory.apps ?? [];
   if (flags.isLoading) return <PanelLoading />;
-  if (flags.error || directory.directoryStatus === "unavailable")
+  if (
+    flags.error ||
+    (directory.directoryStatus === "unavailable" && !hasFleetApps(directory))
+  )
     return (
       <StatusState
         title={t("agents.flagsUnavailable")}
@@ -226,6 +233,14 @@ export function FeatureFlagsFleetPanel() {
           {t("agents.reloadFlags")}
         </Button>
       </div>
+      {directory.directoryStatus === "unavailable" ? (
+        <p
+          className="rounded-lg border px-4 py-3 text-sm text-muted-foreground"
+          role="status"
+        >
+          {t("agents.flagsUnreachable")}
+        </p>
+      ) : null}
       {apps.map((app) => (
         <section key={appId(app)} className="overflow-hidden rounded-lg border">
           <div className="flex items-center justify-between gap-3 border-b bg-muted/30 px-4 py-3">

--- a/templates/analytics/changelog/2026-08-27-show-analytics-s-own-registered-flags-in-fleet-feature-flag-.md
+++ b/templates/analytics/changelog/2026-08-27-show-analytics-s-own-registered-flags-in-fleet-feature-flag-.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-27
+---
+
+Show Analytics's own registered flags in fleet feature flag management.

--- a/templates/analytics/server/lib/workspace-feature-flags.spec.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.spec.ts
@@ -5,7 +5,10 @@ const mocks = vi.hoisted(() => ({
   fetchOrgApps: vi.fn(),
   fetchOrgAppsResult: vi.fn(),
   getOrgDomain: vi.fn(),
+  getAppConfig: vi.fn(),
   isFeatureFlagEnabled: vi.fn(),
+  listLocalFeatureFlags: vi.fn(),
+  setLocalFeatureFlag: vi.fn(),
   signA2AToken: vi.fn(),
 }));
 
@@ -15,6 +18,12 @@ vi.mock("@agent-native/core/a2a", () => ({
 vi.mock("@agent-native/core/feature-flags", () => ({
   isFeatureFlagEnabled: mocks.isFeatureFlagEnabled,
 }));
+vi.mock("@agent-native/core/feature-flags/actions/list-feature-flags", () => ({
+  default: { run: mocks.listLocalFeatureFlags },
+}));
+vi.mock("@agent-native/core/feature-flags/actions/set-feature-flag", () => ({
+  default: { run: mocks.setLocalFeatureFlag },
+}));
 vi.mock("@agent-native/core/mcp", () => ({
   fetchOrgApps: mocks.fetchOrgApps,
   fetchOrgAppsResult: mocks.fetchOrgAppsResult,
@@ -22,10 +31,15 @@ vi.mock("@agent-native/core/mcp", () => ({
 vi.mock("@agent-native/core/org", () => ({
   getOrgDomain: mocks.getOrgDomain,
 }));
+vi.mock("@agent-native/core/server", () => ({
+  getAppConfig: mocks.getAppConfig,
+}));
 
 import {
   classifyWorkspaceFeatureFlagTargetFailure,
   classifyWorkspaceFeatureFlagList,
+  getWorkspaceFlagTarget,
+  listWorkspaceFeatureFlags,
   setWorkspaceFeatureFlag,
   validateWorkspaceFeatureFlagMutation,
   WorkspaceFeatureFlagFailure,
@@ -67,6 +81,30 @@ function mutationBody(rules: Record<string, unknown>) {
   };
 }
 
+function localListBody(
+  rules: Record<string, unknown> = {
+    mode: "off",
+    emails: [],
+    orgIds: [],
+    percentage: 0,
+  },
+) {
+  return {
+    contractVersion: 1,
+    status: "ready",
+    flags: [
+      {
+        key: "analytics.resilient-fleet-flag-directory",
+        displayName: "Resilient fleet flag directory",
+        defaultValue: false,
+        rules,
+        enabledForCurrentUser: rules.mode !== "off",
+      },
+    ],
+    canManage: true,
+  };
+}
+
 describe("verified fleet feature flag transaction", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -77,8 +115,112 @@ describe("verified fleet feature flag transaction", () => {
       apps: [app],
     });
     mocks.getOrgDomain.mockResolvedValue("example.test");
+    mocks.getAppConfig.mockReturnValue({
+      app: { url: "https://analytics.example.com" },
+    });
     mocks.isFeatureFlagEnabled.mockResolvedValue(true);
+    mocks.listLocalFeatureFlags.mockResolvedValue(localListBody());
     mocks.signA2AToken.mockResolvedValue("example-delegated-token");
+  });
+
+  it("keeps Analytics ready when the peer directory is unavailable", async () => {
+    mocks.fetchOrgAppsResult.mockResolvedValue({
+      status: "unavailable",
+      reason: "network",
+    });
+    const targetFetch = vi.spyOn(globalThis, "fetch");
+
+    await expect(listWorkspaceFeatureFlags(admin)).resolves.toEqual({
+      directoryStatus: "unavailable",
+      apps: [
+        expect.objectContaining({
+          appId: "analytics",
+          appName: "Analytics",
+          appOrigin: "https://analytics.example.com",
+          state: "ready",
+          flags: [
+            expect.objectContaining({
+              key: "analytics.resilient-fleet-flag-directory",
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(mocks.listLocalFeatureFlags).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        userEmail: admin.userEmail,
+        orgId: admin.orgId,
+        actionName: "list-feature-flags",
+      }),
+    );
+    expect(targetFetch).not.toHaveBeenCalled();
+  });
+
+  it("prepends Analytics without changing directory-backed sibling listing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(200, {
+        contractVersion: 1,
+        status: "no-definitions",
+        flags: [],
+        canManage: true,
+      }),
+    );
+
+    await expect(listWorkspaceFeatureFlags(admin)).resolves.toMatchObject({
+      directoryStatus: "available",
+      apps: [
+        { appId: "analytics", state: "ready" },
+        { appId: "mail", state: "no-definitions" },
+      ],
+    });
+    expect(mocks.signA2AToken).toHaveBeenCalledOnce();
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("mutates and verifies Analytics locally without directory or A2A", async () => {
+    const targetFetch = vi.spyOn(globalThis, "fetch");
+    const rules = {
+      mode: "rules",
+      emails: [admin.userEmail],
+      orgIds: [],
+      percentage: 0,
+    };
+    mocks.setLocalFeatureFlag.mockResolvedValue({
+      contractVersion: 2,
+      status: "ready",
+      key: "analytics.resilient-fleet-flag-directory",
+      rules,
+      scope: { orgId: admin.orgId, orgDomain: "example.test" },
+    });
+    mocks.listLocalFeatureFlags.mockResolvedValue(localListBody(rules));
+
+    await expect(
+      setWorkspaceFeatureFlag(admin, {
+        appId: "analytics",
+        key: "analytics.resilient-fleet-flag-directory",
+        operation: "enable-for-current-user",
+      }),
+    ).resolves.toMatchObject({
+      contractVersion: 3,
+      status: "verified",
+      enabledForCurrentUser: true,
+      rules,
+    });
+    expect(mocks.setLocalFeatureFlag).toHaveBeenCalledOnce();
+    expect(mocks.listLocalFeatureFlags).toHaveBeenCalledOnce();
+    expect(mocks.fetchOrgApps).not.toHaveBeenCalled();
+    expect(mocks.fetchOrgAppsResult).not.toHaveBeenCalled();
+    expect(mocks.signA2AToken).not.toHaveBeenCalled();
+    expect(targetFetch).not.toHaveBeenCalled();
+  });
+
+  it("reads Analytics target state locally without directory or A2A", async () => {
+    await expect(
+      getWorkspaceFlagTarget(admin, "analytics"),
+    ).resolves.toMatchObject({ appId: "analytics", state: "ready" });
+    expect(mocks.fetchOrgApps).not.toHaveBeenCalled();
+    expect(mocks.signA2AToken).not.toHaveBeenCalled();
   });
 
   it("independently reads back Alice-targeted enablement", async () => {

--- a/templates/analytics/server/lib/workspace-feature-flags.spec.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.spec.ts
@@ -178,6 +178,32 @@ describe("verified fleet feature flag transaction", () => {
     expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 
+  it("keeps healthy peers visible when the local Analytics list fails", async () => {
+    mocks.listLocalFeatureFlags.mockRejectedValueOnce(
+      new Error("private local store detail"),
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      response(200, {
+        contractVersion: 1,
+        status: "no-definitions",
+        flags: [],
+        canManage: true,
+      }),
+    );
+
+    await expect(listWorkspaceFeatureFlags(admin)).resolves.toMatchObject({
+      directoryStatus: "available",
+      apps: [
+        {
+          appId: "analytics",
+          state: "unreachable",
+          reason: "target-execution",
+        },
+        { appId: "mail", state: "no-definitions" },
+      ],
+    });
+  });
+
   it("mutates and verifies Analytics locally without directory or A2A", async () => {
     const targetFetch = vi.spyOn(globalThis, "fetch");
     const rules = {
@@ -213,6 +239,53 @@ describe("verified fleet feature flag transaction", () => {
     expect(mocks.fetchOrgAppsResult).not.toHaveBeenCalled();
     expect(mocks.signA2AToken).not.toHaveBeenCalled();
     expect(targetFetch).not.toHaveBeenCalled();
+  });
+
+  it("preserves agent-run provenance for a local Analytics mutation", async () => {
+    const rules = {
+      mode: "off",
+      emails: [],
+      orgIds: [],
+      percentage: 0,
+    };
+    mocks.setLocalFeatureFlag.mockResolvedValue({
+      contractVersion: 2,
+      status: "ready",
+      key: "analytics.resilient-fleet-flag-directory",
+      rules,
+      scope: { orgId: admin.orgId, orgDomain: "example.test" },
+    });
+    mocks.listLocalFeatureFlags.mockResolvedValue(localListBody(rules));
+    const sourceContext = {
+      caller: "tool" as const,
+      threadId: "thread-1",
+      runId: "run-1",
+      turnId: "turn-1",
+    };
+
+    await setWorkspaceFeatureFlag(
+      admin,
+      {
+        appId: "analytics",
+        key: "analytics.resilient-fleet-flag-directory",
+        operation: "off",
+      },
+      sourceContext,
+    );
+
+    expect(mocks.setLocalFeatureFlag).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        caller: "tool",
+        threadId: "thread-1",
+        runId: "run-1",
+        turnId: "turn-1",
+        userEmail: admin.userEmail,
+        orgId: admin.orgId,
+        appId: "analytics",
+        actionName: "set-feature-flag",
+      }),
+    );
   });
 
   it("reads Analytics target state locally without directory or A2A", async () => {

--- a/templates/analytics/server/lib/workspace-feature-flags.spec.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.spec.ts
@@ -288,6 +288,36 @@ describe("verified fleet feature flag transaction", () => {
     );
   });
 
+  it("classifies a local mutation authorization rejection", async () => {
+    mocks.setLocalFeatureFlag.mockRejectedValue(
+      Object.assign(new Error("private permission detail"), {
+        statusCode: 403,
+      }),
+    );
+
+    await expect(
+      setWorkspaceFeatureFlag(admin, {
+        appId: "analytics",
+        key: "analytics.resilient-fleet-flag-directory",
+        operation: "off",
+      }),
+    ).rejects.toMatchObject({ phase: "authorization" });
+  });
+
+  it("classifies other local mutation errors as target action failures", async () => {
+    mocks.setLocalFeatureFlag.mockRejectedValue(
+      new Error("Unknown feature flag: analytics.retired-flag"),
+    );
+
+    await expect(
+      setWorkspaceFeatureFlag(admin, {
+        appId: "analytics",
+        key: "analytics.retired-flag",
+        operation: "off",
+      }),
+    ).rejects.toMatchObject({ phase: "target-action" });
+  });
+
   it("classifies local readback authorization loss after persistence", async () => {
     const rules = {
       mode: "off",

--- a/templates/analytics/server/lib/workspace-feature-flags.spec.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.spec.ts
@@ -288,6 +288,63 @@ describe("verified fleet feature flag transaction", () => {
     );
   });
 
+  it("classifies local readback authorization loss after persistence", async () => {
+    const rules = {
+      mode: "off",
+      emails: [],
+      orgIds: [],
+      percentage: 0,
+    };
+    mocks.setLocalFeatureFlag.mockResolvedValue({
+      contractVersion: 2,
+      status: "ready",
+      key: "analytics.resilient-fleet-flag-directory",
+      rules,
+      scope: { orgId: admin.orgId, orgDomain: "example.test" },
+    });
+    mocks.listLocalFeatureFlags.mockResolvedValue({
+      contractVersion: 1,
+      status: "forbidden",
+      flags: [],
+      canManage: false,
+    });
+
+    await expect(
+      setWorkspaceFeatureFlag(admin, {
+        appId: "analytics",
+        key: "analytics.resilient-fleet-flag-directory",
+        operation: "off",
+      }),
+    ).rejects.toMatchObject({ phase: "authorization" });
+  });
+
+  it("classifies local readback store errors after persistence", async () => {
+    const rules = {
+      mode: "off",
+      emails: [],
+      orgIds: [],
+      percentage: 0,
+    };
+    mocks.setLocalFeatureFlag.mockResolvedValue({
+      contractVersion: 2,
+      status: "ready",
+      key: "analytics.resilient-fleet-flag-directory",
+      rules,
+      scope: { orgId: admin.orgId, orgDomain: "example.test" },
+    });
+    mocks.listLocalFeatureFlags.mockRejectedValue(
+      new Error("private local store detail"),
+    );
+
+    await expect(
+      setWorkspaceFeatureFlag(admin, {
+        appId: "analytics",
+        key: "analytics.resilient-fleet-flag-directory",
+        operation: "off",
+      }),
+    ).rejects.toMatchObject({ phase: "verification" });
+  });
+
   it("reads Analytics target state locally without directory or A2A", async () => {
     await expect(
       getWorkspaceFlagTarget(admin, "analytics"),

--- a/templates/analytics/server/lib/workspace-feature-flags.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.ts
@@ -6,12 +6,15 @@ import {
   AgentActionStopError,
 } from "@agent-native/core/action";
 import { isFeatureFlagEnabled } from "@agent-native/core/feature-flags";
+import listLocalFeatureFlagsAction from "@agent-native/core/feature-flags/actions/list-feature-flags";
+import setLocalFeatureFlagAction from "@agent-native/core/feature-flags/actions/set-feature-flag";
 import {
   fetchOrgApps,
   fetchOrgAppsResult,
   type OrgApp,
 } from "@agent-native/core/mcp";
 import { getOrgDomain } from "@agent-native/core/org";
+import { getAppConfig } from "@agent-native/core/server";
 
 import {
   RESILIENT_FLEET_FLAG_DIRECTORY,
@@ -23,6 +26,7 @@ const TARGET_TIMEOUT_MS = 3_000;
 const DIRECTORY_ATTEMPTS = 2;
 const VERIFICATION_ATTEMPTS = 2;
 const CONCURRENCY = 4;
+const ANALYTICS_APP_ID = "analytics";
 
 export type FleetFlagState =
   | "ready"
@@ -89,6 +93,37 @@ export function workspaceFeatureFlagTargetInput(
         },
       }
     : rawTargetInput;
+}
+
+function mutationValidationExpectation(
+  admin: AnalyticsAdminContext,
+  input: WorkspaceFeatureFlagMutationInput,
+  orgDomain: string,
+) {
+  return {
+    key: input.key,
+    orgDomain,
+    allowExplicitNoOrgTarget: true,
+    ...(input.operation === "replace-rules" && input.rules
+      ? {
+          rules: {
+            mode: input.rules.mode,
+            emails: input.rules.emails ?? [],
+            orgIds: input.rules.orgIds ?? [],
+            percentage: input.rules.percentage ?? 0,
+          },
+        }
+      : input.operation === "off"
+        ? {
+            rules: {
+              mode: "off",
+              emails: [],
+              orgIds: [],
+              percentage: 0,
+            },
+          }
+        : { enabledForEmail: admin.userEmail }),
+  };
 }
 
 export function validateWorkspaceFeatureFlagMutation(
@@ -177,6 +212,40 @@ export function validateWorkspaceFeatureFlagMutation(
 
 function targetOrigin(app: OrgApp): string {
   return new URL(app.url).origin;
+}
+
+function localAnalyticsApp(): OrgApp {
+  const configuredUrl = getAppConfig().app.url;
+  const url = configuredUrl ?? "http://analytics.local";
+  return {
+    id: ANALYTICS_APP_ID,
+    name: "Analytics",
+    url,
+    a2aUrl: url,
+  };
+}
+
+function localActionContext(
+  admin: AnalyticsAdminContext,
+  actionName: "list-feature-flags" | "set-feature-flag",
+) {
+  return {
+    caller: "http" as const,
+    userEmail: admin.userEmail,
+    orgId: admin.orgId,
+    appId: ANALYTICS_APP_ID,
+    actionName,
+  };
+}
+
+async function listLocalAnalyticsFeatureFlags(admin: AnalyticsAdminContext) {
+  return classifyWorkspaceFeatureFlagList(localAnalyticsApp(), {
+    status: 200,
+    body: await listLocalFeatureFlagsAction.run(
+      {},
+      localActionContext(admin, "list-feature-flags"),
+    ),
+  });
 }
 
 async function delegatedToken(
@@ -471,13 +540,18 @@ async function mapBounded<T, R>(
 export async function listWorkspaceFeatureFlags(
   admin: AnalyticsAdminContext,
 ): Promise<WorkspaceFeatureFlagsResult> {
-  const apps = await fetchOrgApps({
-    selfId: "analytics",
-    includeDirectoryApp: true,
-    serviceOrgId: admin.orgId,
-  });
-  if (apps.length === 0) return { directoryStatus: "unavailable", apps: [] };
-  const entries = await mapBounded(apps, async (app) => {
+  const [localEntry, directoryResult] = await Promise.all([
+    listLocalAnalyticsFeatureFlags(admin),
+    fetchOrgAppsResult({
+      selfId: ANALYTICS_APP_ID,
+      includeDirectoryApp: true,
+      serviceOrgId: admin.orgId,
+    }),
+  ]);
+  if (directoryResult.status === "unavailable")
+    return { directoryStatus: "unavailable", apps: [localEntry] };
+  const directoryApps = directoryResult.apps;
+  const entries = await mapBounded(directoryApps, async (app) => {
     try {
       return classifyWorkspaceFeatureFlagList(
         app,
@@ -494,13 +568,88 @@ export async function listWorkspaceFeatureFlags(
       };
     }
   });
-  return { directoryStatus: "available", apps: entries };
+  return { directoryStatus: "available", apps: [localEntry, ...entries] };
 }
 
 export async function setWorkspaceFeatureFlag(
   admin: AnalyticsAdminContext,
   input: WorkspaceFeatureFlagMutationInput,
 ): Promise<WorkspaceFeatureFlagMutationResult> {
+  if (input.appId === ANALYTICS_APP_ID) {
+    if (input.operation === "replace-rules" && !input.rules)
+      throw new WorkspaceFeatureFlagFailure("target-action");
+    const localRules = input.rules as
+      | {
+          mode: "off" | "on" | "rules";
+          emails?: string[];
+          orgIds?: string[];
+          percentage?: number;
+        }
+      | undefined;
+    const targetInput =
+      input.operation === "replace-rules"
+        ? {
+            operation: input.operation,
+            key: input.key,
+            rules: localRules!,
+          }
+        : { operation: input.operation, key: input.key };
+    const result = await setLocalFeatureFlagAction.run(
+      targetInput,
+      localActionContext(admin, "set-feature-flag"),
+    );
+    const orgDomain = result.scope.orgDomain ?? "";
+    let mutation: TargetFeatureFlagMutationResult;
+    try {
+      mutation = validateWorkspaceFeatureFlagMutation(
+        result,
+        mutationValidationExpectation(admin, input, orgDomain),
+      );
+    } catch {
+      throw new WorkspaceFeatureFlagFailure("persistence");
+    }
+    const verifiedApp = await listLocalAnalyticsFeatureFlags(admin);
+    const verifiedFlag = verifiedApp.flags.find(
+      (flag) => flag.key === input.key,
+    );
+    if (
+      verifiedApp.state !== "ready" ||
+      !verifiedFlag ||
+      typeof verifiedFlag.enabledForCurrentUser !== "boolean" ||
+      (input.operation === "enable-for-current-user" &&
+        !verifiedFlag.enabledForCurrentUser) ||
+      (input.operation === "off" && verifiedFlag.enabledForCurrentUser)
+    ) {
+      throw new WorkspaceFeatureFlagFailure("verification");
+    }
+    try {
+      validateWorkspaceFeatureFlagMutation(
+        {
+          contractVersion: 2,
+          status: "ready",
+          key: input.key,
+          rules: verifiedFlag.rules,
+          scope: mutation.scope,
+        },
+        {
+          key: input.key,
+          orgDomain,
+          allowExplicitNoOrgTarget: true,
+          rules: mutation.rules,
+        },
+      );
+    } catch {
+      throw new WorkspaceFeatureFlagFailure("verification");
+    }
+    return {
+      contractVersion: 3,
+      status: "verified",
+      key: mutation.key,
+      rules: verifiedFlag.rules as Record<string, unknown>,
+      scope: mutation.scope,
+      enabledForCurrentUser: verifiedFlag.enabledForCurrentUser,
+    };
+  }
   const app = await resolveTargetApp(admin, input.appId);
   const targetInput = workspaceFeatureFlagTargetInput(input);
   let orgDomain: string | undefined;
@@ -533,30 +682,10 @@ export async function setWorkspaceFeatureFlag(
     throw new WorkspaceFeatureFlagFailure("target-action");
   let mutation: TargetFeatureFlagMutationResult;
   try {
-    mutation = validateWorkspaceFeatureFlagMutation(result.body, {
-      key: input.key,
-      orgDomain,
-      allowExplicitNoOrgTarget: true,
-      ...(input.operation === "replace-rules" && input.rules
-        ? {
-            rules: {
-              mode: input.rules.mode,
-              emails: input.rules.emails ?? [],
-              orgIds: input.rules.orgIds ?? [],
-              percentage: input.rules.percentage ?? 0,
-            },
-          }
-        : input.operation === "off"
-          ? {
-              rules: {
-                mode: "off",
-                emails: [],
-                orgIds: [],
-                percentage: 0,
-              },
-            }
-          : { enabledForEmail: admin.userEmail }),
-    });
+    mutation = validateWorkspaceFeatureFlagMutation(
+      result.body,
+      mutationValidationExpectation(admin, input, orgDomain),
+    );
   } catch {
     throw new WorkspaceFeatureFlagFailure("persistence");
   }
@@ -632,6 +761,7 @@ export async function getWorkspaceFlagTarget(
   admin: AnalyticsAdminContext,
   appId: string,
 ): Promise<FleetFlagApp> {
+  if (appId === ANALYTICS_APP_ID) return listLocalAnalyticsFeatureFlags(admin);
   const apps = await fetchOrgApps({
     selfId: "analytics",
     includeDirectoryApp: true,

--- a/templates/analytics/server/lib/workspace-feature-flags.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.ts
@@ -382,6 +382,18 @@ function targetFailure(error: unknown): WorkspaceFeatureFlagFailure {
   return new WorkspaceFeatureFlagFailure(reason);
 }
 
+function localMutationFailure(error: unknown): WorkspaceFeatureFlagFailure {
+  const statusCode =
+    error && typeof error === "object" && "statusCode" in error
+      ? (error as { statusCode?: unknown }).statusCode
+      : undefined;
+  return new WorkspaceFeatureFlagFailure(
+    statusCode === 401 || statusCode === 403
+      ? "authorization"
+      : "target-action",
+  );
+}
+
 async function resolveTargetApp(
   admin: AnalyticsAdminContext,
   appId: string,
@@ -612,10 +624,15 @@ export async function setWorkspaceFeatureFlag(
             rules: localRules!,
           }
         : { operation: input.operation, key: input.key };
-    const result = await setLocalFeatureFlagAction.run(
-      targetInput,
-      localActionContext(admin, "set-feature-flag", sourceContext),
-    );
+    let result;
+    try {
+      result = await setLocalFeatureFlagAction.run(
+        targetInput,
+        localActionContext(admin, "set-feature-flag", sourceContext),
+      );
+    } catch (error) {
+      throw localMutationFailure(error);
+    }
     const orgDomain = result.scope.orgDomain ?? "";
     let mutation: TargetFeatureFlagMutationResult;
     try {

--- a/templates/analytics/server/lib/workspace-feature-flags.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.ts
@@ -4,6 +4,7 @@ import { signA2AToken } from "@agent-native/core/a2a";
 import {
   ActionContractError,
   AgentActionStopError,
+  type ActionRunContext,
 } from "@agent-native/core/action";
 import { isFeatureFlagEnabled } from "@agent-native/core/feature-flags";
 import listLocalFeatureFlagsAction from "@agent-native/core/feature-flags/actions/list-feature-flags";
@@ -228,9 +229,11 @@ function localAnalyticsApp(): OrgApp {
 function localActionContext(
   admin: AnalyticsAdminContext,
   actionName: "list-feature-flags" | "set-feature-flag",
+  sourceContext?: ActionRunContext,
 ) {
   return {
-    caller: "http" as const,
+    ...sourceContext,
+    caller: sourceContext?.caller ?? ("http" as const),
     userEmail: admin.userEmail,
     orgId: admin.orgId,
     appId: ANALYTICS_APP_ID,
@@ -246,6 +249,18 @@ async function listLocalAnalyticsFeatureFlags(admin: AnalyticsAdminContext) {
       localActionContext(admin, "list-feature-flags"),
     ),
   });
+}
+
+function unreachableLocalAnalyticsEntry(): FleetFlagApp {
+  const app = localAnalyticsApp();
+  return {
+    appId: app.id,
+    appName: app.name,
+    appOrigin: targetOrigin(app),
+    state: "unreachable",
+    flags: [],
+    reason: "target-execution",
+  };
 }
 
 async function delegatedToken(
@@ -541,7 +556,9 @@ export async function listWorkspaceFeatureFlags(
   admin: AnalyticsAdminContext,
 ): Promise<WorkspaceFeatureFlagsResult> {
   const [localEntry, directoryResult] = await Promise.all([
-    listLocalAnalyticsFeatureFlags(admin),
+    listLocalAnalyticsFeatureFlags(admin).catch(() =>
+      unreachableLocalAnalyticsEntry(),
+    ),
     fetchOrgAppsResult({
       selfId: ANALYTICS_APP_ID,
       includeDirectoryApp: true,
@@ -574,6 +591,7 @@ export async function listWorkspaceFeatureFlags(
 export async function setWorkspaceFeatureFlag(
   admin: AnalyticsAdminContext,
   input: WorkspaceFeatureFlagMutationInput,
+  sourceContext?: ActionRunContext,
 ): Promise<WorkspaceFeatureFlagMutationResult> {
   if (input.appId === ANALYTICS_APP_ID) {
     if (input.operation === "replace-rules" && !input.rules)
@@ -596,7 +614,7 @@ export async function setWorkspaceFeatureFlag(
         : { operation: input.operation, key: input.key };
     const result = await setLocalFeatureFlagAction.run(
       targetInput,
-      localActionContext(admin, "set-feature-flag"),
+      localActionContext(admin, "set-feature-flag", sourceContext),
     );
     const orgDomain = result.scope.orgDomain ?? "";
     let mutation: TargetFeatureFlagMutationResult;

--- a/templates/analytics/server/lib/workspace-feature-flags.ts
+++ b/templates/analytics/server/lib/workspace-feature-flags.ts
@@ -626,7 +626,14 @@ export async function setWorkspaceFeatureFlag(
     } catch {
       throw new WorkspaceFeatureFlagFailure("persistence");
     }
-    const verifiedApp = await listLocalAnalyticsFeatureFlags(admin);
+    let verifiedApp: FleetFlagApp;
+    try {
+      verifiedApp = await listLocalAnalyticsFeatureFlags(admin);
+    } catch {
+      throw new WorkspaceFeatureFlagFailure("verification");
+    }
+    if (verifiedApp.state === "forbidden")
+      throw new WorkspaceFeatureFlagFailure("authorization");
     const verifiedFlag = verifiedApp.flags.find(
       (flag) => flag.key === input.key,
     );


### PR DESCRIPTION
## Problem

Workspace administrators manage feature flags from Analytics, but Analytics currently builds that fleet entirely from Dispatch's peer-app directory. The directory intentionally filters out its caller to prevent self-delegation, so Analytics never sees its own registered flags—including `analytics.resilient-fleet-flag-directory`—in the UI meant to manage them.

This is separate from the transient directory retry fixed by #3513. That retry works after a target app has been discovered; this PR fixes the control-plane inventory boundary that made Analytics's own flags invisible in the first place.

## Approach

Treat Analytics and peer apps according to their existing ownership boundaries:

- Analytics lists and mutates its own flags through Core's mounted local `list-feature-flags` and `set-feature-flag` actions.
- Sibling apps continue to be discovered through Dispatch and managed through exact-audience A2A calls.
- The shared directory self-filter remains unchanged.

The local path therefore keeps Core's existing manager authorization, atomic rollout storage, mutation audit wrapper, response contract, and evaluated readback without adding a self-network dependency.

## What changed

- Compose one local Analytics fleet entry with directory-backed sibling entries.
- Preserve that local entry when Dispatch reports the peer directory unavailable, while the UI shows a compact directory-unavailable status instead of hiding every flag.
- Classify a failed local Analytics list independently, so healthy directory-backed peers remain visible instead of the entire fleet failing.
- Route `appId: "analytics"` mutations and target readbacks through Core's local operator actions, returning the same independently verified fleet mutation contract the UI already reconciles.
- Preserve the originating action caller and agent thread/run/turn identifiers when the local Core mutation records its audit event.
- Classify local post-write authorization loss and readback-store failures through the same safe workspace error contract used by peer verification.
- Map local write authorization and target-action failures into that same workspace contract instead of exposing raw Core errors.
- Keep sibling directory resolution, A2A mutation, retry, failure classification, and verification behavior unchanged.
- Add focused regression coverage and an Analytics changelog entry.

## Safety and operations

This is system-ready without another rollout flag. Gating the fix behind the inaccessible control plane it repairs would recreate the bootstrap problem. Rollback is code-only: removing the local adapter restores the previous inventory behavior, with no migration or data conversion.

There are no schema, credential, or shared-directory contract changes. This PR does not deploy or alter beta/production flag state. A safe tenant-scoped beta directory fault mechanism remains a separately shaped follow-up because it would add an operational fault-control surface beyond this PR.

## Verification

- `pnpm --filter analytics exec vitest --run server/lib/workspace-feature-flags.spec.ts app/components/agents/FeatureFlagsFleetPanel.spec.ts actions/set-workspace-feature-flag.spec.ts` — 64 tests passed. New cases prove local listing and mutation/readback perform zero directory, A2A-token, or target-network calls, keep healthy peers visible through a local-list failure, preserve agent-run audit provenance, and safely classify local write authorization/target-action failures plus post-write authorization/readback failures; existing sibling retry and verification cases remain green.
- `pnpm --filter analytics typecheck` — passed. The command also printed the expected local warnings about absent production-only auth/database configuration; those are environment diagnostics, not type errors.
- `pnpm guards` — all 65 repository guards passed, including silent-coercion, localization, default-chrome, credential, and request-storm checks.
- Isolated real-interface check at `/agents?view=flags` — Analytics stayed visible with both registered flags while the peer directory was unavailable. Enabling `analytics.resilient-fleet-flag-directory` read back as Targeted for the isolated `dev@local.test` operator; cleanup restored Off. No browser console errors were recorded, and no beta or production request was made.
- Independent bounded review of `ca91cd3c4c` — no findings; the reviewer confirmed the local Core action wrapper preserves authorization/audit/storage semantics and the peer path remains intact.

## Review focus

- Is invoking the mounted Core actions directly the right local boundary for preserving authorization and audit semantics without self-A2A?
- Does the mixed local/peer result stay honest for every directory availability state?
- Does the local verified readback reject any mutation result that does not match the requested rollout operation?

## Follow-up

Separately shape a beta-only, tenant-scoped one-shot directory-failure evidence mechanism before adding any fault-control surface. That observability work is not required for this PR's local self-management outcome.
