### PR TITLE
Fix Slides working indicator visibility

### DIFF
--- a/templates/slides/app/components/layout/AgentWorkIndicator.test.tsx
+++ b/templates/slides/app/components/layout/AgentWorkIndicator.test.tsx
@@ -14,6 +14,7 @@ import { CHAT_STOP_DEBOUNCE_MS } from "@/hooks/use-agent-generating";
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({
   focusAgentChat: vi.fn(),
+  SIDEBAR_STATE_CHANGE_EVENT: "agent-panel:state-change",
 }));
 
 vi.mock("@agent-native/core/client/i18n", () => ({
@@ -105,6 +106,22 @@ describe("AgentWorkIndicator", () => {
     await waitFor(() => {
       expect(screen.queryByText("Agent is working")).toBeNull();
     });
+  });
+
+  it("uses the authoritative sidebar state while the panel is mounting", () => {
+    render(<AgentWorkIndicator />);
+    dispatchRunning(true);
+    expect(screen.getByText("Agent is working")).toBeTruthy();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("agent-panel:state-change", {
+          detail: { open: true, source: "app", mode: "app" },
+        }),
+      );
+    });
+
+    expect(screen.queryByText("Agent is working")).toBeNull();
   });
 
   it("hides when the portal wrapper becomes inaccessible", async () => {

--- a/templates/slides/app/components/layout/AgentWorkIndicator.tsx
+++ b/templates/slides/app/components/layout/AgentWorkIndicator.tsx
@@ -1,4 +1,8 @@
-import { focusAgentChat } from "@agent-native/core/client/agent-chat";
+import {
+  focusAgentChat,
+  SIDEBAR_STATE_CHANGE_EVENT,
+  type AgentSidebarStateChangeDetail,
+} from "@agent-native/core/client/agent-chat";
 import { useT } from "@agent-native/core/client/i18n";
 import { IconLoader2, IconMessageCircle } from "@tabler/icons-react";
 import { useEffect, useRef, useState } from "react";
@@ -38,9 +42,19 @@ export function isAgentSidebarVisible() {
 
 function useAgentSidebarVisible() {
   const [visible, setVisible] = useState(false);
+  const sidebarStateRef = useRef<boolean | null>(null);
 
   useEffect(() => {
-    const update = () => setVisible(isAgentSidebarVisible());
+    const update = () => {
+      setVisible(sidebarStateRef.current ?? isAgentSidebarVisible());
+    };
+    const handleStateChange = (event: Event) => {
+      const detail = (event as CustomEvent<AgentSidebarStateChangeDetail>)
+        .detail;
+      if (typeof detail?.open !== "boolean") return;
+      sidebarStateRef.current = detail.open;
+      setVisible(detail.open);
+    };
     update();
 
     // The panel is a portal and is normally a direct child of body. Discover
@@ -78,6 +92,7 @@ function useAgentSidebarVisible() {
     discovery.observe(document.body, { childList: true });
     updateAndObserve();
     window.addEventListener("resize", update);
+    window.addEventListener(SIDEBAR_STATE_CHANGE_EVENT, handleStateChange);
     window.addEventListener("agent-panel:open", update);
     window.addEventListener("agent-panel:toggle", update);
     window.addEventListener("agent-panel:set-mode", update);
@@ -87,6 +102,7 @@ function useAgentSidebarVisible() {
       panelObserver?.disconnect();
       parentObserver?.disconnect();
       window.removeEventListener("resize", update);
+      window.removeEventListener(SIDEBAR_STATE_CHANGE_EVENT, handleStateChange);
       window.removeEventListener("agent-panel:open", update);
       window.removeEventListener("agent-panel:toggle", update);
       window.removeEventListener("agent-panel:set-mode", update);


### PR DESCRIPTION
## Summary

- Use the shared agent sidebar state event as the visibility source of truth.
- Hide the Slides working indicator while the sidebar is open, including during mounting.
- Add regression coverage for the mounting transition.

## Validation

- Focused AgentWorkIndicator tests: 10 passed
- Slides typecheck and build passed
- Formatting, diff check, and 65 repository guards passed