### PR TITLE
fix(clips): restore comment composer border

### DIFF
--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -139,6 +139,9 @@ describe("CommentsPanel reply composer", () => {
     );
 
     expect(composer?.className).toContain("px-3 py-2");
+    expect(composer?.parentElement?.className).toContain(
+      "border border-border",
+    );
   });
 
   it("renders inline Markdown while flattening headings", () => {

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -664,7 +664,8 @@ function CommentComposer({
       <div
         className={cn(
           "flex gap-2",
-          isSharePresentation && "items-start rounded-md p-3 shadow-sm",
+          isSharePresentation &&
+            "items-start rounded-md border border-border p-3 shadow-sm",
         )}
       >
         {isSharePresentation ? (


### PR DESCRIPTION
Restores the visible border around the Clips share-page comment composer and adds a regression assertion. This restores the styling removed from the share composer wrapper while preserving the current surface treatment.\n\nValidation: focused comments-panel tests, Clips typecheck, pnpm guards, git diff --check, and live local share-page DOM/screenshot verification.