### PR TITLE
fix: keep Builder connect callbacks on Builder Cloud apps

### DIFF
--- a/.changeset/fix-builder-cloud-connect-callback.md
+++ b/.changeset/fix-builder-cloud-connect-callback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix Builder OAuth callbacks for apps hosted on Builder Cloud origins

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -451,6 +451,7 @@ describe("Builder callback CSRF state", () => {
       process.env.NODE_ENV = "production";
       process.env.APP_URL = "https://default-template.netlify.app";
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host": "the-grand-tour.builder.cloud",
         "x-forwarded-proto": "https",
       });
@@ -475,6 +476,23 @@ describe("Builder callback CSRF state", () => {
           event,
         ),
       ).toBe(false);
+    });
+
+    it("ignores a spoofed Builder Cloud forwarded host from a direct request", () => {
+      process.env.NODE_ENV = "production";
+      process.env.APP_URL = "https://default-template.netlify.app";
+      const event = createBuilderBrowserEvent({
+        host: "app.example.com",
+        "x-forwarded-host": "attacker.builder.cloud",
+        "x-forwarded-proto": "https",
+      });
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/connect",
+      );
+      expect(resolveBuilderConnectCallbackUrl(event, "<STATE_EXAMPLE>")).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/callback?state=%3CSTATE_EXAMPLE%3E",
+      );
     });
 
     it("recovers state from the callback cookie when Builder omits query state", () => {

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -85,13 +85,17 @@ import {
   type BuilderRelayCredentials,
 } from "./builder-browser.js";
 
-function createBuilderBrowserEvent(headers: Record<string, string>): H3Event {
+function createBuilderBrowserEvent(
+  headers: Record<string, string>,
+  remoteAddress = "127.0.0.1",
+): H3Event {
   const requestHeaders = new Headers(headers);
   return {
     req: {
       method: "GET",
       url: "https://agent-workspace.builder.io/_agent-native/builder/status",
       headers: requestHeaders,
+      context: { clientAddress: remoteAddress },
     },
     url: new URL(
       "https://agent-workspace.builder.io/_agent-native/builder/status",
@@ -103,6 +107,7 @@ function createBuilderBrowserEvent(headers: Record<string, string>): H3Event {
     node: {
       req: {
         headers,
+        socket: { remoteAddress },
         url: "/_agent-native/builder/status",
         method: "GET",
       },
@@ -502,6 +507,26 @@ describe("Builder callback CSRF state", () => {
         "x-forwarded-host": "attacker.builder.cloud",
         "x-forwarded-proto": "https",
       });
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/connect",
+      );
+      expect(getBuilderCliAuthCallbackOriginForEvent(event)).toBe(
+        "https://default-template.netlify.app",
+      );
+    });
+
+    it("ignores a forwarded Builder Cloud host from an untrusted loopback host", () => {
+      process.env.NODE_ENV = "production";
+      process.env.APP_URL = "https://default-template.netlify.app";
+      const event = createBuilderBrowserEvent(
+        {
+          host: "127.0.0.1:8080",
+          "x-forwarded-host": "attacker.builder.cloud",
+          "x-forwarded-proto": "https",
+        },
+        "203.0.113.10",
+      );
 
       expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
         "https://default-template.netlify.app/_agent-native/builder/connect",

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -118,6 +118,32 @@ function createBuilderBrowserEvent(
   } as unknown as H3Event;
 }
 
+const BUILDER_ORIGIN_ENV_KEYS = [
+  "WORKSPACE_OAUTH_ORIGIN",
+  "VITE_WORKSPACE_OAUTH_ORIGIN",
+  "APP_URL",
+  "VITE_APP_URL",
+  "BETTER_AUTH_URL",
+  "VITE_BETTER_AUTH_URL",
+  "URL",
+  "DEPLOY_URL",
+  "WORKSPACE_GATEWAY_URL",
+  "VITE_WORKSPACE_GATEWAY_URL",
+  "FUSION_ENV_ORIGIN",
+  "VITE_FUSION_ENV_ORIGIN",
+  "BUILDER_PREVIEW_URL",
+  "VITE_BUILDER_PREVIEW_URL",
+] as const;
+
+function clearBuilderOriginEnv(): void {
+  for (const key of BUILDER_ORIGIN_ENV_KEYS) delete process.env[key];
+}
+
+function setOnlyBuilderAppUrl(origin: string): void {
+  clearBuilderOriginEnv();
+  process.env.APP_URL = origin;
+}
+
 describe("Builder callback CSRF state", () => {
   const originalEnv = { ...process.env };
 
@@ -454,7 +480,7 @@ describe("Builder callback CSRF state", () => {
 
     it("keeps Builder-hosted app connect callbacks on the active app origin", () => {
       process.env.NODE_ENV = "production";
-      process.env.APP_URL = "https://default-template.netlify.app";
+      setOnlyBuilderAppUrl("https://default-template.netlify.app");
       const event = createBuilderBrowserEvent({
         host: "127.0.0.1:8080",
         "x-forwarded-host": "the-grand-tour.builder.cloud",
@@ -485,7 +511,7 @@ describe("Builder callback CSRF state", () => {
 
     it("ignores a spoofed Builder Cloud forwarded host from a direct request", () => {
       process.env.NODE_ENV = "production";
-      process.env.APP_URL = "https://default-template.netlify.app";
+      setOnlyBuilderAppUrl("https://default-template.netlify.app");
       const event = createBuilderBrowserEvent({
         host: "app.example.com",
         "x-forwarded-host": "attacker.builder.cloud",
@@ -502,7 +528,7 @@ describe("Builder callback CSRF state", () => {
 
     it("ignores a forwarded Builder Cloud host without a proxy host", () => {
       process.env.NODE_ENV = "production";
-      process.env.APP_URL = "https://default-template.netlify.app";
+      setOnlyBuilderAppUrl("https://default-template.netlify.app");
       const event = createBuilderBrowserEvent({
         "x-forwarded-host": "attacker.builder.cloud",
         "x-forwarded-proto": "https",
@@ -518,7 +544,7 @@ describe("Builder callback CSRF state", () => {
 
     it("ignores a forwarded Builder Cloud host from an untrusted loopback host", () => {
       process.env.NODE_ENV = "production";
-      process.env.APP_URL = "https://default-template.netlify.app";
+      setOnlyBuilderAppUrl("https://default-template.netlify.app");
       const event = createBuilderBrowserEvent(
         {
           host: "127.0.0.1:8080",
@@ -538,16 +564,7 @@ describe("Builder callback CSRF state", () => {
 
     it("does not reuse a rejected forwarded host without a configured origin", () => {
       process.env.NODE_ENV = "production";
-      for (const key of [
-        "APP_URL",
-        "VITE_APP_URL",
-        "BETTER_AUTH_URL",
-        "VITE_BETTER_AUTH_URL",
-        "WORKSPACE_GATEWAY_URL",
-        "VITE_WORKSPACE_GATEWAY_URL",
-      ]) {
-        delete process.env[key];
-      }
+      clearBuilderOriginEnv();
       const event = createBuilderBrowserEvent(
         {
           host: "127.0.0.1:8080",
@@ -748,7 +765,7 @@ describe("Builder callback CSRF state", () => {
     it("uses a Builder-accepted gateway callback for preview-host cli-auth redirects", () => {
       process.env.NODE_ENV = "production";
       process.env.AGENT_NATIVE_WORKSPACE = "1";
-      process.env.APP_URL = "https://agent-workspace.builder.io";
+      setOnlyBuilderAppUrl("https://agent-workspace.builder.io");
       process.env.WORKSPACE_GATEWAY_URL = "https://agent-workspace.builder.io";
       process.env.APP_BASE_PATH = "/dispatch";
 
@@ -792,6 +809,7 @@ describe("Builder callback CSRF state", () => {
     it("keeps Builder preview connect URLs on the preview deployment in workspace mode", () => {
       process.env.NODE_ENV = "production";
       process.env.AGENT_NATIVE_WORKSPACE = "1";
+      clearBuilderOriginEnv();
       process.env.WORKSPACE_GATEWAY_URL = "https://agent-workspace.builder.io";
       process.env.APP_BASE_PATH = "/dispatch";
 
@@ -810,6 +828,7 @@ describe("Builder callback CSRF state", () => {
     it("uses Fusion's public preview origin instead of a loopback gateway for Builder connect", () => {
       process.env.NODE_ENV = "production";
       process.env.AGENT_NATIVE_WORKSPACE = "1";
+      clearBuilderOriginEnv();
       process.env.WORKSPACE_GATEWAY_URL = "http://127.0.0.1:8080";
       process.env.FUSION_ENV_ORIGIN =
         "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz";
@@ -968,7 +987,7 @@ describe("Builder callback CSRF state", () => {
     it("returns users to the preview opener after a gateway callback", () => {
       process.env.NODE_ENV = "production";
       process.env.AGENT_NATIVE_WORKSPACE = "1";
-      process.env.APP_URL = "https://agent-workspace.builder.io";
+      setOnlyBuilderAppUrl("https://agent-workspace.builder.io");
       process.env.WORKSPACE_GATEWAY_URL = "https://agent-workspace.builder.io";
       process.env.APP_BASE_PATH = "/dispatch";
 
@@ -992,6 +1011,7 @@ describe("Builder callback CSRF state", () => {
     it("falls back to the configured public origin for untrusted hosts", () => {
       process.env.NODE_ENV = "production";
       process.env.AGENT_NATIVE_WORKSPACE = "1";
+      clearBuilderOriginEnv();
       process.env.WORKSPACE_GATEWAY_URL = "https://agent-workspace.builder.io";
 
       const event = createBuilderBrowserEvent({
@@ -1011,16 +1031,7 @@ describe("Builder callback CSRF state", () => {
       // Builder redirects to its own dead http://localhost:10110/auth.
       delete process.env.NODE_ENV;
       process.env.PORT = "8080";
-      for (const key of [
-        "APP_URL",
-        "VITE_APP_URL",
-        "BETTER_AUTH_URL",
-        "VITE_BETTER_AUTH_URL",
-        "WORKSPACE_GATEWAY_URL",
-        "VITE_WORKSPACE_GATEWAY_URL",
-      ]) {
-        delete process.env[key];
-      }
+      clearBuilderOriginEnv();
 
       const event = createBuilderBrowserEvent({
         host: "127.0.0.1:8080",
@@ -1036,16 +1047,7 @@ describe("Builder callback CSRF state", () => {
     it("does not use the localhost cli-auth fallback in production", () => {
       process.env.NODE_ENV = "production";
       process.env.PORT = "8080";
-      for (const key of [
-        "APP_URL",
-        "VITE_APP_URL",
-        "BETTER_AUTH_URL",
-        "VITE_BETTER_AUTH_URL",
-        "WORKSPACE_GATEWAY_URL",
-        "VITE_WORKSPACE_GATEWAY_URL",
-      ]) {
-        delete process.env[key];
-      }
+      clearBuilderOriginEnv();
 
       const event = createBuilderBrowserEvent({
         host: "127.0.0.1:8080",

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -536,6 +536,35 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("does not reuse a rejected forwarded host without a configured origin", () => {
+      process.env.NODE_ENV = "production";
+      for (const key of [
+        "APP_URL",
+        "VITE_APP_URL",
+        "BETTER_AUTH_URL",
+        "VITE_BETTER_AUTH_URL",
+        "WORKSPACE_GATEWAY_URL",
+        "VITE_WORKSPACE_GATEWAY_URL",
+      ]) {
+        delete process.env[key];
+      }
+      const event = createBuilderBrowserEvent(
+        {
+          host: "127.0.0.1:8080",
+          "x-forwarded-host": "attacker.builder.cloud",
+          "x-forwarded-proto": "https",
+        },
+        "203.0.113.10",
+      );
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://127.0.0.1:8080/_agent-native/builder/connect",
+      );
+      expect(getBuilderCliAuthCallbackOriginForEvent(event)).toBe(
+        "https://127.0.0.1:8080",
+      );
+    });
+
     it("recovers state from the callback cookie when Builder omits query state", () => {
       const state = createBuilderConnectState();
       const otherState = createBuilderConnectState();
@@ -994,6 +1023,7 @@ describe("Builder callback CSRF state", () => {
       }
 
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host": "alice.builderio.xyz",
         "x-forwarded-proto": "https",
       });
@@ -1018,6 +1048,7 @@ describe("Builder callback CSRF state", () => {
       }
 
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host": "alice.builderio.xyz",
         "x-forwarded-proto": "https",
       });

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -447,6 +447,36 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("keeps Builder-hosted app connect callbacks on the active app origin", () => {
+      process.env.NODE_ENV = "production";
+      process.env.APP_URL = "https://default-template.netlify.app";
+      const event = createBuilderBrowserEvent({
+        "x-forwarded-host": "the-grand-tour.builder.cloud",
+        "x-forwarded-proto": "https",
+      });
+
+      const callbackUrl = resolveBuilderConnectCallbackUrl(
+        event,
+        "<STATE_EXAMPLE>",
+      );
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://the-grand-tour.builder.cloud/_agent-native/builder/connect",
+      );
+      expect(callbackUrl).toBe(
+        "https://the-grand-tour.builder.cloud/_agent-native/builder/callback?state=%3CSTATE_EXAMPLE%3E",
+      );
+      expect(isBuilderConnectCallbackUrlAllowed(callbackUrl!, event)).toBe(
+        true,
+      );
+      expect(
+        isBuilderConnectCallbackUrlAllowed(
+          "https://other.builder.cloud/_agent-native/builder/callback",
+          event,
+        ),
+      ).toBe(false);
+    });
+
     it("recovers state from the callback cookie when Builder omits query state", () => {
       const state = createBuilderConnectState();
       const otherState = createBuilderConnectState();

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -562,6 +562,28 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("ignores an unconfigured direct Builder Cloud host", () => {
+      process.env.NODE_ENV = "production";
+      setOnlyBuilderAppUrl("https://default-template.netlify.app");
+      const event = createBuilderBrowserEvent(
+        {
+          host: "attacker.builder.cloud",
+          "x-forwarded-proto": "https",
+        },
+        "203.0.113.10",
+      );
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/connect",
+      );
+      expect(getBuilderCliAuthCallbackOriginForEvent(event)).toBe(
+        "https://default-template.netlify.app",
+      );
+      expect(resolveBuilderConnectCallbackUrl(event, "<STATE_EXAMPLE>")).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/callback?state=%3CSTATE_EXAMPLE%3E",
+      );
+    });
+
     it("does not reuse a rejected forwarded host without a configured origin", () => {
       process.env.NODE_ENV = "production";
       clearBuilderOriginEnv();

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -495,6 +495,22 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("ignores a forwarded Builder Cloud host without a proxy host", () => {
+      process.env.NODE_ENV = "production";
+      process.env.APP_URL = "https://default-template.netlify.app";
+      const event = createBuilderBrowserEvent({
+        "x-forwarded-host": "attacker.builder.cloud",
+        "x-forwarded-proto": "https",
+      });
+
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://default-template.netlify.app/_agent-native/builder/connect",
+      );
+      expect(getBuilderCliAuthCallbackOriginForEvent(event)).toBe(
+        "https://default-template.netlify.app",
+      );
+    });
+
     it("recovers state from the callback cookie when Builder omits query state", () => {
       const state = createBuilderConnectState();
       const otherState = createBuilderConnectState();
@@ -683,6 +699,7 @@ describe("Builder callback CSRF state", () => {
       process.env.APP_BASE_PATH = "/dispatch";
 
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host":
           "940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
         "x-forwarded-proto": "https",
@@ -725,6 +742,7 @@ describe("Builder callback CSRF state", () => {
       process.env.APP_BASE_PATH = "/dispatch";
 
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host":
           "940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
         "x-forwarded-proto": "https",
@@ -744,6 +762,7 @@ describe("Builder callback CSRF state", () => {
       process.env.APP_BASE_PATH = "/dispatch";
 
       const event = createBuilderBrowserEvent({
+        host: "127.0.0.1:8080",
         "x-forwarded-host": "127.0.0.1:8080",
         "x-forwarded-proto": "http",
       });

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -584,6 +584,25 @@ describe("Builder callback CSRF state", () => {
       );
     });
 
+    it("fails closed for a direct Builder Cloud host without origin config", () => {
+      process.env.NODE_ENV = "production";
+      clearBuilderOriginEnv();
+      const event = createBuilderBrowserEvent(
+        {
+          host: "attacker.builder.cloud",
+          "x-forwarded-proto": "https",
+        },
+        "203.0.113.10",
+      );
+
+      expect(getBuilderBrowserOriginForEvent(event)).toBe("");
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe("");
+      expect(getBuilderCliAuthCallbackOriginForEvent(event)).toBe("");
+      expect(resolveBuilderConnectCallbackUrl(event, "<STATE_EXAMPLE>")).toBe(
+        null,
+      );
+    });
+
     it("does not reuse a rejected forwarded host without a configured origin", () => {
       process.env.NODE_ENV = "production";
       clearBuilderOriginEnv();

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1250,7 +1250,8 @@ function getBuilderRequestHost(event: H3Event): string | undefined {
   // forwarded Builder preview host. Direct requests keep their own Host so a
   // caller cannot steer OAuth redirects with an arbitrary forwarded header.
   return forwardedHost &&
-    (!requestHost || isLoopbackBuilderRequestHost(requestHost))
+    requestHost &&
+    isLoopbackBuilderRequestHost(requestHost)
     ? forwardedHost
     : requestHost;
 }

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -169,7 +169,14 @@ export function isBuilderConnectCallbackUrlAllowed(
   candidate: string,
   event: H3Event,
 ): boolean {
-  if (!isAllowedOAuthRedirectUri(candidate, event)) return false;
+  if (
+    !isAllowedOAuthRedirectUri(
+      candidate,
+      event,
+      getBuilderConnectCallbackOrigin(event),
+    )
+  )
+    return false;
   let url: URL;
   try {
     url = new URL(candidate);
@@ -203,11 +210,12 @@ export function resolveBuilderConnectCallbackUrl(
   state?: string,
 ): string | null {
   const stateSuffix = state ? `?state=${encodeURIComponent(state)}` : "";
-  const withBase = `${getOrigin(event)}${getAppBasePath()}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
+  const callbackOrigin = getBuilderConnectCallbackOrigin(event);
+  const withBase = `${callbackOrigin}${getAppBasePath()}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
   if (isBuilderConnectCallbackUrlAllowed(withBase, event)) return withBase;
   // Match google-oauth default-redirect behavior when the request is not under
   // APP_BASE_PATH: fall back to the root `/_agent-native/...` callback.
-  const root = `${getOrigin(event)}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
+  const root = `${callbackOrigin}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
   if (root !== withBase && isBuilderConnectCallbackUrlAllowed(root, event)) {
     return root;
   }
@@ -1251,11 +1259,34 @@ function isTrustedBuilderRequestHost(host: string | undefined): boolean {
       hostname === "builder.io" ||
       hostname.endsWith(".builder.io") ||
       hostname === "builder.my" ||
-      hostname.endsWith(".builder.my")
+      hostname.endsWith(".builder.my") ||
+      hostname === "builder.cloud" ||
+      hostname.endsWith(".builder.cloud")
     );
   } catch {
     return false;
   }
+}
+
+function isBuilderCloudRequestHost(host: string | undefined): boolean {
+  if (!host) return false;
+  try {
+    const hostname = new URL(`http://${host}`).hostname.toLowerCase();
+    return hostname === "builder.cloud" || hostname.endsWith(".builder.cloud");
+  } catch {
+    // coercion-ok: malformed hosts cannot be trusted as Builder Cloud origins.
+    return false;
+  }
+}
+
+function getBuilderConnectCallbackOrigin(event: H3Event): string {
+  const headerHost = firstHeaderValue(
+    readEventHeader(event, "x-forwarded-host") ||
+      readEventHeader(event, "host"),
+  );
+  return isBuilderCloudRequestHost(headerHost)
+    ? getBuilderBrowserOriginForEvent(event)
+    : getOrigin(event);
 }
 
 function isLoopbackBuilderRequestHost(host: string | undefined): boolean {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -6,7 +6,7 @@ import {
 } from "node:crypto";
 
 import type { H3Event } from "h3";
-import { getHeader } from "h3";
+import { getHeader, getRequestIP } from "h3";
 
 import { getSetting } from "../settings/store.js";
 import { applyBuilderUtmTrackingParams } from "../shared/builder-link-tracking.js";
@@ -1249,11 +1249,29 @@ function getBuilderRequestHost(event: H3Event): string | undefined {
   // Only the local proxy boundary may replace the request host with a
   // forwarded Builder preview host. Direct requests keep their own Host so a
   // caller cannot steer OAuth redirects with an arbitrary forwarded header.
-  return forwardedHost &&
+  if (
+    forwardedHost &&
     requestHost &&
     isLoopbackBuilderRequestHost(requestHost)
-    ? forwardedHost
-    : requestHost;
+  ) {
+    return isLoopbackBuilderProxyPeer(event) ? forwardedHost : undefined;
+  }
+  return requestHost;
+}
+
+function isLoopbackBuilderProxyPeer(event: H3Event): boolean {
+  try {
+    const ip = getRequestIP(event, { xForwardedFor: false });
+    return (
+      ip === "127.0.0.1" ||
+      ip === "::1" ||
+      ip === "::ffff:127.0.0.1" ||
+      ip?.startsWith("127.") === true
+    );
+    // coercion-ok: unavailable peer data is not trusted as a proxy.
+  } catch {
+    return false;
+  }
 }
 
 function isTrustedBuilderRequestHost(host: string | undefined): boolean {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1241,6 +1241,20 @@ function readEventHeader(event: H3Event, name: string): string | undefined {
   }
 }
 
+function getBuilderRequestHost(event: H3Event): string | undefined {
+  const requestHost = firstHeaderValue(readEventHeader(event, "host"));
+  const forwardedHost = firstHeaderValue(
+    readEventHeader(event, "x-forwarded-host"),
+  );
+  // Only the local proxy boundary may replace the request host with a
+  // forwarded Builder preview host. Direct requests keep their own Host so a
+  // caller cannot steer OAuth redirects with an arbitrary forwarded header.
+  return forwardedHost &&
+    (!requestHost || isLoopbackBuilderRequestHost(requestHost))
+    ? forwardedHost
+    : requestHost;
+}
+
 function isTrustedBuilderRequestHost(host: string | undefined): boolean {
   if (!host) return false;
   try {
@@ -1280,10 +1294,7 @@ function isBuilderCloudRequestHost(host: string | undefined): boolean {
 }
 
 function getBuilderConnectCallbackOrigin(event: H3Event): string {
-  const headerHost = firstHeaderValue(
-    readEventHeader(event, "x-forwarded-host") ||
-      readEventHeader(event, "host"),
-  );
+  const headerHost = getBuilderRequestHost(event);
   return isBuilderCloudRequestHost(headerHost)
     ? getBuilderBrowserOriginForEvent(event)
     : getOrigin(event);
@@ -1332,10 +1343,7 @@ function firstPublicBuilderPreviewOriginFromEnv(): string | null {
  * the same deployment that minted the signed connect token.
  */
 export function getBuilderBrowserOriginForEvent(event: H3Event): string {
-  const headerHost = firstHeaderValue(
-    readEventHeader(event, "x-forwarded-host") ||
-      readEventHeader(event, "host"),
-  );
+  const headerHost = getBuilderRequestHost(event);
   if (!isTrustedBuilderRequestHost(headerHost)) return getOrigin(event);
   if (isLoopbackBuilderRequestHost(headerHost)) {
     const publicPreviewOrigin = firstPublicBuilderPreviewOriginFromEnv();

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -170,12 +170,10 @@ export function isBuilderConnectCallbackUrlAllowed(
   candidate: string,
   event: H3Event,
 ): boolean {
+  const callbackOrigin = getBuilderConnectCallbackOrigin(event);
   if (
-    !isAllowedOAuthRedirectUri(
-      candidate,
-      event,
-      getBuilderConnectCallbackOrigin(event),
-    )
+    !callbackOrigin ||
+    !isAllowedOAuthRedirectUri(candidate, event, callbackOrigin)
   )
     return false;
   let url: URL;
@@ -212,6 +210,7 @@ export function resolveBuilderConnectCallbackUrl(
 ): string | null {
   const stateSuffix = state ? `?state=${encodeURIComponent(state)}` : "";
   const callbackOrigin = getBuilderConnectCallbackOrigin(event);
+  if (!callbackOrigin) return null;
   const withBase = `${callbackOrigin}${getAppBasePath()}${BUILDER_CALLBACK_PATH}${stateSuffix}`;
   if (isBuilderConnectCallbackUrlAllowed(withBase, event)) return withBase;
   // Match google-oauth default-redirect behavior when the request is not under
@@ -1327,11 +1326,27 @@ function isConfiguredBuilderRequestHost(event: H3Event, host: string): boolean {
   return isConfiguredAppOrigin(`${proto}://${host}`);
 }
 
-function getBuilderConnectCallbackOrigin(event: H3Event): string {
+function getBuilderConnectCallbackOrigin(event: H3Event): string | null {
+  const requestHost = firstHeaderValue(readEventHeader(event, "host"));
   const headerHost = getBuilderRequestHost(event);
+  if (isRejectedDirectBuilderCloudHost(requestHost, headerHost)) {
+    return getConfiguredBuilderFallbackOrigin(event);
+  }
   return isBuilderCloudRequestHost(headerHost)
     ? getBuilderBrowserOriginForEvent(event)
     : getOrigin(event, { useForwardedHost: false });
+}
+
+function isRejectedDirectBuilderCloudHost(
+  requestHost: string | undefined,
+  resolvedHost: string | undefined,
+): boolean {
+  return isBuilderCloudRequestHost(requestHost) && requestHost !== resolvedHost;
+}
+
+function getConfiguredBuilderFallbackOrigin(event: H3Event): string | null {
+  const origin = getOrigin(event, { useForwardedHost: false });
+  return isConfiguredAppOrigin(origin) ? origin : null;
 }
 
 function isLoopbackBuilderRequestHost(host: string | undefined): boolean {
@@ -1377,7 +1392,11 @@ function firstPublicBuilderPreviewOriginFromEnv(): string | null {
  * the same deployment that minted the signed connect token.
  */
 export function getBuilderBrowserOriginForEvent(event: H3Event): string {
+  const requestHost = firstHeaderValue(readEventHeader(event, "host"));
   const headerHost = getBuilderRequestHost(event);
+  if (isRejectedDirectBuilderCloudHost(requestHost, headerHost)) {
+    return getConfiguredBuilderFallbackOrigin(event) ?? "";
+  }
   if (!isTrustedBuilderRequestHost(headerHost)) {
     return getOrigin(event, { useForwardedHost: false });
   }
@@ -1446,7 +1465,7 @@ export function getBuilderBrowserStatus(origin: string): BuilderBrowserStatus {
     credentialSource: envManaged ? "env" : undefined,
     appHost: getBuilderAppHost(),
     apiHost: getBuilderApiHost(),
-    connectUrl: getBuilderBrowserConnectUrl(origin),
+    connectUrl: origin ? getBuilderBrowserConnectUrl(origin) : "",
     publicKeyConfigured: !!process.env.BUILDER_PUBLIC_KEY,
     privateKeyConfigured: !!process.env.BUILDER_PRIVATE_KEY,
     userId: process.env.BUILDER_USER_ID || undefined,

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1316,7 +1316,7 @@ function getBuilderConnectCallbackOrigin(event: H3Event): string {
   const headerHost = getBuilderRequestHost(event);
   return isBuilderCloudRequestHost(headerHost)
     ? getBuilderBrowserOriginForEvent(event)
-    : getOrigin(event);
+    : getOrigin(event, { useForwardedHost: false });
 }
 
 function isLoopbackBuilderRequestHost(host: string | undefined): boolean {
@@ -1363,7 +1363,9 @@ function firstPublicBuilderPreviewOriginFromEnv(): string | null {
  */
 export function getBuilderBrowserOriginForEvent(event: H3Event): string {
   const headerHost = getBuilderRequestHost(event);
-  if (!isTrustedBuilderRequestHost(headerHost)) return getOrigin(event);
+  if (!isTrustedBuilderRequestHost(headerHost)) {
+    return getOrigin(event, { useForwardedHost: false });
+  }
   if (isLoopbackBuilderRequestHost(headerHost)) {
     const publicPreviewOrigin = firstPublicBuilderPreviewOriginFromEnv();
     if (publicPreviewOrigin) return publicPreviewOrigin;

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -21,6 +21,7 @@ import {
   getOrigin,
   getOAuthStateSigningKey,
   isAllowedOAuthRedirectUri,
+  isConfiguredAppOrigin,
 } from "./google-oauth.js";
 import { getRequestOrgId, getRequestUserEmail } from "./request-context.js";
 
@@ -1256,6 +1257,13 @@ function getBuilderRequestHost(event: H3Event): string | undefined {
   ) {
     return isLoopbackBuilderProxyPeer(event) ? forwardedHost : undefined;
   }
+  if (
+    requestHost &&
+    isBuilderCloudRequestHost(requestHost) &&
+    !isConfiguredBuilderRequestHost(event, requestHost)
+  ) {
+    return undefined;
+  }
   return requestHost;
 }
 
@@ -1310,6 +1318,13 @@ function isBuilderCloudRequestHost(host: string | undefined): boolean {
     // coercion-ok: malformed hosts cannot be trusted as Builder Cloud origins.
     return false;
   }
+}
+
+function isConfiguredBuilderRequestHost(event: H3Event, host: string): boolean {
+  const proto =
+    firstHeaderValue(readEventHeader(event, "x-forwarded-proto")) ||
+    (process.env.NODE_ENV === "production" ? "https" : "http");
+  return isConfiguredAppOrigin(`${proto}://${host}`);
 }
 
 function getBuilderConnectCallbackOrigin(event: H3Event): string {

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -369,8 +369,9 @@ function getDefaultOAuthRedirectUrl(event: H3Event, path: string): string {
  * as a 400.
  *
  * The intentional shape is exact-prefix:
- *   - Origin must equal `getOrigin(event)` — no Host-header injection
- *     reusing somebody else's registered redirect URI.
+ *   - Origin must equal the resolved request origin — no Host-header injection
+ *     reusing somebody else's registered redirect URI. Callers with a
+ *     separately verified origin may pass it as `expectedOrigin`.
  *   - Path must start with `${appBasePath}/_agent-native/` so we never
  *     hand auth codes to a public marketing or open-redirect endpoint
  *     on the same registered host.
@@ -382,6 +383,7 @@ function getDefaultOAuthRedirectUrl(event: H3Event, path: string): string {
 export function isAllowedOAuthRedirectUri(
   candidate: string,
   event: H3Event,
+  expectedOrigin = getOrigin(event),
 ): boolean {
   if (typeof candidate !== "string" || candidate.length === 0) return false;
   let url: URL;
@@ -391,7 +393,6 @@ export function isAllowedOAuthRedirectUri(
     return false;
   }
   // Must be same origin as our server.
-  const expectedOrigin = getOrigin(event);
   let expectedUrl: URL;
   try {
     expectedUrl = new URL(expectedOrigin);

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -251,9 +251,14 @@ function isBuilderPreviewHost(host: string | undefined): boolean {
  * The protocol defaults to `https` in production (so a TLS-terminating proxy
  * that drops `x-forwarded-proto` doesn't downgrade us to plain HTTP).
  */
-export function getOrigin(event: H3Event): string {
+export function getOrigin(
+  event: H3Event,
+  options: { useForwardedHost?: boolean } = {},
+): string {
   const headerHost =
-    getHeader(event, "x-forwarded-host") || getHeader(event, "host");
+    options.useForwardedHost === false
+      ? getHeader(event, "host")
+      : getHeader(event, "x-forwarded-host") || getHeader(event, "host");
   const isProd = process.env.NODE_ENV === "production";
   const headerProto =
     getHeader(event, "x-forwarded-proto") || (isProd ? "https" : "http");


### PR DESCRIPTION
## Summary
- keep Builder connect status and OAuth callbacks on the active `*.builder.cloud` app origin
- preserve exact-origin callback validation while retaining the existing fallback for other hosts
- add a regression test and core patch changeset

## Verification
- `corepack pnpm --filter @agent-native/core exec vitest --run src/server/builder-browser.spec.ts --config vitest.config.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guard:no-silent-coercion`
- `git diff --check`