### PR TITLE
fix(dispatch): keep vault secret values write-only

### DIFF
--- a/.changeset/quiet-vault-reads.md
+++ b/.changeset/quiet-vault-reads.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Prevent vault actions and the Dispatch UI from exposing stored secret values.

--- a/packages/dispatch/src/actions/create-vault-secret.ts
+++ b/packages/dispatch/src/actions/create-vault-secret.ts
@@ -1,7 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
 import { z } from "zod";
 
-import { createSecret } from "../server/lib/vault-store.js";
+import {
+  createSecret,
+  toVaultSecretMetadata,
+} from "../server/lib/vault-store.js";
 
 export default defineAction({
   description:
@@ -24,5 +27,5 @@ export default defineAction({
   // the value. Opt out of input capture so the trail can't become a second
   // durable credential store.
   audit: { recordInputs: false },
-  run: async (args) => createSecret(args),
+  run: async (args) => toVaultSecretMetadata(await createSecret(args)),
 });

--- a/packages/dispatch/src/actions/delete-vault-secret.ts
+++ b/packages/dispatch/src/actions/delete-vault-secret.ts
@@ -9,5 +9,8 @@ export default defineAction({
   schema: z.object({
     id: z.string().describe("Secret ID to delete"),
   }),
-  run: async (args) => deleteSecret(args.id),
+  run: async ({ id }) => {
+    await deleteSecret(id);
+    return { deleted: true, id };
+  },
 });

--- a/packages/dispatch/src/actions/list-vault-secrets.ts
+++ b/packages/dispatch/src/actions/list-vault-secrets.ts
@@ -1,27 +1,18 @@
 import { defineAction } from "@agent-native/core/action";
 import { z } from "zod";
 
-import { listSecrets } from "../server/lib/vault-store.js";
+import {
+  listSecrets,
+  toVaultSecretMetadata,
+} from "../server/lib/vault-store.js";
 
 export default defineAction({
   description:
-    "List all secrets stored in the workspace vault. Admin only. Includes raw values so the UI mask/unmask toggle works — masking is a UI concern, not a data concern. Agent responses should still mask values when echoing them to users.",
+    "List all secrets stored in the workspace vault. Admin only. Returns metadata and a masked last-four preview; never returns secret values.",
   schema: z.object({}),
   http: { method: "GET" },
   run: async () => {
     const secrets = await listSecrets();
-    return secrets.map((s) => ({
-      id: s.id,
-      name: s.name,
-      credentialKey: s.credentialKey,
-      // Included so the vault UI's eye-icon toggle can reveal the stored
-      // value. Without this the "unmask" click shows an empty string.
-      value: s.value,
-      provider: s.provider,
-      description: s.description,
-      createdBy: s.createdBy,
-      createdAt: s.createdAt,
-      updatedAt: s.updatedAt,
-    }));
+    return secrets.map(toVaultSecretMetadata);
   },
 });

--- a/packages/dispatch/src/actions/update-vault-secret.ts
+++ b/packages/dispatch/src/actions/update-vault-secret.ts
@@ -1,7 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
 import { z } from "zod";
 
-import { updateSecret } from "../server/lib/vault-store.js";
+import {
+  toVaultSecretMetadata,
+  updateSecret,
+} from "../server/lib/vault-store.js";
 
 export default defineAction({
   description:
@@ -15,7 +18,11 @@ export default defineAction({
         .min(1)
         .optional()
         .describe("Environment variable name, e.g. GOOGLE_CLIENT_ID"),
-      value: z.string().min(1).optional().describe("New secret value"),
+      value: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("New secret value; omit to keep the existing value"),
       name: z
         .string()
         .trim()
@@ -45,5 +52,5 @@ export default defineAction({
   // Carries a secret `value`. Record THAT the secret changed, never the value —
   // keep the audit trail from becoming a second credential store.
   audit: { recordInputs: false },
-  run: async (args) => updateSecret(args.id, args),
+  run: async (args) => toVaultSecretMetadata(await updateSecret(args.id, args)),
 });

--- a/packages/dispatch/src/routes/pages/vault.tsx
+++ b/packages/dispatch/src/routes/pages/vault.tsx
@@ -7,8 +7,6 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconEdit,
-  IconEye,
-  IconEyeOff,
   IconKey,
   IconPlus,
   IconRefresh,
@@ -196,16 +194,14 @@ function EditSecretDialog({ secret }: { secret: any }) {
     secret.credentialKey || "",
   );
   const [name, setName] = useState(secret.name || "");
-  const [value, setValue] = useState(secret.value || "");
+  const [value, setValue] = useState("");
   const [provider, setProvider] = useState(secret.provider || "");
   const [description, setDescription] = useState(secret.description || "");
-  const [showValue, setShowValue] = useState(false);
 
   const update = useActionMutation("update-vault-secret", {
     onSuccess: () => {
       toast.success("Secret updated");
       setOpen(false);
-      setShowValue(false);
     },
     onError: (err) => toast.error(String(err)),
   });
@@ -213,10 +209,9 @@ function EditSecretDialog({ secret }: { secret: any }) {
   const resetDraft = () => {
     setCredentialKey(secret.credentialKey || "");
     setName(secret.name || "");
-    setValue(secret.value || "");
+    setValue("");
     setProvider(secret.provider || "");
     setDescription(secret.description || "");
-    setShowValue(false);
   };
 
   return (
@@ -238,7 +233,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
           <DialogTitle>Edit vault secret</DialogTitle>
           <DialogDescription>
             Update the stored key and metadata. Changes sync to the shared
-            credential store.
+            credential store. Leave the value blank to keep the existing secret.
           </DialogDescription>
         </DialogHeader>
         <form
@@ -249,7 +244,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
               id: secret.id,
               credentialKey,
               name,
-              value,
+              ...(value ? { value } : {}),
               provider: provider || null,
               description: description || null,
             });
@@ -275,27 +270,17 @@ function EditSecretDialog({ secret }: { secret: any }) {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor={`vault-secret-value-${secret.id}`}>Value</Label>
-            <div className="flex gap-2">
-              <Input
-                id={`vault-secret-value-${secret.id}`}
-                type={showValue ? "text" : "password"}
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                className="font-mono text-sm"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                onClick={() => setShowValue((current) => !current)}
-                aria-label={
-                  showValue ? "Hide secret value" : "Show secret value"
-                }
-              >
-                {showValue ? <IconEyeOff size={15} /> : <IconEye size={15} />}
-              </Button>
-            </div>
+            <Label htmlFor={`vault-secret-value-${secret.id}`}>
+              New value (optional)
+            </Label>
+            <Input
+              id={`vault-secret-value-${secret.id}`}
+              type="password"
+              placeholder="Enter a new value to rotate it"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="font-mono text-sm"
+            />
           </div>
           <div className="space-y-2">
             <Label>Provider</Label>
@@ -343,10 +328,7 @@ function EditSecretDialog({ secret }: { secret: any }) {
             <Button
               type="submit"
               disabled={
-                !credentialKey.trim() ||
-                !name.trim() ||
-                !value ||
-                update.isPending
+                !credentialKey.trim() || !name.trim() || update.isPending
               }
             >
               {update.isPending ? "Saving..." : "Save changes"}
@@ -473,7 +455,6 @@ function SecretRow({
   accessMode: VaultAccessMode;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [showValue, setShowValue] = useState(false);
 
   const deleteSecret = useActionMutation("delete-vault-secret", {
     onSuccess: () => toast.success("Secret deleted"),
@@ -539,15 +520,8 @@ function SecretRow({
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground">Value:</span>
             <code className="text-xs font-mono text-foreground">
-              {showValue ? secret.value : `••••${secret.value.slice(-4)}`}
+              {secret.last4}
             </code>
-            <button
-              type="button"
-              onClick={() => setShowValue(!showValue)}
-              className="text-muted-foreground hover:text-foreground cursor-pointer"
-            >
-              {showValue ? <IconEyeOff size={14} /> : <IconEye size={14} />}
-            </button>
           </div>
 
           <div className="space-y-2">

--- a/packages/dispatch/src/server/lib/vault-store.spec.ts
+++ b/packages/dispatch/src/server/lib/vault-store.spec.ts
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => ({
   writeAppSecret: vi.fn(),
 }));
 
-vi.mock("@agent-native/core/secrets", () => ({
+vi.mock("@agent-native/core/secrets", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@agent-native/core/secrets")>()),
   deleteAppSecret: mocks.deleteAppSecret,
   listAppSecretsForScope: mocks.listAppSecretsForScope,
   readAppSecret: mocks.readAppSecret,
@@ -64,6 +65,7 @@ import {
   resyncAllVaultSecretsToCredentialStore,
   syncGrantsToApp,
   syncSecretsToCredentialStore,
+  toVaultSecretMetadata,
 } from "./vault-store.js";
 
 afterEach(() => {
@@ -143,6 +145,30 @@ describe("vault authorization", () => {
 
     await expect(assertCanManageVault()).resolves.toBeUndefined();
     expect(mocks.getDbExec).not.toHaveBeenCalled();
+  });
+});
+
+describe("toVaultSecretMetadata", () => {
+  it("returns only masked metadata", () => {
+    const metadata = toVaultSecretMetadata({
+      id: "secret-1",
+      name: "Test key",
+      credentialKey: "TEST_KEY",
+      value: "sk-test-example",
+      provider: "other",
+      description: "Fake test credential",
+      createdBy: "owner@example.test",
+      createdAt: 1,
+      updatedAt: 2,
+    } as any);
+
+    expect(metadata).toMatchObject({
+      id: "secret-1",
+      credentialKey: "TEST_KEY",
+      last4: "••••mple",
+    });
+    expect(metadata).not.toHaveProperty("value");
+    expect(JSON.stringify(metadata)).not.toContain("sk-test-example");
   });
 });
 

--- a/packages/dispatch/src/server/lib/vault-store.ts
+++ b/packages/dispatch/src/server/lib/vault-store.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, isNull, or, sql } from "@agent-native/core/db/schema";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
 import {
   deleteAppSecret,
+  last4,
   listAppSecretsForScope,
   writeAppSecret,
   type SecretScope,
@@ -812,6 +813,36 @@ export async function revokeGrant(
 // ─── Shared Credential Store Sync ─────────────────────────────────
 
 type VaultSecretRow = typeof schema.vaultSecrets.$inferSelect;
+
+export interface VaultSecretMetadata {
+  id: string;
+  name: string;
+  credentialKey: string;
+  last4: string;
+  provider: string | null;
+  description: string | null;
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Return the fields safe to expose to clients, agents, and action callers. */
+export function toVaultSecretMetadata(
+  secret: VaultSecretRow | null,
+): VaultSecretMetadata | null {
+  if (!secret) return null;
+  return {
+    id: secret.id,
+    name: secret.name,
+    credentialKey: secret.credentialKey,
+    last4: last4(secret.value),
+    provider: secret.provider,
+    description: secret.description,
+    createdBy: secret.createdBy,
+    createdAt: secret.createdAt,
+    updatedAt: secret.updatedAt,
+  };
+}
 
 export function credentialStoreScopeForVaultCtx(ctx: VaultCtx): {
   scope: Extract<SecretScope, "org" | "workspace">;


### PR DESCRIPTION
## Summary\n\n- prevent vault list, create, update, and delete actions from returning raw secret values\n- return masked last-four metadata and make the Vault UI rotation flow write-only\n- add regression coverage and a dispatch changeset\n\n## Validation\n\n- focused vault-store Vitest suite\n- Dispatch typecheck\n- all repository guards\n- oxfmt and diff checks