### PR TITLE
fix: preserve hyperlinks in Slides PDF exports

### DIFF
--- a/templates/slides/app/lib/export-pdf-client.test.ts
+++ b/templates/slides/app/lib/export-pdf-client.test.ts
@@ -292,6 +292,22 @@ describe("exportDeckAsPdf", () => {
     });
   });
 
+  it("clips link annotations to the rendered slide bounds", async () => {
+    const canvas = renderSlide("s1");
+    const link = document.createElement("a");
+    link.setAttribute("href", "https://example.com/docs");
+    link.textContent = "Read more";
+    link.getBoundingClientRect = () =>
+      ({ width: 120, height: 40, left: 900, top: 520 }) as DOMRect;
+    canvas.append(link);
+
+    await exportDeckAsPdf("Q3 review", [{ id: "s1", content: "<div></div>" }]);
+
+    expect(mocks.link).toHaveBeenCalledWith(900, 520, 60, 20, {
+      url: "https://example.com/docs",
+    });
+  });
+
   it("sizes the text layer from the slide's own layout, not its on-screen scale", async () => {
     // Every slide canvas renders inside a `scale(var(--slide-scale))` wrapper,
     // so the same deck exports from a quarter-scale thumbnail and a full-size

--- a/templates/slides/app/lib/export-pdf-client.test.ts
+++ b/templates/slides/app/lib/export-pdf-client.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   addMetadata: vi.fn(),
   addPage: vi.fn(),
   domToJpeg: vi.fn(async () => "data:image/jpeg;base64,AA=="),
+  link: vi.fn(),
   setFontSize: vi.fn(),
   text: vi.fn(),
 }));
