### PR TITLE
fix: clarify slash command execution in shared composer

### DIFF
--- a/.changeset/clear-slash-command-noop.md
+++ b/.changeset/clear-slash-command-noop.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Keep slash-prefixed prompts when no command handler is available.

--- a/packages/toolkit/agent-native.eject.json
+++ b/packages/toolkit/agent-native.eject.json
@@ -211,6 +211,7 @@
         "clsx",
         "react",
         "react-dom",
+        "sonner",
         "tailwind-merge"
       ],
       "protectedImports": [

--- a/packages/toolkit/src/composer/PromptComposer.tsx
+++ b/packages/toolkit/src/composer/PromptComposer.tsx
@@ -142,7 +142,7 @@ export interface PromptComposerProps {
   slashCommands?: SlashCommand[];
   /** Additional slash skills surfaced in the shared / menu. */
   slashSkills?: SkillResult[];
-  /** Include built-in sidebar slash commands like /clear and /help. Default true. */
+  /** Include built-in sidebar slash commands when onSlashCommand is provided. */
   includeDefaultSlashCommands?: boolean;
   /** Include app-discovered skills from the default agent endpoint. Default true. */
   includeDefaultSlashSkills?: boolean;

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -1,8 +1,21 @@
 // @vitest-environment happy-dom
 
+import {
+  AssistantRuntimeProvider,
+  useLocalRuntime,
+  type ChatModelAdapter,
+} from "@assistant-ui/react";
 import { Editor } from "@tiptap/core";
-import { describe, expect, it } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn() },
+}));
+
+import { TooltipProvider } from "../ui/tooltip.js";
 import {
   canSubmitComposerContent,
   canRemoveVoicePreview,
@@ -28,7 +41,29 @@ import {
   shouldRenderModelSelector,
   shouldShowModelSelectorSkeleton,
   shouldShowOnlyConnectPath,
+  TiptapComposer,
+  type TiptapComposerHandle,
 } from "./TiptapComposer.js";
+
+const emptyChatModelAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
 
 describe("createTiptapComposerExtensions", () => {
   it("refreshes the rendered placeholder after a locale change", () => {
@@ -630,6 +665,106 @@ describe("createTiptapComposerExtensions", () => {
     expect(shouldRenderModelSelector([], () => {})).toBe(false);
     expect(shouldRenderModelSelector(unconfigured, undefined)).toBe(false);
     expect(shouldRenderModelSelector(undefined, () => {})).toBe(false);
+  });
+});
+
+describe("TiptapComposer slash commands", () => {
+  it("submits a slash-prefixed prompt when no command handler is provided", async () => {
+    const onSubmit = vi.fn();
+    const focusRef = React.createRef<TiptapComposerHandle>();
+
+    function Harness() {
+      const runtime = useLocalRuntime(emptyChatModelAdapter);
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            focusRef,
+            onSubmit,
+            clearOnSubmit: false,
+            includeDefaultSlashSkills: false,
+            plusMenuMode: "hidden",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    act(() => root.render(React.createElement(Harness)));
+    act(() => focusRef.current?.setText("/act"));
+
+    const editor = container.querySelector(
+      ".agent-composer-prosemirror",
+    ) as HTMLElement;
+    await act(async () => {
+      editor.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Enter",
+        }),
+      );
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "/act",
+      [],
+      [],
+      expect.objectContaining({ intent: "immediate" }),
+    );
+    expect(editor.textContent).toBe("/act");
+  });
+
+  it("acknowledges an executed slash command", async () => {
+    const onSlashCommand = vi.fn();
+    const focusRef = React.createRef<TiptapComposerHandle>();
+
+    function Harness() {
+      const runtime = useLocalRuntime(emptyChatModelAdapter);
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            focusRef,
+            onSlashCommand,
+            includeDefaultSlashSkills: false,
+            plusMenuMode: "hidden",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    act(() => root.render(React.createElement(Harness)));
+    act(() => focusRef.current?.setText("/act"));
+
+    const editor = container.querySelector(
+      ".agent-composer-prosemirror",
+    ) as HTMLElement;
+    await act(async () => {
+      editor.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Enter",
+        }),
+      );
+    });
+
+    expect(onSlashCommand).toHaveBeenCalledWith("act");
+    expect(toast.success).toHaveBeenCalledWith(
+      "/act",
+      expect.objectContaining({
+        description: "Switch back to acting",
+        duration: 1800,
+      }),
+    );
   });
 });
 

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -28,6 +28,7 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from "react";
+import { toast } from "sonner";
 
 import {
   Popover,
@@ -741,7 +742,7 @@ export interface TiptapComposerProps {
   slashCommands?: SlashCommand[];
   /** Additional slash skills surfaced in the shared / menu. */
   slashSkills?: SkillResult[];
-  /** Include built-in sidebar slash commands like /clear and /help. Default true. */
+  /** Include built-in sidebar slash commands when onSlashCommand is provided. */
   includeDefaultSlashCommands?: boolean;
   /** Include app-discovered skills from the default agent endpoint. Default true. */
   includeDefaultSlashSkills?: boolean;
@@ -2355,14 +2356,14 @@ export function TiptapComposer({
     isLoading: skillsLoading,
   } = useSkills(includeDefaultSlashSkills && popover?.type === "/");
 
-  const allSlashCommands = useMemo(
-    () =>
-      mergeSlashCommands([
-        ...(includeDefaultSlashCommands ? builtInCommands(t) : []),
-        ...slashCommands,
-      ]),
-    [includeDefaultSlashCommands, slashCommands, t],
-  );
+  const allSlashCommands = useMemo(() => {
+    // A command without a host callback would be deleted as an invisible no-op.
+    if (!onSlashCommand) return [];
+    return mergeSlashCommands([
+      ...(includeDefaultSlashCommands ? builtInCommands(t) : []),
+      ...slashCommands,
+    ]);
+  }, [includeDefaultSlashCommands, onSlashCommand, slashCommands, t]);
 
   const allSlashSkills = useMemo(
     () =>
@@ -2404,6 +2405,15 @@ export function TiptapComposer({
   filteredSkillsRef.current = filteredSkills;
   const onSlashCommandRef = useRef(onSlashCommand);
   onSlashCommandRef.current = onSlashCommand;
+  const announceSlashCommand = useCallback((command: SlashCommand) => {
+    const handler = onSlashCommandRef.current;
+    if (!handler) return;
+    handler(command.name);
+    toast.success(`/${command.name}`, {
+      description: command.description,
+      duration: 1800,
+    });
+  }, []);
   const onTextChangeRef = useRef(onTextChange);
   onTextChangeRef.current = onTextChange;
   const contextItemsRef = useRef(contextItems);
@@ -3336,7 +3346,7 @@ export function TiptapComposer({
         const matched = allSlashCommands.find((c) => c.name === cmdName);
         if (matched) {
           clearEditorAfterSubmit();
-          onSlashCommandRef.current?.(matched.name);
+          announceSlashCommand(matched);
           return;
         }
       }
@@ -3461,6 +3471,7 @@ export function TiptapComposer({
       syncComposerState,
       voice,
       allSlashCommands,
+      announceSlashCommand,
       t,
     ],
   );
@@ -3495,7 +3506,7 @@ export function TiptapComposer({
     ed.chain().focus().deleteRange({ from: deleteFrom, to: currentPos }).run();
     popoverStateRef.current = null;
     setPopover(null);
-    onSlashCommandRef.current?.(command.name);
+    announceSlashCommand(command);
   }
 
   function selectSkill(
@@ -3548,9 +3559,9 @@ export function TiptapComposer({
         .deleteRange({ from: deleteFrom, to: currentPos })
         .run();
       closePopover();
-      onSlashCommand?.(command.name);
+      announceSlashCommand(command);
     },
-    [editor, popover, closePopover, onSlashCommand],
+    [editor, popover, closePopover, announceSlashCommand],
   );
 
   const handleSelectSkill = useCallback(

--- a/templates/slides/changelog/2026-08-27-ai-editing-presence-sits-with-right-side-sharing-controls.md
+++ b/templates/slides/changelog/2026-08-27-ai-editing-presence-sits-with-right-side-sharing-controls.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-08-27
 ---
+
 AI editing presence now sits with the editor's right-side sharing controls.


### PR DESCRIPTION
## Summary
- preserve slash-prefixed prompts when no command handler is available
- show a short confirmation toast when a shared slash command executes
- declare the composer toast dependency in its eject manifest

## Verification
- `pnpm --filter @agent-native/toolkit exec vitest --run src/composer/TiptapComposer.spec.ts src/composer/PromptComposer.spec.ts --config vitest.config.ts` (39 passed)
- `pnpm typecheck` (passed)
- `pnpm guards` (65 passed)
- Live Analytics browser: Plan mode -> `/act` -> Return showed the mode switch and `/act` confirmation toast

The aggregate `pnpm prep` test lane was stopped after unrelated core failures from the local better-sqlite3 Node ABI mismatch (module 147, runner 137); the changed package suite and all repository guards pass.
