### PR TITLE
fix: harden magic-link and Builder credit signup

### DIFF
--- a/.changeset/quiet-signup-handoff.md
+++ b/.changeset/quiet-signup-handoff.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix magic-link startup and Builder credit signup handoff.

--- a/packages/core/src/client/onboarding/first-run-status.spec.ts
+++ b/packages/core/src/client/onboarding/first-run-status.spec.ts
@@ -13,6 +13,7 @@ describe("first-run onboarding status", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -68,6 +69,38 @@ describe("first-run onboarding status", () => {
     );
   });
 
+  it("shares concurrent status requests", async () => {
+    const listener = vi.fn();
+    window.addEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ firstRun: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      Promise.all([
+        fetchFirstRunOnboardingStatus(),
+        fetchFirstRunOnboardingStatus(),
+      ]),
+    ).resolves.toEqual([true, true]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      firstRun: true,
+    });
+    window.removeEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+  });
+
   it("fails closed when the status request hangs", async () => {
     vi.useFakeTimers();
     const listener = vi.fn();
@@ -81,6 +114,43 @@ describe("first-run onboarding status", () => {
       vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
         requestSignal = init?.signal;
         return new Promise<Response>(() => {});
+      }),
+    );
+
+    const request = fetchFirstRunOnboardingStatus();
+    const requestExpectation = expect(request).rejects.toThrow(
+      "first-run status timed out",
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await requestExpectation;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      firstRun: false,
+    });
+    window.removeEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+  });
+
+  it("times out when the status response body hangs", async () => {
+    vi.useFakeTimers();
+    const listener = vi.fn();
+    let requestSignal: AbortSignal | undefined;
+    window.addEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+        requestSignal = init?.signal;
+        return Promise.resolve({
+          ok: true,
+          json: () => new Promise<never>(() => {}),
+        } as Response);
       }),
     );
 

--- a/packages/core/src/client/onboarding/first-run-status.spec.ts
+++ b/packages/core/src/client/onboarding/first-run-status.spec.ts
@@ -67,4 +67,38 @@ describe("first-run onboarding status", () => {
       listener,
     );
   });
+
+  it("fails closed when the status request hangs", async () => {
+    vi.useFakeTimers();
+    const listener = vi.fn();
+    let requestSignal: AbortSignal | undefined;
+    window.addEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_: RequestInfo | URL, init?: RequestInit) => {
+        requestSignal = init?.signal;
+        return new Promise<Response>(() => {});
+      }),
+    );
+
+    const request = fetchFirstRunOnboardingStatus();
+    const requestExpectation = expect(request).rejects.toThrow(
+      "first-run status timed out",
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await requestExpectation;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(listener).toHaveBeenCalledOnce();
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      firstRun: false,
+    });
+    window.removeEventListener(
+      FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT,
+      listener,
+    );
+  });
 });

--- a/packages/core/src/client/onboarding/first-run-status.ts
+++ b/packages/core/src/client/onboarding/first-run-status.ts
@@ -5,6 +5,8 @@ export const FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT =
 
 const FIRST_RUN_STATUS_TIMEOUT_MS = 10_000;
 
+let firstRunStatusRequest: Promise<boolean> | null = null;
+
 export interface FirstRunOnboardingStatusDetail {
   firstRun: boolean;
 }
@@ -19,31 +21,35 @@ export function dispatchFirstRunOnboardingStatus(firstRun: boolean): void {
   );
 }
 
