### PR TITLE
fix(slides): keep thumbnail rail vertically scrollable

### DIFF
--- a/templates/slides/app/components/editor/EditorSidebar.test.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.test.tsx
@@ -93,6 +93,9 @@ describe("EditorSidebar thumbnail scroll cue", () => {
     const thumbnailScrollArea = container.querySelector<HTMLElement>(
       "[data-slides-thumbnail-scroll] > div",
     );
+    expect(thumbnailScrollArea?.classList.contains("overflow-x-hidden")).toBe(
+      true,
+    );
     expect(thumbnailPane?.dataset.slidesThumbnailScroll).toBe("top");
 
     act(() => {

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -686,7 +686,7 @@ export default function EditorSidebar({
         }
       >
         <div
-          className="h-full min-h-0 space-y-1 overflow-y-auto overscroll-contain p-2"
+          className="h-full min-h-0 space-y-1 overflow-x-hidden overflow-y-auto overscroll-contain p-2"
           onScroll={(event) => {
             setThumbnailListScrolled(event.currentTarget.scrollTop > 1);
           }}


### PR DESCRIPTION
## Summary\n- clip horizontal overflow in the slide thumbnail rail\n- preserve vertical scrolling while dragging thumbnails\n\n## Validation\n- corepack pnpm --filter slides exec oxfmt --write app/components/editor/EditorSidebar.tsx app/components/editor/EditorSidebar.test.tsx\n- corepack pnpm --filter slides exec vitest --run app/components/editor/EditorSidebar.test.tsx