### PR TITLE
Harden Design mutation completion proof

### DIFF
--- a/templates/design/actions/apply-tweaks.ts
+++ b/templates/design/actions/apply-tweaks.ts
@@ -102,6 +102,7 @@ export default defineAction({
 
     return {
       designId,
+      applied: Object.keys(selections).length > 0,
       appliedTweaks: readSelections(persistedData),
       selectionsHash: tweakSelectionsHash(readSelections(persistedData)),
       deepLink: designDeepLink(designId),

--- a/templates/design/actions/design-data-mutations.interleave.spec.ts
+++ b/templates/design/actions/design-data-mutations.interleave.spec.ts
@@ -348,8 +348,19 @@ describe("design data mutation interleaving", () => {
     const first = await applyTweaks.run(params);
     const retry = await applyTweaks.run(params);
 
+    expect(first.applied).toBe(true);
+    expect(retry.applied).toBe(true);
     expect(retry.appliedTweaks).toMatchObject({ density: "compact" });
     expect(retry.selectionsHash).toBe(first.selectionsHash);
+  });
+
+  it("does not report an empty tweak snapshot as applied", async () => {
+    const result = await applyTweaks.run({
+      designId: "design_1",
+      selections: {},
+    });
+
+    expect(result.applied).toBe(false);
   });
 
   it("lets only one of two full snapshots from the same base win", async () => {

--- a/templates/design/actions/update-design.spec.ts
+++ b/templates/design/actions/update-design.spec.ts
@@ -201,6 +201,15 @@ describe("update-design data concurrency", () => {
     mocks.assertAccess.mockResolvedValue(undefined);
   });
 
+  it("rejects an ID-only update instead of reporting a content change", async () => {
+    const previousUpdatedAt = mocks.state.row.updatedAt;
+
+    await expect(action.run({ id: "design-1" } as never)).rejects.toThrow(
+      "At least one design field or data operation is required.",
+    );
+    expect(mocks.state.row.updatedAt).toBe(previousUpdatedAt);
+  });
+
   it("rejects one ambiguous legacy snapshot instead of silently losing a concurrent frame edit", async () => {
     mocks.resetReadGate(2);
     const moveA = {
@@ -301,7 +310,7 @@ describe("update-design data concurrency", () => {
       operationRevision: 1,
     } as never);
 
-    expect(newer).toEqual({ id: "design-1", updated: true });
+    expect(newer).toEqual({ id: "design-1", updated: true, changed: true });
     expect(stale).toEqual({ id: "design-1", updated: true, stale: true });
     expect(
       (JSON.parse(mocks.state.row.data!) as typeof BASE_DATA).canvasFrames[

--- a/templates/design/actions/update-design.ts
+++ b/templates/design/actions/update-design.ts
@@ -377,6 +377,18 @@ export default defineAction({
     if (designSystemId != null) {
       await assertAccess("design-system", designSystemId, "viewer");
     }
+    if (
+      title === undefined &&
+      description === undefined &&
+      data === undefined &&
+      dataOperations === undefined &&
+      projectType === undefined &&
+      designSystemId === undefined
+    ) {
+      throw new Error(
+        "At least one design field or data operation is required.",
+      );
+    }
 
     const db = getDb();
 
@@ -396,7 +408,7 @@ export default defineAction({
         .update(schema.designs)
         .set(staticUpdates())
         .where(eq(schema.designs.id, id));
-      return { id, updated: true };
+      return { id, updated: true, changed: true };
     }
 
     const maxAttempts = dataOperations ? MAX_DATA_CAS_ATTEMPTS : 1;
@@ -484,7 +496,7 @@ export default defineAction({
       }
 
       if (affected > 0) {
-        return { id, updated: true };
+        return { id, updated: true, changed: true };
       }
     }
 

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -215,6 +215,7 @@ describe("Design final response guard", () => {
           designId: "design-1",
           timelineId: "timeline-1",
           persisted: true,
+          contentPatched: true,
         }),
       ],
       [toolResult("apply-a11y-fix", { designId: "design-1", applied: true })],
@@ -312,6 +313,14 @@ describe("Design final response guard", () => {
           id: "design-1",
           updated: true,
           stale: true,
+        }),
+      ],
+      [
+        toolResult("apply-motion-edit", {
+          designId: "design-1",
+          timelineId: "timeline-1",
+          persisted: true,
+          contentPatched: false,
         }),
       ],
     ]) {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -81,6 +81,11 @@ describe("Design final response guard", () => {
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        "improve my web and mobile UI design skills",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
         "improve my design skills and update the color palette",
       ),
     ).toBe(true);
@@ -122,6 +127,14 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest(
         "review this card and then fix the button",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("review this card. Please fix the button"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "review this card, could you fix the button?",
       ),
     ).toBe(true);
     expect(

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -103,6 +103,16 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("review this card; fix the button"),
     ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "review this card and recommend changes, then improve the design",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "review this card; suggest changes; fix the button",
+      ),
+    ).toBe(true);
   });
 
   it("retries prose-only completion for a design mutation", () => {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -75,6 +75,11 @@ describe("Design final response guard", () => {
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        "improve my design skills and update the color palette",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "can you review this card and recommend changes?",
       ),
     ).toBe(false);

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -86,6 +86,16 @@ describe("Design final response guard", () => {
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        "improve my design skills and improve my interaction design skills",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        `improve my ${"web ".repeat(2_000)}design skills`,
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
         "improve my design skills and update the color palette",
       ),
     ).toBe(true);

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -64,6 +64,23 @@ describe("Design final response guard", () => {
     expect(looksLikeDesignMutationRequest("update the color palette")).toBe(
       true,
     );
+    expect(looksLikeDesignMutationRequest("add an animation to the hero")).toBe(
+      true,
+    );
+    expect(looksLikeDesignMutationRequest("change the interaction state")).toBe(
+      true,
+    );
+    expect(
+      looksLikeDesignMutationRequest("I want to improve my design skills"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "can you review this card and recommend changes?",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("review this card and fix the button"),
+    ).toBe(true);
   });
 
   it("retries prose-only completion for a design mutation", () => {
@@ -126,11 +143,20 @@ describe("Design final response guard", () => {
       [
         toolResult("apply-tweaks", {
           designId: "design-1",
+          applied: true,
           appliedTweaks: { "theme-accent": "#0EA5E9" },
         }),
       ],
       [toolResult("create-design-system", { id: "design-system-1" })],
       [toolResult("update-file", { id: "file-1", updated: true })],
+      [toolResult("update-design", { id: "design-1", updated: true })],
+      [
+        toolResult("import-figma-clipboard", {
+          designId: "design-1",
+          strategy: "htmlFallback",
+          files: [{ id: "file-1", filename: "screen.html" }],
+        }),
+      ],
       [
         toolResult("import-figma-frame", {
           designId: "design-1",
@@ -174,6 +200,7 @@ describe("Design final response guard", () => {
       [
         toolResult("apply-tweaks", {
           designId: "design-1",
+          applied: false,
           appliedTweaks: {},
         }),
       ],
@@ -182,6 +209,13 @@ describe("Design final response guard", () => {
           id: "file-1",
           updated: true,
           skippedStaleMirror: true,
+        }),
+      ],
+      [
+        toolResult("update-design", {
+          id: "design-1",
+          updated: true,
+          stale: true,
         }),
       ],
     ]) {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -81,6 +81,28 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("review this card and fix the button"),
     ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "please give me advice to improve this design",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "please provide suggestions for this design",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("improve your design skills card layout"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("improve your Design Skills section"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("review this card. fix the button"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest("review this card; fix the button"),
+    ).toBe(true);
   });
 
   it("retries prose-only completion for a design mutation", () => {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -96,6 +96,11 @@ describe("Design final response guard", () => {
     ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
+        `improve my ${"web ".repeat(2_000)}portfolio`,
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
         "improve my design skills and update the color palette",
       ),
     ).toBe(true);
@@ -126,6 +131,11 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest("improve my Design Skills hero section"),
     ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "I want to improve my design skills in card layout and improve my portfolio",
+      ),
+    ).toBe(false);
     expect(
       looksLikeDesignMutationRequest(
         "please give feedback to improve this design",
@@ -246,7 +256,13 @@ describe("Design final response guard", () => {
       ],
       [toolResult("create-design-system", { id: "design-system-1" })],
       [toolResult("update-file", { id: "file-1", updated: true })],
-      [toolResult("update-design", { id: "design-1", updated: true })],
+      [
+        toolResult("update-design", {
+          id: "design-1",
+          updated: true,
+          changed: true,
+        }),
+      ],
       [
         toolResult("import-figma-clipboard", {
           designId: "design-1",
@@ -315,6 +331,7 @@ describe("Design final response guard", () => {
           stale: true,
         }),
       ],
+      [toolResult("update-design", { id: "design-1", updated: true })],
       [
         toolResult("apply-motion-edit", {
           designId: "design-1",

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -124,6 +124,19 @@ describe("Design final response guard", () => {
       looksLikeDesignMutationRequest("improve your Design Skills section"),
     ).toBe(true);
     expect(
+      looksLikeDesignMutationRequest("improve my Design Skills hero section"),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "please give feedback to improve this design",
+      ),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest(
+        "please share your thoughts on this design",
+      ),
+    ).toBe(false);
+    expect(
       looksLikeDesignMutationRequest("review this card. fix the button"),
     ).toBe(true);
     expect(
@@ -197,6 +210,13 @@ describe("Design final response guard", () => {
       ],
       [toolResult("edit-design", { fileId: "file-1", changed: true })],
       [toolResult("insert-asset", { fileId: "file-1", inserted: true })],
+      [
+        toolResult("apply-motion-edit", {
+          designId: "design-1",
+          timelineId: "timeline-1",
+          persisted: true,
+        }),
+      ],
       [toolResult("apply-a11y-fix", { designId: "design-1", applied: true })],
       [
         toolResult("apply-component-prop-edit", {

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -74,6 +74,12 @@ describe("Design final response guard", () => {
       looksLikeDesignMutationRequest("I want to improve my design skills"),
     ).toBe(false);
     expect(
+      looksLikeDesignMutationRequest("improve my product design skills"),
+    ).toBe(false);
+    expect(
+      looksLikeDesignMutationRequest("improve my interaction design skills"),
+    ).toBe(false);
+    expect(
       looksLikeDesignMutationRequest(
         "improve my design skills and update the color palette",
       ),
@@ -111,6 +117,11 @@ describe("Design final response guard", () => {
     expect(
       looksLikeDesignMutationRequest(
         "review this card, then polish the button",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
+        "review this card and then fix the button",
       ),
     ).toBe(true);
     expect(

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -110,6 +110,11 @@ describe("Design final response guard", () => {
     ).toBe(true);
     expect(
       looksLikeDesignMutationRequest(
+        "review this card, then polish the button",
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeDesignMutationRequest(
         "review this card and recommend changes, then improve the design",
       ),
     ).toBe(true);

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -36,7 +36,7 @@ const DESIGN_MUTATION_OBJECTS =
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|recommend(?:ation)?s?|review|suggest(?:ion)?s?)\b/i;
 const DESIGN_ADVISORY_SKILLS =
-  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:(?:[\w-]+\s+){0,3})skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
+  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:[\w-]+\s+)*?skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -198,7 +198,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
       advisoryMatch.index + advisoryMatch[0].length,
     );
     const followsAdvisory =
-      /(?:\b(?:(?:and|also|but)(?:\s+then)?|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|polish|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
+      /(?:\b(?:(?:and|also|but)(?:\s+then)?|then)\s+|[.!?;:,]\s*)(?:(?:please|kindly)\s+|(?:(?:can|could|would)\s+you(?:\s+please)?\s+))?(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|polish|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
         afterAdvisory,
       );
     if (!DESIGN_MUTATION_VERBS.test(beforeAdvisory) && !followsAdvisory) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -183,12 +183,18 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
     return false;
   }
   if (/\bhow\s+to\b/i.test(normalized)) return false;
-  if (DESIGN_ADVISORY_SKILLS.test(normalized)) return false;
 
-  const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(normalized);
+  const advisorySkillsMatch = DESIGN_ADVISORY_SKILLS.exec(normalized);
+  const mutationText = advisorySkillsMatch
+    ? `${normalized.slice(0, advisorySkillsMatch.index)} ${normalized.slice(
+        advisorySkillsMatch.index + advisorySkillsMatch[0].length,
+      )}`
+    : normalized;
+
+  const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(mutationText);
   if (advisoryMatch) {
-    const beforeAdvisory = normalized.slice(0, advisoryMatch.index);
-    const afterAdvisory = normalized.slice(
+    const beforeAdvisory = mutationText.slice(0, advisoryMatch.index);
+    const afterAdvisory = mutationText.slice(
       advisoryMatch.index + advisoryMatch[0].length,
     );
     const followsAdvisory =
@@ -201,8 +207,8 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   }
 
   return (
-    DESIGN_MUTATION_VERBS.test(normalized) &&
-    DESIGN_MUTATION_OBJECTS.test(normalized)
+    DESIGN_MUTATION_VERBS.test(mutationText) &&
+    DESIGN_MUTATION_OBJECTS.test(mutationText)
   );
 }
 

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -157,7 +157,8 @@ function hasSuccessfulMutation(
       return (
         parsed.persisted === true &&
         typeof parsed.designId === "string" &&
-        typeof parsed.timelineId === "string"
+        typeof parsed.timelineId === "string" &&
+        parsed.contentPatched === true
       );
     }
 

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -35,8 +35,21 @@ const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|recommend(?:ation)?s?|review|suggest(?:ion)?s?)\b/i;
-const DESIGN_ADVISORY_SKILLS =
-  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:[\w-]+\s+)*?skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
+const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
+const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
+const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
+const DESIGN_SKILL_UI_TARGETS = new Set([
+  "button",
+  "card",
+  "component",
+  "layout",
+  "page",
+  "panel",
+  "row",
+  "screen",
+  "section",
+  "text",
+]);
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -173,6 +186,73 @@ function hasSuccessfulMutation(
   });
 }
 
+function removeAdvisorySkillsClauses(text: string): string {
+  const words = Array.from(text.matchAll(DESIGN_WORD_PATTERN)).map((match) => {
+    const start = match.index ?? 0;
+    return {
+      end: start + match[0].length,
+      start,
+      value: match[0].toLowerCase(),
+    };
+  });
+  const removals: Array<[number, number]> = [];
+
+  const isWhitespaceBetween = (left: number, right: number) =>
+    text.slice(left, right).trim() === "";
+
+  let index = 0;
+  while (index < words.length - 2) {
+    const verb = words[index];
+    const pronoun = words[index + 1];
+    if (
+      !DESIGN_ADVISORY_SKILL_VERBS.has(verb.value) ||
+      !DESIGN_ADVISORY_SKILL_PRONOUNS.has(pronoun.value) ||
+      !isWhitespaceBetween(verb.end, pronoun.start)
+    ) {
+      index += 1;
+      continue;
+    }
+
+    let skillIndex = index + 2;
+    while (
+      skillIndex < words.length &&
+      isWhitespaceBetween(words[skillIndex - 1].end, words[skillIndex].start) &&
+      !/^skills?$/.test(words[skillIndex].value)
+    ) {
+      skillIndex += 1;
+    }
+
+    const skill = words[skillIndex];
+    if (
+      !skill ||
+      !/^skills?$/.test(skill.value) ||
+      !isWhitespaceBetween(words[skillIndex - 1].end, skill.start)
+    ) {
+      index = skillIndex;
+      continue;
+    }
+
+    const nextWord = words[skillIndex + 1];
+    const targetsUiContent =
+      nextWord &&
+      isWhitespaceBetween(skill.end, nextWord.start) &&
+      DESIGN_SKILL_UI_TARGETS.has(nextWord.value);
+    if (!targetsUiContent) removals.push([verb.start, skill.end]);
+    index = skillIndex + 1;
+  }
+
+  if (removals.length === 0) return text;
+
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const [start, end] of removals) {
+    parts.push(text.slice(cursor, start), " ");
+    cursor = end;
+  }
+  parts.push(text.slice(cursor));
+  return parts.join("");
+}
+
 export function looksLikeDesignMutationRequest(text: string): boolean {
   const normalized = text.trim();
   if (!normalized) return false;
@@ -184,12 +264,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   }
   if (/\bhow\s+to\b/i.test(normalized)) return false;
 
-  const advisorySkillsMatch = DESIGN_ADVISORY_SKILLS.exec(normalized);
-  const mutationText = advisorySkillsMatch
-    ? `${normalized.slice(0, advisorySkillsMatch.index)} ${normalized.slice(
-        advisorySkillsMatch.index + advisorySkillsMatch[0].length,
-      )}`
-    : normalized;
+  const mutationText = removeAdvisorySkillsClauses(normalized);
 
   const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(mutationText);
   if (advisoryMatch) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -6,6 +6,7 @@ import type {
 const DESIGN_MUTATION_ACTIONS = new Set([
   "apply-a11y-fix",
   "apply-component-prop-edit",
+  "apply-motion-edit",
   "apply-source-edit",
   "apply-tweaks",
   "apply-visual-edit",
@@ -34,7 +35,7 @@ const DESIGN_MUTATION_VERBS =
 const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
-  /\b(?:advise|advice|analy[sz]e|audit|critique|recommend(?:ation)?s?|review|suggest(?:ion)?s?)\b/i;
+  /\b(?:advise|advice|analy[sz]e|audit|critique|feedback|recommend(?:ation)?s?|review|suggest(?:ion)?s?|thoughts?)\b/i;
 const DESIGN_WORD_PATTERN = /\b[\w-]+\b/g;
 const DESIGN_ADVISORY_SKILL_VERBS = new Set(["develop", "improve", "learn"]);
 const DESIGN_ADVISORY_SKILL_PRONOUNS = new Set(["my", "your"]);
@@ -49,6 +50,12 @@ const DESIGN_SKILL_UI_TARGETS = new Set([
   "screen",
   "section",
   "text",
+]);
+const DESIGN_SKILL_UI_TARGET_PHRASES = new Set([
+  "footer row",
+  "header row",
+  "hero section",
+  "nav item",
 ]);
 
 function normalizeToolName(name: unknown): string {
@@ -146,6 +153,14 @@ function hasSuccessfulMutation(
       );
     }
 
+    if (name === "apply-motion-edit") {
+      return (
+        parsed.persisted === true &&
+        typeof parsed.designId === "string" &&
+        typeof parsed.timelineId === "string"
+      );
+    }
+
     if (name === "create-design-system") {
       return typeof parsed.id === "string";
     }
@@ -233,10 +248,19 @@ function removeAdvisorySkillsClauses(text: string): string {
     }
 
     const nextWord = words[skillIndex + 1];
+    const nextNextWord = words[skillIndex + 2];
+    const nextTargetPhrase =
+      nextWord &&
+      nextNextWord &&
+      isWhitespaceBetween(skill.end, nextWord.start) &&
+      isWhitespaceBetween(nextWord.end, nextNextWord.start)
+        ? `${nextWord.value} ${nextNextWord.value}`
+        : "";
     const targetsUiContent =
       nextWord &&
       isWhitespaceBetween(skill.end, nextWord.start) &&
-      DESIGN_SKILL_UI_TARGETS.has(nextWord.value);
+      (DESIGN_SKILL_UI_TARGETS.has(nextWord.value) ||
+        DESIGN_SKILL_UI_TARGET_PHRASES.has(nextTargetPhrase));
     if (!targetsUiContent) removals.push([verb.start, skill.end]);
     index = skillIndex + 1;
   }

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -57,6 +57,18 @@ const DESIGN_SKILL_UI_TARGET_PHRASES = new Set([
   "hero section",
   "nav item",
 ]);
+const DESIGN_SKILL_DOMAIN_PREPOSITIONS = new Set([
+  "about",
+  "across",
+  "for",
+  "in",
+  "on",
+  "through",
+  "toward",
+  "within",
+  "with",
+]);
+const DESIGN_SKILL_CLAUSE_BOUNDARIES = new Set(["also", "and", "but", "then"]);
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -167,7 +179,11 @@ function hasSuccessfulMutation(
     }
 
     if (name === "update-design") {
-      return parsed.updated === true && parsed.stale !== true;
+      return (
+        parsed.updated === true &&
+        parsed.changed === true &&
+        parsed.stale !== true
+      );
     }
 
     if (name === "update-file") {
@@ -203,18 +219,25 @@ function hasSuccessfulMutation(
 }
 
 function removeAdvisorySkillsClauses(text: string): string {
-  const words = Array.from(text.matchAll(DESIGN_WORD_PATTERN)).map((match) => {
+  const words: Array<{
+    end: number;
+    start: number;
+    value: string;
+    whitespaceBefore: boolean;
+  }> = [];
+  let previousEnd = 0;
+  for (const match of text.matchAll(DESIGN_WORD_PATTERN)) {
     const start = match.index ?? 0;
-    return {
-      end: start + match[0].length,
+    const end = start + match[0].length;
+    words.push({
+      end,
       start,
       value: match[0].toLowerCase(),
-    };
-  });
+      whitespaceBefore: text.slice(previousEnd, start).trim() === "",
+    });
+    previousEnd = end;
+  }
   const removals: Array<[number, number]> = [];
-
-  const isWhitespaceBetween = (left: number, right: number) =>
-    text.slice(left, right).trim() === "";
 
   let index = 0;
   while (index < words.length - 2) {
@@ -223,7 +246,7 @@ function removeAdvisorySkillsClauses(text: string): string {
     if (
       !DESIGN_ADVISORY_SKILL_VERBS.has(verb.value) ||
       !DESIGN_ADVISORY_SKILL_PRONOUNS.has(pronoun.value) ||
-      !isWhitespaceBetween(verb.end, pronoun.start)
+      !pronoun.whitespaceBefore
     ) {
       index += 1;
       continue;
@@ -232,18 +255,14 @@ function removeAdvisorySkillsClauses(text: string): string {
     let skillIndex = index + 2;
     while (
       skillIndex < words.length &&
-      isWhitespaceBetween(words[skillIndex - 1].end, words[skillIndex].start) &&
+      words[skillIndex].whitespaceBefore &&
       !/^skills?$/.test(words[skillIndex].value)
     ) {
       skillIndex += 1;
     }
 
     const skill = words[skillIndex];
-    if (
-      !skill ||
-      !/^skills?$/.test(skill.value) ||
-      !isWhitespaceBetween(words[skillIndex - 1].end, skill.start)
-    ) {
+    if (!skill || !/^skills?$/.test(skill.value) || !skill.whitespaceBefore) {
       index = skillIndex;
       continue;
     }
@@ -253,16 +272,33 @@ function removeAdvisorySkillsClauses(text: string): string {
     const nextTargetPhrase =
       nextWord &&
       nextNextWord &&
-      isWhitespaceBetween(skill.end, nextWord.start) &&
-      isWhitespaceBetween(nextWord.end, nextNextWord.start)
+      nextWord.whitespaceBefore &&
+      nextNextWord.whitespaceBefore
         ? `${nextWord.value} ${nextNextWord.value}`
         : "";
     const targetsUiContent =
       nextWord &&
-      isWhitespaceBetween(skill.end, nextWord.start) &&
+      nextWord.whitespaceBefore &&
       (DESIGN_SKILL_UI_TARGETS.has(nextWord.value) ||
         DESIGN_SKILL_UI_TARGET_PHRASES.has(nextTargetPhrase));
-    if (!targetsUiContent) removals.push([verb.start, skill.end]);
+    let removalEnd = skill.end;
+    if (
+      !targetsUiContent &&
+      nextWord &&
+      nextWord.whitespaceBefore &&
+      DESIGN_SKILL_DOMAIN_PREPOSITIONS.has(nextWord.value)
+    ) {
+      let domainIndex = skillIndex + 1;
+      while (
+        domainIndex < words.length &&
+        words[domainIndex].whitespaceBefore &&
+        !DESIGN_SKILL_CLAUSE_BOUNDARIES.has(words[domainIndex].value)
+      ) {
+        removalEnd = words[domainIndex].end;
+        domainIndex += 1;
+      }
+    }
+    if (!targetsUiContent) removals.push([verb.start, removalEnd]);
     index = skillIndex + 1;
   }
 

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -198,7 +198,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
       advisoryMatch.index + advisoryMatch[0].length,
     );
     const followsAdvisory =
-      /(?:\b(?:and|also|but|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
+      /(?:\b(?:and|also|but|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|polish|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
         afterAdvisory,
       );
     if (!DESIGN_MUTATION_VERBS.test(beforeAdvisory) && !followsAdvisory) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -32,7 +32,11 @@ const DESIGN_MUTATION_ACTIONS = new Set([
 const DESIGN_MUTATION_VERBS =
   /\b(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|polish|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i;
 const DESIGN_MUTATION_OBJECTS =
-  /\b(?:asset|background|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|it|layout|mockup|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|style|styles|text|this|theme|typography|variant|version|width|wireframe)\b/i;
+  /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|width|wireframe)\b/i;
+const DESIGN_ADVISORY_WORDS =
+  /\b(?:advise|analy[sz]e|audit|critique|recommend|review|suggest)\b/i;
+const DESIGN_ADVISORY_SKILLS =
+  /\b(?:improve|learn|develop)\s+(?:my|your|design|visual|ui)?\s*(?:design\s+)?skills?\b/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -123,6 +127,7 @@ function hasSuccessfulMutation(
     if (name === "apply-tweaks") {
       return (
         typeof parsed.designId === "string" &&
+        parsed.applied === true &&
         isRecord(parsed.appliedTweaks) &&
         Object.keys(parsed.appliedTweaks).length > 0
       );
@@ -130,6 +135,10 @@ function hasSuccessfulMutation(
 
     if (name === "create-design-system") {
       return typeof parsed.id === "string";
+    }
+
+    if (name === "update-design") {
+      return parsed.updated === true && parsed.stale !== true;
     }
 
     if (name === "update-file") {
@@ -174,6 +183,22 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
     return false;
   }
   if (/\bhow\s+to\b/i.test(normalized)) return false;
+  if (DESIGN_ADVISORY_SKILLS.test(normalized)) return false;
+
+  const advisoryMatch = DESIGN_ADVISORY_WORDS.exec(normalized);
+  if (advisoryMatch) {
+    const beforeAdvisory = normalized.slice(0, advisoryMatch.index);
+    const afterAdvisory = normalized.slice(
+      advisoryMatch.index + advisoryMatch[0].length,
+    );
+    const followsAdvisory =
+      /\b(?:and|also|but|then)\s+(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
+        afterAdvisory,
+      );
+    if (!DESIGN_MUTATION_VERBS.test(beforeAdvisory) && !followsAdvisory) {
+      return false;
+    }
+  }
 
   return (
     DESIGN_MUTATION_VERBS.test(normalized) &&

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -36,7 +36,7 @@ const DESIGN_MUTATION_OBJECTS =
 const DESIGN_ADVISORY_WORDS =
   /\b(?:advise|advice|analy[sz]e|audit|critique|recommend(?:ation)?s?|review|suggest(?:ion)?s?)\b/i;
 const DESIGN_ADVISORY_SKILLS =
-  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:(?:design|visual|ui)\s+)?skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
+  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:(?:[\w-]+\s+){0,3})skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -198,7 +198,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
       advisoryMatch.index + advisoryMatch[0].length,
     );
     const followsAdvisory =
-      /(?:\b(?:and|also|but|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|polish|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
+      /(?:\b(?:(?:and|also|but)(?:\s+then)?|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|polish|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
         afterAdvisory,
       );
     if (!DESIGN_MUTATION_VERBS.test(beforeAdvisory) && !followsAdvisory) {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -34,9 +34,9 @@ const DESIGN_MUTATION_VERBS =
 const DESIGN_MUTATION_OBJECTS =
   /\b(?:animation|animations|asset|background|behavior|behaviors|border|button|canvas|card|color|colors|component|design|file|footer|font|gap|header|height|hero|image|interaction|interactions|it|layout|mockup|motion|nav|page|palette|padding|prototype|radius|screen|shadow|size|spacing|state|states|style|styles|text|this|theme|transition|transitions|typography|variant|version|width|wireframe)\b/i;
 const DESIGN_ADVISORY_WORDS =
-  /\b(?:advise|analy[sz]e|audit|critique|recommend|review|suggest)\b/i;
+  /\b(?:advise|advice|analy[sz]e|audit|critique|recommend(?:ation)?s?|review|suggest(?:ion)?s?)\b/i;
 const DESIGN_ADVISORY_SKILLS =
-  /\b(?:improve|learn|develop)\s+(?:my|your|design|visual|ui)?\s*(?:design\s+)?skills?\b/i;
+  /\b(?:improve|learn|develop)\s+(?:my|your)\s+(?:(?:design|visual|ui)\s+)?skills?\b(?!\s+(?:section|card|component|layout|panel|row|screen|page|button|text)\b)/i;
 
 function normalizeToolName(name: unknown): string {
   return String(name ?? "")
@@ -192,7 +192,7 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
       advisoryMatch.index + advisoryMatch[0].length,
     );
     const followsAdvisory =
-      /\b(?:and|also|but|then)\s+(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
+      /(?:\b(?:and|also|but|then)\s+|[.!?;:,]\s*)(?:add|adjust|align|apply|build|change|clean|create|decrease|delete|design|duplicate|edit|enhance|fix|generate|improve|import|increase|insert|make|modify|move|place|reduce|refine|remove|replace|resize|restyle|rework|tune|update)\b/i.test(
         afterAdvisory,
       );
     if (!DESIGN_MUTATION_VERBS.test(beforeAdvisory) && !followsAdvisory) {


### PR DESCRIPTION
Follow-up hardening for #3794.

- Reject stale update-design no-ops as completion proof.
- Make apply-tweaks return request-scoped applied proof and reject empty snapshots.
- Cover animation and interaction requests while excluding advisory review/skills prompts.
- Add regression coverage for clipboard fallback, stale results, and action proof.

Focused tests: 16 passed. Scoped guards passed. Local Design typecheck remains blocked by two pre-existing baseline errors in PromptComposerSubmitOptions.attachments and FIGMA_BLUR_RADIUS_TO_CSS_BLUR.