### PR TITLE
Smooth out skeleton loading animation

### DIFF
--- a/.changeset/smooth-skeleton-pulse.md
+++ b/.changeset/smooth-skeleton-pulse.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/core": patch
+---
+
+Smooth out the skeleton loading animation. Tailwind's stock `animate-pulse`
+swings opacity 1 → 0.5 and eases hard into both ends, and skeletons that mount
+at different moments never line up — at that amplitude a screen of placeholders
+strobes. The shared stylesheet now defines `--animate-pulse` as a calmer
+1 → 0.72 breathe, honours `prefers-reduced-motion` globally, and the two
+hand-rolled skeleton keyframes reuse it.

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -490,6 +490,13 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
 
+  /* Tailwind's stock pulse swings opacity 1 -> 0.5 and eases hard into both
+     ends, so a placeholder reads as blinking rather than breathing. Skeletons
+     also mount at different moments, so their cycles never line up: at that
+     amplitude a screen of them strobes. Keep the swing small enough that
+     out-of-phase neighbours stay calm. */
+  --animate-pulse: skeleton-pulse 2s ease-in-out infinite;
+
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
   --animate-bounce-once: bounce-once 0.46s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -536,6 +543,21 @@
     100% {
       transform: translateX(100%);
     }
+  }
+}
+
+/* Declared at top level, not inside `@theme`, so it is emitted even in a build
+   where no `animate-pulse` utility survives tree-shaking — other stylesheets
+   reference it by name. */
+@keyframes skeleton-pulse {
+  50% {
+    opacity: 0.72;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse {
+    animation: none;
   }
 }
 

--- a/packages/core/src/styles/blocks.css
+++ b/packages/core/src/styles/blocks.css
@@ -1835,15 +1835,6 @@
 
 @media (prefers-reduced-motion: no-preference) {
   .plan-wf[data-skeleton="true"] {
-    animation: plan-skeleton-pulse 1.6s ease-in-out infinite;
-  }
-}
-@keyframes plan-skeleton-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
+    animation: skeleton-pulse 2s ease-in-out infinite;
   }
 }

--- a/templates/analytics/app/global.css
+++ b/templates/analytics/app/global.css
@@ -140,17 +140,7 @@
 
 .analytics-dashboard-panel-skeleton {
   background-color: hsl(var(--muted-foreground) / 0.12);
-  animation: analytics-dashboard-skeleton-pulse 1.6s ease-in-out infinite;
-}
-
-@keyframes analytics-dashboard-skeleton-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.74;
-  }
+  animation: skeleton-pulse 2s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Problem

Skeleton loaders across Slides, Analytics, and every other template read as a blinking, erratic strobe rather than a calm loading state.

Every `Skeleton` in the repo — and ~100 raw `animate-pulse` divs in core — resolve to Tailwind's stock pulse:

```css
--animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
@keyframes pulse { 50% { opacity: 0.5 } }
```

Two things make that strobe:

1. **Amplitude.** A 1 → 0.5 opacity swing is huge for a placeholder, and the bezier is applied to *each half* of the two-stop keyframe, so it dwells at both extremes and races through the middle — an on/off blink rather than a breathe.
2. **Phase.** A CSS animation starts when its element mounts. Skeletons appear at different moments (sidebar first, canvas when generation starts, list items as data streams in), so neighbouring placeholders are permanently out of phase. At 0.5 amplitude that reads as erratic flashing across the screen.

Every hand-tuned skeleton already in this repo had independently settled near 0.72 (`analytics-dashboard-skeleton-pulse` at 0.74, `plan-skeleton-pulse` at 0.7). The shared utility was the outlier.

## Change

`packages/core/src/styles/agent-native.css` overrides `--animate-pulse` once, so every template that imports the shared stylesheet picks it up:

```css
--animate-pulse: skeleton-pulse 2s ease-in-out infinite;
@keyframes skeleton-pulse { 50% { opacity: 0.72 } }
```

Also:

- `prefers-reduced-motion: reduce` now disables `.animate-pulse` globally — most raw `animate-pulse` divs never had `motion-reduce:animate-none`.
- The two hand-rolled duplicates (`analytics-dashboard-skeleton-pulse`, `plan-skeleton-pulse`) are deleted and reuse the shared keyframes, so nothing beats against anything else at a different period.
- `skeleton-pulse` is declared at top level rather than inside `@theme`, so it is emitted even in a build where no `animate-pulse` utility survives tree-shaking — otherwise the other two stylesheets would silently stop animating.

## Verification

Slides dev server, real signed-in app page:

- `.animate-pulse` resolves to `skeleton-pulse / 2s / ease-in-out`; the stock `@keyframes pulse` is gone from the emitted CSS.
- A real `animate-pulse rounded-md bg-muted` element sampled across a full cycle: opacity range 1 → 0.72, peak per-frame change **0.008** (stock measured **0.0139** on the same machine) — 1.73× calmer, on a swing 44% the size.
- `pnpm guards` — all 65 checks passed.
- Core styles + wireframe render specs — 41 passed.

## Known limit

This does not phase-lock skeletons that mount at different times; pure CSS cannot anchor an animation to a shared clock. The reduced amplitude is what makes the residual desync read as calm rather than erratic. If it ever needs to be exact, that requires a JS-set negative `animation-delay` against a shared origin.