### PR TITLE
Replace pulsing skeleton loaders with smooth shine

### DIFF
--- a/.changeset/smooth-skeleton-shine.md
+++ b/.changeset/smooth-skeleton-shine.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+---
+
+Replace flashing skeleton pulses with a smooth whole-surface loading shine.

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -490,13 +490,6 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
 
-  /* Tailwind's stock pulse swings opacity 1 -> 0.5 and eases hard into both
-     ends, so a placeholder reads as blinking rather than breathing. Skeletons
-     also mount at different moments, so their cycles never line up: at that
-     amplitude a screen of them strobes. Keep the swing small enough that
-     out-of-phase neighbours stay calm. */
-  --animate-pulse: skeleton-pulse 2s ease-in-out infinite;
-
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
   --animate-bounce-once: bounce-once 0.46s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -546,16 +539,45 @@
   }
 }
 
-/* Declared at top level, not inside `@theme`, so it is emitted even in a build
-   where no `animate-pulse` utility survives tree-shaking — other stylesheets
-   reference it by name. */
-@keyframes skeleton-pulse {
-  50% {
-    opacity: 0.72;
+/* Whole-surface loading treatment. The muted selectors keep hand-rolled
+   placeholders on the same motion until they migrate to the shared class. */
+.skeleton-shimmer,
+.animate-pulse[class~="bg-muted"],
+.animate-pulse[class*="bg-muted/"],
+.animate-pulse[class~="bg-card"],
+.animate-pulse[class~="bg-border"],
+.animate-pulse[class*="bg-border/"] {
+  background-image: linear-gradient(
+    100deg,
+    transparent 30%,
+    hsl(var(--foreground, var(--ui-foreground)) / 0.12) 50%,
+    transparent 70%
+  );
+  background-position: 150% 0;
+  background-repeat: repeat;
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.6s linear infinite;
+}
+
+@keyframes skeleton-shimmer {
+  from {
+    background-position: 150% 0;
+  }
+  to {
+    background-position: -50% 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer,
+  .animate-pulse[class~="bg-muted"],
+  .animate-pulse[class*="bg-muted/"],
+  .animate-pulse[class~="bg-card"],
+  .animate-pulse[class~="bg-border"],
+  .animate-pulse[class*="bg-border/"] {
+    animation: none;
+  }
+
   .animate-pulse {
     animation: none;
   }

--- a/packages/core/src/styles/agent-native.spec.ts
+++ b/packages/core/src/styles/agent-native.spec.ts
@@ -118,6 +118,20 @@ describe("agent-native shell surface tokens", () => {
     );
   });
 
+  it("uses a shared linear whole-surface shimmer for skeletons", () => {
+    const css = readFileSync(new URL("./agent-native.css", import.meta.url), {
+      encoding: "utf8",
+    });
+
+    expect(css).toMatch(
+      /\.skeleton-shimmer,[\s\S]*?background-image: linear-gradient\([\s\S]*?animation: skeleton-shimmer 1\.6s linear infinite;/s,
+    );
+    expect(css).toMatch(
+      /@keyframes skeleton-shimmer[\s\S]*?background-position: 150% 0;[\s\S]*?background-position: -50% 0;/s,
+    );
+    expect(css).not.toContain("skeleton-pulse");
+  });
+
   it("uses a surface-independent mask for the scrolled chat fade", () => {
     const css = readFileSync(new URL("./agent-native.css", import.meta.url), {
       encoding: "utf8",

--- a/packages/core/src/styles/blocks.css
+++ b/packages/core/src/styles/blocks.css
@@ -1832,9 +1832,3 @@
 .plan-wf[data-skeleton="true"] {
   --radius: 7px;
 }
-
-@media (prefers-reduced-motion: no-preference) {
-  .plan-wf[data-skeleton="true"] {
-    animation: skeleton-pulse 2s ease-in-out infinite;
-  }
-}

--- a/packages/dispatch/src/components/ui/skeleton.tsx
+++ b/packages/dispatch/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer rounded-md bg-muted", className)}
       {...props}
     />
   );

--- a/packages/toolkit/src/ui/skeleton.tsx
+++ b/packages/toolkit/src/ui/skeleton.tsx
@@ -6,10 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn(
-        "animate-pulse motion-reduce:animate-none rounded-md bg-muted",
-        className,
-      )}
+      className={cn("skeleton-shimmer rounded-md bg-muted", className)}
       {...props}
     />
   );

--- a/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.refresh.spec.tsx
@@ -102,7 +102,7 @@ describe("SqlChart refresh feedback", () => {
       '[data-dashboard-report-loading="true"]',
     );
     expect(loadingSkeleton).not.toBeNull();
-    expect(loadingSkeleton?.className).toContain("animate-pulse");
+    expect(loadingSkeleton?.className).toContain("skeleton-shimmer");
     expect(loadingSkeleton?.className).toContain(
       "analytics-dashboard-panel-skeleton",
     );

--- a/templates/analytics/app/global.css
+++ b/templates/analytics/app/global.css
@@ -140,13 +140,6 @@
 
 .analytics-dashboard-panel-skeleton {
   background-color: hsl(var(--muted-foreground) / 0.12);
-  animation: skeleton-pulse 2s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .analytics-dashboard-panel-skeleton {
-    animation: none;
-  }
 }
 
 .analytics-mobile-nav {

--- a/templates/analytics/changelog/2026-08-28-analytics-loading-placeholders-now-use-a-smooth-whole-surfac.md
+++ b/templates/analytics/changelog/2026-08-28-analytics-loading-placeholders-now-use-a-smooth-whole-surfac.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Analytics loading placeholders now use a smooth whole-surface shine

--- a/templates/clips/desktop/src/components/ui/skeleton.tsx
+++ b/templates/clips/desktop/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer rounded-md bg-muted", className)}
       {...props}
     />
   );

--- a/templates/clips/desktop/src/tailwind.css
+++ b/templates/clips/desktop/src/tailwind.css
@@ -23,6 +23,34 @@
 
 @source "./**/*.{ts,tsx}";
 
+.skeleton-shimmer {
+  background-image: linear-gradient(
+    100deg,
+    transparent 30%,
+    hsl(var(--ui-foreground) / 0.12) 50%,
+    transparent 70%
+  );
+  background-position: 150% 0;
+  background-repeat: repeat;
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.6s linear infinite;
+}
+
+@keyframes skeleton-shimmer {
+  from {
+    background-position: 150% 0;
+  }
+  to {
+    background-position: -50% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer {
+    animation: none;
+  }
+}
+
 /**
  * The parts of preflight a Tailwind-era surface cannot live without, scoped to
  * subtrees marked `data-tw-surface` so the hand-written tray surfaces keep the

--- a/templates/content/app/components/editor/database/sidebar.test.tsx
+++ b/templates/content/app/components/editor/database/sidebar.test.tsx
@@ -275,7 +275,7 @@ describe("DatabaseSidebarView", () => {
 
     expect(markup).not.toContain("Loading");
     expect(markup).not.toContain("animate-spin");
-    expect(markup).toContain("animate-pulse");
+    expect(markup).toContain("skeleton-shimmer");
   });
 
   it("renders compact router links for an ungrouped saved view", () => {

--- a/templates/plan/app/components/plan/wireframe/Wireframe.tsx
+++ b/templates/plan/app/components/plan/wireframe/Wireframe.tsx
@@ -494,7 +494,7 @@ function HtmlArtboard({
       render={({ theme, style }) => (
         <div
           ref={htmlRef}
-          className="plan-html-frame"
+          className={cn("plan-html-frame", data.skeleton && "skeleton-shimmer")}
           data-theme={theme}
           data-style={style}
           data-frame={showFrame ? "show" : "hide"}

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -268,9 +268,24 @@
   --wf-card: var(--plan-block, hsl(var(--card)));
   --wf-accent: var(--plan-muted-line, hsl(var(--border)));
   --wf-accent-soft: var(--plan-block, hsl(var(--card)));
+  background-image: linear-gradient(
+    100deg,
+    transparent 30%,
+    hsl(var(--foreground) / 0.12) 50%,
+    transparent 70%
+  );
+  background-position: 150% 0;
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.6s linear infinite;
 }
 .plan-html-frame[data-skeleton="true"] * {
   color: transparent !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan-html-frame[data-skeleton="true"] {
+    animation: none;
+  }
 }
 
 /*

--- a/templates/plan/app/components/plan/wireframe/kit/plan-wireframe-tokens.css
+++ b/templates/plan/app/components/plan/wireframe/kit/plan-wireframe-tokens.css
@@ -125,18 +125,3 @@
 .plan-wf[data-skeleton="true"] {
   --radius: 7px;
 }
-
-@media (prefers-reduced-motion: no-preference) {
-  .plan-wf[data-skeleton="true"] {
-    animation: plan-skeleton-pulse 1.6s ease-in-out infinite;
-  }
-}
-@keyframes plan-skeleton-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
-  }
-}

--- a/templates/plan/app/components/plan/wireframe/kit/primitives.tsx
+++ b/templates/plan/app/components/plan/wireframe/kit/primitives.tsx
@@ -112,7 +112,7 @@ export function Screen({
   void sketch;
   return (
     <div
-      className="plan-wf"
+      className={isSkeleton ? "plan-wf skeleton-shimmer" : "plan-wf"}
       data-density={density ?? "regular"}
       data-theme={wfTheme}
       data-skeleton={isSkeleton ? "true" : undefined}
@@ -121,7 +121,7 @@ export function Screen({
         position: "relative",
         width: "100%",
         height: "100%",
-        background: V.paper,
+        backgroundColor: V.paper,
         color: V.ink,
         fontFamily: V.hand,
         fontSize: V.fs,

--- a/templates/plan/app/pages/PlansPage.tsx
+++ b/templates/plan/app/pages/PlansPage.tsx
@@ -7410,11 +7410,11 @@ function PlanSkillDemoVideo({ demo }: { demo: PlanSkillDemo }) {
         />
         <div
           aria-hidden
-          className={`pointer-events-none absolute inset-0 bg-muted transition-opacity duration-300 ${
+          className={`skeleton-shimmer pointer-events-none absolute inset-0 bg-muted transition-opacity duration-300 ${
             isLoaded ? "opacity-0" : "opacity-100"
           }`}
         >
-          <div className="flex size-full animate-pulse flex-col justify-between p-4">
+          <div className="flex size-full flex-col justify-between p-4">
             <div className="space-y-2">
               <div className="h-3 w-1/3 rounded-full bg-border" />
               <div className="h-2.5 w-2/3 rounded-full bg-border/80" />

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1171,23 +1171,15 @@ button[title="Open agent sidebar"] {
    Sits above the rendered slide so it reads as "in progress" instead of a
    static placeholder for the length of the generation run. */
 .slide-thumbnail-ai-shimmer {
-  background: linear-gradient(
+  background-image: linear-gradient(
     100deg,
     transparent 30%,
     rgba(255, 255, 255, 0.16) 50%,
     transparent 70%
   );
+  background-position: 150% 0;
   background-size: 200% 100%;
-  animation: slide-thumbnail-shimmer 1.6s ease-in-out infinite;
-}
-
-@keyframes slide-thumbnail-shimmer {
-  from {
-    background-position: 150% 0;
-  }
-  to {
-    background-position: -50% 0;
-  }
+  animation: skeleton-shimmer 1.6s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/templates/slides/app/pages/DesignSystems.tsx
+++ b/templates/slides/app/pages/DesignSystems.tsx
@@ -185,8 +185,8 @@ export default function DesignSystems() {
         {isLoading ? (
           <>
             <div className="flex items-center justify-between mb-6">
-              <div className="h-5 w-40 rounded-md bg-muted animate-pulse" />
-              <div className="h-3 w-16 rounded bg-muted animate-pulse" />
+              <div className="skeleton-shimmer h-5 w-40 rounded-md bg-muted" />
+              <div className="skeleton-shimmer h-3 w-16 rounded bg-muted" />
             </div>
             <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,320px))] gap-4">
               {Array.from({ length: 4 }).map((_, i) => (
@@ -194,10 +194,10 @@ export default function DesignSystems() {
                   key={i}
                   className="rounded-xl border border-border bg-card overflow-hidden"
                 >
-                  <div className="aspect-video bg-muted/50 animate-pulse" />
+                  <div className="skeleton-shimmer aspect-video bg-muted/50" />
                   <div className="p-4 space-y-2">
-                    <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
-                    <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
+                    <div className="skeleton-shimmer h-4 w-3/4 rounded bg-muted" />
+                    <div className="skeleton-shimmer h-3 w-1/2 rounded bg-muted" />
                   </div>
                 </div>
               ))}

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1561,16 +1561,16 @@ export default function Index() {
       {loading ? (
         <>
           <div className="mb-4 flex items-center justify-end">
-            <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+            <div className="skeleton-shimmer h-3 w-16 rounded bg-muted" />
           </div>
           <div className="deck-grid-container">
             <div className="deck-grid grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {Array.from({ length: 8 }).map((_, i) => (
                 <div key={i} className="overflow-hidden rounded-xl bg-card">
-                  <div className="aspect-video animate-pulse bg-muted/50" />
+                  <div className="skeleton-shimmer aspect-video bg-muted/50" />
                   <div className="space-y-2 p-4">
-                    <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
-                    <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+                    <div className="skeleton-shimmer h-4 w-3/4 rounded bg-muted" />
+                    <div className="skeleton-shimmer h-3 w-1/2 rounded bg-muted" />
                   </div>
                 </div>
               ))}

--- a/templates/slides/app/pages/SharedPresentation.tsx
+++ b/templates/slides/app/pages/SharedPresentation.tsx
@@ -66,7 +66,7 @@ export default function SharedPresentation({
   if (loading) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center p-8">
-        <div className="w-full max-w-5xl aspect-video rounded-xl bg-white/[0.04] animate-pulse" />
+        <div className="skeleton-shimmer w-full max-w-5xl aspect-video rounded-xl bg-foreground/[0.04]" />
       </div>
     );
   }


### PR DESCRIPTION
## Summary\n- Replace the shared skeleton pulse with a smooth whole-surface shine matching the Slides AI editing treatment.\n- Apply the same motion to Slides, Analytics, Plan, Dispatch, Toolkit, and Clips loading surfaces.\n- Preserve reduced-motion behavior and add the Analytics product changelog entry.\n\n## Validation\n- Focused Core, Analytics, Slides, and Plan tests passed.\n- All 65 repository guards passed.\n- Live Slides and Analytics loading routes verified in-browser with screenshots and computed linear shimmer styles.