### PR TITLE
fix: avoid routine main merges during ship

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -74,7 +74,8 @@ can change within minutes, so re-check before every actionable push.
 
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
 2. If `CONFLICTING`: bring `main` in and resolve. **Publish any intentional
-   actionable fix first (Step 0)**, then prefer a **merge** over a rebase —
+   actionable fix first (Step 0)**, after verifying the dirty paths all belong
+   to that fix; then prefer a **merge** over a rebase —
    `git fetch origin main && git merge --no-edit
    origin/main` — because this branch is shared with concurrent agents and a
    rebase would rewrite history and require a force-push that can clobber their
@@ -82,7 +83,10 @@ can change within minutes, so re-check before every actionable push.
    with `git checkout --theirs -- pnpm-lock.yaml` then regenerate with `pnpm
    install --lockfile-only` against the merged `package.json`), complete the
    merge commit, and push (a normal push, never `--force`). This resets the soak
-   timer. Do not merge `origin/main` again while the PR remains conflict-free.
+   timer. If unrelated or incomplete concurrent work keeps the worktree dirty,
+   preserve it and wait for its owner instead of stashing, restoring, or
+   forcing the merge. Do not merge `origin/main` again while the PR remains
+   conflict-free.
    Only rebase if the user explicitly asks for a linear history.
 3. If `MERGEABLE` or `UNKNOWN`: proceed. (`mergeStateStatus: BLOCKED` with `mergeable: MERGEABLE` just means required checks are still pending/red — that is not a conflict; keep going.)
 

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -16,8 +16,10 @@ to the shared checkout or require that an agent publish from the root checkout.
 ## Branch-wide Snapshot Rule
 
 During `/babysit-pr`, the PR remains the unit of review and the shared checkout
-is the branch snapshot. At the first tick, record the status and publish the
-requested initial work when it has not already been published. On later ticks,
+is the branch snapshot. At the first tick, record dirty paths and unpushed
+commits; publish the requested initial work only after verifying that every
+candidate belongs to this PR's requested fix. If unrelated or incomplete
+concurrent work is present, preserve it for its owner and wait. On later ticks,
 inspect the tree before every push. Run `corepack pnpm ship:push` only when the
 current branch contains an actionable change required by failing CI, PR
 feedback, a real merge conflict, or an explicit user request. A clean tree,
@@ -73,10 +75,12 @@ can change within minutes, so re-check before every actionable push.
 **Step 1 — check for merge conflicts:**
 
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
-2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree;
-   do not run the merge until `git status --short` is empty. **Publish any
-   intentional actionable fix first (Step 0)**, after verifying the dirty paths
-   all belong to that fix; then prefer a **merge** over a rebase —
+2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree
+   and unpushed commits; do not run the merge until both `git status --short`
+   and `git log --oneline origin/$(git branch --show-current)..HEAD` are empty.
+   **Publish any intentional actionable fix first (Step 0)**, after verifying
+   every dirty path and unpushed commit belongs to that fix; then prefer a
+   **merge** over a rebase —
    `git fetch origin main && git merge --no-edit
    origin/main` — because this branch is shared with concurrent agents and a
    rebase would rewrite history and require a force-push that can clobber their

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -57,7 +57,7 @@ merging, except when the user explicitly invokes `/ship-now`.
 ```bash
 git status --short
 git diff --name-only
-git log --oneline origin/$(git branch --show-current)..HEAD
+git log --oneline --decorate HEAD --not --remotes=origin
 ```
 
 After the status check, run `corepack pnpm ship:push` only when the dirty or
@@ -77,7 +77,7 @@ can change within minutes, so re-check before every actionable push.
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
 2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree
    and unpushed commits; do not run the merge until both `git status --short`
-   and `git log --oneline origin/$(git branch --show-current)..HEAD` are empty.
+   and `git log --oneline --decorate HEAD --not --remotes=origin` are empty.
    **Publish any intentional actionable fix first (Step 0)**, after verifying
    every dirty path and unpushed commit belongs to that fix; then prefer a
    **merge** over a rebase —

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -55,7 +55,10 @@ merging, except when the user explicitly invokes `/ship-now`.
 **Step 0 — always do this first, before anything else:**
 
 ```bash
-git fetch origin --quiet
+if ! git fetch origin --quiet; then
+  echo "Cannot refresh origin refs; stop before checking unpublished commits." >&2
+  exit 1
+fi
 git status --short
 git diff --name-only
 if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
@@ -81,8 +84,22 @@ can change within minutes, so re-check before every actionable push.
 
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
 2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree
-   and unpushed commits; do not run the merge until both `git status --short`
-   and the branch-specific unpublished-commit check in Step 0 are empty.
+   and unpushed commits; do not run the merge until the publishable-path check
+   `git status --short -- . ':(exclude)learnings.md' ':(exclude)bridge/**'
+   ':(exclude)data/**'` and the branch-specific unpublished-commit check in
+   Step 0 are empty. Preserve and report excluded paths; they do not block
+   recovery unless the merge itself touches them.
+   Before merging, compare the local checkout with the live PR head:
+
+   ```bash
+   pr_head=$(gh pr view $ARGUMENTS --json headRefOid --jq '.headRefOid')
+   if [ "$(git rev-parse HEAD)" != "$pr_head" ]; then
+     echo "Local HEAD is not the live PR head; stop and let the branch owner reconcile it." >&2
+     exit 1
+   fi
+   ```
+
+   Do not merge an obsolete local head.
    **Publish any intentional actionable fix first (Step 0)**, after verifying
    every dirty path and unpushed commit belongs to that fix; then prefer a
    **merge** over a rebase —

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -45,7 +45,8 @@ merging, except when the user explicitly invokes `/ship-now`.
 - **Do not let slow or flaky local validation block the loop.** `pnpm run prep` / `vitest` can hang or take minutes, and on a branch with concurrent edits a full local run is contaminated by other agents' in-flight files anyway. If local validation is slow, hung, or unreliable, **push and let the CI you are already monitoring be the validation gate** — a red CI job is caught and fixed on the very next tick. Prefer pushing your work over holding it for a clean local run.
 - **Every tick, expect new local files.** On an active shared branch, concurrent
   agents may edit the checkout continuously. Re-run Step 0 every single tick
-  and publish all nonignored changes in the current branch snapshot.
+  to detect actionable changes, but publish only the fixes allowed by the
+  Branch-wide Snapshot Rule above.
 
 ## Each tick
 

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -62,9 +62,9 @@ fi
 git status --short
 git diff --name-only
 if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
-  git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
+  git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD -- . ':(exclude)learnings.md' ':(exclude)bridge/**' ':(exclude)data/**'
 else
-  git log --oneline --decorate HEAD --not --remotes=origin
+  git log --oneline --decorate HEAD --not --remotes=origin -- . ':(exclude)learnings.md' ':(exclude)bridge/**' ':(exclude)data/**'
 fi
 ```
 
