### PR TITLE
fix(slides): use shape icon for shape picker

### DIFF
--- a/templates/slides/app/components/editor/EditorActionCluster.tsx
+++ b/templates/slides/app/components/editor/EditorActionCluster.tsx
@@ -4,7 +4,7 @@ import {
   IconCircle,
   IconLine,
   IconPlus,
-  IconShape2,
+  IconShape,
   IconSquare,
   IconTextSize,
   IconTriangle,
@@ -158,7 +158,7 @@ export function EditorActionCluster({
                       shapeMenuOpen || shapeType ? ACTIVE_CLASS : IDLE_CLASS,
                     )}
                   >
-                    <IconShape2 className="size-4" />
+                    <IconShape className="size-4" />
                   </button>
                 </PopoverTrigger>
               </TooltipTrigger>


### PR DESCRIPTION
## Summary\n\nUse the Tabler IconShape glyph for the Slides shape-picker toolbar button.\n\n## Validation\n\n- Slides EditorToolbar tests: 14 passed\n- oxfmt check passed\n- git diff --check passed\n\nThe broader core build remains affected by existing package-export/type errors outside this change.