@@ -19,6 +20,7 @@ vi.mock("jspdf", () => ({
     addImage = mocks.addImage;
     addMetadata = mocks.addMetadata;
     addPage = mocks.addPage;
+    link = mocks.link;
     // jsPDF's px unit: coordinates are scaled by 96/72, font sizes are not.
     internal = { scaleFactor: 96 / 72 };
     output = () => new Blob();
@@ -119,6 +121,7 @@ describe("exportDeckAsPdf", () => {
     mocks.addImage.mockClear();
     mocks.addMetadata.mockClear();
     mocks.text.mockClear();
+    mocks.link.mockClear();
     mocks.setFontSize.mockClear();
     mocks.domToJpeg.mockClear();
   });
@@ -265,6 +268,28 @@ describe("exportDeckAsPdf", () => {
     // replacement bytes, and text that extracts as mojibake is worse than text
     // that is absent. The sidecar carries it either way.
     expect(drawn).not.toContain("売上高");
+  });
+
+  it("preserves safe slide links as PDF annotations", async () => {
+    const canvas = renderSlide("s1");
+    const safeLink = document.createElement("a");
+    safeLink.setAttribute("href", "https://example.com/docs");
+    safeLink.textContent = "Read more";
+    safeLink.getBoundingClientRect = () =>
+      ({ width: 160, height: 24, left: 120, top: 90 }) as DOMRect;
+    const unsafeLink = document.createElement("a");
+    unsafeLink.setAttribute("href", "javascript:alert(1)");
+    unsafeLink.textContent = "Unsafe";
+    unsafeLink.getBoundingClientRect = () =>
+      ({ width: 80, height: 24, left: 300, top: 90 }) as DOMRect;
+    canvas.append(safeLink, unsafeLink);
+
+    await exportDeckAsPdf("Q3 review", [{ id: "s1", content: "<div></div>" }]);
+
+    expect(mocks.link).toHaveBeenCalledTimes(1);
+    expect(mocks.link).toHaveBeenCalledWith(120, 90, 160, 24, {
+      url: "https://example.com/docs",
+    });
   });
 
   it("sizes the text layer from the slide's own layout, not its on-screen scale", async () => {

--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -20,6 +20,7 @@ import {
 
 import { type AspectRatio, getAspectRatioDims } from "./aspect-ratios";
 import { importExportModule } from "./dynamic-import";
+import { sanitizeSlideUrl } from "./sanitize-slide-html";
 
 /** Same-origin URL that re-serves a remote image, bypassing its missing CORS. */
 export function imageProxyUrl(src: string): string {
@@ -279,6 +280,46 @@ function drawSelectableTextLayer(
   }
 }
 
+function drawLinkAnnotations(
+  pdf: import("jspdf").jsPDF,
+  source: HTMLElement,
+  dims: { width: number; height: number },
+): void {
+  const sourceRect = source.getBoundingClientRect();
+  if (sourceRect.width <= 0 || sourceRect.height <= 0) return;
+
+  const positionScale = dims.width / sourceRect.width;
+  for (const link of source.querySelectorAll<HTMLAnchorElement>("a[href]")) {
+    const safeHref = sanitizeSlideUrl(
+      link.getAttribute("href") ?? undefined,
+      "link",
+    );
+    if (!safeHref) continue;
+
+    let url: string;
+    try {
+      url = new URL(safeHref, window.location.href).href;
+    } catch {
+      continue;
+    }
+
+    const rects = Array.from(link.getClientRects()).filter(
+      (rect) => rect.width > 0 && rect.height > 0,
+    );
+    const measuredRects = rects.length ? rects : [link.getBoundingClientRect()];
+    for (const rect of measuredRects) {
+      if (rect.width <= 0 || rect.height <= 0) continue;
+      pdf.link(
+        (rect.left - sourceRect.left) * positionScale,
+        (rect.top - sourceRect.top) * positionScale,
+        rect.width * positionScale,
+        rect.height * positionScale,
+        { url },
+      );
+    }
+  }
+}
+
 /**
  * One entry per line the browser actually laid this text node out on, with the
  * substring that sits on it.
@@ -427,6 +468,7 @@ export async function exportDeckAsPdf(
     if (i > 0) pdf.addPage([dims.width, dims.height], orientation);
     pdf.addImage(dataUrl, "JPEG", 0, 0, dims.width, dims.height);
     drawSelectableTextLayer(pdf, source, dims);
+    drawLinkAnnotations(pdf, source, dims);
   }
 
   // Carried so `import-file` can hand back the deck that was exported instead

--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -309,11 +309,22 @@ function drawLinkAnnotations(
     const measuredRects = rects.length ? rects : [link.getBoundingClientRect()];
     for (const rect of measuredRects) {
       if (rect.width <= 0 || rect.height <= 0) continue;
+      const left = Math.max(rect.left, sourceRect.left);
+      const top = Math.max(rect.top, sourceRect.top);
+      const right = Math.min(
+        rect.left + rect.width,
+        sourceRect.left + sourceRect.width,
+      );
+      const bottom = Math.min(
+        rect.top + rect.height,
+        sourceRect.top + sourceRect.height,
+      );
+      if (right <= left || bottom <= top) continue;
       pdf.link(
-        (rect.left - sourceRect.left) * positionScale,
-        (rect.top - sourceRect.top) * positionScale,
-        rect.width * positionScale,
-        rect.height * positionScale,
+        (left - sourceRect.left) * positionScale,
+        (top - sourceRect.top) * positionScale,
+        (right - left) * positionScale,
+        (bottom - top) * positionScale,
         { url },
       );
     }


### PR DESCRIPTION
## Summary

- preserve safe hyperlink targets when exporting Slides decks to PDF
- map visible anchor rectangles to jsPDF link annotations without changing the raster or selectable text layers
- reuse the shared Slides URL sanitizer so unsafe schemes are ignored

## Latest feedback handoff

Oliver reported that Slides PDF hyperlinks do not persist. This PR fixes that concrete repo-owned path. Oliver later supplied the PPTX and native Google Slides copy; the Google Slides access-blocked report remains in the existing OAuth/configuration investigation, while the PPTX-to-Google Slides formatting report needs a rendered before/after comparison and remains a follow-up outside this focused PDF fix.

## Checks

- `corepack pnpm --filter slides exec vitest --run app/lib/export-pdf-client.test.ts`
- `corepack pnpm --filter slides typecheck`
- `corepack pnpm guards` - all 65 checks passed
