### PR TITLE
fix(slides): name imported decks from their source

### DIFF
--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -34,6 +34,7 @@ import {
   type AspectRatio,
 } from "../shared/aspect-ratios.js";
 import {
+  DEFAULT_IMPORTED_DECK_TITLE,
   isOpaqueDeckTitle,
   resolveImportedDeckTitle,
 } from "../shared/deck-title.js";
@@ -200,7 +201,8 @@ export default defineAction({
       const { parsePptx } =
         await import("../server/handlers/import/pptx-parser.js");
       const presentation = await parsePptx(fileBuffer);
-      const title = presentation.title || titleFromPath(filename);
+      const fallbackTitle = titleFromPath(filename);
+      const title = presentation.title || "";
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
@@ -258,6 +260,7 @@ export default defineAction({
           aspectRatio,
           sourceImport,
           pptxResults[0]?.sourceText,
+          fallbackTitle,
           presentation.theme,
         );
         return {
@@ -274,7 +277,11 @@ export default defineAction({
 
       return {
         format: "pptx",
-        title,
+        title: resolveImportedDeckTitle(
+          title,
+          presentation.slides[0]?.texts.map((text) => text.content).join("\n"),
+          fallbackTitle,
+        ),
         slideCount: presentation.slides.length,
         slides: presentation.slides.map((slide, i) => ({
           index: i,
@@ -299,7 +306,8 @@ export default defineAction({
         await import("../server/handlers/import/html-converter.js");
       const doc = await parseDocx(fileBuffer);
       const slideHtmlArray = convertSectionsToSlides(doc.sections);
-      const title = doc.title || titleFromPath(filename);
+      const fallbackTitle = titleFromPath(filename);
+      const title = doc.title || "";
 
       if (importIntoDeck) {
         if (!deckId) throw new Error("deckId is required to import into deck");
@@ -320,6 +328,7 @@ export default defineAction({
           undefined,
           undefined,
           doc.text,
+          fallbackTitle,
         );
         return {
           format: "docx",
@@ -334,7 +343,7 @@ export default defineAction({
 
       return {
         format: "docx",
-        title,
+        title: resolveImportedDeckTitle(title, doc.text, fallbackTitle),
         sectionCount: doc.sections.length,
         text: truncateText(doc.text, sourceLimit).text,
         sections: summarizeSections(doc.sections),
@@ -363,10 +372,11 @@ export default defineAction({
         if (!deckId) throw new Error("deckId is required to import into deck");
         return importPdfPagesWithFidelity({
           fileBuffer,
-          title,
+          title: "",
           deckId,
           PDFParse,
           canvasFactory,
+          fallbackTitle: title,
         });
       }
 
@@ -458,10 +468,13 @@ async function importPdfFromSidecar(args: {
 
   const importedTitle = await appendDeckSlides(
     deckId,
-    sidecar.title?.trim() || fallbackTitle,
+    sidecar.title?.trim() || "",
     slides,
     "import-file:pdf-sidecar",
     aspectRatio,
+    undefined,
+    undefined,
+    fallbackTitle,
   );
 
   return {
@@ -480,10 +493,12 @@ async function importPdfPagesWithFidelity(args: {
   fileBuffer: Buffer;
   title: string;
   deckId: string;
+  fallbackTitle: string;
   PDFParse: Awaited<ReturnType<typeof setupPdfParse>>["PDFParse"];
   canvasFactory: object | undefined;
 }) {
-  const { fileBuffer, title, deckId, PDFParse, canvasFactory } = args;
+  const { fileBuffer, title, deckId, fallbackTitle, PDFParse, canvasFactory } =
+    args;
   const { convertToSlideHtml, convertSectionsToSlides } =
     await import("../server/handlers/import/html-converter.js");
   const { parsePdfFidelity } =
@@ -688,6 +703,7 @@ async function importPdfPagesWithFidelity(args: {
     aspectRatio,
     sourceImport,
     imported[0]?.snapshot.text,
+    fallbackTitle,
   );
 
   return {
@@ -750,7 +766,7 @@ async function buildPptxSlide(
 
 function titleFromPath(filePath: string): string {
   const base = path.basename(filePath, path.extname(filePath)).trim();
-  return base && !isOpaqueDeckTitle(base) ? base : "Imported File";
+  return base && !isOpaqueDeckTitle(base) ? base : DEFAULT_IMPORTED_DECK_TITLE;
 }
 
 function normalizePdfPages(result: unknown): { num: number; text: string }[] {
@@ -838,6 +854,7 @@ async function appendDeckSlides(
   aspectRatio?: AspectRatio,
   sourceImport?: ReturnType<typeof buildSourceImportMetadata>,
   titleSource?: unknown,
+  fallbackTitle?: unknown,
   theme?: import("../server/handlers/import/pptx-parser.js").ParsedPresentation["theme"],
 ): Promise<string> {
   await assertAccess("deck", deckId, "editor");
@@ -873,8 +890,16 @@ async function appendDeckSlides(
     // every slide already on it.
     const hadExistingSlides = previousSlides.length > 0;
     const nextTitle = hadExistingSlides
-      ? (existing[0].title ?? title)
-      : resolveImportedDeckTitle(title, titleSource ?? slides[0]?.content);
+      ? resolveImportedDeckTitle(
+          existing[0].title ?? title,
+          titleSource ?? slides[0]?.content,
+          fallbackTitle ?? title,
+        )
+      : resolveImportedDeckTitle(
+          title,
+          titleSource ?? slides[0]?.content,
+          fallbackTitle,
+        );
     resolvedTitle = nextTitle;
     const nextSourceImport = sourceImport
       ? mergeSourceImportMetadata(

--- a/templates/slides/actions/import-file.ts
+++ b/templates/slides/actions/import-file.ts
@@ -541,7 +541,7 @@ async function importPdfPagesWithFidelity(args: {
     if (sidecar.status === "found") {
       return await importPdfFromSidecar({
         sidecar: sidecar.sidecar,
-        fallbackTitle: title,
+        fallbackTitle,
         deckId,
       });
     }

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -182,7 +182,7 @@ export async function importPptxBufferToDeck(args: {
   const slides = results.map((r) => r.slide);
   const deckTitle = resolveImportedDeckTitle(
     requestedTitle,
-    slides[0]?.content,
+    results[0]?.sourceText || slides[0]?.content,
   );
   assertHumanReadableDeckTitle(deckTitle);
   const imagesSkipped = results.reduce(

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -28,6 +28,10 @@ import {
   DEFAULT_ASPECT_RATIO,
   type AspectRatio,
 } from "../shared/aspect-ratios.js";
+import {
+  assertHumanReadableDeckTitle,
+  resolveImportedDeckTitle,
+} from "../shared/deck-title.js";
 import { getDeckUrl } from "./_app-url.js";
 import { readUserUploadedFile } from "./_uploaded-files.js";
 import { withDeckLock } from "./patch-deck.js";
@@ -117,7 +121,7 @@ export async function importPptxBufferToDeck(args: {
   } = args;
   const presentation = parsedPresentation ?? (await parsePptx(fileBuffer));
   applyImageFallbacks(presentation, imageFallbacks);
-  const deckTitle = title || presentation.title || "Imported Presentation";
+  const requestedTitle = title?.trim() || presentation.title || "";
   const ownerEmail = getRequestUserEmail();
   if (!ownerEmail) throw new Error("no authenticated user");
   const themeFont = presentation.theme?.fonts?.[0];
@@ -176,6 +180,11 @@ export async function importPptxBufferToDeck(args: {
     ),
   );
   const slides = results.map((r) => r.slide);
+  const deckTitle = resolveImportedDeckTitle(
+    requestedTitle,
+    slides[0]?.content,
+  );
+  assertHumanReadableDeckTitle(deckTitle);
   const imagesSkipped = results.reduce(
     (total, r) => total + r.imageSkippedCount,
     0,

--- a/templates/slides/shared/deck-title.test.ts
+++ b/templates/slides/shared/deck-title.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertHumanReadableDeckTitle,
+  DEFAULT_IMPORTED_DECK_TITLE,
   deriveDeckTitleFromSlideContent,
+  isGeneratedDeckTitle,
   isOpaqueDeckTitle,
   repairGeneratedDeckTitle,
   resolveImportedDeckTitle,
@@ -13,6 +15,11 @@ describe("deck title safeguards", () => {
     expect(isOpaqueDeckTitle("H3sVsnns-TEVUOpz9w")).toBe(true);
     expect(isOpaqueDeckTitle("Agent-Native Strategy")).toBe(false);
     expect(isOpaqueDeckTitle("Q4 Pipeline Review")).toBe(false);
+  });
+
+  it("recognizes imported placeholders as generated titles", () => {
+    expect(isGeneratedDeckTitle("Imported File")).toBe(true);
+    expect(isGeneratedDeckTitle("Imported Presentation")).toBe(true);
   });
 
   it("derives the title from the largest styled text on the title slide", () => {
@@ -33,6 +40,12 @@ describe("deck title safeguards", () => {
 
     expect(deriveDeckTitleFromSlideContent(content)).toBe(
       "Agent-Native Strategy",
+    );
+  });
+
+  it("derives a title from plain source text", () => {
+    expect(deriveDeckTitleFromSlideContent("Q3 FY27 Board Update")).toBe(
+      "Q3 FY27 Board Update",
     );
   });
 
@@ -59,9 +72,12 @@ describe("deck title safeguards", () => {
         '<div style="font-size: 54px;">Agent-Native Strategy</div>',
       ),
     ).toBe("Agent-Native Strategy");
-    expect(resolveImportedDeckTitle("Untitled scene", "<div></div>")).toBe(
-      "Imported File",
+    expect(resolveImportedDeckTitle("Imported File", "<div></div>")).toBe(
+      DEFAULT_IMPORTED_DECK_TITLE,
     );
+    expect(
+      resolveImportedDeckTitle("Imported File", "<div></div>", "Board update"),
+    ).toBe("Board update");
     expect(
       resolveImportedDeckTitle(
         "Quarterly Business Review",

--- a/templates/slides/shared/deck-title.test.ts
+++ b/templates/slides/shared/deck-title.test.ts
@@ -19,6 +19,7 @@ describe("deck title safeguards", () => {
 
   it("recognizes imported placeholders as generated titles", () => {
     expect(isGeneratedDeckTitle("Imported File")).toBe(true);
+    expect(isGeneratedDeckTitle("Imported Document")).toBe(true);
     expect(isGeneratedDeckTitle("Imported Presentation")).toBe(true);
   });
 
@@ -75,6 +76,9 @@ describe("deck title safeguards", () => {
     expect(resolveImportedDeckTitle("Imported File", "<div></div>")).toBe(
       DEFAULT_IMPORTED_DECK_TITLE,
     );
+    expect(
+      resolveImportedDeckTitle("Imported Document", "Q3 FY27 Board Update"),
+    ).toBe("Q3 FY27 Board Update");
     expect(
       resolveImportedDeckTitle("Imported File", "<div></div>", "Board update"),
     ).toBe("Board update");

--- a/templates/slides/shared/deck-title.ts
+++ b/templates/slides/shared/deck-title.ts
@@ -1,3 +1,17 @@
+export const DEFAULT_DECK_TITLE = "Untitled Deck";
+export const DEFAULT_IMPORTED_DECK_TITLE = "New Presentation";
+
+const IMPORTED_TITLE_PLACEHOLDERS = new Set([
+  "untitled deck",
+  "untitled file",
+  "untitled presentation",
+  "untitled scene",
+  "untitled slide",
+  "imported file",
+  "imported presentation",
+  DEFAULT_IMPORTED_DECK_TITLE.toLowerCase(),
+]);
+
 const GENERATED_TITLE_PLACEHOLDERS = new Set([
   "deck",
   "date",
@@ -9,14 +23,7 @@ const GENERATED_TITLE_PLACEHOLDERS = new Set([
   "untitled",
   "untitled deck",
   "your name",
-]);
-
-const IMPORTED_TITLE_PLACEHOLDERS = new Set([
-  "untitled deck",
-  "untitled file",
-  "untitled presentation",
-  "untitled scene",
-  "untitled slide",
+  ...IMPORTED_TITLE_PLACEHOLDERS,
 ]);
 
 /**
@@ -26,8 +33,6 @@ const IMPORTED_TITLE_PLACEHOLDERS = new Set([
  */
 const OPAQUE_DECK_TITLE_PATTERN =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z0-9_-]{12,64}$/;
-
-export const DEFAULT_DECK_TITLE = "Untitled Deck";
 
 export function isOpaqueDeckTitle(value: unknown): value is string {
   return (
@@ -83,7 +88,7 @@ function plainTextLines(value: string): string[] {
 function usableCandidate(value: string): string | null {
   const candidate = plainText(value).replace(/^[•●▪‣\-\s]+/, "");
   if (!candidate || candidate.length > 140) return null;
-  if (GENERATED_TITLE_PLACEHOLDERS.has(candidate.toLowerCase())) return null;
+  if (isGeneratedDeckTitle(candidate)) return null;
   return candidate;
 }
 
@@ -127,7 +132,8 @@ export function deriveDeckTitleFromSlideContent(
   }
 
   const fallbackLines = plainTextLines(content);
-  if (fallbackLines.length > 1) {
+  const hasMarkup = /<[^>]+>/.test(content);
+  if (fallbackLines.length > 1 || !hasMarkup) {
     for (const line of fallbackLines) {
       const text = usableCandidate(line);
       if (text) {
@@ -171,23 +177,20 @@ export function repairGeneratedDeckTitle(
 export function resolveImportedDeckTitle(
   requestedTitle: unknown,
   firstSlideContent: unknown,
+  fallbackTitle?: unknown,
 ): string {
-  if (typeof requestedTitle === "string") {
-    const title = requestedTitle.trim();
-    const opaqueTitle = isOpaqueDeckTitle(requestedTitle);
-    if (
-      title &&
-      !opaqueTitle &&
-      !IMPORTED_TITLE_PLACEHOLDERS.has(title.toLowerCase())
-    ) {
-      return title;
-    }
-  }
+  const title = usableCandidate(
+    typeof requestedTitle === "string" ? requestedTitle : "",
+  );
+  if (title) return title;
 
   const derivedTitle = deriveDeckTitleFromSlideContent(firstSlideContent);
   if (derivedTitle) return derivedTitle;
 
-  return "Imported File";
+  const fallback = usableCandidate(
+    typeof fallbackTitle === "string" ? fallbackTitle : "",
+  );
+  return fallback ?? DEFAULT_IMPORTED_DECK_TITLE;
 }
 
 export function assertHumanReadableDeckTitle(title: string): void {

--- a/templates/slides/shared/deck-title.ts
+++ b/templates/slides/shared/deck-title.ts
@@ -8,6 +8,7 @@ const IMPORTED_TITLE_PLACEHOLDERS = new Set([
   "untitled scene",
   "untitled slide",
   "imported file",
+  "imported document",
   "imported presentation",
   DEFAULT_IMPORTED_DECK_TITLE.toLowerCase(),
 ]);


### PR DESCRIPTION
## Summary
- treat imported/generated placeholders as invalid deck titles
- derive imported names from source slide text before using a filename fallback
- apply the same resolver to PDF, DOCX, and PPTX imports

## Verification
- VITEST_CONCURRENCY=1 corepack pnpm exec vitest --run shared/deck-title.test.ts actions/import-file.test.ts --reporter=dot --pool=threads
- corepack pnpm --dir templates/slides typecheck
- corepack pnpm guards