### PR TITLE
fix(core): preserve Builder navigation context across SPA routes

### DIFF
--- a/.changeset/keep-builder-navigation-context.md
+++ b/.changeset/keep-builder-navigation-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Builder editing detection active after SPA navigation removes preview URL markers.

--- a/packages/core/src/client/builder-frame.spec.ts
+++ b/packages/core/src/client/builder-frame.spec.ts
@@ -5,6 +5,7 @@ import {
   _resetBuilderFrameDetectionForTests,
   isBuildAppOrAgentRequest,
   isInBuilderFrame,
+  isTrustedBuilderMessage,
   sendToBuilderChat,
   shouldParentFrameOwnAgentPanel,
 } from "./builder-frame.js";
@@ -57,6 +58,24 @@ describe("isInBuilderFrame", () => {
     window.history.pushState({}, "", "/apps/mail");
 
     expect(isInBuilderFrame()).toBe(true);
+  });
+
+  it("keeps the verified local Builder origin for messages after navigation", () => {
+    const parent = { postMessage: vi.fn() };
+    setParentWindow(parent);
+    setAncestorOrigin("http://localhost:3000");
+    window.history.replaceState({}, "", "/?builder.preview=interact");
+
+    expect(isInBuilderFrame()).toBe(true);
+
+    window.history.pushState({}, "", "/apps/mail");
+
+    expect(
+      isTrustedBuilderMessage({
+        origin: "http://localhost:3000",
+        source: parent,
+      } as MessageEvent),
+    ).toBe(true);
   });
 
   it("captures the Builder signal before the first SPA navigation", async () => {

--- a/packages/core/src/client/builder-frame.spec.ts
+++ b/packages/core/src/client/builder-frame.spec.ts
@@ -80,13 +80,17 @@ describe("isInBuilderFrame", () => {
 
   it("captures the Builder signal before the first SPA navigation", async () => {
     vi.resetModules();
-    window.history.replaceState({}, "", "/?builder.preview=interact");
+    try {
+      window.history.replaceState({}, "", "/?builder.preview=interact");
 
-    const { isInBuilderFrame: detectBuilderFrame } =
-      await import("./builder-frame.js");
-    window.history.pushState({}, "", "/apps/mail");
+      const { isInBuilderFrame: detectBuilderFrame } =
+        await import("./builder-frame.js");
+      window.history.pushState({}, "", "/apps/mail");
 
-    expect(detectBuilderFrame()).toBe(true);
+      expect(detectBuilderFrame()).toBe(true);
+    } finally {
+      vi.resetModules();
+    }
   });
 });
 

--- a/packages/core/src/client/builder-frame.spec.ts
+++ b/packages/core/src/client/builder-frame.spec.ts
@@ -2,11 +2,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _resetBuilderFrameDetectionForTests,
   isBuildAppOrAgentRequest,
   isInBuilderFrame,
   sendToBuilderChat,
   shouldParentFrameOwnAgentPanel,
 } from "./builder-frame.js";
+
+afterEach(() => {
+  _resetBuilderFrameDetectionForTests();
+});
 
 function setParentWindow(value: unknown) {
   Object.defineProperty(window, "parent", {
@@ -43,6 +48,26 @@ describe("isInBuilderFrame", () => {
     window.history.replaceState({}, "", "/?builder.preview=interact");
 
     expect(isInBuilderFrame()).toBe(true);
+  });
+
+  it("keeps Builder detection after SPA navigation drops preview params", () => {
+    window.history.replaceState({}, "", "/?builder.preview=interact");
+    expect(isInBuilderFrame()).toBe(true);
+
+    window.history.pushState({}, "", "/apps/mail");
+
+    expect(isInBuilderFrame()).toBe(true);
+  });
+
+  it("captures the Builder signal before the first SPA navigation", async () => {
+    vi.resetModules();
+    window.history.replaceState({}, "", "/?builder.preview=interact");
+
+    const { isInBuilderFrame: detectBuilderFrame } =
+      await import("./builder-frame.js");
+    window.history.pushState({}, "", "/apps/mail");
+
+    expect(detectBuilderFrame()).toBe(true);
   });
 });
 

--- a/packages/core/src/client/builder-frame.ts
+++ b/packages/core/src/client/builder-frame.ts
@@ -60,6 +60,7 @@ function hasBuilderPreviewParams(): boolean {
 }
 
 let builderFrameDetected = false;
+let builderParentOrigin: string | null = null;
 
 /**
  * For *.builder.io / *.builder.my the parent origin alone is sufficient — those
@@ -72,7 +73,7 @@ let builderFrameDetected = false;
  * real Builder editor sessions and `HomeChatPanel` submissions silently fell
  * through to `agentNative.submitChat` (which Builder ignores).
  */
-export function getBuilderParentOrigin(): string | null {
+function detectBuilderParentOrigin(): string | null {
   const frameOrigin = getFrameOrigin();
   if (frameOrigin) {
     if (isStrictBuilderHost(frameOrigin)) return frameOrigin;
@@ -88,6 +89,12 @@ export function getBuilderParentOrigin(): string | null {
     }
   }
   return null;
+}
+
+export function getBuilderParentOrigin(): string | null {
+  const detectedOrigin = detectBuilderParentOrigin();
+  if (detectedOrigin) builderParentOrigin = detectedOrigin;
+  return detectedOrigin ?? builderParentOrigin;
 }
 
 // Capture the initial Builder signal before client-side routing can remove its
@@ -111,6 +118,7 @@ export function isInBuilderFrame(): boolean {
 
 export function _resetBuilderFrameDetectionForTests(): void {
   builderFrameDetected = false;
+  builderParentOrigin = null;
 }
 
 export function shouldParentFrameOwnAgentPanel(): boolean {

--- a/packages/core/src/client/builder-frame.ts
+++ b/packages/core/src/client/builder-frame.ts
@@ -59,6 +59,8 @@ function hasBuilderPreviewParams(): boolean {
   );
 }
 
+let builderFrameDetected = false;
+
 /**
  * For *.builder.io / *.builder.my the parent origin alone is sufficient — those
  * are Builder-owned hosts and any iframe they load is by definition a Builder
@@ -88,14 +90,27 @@ export function getBuilderParentOrigin(): string | null {
   return null;
 }
 
+// Capture the initial Builder signal before client-side routing can remove its
+// query markers from a top-level Electron webview.
+if (typeof window !== "undefined") {
+  builderFrameDetected =
+    getBuilderParentOrigin() !== null || hasBuilderPreviewParams();
+}
+
 export function isInBuilderFrame(): boolean {
   if (typeof window === "undefined") return false;
-  if (getBuilderParentOrigin() !== null) return true;
+  if (builderFrameDetected) return true;
 
   // Electron webviews run the preview as a top-level page, so there is no
   // parent frame to inspect. Builder still marks those URLs with builder.*
   // preview params, and sendToBuilderChat will use the console relay.
-  return hasBuilderPreviewParams();
+  builderFrameDetected =
+    getBuilderParentOrigin() !== null || hasBuilderPreviewParams();
+  return builderFrameDetected;
+}
+
+export function _resetBuilderFrameDetectionForTests(): void {
+  builderFrameDetected = false;
 }
 
 export function shouldParentFrameOwnAgentPanel(): boolean {


### PR DESCRIPTION
## Summary

- Preserve trusted Builder detection after SPA navigation removes Builder preview query markers.
- Keep ordinary iframe app opens inline; only Builder editor sessions use top-window navigation.
- Add regression coverage for initial detection and marker loss after route changes.

## Validation

- `pnpm --filter @agent-native/core exec vitest --run src/client/builder-frame.spec.ts`
- `pnpm --filter @agent-native/dispatch exec vitest --run src/lib/workspace-apps.test.ts src/components/workspace-app-host.spec.tsx src/components/workspace-app-card.spec.tsx`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/dispatch typecheck`
- `pnpm guards`