### PR TITLE
fix(calendar): restore compact event popover sizing

### DIFF
--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -272,7 +272,7 @@ describe("EventDetailPopover characterization", () => {
       'div[class*="radix-popover-content-available-height"]',
     );
     expect(content).toBeTruthy();
-    expect(content?.className).toContain("w-[min(18rem,calc(100vw-2rem))]");
+    expect(content?.className).toContain("w-[min(420px,calc(100vw-2rem))]");
   });
 
   it("keeps the fallback label out of the input when renaming an unnamed event", () => {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -273,6 +273,9 @@ describe("EventDetailPopover characterization", () => {
     );
     expect(content).toBeTruthy();
     expect(content?.className).toContain("w-[min(420px,calc(100vw-2rem))]");
+    expect(content?.innerHTML).toContain(
+      "text-[11px] font-medium uppercase tracking-wider",
+    );
   });
 
   it("keeps the fallback label out of the input when renaming an unnamed event", () => {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1524,7 +1524,7 @@ export function EventDetailPopover({
         side={isMobile ? "bottom" : (popoverSide ?? "right")}
         sideOffset={isMobile ? 6 : 8}
         collisionPadding={12}
-        className="flex max-h-[var(--radix-popover-content-available-height)] w-[min(18rem,calc(100vw-2rem))] flex-col overflow-hidden p-0"
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-[min(420px,calc(100vw-2rem))] flex-col overflow-hidden p-0"
         onClick={(e) => e.stopPropagation()}
         onOpenAutoFocus={(e) => {
           e.preventDefault();

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1553,8 +1553,8 @@ export function EventDetailPopover({
       >
         <TooltipProvider>
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-border/60 px-4 py-3">
-            <div className="text-base font-medium text-foreground">
+          <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
               <span>
                 {isWorkingLocation
                   ? t("eventForm.workingLocation")


### PR DESCRIPTION
## Summary

- Restore the prior 420px event detail popover width cap.
- Restore the compact 11px uppercase header typography from before PR #3724.
- Keep the recent progressive-disclosure behavior.

## Verification

- `corepack pnpm --filter calendar exec vitest --run app/components/calendar/EventDetailPopover.test.tsx`
- `corepack pnpm exec oxfmt --write templates/calendar/app/components/calendar/EventDetailPopover.tsx templates/calendar/app/components/calendar/EventDetailPopover.test.tsx`
- `git diff --check`

Feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787916574281449