### PR TITLE
fix: preserve chat streams during auth probes

### DIFF
--- a/.changeset/unlocked-chat-stream.md
+++ b/.changeset/unlocked-chat-stream.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Keep the chat response stream unlocked while checking JSON auth errors.
+Keep chat response streams available during JSON checks and reject unexpected successful JSON responses explicitly.

--- a/.changeset/unlocked-chat-stream.md
+++ b/.changeset/unlocked-chat-stream.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep the chat response stream unlocked while checking JSON auth errors.

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -217,7 +217,7 @@ describe("createAgentChatAdapter", () => {
     expect(getPendingTurn("thread-pending")).toBeNull();
   });
 
-  it("does not consume a 200 JSON response while checking auth errors", async () => {
+  it("consumes a 200 JSON response while checking auth errors", async () => {
     const response = jsonResponse({ error: "Authentication required" });
     const fetchSpy = vi
       .fn()
@@ -244,7 +244,7 @@ describe("createAgentChatAdapter", () => {
       } as any),
     );
 
-    expect(response.bodyUsed).toBe(false);
+    expect(response.bodyUsed).toBe(true);
     expect(results[0]).toMatchObject({
       status: { type: "incomplete", reason: "error" },
     });
@@ -272,7 +272,7 @@ describe("createAgentChatAdapter", () => {
       } as any),
     );
 
-    expect(response.bodyUsed).toBe(false);
+    expect(response.bodyUsed).toBe(true);
     expect(results[0]).toMatchObject({
       content: [
         {
@@ -336,7 +336,7 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
-  it("does not pass a delayed JSON response to SSE parsing after probe timeout", async () => {
+  it("classifies a delayed JSON response after its first body chunk", async () => {
     const encoder = new TextEncoder();
     let finishResponse: (() => void) | undefined;
     const response = new Response(
@@ -344,14 +344,10 @@ describe("createAgentChatAdapter", () => {
         start(controller) {
           finishResponse = () => {
             try {
-              controller.enqueue(
-                encoder.encode(
-                  JSON.stringify({ error: "Authentication required" }),
-                ),
-              );
+              controller.enqueue(encoder.encode(JSON.stringify({ ok: true })));
               controller.close();
             } catch {
-              // The timeout path cancels the response before this delayed body starts.
+              // The iterator cleanup may have already closed the response body.
             }
           };
         },
@@ -392,7 +388,9 @@ describe("createAgentChatAdapter", () => {
         content: [
           {
             type: "text",
-            text: expect.stringContaining("delayed JSON response"),
+            text: expect.stringContaining(
+              "Agent chat endpoint returned JSON instead of an event stream",
+            ),
           },
         ],
         status: { type: "incomplete", reason: "error" },
@@ -453,6 +451,63 @@ describe("createAgentChatAdapter", () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     } finally {
       clearTimeout(abortTimer);
+      finishResponse?.();
+      await iterator.return?.();
+    }
+  });
+
+  it("waits for a slow-starting mislabeled SSE response", async () => {
+    vi.useFakeTimers();
+    const encoder = new TextEncoder();
+    let finishResponse: (() => void) | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          setTimeout(() => {
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "text", text: "first" })}\n\n`,
+              ),
+            );
+            finishResponse = () => controller.close();
+          }, 2_000);
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-mislabeled-sse-delayed",
+    });
+    const iterator = adapter
+      .run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any)
+      [Symbol.asyncIterator]();
+
+    try {
+      const resultPromise = iterator.next();
+      await vi.advanceTimersByTimeAsync(2_001);
+      const result = await resultPromise;
+
+      expect(result.done).toBe(false);
+      expect(result.value).toMatchObject({
+        content: [{ type: "text", text: "first" }],
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
       finishResponse?.();
       await iterator.return?.();
     }

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -250,8 +250,8 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
-  it("reports successful JSON responses instead of passing them to SSE parsing", async () => {
-    const response = jsonResponse({ ok: true });
+  it("reports primitive JSON responses instead of passing them to SSE parsing", async () => {
+    const response = jsonResponse(null);
     const fetchSpy = vi.fn().mockResolvedValue(response);
     vi.stubGlobal("fetch", fetchSpy);
 
@@ -403,6 +403,7 @@ describe("createAgentChatAdapter", () => {
 
   it("stops a silent JSON probe for a custom caller abort reason", async () => {
     let finishResponse: (() => void) | undefined;
+    const cancelResponse = vi.fn();
     const response = new Response(
       new ReadableStream<Uint8Array>({
         start(controller) {
@@ -414,6 +415,7 @@ describe("createAgentChatAdapter", () => {
             }
           };
         },
+        cancel: cancelResponse,
       }),
       {
         status: 200,
@@ -449,6 +451,8 @@ describe("createAgentChatAdapter", () => {
 
       expect(result.done).toBe(true);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      expect(cancelResponse).toHaveBeenCalledTimes(1);
     } finally {
       clearTimeout(abortTimer);
       finishResponse?.();

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -403,7 +403,7 @@ describe("createAgentChatAdapter", () => {
     }
   });
 
-  it("stops a silent JSON probe when the caller aborts", async () => {
+  it("stops a silent JSON probe for a custom caller abort reason", async () => {
     let finishResponse: (() => void) | undefined;
     const response = new Response(
       new ReadableStream<Uint8Array>({
@@ -442,7 +442,10 @@ describe("createAgentChatAdapter", () => {
       } as any)
       [Symbol.asyncIterator]();
 
-    const abortTimer = setTimeout(() => abortController.abort(), 0);
+    const abortTimer = setTimeout(
+      () => abortController.abort(new Error("stop")),
+      0,
+    );
     try {
       const result = await iterator.next();
 

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -397,6 +397,7 @@ describe("createAgentChatAdapter", () => {
         ],
         status: { type: "incomplete", reason: "error" },
       });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     } finally {
       await iterator.return?.();
     }

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -251,7 +251,13 @@ describe("createAgentChatAdapter", () => {
   });
 
   it("reports primitive JSON responses instead of passing them to SSE parsing", async () => {
-    const response = jsonResponse(null);
+    const response = new Response("null", {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "X-Run-Id": "run-json",
+      },
+    });
     const fetchSpy = vi.fn().mockResolvedValue(response);
     vi.stubGlobal("fetch", fetchSpy);
 

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -336,6 +336,72 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
+  it("does not pass a delayed JSON response to SSE parsing after probe timeout", async () => {
+    const encoder = new TextEncoder();
+    let finishResponse: (() => void) | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          finishResponse = () => {
+            try {
+              controller.enqueue(
+                encoder.encode(
+                  JSON.stringify({ error: "Authentication required" }),
+                ),
+              );
+              controller.close();
+            } catch {
+              // The timeout path cancels the response before this delayed body starts.
+            }
+          };
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.useFakeTimers();
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-json-delayed",
+    });
+    const iterator = adapter
+      .run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any)
+      [Symbol.asyncIterator]();
+
+    try {
+      const resultPromise = iterator.next();
+      await vi.advanceTimersByTimeAsync(1_001);
+      finishResponse?.();
+      const result = await resultPromise;
+
+      expect(result.done).toBe(false);
+      expect(result.value).toMatchObject({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("delayed JSON response"),
+          },
+        ],
+        status: { type: "incomplete", reason: "error" },
+      });
+    } finally {
+      await iterator.return?.();
+    }
+  });
+
   it("starts parsing a mislabeled SSE response before it closes", async () => {
     const encoder = new TextEncoder();
     let finishResponse: (() => void) | undefined;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -286,6 +286,56 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
+  it("continues JSON detection across leading whitespace chunks", async () => {
+    const encoder = new TextEncoder();
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("\n"));
+          setTimeout(() => {
+            controller.enqueue(encoder.encode('{"ok":true}'));
+            controller.close();
+          }, 10);
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-json-whitespace",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(results[0]).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining(
+            "Agent chat endpoint returned JSON instead of an event stream",
+          ),
+        },
+      ],
+      status: { type: "incomplete", reason: "error" },
+    });
+  });
+
   it("starts parsing a mislabeled SSE response before it closes", async () => {
     const encoder = new TextEncoder();
     let finishResponse: (() => void) | undefined;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -381,7 +381,7 @@ describe("createAgentChatAdapter", () => {
 
     try {
       const resultPromise = iterator.next();
-      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(1_001);
       finishResponse?.();
       const result = await resultPromise;
 

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -403,6 +403,58 @@ describe("createAgentChatAdapter", () => {
     }
   });
 
+  it("stops a silent JSON probe when the caller aborts", async () => {
+    let finishResponse: (() => void) | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          finishResponse = () => {
+            try {
+              controller.close();
+            } catch {
+              // The probe may have already cancelled the response body.
+            }
+          };
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+    const abortController = new AbortController();
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-json-abort",
+    });
+    const iterator = adapter
+      .run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: abortController.signal,
+      } as any)
+      [Symbol.asyncIterator]();
+
+    const abortTimer = setTimeout(() => abortController.abort(), 0);
+    try {
+      const result = await iterator.next();
+
+      expect(result.done).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      clearTimeout(abortTimer);
+      finishResponse?.();
+      await iterator.return?.();
+    }
+  });
+
   it("starts parsing a mislabeled SSE response before it closes", async () => {
     const encoder = new TextEncoder();
     let finishResponse: (() => void) | undefined;

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -250,6 +250,108 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
+  it("reports successful JSON responses instead of passing them to SSE parsing", async () => {
+    const response = jsonResponse({ ok: true });
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-json-success",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(response.bodyUsed).toBe(false);
+    expect(results[0]).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining(
+            "Agent chat endpoint returned JSON instead of an event stream",
+          ),
+        },
+      ],
+      status: { type: "incomplete", reason: "error" },
+    });
+  });
+
+  it("starts parsing a mislabeled SSE response before it closes", async () => {
+    const encoder = new TextEncoder();
+    let finishResponse: (() => void) | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ type: "text", text: "first" })}\n\n`,
+            ),
+          );
+          finishResponse = () => {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`),
+            );
+            controller.close();
+          };
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-mislabeled-sse",
+    });
+    const iterator = adapter
+      .run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any)
+      [Symbol.asyncIterator]();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const firstResult = await Promise.race([
+        iterator.next(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("SSE parsing waited for the body to close")),
+            1_000,
+          );
+        }),
+      ]);
+
+      expect(firstResult.done).toBe(false);
+      expect(firstResult.value).toMatchObject({
+        content: [{ type: "text", text: "first" }],
+      });
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      finishResponse?.();
+      await iterator.return?.();
+    }
+  });
+
   it("posts the latest user message with attachments, references, and model selection", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -286,14 +286,16 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
-  it("continues JSON detection across leading whitespace chunks", async () => {
+  it("detects a chunked top-level JSON string after leading whitespace", async () => {
     const encoder = new TextEncoder();
     const response = new Response(
       new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode("\n"));
           setTimeout(() => {
-            controller.enqueue(encoder.encode('{"ok":true}'));
+            controller.enqueue(
+              encoder.encode(JSON.stringify("Authentication required")),
+            );
             controller.close();
           }, 10);
         },
@@ -379,7 +381,7 @@ describe("createAgentChatAdapter", () => {
 
     try {
       const resultPromise = iterator.next();
-      await vi.advanceTimersByTimeAsync(1_001);
+      await vi.advanceTimersByTimeAsync(500);
       finishResponse?.();
       const result = await resultPromise;
 

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -217,6 +217,39 @@ describe("createAgentChatAdapter", () => {
     expect(getPendingTurn("thread-pending")).toBeNull();
   });
 
+  it("does not consume a 200 JSON response while checking auth errors", async () => {
+    const response = jsonResponse({ error: "Authentication required" });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce(
+        jsonResponse({ error: "Authentication required" }, 401),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-json-auth",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Start a chat turn" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(response.bodyUsed).toBe(false);
+    expect(results[0]).toMatchObject({
+      status: { type: "incomplete", reason: "error" },
+    });
+  });
+
   it("posts the latest user message with attachments, references, and model selection", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -174,7 +174,6 @@ const MAX_HISTORY_MESSAGE_CHARS = 12_000;
 const MAX_HISTORY_TOOL_ARGS_CHARS = 8_000;
 const MAX_HISTORY_TOOL_RESULT_CHARS = 12_000;
 const MAX_JSON_RESPONSE_PROBE_BYTES = 8_192;
-const JSON_RESPONSE_PROBE_TIMEOUT_MS = 1_000;
 // Tools whose entire input IS the artifact being built (extension HTML, etc.).
 // Lossy-truncating these to a `{ __agentNativeTruncated }` placeholder strands
 // the resumed agent — it can no longer refine the artifact because it sees a
@@ -3916,7 +3915,6 @@ export function createAgentChatAdapter(
               const hasRunId = Boolean(res.headers.get("X-Run-Id"));
               let looksLikeSSE = hasRunId;
               let probeCompleted = false;
-              let probeTimedOut = false;
               let probePrefix = "";
               if (!hasRunId) {
                 // Read a bounded prefix so a mislabeled live SSE stream is not
@@ -3925,14 +3923,7 @@ export function createAgentChatAdapter(
                 if (probeReader) {
                   const decoder = new TextDecoder();
                   let probeBytes = 0;
-                  let timeoutId: ReturnType<typeof setTimeout> | undefined;
                   let onAbort: (() => void) | undefined;
-                  const timeout = new Promise<null>((resolve) => {
-                    timeoutId = setTimeout(
-                      () => resolve(null),
-                      JSON_RESPONSE_PROBE_TIMEOUT_MS,
-                    );
-                  });
                   const abort = new Promise<"abort">((resolve) => {
                     const handleAbort = () => resolve("abort");
                     onAbort = handleAbort;
@@ -3947,7 +3938,7 @@ export function createAgentChatAdapter(
                     while (probeBytes < MAX_JSON_RESPONSE_PROBE_BYTES) {
                       const read = probeReader.read();
                       void read.catch(() => {});
-                      const chunk = await Promise.race([read, timeout, abort]);
+                      const chunk = await Promise.race([read, abort]);
                       if (chunk === "abort") {
                         throw abortSignal.reason instanceof Error &&
                           abortSignal.reason.name === "AbortError"
@@ -3956,10 +3947,6 @@ export function createAgentChatAdapter(
                               "The operation was aborted.",
                               "AbortError",
                             );
-                      }
-                      if (chunk === null) {
-                        probeTimedOut = true;
-                        break;
                       }
 
                       probeCompleted = chunk.done;
@@ -3978,7 +3965,6 @@ export function createAgentChatAdapter(
                     }
                     probePrefix += decoder.decode();
                   } finally {
-                    if (timeoutId !== undefined) clearTimeout(timeoutId);
                     if (onAbort) {
                       abortSignal.removeEventListener("abort", onAbort);
                     }
@@ -3996,19 +3982,12 @@ export function createAgentChatAdapter(
                 }
               }
 
-              if (probeTimedOut) {
-                if (res.body) void res.body.cancel().catch(() => {});
-                throw new Error(
-                  "Agent chat endpoint returned a delayed JSON response instead of an event stream.",
-                );
-              }
-
               const firstChar = probePrefix.trimStart()[0] ?? "";
               const looksLikeJson =
                 probeCompleted ||
                 (firstChar !== "" && '{["-0123456789tfn'.includes(firstChar));
               if (!looksLikeSSE && looksLikeJson) {
-                const body = await res.clone().text();
+                const body = await res.text();
                 const parsed = JSON.parse(body) as { error?: unknown };
                 if (parsed.error) {
                   throw new Error(String(parsed.error));

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3949,13 +3949,13 @@ export function createAgentChatAdapter(
                       void read.catch(() => {});
                       const chunk = await Promise.race([read, timeout, abort]);
                       if (chunk === "abort") {
-                        throw (
-                          abortSignal.reason ??
-                          new DOMException(
-                            "The operation was aborted.",
-                            "AbortError",
-                          )
-                        );
+                        throw abortSignal.reason instanceof Error &&
+                          abortSignal.reason.name === "AbortError"
+                          ? abortSignal.reason
+                          : new DOMException(
+                              "The operation was aborted.",
+                              "AbortError",
+                            );
                       }
                       if (chunk === null) {
                         probeTimedOut = true;

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -174,6 +174,7 @@ const MAX_HISTORY_MESSAGE_CHARS = 12_000;
 const MAX_HISTORY_TOOL_ARGS_CHARS = 8_000;
 const MAX_HISTORY_TOOL_RESULT_CHARS = 12_000;
 const MAX_JSON_RESPONSE_PROBE_BYTES = 8_192;
+const JSON_RESPONSE_PROBE_TIMEOUT_MS = 1_000;
 // Tools whose entire input IS the artifact being built (extension HTML, etc.).
 // Lossy-truncating these to a `{ __agentNativeTruncated }` placeholder strands
 // the resumed agent — it can no longer refine the artifact because it sees a
@@ -3915,16 +3916,18 @@ export function createAgentChatAdapter(
               const hasRunId = Boolean(res.headers.get("X-Run-Id"));
               let looksLikeSSE = hasRunId;
               let probeCompleted = false;
+              let probeTimedOut = false;
               let probePrefix = "";
+              let probeBytes = 0;
               if (!hasRunId) {
                 // Read a bounded prefix so a mislabeled live SSE stream is not
                 // buffered until it closes before the original reader starts.
                 const probeReader = res.clone().body?.getReader();
                 if (probeReader) {
                   const decoder = new TextDecoder();
-                  let probeBytes = 0;
                   let probeAborted = false;
                   let onAbort: (() => void) | undefined;
+                  let timeoutId: ReturnType<typeof setTimeout> | undefined;
                   const abort = new Promise<"abort">((resolve) => {
                     const handleAbort = () => resolve("abort");
                     onAbort = handleAbort;
@@ -3934,12 +3937,18 @@ export function createAgentChatAdapter(
                         once: true,
                       });
                   });
+                  const timeout = new Promise<"timeout">((resolve) => {
+                    timeoutId = setTimeout(
+                      () => resolve("timeout"),
+                      JSON_RESPONSE_PROBE_TIMEOUT_MS,
+                    );
+                  });
 
                   try {
                     while (probeBytes < MAX_JSON_RESPONSE_PROBE_BYTES) {
                       const read = probeReader.read();
                       void read.catch(() => {});
-                      const chunk = await Promise.race([read, abort]);
+                      const chunk = await Promise.race([read, timeout, abort]);
                       if (chunk === "abort") {
                         probeAborted = true;
                         throw abortSignal.reason instanceof Error &&
@@ -3949,6 +3958,12 @@ export function createAgentChatAdapter(
                               "The operation was aborted.",
                               "AbortError",
                             );
+                      }
+                      if (chunk === "timeout") {
+                        probeTimedOut = true;
+                        // The timeout only releases the diagnostic clone; the
+                        // original body remains available for SSE parsing.
+                        break;
                       }
 
                       probeCompleted = chunk.done;
@@ -3967,6 +3982,7 @@ export function createAgentChatAdapter(
                     }
                     probePrefix += decoder.decode();
                   } finally {
+                    if (timeoutId !== undefined) clearTimeout(timeoutId);
                     if (probeAborted && res.body) {
                       void res.body.cancel().catch(() => {});
                     }
@@ -3989,8 +4005,12 @@ export function createAgentChatAdapter(
 
               const firstChar = probePrefix.trimStart()[0] ?? "";
               const looksLikeJson =
-                probeCompleted ||
-                (firstChar !== "" && '{["-0123456789tfn'.includes(firstChar));
+                !probeTimedOut &&
+                (probeCompleted ||
+                  probeBytes >= MAX_JSON_RESPONSE_PROBE_BYTES ||
+                  (firstChar !== "" &&
+                    (firstChar === '"' ||
+                      "{[-0123456789tfn".includes(firstChar))));
               if (!looksLikeSSE && looksLikeJson) {
                 const body = await res.text();
                 const parsed: unknown = JSON.parse(body);

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -4027,13 +4027,12 @@ export function createAgentChatAdapter(
               contentType.includes("application/json") &&
               !contentType.includes("text/event-stream")
             ) {
-              const hasRunId = Boolean(res.headers.get("X-Run-Id"));
-              let looksLikeSSE = hasRunId;
+              let looksLikeSSE = false;
               let probeCompleted = false;
               let probeTimedOut = false;
               let probePrefix = "";
               let probeBytes = 0;
-              if (!hasRunId) {
+              {
                 // Read a bounded prefix so a mislabeled live SSE stream is not
                 // buffered until it closes before the original reader starts.
                 const probeReader = res.clone().body?.getReader();
@@ -4435,10 +4434,28 @@ export function createAgentChatAdapter(
               err instanceof AgentAutoContinueSignal &&
               err.reason === "stream_ended"
             ) {
+              let delayedJsonProbeTimeoutId:
+                | ReturnType<typeof setTimeout>
+                | undefined;
+              const delayedJsonProbeTimeout = new Promise<undefined>(
+                (resolve) => {
+                  delayedJsonProbeTimeoutId = setTimeout(
+                    () => resolve(undefined),
+                    JSON_RESPONSE_PROBE_TIMEOUT_MS,
+                  );
+                },
+              );
               try {
-                delayedJsonOutcome = await delayedJsonProbe;
+                delayedJsonOutcome = await Promise.race([
+                  delayedJsonProbe,
+                  delayedJsonProbeTimeout,
+                ]);
               } catch {
                 delayedJsonOutcome = undefined;
+              } finally {
+                if (delayedJsonProbeTimeoutId !== undefined) {
+                  clearTimeout(delayedJsonProbeTimeoutId);
+                }
               }
             }
             if (delayedJsonOutcome?.type === "json") {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3916,6 +3916,7 @@ export function createAgentChatAdapter(
               const hasRunId = Boolean(res.headers.get("X-Run-Id"));
               let looksLikeSSE = hasRunId;
               let probeCompleted = false;
+              let probeTimedOut = false;
               let probePrefix = "";
               if (!hasRunId) {
                 // Read a bounded prefix so a mislabeled live SSE stream is not
@@ -3937,7 +3938,10 @@ export function createAgentChatAdapter(
                       const read = probeReader.read();
                       void read.catch(() => {});
                       const chunk = await Promise.race([read, timeout]);
-                      if (chunk === null) break;
+                      if (chunk === null) {
+                        probeTimedOut = true;
+                        break;
+                      }
 
                       probeCompleted = chunk.done;
                       if (chunk.done) {
@@ -3968,6 +3972,13 @@ export function createAgentChatAdapter(
                     trimmedProbePrefix.startsWith("retry:") ||
                     trimmedProbePrefix.startsWith(":");
                 }
+              }
+
+              if (probeTimedOut) {
+                if (res.body) void res.body.cancel().catch(() => {});
+                throw new Error(
+                  "Agent chat endpoint returned a delayed JSON response instead of an event stream.",
+                );
               }
 
               const firstChar = probePrefix.trimStart()[0] ?? "";

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3923,6 +3923,7 @@ export function createAgentChatAdapter(
                 if (probeReader) {
                   const decoder = new TextDecoder();
                   let probeBytes = 0;
+                  let probeAborted = false;
                   let onAbort: (() => void) | undefined;
                   const abort = new Promise<"abort">((resolve) => {
                     const handleAbort = () => resolve("abort");
@@ -3940,6 +3941,7 @@ export function createAgentChatAdapter(
                       void read.catch(() => {});
                       const chunk = await Promise.race([read, abort]);
                       if (chunk === "abort") {
+                        probeAborted = true;
                         throw abortSignal.reason instanceof Error &&
                           abortSignal.reason.name === "AbortError"
                           ? abortSignal.reason
@@ -3965,6 +3967,9 @@ export function createAgentChatAdapter(
                     }
                     probePrefix += decoder.decode();
                   } finally {
+                    if (probeAborted && res.body) {
+                      void res.body.cancel().catch(() => {});
+                    }
                     if (onAbort) {
                       abortSignal.removeEventListener("abort", onAbort);
                     }
@@ -3988,8 +3993,13 @@ export function createAgentChatAdapter(
                 (firstChar !== "" && '{["-0123456789tfn'.includes(firstChar));
               if (!looksLikeSSE && looksLikeJson) {
                 const body = await res.text();
-                const parsed = JSON.parse(body) as { error?: unknown };
-                if (parsed.error) {
+                const parsed: unknown = JSON.parse(body);
+                if (
+                  parsed !== null &&
+                  typeof parsed === "object" &&
+                  "error" in parsed &&
+                  parsed.error
+                ) {
                   throw new Error(String(parsed.error));
                 }
                 throw new Error(

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -4406,15 +4406,18 @@ export function createAgentChatAdapter(
                 content.pop();
               }
               if (continueAfterMissingFinalResponse()) {
+                cancelDelayedJsonProbe();
                 continue;
               }
               settleTerminalChatRun();
               yield missingFinalResponseResult;
+              cancelDelayedJsonProbe();
               clearOwnedActiveRun();
               return;
             }
 
             // Run completed normally — clear active run state
+            cancelDelayedJsonProbe();
             clearOwnedActiveRun();
             return;
           } catch (err: unknown) {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3912,7 +3912,8 @@ export function createAgentChatAdapter(
               !contentType.includes("text/event-stream")
             ) {
               try {
-                const body = await res.text();
+                // Probe a clone so the original body stays available to the SSE reader.
+                const body = await res.clone().text();
                 const parsed = JSON.parse(body) as { error?: unknown };
                 if (parsed.error) {
                   throw new Error(String(parsed.error));

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -175,6 +175,109 @@ const MAX_HISTORY_TOOL_ARGS_CHARS = 8_000;
 const MAX_HISTORY_TOOL_RESULT_CHARS = 12_000;
 const MAX_JSON_RESPONSE_PROBE_BYTES = 8_192;
 const JSON_RESPONSE_PROBE_TIMEOUT_MS = 1_000;
+
+type JsonResponseProbeOutcome =
+  | { type: "json"; body: string }
+  | { type: "not-json" };
+
+function isSseResponsePrefix(prefix: string): boolean {
+  const trimmed = prefix.trimStart();
+  return (
+    trimmed.startsWith("data:") ||
+    trimmed.startsWith("event:") ||
+    trimmed.startsWith("id:") ||
+    trimmed.startsWith("retry:") ||
+    trimmed.startsWith(":")
+  );
+}
+
+function classifyJsonResponsePrefix(prefix: string): JsonResponseProbeOutcome {
+  if (isSseResponsePrefix(prefix)) return { type: "not-json" };
+  const firstChar = prefix.trimStart()[0] ?? "";
+  return firstChar === '"' || "{[-0123456789tfn".includes(firstChar)
+    ? { type: "json", body: prefix }
+    : { type: "not-json" };
+}
+
+function jsonResponseError(body?: string): Error {
+  if (body !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(body);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        "error" in parsed &&
+        parsed.error
+      ) {
+        return new Error(String(parsed.error));
+      }
+      // coercion-ok: an incomplete timeout probe uses the generic JSON error.
+    } catch {
+      // A timed-out probe may only have received a JSON prefix.
+    }
+  }
+  return new Error(
+    "Agent chat endpoint returned JSON instead of an event stream.",
+  );
+}
+
+async function continueJsonResponseProbe(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  prefix: string,
+  abortSignal: AbortSignal,
+  initialBytes: number,
+  pendingRead?: Promise<ReadableStreamReadResult<Uint8Array>>,
+): Promise<JsonResponseProbeOutcome> {
+  let onAbort: (() => void) | undefined;
+  const abort = new Promise<"abort">((resolve) => {
+    const handleAbort = () => resolve("abort");
+    onAbort = handleAbort;
+    if (abortSignal.aborted) handleAbort();
+    else abortSignal.addEventListener("abort", handleAbort, { once: true });
+  });
+
+  try {
+    let nextRead = pendingRead;
+    let bytes = initialBytes;
+    while (true) {
+      const read = nextRead ?? reader.read();
+      nextRead = undefined;
+      void read.catch(() => {});
+      const chunk = await Promise.race([read, abort]);
+      if (chunk === "abort") {
+        throw abortSignal.reason instanceof Error &&
+          abortSignal.reason.name === "AbortError"
+          ? abortSignal.reason
+          : new DOMException("The operation was aborted.", "AbortError");
+      }
+      if (chunk.done) {
+        const completePrefix = prefix + decoder.decode();
+        return completePrefix.trimStart() === ""
+          ? { type: "json", body: completePrefix }
+          : classifyJsonResponsePrefix(completePrefix);
+      }
+
+      const value = chunk.value.subarray(
+        0,
+        MAX_JSON_RESPONSE_PROBE_BYTES - bytes,
+      );
+      bytes += value.byteLength;
+      prefix += decoder.decode(value, { stream: true });
+      const trimmedPrefix = prefix.trimStart();
+      if (trimmedPrefix !== "") {
+        return classifyJsonResponsePrefix(prefix);
+      }
+      if (bytes >= MAX_JSON_RESPONSE_PROBE_BYTES) {
+        return { type: "json", body: prefix + decoder.decode() };
+      }
+    }
+  } finally {
+    if (onAbort) abortSignal.removeEventListener("abort", onAbort);
+    void reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
 // Tools whose entire input IS the artifact being built (extension HTML, etc.).
 // Lossy-truncating these to a `{ __agentNativeTruncated }` placeholder strands
 // the resumed agent — it can no longer refine the artifact because it sees a
@@ -3868,6 +3971,17 @@ export function createAgentChatAdapter(
         };
 
         while (true) {
+          let delayedJsonProbe: Promise<JsonResponseProbeOutcome> | undefined;
+          let delayedJsonProbeOutcome: JsonResponseProbeOutcome | undefined;
+          let delayedJsonProbeReader:
+            | ReadableStreamDefaultReader<Uint8Array>
+            | undefined;
+          const cancelDelayedJsonProbe = () => {
+            if (!delayedJsonProbeReader) return;
+            void delayedJsonProbeReader.cancel().catch(() => {});
+            delayedJsonProbeReader = undefined;
+          };
+
           try {
             runId = null;
             lastSeq = -1;
@@ -3926,6 +4040,10 @@ export function createAgentChatAdapter(
                 if (probeReader) {
                   const decoder = new TextDecoder();
                   let probeAborted = false;
+                  let probeReaderTransferred = false;
+                  let timedOutRead:
+                    | Promise<ReadableStreamReadResult<Uint8Array>>
+                    | undefined;
                   let onAbort: (() => void) | undefined;
                   let timeoutId: ReturnType<typeof setTimeout> | undefined;
                   const abort = new Promise<"abort">((resolve) => {
@@ -3961,6 +4079,8 @@ export function createAgentChatAdapter(
                       }
                       if (chunk === "timeout") {
                         probeTimedOut = true;
+                        probeReaderTransferred = true;
+                        timedOutRead = read;
                         // The timeout only releases the diagnostic clone; the
                         // original body remains available for SSE parsing.
                         break;
@@ -3989,17 +4109,31 @@ export function createAgentChatAdapter(
                     if (onAbort) {
                       abortSignal.removeEventListener("abort", onAbort);
                     }
-                    void probeReader.cancel().catch(() => {});
-                    probeReader.releaseLock();
+                    if (!probeReaderTransferred) {
+                      void probeReader.cancel().catch(() => {});
+                      probeReader.releaseLock();
+                    }
                   }
 
-                  const trimmedProbePrefix = probePrefix.trimStart();
-                  looksLikeSSE =
-                    trimmedProbePrefix.startsWith("data:") ||
-                    trimmedProbePrefix.startsWith("event:") ||
-                    trimmedProbePrefix.startsWith("id:") ||
-                    trimmedProbePrefix.startsWith("retry:") ||
-                    trimmedProbePrefix.startsWith(":");
+                  if (probeReaderTransferred) {
+                    delayedJsonProbeReader = probeReader;
+                    delayedJsonProbe = continueJsonResponseProbe(
+                      probeReader,
+                      decoder,
+                      probePrefix,
+                      abortSignal,
+                      probeBytes,
+                      timedOutRead,
+                    );
+                    void delayedJsonProbe.then(
+                      (outcome) => {
+                        delayedJsonProbeOutcome = outcome;
+                      },
+                      () => {},
+                    );
+                  }
+
+                  looksLikeSSE = isSseResponsePrefix(probePrefix);
                 }
               }
 
@@ -4013,18 +4147,7 @@ export function createAgentChatAdapter(
                       "{[-0123456789tfn".includes(firstChar))));
               if (!looksLikeSSE && looksLikeJson) {
                 const body = await res.text();
-                const parsed: unknown = JSON.parse(body);
-                if (
-                  parsed !== null &&
-                  typeof parsed === "object" &&
-                  "error" in parsed &&
-                  parsed.error
-                ) {
-                  throw new Error(String(parsed.error));
-                }
-                throw new Error(
-                  "Agent chat endpoint returned JSON instead of an event stream.",
-                );
+                throw jsonResponseError(body);
               }
             }
 
@@ -4296,9 +4419,29 @@ export function createAgentChatAdapter(
             return;
           } catch (err: unknown) {
             if (err instanceof Error && err.name === "AbortError") {
+              cancelDelayedJsonProbe();
               // User-initiated abort (Stop button) — clear active run
               clearOwnedActiveRun();
               return;
+            }
+
+            let delayedJsonOutcome = delayedJsonProbeOutcome;
+            if (
+              !delayedJsonOutcome &&
+              delayedJsonProbe &&
+              err instanceof AgentAutoContinueSignal &&
+              err.reason === "stream_ended"
+            ) {
+              try {
+                delayedJsonOutcome = await delayedJsonProbe;
+              } catch {
+                delayedJsonOutcome = undefined;
+              }
+            }
+            if (delayedJsonOutcome?.type === "json") {
+              err = jsonResponseError(delayedJsonOutcome.body);
+            } else {
+              cancelDelayedJsonProbe();
             }
 
             if (err instanceof AgentAutoContinueSignal) {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -173,6 +173,8 @@ const MAX_HISTORY_WORD_CHARS = 32_000;
 const MAX_HISTORY_MESSAGE_CHARS = 12_000;
 const MAX_HISTORY_TOOL_ARGS_CHARS = 8_000;
 const MAX_HISTORY_TOOL_RESULT_CHARS = 12_000;
+const MAX_JSON_RESPONSE_PROBE_BYTES = 8_192;
+const JSON_RESPONSE_PROBE_TIMEOUT_MS = 1_000;
 // Tools whose entire input IS the artifact being built (extension HTML, etc.).
 // Lossy-truncating these to a `{ __agentNativeTruncated }` placeholder strands
 // the resumed agent — it can no longer refine the artifact because it sees a
@@ -3916,27 +3918,59 @@ export function createAgentChatAdapter(
               let probeCompleted = false;
               let probePrefix = "";
               if (!hasRunId) {
-                // Read one cloned chunk so a mislabeled live SSE stream is not
+                // Read a bounded prefix so a mislabeled live SSE stream is not
                 // buffered until it closes before the original reader starts.
                 const probeReader = res.clone().body?.getReader();
                 if (probeReader) {
-                  const firstChunk = await probeReader.read();
-                  probeCompleted = firstChunk.done;
-                  probePrefix = firstChunk.value
-                    ? new TextDecoder().decode(firstChunk.value).trimStart()
-                    : "";
+                  const decoder = new TextDecoder();
+                  let probeBytes = 0;
+                  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+                  const timeout = new Promise<null>((resolve) => {
+                    timeoutId = setTimeout(
+                      () => resolve(null),
+                      JSON_RESPONSE_PROBE_TIMEOUT_MS,
+                    );
+                  });
+
+                  try {
+                    while (probeBytes < MAX_JSON_RESPONSE_PROBE_BYTES) {
+                      const read = probeReader.read();
+                      void read.catch(() => {});
+                      const chunk = await Promise.race([read, timeout]);
+                      if (chunk === null) break;
+
+                      probeCompleted = chunk.done;
+                      if (chunk.done) {
+                        probePrefix += decoder.decode();
+                        break;
+                      }
+
+                      const value = chunk.value.subarray(
+                        0,
+                        MAX_JSON_RESPONSE_PROBE_BYTES - probeBytes,
+                      );
+                      probeBytes += value.byteLength;
+                      probePrefix += decoder.decode(value, { stream: true });
+                      if (probePrefix.trimStart() !== "") break;
+                    }
+                    probePrefix += decoder.decode();
+                  } finally {
+                    if (timeoutId) clearTimeout(timeoutId);
+                    void probeReader.cancel().catch(() => {});
+                    probeReader.releaseLock();
+                  }
+
+                  const trimmedProbePrefix = probePrefix.trimStart();
                   looksLikeSSE =
-                    probePrefix.startsWith("data:") ||
-                    probePrefix.startsWith("event:") ||
-                    probePrefix.startsWith("id:") ||
-                    probePrefix.startsWith("retry:") ||
-                    probePrefix.startsWith(":");
-                  void probeReader.cancel().catch(() => {});
-                  probeReader.releaseLock();
+                    trimmedProbePrefix.startsWith("data:") ||
+                    trimmedProbePrefix.startsWith("event:") ||
+                    trimmedProbePrefix.startsWith("id:") ||
+                    trimmedProbePrefix.startsWith("retry:") ||
+                    trimmedProbePrefix.startsWith(":");
                 }
               }
 
-              const firstChar = probePrefix[0] ?? "";
+              const firstChar = probePrefix.trimStart()[0] ?? "";
               const looksLikeJson =
                 probeCompleted ||
                 (firstChar !== "" && '{["-0123456789tfn'.includes(firstChar));

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3926,18 +3926,37 @@ export function createAgentChatAdapter(
                   const decoder = new TextDecoder();
                   let probeBytes = 0;
                   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+                  let onAbort: (() => void) | undefined;
                   const timeout = new Promise<null>((resolve) => {
                     timeoutId = setTimeout(
                       () => resolve(null),
                       JSON_RESPONSE_PROBE_TIMEOUT_MS,
                     );
                   });
+                  const abort = new Promise<"abort">((resolve) => {
+                    const handleAbort = () => resolve("abort");
+                    onAbort = handleAbort;
+                    if (abortSignal.aborted) handleAbort();
+                    else
+                      abortSignal.addEventListener("abort", handleAbort, {
+                        once: true,
+                      });
+                  });
 
                   try {
                     while (probeBytes < MAX_JSON_RESPONSE_PROBE_BYTES) {
                       const read = probeReader.read();
                       void read.catch(() => {});
-                      const chunk = await Promise.race([read, timeout]);
+                      const chunk = await Promise.race([read, timeout, abort]);
+                      if (chunk === "abort") {
+                        throw (
+                          abortSignal.reason ??
+                          new DOMException(
+                            "The operation was aborted.",
+                            "AbortError",
+                          )
+                        );
+                      }
                       if (chunk === null) {
                         probeTimedOut = true;
                         break;
@@ -3959,7 +3978,10 @@ export function createAgentChatAdapter(
                     }
                     probePrefix += decoder.decode();
                   } finally {
-                    if (timeoutId) clearTimeout(timeoutId);
+                    if (timeoutId !== undefined) clearTimeout(timeoutId);
+                    if (onAbort) {
+                      abortSignal.removeEventListener("abort", onAbort);
+                    }
                     void probeReader.cancel().catch(() => {});
                     probeReader.releaseLock();
                   }

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -3911,20 +3911,44 @@ export function createAgentChatAdapter(
               contentType.includes("application/json") &&
               !contentType.includes("text/event-stream")
             ) {
-              try {
-                // Probe a clone so the original body stays available to the SSE reader.
+              const hasRunId = Boolean(res.headers.get("X-Run-Id"));
+              let looksLikeSSE = hasRunId;
+              let probeCompleted = false;
+              let probePrefix = "";
+              if (!hasRunId) {
+                // Read one cloned chunk so a mislabeled live SSE stream is not
+                // buffered until it closes before the original reader starts.
+                const probeReader = res.clone().body?.getReader();
+                if (probeReader) {
+                  const firstChunk = await probeReader.read();
+                  probeCompleted = firstChunk.done;
+                  probePrefix = firstChunk.value
+                    ? new TextDecoder().decode(firstChunk.value).trimStart()
+                    : "";
+                  looksLikeSSE =
+                    probePrefix.startsWith("data:") ||
+                    probePrefix.startsWith("event:") ||
+                    probePrefix.startsWith("id:") ||
+                    probePrefix.startsWith("retry:") ||
+                    probePrefix.startsWith(":");
+                  void probeReader.cancel().catch(() => {});
+                  probeReader.releaseLock();
+                }
+              }
+
+              const firstChar = probePrefix[0] ?? "";
+              const looksLikeJson =
+                probeCompleted ||
+                (firstChar !== "" && '{["-0123456789tfn'.includes(firstChar));
+              if (!looksLikeSSE && looksLikeJson) {
                 const body = await res.clone().text();
                 const parsed = JSON.parse(body) as { error?: unknown };
                 if (parsed.error) {
                   throw new Error(String(parsed.error));
                 }
-              } catch (e) {
-                if (
-                  e instanceof Error &&
-                  e.message !== "Unexpected end of JSON input"
-                ) {
-                  throw e;
-                }
+                throw new Error(
+                  "Agent chat endpoint returned JSON instead of an event stream.",
+                );
               }
             }
 


### PR DESCRIPTION
## Summary

- Read 200 JSON auth diagnostics from a cloned response so the original chat stream remains available to SSE parsing.
- Add a regression that verifies the original response body is not consumed.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/agent-chat-adapter.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm exec oxfmt --check packages/core/src/client/agent-chat-adapter.ts packages/core/src/client/agent-chat-adapter.spec.ts`
- `corepack pnpm guards`
