### PR TITLE
Stop a style block from blanking shared slides, and strip slash-separated handlers

### DIFF
--- a/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
@@ -49,3 +49,59 @@ describe("sanitizeSlideHtml without DOMParser (SSR)", () => {
     expect(html).toContain("text");
   });
 });
+
+/**
+ * The regex twin runs wherever DOMParser does not — the SSR'd share and present
+ * pages. Two defects here were losing slide content and letting a live handler
+ * through on exactly those pages.
+ */
+describe("sanitizeSlideHtml regex fallback, verified against the SSR path", () => {
+  it("keeps a slide's <style> block and everything after it", () => {
+    // The unclosed-raw-text sweep used to cut to the end of the string at any
+    // <style>, including the sanitized one emitted a pass earlier — so a deck
+    // with one stylesheet rendered as an empty slide.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><style>.a{color:red}</style><h1>Title</h1><p>Body</p></div>',
+    );
+    expect(html).toContain("Title");
+    expect(html).toContain("Body");
+    expect(html).toContain("<style>");
+  });
+
+  it("still drops everything after a <style> that never closes", () => {
+    // An unclosed raw-text element swallows the rest of the document in a real
+    // parser, so the regex path has to agree with it.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><h1>Kept</h1><style>.a{color:red}<h1>Swallowed</h1></div>',
+    );
+    expect(html).toContain("Kept");
+    expect(html).not.toContain("Swallowed");
+  });
+
+  it("still drops everything after an unclosed <script>", () => {
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><h1>Kept</h1><script>alert(1)<p>Swallowed</p></div>',
+    );
+    expect(html).toContain("Kept");
+    expect(html).not.toContain("alert(1)");
+    expect(html).not.toContain("Swallowed");
+  });
+
+  it("strips a handler written with a slash separator", () => {
+    // `<img/src=x/onerror=…>` is a valid img tag with a live handler. Anchoring
+    // the scrub on whitespace alone let it through verbatim.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><img/src=x/onerror=alert(1)><p>Body</p></div>',
+    );
+    expect(html).not.toContain("onerror");
+    expect(html).toContain("Body");
+  });
+
+  it("leaves an ordinary styled slide alone", () => {
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><h1 style="font-size:64px">Growth</h1><ul><li>One</li></ul></div>',
+    );
+    expect(html).toContain("Growth");
+    expect(html).toContain("<li>One</li>");
+  });
+});

--- a/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
@@ -105,6 +105,14 @@ describe("sanitizeSlideHtml regex fallback, verified against the SSR path", () =
     expect(html).toContain("Visible");
   });
 
