### PR TITLE
Fix Slides multi-selection and overlay positioning

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
+++ b/templates/slides/app/components/editor/SlideEditor.render-phase.test.ts
@@ -92,4 +92,42 @@ describe("SlideEditor render-phase safety", () => {
       pointerDownBody.indexOf("clearCanvasSelection"),
     );
   });
+
+  it("ends native text editing before entering a multi-selection", () => {
+    const start = source.indexOf("const applyMultiSelection");
+    const end = source.indexOf("const clearMultiSelection", start);
+    const multiSelectionBody = source.slice(start, end);
+
+    expect(multiSelectionBody).toContain(
+      "if (ids.size > 0 && editingElRef.current) exitInlineEdit();",
+    );
+    expect(source).toContain("window.getSelection()?.removeAllRanges();");
+  });
+
+  it("lets additive canvas selection leave an active text edit", () => {
+    const start = source.indexOf("const handleSlidePointerDown");
+    const end = source.indexOf(
+      "// Keep these listeners stable while React re-renders the marquee overlay.",
+      start,
+    );
+    const pointerDownBody = source.slice(start, end);
+
+    expect(pointerDownBody).toContain("const additive =");
+    expect(pointerDownBody).toContain("const targetIsEditingBlock =");
+    expect(pointerDownBody).toContain("exitInlineEdit();");
+  });
+
+  it("re-measures portaled selection chrome after the editor layout moves", () => {
+    const start = source.indexOf("const refreshMultiSelectionRects");
+    const end = source.indexOf("// Keep cached rects fresh", start);
+    const layoutBody = source.slice(start, end);
+
+    expect(layoutBody).toContain("useLayoutEffect(() => {");
+    expect(layoutBody).toContain(
+      'scrollContainer.closest(".deck-editor-workspace")',
+    );
+    expect(layoutBody).toContain("new ResizeObserver(update)");
+    expect(layoutBody).toContain("new MutationObserver(update)");
+    expect(layoutBody).toContain("invalidateSelectionOverlayMeasurement();");
+  });
 });

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2102,6 +2102,7 @@ export default function SlideEditor({
     richTextSelectionRef.current = null;
     el.contentEditable = "false";
     el.removeAttribute("data-editing-block");
+    window.getSelection()?.removeAllRanges();
 
     // Selection and freeform promotion are separate operations. Merely ending
     // text editing must not turn a flow-layout block into an absolutely
@@ -2598,6 +2599,10 @@ export default function SlideEditor({
    */
   const applyMultiSelection = useCallback(
     (ids: Set<string>) => {
+      // A canvas selection supersedes native text selection. Keep every entry
+      // point (shift-click, marquee, layer panel, and restored selection) in
+      // the same object-selection mode.
+      if (ids.size > 0 && editingElRef.current) exitInlineEdit();
       const slideContent = getSlideContent();
       const rects = new Map<
         string,
@@ -2640,7 +2645,12 @@ export default function SlideEditor({
         items.length > 0 ? buildSelectionState("multi", items) : null,
       );
     },
-    [buildSelectionState, clearSelectedElement, getSlideContent],
+    [
+      buildSelectionState,
+      clearSelectedElement,
+      exitInlineEdit,
+      getSlideContent,
+    ],
   );
 
   const clearMultiSelection = useCallback(() => {
@@ -3046,6 +3056,72 @@ export default function SlideEditor({
     },
     [getSlideContent],
   );
+
+  // Portal selection chrome uses viewport coordinates, so a flex layout change
+  // can move the canvas without resizing the selected element. Re-measure the
+  // active selection when the editor layout changes, not only on canvas input.
+  useLayoutEffect(() => {
+    if (
+      !selectedImg &&
+      multiSelection.size === 0 &&
+      (!selectedElementPath || !selectedElementSelector)
+    ) {
+      return;
+    }
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const update = () => {
+      setSelectionViewportRect(scrollContainer.getBoundingClientRect());
+      if (selectedImg) setSelectionRect(selectedImg.getBoundingClientRect());
+      if (multiSelection.size > 0) {
+        refreshMultiSelectionRects(multiSelection);
+      }
+      if (selectedElementPath && selectedElementSelector) {
+        invalidateSelectionOverlayMeasurement();
+      }
+    };
+
+    update();
+    const layoutRoot = scrollContainer.closest(".deck-editor-workspace");
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+    for (const element of [
+      layoutRoot,
+      scrollContainer,
+      canvasTrackRef.current,
+      containerRef.current,
+      slideCanvasRef.current,
+      selectedImg,
+    ]) {
+      if (element) resizeObserver?.observe(element);
+    }
+    const mutationObserver =
+      typeof MutationObserver === "undefined" || !layoutRoot
+        ? null
+        : new MutationObserver(update);
+    if (mutationObserver && layoutRoot) {
+      mutationObserver.observe(layoutRoot, { childList: true });
+    }
+    layoutRoot?.addEventListener("animationend", update);
+    layoutRoot?.addEventListener("transitionend", update);
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      layoutRoot?.removeEventListener("animationend", update);
+      layoutRoot?.removeEventListener("transitionend", update);
+    };
+  }, [
+    animationsOpen,
+    invalidateSelectionOverlayMeasurement,
+    layersOpen,
+    multiSelection,
+    refreshMultiSelectionRects,
+    selectedElementPath,
+    selectedElementSelector,
+    selectedImg,
+  ]);
 
   // Keep cached rects fresh on scroll/resize so outlines + chip stay aligned.
   // Group drag calls the same helper every pointer move so its outlines do not
@@ -5597,7 +5673,15 @@ export default function SlideEditor({
         if (e.pointerId >= 0) e.currentTarget.setPointerCapture(e.pointerId);
         return;
       }
-      if (
+      const additive = e.shiftKey || e.metaKey || e.ctrlKey;
+      const targetIsEditingBlock =
+        editingEl?.contains(e.target as Node) ?? false;
+      if (editingEl) {
+        if (targetIsEditingBlock && !additive && multiSelection.size === 0) {
+          return;
+        }
+        exitInlineEdit();
+      } else if (
         isSlideTextEditingTarget(e.target, document.activeElement, editingEl)
       ) {
         return;


### PR DESCRIPTION
## Summary
- Exit rich text editing and native text selection when a canvas multi-selection begins.
- Keep multi-selection drag, nudge, and resize on the object-selection path.
- Re-measure portaled selection chrome when the editor canvas moves with a sidebar or layout transition.

## Validation
- `corepack pnpm --dir templates/slides test`
- `corepack pnpm --dir templates/slides typecheck`
- `corepack pnpm --dir templates/slides build`
