### PR TITLE
fix(core): wait for lazy MCP app initialization

### DIFF
--- a/.changeset/lazy-app-mcp-init.md
+++ b/.changeset/lazy-app-mcp-init.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Wait for lazy MCP initialization before app-visible MCP actions read the shared manager.

--- a/packages/core/src/mcp-client/app-api.spec.ts
+++ b/packages/core/src/mcp-client/app-api.spec.ts
@@ -73,6 +73,29 @@ describe("MCP app API", () => {
     expect(result[0]).not.toHaveProperty("config");
   });
 
+  it("waits for lazy MCP initialization before reading app tools", async () => {
+    let initialized = false;
+    const lazyManager = {
+      getTools: () => (initialized ? tools : []),
+      getToolsForServer: (serverId: string) =>
+        initialized
+          ? tools.filter((tool: any) => tool.source === serverId)
+          : [],
+      callTool,
+    };
+    setGlobalMcpManager(lazyManager as any, async () => {
+      initialized = true;
+    });
+
+    await runWithRequestContext(
+      { userEmail: "alice@example.com", orgId: "acme" },
+      async () => {
+        await expect(listVisibleMcpTools()).resolves.toHaveLength(1);
+        expect(initialized).toBe(true);
+      },
+    );
+  });
+
   it("fails closed when an org-scoped request has no active org", async () => {
     await expect(
       runWithRequestContext({ userEmail: "alice@example.com" }, () =>

--- a/packages/core/src/mcp-client/app-api.ts
+++ b/packages/core/src/mcp-client/app-api.ts
@@ -1,6 +1,6 @@
 import { isToolVisibilityModelOnly } from "@modelcontextprotocol/ext-apps/app-bridge";
 
-import { getGlobalMcpManager } from "../server/agent-chat/mcp-glue.js";
+import { waitForGlobalMcpManager } from "../server/agent-chat/mcp-glue.js";
 import { getRequestContext } from "../server/request-context.js";
 import {
   buildMcpToolName,
@@ -48,7 +48,7 @@ export async function listVisibleMcpTools(
   options: ListVisibleMcpToolsOptions = {},
 ): Promise<AppMcpTool[]> {
   const context = requireAuthenticatedRequest();
-  const manager = requireMcpManager();
+  const manager = await requireMcpManager();
   const tools = options.serverId
     ? manager.getToolsForServer(options.serverId)
     : manager.getTools();
@@ -69,7 +69,7 @@ export async function callMcpTool(
   args: Record<string, unknown> = {},
 ): Promise<unknown> {
   const context = requireAuthenticatedRequest();
-  const manager = requireMcpManager();
+  const manager = await requireMcpManager();
   const tool = manager
     .getToolsForServer(serverId)
     .find((candidate) => candidate.originalName === originalToolName);
@@ -92,8 +92,8 @@ function requireAuthenticatedRequest() {
   return context;
 }
 
-function requireMcpManager(): McpClientManager {
-  const manager = getGlobalMcpManager();
+async function requireMcpManager(): Promise<McpClientManager> {
+  const manager = await waitForGlobalMcpManager();
   if (!manager) {
     throw new McpAppApiError("MCP client is not configured.", 503);
   }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -750,7 +750,6 @@ export function createAgentChatPlugin(
       // manager, then hydrate it after every live action registry has subscribed
       // to manager changes.
       const mcpManager = new McpClientManager(null);
-      setGlobalMcpManager(mcpManager);
       const mcpActionEntries: Record<string, ActionEntry> = {};
       let mcpInitializationPromise: Promise<void> | null = null;
       const initializeMcpManager = async (): Promise<void> => {
@@ -786,6 +785,7 @@ export function createAgentChatPlugin(
         }
         return mcpInitializationPromise;
       };
+      setGlobalMcpManager(mcpManager, ensureMcpInitialized);
       const getJobMcpActionEntries = async (
         job?: RecurringJobContext,
       ): Promise<Record<string, ActionEntry>> => {

--- a/packages/core/src/server/agent-chat/mcp-glue.spec.ts
+++ b/packages/core/src/server/agent-chat/mcp-glue.spec.ts
@@ -24,7 +24,11 @@ vi.mock("../framework-request-handler.js", () => ({
   getH3App: (app: { h3: unknown }) => app.h3,
 }));
 
-import { refreshGlobalMcpManager, setGlobalMcpManager } from "./mcp-glue.js";
+import {
+  refreshGlobalMcpManager,
+  setGlobalMcpManager,
+  waitForGlobalMcpManager,
+} from "./mcp-glue.js";
 
 describe("refreshGlobalMcpManager", () => {
   beforeEach(() => {
@@ -51,5 +55,66 @@ describe("refreshGlobalMcpManager", () => {
 
     await expect(refreshGlobalMcpManager()).resolves.toBe(true);
     expect(manager.reconfigure).toHaveBeenCalledWith(config);
+  });
+
+  it("waits for lazy initialization before refreshing", async () => {
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const manager = { reconfigure: vi.fn().mockResolvedValue(undefined) };
+    const config = { source: "settings", servers: {} };
+    setGlobalMcpManager(manager as never, () => ready);
+    mockedMcp.buildMergedConfig.mockResolvedValue(config);
+
+    const refresh = refreshGlobalMcpManager();
+    await Promise.resolve();
+    expect(mockedMcp.buildMergedConfig).not.toHaveBeenCalled();
+
+    releaseReady();
+    await expect(refresh).resolves.toBe(true);
+    expect(manager.reconfigure).toHaveBeenCalledWith(config);
+  });
+
+  it("serializes concurrent refresh snapshots", async () => {
+    let releaseFirst!: () => void;
+    const firstConfig = new Promise((resolve) => {
+      releaseFirst = () => resolve({ source: "first", servers: {} });
+    });
+    const secondConfig = { source: "second", servers: {} };
+    const manager = { reconfigure: vi.fn().mockResolvedValue(undefined) };
+    setGlobalMcpManager(manager as never);
+    mockedMcp.buildMergedConfig
+      .mockReturnValueOnce(firstConfig)
+      .mockResolvedValueOnce(secondConfig);
+
+    const first = refreshGlobalMcpManager();
+    await Promise.resolve();
+    const second = refreshGlobalMcpManager();
+    await Promise.resolve();
+    expect(mockedMcp.buildMergedConfig).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(manager.reconfigure.mock.calls).toEqual([
+      [{ source: "first", servers: {} }],
+      [secondConfig],
+    ]);
+  });
+
+  it("returns the current manager after readiness completes", async () => {
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const initialManager = {};
+    const currentManager = {};
+    setGlobalMcpManager(initialManager as never, () => ready);
+
+    const waiting = waitForGlobalMcpManager();
+    setGlobalMcpManager(currentManager as never);
+    releaseReady();
+
+    await expect(waiting).resolves.toBe(currentManager);
   });
 });

--- a/packages/core/src/server/agent-chat/mcp-glue.spec.ts
+++ b/packages/core/src/server/agent-chat/mcp-glue.spec.ts
@@ -117,4 +117,65 @@ describe("refreshGlobalMcpManager", () => {
 
     await expect(waiting).resolves.toBe(currentManager);
   });
+
+  it("waits for the replacement manager's readiness", async () => {
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const initialManager = {};
+    const currentManager = {};
+    setGlobalMcpManager(initialManager as never, () => Promise.resolve());
+
+    const waiting = waitForGlobalMcpManager();
+    setGlobalMcpManager(currentManager as never, () => ready);
+    await Promise.resolve();
+    let settled = false;
+    void waiting.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseReady();
+    await expect(waiting).resolves.toBe(currentManager);
+  });
+
+  it("does not refresh a replacement manager with stale state", async () => {
+    let releaseInitialReady!: () => void;
+    const initialReady = new Promise<void>((resolve) => {
+      releaseInitialReady = resolve;
+    });
+    let releaseCurrentReady!: () => void;
+    const currentReady = new Promise<void>((resolve) => {
+      releaseCurrentReady = resolve;
+    });
+    const initialManager = { reconfigure: vi.fn() };
+    const currentManager = { reconfigure: vi.fn() };
+    setGlobalMcpManager(initialManager as never, () => initialReady);
+
+    const initialRefresh = refreshGlobalMcpManager();
+    await Promise.resolve();
+    setGlobalMcpManager(currentManager as never, () => currentReady);
+    releaseInitialReady();
+    await expect(initialRefresh).resolves.toBe(false);
+    expect(mockedMcp.buildMergedConfig).not.toHaveBeenCalled();
+    expect(initialManager.reconfigure).not.toHaveBeenCalled();
+    expect(currentManager.reconfigure).not.toHaveBeenCalled();
+
+    mockedMcp.buildMergedConfig.mockResolvedValue({
+      source: "current",
+      servers: {},
+    });
+    const currentRefresh = refreshGlobalMcpManager();
+    await Promise.resolve();
+    expect(mockedMcp.buildMergedConfig).not.toHaveBeenCalled();
+
+    releaseCurrentReady();
+    await expect(currentRefresh).resolves.toBe(true);
+    expect(currentManager.reconfigure).toHaveBeenCalledWith({
+      source: "current",
+      servers: {},
+    });
+  });
 });

--- a/packages/core/src/server/agent-chat/mcp-glue.ts
+++ b/packages/core/src/server/agent-chat/mcp-glue.ts
@@ -20,15 +20,24 @@ import { getH3App } from "../framework-request-handler.js";
 
 let _globalMcpManager: McpClientManager | null = null;
 let _globalMcpManagerReady: (() => Promise<void>) | null = null;
+let _globalMcpManagerGeneration = 0;
+let _resolveGlobalMcpManagerChange: (() => void) | null = null;
+let _globalMcpManagerChange = new Promise<void>((resolve) => {
+  _resolveGlobalMcpManagerChange = resolve;
+});
 let _globalMcpRefreshQueue: Promise<void> = Promise.resolve();
 
 export function setGlobalMcpManager(
   manager: McpClientManager | null,
   ready?: (() => Promise<void>) | null,
 ): void {
+  _globalMcpManagerGeneration += 1;
+  _resolveGlobalMcpManagerChange?.();
+  _globalMcpManagerChange = new Promise<void>((resolve) => {
+    _resolveGlobalMcpManagerChange = resolve;
+  });
   _globalMcpManager = manager;
   _globalMcpManagerReady = manager ? (ready ?? null) : null;
-  _globalMcpRefreshQueue = Promise.resolve();
 }
 
 /** Internal: access the current process's MCP client manager, if any. */
@@ -38,9 +47,21 @@ export function getGlobalMcpManager(): McpClientManager | null {
 
 /** Wait for lazy serverless MCP hydration before an app-visible call. */
 export async function waitForGlobalMcpManager(): Promise<McpClientManager | null> {
-  const manager = getGlobalMcpManager();
-  if (manager) await _globalMcpManagerReady?.();
-  return getGlobalMcpManager();
+  while (true) {
+    const manager = getGlobalMcpManager();
+    if (!manager) return null;
+    const generation = _globalMcpManagerGeneration;
+    const ready = _globalMcpManagerReady;
+    const change = _globalMcpManagerChange;
+    if (ready) await Promise.race([ready(), change]);
+    if (
+      generation === _globalMcpManagerGeneration &&
+      manager === _globalMcpManager &&
+      ready === _globalMcpManagerReady
+    ) {
+      return manager;
+    }
+  }
 }
 
 /** Internal: reload the process's MCP client manager after persisted settings change. */
@@ -48,11 +69,27 @@ export async function refreshGlobalMcpManager(): Promise<boolean> {
   const refresh = _globalMcpRefreshQueue.then(async () => {
     const manager = getGlobalMcpManager();
     if (!manager) return false;
+    const generation = _globalMcpManagerGeneration;
+    const ready = _globalMcpManagerReady;
+    const change = _globalMcpManagerChange;
     try {
-      await _globalMcpManagerReady?.();
-      const currentManager = getGlobalMcpManager();
-      if (!currentManager) return false;
-      await currentManager.reconfigure(await buildMergedConfig());
+      if (ready) await Promise.race([ready(), change]);
+      if (
+        generation !== _globalMcpManagerGeneration ||
+        manager !== _globalMcpManager ||
+        ready !== _globalMcpManagerReady
+      ) {
+        return false;
+      }
+      const config = await buildMergedConfig();
+      if (
+        generation !== _globalMcpManagerGeneration ||
+        manager !== _globalMcpManager ||
+        ready !== _globalMcpManagerReady
+      ) {
+        return false;
+      }
+      await manager.reconfigure(config);
       return true;
     } catch (err) {
       if (err instanceof McpConfigUnreadableError) {

--- a/packages/core/src/server/agent-chat/mcp-glue.ts
+++ b/packages/core/src/server/agent-chat/mcp-glue.ts
@@ -19,14 +19,26 @@ import { getH3App } from "../framework-request-handler.js";
 // ---------------------------------------------------------------------------
 
 let _globalMcpManager: McpClientManager | null = null;
+let _globalMcpManagerReady: (() => Promise<void>) | null = null;
 
-export function setGlobalMcpManager(manager: McpClientManager): void {
+export function setGlobalMcpManager(
+  manager: McpClientManager | null,
+  ready?: (() => Promise<void>) | null,
+): void {
   _globalMcpManager = manager;
+  _globalMcpManagerReady = manager ? (ready ?? null) : null;
 }
 
 /** Internal: access the current process's MCP client manager, if any. */
 export function getGlobalMcpManager(): McpClientManager | null {
   return _globalMcpManager;
+}
+
+/** Wait for lazy serverless MCP hydration before an app-visible call. */
+export async function waitForGlobalMcpManager(): Promise<McpClientManager | null> {
+  const manager = getGlobalMcpManager();
+  if (manager) await _globalMcpManagerReady?.();
+  return manager;
 }
 
 /** Internal: reload the process's MCP client manager after persisted settings change. */

--- a/packages/core/src/server/agent-chat/mcp-glue.ts
+++ b/packages/core/src/server/agent-chat/mcp-glue.ts
@@ -20,6 +20,7 @@ import { getH3App } from "../framework-request-handler.js";
 
 let _globalMcpManager: McpClientManager | null = null;
 let _globalMcpManagerReady: (() => Promise<void>) | null = null;
+let _globalMcpRefreshQueue: Promise<void> = Promise.resolve();
 
 export function setGlobalMcpManager(
   manager: McpClientManager | null,
@@ -27,6 +28,7 @@ export function setGlobalMcpManager(
 ): void {
   _globalMcpManager = manager;
   _globalMcpManagerReady = manager ? (ready ?? null) : null;
+  _globalMcpRefreshQueue = Promise.resolve();
 }
 
 /** Internal: access the current process's MCP client manager, if any. */
@@ -38,23 +40,33 @@ export function getGlobalMcpManager(): McpClientManager | null {
 export async function waitForGlobalMcpManager(): Promise<McpClientManager | null> {
   const manager = getGlobalMcpManager();
   if (manager) await _globalMcpManagerReady?.();
-  return manager;
+  return getGlobalMcpManager();
 }
 
 /** Internal: reload the process's MCP client manager after persisted settings change. */
 export async function refreshGlobalMcpManager(): Promise<boolean> {
-  const manager = getGlobalMcpManager();
-  if (!manager) return false;
-  try {
-    await manager.reconfigure(await buildMergedConfig());
-    return true;
-  } catch (err) {
-    if (err instanceof McpConfigUnreadableError) {
-      console.warn(`[mcp-client] global refresh skipped: ${err.message}`);
-      return false;
+  const refresh = _globalMcpRefreshQueue.then(async () => {
+    const manager = getGlobalMcpManager();
+    if (!manager) return false;
+    try {
+      await _globalMcpManagerReady?.();
+      const currentManager = getGlobalMcpManager();
+      if (!currentManager) return false;
+      await currentManager.reconfigure(await buildMergedConfig());
+      return true;
+    } catch (err) {
+      if (err instanceof McpConfigUnreadableError) {
+        console.warn(`[mcp-client] global refresh skipped: ${err.message}`);
+        return false;
+      }
+      throw err;
     }
-    throw err;
-  }
+  });
+  _globalMcpRefreshQueue = refresh.then(
+    () => undefined,
+    () => undefined,
+  );
+  return refresh;
 }
 
 export function mountMcpHubStatusRoute(nitroApp: any): void {


### PR DESCRIPTION
## Summary

- wait for the existing lazy MCP initializer before app-visible MCP actions read the shared manager
- cover cold-start tool listing with a focused regression test

Reported in [Dispatch Slack feedback](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787861444674429).

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/mcp-client/app-api.spec.ts src/server/agent-chat/mcp-glue.spec.ts`
- `corepack pnpm --filter @agent-native/core exec vitest --run src/server/agent-chat-plugin-startup.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`