### PR TITLE
Always approve Liam DeBeasi pull requests

### DIFF
--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -62,16 +62,17 @@ auto-approved, even when the patch looks safe or the issue is obviously valid.
 
 ## Liamdebeasi approval policy
 
-For a PR authored by the exact GitHub login `liamdebeasi`, always submit an
-approval when it is a current, non-draft PR in `BuilderIO/agent-native` and
-does not already have a current, non-dismissed approval; never duplicate an
-existing approval. This exception overrides the ordinary membership, check,
-review-feedback, scope, and UX-owner gates. It does not authorize a merge,
-suppress the ultra-scary safety gate, or permit approval when the diff shows a
-credible auth bypass, permission or tenant-isolation failure, secret or
-credential leak, destructive data loss or migration, remote code execution,
-SSRF, payment compromise, deployment compromise, or similarly severe
-production risk.
+For a PR authored by the exact GitHub login `liamdebeasi` and immutable user
+ID `2721089`, always submit an approval when it is a current, non-draft PR in
+`BuilderIO/agent-native`, the membership API verifies current BuilderIO
+membership, and it does not already have a current-head, non-dismissed
+approval; never duplicate an existing approval. This exception overrides the
+ordinary check, ordinary review-feedback, scope, and UX-owner gates. It does
+not override membership verification, the ultra-scary safety gate, or the
+independent-review requirement for PRs changing review or approval policy,
+agent-safety instructions, membership verification, or CI/deployment security
+controls. Active credible safety findings remain approval-blocking. It does
+not authorize a merge.
 
 ## Internal-author approval policy
 

--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-prs
 description: >-
-  Review recent BuilderIO/agent-native pull requests, always approve PRs from
+  Review recent BuilderIO/agent-native pull requests, approve eligible PRs from
   liamdebeasi, approve other safe internal fixes under the internal-author and
   owner exceptions, merge safe Dependabot updates, skip drafts, and recap
   every disposition. Use for scheduled or manual PR review sweeps.
@@ -41,8 +41,9 @@ draft state and current review summary:
    approval; do not submit a duplicate approval.
 
 Only the remaining non-draft, unapproved PRs enter the ordinary evidence
-sweep below; non-draft Dependabot candidates also enter the merge evidence
-sweep even when they already have an approval.
+sweep below. Eligible Liam PRs with only older-head approvals also enter the
+sweep so the current head can be approved; non-draft Dependabot candidates
+also enter the merge evidence sweep even when they already have an approval.
 
 For every PR you inspect, read:
 

--- a/.agents/skills/review-prs/SKILL.md
+++ b/.agents/skills/review-prs/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: review-prs
 description: >-
-  Review recent BuilderIO/agent-native pull requests, approve safe internal
-  fixes under the internal-author and owner exceptions, merge safe Dependabot
-  updates, skip drafts, and recap every disposition. Use for scheduled or
-  manual PR review sweeps.
+  Review recent BuilderIO/agent-native pull requests, always approve PRs from
+  liamdebeasi, approve other safe internal fixes under the internal-author and
+  owner exceptions, merge safe Dependabot updates, skip drafts, and recap
+  every disposition. Use for scheduled or manual PR review sweeps.
 user-invocable: true
 scope: dev
 metadata:
@@ -59,6 +59,19 @@ member of `BuilderIO`. Do not infer internal status from a display name, email,
 company claim, branch name, `authorAssociation`, or a familiar-looking bot.
 If membership cannot be verified, do not approve. External authors are never
 auto-approved, even when the patch looks safe or the issue is obviously valid.
+
+## Liamdebeasi approval policy
+
+For a PR authored by the exact GitHub login `liamdebeasi`, always submit an
+approval when it is a current, non-draft PR in `BuilderIO/agent-native` and
+does not already have a current, non-dismissed approval; never duplicate an
+existing approval. This exception overrides the ordinary membership, check,
+review-feedback, scope, and UX-owner gates. It does not authorize a merge,
+suppress the ultra-scary safety gate, or permit approval when the diff shows a
+credible auth bypass, permission or tenant-isolation failure, secret or
+credential leak, destructive data loss or migration, remote code execution,
+SSRF, payment compromise, deployment compromise, or similarly severe
+production risk.
 
 ## Internal-author approval policy
 

--- a/templates/factory/AGENTS.md
+++ b/templates/factory/AGENTS.md
@@ -25,7 +25,8 @@ decisions, feedback, agent runs, and provider audit records.
   messages or `@handles`. GitHub/Sentry use the Builder run API. Read
   `review-latest-feedback` for thread evidence and disposition rules.
 - PR governance follows `review-prs`: verify membership and evidence; skip
