### PR TITLE
chore: rerun CI on latest main

### DIFF
--- a/templates/slides/changelog/2026-08-27-canvas-comments-now-open-from-c-and-keep-their-position.md
+++ b/templates/slides/changelog/2026-08-27-canvas-comments-now-open-from-c-and-keep-their-position.md
@@ -2,4 +2,5 @@
 type: added
 date: 2026-08-27
 ---
+
 Slides let you place persistent comments on the canvas with C, hover previews, and click-to-open threads.

--- a/templates/slides/changelog/2026-08-27-powerpoint-exports-keep-their-fonts-and-layout.md
+++ b/templates/slides/changelog/2026-08-27-powerpoint-exports-keep-their-fonts-and-layout.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-27
 ---
+
 PowerPoint exports now embed the deck's own fonts and pin every text box, so a deck opened in PowerPoint or moved into Google Slides keeps the type and layout it had in the editor.


### PR DESCRIPTION
Refreshes the latest origin/main tip with the formatter-only prep output in two Slides changelog front matters so the merged main snapshot gets a fresh CI run. Local validation: pnpm guards and pnpm typecheck pass after rebuilding local core/toolkit artifacts; 182 focused core tests pass. The full local test phase is contaminated by the shared better-sqlite3 Node ABI mismatch (147 vs local 137) and unavailable browser/GPU support, so GitHub Actions is the authoritative gate.