-/** Fetch the server-owned first-run decision and notify other initial flows. */
-export async function fetchFirstRunOnboardingStatus(): Promise<boolean> {
+async function requestFirstRunOnboardingStatus(): Promise<boolean> {
   const controller =
     typeof AbortController === "undefined" ? null : new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<Response>((_, reject) => {
+  const timeout = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
       controller?.abort();
       reject(new Error("first-run status timed out"));
     }, FIRST_RUN_STATUS_TIMEOUT_MS);
   });
   try {
-    const response = await Promise.race([
-      fetch(agentNativePath("/_agent-native/onboarding/first-run/status"), {
-        cache: "no-store",
-        credentials: "same-origin",
-        ...(controller ? { signal: controller.signal } : {}),
-      }),
+    const firstRun = await Promise.race([
+      (async () => {
+        const response = await fetch(
+          agentNativePath("/_agent-native/onboarding/first-run/status"),
+          {
+            cache: "no-store",
+            credentials: "same-origin",
+            ...(controller ? { signal: controller.signal } : {}),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(`first-run status: ${response.status}`);
+        }
+        const data = (await response.json()) as { firstRun?: unknown };
+        return data.firstRun === true;
+      })(),
       timeout,
     ]);
-    if (!response.ok) {
-      throw new Error(`first-run status: ${response.status}`);
-    }
-    const data = (await response.json()) as { firstRun?: unknown };
-    const firstRun = data.firstRun === true;
     dispatchFirstRunOnboardingStatus(firstRun);
     return firstRun;
   } catch (error) {
@@ -69,4 +75,13 @@ export async function saveFirstRunOnboardingRole(role: string): Promise<void> {
   if (!response.ok) {
     throw new Error(`first-run role save failed: ${response.status}`);
   }
+}
+
+/** Fetch the server-owned first-run decision and notify other initial flows. */
+export function fetchFirstRunOnboardingStatus(): Promise<boolean> {
+  if (firstRunStatusRequest) return firstRunStatusRequest;
+  firstRunStatusRequest = requestFirstRunOnboardingStatus().finally(() => {
+    firstRunStatusRequest = null;
+  });
+  return firstRunStatusRequest;
 }

--- a/packages/core/src/client/onboarding/first-run-status.ts
+++ b/packages/core/src/client/onboarding/first-run-status.ts
@@ -3,6 +3,8 @@ import { agentNativePath } from "../api-path.js";
 export const FIRST_RUN_ONBOARDING_STATUS_RESOLVED_EVENT =
   "agent-native:first-run-status-resolved";
 
+const FIRST_RUN_STATUS_TIMEOUT_MS = 10_000;
+
 export interface FirstRunOnboardingStatusDetail {
   firstRun: boolean;
 }
@@ -19,10 +21,24 @@ export function dispatchFirstRunOnboardingStatus(firstRun: boolean): void {
 
 /** Fetch the server-owned first-run decision and notify other initial flows. */
 export async function fetchFirstRunOnboardingStatus(): Promise<boolean> {
+  const controller =
+    typeof AbortController === "undefined" ? null : new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<Response>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller?.abort();
+      reject(new Error("first-run status timed out"));
+    }, FIRST_RUN_STATUS_TIMEOUT_MS);
+  });
   try {
-    const response = await fetch(
-      agentNativePath("/_agent-native/onboarding/first-run/status"),
-    );
+    const response = await Promise.race([
+      fetch(agentNativePath("/_agent-native/onboarding/first-run/status"), {
+        cache: "no-store",
+        credentials: "same-origin",
+        ...(controller ? { signal: controller.signal } : {}),
+      }),
+      timeout,
+    ]);
     if (!response.ok) {
       throw new Error(`first-run status: ${response.status}`);
     }
@@ -35,6 +51,8 @@ export async function fetchFirstRunOnboardingStatus(): Promise<boolean> {
     // onboarding. Callers can still surface the error through their own path.
     dispatchFirstRunOnboardingStatus(false);
     throw error;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
 }
 

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -579,7 +579,7 @@ describe("useBuilderConnectFlow", () => {
     );
   });
 
-  it("surfaces an error when the callback succeeds but status never confirms credentials", async () => {
+  it("keeps polling when the callback status remains not configured", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
     setUserAgent("Mozilla/5.0 Chrome/140.0");
@@ -623,8 +623,17 @@ describe("useBuilderConnectFlow", () => {
       await vi.advanceTimersByTimeAsync(5000);
     });
 
+    expect(container.textContent).toContain("not-configured connecting");
+    expect(container.textContent).not.toContain(
+      "Couldn't start Builder connect",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    });
+
     expect(container.textContent).toContain("not-configured idle");
-    expect(container.textContent).toContain("Couldn't start Builder connect");
+    expect(container.textContent).toContain("Didn't hear back from Builder");
   });
 
   it("keeps polling when the popup closes before status confirms credentials", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -502,7 +502,7 @@ describe("useBuilderConnectFlow", () => {
     expect(container.textContent).toContain("configured");
   });
 
-  it("keeps polling when the callback succeeds but status has not confirmed credentials", async () => {
+  it("surfaces an error when the callback succeeds but status never confirms credentials", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
     setUserAgent("Mozilla/5.0 Chrome/140.0");
@@ -546,8 +546,8 @@ describe("useBuilderConnectFlow", () => {
       await vi.advanceTimersByTimeAsync(5000);
     });
 
-    expect(container.textContent).toContain("not-configured connecting");
-    expect(container.textContent).not.toContain("couldn't confirm");
+    expect(container.textContent).toContain("not-configured idle");
+    expect(container.textContent).toContain("Couldn't start Builder connect");
   });
 
   it("keeps polling when the popup closes before status confirms credentials", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -502,6 +502,83 @@ describe("useBuilderConnectFlow", () => {
     expect(container.textContent).toContain("configured");
   });
 
+  it("keeps polling when callback confirmation status is unknown", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse({ configured: false }))
+      .mockResolvedValueOnce(jsonResponse({ configured: false }))
+      .mockResolvedValue(new Response("unavailable", { status: 503 }));
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://agent-workspace.builder.io",
+          data: { type: "builder-connect-success" },
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(container.textContent).toContain("not-configured connecting");
+    expect(container.textContent).not.toContain(
+      "Couldn't start Builder connect",
+    );
+  });
+
+  it("ignores duplicate callback success messages", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse({ configured: false }))
+      .mockResolvedValueOnce(jsonResponse({ configured: false }))
+      .mockResolvedValueOnce(jsonResponse(connectedBuilderStatus))
+      .mockResolvedValueOnce(jsonResponse({ configured: false }));
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      const message = new MessageEvent("message", {
+        origin: "https://agent-workspace.builder.io",
+        data: { type: "builder-connect-success" },
+      });
+      window.dispatchEvent(message);
+      window.dispatchEvent(message);
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(container.textContent).toContain("configured idle resolved");
+    expect(container.textContent).not.toContain(
+      "Couldn't start Builder connect",
+    );
+  });
+
   it("surfaces an error when the callback succeeds but status never confirms credentials", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -1011,6 +1011,15 @@ export function useBuilderConnectFlow(
           setError(
             `Couldn't save Builder credentials: ${connectError.message}. Try again or contact support.`,
           );
+        } else {
+          // The callback page only broadcasts after the server has completed
+          // the OAuth callback. Do not leave the onboarding surface waiting
+          // for a status response that may never arrive.
+          connectStartedAtRef.current = null;
+          setConnecting(false);
+          setError(
+            "Couldn't start Builder connect. Refresh this page and try again.",
+          );
         }
         return;
       }

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -583,6 +583,7 @@ export function useBuilderConnectFlow(
   // gesture path (browser/editor embeds).
   const statusConnectUrlAtRef = useRef<number | null>(null);
   const connectStartedAtRef = useRef<number | null>(null);
+  const callbackSuccessStartedAtRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
   const notifiedConnectedRef = useRef(false);
   // Keep onConnected in a ref so start() doesn't need to re-create when the
@@ -735,6 +736,7 @@ export function useBuilderConnectFlow(
         startOptions?.trackingSource ?? trackingSource;
       const clickTrackingFlow = startOptions?.trackingFlow ?? trackingFlow;
       connectStartedAtRef.current = started;
+      callbackSuccessStartedAtRef.current = null;
       activeTrackingRef.current = {
         source: clickTrackingSource,
         flow: clickTrackingFlow,
@@ -971,26 +973,30 @@ export function useBuilderConnectFlow(
       setError(`Couldn't save Builder credentials: ${message}.`);
     };
     const handleSuccess = async () => {
+      const started = connectStartedAtRef.current;
+      if (started == null || callbackSuccessStartedAtRef.current === started) {
+        return;
+      }
+      callbackSuccessStartedAtRef.current = started;
       let s: Awaited<ReturnType<typeof fetchStatus>> = null;
       for (let i = 0; i < CALLBACK_SUCCESS_STATUS_RETRIES; i += 1) {
         s = await fetchStatus();
-        if (!mountedRef.current) return;
-        if (
-          s?.configured ||
-          isCurrentConnectError(s?.connectError, connectStartedAtRef.current)
-        ) {
+        if (!mountedRef.current || connectStartedAtRef.current !== started) {
+          return;
+        }
+        if (s?.configured || isCurrentConnectError(s?.connectError, started)) {
           break;
         }
         if (i < CALLBACK_SUCCESS_STATUS_RETRIES - 1) {
           await delay(CALLBACK_SUCCESS_STATUS_RETRY_MS);
         }
       }
-      if (!mountedRef.current) return;
-      if (!s?.configured) {
-        const connectError = isCurrentConnectError(
-          s?.connectError,
-          connectStartedAtRef.current,
-        )
+      if (!mountedRef.current || connectStartedAtRef.current !== started) {
+        return;
+      }
+      if (!s) return;
+      if (!s.configured) {
+        const connectError = isCurrentConnectError(s?.connectError, started)
           ? s?.connectError
           : null;
         setHasFetchedStatus(true);
@@ -1012,9 +1018,8 @@ export function useBuilderConnectFlow(
             `Couldn't save Builder credentials: ${connectError.message}. Try again or contact support.`,
           );
         } else {
-          // The callback page only broadcasts after the server has completed
-          // the OAuth callback. Do not leave the onboarding surface waiting
-          // for a status response that may never arrive.
+          // A known non-configured response means the callback completed but
+          // credentials were not persisted. Unknown status stays on polling.
           connectStartedAtRef.current = null;
           setConnecting(false);
           setError(

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -1017,14 +1017,6 @@ export function useBuilderConnectFlow(
           setError(
             `Couldn't save Builder credentials: ${connectError.message}. Try again or contact support.`,
           );
-        } else {
-          // A known non-configured response means the callback completed but
-          // credentials were not persisted. Unknown status stays on polling.
-          connectStartedAtRef.current = null;
-          setConnecting(false);
-          setError(
-            "Couldn't start Builder connect. Refresh this page and try again.",
-          );
         }
         return;
       }

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -504,6 +504,7 @@ describe("Builder callback CSRF state", () => {
       expect(redirectUrl).toBeTruthy();
       const parsedRedirect = new URL(redirectUrl!);
       expect(parsedRedirect.pathname).toBe(BUILDER_CALLBACK_PATH);
+      expect(parsed.searchParams.get("cli")).toBe("true");
       // No _an_state — Builder can safely append its own params.
       expect(parsedRedirect.searchParams.has(BUILDER_STATE_PARAM)).toBe(false);
     });

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1184,6 +1184,7 @@ export function buildBuilderCliAuthUrl(
     "preview_url",
     `${normalizedPreviewOrigin}${appBasePath}`,
   );
+  url.searchParams.set("cli", "true");
   url.searchParams.set("framework", "agent-native");
   applyBuilderConnectTrackingParams(url.searchParams, tracking);
   applyBuilderUtmTrackingParams(url.searchParams, {


### PR DESCRIPTION
## Summary

- Bound the first-run status request so a slow auth return cannot strand the app on its loading shell.
- Mark the Builder credit handoff as CLI auth so Builder skips its onboarding questions.
- Surface a retryable error when the Builder callback succeeds without confirmed credentials.

## Verification

- Focused Vitest: 98 tests passed
- @agent-native/core typecheck passed
- pnpm guards: 65 checks passed
- Live local authenticated flow rendered the Slides dashboard