### PR TITLE
Show agent deck edits while the editor has unsaved work

### DIFF
--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -263,7 +263,10 @@ describe("update-slide", () => {
       edits: [{ find: "Missing", replace: "Never written", required: false }],
     })) as Record<string, unknown>;
 
-    expect(result).toMatchObject({ ok: true, applied: false });
+    expect(result).toMatchObject({ ok: false, applied: false });
+    // The slide is unchanged, so the result must say so — `applied: false`
+    // paired with `ok: true` read as success and was reported as done.
+    expect(String(result.message)).toContain("Nothing was written");
     expect(lastUpdateSet).toBeUndefined();
     expect(mockNotifyClients).not.toHaveBeenCalled();
   });
@@ -287,7 +290,10 @@ describe("update-slide", () => {
       edits: [{ find: "Missing", replace: "Never written", required: false }],
     })) as Record<string, unknown>;
 
-    expect(result).toMatchObject({ ok: true, applied: false });
+    expect(result).toMatchObject({ ok: false, applied: false });
+    // The slide is unchanged, so the result must say so — `applied: false`
+    // paired with `ok: true` read as success and was reported as done.
+    expect(String(result.message)).toContain("Nothing was written");
     expect(lastUpdateSet).toBeUndefined();
     expect(
       JSON.parse(mockDeckRow!.data as string).slides[0].animations,
@@ -342,15 +348,16 @@ describe("update-slide", () => {
       ],
     })) as Record<string, unknown>;
 
-    // The required find/replace matched and the batch is reported applied,
-    // but the optional image insert never found its marker and silently
-    // no-opped -- a caller trusting only the aggregate `applied` boolean has
-    // no way to tell the image was never inserted.
-    expect(result).toMatchObject({ ok: true, applied: true });
+    // The required find/replace matched, but the optional image insert never
+    // found its marker. The aggregate `applied` boolean cannot express that,
+    // so the result flags it explicitly — otherwise the agent reports the
+    // image as inserted.
+    expect(result).toMatchObject({ ok: true, applied: true, partial: true });
     const deck = JSON.parse(lastUpdateSet!.data as string);
     expect(deck.slides[0].content).toBe("<div>New</div>");
 
     expect(result.editResults).toEqual(["replace:first", "insert-after:0"]);
+    expect(String(result.message)).toContain("insert-after:0");
   });
 
   it("does not write a partial edit list when a later edit fails", async () => {

--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -257,16 +257,16 @@ describe("update-slide", () => {
       ],
     });
 
-    const result = (await action.run({
-      deckId: "deck-1",
-      slideId: "slide-1",
-      edits: [{ find: "Missing", replace: "Never written", required: false }],
-    })) as Record<string, unknown>;
-
-    expect(result).toMatchObject({ ok: false, applied: false });
-    // The slide is unchanged, so the result must say so — `applied: false`
-    // paired with `ok: true` read as success and was reported as done.
-    expect(String(result.message)).toContain("Nothing was written");
+    // Nothing matched, so nothing was written — and that must reach the
+    // runner as a throw. A returned value is stamped `completedSideEffect`
+    // and replayed to a resumed run as work already done.
+    await expect(
+      action.run({
+        deckId: "deck-1",
+        slideId: "slide-1",
+        edits: [{ find: "Missing", replace: "Never written", required: false }],
+      }),
+    ).rejects.toThrow("Nothing was written");
     expect(lastUpdateSet).toBeUndefined();
     expect(mockNotifyClients).not.toHaveBeenCalled();
   });
@@ -283,17 +283,14 @@ describe("update-slide", () => {
       ],
     });
 
-    const result = (await action.run({
-      deckId: "deck-1",
-      slideId: "slide-1",
-      format: true,
-      edits: [{ find: "Missing", replace: "Never written", required: false }],
-    })) as Record<string, unknown>;
-
-    expect(result).toMatchObject({ ok: false, applied: false });
-    // The slide is unchanged, so the result must say so — `applied: false`
-    // paired with `ok: true` read as success and was reported as done.
-    expect(String(result.message)).toContain("Nothing was written");
+    await expect(
+      action.run({
+        deckId: "deck-1",
+        slideId: "slide-1",
+        format: true,
+        edits: [{ find: "Missing", replace: "Never written", required: false }],
+      }),
+    ).rejects.toThrow("Nothing was written");
     expect(lastUpdateSet).toBeUndefined();
     expect(
       JSON.parse(mockDeckRow!.data as string).slides[0].animations,
@@ -531,16 +528,15 @@ describe("update-slide", () => {
     );
   });
 
-  it("returns ok:false without writing when the find text is missing", async () => {
-    const result = (await action.run({
-      deckId: "deck-1",
-      slideId: "slide-1",
-      find: "this text does not exist in the slide",
-      replace: "x",
-    })) as Record<string, unknown>;
-
-    expect(result.ok).toBe(false);
-    expect(result.layoutOverflow).toBeUndefined();
+  it("throws without writing when the find text is missing", async () => {
+    await expect(
+      action.run({
+        deckId: "deck-1",
+        slideId: "slide-1",
+        find: "this text does not exist in the slide",
+        replace: "x",
+      }),
+    ).rejects.toThrow("Nothing was written");
     expect(lastUpdateSet).toBeUndefined();
     expect(mockNotifyClients).not.toHaveBeenCalled();
   });
@@ -625,16 +621,15 @@ describe("update-slide", () => {
       },
     };
 
-    const result = (await action.run({
-      deckId: "deck-1",
-      slideId: "slide-1",
-      find: "this text does not exist in the slide",
-      replace: "x",
-    })) as Record<string, unknown>;
-
-    // When find is not found, the action returns ok: false BEFORE the
-    // fit-check. layoutOverflow must NOT appear.
-    expect(result.ok).toBe(false);
-    expect(result.layoutOverflow).toBeUndefined();
+    // When find is not found the action throws BEFORE the fit-check, so no
+    // overflow measurement is taken or reported.
+    await expect(
+      action.run({
+        deckId: "deck-1",
+        slideId: "slide-1",
+        find: "this text does not exist in the slide",
+        replace: "x",
+      }),
+    ).rejects.toThrow("Nothing was written");
   });
 });

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -487,35 +487,34 @@ export default defineAction({
       };
     });
 
