### PR TITLE
fix: keep production desktop releases fresh

### DIFF
--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -49,6 +49,7 @@ jobs:
             const startedAt = Date.now();
             const coordinatorDeadline = startedAt + 355 * 60_000;
             const pollIntervalMs = 15_000;
+            const reservedTags = new Map();
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
             const phaseDeadline = (timeoutMs) =>
@@ -125,6 +126,19 @@ jobs:
               }
             }
 
+            async function getReleaseByTag(tag) {
+              try {
+                return (await github.rest.repos.getReleaseByTag({
+                  owner,
+                  repo,
+                  tag,
+                })).data;
+              } catch (error) {
+                if (error.status === 404) return null;
+                throw error;
+              }
+            }
+
             function parseStableVersion(value, label) {
               const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
               if (!match) {
@@ -178,6 +192,7 @@ jobs:
                     ref: `refs/tags/${tagPrefix}${version}`,
                     sha: sourceSha,
                   });
+                  reservedTags.set(`${tagPrefix}${version}`, sourceSha);
                   return version;
                 } catch (error) {
                   if (error.status !== 422) throw error;
@@ -185,6 +200,50 @@ jobs:
                 }
               }
               throw new Error(`Could not reserve a stable ${tagPrefix} version after 20 attempts.`);
+            }
+
+            async function cleanupReservedTags() {
+              const cleanup = await Promise.allSettled(
+                [...reservedTags].map(async ([tag, sourceSha]) => {
+                  const tagSha = await getRemoteTagSha(tag);
+                  if (tagSha && tagSha !== sourceSha) {
+                    core.warning(`Keeping changed stable tag ${tag}; it is not owned by this run.`);
+                    return;
+                  }
+                  const release = await getReleaseByTag(tag);
+                  if (release && !release.draft) {
+                    core.info(`Keeping published stable release ${tag}.`);
+                    return;
+                  }
+                  if (release) {
+                    try {
+                      await github.rest.repos.deleteRelease({
+                        owner,
+                        repo,
+                        release_id: release.id,
+                      });
+                    } catch (error) {
+                      if (error.status !== 404) throw error;
+                    }
+                  }
+                  try {
+                    await github.rest.git.deleteRef({
+                      owner,
+                      repo,
+                      ref: `tags/${tag}`,
+                    });
+                    core.info(`Removed reserved stable tag ${tag}.`);
+                  } catch (error) {
+                    if (error.status !== 404) throw error;
+                  }
+                }),
+              );
+              const failures = cleanup
+                .filter((result) => result.status === "rejected")
+                .map((result) => result.reason instanceof Error ? result.reason.message : String(result.reason));
+              if (failures.length > 0) {
+                core.warning(`Could not clean up reserved stable tags:\n${failures.join("\n")}`);
+              }
             }
 
             async function getFirstParentSha(ref) {
@@ -391,6 +450,7 @@ jobs:
               releaseSha,
               "scripts/netlify-production-sites.json",
             );
+            try {
             // Private desktop packages do not advance in the npm release commit.
             const desktopVersion = await reserveStableVersion(
               "v",
@@ -460,3 +520,7 @@ jobs:
               .write();
 
             core.info(`Release everything completed from ${releaseBaseSha} through ${releaseSha}.`);
+            } catch (error) {
+              await cleanupReservedTags();
+              throw error;
+            }

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -47,7 +47,7 @@ jobs:
             const apiVersion = "2026-03-10";
             const releaseType = process.env.RELEASE_TYPE;
             const startedAt = Date.now();
-            const coordinatorDeadline = startedAt + 355 * 60_000;
+            const coordinatorDeadline = startedAt + 350 * 60_000;
             const pollIntervalMs = 15_000;
             const reservedTags = new Map();
 
@@ -450,28 +450,36 @@ jobs:
               releaseSha,
               "scripts/netlify-production-sites.json",
             );
