### PR TITLE
perf(clips): cache release manifest and simplify download options

### DIFF
--- a/templates/clips/actions/clips-latest.test.ts
+++ b/templates/clips/actions/clips-latest.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   classifyClipsAsset,
   compareClipsReleaseTags,
+  __clipsLatestTest,
+  CLIPS_RELEASE_CACHE_HEADERS,
   isClipsReleaseForChannel,
   normalizeClipsReleaseChannel,
 } from "../server/routes/api/clips-latest.json.get";
+
+function jsonResponse(json: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => json,
+  } as Response;
+}
 
 describe("classifyClipsAsset", () => {
   it("recognizes Clips installer assets", () => {
@@ -95,5 +105,73 @@ describe("Clips release channels", () => {
     expect(normalizeClipsReleaseChannel("nightly")).toBe("nightly");
     expect(normalizeClipsReleaseChannel("production")).toBe("production");
     expect(normalizeClipsReleaseChannel("other")).toBe("production");
+  });
+});
+
+describe("Clips release manifest cache", () => {
+  afterEach(() => {
+    __clipsLatestTest.reset();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("serves stale manifests immediately while revalidating", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T00:00:00Z"));
+    const release = (tag_name: string) => ({
+      tag_name,
+      name: tag_name,
+      published_at: "2026-08-28T00:00:00Z",
+      draft: false,
+      prerelease: false,
+      assets: [
+        {
+          name: "Clips_universal.dmg",
+          browser_download_url: `https://downloads.example.com/${tag_name}.dmg`,
+          size: 1,
+        },
+      ],
+    });
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("pointer unavailable"))
+      .mockResolvedValueOnce(jsonResponse([release("clips-v1.0.0")]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    let resolveRefresh!: (response: Response) => void;
+    fetchMock
+      .mockRejectedValueOnce(new Error("pointer unavailable"))
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+    await Promise.resolve();
+    resolveRefresh(jsonResponse([release("clips-v1.1.0")]));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.1.0",
+    });
+  });
+
+  it("exposes durable stale-while-revalidate headers", () => {
+    expect(CLIPS_RELEASE_CACHE_HEADERS).toEqual({
+      "cache-control":
+        "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+      "cdn-cache-control":
+        "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+      "netlify-cdn-cache-control":
+        "public, durable, s-maxage=300, stale-while-revalidate=86400, stale-if-error=86400",
+    });
   });
 });

--- a/templates/clips/actions/clips-latest.test.ts
+++ b/templates/clips/actions/clips-latest.test.ts
@@ -151,17 +151,64 @@ describe("Clips release manifest cache", () => {
           resolveRefresh = resolve;
         }),
       );
+    const backgroundRefreshes: Promise<unknown>[] = [];
 
-    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
-      version: "1.0.0",
-    });
+    await expect(
+      __clipsLatestTest.getManifest("production", (promise) =>
+        backgroundRefreshes.push(promise),
+      ),
+    ).resolves.toMatchObject({ version: "1.0.0" });
+    expect(backgroundRefreshes).toHaveLength(1);
     await Promise.resolve();
     resolveRefresh(jsonResponse([release("clips-v1.1.0")]));
     for (let i = 0; i < 10; i++) await Promise.resolve();
+    await backgroundRefreshes[0];
 
     await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
       version: "1.1.0",
     });