-  drafts and external authors; keep ultra-scary risks manual; never auto-merge.
+  drafts and external authors; apply the verified `liamdebeasi` exception for
+  ordinary gates; keep ultra-scary risks manual; never auto-merge.
 - Graph edits create immutable blueprint versions. AI proposes with `source=ai`;
   a person reviews and publishes through the same action surface.
 - Provider credentials belong to Dispatch/shared workspace integrations, never

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -328,6 +328,20 @@ export default defineAction({
           itemId,
           snapshot.headSha,
         );
+        if (previouslyFinalized) {
+          await getDb()
+            .update(triageDecisions)
+            .set({ outcome: "auto_approve" })
+            .where(
+              and(
+                eq(triageDecisions.id, decisionId),
+                eq(triageDecisions.itemId, itemId),
+                eq(triageDecisions.orgId, orgId),
+                eq(triageDecisions.factoryId, factoryId),
+                eq(triageDecisions.outcome, "auto_approval_claimed"),
+              ),
+            );
+        }
         const authenticatedUser = await github.getAuthenticatedUser();
         const currentAuthorMembership = await github.checkOrganizationMember(
           "BuilderIO",
@@ -815,31 +829,62 @@ export default defineAction({
             const claimCanBeReleased =
               definitiveRejection || !error.requestAttempted;
             if (claimCanBeReleased) {
-              await getDb()
-                .update(triageDecisions)
-                .set({
-                  outcome: "needs_manual",
-                  reason: definitiveRejection
-                    ? `GitHub rejected the approval request definitively: ${error.message}`
-                    : `GitHub approval request was unavailable before the provider call: ${error.message}`,
-                })
-                .where(
-                  and(
-                    eq(
-                      triageDecisions.id,
-                      stableId(
-                        "pr-governance",
-                        orgId,
-                        itemId,
-                        snapshot.headSha,
+              const rejectionReason = definitiveRejection
+                ? `GitHub rejected the approval request definitively: ${error.message}`
+                : `GitHub approval request was unavailable before the provider call: ${error.message}`;
+              await getDb().transaction(async (tx) => {
+                const released = await tx
+                  .update(triageDecisions)
+                  .set({ outcome: "needs_manual", reason: rejectionReason })
+                  .where(
+                    and(
+                      eq(
+                        triageDecisions.id,
+                        stableId(
+                          "pr-governance",
+                          orgId,
+                          itemId,
+                          snapshot.headSha,
+                        ),
                       ),
+                      eq(triageDecisions.itemId, itemId),
+                      eq(triageDecisions.orgId, orgId),
+                      eq(triageDecisions.factoryId, factoryId),
+                      eq(triageDecisions.outcome, "auto_approval_claimed"),
                     ),
-                    eq(triageDecisions.itemId, itemId),
-                    eq(triageDecisions.orgId, orgId),
-                    eq(triageDecisions.factoryId, factoryId),
-                    eq(triageDecisions.outcome, "auto_approval_claimed"),
-                  ),
+                  )
+                  .returning({ id: triageDecisions.id });
+                if (released[0] && definitiveRejection) {
+                  await tx
+                    .update(triageItems)
+                    .set({
+                      status: "needs_manual",
+                      updatedAt: new Date().toISOString(),
+                    })
+                    .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+                }
+              });
+              if (definitiveRejection) {
+                await recordFactoryAudit(
+                  context,
+                  { userEmail, orgId },
+                  {
+                    action: "govern-agent-native-pull-request",
+                    kind: "external_action",
+                    status: "failure",
+                    itemId,
+                    source: "github",
+                    sourceUrl: pullRequest.htmlUrl,
+                    summary: rejectionReason,
+                    details: {
+                      repo,
+                      pullRequestNumber,
+                      status: error.status,
+                    },
+                  },
+                  factoryId,
                 );
+              }
             }
           }
           throw error;

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -274,6 +274,7 @@ export default defineAction({
     }
     const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
       snapshot.reviews,
+      snapshot.headSha,
     );
     const safetyFindingsClean =
       !snapshot.commentsTruncated &&
@@ -399,10 +400,12 @@ export default defineAction({
             );
         }
         const authenticatedUser = await github.getAuthenticatedUser();
-        const currentAuthorMembership = await github.checkOrganizationMember(
-          "BuilderIO",
-          pullRequest.userLogin,
-        );
+        const currentAuthorMembership =
+          await github.checkOrganizationMemberById(
+            "BuilderIO",
+            pullRequest.userId,
+            pullRequest.userLogin,
+          );
         const attributedApproval = currentApprovals.find(
           (approval) =>
             approval.reviewerLogin ===
@@ -757,7 +760,10 @@ export default defineAction({
         throw error;
       }
       const postClaimBlockingReviewStatesClean =
-        !hasCurrentBlockingPullRequestReview(postClaimSnapshot.reviews);
+        !hasCurrentBlockingPullRequestReview(
+          postClaimSnapshot.reviews,
+          postClaimSnapshot.headSha,
+        );
       const postClaimSafetyFindingsClean =
         !postClaimSnapshot.commentsTruncated &&
         !hasActiveCredibleSafetyFinding(
@@ -793,8 +799,9 @@ export default defineAction({
       });
       const postClaimReviewFeedbackHandled =
         postClaimBlockingReviewStatesClean && postClaimReviewFeedback.isClean;
-      const postClaimInternalMember = await github.checkOrganizationMember(
+      const postClaimInternalMember = await github.checkOrganizationMemberById(
         "BuilderIO",
+        pullRequest.userId,
         pullRequest.userLogin,
       );
       const postClaimGovernance = decidePullRequestGovernance({
@@ -932,6 +939,69 @@ export default defineAction({
               "Live GitHub pull-request state changed after review; no approval was posted.",
           };
         }
+        let finalReviewSnapshot;
+        try {
+          finalReviewSnapshot = await aiServicesGit.fetchPullRequest({
+            projectId,
+            repo,
+            pullRequestNumber,
+          });
+          if (finalReviewSnapshot.headSha !== snapshot.headSha) {
+            throw new Error(
+              `PR review evidence changed before approval: expected ${snapshot.headSha}, received ${finalReviewSnapshot.headSha}.`,
+            );
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "unknown review evidence error";
+          await reconcileClaim(
+            snapshot.headSha,
+            `Review evidence could not be revalidated before approval: ${message}. Reconciliation is required before approval.`,
+          );
+          throw error;
+        }
+        let finalApprovals;
+        try {
+          finalApprovals = currentPullRequestApprovals(
+            finalReviewSnapshot.reviews,
+            finalReviewSnapshot.headSha,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "unknown approval evidence error";
+          await reconcileClaim(
+            snapshot.headSha,
+            `Approval evidence could not be revalidated before approval: ${message}. Reconciliation is required before approval.`,
+          );
+          throw error;
+        }
+        if (
+          finalApprovals.length > 0 ||
+          hasCurrentBlockingPullRequestReview(
+            finalReviewSnapshot.reviews,
+            finalReviewSnapshot.headSha,
+          ) ||
+          finalReviewSnapshot.commentsTruncated ||
+          hasActiveCredibleSafetyFinding(
+            finalReviewSnapshot.reviews,
+            finalReviewSnapshot.comments,
+          )
+        ) {
+          await reconcileClaim(
+            snapshot.headSha,
+            "Review evidence changed before approval; reconciliation is required before retrying.",
+          );
+          return {
+            ok: true,
+            action: "needs_manual",
+            reason:
+              "Review evidence changed before approval; no duplicate or unsafe approval was posted.",
+          };
+        }
         const decisionId = stableId(
           "pr-governance",
           orgId,
@@ -1021,6 +1091,33 @@ export default defineAction({
           throw error;
         }
         approvalUrl = approval.htmlUrl;
+        let postApprovalPullRequest;
+        try {
+          postApprovalPullRequest = await github.getPullRequestSummary(
+            repository,
+            pullRequestNumber,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "unknown GitHub error";
+          await reconcileClaim(
+            snapshot.headSha,
+            `Live GitHub state could not be revalidated after approval: ${message}. Reconciliation is required before finalizing.`,
+          );
+          throw error;
+        }
+        if (postApprovalPullRequest.headSha !== snapshot.headSha) {
+          await reconcileClaim(
+            snapshot.headSha,
+            "The pull request changed after approval was posted; reconciliation is required before finalizing.",
+          );
+          return {
+            ok: true,
+            action: "needs_manual",
+            reason:
+              "The pull request changed after approval was posted; durable approval state was not finalized.",
+          };
+        }
         const latestItem = (
           await getDb()
             .select({ metadataJson: triageItems.metadataJson })

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -422,8 +422,8 @@ export default defineAction({
           governance.trustException
             ? `Factory auto-approved under the verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
             : governance.ownerException
-            ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
-            : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
+              ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
+              : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
         );
         approvalUrl = approval.htmlUrl;
         metadata.autoApprovedAt = new Date().toISOString();

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -121,7 +121,7 @@ export default defineAction({
     factoryId: factoryIdSchema.default(DEFAULT_FACTORY_ID),
     repo: z.string().trim().min(1).max(256),
     pullRequestNumber: z.number().int().positive(),
-    itemId: z.string().min(1).optional(),
+    itemId: z.string().min(1),
     clearBug: z.boolean(),
     productUxImplications: z.boolean().default(false),
     reason: z.string().trim().min(1).max(4_000),
@@ -394,9 +394,30 @@ export default defineAction({
           .onConflictDoNothing()
           .returning({ id: triageDecisions.id });
         if (governance.autoApprove && !inserted[0]) {
-          throw new Error(
-            "A pull-request approval intent already exists; reconcile the provider result before retrying.",
-          );
+          const reclaimed = await tx
+            .update(triageDecisions)
+            .set({
+              outcome: "auto_approval_claimed",
+              reason: `${reason} ${governance.reason}`.trim(),
+              guardResultsJson: JSON.stringify(governance.guardResults),
+              createdAt: new Date().toISOString(),
+              ownerEmail: userEmail,
+            })
+            .where(
+              and(
+                eq(triageDecisions.id, decisionId),
+                eq(triageDecisions.itemId, itemId),
+                eq(triageDecisions.orgId, orgId),
+                eq(triageDecisions.factoryId, factoryId),
+                eq(triageDecisions.outcome, "needs_manual"),
+              ),
+            )
+            .returning({ id: triageDecisions.id });
+          if (!reclaimed[0]) {
+            throw new Error(
+              "A pull-request approval intent already exists; reconcile the provider result before retrying.",
+            );
+          }
         }
         await requireExistingFactory(
           tx as unknown as ReturnType<typeof getDb>,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -224,7 +224,7 @@ export default defineAction({
     const reconcileClaim = async (headSha: string, reason: string) => {
       if (!itemId) return;
       await getDb().transaction(async (tx) => {
-        await tx
+        const released = await tx
           .update(triageDecisions)
           .set({ outcome: "needs_manual", reason })
           .where(
@@ -238,7 +238,9 @@ export default defineAction({
               eq(triageDecisions.factoryId, factoryId),
               eq(triageDecisions.outcome, "auto_approval_claimed"),
             ),
-          );
+          )
+          .returning({ id: triageDecisions.id });
+        if (!released[0]) return;
         await tx
           .update(triageItems)
           .set({
@@ -264,10 +266,23 @@ export default defineAction({
     const safetyFindingsClean =
       !snapshot.commentsTruncated &&
       !hasActiveCredibleSafetyFinding(snapshot.reviews, snapshot.comments);
-    const currentApprovals = currentPullRequestApprovals(
-      snapshot.reviews,
-      snapshot.headSha,
-    );
+    let currentApprovals;
+    try {
+      currentApprovals = currentPullRequestApprovals(
+        snapshot.reviews,
+        snapshot.headSha,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "unknown approval evidence error";
+      await reconcileClaim(
+        snapshot.headSha,
+        `Approval evidence could not be verified: ${message}. Reconciliation is required before approval.`,
+      );
+      throw error;
+    }
     const currentApproval = currentApprovals[0] ?? null;
     if (currentApproval) {
       await recordFactoryAudit(
@@ -497,7 +512,7 @@ export default defineAction({
       {
         action: "govern-agent-native-pull-request",
         kind: "governance",
-        status: governance.autoApprove ? "success" : "skipped",
+        status: "skipped",
         itemId: itemId ?? null,
         source: "github",
         sourceUrl: pullRequest.htmlUrl,
@@ -788,6 +803,7 @@ export default defineAction({
               : governance.ownerException
                 ? `Factory auto-approved under decision ${decisionId}; verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
                 : `Factory auto-approved under decision ${decisionId}; verified BuilderIO membership; ordinary check and review states remain recorded.`,
+            snapshot.headSha,
           );
         } catch (error) {
           if (error instanceof GitHubRequestError) {

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -38,6 +38,7 @@ import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
 import {
   decidePullRequestGovernance,
   currentPullRequestApproval,
+  FACTORY_APPROVAL_BODY_MARKER,
   hasCurrentBlockingPullRequestReview,
 } from "../server/triage/pr-policy.js";
 
@@ -245,28 +246,54 @@ export default defineAction({
         factoryId,
       );
       let recoveredApproval = false;
+      let previouslyFinalized = false;
       if (itemId) {
+        const existingItem = (
+          await getDb()
+            .select({
+              metadataJson: triageItems.metadataJson,
+              status: triageItems.status,
+            })
+            .from(triageItems)
+            .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId))
+            .limit(1)
+        )[0];
+        if (!existingItem) {
+          throw new Error("Factory item disappeared during approval recovery.");
+        }
+        const existingMetadata = parseTriageMetadata(existingItem.metadataJson);
+        previouslyFinalized =
+          existingItem.status === "auto_approved" &&
+          existingMetadata.autoApprovalHeadSha === snapshot.headSha &&
+          typeof existingMetadata.autoApprovalUrl === "string";
         const decisionId = stableId(
           "pr-governance",
           orgId,
           itemId,
           snapshot.headSha,
         );
-        const recovered = await getDb()
-          .update(triageDecisions)
-          .set({ outcome: "auto_approve" })
-          .where(
-            and(
-              eq(triageDecisions.id, decisionId),
-              eq(triageDecisions.itemId, itemId),
-              eq(triageDecisions.orgId, orgId),
-              eq(triageDecisions.factoryId, factoryId),
-              eq(triageDecisions.outcome, "auto_approval_claimed"),
-            ),
-          )
-          .returning({ id: triageDecisions.id });
-        if (recovered[0]) {
-          recoveredApproval = true;
+        const authenticatedUser = await github.getAuthenticatedUser();
+        const attributedApproval =
+          currentApproval.reviewerLogin ===
+            authenticatedUser.login.trim().toLowerCase() &&
+          currentApproval.body?.startsWith(FACTORY_APPROVAL_BODY_MARKER);
+        if (attributedApproval) {
+          const recovered = await getDb()
+            .update(triageDecisions)
+            .set({ outcome: "auto_approve" })
+            .where(
+              and(
+                eq(triageDecisions.id, decisionId),
+                eq(triageDecisions.itemId, itemId),
+                eq(triageDecisions.orgId, orgId),
+                eq(triageDecisions.factoryId, factoryId),
+                eq(triageDecisions.outcome, "auto_approval_claimed"),
+              ),
+            )
+            .returning({ id: triageDecisions.id });
+          recoveredApproval = Boolean(recovered[0]);
+        }
+        if (recoveredApproval) {
           const latestItem = (
             await getDb()
               .select({ metadataJson: triageItems.metadataJson })
@@ -294,7 +321,7 @@ export default defineAction({
             .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
         }
       }
-      if (itemId && !recoveredApproval) {
+      if (itemId && !recoveredApproval && !previouslyFinalized) {
         await getDb()
           .update(triageItems)
           .set({

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -51,6 +51,18 @@ function repositoryRef(value: string): { owner: string; repo: string } {
   return { owner: match[1], repo: match[2] };
 }
 
+function hasUsableChangedFiles(
+  changedFiles: readonly string[] | undefined,
+): changedFiles is readonly [string, ...string[]] {
+  return (
+    Array.isArray(changedFiles) &&
+    changedFiles.length > 0 &&
+    changedFiles.every(
+      (file) => typeof file === "string" && file.trim().length > 0,
+    )
+  );
+}
+
 function requiredAiServicesEnv(
   name: "BUILDER_AI_SERVICES_URL" | "BUILDER_PROJECT_ID",
 ): string {
@@ -284,6 +296,19 @@ export default defineAction({
       throw error;
     }
     const currentApproval = currentApprovals[0] ?? null;
+    if (!hasUsableChangedFiles(snapshot.changedFiles)) {
+      const missingFilesReason =
+        "Changed-file evidence is missing or invalid; approval requires reconciliation before retrying.";
+      await reconcileClaim(snapshot.headSha, missingFilesReason);
+      await getDb()
+        .update(triageItems)
+        .set({
+          status: "needs_manual",
+          updatedAt: new Date().toISOString(),
+        })
+        .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+      return { ok: true, action: "needs_manual", reason: missingFilesReason };
+    }
     if (currentApproval) {
       await recordFactoryAudit(
         context,
@@ -318,6 +343,37 @@ export default defineAction({
           throw new Error("Factory item disappeared during approval recovery.");
         }
         const existingMetadata = parseTriageMetadata(existingItem.metadataJson);
+        let livePullRequest;
+        try {
+          livePullRequest = await github.getPullRequestSummary(
+            repository,
+            pullRequestNumber,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "unknown GitHub error";
+          await reconcileClaim(
+            snapshot.headSha,
+            `Live GitHub state could not be revalidated during approval recovery: ${message}. Reconciliation is required before approval.`,
+          );
+          throw error;
+        }
+        if (
+          livePullRequest.headSha !== snapshot.headSha ||
+          livePullRequest.state !== "open" ||
+          livePullRequest.draft
+        ) {
+          await reconcileClaim(
+            snapshot.headSha,
+            "Live GitHub pull-request state changed during approval recovery; reconciliation is required before approval.",
+          );
+          return {
+            ok: true,
+            action: "needs_manual",
+            reason:
+              "Live GitHub pull-request state changed during approval recovery; no approval state was finalized.",
+          };
+        }
         previouslyFinalized =
           existingItem.status === "auto_approved" &&
           existingMetadata.autoApprovalHeadSha === snapshot.headSha &&
@@ -362,7 +418,8 @@ export default defineAction({
           currentAuthorMembership.isMember &&
           blockingReviewStatesClean &&
           safetyFindingsClean &&
-          !isUltraScaryChange(snapshot.changedFiles ?? [])
+          hasUsableChangedFiles(snapshot.changedFiles) &&
+          !isUltraScaryChange(snapshot.changedFiles)
         ) {
           recoveredApproval = await getDb().transaction(async (tx) => {
             const recovered = await tx
@@ -508,7 +565,7 @@ export default defineAction({
       repository: repo,
       title: pullRequest.title,
       summary: pullRequest.body,
-      changedFiles: snapshot.changedFiles ?? [],
+      changedFiles: snapshot.changedFiles,
       clearBug,
       productUxImplications,
       checksPassed,
@@ -591,6 +648,37 @@ export default defineAction({
           .onConflictDoNothing()
           .returning({ id: triageDecisions.id });
         if (governance.autoApprove && !inserted[0]) {
+          const staleFinalized = await tx
+            .update(triageDecisions)
+            .set({
+              outcome: "needs_manual",
+              reason:
+                "A previously posted Factory approval was dismissed; reconciliation is required before retrying.",
+            })
+            .where(
+              and(
+                eq(triageDecisions.id, decisionId),
+                eq(triageDecisions.itemId, itemId),
+                eq(triageDecisions.orgId, orgId),
+                eq(triageDecisions.factoryId, factoryId),
+                eq(triageDecisions.outcome, "auto_approve"),
+              ),
+            )
+            .returning({ id: triageDecisions.id });
+          if (staleFinalized[0]) {
+            await tx
+              .update(triageItems)
+              .set({
+                status: "reconciliation_required",
+                updatedAt: new Date().toISOString(),
+              })
+              .where(
+                and(
+                  orgFactoryScopedItemWhere(itemId, orgId, factoryId),
+                  eq(triageItems.status, "auto_approved"),
+                ),
+              );
+          }
           const reclaimed = await tx
             .update(triageDecisions)
             .set({
@@ -676,6 +764,18 @@ export default defineAction({
           postClaimSnapshot.reviews,
           postClaimSnapshot.comments,
         );
+      if (!hasUsableChangedFiles(postClaimSnapshot.changedFiles)) {
+        await reconcileClaim(
+          snapshot.headSha,
+          "Changed-file evidence disappeared after approval claim; reconciliation is required before approval.",
+        );
+        return {
+          ok: true,
+          action: "needs_manual",
+          reason:
+            "Changed-file evidence disappeared after approval claim; no approval was posted.",
+        };
+      }
       const postClaimChecksPassed =
         postClaimSnapshot.coverage === "complete" &&
         postClaimSnapshot.checks.length > 0 &&
@@ -703,7 +803,7 @@ export default defineAction({
         repository: repo,
         title: postClaimSnapshot.title,
         summary: postClaimSnapshot.summary,
-        changedFiles: postClaimSnapshot.changedFiles ?? [],
+        changedFiles: postClaimSnapshot.changedFiles,
         clearBug,
         productUxImplications,
         checksPassed: postClaimChecksPassed,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -801,6 +801,37 @@ export default defineAction({
         typeof metadata.autoApprovalUrl === "string";
       if (previouslyApproved) approvalUrl = metadata.autoApprovalUrl as string;
       if (!previouslyApproved) {
+        let livePullRequest;
+        try {
+          livePullRequest = await github.getPullRequestSummary(
+            repository,
+            pullRequestNumber,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "unknown GitHub error";
+          await reconcileClaim(
+            snapshot.headSha,
+            `Live GitHub state could not be revalidated: ${message}. Reconciliation is required before approval.`,
+          );
+          throw error;
+        }
+        if (
+          livePullRequest.headSha !== snapshot.headSha ||
+          livePullRequest.state !== "open" ||
+          livePullRequest.draft
+        ) {
+          await reconcileClaim(
+            snapshot.headSha,
+            "Live GitHub pull-request state changed after review; reconciliation is required before approval.",
+          );
+          return {
+            ok: true,
+            action: "needs_manual",
+            reason:
+              "Live GitHub pull-request state changed after review; no approval was posted.",
+          };
+        }
         const decisionId = stableId(
           "pr-governance",
           orgId,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -280,7 +280,6 @@ export default defineAction({
       snapshot.checks.every((check) => check.state === "passed");
     const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
       snapshot.reviews,
-      snapshot.headSha,
     );
     const reviewFeedback = reconcileBabysitState({
       comments: snapshot.comments,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -620,7 +620,8 @@ export default defineAction({
             const definitiveRejection =
               error.status !== null &&
               error.status >= 400 &&
-              error.status < 500;
+              error.status < 500 &&
+              !error.rateLimited;
             const claimCanBeReleased =
               definitiveRejection || !error.requestAttempted;
             if (claimCanBeReleased) {

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -286,6 +286,7 @@ export default defineAction({
     });
     const governance = decidePullRequestGovernance({
       author: pullRequest.userLogin,
+      authorId: pullRequest.userId,
       repository: repo,
       title: pullRequest.title,
       summary: pullRequest.body,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -37,6 +37,7 @@ import {
 import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
 import {
   decidePullRequestGovernance,
+  hasActiveCredibleSafetyFinding,
   currentPullRequestApprovals,
   FACTORY_APPROVAL_BODY_MARKER,
   hasCurrentBlockingPullRequestReview,
@@ -325,13 +326,53 @@ export default defineAction({
               updatedAt: new Date().toISOString(),
             })
             .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+          await recordFactoryAudit(
+            context,
+            { userEmail, orgId },
+            {
+              action: "govern-agent-native-pull-request",
+              kind: "external_action",
+              status: "success",
+              itemId,
+              source: "github",
+              sourceUrl: attributedApprovalUrl,
+              summary:
+                "Recovered the attributed Factory approval after an ambiguous provider result.",
+              details: {
+                repo,
+                pullRequestNumber,
+                decisionId,
+                approvalUrl: attributedApprovalUrl,
+              },
+            },
+            factoryId,
+          );
         }
       }
       if (itemId && !recoveredApproval && !previouslyFinalized) {
         await getDb()
+          .update(triageDecisions)
+          .set({
+            outcome: "needs_manual",
+            reason:
+              "A current approval could not be correlated to the Factory claim; reconciliation is required.",
+          })
+          .where(
+            and(
+              eq(
+                triageDecisions.id,
+                stableId("pr-governance", orgId, itemId, snapshot.headSha),
+              ),
+              eq(triageDecisions.itemId, itemId),
+              eq(triageDecisions.orgId, orgId),
+              eq(triageDecisions.factoryId, factoryId),
+              eq(triageDecisions.outcome, "auto_approval_claimed"),
+            ),
+          );
+        await getDb()
           .update(triageItems)
           .set({
-            status: "pr_observed",
+            status: "reconciliation_required",
             updatedAt: new Date().toISOString(),
           })
           .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
@@ -350,6 +391,10 @@ export default defineAction({
       snapshot.checks.every((check) => check.state === "passed");
     const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
       snapshot.reviews,
+    );
+    const safetyFindingsClean = !hasActiveCredibleSafetyFinding(
+      snapshot.reviews,
+      snapshot.comments,
     );
     const reviewFeedback = reconcileBabysitState({
       comments: snapshot.comments,
@@ -387,6 +432,7 @@ export default defineAction({
       checksPassed,
       reviewFeedbackHandled,
       blockingReviewStatesClean,
+      safetyFindingsClean,
       openNonDraft: pullRequest.state === "open" && !pullRequest.draft,
       internalBuilderMember: internalMember.isMember,
       factoryTriggered,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -221,6 +221,33 @@ export default defineAction({
       baseUrl: requiredAiServicesEnv("BUILDER_AI_SERVICES_URL"),
       authorization: `Bearer ${privateKey.startsWith("bpk-") ? privateKey : `bpk-${privateKey}`}`,
     });
+    const reconcileClaim = async (headSha: string, reason: string) => {
+      if (!itemId) return;
+      await getDb().transaction(async (tx) => {
+        await tx
+          .update(triageDecisions)
+          .set({ outcome: "needs_manual", reason })
+          .where(
+            and(
+              eq(
+                triageDecisions.id,
+                stableId("pr-governance", orgId, itemId, headSha),
+              ),
+              eq(triageDecisions.itemId, itemId),
+              eq(triageDecisions.orgId, orgId),
+              eq(triageDecisions.factoryId, factoryId),
+              eq(triageDecisions.outcome, "auto_approval_claimed"),
+            ),
+          );
+        await tx
+          .update(triageItems)
+          .set({
+            status: "reconciliation_required",
+            updatedAt: new Date().toISOString(),
+          })
+          .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+      });
+    };
     const snapshot = await aiServicesGit.fetchPullRequest({
       projectId,
       repo,
@@ -589,22 +616,105 @@ export default defineAction({
     }
 
     if (itemId) {
-      const postClaimSnapshot = await aiServicesGit.fetchPullRequest({
-        projectId,
-        repo,
-        pullRequestNumber,
-      });
-      if (postClaimSnapshot.headSha !== snapshot.headSha) {
-        throw new Error(
-          `PR evidence changed after approval claim: expected ${snapshot.headSha}, received ${postClaimSnapshot.headSha}.`,
+      let postClaimSnapshot: Awaited<
+        ReturnType<typeof aiServicesGit.fetchPullRequest>
+      >;
+      try {
+        postClaimSnapshot = await aiServicesGit.fetchPullRequest({
+          projectId,
+          repo,
+          pullRequestNumber,
+        });
+        if (postClaimSnapshot.headSha !== snapshot.headSha) {
+          throw new Error(
+            `PR evidence changed after approval claim: expected ${snapshot.headSha}, received ${postClaimSnapshot.headSha}.`,
+          );
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "unknown evidence error";
+        await reconcileClaim(
+          snapshot.headSha,
+          `Post-claim PR evidence could not be verified: ${message}. Reconciliation is required before approval.`,
         );
+        throw error;
       }
-      if (
-        currentPullRequestApprovals(
+      const postClaimBlockingReviewStatesClean =
+        !hasCurrentBlockingPullRequestReview(postClaimSnapshot.reviews);
+      const postClaimSafetyFindingsClean =
+        !postClaimSnapshot.commentsTruncated &&
+        !hasActiveCredibleSafetyFinding(
+          postClaimSnapshot.reviews,
+          postClaimSnapshot.comments,
+        );
+      const postClaimChecksPassed =
+        postClaimSnapshot.coverage === "complete" &&
+        postClaimSnapshot.checks.length > 0 &&
+        postClaimSnapshot.checks.every((check) => check.state === "passed");
+      const postClaimReviewFeedback = reconcileBabysitState({
+        comments: postClaimSnapshot.comments,
+        checks: postClaimSnapshot.checks,
+        commentsTruncated: postClaimSnapshot.commentsTruncated,
+        botAuthors: [
+          "github-actions",
+          "github-actions[bot]",
+          "dependabot[bot]",
+          "builderio[bot]",
+        ],
+      });
+      const postClaimReviewFeedbackHandled =
+        postClaimBlockingReviewStatesClean && postClaimReviewFeedback.isClean;
+      const postClaimInternalMember = await github.checkOrganizationMember(
+        "BuilderIO",
+        pullRequest.userLogin,
+      );
+      const postClaimGovernance = decidePullRequestGovernance({
+        author: pullRequest.userLogin,
+        authorId: pullRequest.userId,
+        repository: repo,
+        title: postClaimSnapshot.title,
+        summary: postClaimSnapshot.summary,
+        changedFiles: postClaimSnapshot.changedFiles,
+        clearBug,
+        productUxImplications,
+        checksPassed: postClaimChecksPassed,
+        reviewFeedbackHandled: postClaimReviewFeedbackHandled,
+        blockingReviewStatesClean: postClaimBlockingReviewStatesClean,
+        safetyFindingsClean: postClaimSafetyFindingsClean,
+        openNonDraft: pullRequest.state === "open" && !pullRequest.draft,
+        internalBuilderMember: postClaimInternalMember.isMember,
+        factoryTriggered,
+      });
+      if (!postClaimGovernance.autoApprove) {
+        await reconcileClaim(
+          snapshot.headSha,
+          `Post-claim PR evidence no longer satisfies the approval gates: ${postClaimGovernance.reason}`,
+        );
+        return {
+          ok: true,
+          action: "needs_manual",
+          reason:
+            "Post-claim PR evidence no longer satisfies the approval gates; reconciliation is required.",
+        };
+      }
+      let postClaimApprovals;
+      try {
+        postClaimApprovals = currentPullRequestApprovals(
           postClaimSnapshot.reviews,
           postClaimSnapshot.headSha,
-        ).length > 0
-      ) {
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "unknown approval evidence error";
+        await reconcileClaim(
+          snapshot.headSha,
+          `Post-claim approval evidence could not be verified: ${message}. Reconciliation is required before approval.`,
+        );
+        throw error;
+      }
+      if (postClaimApprovals.length > 0) {
         await getDb().transaction(async (tx) => {
           await tx
             .update(triageDecisions)

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -257,7 +257,7 @@ export default defineAction({
       snapshot.coverage === "complete" &&
       snapshot.checks.length > 0 &&
       snapshot.checks.every((check) => check.state === "passed");
-    const reviewStateClean = snapshot.reviews.every(
+    const blockingReviewStatesClean = snapshot.reviews.every(
       (review) =>
         review.state !== "changes_requested" && review.state !== "pending",
     );
@@ -272,7 +272,8 @@ export default defineAction({
         "builderio[bot]",
       ],
     });
-    const reviewFeedbackHandled = reviewStateClean && reviewFeedback.isClean;
+    const reviewFeedbackHandled =
+      blockingReviewStatesClean && reviewFeedback.isClean;
     const internalMember = await github.checkOrganizationMember(
       "BuilderIO",
       pullRequest.userLogin,
@@ -295,6 +296,7 @@ export default defineAction({
       productUxImplications,
       checksPassed,
       reviewFeedbackHandled,
+      blockingReviewStatesClean,
       openNonDraft: pullRequest.state === "open" && !pullRequest.draft,
       internalBuilderMember: internalMember.isMember,
       factoryTriggered,
@@ -417,6 +419,34 @@ export default defineAction({
         typeof metadata.autoApprovalUrl === "string";
       if (previouslyApproved) approvalUrl = metadata.autoApprovalUrl as string;
       if (!previouslyApproved) {
+        if (metadata.autoApprovalClaimHeadSha) {
+          throw new Error(
+            "A pull-request approval intent already exists; reconcile the provider result before retrying.",
+          );
+        }
+        const approvalClaim = serializeTriageMetadata({
+          ...metadata,
+          autoApprovalClaimHeadSha: snapshot.headSha,
+          autoApprovalClaimedAt: new Date().toISOString(),
+        });
+        const claimed = await getDb()
+          .update(triageItems)
+          .set({
+            metadataJson: approvalClaim,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(
+            and(
+              orgFactoryScopedItemWhere(itemId, orgId, factoryId),
+              eq(triageItems.metadataJson, item.metadataJson),
+            ),
+          )
+          .returning({ id: triageItems.id });
+        if (!claimed[0]) {
+          throw new Error(
+            "A concurrent pull-request approval changed the Factory item; reconcile before retrying.",
+          );
+        }
         const approval = await github.approvePullRequest(
           repository,
           pullRequestNumber,
@@ -430,6 +460,8 @@ export default defineAction({
         metadata.autoApprovedAt = new Date().toISOString();
         metadata.autoApprovalUrl = approval.htmlUrl;
         metadata.autoApprovalHeadSha = snapshot.headSha;
+        delete metadata.autoApprovalClaimHeadSha;
+        delete metadata.autoApprovalClaimedAt;
         await getDb()
           .update(triageItems)
           .set({
@@ -440,15 +472,9 @@ export default defineAction({
           .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
       }
     } else {
-      approvalUrl = (
-        await github.approvePullRequest(
-          repository,
-          pullRequestNumber,
-          governance.ownerException
-            ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
-            : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
-        )
-      ).htmlUrl;
+      throw new Error(
+        "PR governance requires a Factory item for an atomic approval claim.",
+      );
     }
 
     await recordFactoryAudit(

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -41,6 +41,7 @@ import {
   currentPullRequestApprovals,
   FACTORY_APPROVAL_BODY_MARKER,
   hasCurrentBlockingPullRequestReview,
+  isUltraScaryChange,
 } from "../server/triage/pr-policy.js";
 
 function repositoryRef(value: string): { owner: string; repo: string } {
@@ -225,6 +226,12 @@ export default defineAction({
         `PR evidence is stale: GitHub reports ${pullRequest.headSha}, ai-services reports ${snapshot.headSha}.`,
       );
     }
+    const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
+      snapshot.reviews,
+    );
+    const safetyFindingsClean =
+      !snapshot.commentsTruncated &&
+      !hasActiveCredibleSafetyFinding(snapshot.reviews, snapshot.comments);
     const currentApprovals = currentPullRequestApprovals(
       snapshot.reviews,
       snapshot.headSha,
@@ -285,47 +292,55 @@ export default defineAction({
         );
         const attributedApprovalUrl =
           attributedApproval?.htmlUrl ?? pullRequest.htmlUrl;
-        if (attributedApproval) {
-          const recovered = await getDb()
-            .update(triageDecisions)
-            .set({ outcome: "auto_approve" })
-            .where(
-              and(
-                eq(triageDecisions.id, decisionId),
-                eq(triageDecisions.itemId, itemId),
-                eq(triageDecisions.orgId, orgId),
-                eq(triageDecisions.factoryId, factoryId),
-                eq(triageDecisions.outcome, "auto_approval_claimed"),
-              ),
-            )
-            .returning({ id: triageDecisions.id });
-          recoveredApproval = Boolean(recovered[0]);
+        if (
+          attributedApproval &&
+          blockingReviewStatesClean &&
+          safetyFindingsClean &&
+          !isUltraScaryChange(snapshot.changedFiles ?? [])
+        ) {
+          recoveredApproval = await getDb().transaction(async (tx) => {
+            const recovered = await tx
+              .update(triageDecisions)
+              .set({ outcome: "auto_approve" })
+              .where(
+                and(
+                  eq(triageDecisions.id, decisionId),
+                  eq(triageDecisions.itemId, itemId),
+                  eq(triageDecisions.orgId, orgId),
+                  eq(triageDecisions.factoryId, factoryId),
+                  eq(triageDecisions.outcome, "auto_approval_claimed"),
+                ),
+              )
+              .returning({ id: triageDecisions.id });
+            if (!recovered[0]) return false;
+            const latestItem = (
+              await tx
+                .select({ metadataJson: triageItems.metadataJson })
+                .from(triageItems)
+                .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId))
+                .limit(1)
+            )[0];
+            if (!latestItem) {
+              throw new Error(
+                "Factory item disappeared during approval recovery.",
+              );
+            }
+            const metadata = parseTriageMetadata(latestItem.metadataJson);
+            metadata.autoApprovedAt = new Date().toISOString();
+            metadata.autoApprovalUrl = attributedApprovalUrl;
+            metadata.autoApprovalHeadSha = snapshot.headSha;
+            await tx
+              .update(triageItems)
+              .set({
+                metadataJson: serializeTriageMetadata(metadata),
+                status: "auto_approved",
+                updatedAt: new Date().toISOString(),
+              })
+              .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+            return true;
+          });
         }
         if (recoveredApproval) {
-          const latestItem = (
-            await getDb()
-              .select({ metadataJson: triageItems.metadataJson })
-              .from(triageItems)
-              .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId))
-              .limit(1)
-          )[0];
-          if (!latestItem) {
-            throw new Error(
-              "Factory item disappeared during approval recovery.",
-            );
-          }
-          const metadata = parseTriageMetadata(latestItem.metadataJson);
-          metadata.autoApprovedAt = new Date().toISOString();
-          metadata.autoApprovalUrl = attributedApprovalUrl;
-          metadata.autoApprovalHeadSha = snapshot.headSha;
-          await getDb()
-            .update(triageItems)
-            .set({
-              metadataJson: serializeTriageMetadata(metadata),
-              status: "auto_approved",
-              updatedAt: new Date().toISOString(),
-            })
-            .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
           await recordFactoryAudit(
             context,
             { userEmail, orgId },
@@ -397,13 +412,6 @@ export default defineAction({
       snapshot.coverage === "complete" &&
       snapshot.checks.length > 0 &&
       snapshot.checks.every((check) => check.state === "passed");
-    const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
-      snapshot.reviews,
-    );
-    const safetyFindingsClean = !hasActiveCredibleSafetyFinding(
-      snapshot.reviews,
-      snapshot.comments,
-    );
     const reviewFeedback = reconcileBabysitState({
       comments: snapshot.comments,
       checks: snapshot.checks,
@@ -608,31 +616,40 @@ export default defineAction({
                 : `Factory auto-approved under decision ${decisionId}; verified BuilderIO membership; ordinary check and review states remain recorded.`,
           );
         } catch (error) {
-          if (
-            error instanceof GitHubRequestError &&
-            (!error.requestAttempted ||
-              (error.status !== null &&
-                error.status >= 400 &&
-                error.status < 500))
-          ) {
-            await getDb()
-              .update(triageDecisions)
-              .set({
-                outcome: "needs_manual",
-                reason: `GitHub rejected the approval request definitively: ${error.message}`,
-              })
-              .where(
-                and(
-                  eq(
-                    triageDecisions.id,
-                    stableId("pr-governance", orgId, itemId, snapshot.headSha),
+          if (error instanceof GitHubRequestError) {
+            const definitiveRejection =
+              error.status !== null &&
+              error.status >= 400 &&
+              error.status < 500;
+            const claimCanBeReleased =
+              definitiveRejection || !error.requestAttempted;
+            if (claimCanBeReleased) {
+              await getDb()
+                .update(triageDecisions)
+                .set({
+                  outcome: "needs_manual",
+                  reason: definitiveRejection
+                    ? `GitHub rejected the approval request definitively: ${error.message}`
+                    : `GitHub approval request was unavailable before the provider call: ${error.message}`,
+                })
+                .where(
+                  and(
+                    eq(
+                      triageDecisions.id,
+                      stableId(
+                        "pr-governance",
+                        orgId,
+                        itemId,
+                        snapshot.headSha,
+                      ),
+                    ),
+                    eq(triageDecisions.itemId, itemId),
+                    eq(triageDecisions.orgId, orgId),
+                    eq(triageDecisions.factoryId, factoryId),
+                    eq(triageDecisions.outcome, "auto_approval_claimed"),
                   ),
-                  eq(triageDecisions.itemId, itemId),
-                  eq(triageDecisions.orgId, orgId),
-                  eq(triageDecisions.factoryId, factoryId),
-                  eq(triageDecisions.outcome, "auto_approval_claimed"),
-                ),
-              );
+                );
+            }
           }
           throw error;
         }

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -25,7 +25,10 @@ import {
 } from "../server/lib/require-workspace-member.js";
 import { createAiServicesGitReadClient } from "../server/triage/ai-services-git.js";
 import { recordFactoryAudit } from "../server/triage/audit.js";
-import { createGitHubClient } from "../server/triage/github-client.js";
+import {
+  GitHubRequestError,
+  createGitHubClient,
+} from "../server/triage/github-client.js";
 import { stableId } from "../server/triage/ids.js";
 import {
   parseTriageMetadata,
@@ -34,8 +37,8 @@ import {
 import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
 import {
   decidePullRequestGovernance,
+  currentPullRequestApproval,
   hasCurrentBlockingPullRequestReview,
-  hasCurrentPullRequestApproval,
 } from "../server/triage/pr-policy.js";
 
 function repositoryRef(value: string): { owner: string; repo: string } {
@@ -220,7 +223,11 @@ export default defineAction({
         `PR evidence is stale: GitHub reports ${pullRequest.headSha}, ai-services reports ${snapshot.headSha}.`,
       );
     }
-    if (hasCurrentPullRequestApproval(snapshot.reviews, snapshot.headSha)) {
+    const currentApproval = currentPullRequestApproval(
+      snapshot.reviews,
+      snapshot.headSha,
+    );
+    if (currentApproval) {
       await recordFactoryAudit(
         context,
         { userEmail, orgId },
@@ -237,6 +244,7 @@ export default defineAction({
         },
         factoryId,
       );
+      let recoveredApproval = false;
       if (itemId) {
         const decisionId = stableId(
           "pr-governance",
@@ -244,7 +252,7 @@ export default defineAction({
           itemId,
           snapshot.headSha,
         );
-        await getDb()
+        const recovered = await getDb()
           .update(triageDecisions)
           .set({ outcome: "auto_approve" })
           .where(
@@ -255,9 +263,38 @@ export default defineAction({
               eq(triageDecisions.factoryId, factoryId),
               eq(triageDecisions.outcome, "auto_approval_claimed"),
             ),
-          );
+          )
+          .returning({ id: triageDecisions.id });
+        if (recovered[0]) {
+          recoveredApproval = true;
+          const latestItem = (
+            await getDb()
+              .select({ metadataJson: triageItems.metadataJson })
+              .from(triageItems)
+              .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId))
+              .limit(1)
+          )[0];
+          if (!latestItem) {
+            throw new Error(
+              "Factory item disappeared during approval recovery.",
+            );
+          }
+          const metadata = parseTriageMetadata(latestItem.metadataJson);
+          metadata.autoApprovedAt = new Date().toISOString();
+          metadata.autoApprovalUrl =
+            currentApproval.htmlUrl ?? pullRequest.htmlUrl;
+          metadata.autoApprovalHeadSha = snapshot.headSha;
+          await getDb()
+            .update(triageItems)
+            .set({
+              metadataJson: serializeTriageMetadata(metadata),
+              status: "auto_approved",
+              updatedAt: new Date().toISOString(),
+            })
+            .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+        }
       }
-      if (itemId) {
+      if (itemId && !recoveredApproval) {
         await getDb()
           .update(triageItems)
           .set({
@@ -466,15 +503,40 @@ export default defineAction({
         typeof metadata.autoApprovalUrl === "string";
       if (previouslyApproved) approvalUrl = metadata.autoApprovalUrl as string;
       if (!previouslyApproved) {
-        const approval = await github.approvePullRequest(
-          repository,
-          pullRequestNumber,
-          governance.trustException
-            ? `Factory auto-approved under the verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
-            : governance.ownerException
-              ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
-              : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
-        );
+        let approval: Awaited<ReturnType<typeof github.approvePullRequest>>;
+        try {
+          approval = await github.approvePullRequest(
+            repository,
+            pullRequestNumber,
+            governance.trustException
+              ? `Factory auto-approved under the verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
+              : governance.ownerException
+                ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
+                : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
+          );
+        } catch (error) {
+          if (error instanceof GitHubRequestError && !error.requestAttempted) {
+            await getDb()
+              .update(triageDecisions)
+              .set({
+                outcome: "needs_manual",
+                reason: `GitHub approval request was not attempted: ${error.message}`,
+              })
+              .where(
+                and(
+                  eq(
+                    triageDecisions.id,
+                    stableId("pr-governance", orgId, itemId, snapshot.headSha),
+                  ),
+                  eq(triageDecisions.itemId, itemId),
+                  eq(triageDecisions.orgId, orgId),
+                  eq(triageDecisions.factoryId, factoryId),
+                  eq(triageDecisions.outcome, "auto_approval_claimed"),
+                ),
+              );
+          }
+          throw error;
+        }
         approvalUrl = approval.htmlUrl;
         const latestItem = (
           await getDb()

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -282,6 +282,8 @@ export default defineAction({
               `${FACTORY_APPROVAL_BODY_MARKER}${decisionId};`,
             ),
         );
+        const attributedApprovalUrl =
+          attributedApproval?.htmlUrl ?? pullRequest.htmlUrl;
         if (attributedApproval) {
           const recovered = await getDb()
             .update(triageDecisions)
@@ -313,8 +315,7 @@ export default defineAction({
           }
           const metadata = parseTriageMetadata(latestItem.metadataJson);
           metadata.autoApprovedAt = new Date().toISOString();
-          metadata.autoApprovalUrl =
-            attributedApproval.htmlUrl ?? pullRequest.htmlUrl;
+          metadata.autoApprovalUrl = attributedApprovalUrl;
           metadata.autoApprovalHeadSha = snapshot.headSha;
           await getDb()
             .update(triageItems)
@@ -535,6 +536,12 @@ export default defineAction({
         typeof metadata.autoApprovalUrl === "string";
       if (previouslyApproved) approvalUrl = metadata.autoApprovalUrl as string;
       if (!previouslyApproved) {
+        const decisionId = stableId(
+          "pr-governance",
+          orgId,
+          itemId,
+          snapshot.headSha,
+        );
         let approval: Awaited<ReturnType<typeof github.approvePullRequest>>;
         try {
           approval = await github.approvePullRequest(

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -217,10 +217,15 @@ export default defineAction({
         "BUILDER_PRIVATE_KEY is required to read PR review evidence.",
       );
     const projectId = requiredAiServicesEnv("BUILDER_PROJECT_ID");
-    const snapshot = await createAiServicesGitReadClient({
+    const aiServicesGit = createAiServicesGitReadClient({
       baseUrl: requiredAiServicesEnv("BUILDER_AI_SERVICES_URL"),
       authorization: `Bearer ${privateKey.startsWith("bpk-") ? privateKey : `bpk-${privateKey}`}`,
-    }).fetchPullRequest({ projectId, repo, pullRequestNumber });
+    });
+    const snapshot = await aiServicesGit.fetchPullRequest({
+      projectId,
+      repo,
+      pullRequestNumber,
+    });
     if (snapshot.headSha !== pullRequest.headSha) {
       throw new Error(
         `PR evidence is stale: GitHub reports ${pullRequest.headSha}, ai-services reports ${snapshot.headSha}.`,
@@ -581,6 +586,60 @@ export default defineAction({
         checksPassed,
         reviewFeedbackHandled,
       };
+    }
+
+    if (itemId) {
+      const postClaimSnapshot = await aiServicesGit.fetchPullRequest({
+        projectId,
+        repo,
+        pullRequestNumber,
+      });
+      if (postClaimSnapshot.headSha !== snapshot.headSha) {
+        throw new Error(
+          `PR evidence changed after approval claim: expected ${snapshot.headSha}, received ${postClaimSnapshot.headSha}.`,
+        );
+      }
+      if (
+        currentPullRequestApprovals(
+          postClaimSnapshot.reviews,
+          postClaimSnapshot.headSha,
+        ).length > 0
+      ) {
+        await getDb().transaction(async (tx) => {
+          await tx
+            .update(triageDecisions)
+            .set({
+              outcome: "needs_manual",
+              reason:
+                "A current approval appeared after the Factory claim; reconciliation is required before posting another review.",
+            })
+            .where(
+              and(
+                eq(
+                  triageDecisions.id,
+                  stableId("pr-governance", orgId, itemId, snapshot.headSha),
+                ),
+                eq(triageDecisions.itemId, itemId),
+                eq(triageDecisions.orgId, orgId),
+                eq(triageDecisions.factoryId, factoryId),
+                eq(triageDecisions.outcome, "auto_approval_claimed"),
+              ),
+            );
+          await tx
+            .update(triageItems)
+            .set({
+              status: "reconciliation_required",
+              updatedAt: new Date().toISOString(),
+            })
+            .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+        });
+        return {
+          ok: true,
+          action: "needs_manual",
+          reason:
+            "A current approval appeared after the Factory claim; no duplicate review was created.",
+        };
+      }
     }
 
     let approvalUrl: string | null = null;

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -37,7 +37,7 @@ import {
 import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
 import {
   decidePullRequestGovernance,
-  currentPullRequestApproval,
+  currentPullRequestApprovals,
   FACTORY_APPROVAL_BODY_MARKER,
   hasCurrentBlockingPullRequestReview,
 } from "../server/triage/pr-policy.js";
@@ -224,10 +224,11 @@ export default defineAction({
         `PR evidence is stale: GitHub reports ${pullRequest.headSha}, ai-services reports ${snapshot.headSha}.`,
       );
     }
-    const currentApproval = currentPullRequestApproval(
+    const currentApprovals = currentPullRequestApprovals(
       snapshot.reviews,
       snapshot.headSha,
     );
+    const currentApproval = currentApprovals[0] ?? null;
     if (currentApproval) {
       await recordFactoryAudit(
         context,
@@ -273,10 +274,14 @@ export default defineAction({
           snapshot.headSha,
         );
         const authenticatedUser = await github.getAuthenticatedUser();
-        const attributedApproval =
-          currentApproval.reviewerLogin ===
-            authenticatedUser.login.trim().toLowerCase() &&
-          currentApproval.body?.startsWith(FACTORY_APPROVAL_BODY_MARKER);
+        const attributedApproval = currentApprovals.find(
+          (approval) =>
+            approval.reviewerLogin ===
+              authenticatedUser.login.trim().toLowerCase() &&
+            approval.body?.startsWith(
+              `${FACTORY_APPROVAL_BODY_MARKER}${decisionId};`,
+            ),
+        );
         if (attributedApproval) {
           const recovered = await getDb()
             .update(triageDecisions)
@@ -309,7 +314,7 @@ export default defineAction({
           const metadata = parseTriageMetadata(latestItem.metadataJson);
           metadata.autoApprovedAt = new Date().toISOString();
           metadata.autoApprovalUrl =
-            currentApproval.htmlUrl ?? pullRequest.htmlUrl;
+            attributedApproval.htmlUrl ?? pullRequest.htmlUrl;
           metadata.autoApprovalHeadSha = snapshot.headSha;
           await getDb()
             .update(triageItems)
@@ -536,10 +541,10 @@ export default defineAction({
             repository,
             pullRequestNumber,
             governance.trustException
-              ? `Factory auto-approved under the verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
+              ? `Factory auto-approved under decision ${decisionId}; verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
               : governance.ownerException
-                ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
-                : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
+                ? `Factory auto-approved under decision ${decisionId}; verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
+                : `Factory auto-approved under decision ${decisionId}; verified BuilderIO membership; ordinary check and review states remain recorded.`,
           );
         } catch (error) {
           if (error instanceof GitHubRequestError && !error.requestAttempted) {

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -902,7 +902,7 @@ export default defineAction({
                   {
                     action: "govern-agent-native-pull-request",
                     kind: "external_action",
-                    status: "failure",
+                    status: "error",
                     itemId,
                     source: "github",
                     sourceUrl: pullRequest.htmlUrl,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -282,6 +282,10 @@ export default defineAction({
           snapshot.headSha,
         );
         const authenticatedUser = await github.getAuthenticatedUser();
+        const currentAuthorMembership = await github.checkOrganizationMember(
+          "BuilderIO",
+          pullRequest.userLogin,
+        );
         const attributedApproval = currentApprovals.find(
           (approval) =>
             approval.reviewerLogin ===
@@ -294,6 +298,7 @@ export default defineAction({
           attributedApproval?.htmlUrl ?? pullRequest.htmlUrl;
         if (
           attributedApproval &&
+          currentAuthorMembership.isMember &&
           blockingReviewStatesClean &&
           safetyFindingsClean &&
           !isUltraScaryChange(snapshot.changedFiles ?? [])

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -1,5 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, ne } from "drizzle-orm";
 import { z } from "zod";
 
 import { resolveConnectorSecret } from "../server/connectors/credentials.js";
@@ -350,7 +350,7 @@ export default defineAction({
         }
       }
       if (itemId && !recoveredApproval && !previouslyFinalized) {
-        await getDb()
+        const uncorrelatedClaim = await getDb()
           .update(triageDecisions)
           .set({
             outcome: "needs_manual",
@@ -368,14 +368,22 @@ export default defineAction({
               eq(triageDecisions.factoryId, factoryId),
               eq(triageDecisions.outcome, "auto_approval_claimed"),
             ),
-          );
-        await getDb()
-          .update(triageItems)
-          .set({
-            status: "reconciliation_required",
-            updatedAt: new Date().toISOString(),
-          })
-          .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+          )
+          .returning({ id: triageDecisions.id });
+        if (uncorrelatedClaim[0]) {
+          await getDb()
+            .update(triageItems)
+            .set({
+              status: "reconciliation_required",
+              updatedAt: new Date().toISOString(),
+            })
+            .where(
+              and(
+                orgFactoryScopedItemWhere(itemId, orgId, factoryId),
+                ne(triageItems.status, "auto_approved"),
+              ),
+            );
+        }
       }
       return {
         ok: true,
@@ -600,12 +608,18 @@ export default defineAction({
                 : `Factory auto-approved under decision ${decisionId}; verified BuilderIO membership; ordinary check and review states remain recorded.`,
           );
         } catch (error) {
-          if (error instanceof GitHubRequestError && !error.requestAttempted) {
+          if (
+            error instanceof GitHubRequestError &&
+            (!error.requestAttempted ||
+              (error.status !== null &&
+                error.status >= 400 &&
+                error.status < 500))
+          ) {
             await getDb()
               .update(triageDecisions)
               .set({
                 outcome: "needs_manual",
-                reason: `GitHub approval request was not attempted: ${error.message}`,
+                reason: `GitHub rejected the approval request definitively: ${error.message}`,
               })
               .where(
                 and(

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -115,7 +115,7 @@ async function hasVerifiedFactoryRun(input: {
 
 export default defineAction({
   description:
-    "Govern one agent-native pull request after fetching bounded GitHub and ai-services evidence. Auto-approve only under the current review-prs membership, owner, evidence, and ultra-scary gates. Never auto-merge. Clips, Design, and Content feedback remains owner-managed while their verified PR-owner exceptions still apply.",
+    "Govern one agent-native pull request after fetching bounded GitHub and ai-services evidence. Auto-approve only under the current review-prs membership, Liam trust, owner, evidence, and ultra-scary gates. Never auto-merge. Clips, Design, and Content feedback remains owner-managed while their verified PR-owner exceptions still apply.",
   schema: z.object({
     factoryId: factoryIdSchema.default(DEFAULT_FACTORY_ID),
     repo: z.string().trim().min(1).max(256),
@@ -219,7 +219,7 @@ export default defineAction({
         `PR evidence is stale: GitHub reports ${pullRequest.headSha}, ai-services reports ${snapshot.headSha}.`,
       );
     }
-    if (hasCurrentPullRequestApproval(snapshot.reviews)) {
+    if (hasCurrentPullRequestApproval(snapshot.reviews, snapshot.headSha)) {
       await recordFactoryAudit(
         context,
         { userEmail, orgId },
@@ -322,6 +322,7 @@ export default defineAction({
           autoApprove: governance.autoApprove,
           autoMerge: governance.autoMerge,
           ownerException: governance.ownerException,
+          trustException: governance.trustException,
           ownerOwnedArea: governance.ownerOwnedArea ?? null,
           guardResults: governance.guardResults,
         },
@@ -418,7 +419,9 @@ export default defineAction({
         const approval = await github.approvePullRequest(
           repository,
           pullRequestNumber,
-          governance.ownerException
+          governance.trustException
+            ? `Factory auto-approved under the verified ${governance.trustException} trust exception; ordinary check and review states remain recorded.`
+            : governance.ownerException
             ? `Factory auto-approved under the verified ${governance.ownerException} owner exception; ordinary check and review states remain recorded.`
             : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
         );

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -674,7 +674,7 @@ export default defineAction({
         repository: repo,
         title: postClaimSnapshot.title,
         summary: postClaimSnapshot.summary,
-        changedFiles: postClaimSnapshot.changedFiles,
+        changedFiles: postClaimSnapshot.changedFiles ?? [],
         clearBug,
         productUxImplications,
         checksPassed: postClaimChecksPassed,

--- a/templates/factory/actions/govern-agent-native-pull-request.ts
+++ b/templates/factory/actions/govern-agent-native-pull-request.ts
@@ -34,6 +34,7 @@ import {
 import { reconcileBabysitState } from "../server/triage/pr-babysit.js";
 import {
   decidePullRequestGovernance,
+  hasCurrentBlockingPullRequestReview,
   hasCurrentPullRequestApproval,
 } from "../server/triage/pr-policy.js";
 
@@ -237,6 +238,26 @@ export default defineAction({
         factoryId,
       );
       if (itemId) {
+        const decisionId = stableId(
+          "pr-governance",
+          orgId,
+          itemId,
+          snapshot.headSha,
+        );
+        await getDb()
+          .update(triageDecisions)
+          .set({ outcome: "auto_approve" })
+          .where(
+            and(
+              eq(triageDecisions.id, decisionId),
+              eq(triageDecisions.itemId, itemId),
+              eq(triageDecisions.orgId, orgId),
+              eq(triageDecisions.factoryId, factoryId),
+              eq(triageDecisions.outcome, "auto_approval_claimed"),
+            ),
+          );
+      }
+      if (itemId) {
         await getDb()
           .update(triageItems)
           .set({
@@ -257,9 +278,9 @@ export default defineAction({
       snapshot.coverage === "complete" &&
       snapshot.checks.length > 0 &&
       snapshot.checks.every((check) => check.state === "passed");
-    const blockingReviewStatesClean = snapshot.reviews.every(
-      (review) =>
-        review.state !== "changes_requested" && review.state !== "pending",
+    const blockingReviewStatesClean = !hasCurrentBlockingPullRequestReview(
+      snapshot.reviews,
+      snapshot.headSha,
     );
     const reviewFeedback = reconcileBabysitState({
       comments: snapshot.comments,
@@ -349,7 +370,7 @@ export default defineAction({
         snapshot.headSha,
       );
       await getDb().transaction(async (tx) => {
-        await tx
+        const inserted = await tx
           .insert(triageDecisions)
           .values({
             id: decisionId,
@@ -359,7 +380,7 @@ export default defineAction({
             outcome: governance.autoMerge
               ? "auto_merge"
               : governance.autoApprove
-                ? "auto_approve"
+                ? "auto_approval_claimed"
                 : "needs_manual",
             reason: `${reason} ${governance.reason}`.trim(),
             guardResultsJson: JSON.stringify(governance.guardResults),
@@ -370,7 +391,13 @@ export default defineAction({
             orgId,
             factoryId,
           })
-          .onConflictDoNothing();
+          .onConflictDoNothing()
+          .returning({ id: triageDecisions.id });
+        if (governance.autoApprove && !inserted[0]) {
+          throw new Error(
+            "A pull-request approval intent already exists; reconcile the provider result before retrying.",
+          );
+        }
         await requireExistingFactory(
           tx as unknown as ReturnType<typeof getDb>,
           orgId,
@@ -419,34 +446,6 @@ export default defineAction({
         typeof metadata.autoApprovalUrl === "string";
       if (previouslyApproved) approvalUrl = metadata.autoApprovalUrl as string;
       if (!previouslyApproved) {
-        if (metadata.autoApprovalClaimHeadSha) {
-          throw new Error(
-            "A pull-request approval intent already exists; reconcile the provider result before retrying.",
-          );
-        }
-        const approvalClaim = serializeTriageMetadata({
-          ...metadata,
-          autoApprovalClaimHeadSha: snapshot.headSha,
-          autoApprovalClaimedAt: new Date().toISOString(),
-        });
-        const claimed = await getDb()
-          .update(triageItems)
-          .set({
-            metadataJson: approvalClaim,
-            updatedAt: new Date().toISOString(),
-          })
-          .where(
-            and(
-              orgFactoryScopedItemWhere(itemId, orgId, factoryId),
-              eq(triageItems.metadataJson, item.metadataJson),
-            ),
-          )
-          .returning({ id: triageItems.id });
-        if (!claimed[0]) {
-          throw new Error(
-            "A concurrent pull-request approval changed the Factory item; reconcile before retrying.",
-          );
-        }
         const approval = await github.approvePullRequest(
           repository,
           pullRequestNumber,
@@ -457,19 +456,43 @@ export default defineAction({
               : "Factory auto-approved under verified BuilderIO membership; ordinary check and review states remain recorded.",
         );
         approvalUrl = approval.htmlUrl;
-        metadata.autoApprovedAt = new Date().toISOString();
-        metadata.autoApprovalUrl = approval.htmlUrl;
-        metadata.autoApprovalHeadSha = snapshot.headSha;
-        delete metadata.autoApprovalClaimHeadSha;
-        delete metadata.autoApprovalClaimedAt;
+        const latestItem = (
+          await getDb()
+            .select({ metadataJson: triageItems.metadataJson })
+            .from(triageItems)
+            .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId))
+            .limit(1)
+        )[0];
+        if (!latestItem) {
+          throw new Error("Factory item disappeared after GitHub approval.");
+        }
+        const latestMetadata = parseTriageMetadata(latestItem.metadataJson);
+        latestMetadata.autoApprovedAt = new Date().toISOString();
+        latestMetadata.autoApprovalUrl = approval.htmlUrl;
+        latestMetadata.autoApprovalHeadSha = snapshot.headSha;
         await getDb()
           .update(triageItems)
           .set({
-            metadataJson: serializeTriageMetadata(metadata),
+            metadataJson: serializeTriageMetadata(latestMetadata),
             status: "auto_approved",
             updatedAt: new Date().toISOString(),
           })
           .where(orgFactoryScopedItemWhere(itemId, orgId, factoryId));
+        await getDb()
+          .update(triageDecisions)
+          .set({ outcome: "auto_approve" })
+          .where(
+            and(
+              eq(
+                triageDecisions.id,
+                stableId("pr-governance", orgId, itemId, snapshot.headSha),
+              ),
+              eq(triageDecisions.itemId, itemId),
+              eq(triageDecisions.orgId, orgId),
+              eq(triageDecisions.factoryId, factoryId),
+              eq(triageDecisions.outcome, "auto_approval_claimed"),
+            ),
+          );
       }
     } else {
       throw new Error(

--- a/templates/factory/actions/ingest-github-observation.ts
+++ b/templates/factory/actions/ingest-github-observation.ts
@@ -20,6 +20,7 @@ import type {
 const reviewSchema: z.ZodType<PullRequestReviewObservation> = z.object({
   author: z.string().min(1),
   state: z.enum(["approved", "changes_requested", "commented", "pending"]),
+  commitSha: z.string().max(128).nullable().optional(),
   observedAt: z.string().datetime(),
 });
 

--- a/templates/factory/actions/ingest-github-observation.ts
+++ b/templates/factory/actions/ingest-github-observation.ts
@@ -21,6 +21,7 @@ const reviewSchema: z.ZodType<PullRequestReviewObservation> = z.object({
   author: z.string().min(1),
   state: z.enum(["approved", "changes_requested", "commented", "pending"]),
   commitSha: z.string().max(128).nullable().optional(),
+  htmlUrl: z.string().url().nullable().optional(),
   observedAt: z.string().datetime(),
 });
 

--- a/templates/factory/actions/ingest-github-observation.ts
+++ b/templates/factory/actions/ingest-github-observation.ts
@@ -19,7 +19,13 @@ import type {
 
 const reviewSchema: z.ZodType<PullRequestReviewObservation> = z.object({
   author: z.string().min(1),
-  state: z.enum(["approved", "changes_requested", "commented", "pending"]),
+  state: z.enum([
+    "approved",
+    "changes_requested",
+    "commented",
+    "pending",
+    "dismissed",
+  ]),
   commitSha: z.string().max(128).nullable().optional(),
   htmlUrl: z.string().url().nullable().optional(),
   body: z.string().max(4_000).nullable().optional(),

--- a/templates/factory/actions/ingest-github-observation.ts
+++ b/templates/factory/actions/ingest-github-observation.ts
@@ -22,6 +22,7 @@ const reviewSchema: z.ZodType<PullRequestReviewObservation> = z.object({
   state: z.enum(["approved", "changes_requested", "commented", "pending"]),
   commitSha: z.string().max(128).nullable().optional(),
   htmlUrl: z.string().url().nullable().optional(),
+  body: z.string().max(4_000).nullable().optional(),
   observedAt: z.string().datetime(),
 });
 

--- a/templates/factory/actions/reconcile-triage-run.ts
+++ b/templates/factory/actions/reconcile-triage-run.ts
@@ -33,6 +33,7 @@ const reviewSchema = z.object({
     "dismissed",
   ]),
   commitSha: z.string().max(128).nullable().optional(),
+  htmlUrl: z.string().url().nullable().optional(),
   observedAt: z.string().datetime(),
 });
 const checkSchema = z.object({

--- a/templates/factory/actions/reconcile-triage-run.ts
+++ b/templates/factory/actions/reconcile-triage-run.ts
@@ -32,6 +32,7 @@ const reviewSchema = z.object({
     "pending",
     "dismissed",
   ]),
+  commitSha: z.string().max(128).nullable().optional(),
   observedAt: z.string().datetime(),
 });
 const checkSchema = z.object({

--- a/templates/factory/actions/reconcile-triage-run.ts
+++ b/templates/factory/actions/reconcile-triage-run.ts
@@ -34,6 +34,7 @@ const reviewSchema = z.object({
   ]),
   commitSha: z.string().max(128).nullable().optional(),
   htmlUrl: z.string().url().nullable().optional(),
+  body: z.string().max(4_000).nullable().optional(),
   observedAt: z.string().datetime(),
 });
 const checkSchema = z.object({

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -341,7 +341,8 @@ number, clearBug, productUxImplications, and a short reason. The action fetches
 fresh CI and review evidence before approving. For a verified current BuilderIO
 member, the internal-author exception means ordinary failed, pending, skipped,
 or unknown checks and unresolved ordinary feedback do not by themselves block
-approval; record their exact states and never call them clean. Apply the
+approval; record their exact states and never call them clean. Active credible
+safety findings in fresh review evidence always block approval. Apply the
 verified Alice/Content, Nick/Slides, Enzo/Factory-specific, Sid/Design, and
 docs-only owner exceptions from review-prs only after membership and an
 explicit ultra-scary assessment. Those exceptions do not waive membership,

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -319,6 +319,14 @@ pending, skipped, unknown, and unresolved ordinary feedback accurately - never
 call it clean just because the author is internal. Sid's verified Design-owner
 exception still does not waive membership or the ultra-scary gate.
 
+For the exact `liamdebeasi` login and immutable GitHub user ID `2721089`, keep
+current BuilderIO membership mandatory. If the current, non-draft PR has no
+current-head, non-dismissed approval, the Liam exception permits approval
+through ordinary check, review-feedback, scope, and UX-owner gates. It never
+waives ultra-scary review or the independent-review requirement for changes to
+review/approval policy, agent-safety instructions, membership verification, or
+CI/deployment security controls, and it never authorizes a merge.
+
 Read the Factory configuration. When GitHub polling is enabled and a repository
 is configured, call poll-github-sources with includeIssues false and
 includePullRequests true. List at most 3 new or changed pull requests by

--- a/templates/factory/server/plugins/factory-scheduler-job.ts
+++ b/templates/factory/server/plugins/factory-scheduler-job.ts
@@ -319,7 +319,7 @@ pending, skipped, unknown, and unresolved ordinary feedback accurately - never
 call it clean just because the author is internal. Sid's verified Design-owner
 exception still does not waive membership or the ultra-scary gate.
 
-For the exact `liamdebeasi` login and immutable GitHub user ID `2721089`, keep
+For the exact \`liamdebeasi\` login and immutable GitHub user ID \`2721089\`, keep
 current BuilderIO membership mandatory. If the current, non-draft PR has no
 current-head, non-dismissed approval, the Liam exception permits approval
 through ordinary check, review-feedback, scope, and UX-owner gates. It never

--- a/templates/factory/server/triage/ai-services-git.spec.ts
+++ b/templates/factory/server/triage/ai-services-git.spec.ts
@@ -33,6 +33,7 @@ describe("ai-services Git read client", () => {
               user: { login: "reviewer" },
               state: "APPROVED",
               submittedAt: "2026-07-31T10:00:00.000Z",
+              commitId: "sha-1",
               comments: [],
             },
           ],
@@ -72,6 +73,7 @@ describe("ai-services Git read client", () => {
       changedFiles: ["src/a.ts"],
       diffLines: 6,
       coverage: "complete",
+      reviews: [{ author: "reviewer", state: "approved", commitSha: "sha-1" }],
       comments: [],
       commentsTruncated: false,
     });

--- a/templates/factory/server/triage/ai-services-git.ts
+++ b/templates/factory/server/triage/ai-services-git.ts
@@ -76,7 +76,7 @@ export function createAiServicesGitReadClient(
             user: { login: string };
             state: string;
             submittedAt: string;
-            commitId?: string;
+            commitId?: string | null;
             comments?: Array<{
               id: number;
               user: { login: string };

--- a/templates/factory/server/triage/ai-services-git.ts
+++ b/templates/factory/server/triage/ai-services-git.ts
@@ -76,6 +76,7 @@ export function createAiServicesGitReadClient(
             user: { login: string };
             state: string;
             submittedAt: string;
+            commitId?: string;
             comments?: Array<{
               id: number;
               user: { login: string };
@@ -112,6 +113,7 @@ export function createAiServicesGitReadClient(
         reviews.reviews.map((review) => ({
           author: review.user.login,
           state: normalizeReviewState(review.state),
+          commitSha: review.commitId,
           observedAt: review.submittedAt || observedAt,
         }));
       const reviewComments: ReviewCommentObservation[] =

--- a/templates/factory/server/triage/ai-services-git.ts
+++ b/templates/factory/server/triage/ai-services-git.ts
@@ -77,6 +77,7 @@ export function createAiServicesGitReadClient(
             state: string;
             submittedAt: string;
             commitId?: string | null;
+            htmlUrl?: string | null;
             comments?: Array<{
               id: number;
               user: { login: string };
@@ -114,6 +115,7 @@ export function createAiServicesGitReadClient(
           author: review.user.login,
           state: normalizeReviewState(review.state),
           commitSha: review.commitId,
+          htmlUrl: review.htmlUrl,
           observedAt: review.submittedAt || observedAt,
         }));
       const reviewComments: ReviewCommentObservation[] =

--- a/templates/factory/server/triage/ai-services-git.ts
+++ b/templates/factory/server/triage/ai-services-git.ts
@@ -78,6 +78,7 @@ export function createAiServicesGitReadClient(
             submittedAt: string;
             commitId?: string | null;
             htmlUrl?: string | null;
+            body?: string | null;
             comments?: Array<{
               id: number;
               user: { login: string };
@@ -116,6 +117,7 @@ export function createAiServicesGitReadClient(
           state: normalizeReviewState(review.state),
           commitSha: review.commitId,
           htmlUrl: review.htmlUrl,
+          body: review.body,
           observedAt: review.submittedAt || observedAt,
         }));
       const reviewComments: ReviewCommentObservation[] =

--- a/templates/factory/server/triage/contracts.ts
+++ b/templates/factory/server/triage/contracts.ts
@@ -46,6 +46,7 @@ export const triageDecisionOutcomeSchema = z.enum([
   "needs_manual",
   "propose_fix",
   "propose_review",
+  "auto_approval_claimed",
   "auto_approve",
   "auto_merge",
 ]);

--- a/templates/factory/server/triage/github-client.spec.ts
+++ b/templates/factory/server/triage/github-client.spec.ts
@@ -143,8 +143,16 @@ describe("GitHub triage client", () => {
       permission: null,
     });
     await expect(
-      client.approvePullRequest(repository, 2),
+      client.approvePullRequest(repository, 2, "Factory approval", "head-sha"),
     ).resolves.toMatchObject({ id: 9, state: "APPROVED" });
+    const approvalRequest = fetchImpl.mock.calls.find(([input]) =>
+      new URL(String(input)).pathname.endsWith("/reviews"),
+    );
+    expect(JSON.parse(String(approvalRequest?.[1]?.body))).toMatchObject({
+      event: "APPROVE",
+      body: "Factory approval",
+      commit_id: "head-sha",
+    });
     await expect(
       client.createIssueComment(repository, 2, "@builderio-bot please fix"),
     ).resolves.toEqual({

--- a/templates/factory/server/triage/github-client.spec.ts
+++ b/templates/factory/server/triage/github-client.spec.ts
@@ -104,6 +104,8 @@ describe("GitHub triage client", () => {
           },
         ]);
       }
+      if (path === "/users/reviewer")
+        return response({ id: 17, login: "reviewer" });
       if (path.endsWith("/permission")) return response({ permission: "push" });
       if (path.includes("/orgs/")) return emptyResponse(204);
       if (path.endsWith("/reviews"))
@@ -137,6 +139,13 @@ describe("GitHub triage client", () => {
     });
     await expect(
       client.checkOrganizationMember("BuilderIO", "reviewer"),
+    ).resolves.toEqual({
+      username: "reviewer",
+      isMember: true,
+      permission: null,
+    });
+    await expect(
+      client.checkOrganizationMemberById("BuilderIO", 17, "reviewer"),
     ).resolves.toEqual({
       username: "reviewer",
       isMember: true,

--- a/templates/factory/server/triage/github-client.spec.ts
+++ b/templates/factory/server/triage/github-client.spec.ts
@@ -39,7 +39,7 @@ describe("GitHub triage client", () => {
           state: "open",
           draft: false,
           html_url: "https://github.test/pull/7",
-          user: { login: "author" },
+          user: { id: 17, login: "author" },
           head: { sha: "sha-7", ref: "fix" },
           base: { ref: "main" },
           created_at: "2026-08-04T00:00:00Z",
@@ -54,7 +54,11 @@ describe("GitHub triage client", () => {
       fetchImpl,
     }).listOpenPullRequests(repository);
 
-    expect(pullRequests[0]).toMatchObject({ number: 7, headSha: "sha-7" });
+    expect(pullRequests[0]).toMatchObject({
+      number: 7,
+      headSha: "sha-7",
+      userId: 17,
+    });
     expect(
       new URL(String(fetchImpl.mock.calls[0]?.[0])).searchParams.get(
         "per_page",

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -379,6 +379,40 @@ export function createGitHubClient(options: GitHubClientOptions) {
       }
     },
 
+    async checkOrganizationMemberById(
+      organization: string,
+      userId: number,
+      username: string,
+    ): Promise<GitHubMemberCheck> {
+      const member = username.trim();
+      if (!organization.trim() || !member || !Number.isInteger(userId)) {
+        throw new Error(
+          "GitHub organization, member username, and user ID are required",
+        );
+      }
+      try {
+        const user = record(
+          await request<unknown>(`/users/${encodeURIComponent(member)}`),
+        );
+        const resolvedId = requiredNumber(user.id, "GitHub user ID");
+        const resolvedLogin = requiredString(user.login, "GitHub user login");
+        if (resolvedId !== userId || resolvedLogin !== member) {
+          return { username: member, isMember: false, permission: null };
+        }
+        await request<undefined>(
+          `/orgs/${encodeURIComponent(organization.trim())}/members/${encodeURIComponent(resolvedLogin)}`,
+          {},
+          { allowEmpty: true },
+        );
+        return { username: member, isMember: true, permission: null };
+      } catch (error) {
+        if (error instanceof GitHubRequestError && error.status === 404) {
+          return { username: member, isMember: false, permission: null };
+        }
+        throw error;
+      }
+    },
+
     async approvePullRequest(
       repository: GitHubRepositoryRef,
       pullRequestNumber: number,

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -27,6 +27,7 @@ export interface GitHubPullRequest {
   state: string;
   draft: boolean;
   htmlUrl: string;
+  userId: number;
   userLogin: string;
   headSha: string;
   headRef: string;
@@ -145,6 +146,7 @@ function parsePullRequest(value: unknown): GitHubPullRequest {
     state: requiredString(item.state, "pull request state"),
     draft: requiredBoolean(item.draft, "pull request draft state"),
     htmlUrl: requiredString(item.html_url, "pull request URL"),
+    userId: requiredNumber(user.id, "pull request author ID"),
     userLogin: requiredString(user.login, "pull request author"),
     headSha: requiredString(head.sha, "pull request head SHA"),
     headRef: requiredString(head.ref, "pull request head branch"),

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -383,6 +383,7 @@ export function createGitHubClient(options: GitHubClientOptions) {
       repository: GitHubRepositoryRef,
       pullRequestNumber: number,
       body?: string,
+      commitSha?: string,
     ): Promise<GitHubApproval> {
       if (!Number.isInteger(pullRequestNumber) || pullRequestNumber < 1)
         throw new Error(
@@ -397,6 +398,7 @@ export function createGitHubClient(options: GitHubClientOptions) {
             body: JSON.stringify({
               event: "APPROVE",
               ...(body ? { body: body.slice(0, 4_000) } : {}),
+              ...(commitSha ? { commit_id: commitSha } : {}),
             }),
           },
         ),

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -79,6 +79,16 @@ export interface GitHubComment {
   htmlUrl: string;
 }
 
+export class GitHubRequestError extends Error {
+  constructor(
+    message: string,
+    readonly requestAttempted: boolean,
+  ) {
+    super(message);
+    this.name = "GitHubRequestError";
+  }
+}
+
 interface JsonResponse {
   ok: boolean;
   status: number;
@@ -200,23 +210,35 @@ export function createGitHubClient(options: GitHubClientOptions) {
     init: RequestInit = {},
     options: { allowEmpty?: boolean } = {},
   ): Promise<T> {
-    const response = (await fetchImpl(`${baseUrl}${path}`, {
-      ...init,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${await token()}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        ...Object.fromEntries(new Headers(init.headers).entries()),
-      },
-    })) as JsonResponse;
-    if (!response.ok) {
-      const detail = (await response.text()).slice(0, 500);
-      throw new Error(
-        `GitHub API request failed: HTTP ${response.status}${detail ? ` - ${detail}` : ""}`,
+    let requestAttempted = false;
+    try {
+      const authorization = `Bearer ${await token()}`;
+      requestAttempted = true;
+      const response = (await fetchImpl(`${baseUrl}${path}`, {
+        ...init,
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: authorization,
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...Object.fromEntries(new Headers(init.headers).entries()),
+        },
+      })) as JsonResponse;
+      if (!response.ok) {
+        const detail = (await response.text()).slice(0, 500);
+        throw new GitHubRequestError(
+          `GitHub API request failed: HTTP ${response.status}${detail ? ` - ${detail}` : ""}`,
+          true,
+        );
+      }
+      if (response.status === 204 && options.allowEmpty) return undefined as T;
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof GitHubRequestError) throw error;
+      throw new GitHubRequestError(
+        error instanceof Error ? error.message : "GitHub request failed",
+        requestAttempted,
       );
     }
-    if (response.status === 204 && options.allowEmpty) return undefined as T;
-    return (await response.json()) as T;
   }
 
   return {

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -84,6 +84,7 @@ export class GitHubRequestError extends Error {
     message: string,
     readonly requestAttempted: boolean,
     readonly status: number | null = null,
+    readonly rateLimited = false,
   ) {
     super(message);
     this.name = "GitHubRequestError";
@@ -226,10 +227,17 @@ export function createGitHubClient(options: GitHubClientOptions) {
       })) as JsonResponse;
       if (!response.ok) {
         const detail = (await response.text()).slice(0, 500);
+        const rateLimited =
+          response.status === 429 ||
+          (response.status === 403 &&
+            /rate limit|secondary rate|abuse detection|retry after/i.test(
+              detail,
+            ));
         throw new GitHubRequestError(
           `GitHub API request failed: HTTP ${response.status}${detail ? ` - ${detail}` : ""}`,
           true,
           response.status,
+          rateLimited,
         );
       }
       if (response.status === 204 && options.allowEmpty) return undefined as T;

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -83,6 +83,7 @@ export class GitHubRequestError extends Error {
   constructor(
     message: string,
     readonly requestAttempted: boolean,
+    readonly status: number | null = null,
   ) {
     super(message);
     this.name = "GitHubRequestError";
@@ -228,6 +229,7 @@ export function createGitHubClient(options: GitHubClientOptions) {
         throw new GitHubRequestError(
           `GitHub API request failed: HTTP ${response.status}${detail ? ` - ${detail}` : ""}`,
           true,
+          response.status,
         );
       }
       if (response.status === 204 && options.allowEmpty) return undefined as T;

--- a/templates/factory/server/triage/github-client.ts
+++ b/templates/factory/server/triage/github-client.ts
@@ -303,6 +303,14 @@ export function createGitHubClient(options: GitHubClientOptions) {
       } satisfies GitHubPullRequestSummary;
     },
 
+    async getAuthenticatedUser() {
+      const item = record(await request<unknown>("/user"));
+      return {
+        login: requiredString(item.login, "authenticated GitHub user login"),
+        id: requiredNumber(item.id, "authenticated GitHub user id"),
+      };
+    },
+
     async checkMember(
       repository: GitHubRepositoryRef,
       username: string,

--- a/templates/factory/server/triage/pr-monitor.ts
+++ b/templates/factory/server/triage/pr-monitor.ts
@@ -10,6 +10,7 @@ export type PullRequestReviewState =
 export interface PullRequestReviewObservation {
   author: string;
   state: PullRequestReviewState;
+  commitSha?: string;
   observedAt: string;
 }
 

--- a/templates/factory/server/triage/pr-monitor.ts
+++ b/templates/factory/server/triage/pr-monitor.ts
@@ -12,6 +12,7 @@ export interface PullRequestReviewObservation {
   state: PullRequestReviewState;
   commitSha?: string | null;
   htmlUrl?: string | null;
+  body?: string | null;
   observedAt: string;
 }
 

--- a/templates/factory/server/triage/pr-monitor.ts
+++ b/templates/factory/server/triage/pr-monitor.ts
@@ -10,7 +10,7 @@ export type PullRequestReviewState =
 export interface PullRequestReviewObservation {
   author: string;
   state: PullRequestReviewState;
-  commitSha?: string;
+  commitSha?: string | null;
   observedAt: string;
 }
 

--- a/templates/factory/server/triage/pr-monitor.ts
+++ b/templates/factory/server/triage/pr-monitor.ts
@@ -11,6 +11,7 @@ export interface PullRequestReviewObservation {
   author: string;
   state: PullRequestReviewState;
   commitSha?: string | null;
+  htmlUrl?: string | null;
   observedAt: string;
 }
 

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -131,6 +131,12 @@ describe("pull-request governance", () => {
       isUltraScaryChange(["templates/factory/server/triage/pr-policy.ts"]),
     ).toBe(true);
     expect(
+      hasActiveCredibleSafetyFinding(
+        [{ state: "commented", body: "No security issues found." }],
+        [],
+      ),
+    ).toBe(false);
+    expect(
       isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
     ).toBe(true);
     expect(

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -286,30 +286,36 @@ describe("pull-request governance", () => {
 
   it("recognizes a current approval but not a later dismissal", () => {
     expect(
-      hasCurrentPullRequestApproval([
-        {
-          author: "reviewer",
-          state: "approved",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-      ]),
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(true);
     expect(
-      hasCurrentPullRequestApproval([
-        {
-          author: "reviewer",
-          state: "approved",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-        {
-          author: "reviewer",
-          state: "dismissed",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T11:00:00Z",
-        },
-      ]),
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "dismissed",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(false);
     expect(
       hasCurrentPullRequestApproval(
@@ -325,13 +331,16 @@ describe("pull-request governance", () => {
       ),
     ).toBe(false);
     expect(() =>
-      hasCurrentPullRequestApproval([
-        {
-          author: "reviewer",
-          state: "approved",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-      ]),
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toThrow("missing a commit SHA");
   });
 

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -207,6 +207,18 @@ describe("pull-request governance", () => {
     ).toBe(false);
     expect(
       hasActiveCredibleSafetyFinding(
+        [{ state: "commented", body: "The SSRF vulnerability is not fixed." }],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [{ state: "commented", body: "There is no authorization." }],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
         [
           {
             author: "reviewer",

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -5,10 +5,12 @@ import {
   detectOwnerOwnedArea,
   hasCurrentPullRequestApproval,
   isDocsOnly,
+  isUltraScaryChange,
 } from "./pr-policy.js";
 
 const cleanInternalBug = {
   author: "builder-engineer",
+  authorId: 1,
   repository: "BuilderIO/agent-native",
   changedFiles: ["packages/core/src/triage/fix.ts"],
   clearBug: true,
@@ -63,6 +65,7 @@ describe("pull-request governance", () => {
       decidePullRequestGovernance({
         ...cleanInternalBug,
         author: "liamdebeasi",
+        authorId: 2721089,
         changedFiles: ["templates/design/app/pages/DesignEditor.tsx"],
         clearBug: false,
         productUxImplications: true,
@@ -81,6 +84,7 @@ describe("pull-request governance", () => {
       decidePullRequestGovernance({
         ...cleanInternalBug,
         author: "liamdebeasi",
+        authorId: 2721089,
         changedFiles: ["templates/design/app/pages/DesignEditor.tsx"],
         clearBug: false,
         productUxImplications: true,
@@ -91,9 +95,24 @@ describe("pull-request governance", () => {
       decidePullRequestGovernance({
         ...cleanInternalBug,
         author: "liamdebeasi",
+        authorId: 2721089,
         changedFiles: [".agents/skills/review-prs/SKILL.md"],
       }).autoApprove,
     ).toBe(false);
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        authorId: 1,
+        clearBug: false,
+        productUxImplications: true,
+      }).autoApprove,
+    ).toBe(false);
+    expect(isUltraScaryChange(["nested/AGENTS.md"])).toBe(true);
+    expect(isUltraScaryChange([".agents/skills/other/SKILL.md"])).toBe(true);
+    expect(
+      isUltraScaryChange(["templates/factory/server/triage/pr-policy.ts"]),
+    ).toBe(true);
   });
 
   it("does not trust an owner username without verified membership", () => {
@@ -279,5 +298,17 @@ describe("pull-request governance", () => {
         "new-head",
       ),
     ).toBe(false);
+    expect(() =>
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toThrow("missing a commit SHA");
   });
 });

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -58,6 +58,44 @@ describe("pull-request governance", () => {
     });
   });
 
+  it("applies the verified Liam exception across ordinary UX gates", () => {
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        changedFiles: ["templates/design/app/pages/DesignEditor.tsx"],
+        clearBug: false,
+        productUxImplications: true,
+        checksPassed: false,
+        reviewFeedbackHandled: false,
+      }),
+    ).toMatchObject({
+      trustException: "liamdebeasi",
+      autoApprove: true,
+      autoMerge: false,
+    });
+  });
+
+  it("keeps the Liam exception behind membership and governance safety gates", () => {
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        changedFiles: ["templates/design/app/pages/DesignEditor.tsx"],
+        clearBug: false,
+        productUxImplications: true,
+        internalBuilderMember: false,
+      }).autoApprove,
+    ).toBe(false);
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        changedFiles: [".agents/skills/review-prs/SKILL.md"],
+      }).autoApprove,
+    ).toBe(false);
+  });
+
   it("does not trust an owner username without verified membership", () => {
     expect(
       decidePullRequestGovernance({
@@ -201,23 +239,39 @@ describe("pull-request governance", () => {
         {
           author: "reviewer",
           state: "approved",
+          commitSha: "head-1",
           observedAt: "2026-08-19T10:00:00Z",
         },
-      ]),
+      ], "head-1"),
     ).toBe(true);
     expect(
       hasCurrentPullRequestApproval([
         {
           author: "reviewer",
           state: "approved",
+          commitSha: "head-1",
           observedAt: "2026-08-19T10:00:00Z",
         },
         {
           author: "reviewer",
           state: "dismissed",
+          commitSha: "head-1",
           observedAt: "2026-08-19T11:00:00Z",
         },
-      ]),
+      ], "head-1"),
+    ).toBe(false);
+    expect(
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "old-head",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "new-head",
+      ),
     ).toBe(false);
   });
 });

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -131,6 +131,20 @@ describe("pull-request governance", () => {
     expect(
       isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
     ).toBe(true);
+    expect(
+      isUltraScaryChange([
+        "templates/factory/server/triage/ai-services-git.ts",
+        "templates/factory/server/triage/pr-monitor.ts",
+        "templates/factory/actions/ingest-github-observation.ts",
+        "templates/factory/actions/reconcile-triage-run.ts",
+      ]),
+    ).toBe(true);
+    expect(
+      isUltraScaryChange([
+        "templates/factory/actions/approve-factory-item.ts",
+        "templates/factory/actions/start-builder-for-item.ts",
+      ]),
+    ).toBe(true);
   });
 
   it("does not trust an owner username without verified membership", () => {
@@ -272,36 +286,30 @@ describe("pull-request governance", () => {
 
   it("recognizes a current approval but not a later dismissal", () => {
     expect(
-      hasCurrentPullRequestApproval(
-        [
-          {
-            author: "reviewer",
-            state: "approved",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentPullRequestApproval([
+        {
+          author: "reviewer",
+          state: "approved",
+          commitSha: "head-1",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+      ]),
     ).toBe(true);
     expect(
-      hasCurrentPullRequestApproval(
-        [
-          {
-            author: "reviewer",
-            state: "approved",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-          {
-            author: "reviewer",
-            state: "dismissed",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T11:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentPullRequestApproval([
+        {
+          author: "reviewer",
+          state: "approved",
+          commitSha: "head-1",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+        {
+          author: "reviewer",
+          state: "dismissed",
+          commitSha: "head-1",
+          observedAt: "2026-08-19T11:00:00Z",
+        },
+      ]),
     ).toBe(false);
     expect(
       hasCurrentPullRequestApproval(
@@ -317,69 +325,53 @@ describe("pull-request governance", () => {
       ),
     ).toBe(false);
     expect(() =>
-      hasCurrentPullRequestApproval(
-        [
-          {
-            author: "reviewer",
-            state: "approved",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentPullRequestApproval([
+        {
+          author: "reviewer",
+          state: "approved",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+      ]),
     ).toThrow("missing a commit SHA");
   });
 
   it("preserves active changes requests across comments", () => {
     expect(
-      hasCurrentBlockingPullRequestReview(
-        [
-          {
-            author: "reviewer",
-            state: "changes_requested",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-          {
-            author: "reviewer",
-            state: "approved",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T11:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentBlockingPullRequestReview([
+        {
+          author: "reviewer",
+          state: "changes_requested",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+        {
+          author: "reviewer",
+          state: "approved",
+          observedAt: "2026-08-19T11:00:00Z",
+        },
+      ]),
     ).toBe(false);
     expect(
-      hasCurrentBlockingPullRequestReview(
-        [
-          {
-            author: "reviewer",
-            state: "changes_requested",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-          {
-            author: "reviewer",
-            state: "commented",
-            commitSha: "head-1",
-            observedAt: "2026-08-19T11:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentBlockingPullRequestReview([
+        {
+          author: "reviewer",
+          state: "changes_requested",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+        {
+          author: "reviewer",
+          state: "commented",
+          observedAt: "2026-08-19T11:00:00Z",
+        },
+      ]),
     ).toBe(true);
     expect(
-      hasCurrentBlockingPullRequestReview(
-        [
-          {
-            author: "reviewer",
-            state: "pending",
-            observedAt: "2026-08-19T10:00:00Z",
-          },
-        ],
-        "head-1",
-      ),
+      hasCurrentBlockingPullRequestReview([
+        {
+          author: "reviewer",
+          state: "pending",
+          observedAt: "2026-08-19T10:00:00Z",
+        },
+      ]),
     ).toBe(true);
   });
 });

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -160,6 +160,18 @@ describe("pull-request governance", () => {
     ).toBe(true);
     expect(
       hasActiveCredibleSafetyFinding(
+        [{ state: "commented", body: "This change enables XSS." }],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [{ state: "approved", body: "No XSS or CSRF vulnerabilities found." }],
+        [],
+      ),
+    ).toBe(false);
+    expect(
+      hasActiveCredibleSafetyFinding(
         [
           {
             author: "reviewer",

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -127,6 +127,9 @@ describe("pull-request governance", () => {
     ).toBe(false);
     expect(isUltraScaryChange(["nested/AGENTS.md"])).toBe(true);
     expect(isUltraScaryChange([".agents/skills/other/SKILL.md"])).toBe(true);
+    expect(isUltraScaryChange([".github/actions/checkout/action.yml"])).toBe(
+      true,
+    );
     expect(
       isUltraScaryChange(["templates/factory/server/triage/pr-policy.ts"]),
     ).toBe(true);
@@ -153,6 +156,38 @@ describe("pull-request governance", () => {
           {
             state: "commented",
             body: "Authentication middleware does not enforce tenant isolation.",
+          },
+        ],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            author: "reviewer",
+            state: "commented",
+            body: "Authentication is secure but this endpoint has an SSRF vulnerability.",
+            observedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            author: "reviewer",
+            state: "commented",
+            body: "This endpoint has an SSRF vulnerability.",
+            observedAt: "2026-01-01T00:00:00.000Z",
+          },
+          {
+            author: "reviewer",
+            state: "commented",
+            body: "Nit: rename this variable.",
+            observedAt: "2026-01-02T00:00:00.000Z",
           },
         ],
         [],

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -137,6 +137,17 @@ describe("pull-request governance", () => {
       ),
     ).toBe(false);
     expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            state: "commented",
+            body: "Authentication middleware does not enforce tenant isolation.",
+          },
+        ],
+        [],
+      ),
+    ).toBe(true);
+    expect(
       isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
     ).toBe(true);
     expect(

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -125,11 +125,24 @@ describe("pull-request governance", () => {
         productUxImplications: true,
       }).autoApprove,
     ).toBe(false);
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        authorId: 2721089,
+        clearBug: false,
+        productUxImplications: true,
+        factoryTriggered: false,
+      }).autoApprove,
+    ).toBe(false);
     expect(isUltraScaryChange(["nested/AGENTS.md"])).toBe(true);
     expect(isUltraScaryChange([".agents/skills/other/SKILL.md"])).toBe(true);
     expect(isUltraScaryChange([".github/actions/checkout/action.yml"])).toBe(
       true,
     );
+    expect(isUltraScaryChange(["package.json"])).toBe(true);
+    expect(isUltraScaryChange(["pnpm-lock.yaml"])).toBe(true);
+    expect(isUltraScaryChange(["turbo.json"])).toBe(true);
     expect(
       isUltraScaryChange(["templates/factory/server/triage/pr-policy.ts"]),
     ).toBe(true);
@@ -518,41 +531,74 @@ describe("pull-request governance", () => {
 
   it("preserves active changes requests across comments", () => {
     expect(
-      hasCurrentBlockingPullRequestReview([
-        {
-          author: "reviewer",
-          state: "changes_requested",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-        {
-          author: "reviewer",
-          state: "approved",
-          observedAt: "2026-08-19T11:00:00Z",
-        },
-      ]),
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "changes_requested",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(false);
     expect(
-      hasCurrentBlockingPullRequestReview([
-        {
-          author: "reviewer",
-          state: "changes_requested",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-        {
-          author: "reviewer",
-          state: "commented",
-          observedAt: "2026-08-19T11:00:00Z",
-        },
-      ]),
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "changes_requested",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "commented",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(true);
     expect(
-      hasCurrentBlockingPullRequestReview([
-        {
-          author: "reviewer",
-          state: "pending",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-      ]),
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "pending",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toBe(true);
+    expect(
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "changes_requested",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "old-head",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(true);
   });
 });

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -17,6 +17,7 @@ const cleanInternalBug = {
   productUxImplications: false,
   checksPassed: true,
   reviewFeedbackHandled: true,
+  blockingReviewStatesClean: true,
   openNonDraft: true,
   internalBuilderMember: true,
   factoryTriggered: true,
@@ -53,6 +54,7 @@ describe("pull-request governance", () => {
         ...cleanInternalBug,
         checksPassed: false,
         reviewFeedbackHandled: false,
+        blockingReviewStatesClean: true,
       }),
     ).toMatchObject({
       autoApprove: true,
@@ -71,6 +73,7 @@ describe("pull-request governance", () => {
         productUxImplications: true,
         checksPassed: false,
         reviewFeedbackHandled: false,
+        blockingReviewStatesClean: true,
       }),
     ).toMatchObject({
       trustException: "liamdebeasi",
@@ -103,7 +106,18 @@ describe("pull-request governance", () => {
       decidePullRequestGovernance({
         ...cleanInternalBug,
         author: "liamdebeasi",
-        authorId: 1,
+        authorId: 2721089,
+        clearBug: false,
+        productUxImplications: true,
+        blockingReviewStatesClean: false,
+      }).autoApprove,
+    ).toBe(false);
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        authorId: 2721089,
+        repository: "BuilderIO/other-repo",
         clearBug: false,
         productUxImplications: true,
       }).autoApprove,

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -5,6 +5,7 @@ import {
   detectOwnerOwnedArea,
   hasCurrentBlockingPullRequestReview,
   hasCurrentPullRequestApproval,
+  hasActiveCredibleSafetyFinding,
   isDocsOnly,
   isUltraScaryChange,
 } from "./pr-policy.js";
@@ -19,6 +20,7 @@ const cleanInternalBug = {
   checksPassed: true,
   reviewFeedbackHandled: true,
   blockingReviewStatesClean: true,
+  safetyFindingsClean: true,
   openNonDraft: true,
   internalBuilderMember: true,
   factoryTriggered: true,
@@ -145,6 +147,29 @@ describe("pull-request governance", () => {
         "templates/factory/actions/start-builder-for-item.ts",
       ]),
     ).toBe(true);
+    expect(
+      isUltraScaryChange([
+        "templates/factory/server/plugins/agent-chat.ts",
+        "templates/factory/server/triage/builder-executor.ts",
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps active safety findings blocking", () => {
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [{ state: "commented", body: "This bypasses tenant isolation." }],
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      decidePullRequestGovernance({
+        ...cleanInternalBug,
+        author: "liamdebeasi",
+        authorId: 2721089,
+        safetyFindingsClean: false,
+      }).autoApprove,
+    ).toBe(false);
   });
 
   it("does not trust an owner username without verified membership", () => {

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   decidePullRequestGovernance,
   detectOwnerOwnedArea,
+  hasCurrentBlockingPullRequestReview,
   hasCurrentPullRequestApproval,
   isDocsOnly,
   isUltraScaryChange,
@@ -324,5 +325,52 @@ describe("pull-request governance", () => {
         "head-1",
       ),
     ).toThrow("missing a commit SHA");
+  });
+
+  it("uses the latest reviewer state and current head for blocking reviews", () => {
+    expect(
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "changes_requested",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toBe(false);
+    expect(
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "changes_requested",
+            commitSha: "old-head",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toBe(false);
+    expect(
+      hasCurrentBlockingPullRequestReview(
+        [
+          {
+            author: "reviewer",
+            state: "pending",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toBe(true);
   });
 });

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -235,30 +235,36 @@ describe("pull-request governance", () => {
 
   it("recognizes a current approval but not a later dismissal", () => {
     expect(
-      hasCurrentPullRequestApproval([
-        {
-          author: "reviewer",
-          state: "approved",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-      ], "head-1"),
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(true);
     expect(
-      hasCurrentPullRequestApproval([
-        {
-          author: "reviewer",
-          state: "approved",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T10:00:00Z",
-        },
-        {
-          author: "reviewer",
-          state: "dismissed",
-          commitSha: "head-1",
-          observedAt: "2026-08-19T11:00:00Z",
-        },
-      ], "head-1"),
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "dismissed",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
     ).toBe(false);
     expect(
       hasCurrentPullRequestApproval(

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -148,6 +148,17 @@ describe("pull-request governance", () => {
       ),
     ).toBe(true);
     expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            state: "commented",
+            body: "Authorization is not enforced on this endpoint.",
+          },
+        ],
+        [],
+      ),
+    ).toBe(true);
+    expect(
       isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
     ).toBe(true);
     expect(

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -309,6 +309,25 @@ describe("pull-request governance", () => {
           },
           {
             author: "reviewer",
+            state: "commented",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
+          },
+        ],
+        "head-1",
+      ),
+    ).toBe(true);
+    expect(
+      hasCurrentPullRequestApproval(
+        [
+          {
+            author: "reviewer",
+            state: "approved",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
             state: "dismissed",
             commitSha: "head-1",
             observedAt: "2026-08-19T11:00:00Z",

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -159,6 +159,17 @@ describe("pull-request governance", () => {
       ),
     ).toBe(true);
     expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            state: "commented",
+            body: "The previous authorization issue is resolved, but this endpoint has an SSRF vulnerability.",
+          },
+        ],
+        [],
+      ),
+    ).toBe(true);
+    expect(
       isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
     ).toBe(true);
     expect(

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -128,6 +128,9 @@ describe("pull-request governance", () => {
     expect(
       isUltraScaryChange(["templates/factory/server/triage/pr-policy.ts"]),
     ).toBe(true);
+    expect(
+      isUltraScaryChange(["templates/factory/server/triage/github-client.ts"]),
+    ).toBe(true);
   });
 
   it("does not trust an owner username without verified membership", () => {
@@ -327,7 +330,7 @@ describe("pull-request governance", () => {
     ).toThrow("missing a commit SHA");
   });
 
-  it("uses the latest reviewer state and current head for blocking reviews", () => {
+  it("preserves active changes requests across comments", () => {
     expect(
       hasCurrentBlockingPullRequestReview(
         [
@@ -353,13 +356,19 @@ describe("pull-request governance", () => {
           {
             author: "reviewer",
             state: "changes_requested",
-            commitSha: "old-head",
+            commitSha: "head-1",
             observedAt: "2026-08-19T10:00:00Z",
+          },
+          {
+            author: "reviewer",
+            state: "commented",
+            commitSha: "head-1",
+            observedAt: "2026-08-19T11:00:00Z",
           },
         ],
         "head-1",
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       hasCurrentBlockingPullRequestReview(
         [

--- a/templates/factory/server/triage/pr-policy.spec.ts
+++ b/templates/factory/server/triage/pr-policy.spec.ts
@@ -141,12 +141,42 @@ describe("pull-request governance", () => {
         [
           {
             state: "commented",
+            body: "No security vulnerabilities were identified.",
+          },
+        ],
+        [],
+      ),
+    ).toBe(false);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            state: "commented",
             body: "Authentication middleware does not enforce tenant isolation.",
           },
         ],
         [],
       ),
     ).toBe(true);
+    expect(
+      hasActiveCredibleSafetyFinding(
+        [
+          {
+            author: "reviewer",
+            state: "commented",
+            body: "This endpoint has an SSRF vulnerability.",
+            observedAt: "2026-01-01T00:00:00.000Z",
+          },
+          {
+            author: "reviewer",
+            state: "approved",
+            body: "Resolved.",
+            observedAt: "2026-01-02T00:00:00.000Z",
+          },
+        ],
+        [],
+      ),
+    ).toBe(false);
     expect(
       hasActiveCredibleSafetyFinding(
         [

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -421,7 +421,7 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 const SAFETY_FINDING_PATTERN =
   /\b(auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b/i;
 const NON_FINDING_PATTERN =
-  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:(?:xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:or|and)\s+)*(?:security\s+(?:issues?|findings?|concerns?|risks?)|vulnerabilities?|exploits?)\b(?:\s+(?:were|was|are|is))?\s+(?:found|identified|reported|present)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
+  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:(?:xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:or|and)\s+)*(?:(?:xss|cross-site scripting|csrf|cross-site request forgery)\s+)?(?:security\s+(?:issues?|findings?|concerns?|risks?|vulnerabilities?)|vulnerabilities?|exploits?)\b(?:\s+(?:were|was|are|is))?\s+(?:found|identified|reported|present)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly {
@@ -441,7 +441,7 @@ export function hasActiveCredibleSafetyFinding(
         (sentence) =>
           SAFETY_FINDING_PATTERN.test(sentence) &&
           (!NON_FINDING_PATTERN.test(sentence) ||
-            !/\b(?:not|isn't|is not|never)\b.{0,20}\b(?:resolved|fixed|mitigated|safe|secure)\b/i.test(
+            /\b(?:not|isn't|is not|never)\b.{0,20}\b(?:resolved|fixed|mitigated|safe|secure)\b/i.test(
               sentence,
             )),
       );

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -427,7 +427,13 @@ export function hasActiveCredibleSafetyFinding(
   comments: readonly { body: string; isResolved?: boolean }[],
 ): boolean {
   const isFinding = (body: string) =>
-    SAFETY_FINDING_PATTERN.test(body) && !NON_FINDING_PATTERN.test(body);
+    body
+      .split(/(?:[.!?]\s+|[,;]\s+(?:but|however|while)\s+)/i)
+      .some(
+        (sentence) =>
+          SAFETY_FINDING_PATTERN.test(sentence) &&
+          !NON_FINDING_PATTERN.test(sentence),
+      );
   return (
     reviews.some(
       (review) =>

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -12,7 +12,8 @@ export type PullRequestOwnerException =
 export type PullRequestTrustException = "liamdebeasi";
 
 const LIAMDEBEASI_USER_ID = 2721089;
-export const FACTORY_APPROVAL_BODY_MARKER = "Factory auto-approved under";
+export const FACTORY_APPROVAL_BODY_MARKER =
+  "Factory auto-approved under decision ";
 
 export interface PullRequestGovernanceInput {
   author: string;
@@ -240,7 +241,7 @@ export function hasCurrentPullRequestApproval(
   return currentPullRequestApproval(reviews, headSha) !== null;
 }
 
-export function currentPullRequestApproval(
+export function currentPullRequestApprovals(
   reviews: readonly {
     author: string;
     state: string;
@@ -255,7 +256,7 @@ export function currentPullRequestApproval(
   htmlUrl?: string | null;
   reviewerLogin: string;
   body?: string | null;
-} | null {
+}[] {
   const approvalByAuthor = new Map<
     string,
     {
@@ -295,7 +296,7 @@ export function currentPullRequestApproval(
       "Pull-request approval evidence is missing a commit SHA; reconciliation is required before approval.",
     );
   }
-  const approval = [...approvalByAuthor.values()].find(
+  return [...approvalByAuthor.values()].filter(
     (
       review,
     ): review is {
@@ -305,7 +306,13 @@ export function currentPullRequestApproval(
       body?: string | null;
     } => review.commitSha === headSha,
   );
-  return approval ?? null;
+}
+
+export function currentPullRequestApproval(
+  reviews: Parameters<typeof currentPullRequestApprovals>[0],
+  headSha: string,
+) {
+  return currentPullRequestApprovals(reviews, headSha)[0] ?? null;
 }
 
 export function hasCurrentBlockingPullRequestReview(

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -283,35 +283,44 @@ export function hasCurrentBlockingPullRequestReview(
   }[],
   headSha: string,
 ): boolean {
-  const latestByAuthor = new Map<
+  const stateByAuthor = new Map<
     string,
     {
-      state: string;
+      blocking: boolean;
       commitSha?: string | null;
-      observedAt: string;
-      order: number;
     }
   >();
-  reviews.forEach((review, order) => {
-    const author = review.author.trim().toLowerCase();
-    if (!author) return;
-    const previous = latestByAuthor.get(author);
-    if (
-      !previous ||
-      Date.parse(review.observedAt) > Date.parse(previous.observedAt) ||
-      (review.observedAt === previous.observedAt && order > previous.order)
-    ) {
-      latestByAuthor.set(author, {
-        state: review.state,
-        commitSha: review.commitSha,
-        observedAt: review.observedAt,
-        order,
-      });
-    }
-  });
-  return [...latestByAuthor.values()].some(
+  reviews
+    .map((review, order) => ({ review, order }))
+    .sort(
+      (left, right) =>
+        Date.parse(left.review.observedAt) -
+          Date.parse(right.review.observedAt) || left.order - right.order,
+    )
+    .forEach(({ review }) => {
+      const author = review.author.trim().toLowerCase();
+      if (!author) return;
+      const previous = stateByAuthor.get(author);
+      if (review.state === "approved" || review.state === "dismissed") {
+        stateByAuthor.set(author, { blocking: false });
+      } else if (
+        review.state === "changes_requested" ||
+        review.state === "pending"
+      ) {
+        stateByAuthor.set(author, {
+          blocking: true,
+          commitSha: review.commitSha,
+        });
+      } else if (previous?.blocking) {
+        stateByAuthor.set(author, {
+          blocking: true,
+          commitSha: review.commitSha ?? previous.commitSha,
+        });
+      }
+    });
+  return [...stateByAuthor.values()].some(
     (review) =>
-      (review.state === "changes_requested" || review.state === "pending") &&
+      review.blocking &&
       (review.commitSha === headSha || review.commitSha == null),
   );
 }
@@ -352,6 +361,7 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       normalized === ".agents/skills/review-prs/skill.md" ||
       normalized.includes("/review-skill-alignment.") ||
       normalized.endsWith("/govern-agent-native-pull-request.ts") ||
+      normalized.endsWith("/github-client.ts") ||
       normalized.includes("/pr-policy.") ||
       normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -418,9 +418,9 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 }
 
 const SAFETY_FINDING_PATTERN =
-  /\b(auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
+  /\b(auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b/i;
 const NON_FINDING_PATTERN =
-  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
+  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly {
@@ -450,7 +450,7 @@ export function hasActiveCredibleSafetyFinding(
   return (
     [...latestReviewByAuthor.values()].some(
       (review) =>
-        review.state === "commented" &&
+        review.state !== "dismissed" &&
         typeof review.body === "string" &&
         isFinding(review.body),
     ) ||

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -100,9 +100,7 @@ export function decidePullRequestGovernance(
     {
       code: "unknown_change",
       passed:
-        input.clearBug ||
-        verifiedOwnerException !== null ||
-        liamException,
+        input.clearBug || verifiedOwnerException !== null || liamException,
       reason:
         input.clearBug || verifiedOwnerException !== null || liamException
           ? "The automation classified this as a clear bug with a concrete failure signal."

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -9,6 +9,8 @@ export type PullRequestOwnerException =
   | "sid-design"
   | "docs-only";
 
+export type PullRequestTrustException = "liamdebeasi";
+
 export interface PullRequestGovernanceInput {
   author: string;
   repository: string;
@@ -27,6 +29,7 @@ export interface PullRequestGovernanceInput {
 export interface PullRequestGovernanceDecision {
   ownerOwnedArea: OwnerOwnedArea | null;
   ownerException: PullRequestOwnerException | null;
+  trustException: PullRequestTrustException | null;
   autoApprove: boolean;
   autoMerge: boolean;
   reason: string;
@@ -78,6 +81,10 @@ export function decidePullRequestGovernance(
     ...input.changedFiles,
   ]);
   const ultraScary = isUltraScaryChange(input.changedFiles);
+  const liamException =
+    input.author.trim().toLowerCase() === "liamdebeasi" &&
+    input.internalBuilderMember &&
+    !ultraScary;
   const ownerException = detectPullRequestOwnerException(input);
   const verifiedOwnerException =
     input.internalBuilderMember && !ultraScary ? ownerException : null;
@@ -92,9 +99,12 @@ export function decidePullRequestGovernance(
     },
     {
       code: "unknown_change",
-      passed: input.clearBug || verifiedOwnerException !== null,
+      passed:
+        input.clearBug ||
+        verifiedOwnerException !== null ||
+        liamException,
       reason:
-        input.clearBug || verifiedOwnerException !== null
+        input.clearBug || verifiedOwnerException !== null || liamException
           ? "The automation classified this as a clear bug with a concrete failure signal."
           : "The automation did not establish a clear bug; product requests and guesses stay manual.",
     },
@@ -134,7 +144,8 @@ export function decidePullRequestGovernance(
 
   if (
     ownerOwnedArea &&
-    !ownerExceptionCoversArea(verifiedOwnerException, ownerOwnedArea)
+    !ownerExceptionCoversArea(verifiedOwnerException, ownerOwnedArea) &&
+    !liamException
   ) {
     gates.push({
       code: "owner_owned",
@@ -142,7 +153,11 @@ export function decidePullRequestGovernance(
       reason: `${ownerOwnedArea} is owner-managed and is never auto-approved, auto-merged, or dispatched by this Factory.`,
     });
   }
-  if (input.productUxImplications && verifiedOwnerException === null) {
+  if (
+    input.productUxImplications &&
+    verifiedOwnerException === null &&
+    !liamException
+  ) {
     gates.push({
       code: "unknown_change",
       passed: false,
@@ -156,7 +171,9 @@ export function decidePullRequestGovernance(
   const reason = autoApprove
     ? verifiedOwnerException
       ? `Verified ${verifiedOwnerException} owner exception; approval is safe to automate while ordinary check and review states remain recorded.`
-      : "Clear internal bug fix with verified membership; approval is safe to automate while ordinary check and review states remain recorded."
+      : liamException
+        ? "Verified liamdebeasi exception; approval is safe to automate while ordinary check and review states remain recorded."
+        : "Clear internal bug fix with verified membership; approval is safe to automate while ordinary check and review states remain recorded."
     : gates
         .filter((gate) => !gate.passed)
         .map((gate) => gate.reason)
@@ -165,6 +182,7 @@ export function decidePullRequestGovernance(
   return {
     ownerOwnedArea,
     ownerException: verifiedOwnerException,
+    trustException: liamException ? "liamdebeasi" : null,
     autoApprove,
     autoMerge,
     reason,
@@ -203,12 +221,14 @@ export function hasCurrentPullRequestApproval(
   reviews: readonly {
     author: string;
     state: string;
+    commitSha?: string;
     observedAt: string;
   }[],
+  headSha: string,
 ): boolean {
   const latestByAuthor = new Map<
     string,
-    { state: string; observedAt: string; order: number }
+    { state: string; commitSha?: string; observedAt: string; order: number }
   >();
   reviews.forEach((review, order) => {
     const author = review.author.trim().toLowerCase();
@@ -221,13 +241,14 @@ export function hasCurrentPullRequestApproval(
     ) {
       latestByAuthor.set(author, {
         state: review.state,
+        commitSha: review.commitSha,
         observedAt: review.observedAt,
         order,
       });
     }
   });
   return [...latestByAuthor.values()].some(
-    (review) => review.state === "approved",
+    (review) => review.state === "approved" && review.commitSha === headSha,
   );
 }
 
@@ -259,6 +280,9 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
   return changedFiles.some((file) => {
     const normalized = normalizePath(file);
     return (
+      normalized === ".agents/skills/review-prs/skill.md" ||
+      normalized.includes("/review-skill-alignment.") ||
+      normalized.endsWith("/govern-agent-native-pull-request.ts") ||
       normalized.startsWith(".github/workflows/") ||
       /(^|\/)(auth|authentication|identity|credentials?|secrets?|sessions?|permissions?|tenant|tenants|isolation|security|execution|sandbox|payments?|billing|deploy|deployment|netlify|publish|release|migrations?)(\/|[-_.]|$)/.test(
         normalized,

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -24,6 +24,7 @@ export interface PullRequestGovernanceInput {
   productUxImplications: boolean;
   checksPassed: boolean;
   reviewFeedbackHandled: boolean;
+  blockingReviewStatesClean: boolean;
   openNonDraft: boolean;
   internalBuilderMember: boolean;
   factoryTriggered: boolean;
@@ -87,6 +88,7 @@ export function decidePullRequestGovernance(
   const liamException =
     input.author.trim().toLowerCase() === "liamdebeasi" &&
     input.authorId === LIAMDEBEASI_USER_ID &&
+    input.repository.trim().toLowerCase() === "builderio/agent-native" &&
     input.internalBuilderMember &&
     !ultraScary;
   const ownerException = detectPullRequestOwnerException(input);
@@ -135,12 +137,16 @@ export function decidePullRequestGovernance(
     },
     {
       code: "unknown_change",
-      passed: internalEvidenceException || input.reviewFeedbackHandled,
-      reason: input.reviewFeedbackHandled
-        ? "All observed review feedback is fixed, resolved, replied to, or outdated."
-        : internalEvidenceException
-          ? "Review feedback is unanswered, unresolved, truncated, or otherwise unknown; the verified internal-author exception does not treat that state as clean."
-          : "Review feedback is unanswered, unresolved, truncated, or otherwise unknown.",
+      passed:
+        input.blockingReviewStatesClean &&
+        (internalEvidenceException || input.reviewFeedbackHandled),
+      reason: !input.blockingReviewStatesClean
+        ? "An active changes-requested or pending review remains blocking."
+        : input.reviewFeedbackHandled
+          ? "All observed review feedback is fixed, resolved, replied to, or outdated."
+          : internalEvidenceException
+            ? "Review feedback is unanswered, unresolved, truncated, or otherwise unknown; the verified internal-author exception does not treat that state as clean."
+            : "Review feedback is unanswered, unresolved, truncated, or otherwise unknown.",
     },
   ];
 
@@ -223,14 +229,19 @@ export function hasCurrentPullRequestApproval(
   reviews: readonly {
     author: string;
     state: string;
-    commitSha?: string;
+    commitSha?: string | null;
     observedAt: string;
   }[],
   headSha: string,
 ): boolean {
   const latestByAuthor = new Map<
     string,
-    { state: string; commitSha?: string; observedAt: string; order: number }
+    {
+      state: string;
+      commitSha?: string | null;
+      observedAt: string;
+      order: number;
+    }
   >();
   reviews.forEach((review, order) => {
     const author = review.author.trim().toLowerCase();

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -410,6 +410,7 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       normalized.includes("/pr-policy.") ||
       normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||
+      normalized.startsWith(".github/actions/") ||
       /(^|\/)(auth|authentication|identity|credentials?|secrets?|sessions?|permissions?|tenant|tenants|isolation|security|execution|sandbox|payments?|billing|deploy|deployment|netlify|publish|release|migrations?)(\/|[-_.]|$)/.test(
         normalized,
       )
@@ -433,7 +434,9 @@ export function hasActiveCredibleSafetyFinding(
 ): boolean {
   const isFinding = (body: string) =>
     body
-      .split(/(?:[.!?]\s+|;\s*|,\s+(?:but|however|while)\s+)/i)
+      .split(
+        /(?:[.!?]\s+|;\s*|,\s*(?:but|however|while)\s+|\s+(?:but|however|while)\s+)/i,
+      )
       .some(
         (sentence) =>
           SAFETY_FINDING_PATTERN.test(sentence) &&
@@ -448,12 +451,16 @@ export function hasActiveCredibleSafetyFinding(
     }
   });
   return (
-    [...latestReviewByAuthor.values()].some(
-      (review) =>
+    reviews.some((review) => {
+      const author = review.author?.trim().toLowerCase();
+      const latest = author ? latestReviewByAuthor.get(author) : undefined;
+      return (
         review.state !== "dismissed" &&
         typeof review.body === "string" &&
-        isFinding(review.body),
-    ) ||
+        isFinding(review.body) &&
+        (latest?.state !== "approved" || latest === review)
+      );
+    }) ||
     comments.some(
       (comment) => comment.isResolved !== true && isFinding(comment.body),
     )

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -278,16 +278,13 @@ export function hasCurrentBlockingPullRequestReview(
   reviews: readonly {
     author: string;
     state: string;
-    commitSha?: string | null;
     observedAt: string;
   }[],
-  headSha: string,
 ): boolean {
   const stateByAuthor = new Map<
     string,
     {
       blocking: boolean;
-      commitSha?: string | null;
     }
   >();
   reviews
@@ -307,22 +304,12 @@ export function hasCurrentBlockingPullRequestReview(
         review.state === "changes_requested" ||
         review.state === "pending"
       ) {
-        stateByAuthor.set(author, {
-          blocking: true,
-          commitSha: review.commitSha,
-        });
+        stateByAuthor.set(author, { blocking: true });
       } else if (previous?.blocking) {
-        stateByAuthor.set(author, {
-          blocking: true,
-          commitSha: review.commitSha ?? previous.commitSha,
-        });
+        stateByAuthor.set(author, { blocking: true });
       }
     });
-  return [...stateByAuthor.values()].some(
-    (review) =>
-      review.blocking &&
-      (review.commitSha === headSha || review.commitSha == null),
-  );
+  return [...stateByAuthor.values()].some((review) => review.blocking);
 }
 
 export function isDocsOnly(changedFiles: readonly string[]): boolean {
@@ -362,6 +349,14 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       normalized.includes("/review-skill-alignment.") ||
       normalized.endsWith("/govern-agent-native-pull-request.ts") ||
       normalized.endsWith("/github-client.ts") ||
+      normalized.endsWith("/ai-services-git.ts") ||
+      normalized.endsWith("/github-ingestion.ts") ||
+      normalized.endsWith("/pr-monitor.ts") ||
+      normalized.endsWith("/pr-babysit.ts") ||
+      normalized.endsWith("/ingest-github-observation.ts") ||
+      normalized.endsWith("/reconcile-triage-run.ts") ||
+      normalized.endsWith("/approve-factory-item.ts") ||
+      normalized.endsWith("/start-builder-for-item.ts") ||
       normalized.includes("/pr-policy.") ||
       normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -12,6 +12,7 @@ export type PullRequestOwnerException =
 export type PullRequestTrustException = "liamdebeasi";
 
 const LIAMDEBEASI_USER_ID = 2721089;
+export const FACTORY_APPROVAL_BODY_MARKER = "Factory auto-approved under";
 
 export interface PullRequestGovernanceInput {
   author: string;
@@ -231,6 +232,7 @@ export function hasCurrentPullRequestApproval(
     state: string;
     commitSha?: string | null;
     htmlUrl?: string | null;
+    body?: string | null;
     observedAt: string;
   }[],
   headSha: string,
@@ -244,15 +246,23 @@ export function currentPullRequestApproval(
     state: string;
     commitSha?: string | null;
     htmlUrl?: string | null;
+    body?: string | null;
     observedAt: string;
   }[],
   headSha: string,
-): { commitSha: string; htmlUrl?: string | null } | null {
+): {
+  commitSha: string;
+  htmlUrl?: string | null;
+  reviewerLogin: string;
+  body?: string | null;
+} | null {
   const approvalByAuthor = new Map<
     string,
     {
       commitSha?: string | null;
       htmlUrl?: string | null;
+      reviewerLogin: string;
+      body?: string | null;
     }
   >();
   reviews
@@ -269,6 +279,8 @@ export function currentPullRequestApproval(
         approvalByAuthor.set(author, {
           commitSha: review.commitSha,
           htmlUrl: review.htmlUrl,
+          reviewerLogin: author,
+          body: review.body,
         });
       } else if (
         review.state === "changes_requested" ||
@@ -284,8 +296,14 @@ export function currentPullRequestApproval(
     );
   }
   const approval = [...approvalByAuthor.values()].find(
-    (review): review is { commitSha: string; htmlUrl?: string | null } =>
-      review.commitSha === headSha,
+    (
+      review,
+    ): review is {
+      commitSha: string;
+      htmlUrl?: string | null;
+      reviewerLogin: string;
+      body?: string | null;
+    } => review.commitSha === headSha,
   );
   return approval ?? null;
 }

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -274,6 +274,48 @@ export function hasCurrentPullRequestApproval(
   );
 }
 
+export function hasCurrentBlockingPullRequestReview(
+  reviews: readonly {
+    author: string;
+    state: string;
+    commitSha?: string | null;
+    observedAt: string;
+  }[],
+  headSha: string,
+): boolean {
+  const latestByAuthor = new Map<
+    string,
+    {
+      state: string;
+      commitSha?: string | null;
+      observedAt: string;
+      order: number;
+    }
+  >();
+  reviews.forEach((review, order) => {
+    const author = review.author.trim().toLowerCase();
+    if (!author) return;
+    const previous = latestByAuthor.get(author);
+    if (
+      !previous ||
+      Date.parse(review.observedAt) > Date.parse(previous.observedAt) ||
+      (review.observedAt === previous.observedAt && order > previous.order)
+    ) {
+      latestByAuthor.set(author, {
+        state: review.state,
+        commitSha: review.commitSha,
+        observedAt: review.observedAt,
+        order,
+      });
+    }
+  });
+  return [...latestByAuthor.values()].some(
+    (review) =>
+      (review.state === "changes_requested" || review.state === "pending") &&
+      (review.commitSha === headSha || review.commitSha == null),
+  );
+}
+
 export function isDocsOnly(changedFiles: readonly string[]): boolean {
   return (
     changedFiles.length > 0 &&

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -230,48 +230,64 @@ export function hasCurrentPullRequestApproval(
     author: string;
     state: string;
     commitSha?: string | null;
+    htmlUrl?: string | null;
     observedAt: string;
   }[],
   headSha: string,
 ): boolean {
-  const latestByAuthor = new Map<
+  return currentPullRequestApproval(reviews, headSha) !== null;
+}
+
+export function currentPullRequestApproval(
+  reviews: readonly {
+    author: string;
+    state: string;
+    commitSha?: string | null;
+    htmlUrl?: string | null;
+    observedAt: string;
+  }[],
+  headSha: string,
+): { commitSha: string; htmlUrl?: string | null } | null {
+  const approvalByAuthor = new Map<
     string,
     {
-      state: string;
       commitSha?: string | null;
-      observedAt: string;
-      order: number;
+      htmlUrl?: string | null;
     }
   >();
-  reviews.forEach((review, order) => {
-    const author = review.author.trim().toLowerCase();
-    if (!author) return;
-    const previous = latestByAuthor.get(author);
-    if (
-      !previous ||
-      Date.parse(review.observedAt) > Date.parse(previous.observedAt) ||
-      (review.observedAt === previous.observedAt && order > previous.order)
-    ) {
-      latestByAuthor.set(author, {
-        state: review.state,
-        commitSha: review.commitSha,
-        observedAt: review.observedAt,
-        order,
-      });
-    }
-  });
-  if (
-    [...latestByAuthor.values()].some(
-      (review) => review.state === "approved" && !review.commitSha,
+  reviews
+    .map((review, order) => ({ review, order }))
+    .sort(
+      (left, right) =>
+        Date.parse(left.review.observedAt) -
+          Date.parse(right.review.observedAt) || left.order - right.order,
     )
-  ) {
+    .forEach(({ review }) => {
+      const author = review.author.trim().toLowerCase();
+      if (!author) return;
+      if (review.state === "approved") {
+        approvalByAuthor.set(author, {
+          commitSha: review.commitSha,
+          htmlUrl: review.htmlUrl,
+        });
+      } else if (
+        review.state === "changes_requested" ||
+        review.state === "pending" ||
+        review.state === "dismissed"
+      ) {
+        approvalByAuthor.delete(author);
+      }
+    });
+  if ([...approvalByAuthor.values()].some((review) => !review.commitSha)) {
     throw new Error(
       "Pull-request approval evidence is missing a commit SHA; reconciliation is required before approval.",
     );
   }
-  return [...latestByAuthor.values()].some(
-    (review) => review.state === "approved" && review.commitSha === headSha,
+  const approval = [...approvalByAuthor.values()].find(
+    (review): review is { commitSha: string; htmlUrl?: string | null } =>
+      review.commitSha === headSha,
   );
+  return approval ?? null;
 }
 
 export function hasCurrentBlockingPullRequestReview(

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -423,19 +423,32 @@ const NON_FINDING_PATTERN =
   /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
-  reviews: readonly { state: string; body?: string | null }[],
+  reviews: readonly {
+    author?: string;
+    state: string;
+    body?: string | null;
+    observedAt?: string;
+  }[],
   comments: readonly { body: string; isResolved?: boolean }[],
 ): boolean {
   const isFinding = (body: string) =>
     body
-      .split(/(?:[.!?]\s+|[,;]\s+(?:but|however|while)\s+)/i)
+      .split(/(?:[.!?]\s+|;\s*|,\s+(?:but|however|while)\s+)/i)
       .some(
         (sentence) =>
           SAFETY_FINDING_PATTERN.test(sentence) &&
           !NON_FINDING_PATTERN.test(sentence),
       );
+  const latestReviewByAuthor = new Map<string, (typeof reviews)[number]>();
+  reviews.forEach((review, index) => {
+    const author = review.author?.trim().toLowerCase() || `review-${index}`;
+    const previous = latestReviewByAuthor.get(author);
+    if (!previous || (review.observedAt ?? "") >= (previous.observedAt ?? "")) {
+      latestReviewByAuthor.set(author, review);
+    }
+  });
   return (
-    reviews.some(
+    [...latestReviewByAuthor.values()].some(
       (review) =>
         review.state === "commented" &&
         typeof review.body === "string" &&

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -420,7 +420,7 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 const SAFETY_FINDING_PATTERN =
   /\b(auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
 const NON_FINDING_PATTERN =
-  /\b(no|not|without|resolved|fixed|safe|secure|good|clear|clean|none|zero|mitigated|false positive)\b/i;
+  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly { state: string; body?: string | null }[],

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -93,6 +93,7 @@ export function decidePullRequestGovernance(
     input.authorId === LIAMDEBEASI_USER_ID &&
     input.repository.trim().toLowerCase() === "builderio/agent-native" &&
     input.internalBuilderMember &&
+    input.factoryTriggered &&
     !ultraScary;
   const ownerException = detectPullRequestOwnerException(input);
   const verifiedOwnerException =
@@ -326,8 +327,10 @@ export function hasCurrentBlockingPullRequestReview(
   reviews: readonly {
     author: string;
     state: string;
+    commitSha?: string | null;
     observedAt: string;
   }[],
+  headSha: string,
 ): boolean {
   const stateByAuthor = new Map<
     string,
@@ -346,7 +349,10 @@ export function hasCurrentBlockingPullRequestReview(
       const author = review.author.trim().toLowerCase();
       if (!author) return;
       const previous = stateByAuthor.get(author);
-      if (review.state === "approved" || review.state === "dismissed") {
+      if (
+        (review.state === "approved" || review.state === "dismissed") &&
+        review.commitSha === headSha
+      ) {
         stateByAuthor.set(author, { blocking: false });
       } else if (
         review.state === "changes_requested" ||
@@ -411,6 +417,9 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||
       normalized.startsWith(".github/actions/") ||
+      /(^|\/)(?:package\.json|pnpm-lock\.yaml|package-lock\.json|yarn\.lock|bun\.lockb|pnpm-workspace\.yaml|\.npmrc|\.yarnrc(?:\.yml)?|turbo\.jsonc?|nx\.json|lerna\.json|dockerfile(?:\..*)?|docker-compose(?:\..*)?|\.nvmrc|\.node-version|vite\.config\..*|webpack\.config\..*|rollup\.config\..*|esbuild\.config\..*|tsconfig(?:\..*)?\.json|makefile)$/i.test(
+        normalized,
+      ) ||
       /(^|\/)(auth|authentication|identity|credentials?|secrets?|sessions?|permissions?|tenant|tenants|isolation|security|execution|sandbox|payments?|billing|deploy|deployment|netlify|publish|release|migrations?)(\/|[-_.]|$)/.test(
         normalized,
       )

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -293,7 +293,6 @@ export function currentPullRequestApprovals(
         });
       } else if (
         review.state === "changes_requested" ||
-        review.state === "pending" ||
         review.state === "dismissed"
       ) {
         approvalByAuthor.delete(author);

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -418,9 +418,9 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 }
 
 const SAFETY_FINDING_PATTERN =
-  /\b(auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
+  /\b(auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
 const NON_FINDING_PATTERN =
-  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
+  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly { state: string; body?: string | null }[],

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -11,8 +11,11 @@ export type PullRequestOwnerException =
 
 export type PullRequestTrustException = "liamdebeasi";
 
+const LIAMDEBEASI_USER_ID = 2721089;
+
 export interface PullRequestGovernanceInput {
   author: string;
+  authorId: number;
   repository: string;
   title?: string;
   summary?: string | null;
@@ -83,6 +86,7 @@ export function decidePullRequestGovernance(
   const ultraScary = isUltraScaryChange(input.changedFiles);
   const liamException =
     input.author.trim().toLowerCase() === "liamdebeasi" &&
+    input.authorId === LIAMDEBEASI_USER_ID &&
     input.internalBuilderMember &&
     !ultraScary;
   const ownerException = detectPullRequestOwnerException(input);
@@ -245,6 +249,15 @@ export function hasCurrentPullRequestApproval(
       });
     }
   });
+  if (
+    [...latestByAuthor.values()].some(
+      (review) => review.state === "approved" && !review.commitSha,
+    )
+  ) {
+    throw new Error(
+      "Pull-request approval evidence is missing a commit SHA; reconciliation is required before approval.",
+    );
+  }
   return [...latestByAuthor.values()].some(
     (review) => review.state === "approved" && review.commitSha === headSha,
   );
@@ -278,9 +291,16 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
   return changedFiles.some((file) => {
     const normalized = normalizePath(file);
     return (
+      normalized === "agents.md" ||
+      normalized === "claude.md" ||
+      normalized.endsWith("/agents.md") ||
+      normalized.endsWith("/claude.md") ||
+      normalized.endsWith("/skill.md") ||
       normalized === ".agents/skills/review-prs/skill.md" ||
       normalized.includes("/review-skill-alignment.") ||
       normalized.endsWith("/govern-agent-native-pull-request.ts") ||
+      normalized.includes("/pr-policy.") ||
+      normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||
       /(^|\/)(auth|authentication|identity|credentials?|secrets?|sessions?|permissions?|tenant|tenants|isolation|security|execution|sandbox|payments?|billing|deploy|deployment|netlify|publish|release|migrations?)(\/|[-_.]|$)/.test(
         normalized,

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -27,6 +27,7 @@ export interface PullRequestGovernanceInput {
   checksPassed: boolean;
   reviewFeedbackHandled: boolean;
   blockingReviewStatesClean: boolean;
+  safetyFindingsClean: boolean;
   openNonDraft: boolean;
   internalBuilderMember: boolean;
   factoryTriggered: boolean;
@@ -120,6 +121,13 @@ export function decidePullRequestGovernance(
       reason: ultraScary
         ? "Security-sensitive auth, tenant-isolation, execution, payment, or deployment changes always require manual review."
         : "The changed paths do not match the ultra-scary manual-review categories.",
+    },
+    {
+      code: "security",
+      passed: input.safetyFindingsClean,
+      reason: input.safetyFindingsClean
+        ? "Fresh review evidence contains no active credible safety finding."
+        : "An active credible safety finding requires manual review.",
     },
     {
       code: "security",
@@ -398,6 +406,8 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       normalized.endsWith("/reconcile-triage-run.ts") ||
       normalized.endsWith("/approve-factory-item.ts") ||
       normalized.endsWith("/start-builder-for-item.ts") ||
+      normalized.endsWith("/agent-chat.ts") ||
+      normalized.endsWith("/builder-executor.ts") ||
       normalized.includes("/pr-policy.") ||
       normalized.endsWith("/factory-scheduler-job.ts") ||
       normalized.startsWith(".github/workflows/") ||
@@ -406,6 +416,28 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
       )
     );
   });
+}
+
+const SAFETY_FINDING_PATTERN =
+  /\b(auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
+
+export function hasActiveCredibleSafetyFinding(
+  reviews: readonly { state: string; body?: string | null }[],
+  comments: readonly { body: string; isResolved?: boolean }[],
+): boolean {
+  return (
+    reviews.some(
+      (review) =>
+        review.state === "commented" &&
+        typeof review.body === "string" &&
+        SAFETY_FINDING_PATTERN.test(review.body),
+    ) ||
+    comments.some(
+      (comment) =>
+        comment.isResolved !== true &&
+        SAFETY_FINDING_PATTERN.test(comment.body),
+    )
+  );
 }
 
 function ownerExceptionCoversArea(

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -420,22 +420,24 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 
 const SAFETY_FINDING_PATTERN =
   /\b(auth|authentication|credential|secret|permission|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss)\b/i;
+const NON_FINDING_PATTERN =
+  /\b(no|not|without|resolved|fixed|safe|secure|good|clear|clean|none|zero|mitigated|false positive)\b/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly { state: string; body?: string | null }[],
   comments: readonly { body: string; isResolved?: boolean }[],
 ): boolean {
+  const isFinding = (body: string) =>
+    SAFETY_FINDING_PATTERN.test(body) && !NON_FINDING_PATTERN.test(body);
   return (
     reviews.some(
       (review) =>
         review.state === "commented" &&
         typeof review.body === "string" &&
-        SAFETY_FINDING_PATTERN.test(review.body),
+        isFinding(review.body),
     ) ||
     comments.some(
-      (comment) =>
-        comment.isResolved !== true &&
-        SAFETY_FINDING_PATTERN.test(comment.body),
+      (comment) => comment.isResolved !== true && isFinding(comment.body),
     )
   );
 }

--- a/templates/factory/server/triage/pr-policy.ts
+++ b/templates/factory/server/triage/pr-policy.ts
@@ -421,7 +421,7 @@ export function isUltraScaryChange(changedFiles: readonly string[]): boolean {
 const SAFETY_FINDING_PATTERN =
   /\b(auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|unsafe|bypass|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b/i;
 const NON_FINDING_PATTERN =
-  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
+  /(?:\b(?:no|none|zero)\s+(?:known\s+)?(?:active\s+)?(?:(?:xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:or|and)\s+)*(?:security\s+(?:issues?|findings?|concerns?|risks?)|vulnerabilities?|exploits?)\b(?:\s+(?:were|was|are|is))?\s+(?:found|identified|reported|present)\b)|(?:\b(?:not|isn't|is not)\s+(?:an?\s+)?(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\s+(?:change|issue|finding|concern|risk)\b)|(?:\b(?:auth|authentication|authorization|credential|secret|permission|access control|privilege escalation|tenant|isolation|security|execution|sandbox|payment|billing|deployment|ssrf|rce|injection|vulnerability|exploit|data loss|xss|cross-site scripting|csrf|cross-site request forgery)\b.{0,50}\b(?:resolved|fixed|mitigated|safe|secure|good|clear|clean|false positive)\b)/i;
 
 export function hasActiveCredibleSafetyFinding(
   reviews: readonly {
@@ -440,7 +440,10 @@ export function hasActiveCredibleSafetyFinding(
       .some(
         (sentence) =>
           SAFETY_FINDING_PATTERN.test(sentence) &&
-          !NON_FINDING_PATTERN.test(sentence),
+          (!NON_FINDING_PATTERN.test(sentence) ||
+            !/\b(?:not|isn't|is not|never)\b.{0,20}\b(?:resolved|fixed|mitigated|safe|secure)\b/i.test(
+              sentence,
+            )),
       );
   const latestReviewByAuthor = new Map<string, (typeof reviews)[number]>();
   reviews.forEach((review, index) => {

--- a/templates/factory/server/triage/review-skill-alignment.ts
+++ b/templates/factory/server/triage/review-skill-alignment.ts
@@ -61,7 +61,7 @@ permissions, tenant isolation, secrets, destructive data loss or migrations,
 remote code execution, SSRF, payments, deployment, or unexplained dependency
 and infrastructure risk.
 
-For the exact `liamdebeasi` login and immutable GitHub user ID `2721089`, a
+For the exact \`liamdebeasi\` login and immutable GitHub user ID \`2721089\`, a
 current BuilderIO membership check is still required. When the current,
 non-draft PR has no current-head, non-dismissed approval, the Liam exception
 allows approval across ordinary check, review-feedback, scope, and UX-owner

--- a/templates/factory/server/triage/review-skill-alignment.ts
+++ b/templates/factory/server/triage/review-skill-alignment.ts
@@ -44,9 +44,11 @@ skip or dispatch is recorded.`;
 const PR_ALIGNMENT = `## Current review-prs contract
 
 The repository's \`.agents/skills/review-prs/SKILL.md\` is authoritative.
-Before selecting work, ignore drafts and pull requests with a current,
-non-dismissed APPROVED review, including bot approvals; do not inspect or
-recap those excluded items. For every remaining PR, read the complete title,
+Before selecting work, ignore drafts and ordinary pull requests with a
+current-head, non-dismissed APPROVED review, including bot approvals; do not
+inspect or recap those excluded items. Eligible Liam PRs with only older-head
+approvals remain candidates so the current head can be approved. For every
+remaining PR, read the complete title,
 body, links, changed-file diff (including generated and migration files), all
 review summaries/comments/replies, actual check conclusions, and ownership
 boundary. Verify current BuilderIO organization membership through GitHub's

--- a/templates/factory/server/triage/review-skill-alignment.ts
+++ b/templates/factory/server/triage/review-skill-alignment.ts
@@ -59,7 +59,8 @@ unresolved feedback for a verified BuilderIO member; record those exact states
 and never call them clean. The ultra-scary gate always remains manual for auth,
 permissions, tenant isolation, secrets, destructive data loss or migrations,
 remote code execution, SSRF, payments, deployment, or unexplained dependency
-and infrastructure risk.
+and infrastructure risk. Active credible safety findings in fresh review
+evidence remain blocking for every author, including Liam.
 
 For the exact \`liamdebeasi\` login and immutable GitHub user ID \`2721089\`, a
 current BuilderIO membership check is still required. When the current,

--- a/templates/factory/server/triage/review-skill-alignment.ts
+++ b/templates/factory/server/triage/review-skill-alignment.ts
@@ -61,6 +61,15 @@ permissions, tenant isolation, secrets, destructive data loss or migrations,
 remote code execution, SSRF, payments, deployment, or unexplained dependency
 and infrastructure risk.
 
+For the exact `liamdebeasi` login and immutable GitHub user ID `2721089`, a
+current BuilderIO membership check is still required. When the current,
+non-draft PR has no current-head, non-dismissed approval, the Liam exception
+allows approval across ordinary check, review-feedback, scope, and UX-owner
+gates without authorizing a merge. It does not apply to ultra-scary changes or
+changes to review/approval policy, agent-safety instructions, membership
+verification, or CI/deployment security controls; those require independent
+human review.
+
 The verified owner exceptions are current and must be applied only after
 membership and the ultra-scary assessment: Alice (\`3mdistal\`) for Content,
 Nick (\`NKoech123\`) for Slides, Enzo (\`enzoames\`) for Factory-specific PRs,


### PR DESCRIPTION
Update the review-prs skill to automatically approve eligible pull requests authored by the exact liamdebeasi login, while avoiding duplicate approvals and retaining the ultra-scary safety gate.

Validation: git diff --check passed; workspace skill guard was unavailable because this clean worktree has no node_modules/tsx.