+            let desktopVersion;
+            let clipsVersion;
+            let productionSites;
             try {
-            // Private desktop packages do not advance in the npm release commit.
-            const desktopVersion = await reserveStableVersion(
-              "v",
-              stableVersion(desktopPackage.version, "Desktop app"),
-              releaseSha,
-            );
-            const clipsVersion = await reserveStableVersion(
-              "clips-v",
-              stableVersion(clipsPackage.version, "Clips desktop app"),
-              releaseSha,
-            );
-            core.info(`Selected stable desktop versions: v${desktopVersion}, clips-v${clipsVersion}.`);
-            const productionSites = Object.entries(sitesManifest)
-              .filter(([, site]) =>
-                typeof site?.host === "string" && site.host.endsWith(".agent-native.com"),
-              )
-              .map(([name]) => name);
-            if (productionSites.length === 0) {
-              throw new Error("The production site manifest contains no *.agent-native.com sites.");
+              // Private desktop packages do not advance in the npm release commit.
+              desktopVersion = await reserveStableVersion(
+                "v",
+                stableVersion(desktopPackage.version, "Desktop app"),
+                releaseSha,
+              );
+              clipsVersion = await reserveStableVersion(
+                "clips-v",
+                stableVersion(clipsPackage.version, "Clips desktop app"),
+                releaseSha,
+              );
+              productionSites = Object.entries(sitesManifest)
+                .filter(([, site]) =>
+                  typeof site?.host === "string" && site.host.endsWith(".agent-native.com"),
+                )
+                .map(([name]) => name);
+              if (productionSites.length === 0) {
+                throw new Error("The production site manifest contains no *.agent-native.com sites.");
+              }
+            } catch (error) {
+              await cleanupReservedTags();
+              throw error;
             }
+            core.info(`Selected stable desktop versions: v${desktopVersion}, clips-v${clipsVersion}.`);
 
+            // Downstream workflows own these reserved tags after dispatch.
             const [desktop, clips, production] = await Promise.all([
               dispatch("desktop-release.yml", workflowRef, {
                 channel: "production",
@@ -520,7 +528,3 @@ jobs:
               .write();
 
             core.info(`Release everything completed from ${releaseBaseSha} through ${releaseSha}.`);
-            } catch (error) {
-              await cleanupReservedTags();
-              throw error;
-            }

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -92,48 +92,6 @@ jobs:
               return { id: runId, url };
             }
 
-            async function getPublishedRelease(tag) {
-              try {
-                const response = await github.rest.repos.getReleaseByTag({
-                  owner,
-                  repo,
-                  tag,
-                });
-                return response.data;
-              } catch (error) {
-                if (error.status === 404) return null;
-                throw error;
-              }
-            }
-
-            function hasCompleteClipsRelease(release, version) {
-              if (!release || release.draft || release.prerelease) return false;
-              const assets = new Set(release.assets.map((asset) => asset.name));
-              return [
-                `Clips_${version}_universal.dmg`,
-                `Clips_${version}_x64-setup.exe`,
-                `Clips_${version}_x64_en-US.msi`,
-                "latest.json",
-              ].every((asset) => assets.has(asset));
-            }
-
-            function hasCompleteDesktopRelease(release) {
-              if (!release || release.draft || release.prerelease) return false;
-              const assets = new Set(release.assets.map((asset) => asset.name));
-              return [
-                "Agent-Native-arm64.dmg",
-                "Agent-Native-x64.dmg",
-                "Agent-Native-arm64.exe",
-                "Agent-Native-x64.exe",
-                "Agent-Native-arm64.AppImage",
-                "Agent-Native-x86_64.AppImage",
-                "latest.yml",
-                "latest-mac.yml",
-                "latest-linux.yml",
-                "latest-linux-arm64.yml",
-              ].every((asset) => assets.has(asset));
-            }
-
             async function getRun(runId) {
               return (await github.rest.actions.getWorkflowRun({
                 owner,
@@ -162,6 +120,49 @@ jobs:
                 if (error.status === 404) return null;
                 throw error;
               }
+            }
+
+            function parseStableVersion(value, label) {
+              const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+              if (!match) {
+                throw new Error(`${label} has no exact stable semver: ${value}`);
+              }
+              return match.slice(1).map(Number);
+            }
+
+            function compareStableVersions(left, right) {
+              for (let index = 0; index < left.length; index += 1) {
+                if (left[index] !== right[index]) return left[index] - right[index];
+              }
+              return 0;
+            }
+
+            function formatStableVersion(version) {
+              return version.join(".");
+            }
+
+            async function nextStableVersion(tagPrefix, baseVersion) {
+              let latest = parseStableVersion(baseVersion, `${tagPrefix} base version`);
+              const releases = await github.paginate(github.rest.repos.listReleases, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              for (const release of releases) {
+                if (release.draft || release.prerelease || !release.tag_name.startsWith(tagPrefix)) {
+                  continue;
+                }
+                const version = release.tag_name.slice(tagPrefix.length);
+                if (!/^\d+\.\d+\.\d+$/.test(version)) continue;
+                const parsed = parseStableVersion(version, release.tag_name);
+                if (compareStableVersions(parsed, latest) > 0) latest = parsed;
+              }
+
+              const candidate = [latest[0], latest[1], latest[2] + 1];
+              while (await getRemoteTagSha(`${tagPrefix}${formatStableVersion(candidate)}`)) {
+                candidate[2] += 1;
+              }
+              return formatStableVersion(candidate);
             }
 
             async function getFirstParentSha(ref) {
@@ -328,7 +329,7 @@ jobs:
             await waitForRun(
               packagePreparation,
               "Stable package release preparation",
-              30 * 60_000,
+              90 * 60_000,
             );
 
             const releasePr = await waitForReleasePullRequest(previousReleaseNumbers);
@@ -343,9 +344,7 @@ jobs:
               "packages/core/package.json",
             );
             const stableVersion = (value, label) => {
-              if (typeof value !== "string" || !/^\d+\.\d+\.\d+$/.test(value)) {
-                throw new Error(`${label} has no exact stable semver: ${value}`);
-              }
+              parseStableVersion(value, label);
               return value;
             };
             const coreVersion = stableVersion(corePackage.version, "Core package");
@@ -362,26 +361,24 @@ jobs:
               releaseSha,
               "packages/desktop-app/package.json",
             );
-            const initialDesktopPackage = await readJsonAt(
-              releaseBaseSha,
-              "packages/desktop-app/package.json",
-            );
             const clipsPackage = await readJsonAt(
               releaseSha,
-              "templates/clips/desktop/package.json",
-            );
-            const initialClipsPackage = await readJsonAt(
-              releaseBaseSha,
               "templates/clips/desktop/package.json",
             );
             const sitesManifest = await readJsonAt(
               releaseSha,
               "scripts/netlify-production-sites.json",
             );
-            const desktopVersion = stableVersion(desktopPackage.version, "Desktop app");
-            const clipsVersion = stableVersion(clipsPackage.version, "Clips desktop app");
-            const desktopVersionChanged = initialDesktopPackage.version !== desktopPackage.version;
-            const clipsVersionChanged = initialClipsPackage.version !== clipsPackage.version;
+            // Private desktop packages do not advance in the npm release commit.
+            const desktopVersion = await nextStableVersion(
+              "v",
+              stableVersion(desktopPackage.version, "Desktop app"),
+            );
+            const clipsVersion = await nextStableVersion(
+              "clips-v",
+              stableVersion(clipsPackage.version, "Clips desktop app"),
+            );
+            core.info(`Selected stable desktop versions: v${desktopVersion}, clips-v${clipsVersion}.`);
             const productionSites = Object.entries(sitesManifest)
               .filter(([, site]) =>
                 typeof site?.host === "string" && site.host.endsWith(".agent-native.com"),
@@ -391,69 +388,17 @@ jobs:
               throw new Error("The production site manifest contains no *.agent-native.com sites.");
             }
 
-            const existingDesktopRelease = await getPublishedRelease(`v${desktopVersion}`);
-            const desktopAlreadyPublished = hasCompleteDesktopRelease(existingDesktopRelease);
-            if (desktopAlreadyPublished) {
-              const desktopTagSha = await getRemoteTagSha(`v${desktopVersion}`);
-              if (!desktopTagSha) {
-                throw new Error(`Complete Desktop release v${desktopVersion} has no resolvable tag.`);
-              }
-              if (desktopVersionChanged) {
-                if (desktopTagSha !== releaseSha) {
-                  throw new Error(
-                    `Complete Desktop release v${desktopVersion} points to ${desktopTagSha}, expected ${releaseSha}.`,
-                  );
-                }
-              }
-              core.info(`Desktop v${desktopVersion} is already published with its required assets; treating it as complete.`);
-            } else if (existingDesktopRelease && !existingDesktopRelease.draft) {
-              throw new Error(
-                `Desktop release v${desktopVersion} is published but incomplete; refusing to rebuild a published release. Repair it manually or choose a new version.`,
-              );
-            }
-
-            const existingClipsRelease = await getPublishedRelease(`clips-v${clipsVersion}`);
-            const clipsAlreadyPublished = hasCompleteClipsRelease(existingClipsRelease, clipsVersion);
-            if (clipsAlreadyPublished) {
-              const clipsTagSha = await getRemoteTagSha(`clips-v${clipsVersion}`);
-              if (!clipsTagSha) {
-                throw new Error(`Complete Clips release clips-v${clipsVersion} has no resolvable tag.`);
-              }
-              if (clipsVersionChanged) {
-                if (clipsTagSha !== releaseSha) {
-                  throw new Error(
-                    `Complete Clips release clips-v${clipsVersion} points to ${clipsTagSha}, expected ${releaseSha}.`,
-                  );
-                }
-              }
-              core.info(`Clips v${clipsVersion} is already published with its required assets; treating it as complete.`);
-            } else if (existingClipsRelease && !existingClipsRelease.draft) {
-              throw new Error(
-                `Clips release clips-v${clipsVersion} is published but incomplete; refusing to rebuild a published release. Repair it manually or choose a new version.`,
-              );
-            }
-
             const [desktop, clips, production] = await Promise.all([
-              desktopAlreadyPublished
-                ? Promise.resolve({
-                    url: existingDesktopRelease.html_url,
-                    existing: true,
-                  })
-                : dispatch("desktop-release.yml", workflowRef, {
-                    channel: "production",
-                    version: desktopVersion,
-                    source_ref: releaseSha,
-                  }),
-              clipsAlreadyPublished
-                ? Promise.resolve({
-                    url: existingClipsRelease.html_url,
-                    existing: true,
-                  })
-                : dispatch("clips-desktop-release.yml", workflowRef, {
-                    channel: "production",
-                    version: clipsVersion,
-                    source_ref: releaseSha,
-                  }),
+              dispatch("desktop-release.yml", workflowRef, {
+                channel: "production",
+                version: desktopVersion,
+                source_ref: releaseSha,
+              }),
+              dispatch("clips-desktop-release.yml", workflowRef, {
+                channel: "production",
+                version: clipsVersion,
+                source_ref: releaseSha,
+              }),
               dispatch("deploy-production-sites-prebuilt.yml", workflowRef, {
                 sites: productionSites.join(","),
                 source_ref: releaseSha,
@@ -463,12 +408,8 @@ jobs:
             ]);
 
             const downstream = await Promise.allSettled([
-              desktopAlreadyPublished
-                ? Promise.resolve({ status: "completed", conclusion: "success" })
-                : waitForRun(desktop, "Agent-Native desktop stable release", 120 * 60_000),
-              clipsAlreadyPublished
-                ? Promise.resolve({ status: "completed", conclusion: "success" })
-                : waitForRun(clips, "Clips desktop stable release", 120 * 60_000),
+              waitForRun(desktop, "Agent-Native desktop stable release", 120 * 60_000),
+              waitForRun(clips, "Clips desktop stable release", 120 * 60_000),
               waitForRun(production, "Production site fleet", 120 * 60_000),
             ]);
             const failures = downstream

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -21,7 +21,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   pull-requests: read
 
 concurrency:
@@ -47,9 +47,12 @@ jobs:
             const apiVersion = "2026-03-10";
             const releaseType = process.env.RELEASE_TYPE;
             const startedAt = Date.now();
+            const coordinatorDeadline = startedAt + 355 * 60_000;
             const pollIntervalMs = 15_000;
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const phaseDeadline = (timeoutMs) =>
+              Math.min(coordinatorDeadline, Date.now() + timeoutMs);
 
             async function readJsonAt(ref, path) {
               const response = await github.rest.repos.getContent({
@@ -165,6 +168,25 @@ jobs:
               return formatStableVersion(candidate);
             }
 
+            async function reserveStableVersion(tagPrefix, baseVersion, sourceSha) {
+              for (let attempt = 0; attempt < 20; attempt += 1) {
+                const version = await nextStableVersion(tagPrefix, baseVersion);
+                try {
+                  await github.rest.git.createRef({
+                    owner,
+                    repo,
+                    ref: `refs/tags/${tagPrefix}${version}`,
+                    sha: sourceSha,
+                  });
+                  return version;
+                } catch (error) {
+                  if (error.status !== 422) throw error;
+                  core.warning(`Stable tag ${tagPrefix}${version} was reserved concurrently; retrying.`);
+                }
+              }
+              throw new Error(`Could not reserve a stable ${tagPrefix} version after 20 attempts.`);
+            }
+
             async function getFirstParentSha(ref) {
               const response = await github.rest.repos.getCommit({
                 owner,
@@ -179,7 +201,7 @@ jobs:
             }
 
             async function waitForRun(run, label, timeoutMs) {
-              const deadline = Date.now() + timeoutMs;
+              const deadline = phaseDeadline(timeoutMs);
               let lastStatus = "";
               let lastLoggedAt = 0;
               while (Date.now() < deadline) {
@@ -226,7 +248,7 @@ jobs:
             }
 
             async function waitForReleasePullRequest(previousNumbers) {
-              const deadline = Date.now() + 30 * 60_000;
+              const deadline = phaseDeadline(30 * 60_000);
               while (Date.now() < deadline) {
                 const candidates = (await listReleasePullRequests())
                   .filter(isStableReleasePullRequest)
@@ -251,7 +273,7 @@ jobs:
             }
 
             async function waitForReleaseMerge(pr) {
-              const deadline = Date.now() + 45 * 60_000;
+              const deadline = phaseDeadline(45 * 60_000);
               while (Date.now() < deadline) {
                 const current = (await github.rest.pulls.get({
                   owner,
@@ -274,7 +296,7 @@ jobs:
             }
 
             async function waitForStablePackagePublish(mergeSha, packageTag, requireMergeTag) {
-              const deadline = Date.now() + 120 * 60_000;
+              const deadline = phaseDeadline(120 * 60_000);
               while (Date.now() < deadline) {
                 const response = await github.rest.actions.listWorkflowRuns({
                   owner,
@@ -370,13 +392,15 @@ jobs:
               "scripts/netlify-production-sites.json",
             );
             // Private desktop packages do not advance in the npm release commit.
-            const desktopVersion = await nextStableVersion(
+            const desktopVersion = await reserveStableVersion(
               "v",
               stableVersion(desktopPackage.version, "Desktop app"),
+              releaseSha,
             );
-            const clipsVersion = await nextStableVersion(
+            const clipsVersion = await reserveStableVersion(
               "clips-v",
               stableVersion(clipsPackage.version, "Clips desktop app"),
+              releaseSha,
             );
             core.info(`Selected stable desktop versions: v${desktopVersion}, clips-v${clipsVersion}.`);
             const productionSites = Object.entries(sitesManifest)

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -45,7 +45,7 @@ describe("release everything workflow", () => {
     });
     assert.deepEqual(workflow.permissions, {
       actions: "write",
-      contents: "read",
+      contents: "write",
       "pull-requests": "read",
     });
   });
@@ -60,6 +60,14 @@ describe("release everything workflow", () => {
     assert.match(source, /waitForStablePackagePublish/);
     assert.match(source, /Stable package release preparation/);
     assert.match(source, /90 \* 60_000/);
+    assert.match(
+      source,
+      /const coordinatorDeadline = startedAt \+ 355 \* 60_000/,
+    );
+    assert.match(
+      source,
+      /Math\.min\(coordinatorDeadline, Date\.now\(\) \+ timeoutMs\)/,
+    );
     assert.match(source, /async function getRemoteTagSha\(tag\)/);
     assert.match(source, /github\.rest\.git\.getTag/);
     assert.match(
@@ -69,6 +77,13 @@ describe("release everything workflow", () => {
     assert.match(source, /github\.paginate\(github\.rest\.repos\.listReleases/);
     assert.match(source, /release\.tag_name\.startsWith\(tagPrefix\)/);
     assert.match(source, /candidate\[2\] \+= 1/);
+    assert.match(
+      source,
+      /async function reserveStableVersion\(tagPrefix, baseVersion, sourceSha\)/,
+    );
+    assert.match(source, /github\.rest\.git\.createRef/);
+    assert.match(source, /refs\/tags\/\$\{tagPrefix\}\$\{version\}/);
+    assert.match(source, /error\.status !== 422/);
     assert.match(source, /async function getFirstParentSha\(ref\)/);
     assert.match(
       source,

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -84,6 +84,11 @@ describe("release everything workflow", () => {
     assert.match(source, /github\.rest\.git\.createRef/);
     assert.match(source, /refs\/tags\/\$\{tagPrefix\}\$\{version\}/);
     assert.match(source, /error\.status !== 422/);
+    assert.match(source, /const reservedTags = new Map\(\)/);
+    assert.match(source, /async function cleanupReservedTags\(\)/);
+    assert.match(source, /github\.rest\.repos\.deleteRelease/);
+    assert.match(source, /github\.rest\.git\.deleteRef/);
+    assert.match(source, /await cleanupReservedTags\(\)/);
     assert.match(source, /async function getFirstParentSha\(ref\)/);
     assert.match(
       source,

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -53,13 +53,22 @@ describe("release everything workflow", () => {
   it("waits for package publication before dispatching stable downstream releases", () => {
     assert.equal(
       coordinator.uses,
-      "actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b",
+      "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
     );
     const source = String((coordinator.with as Workflow).script);
     assert.match(source, /auto-publish\.yml/);
     assert.match(source, /waitForStablePackagePublish/);
+    assert.match(source, /Stable package release preparation/);
+    assert.match(source, /90 \* 60_000/);
     assert.match(source, /async function getRemoteTagSha\(tag\)/);
     assert.match(source, /github\.rest\.git\.getTag/);
+    assert.match(
+      source,
+      /async function nextStableVersion\(tagPrefix, baseVersion\)/,
+    );
+    assert.match(source, /github\.paginate\(github\.rest\.repos\.listReleases/);
+    assert.match(source, /release\.tag_name\.startsWith\(tagPrefix\)/);
+    assert.match(source, /candidate\[2\] \+= 1/);
     assert.match(source, /async function getFirstParentSha\(ref\)/);
     assert.match(
       source,
@@ -70,13 +79,11 @@ describe("release everything workflow", () => {
       source,
       /waitForStablePackagePublish\(releaseSha, packageRef, coreVersionChanged\)/,
     );
-    assert.match(source, /tagSha !== mergeSha/);
     assert.match(source, /readJsonAt\(\s*releaseBaseSha,/);
     assert.match(
       source,
       /initialCorePackage\.version !== corePackage\.version/,
     );
-    assert.match(source, /pointing to \$\{mergeSha\}/);
     assert.match(source, /desktop-release\.yml/);
     assert.match(source, /clips-desktop-release\.yml/);
     assert.match(source, /deploy-production-sites-prebuilt\.yml/);
@@ -90,34 +97,12 @@ describe("release everything workflow", () => {
       /const workflowRef = coreVersionChanged \? packageRef : "main"/,
     );
     assert.match(source, /dispatch\("desktop-release\.yml", workflowRef/);
-    assert.match(source, /source_ref: releaseSha/);
-    assert.match(source, /getReleaseByTag/);
-    assert.match(source, /hasCompleteDesktopRelease/);
-    assert.match(source, /desktopAlreadyPublished/);
-    assert.match(source, /desktopVersionChanged/);
-    assert.match(source, /const desktopTagSha = await getRemoteTagSha/);
-    assert.match(
+    assert.match(source, /version: desktopVersion/);
+    assert.match(source, /dispatch\("clips-desktop-release\.yml", workflowRef/);
+    assert.match(source, /version: clipsVersion/);
+    assert.doesNotMatch(
       source,
-      /Desktop release v\$\{desktopVersion\} is published but incomplete/,
-    );
-    assert.match(source, /hasCompleteClipsRelease/);
-    assert.match(source, /initialClipsPackage/);
-    assert.match(source, /clipsVersionChanged/);
-    assert.match(
-      source,
-      /clipsAlreadyPublished[\s\S]*const clipsTagSha = await getRemoteTagSha/,
-    );
-    assert.match(source, /clipsTagSha !== releaseSha/);
-    assert.match(
-      source,
-      /Clips release clips-v\$\{clipsVersion\} is published but incomplete/,
-    );
-    assert.match(source, /Agent-Native-arm64\.dmg/);
-    assert.match(source, /Clips_\$\{version\}_universal\.dmg/);
-    assert.match(source, /clipsAlreadyPublished/);
-    assert.match(
-      source,
-      /desktopAlreadyPublished[\s\S]*Promise\.resolve\(\{ status: "completed"/,
+      /desktopAlreadyPublished|clipsAlreadyPublished/,
     );
     assert.match(source, /source_ref: releaseSha/);
     assert.match(source, /endsWith\("\.agent-native\.com"\)/);

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -62,7 +62,7 @@ describe("release everything workflow", () => {
     assert.match(source, /90 \* 60_000/);
     assert.match(
       source,
-      /const coordinatorDeadline = startedAt \+ 355 \* 60_000/,
+      /const coordinatorDeadline = startedAt \+ 350 \* 60_000/,
     );
     assert.match(
       source,
@@ -89,6 +89,7 @@ describe("release everything workflow", () => {
     assert.match(source, /github\.rest\.repos\.deleteRelease/);
     assert.match(source, /github\.rest\.git\.deleteRef/);
     assert.match(source, /await cleanupReservedTags\(\)/);
+    assert.match(source, /Downstream workflows own these reserved tags/);
     assert.match(source, /async function getFirstParentSha\(ref\)/);
     assert.match(
       source,


### PR DESCRIPTION
## Summary

- wait longer for the serialized stable package preparation run
- allocate fresh stable Electron and Clips tags on every production train
- always dispatch and await both stable desktop builders

## Verification

- `corepack pnpm test:package-release-workflow`
- `corepack pnpm guards`