### PR TITLE
fix(docs): mount the hero once instead of twice on load

### DIFF
--- a/packages/docs/app/components/website-redesign/hero-background.test.tsx
+++ b/packages/docs/app/components/website-redesign/hero-background.test.tsx
@@ -80,13 +80,21 @@ function Settled({ children }: { children: React.ReactNode }) {
 describe("HeroBackground", () => {
   it("renders the ocean when an adapter is available", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     expect(await screen.findByTestId("ocean")).toBeDefined();
   });
 
   it("never flashes the halftone before the ocean", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
 
     // The halftone is the fallback, not a placeholder. Painting it for the
     // few hundred ms before the ocean arrives reads as a different background
@@ -98,14 +106,22 @@ describe("HeroBackground", () => {
 
   it("renders the halftone fallback when WebGPU is absent", async () => {
     removeGpu();
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
 
   it("treats a null adapter as unsupported rather than as a device", async () => {
     stubGpu(async () => null);
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
@@ -114,14 +130,22 @@ describe("HeroBackground", () => {
     stubGpu(async () => {
       throw new Error("adapter exploded");
     });
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
 
   it("renders no background at all while the probe is in flight", () => {
     stubGpu(() => new Promise(() => {}));
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     expect(screen.queryByTestId("halftone")).toBeNull();
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
@@ -130,7 +154,11 @@ describe("HeroBackground", () => {
     stubReducedMotion(true);
     const requestAdapter = vi.fn(async () => ({ name: "adapter" }));
     stubGpu(requestAdapter);
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(requestAdapter).not.toHaveBeenCalled();
   });
@@ -138,7 +166,11 @@ describe("HeroBackground", () => {
   it("demotes to the fallback when reduced motion turns on mid-session", async () => {
     const motion = stubReducedMotion(false);
     stubGpu(async () => ({ name: "adapter" }));
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await screen.findByTestId("ocean");
 
     motion.fire(true);
@@ -147,7 +179,11 @@ describe("HeroBackground", () => {
 
   it("demotes to the fallback when the renderer fails after a good probe", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<Settled><HeroBackground /></Settled>);
+    render(
+      <Settled>
+        <HeroBackground />
+      </Settled>,
+    );
     await screen.findByTestId("ocean");
 
     const { onError } = oceanMount.mock.calls.at(-1)![0];

--- a/packages/docs/app/components/website-redesign/hero-background.test.tsx
+++ b/packages/docs/app/components/website-redesign/hero-background.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ShellSettledProvider } from "../../shell-ready";
 import { HeroBackground } from "./hero-background";
 
 const { oceanMount, shaderMount } = vi.hoisted(() => ({
@@ -70,16 +71,22 @@ afterEach(() => {
   shaderMount.mockClear();
 });
 
+// HeroBackground now waits for the root shell to stop remounting the page.
+// These cases are about GPU probing, so they run with the shell settled.
+function Settled({ children }: { children: React.ReactNode }) {
+  return <ShellSettledProvider value>{children}</ShellSettledProvider>;
+}
+
 describe("HeroBackground", () => {
   it("renders the ocean when an adapter is available", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     expect(await screen.findByTestId("ocean")).toBeDefined();
   });
 
   it("never flashes the halftone before the ocean", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
 
     // The halftone is the fallback, not a placeholder. Painting it for the
     // few hundred ms before the ocean arrives reads as a different background
@@ -91,14 +98,14 @@ describe("HeroBackground", () => {
 
   it("renders the halftone fallback when WebGPU is absent", async () => {
     removeGpu();
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
 
   it("treats a null adapter as unsupported rather than as a device", async () => {
     stubGpu(async () => null);
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
@@ -107,14 +114,14 @@ describe("HeroBackground", () => {
     stubGpu(async () => {
       throw new Error("adapter exploded");
     });
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
 
   it("renders no background at all while the probe is in flight", () => {
     stubGpu(() => new Promise(() => {}));
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     expect(screen.queryByTestId("halftone")).toBeNull();
     expect(screen.queryByTestId("ocean")).toBeNull();
   });
@@ -123,7 +130,7 @@ describe("HeroBackground", () => {
     stubReducedMotion(true);
     const requestAdapter = vi.fn(async () => ({ name: "adapter" }));
     stubGpu(requestAdapter);
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
     expect(requestAdapter).not.toHaveBeenCalled();
   });
@@ -131,7 +138,7 @@ describe("HeroBackground", () => {
   it("demotes to the fallback when reduced motion turns on mid-session", async () => {
     const motion = stubReducedMotion(false);
     stubGpu(async () => ({ name: "adapter" }));
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await screen.findByTestId("ocean");
 
     motion.fire(true);
@@ -140,11 +147,47 @@ describe("HeroBackground", () => {
 
   it("demotes to the fallback when the renderer fails after a good probe", async () => {
     stubGpu(async () => ({ name: "adapter" }));
-    render(<HeroBackground />);
+    render(<Settled><HeroBackground /></Settled>);
     await screen.findByTestId("ocean");
 
     const { onError } = oceanMount.mock.calls.at(-1)![0];
     onError(new Error("device lost"));
     await waitFor(() => expect(screen.getByTestId("halftone")).toBeDefined());
+  });
+});
+
+describe("HeroBackground shell gating", () => {
+  it("does not probe for WebGPU until the root shell has settled", () => {
+    const requestAdapter = vi.fn(async () => ({ name: "adapter" }));
+    stubGpu(requestAdapter);
+
+    render(
+      <ShellSettledProvider value={false}>
+        <HeroBackground />
+      </ShellSettledProvider>,
+    );
+
+    // The shell remounts everything below it when the sidebar chunk resolves.
+    // Probing before that builds the GPU graph, throws it away, and builds it
+    // again -- the flash this gate exists to prevent.
+    expect(requestAdapter).not.toHaveBeenCalled();
+  });
+
+  it("probes once the shell settles", async () => {
+    const requestAdapter = vi.fn(async () => ({ name: "adapter" }));
+    stubGpu(requestAdapter);
+
+    const { rerender } = render(
+      <ShellSettledProvider value={false}>
+        <HeroBackground />
+      </ShellSettledProvider>,
+    );
+    rerender(
+      <ShellSettledProvider value>
+        <HeroBackground />
+      </ShellSettledProvider>,
+    );
+
+    await waitFor(() => expect(requestAdapter).toHaveBeenCalled());
   });
 });

--- a/packages/docs/app/components/website-redesign/hero-background.tsx
+++ b/packages/docs/app/components/website-redesign/hero-background.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { useShellSettled } from "../../shell-ready";
 import { HeroShaderBackground } from "./hero-shader-background";
 import { HeroOceanBackground } from "./ocean/hero-ocean-background";
 import { probeWebgpuSupport } from "./ocean/webgpu-support";
@@ -14,8 +15,16 @@ type Background = "probing" | "ocean" | "fallback";
  */
 export function HeroBackground() {
   const [background, setBackground] = useState<Background>("probing");
+  // The root shell swaps its whole subtree in when the agent sidebar's chunk
+  // resolves, which remounts everything below it. Starting before that means
+  // building the GPU graph, throwing it away mid-fade, and building it again --
+  // the hero visibly flashed between the two. Waiting costs a few hundred
+  // milliseconds of plain background and buys a single, uninterrupted mount.
+  const shellSettled = useShellSettled();
 
   useEffect(() => {
+    if (!shellSettled) return;
+
     // Reduced motion short-circuits ahead of the probe: the fallback already
     // has a designed static draw, and a frozen ocean is a stalled simulation
     // rather than a composition.
@@ -46,7 +55,7 @@ export function HeroBackground() {
       cancelled = true;
       reduced?.removeEventListener("change", demoteToFallback);
     };
-  }, []);
+  }, [shellSettled]);
 
   // A renderer that fails after a good probe -- device lost, shader compile,
   // out of memory -- is still a broken hero, so it demotes the same way.

--- a/packages/docs/app/root-shell.test.tsx
+++ b/packages/docs/app/root-shell.test.tsx
@@ -87,5 +87,4 @@ describe("RootShell tree stability", () => {
     expect(screen.queryByTestId("real-sidebar")).toBeNull();
     expect(screen.getByTestId("settled").textContent).toBe("false");
   });
-
 });

--- a/packages/docs/app/root-shell.test.tsx
+++ b/packages/docs/app/root-shell.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useShellSettled } from "./shell-ready";
+
+const { agentSidebarSpy } = vi.hoisted(() => ({ agentSidebarSpy: vi.fn() }));
+
+function ShellSettledProbe() {
+  const settled = useShellSettled();
+  return (
+    <p data-testid="page">
+      <span data-testid="settled">{String(settled)}</span>
+    </p>
+  );
+}
+
+vi.mock("@agent-native/core/client/agent-chat", () => ({
+  AgentSidebar: ({ children }: { children: React.ReactNode }) => {
+    agentSidebarSpy();
+    return <div data-testid="real-sidebar">{children}</div>;
+  },
+}));
+vi.mock("@agent-native/core/client/host", () => ({
+  AgentNativeRouteWarmup: () => null,
+}));
+// Only the core boundary is stubbed; the app's own modules stay real so this
+// exercises the shell React actually renders.
+vi.mock("@agent-native/core/client/i18n", () => ({
+  useT: () => (key: string) => key,
+  useLocale: () => "en-US",
+  DEFAULT_LOCALE: "en-US",
+  LOCALE_METADATA: { "en-US": { label: "English", dir: "ltr" } },
+  localeDirection: () => "ltr",
+  normalizeLocaleCode: (value: string) => value,
+  resolveLocaleFromCandidates: () => "en-US",
+  AgentNativeI18nProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+vi.mock("react-router", () => ({
+  Outlet: () => <ShellSettledProbe />,
+  useLocation: () => ({ pathname: "/", hash: "", search: "" }),
+  useNavigation: () => ({ state: "idle" }),
+  useMatches: () => [],
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+  useRouteError: () => null,
+  isRouteErrorResponse: () => false,
+  Meta: () => null,
+  Links: () => null,
+  Scripts: () => null,
+  ScrollRestoration: () => null,
+}));
+vi.mock("./components/website-redesign/site-header", () => ({
+  SiteHeader: () => null,
+}));
+vi.mock("./components/website-redesign/footer", () => ({ Footer: () => null }));
+
+afterEach(() => {
+  cleanup();
+  agentSidebarSpy.mockClear();
+});
+
+describe("RootShell tree stability", () => {
+  // The bug: page content lived at one tree position before `mounted` and a
+  // different one after, so React destroyed and rebuilt every element on the
+  // page. The hero's WebGPU renderer was built twice and its fade restarted
+  // mid-animation, which is what read as the background flashing on load.
+  it("keeps page content mounted across the mounted flip", async () => {
+    const { RootShell } = await import("./root");
+    const { rerender } = render(<RootShell mounted={false} />);
+    const before = screen.getAllByTestId("page")[0];
+
+    rerender(<RootShell mounted />);
+
+    // React keeps a suspended subtree in the DOM behind the fallback, so query
+    // all of them: the placeholder's node must be the same object it was.
+    expect(screen.getAllByTestId("page")[0]).toBe(before);
+  });
+
+  it("only marks the shell settled inside the real sidebar subtree", async () => {
+    const { RootShell } = await import("./root");
+    render(<RootShell mounted={false} />);
+
+    // The placeholder subtree is the one React throws away. Anything that waits
+    // on the settled signal must not see it as settled here.
+    expect(screen.queryByTestId("real-sidebar")).toBeNull();
+    expect(screen.getByTestId("settled").textContent).toBe("false");
+  });
+
+});

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -48,6 +48,7 @@ import { SiteHeader } from "./components/website-redesign/site-header";
 import { isStaleDocsChunkError } from "./docs-error-classification.js";
 import { docsI18nCatalog, loadDocsMessages } from "./i18n";
 import { defaultSocialImageMeta } from "./seo";
+import { ShellSettledProvider } from "./shell-ready";
 
 import tokensCss from "./components/website-redesign/tokens.css?url";
 import appCss from "./global.css?url";
@@ -496,7 +497,7 @@ export default function Root() {
   );
 }
 
-function RootShell({ mounted }: { mounted: boolean }) {
+export function RootShell({ mounted }: { mounted: boolean }) {
   const t = useT();
   const content = (
     <DocsChrome>
@@ -515,27 +516,39 @@ function RootShell({ mounted }: { mounted: boolean }) {
     </div>
   );
 
-  if (!mounted) return fallback;
-
+  // One tree shape for every phase. Returning `fallback` bare before mount and
+  // a fragment+Suspense after put the placeholder at two different positions,
+  // so React tore the whole page down and rebuilt it on the `mounted` flip --
+  // on top of the rebuild the lazy swap itself causes. Keeping the fragment and
+  // the Suspense boundary mounted in every phase removes that first teardown.
   return (
     <>
-      <AgentNativeRouteWarmup />
+      {mounted && <AgentNativeRouteWarmup />}
       <Suspense fallback={fallback}>
-        <LazyAgentSidebar
-          storageKey="docs"
-          position="right"
-          defaultOpen={false}
-          defaultSidebarWidth={400}
-          emptyStateText={t("agent.emptyState")}
-          suggestions={[
-            t("agent.suggestionGettingStarted"),
-            t("agent.suggestionActions"),
-            t("agent.suggestionPolling"),
-            t("agent.suggestionDeploy"),
-          ]}
-        >
-          {content}
-        </LazyAgentSidebar>
+        {mounted ? (
+          <LazyAgentSidebar
+            storageKey="docs"
+            position="right"
+            defaultOpen={false}
+            defaultSidebarWidth={400}
+            emptyStateText={t("agent.emptyState")}
+            suggestions={[
+              t("agent.suggestionGettingStarted"),
+              t("agent.suggestionActions"),
+              t("agent.suggestionPolling"),
+              t("agent.suggestionDeploy"),
+            ]}
+          >
+            {/* Provided from inside the final tree, not from a state flag: the
+                lazy component still resolves a tick after its chunk arrives, so
+                anything keyed off "chunk loaded" opens while Suspense is still
+                showing the placeholder -- and mounts into the subtree that is
+                about to be thrown away. */}
+            <ShellSettledProvider value>{content}</ShellSettledProvider>
+          </LazyAgentSidebar>
+        ) : (
+          fallback
+        )}
       </Suspense>
     </>
   );

--- a/packages/docs/app/shell-ready.tsx
+++ b/packages/docs/app/shell-ready.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Whether the root shell has finished swapping in its final tree.
+ *
+ * `AgentSidebar` wraps the whole app surface and is loaded with `lazy()`, so
+ * when its chunk resolves React unmounts the placeholder subtree and mounts a
+ * fresh one -- every page element below it is destroyed and rebuilt. Static
+ * content re-renders invisibly, but anything holding mount-time state pays for
+ * it: the hero's WebGPU renderer was building its whole graph twice and
+ * restarting its fade, which read as the background flashing mid-animation.
+ *
+ * Components that own expensive or animated mount-time state should wait for
+ * this before mounting, so they mount once into the final tree.
+ */
+const ShellSettledContext = createContext(false);
+
+export const ShellSettledProvider = ShellSettledContext.Provider;
+
+export function useShellSettled(): boolean {
+  return useContext(ShellSettledContext);
+}


### PR DESCRIPTION
Fixes the hero background flashing on load, reported as: *"animation flashes on load … it like fades in then flashes then fades in again i think during hydration."*

The guess in that report was right. It is hydration — but the ocean is not the bug.

## What is actually happening

All page content was destroyed and rebuilt **twice** after load. Measured on a production build by tagging the `<h1>` and watching its node identity:

```
29ms   h1 tagged
97ms   h1 REPLACED   ← remount 1
415ms  h1 REPLACED   ← remount 2
```

Static content re-renders invisibly, so nobody noticed. The ocean was the only thing on the page that animates from zero and holds GPU state, so it was the only place the remount showed:

```
321→449ms  fade #1: op 0.012 → 0.105
471ms      0 canvases          ← hero bare: the flash
500ms      1 canvas op=0.000   ← different element
529→1201ms fade #2: op 0 → 0.320
```

Two causes:

1. **`RootShell` had two tree shapes.** It returned `fallback` bare before mount and a fragment + `Suspense` after, so page content sat at two different positions and React tore it down on the `mounted` flip.
2. **`AgentSidebar` is loaded with `lazy()` and requires `children`** — it wraps the whole app surface so it can resize it. Page content therefore sits under a lazy boundary, and React *must* remount that subtree when the component resolves.

## The fix

Cause 1 is removed: one tree shape in every phase.

Cause 2 cannot be removed without changing shared sidebar infrastructure every template depends on, so instead the hero waits for a settled signal and mounts once, into the final tree. The signal is provided from **inside** that tree rather than from a "chunk loaded" flag — `lazy()` resolves a tick after its chunk arrives, so a fetch-keyed flag opens while Suspense is still showing the placeholder and mounts into the subtree that is about to be discarded. I hit exactly that on the first attempt; it is why `shell-ready.tsx` is a context and not a boolean.

## Result

| | before | after |
|---|---|---|
| content remounts | 2 | 1 |
| canvas removals | 1, mid-fade | 0 |
| fades | 2 | 1 |
| GPU graph builds | 2 | 1 |

The remaining remount happens before the hero mounts, so nothing visible is caught by it. The ocean also stops building its full graph (six 512² float targets plus the bloom chain) twice per page load.

## Not fixed here

Page content still remounts once. Any future component that animates from zero or holds mount-time state will hit the same trap unless it waits on `useShellSettled()` — the `shaderEpoch` module-scope hack in `hero-shader-background.tsx` is a previous developer already working around this. The real fix is for `AgentSidebar` to stop wrapping page content; that is a core change with its own testing pass and is deliberately out of scope.

## Verification

- New `app/root-shell.test.tsx` — verified it **fails** against the old two-position shape and passes against the fix, so it is a real guard.
- New gating cases in `hero-background.test.tsx`.
- 406 tests, 65 guards, typecheck clean, `NITRO_PRESET=netlify` build succeeds.
- Before/after measured on real production builds with a document-start recorder; numbers above are from those runs, reproduced across reloads.
