### PR TITLE
fix: restore Slides actions menu and refine layers panel

### DIFF
--- a/templates/slides/app/components/editor/EditorToolbar.test.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.test.tsx
@@ -126,6 +126,7 @@ describe("<EditorToolbar>", () => {
     const onToggleTextBoxMode = vi.fn();
     const onSelectShape = vi.fn();
     const onToggleAnimations = vi.fn();
+    const onToggleLayers = vi.fn();
     const onChangeSlideTransition = vi.fn();
     const slide = {
       id: "slide-1",
@@ -154,6 +155,7 @@ describe("<EditorToolbar>", () => {
           onToggleTextBoxMode={onToggleTextBoxMode}
           onSelectShape={onSelectShape}
           onToggleAnimations={onToggleAnimations}
+          onToggleLayers={onToggleLayers}
           onChangeSlideTransition={onChangeSlideTransition}
         />
       </TooltipProvider>,
@@ -172,6 +174,7 @@ describe("<EditorToolbar>", () => {
         "shape-rectangle",
         "shape-circle",
         "element-animations",
+        "layers",
         "slide-transition-instant",
         "slide-transition-fade",
         "slide-transition-slide",
@@ -190,12 +193,14 @@ describe("<EditorToolbar>", () => {
     run("add-text-box");
     run("shape-rectangle");
     run("element-animations");
+    run("layers");
     run("slide-transition-fade");
 
     expect(onAddEmptySlide).toHaveBeenCalledOnce();
     expect(onToggleTextBoxMode).toHaveBeenCalledOnce();
     expect(onSelectShape).toHaveBeenCalledWith("rectangle");
     expect(onToggleAnimations).toHaveBeenCalledOnce();
+    expect(onToggleLayers).toHaveBeenCalledOnce();
     expect(onChangeSlideTransition).toHaveBeenCalledWith("fade");
   });
 

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -34,7 +34,7 @@ import {
   IconPlus,
   IconSquare,
   IconTextSize,
-  IconTransitionRight,
+  IconBolt,
   IconLayersSubtract,
 } from "@tabler/icons-react";
 import { useTheme } from "next-themes";
@@ -445,9 +445,9 @@ export default function EditorToolbar({
         commands.push({
           id: "element-animations",
           group: "slideTools",
-          label: t("editorToolbar.elementAnimations"),
+          label: t("animations.title"),
           keywords: ["animation", "motion", "transition"],
-          icon: IconTransitionRight,
+          icon: IconBolt,
           active: animationsOpen,
           run: onToggleAnimations,
         });
@@ -505,7 +505,7 @@ export default function EditorToolbar({
           group: "slideTools" as const,
           label: t(transition.labelKey),
           keywords: ["slide", "transition", transition.value],
-          icon: IconTransitionRight,
+          icon: IconBolt,
           active: activeSlideTransition === transition.value,
           run: () => onChangeSlideTransition(transition.value),
         })),
@@ -803,8 +803,8 @@ export default function EditorToolbar({
                           : undefined
                       }
                     >
-                      <IconTransitionRight className="size-4" />
-                      {t("editorToolbar.elementAnimations")}
+                      <IconBolt className="size-4" />
+                      {t("animations.title")}
                     </DropdownMenuItem>
                   )}
                   {canEdit && currentSlide && onToggleLayers && (

--- a/templates/slides/app/components/editor/SlideContextToolbar.tsx
+++ b/templates/slides/app/components/editor/SlideContextToolbar.tsx
@@ -34,7 +34,7 @@ import {
   IconSpacingVertical,
   IconStackBack,
   IconStackFront,
-  IconTransitionRight,
+  IconBolt,
   IconUnderline,
   IconZoomIn,
   IconZoomOut,
@@ -256,14 +256,14 @@ export function SlideContextToolbar({
                   MENU_BUTTON_CLASS,
                   animationsOpen && TOGGLE_ACTIVE_CLASS,
                 )}
-                aria-label={t("editorToolbar.transition")}
+                aria-label={t("animations.title")}
                 aria-pressed={animationsOpen}
                 onClick={onOpenAnimations}
               >
-                <IconTransitionRight className="size-3.5" />
+                <IconBolt className="size-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{t("editorToolbar.transition")}</TooltipContent>
+            <TooltipContent>{t("animations.title")}</TooltipContent>
           </Tooltip>
           <div className={TOOLBAR_DIVIDER} />
         </>

--- a/templates/slides/app/components/editor/SlideEditor.panel-layout.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.panel-layout.test.ts
@@ -51,6 +51,12 @@ describe("editor side panels", () => {
       "setAnimationsOpen((open) => !open);",
     );
   });
+
+  it("rounds the canvas edge consistently for either right-side panel", () => {
+    expect(editorSource).toContain(
+      'animationsOpen || layersOpen ? "rounded-r-lg" : ""',
+    );
+  });
 });
 
 describe("slide context toolbar", () => {

--- a/templates/slides/app/components/editor/SlidesLayersPanel.tsx
+++ b/templates/slides/app/components/editor/SlidesLayersPanel.tsx
@@ -2,17 +2,9 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconGripVertical,
-  IconLayersSubtract,
   IconX,
 } from "@tabler/icons-react";
 import { useState, type DragEvent } from "react";
-
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 export interface SlidesLayerNode {
   id: string;
@@ -82,11 +74,12 @@ function LayerRow({
   return (
     <div
       role="treeitem"
+      aria-level={depth + 1}
       aria-expanded={children.length ? expanded : undefined}
       aria-selected={selected}
     >
       <div
-        className={`group flex min-h-9 items-center gap-1 rounded-md px-2 text-sm transition-colors ${selected ? "bg-accent text-accent-foreground" : "hover:bg-accent/60"} ${dragging ? "opacity-50" : ""}`}
+        className={`group flex h-8 items-center gap-1 rounded-[5px] px-2 text-xs text-foreground/90 transition-colors ${selected ? "bg-accent text-accent-foreground" : "hover:bg-accent hover:text-foreground"} ${dragging ? "opacity-50" : ""}`}
         style={{ paddingLeft: `${8 + depth * 16}px` }}
         onDragOver={(event) => event.preventDefault()}
         onDragEnter={() => setDragging(true)}
@@ -96,14 +89,14 @@ function LayerRow({
         {children.length ? (
           <button
             type="button"
-            className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+            className="rounded-sm p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring"
             aria-label={expanded ? labels.collapse : labels.expand}
             onClick={() => setExpanded((value) => !value)}
           >
             {expanded ? (
-              <IconChevronDown size={15} />
+              <IconChevronDown size={16} />
             ) : (
-              <IconChevronRight size={15} />
+              <IconChevronRight size={16} />
             )}
           </button>
         ) : (
@@ -112,7 +105,7 @@ function LayerRow({
         <button
           type="button"
           draggable
-          className="flex min-w-0 flex-1 items-center gap-2 py-1.5 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2 py-0.5 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring"
           onDragStart={(event) => {
             event.dataTransfer.setData("text/plain", node.id);
             event.dataTransfer.effectAllowed = "move";
@@ -126,7 +119,7 @@ function LayerRow({
           }
         >
           <IconGripVertical
-            size={15}
+            size={14}
             className="shrink-0 text-muted-foreground/60"
             aria-hidden="true"
           />
@@ -162,31 +155,24 @@ export function SlidesLayersPanel({
 }: SlidesLayersPanelProps) {
   return (
     <aside
-      className="flex h-full w-64 flex-col border-l border-border bg-background"
+      className="flex h-full w-72 min-w-0 flex-col bg-background"
       aria-label={labels.title}
     >
-      <header className="flex h-11 items-center justify-between border-b border-border px-3">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <IconLayersSubtract size={16} aria-hidden="true" />
+      <header className="flex h-14 shrink-0 items-center justify-between border-b border-border px-4">
+        <h2 className="text-sm font-semibold text-foreground">
           {labels.title}
-        </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              onClick={onClose}
-              aria-label={labels.close}
-            >
-              <IconX size={16} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{labels.close}</TooltipContent>
-        </Tooltip>
+        </h2>
+        <button
+          type="button"
+          className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={onClose}
+          aria-label={labels.close}
+        >
+          <IconX className="size-4" />
+        </button>
       </header>
       <div
-        className="min-h-0 flex-1 overflow-y-auto p-2"
+        className="min-h-0 flex-1 overflow-y-auto py-2"
         role="tree"
         aria-label={labels.title}
       >

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -486,14 +486,6 @@ export default function DeckEditor() {
   // loading when `createdByMe` already confirms ownership — otherwise a
   // viewer would briefly see (and could click) edit affordances.
   const { canEdit, canComment } = useDeckRole(id, deck?.createdByMe === true);
-  useEffect(() => {
-    const handleToggleLayers = () => {
-      if (canEdit) toggleLayers();
-    };
-    window.addEventListener("slides:toggle-layers", handleToggleLayers);
-    return () =>
-      window.removeEventListener("slides:toggle-layers", handleToggleLayers);
-  }, [canEdit, toggleLayers]);
   const isNewDeckGenerating = shouldShowNewDeckGeneratingProgress({
     generating,
     isNewDeckCreation: wasNewDeckCreation.current,

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -223,28 +223,7 @@ function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const t = useT();
   const navigate = useNavigate();
-  const handleCommandMenuShortcut = useCallback(() => {
-    const editor = document.querySelector<HTMLElement>(
-      "[data-slides-editor-root]",
-    );
-    const active = document.activeElement;
-    const contentEditable =
-      active instanceof HTMLElement &&
-      (active.isContentEditable ||
-        Boolean(active.closest("[contenteditable='true']")));
-    const formControl =
-      active instanceof HTMLInputElement ||
-      active instanceof HTMLTextAreaElement ||
-      active instanceof HTMLSelectElement ||
-      Boolean(active?.closest("[role='textbox']"));
-    if (formControl && !contentEditable) return;
-    if (editor?.dataset.slidesEditorEditable === "true" && !contentEditable) {
-      window.dispatchEvent(new CustomEvent("slides:toggle-layers"));
-      setCmdkOpen(false);
-      return;
-    }
-    setCmdkOpen(true);
-  }, []);
+  const handleCommandMenuShortcut = useCallback(() => setCmdkOpen(true), []);
   useCommandMenuShortcut(handleCommandMenuShortcut, {
     allowContentEditable: true,
   });


### PR DESCRIPTION
## Summary
- keep Cmd+K on the shared actions menu in Slides and expose Layers as a command
- align the Layers sidebar shell with Transitions and compact the layer rows
- rename the transition action to Transitions and use the bolt icon

## Validation
- focused Slides editor tests: 3 files, 21 tests passed
- Slides typecheck passed
- `corepack pnpm guards`: all 65 checks passed
- local browser verified Cmd+K, Layers, sidebar layout, and the updated More menu
