### PR TITLE
Require persisted Design output before completion

### DIFF
--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -54,6 +54,16 @@ describe("Design final response guard", () => {
     expect(looksLikeDesignMutationRequest("move this card")).toBe(true);
     expect(looksLikeDesignMutationRequest("replace the hero image")).toBe(true);
     expect(looksLikeDesignMutationRequest("make it darker")).toBe(true);
+    expect(looksLikeDesignMutationRequest("fix the broken button")).toBe(true);
+    expect(looksLikeDesignMutationRequest("improve the spacing")).toBe(true);
+    expect(looksLikeDesignMutationRequest("polish this screen")).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("change the background to blue"),
+    ).toBe(true);
+    expect(looksLikeDesignMutationRequest("increase the padding")).toBe(true);
+    expect(looksLikeDesignMutationRequest("update the color palette")).toBe(
+      true,
+    );
   });
 
   it("retries prose-only completion for a design mutation", () => {
@@ -119,6 +129,8 @@ describe("Design final response guard", () => {
           appliedTweaks: { "theme-accent": "#0EA5E9" },
         }),
       ],
+      [toolResult("create-design-system", { id: "design-system-1" })],
+      [toolResult("update-file", { id: "file-1", updated: true })],
       [
         toolResult("import-figma-frame", {
           designId: "design-1",
@@ -155,6 +167,30 @@ describe("Design final response guard", () => {
     );
 
     expect(result).not.toBeNull();
+  });
+
+  it("does not accept empty tweaks or a stale mirrored file update", () => {
+    for (const toolResults of [
+      [
+        toolResult("apply-tweaks", {
+          designId: "design-1",
+          appliedTweaks: {},
+        }),
+      ],
+      [
+        toolResult("update-file", {
+          id: "file-1",
+          updated: true,
+          skippedStaleMirror: true,
+        }),
+      ],
+    ]) {
+      expect(
+        designFinalResponseGuard(
+          guardContext("make it darker", { toolResults }),
+        ),
+      ).not.toBeNull();
+    }
   });
 
   it("does not accept a failed mutation result", () => {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -1,0 +1,137 @@
+import type { AgentLoopFinalResponseGuardContext } from "@agent-native/core/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  designFinalResponseGuard,
+  looksLikeDesignMutationRequest,
+} from "./design-response-guard.js";
+
+function guardContext(
+  requestText: string,
+  overrides: Partial<AgentLoopFinalResponseGuardContext> = {},
+): AgentLoopFinalResponseGuardContext {
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: requestText }],
+      },
+    ],
+    requestText,
+    assistantContent: [],
+    text: "Done.",
+    toolCalls: [],
+    toolResults: [],
+    retryCount: 0,
+    executionMode: "act",
+    ...overrides,
+  };
+}
+
+function toolResult(
+  name: string,
+  value: Record<string, unknown>,
+  isError = false,
+): AgentLoopFinalResponseGuardContext["toolResults"][number] {
+  return { name, content: JSON.stringify(value), isError };
+}
+
+describe("Design final response guard", () => {
+  it("recognizes design mutations while excluding how-to and preview requests", () => {
+    expect(
+      looksLikeDesignMutationRequest("can you create another version of this"),
+    ).toBe(true);
+    expect(looksLikeDesignMutationRequest("how do I create a design?")).toBe(
+      false,
+    );
+    expect(
+      looksLikeDesignMutationRequest(
+        "[Reprompt selection] make the card darker",
+      ),
+    ).toBe(false);
+  });
+
+  it("retries prose-only completion for a design mutation", () => {
+    const result = designFinalResponseGuard(
+      guardContext("can you create another version of this"),
+    );
+
+    expect(result).toMatchObject({
+      maxRetries: 1,
+      expandToolSurface: true,
+      retryMessage: expect.stringContaining("generate-design"),
+    });
+  });
+
+  it("does not accept the empty project shell as a completed design", () => {
+    const result = designFinalResponseGuard(
+      guardContext("create a new design", {
+        toolResults: [
+          toolResult("create-design", {
+            id: "design-1",
+            renderable: false,
+          }),
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  it("accepts persisted generation, edit, and asset placement proof", () => {
+    for (const toolResults of [
+      [
+        toolResult("generate-design", {
+          designId: "design-1",
+          renderable: true,
+          savedFiles: [{ id: "file-1", filename: "index.html" }],
+        }),
+      ],
+      [toolResult("edit-design", { fileId: "file-1", changed: true })],
+      [toolResult("insert-asset", { fileId: "file-1", inserted: true })],
+      [
+        toolResult("import-figma-frame", {
+          designId: "design-1",
+          files: [{ id: "file-1", filename: "screen.html" }],
+        }),
+      ],
+      [
+        toolResult("create-component", {
+          designId: "design-1",
+          persisted: true,
+        }),
+      ],
+    ]) {
+      expect(
+        designFinalResponseGuard(
+          guardContext("create another version of this", { toolResults }),
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("does not accept a failed mutation result", () => {
+    const result = designFinalResponseGuard(
+      guardContext("create another version of this", {
+        toolResults: [
+          toolResult("generate-design", { renderable: true }, true),
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  it("does not guard read-only or plan turns", () => {
+    expect(
+      designFinalResponseGuard(guardContext("what is a design system?")),
+    ).toBeNull();
+    expect(
+      designFinalResponseGuard(
+        guardContext("create another version of this", {
+          executionMode: "plan",
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -49,6 +49,11 @@ describe("Design final response guard", () => {
         "[Reprompt selection] make the card darker",
       ),
     ).toBe(false);
+    expect(looksLikeDesignMutationRequest("delete this screen")).toBe(true);
+    expect(looksLikeDesignMutationRequest("remove this button")).toBe(true);
+    expect(looksLikeDesignMutationRequest("move this card")).toBe(true);
+    expect(looksLikeDesignMutationRequest("replace the hero image")).toBe(true);
+    expect(looksLikeDesignMutationRequest("make it darker")).toBe(true);
   });
 
   it("retries prose-only completion for a design mutation", () => {
@@ -89,6 +94,31 @@ describe("Design final response guard", () => {
       ],
       [toolResult("edit-design", { fileId: "file-1", changed: true })],
       [toolResult("insert-asset", { fileId: "file-1", inserted: true })],
+      [toolResult("apply-a11y-fix", { designId: "design-1", applied: true })],
+      [
+        toolResult("apply-component-prop-edit", {
+          designId: "design-1",
+          persisted: true,
+        }),
+      ],
+      [
+        toolResult("apply-source-edit", {
+          designId: "design-1",
+          changed: true,
+        }),
+      ],
+      [
+        toolResult("apply-visual-edit", {
+          designId: "design-1",
+          persisted: true,
+        }),
+      ],
+      [
+        toolResult("apply-tweaks", {
+          designId: "design-1",
+          appliedTweaks: { "theme-accent": "#0EA5E9" },
+        }),
+      ],
       [
         toolResult("import-figma-frame", {
           designId: "design-1",
@@ -108,6 +138,23 @@ describe("Design final response guard", () => {
         ),
       ).toBeNull();
     }
+  });
+
+  it("does not accept a partial generation", () => {
+    const result = designFinalResponseGuard(
+      guardContext("create another version of this", {
+        toolResults: [
+          toolResult("generate-design", {
+            designId: "design-1",
+            renderable: true,
+            savedFiles: [{ id: "file-1", filename: "index.html" }],
+            fileErrors: [{ filename: "styles.css", error: "conflict" }],
+          }),
+        ],
+      }),
+    );
+
+    expect(result).not.toBeNull();
   });
 
   it("does not accept a failed mutation result", () => {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -4,7 +4,11 @@ import type {
 } from "@agent-native/core/server";
 
 const DESIGN_MUTATION_ACTIONS = new Set([
+  "apply-a11y-fix",
+  "apply-component-prop-edit",
+  "apply-source-edit",
   "apply-tweaks",
+  "apply-visual-edit",
   "create-design",
   "create-design-from-template",
   "create-component",
@@ -25,9 +29,9 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 ]);
 
 const DESIGN_MUTATION_VERBS =
-  /\b(?:add|build|change|create|design|duplicate|edit|generate|import|insert|make|modify|place|refine|update)\b/i;
+  /\b(?:add|apply|build|change|create|delete|design|duplicate|edit|generate|import|insert|make|modify|move|place|refine|remove|replace|resize|update)\b/i;
 const DESIGN_MUTATION_OBJECTS =
-  /\b(?:asset|button|canvas|component|design|file|hero|image|layout|mockup|page|prototype|screen|this|variant|version|wireframe)\b/i;
+  /\b(?:asset|button|canvas|card|component|design|file|hero|image|it|layout|mockup|page|prototype|screen|this|variant|version|wireframe)\b/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -71,6 +75,14 @@ function nonEmptyArray(value: unknown): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function hasNoFileErrors(value: unknown): boolean {
+  return value === undefined || (Array.isArray(value) && value.length === 0);
+}
+
 function hasSuccessfulMutation(
   toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
 ): boolean {
@@ -88,7 +100,11 @@ function hasSuccessfulMutation(
     if (name === "create-design") return false;
 
     if (name === "generate-design") {
-      return parsed.renderable === true && nonEmptyArray(parsed.savedFiles);
+      return (
+        parsed.renderable === true &&
+        nonEmptyArray(parsed.savedFiles) &&
+        hasNoFileErrors(parsed.fileErrors)
+      );
     }
 
     if (name === "present-design-variants") {
@@ -102,6 +118,12 @@ function hasSuccessfulMutation(
     }
 
     if (name === "edit-design") return parsed.changed === true;
+
+    if (name === "apply-tweaks") {
+      return (
+        typeof parsed.designId === "string" && isRecord(parsed.appliedTweaks)
+      );
+    }
 
     if (name === "create-file") {
       return (

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -11,6 +11,7 @@ const DESIGN_MUTATION_ACTIONS = new Set([
   "apply-visual-edit",
   "create-design",
   "create-design-from-template",
+  "create-design-system",
   "create-component",
   "create-file",
   "delete-design",
@@ -29,9 +30,9 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 ]);
 
 const DESIGN_MUTATION_VERBS =
-  /\b(?:add|apply|build|change|create|delete|design|duplicate|edit|generate|import|insert|make|modify|move|place|refine|remove|replace|resize|update)\b/i;
+  /\b(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|polish|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i;
 const DESIGN_MUTATION_OBJECTS =
-  /\b(?:asset|button|canvas|card|component|design|file|hero|image|it|layout|mockup|page|prototype|screen|this|variant|version|wireframe)\b/i;
+  /\b(?:asset|background|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|it|layout|mockup|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|style|styles|text|this|theme|typography|variant|version|width|wireframe)\b/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -121,8 +122,18 @@ function hasSuccessfulMutation(
 
     if (name === "apply-tweaks") {
       return (
-        typeof parsed.designId === "string" && isRecord(parsed.appliedTweaks)
+        typeof parsed.designId === "string" &&
+        isRecord(parsed.appliedTweaks) &&
+        Object.keys(parsed.appliedTweaks).length > 0
       );
+    }
+
+    if (name === "create-design-system") {
+      return typeof parsed.id === "string";
+    }
+
+    if (name === "update-file") {
+      return parsed.updated === true && parsed.skippedStaleMirror !== true;
     }
 
     if (name === "create-file") {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -1,0 +1,175 @@
+import type {
+  AgentLoopFinalResponseGuardContext,
+  AgentLoopFinalResponseGuardResult,
+} from "@agent-native/core/server";
+
+const DESIGN_MUTATION_ACTIONS = new Set([
+  "apply-tweaks",
+  "create-design",
+  "create-design-from-template",
+  "create-component",
+  "create-file",
+  "delete-design",
+  "delete-file",
+  "duplicate-design",
+  "edit-design",
+  "generate-design",
+  "import-figma-clipboard",
+  "import-figma-frame",
+  "insert-asset",
+  "insert-design-native-asset",
+  "insert-figma-library-asset",
+  "present-design-variants",
+  "update-design",
+  "update-file",
+]);
+
+const DESIGN_MUTATION_VERBS =
+  /\b(?:add|build|change|create|design|duplicate|edit|generate|import|insert|make|modify|place|refine|update)\b/i;
+const DESIGN_MUTATION_OBJECTS =
+  /\b(?:asset|button|canvas|component|design|file|hero|image|layout|mockup|page|prototype|screen|this|variant|version|wireframe)\b/i;
+
+function normalizeToolName(name: unknown): string {
+  return String(name ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^agent:/, "")
+    .replace(/[\s_]+/g, "-");
+}
+
+function latestUserText(
+  messages: AgentLoopFinalResponseGuardContext["messages"],
+): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user" || !Array.isArray(message.content)) {
+      continue;
+    }
+    const text = message.content
+      .filter((part: any) => part?.type === "text")
+      .map((part: any) => String(part.text ?? ""))
+      .join("\n");
+    if (text.trim()) return text;
+  }
+  return "";
+}
+
+function parseResult(content: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    // coercion-ok: malformed action output is unreadable and must fail closed
+    // rather than count as proof that Design content was persisted.
+    return null;
+  }
+}
+
+function nonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function hasSuccessfulMutation(
+  toolResults: AgentLoopFinalResponseGuardContext["toolResults"],
+): boolean {
+  return (toolResults ?? []).some((result) => {
+    if (result.isError) return false;
+
+    const name = normalizeToolName(result.name);
+    if (!DESIGN_MUTATION_ACTIONS.has(name)) return false;
+
+    const parsed = parseResult(String(result.content ?? ""));
+    if (!parsed) return false;
+
+    // Creating the project shell is not the requested design. Require the
+    // follow-up action that writes a renderable file before accepting success.
+    if (name === "create-design") return false;
+
+    if (name === "generate-design") {
+      return parsed.renderable === true && nonEmptyArray(parsed.savedFiles);
+    }
+
+    if (name === "present-design-variants") {
+      return (
+        typeof parsed.designId === "string" && nonEmptyArray(parsed.screens)
+      );
+    }
+
+    if (name === "import-figma-frame" || name === "import-figma-clipboard") {
+      return typeof parsed.designId === "string" && nonEmptyArray(parsed.files);
+    }
+
+    if (name === "edit-design") return parsed.changed === true;
+
+    if (name === "create-file") {
+      return (
+        typeof parsed.id === "string" &&
+        (parsed.renderable === true || parsed.fileType === "css")
+      );
+    }
+
+    if (name === "create-design-from-template" || name === "duplicate-design") {
+      return (
+        typeof parsed.id === "string" &&
+        typeof parsed.fileCount === "number" &&
+        parsed.fileCount > 0 &&
+        parsed.promptPending !== true
+      );
+    }
+
+    return (
+      parsed.updated === true ||
+      parsed.inserted === true ||
+      parsed.deleted === true ||
+      parsed.changed === true ||
+      parsed.applied === true ||
+      parsed.persisted === true ||
+      parsed.saved === true
+    );
+  });
+}
+
+export function looksLikeDesignMutationRequest(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  if (/^\[(?:reprompt selection|selection question)\]/i.test(normalized)) {
+    return false;
+  }
+  if (/^(?:how|what|why|when|where|which)\b/i.test(normalized)) {
+    return false;
+  }
+  if (/\bhow\s+to\b/i.test(normalized)) return false;
+
+  return (
+    DESIGN_MUTATION_VERBS.test(normalized) &&
+    DESIGN_MUTATION_OBJECTS.test(normalized)
+  );
+}
+
+export function designFinalResponseGuard(
+  context: AgentLoopFinalResponseGuardContext,
+): AgentLoopFinalResponseGuardResult | null {
+  if (context.executionMode === "plan") return null;
+
+  const requestText =
+    context.requestText?.trim() || latestUserText(context.messages);
+  if (!looksLikeDesignMutationRequest(requestText)) return null;
+  if (hasSuccessfulMutation(context.toolResults)) return null;
+
+  return {
+    retryMessage:
+      "This is a design-changing request, so a text-only answer is not completion. " +
+      "Continue in this turn and call the appropriate mutating Design action. " +
+      "For a new design, create the project if needed and then call `generate-design` " +
+      "or `present-design-variants`; for an existing design, read it and call `edit-design`. " +
+      "If an image or asset is involved, finish with `insert-asset` when placement is needed. " +
+      "Do not claim the design is created, updated, or ready until the action result proves " +
+      "that content was persisted.",
+    fallbackMessage:
+      "I couldn't confirm that a Design artifact was saved, so I haven't marked this request complete. Please retry.",
+    maxRetries: 1,
+    expandToolSurface: true,
+  };
+}

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -5,6 +5,7 @@ import {
 } from "@agent-native/core/server";
 
 import actionsRegistry from "../../.generated/actions-registry.js";
+import { designFinalResponseGuard } from "../lib/design-response-guard.js";
 import { guardRepromptActionRegistry } from "../lib/reprompt-action-guard.js";
 import "../register-secrets.js";
 
@@ -55,6 +56,7 @@ export default createAgentChatPlugin({
     loadActionsFromStaticRegistry(actionsRegistry),
   ),
   initialToolNames: INITIAL_TOOL_NAMES,
+  finalResponseGuard: designFinalResponseGuard,
   // Enable sandboxed JavaScript execution so Design agents can fetch,
   // paginate, and reduce provider data through providerFetch() without us
   // hardcoding one action per GitHub endpoint.
@@ -66,6 +68,8 @@ export default createAgentChatPlugin({
   systemPrompt: `You are an AI prototyping assistant. You create and edit designs, files, design systems, variants, exports, sharing, and connected repository context through actions and shared application state.
 
 Final responses should be concise and operational. Lead with what changed or what is needed. For ordinary design actions, use 1-3 short sentences or at most 3 flat bullets. Do not narrate your process, repeat the user's request, paste HTML or tool results, or write an essay. Mention screenshots and audits only as brief completion evidence. Expand only when the user explicitly asks for an explanation or detailed critique.
+
+Completion is evidence-based: any request to create, generate, build, edit, refine, add, or insert design content must finish with a successful mutating action result. Do not report a design, screen, variant, or asset as created, updated, or ready from prose alone. "create-design" creates only an empty shell (renderable: false), so continue to "generate-design", "present-design-variants", or the required "insert-asset" placement action and wait for its persisted proof.
 
 When a user message begins with [Reprompt selection], the design must remain unchanged until the user accepts a preview. Call propose-node-rewrite with the exact repromptId, target, and baseVersionHash from the message. Never call edit-design, update-design, update-file, generate-design, apply-visual-edit, or any other content-writing action for that turn. The proposal action stores preview state only; the frontend-only resolve-node-rewrite action persists a chosen variant after the user presses Accept.
 


### PR DESCRIPTION
## Summary
- reject prose-only Design completion for content-changing requests
- require persisted generation, edit, import, asset, or component proof before reporting success
- retry once with the authorized Design action surface when the proof is missing

## Verification
- `corepack pnpm --filter design exec vitest --run server/lib/design-response-guard.spec.ts --config vitest.config.ts`
- `corepack pnpm --filter design typecheck`
- `corepack pnpm --filter design build`
