### PR TITLE
fix(slides): paste copied slides across decks

### DIFF
--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -50,9 +50,25 @@ export function resolveSlideClipboardForPaste(
   cachedSlide: Slide | null,
   cachedStorageKey: string | null,
   storageKey: string,
+  cachedCopiedAt: number | null = null,
+  cachedPersistenceFailed = false,
 ): Slide | null {
+  const isSameScope = cachedStorageKey === storageKey;
+  if (
+    result.status === "ready" &&
+    isSameScope &&
+    cachedPersistenceFailed &&
+    cachedSlide &&
+    cachedCopiedAt !== null &&
+    cachedCopiedAt > result.copiedAt
+  ) {
+    return cachedSlide;
+  }
   if (result.status === "ready") return result.slide;
-  if (result.status === "unavailable" && cachedStorageKey === storageKey) {
+  if (
+    isSameScope &&
+    (result.status === "unavailable" || cachedPersistenceFailed)
+  ) {
     return cachedSlide;
   }
   return null;

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -1,0 +1,115 @@
+import type { Slide } from "@/context/DeckContext";
+
+export const SLIDE_CLIPBOARD_STORAGE_KEY = "slides:slide-clipboard";
+
+const SLIDE_CLIPBOARD_VERSION = 1;
+const SLIDE_LAYOUTS: readonly string[] = [
+  "title",
+  "section",
+  "content",
+  "two-column",
+  "image",
+  "statement",
+  "full-image",
+  "blank",
+];
+
+type SlideClipboardStorage = Pick<Storage, "getItem" | "setItem">;
+
+interface StoredSlideClipboard {
+  version: number;
+  slide: Slide;
+  copiedAt: number;
+}
+
+export type SlideClipboardReadResult =
+  | {
+      status: "unavailable" | "empty" | "unreadable";
+      slide: null;
+      copiedAt: null;
+    }
+  | { status: "ready"; slide: Slide; copiedAt: number };
+
+function getBrowserStorage(): SlideClipboardStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    // Storage can be disabled by an embedded browser or privacy setting.
+    return null;
+  }
+}
+
+function isSlide(value: unknown): value is Slide {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Partial<Slide>;
+  return (
+    typeof candidate.id === "string" &&
+    candidate.id.length > 0 &&
+    typeof candidate.content === "string" &&
+    typeof candidate.notes === "string" &&
+    typeof candidate.layout === "string" &&
+    SLIDE_LAYOUTS.includes(candidate.layout)
+  );
+}
+
+export function readSlideClipboard(
+  storage: SlideClipboardStorage | null = getBrowserStorage(),
+): SlideClipboardReadResult {
+  if (!storage) {
+    return { status: "unavailable", slide: null, copiedAt: null };
+  }
+
+  let raw: string | null;
+  try {
+    raw = storage.getItem(SLIDE_CLIPBOARD_STORAGE_KEY);
+  } catch {
+    // A failed read is not the same as an empty clipboard.
+    return { status: "unreadable", slide: null, copiedAt: null };
+  }
+  if (raw === null) return { status: "empty", slide: null, copiedAt: null };
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredSlideClipboard>;
+    if (
+      parsed.version !== SLIDE_CLIPBOARD_VERSION ||
+      !isSlide(parsed.slide) ||
+      typeof parsed.copiedAt !== "number" ||
+      !Number.isFinite(parsed.copiedAt)
+    ) {
+      return { status: "unreadable", slide: null, copiedAt: null };
+    }
+    return {
+      status: "ready",
+      slide: parsed.slide,
+      copiedAt: parsed.copiedAt,
+    };
+  } catch {
+    // A malformed local value must not become a pasteable slide.
+    return { status: "unreadable", slide: null, copiedAt: null };
+  }
+}
+
+export function writeSlideClipboard(
+  slide: Slide,
+  copiedAt: number,
+  storage: SlideClipboardStorage | null = getBrowserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(
+      SLIDE_CLIPBOARD_STORAGE_KEY,
+      JSON.stringify({
+        version: SLIDE_CLIPBOARD_VERSION,
+        slide,
+        copiedAt,
+      } satisfies StoredSlideClipboard),
+    );
+    return true;
+  } catch {
+    // The in-memory editor clipboard remains available when persistence fails.
+    return false;
+  }
+}

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -45,6 +45,19 @@ export type SlideClipboardReadResult =
     }
   | { status: "ready"; slide: Slide; copiedAt: number };
 
