### PR TITLE
fix(calendar): keep all-day events compact and expose availability

### DIFF
--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -1150,6 +1150,37 @@ export function CreateEventPopover({
                     </SelectContent>
                   </Select>
                 </div>
+                {eventType === "default" && (
+                  <div className="flex items-center justify-between gap-3 py-1">
+                    <Label
+                      htmlFor="event-availability"
+                      className="text-sm text-muted-foreground"
+                    >
+                      {t("eventForm.showAs")}
+                    </Label>
+                    <Select
+                      value={availability}
+                      onValueChange={(value) =>
+                        setAvailability(value as Availability)
+                      }
+                    >
+                      <SelectTrigger
+                        id="event-availability"
+                        className="h-8 w-28 text-sm"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="opaque">
+                          {t("eventForm.busy")}
+                        </SelectItem>
+                        <SelectItem value="transparent">
+                          {t("eventForm.free")}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
                 {videoProvider === "zoom" && !zoomStatus.data?.connected && (
                   <div className="ml-7 rounded-md border border-border/60 bg-muted/20 p-2">
                     <div className="flex items-center justify-between gap-2">
@@ -1483,75 +1514,37 @@ export function CreateEventPopover({
                     </div>
                   )}
 
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="event-availability" className="text-xs">
-                        {t("eventForm.showAs")}
-                      </Label>
-                      <Select
-                        value={
-                          eventType === "workingLocation"
-                            ? "transparent"
-                            : eventType === "default"
-                              ? availability
-                              : "opaque"
-                        }
-                        onValueChange={(value) =>
-                          setAvailability(value as Availability)
-                        }
-                        disabled={eventType !== "default"}
+                  <div className="space-y-1.5">
+                    <Label htmlFor="event-visibility" className="text-xs">
+                      {t("eventForm.visibility")}
+                    </Label>
+                    <Select
+                      value={
+                        eventType === "workingLocation" ? "public" : visibility
+                      }
+                      onValueChange={(value) =>
+                        setVisibility(value as Visibility)
+                      }
+                      disabled={eventType === "workingLocation"}
+                    >
+                      <SelectTrigger
+                        id="event-visibility"
+                        className="h-8 text-sm"
                       >
-                        <SelectTrigger
-                          id="event-availability"
-                          className="h-8 text-sm"
-                        >
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="opaque">
-                            {t("eventForm.busy")}
-                          </SelectItem>
-                          <SelectItem value="transparent">
-                            {t("eventForm.free")}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-1.5">
-                      <Label htmlFor="event-visibility" className="text-xs">
-                        {t("eventForm.visibility")}
-                      </Label>
-                      <Select
-                        value={
-                          eventType === "workingLocation"
-                            ? "public"
-                            : visibility
-                        }
-                        onValueChange={(value) =>
-                          setVisibility(value as Visibility)
-                        }
-                        disabled={eventType === "workingLocation"}
-                      >
-                        <SelectTrigger
-                          id="event-visibility"
-                          className="h-8 text-sm"
-                        >
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="default">
-                            {t("eventForm.default")}
-                          </SelectItem>
-                          <SelectItem value="public">
-                            {t("eventForm.public")}
-                          </SelectItem>
-                          <SelectItem value="private">
-                            {t("eventForm.private")}
-                          </SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="default">
+                          {t("eventForm.default")}
+                        </SelectItem>
+                        <SelectItem value="public">
+                          {t("eventForm.public")}
+                        </SelectItem>
+                        <SelectItem value="private">
+                          {t("eventForm.private")}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div className="space-y-1.5">

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -27,6 +27,7 @@ import {
   getDateKeyInTimezone,
   getEventDateKey,
   getEventSegmentForCalendarDay,
+  isAllDayCalendarEvent,
 } from "@/lib/calendar-timezone";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import {
@@ -556,7 +557,9 @@ export const DayView = memo(function DayView({
   const allDayEvents = useMemo(
     () =>
       events.filter(
-        (event) => event.allDay || fullDayOutOfOfficeCoversDate(event, date),
+        (event) =>
+          isAllDayCalendarEvent(event) ||
+          fullDayOutOfOfficeCoversDate(event, date),
       ),
     [date, events],
   );
@@ -568,14 +571,17 @@ export const DayView = memo(function DayView({
     () =>
       events.filter(
         (event) =>
-          !event.allDay &&
+          !isAllDayCalendarEvent(event) &&
           isOutOfOfficeEvent(event) &&
           !isFullDayOutOfOfficeEvent(event),
       ),
     [events],
   );
   const timedEvents = useMemo(
-    () => events.filter((event) => !event.allDay && !isOutOfOfficeEvent(event)),
+    () =>
+      events.filter(
+        (event) => !isAllDayCalendarEvent(event) && !isOutOfOfficeEvent(event),
+      ),
     [events],
   );
   const layout = useMemo(

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -42,6 +42,7 @@ import {
   getDateKeyInTimezone,
   getEventDateKey,
   getEventSegmentForCalendarDay,
+  isAllDayCalendarEvent,
 } from "@/lib/calendar-timezone";
 import { getEventDisplayColor, allOtherDeclined } from "@/lib/event-colors";
 import {
@@ -633,7 +634,8 @@ export const WeekView = memo(function WeekView({
   const allDayEvents = useMemo(
     () =>
       events.filter(
-        (event) => event.allDay || isFullDayOutOfOfficeEvent(event),
+        (event) =>
+          isAllDayCalendarEvent(event) || isFullDayOutOfOfficeEvent(event),
       ),
     [events],
   );
@@ -642,7 +644,7 @@ export const WeekView = memo(function WeekView({
     () =>
       events.filter(
         (event) =>
-          !event.allDay &&
+          !isAllDayCalendarEvent(event) &&
           isOutOfOfficeEvent(event) &&
           !isFullDayOutOfOfficeEvent(event),
       ),
@@ -650,7 +652,10 @@ export const WeekView = memo(function WeekView({
   );
 
   const timedEvents = useMemo(
-    () => events.filter((event) => !event.allDay && !isOutOfOfficeEvent(event)),
+    () =>
+      events.filter(
+        (event) => !isAllDayCalendarEvent(event) && !isOutOfOfficeEvent(event),
+      ),
     [events],
   );
 

--- a/templates/calendar/app/lib/calendar-timezone.test.ts
+++ b/templates/calendar/app/lib/calendar-timezone.test.ts
@@ -9,6 +9,7 @@ import {
   getDateKeyInTimezone,
   getEventSegmentForCalendarDay,
   getViewDateRange,
+  isAllDayCalendarEvent,
   moveEventToCalendarDate,
   normalizeTimezone,
 } from "./calendar-timezone";
@@ -71,6 +72,22 @@ describe("calendar timezone helpers", () => {
       startsOnDay: true,
       endsOnDay: true,
     });
+  });
+
+  it("recognizes date-only bounds as all-day even when the flag is false", () => {
+    const event = {
+      start: "2026-08-13",
+      end: "2026-08-14",
+      allDay: false as const,
+    };
+
+    expect(isAllDayCalendarEvent(event)).toBe(true);
+    expect(
+      eventOverlapsCalendarDay(event, dateKeyToDate("2026-08-13"), "UTC"),
+    ).toBe(true);
+    expect(
+      getEventSegmentForCalendarDay(event, dateKeyToDate("2026-08-13"), "UTC"),
+    ).toMatchObject({ topMinutes: 0, durationMinutes: 24 * 60 });
   });
 
   it("formats event wall-clock fields in the event timezone", () => {

--- a/templates/calendar/app/lib/calendar-timezone.ts
+++ b/templates/calendar/app/lib/calendar-timezone.ts
@@ -47,6 +47,15 @@ export function normalizeTimezone(timezone?: string): string {
   return isCalendarTimezone(timezone) ? timezone : getBrowserTimezone();
 }
 
+export function isAllDayCalendarEvent(
+  event: Pick<CalendarEvent, "allDay" | "start" | "end">,
+): boolean {
+  return (
+    event.allDay ||
+    (DATE_ONLY_PATTERN.test(event.start) && DATE_ONLY_PATTERN.test(event.end))
+  );
+}
+
 /** Date carriers are kept at local noon so browser DST never changes their date. */
 export function dateKeyToDate(date: string): Date {
   const [year, month, day] = date.split("-").map(Number);
@@ -205,7 +214,7 @@ function eventDateRange(
   event: Pick<CalendarEvent, "start" | "end" | "allDay">,
   timezone: string,
 ) {
-  if (event.allDay) {
+  if (isAllDayCalendarEvent(event)) {
     const startDate = dateOnlyPart(event.start);
     const endDate =
       dateOnlyPart(event.end) ??
@@ -234,7 +243,7 @@ export function moveEventToCalendarDate(
   const sourceStartDate = getEventDateKey(event, timezone);
   if (!sourceStartDate) return null;
 
-  if (event.allDay) {
+  if (isAllDayCalendarEvent(event)) {
     const sourceEndDate =
       dateOnlyPart(event.end) ?? addCalendarDays(sourceStartDate, 1);
     const spanDays = Math.max(
@@ -285,7 +294,7 @@ export function eventOverlapsCalendarDay(
 ): boolean {
   const normalizedTimezone = normalizeTimezone(timezone);
   const dayBounds = getCalendarDayBounds(day, normalizedTimezone);
-  if (event.allDay) {
+  if (isAllDayCalendarEvent(event)) {
     const range = eventDateRange(event, normalizedTimezone);
     const dayDate = dayBounds.date;
     return Boolean(

--- a/templates/calendar/changelog/2026-08-28-all-day-events-stay-in-the-compact-top-bar-in-day-and-week-v.md
+++ b/templates/calendar/changelog/2026-08-28-all-day-events-stay-in-the-compact-top-bar-in-day-and-week-v.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-28
+---
+
+All-day events stay in the compact top bar in day and week views.

--- a/templates/calendar/changelog/2026-08-28-event-creators-can-choose-whether-a-meeting-shows-as-free-or.md
+++ b/templates/calendar/changelog/2026-08-28-event-creators-can-choose-whether-a-meeting-shows-as-free-or.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Event creators can choose whether a meeting shows as Free or Busy.


### PR DESCRIPTION
## Summary
- expose the existing Free/Busy control in the primary event creation form
- recognize date-only calendar bounds as all-day in Day and Week views
- add focused regression coverage and Calendar changelog entries

## Verification
- corepack pnpm --dir templates/calendar exec vitest --run app/lib/calendar-timezone.test.ts app/lib/all-day-layout.test.ts server/lib/ical-fetcher.spec.ts
- corepack pnpm --dir templates/calendar exec vitest --run actions/create-event.test.ts actions/update-event.test.ts app/components/calendar/EventDetailPopover.test.tsx
- corepack pnpm --dir templates/calendar typecheck
- corepack pnpm guards
- oxfmt --check
- git diff --check