@@ -87,7 +87,9 @@ can change within minutes, so re-check before every actionable push.
    and unpushed commits; do not run the merge until the publishable-path check
    `git status --short -- . ':(exclude)learnings.md' ':(exclude)bridge/**'
    ':(exclude)data/**'` and the branch-specific unpublished-commit check in
-   Step 0 are empty. Preserve and report excluded paths; they do not block
+   Step 0 are empty. The unpublished-commit check is also scoped to
+   publishable paths, so excluded-only commits do not block recovery. Preserve
+   and report excluded paths; they do not block
    recovery unless the merge itself touches them.
    Before merging, compare the local checkout with the live PR head:
 
@@ -226,8 +228,8 @@ of waiting for this section's remote-CI and soak requirements.
 When the user does ask to merge, all of these must be true **simultaneously for 10 consecutive minutes** before merging:
 
 1. **No local uncommitted changes** except the documented routine exclusions
-2. **No unpushed commits** — `git log --oneline origin/<branch>..HEAD` must be
-   empty
+2. **No unpushed commits** — the publishable-path `git log` check from Step 0
+   must be empty
 3. **All GitHub Actions CI green** — Build, Lint, Test, Typecheck, Scaffold E2E, Guard
 4. **All review comments addressed** — every human/bot inline comment and review-body item has a fix or a reply
 5. **No merge conflicts** — `gh pr view --json mergeable --jq '.mergeable'` must be `MERGEABLE`

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -57,7 +57,11 @@ merging, except when the user explicitly invokes `/ship-now`.
 ```bash
 git status --short
 git diff --name-only
-git log --oneline --decorate HEAD --not --remotes=origin
+if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
+  git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
+else
+  git log --oneline --decorate HEAD --not --remotes=origin
+fi
 ```
 
 After the status check, run `corepack pnpm ship:push` only when the dirty or
@@ -77,7 +81,7 @@ can change within minutes, so re-check before every actionable push.
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
 2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree
    and unpushed commits; do not run the merge until both `git status --short`