+export function resolveSlideClipboardForPaste(
+  result: SlideClipboardReadResult,
+  cachedSlide: Slide | null,
+  cachedStorageKey: string | null,
+  storageKey: string,
+): Slide | null {
+  if (result.status === "ready") return result.slide;
+  if (result.status === "unavailable" && cachedStorageKey === storageKey) {
+    return cachedSlide;
+  }
+  return null;
+}
+
 function getBrowserStorage(): SlideClipboardStorage | null {
   if (typeof window === "undefined") return null;
   try {

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -1,9 +1,9 @@
-import type { Slide } from "@/context/DeckContext";
+import type { Slide, SlideLayout } from "@/context/DeckContext";
 
 export const SLIDE_CLIPBOARD_STORAGE_KEY = "slides:slide-clipboard";
 
 const SLIDE_CLIPBOARD_VERSION = 1;
-const SLIDE_LAYOUTS: readonly string[] = [
+const SLIDE_LAYOUTS: readonly SlideLayout[] = [
   "title",
   "section",
   "content",
@@ -41,19 +41,39 @@ function getBrowserStorage(): SlideClipboardStorage | null {
   }
 }
 
-function isSlide(value: unknown): value is Slide {
+function normalizeSlide(value: unknown): Slide | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
+    return null;
   }
   const candidate = value as Partial<Slide>;
-  return (
-    typeof candidate.id === "string" &&
-    candidate.id.length > 0 &&
-    typeof candidate.content === "string" &&
-    typeof candidate.notes === "string" &&
-    typeof candidate.layout === "string" &&
-    SLIDE_LAYOUTS.includes(candidate.layout)
-  );
+  if (
+    typeof candidate.id !== "string" ||
+    candidate.id.length === 0 ||
+    typeof candidate.content !== "string"
+  ) {
+    return null;
+  }
+
+  const notes = candidate.notes;
+  if (notes !== undefined && notes !== null && typeof notes !== "string") {
+    return null;
+  }
+
+  const layout = candidate.layout;
+  if (
+    layout !== undefined &&
+    layout !== null &&
+    (typeof layout !== "string" ||
+      !SLIDE_LAYOUTS.includes(layout as SlideLayout))
+  ) {
+    return null;
+  }
+
+  return {
+    ...candidate,
+    notes: notes ?? "",
+    layout: (layout as SlideLayout | null | undefined) ?? "content",
+  } as Slide;
 }
 
 export function readSlideClipboard(
@@ -75,9 +95,10 @@ export function readSlideClipboard(
 
   try {
     const parsed = JSON.parse(raw) as Partial<StoredSlideClipboard>;
+    const slide = normalizeSlide(parsed.slide);
     if (
       parsed.version !== SLIDE_CLIPBOARD_VERSION ||
-      !isSlide(parsed.slide) ||
+      !slide ||
       typeof parsed.copiedAt !== "number" ||
       !Number.isFinite(parsed.copiedAt)
     ) {
@@ -85,7 +106,7 @@ export function readSlideClipboard(
     }
     return {
       status: "ready",
-      slide: parsed.slide,
+      slide,
       copiedAt: parsed.copiedAt,
     };
   } catch {
@@ -100,13 +121,14 @@ export function writeSlideClipboard(
   copiedAt: number,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): boolean {
-  if (!storage) return false;
+  const normalizedSlide = normalizeSlide(slide);
+  if (!storage || !normalizedSlide) return false;
   try {
     storage.setItem(
       SLIDE_CLIPBOARD_STORAGE_KEY,
       JSON.stringify({
         version: SLIDE_CLIPBOARD_VERSION,
-        slide,
+        slide: normalizedSlide,
         copiedAt,
       } satisfies StoredSlideClipboard),
     );

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -53,11 +53,13 @@ export function resolveSlideClipboardForPaste(
   cachedCopiedAt: number | null = null,
   cachedPersistenceFailed = false,
 ): Slide | null {
-  const isSameScope = cachedStorageKey === storageKey;
+  const canUseCachedClipboard =
+    cachedStorageKey === storageKey ||
+    (cachedStorageKey === null && cachedSlide !== null);
   if (
     result.status === "ready" &&
-    isSameScope &&
-    cachedPersistenceFailed &&
+    canUseCachedClipboard &&
+    (cachedPersistenceFailed || cachedStorageKey === null) &&
     cachedSlide &&
     cachedCopiedAt !== null &&
     cachedCopiedAt > result.copiedAt
@@ -66,8 +68,10 @@ export function resolveSlideClipboardForPaste(
   }
   if (result.status === "ready") return result.slide;
   if (
-    isSameScope &&
-    (result.status === "unavailable" || cachedPersistenceFailed)
+    canUseCachedClipboard &&
+    (result.status === "unavailable" ||
+      cachedPersistenceFailed ||
+      cachedStorageKey === null)
   ) {
     return cachedSlide;
   }

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -1,9 +1,9 @@
 import type { Slide, SlideLayout } from "@/context/DeckContext";
 
-export const SLIDE_CLIPBOARD_STORAGE_KEY = "slides:slide-clipboard";
+export const SLIDE_CLIPBOARD_STORAGE_PREFIX = "slides:slide-clipboard";
 
 export function getSlideClipboardStorageKey(email: string): string {
-  return `${SLIDE_CLIPBOARD_STORAGE_KEY}:${encodeURIComponent(email)}`;
+  return `${SLIDE_CLIPBOARD_STORAGE_PREFIX}:${encodeURIComponent(email)}`;
 }
 
 const SLIDE_CLIPBOARD_VERSION = 1;

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -1,4 +1,9 @@
-import type { Slide, SlideLayout } from "@/context/DeckContext";
+import type {
+  AnimationType,
+  Slide,
+  SlideAnimation,
+  SlideLayout,
+} from "@/context/DeckContext";
 
 export const SLIDE_CLIPBOARD_STORAGE_PREFIX = "slides:slide-clipboard";
 
@@ -16,6 +21,12 @@ const SLIDE_LAYOUTS: readonly SlideLayout[] = [
   "statement",
   "full-image",
   "blank",
+];
+const ANIMATION_TYPES: readonly AnimationType[] = [
+  "appear",
+  "fade",
+  "slide-up",
+  "zoom",
 ];
 
 type SlideClipboardStorage = Pick<Storage, "getItem" | "setItem">;
@@ -49,7 +60,7 @@ function normalizeSlide(value: unknown): Slide | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
-  const candidate = value as Partial<Slide>;
+  const candidate = value as Partial<Slide> & Record<string, unknown>;
   if (
     typeof candidate.id !== "string" ||
     candidate.id.length === 0 ||
@@ -73,11 +84,94 @@ function normalizeSlide(value: unknown): Slide | null {
     return null;
   }
 
-  return {
-    ...candidate,
+  const normalized: Slide = {
     notes: notes ?? "",
     layout: (layout as SlideLayout | null | undefined) ?? "content",
+    id: candidate.id,
+    content: candidate.content,
   } as Slide;
+
+  const optionalStrings = [
+    "background",
+    "imageUrl",
+    "imagePrompt",
+    "excalidrawData",
+  ] as const;
+  for (const key of optionalStrings) {
+    const field = candidate[key];
+    if (field !== undefined && typeof field !== "string") return null;
+    if (field !== undefined) normalized[key] = field;
+  }
+
+  if (candidate.transition !== undefined) {
+    if (
+      typeof candidate.transition !== "string" ||
+      !["instant", "none", "fade", "slide", "zoom"].includes(
+        candidate.transition,
+      )
+    ) {
+      return null;
+    }
+    normalized.transition = candidate.transition as Slide["transition"];
+  }
+
+  for (const key of ["splitByParagraph", "skipped"] as const) {
+    const field = candidate[key];
+    if (field !== undefined && typeof field !== "boolean") return null;
+    if (field !== undefined) normalized[key] = field;
+  }
+
+  if (candidate.animations !== undefined) {
+    if (!Array.isArray(candidate.animations)) return null;
+    const animations: SlideAnimation[] = [];
+    for (const value of candidate.animations) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return null;
+      }
+      const animation = value as Partial<SlideAnimation> &
+        Record<string, unknown>;
+      if (
+        typeof animation.id !== "string" ||
+        animation.id.length === 0 ||
+        typeof animation.elementIndex !== "number" ||
+        !Number.isInteger(animation.elementIndex) ||
+        animation.elementIndex < 0 ||
+        typeof animation.type !== "string" ||
+        !ANIMATION_TYPES.includes(animation.type as AnimationType)
+      ) {
+        return null;
+      }
+      if (
+        animation.elementPath !== undefined &&
+        (!Array.isArray(animation.elementPath) ||
+          animation.elementPath.some(
+            (index) => typeof index !== "number" || !Number.isInteger(index),
+          ))
+      ) {
+        return null;
+      }
+      if (
+        animation.byParagraph !== undefined &&
+        typeof animation.byParagraph !== "boolean"
+      ) {
+        return null;
+      }
+      animations.push({
+        id: animation.id,
+        elementIndex: animation.elementIndex,
+        ...(animation.elementPath !== undefined
+          ? { elementPath: animation.elementPath as number[] }
+          : {}),
+        ...(animation.byParagraph !== undefined
+          ? { byParagraph: animation.byParagraph }
+          : {}),
+        type: animation.type as AnimationType,
+      });
+    }
+    normalized.animations = animations;
+  }
+
+  return normalized;
 }
 
 export function readSlideClipboard(
@@ -128,7 +222,7 @@ export function writeSlideClipboard(
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): boolean {
   const normalizedSlide = normalizeSlide(slide);
-  if (!storage || !normalizedSlide) return false;
+  if (!storage || !normalizedSlide || !Number.isFinite(copiedAt)) return false;
   try {
     storage.setItem(
       storageKey,

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -89,7 +89,7 @@ function getBrowserStorage(): SlideClipboardStorage | null {
   }
 }
 
-function normalizeSlide(value: unknown): Slide | null {
+export function normalizeSlideClipboard(value: unknown): Slide | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -227,7 +227,7 @@ export function readSlideClipboard(
 
   try {
     const parsed = JSON.parse(raw) as Partial<StoredSlideClipboard>;
-    const slide = normalizeSlide(parsed.slide);
+    const slide = normalizeSlideClipboard(parsed.slide);
     if (
       parsed.version !== SLIDE_CLIPBOARD_VERSION ||
       !slide ||
@@ -254,7 +254,7 @@ export function writeSlideClipboard(
   copiedAt: number,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): boolean {
-  const normalizedSlide = normalizeSlide(slide);
+  const normalizedSlide = normalizeSlideClipboard(slide);
   if (!storage || !normalizedSlide || !Number.isFinite(copiedAt)) return false;
   try {
     storage.setItem(

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -2,6 +2,10 @@ import type { Slide, SlideLayout } from "@/context/DeckContext";
 
 export const SLIDE_CLIPBOARD_STORAGE_KEY = "slides:slide-clipboard";
 
+export function getSlideClipboardStorageKey(email: string): string {
+  return `${SLIDE_CLIPBOARD_STORAGE_KEY}:${encodeURIComponent(email)}`;
+}
+
 const SLIDE_CLIPBOARD_VERSION = 1;
 const SLIDE_LAYOUTS: readonly SlideLayout[] = [
   "title",
@@ -77,6 +81,7 @@ function normalizeSlide(value: unknown): Slide | null {
 }
 
 export function readSlideClipboard(
+  storageKey: string,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
 ): SlideClipboardReadResult {
   if (!storage) {
@@ -85,7 +90,7 @@ export function readSlideClipboard(
 
   let raw: string | null;
   try {
-    raw = storage.getItem(SLIDE_CLIPBOARD_STORAGE_KEY);
+    raw = storage.getItem(storageKey);
   } catch {
     // coercion-ok: storage read failures return an explicit unreadable status.
     // A failed read is not the same as an empty clipboard.
@@ -117,6 +122,7 @@ export function readSlideClipboard(
 }
 
 export function writeSlideClipboard(
+  storageKey: string,
   slide: Slide,
   copiedAt: number,
   storage: SlideClipboardStorage | null = getBrowserStorage(),
@@ -125,7 +131,7 @@ export function writeSlideClipboard(
   if (!storage || !normalizedSlide) return false;
   try {
     storage.setItem(
-      SLIDE_CLIPBOARD_STORAGE_KEY,
+      storageKey,
       JSON.stringify({
         version: SLIDE_CLIPBOARD_VERSION,
         slide: normalizedSlide,

--- a/templates/slides/app/lib/slide-clipboard.ts
+++ b/templates/slides/app/lib/slide-clipboard.ts
@@ -35,6 +35,7 @@ function getBrowserStorage(): SlideClipboardStorage | null {
   try {
     return window.localStorage;
   } catch {
+    // coercion-ok: storage availability is reported as an explicit unavailable status.
     // Storage can be disabled by an embedded browser or privacy setting.
     return null;
   }
@@ -66,6 +67,7 @@ export function readSlideClipboard(
   try {
     raw = storage.getItem(SLIDE_CLIPBOARD_STORAGE_KEY);
   } catch {
+    // coercion-ok: storage read failures return an explicit unreadable status.
     // A failed read is not the same as an empty clipboard.
     return { status: "unreadable", slide: null, copiedAt: null };
   }
@@ -87,6 +89,7 @@ export function readSlideClipboard(
       copiedAt: parsed.copiedAt,
     };
   } catch {
+    // coercion-ok: malformed storage data returns an explicit unreadable status.
     // A malformed local value must not become a pasteable slide.
     return { status: "unreadable", slide: null, copiedAt: null };
   }
@@ -109,6 +112,7 @@ export function writeSlideClipboard(
     );
     return true;
   } catch {
+    // coercion-ok: a failed write returns false while the in-memory clipboard remains usable.
     // The in-memory editor clipboard remains available when persistence fails.
     return false;
   }

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  readSlideClipboard,
+  writeSlideClipboard,
+} from "../lib/slide-clipboard";
+import {
   isSlideClipboardStillArmed,
   SLIDE_CLIPBOARD_ARM_WINDOW_MS,
 } from "./DeckEditor";
+
+function createStorage(initial?: Record<string, string>) {
+  const values = new Map(Object.entries(initial ?? {}));
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
 
 // Reproduces the Andrew Rohman Slack thread (C0ATH3CCZT4 / 1786711059459639):
 // a slide copied once early in the session kept silently re-duplicating on
@@ -30,5 +42,45 @@ describe("isSlideClipboardStillArmed", () => {
 
   it("is never armed when nothing has been copied", () => {
     expect(isSlideClipboardStillArmed(null, Date.now())).toBe(false);
+  });
+});
+
+describe("slide clipboard storage", () => {
+  const slide = {
+    id: "slide-1",
+    content: "<div>Copied</div>",
+    notes: "Speaker note",
+    layout: "content" as const,
+    skipped: true,
+  };
+
+  it("round-trips a slide snapshot and copy timestamp", () => {
+    const storage = createStorage();
+
+    expect(writeSlideClipboard(slide, 1_000, storage)).toBe(true);
+    expect(readSlideClipboard(storage)).toEqual({
+      status: "ready",
+      slide,
+      copiedAt: 1_000,
+    });
+  });
+
+  it("distinguishes an empty or malformed clipboard", () => {
+    expect(readSlideClipboard(createStorage())).toEqual({
+      status: "empty",
+      slide: null,
+      copiedAt: null,
+    });
+    expect(
+      readSlideClipboard(
+        createStorage({
+          "slides:slide-clipboard": JSON.stringify({ version: 1 }),
+        }),
+      ),
+    ).toEqual({
+      status: "unreadable",
+      slide: null,
+      copiedAt: null,
+    });
   });
 });

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getSlideClipboardStorageKey,
+  normalizeSlideClipboard,
   readSlideClipboard,
   resolveSlideClipboardForPaste,
   writeSlideClipboard,
@@ -135,6 +136,16 @@ describe("slide clipboard storage", () => {
       },
       copiedAt: 2_500,
     });
+  });
+
+  it("normalizes the in-memory fallback before paste", () => {
+    expect(
+      normalizeSlideClipboard({
+        ...slide,
+        imageLoading: true,
+        unexpected: true,
+      }),
+    ).toEqual(slide);
   });
 
   it("rejects malformed optional fields", () => {

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getSlideClipboardStorageKey,
   readSlideClipboard,
   writeSlideClipboard,
 } from "../lib/slide-clipboard";
@@ -56,9 +57,10 @@ describe("slide clipboard storage", () => {
 
   it("round-trips a slide snapshot and copy timestamp", () => {
     const storage = createStorage();
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
 
-    expect(writeSlideClipboard(slide, 1_000, storage)).toBe(true);
-    expect(readSlideClipboard(storage)).toEqual({
+    expect(writeSlideClipboard(storageKey, slide, 1_000, storage)).toBe(true);
+    expect(readSlideClipboard(storageKey, storage)).toEqual({
       status: "ready",
       slide,
       copiedAt: 1_000,
@@ -66,15 +68,17 @@ describe("slide clipboard storage", () => {
   });
 
   it("distinguishes an empty or malformed clipboard", () => {
-    expect(readSlideClipboard(createStorage())).toEqual({
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    expect(readSlideClipboard(storageKey, createStorage())).toEqual({
       status: "empty",
       slide: null,
       copiedAt: null,
     });
     expect(
       readSlideClipboard(
+        storageKey,
         createStorage({
-          "slides:slide-clipboard": JSON.stringify({ version: 1 }),
+          [storageKey]: JSON.stringify({ version: 1 }),
         }),
       ),
     ).toEqual({
@@ -85,9 +89,11 @@ describe("slide clipboard storage", () => {
   });
 
   it("normalizes omitted notes and layout from older slides", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
     const result = readSlideClipboard(
+      storageKey,
       createStorage({
-        "slides:slide-clipboard": JSON.stringify({
+        [storageKey]: JSON.stringify({
           version: 1,
           slide: { ...slide, notes: null, layout: null },
           copiedAt: 2_000,
@@ -100,5 +106,19 @@ describe("slide clipboard storage", () => {
       slide: { ...slide, notes: "", layout: "content" },
       copiedAt: 2_000,
     });
+  });
+
+  it("keeps clipboard snapshots isolated by signed-in user", () => {
+    const storage = createStorage();
+    const aliceKey = getSlideClipboardStorageKey("alice@example.com");
+    const bobKey = getSlideClipboardStorageKey("bob@example.com");
+
+    expect(writeSlideClipboard(aliceKey, slide, 3_000, storage)).toBe(true);
+    expect(readSlideClipboard(bobKey, storage)).toEqual({
+      status: "empty",
+      slide: null,
+      copiedAt: null,
+    });
+    expect(readSlideClipboard(aliceKey, storage).status).toBe("ready");
   });
 });

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getSlideClipboardStorageKey,
   readSlideClipboard,
+  resolveSlideClipboardForPaste,
   writeSlideClipboard,
 } from "../lib/slide-clipboard";
 import {
@@ -168,5 +169,20 @@ describe("slide clipboard storage", () => {
       copiedAt: null,
     });
     expect(readSlideClipboard(aliceKey, storage).status).toBe("ready");
+  });
+
+  it("uses a newer cross-tab snapshot instead of a stale cached slide", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const cachedSlide = { ...slide, content: "Cached" };
+    const latestSlide = { ...slide, content: "Latest" };
+
+    expect(
+      resolveSlideClipboardForPaste(
+        { status: "ready", slide: latestSlide, copiedAt: 4_000 },
+        cachedSlide,
+        storageKey,
+        storageKey,
+      ),
+    ).toEqual(latestSlide);
   });
 });

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -83,4 +83,22 @@ describe("slide clipboard storage", () => {
       copiedAt: null,
     });
   });
+
+  it("normalizes omitted notes and layout from older slides", () => {
+    const result = readSlideClipboard(
+      createStorage({
+        "slides:slide-clipboard": JSON.stringify({
+          version: 1,
+          slide: { ...slide, notes: null, layout: null },
+          copiedAt: 2_000,
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      status: "ready",
+      slide: { ...slide, notes: "", layout: "content" },
+      copiedAt: 2_000,
+    });
+  });
 });

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -108,6 +108,54 @@ describe("slide clipboard storage", () => {
     });
   });
 
+  it("keeps only validated optional fields and drops transient data", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const result = readSlideClipboard(
+      storageKey,
+      createStorage({
+        [storageKey]: JSON.stringify({
+          version: 1,
+          slide: {
+            ...slide,
+            imageLoading: true,
+            unexpected: "stale data",
+            animations: [{ id: "animation-1", elementIndex: 0, type: "fade" }],
+          },
+          copiedAt: 2_500,
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      status: "ready",
+      slide: {
+        ...slide,
+        animations: [{ id: "animation-1", elementIndex: 0, type: "fade" }],
+      },
+      copiedAt: 2_500,
+    });
+  });
+
+  it("rejects malformed optional fields", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    expect(
+      readSlideClipboard(
+        storageKey,
+        createStorage({
+          [storageKey]: JSON.stringify({
+            version: 1,
+            slide: { ...slide, animations: [{ id: "bad" }] },
+            copiedAt: 2_500,
+          }),
+        }),
+      ),
+    ).toEqual({
+      status: "unreadable",
+      slide: null,
+      copiedAt: null,
+    });
+  });
+
   it("keeps clipboard snapshots isolated by signed-in user", () => {
     const storage = createStorage();
     const aliceKey = getSlideClipboardStorageKey("alice@example.com");

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -185,4 +185,41 @@ describe("slide clipboard storage", () => {
       ),
     ).toEqual(latestSlide);
   });
+
+  it("keeps a fresh in-memory snapshot when persistence is rejected", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const cachedSlide = { ...slide, content: "Fresh cached copy" };
+    const olderSlide = { ...slide, content: "Older persisted copy" };
+    const rejectedStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("storage write rejected");
+      },
+    };
+
+    expect(
+      writeSlideClipboard(storageKey, cachedSlide, 4_000, rejectedStorage),
+    ).toBe(false);
+
+    expect(
+      resolveSlideClipboardForPaste(
+        { status: "ready", slide: olderSlide, copiedAt: 3_000 },
+        cachedSlide,
+        storageKey,
+        storageKey,
+        4_000,
+        true,
+      ),
+    ).toEqual(cachedSlide);
+    expect(
+      resolveSlideClipboardForPaste(
+        { status: "empty", slide: null, copiedAt: null },
+        cachedSlide,
+        storageKey,
+        storageKey,
+        4_000,
+        true,
+      ),
+    ).toEqual(cachedSlide);
+  });
 });

--- a/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
+++ b/templates/slides/app/pages/DeckEditor.slide-clipboard.test.ts
@@ -222,4 +222,29 @@ describe("slide clipboard storage", () => {
       ),
     ).toEqual(cachedSlide);
   });
+
+  it("keeps a pending copy while the session scope hydrates", () => {
+    const storageKey = getSlideClipboardStorageKey("alice@example.com");
+    const cachedSlide = { ...slide, content: "Copied before session loaded" };
+    const olderSlide = { ...slide, content: "Older persisted copy" };
+
+    expect(
+      resolveSlideClipboardForPaste(
+        { status: "ready", slide: olderSlide, copiedAt: 3_000 },
+        cachedSlide,
+        null,
+        storageKey,
+        4_000,
+      ),
+    ).toEqual(cachedSlide);
+    expect(
+      resolveSlideClipboardForPaste(
+        { status: "empty", slide: null, copiedAt: null },
+        cachedSlide,
+        null,
+        storageKey,
+        4_000,
+      ),
+    ).toEqual(cachedSlide);
+  });
 });

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -116,8 +116,8 @@ import {
 } from "@/lib/pending-deck-changes";
 import type { SelectedAnimationTarget } from "@/lib/slide-animation-elements";
 import {
+  getSlideClipboardStorageKey,
   readSlideClipboard,
-  SLIDE_CLIPBOARD_STORAGE_KEY,
   writeSlideClipboard,
 } from "@/lib/slide-clipboard";
 import { imageFileLooksSupported } from "@/lib/slide-image-replacement";
@@ -1118,34 +1118,49 @@ export default function DeckEditor() {
   // long ago the copy happened.
   const slideClipboardArmedAtRef = useRef<number | null>(null);
   const [hasSlideClipboard, setHasSlideClipboard] = useState(false);
+  const slideClipboardStorageKey = session?.email
+    ? getSlideClipboardStorageKey(session.email)
+    : null;
 
   const syncSlideClipboard = useCallback(() => {
-    const result = readSlideClipboard();
+    if (!slideClipboardStorageKey) {
+      slideClipboardRef.current = null;
+      slideClipboardArmedAtRef.current = null;
+      setHasSlideClipboard(false);
+      return null;
+    }
+    const result = readSlideClipboard(slideClipboardStorageKey);
     const slide = result.status === "ready" ? result.slide : null;
     slideClipboardRef.current = slide;
     slideClipboardArmedAtRef.current =
       result.status === "ready" ? result.copiedAt : null;
     setHasSlideClipboard(slide !== null);
     return slide;
-  }, []);
+  }, [slideClipboardStorageKey]);
 
   useEffect(() => {
     syncSlideClipboard();
+    if (!slideClipboardStorageKey) return;
     const handleStorage = (event: StorageEvent) => {
-      if (event.key === SLIDE_CLIPBOARD_STORAGE_KEY) syncSlideClipboard();
+      if (event.key === slideClipboardStorageKey) syncSlideClipboard();
     };
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
-  }, [syncSlideClipboard]);
+  }, [slideClipboardStorageKey, syncSlideClipboard]);
 
-  const saveSlideToClipboard = useCallback((slide: Slide) => {
-    const copiedAt = Date.now();
-    const snapshot = { ...slide };
-    slideClipboardRef.current = snapshot;
-    slideClipboardArmedAtRef.current = copiedAt;
-    setHasSlideClipboard(true);
-    writeSlideClipboard(snapshot, copiedAt);
-  }, []);
+  const saveSlideToClipboard = useCallback(
+    (slide: Slide) => {
+      const copiedAt = Date.now();
+      const snapshot = { ...slide };
+      slideClipboardRef.current = snapshot;
+      slideClipboardArmedAtRef.current = copiedAt;
+      setHasSlideClipboard(true);
+      if (slideClipboardStorageKey) {
+        writeSlideClipboard(slideClipboardStorageKey, snapshot, copiedAt);
+      }
+    },
+    [slideClipboardStorageKey],
+  );
 
   const copySlide = useCallback(
     (slideId: string) => {

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1137,6 +1137,8 @@ export default function DeckEditor() {
     const result = readSlideClipboard(slideClipboardStorageKey);
     const cachedSlide = slideClipboardRef.current;
     const cachedCopiedAt = slideClipboardArmedAtRef.current;
+    const isPendingSessionClipboard =
+      cachedSlide !== null && slideClipboardScopeRef.current === null;
     const slide = resolveSlideClipboardForPaste(
       result,
       cachedSlide,
@@ -1153,7 +1155,17 @@ export default function DeckEditor() {
       : result.status === "ready"
         ? result.copiedAt
         : null;
-    if (!usedCachedClipboard) {
+    if (
+      isPendingSessionClipboard &&
+      usedCachedClipboard &&
+      cachedCopiedAt !== null
+    ) {
+      slideClipboardPersistenceFailedRef.current = !writeSlideClipboard(
+        slideClipboardStorageKey,
+        slide,
+        cachedCopiedAt,
+      );
+    } else if (!usedCachedClipboard) {
       slideClipboardPersistenceFailedRef.current = false;
     }
     setHasSlideClipboard(slide !== null);

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1112,6 +1112,7 @@ export default function DeckEditor() {
   // (rather than just an id) so paste still works after Cut has already
   // removed the original slide from the deck.
   const slideClipboardRef = useRef<Slide | null>(null);
+  const slideClipboardScopeRef = useRef<string | null>(null);
   // Only gates the ambient document-level Cmd/Ctrl+V shortcut below — the
   // rail's right-click "Paste" menu item is an explicit click with no
   // ambiguity risk, so it keeps working off `hasSlideClipboard` alone however
@@ -1125,6 +1126,7 @@ export default function DeckEditor() {
   const syncSlideClipboard = useCallback(() => {
     if (!slideClipboardStorageKey) {
       slideClipboardRef.current = null;
+      slideClipboardScopeRef.current = null;
       slideClipboardArmedAtRef.current = null;
       setHasSlideClipboard(false);
       return null;
@@ -1132,6 +1134,7 @@ export default function DeckEditor() {
     const result = readSlideClipboard(slideClipboardStorageKey);
     const slide = result.status === "ready" ? result.slide : null;
     slideClipboardRef.current = slide;
+    slideClipboardScopeRef.current = slideClipboardStorageKey;
     slideClipboardArmedAtRef.current =
       result.status === "ready" ? result.copiedAt : null;
     setHasSlideClipboard(slide !== null);
@@ -1153,6 +1156,7 @@ export default function DeckEditor() {
       const copiedAt = Date.now();
       const snapshot = { ...slide };
       slideClipboardRef.current = snapshot;
+      slideClipboardScopeRef.current = slideClipboardStorageKey;
       slideClipboardArmedAtRef.current = copiedAt;
       setHasSlideClipboard(true);
       if (slideClipboardStorageKey) {
@@ -1189,13 +1193,16 @@ export default function DeckEditor() {
 
   const pasteSlideAfter = useCallback(
     (targetSlideId: string) => {
-      const clipboard = slideClipboardRef.current ?? syncSlideClipboard();
+      const clipboard =
+        slideClipboardScopeRef.current === slideClipboardStorageKey
+          ? (slideClipboardRef.current ?? syncSlideClipboard())
+          : syncSlideClipboard();
       if (!clipboard || !id) return;
       const { id: _clipboardId, ...fields } = clipboard;
       const newId = pasteSlide(id, targetSlideId, fields);
       if (newId) setActiveSlideId(newId);
     },
-    [id, pasteSlide, syncSlideClipboard],
+    [id, pasteSlide, slideClipboardStorageKey, syncSlideClipboard],
   );
 
   // Handlers backing the slide rail's right-click menu.

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -118,6 +118,7 @@ import type { SelectedAnimationTarget } from "@/lib/slide-animation-elements";
 import {
   getSlideClipboardStorageKey,
   readSlideClipboard,
+  resolveSlideClipboardForPaste,
   writeSlideClipboard,
 } from "@/lib/slide-clipboard";
 import { imageFileLooksSupported } from "@/lib/slide-image-replacement";
@@ -1132,11 +1133,20 @@ export default function DeckEditor() {
       return null;
     }
     const result = readSlideClipboard(slideClipboardStorageKey);
-    const slide = result.status === "ready" ? result.slide : null;
+    const slide = resolveSlideClipboardForPaste(
+      result,
+      slideClipboardRef.current,
+      slideClipboardScopeRef.current,
+      slideClipboardStorageKey,
+    );
     slideClipboardRef.current = slide;
     slideClipboardScopeRef.current = slideClipboardStorageKey;
     slideClipboardArmedAtRef.current =
-      result.status === "ready" ? result.copiedAt : null;
+      result.status === "ready"
+        ? result.copiedAt
+        : slide
+          ? slideClipboardArmedAtRef.current
+          : null;
     setHasSlideClipboard(slide !== null);
     return slide;
   }, [slideClipboardStorageKey]);
@@ -1193,10 +1203,7 @@ export default function DeckEditor() {
 
   const pasteSlideAfter = useCallback(
     (targetSlideId: string) => {
-      const clipboard =
-        slideClipboardScopeRef.current === slideClipboardStorageKey
-          ? (slideClipboardRef.current ?? syncSlideClipboard())
-          : syncSlideClipboard();
+      const clipboard = syncSlideClipboard();
       if (!clipboard || !id) return;
       const { id: _clipboardId, ...fields } = clipboard;
       const newId = pasteSlide(id, targetSlideId, fields);

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1127,6 +1127,13 @@ export default function DeckEditor() {
 
   const syncSlideClipboard = useCallback(() => {
     if (!slideClipboardStorageKey) {
+      if (
+        slideClipboardRef.current !== null &&
+        slideClipboardScopeRef.current === null
+      ) {
+        setHasSlideClipboard(true);
+        return slideClipboardRef.current;
+      }
       slideClipboardRef.current = null;
       slideClipboardScopeRef.current = null;
       slideClipboardPersistenceFailedRef.current = false;

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -115,6 +115,11 @@ import {
   usePendingDeckUnloadGuard,
 } from "@/lib/pending-deck-changes";
 import type { SelectedAnimationTarget } from "@/lib/slide-animation-elements";
+import {
+  readSlideClipboard,
+  SLIDE_CLIPBOARD_STORAGE_KEY,
+  writeSlideClipboard,
+} from "@/lib/slide-clipboard";
 import { imageFileLooksSupported } from "@/lib/slide-image-replacement";
 import {
   insertDroppedImageIntoSlideHtml,
@@ -1114,15 +1119,41 @@ export default function DeckEditor() {
   const slideClipboardArmedAtRef = useRef<number | null>(null);
   const [hasSlideClipboard, setHasSlideClipboard] = useState(false);
 
+  const syncSlideClipboard = useCallback(() => {
+    const result = readSlideClipboard();
+    const slide = result.status === "ready" ? result.slide : null;
+    slideClipboardRef.current = slide;
+    slideClipboardArmedAtRef.current =
+      result.status === "ready" ? result.copiedAt : null;
+    setHasSlideClipboard(slide !== null);
+    return slide;
+  }, []);
+
+  useEffect(() => {
+    syncSlideClipboard();
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === SLIDE_CLIPBOARD_STORAGE_KEY) syncSlideClipboard();
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [syncSlideClipboard]);
+
+  const saveSlideToClipboard = useCallback((slide: Slide) => {
+    const copiedAt = Date.now();
+    const snapshot = { ...slide };
+    slideClipboardRef.current = snapshot;
+    slideClipboardArmedAtRef.current = copiedAt;
+    setHasSlideClipboard(true);
+    writeSlideClipboard(snapshot, copiedAt);
+  }, []);
+
   const copySlide = useCallback(
     (slideId: string) => {
       const slide = deck?.slides.find((s) => s.id === slideId);
       if (!slide) return;
-      slideClipboardRef.current = slide;
-      slideClipboardArmedAtRef.current = Date.now();
-      setHasSlideClipboard(true);
+      saveSlideToClipboard(slide);
     },
-    [deck],
+    [deck, saveSlideToClipboard],
   );
 
   const cutSlide = useCallback(
@@ -1130,9 +1161,7 @@ export default function DeckEditor() {
       if (!deck || !id || deck.slides.length <= 1) return; // don't cut the last slide
       const slide = deck.slides.find((s) => s.id === slideId);
       if (!slide) return;
-      slideClipboardRef.current = slide;
-      slideClipboardArmedAtRef.current = Date.now();
-      setHasSlideClipboard(true);
+      saveSlideToClipboard(slide);
       const idx = deck.slides.findIndex((s) => s.id === slideId);
       const nextSlide = deck.slides[idx + 1] || deck.slides[idx - 1];
       deleteSlideWithUndo(id, slideId);
@@ -1140,18 +1169,18 @@ export default function DeckEditor() {
         setActiveSlideId(nextSlide.id);
       }
     },
-    [deck, id, activeSlideId, deleteSlideWithUndo],
+    [deck, id, activeSlideId, deleteSlideWithUndo, saveSlideToClipboard],
   );
 
   const pasteSlideAfter = useCallback(
     (targetSlideId: string) => {
-      const clipboard = slideClipboardRef.current;
+      const clipboard = slideClipboardRef.current ?? syncSlideClipboard();
       if (!clipboard || !id) return;
       const { id: _clipboardId, ...fields } = clipboard;
       const newId = pasteSlide(id, targetSlideId, fields);
       if (newId) setActiveSlideId(newId);
     },
-    [id, pasteSlide],
+    [id, pasteSlide, syncSlideClipboard],
   );
 
   // Handlers backing the slide rail's right-click menu.

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -1114,6 +1114,7 @@ export default function DeckEditor() {
   // removed the original slide from the deck.
   const slideClipboardRef = useRef<Slide | null>(null);
   const slideClipboardScopeRef = useRef<string | null>(null);
+  const slideClipboardPersistenceFailedRef = useRef(false);
   // Only gates the ambient document-level Cmd/Ctrl+V shortcut below — the
   // rail's right-click "Paste" menu item is an explicit click with no
   // ambiguity risk, so it keeps working off `hasSlideClipboard` alone however
@@ -1128,25 +1129,33 @@ export default function DeckEditor() {
     if (!slideClipboardStorageKey) {
       slideClipboardRef.current = null;
       slideClipboardScopeRef.current = null;
+      slideClipboardPersistenceFailedRef.current = false;
       slideClipboardArmedAtRef.current = null;
       setHasSlideClipboard(false);
       return null;
     }
     const result = readSlideClipboard(slideClipboardStorageKey);
+    const cachedSlide = slideClipboardRef.current;
+    const cachedCopiedAt = slideClipboardArmedAtRef.current;
     const slide = resolveSlideClipboardForPaste(
       result,
-      slideClipboardRef.current,
+      cachedSlide,
       slideClipboardScopeRef.current,
       slideClipboardStorageKey,
+      cachedCopiedAt,
+      slideClipboardPersistenceFailedRef.current,
     );
+    const usedCachedClipboard = slide !== null && slide === cachedSlide;
     slideClipboardRef.current = slide;
     slideClipboardScopeRef.current = slideClipboardStorageKey;
-    slideClipboardArmedAtRef.current =
-      result.status === "ready"
+    slideClipboardArmedAtRef.current = usedCachedClipboard
+      ? cachedCopiedAt
+      : result.status === "ready"
         ? result.copiedAt
-        : slide
-          ? slideClipboardArmedAtRef.current
-          : null;
+        : null;
+    if (!usedCachedClipboard) {
+      slideClipboardPersistenceFailedRef.current = false;
+    }
     setHasSlideClipboard(slide !== null);
     return slide;
   }, [slideClipboardStorageKey]);
@@ -1170,7 +1179,13 @@ export default function DeckEditor() {
       slideClipboardArmedAtRef.current = copiedAt;
       setHasSlideClipboard(true);
       if (slideClipboardStorageKey) {
-        writeSlideClipboard(slideClipboardStorageKey, snapshot, copiedAt);
+        slideClipboardPersistenceFailedRef.current = !writeSlideClipboard(
+          slideClipboardStorageKey,
+          snapshot,
+          copiedAt,
+        );
+      } else {
+        slideClipboardPersistenceFailedRef.current = false;
       }
     },
     [slideClipboardStorageKey],

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -117,6 +117,7 @@ import {
 import type { SelectedAnimationTarget } from "@/lib/slide-animation-elements";
 import {
   getSlideClipboardStorageKey,
+  normalizeSlideClipboard,
   readSlideClipboard,
   resolveSlideClipboardForPaste,
   writeSlideClipboard,
@@ -1192,7 +1193,8 @@ export default function DeckEditor() {
   const saveSlideToClipboard = useCallback(
     (slide: Slide) => {
       const copiedAt = Date.now();
-      const snapshot = { ...slide };
+      const snapshot = normalizeSlideClipboard(slide);
+      if (!snapshot) return;
       slideClipboardRef.current = snapshot;
       slideClipboardScopeRef.current = slideClipboardStorageKey;
       slideClipboardArmedAtRef.current = copiedAt;

--- a/templates/slides/changelog/2026-08-27-copy-slides-between-decks.md
+++ b/templates/slides/changelog/2026-08-27-copy-slides-between-decks.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-27
+---
+
+Copying a slide in Slides now makes it available to paste into another deck.


### PR DESCRIPTION
## Summary
- persist the Slides slide clipboard per browser origin so separate deck links can share it
- sync already-open deck editors through the storage event and preserve the copy timestamp for keyboard paste
- add focused clipboard serialization coverage and a user-facing changelog entry

## Verification
- formatter and git diff --check passed
- focused tests pending dependency setup in this worktree