### PR TITLE
fix: repair stale better-sqlite3 bindings before tests

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,5 +1,9 @@
 // Core owns the shared base config, so it reads the source directly rather than
 // going through the monorepo-root re-export.
+import { ensureNativeDependencies } from "./src/cli/native-dependencies.ts";
 import baseConfig from "./src/vitest-config";
+
+// Core specs import the native driver directly, before app startup can repair it.
+ensureNativeDependencies({ repair: true, label: "vitest" });
 
 export default baseConfig;

--- a/scripts/workspace-run.ts
+++ b/scripts/workspace-run.ts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
 import os from "node:os";
 
+import { ensureNativeDependencies } from "../packages/core/src/cli/native-dependencies.ts";
+
 type ProfileName = "test" | "typecheck";
 
 type Profile = {
@@ -80,6 +82,15 @@ console.error(
 if (parsedArgs.dryRun) {
   console.log([command, ...pnpmArgs.map(quoteArg)].join(" "));
   process.exit(0);
+}
+
+// Test files can import better-sqlite3 before an app startup preflight runs.
+if (profileName === "test") {
+  ensureNativeDependencies({
+    fromDirectory: process.cwd(),
+    label: "workspace-test",
+    repair: true,
+  });
 }
 
 const child = spawn(command, pnpmArgs, {

--- a/templates/slides/changelog/2026-08-27-canvas-comments-now-open-from-c-and-keep-their-position.md
+++ b/templates/slides/changelog/2026-08-27-canvas-comments-now-open-from-c-and-keep-their-position.md
@@ -2,4 +2,5 @@
 type: added
 date: 2026-08-27
 ---
+
 Slides let you place persistent comments on the canvas with C, hover previews, and click-to-open threads.

--- a/templates/slides/changelog/2026-08-27-powerpoint-exports-keep-their-fonts-and-layout.md
+++ b/templates/slides/changelog/2026-08-27-powerpoint-exports-keep-their-fonts-and-layout.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-27
 ---
+
 PowerPoint exports now embed the deck's own fonts and pin every text box, so a deck opened in PowerPoint or moved into Google Slides keeps the type and layout it had in the editor.


### PR DESCRIPTION
## Summary

- repair stale better-sqlite3 binaries before recursive workspace tests
- repair the binding before Core Vitest imports native database specs
- reuse the existing locked current-Node rebuild path

## Verification

- Core auth and native dependency specs pass: 213 tests
- stale binding rehearsal passed: Vitest detected a missing native module, rebuilt it, and passed the native dependency specs