### PR TITLE
fix(plan): disable first-run onboarding

### DIFF
--- a/templates/plan/agent-native-config.spec.ts
+++ b/templates/plan/agent-native-config.spec.ts
@@ -1,0 +1,23 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgentNativeConfigContext,
+  loadResolvedAgentNativeConfig,
+} from "../../packages/core/src/vite/agent-native-config-loader.js";
+
+const planRoot = path.dirname(fileURLToPath(import.meta.url));
+
+describe("Plan onboarding config", () => {
+  it("keeps first-run onboarding off for production builds", async () => {
+    const config = await loadResolvedAgentNativeConfig(
+      planRoot,
+      createAgentNativeConfigContext("build", "production"),
+      { loadProjectConfig: false },
+    );
+
+    expect(config.onboarding?.firstRun).toBe("off");
+  });
+});

--- a/templates/plan/agent-native.json
+++ b/templates/plan/agent-native.json
@@ -1,10 +1,7 @@
 {
   "version": 1,
   "onboarding": {
-    "firstRun": {
-      "development": "off",
-      "production": "connect-and-integrations"
-    }
+    "firstRun": "off"
   },
   "doctor": {
     "failOnBuild": false

--- a/templates/plan/e2e/guest-mode.guest.spec.ts
+++ b/templates/plan/e2e/guest-mode.guest.spec.ts
@@ -115,6 +115,7 @@ test.describe("guest mode + claim", () => {
     );
 
     await expect(page.getByText("Start with /visual-plan")).toBeVisible();
+    await expect(page.locator("[data-onboarding-screen]")).toHaveCount(0);
     await expect(
       page.getByText(PLAN_SKILL_INSTALL_COMMAND, { exact: true }),
     ).toBeVisible();
@@ -388,6 +389,7 @@ test.describe("guest mode + claim", () => {
     // Reload the app as the now-authenticated user.
     await page.goto("/plans");
     await page.waitForLoadState("domcontentloaded");
+    await expect(page.locator("[data-onboarding-screen]")).toHaveCount(0);
 
     // Banner must be GONE once signed in.
     await expect(


### PR DESCRIPTION
## Summary

- Disable the shared first-run onboarding flow for Plan in every environment.
- Assert anonymous and post-sign-in Plan routes never render the onboarding screen.
- Cover the real Plan manifest with a `build/production` config-resolution test.

## Validation

- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/onboarding/first-run-enabled.spec.ts` (11 passed)
- `corepack pnpm --filter plan exec vitest --run agent-native-config.spec.ts` (1 passed)
- `corepack pnpm --filter plan build` (passed; existing broad doctor findings reported during build)
- `corepack pnpm --filter plan typecheck` (passed)
- `corepack pnpm guards` (65 passed)
- Production-auth guest browser suite: 10 passed, 1 existing local fixture failure because the demo video content is unavailable; onboarding assertions passed.
- Plan app handoff via `open_app` completed successfully.