### PR TITLE
fix: remove settings from agent chat

### DIFF
--- a/.changeset/remove-chat-settings-mode.md
+++ b/.changeset/remove-chat-settings-mode.md
@@ -1,5 +1,5 @@
 ---
-"@agent-native/core": patch
+"@agent-native/core": major
 "@agent-native/dispatch": patch
 ---
 

--- a/.changeset/remove-chat-settings-mode.md
+++ b/.changeset/remove-chat-settings-mode.md
@@ -1,5 +1,6 @@
 ---
 "@agent-native/core": patch
+"@agent-native/dispatch": patch
 ---
 
 Remove the legacy settings view from agent chat surfaces.

--- a/.changeset/remove-chat-settings-mode.md
+++ b/.changeset/remove-chat-settings-mode.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Remove the legacy settings view from agent chat surfaces.

--- a/packages/core/docs/content/client-agent-chat.mdx
+++ b/packages/core/docs/content/client-agent-chat.mdx
@@ -234,7 +234,7 @@ If the current screen doesn't match anything the heuristic recognizes and nothin
 ## openAgentSettings(section?) {#openagentsettings}
 
 Use `openAgentSettings()` when an app settings page or setup card should open
-the agent sidebar's Settings tab. Pass a section id such as `"llm"`, `"secrets"`,
+the canonical `/settings` page. Pass a section id such as `"llm"`, `"secrets"`,
 `"automations"`, `"voice"`, or `"limits"` to open a specific section.
 
 ```ts

--- a/packages/core/docs/content/locales/ar-SA/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/ar-SA/client-agent-chat.mdx
@@ -233,7 +233,7 @@ sendToAgentChat({
 ## openAgentSettings(section?) {#openagentsettings}
 
 استخدم `openAgentSettings()` عندما ينبغي أن تفتح صفحة إعدادات التطبيق أو بطاقة الإعداد
-علامة تبويب الإعدادات في الشريط الجانبي للوكيل. مرر معرف قسم مثل `"llm"`، أو `"secrets"`،
+صفحة `/settings` الأساسية. مرر معرف قسم مثل `"llm"`، أو `"secrets"`،
 أو `"automations"`، أو `"voice"`، أو `"limits"` لفتح قسم معين.
 
 ```ts

--- a/packages/core/docs/content/locales/de-DE/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/de-DE/client-agent-chat.mdx
@@ -236,7 +236,7 @@ Wenn der aktuelle Bildschirm zu nichts passt, was die Heuristik erkennt, und nic
 ## openAgentSettings(section?) {#openagentsettings}
 
 Verwenden Sie `openAgentSettings()`, wenn eine App-Einstellungsseite oder eine Setup-Karte
-den Tab "Einstellungen" der Agenten-Seitenleiste öffnen soll. Übergeben Sie eine Abschnitts-Id wie `"llm"`, `"secrets"`,
+die kanonische Seite `/settings` öffnen soll. Übergeben Sie eine Abschnitts-Id wie `"llm"`, `"secrets"`,
 `"automations"`, `"voice"` oder `"limits"`, um einen bestimmten Abschnitt zu öffnen.
 
 ```ts

--- a/packages/core/docs/content/locales/es-ES/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/es-ES/client-agent-chat.mdx
@@ -236,7 +236,7 @@ Si la pantalla actual no coincide con nada que reconozca la heurística y no hay
 ## openAgentSettings(section?) {#openagentsettings}
 
 Usa `openAgentSettings()` cuando una página de configuración de la app o una tarjeta de configuración deba
-abrir la pestaña Settings de la barra lateral del agente. Pasa un id de sección como `"llm"`, `"secrets"`,
+abrir la página canónica `/settings`. Pasa un id de sección como `"llm"`, `"secrets"`,
 `"automations"`, `"voice"` o `"limits"` para abrir una sección específica.
 
 ```ts

--- a/packages/core/docs/content/locales/fr-FR/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/fr-FR/client-agent-chat.mdx
@@ -237,7 +237,7 @@ Si l'écran actuel ne correspond à rien que l'heuristique reconnaît et que rie
 ## openAgentSettings(section?) {#openagentsettings}
 
 Utilisez `openAgentSettings()` lorsqu'une page de paramètres d'application ou une carte
-de configuration doit ouvrir l'onglet Paramètres du panneau latéral de l'agent.
+de configuration doit ouvrir la page canonique `/settings`.
 Transmettez un identifiant de section tel que `"llm"`, `"secrets"`,
 `"automations"`, `"voice"`, ou `"limits"` pour ouvrir une section spécifique.
 