+  });
+
+  it("backs off repeated stale refreshes after an upstream failure", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-28T00:00:00Z"));
+    const release = (tag_name: string) => ({
+      tag_name,
+      name: tag_name,
+      published_at: "2026-08-28T00:00:00Z",
+      draft: false,
+      prerelease: false,
+      assets: [
+        {
+          name: "Clips_universal.dmg",
+          browser_download_url: `https://downloads.example.com/${tag_name}.dmg`,
+          size: 1,
+        },
+      ],
+    });
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("pointer unavailable"))
+      .mockResolvedValueOnce(jsonResponse([release("clips-v1.0.0")]))
+      .mockRejectedValueOnce(new Error("pointer unavailable"))
+      .mockRejectedValueOnce(new Error("releases unavailable"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+
+    vi.advanceTimersByTime(5 * 60_000 + 1);
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    const attemptsAfterFailure = fetchMock.mock.calls.length;
+
+    await expect(__clipsLatestTest.getManifest()).resolves.toMatchObject({
+      version: "1.0.0",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(attemptsAfterFailure);
   });
 
   it("exposes durable stale-while-revalidate headers", () => {

--- a/templates/clips/app/i18n/ar-SA.ts
+++ b/templates/clips/app/i18n/ar-SA.ts
@@ -637,6 +637,8 @@ const messages = {
     macSublabel: "عالمي (Apple Silicon + Intel)",
     windowsSublabel: "المثبت 64 بت MSI",
     downloadFor: "تحميل {{platform}}",
+    downloadStarted: "بدأ التنزيل",
+    downloadAgain: "لم ينجح؟ حاول التنزيل مرة أخرى",
     alsoFor: "متاح أيضًا لـ {{platform}}",
     backToLibrary: "العودة إلى المكتبة",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/de-DE.ts
+++ b/templates/clips/app/i18n/de-DE.ts
@@ -654,6 +654,8 @@ const messages = {
     macSublabel: "Universell (Apple Silicon + Intel)",
     windowsSublabel: "64-Bit-MSI-Installationsprogramm",
     downloadFor: "Herunterladen für {{platform}}",
+    downloadStarted: "Download gestartet",
+    downloadAgain: "Hat es nicht funktioniert? Erneut herunterladen",
     alsoFor: "Auch verfügbar für {{platform}}",
     backToLibrary: "Zurück zur Bibliothek",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/en-US.ts
+++ b/templates/clips/app/i18n/en-US.ts
@@ -631,6 +631,8 @@ const messages = {
     macSublabel: "Universal (Apple Silicon + Intel)",
     windowsSublabel: "64-bit MSI installer",
     downloadFor: "Download for {{platform}}",
+    downloadStarted: "Download started",
+    downloadAgain: "Didn't work? Try downloading again",
     alsoFor: "Also available for {{platform}}",
     backToLibrary: "Back to library",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/es-ES.ts
+++ b/templates/clips/app/i18n/es-ES.ts
@@ -651,6 +651,8 @@ const messages = {
     macSublabel: "Traducido: Universal (Apple Silicon + Intel)",
     windowsSublabel: "Instalador MSI de 64 bits",
     downloadFor: "Descargar para {{platform}}",
+    downloadStarted: "Descarga iniciada",
+    downloadAgain: "¿No funcionó? Intenta descargar de nuevo",
     alsoFor: "También disponible para {{platform}}",
     backToLibrary: "Volver a la biblioteca",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/fr-FR.ts
+++ b/templates/clips/app/i18n/fr-FR.ts
@@ -649,6 +649,8 @@ const messages = {
     macSublabel: "Universel (Apple Silicon + Intel)",
     windowsSublabel: "Programme d'installation de MSI 64 bits",
     downloadFor: "Télécharger pour {{platform}}",
+    downloadStarted: "Téléchargement lancé",
+    downloadAgain: "Cela n’a pas fonctionné ? Réessayez de télécharger",
     alsoFor: "Également disponible pour {{platform}}",
     backToLibrary: "Retour à la bibliothèque",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/hi-IN.ts
+++ b/templates/clips/app/i18n/hi-IN.ts
@@ -627,6 +627,8 @@ const messages = {
     macSublabel: "यूनिवर्सल (Apple Silicon + Intel)",
     windowsSublabel: "64-बिट MSI इंस्टॉलर",
     downloadFor: "{{platform}} के लिए डाउनलोड करें",
+    downloadStarted: "डाउनलोड शुरू हो गया",
+    downloadAgain: "काम नहीं किया? फिर से डाउनलोड करें",
     alsoFor: "{{platform}} के लिए भी उपलब्ध है",
     backToLibrary: "लाइब्रेरी पर वापस जाएँ",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/ja-JP.ts
+++ b/templates/clips/app/i18n/ja-JP.ts
@@ -645,6 +645,8 @@ const messages = {
     macSublabel: "ユニバーサル (Apple Silicon + Intel)",
     windowsSublabel: "64 ビット MSI インストーラー",
     downloadFor: "翻訳済み: Download for {{platform}}",
+    downloadStarted: "ダウンロードを開始しました",
+    downloadAgain: "うまくいきませんでしたか？もう一度ダウンロード",
     alsoFor: "{{platform}}でもご利用いただけます",
     backToLibrary: "ライブラリに戻る",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/ko-KR.ts
+++ b/templates/clips/app/i18n/ko-KR.ts
@@ -635,6 +635,8 @@ const messages = {
     macSublabel: "범용(Apple Silicon + Intel)",
     windowsSublabel: "64비트 MSI 설치 프로그램",
     downloadFor: "{{platform}}용 다운로드",
+    downloadStarted: "다운로드가 시작되었습니다",
+    downloadAgain: "작동하지 않았나요? 다시 다운로드",
     alsoFor: "{{platform}}에도 사용 가능",
     backToLibrary: "라이브러리로 돌아가기",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/pt-BR.ts
+++ b/templates/clips/app/i18n/pt-BR.ts
@@ -646,6 +646,8 @@ const messages = {
     macSublabel: "Universais (Apple Silicon + Intel)",
     windowsSublabel: "Instalador MSI de 64 bits",
     downloadFor: "Baixar para {{platform}}",
+    downloadStarted: "Download iniciado",
+    downloadAgain: "Não funcionou? Tente baixar novamente",
     alsoFor: "Também disponível para {{platform}}",
     backToLibrary: "Voltar à biblioteca",
     clipsDesktop: "Clips Desktop",

--- a/templates/clips/app/i18n/zh-CN.ts
+++ b/templates/clips/app/i18n/zh-CN.ts
@@ -607,6 +607,8 @@ const messages = {
     macSublabel: "通用（Apple Silicon + Intel）",
     windowsSublabel: "64 位 MSI 安装程序",
     downloadFor: "下载 {{platform}}",
+    downloadStarted: "下载已开始",
+    downloadAgain: "没有成功？请再次下载",
     alsoFor: "也可用于 {{platform}}",
     backToLibrary: "返回资料库",
     clipsDesktop: "Clips 桌面版",

--- a/templates/clips/app/i18n/zh-TW.ts
+++ b/templates/clips/app/i18n/zh-TW.ts
@@ -607,6 +607,8 @@ const messages = {
     macSublabel: "通用（Apple Silicon + Intel）",
     windowsSublabel: "64 位 MSI 安裝程式",
     downloadFor: "下載 {{platform}}",
+    downloadStarted: "下載已開始",
+    downloadAgain: "沒有成功？請再次下載",
     alsoFor: "也可用於 {{platform}}",
     backToLibrary: "返回媒體庫",
     clipsDesktop: "Clips 桌面版",

--- a/templates/clips/app/routes/download.test.tsx
+++ b/templates/clips/app/routes/download.test.tsx
@@ -96,6 +96,7 @@ describe("Clips download page", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    window.localStorage.clear();
     fetchMock.mockImplementation(async (input: string) => ({
       ok: true,
       json: async () =>
@@ -115,6 +116,7 @@ describe("Clips download page", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    window.localStorage.clear();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });

--- a/templates/clips/app/routes/download.test.tsx
+++ b/templates/clips/app/routes/download.test.tsx
@@ -21,6 +21,8 @@ vi.mock("@agent-native/core/client/i18n", () => ({
       "downloadRoute.clipsDesktop": "Clips Desktop",
       "downloadRoute.heroDescription": "Record your screen.",
       "downloadRoute.downloadFor": "Download for {{platform}}",
+      "downloadRoute.downloadStarted": "Download started",
+      "downloadRoute.downloadAgain": "Didn't work? Try downloading again",
       "downloadRoute.retry": "Try again",
       "downloadRoute.stable": "Stable",
       "downloadRoute.nightly": "Nightly",
@@ -169,5 +171,22 @@ describe("Clips download page", () => {
         .querySelector('button[role="switch"]')
         ?.getAttribute("aria-checked"),
     ).toBe("true");
+  });
+
+  it("confirms the download and offers a retry link after clicking", () => {
+    const download = container.querySelector<HTMLAnchorElement>("a[download]");
+    expect(download).toBeTruthy();
+
+    act(() => {
+      download?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(markDownloaded).toHaveBeenCalledTimes(1);
+    expect(download?.textContent).toContain("Download started");
+    expect(container.textContent).toContain(
+      "Didn't work? Try downloading again",
+    );
   });
 });

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -4,6 +4,7 @@ import {
   IconBrandChrome,
   IconBrandApple,
   IconBrandWindows,
+  IconCheck,
   IconExternalLink,
   IconTerminal2,
 } from "@tabler/icons-react";
@@ -86,6 +87,11 @@ interface Manifest {
   }[];
 }
 
+interface ConfirmedDownload {
+  asset: Manifest["assets"][number];
+  label: string;
+}
+
 function manifestStorageKey(channel: DownloadReleaseChannel): string {
   return `${MANIFEST_STORAGE_KEY}-${channel}`;
 }
@@ -152,11 +158,11 @@ function detectPlatform(): PlatformId | null {
 function pickAsset(
   manifest: Manifest | null,
   variant: PlatformVariant,
-): { url: string; name: string } | null {
+): Manifest["assets"][number] | null {
   if (!manifest) return null;
   for (const kind of variant.assetKinds) {
     const asset = manifest.assets.find((a) => a.kind === kind);
-    if (asset) return { url: asset.url, name: asset.name };
+    if (asset) return asset;
   }
   return null;
 }
@@ -168,6 +174,9 @@ function primaryDownloadButton(
   downloadLabel: string,
   retryLabel: string,
   onRetry: () => void,
+  downloadStarted: boolean,
+  downloadStartedLabel: string,
+  onDownload: (asset: Manifest["assets"][number]) => void,
 ) {
   const asset = pickAsset(manifest, variant);
   const Icon = variant.icon;
@@ -178,9 +187,13 @@ function primaryDownloadButton(
         size="lg"
         className="h-12 min-w-[252px] gap-2 px-6 text-base"
       >
-        <a href={asset.url} download onClick={markDesktopAppDownloaded}>
-          <Icon className="h-5 w-5" />
-          {downloadLabel}
+        <a href={asset.url} download onClick={() => onDownload(asset)}>
+          {downloadStarted ? (
+            <IconCheck className="h-5 w-5" />
+          ) : (
+            <Icon className="h-5 w-5" />
+          )}
+          {downloadStarted ? downloadStartedLabel : downloadLabel}
         </a>
       </Button>
     );
@@ -223,6 +236,8 @@ export default function DownloadPage() {
   const [manifestError, setManifestError] = useState(false);
   const [detected, setDetected] = useState<PlatformId | null>(null);
   const [manifestRequest, setManifestRequest] = useState(0);
+  const [confirmedDownload, setConfirmedDownload] =
+    useState<ConfirmedDownload | null>(null);
 
   useEffect(() => {
     setDetected(detectPlatform());
@@ -263,6 +278,7 @@ export default function DownloadPage() {
   }, [channel, hostResolved, manifestRequest]);
 
   const retryManifest = () => {
+    setConfirmedDownload(null);
     setManifestRequest((request) => request + 1);
   };
 
@@ -271,13 +287,27 @@ export default function DownloadPage() {
 
     setManifest(null);
     setManifestError(false);
+    setConfirmedDownload(null);
     setChannel(nextChannel);
   };
 
   const primary = VARIANTS.find((v) => v.id === detected) ?? VARIANTS[0];
+  const primaryAsset = pickAsset(manifest, primary);
+  const downloadLabel = t("downloadRoute.downloadFor", {
+    platform: primary.label,
+  });
+  const downloadStartedLabel = t("downloadRoute.downloadStarted");
+  const primaryDownloadStarted =
+    confirmedDownload?.asset.url === primaryAsset?.url;
+
+  const handleDownload = (asset: Manifest["assets"][number], label: string) => {
+    markDesktopAppDownloaded();
+    setConfirmedDownload({ asset, label });
+  };
 
   const handlePlatformChange = (nextPlatform: PlatformId) => {
     if (nextPlatform === detected) return;
+    setConfirmedDownload(null);
     setDetected(nextPlatform);
   };
 
@@ -358,9 +388,35 @@ export default function DownloadPage() {
                 primary,
                 manifest,
                 manifestError,
-                t("downloadRoute.downloadFor", { platform: primary.label }),
+                downloadLabel,
                 t("downloadRoute.retry"),
                 retryManifest,
+                primaryDownloadStarted,
+                downloadStartedLabel,
+                (asset) => handleDownload(asset, downloadLabel),
+              )}
+
+              {primaryDownloadStarted && confirmedDownload && (
+                <p
+                  aria-live="polite"
+                  className="mt-3 text-xs text-muted-foreground"
+                >
+                  <span className="sr-only">{downloadStartedLabel}</span>
+                  <a
+                    href={confirmedDownload.asset.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() =>
+                      handleDownload(
+                        confirmedDownload.asset,
+                        confirmedDownload.label,
+                      )
+                    }
+                    className="text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                  >
+                    {t("downloadRoute.downloadAgain")}
+                  </a>
+                </p>
               )}
 
               <div className="mt-5 flex justify-center">

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -50,6 +50,7 @@ interface PlatformVariant {
 }
 
 const LATEST_JSON_URL = `${appBasePath()}/api/clips-latest.json`;
+const MANIFEST_STORAGE_KEY = "clips-download-manifest-v1";
 
 const VARIANTS: PlatformVariant[] = [
   {
@@ -83,6 +84,60 @@ interface Manifest {
     size: number;
     kind: string;
   }[];
+}
+
+function manifestStorageKey(channel: DownloadReleaseChannel): string {
+  return `${MANIFEST_STORAGE_KEY}-${channel}`;
+}
+
+function isManifest(value: unknown): value is Manifest {
+  if (!value || typeof value !== "object") return false;
+  const manifest = value as Partial<Manifest>;
+  return (
+    typeof manifest.version === "string" &&
+    typeof manifest.tag === "string" &&
+    (typeof manifest.pub_date === "string" || manifest.pub_date === null) &&
+    Array.isArray(manifest.assets) &&
+    manifest.assets.every((asset) => {
+      if (!asset || typeof asset !== "object") return false;
+      const candidate = asset as Partial<Manifest["assets"][number]>;
+      return (
+        typeof candidate.name === "string" &&
+        typeof candidate.url === "string" &&
+        typeof candidate.size === "number" &&
+        typeof candidate.kind === "string"
+      );
+    })
+  );
+}
+
+function readCachedManifest(channel: DownloadReleaseChannel): Manifest | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(manifestStorageKey(channel));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isManifest(parsed) ? parsed : null;
+    // coercion-ok: an unreadable browser cache is absent; the network fetch remains authoritative.
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedManifest(
+  channel: DownloadReleaseChannel,
+  manifest: Manifest,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      manifestStorageKey(channel),
+      JSON.stringify(manifest),
+    );
+    // coercion-ok: browser storage is optional and must not block the download action.
+  } catch {
+    // Storage can be unavailable in private browsing or locked-down contexts.
+  }
 }
 
 function detectPlatform(): PlatformId | null {
@@ -182,7 +237,8 @@ export default function DownloadPage() {
     if (!hostResolved) return;
 
     let cancelled = false;
-    setManifest(null);
+    const cachedManifest = readCachedManifest(channel);
+    setManifest(cachedManifest);
     setManifestError(false);
     const manifestUrl =
       channel === "nightly"
@@ -191,10 +247,15 @@ export default function DownloadPage() {
     fetch(manifestUrl)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
       .then((json) => {
-        if (!cancelled) setManifest(json as Manifest);
+        if (!isManifest(json)) throw new Error("Invalid manifest");
+        if (!cancelled) {
+          setManifest(json);
+          setManifestError(false);
+          writeCachedManifest(channel, json);
+        }
       })
       .catch(() => {
-        if (!cancelled) setManifestError(true);
+        if (!cancelled && !cachedManifest) setManifestError(true);
       });
     return () => {
       cancelled = true;
@@ -349,25 +410,23 @@ export default function DownloadPage() {
           </div>
 
           {chromeExtensionEnabled && (
-            <section className="mt-10 w-full max-w-xl rounded-2xl border border-border bg-card p-4 text-start shadow-sm">
-              <div className="flex items-start gap-3">
-                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <section className="mt-16 w-full max-w-md text-start">
+              <div className="flex items-center gap-2">
+                <div className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
                   <IconBrandChrome className="h-4 w-4" />
                 </div>
                 <div className="min-w-0 flex-1">
                   <h2 className="text-sm font-semibold text-foreground">
                     {t("downloadRoute.chromeTitle")}
                   </h2>
-                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                    {t("downloadRoute.chromeDescription")}
-                  </p>
                 </div>
               </div>
               <Button
                 asChild={Boolean(clipsChromeExtensionUrl)}
                 disabled={!clipsChromeExtensionUrl}
                 variant="outline"
-                className="mt-4 w-full gap-2"
+                size="sm"
+                className="mt-3 w-full gap-2"
               >
                 {clipsChromeExtensionUrl ? (
                   <a

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -47,6 +47,7 @@ const PER_PAGE = 100;
 // by then, something else is wrong and the 404 is correct.
 const MAX_PAGES = 10;
 const CACHE_TTL_MS = 5 * 60_000;
+const CACHE_RETRY_BACKOFF_MS = 60_000;
 
 export const CLIPS_RELEASE_CACHE_HEADERS = {
   "cache-control":
@@ -210,6 +211,9 @@ const cache = new Map<
   { data: DownloadManifest; ts: number }
 >();
 const inFlight = new Map<ClipsReleaseChannel, Promise<DownloadManifest>>();
+const retryAfter = new Map<ClipsReleaseChannel, number>();
+
+type WaitUntil = (promise: Promise<unknown>) => void;
 
 class UpstreamError extends Error {
   statusCode: number;
@@ -362,9 +366,15 @@ function refreshManifest(
   const pending = inFlight.get(channel);
   if (pending) return pending;
   const request = (async () => {
-    const data = await buildManifest(channel);
-    cache.set(channel, { data, ts: Date.now() });
-    return data;
+    try {
+      const data = await buildManifest(channel);
+      cache.set(channel, { data, ts: Date.now() });
+      retryAfter.delete(channel);
+      return data;
+    } catch (error) {
+      retryAfter.set(channel, Date.now() + CACHE_RETRY_BACKOFF_MS);
+      throw error;
+    }
   })();
   inFlight.set(
     channel,
@@ -375,14 +385,30 @@ function refreshManifest(
   return inFlight.get(channel)!;
 }
 
+function refreshInBackground(
+  channel: ClipsReleaseChannel,
+  waitUntil?: WaitUntil,
+): void {
+  const refresh = refreshManifest(channel).catch(() => undefined);
+  if (waitUntil) {
+    waitUntil(refresh);
+  } else {
+    void refresh;
+  }
+}
+
 async function getManifest(
   channel: ClipsReleaseChannel = "production",
+  waitUntil?: WaitUntil,
 ): Promise<DownloadManifest> {
   const now = Date.now();
   const cached = cache.get(channel);
   if (cached) {
-    if (now - cached.ts >= CACHE_TTL_MS) {
-      void refreshManifest(channel).catch(() => undefined);
+    if (
+      now - cached.ts >= CACHE_TTL_MS &&
+      now >= (retryAfter.get(channel) ?? 0)
+    ) {
+      refreshInBackground(channel, waitUntil);
     }
     return cached.data;
   }
@@ -394,6 +420,7 @@ export const __clipsLatestTest = {
   reset() {
     cache.clear();
     inFlight.clear();
+    retryAfter.clear();
   },
 };
 
@@ -407,7 +434,11 @@ export default defineEventHandler(async (event) => {
   const channel = normalizeClipsReleaseChannel(getQuery(event).channel);
   let manifest: DownloadManifest;
   try {
-    manifest = await getManifest(channel);
+    const waitUntil =
+      typeof event.waitUntil === "function"
+        ? (promise: Promise<unknown>) => event.waitUntil(promise)
+        : undefined;
+    manifest = await getManifest(channel, waitUntil);
   } catch (err) {
     const e = err as {
       statusCode?: number;

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -32,12 +32,12 @@ import {
  *
  *   - A 5-minute process-wide memoization (`cached`) — every request
  *     for 5 min shares one upstream fetch.
- *   - A stale-while-error fallback — if GitHub ever errors out AND we
- *     have a previously-successful payload (even expired), we return
- *     it. Avoids a download outage during a transient GitHub hiccup or
- *     a rate-limit burst.
- *   - HTTP `cache-control: max-age=60` on the response so downstream
- *     CDNs + the browser cache this aggressively.
+ *   - A stale-while-revalidate refresh — once the cache expires, we return the
+ *     previous payload immediately and refresh it in the background.
+ *   - A stale-while-error fallback — if GitHub ever errors out AND we have a
+ *     previously-successful payload (even expired), we keep serving it.
+ *   - Durable HTTP cache headers with short freshness and a long stale window
+ *     for downstream CDNs + the browser.
  */
 
 const RELEASES_URL_BASE =
@@ -47,6 +47,15 @@ const PER_PAGE = 100;
 // by then, something else is wrong and the 404 is correct.
 const MAX_PAGES = 10;
 const CACHE_TTL_MS = 5 * 60_000;
+
+export const CLIPS_RELEASE_CACHE_HEADERS = {
+  "cache-control":
+    "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+  "cdn-cache-control":
+    "public, max-age=300, stale-while-revalidate=86400, stale-if-error=86400",
+  "netlify-cdn-cache-control":
+    "public, durable, s-maxage=300, stale-while-revalidate=86400, stale-if-error=86400",
+} as const;
 
 export type ClipsReleaseChannel = "production" | "nightly";
 
@@ -347,31 +356,46 @@ async function buildManifest(
   };
 }
 
+function refreshManifest(
+  channel: ClipsReleaseChannel,
+): Promise<DownloadManifest> {
+  const pending = inFlight.get(channel);
+  if (pending) return pending;
+  const request = (async () => {
+    const data = await buildManifest(channel);
+    cache.set(channel, { data, ts: Date.now() });
+    return data;
+  })();
+  inFlight.set(
+    channel,
+    request.finally(() => {
+      inFlight.delete(channel);
+    }),
+  );
+  return inFlight.get(channel)!;
+}
+
 async function getManifest(
   channel: ClipsReleaseChannel = "production",
 ): Promise<DownloadManifest> {
   const now = Date.now();
   const cached = cache.get(channel);
-  if (cached && now - cached.ts < CACHE_TTL_MS) return cached.data;
-  const pending = inFlight.get(channel);
-  if (pending) return pending;
-  const request = (async () => {
-    try {
-      const data = await buildManifest(channel);
-      cache.set(channel, { data, ts: Date.now() });
-      return data;
-    } catch (err) {
-      // Stale-while-error: if we have an older payload, serve it. Only
-      // bubble the error if the cache is empty.
-      if (cached) return cached.data;
-      throw err;
-    } finally {
-      inFlight.delete(channel);
+  if (cached) {
+    if (now - cached.ts >= CACHE_TTL_MS) {
+      void refreshManifest(channel).catch(() => undefined);
     }
-  })();
-  inFlight.set(channel, request);
-  return request;
+    return cached.data;
+  }
+  return refreshManifest(channel);
 }
+
+export const __clipsLatestTest = {
+  getManifest,
+  reset() {
+    cache.clear();
+    inFlight.clear();
+  },
+};
 
 export function normalizeClipsReleaseChannel(
   value: unknown,
@@ -397,7 +421,7 @@ export default defineEventHandler(async (event) => {
   }
   setResponseHeaders(event, {
     "content-type": "application/json; charset=utf-8",
-    "cache-control": "public, max-age=60",
+    ...CLIPS_RELEASE_CACHE_HEADERS,
   });
   return manifest;
 });


### PR DESCRIPTION
## Summary

- Serve cached Clips release manifests immediately while refreshing them in the background.
- Add durable CDN/browser stale-while-revalidate headers and a browser manifest cache.
- Move the Chrome extension option lower, make it narrower and borderless, and remove secondary copy.

## Verification

- Clips download page test
- Clips release-cache test (7 tests)
- Clips typecheck
- oxfmt check
- 65 repository guards
- Local browser verification at desktop and mobile widths