### PR TITLE
fix: keep Nightly in its own desktop profile

### DIFF
--- a/packages/desktop-app/src/main/desktop-startup.spec.ts
+++ b/packages/desktop-app/src/main/desktop-startup.spec.ts
@@ -6,6 +6,7 @@ import {
   resolveDesktopSsoBrokerStatePath,
   resolveStableUserDataPath,
   runDesktopStartupStep,
+  type DesktopStartupDependencies,
 } from "./desktop-startup.js";
 
 describe("desktopRequestedUserDataPath", () => {
@@ -27,13 +28,14 @@ describe("desktopRequestedUserDataPath", () => {
 
 function createDependencies(
   overrides: Partial<Parameters<typeof initializeDesktopStartup>[0]> = {},
-) {
+): { events: string[]; dependencies: DesktopStartupDependencies } {
   const events: string[] = [];
   return {
     events,
     dependencies: {
       isPackaged: true,
       version: "0.1.150-desktop-sso-canary.20",
+      releaseChannel: "production",
       appDataPath: "/application-support",
       defaultUserDataPath: "/application-support/Agent-Native",
       pathExists: vi.fn(() => false),
@@ -171,6 +173,22 @@ describe("initializeDesktopStartup", () => {
     expect(dependencies.setUserDataPath).toHaveBeenCalledWith(
       "/application-support/Agent Native", // agent-native-brand-ok: preserve the legacy Electron profile directory.
     );
+  });
+
+  it("does not reuse the stable profile for packaged Nightly", () => {
+    const { dependencies, events } = createDependencies({
+      releaseChannel: "nightly",
+      version: "0.1.150-nightly.296",
+      defaultUserDataPath: "/application-support/Agent-Native Nightly",
+      pathExists: vi.fn(() => true),
+    });
+
+    initializeDesktopStartup(dependencies);
+
+    expect(dependencies.pathExists).not.toHaveBeenCalled();
+    expect(dependencies.createDirectory).not.toHaveBeenCalled();
+    expect(dependencies.setUserDataPath).not.toHaveBeenCalled();
+    expect(events).toEqual(["sentry", "logger"]);
   });
 
   it("uses an explicit profile for packaged Desktop before profile consumers", () => {

--- a/packages/desktop-app/src/main/desktop-startup.ts
+++ b/packages/desktop-app/src/main/desktop-startup.ts
@@ -1,11 +1,14 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
+import type { DesktopReleaseChannel } from "@shared/release-channel";
+
 import { resolveDesktopUserDataDirectoryName } from "./ipc/update-policy.js";
 
 export interface DesktopStartupDependencies {
   isPackaged: boolean;
   version: string;
+  releaseChannel: DesktopReleaseChannel;
   appDataPath: string;
   defaultUserDataPath: string;
   pathExists?: (directoryPath: string) => boolean;
@@ -68,6 +71,7 @@ export async function runDesktopStartupStep({
 export function initializeDesktopStartup({
   isPackaged,
   version,
+  releaseChannel,
   appDataPath,
   defaultUserDataPath,
   pathExists,
@@ -84,7 +88,10 @@ export function initializeDesktopStartup({
     version,
   );
   const stableUserDataPath =
-    isPackaged && !requestedUserDataPath && !isolatedUserDataDirectoryName
+    isPackaged &&
+    releaseChannel === "production" &&
+    !requestedUserDataPath &&
+    !isolatedUserDataDirectoryName
       ? resolveStableUserDataPath(appDataPath, defaultUserDataPath, pathExists)
       : null;
   const isolatedUserDataPath = requestedUserDataPath

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -125,7 +125,10 @@ import {
   type DesktopIdentitySettings,
   type DesktopIdentityMagicLinkRequest,
 } from "@shared/ipc-channels";
-import { DESKTOP_DEEP_LINK_PROTOCOL } from "@shared/release-channel";
+import {
+  DESKTOP_DEEP_LINK_PROTOCOL,
+  DESKTOP_RELEASE_CHANNEL,
+} from "@shared/release-channel";
 import {
   app,
   BrowserWindow,
@@ -329,6 +332,7 @@ import { loadDesktopWorkspaceApps } from "./workspace-apps.js";
 initializeDesktopStartup({
   isPackaged: app.isPackaged,
   version: app.getVersion(),
+  releaseChannel: DESKTOP_RELEASE_CHANNEL,
   appDataPath: app.getPath("appData"),
   defaultUserDataPath: app.getPath("userData"),
   requestedUserDataPath: desktopRequestedUserDataPath(


### PR DESCRIPTION
## Summary
- limit legacy stable profile migration to the production release channel
- pass the compiled Desktop release channel into startup initialization
- add a regression test covering packaged Nightly launches

## Validation
- desktop startup tests
- desktop typecheck
- Nightly-mode desktop package build
- full repository guards