--- a/packages/core/docs/content/locales/hi-IN/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/hi-IN/client-agent-chat.mdx
@@ -235,7 +235,7 @@ sendToAgentChat({
 ## openAgentSettings(section?) {#openagentsettings}
 
 `openAgentSettings()` का उपयोग तब करें जब किसी ऐप सेटिंग्स पेज या सेटअप कार्ड को
-एजेंट साइडबार का Settings टैब खोलना चाहिए। किसी विशिष्ट सेक्शन को खोलने के लिए
+कैनोनिकल `/settings` पेज खोलना चाहिए। किसी विशिष्ट सेक्शन को खोलने के लिए
 `"llm"`, `"secrets"`, `"automations"`, `"voice"`, या `"limits"` जैसा एक सेक्शन id पास करें।
 
 ```ts

--- a/packages/core/docs/content/locales/ja-JP/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/ja-JP/client-agent-chat.mdx
@@ -233,7 +233,7 @@ MCP アプリ埋め込み内からこれを実行する場合や、サイドバ�
 
 ## openAgentSettings(section?) {#openagentsettings}
 
-アプリの設定ページやセットアップ カードがエージェント サイドバーの設定タブを開くべきときは、`openAgentSettings()` を使用します。特定のセクションを開くには、`"llm"`、`"secrets"`、`"automations"`、`"voice"`、`"limits"` などのセクション id を渡します。
+アプリの設定ページやセットアップ カードが正規の `/settings` ページを開く必要があるときは、`openAgentSettings()` を使用します。特定のセクションを開くには、`"llm"`、`"secrets"`、`"automations"`、`"voice"`、`"limits"` などのセクション id を渡します。
 
 ```ts
 import { openAgentSettings } from "@agent-native/core/client/navigation";

--- a/packages/core/docs/content/locales/ko-KR/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/ko-KR/client-agent-chat.mdx
@@ -235,7 +235,7 @@ MCP 앱 임베드 내부에서 이를 실행하는 경우, 또는 사이드바�
 
 ## openAgentSettings(section?) {#openagentsettings}
 
-앱 설정 페이지나 설정 카드가 에이전트 사이드바의 설정 탭을 열어야 할 때
+앱 설정 페이지나 설정 카드가 표준 `/settings` 페이지를 열어야 할 때
 `openAgentSettings()`를 사용하세요. 특정 섹션을 열려면 `"llm"`, `"secrets"`,
 `"automations"`, `"voice"`, `"limits"`와 같은 섹션 id를 전달하세요.
 

--- a/packages/core/docs/content/locales/pt-BR/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/pt-BR/client-agent-chat.mdx
@@ -236,7 +236,7 @@ Se a tela atual não corresponder a nada que a heurística reconheça e nada est
 ## openAgentSettings(section?) {#openagentsettings}
 
 Use `openAgentSettings()` quando uma página de configurações do aplicativo ou um card de setup
-deve abrir a aba Settings da barra lateral do agente. Passe um id de seção como `"llm"`, `"secrets"`,
+deve abrir a página canônica `/settings`. Passe um id de seção como `"llm"`, `"secrets"`,
 `"automations"`, `"voice"`, ou `"limits"` para abrir uma seção específica.
 
 ```ts

--- a/packages/core/docs/content/locales/zh-CN/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/zh-CN/client-agent-chat.mdx
@@ -232,7 +232,7 @@ sendToAgentChat({
 
 ## openAgentSettings(section?) {#openagentsettings}
 
-当某个应用设置页面或设置卡需要打开代理侧边栏的设置选项卡时，使用 `openAgentSettings()`。传入一个区块 id，例如 `"llm"`、`"secrets"`、`"automations"`、`"voice"` 或 `"limits"`，可以打开特定的区块。
+当某个应用设置页面或设置卡需要打开规范的 `/settings` 页面时，使用 `openAgentSettings()`。传入一个区块 id，例如 `"llm"`、`"secrets"`、`"automations"`、`"voice"` 或 `"limits"`，可以打开特定的区块。
 
 ```ts
 import { openAgentSettings } from "@agent-native/core/client/navigation";

--- a/packages/core/docs/content/locales/zh-TW/client-agent-chat.mdx
+++ b/packages/core/docs/content/locales/zh-TW/client-agent-chat.mdx
@@ -231,7 +231,7 @@ sendToAgentChat({
 
 ## openAgentSettings(section?) {#openagentsettings}
 
-當應用程式設定頁面或設定卡應該開啟代理側邊欄的「設定」分頁時，使用 `openAgentSettings()`。傳入一個區段 id，例如 `"llm"`、`"secrets"`、
+當應用程式設定頁面或設定卡應該開啟標準的 `/settings` 頁面時，使用 `openAgentSettings()`。傳入一個區段 id，例如 `"llm"`、`"secrets"`、
 `"automations"`、`"voice"` 或 `"limits"`，以開啟特定區段。
 
 ```ts

--- a/packages/core/docs/content/toolkit-settings.mdx
+++ b/packages/core/docs/content/toolkit-settings.mdx
@@ -33,7 +33,7 @@ free the moment an app adopts the shared page.
 | `useAgentSettingsTabs()` | Framework-provided agent, model, key, automation, and voice tabs that apps can mount.              |
 | `SettingsSearchEntry`    | A deep-link target (label, keywords, tab, and hash) that makes a control findable.                 |
 | `<LanguagePicker>`       | Standard language selector for app settings.                                                       |
-| `openAgentSettings()`    | Compatibility escape hatch for opening the sidebar settings tab when needed.                       |
+| `openAgentSettings()`    | Opens the canonical `/settings` page at the requested section.                                       |
 | Deep links               | Stable links such as `/settings/integrations/secrets/OPENAI_API_KEY` and `/settings/integrations`. |
 
 ## Page Contract {#page-contract}
@@ -111,8 +111,8 @@ on so settings stay findable everywhere.
   control so users can find settings by name instead of scanning tabs.
 - Link to tabs by hash so setup prompts can send users to the exact missing
   credential.
-- Use the agent sidebar settings only as a compact access point, not as the
-  primary home for every setting.
+- Keep settings in the canonical `/settings` pages. Agent chat should remain
+  focused on conversation and never render settings inline.
 
 ## What's next
 

--- a/packages/core/docs/content/toolkit-settings.mdx
+++ b/packages/core/docs/content/toolkit-settings.mdx
@@ -33,7 +33,7 @@ free the moment an app adopts the shared page.
 | `useAgentSettingsTabs()` | Framework-provided agent, model, key, automation, and voice tabs that apps can mount.              |
 | `SettingsSearchEntry`    | A deep-link target (label, keywords, tab, and hash) that makes a control findable.                 |
 | `<LanguagePicker>`       | Standard language selector for app settings.                                                       |
-| `openAgentSettings()`    | Opens the canonical `/settings` page at the requested section.                                       |
+| `openAgentSettings()`    | Opens the canonical `/settings` page at the requested section.                                     |
 | Deep links               | Stable links such as `/settings/integrations/secrets/OPENAI_API_KEY` and `/settings/integrations`. |
 
 ## Page Contract {#page-contract}

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -222,6 +222,46 @@ describe("AgentPanel settings navigation", () => {
       container.remove();
     }
   });
+
+  it("preserves the app base path when opening settings", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    let pathname = "";
+
+    function LocationProbe() {
+      pathname = useLocation().pathname;
+      return null;
+    }
+
+    try {
+      act(() => {
+        window.history.replaceState(null, "", "/dispatch/_agent-native/poll");
+        root.render(
+          React.createElement(
+            MemoryRouter,
+            { initialEntries: ["/"] },
+            React.createElement(AgentPanelSettingsNavigation),
+            React.createElement(LocationProbe),
+          ),
+        );
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:open-settings", {
+            detail: { section: "voice" },
+          }),
+        );
+      });
+
+      expect(pathname).toBe("/dispatch/settings");
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      window.history.replaceState(null, "", "/");
+    }
+  });
 });
 
 describe("AgentPanel mode and full-view visibility", () => {
@@ -466,7 +506,7 @@ describe("AgentChatSurface chrome defaults", () => {
     expect(source).not.toContain("SettingsPanel");
     expect(source).not.toContain("allowSettingsMode");
     expect(source).not.toContain('mode === "settings"');
-    expect(source).toContain('pathname: "/settings"');
+    expect(source).toContain('pathname: appPath("/settings")');
   });
 
   it("mounts URL command sync for a full-page chat surface", () => {

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -169,12 +169,18 @@ describe("AgentPanel header tab visibility", () => {
     expect(settingsRouteHashForSection("secrets:FIGMA_ACCESS_TOKEN")).toBe(
       "#secrets:FIGMA_ACCESS_TOKEN",
     );
+    expect(
+      settingsRouteHashForSection("secrets", "#secrets:OPENAI_API_KEY"),
+    ).toBe("#secrets:OPENAI_API_KEY");
+    expect(settingsRouteHashForSection("automations")).toBe(
+      "#agent:automations",
+    );
     expect(settingsRouteHashForSection("voice")).toBe("#voice");
   });
 });
 
 describe("AgentPanel settings navigation", () => {
-  it("routes a mounted settings request to a secret-specific canonical hash", () => {
+  it("routes a mounted settings request to an existing secret-specific hash", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root: Root = createRoot(container);
@@ -190,6 +196,7 @@ describe("AgentPanel settings navigation", () => {
 
     try {
       act(() => {
+        window.history.replaceState(null, "", "/#secrets:OPENAI_API_KEY");
         root.render(
           React.createElement(
             MemoryRouter,
@@ -203,13 +210,13 @@ describe("AgentPanel settings navigation", () => {
       act(() => {
         window.dispatchEvent(
           new CustomEvent("agent-panel:open-settings", {
-            detail: { section: "secrets:FIGMA_ACCESS_TOKEN" },
+            detail: { section: "secrets" },
           }),
         );
       });
 
       expect(pathname).toBe("/settings");
-      expect(hash).toBe("#secrets:FIGMA_ACCESS_TOKEN");
+      expect(hash).toBe("#secrets:OPENAI_API_KEY");
     } finally {
       act(() => root.unmount());
       container.remove();

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -2,10 +2,14 @@
 
 import { readFileSync } from "node:fs";
 
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   AgentChatSurface,
+  AgentPanelSettingsNavigation,
   consumeAgentPanelOverlayFocusRestore,
   deferAgentPanelOverlayOpen,
   getAgentPanelShortcutHints,
@@ -22,6 +26,7 @@ import {
   shouldShowAgentPanelSidebarChatTabs,
   shouldShowAgentPanelCliTabBar,
   shouldShowAgentPanelModeButtons,
+  settingsRouteHashForSection,
 } from "./AgentPanel.js";
 
 describe("resolveAgentPanelChatSurface", () => {
@@ -158,6 +163,57 @@ describe("AgentPanel header tab visibility", () => {
     expect(normalizeAgentPanelModeForSurface("resources")).toBe("resources");
     expect(normalizeAgentPanelModeForSurface("resources", true)).toBe("chat");
     expect(normalizeAgentPanelModeForSurface("cli", true)).toBe("chat");
+  });
+
+  it("preserves secret-specific hashes for canonical settings navigation", () => {
+    expect(settingsRouteHashForSection("secrets:FIGMA_ACCESS_TOKEN")).toBe(
+      "#secrets:FIGMA_ACCESS_TOKEN",
+    );
+    expect(settingsRouteHashForSection("voice")).toBe("#voice");
+  });
+});
+
+describe("AgentPanel settings navigation", () => {
+  it("routes a mounted settings request to a secret-specific canonical hash", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    let pathname = "";
+    let hash = "";
+
+    function LocationProbe() {
+      const location = useLocation();
+      pathname = location.pathname;
+      hash = location.hash;
+      return null;
+    }
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(
+            MemoryRouter,
+            { initialEntries: ["/"] },
+            React.createElement(AgentPanelSettingsNavigation),
+            React.createElement(LocationProbe),
+          ),
+        );
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:open-settings", {
+            detail: { section: "secrets:FIGMA_ACCESS_TOKEN" },
+          }),
+        );
+      });
+
+      expect(pathname).toBe("/settings");
+      expect(hash).toBe("#secrets:FIGMA_ACCESS_TOKEN");
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 });
 

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -186,13 +186,13 @@ describe("AgentPanel header tab visibility", () => {
       "limits",
       "app-models",
       "background",
-      "a2a",
       "email",
       "browser",
       "usage",
     ]) {
       expect(settingsRouteHashForSection(section)).toBe(`#${section}`);
     }
+    expect(settingsRouteHashForSection("a2a")).toBe("#agent:agents");
   });
 });
 

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -176,10 +176,61 @@ describe("AgentPanel header tab visibility", () => {
       "#agent:automations",
     );
     expect(settingsRouteHashForSection("voice")).toBe("#voice");
+    for (const section of [
+      "llm",
+      "uploads",
+      "hosting",
+      "database",
+      "auth",
+      "demo-mode",
+      "limits",
+      "app-models",
+      "background",
+      "a2a",
+      "email",
+      "browser",
+      "usage",
+    ]) {
+      expect(settingsRouteHashForSection(section)).toBe(`#${section}`);
+    }
   });
 });
 
 describe("AgentPanel settings navigation", () => {
+  it("routes settings requests to a host-owned settings surface", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    const onOpenSettings = vi.fn();
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(
+            MemoryRouter,
+            { initialEntries: ["/"] },
+            React.createElement(AgentPanelSettingsNavigation, {
+              onOpenSettings,
+            }),
+          ),
+        );
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:open-settings", {
+            detail: { section: "voice" },
+          }),
+        );
+      });
+
+      expect(onOpenSettings).toHaveBeenCalledWith("voice");
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
   it("routes a mounted settings request to an existing secret-specific hash", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -260,6 +311,44 @@ describe("AgentPanel settings navigation", () => {
       act(() => root.unmount());
       container.remove();
       window.history.replaceState(null, "", "/");
+    }
+  });
+
+  it("notifies mounted settings sections after browser navigation", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    const popstate = vi.fn();
+    const hashchange = vi.fn();
+    window.addEventListener("popstate", popstate);
+    window.addEventListener("hashchange", hashchange);
+
+    try {
+      act(() => {
+        root.render(
+          React.createElement(
+            MemoryRouter,
+            { initialEntries: ["/"] },
+            React.createElement(AgentPanelSettingsNavigation),
+          ),
+        );
+      });
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:open-settings", {
+            detail: { section: "uploads" },
+          }),
+        );
+      });
+
+      expect(popstate).toHaveBeenCalledTimes(1);
+      expect(hashchange).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener("popstate", popstate);
+      window.removeEventListener("hashchange", hashchange);
+      act(() => root.unmount());
+      container.remove();
     }
   });
 });