-   and `git log --oneline --decorate HEAD --not --remotes=origin` are empty.
+   and the branch-specific unpublished-commit check in Step 0 are empty.
    **Publish any intentional actionable fix first (Step 0)**, after verifying
    every dirty path and unpushed commit belongs to that fix; then prefer a
    **merge** over a rebase —

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -55,6 +55,7 @@ merging, except when the user explicitly invokes `/ship-now`.
 **Step 0 — always do this first, before anything else:**
 
 ```bash
+git fetch origin --quiet
 git status --short
 git diff --name-only
 if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -16,13 +16,17 @@ to the shared checkout or require that an agent publish from the root checkout.
 ## Branch-wide Snapshot Rule
 
 During `/babysit-pr`, the PR remains the unit of review and the shared checkout
-is the branch snapshot. At the first tick, record the status. Every later tick
-must publish all nonignored local work with `corepack pnpm ship:push`; the helper
-excludes `learnings.md`, `bridge/**`, and `data/**`. Never revert, stash,
-overwrite, or absorb concurrent work.
+is the branch snapshot. At the first tick, record the status and publish the
+requested initial work when it has not already been published. On later ticks,
+inspect the tree before every push. Run `corepack pnpm ship:push` only when the
+current branch contains an actionable change required by failing CI, PR
+feedback, a real merge conflict, or an explicit user request. A clean tree,
+`origin/main` drift, queued checks, or a timer tick is not a reason to commit
+or push. Never publish unrelated concurrent work, and never revert, stash, or
+overwrite it.
 
-When the branch is actively changing, publish a coherent snapshot for no more
-than two minutes, then push it to the existing PR so CI and review agents can
+When an actionable fix is actively changing, publish one coherent snapshot
+once it is ready, then push it to the existing PR so CI and review agents can
 work in parallel. The final clean-tree and merge-soak gates still apply before
 merging, except when the user explicitly invokes `/ship-now`.
 
@@ -53,20 +57,23 @@ git diff --name-only
 git log --oneline origin/$(git branch --show-current)..HEAD
 ```
 
-Run `corepack pnpm ship:push` after the status check to commit and push all
-nonignored local work. If the tree is clean but the branch has unpushed commits,
-push those commits directly.
+After the status check, run `corepack pnpm ship:push` only when the dirty or
+unpushed work is the intentional fix for a concrete CI failure, PR feedback,
+merge conflict, or explicit user request. If the tree is clean and already
+pushed, do nothing. If it is clean with unpushed commits, push them directly
+only when those commits are already an intentional actionable fix; never create
+a new maintenance commit merely to make the branch look current.
 
 Every tick starts here, no exceptions: on an active shared branch local files
-can change within minutes, so re-check before every push.
+can change within minutes, so re-check before every actionable push.
 
 **Never `git stash` concurrent changes.** Stashes get orphaned, and a stash named `babysit-tickN-concurrent-work-*` left on the source branch while babysit-pr's PR ships without it is exactly how real work gets lost. If you see local changes you don't recognize, preserve them for their owner; do not hide them in a stash or commit them here.
 
 **Step 1 — check for merge conflicts:**
 
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
-2. If `CONFLICTING`: bring `main` in and resolve. **Publish the complete
-   current snapshot first (Step 0)**, then prefer a **merge** over a rebase —
+2. If `CONFLICTING`: bring `main` in and resolve. **Publish any intentional
+   actionable fix first (Step 0)**, then prefer a **merge** over a rebase —
    `git fetch origin main && git merge --no-edit
    origin/main` — because this branch is shared with concurrent agents and a
    rebase would rewrite history and require a force-push that can clobber their
@@ -74,7 +81,8 @@ can change within minutes, so re-check before every push.
    with `git checkout --theirs -- pnpm-lock.yaml` then regenerate with `pnpm
    install --lockfile-only` against the merged `package.json`), complete the
    merge commit, and push (a normal push, never `--force`). This resets the soak
-   timer. Only rebase if the user explicitly asks for a linear history.
+   timer. Do not merge `origin/main` again while the PR remains conflict-free.
+   Only rebase if the user explicitly asks for a linear history.
 3. If `MERGEABLE` or `UNKNOWN`: proceed. (`mergeStateStatus: BLOCKED` with `mergeable: MERGEABLE` just means required checks are still pending/red — that is not a conflict; keep going.)
 
 ## Latest-feedback handoff

--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -73,9 +73,10 @@ can change within minutes, so re-check before every actionable push.
 **Step 1 — check for merge conflicts:**
 
 1. Run `gh pr view $ARGUMENTS --json mergeable --jq '.mergeable'`.
-2. If `CONFLICTING`: bring `main` in and resolve. **Publish any intentional
-   actionable fix first (Step 0)**, after verifying the dirty paths all belong
-   to that fix; then prefer a **merge** over a rebase —
+2. If `CONFLICTING`: bring `main` in and resolve. First inspect the worktree;
+   do not run the merge until `git status --short` is empty. **Publish any
+   intentional actionable fix first (Step 0)**, after verifying the dirty paths
+   all belong to that fix; then prefer a **merge** over a rebase —
    `git fetch origin main && git merge --no-edit
    origin/main` — because this branch is shared with concurrent agents and a
    rebase would rewrite history and require a force-push that can clobber their

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -235,7 +235,10 @@ branch, stay on it.
    fallback:
 
    ```bash
-   git fetch origin --quiet
+   if ! git fetch origin --quiet; then
+     echo "Cannot refresh origin refs; stop before checking unpublished commits." >&2
+     exit 1
+   fi
    if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
      git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
    else
@@ -255,7 +258,10 @@ branch, stay on it.
    confidently-wrong clean answer this check exists to catch.
 
    ```bash
-   git fetch origin main --quiet
+   if ! git fetch origin main --quiet; then
+     echo "Cannot refresh origin/main; stop before checking branch freshness." >&2
+     exit 1
+   fi
    git rev-list --count HEAD..origin/main
    ```
 
@@ -266,8 +272,11 @@ branch, stay on it.
    current `origin/main` only when GitHub reports `CONFLICTING` (or a local
    merge proves a real conflict blocks shipment). In that case, merge
    `origin/main` once, resolve it, push, and wait for the new checks. Before
-   that merge, both `git status --short` and the branch-specific
-   unpublished-commit check above must be empty. If either is not empty,
+   that merge, both `git status --short -- . ':(exclude)learnings.md'
+   ':(exclude)bridge/**' ':(exclude)data/**'` and the branch-specific
+   unpublished-commit check above must be empty. The excluded paths remain
+   preserved and reported, but do not block conflict recovery unless the
+   merge itself touches them. If either publishable-path check is not empty,
    inspect every dirty path and unpushed commit; publish them first only when
    all of them belong to the same
    actionable fix. If any unrelated or incomplete concurrent work overlaps the

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -331,6 +331,11 @@ branch, stay on it.
    clean working tree, no unpushed commits, GitHub Actions green, all review
    comments addressed/replied, and mergeable.
 
+   If conflict recovery was required, compare the local checkout with the
+   live PR head before merging `origin/main`; do not update or merge an
+   obsolete local head while another session has advanced the PR branch.
+   `/babysit-pr` provides the exact `headRefOid` check for this gate.
+
    If this invocation also found a Dependabot PR, apply the dedicated
    `review-prs` exception above and merge each qualifying update with its
    expected head SHA. Immediately before each merge, re-read the current head,

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -258,15 +258,18 @@ branch, stay on it.
    record the exact failure, keep pushing stable slices, and let GitHub Actions
    be the validation gate that `/babysit-pr` monitors.
 
-4. **Publish the branch snapshot**: run `corepack pnpm ship:push` to stage,
-   commit, and push all nonignored current-branch work. Never add
-   `Co-Authored-By` or other agent attribution.
+4. **Publish the branch snapshot**: for the requested initial handoff, run
+   `corepack pnpm ship:push` to stage, commit, and push all nonignored
+   current-branch work. For later snapshots, run it only for an actionable fix
+   required by failing CI, PR feedback, a real merge conflict, or an explicit
+   user request. Never add `Co-Authored-By` or other agent attribution.
 
    The first successful push is the review handoff point: open or update the
    ready PR immediately, before waiting on `pnpm prep`, a stability window, or
-   additional concurrent work. Later commits update that same PR and let CI
-   and review run in parallel with the rest of the ship workflow. Push each
-   later coherent branch snapshot as soon as it is available.
+   additional concurrent work. An actionable later commit updates that same PR
+   and lets CI and review run in parallel with the rest of the ship workflow.
+   Do not create or push a later snapshot for a clean tree, `origin/main` drift,
+   queued checks, or a babysit timer tick.
 
 5. **Open or update a ready PR immediately after the first push**: use the
    current branch. PRs are ready for review by default, not drafts. Do not put
@@ -281,8 +284,9 @@ branch, stay on it.
 
 6. **Babysit immediately**: run `/babysit-pr <number>` and follow that skill’s
    tick loop exactly. Treat `babysit-pr` as the source of truth for how to watch
-   the PR. Its Step 0 publishes the current nonignored branch snapshot, then
-   checks mergeability, every unaddressed review comment by reply state, and CI.
+   the PR. Its Step 0 checks the current nonignored branch snapshot and
+   publishes only actionable work, then checks mergeability, every unaddressed
+   review comment by reply state, and CI.
    Keep going until the PR is either merged/closed or the user explicitly tells
    you to stop.
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -235,6 +235,7 @@ branch, stay on it.
    fallback:
 
    ```bash
+   git fetch origin --quiet
    if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
      git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
    else

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -327,9 +327,10 @@ branch, stay on it.
 ## Important
 
 - **Multiple agents run concurrently.** There will often be locally changed
-  files you didn't generate. This is normal. Include those paths in the next
-  complete branch snapshot. Don't revert or overwrite other agents' work; fix
-  real bugs if CI or review feedback flags them.
+  files you didn't generate. This is normal. Include a path in a later branch
+  snapshot only when it belongs to the same actionable fix; otherwise preserve
+  it for its owner and report it. Don't revert or overwrite other agents' work;
+  fix real bugs if CI or review feedback flags them.
 - Never commit `learnings.md` or files in `.gitignore`.
 - If feedback appears in inline comments or review bodies, every item needs a
   fix or a reply before merge.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -229,12 +229,22 @@ branch, stay on it.
    shared/platform-managed worktrees; ship the branch belonging to this
    worktree.
 
-2. **Check local changes**: run `git status --short`, `git diff --stat`, and
-   `git log --oneline --decorate HEAD --not --remotes=origin` to establish the
-   branch snapshot. This works even before the first push, when
-   `origin/<branch>` does not exist. Multiple agents may have added work;
-   include a path or unpushed commit only after confirming it belongs to this
-   requested fix.
+2. **Check local changes**: run `git status --short` and `git diff --stat`,
+   then inspect the current branch's unpublished commits. Use the
+   branch-specific remote ref when it exists; otherwise use the first-push
+   fallback:
+
+   ```bash
+   if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
+     git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
+   else
+     git log --oneline --decorate HEAD --not --remotes=origin
+   fi
+   ```
+
+   This works even before the first push, when `origin/<branch>` does not
+   exist. Multiple agents may have added work; include a path or unpushed
+   commit only after confirming it belongs to this requested fix.
 
    Then confirm the base is current, before validating or pushing anything. A
    worktree can be created from a stale ref, and its local `main` ref is stale
@@ -255,9 +265,10 @@ branch, stay on it.
    current `origin/main` only when GitHub reports `CONFLICTING` (or a local
    merge proves a real conflict blocks shipment). In that case, merge
    `origin/main` once, resolve it, push, and wait for the new checks. Before
-   that merge, both `git status --short` and the unpushed-commit log above must
-   be empty. If either is not empty, inspect every dirty path and unpushed
-   commit; publish them first only when all of them belong to the same
+   that merge, both `git status --short` and the branch-specific
+   unpublished-commit check above must be empty. If either is not empty,
+   inspect every dirty path and unpushed commit; publish them first only when
+   all of them belong to the same
    actionable fix. If any unrelated or incomplete concurrent work overlaps the
    checkout, preserve it and wait for its owner rather than stashing, restoring,
    or forcing the merge. Do not repeat the merge while the PR is mergeable or

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -240,9 +240,9 @@ branch, stay on it.
      exit 1
    fi
    if git show-ref --verify --quiet "refs/remotes/origin/$(git branch --show-current)"; then
-     git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD
+     git log --oneline --decorate "origin/$(git branch --show-current)"..HEAD -- . ':(exclude)learnings.md' ':(exclude)bridge/**' ':(exclude)data/**'
    else
-     git log --oneline --decorate HEAD --not --remotes=origin
+     git log --oneline --decorate HEAD --not --remotes=origin -- . ':(exclude)learnings.md' ':(exclude)bridge/**' ':(exclude)data/**'
    fi
    ```
 
@@ -274,7 +274,9 @@ branch, stay on it.
    `origin/main` once, resolve it, push, and wait for the new checks. Before
    that merge, both `git status --short -- . ':(exclude)learnings.md'
    ':(exclude)bridge/**' ':(exclude)data/**'` and the branch-specific
-   unpublished-commit check above must be empty. The excluded paths remain
+   unpublished-commit check above must be empty. The check is also scoped to
+   publishable paths, so a commit containing only an excluded path does not
+   block recovery. The excluded paths remain
    preserved and reported, but do not block conflict recovery unless the
    merge itself touches them. If either publishable-path check is not empty,
    inspect every dirty path and unpushed commit; publish them first only when

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -230,9 +230,11 @@ branch, stay on it.
    worktree.
 
 2. **Check local changes**: run `git status --short`, `git diff --stat`, and
-   `git log --oneline origin/$(git branch --show-current)..HEAD` to establish
-   the branch snapshot. Multiple agents may have added work; include a path or
-   unpushed commit only after confirming it belongs to this requested fix.
+   `git log --oneline --decorate HEAD --not --remotes=origin` to establish the
+   branch snapshot. This works even before the first push, when
+   `origin/<branch>` does not exist. Multiple agents may have added work;
+   include a path or unpushed commit only after confirming it belongs to this
+   requested fix.
 
    Then confirm the base is current, before validating or pushing anything. A
    worktree can be created from a stale ref, and its local `main` ref is stale

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -237,10 +237,15 @@ branch, stay on it.
    git rev-list --count HEAD..origin/main
    ```
 
-   Non-zero means reapply the work onto current `origin/main` before pushing —
-   shipping from a stale base conflicts with or reverts whatever landed in the
-   gap. Measured 2026-08-18: four live Codex worktrees sat 1,144 commits behind
-   `origin/main` while reporting themselves clean from the inside.
+   A non-zero count is a freshness signal, not a problem by itself. Do not
+   merge, rebase, or otherwise update the branch merely because `origin/main`
+   advanced; a PR may be behind `main` while remaining valid and mergeable.
+   Keep the branch head stable so its checks remain meaningful. Update from
+   current `origin/main` only when GitHub reports `CONFLICTING` (or a local
+   merge proves a real conflict blocks shipment). In that case, merge
+   `origin/main` once, resolve it, push, and wait for the new checks. Do not
+   repeat the merge while the PR is mergeable or checks are merely pending. A
+   behind count alone never justifies a merge commit.
 
 3. **Validate enough to avoid obvious breakage**: run focused tests for the
    changed area. Push the first safe slice before running `pnpm run prep` or

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -28,9 +28,12 @@ same branch snapshot. The checkpoint helper excludes `learnings.md`,
 
 `/ship` ships the complete nonignored branch snapshot, not a hand-selected
 subset of dirty paths. At the start of the flow, record the status and publish
-all current local changes with the checkpoint helper. If another session adds a
-path during the flow, include it in the next coherent snapshot; never revert,
-stash, or overwrite it.
+the requested initial work with the checkpoint helper. Before any later
+actionable push, verify that every dirty or unpushed path belongs to that same
+fix; the helper stages the whole nonignored tree, so do not run it when the
+checkout mixes unrelated or incomplete concurrent work. Preserve those paths
+for their owner and report them instead. Never revert, stash, or overwrite
+concurrent work.
 
 Invoking `/ship` is explicit authorization to merge this PR once the merge gates
 below pass, unless the user says not to merge. Do not ask again just to merge a
@@ -247,7 +250,11 @@ branch, stay on it.
    Keep the branch head stable so its checks remain meaningful. Update from
    current `origin/main` only when GitHub reports `CONFLICTING` (or a local
    merge proves a real conflict blocks shipment). In that case, merge
-   `origin/main` once, resolve it, push, and wait for the new checks. Do not
+   `origin/main` once, resolve it, push, and wait for the new checks. Before
+   that merge, the worktree must be clean. If dirty paths are all part of the
+   same actionable fix, publish them first; if any unrelated or incomplete
+   concurrent work overlaps the checkout, preserve it and wait for its owner
+   to clear it rather than stashing, restoring, or forcing the merge. Do not
    repeat the merge while the PR is mergeable or checks are merely pending. A
    behind count alone never justifies a merge commit.
 
@@ -262,7 +269,8 @@ branch, stay on it.
    `corepack pnpm ship:push` to stage, commit, and push all nonignored
    current-branch work. For later snapshots, run it only for an actionable fix
    required by failing CI, PR feedback, a real merge conflict, or an explicit
-   user request. Never add `Co-Authored-By` or other agent attribution.
+   user request, after verifying that all dirty paths belong to that fix.
+   Never add `Co-Authored-By` or other agent attribution.
 
    The first successful push is the review handoff point: open or update the
    ready PR immediately, before waiting on `pnpm prep`, a stability window, or

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -69,8 +69,12 @@ branch and read the remote sha back.
 
 Treat these as an immediate call to it: `/ship`, "ship our latest local
 changes", or "push up my local changes". Push the first coherent branch
-snapshot before long validation so CI and review can start, then publish later
-snapshots as local work arrives.
+snapshot before long validation so CI and review can start. After that first
+handoff, publish a later snapshot only when it contains an actionable change
+required by failing CI, PR feedback, a real merge conflict, or an explicit user
+request. Do not run `ship:push` on a clean or merely behind branch, and do not
+create a maintenance or `chore: publish branch work` commit just to refresh
+`main`, restart checks, or satisfy a babysit tick.
 
 ## Deployment split
 
@@ -268,9 +272,12 @@ branch, stay on it.
    current branch. PRs are ready for review by default, not drafts. Do not put
    `codex`, `[codex]`, or similar agent labels in the title/body.
 
-   For every later safe slice, update this same PR immediately after pushing;
-   do not create a second PR or wait for prep to finish before handing the
-   slice to CI and review.
+   For every later safe slice that fixes failing CI, addresses PR feedback,
+   resolves a real merge conflict, or implements an explicit user request,
+   update this same PR immediately after pushing. Do not create a second PR or
+   wait for prep to finish before handing the slice to CI and review. A clean
+   tree, `origin/main` drift, queued checks, or a timer tick is not a safe
+   slice and must not produce a commit or push.
 
 6. **Babysit immediately**: run `/babysit-pr <number>` and follow that skill’s
    tick loop exactly. Treat `babysit-pr` as the source of truth for how to watch

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -19,21 +19,22 @@ Ship the complete nonignored current-branch snapshot end-to-end: commit and
 push it, open or update a ready PR, run `/babysit-pr`, merge when its normal
 gates are satisfied, then run `/new-branch` after the merge lands.
 
-`/ship` means all nonignored local changes on the current branch. The shared
-checkout is the source of truth, so include concurrent-session changes in the
-same branch snapshot. The checkpoint helper excludes `learnings.md`,
-`bridge/**`, and `data/**`.
+`/ship` means all nonignored local changes belonging to the requested work on
+the current branch. The shared checkout is the source of truth, but unrelated
+or incomplete concurrent work stays with its owner and is not part of this PR
+snapshot. The checkpoint helper excludes `learnings.md`, `bridge/**`, and
+`data/**`.
 
 ## Non-Negotiable Shipping Invariant
 
-`/ship` ships the complete nonignored branch snapshot, not a hand-selected
-subset of dirty paths. At the start of the flow, record the status and publish
-the requested initial work with the checkpoint helper. Before any later
-actionable push, verify that every dirty or unpushed path belongs to that same
-fix; the helper stages the whole nonignored tree, so do not run it when the
-checkout mixes unrelated or incomplete concurrent work. Preserve those paths
-for their owner and report them instead. Never revert, stash, or overwrite
-concurrent work.
+`/ship` ships the complete nonignored snapshot of the requested work, not a
+hand-selected subset of that work. At the start of the flow, record the status
+and every unpushed commit, then verify that every candidate path and commit
+belongs to the requested fix before invoking the checkpoint helper. If the
+checkout mixes unrelated or incomplete concurrent work, do not run the helper:
+preserve those paths for their owner and report them instead. Apply the same
+ownership check before every later actionable push. Never revert, stash, or
+overwrite concurrent work.
 
 Invoking `/ship` is explicit authorization to merge this PR once the merge gates
 below pass, unless the user says not to merge. Do not ask again just to merge a
@@ -228,9 +229,10 @@ branch, stay on it.
    shared/platform-managed worktrees; ship the branch belonging to this
    worktree.
 
-2. **Check local changes**: run `git status --short` and `git diff --stat` to
-   establish the branch snapshot. Multiple agents may have added work; include
-   those paths in the complete nonignored snapshot.
+2. **Check local changes**: run `git status --short`, `git diff --stat`, and
+   `git log --oneline origin/$(git branch --show-current)..HEAD` to establish
+   the branch snapshot. Multiple agents may have added work; include a path or
+   unpushed commit only after confirming it belongs to this requested fix.
 
    Then confirm the base is current, before validating or pushing anything. A
    worktree can be created from a stale ref, and its local `main` ref is stale
@@ -251,12 +253,14 @@ branch, stay on it.
    current `origin/main` only when GitHub reports `CONFLICTING` (or a local
    merge proves a real conflict blocks shipment). In that case, merge
    `origin/main` once, resolve it, push, and wait for the new checks. Before
-   that merge, the worktree must be clean. If dirty paths are all part of the
-   same actionable fix, publish them first; if any unrelated or incomplete
-   concurrent work overlaps the checkout, preserve it and wait for its owner
-   to clear it rather than stashing, restoring, or forcing the merge. Do not
-   repeat the merge while the PR is mergeable or checks are merely pending. A
-   behind count alone never justifies a merge commit.
+   that merge, both `git status --short` and the unpushed-commit log above must
+   be empty. If either is not empty, inspect every dirty path and unpushed
+   commit; publish them first only when all of them belong to the same
+   actionable fix. If any unrelated or incomplete concurrent work overlaps the
+   checkout, preserve it and wait for its owner rather than stashing, restoring,
+   or forcing the merge. Do not repeat the merge while the PR is mergeable or
+   checks are merely pending. A behind count alone never justifies a merge
+   commit.
 
 3. **Validate enough to avoid obvious breakage**: run focused tests for the
    changed area. Push the first safe slice before running `pnpm run prep` or

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -71,7 +71,7 @@ const FEEDBACK_REGEX_CASES = [
   [false, "eyes-only thread"],
 ];
 
-const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|only|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|only|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -82,6 +82,7 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [true, "Do not run ship:push on a clean or merely behind branch."],
   [false, "The build completed successfully."],
   [false, "The branch contains a useful chore commit."],
+  [false, "Only commit relevant changes."],
 ];
 
 if (process.argv.includes("--self-test")) {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[^.!?\n]{0,220}\b(?:(?:routine|generic|maintenance|chore|repeated|again|100\s+times|clean|behind|timer)\b|unless[^.!?\n]{0,60}\b(?:conflict\w*|necessary|routine|chore|clear)\b))[^.!?\n]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[^.!?\n]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[^.!?\n]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[^.!?\n]{0,220}\b(?:(?:routin\w*|generic|maintenance|chore|repeated|again|100\s+times|clean|behind|timer)\b|unless[^.!?\n]{0,60}\b(?:conflict\w*|necessary|routin\w*|chore|clear)\b))[^.!?\n]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance|unnecessary)\s+(?:ship|publish)?\s*(?:commits?|changes?)|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:(?:generic|routine|maintenance|unnecessary)\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[^.!?\n]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[^.!?\n]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -96,6 +96,8 @@ const SHIPPING_CHURN_REGEX_CASES = [
   ],
   [false, "Do not merge main after CI passes."],
   [false, "Do not merge main. The branch contains a routine chore commit."],
+  [true, "Do not push routine commits."],
+  [true, "Do not push commits routinely."],
 ];
 
 if (process.argv.includes("--self-test")) {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -71,10 +71,11 @@ const FEEDBACK_REGEX_CASES = [
   [false, "eyes-only thread"],
 ];
 
-const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|only|stop)\b[\s\S]{0,220}\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|only|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|only|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|only|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
+  [true, "Stop merging main unless there is a real conflict."],
   [true, "only push up commits if there are clear CI errors or PR feedback."],
   [true, "Do not create or push a routine chore: publish branch work commit."],
   [true, "I don't want those chore commits unless absolutely necessary."],
@@ -98,7 +99,7 @@ if (process.argv.includes("--self-test")) {
     process.exitCode = 1;
   } else {
     console.log(
-      `Feedback regex self-test passed (${FEEDBACK_REGEX_CASES.length} cases).`,
+      `Friction regex self-test passed (${FEEDBACK_REGEX_CASES.length + SHIPPING_CHURN_REGEX_CASES.length} cases).`,
     );
   }
   process.exit(failures.length > 0 ? 1 : 0);

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -84,6 +84,7 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [true, "Stop updating or syncing the branch from main unless conflicting."],
   [true, "Stop creating generic ship commits unless CI requires them."],
   [true, "Do not merge `main` into every PR unless there is a conflict."],
+  [false, "Don't forget to merge main when everything is green."],
   [false, "The build completed successfully."],
   [false, "The branch contains a useful chore commit."],
   [false, "Only commit relevant changes."],

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -71,7 +71,8 @@ const FEEDBACK_REGEX_CASES = [
   [false, "eyes-only thread"],
 ];
 
-const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+const SHIPPING_CHURN_RE =
+  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -112,8 +113,7 @@ const PATTERNS = [
     // generic ship commits as a measurable source of CI churn.
     key: "shipping-churn",
     label: "Had to stop routine ship commits or main merges",
-    fixedBy:
-      ".agents/skills/ship + .agents/skills/babysit-pr (2026-08-27)",
+    fixedBy: ".agents/skills/ship + .agents/skills/babysit-pr (2026-08-27)",
     re: SHIPPING_CHURN_RE,
   },
   {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[\s\S]{0,220}\b(?:unless|unnecessary|necessary|routine|repeated|again|100\s+times|only|merely|clear|conflict|CI|feedback|clean|behind|timer)\b)[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -88,6 +88,8 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [false, "The build completed successfully."],
   [false, "The branch contains a useful chore commit."],
   [false, "Only commit relevant changes."],
+  [false, "Do not merge main when every required check passes."],
+  [false, "Should we merge main after the checks pass?"],
 ];
 
 if (process.argv.includes("--self-test")) {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -89,6 +89,15 @@ if (process.argv.includes("--self-test")) {
 
 const PATTERNS = [
   {
+    // Added 2026-08-27 after the PR queue exposed routine main merges and
+    // generic ship commits as a measurable source of CI churn.
+    key: "shipping-churn",
+    label: "Had to stop routine ship commits or main merges",
+    fixedBy:
+      ".agents/skills/ship + .agents/skills/babysit-pr (2026-08-27)",
+    re: /\b(?:don['’]?t|do not|only|stop)\b[^.!?]{0,180}\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- ])?commits?|(?:push|commit)(?:ing)?\s+(?:up|and)?\s*(?:commits?|changes?))\b|\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- ])?commits?)\b[^.!?]{0,180}\b(?:unless|only|unnecessary|necessary|clear)\b/i,
+  },
+  {
     key: "branch-moves",
     label: "Unrequested branch creation / movement",
     fixedBy: ".agents/skills/new-branch (activation guard, 2026-07-28)",

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[\s\S]{0,220}\b(?:unless|unnecessary|necessary|routine|repeated|again|100\s+times|only|merely|clear|conflict|CI|feedback|clean|behind|timer)\b)[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[\s\S]{0,220}\b(?:(?:routine|generic|maintenance|chore|repeated|again|100\s+times|clean|behind|timer)\b|unless[\s\S]{0,60}\b(?:conflict\w*|necessary|routine|chore|clear)\b))[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -90,6 +90,11 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [false, "Only commit relevant changes."],
   [false, "Do not merge main when every required check passes."],
   [false, "Should we merge main after the checks pass?"],
+  [
+    false,
+    "Do not commit or push changes unless they belong to this requested fix.",
+  ],
+  [false, "Do not merge main after CI passes."],
 ];
 
 if (process.argv.includes("--self-test")) {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+(?:origin\/)?main)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -82,6 +82,8 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [true, "I don't want those chore commits unless absolutely necessary."],
   [true, "Do not run ship:push on a clean or merely behind branch."],
   [true, "Stop updating or syncing the branch from main unless conflicting."],
+  [true, "Stop creating generic ship commits unless CI requires them."],
+  [true, "Do not merge `main` into every PR unless there is a conflict."],
   [false, "The build completed successfully."],
   [false, "The branch contains a useful chore commit."],
   [false, "Only commit relevant changes."],

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[\s\S]{0,220}\b(?:(?:routine|generic|maintenance|chore|repeated|again|100\s+times|clean|behind|timer)\b|unless[\s\S]{0,60}\b(?:conflict\w*|necessary|routine|chore|clear)\b))[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b(?!\s+(?:forget|remember)\b)(?=[^.!?\n]{0,220}\b(?:(?:routine|generic|maintenance|chore|repeated|again|100\s+times|clean|behind|timer)\b|unless[^.!?\n]{0,60}\b(?:conflict\w*|necessary|routine|chore|clear)\b))[^.!?\n]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:generic|routine|maintenance)\s+(?:ship|publish)\s+commits?|(?:ship|publish)\s+(?:(?:a|the|generic|routine|maintenance)\s+)?(?:commits?|changes?)|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[^.!?\n]{0,80}\b(?:from|with|against)\s+`?(?:origin\/)?main`?)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:the\s+)?`?(?:origin\/)?main`?)\b[^.!?\n]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -95,6 +95,7 @@ const SHIPPING_CHURN_REGEX_CASES = [
     "Do not commit or push changes unless they belong to this requested fix.",
   ],
   [false, "Do not merge main after CI passes."],
+  [false, "Do not merge main. The branch contains a routine chore commit."],
 ];
 
 if (process.argv.includes("--self-test")) {

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -71,10 +71,27 @@ const FEEDBACK_REGEX_CASES = [
   [false, "eyes-only thread"],
 ];
 
+const SHIPPING_CHURN_RE = /\b(?:don['’]?t|do not|only|stop)\b[\s\S]{0,220}\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|only|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+
+const SHIPPING_CHURN_REGEX_CASES = [
+  [true, "don't merge main 100 times unless there is a clear conflict."],
+  [true, "only push up commits if there are clear CI errors or PR feedback."],
+  [true, "Do not create or push a routine chore: publish branch work commit."],
+  [true, "I don't want those chore commits unless absolutely necessary."],
+  [true, "Do not run ship:push on a clean or merely behind branch."],
+  [false, "The build completed successfully."],
+  [false, "The branch contains a useful chore commit."],
+];
+
 if (process.argv.includes("--self-test")) {
   const failures = FEEDBACK_REGEX_CASES.filter(
     ([expected, message]) =>
       UNANSWERED_FEEDBACK_FOLLOWUP_RE.test(message) !== expected,
+  );
+  failures.push(
+    ...SHIPPING_CHURN_REGEX_CASES.filter(
+      ([expected, message]) => SHIPPING_CHURN_RE.test(message) !== expected,
+    ),
   );
   if (failures.length > 0) {
     console.error("Feedback regex self-test failed:", failures);
@@ -95,7 +112,7 @@ const PATTERNS = [
     label: "Had to stop routine ship commits or main merges",
     fixedBy:
       ".agents/skills/ship + .agents/skills/babysit-pr (2026-08-27)",
-    re: /\b(?:don['’]?t|do not|only|stop)\b[^.!?]{0,180}\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- ])?commits?|(?:push|commit)(?:ing)?\s+(?:up|and)?\s*(?:commits?|changes?))\b|\b(?:merge(?:d|s)?\s+(?:origin\/)?main|chore(?:\s+|[- ])?commits?)\b[^.!?]{0,180}\b(?:unless|only|unnecessary|necessary|clear)\b/i,
+    re: SHIPPING_CHURN_RE,
   },
   {
     key: "branch-moves",

--- a/scripts/agent-friction-report.mjs
+++ b/scripts/agent-friction-report.mjs
@@ -72,7 +72,7 @@ const FEEDBACK_REGEX_CASES = [
 ];
 
 const SHIPPING_CHURN_RE =
-  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?))\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
+  /\b(?:don['’]?t|do not|stop)\b[\s\S]{0,220}\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push|(?:push|commit)(?:ting|ing)?\s+(?:up\s+)?(?:commits?|changes?)|(?:updat(?:e|ing|ed)|sync(?:e|ing)|refresh(?:e|ing))\b[\s\S]{0,80}\b(?:from|with|against)\s+(?:origin\/)?main)\b|\bonly\s+(?:push(?:\s+up)?|merg(?:e|ed|es|ing)\s+(?:origin\/)?main)\b[\s\S]{0,220}\b(?:CI\s+errors?|PR\s+feedback|merge\s+conflicts?|clear\s+(?:CI|merge)|prevent(?:s|ing)?\s+merge)\b|\b(?:merg(?:e|ed|es|ing)\s+(?:origin\/)?main|chore(?:\s+|[- :])?\s*(?:publish\s+branch\s+work\s+)?commits?|ship:push)\b[\s\S]{0,220}\b(?:unless|unnecessary|necessary|clear|routine|clean|behind|timer)\b/i;
 
 const SHIPPING_CHURN_REGEX_CASES = [
   [true, "don't merge main 100 times unless there is a clear conflict."],
@@ -81,6 +81,7 @@ const SHIPPING_CHURN_REGEX_CASES = [
   [true, "Do not create or push a routine chore: publish branch work commit."],
   [true, "I don't want those chore commits unless absolutely necessary."],
   [true, "Do not run ship:push on a clean or merely behind branch."],
+  [true, "Stop updating or syncing the branch from main unless conflicting."],
   [false, "The build completed successfully."],
   [false, "The branch contains a useful chore commit."],
   [false, "Only commit relevant changes."],


### PR DESCRIPTION
Update the ship workflow so a branch being behind origin/main is only a freshness signal. Agents update from main when GitHub reports a real conflict, then resolve and push once; pending checks or a mergeable PR do not justify repeated main merge commits.