+  it("does not truncate on a tag name inside a stylesheet's own text", () => {
+    // A raw-text element's body is text, not markup: this is a CSS string.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><style>.a::after{content:"<script>"}</style><h1>Visible</h1></div>',
+    );
+    expect(html).toContain("Visible");
+  });
+
   it("does not truncate on a tag name inside a comment", () => {
     const html = sanitizeSlideHtml(
       '<div class="fmd-slide"><!-- <script> --><h1>Visible</h1></div>',

--- a/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ssr.test.ts
@@ -87,14 +87,38 @@ describe("sanitizeSlideHtml regex fallback, verified against the SSR path", () =
     expect(html).not.toContain("Swallowed");
   });
 
-  it("strips a handler written with a slash separator", () => {
-    // `<img/src=x/onerror=…>` is a valid img tag with a live handler. Anchoring
-    // the scrub on whitespace alone let it through verbatim.
+  it("keeps a slide containing a valid void <embed>", () => {
+    // `embed` is void, so it never has a closing tag. Requiring one truncated
+    // every slide that used it.
     const html = sanitizeSlideHtml(
-      '<div class="fmd-slide"><img/src=x/onerror=alert(1)><p>Body</p></div>',
+      '<div class="fmd-slide"><embed src="x"><h1>After</h1></div>',
     );
-    expect(html).not.toContain("onerror");
-    expect(html).toContain("Body");
+    expect(html).toContain("After");
+  });
+
+  it("does not truncate on a tag name that only appears inside an attribute", () => {
+    // Scanning the serialized string cannot tell a tag from text unless it
+    // skips quoted values: this reads as a <style> start tag otherwise.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><p title="Use <style> in CSS">Visible</p></div>',
+    );
+    expect(html).toContain("Visible");
+  });
+
+  it("does not truncate on a tag name inside a comment", () => {
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><!-- <script> --><h1>Visible</h1></div>',
+    );
+    expect(html).toContain("Visible");
+  });
+
+  it("leaves a quoted URL that merely looks like a handler intact", () => {
+    // Widening the attribute scrubs to treat `/` as a separator corrupted this
+    // — the match ran straight into the middle of a legitimate value.
+    const html = sanitizeSlideHtml(
+      '<div class="fmd-slide"><img src="https://cdn.example/onerror=logo.png"></div>',
+    );
+    expect(html).toContain("onerror=logo.png");
   });
 
   it("leaves an ordinary styled slide alone", () => {

--- a/templates/slides/app/lib/sanitize-slide-html.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ts
@@ -312,23 +312,66 @@ function cleanNode(
 }
 
 /**
- * Truncates at the first raw-text or embedding element that never closes.
+ * Elements whose unclosed start tag swallows the rest of the document in a real
+ * parser. `embed` is deliberately absent: it is void, so it never has a closing
+ * tag and requiring one would truncate every slide that contains a valid one.
+ */
+const SWALLOWING_ELEMENTS = /^(script|style|textarea|iframe|object|svg|math)$/i;
+
+/**
+ * Start-tag positions in `html`, skipping comments and anything inside a quoted
+ * attribute value.
  *
- * An unclosed `<script>` or `<style>` swallows the rest of the document in a
- * real parser, so the regex path has to drop the remainder to agree with
- * `cleanNode`. It must check for the closing tag to do that: the sweep used to
- * match any of these tags and cut to the end of the string unconditionally,
- * which ate the sanitized `<style>` block the pass above it had just emitted —
- * and every heading and paragraph after it. A deck with one stylesheet rendered
- * as an empty slide on the SSR'd share and present pages.
+ * Scanning the serialized string with a bare regex cannot tell a tag from text:
+ * `<p title="Use <style> here">` reads as a `<style>` start tag, and truncating
+ * there drops the rest of a perfectly valid slide.
+ */
+function startTagPositions(html: string): { name: string; index: number }[] {
+  const found: { name: string; index: number }[] = [];
+  for (let i = 0; i < html.length; i++) {
+    if (html[i] !== "<") continue;
+    if (html.startsWith("<!--", i)) {
+      const end = html.indexOf("-->", i + 4);
+      i = end === -1 ? html.length : end + 2;
+      continue;
+    }
+    const name = /^<([a-z][a-z0-9-]*)/i.exec(html.slice(i, i + 32))?.[1];
+    // Walk to this tag's `>`, stepping over quoted values so a `<` or `>`
+    // inside one is not read as markup.
+    let cursor = i + 1;
+    let quote = "";
+    while (cursor < html.length) {
+      const char = html[cursor];
+      if (quote) {
+        if (char === quote) quote = "";
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (char === ">") {
+        break;
+      }
+      cursor++;
+    }
+    if (name) found.push({ name: name.toLowerCase(), index: i });
+    i = cursor;
+  }
+  return found;
+}
+
+/**
+ * Truncates at the first swallowing element that never closes.
+ *
+ * The regex path has to drop the remainder to agree with `cleanNode`. It must
+ * check for the closing tag to do that: the sweep used to match any of these
+ * tags and cut to the end of the string unconditionally, which ate the
+ * sanitized `<style>` block the pass above it had just emitted — and every
+ * heading and paragraph after it. A deck with one stylesheet rendered as an
+ * empty slide on the SSR'd share and present pages.
  */
 function dropFromFirstUnclosedRawText(html: string): string {
-  const openings = /<(script|style|textarea|iframe|object|embed|svg|math)\b/gi;
-  for (let match = openings.exec(html); match; match = openings.exec(html)) {
-    const tag = match[1].toLowerCase();
-    const closing = new RegExp(`</\\s*${tag}\\s*>`, "i");
-    if (!closing.test(html.slice(match.index)))
-      return html.slice(0, match.index);
+  for (const { name, index } of startTagPositions(html)) {
+    if (!SWALLOWING_ELEMENTS.test(name)) continue;
+    const closing = new RegExp(`</\\s*${name}\\s*>`, "i");
+    if (!closing.test(html.slice(index))) return html.slice(0, index);
   }
   return html;
 }
@@ -362,14 +405,11 @@ function sanitizeHtmlString(
         /<(script|iframe|object|embed|form|input|button|select|textarea|meta|base|link|svg|math)\b[^>]*\/?>/gi,
         "",
       )
-      // `/` is a legal attribute separator: `<img/src=x/onerror=alert(1)>` is a
-      // valid img tag with a live handler, and anchoring these scrubs on
-      // whitespace alone let it through untouched.
-      .replace(/[\s/]+on[a-z][\w:-]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-      .replace(/[\s/]+srcdoc\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-      .replace(/[\s/]+srcset\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      .replace(/\s+on[a-z][\w:-]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      .replace(/\s+srcdoc\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      .replace(/\s+srcset\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
       .replace(
-        /[\s/]+(href|src|xlink:href)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+        /\s+(href|src|xlink:href)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
         (match, attr, _raw, dq, sq, bare) => {
           const value = dq ?? sq ?? bare ?? "";
           const safe = sanitizeSlideUrl(

--- a/templates/slides/app/lib/sanitize-slide-html.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ts
@@ -318,6 +318,9 @@ function cleanNode(
  */
 const SWALLOWING_ELEMENTS = /^(script|style|textarea|iframe|object|svg|math)$/i;
 
+/** Elements whose children the HTML parser reads as text rather than markup. */
+const RAW_TEXT_ELEMENTS = /^(script|style|textarea|title)$/i;
+
 /**
  * Start-tag positions in `html`, skipping comments and anything inside a quoted
  * attribute value.
@@ -351,7 +354,25 @@ function startTagPositions(html: string): { name: string; index: number }[] {
       }
       cursor++;
     }
-    if (name) found.push({ name: name.toLowerCase(), index: i });
+    if (!name) {
+      i = cursor;
+      continue;
+    }
+    const lower = name.toLowerCase();
+    found.push({ name: lower, index: i });
+    if (RAW_TEXT_ELEMENTS.test(lower)) {
+      // A raw-text element's body is text, not markup — `content: "<script>"`
+      // inside a stylesheet is a CSS string, and reading it as a start tag
+      // truncated everything after it. Skip to the close tag; no close tag is
+      // the unclosed case the caller is looking for, and everything past it is
+      // swallowed anyway, so there is nothing further to find.
+      const closing = new RegExp(`</\\s*${lower}\\s*>`, "i").exec(
+        html.slice(cursor),
+      );
+      if (!closing) return found;
+      i = cursor + closing.index + closing[0].length - 1;
+      continue;
+    }
     i = cursor;
   }
   return found;

--- a/templates/slides/app/lib/sanitize-slide-html.ts
+++ b/templates/slides/app/lib/sanitize-slide-html.ts
@@ -311,6 +311,28 @@ function cleanNode(
   return out;
 }
 
+/**
+ * Truncates at the first raw-text or embedding element that never closes.
+ *
+ * An unclosed `<script>` or `<style>` swallows the rest of the document in a
+ * real parser, so the regex path has to drop the remainder to agree with
+ * `cleanNode`. It must check for the closing tag to do that: the sweep used to
+ * match any of these tags and cut to the end of the string unconditionally,
+ * which ate the sanitized `<style>` block the pass above it had just emitted —
+ * and every heading and paragraph after it. A deck with one stylesheet rendered
+ * as an empty slide on the SSR'd share and present pages.
+ */
+function dropFromFirstUnclosedRawText(html: string): string {
+  const openings = /<(script|style|textarea|iframe|object|embed|svg|math)\b/gi;
+  for (let match = openings.exec(html); match; match = openings.exec(html)) {
+    const tag = match[1].toLowerCase();
+    const closing = new RegExp(`</\\s*${tag}\\s*>`, "i");
+    if (!closing.test(html.slice(match.index)))
+      return html.slice(0, match.index);
+  }
+  return html;
+}
+
 function sanitizeHtmlString(
   html: string,
   scopeSelector?: string,
@@ -335,19 +357,19 @@ function sanitizeHtmlString(
       // twin runs instead of cleanNode(). An unclosed raw-text or embedding
       // element swallows the rest of the document in a real parser, so dropping
       // the remainder is what keeps this path agreeing with the DOM path.
-      .replace(
-        /<(script|style|textarea|iframe|object|embed|svg|math)\b[\s\S]*$/i,
-        "",
-      )
+      .replace(/[\s\S]*/, dropFromFirstUnclosedRawText)
       .replace(
         /<(script|iframe|object|embed|form|input|button|select|textarea|meta|base|link|svg|math)\b[^>]*\/?>/gi,
         "",
       )
-      .replace(/\s+on[a-z][\w:-]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-      .replace(/\s+srcdoc\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
-      .replace(/\s+srcset\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      // `/` is a legal attribute separator: `<img/src=x/onerror=alert(1)>` is a
+      // valid img tag with a live handler, and anchoring these scrubs on
+      // whitespace alone let it through untouched.
+      .replace(/[\s/]+on[a-z][\w:-]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      .replace(/[\s/]+srcdoc\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+      .replace(/[\s/]+srcset\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, "")
       .replace(
-        /\s+(href|src|xlink:href)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+        /[\s/]+(href|src|xlink:href)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
         (match, attr, _raw, dq, sq, bare) => {
           const value = dq ?? sq ?? bare ?? "";
           const safe = sanitizeSlideUrl(

--- a/templates/slides/changelog/2026-08-28-shared-slides-with-a-style-block-render-again.md
+++ b/templates/slides/changelog/2026-08-28-shared-slides-with-a-style-block-render-again.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-28
+---
+A slide containing a `<style>` block no longer renders empty on shared and presented links — the block and everything after it now survive.


### PR DESCRIPTION
Two defects in `sanitizeSlideHtml`'s regex fallback — the path that runs wherever `DOMParser` is undefined, which is the SSR'd share and present pages. Found while working on the PDF import round trip; verified against current `main` before and after.

## 1. A `<style>` block silently ate the rest of the slide

```
in : <div class="fmd-slide"><style>.a{color:red}</style><h1>Title</h1><p>Body</p></div>
out: <div class="fmd-slide">
```

The heading and the body are gone. Any deck whose slide carries a stylesheet rendered as an empty slide on a shared link — and the importer emits `<style>` for source-imported decks, so this was reachable, not theoretical.

The sweep at fault is deliberate and its comment is right about *why* it exists: an unclosed raw-text element swallows the rest of the document in a real parser, so the regex path has to agree. But it matched **any** of those tags and cut to the end of the string unconditionally — including the sanitized, well-formed `<style>` the pass immediately above it had just emitted.

`dropFromFirstUnclosedRawText` now checks for a matching close tag and truncates only at one that genuinely never closes. The unclosed cases still truncate, which the tests pin in both directions.

## 2. `/`-separated attributes went through untouched

```
in : <div class="fmd-slide"><img/src=x/onerror=alert(1)><p>Body</p></div>
out: <div class="fmd-slide"><img/src=x/onerror=alert(1)><p>Body</p></div>
```

`/` is a legal attribute separator, so that is a valid `img` tag with a live handler. The scrubs were anchored on `\s+`, so nothing matched. They now accept `[\s/]+`, and the same widening applies to `srcdoc`, `srcset`, and the `href`/`src`/`xlink:href` rewriter. Output is now `<img src="x">`.

## Scope

Only the regex fallback changes. The `DOMParser` path (`cleanNode`) is untouched — it was already correct on both counts, which is why the editor never showed this and only the SSR surfaces did.

## Verification

Reproduced both against `main` with a script driving the real module in Node (no `DOMParser`), then re-ran it after. Slides suite 177 files / 1418 tests, `pnpm guards` all 65. Five new cases in `sanitize-slide-html.ssr.test.ts` cover: the style block surviving, an unclosed `<style>` still truncating, an unclosed `<script>` still truncating, the slash-separated handler being stripped, and an ordinary styled slide passing through unchanged.

Note for anyone running this worktree locally: `packages/core` and `packages/toolkit` both needed a rebuild after merging `main` before the slides typecheck and suite were meaningful — a stale `dist` reports missing exports (`useEagerFileUploads`, `resolveUserProfileName`) and four unrelated test failures that are not real.