--- a/packages/core/src/client/AgentPanel.header.spec.ts
+++ b/packages/core/src/client/AgentPanel.header.spec.ts
@@ -14,7 +14,6 @@ import {
   normalizeAgentPanelModeForSurface,
   resolveAgentPanelFullViewAction,
   resolveAgentPanelChatSurface,
-  shouldAllowAgentChatSurfaceSettingsMode,
   shouldDefaultAgentChatSurfacePageNewChatButton,
   shouldHandleAgentSidebarToggle,
   shouldShowAgentPanelFullViewAction,
@@ -153,34 +152,12 @@ describe("AgentPanel header tab visibility", () => {
     );
   });
 
-  it("does not allow sidebar settings mode in page chat by default", () => {
-    expect(shouldAllowAgentChatSurfaceSettingsMode("page", undefined)).toBe(
-      false,
-    );
-    expect(shouldAllowAgentChatSurfaceSettingsMode("panel", undefined)).toBe(
-      true,
-    );
-    expect(shouldAllowAgentChatSurfaceSettingsMode("page", true)).toBe(true);
-  });
-
-  it("normalizes settings back to chat when settings mode is not allowed", () => {
-    expect(normalizeAgentPanelModeForSurface("settings", false)).toBe("chat");
-    expect(normalizeAgentPanelModeForSurface("settings", true)).toBe(
-      "settings",
-    );
-    expect(normalizeAgentPanelModeForSurface("resources", false)).toBe(
-      "resources",
-    );
-  });
-
-  it("normalizes every legacy sidebar mode back to chat on chat-only surfaces", () => {
-    expect(normalizeAgentPanelModeForSurface("resources", false, true)).toBe(
-      "chat",
-    );
-    expect(normalizeAgentPanelModeForSurface("cli", false, true)).toBe("chat");
-    expect(normalizeAgentPanelModeForSurface("settings", true, true)).toBe(
-      "chat",
-    );
+  it("normalizes legacy and unknown modes back to chat", () => {
+    expect(normalizeAgentPanelModeForSurface("settings")).toBe("chat");
+    expect(normalizeAgentPanelModeForSurface("unknown")).toBe("chat");
+    expect(normalizeAgentPanelModeForSurface("resources")).toBe("resources");
+    expect(normalizeAgentPanelModeForSurface("resources", true)).toBe("chat");
+    expect(normalizeAgentPanelModeForSurface("cli", true)).toBe("chat");
   });
 });
 
@@ -190,11 +167,10 @@ describe("AgentPanel mode and full-view visibility", () => {
     expect(shouldShowAgentPanelModeButtons(false)).toBe(true);
   });
 