+    // ─── Non-write exits must THROW, not return ───────────────────────────
+    //
+    // Returning any value — `{ ok: false }` included — is indistinguishable
+    // from a successful write to everything above this action. `isError` is
+    // set only from the runner's catch, so a returned no-op is stamped
+    // `completedSideEffect: true` and the journal later replays it to a
+    // resumed run under "Already completed (do NOT re-run these — their side
+    // effects already happened)". It is also invisible to the repeat
+    // breakers, which is how one production thread ran 20 consecutive
+    // identical "text not found" calls without one firing. Throwing is the
+    // only channel that says "the deck was not modified", and it is already
+    // this file's idiom for the stale-hash rejection above.
     if (rmw.notFound) {
-      return {
-        ok: false,
-        message: `Text not found in slide: "${find!.slice(0, 60)}". Use get-deck with this slideId to see the current slide HTML.`,
-      };
+      throw new Error(
+        `Nothing was written: text not found in slide: "${find!.slice(0, 60)}". Current slide contentHash is ${rmw.contentHash}; call get-deck with this slideId and rebase the patch against the current HTML.`,
+      );
     }
 
     const { applied, editResults } = rmw;
-    // An optional edit whose marker matched nothing writes nothing. Reporting
-    // that only as `applied: false` (or, for a partly-applied batch, only in
-    // `editResults`) left "nothing was written" indistinguishable from
-    // success, and the agent told users their deck had changed when it had
-    // not. Say which edits found no match, in the result the model reads.
     const unmatched = (editResults ?? []).filter((entry) =>
       entry.endsWith(":0"),
     );
     if (!applied) {
-      return {
-        ok: false,
-        deckId,
-        slideId,
-        applied: false,
-        editResults,
-        contentHash: rmw.contentHash,
-        message: unmatched.length
-          ? `Nothing was written: ${unmatched.join(", ")} matched no text in the slide. Call get-deck with this slideId and rebase the patch against the current HTML.`
-          : "Nothing was written: the result is identical to the current slide content.",
-        deepLink: deckDeepLink(deckId),
-      };
+      throw new Error(
+        unmatched.length
+          ? `Nothing was written: ${unmatched.join(", ")} matched no text in the slide. Current slide contentHash is ${rmw.contentHash}; call get-deck with this slideId and rebase the patch against the current HTML.`
+          : `Nothing was written: the result is identical to the current slide content (contentHash ${rmw.contentHash}). The slide already says what this edit would have made it say.`,
+      );
     }
 
     // Start the freshness window after the SQL write and before notifying the

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -495,14 +495,25 @@ export default defineAction({
     }
 
     const { applied, editResults } = rmw;
+    // An optional edit whose marker matched nothing writes nothing. Reporting
+    // that only as `applied: false` (or, for a partly-applied batch, only in
+    // `editResults`) left "nothing was written" indistinguishable from
+    // success, and the agent told users their deck had changed when it had
+    // not. Say which edits found no match, in the result the model reads.
+    const unmatched = (editResults ?? []).filter((entry) =>
+      entry.endsWith(":0"),
+    );
     if (!applied) {
       return {
-        ok: true,
+        ok: false,
         deckId,
         slideId,
         applied: false,
         editResults,
         contentHash: rmw.contentHash,
+        message: unmatched.length
+          ? `Nothing was written: ${unmatched.join(", ")} matched no text in the slide. Call get-deck with this slideId and rebase the patch against the current HTML.`
+          : "Nothing was written: the result is identical to the current slide content.",
         deepLink: deckDeepLink(deckId),
       };
     }
@@ -547,6 +558,12 @@ export default defineAction({
       slideId,
       applied,
       editResults,
+      ...(unmatched.length
+        ? {
+            partial: true,
+            message: `Applied, but ${unmatched.join(", ")} matched no text and was skipped — do not report those parts as done.`,
+          }
+        : {}),
       contentHash: rmw.contentHash,
       deepLink: deckDeepLink(deckId),
       ...(rmw.contextMode
@@ -569,7 +586,11 @@ export default defineAction({
           viewportWidth: fit.measurement.viewportWidth,
           viewportHeight: fit.measurement.viewportHeight,
         },
-        message: formatOverflowForTool(deckId, fit.measurement),
+        // Keep the skipped-edit warning: an overflow report must not be the
+        // only thing the model sees when part of the patch never landed.
+        message: [base.message, formatOverflowForTool(deckId, fit.measurement)]
+          .filter(Boolean)
+          .join("\n\n"),
       };
     }
 

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -2066,6 +2066,68 @@ describe("DeckContext deck creation persistence", () => {
     vi.useRealTimers();
   });
 
+  it("does not let a read that spans a local save revert the saved slide", async () => {
+    // The write starts AFTER the read is issued, so nothing is pending at
+    // either endpoint to reveal that the response predates it. Only the local
+    // write counter can see this; without it the clean-deck branch adopts the
+    // stale snapshot wholesale and the user's edit visibly reverts.
+    window.history.pushState({}, "", "/deck/race-deck");
+    const original: Deck = {
+      id: "race-deck",
+      title: "Race Deck",
+      createdAt: "2026-05-12T00:00:00.000Z",
+      updatedAt: "2026-05-12T00:00:00.000Z",
+      slides: [
+        {
+          id: "slide-1",
+          content: "<h1>Server before save</h1>",
+          notes: "",
+          layout: "title",
+        },
+      ],
+    };
+    const { setAccessibleDeck, deferNextGetDeck, resolveDeferredGetDeck } =
+      setupFetch();
+    const { result } = renderHook(() => useDecks(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    setAccessibleDeck(original);
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await waitFor(() =>
+      expect(result.current.getDeck("race-deck")?.slides).toHaveLength(1),
+    );
+
+    // Read starts while the deck is clean — the server still holds the old body.
+    deferNextGetDeck();
+    const staleRefresh = result.current.refreshOpenDeck("race-deck");
+
+    // ...then the user edits and the save completes, entirely inside the read.
+    vi.useFakeTimers();
+    act(() => {
+      result.current.updateSlide("race-deck", "slide-1", {
+        content: "<h1>Just typed</h1>",
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    vi.useRealTimers();
+    await waitFor(() =>
+      expect(hasUncommittedDeckChanges("race-deck", new Set())).toBe(false),
+    );
+
+    resolveDeferredGetDeck();
+    await act(async () => {
+      await staleRefresh;
+    });
+
+    expect(result.current.getDeck("race-deck")?.slides[0]?.content).toBe(
+      "<h1>Just typed</h1>",
+    );
+  });
+
   it("does not let a stale baseline reload resurrect a deleted slide", async () => {
     window.history.pushState({}, "", "/deck/shared-deck");
     const original: Deck = {

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -23,6 +23,7 @@ import {
   hasUncommittedDeckChanges,
   markSlideEditingActive,
   mergeServerAddedSlides,
+  mergeServerSlideUpdate,
   useDecks,
   type Deck,
   type DeckReloadStatus,
@@ -3035,8 +3036,11 @@ describe("DeckContext deck creation persistence", () => {
       expect(result.current.getDeck("live-dirty-deck")?.slides).toHaveLength(1),
     );
 
+    // The human is typing in slide-1. That — not a deck-wide dirty flag — is
+    // what must hold the agent's copy of slide-1 back.
     act(() => {
       result.current.markDeckDirty("live-dirty-deck");
+      markSlideEditingActive("live-dirty-deck", "slide-1");
     });
     setAccessibleDeck({
       ...initial,
@@ -3073,6 +3077,21 @@ describe("DeckContext deck creation persistence", () => {
     const deck = result.current.getDeck("live-dirty-deck")!;
     expect(deck.slides[0]?.content).toBe("<h1>Local draft</h1>");
     expect(deck.slides[1]?.content).toBe("<h1>Agent added slide</h1>");
+
+    // Once the user stops typing, the next reconcile delivers the edit that
+    // was held back. Sync events never replay, so the poll has to heal this;
+    // the reconcile is therefore idempotent rather than event-triggered once.
+    act(() => {
+      clearSlideEditingActive("live-dirty-deck", "slide-1");
+    });
+    await act(async () => {
+      await result.current.reloadDecks();
+    });
+    await waitFor(() =>
+      expect(
+        result.current.getDeck("live-dirty-deck")?.slides[0]?.content,
+      ).toBe("<h1>Agent rewrote local slide</h1>"),
+    );
   });
 
   it("adopts a targeted agent edit while an unrelated local write is in flight", async () => {
@@ -3353,9 +3372,12 @@ describe("DeckContext deck creation persistence", () => {
         expect(result.current.getDeck("dirty-deck")?.slides.length).toBe(1),
       );
 
-      // Human is mid-edit: the exact state that used to suppress the refetch.
+      // Human is mid-edit on slide-1: the exact state that used to suppress
+      // the refetch. Only slide-1 is protected — a dirty deck is not a reason
+      // to hide agent work on any other slide.
       act(() => {
         result.current.markDeckDirty("dirty-deck");
+        markSlideEditingActive("dirty-deck", "slide-1");
       });
 
       const source = MockEventSource.lastInstance!;
@@ -3558,6 +3580,58 @@ describe("DeckContext deck creation persistence", () => {
       expect([...merged.slides.map((s) => s.id)].sort()).toEqual(
         ["a", "b", "local-only"].sort(),
       );
+    });
+  });
+
+  describe("mergeServerSlideUpdate", () => {
+    const slide = (id: string, content: string): Slide => ({
+      id,
+      content,
+      notes: "",
+      layout: "content",
+    });
+    const deckOf = (slides: Slide[]): Deck => ({
+      id: "dirty-deck",
+      title: "t",
+      createdAt: "",
+      updatedAt: "",
+      slides,
+    });
+
+    afterEach(() => {
+      clearSlideEditingActive("dirty-deck", "a");
+    });
+
+    // The regression this guards: an agent edit used to be adopted only for
+    // the single slide id carried in the SSE payload, so an edit announced
+    // without one — patch-deck over several slides, or any fallback poll —
+    // stayed invisible while the deck had unrelated local edits.
+    it("adopts server content for every slide with no pending local write", () => {
+      const local = deckOf([slide("a", "LOCAL a"), slide("b", "LOCAL b")]);
+      const server = deckOf([slide("a", "AGENT a"), slide("b", "AGENT b")]);
+      const merged = mergeServerSlideUpdate(local, server, "dirty-deck");
+      expect(merged.slides.map((s) => s.content)).toEqual([
+        "AGENT a",
+        "AGENT b",
+      ]);
+    });
+
+    it("holds back a slide the user is mid inline-edit", () => {
+      markSlideEditingActive("dirty-deck", "a");
+      const local = deckOf([slide("a", "TYPING a"), slide("b", "LOCAL b")]);
+      const server = deckOf([slide("a", "AGENT a"), slide("b", "AGENT b")]);
+      const merged = mergeServerSlideUpdate(local, server, "dirty-deck");
+      expect(merged.slides.map((s) => s.content)).toEqual([
+        "TYPING a",
+        "AGENT b",
+      ]);
+    });
+
+    // Runs on every poll, so an unchanged deck must not churn React state.
+    it("returns the same local reference when the server matches", () => {
+      const local = deckOf([slide("a", "a"), slide("b", "b")]);
+      const server = deckOf([slide("a", "a"), slide("b", "b")]);
+      expect(mergeServerSlideUpdate(local, server, "dirty-deck")).toBe(local);
     });
   });
 });

--- a/templates/slides/app/context/DeckContext.persistence.test.ts
+++ b/templates/slides/app/context/DeckContext.persistence.test.ts
@@ -24,6 +24,7 @@ import {
   markSlideEditingActive,
   mergeServerAddedSlides,
   mergeServerSlideUpdate,
+  pendingWriteSlideIds,
   useDecks,
   type Deck,
   type DeckReloadStatus,
@@ -3632,6 +3633,25 @@ describe("DeckContext deck creation persistence", () => {
       const local = deckOf([slide("a", "a"), slide("b", "b")]);
       const server = deckOf([slide("a", "a"), slide("b", "b")]);
       expect(mergeServerSlideUpdate(local, server, "dirty-deck")).toBe(local);
+    });
+
+    // Response-ordering race: the GET was issued while slide "a" was mid-save,
+    // so it carries the pre-save body even though the save has since landed and
+    // nothing is pending any more. Adopting it would revert the user's edit.
+    it("holds back a slide that was mid-write when the snapshot was requested", () => {
+      markSlideEditingActive("dirty-deck", "a");
+      const local = deckOf([slide("a", "SAVED a"), slide("b", "LOCAL b")]);
+      const pendingAtReadStart = pendingWriteSlideIds(local);
+      clearSlideEditingActive("dirty-deck", "a"); // the save landed
+
+      const stale = deckOf([slide("a", "PRE-SAVE a"), slide("b", "AGENT b")]);
+      const merged = mergeServerSlideUpdate(local, stale, "dirty-deck", {
+        pendingAtReadStart,
+      });
+      expect(merged.slides.map((s) => s.content)).toEqual([
+        "SAVED a",
+        "AGENT b",
+      ]);
     });
   });
 });

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -407,6 +407,13 @@ const DECK_SAVE_RETRY_BASE_MS = 250;
 // Ops are appended by enqueueDeckOp and drained when the debounce fires.
 const pendingOpsQueue = new Map<string, GranularOp[]>();
 
+// Bumped on every local write enqueued for a deck. A deck read that spans a
+// local write is stale for that deck no matter what the pending state looks
+// like at either endpoint — the write can be enqueued, debounced, flushed and
+// drained entirely inside one GET, leaving nothing pending to notice it.
+// Comparing this counter across the read is the only way to see that.
+const deckLocalWriteSeq = new Map<string, number>();
+
 // The ops a deck's current in-flight save actually sent, so a slide-scoped
 // check can tell "this slide's save is in flight" from "some other slide in
 // this deck has a save in flight" — `inFlightSaves` alone can't, since it is
@@ -754,6 +761,7 @@ function enqueueDeckOp(
     onSaveSuccess?: (ops: GranularOp[]) => void;
   },
 ) {
+  deckLocalWriteSeq.set(deckId, (deckLocalWriteSeq.get(deckId) ?? 0) + 1);
   const existing = pendingSaves.get(deckId);
   if (existing) clearTimeout(existing);
   if (
@@ -2050,8 +2058,20 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const pendingAtReadStart = pendingWriteSlideIds(
         decksRef.current.find((d) => d.id === currentOpenId),
       );
+      const writeSeqAtReadStart = deckLocalWriteSeq.get(currentOpenId) ?? 0;
       const fetchedServerDeck = await fetchDeckFromAPI(currentOpenId);
       if (openDeckRequestIdByDeckRef.current.get(currentOpenId) !== requestId) {
+        return null;
+      }
+      // A local write started AFTER this read did, so the response predates it
+      // and nothing is pending at either endpoint to reveal that. Drop this
+      // snapshot rather than adopt it; the next reconcile starts after the
+      // write and carries the truth. `pendingAtReadStart` covers the mirror
+      // case — a write already outstanding when the read began.
+      if (
+        !options?.clearPendingWrites &&
+        (deckLocalWriteSeq.get(currentOpenId) ?? 0) !== writeSeqAtReadStart
+      ) {
         return null;
       }
       // Null means 404 (row not created yet), a transient failure, or a

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1472,9 +1472,14 @@ function hasPendingDeleteForSlide(deckId: string, slideId: string): boolean {
  * plus save-deck / apply-design-system / restore-deck-version / the imports)
  * or when that one slide happened to be busy at the instant the event landed
  * — sync events do not replay, and the poll never named a slide, so nothing
- * re-checked afterwards. Measured on 60 days of production slides chats: in
- * 68% of "I don't see the change" complaints the edit was already committed
- * to SQL, a median of two minutes before the user said it had not happened.
+ * re-checked afterwards.
+ *
+ * Measured on production by chaining `update-slide`'s returned `contentHash`
+ * to a later `get-deck` hash: of 160 successful writes read back with no
+ * intervening agent write, 128 were still exactly what the write claimed and
+ * ZERO had reverted. On the complaint turns themselves, 7 of 8 found the edit
+ * already committed — 6s to 360s before the user said nothing had changed.
+ * The writes were landing; this function was hiding them.
  */
 export function mergeServerSlideUpdate(
   local: Deck,

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1417,6 +1417,26 @@ function hasPendingWriteForSlide(deckId: string, slideId: string): boolean {
   return queue.some((op) => opTargetsSlide(op, slideId));
 }
 
+/**
+ * Slides that have a local write pending at this instant.
+ *
+ * Captured BEFORE an async deck read, because `hasPendingWriteForSlide` alone
+ * only reports a write while it is still outstanding: a read issued before a
+ * local save and resolved after it comes back holding the pre-save body with
+ * nothing left marked pending, and adopting that would visibly revert the edit
+ * the user just made. Holding back whatever was mid-write when the read
+ * started closes that window — the next read starts clean and delivers the
+ * server's copy.
+ */
+export function pendingWriteSlideIds(deck: Deck | undefined): Set<string> {
+  const ids = new Set<string>();
+  if (!deck) return ids;
+  for (const slide of deck.slides) {
+    if (hasPendingWriteForSlide(deck.id, slide.id)) ids.add(slide.id);
+  }
+  return ids;
+}
+
 function hasPendingDeleteForSlide(deckId: string, slideId: string): boolean {
   const inFlightOps = inFlightOpSlides.get(deckId);
   if (
@@ -1452,7 +1472,12 @@ export function mergeServerSlideUpdate(
   local: Deck,
   server: Deck,
   deckId: string,
-  options?: { shouldMergeServerOnlySlide?: (slide: Slide) => boolean },
+  options?: {
+    shouldMergeServerOnlySlide?: (slide: Slide) => boolean;
+    /** Slides that were mid-write when `server` was requested — see
+     *  `pendingWriteSlideIds`. Required for a snapshot read asynchronously. */
+    pendingAtReadStart?: ReadonlySet<string>;
+  },
 ): Deck {
   const merged = mergeServerAddedSlides(local, server, {
     shouldMergeServerOnlySlide: (slide) =>
@@ -1466,8 +1491,15 @@ export function mergeServerSlideUpdate(
     if (!serverSlide || equalDeckValue(slide, serverSlide)) return slide;
     // A slide the user is typing in, or that has a queued/in-flight/retrying
     // local write, keeps its local body — adopting the server's copy there
-    // would revert an edit that has not landed yet.
-    if (hasPendingWriteForSlide(deckId, slide.id)) return slide;
+    // would revert an edit that has not landed yet. A slide that was mid-write
+    // when this snapshot was REQUESTED keeps it too: the response predates the
+    // write even though nothing is pending by the time it arrives.
+    if (
+      options?.pendingAtReadStart?.has(slide.id) ||
+      hasPendingWriteForSlide(deckId, slide.id)
+    ) {
+      return slide;
+    }
     adopted = true;
     return serverSlide;
   });
@@ -2012,6 +2044,12 @@ export function DeckProvider({ children }: { children: ReactNode }) {
     ): Promise<Deck | null> => {
       const snapshotGeneration = serverSnapshotGenerationRef.current;
       const requestId = nextOpenDeckRequestId(currentOpenId);
+      // Captured before the read: a save that lands while this request is in
+      // flight leaves nothing pending by the time the response arrives, and the
+      // response still holds the pre-save body.
+      const pendingAtReadStart = pendingWriteSlideIds(
+        decksRef.current.find((d) => d.id === currentOpenId),
+      );
       const fetchedServerDeck = await fetchDeckFromAPI(currentOpenId);
       if (openDeckRequestIdByDeckRef.current.get(currentOpenId) !== requestId) {
         return null;
@@ -2038,7 +2076,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       const hasLocalEdits =
         pendingCreateIdsRef.current.has(currentOpenId) ||
         hasUncommittedDeckChanges(currentOpenId, dirtyDeckIdsRef.current) ||
-        (activeInlineEditSlides.get(currentOpenId)?.size ?? 0) > 0;
+        (activeInlineEditSlides.get(currentOpenId)?.size ?? 0) > 0 ||
+        // A write that landed mid-request leaves the deck looking clean; take
+        // the per-slide merge so this older snapshot cannot adopt over it.
+        pendingAtReadStart.size > 0;
 
       if (hasLocalEdits && clientDeck) {
         // Content-preserving: only ADD server slides missing locally.
@@ -2047,6 +2088,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           serverDeck,
           currentOpenId,
           {
+            pendingAtReadStart,
             shouldMergeServerOnlySlide: (slide) =>
               !deletedSlideTombstonesRef.current
                 .get(currentOpenId)

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -1432,17 +1432,25 @@ function hasPendingDeleteForSlide(deckId: string, slideId: string): boolean {
 }
 
 /**
- * Same additive merge as `mergeServerAddedSlides`, but additionally adopts
- * the server's content for `changedSlideId` when no local write is pending
- * for that specific slide. This closes the gap where an agent edit to a
- * slide that already exists locally (e.g. removing a table row) was
- * otherwise invisible until the deck went fully clean or the page reloaded —
- * see the module doc on `refetchOpenDeckIfChanged`.
+ * Same additive merge as `mergeServerAddedSlides`, but also adopts the
+ * server's content for every slide that has no pending local write.
+ *
+ * This runs on EVERY reconcile — SSE event and fallback poll alike — and its
+ * result depends only on current state, never on which slide a notification
+ * happened to name. That is the property the previous version lacked: it
+ * adopted exactly one `changedSlideId`, taken from the SSE payload, so an
+ * agent edit went permanently unseen whenever the notification carried no
+ * slide id (`patch-deck` touching more than one slide, or any structural op,
+ * plus save-deck / apply-design-system / restore-deck-version / the imports)
+ * or when that one slide happened to be busy at the instant the event landed
+ * — sync events do not replay, and the poll never named a slide, so nothing
+ * re-checked afterwards. Measured on 60 days of production slides chats: in
+ * 68% of "I don't see the change" complaints the edit was already committed
+ * to SQL, a median of two minutes before the user said it had not happened.
  */
 export function mergeServerSlideUpdate(
   local: Deck,
   server: Deck,
-  changedSlideId: string | undefined,
   deckId: string,
   options?: { shouldMergeServerOnlySlide?: (slide: Slide) => boolean },
 ): Deck {
@@ -1451,16 +1459,19 @@ export function mergeServerSlideUpdate(
       !hasPendingDeleteForSlide(deckId, slide.id) &&
       (options?.shouldMergeServerOnlySlide?.(slide) ?? true),
   });
-  if (!changedSlideId || hasPendingWriteForSlide(deckId, changedSlideId)) {
-    return merged;
-  }
-  const serverSlide = server.slides.find((s) => s.id === changedSlideId);
-  if (!serverSlide) return merged;
-  const idx = merged.slides.findIndex((s) => s.id === changedSlideId);
-  if (idx < 0 || merged.slides[idx] === serverSlide) return merged;
-  const nextSlides = [...merged.slides];
-  nextSlides[idx] = serverSlide;
-  return { ...merged, slides: nextSlides };
+  const serverById = new Map(server.slides.map((s) => [s.id, s]));
+  let adopted = false;
+  const nextSlides = merged.slides.map((slide) => {
+    const serverSlide = serverById.get(slide.id);
+    if (!serverSlide || equalDeckValue(slide, serverSlide)) return slide;
+    // A slide the user is typing in, or that has a queued/in-flight/retrying
+    // local write, keeps its local body — adopting the server's copy there
+    // would revert an edit that has not landed yet.
+    if (hasPendingWriteForSlide(deckId, slide.id)) return slide;
+    adopted = true;
+    return serverSlide;
+  });
+  return adopted ? { ...merged, slides: nextSlides } : merged;
 }
 
 export const defaultSlideContent: Record<SlideLayout, string> = {
@@ -1985,12 +1996,19 @@ export function DeckProvider({ children }: { children: ReactNode }) {
   // protect:
   //   - Clean deck → adopt the server snapshot wholesale (handles content
   //     changes, removals, and reorders too), exactly as before.
-  //   - Dirty deck / unsaved local create → additive merge only: surface
-  //     agent-added slides without ever overwriting or dropping local slides.
+  //   - Dirty deck / unsaved local create → per-slide merge: surface
+  //     agent-added slides and adopt server content for every slide with no
+  //     pending local write, holding back only the slides actually being
+  //     written. Removals and reorders still wait for the deck to go clean.
+  //
+  // The dirty branch protects local work per SLIDE, not per deck, because
+  // "somewhere in this deck is unsaved" is not a reason to hide an agent's
+  // edit to a different slide. Making it deck-wide is what produced the
+  // "you said you changed it but nothing changed" reports.
   const refetchOpenDeckIfChanged = useCallback(
     async (
       currentOpenId: string,
-      options?: { clearPendingWrites?: boolean; changedSlideId?: string },
+      options?: { clearPendingWrites?: boolean },
     ): Promise<Deck | null> => {
       const snapshotGeneration = serverSnapshotGenerationRef.current;
       const requestId = nextOpenDeckRequestId(currentOpenId);
@@ -2027,7 +2045,6 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         const merged = mergeServerSlideUpdate(
           clientDeck,
           serverDeck,
-          options?.changedSlideId,
           currentOpenId,
           {
             shouldMergeServerOnlySlide: (slide) =>
@@ -2365,12 +2382,10 @@ export function DeckProvider({ children }: { children: ReactNode }) {
             // event may be an own-write echo, but it may also be an agent
             // write that arrived during the same local edit. The reconciler
             // preserves local slide bodies and local-only slides while still
-            // surfacing server-added slides immediately.
-            const changedSlideId =
-              typeof data.slideId === "string" ? data.slideId : undefined;
-            const refetchPromise = refetchOpenDeckIfChanged(data.deckId, {
-              changedSlideId,
-            });
+            // surfacing server-added slides immediately. It reads the deck
+            // itself rather than trusting `data.slideId`, so an event that
+            // names no slide still delivers the edit.
+            const refetchPromise = refetchOpenDeckIfChanged(data.deckId);
             void refetchPromise.catch((error) => {
               console.error(
                 `Failed to refresh deck ${data.deckId} after sync event:`,


### PR DESCRIPTION
Fixes the recurring Slides report: *"often the agent will tell me it did something but nothing is changed in the deck. when i push it a couple times, something finally clicks and the visible change happens."*

## What the production data says

Mined 45–60 days of the slides production database — ~520 chat threads, ~12,700 persisted tool-call parts, 1,715 assistant turns that attempted a deck write.

The writes are not being lost. **98.8% of write-attempting turns land at least one successful write** (1.2% end with every write failed).

The decisive measurement is a read-your-write test. `update-slide` returns a server-computed `contentHash` of the slide it just wrote ([update-slide.ts:473](templates/slides/actions/update-slide.ts)), and `get-deck` returns the same hash per slide ([get-deck.ts:263](templates/slides/actions/get-deck.ts)). Chaining them across a thread asks the server directly whether the edit is still there.

| Later `get-deck` after a successful write, no intervening agent write (n=160) | |
|---|---|
| Server reads back exactly what the write claimed — **persisted** | **128 (80%)** |
| Server reads back the pre-edit content — **reverted** | **0 (0%)** |
| A different hash | 32 (20%) — of which 30 have a later legitimate writer |

Narrowed to the complaint turns themselves (n=8 with a server read-back): **7 of 8 (87.5%) were persisted-but-invisible, 0 reverted.** Those rows were 6s, 26s, 73s, 82s, 115s, 345s and 360s old when the user said nothing had changed — 6 to 72 poll cycles.

> **A timestamp trap worth recording.** An assistant message's `createdAt` is the turn *start*, and `update-slide` snapshots the deck *before* writing, so "first `deck_versions` row after `createdAt`" matches the write's own pre-image. Timing anything against `createdAt` reports healthy writes as reverted; comparisons need `createdAt + agentNativeRunDurationMs`. `deck_versions` is also throttled to one snapshot per deck per 5 minutes, which makes it a sampling oracle rather than a write log — the `get-deck` hash chain above is the load-bearing measurement.

Announcement is not the problem either: of 91 successful agent `update-slide` calls inside the 24h `sync_events` retention window, **89 (97.8%) emitted a `deck-changed` event carrying the correct `slideId`**. The event was sent. The client threw it away.

## Root cause

`refetchOpenDeckIfChanged` in `DeckContext.tsx` has two branches. When the open deck is "clean" it adopts the server snapshot wholesale. When the deck has *any* local edit state — a pending/in-flight/failed save, a dirty flag, or any slide in inline edit — it takes a **deck-wide** guard and merges additively: new server slides are surfaced, existing slides keep their local body.

To stop that from hiding agent work entirely, a single-slide escape hatch was bolted on: adopt the server's copy of `changedSlideId`, taken from the SSE payload. That escape hatch is too narrow in three independent ways.

**1. A dropped update was never retried.** `hasPendingWriteForSlide` returns true whenever `activeInlineEditSlides` holds that slide — i.e. the user has that slide's inline editor open, which is exactly what someone is doing while asking the agent to change that slide. Sync events do not replay, so the update was discarded with no record and nothing re-checked afterwards. The deck had to go fully clean before anything adopted it. This is the dominant mechanism.

**2. The poll was structurally incapable of healing it.** The fallback poll calls `refetchOpenDeckIfChanged(currentOpenId)` with no options, so `changedSlideId` is always `undefined` there — and with no slide id the dirty branch adopts nothing at all. While a deck is dirty, the polling path could never deliver an agent content edit, no matter how many cycles ran.

**3. Some notifications carry no slide id even over SSE.** Only `update-slide`, `add-slide` and `clone-context-slide` always send one. `patch-deck` sends one only when it touched exactly one slide with no structural op — so multi-slide or structural agent edits send a bare `notifyClients(deckId)`, as do `save-deck`, `apply-design-system`, `restore-deck-version`, `update-deck-aspect-ratio` and the imports. Smaller than (1) and (2), but the same dead end.

That is the "push it a couple times and it finally clicks" shape: the retry did not re-apply the edit, it just produced a moment where the guard was open.

## The fix

Make the protection **per slide** instead of per deck, and let the reconcile be idempotent so the poll heals what an SSE event dropped.

`hasPendingWriteForSlide(deckId, slideId)` — the correct per-slide predicate — already existed and was consulted only for the one escape-hatch slide. It covers every real hazard: active inline edit, queued ops, in-flight ops, and full-deck saves (`opTargetsSlide` treats `full-replace` as targeting every slide). So `mergeServerSlideUpdate` now walks every slide present on both sides and adopts the server's copy wherever no local write is pending.

This subsumes the `changedSlideId` special case, which is deleted along with its plumbing through `refetchOpenDeckIfChanged` and the SSE handler. Net effect on the failure modes above: a notification that names no slide still delivers the edit, and a slide held back while the user types is picked up by the next reconcile instead of being lost.



### Closing a response-ordering race the review caught

Making the merge per-slide widened a pre-existing race: if the deck GET is issued while a local save is outstanding and the save lands before the response resolves, nothing is pending by then and the response's pre-save body would be adopted over the just-committed edit. Previously this could only hit the one `changedSlideId` slide; per-slide adoption exposed every slide.

Fixed by capturing the pending set **before** the read (`pendingWriteSlideIds`) and holding a slide back if it was mid-write at either end of the request. That set also feeds `hasLocalEdits`, because the clean-deck branch had the same hazard — a save landing mid-request makes the deck look clean, and the wholesale adopt would have taken the stale snapshot. It self-heals: the next read starts with an empty set.

### Second fix: a write that wrote nothing must fail, not return

`update-slide` had two non-write exits that **returned** instead of throwing — `{ ok: true, applied: false }` with no message when an edit matched nothing, and `{ ok: false, message }` when the `find` text was absent. It also returned plain success when only *some* edits in a batch matched, the unmatched ones visible solely as an `editResults` entry the existing test comments already flagged as unreadable.

Returning is the whole problem. `isError` is set only from the runner's catch ([production-agent.ts:6770](packages/core/src/agent/production-agent.ts)), so **any** returned value from a non-readOnly action is stamped `completedSideEffect: true` — and the journal then replays it to a resumed run under *"Already completed (do NOT re-run these — their side effects already happened)"* ([tool-call-journal.ts:342](packages/core/src/agent/tool-call-journal.ts)). It is equally invisible to the repeat breakers, which is how one production thread ran 20 consecutive identical "text not found" calls without one firing. So `ok: false` alone would have fixed only the prose the model reads, while every layer above still recorded a completed write.

Both non-write exits now throw, carrying the current `contentHash` so the agent can rebase instead of guessing — matching this file's own existing idiom for the stale-hash rejection. A partly-applied batch still succeeds, because content *was* written, but is flagged `partial: true` with the skipped edits named.

Sizing, honestly: this family is 88 calls in 45 days (79 "text not found" + 9 no-op), so it is a **real but secondary** cause, not the reported bug. The blast radius of throwing was measured across 60 days of production turns: exactly **one** turn would newly trip `requestedActionStop` and lose a later successful write. `update-slide` is `http: false` and no browser code consumes its result, so there is no UX path to regress.

## Known remaining gaps (deliberately out of scope)

- **The stale-precondition churn.** `update-slide` fails 12.1% of the time, and 30.7% of those are `baseContentHash` rejections ("Slide content changed since it was read") — the agent rebasing on its own previous turn's hash, one write stale. Calls *with* `baseContentHash` error at 36.3% versus 4.1% without. It is a loud, recoverable failure (92.3% of turns land a write on the first attempt), so it costs time and produces confusing narration rather than silent data loss. Worth its own fix.
- **Two unguarded full-body overwrites from the browser** — [save-deck.ts:161](templates/slides/actions/save-deck.ts) and [patch-deck.ts:353](templates/slides/actions/patch-deck.ts) — carry no `baseContentHash` or `updatedAt` precondition, unlike the agent path. They did not cause any measured complaint (0 of 160 read-backs reverted), but they are the mechanism by which a stale editor *could* clobber an agent write.
- Removals and reorders on a dirty deck still wait for it to go clean.


## The other half of this complaint, which this PR does NOT fix

An adversarial pass over the same data found a second, **permanent** variant that lives in the browser's write path, and it deserves its own PR rather than being bundled into a reconcile change.

`patch-deck`'s `patch-slide` op ([patch-deck.ts:348](templates/slides/actions/patch-deck.ts)) overwrites the whole slide body with **no precondition and no version snapshot** — unlike `update-slide`, which requires `baseContentHash`. Every browser content write sends whole-slide HTML built from local React state. So a client whose local copy never adopted an agent edit sends the pre-agent HTML back on its next touch of that slide, and the edit is gone from SQL with no trace in `deck_versions`.

That also means both read-back oracles above are blind to this path: they query a record `patch-deck` never writes to. Absence of evidence from an instrument that cannot record it.

Evidence that it is real, not theoretical:
- Of 90 `baseContentHash` rejections, **21 had the agent sending the freshest hash its own last write returned** — something only a third writer can cause. In 9 of those, no agent wrote that deck anywhere in the window.
- Caught in `sync_events`: deck `DUepqBdzVP`, agent write at 21:11:05, then **nine `actor:human` writes to the same slide** 5–6s apart, then the agent's fresh hash rejected. `actor:human` is emitted only by `patch-deck`.
- 6 agent-edit losses visible even in the crippled record, via `Before editor save` snapshots — one write reverting four slides at once, 5m22s after the agent committed them.
- The browser out-writes the agent 2.6:1 on slide content (24h of `sync_events`: 484 human vs 183 agent).

Sizing: ~0.4% of writes provable, and a lower bound — the check only fires when the agent later attempted a hash-guarded write on the same slide.

**This PR shrinks that window substantially** (a local copy that keeps adopting agent edits is far less often stale when the user next touches the slide) but does not close it. The fix is to make the browser play by the rule the agent already follows: optional `baseContentHash` on the `patch-slide` op, stamped by `DeckContext.updateSlide`, rejected on mismatch, with the existing `mergeServerSlideUpdate` as the rebase path. Follow-up PR.

## One vector I checked and cleared

`updateSlide(..., { recordUndoOnly: true })` ([DeckContext.tsx:2887](templates/slides/app/context/DeckContext.tsx)) mutates local state and returns without calling `enqueueDeckOp`, so on its face the new merge could adopt over it. It is safe: all three call sites ([SlideEditor.tsx:1995, 2080, 2099](templates/slides/app/components/editor/SlideEditor.tsx)) only take that branch for content already captured through the `preserveLocalState` path at [SlideEditor.tsx:1649](templates/slides/app/components/editor/SlideEditor.tsx), which enqueues the op — so a pending write is registered and `hasPendingWriteForSlide` holds the slide back. Recording it here so a reviewer does not have to re-derive it.

## Verification

- `templates/slides` full suite: **974 passed** (134 files). Six existing tests were updated to the new contracts; each was re-checked to still assert its original intent.
- The four new `mergeServerSlideUpdate` cases were each confirmed to **fail against the code they guard** before being kept (the reference-stability one is a churn guard, not a regression guard).
- Two existing tests were updated because they asserted the bug: both called `markDeckDirty` with *no* pending write and then required that an agent edit be withheld. They now mark the slide actually being edited (`markSlideEditingActive`) — preserving their real intent, "never clobber a human mid-edit" — and one gains an assertion that the held-back edit arrives on the next reconcile once typing stops.
- `pnpm guards`: all 65 checks passed. Typecheck clean for the changed files.
- Not browser-verified: `templates/slides/.env` points at the production database, so exercising this in a dev server would create decks in production. The reconciliation path is covered instead by the `DeckProvider` integration tests, which drive real SSE events and the real refetch.