-  it("shows the full-view action for resources and settings when a page href exists", () => {
+  it("shows the full-view action for resources when a page href exists", () => {
     expect(shouldShowAgentPanelFullViewAction("/agent", "resources")).toBe(
       true,
     );
-    expect(shouldShowAgentPanelFullViewAction("/agent", "settings")).toBe(true);
   });
 
   it("keeps the full Agent page reachable from chat-only sidebars", () => {
@@ -232,9 +208,6 @@ describe("AgentPanel mode and full-view visibility", () => {
   it("hides the full-view action for CLI or a missing page href", () => {
     expect(shouldShowAgentPanelFullViewAction("/agent", "cli")).toBe(false);
     expect(shouldShowAgentPanelFullViewAction(undefined, "resources")).toBe(
-      false,
-    );
-    expect(shouldShowAgentPanelFullViewAction(undefined, "settings")).toBe(
       false,
     );
   });
@@ -419,6 +392,18 @@ describe("AgentChatSurface chrome defaults", () => {
 
     expect(panel.props.showHeader).toBe(false);
     expect(panel.props.showTabBar).toBe(false);
+    expect(panel.props).not.toHaveProperty("allowSettingsMode");
+  });
+
+  it("keeps settings out of every chat surface", () => {
+    const source = readFileSync("src/client/AgentPanel.tsx", {
+      encoding: "utf8",
+    });
+
+    expect(source).not.toContain("SettingsPanel");
+    expect(source).not.toContain("allowSettingsMode");
+    expect(source).not.toContain('mode === "settings"');
+    expect(source).toContain('pathname: "/settings"');
   });
 
   it("mounts URL command sync for a full-page chat surface", () => {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -179,9 +179,13 @@ function postPerAppChatSidebarStateToEmbeddedFrames(open: boolean): void {
   }
 }
 
-function settingsRouteHashForSection(section?: string | null): string {
-  const normalized = section?.replace(/^#/, "").toLowerCase() ?? "";
+export function settingsRouteHashForSection(section?: string | null): string {
+  const raw = section?.replace(/^#/, "").trim() ?? "";
+  const normalized = raw.toLowerCase();
   if (normalized === "voice") return "#voice";
+  if (normalized.startsWith("secrets:")) {
+    return `#secrets:${raw.slice("secrets:".length)}`;
+  }
   if (
     normalized.startsWith("secrets") ||
     normalized.includes("api") ||
@@ -207,6 +211,32 @@ function settingsRouteHashForSection(section?: string | null): string {
     return "#workspace";
   }
   return "#agent";
+}
+
+export function AgentPanelSettingsNavigation() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    function handleOpenSettings(event: Event) {
+      const section = (event as CustomEvent<{ section?: string }>).detail
+        ?.section;
+      void navigate({
+        pathname: "/settings",
+        hash: settingsRouteHashForSection(section),
+      });
+    }
+    window.addEventListener(
+      AGENT_PANEL_OPEN_SETTINGS_EVENT,
+      handleOpenSettings,
+    );
+    return () =>
+      window.removeEventListener(
+        AGENT_PANEL_OPEN_SETTINGS_EVENT,
+        handleOpenSettings,
+      );
+  }, [navigate]);
+
+  return null;
 }
 const AGENT_CHAT_RUNNING_EVENT = "agentNative.chatRunning";
 
@@ -943,7 +973,6 @@ function AgentPanelInner({
   ...assistantChatProps
 }: AgentPanelProps) {
   const t = useT();
-  const navigate = useNavigate();
   const location = useLocation();
   const mounted = useClientOnly();
   const onboardingPreviewMode = useOnboardingPreviewMode();
@@ -1079,27 +1108,6 @@ function AgentPanelInner({
     return () =>
       window.removeEventListener(AGENT_PANEL_SET_MODE_EVENT, handler);
   }, [switchMode]);
-
-  // Open the canonical settings page when requested.
-  useEffect(() => {
-    function handleOpenSettings(event: Event) {
-      const section = (event as CustomEvent<{ section?: string }>).detail
-        ?.section;
-      void navigate({
-        pathname: "/settings",
-        hash: settingsRouteHashForSection(section),
-      });
-    }
-    window.addEventListener(
-      AGENT_PANEL_OPEN_SETTINGS_EVENT,
-      handleOpenSettings,
-    );
-    return () =>
-      window.removeEventListener(
-        AGENT_PANEL_OPEN_SETTINGS_EVENT,
-        handleOpenSettings,
-      );
-  }, [navigate]);
 
   // CLI terminal tabs (ephemeral — not persisted to SQL)
   const [cliTabs, setCliTabs] = useState<string[]>(["cli-1"]);
@@ -2189,6 +2197,7 @@ function AgentPanelInner({
 
   return (
     <ThinkingDisplayProvider value={assistantChatProps.thinkingDisplay}>
+      <AgentPanelSettingsNavigation />
       <div
         className={cn(
           "agent-panel-root flex flex-1 flex-col min-h-0 h-full text-[13px] leading-[1.2] antialiased",

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -198,13 +198,13 @@ export function settingsRouteHashForSection(
       "email",
       "browser",
       "background",
-      "a2a",
       "usage",
     ].includes(normalized)
   ) {
     return `#${normalized}`;
   }
   if (normalized === "voice") return "#voice";
+  if (normalized === "a2a") return "#agent:agents";
   if (normalized.startsWith("secrets:")) {
     return `#secrets:${raw.slice("secrets:".length)}`;
   }

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -185,6 +185,25 @@ export function settingsRouteHashForSection(
 ): string {
   const raw = section?.replace(/^#/, "").trim() ?? "";
   const normalized = raw.toLowerCase();
+  if (
+    [
+      "llm",
+      "app-models",
+      "limits",
+      "demo-mode",
+      "hosting",
+      "database",
+      "uploads",
+      "auth",
+      "email",
+      "browser",
+      "background",
+      "a2a",
+      "usage",
+    ].includes(normalized)
+  ) {
+    return `#${normalized}`;
+  }
   if (normalized === "voice") return "#voice";
   if (normalized.startsWith("secrets:")) {
     return `#secrets:${raw.slice("secrets:".length)}`;
@@ -200,9 +219,7 @@ export function settingsRouteHashForSection(
     normalized.startsWith("secrets") ||
     normalized.includes("api") ||
     normalized === "integrations" ||
-    normalized === "connections" ||
-    normalized === "email" ||
-    normalized === "browser"
+    normalized === "connections"
   ) {
     return "#integrations";
   }
@@ -211,29 +228,40 @@ export function settingsRouteHashForSection(
     normalized === "workspace" ||
     normalized === "workspace-settings" ||
     normalized === "organization" ||
-    normalized === "org" ||
-    normalized === "hosting" ||
-    normalized === "database" ||
-    normalized === "uploads" ||
-    normalized === "auth" ||
-    normalized === "demo-mode"
+    normalized === "org"
   ) {
     return "#workspace";
   }
   return "#agent";
 }
 
-export function AgentPanelSettingsNavigation() {
+export function AgentPanelSettingsNavigation({
+  onOpenSettings,
+}: {
+  onOpenSettings?: (section?: string) => void;
+} = {}) {
   const navigate = useNavigate();
 
   useEffect(() => {
     function handleOpenSettings(event: Event) {
       const section = (event as CustomEvent<{ section?: string }>).detail
         ?.section;
-      void navigate({
+      if (onOpenSettings) {
+        onOpenSettings(section);
+        return;
+      }
+      const navigation = navigate({
         pathname: appPath("/settings"),
         hash: settingsRouteHashForSection(section, window.location.hash),
       });
+      const notifyLocationChange = () => {
+        window.dispatchEvent(new Event("popstate"));
+        window.dispatchEvent(new Event("hashchange"));
+      };
+      void Promise.resolve(navigation).then(
+        notifyLocationChange,
+        () => undefined,
+      );
     }
     window.addEventListener(
       AGENT_PANEL_OPEN_SETTINGS_EVENT,
@@ -244,7 +272,7 @@ export function AgentPanelSettingsNavigation() {
         AGENT_PANEL_OPEN_SETTINGS_EVENT,
         handleOpenSettings,
       );
-  }, [navigate]);
+  }, [navigate, onOpenSettings]);
 
   return null;
 }
@@ -796,6 +824,8 @@ export interface AgentPanelProps extends Omit<
   isWideDrawer?: boolean;
   /** Called when the user returns the wide drawer to the normal layout. */
   onExitWideDrawer?: () => void;
+  /** Route settings requests to a host-owned settings surface. */
+  onOpenSettings?: (section?: string) => void;
   /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
   storageKey?: string;
   /** Restore the previously active chat thread on mount. Default: true. */
@@ -967,6 +997,7 @@ function AgentPanelInner({
   onSnapTo75Percent,
   isWideDrawer,
   onExitWideDrawer,
+  onOpenSettings,
   storageKey,
   restoreActiveThread = true,
   scope,
@@ -2207,7 +2238,7 @@ function AgentPanelInner({
 
   return (
     <ThinkingDisplayProvider value={assistantChatProps.thinkingDisplay}>
-      <AgentPanelSettingsNavigation />
+      <AgentPanelSettingsNavigation onOpenSettings={onOpenSettings} />
       <div
         className={cn(
           "agent-panel-root flex flex-1 flex-col min-h-0 h-full text-[13px] leading-[1.2] antialiased",
@@ -3105,6 +3136,8 @@ export interface AgentSidebarProps {
   openOnChatRunning?: boolean;
   /** Called when the user selects the full-view action from the chat sidebar. */
   onFullscreenRequest?: () => void;
+  /** Route settings requests to a host-owned settings surface. */
+  onOpenSettings?: (section?: string) => void;
   /** Ambient resource context rendered as a composer chip. */
   scope?: import("./use-chat-threads.js").ChatThreadScope | null;
   /** Identity used to route host-scoped sidebar toggle events. */
@@ -3174,6 +3207,7 @@ export function AgentSidebar({
   composerPlaceholder,
   openOnChatRunning = false,
   onFullscreenRequest,
+  onOpenSettings,
   scope,
   toggleScopeId,
   isolateHistoryByScope = false,
@@ -3996,6 +4030,7 @@ export function AgentSidebar({
             isWideDrawer={isMobile ? false : isWideDrawer}
             onExitWideDrawer={isMobile ? undefined : exitWideDrawer}
             onFullViewRequest={onFullscreenRequest}
+            onOpenSettings={onOpenSettings}
             storageKey={storageKey}
             restoreActiveThread={restoreActiveThread}
             scope={scope}

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -179,13 +179,23 @@ function postPerAppChatSidebarStateToEmbeddedFrames(open: boolean): void {
   }
 }
 
-export function settingsRouteHashForSection(section?: string | null): string {
+export function settingsRouteHashForSection(
+  section?: string | null,
+  currentHash?: string | null,
+): string {
   const raw = section?.replace(/^#/, "").trim() ?? "";
   const normalized = raw.toLowerCase();
   if (normalized === "voice") return "#voice";
   if (normalized.startsWith("secrets:")) {
     return `#secrets:${raw.slice("secrets:".length)}`;
   }
+  if (normalized === "secrets") {
+    const existing = currentHash?.replace(/^#/, "").trim() ?? "";
+    if (existing.toLowerCase().startsWith("secrets:") && existing.length > 8) {
+      return `#secrets:${existing.slice("secrets:".length)}`;
+    }
+  }
+  if (normalized === "automations") return "#agent:automations";
   if (
     normalized.startsWith("secrets") ||
     normalized.includes("api") ||
@@ -222,7 +232,7 @@ export function AgentPanelSettingsNavigation() {
         ?.section;
       void navigate({
         pathname: "/settings",
-        hash: settingsRouteHashForSection(section),
+        hash: settingsRouteHashForSection(section, window.location.hash),
       });
     }
     window.addEventListener(

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -26,7 +26,6 @@ import {
   IconMessageCircle,
   IconMessageDots,
   IconTerminal2,
-  IconSettings,
   IconLayoutSidebarRightCollapse,
   IconLayoutGrid,
   IconCheck,
@@ -222,13 +221,6 @@ const ResourcesPanel = lazy(() =>
   })),
 );
 
-// Lazy-load SettingsPanel to avoid bundling when not needed
-const SettingsPanel = lazy(() =>
-  import("./settings/index.js").then((m) => ({
-    default: m.SettingsPanel,
-  })),
-);
-
 // Lazy-load OnboardingPanel — only pulled in when onboarding is active.
 const OnboardingPanel = lazy(() =>
   import("./onboarding/OnboardingPanel.js").then((m) => ({
@@ -252,8 +244,8 @@ const SetupButton = lazy(() =>
 
 // The setup/onboarding checklist that used to appear above chat is disabled
 // for every app — setup (AI engine, image/video gen, asset storage, email,
-// GitHub, etc.) is surfaced in better places (the settings panel and the
-// per-feature setup affordances). Keep this off; do not re-enable globally.
+// GitHub, etc.) is surfaced in the settings pages and per-feature setup
+// affordances. Keep this off; do not re-enable globally.
 const SHOW_ONBOARDING = false;
 const SHOW_FIRST_RUN_ONBOARDING = isFirstRunOnboardingEnabled();
 const AgentSidebarOnboardingContext = React.createContext(false);
@@ -262,14 +254,13 @@ const CLI_STORAGE_KEY = "agent-native-cli-command";
 const CLI_DEFAULT = "claude";
 const EXEC_MODE_KEY = "agent-native-exec-mode";
 type ExecMode = "build" | "plan";
-type PanelMode = "chat" | "cli" | "resources" | "settings";
+type PanelMode = "chat" | "cli" | "resources";
 export function normalizeAgentPanelModeForSurface(
-  mode: PanelMode,
-  allowSettingsMode: boolean,
+  mode: string,
   chatOnly = false,
 ): PanelMode {
   if (chatOnly) return "chat";
-  return mode === "settings" && !allowSettingsMode ? "chat" : mode;
+  return mode === "cli" || mode === "resources" ? mode : "chat";
 }
 const AGENT_PANEL_FONT_FAMILY =
   'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
@@ -587,7 +578,7 @@ export function shouldShowAgentPanelFullViewAction(
   return (
     Boolean(agentPageHref) &&
     currentPath !== agentPageHref &&
-    (isSidebar || mode === "resources" || mode === "settings")
+    (isSidebar || mode === "resources")
   );
 }
 
@@ -765,8 +756,6 @@ export interface AgentPanelProps extends Omit<
   isWideDrawer?: boolean;
   /** Called when the user returns the wide drawer to the normal layout. */
   onExitWideDrawer?: () => void;
-  /** URL of the app being developed (shown as "Open app in new tab" in settings). Set by frame. */
-  devAppUrl?: string;
   /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
   storageKey?: string;
   /** Restore the previously active chat thread on mount. Default: true. */
@@ -787,11 +776,9 @@ export interface AgentPanelProps extends Omit<
   showTabBar?: boolean;
   /** Show a compact New chat action in page chat when the main header is hidden. */
   showPageNewChatButton?: boolean;
-  /** Allow the sidebar settings view to render inside this panel. Default: true. */
-  allowSettingsMode?: boolean;
   /** Keep this surface on chat even when mode controls are hidden. */
   chatOnly?: boolean;
-  /** Optional link shown in Resources and Settings modes for the full Agent page. */
+  /** Optional link shown in Resources mode for the full Agent page. */
   agentPageHref?: string;
   /** Capability gate for source edits and CLI access. */
   codeAccess?: AgentPanelCodeAccess;
@@ -940,7 +927,6 @@ function AgentPanelInner({
   onSnapTo75Percent,
   isWideDrawer,
   onExitWideDrawer,
-  devAppUrl,
   storageKey,
   restoreActiveThread = true,
   scope,
@@ -951,7 +937,6 @@ function AgentPanelInner({
   chatNotice,
   showTabBar = true,
   showPageNewChatButton = false,
-  allowSettingsMode = true,
   chatOnly = false,
   agentPageHref,
   codeAccess,
@@ -1014,51 +999,27 @@ function AgentPanelInner({
   const [mode, setMode] = useState<PanelMode>(() => {
     try {
       const saved = localStorage.getItem(panelModeKey);
-      if (
-        saved === "chat" ||
-        saved === "cli" ||
-        saved === "resources" ||
-        saved === "settings"
-      )
-        return normalizeAgentPanelModeForSurface(
-          saved,
-          allowSettingsMode,
-          chatOnly,
-        );
+      return normalizeAgentPanelModeForSurface(saved ?? defaultMode, chatOnly);
     } catch {}
-    return normalizeAgentPanelModeForSurface(
-      defaultMode,
-      allowSettingsMode,
-      chatOnly,
-    );
+    return normalizeAgentPanelModeForSurface(defaultMode, chatOnly);
   });
   useEffect(() => {
     try {
       localStorage.setItem(panelModeKey, mode);
     } catch {}
   }, [mode, panelModeKey]);
-  const [settingsSection, setSettingsSection] = useState<{
-    section: string | null;
-    requestKey: number;
-  }>({ section: null, requestKey: 0 });
   const switchMode = useCallback(
     (m: PanelMode) => {
       startTransition(() =>
-        setMode(
-          normalizeAgentPanelModeForSurface(m, allowSettingsMode, chatOnly),
-        ),
+        setMode(normalizeAgentPanelModeForSurface(m, chatOnly)),
       );
     },
-    [allowSettingsMode, chatOnly],
+    [chatOnly],
   );
   useEffect(() => {
-    const nextMode = normalizeAgentPanelModeForSurface(
-      mode,
-      allowSettingsMode,
-      chatOnly,
-    );
+    const nextMode = normalizeAgentPanelModeForSurface(mode, chatOnly);
     if (nextMode !== mode) switchMode(nextMode);
-  }, [mode, allowSettingsMode, chatOnly, switchMode]);
+  }, [mode, chatOnly, switchMode]);
   const openRunThread = useCallback(
     (threadId: string, run?: AgentRun) => {
       switchMode("chat");
@@ -1105,32 +1066,29 @@ function AgentPanelInner({
   // Listen for mode changes from the frame parent (via AgentSidebar)
   useEffect(() => {
     function handler(e: Event) {
-      const detail = (e as CustomEvent).detail;
-      if (detail?.mode) switchMode(detail.mode);
+      const requestedMode = (e as CustomEvent<{ mode?: unknown }>).detail?.mode;
+      if (
+        requestedMode === "chat" ||
+        requestedMode === "cli" ||
+        requestedMode === "resources"
+      ) {
+        switchMode(requestedMode);
+      }
     }
     window.addEventListener(AGENT_PANEL_SET_MODE_EVENT, handler);
     return () =>
       window.removeEventListener(AGENT_PANEL_SET_MODE_EVENT, handler);
   }, [switchMode]);
 
-  // Open settings tab when requested (replaces the old popover open event)
+  // Open the canonical settings page when requested.
   useEffect(() => {
     function handleOpenSettings(event: Event) {
       const section = (event as CustomEvent<{ section?: string }>).detail
         ?.section;
-      setSettingsSection((prev) => ({
-        section: section ?? null,
-        requestKey: prev.requestKey + 1,
-      }));
-      if (!allowSettingsMode) {
-        void navigate({
-          pathname: "/settings",
-          hash: settingsRouteHashForSection(section),
-        });
-        switchMode("chat");
-        return;
-      }
-      switchMode("settings");
+      void navigate({
+        pathname: "/settings",
+        hash: settingsRouteHashForSection(section),
+      });
     }
     window.addEventListener(
       AGENT_PANEL_OPEN_SETTINGS_EVENT,
@@ -1141,7 +1099,7 @@ function AgentPanelInner({
         AGENT_PANEL_OPEN_SETTINGS_EVENT,
         handleOpenSettings,
       );
-  }, [allowSettingsMode, navigate, switchMode]);
+  }, [navigate]);
 
   // CLI terminal tabs (ephemeral — not persisted to SQL)
   const [cliTabs, setCliTabs] = useState<string[]>(["cli-1"]);
@@ -1217,7 +1175,7 @@ function AgentPanelInner({
 
   const availableClis = useAvailableClis();
   const [selectedCli, selectCli] = useCliSelection(keyPrefix);
-  const { isDevMode, canToggle, setDevMode } = useDevMode(apiUrl);
+  const { isDevMode } = useDevMode(apiUrl);
   const effectiveAgentChatSurface = resolveAgentPanelChatSurface(
     assistantChatProps.agentChatSurface,
     isDesktopCodeSurfaceRequested(),
@@ -1272,14 +1230,6 @@ function AgentPanelInner({
       }
     }
   }, [isDevMode]);
-
-  const isLocalhost =
-    mounted &&
-    typeof window !== "undefined" &&
-    (window.location.hostname === "localhost" ||
-      window.location.hostname === "127.0.0.1" ||
-      window.location.hostname === "::1");
-  const showDevToggle = canToggle && isLocalhost && isCodeEditingChatSurface;
 
   const renderModeButtons = useCallback(
     (activeMode: PanelMode) => (
@@ -1525,8 +1475,7 @@ function AgentPanelInner({
             <button
               className={cn(
                 "flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50",
-                (headerMenuOpen || mode === "settings") &&
-                  "bg-accent text-foreground",
+                headerMenuOpen && "bg-accent text-foreground",
               )}
               aria-label={t("agentPanel.panelOptions")}
             >
@@ -1675,17 +1624,6 @@ function AgentPanelInner({
               </>
             )}
             {mode === "chat" && <ThinkingDisplayMenuItem />}
-            {allowSettingsMode && (
-              <DropdownMenuItem
-                onSelect={() => switchMode("settings")}
-                className={cn(
-                  mode === "settings" ? "font-medium" : "text-muted-foreground",
-                )}
-              >
-                <IconSettings size={14} className="shrink-0" />
-                {t("agentPanel.settings")}
-              </DropdownMenuItem>
-            )}
             {feedbackEnabled ? (
               <DropdownMenuItem
                 onSelect={(event) =>
@@ -1777,7 +1715,6 @@ function AgentPanelInner({
     [
       activeCliTab,
       addCliTab,
-      allowSettingsMode,
       availableClis,
       canUseCodeTools,
       closeHeaderMenuForOverlay,
@@ -2297,7 +2234,7 @@ function AgentPanelInner({
               `margin-left:auto;margin-right:auto;width:100%;}`,
           }}
         />
-        {/* Framework onboarding — appears above the chat/cli/settings tabs
+        {/* Framework onboarding — appears above the chat, CLI, and resources tabs
           so it's visible regardless of which tab the user is on. The panel
           hides itself once all required steps are done or the user dismisses
           it. */}
@@ -2442,30 +2379,6 @@ function AgentPanelInner({
               }
             >
               <ResourcesPanel />
-            </Suspense>
-          </div>
-        )}
-
-        {/* Settings / Setup view */}
-        {mode === "settings" && (
-          <div className="flex flex-col flex-1 min-h-0">
-            <Suspense
-              fallback={
-                <div className="p-3 space-y-2">
-                  <div className="h-10 w-full rounded-lg bg-muted animate-pulse" />
-                  <div className="h-10 w-full rounded-lg bg-muted animate-pulse" />
-                  <div className="h-10 w-full rounded-lg bg-muted animate-pulse" />
-                </div>
-              }
-            >
-              <SettingsPanel
-                isDevMode={isDevMode}
-                onToggleDevMode={() => setDevMode(!isDevMode)}
-                showDevToggle={showDevToggle}
-                devAppUrl={devAppUrl}
-                initialSection={settingsSection.section}
-                sectionRequestKey={settingsSection.requestKey}
-              />
             </Suspense>
           </div>
         )}
@@ -3032,13 +2945,6 @@ export function shouldDefaultAgentChatSurfacePageNewChatButton(
   return mode === "page";
 }
 
-export function shouldAllowAgentChatSurfaceSettingsMode(
-  mode: AgentChatSurfaceMode | undefined,
-  allowSettingsMode: boolean | undefined,
-): boolean {
-  return allowSettingsMode ?? mode !== "page";
-}
-
 /**
  * Reusable chat surface backed by AgentPanel internals.
  *
@@ -3069,10 +2975,6 @@ export function AgentChatSurface({
       showHeader={showHeader}
       showTabBar={showTabBar}
       isFullscreen={isFullscreen ?? pageMode}
-      allowSettingsMode={shouldAllowAgentChatSurfaceSettingsMode(
-        mode,
-        props.allowSettingsMode,
-      )}
       showPageNewChatButton={
         showPageNewChatButton ?? defaultShowPageNewChatButton
       }
@@ -3196,7 +3098,7 @@ export interface AgentSidebarProps {
   browserTabId?: string;
   /** Keep chat thread selection in URL state. */
   threadUrlSync?: MultiTabAssistantChatProps["threadUrlSync"];
-  /** Optional link shown in Resources and Settings modes for the full Agent page. */
+  /** Optional link shown in Resources mode for the full Agent page. */
   agentPageHref?: string;
   /** Suppress first-run onboarding while a deep-linked resource is open. */
   suppressFirstRunOnboarding?: boolean;
@@ -4084,7 +3986,6 @@ export function AgentSidebar({
             threadUrlSync={threadUrlSync}
             agentPageHref={agentPageHref}
             thinkingDisplay={thinkingDisplay}
-            allowSettingsMode={false}
             chatOnly
           />
         </div>

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -231,7 +231,7 @@ export function AgentPanelSettingsNavigation() {
       const section = (event as CustomEvent<{ section?: string }>).detail
         ?.section;
       void navigate({
-        pathname: "/settings",
+        pathname: appPath("/settings"),
         hash: settingsRouteHashForSection(section, window.location.hash),
       });
     }

--- a/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
@@ -496,6 +496,8 @@ describe("SettingsTabsPage", () => {
       );
     });
 
+    expect(window.location.pathname).toBe("/settings/agent");
+    expect(window.location.hash).toBe("");
     expect(container.textContent).toContain("Agent content");
     const navigateButton = container.querySelector("button");
     expect(navigateButton).not.toBeNull();
@@ -507,7 +509,7 @@ describe("SettingsTabsPage", () => {
   });
 
   it("keeps BrowserRouter in sync when a tab updates native history", () => {
-    window.history.replaceState(null, "", "/settings/agent");
+    window.history.replaceState(null, "", "/settings#agent");
 
     act(() => {
       root.render(

--- a/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, MemoryRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsTabsPage } from "./SettingsTabsPage.js";
+import { useSettingsPanelController } from "./useSettingsPanelController.js";
 
 function stubMobileViewport(isMobile: boolean) {
   vi.stubGlobal(
@@ -660,6 +661,56 @@ describe("SettingsTabsPage", () => {
 
     expect(container.textContent).toContain("Agent voice settings");
     expect(container.textContent).not.toContain("General content");
+  });
+
+  it("opens the inner section after BrowserRouter canonicalizes a hash", async () => {
+    window.history.replaceState(null, "", "/settings#uploads");
+
+    function SectionProbe() {
+      const { openSection } = useSettingsPanelController({
+        sections: ["voice", "uploads"],
+      });
+      return <span data-testid="open-section">{openSection}</span>;
+    }
+
+    await act(async () => {
+      root.render(
+        <BrowserRouter>
+          <SettingsTabsPage
+            general={<div>General content</div>}
+            extraTabs={[
+              {
+                id: "agent",
+                label: "Agent",
+                content: <SectionProbe />,
+                searchEntries: [
+                  { id: "section:voice", label: "Voice", hash: "voice" },
+                  {
+                    id: "section:uploads",
+                    label: "Uploads",
+                    hash: "uploads",
+                  },
+                ],
+              },
+            ]}
+          />
+        </BrowserRouter>,
+      );
+    });
+
+    expect(
+      container.querySelector("[data-testid=open-section]")?.textContent,
+    ).toBe("uploads");
+
+    await act(async () => {
+      window.history.pushState(null, "", "/settings#voice");
+      window.dispatchEvent(new Event("popstate"));
+    });
+
+    expect(window.location.pathname).toBe("/settings/agent/voice");
+    expect(
+      container.querySelector("[data-testid=open-section]")?.textContent,
+    ).toBe("voice");
   });
 
   it("selects the deepest matching tab for nested agent deep links", () => {

--- a/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
@@ -2,7 +2,7 @@
 
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, useNavigate } from "react-router";
+import { BrowserRouter, MemoryRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsTabsPage } from "./SettingsTabsPage.js";
@@ -64,6 +64,7 @@ describe("SettingsTabsPage", () => {
     container.remove();
     document.body.innerHTML = "";
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("focuses the settings search on desktop entry", () => {
@@ -501,6 +502,44 @@ describe("SettingsTabsPage", () => {
 
     act(() => navigateButton!.click());
 
+    expect(container.textContent).toContain("Workspace content");
+    expect(container.textContent).not.toContain("Agent content");
+  });
+
+  it("keeps BrowserRouter in sync when a tab updates native history", () => {
+    window.history.replaceState(null, "", "/settings/agent");
+
+    act(() => {
+      root.render(
+        <BrowserRouter>
+          <SettingsTabsPage
+            general={<div>General content</div>}
+            extraTabs={[
+              {
+                id: "agent",
+                label: "Agent",
+                content: <div>Agent content</div>,
+              },
+              {
+                id: "workspace",
+                label: "Workspace",
+                content: <div>Workspace content</div>,
+              },
+            ]}
+          />
+        </BrowserRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Agent content");
+    const workspaceTab = container.querySelector<HTMLButtonElement>(
+      "#settings-tab-workspace",
+    );
+    expect(workspaceTab).not.toBeNull();
+
+    act(() => workspaceTab!.click());
+
+    expect(window.location.pathname).toBe("/settings/workspace");
     expect(container.textContent).toContain("Workspace content");
     expect(container.textContent).not.toContain("Agent content");
   });

--- a/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.spec.tsx
@@ -2,7 +2,7 @@
 
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsTabsPage } from "./SettingsTabsPage.js";
@@ -457,6 +457,52 @@ describe("SettingsTabsPage", () => {
     expect(
       workspaceLink?.closest('[data-settings-tab-group="workspace"]'),
     ).not.toBeNull();
+  });
+
+  it("syncs the active tab after router-only settings navigation", () => {
+    function NavigationProbe() {
+      const navigate = useNavigate();
+      return (
+        <button
+          type="button"
+          onClick={() => void navigate("/settings#workspace")}
+        >
+          Navigate
+        </button>
+      );
+    }
+
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/settings#agent"]}>
+          <NavigationProbe />
+          <SettingsTabsPage
+            general={<div>General content</div>}
+            extraTabs={[
+              {
+                id: "agent",
+                label: "Agent",
+                content: <div>Agent content</div>,
+              },
+              {
+                id: "workspace",
+                label: "Workspace",
+                content: <div>Workspace content</div>,
+              },
+            ]}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(container.textContent).toContain("Agent content");
+    const navigateButton = container.querySelector("button");
+    expect(navigateButton).not.toBeNull();
+
+    act(() => navigateButton!.click());
+
+    expect(container.textContent).toContain("Workspace content");
+    expect(container.textContent).not.toContain("Agent content");
   });
 
   it("honors the controlled value and reports changes without touching the hash", () => {

--- a/packages/core/src/client/settings/SettingsTabsPage.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.tsx
@@ -417,10 +417,14 @@ function SettingsTabsPageContent({
 
   useEffect(() => {
     if (isControlled) return;
-    const syncLocation = () => {
-      const pathname = routerLocation?.pathname ?? window.location.pathname;
-      const hash = routerLocation?.hash ?? window.location.hash;
-      const fromPath = activeTabFromLocation(tabs, fallbackTab, routerLocation);
+    const syncLocation = (event?: Event) => {
+      // Native history events carry the live browser URL. Reading the
+      // render-captured router location here would re-canonicalize the same
+      // legacy hash before BrowserRouter has rerendered.
+      const location = event ? undefined : routerLocation;
+      const pathname = location?.pathname ?? window.location.pathname;
+      const hash = location?.hash ?? window.location.hash;
+      const fromPath = activeTabFromLocation(tabs, fallbackTab, location);
       if (fromPath) setInternalTab(fromPath);
       if (appLocalPathname(pathname).startsWith("/settings/")) return;
       const hashValue = hash.replace(/^#/, "");

--- a/packages/core/src/client/settings/SettingsTabsPage.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.tsx
@@ -260,6 +260,7 @@ function updateRouteForTab(tabId: string, section?: string) {
     "",
     `${appPath(route)}${window.location.search}`,
   );
+  window.dispatchEvent(new Event("popstate"));
 }
 
 function isEditableElement(element: Element | null): boolean {
@@ -564,7 +565,6 @@ function SettingsTabsPageContent({
     if (section) {
       updateRouteForTab(entry.tabId, section);
       // Let the inner panels open + scroll to their section.
-      window.dispatchEvent(new Event("popstate"));
       window.dispatchEvent(new Event("hashchange"));
       window.requestAnimationFrame(() => {
         document

--- a/packages/core/src/client/settings/SettingsTabsPage.tsx
+++ b/packages/core/src/client/settings/SettingsTabsPage.tsx
@@ -17,7 +17,7 @@ import {
   type ComponentType,
   type ReactNode,
 } from "react";
-import { Link } from "react-router";
+import { Link, useInRouterContext, useLocation } from "react-router";
 
 import { appBasePath, appPath } from "../../client/api-path.js";
 import { buildSettingsRoute } from "../../navigation/index.js";
@@ -118,6 +118,11 @@ interface ResolvedSearchEntry extends SettingsSearchEntry {
   haystack: string;
 }
 
+interface SettingsRouterLocation {
+  pathname: string;
+  hash: string;
+}
+
 function normalizeTabId(value?: string | null): string | null {
   let decoded = value?.replace(/^#/, "").trim() ?? "";
   try {
@@ -191,12 +196,14 @@ function resolveTabId(
 function activeTabFromLocation(
   tabs: SettingsTabItem[],
   defaultTab: string,
+  location?: SettingsRouterLocation,
 ): string {
-  if (typeof window === "undefined") return defaultTab;
-  const pathname = appLocalPathname();
+  if (typeof window === "undefined" && !location) return defaultTab;
+  const pathname = appLocalPathname(location?.pathname);
+  const hash = location?.hash ?? window.location.hash;
   const settingsPrefix = "/settings";
   if (pathname === settingsPrefix) {
-    return resolveTabId(tabs, window.location.hash) ?? defaultTab;
+    return resolveTabId(tabs, hash) ?? defaultTab;
   }
   if (pathname.startsWith(`${settingsPrefix}/`)) {
     const segments = pathname
@@ -215,20 +222,20 @@ function activeTabFromLocation(
       if (tabId) return tabId;
     }
   }
-  return resolveTabId(tabs, window.location.hash) ?? defaultTab;
+  return resolveTabId(tabs, hash) ?? defaultTab;
 }
 
-function appLocalPathname(): string {
-  if (typeof window === "undefined") return "/";
-  const pathname = window.location.pathname;
+function appLocalPathname(pathname?: string): string {
+  if (typeof window === "undefined" && !pathname) return "/";
+  const currentPathname = pathname ?? window.location.pathname;
   const basePath = appBasePath();
   if (
     basePath &&
-    (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    (currentPathname === basePath || currentPathname.startsWith(`${basePath}/`))
   ) {
-    return pathname.slice(basePath.length) || "/";
+    return currentPathname.slice(basePath.length) || "/";
   }
-  return pathname;
+  return currentPathname;
 }
 
 function buildSettingsEntryRoute(tabId: string, section?: string): string {
@@ -266,7 +273,7 @@ function isEditableElement(element: Element | null): boolean {
   );
 }
 
-export function SettingsTabsPage({
+function SettingsTabsPageContent({
   general,
   account,
   team,
@@ -288,7 +295,8 @@ export function SettingsTabsPage({
   generalSearchEntries,
   value,
   onValueChange,
-}: SettingsTabsPageProps) {
+  routerLocation,
+}: SettingsTabsPageProps & { routerLocation?: SettingsRouterLocation }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const autoFocusedSearchRef = useRef(false);
@@ -382,7 +390,7 @@ export function SettingsTabsPage({
   };
   const isControlled = value !== undefined;
   const [internalTab, setInternalTab] = useState(() =>
-    activeTabFromLocation(tabs, fallbackTab),
+    activeTabFromLocation(tabs, fallbackTab, routerLocation),
   );
   const activeTab = isControlled ? value : internalTab;
   const [query, setQuery] = useState("");
@@ -409,10 +417,12 @@ export function SettingsTabsPage({
   useEffect(() => {
     if (isControlled) return;
     const syncLocation = () => {
-      const fromPath = activeTabFromLocation(tabs, fallbackTab);
+      const pathname = routerLocation?.pathname ?? window.location.pathname;
+      const hash = routerLocation?.hash ?? window.location.hash;
+      const fromPath = activeTabFromLocation(tabs, fallbackTab, routerLocation);
       if (fromPath) setInternalTab(fromPath);
-      if (appLocalPathname().startsWith("/settings/")) return;
-      const hashValue = window.location.hash.replace(/^#/, "");
+      if (appLocalPathname(pathname).startsWith("/settings/")) return;
+      const hashValue = hash.replace(/^#/, "");
       const fromHash = resolveTabId(tabs, hashValue);
       if (!fromHash || !hashValue) return;
       const isTabHash = fromHash === hashValue;
@@ -425,18 +435,20 @@ export function SettingsTabsPage({
       window.removeEventListener("hashchange", syncLocation);
       window.removeEventListener("popstate", syncLocation);
     };
-  }, [fallbackTab, isControlled, tabs]);
+  }, [fallbackTab, isControlled, routerLocation, tabs]);
 
   useEffect(() => {
     if (!isControlled) return;
     const syncControlledLocation = () => {
-      const fromPath = appLocalPathname().startsWith("/settings/")
-        ? activeTabFromLocation(tabs, defaultTab)
+      const pathname = routerLocation?.pathname ?? window.location.pathname;
+      const hash = routerLocation?.hash ?? window.location.hash;
+      const fromPath = appLocalPathname(pathname).startsWith("/settings/")
+        ? activeTabFromLocation(tabs, defaultTab, routerLocation)
         : null;
-      const hashValue = window.location.hash.replace(/^#/, "");
+      const hashValue = hash.replace(/^#/, "");
       const fromHash = hashValue ? resolveTabId(tabs, hashValue) : null;
       const next = fromPath ?? fromHash;
-      const key = `${window.location.pathname}${window.location.hash}`;
+      const key = `${pathname}${hash}`;
       if (!next || next === value || controlledHashRef.current === key) {
         controlledHashRef.current = key;
         return;
@@ -451,7 +463,7 @@ export function SettingsTabsPage({
       window.removeEventListener("hashchange", syncControlledLocation);
       window.removeEventListener("popstate", syncControlledLocation);
     };
-  }, [defaultTab, isControlled, onValueChange, tabs, value]);
+  }, [defaultTab, isControlled, onValueChange, routerLocation, tabs, value]);
 
   useEffect(() => {
     if (!enableSearch || autoFocusedSearchRef.current) return;
@@ -799,5 +811,19 @@ export function SettingsTabsPage({
         </div>
       </div>
     </div>
+  );
+}
+
+function SettingsTabsPageWithRouter(props: SettingsTabsPageProps) {
+  const location = useLocation();
+  return <SettingsTabsPageContent {...props} routerLocation={location} />;
+}
+
+export function SettingsTabsPage(props: SettingsTabsPageProps) {
+  const inRouterContext = useInRouterContext();
+  return inRouterContext ? (
+    <SettingsTabsPageWithRouter {...props} />
+  ) : (
+    <SettingsTabsPageContent {...props} />
   );
 }

--- a/packages/desktop-app/src/renderer/App.spec.ts
+++ b/packages/desktop-app/src/renderer/App.spec.ts
@@ -11,6 +11,8 @@ describe("desktop chat-first shell", () => {
 
     expect(appSource).toContain("content-area content-area--chat-first");
     expect(appSource).toContain("<CodeAgentsHub");
+    expect(appSource).toContain("key={settingsTab}");
+    expect(appSource).toContain("initialTab={settingsTab}");
     expect(appSource).not.toContain("chatFirstMode");
     expect(appSource).not.toContain("Sidebar");
     expect(appSource).not.toContain("TabBar");

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -474,6 +474,7 @@ export default function App() {
 
       {showSettings ? (
         <AppSettings
+          key={settingsTab}
           apps={apps}
           initialTab={settingsTab}
           onClose={() => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2699,6 +2699,7 @@ export default function CodeAgentsHub({
               <DesktopAppChatShell
                 appId={surfaceApp.id}
                 appName={surfaceApp.name}
+                onOpenSettings={onOpenSettings}
                 desktopIdentityUnauthenticated={isDesktopIdentityGateUnauthenticated(
                   desktopIdentityStatus,
                 )}
@@ -2818,6 +2819,7 @@ export default function CodeAgentsHub({
       host,
       isActive,
       onLocalCodeChangeStarted,
+      onOpenSettings,
       refreshKey,
       surfaceApps,
       terminalPreferences.agent,

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -3,11 +3,22 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  desktopSettingsTabForSection,
   shouldAnimateDesktopAppChatSidebar,
   shouldShowDesktopAppChatSidebar,
 } from "./DesktopAppChatShell.js";
 
 describe("desktop app chat shell", () => {
+  it("routes chat settings requests to the native settings surface", () => {
+    expect(desktopSettingsTabForSection("llm")).toBe("providers");
+    expect(desktopSettingsTabForSection("secrets:OPENAI_API_KEY")).toBe(
+      "connections",
+    );
+    expect(desktopSettingsTabForSection("uploads")).toBe("workspace");
+    expect(desktopSettingsTabForSection("terminal")).toBe("terminal");
+    expect(desktopSettingsTabForSection("voice")).toBe("general");
+  });
+
   it("animates only the first active presentation of a cached app tab", () => {
     expect(
       shouldAnimateDesktopAppChatSidebar({

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -76,6 +76,7 @@ export interface DesktopAppChatShellProps {
   appId: string;
   appName: string;
   children: ReactNode;
+  onOpenSettings?: (section?: string) => void;
   desktopIdentityUnauthenticated?: boolean;
   desktopIdentityAuthenticated?: boolean;
   desktopIdentityStatus?: DesktopIdentityStatus | "checking";
@@ -90,6 +91,34 @@ export interface DesktopAppChatShellProps {
 
 const DESKTOP_APP_CHAT_OPEN_STORAGE_KEY =
   "agent-native.desktop-app-chat.sidebar-open";
+
+export function desktopSettingsTabForSection(section?: string | null): string {
+  const normalized = section?.replace(/^#/, "").trim().toLowerCase() ?? "";
+  if (normalized === "terminal") return "terminal";
+  if (normalized === "llm" || normalized === "app-models") return "providers";
+  if (
+    normalized === "integrations" ||
+    normalized === "connections" ||
+    normalized.startsWith("secrets:") ||
+    normalized === "secrets" ||
+    normalized === "email" ||
+    normalized === "browser"
+  ) {
+    return "connections";
+  }
+  if (
+    normalized === "hosting" ||
+    normalized === "database" ||
+    normalized === "uploads" ||
+    normalized === "auth" ||
+    normalized === "demo-mode" ||
+    normalized === "workspace" ||
+    normalized === "workspace-settings"
+  ) {
+    return "workspace";
+  }
+  return "general";
+}
 
 function wasDesktopAppChatSidebarOpenBeforeMount(): boolean {
   if (typeof window === "undefined") return false;
@@ -145,6 +174,7 @@ export default function DesktopAppChatShell({
   appId,
   appName,
   children,
+  onOpenSettings,
   desktopIdentityUnauthenticated = false,
   desktopIdentityAuthenticated = false,
   desktopIdentityStatus,
@@ -297,6 +327,11 @@ export default function DesktopAppChatShell({
     () =>
       localAgentId ? createDesktopLocalAgentRuntime(localAgentId) : undefined,
     [localAgentId],
+  );
+  const openDesktopSettings = useCallback(
+    (section?: string) =>
+      onOpenSettings?.(desktopSettingsTabForSection(section)),
+    [onOpenSettings],
   );
 
   installDesktopChatFetchRelay();
@@ -552,6 +587,9 @@ export default function DesktopAppChatShell({
                 contextKey: `desktop-app:${appId}`,
               }}
               toggleScopeId={toggleScopeId}
+              onOpenSettings={
+                onOpenSettings && isActive ? openDesktopSettings : undefined
+              }
               apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
               isolateHistoryByScope
               agentChatSurface="desktop"

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -333,6 +333,7 @@ export default function DesktopAppChatShell({
       onOpenSettings?.(desktopSettingsTabForSection(section)),
     [onOpenSettings],
   );
+  const ignoreOpenSettings = useCallback(() => undefined, []);
 
   installDesktopChatFetchRelay();
 
@@ -588,7 +589,11 @@ export default function DesktopAppChatShell({
               }}
               toggleScopeId={toggleScopeId}
               onOpenSettings={
-                onOpenSettings && isActive ? openDesktopSettings : undefined
+                isActive
+                  ? onOpenSettings
+                    ? openDesktopSettings
+                    : undefined
+                  : ignoreOpenSettings
               }
               apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
               isolateHistoryByScope

--- a/packages/dispatch/src/routes/pages/browser-chat.spec.tsx
+++ b/packages/dispatch/src/routes/pages/browser-chat.spec.tsx
@@ -81,7 +81,6 @@ describe("BrowserChatRoute", () => {
       storageKey: "dispatch",
       showHeader: false,
       showTabBar: false,
-      allowSettingsMode: false,
       composerPlaceholder: "Ask about this page…",
     });
   });

--- a/packages/dispatch/src/routes/pages/browser-chat.tsx
+++ b/packages/dispatch/src/routes/pages/browser-chat.tsx
@@ -70,7 +70,6 @@ export default function BrowserChatRoute() {
           storageKey="dispatch"
           showHeader={false}
           showTabBar={false}
-          allowSettingsMode={false}
           dynamicSuggestions={false}
           suggestions={[]}
           emptyStateDisplay="hidden"

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -672,7 +672,6 @@ export function App() {
                   onSnapTo75Percent={snapSidebarTo75Percent}
                   isWideDrawer={sidebarWideDrawer}
                   onExitWideDrawer={exitSidebarDrawer}
-                  devAppUrl={appUrl}
                   storageKey={appId}
                   scope={
                     appId


### PR DESCRIPTION
## Summary
- remove the embedded settings mode and SettingsPanel path from AgentPanel
- normalize legacy persisted settings values to chat and route settings events to canonical /settings pages
- update dispatch/frame consumers and localized documentation

## Validation
- focused AgentPanel and browser-chat Vitest suites
- core, dispatch, and frame TypeScript checks
- i18n catalog and changed-copy guards
- pnpm guards: all 65 checks passed
- live Design browser verification was unavailable because the local Nitro dev environment failed with Vite environment "nitro" is unavailable