### PR TITLE
fix: restore hosted first-run onboarding

### DIFF
--- a/.changeset/restore-hosted-onboarding.md
+++ b/.changeset/restore-hosted-onboarding.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restore hosted first-run onboarding after email verification and sign-in redirects.

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getSessionMock = vi.hoisted(() => vi.fn());
 const appStateGetMock = vi.hoisted(() => vi.fn());
@@ -12,6 +12,10 @@ vi.mock("../deploy/route-discovery.js", () => ({
 }));
 
 vi.mock("../server/auth.js", () => ({
+  cookieDomainAttrs: () => {
+    const domain = process.env.COOKIE_DOMAIN;
+    return domain ? { domain } : {};
+  },
   getSession: (...args: any[]) => getSessionMock(...args),
 }));
 
@@ -119,6 +123,10 @@ function registerRequestContextProbeStep() {
 }
 
 describe("onboarding plugin routes", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     __resetOnboardingRegistry();
     vi.clearAllMocks();
@@ -248,6 +256,7 @@ describe("onboarding plugin routes", () => {
   });
 
   it("keeps first-run onboarding tied to the signup cookie and completion state", async () => {
+    vi.stubEnv("COOKIE_DOMAIN", ".example.com");
     const nitroApp = createNitroApp();
     await createOnboardingPlugin({ skipDefaultSteps: true })(nitroApp);
 
@@ -294,9 +303,11 @@ describe("onboarding plugin routes", () => {
     expect(finish.headers.get("set-cookie")).toContain(
       `${FIRST_RUN_ONBOARDING_COOKIE}=`,
     );
+    expect(finish.headers.get("set-cookie")).toContain("Domain=.example.com");
   });
 
   it("does not show first-run onboarding to a member of an existing organization", async () => {
+    vi.stubEnv("COOKIE_DOMAIN", ".example.com");
     getOrgContextMock.mockResolvedValue({
       email: "alice@example.com",
       orgId: "org-existing",
@@ -318,6 +329,7 @@ describe("onboarding plugin routes", () => {
     expect(result.headers.get("set-cookie")).toContain(
       `${FIRST_RUN_ONBOARDING_COOKIE}=`,
     );
+    expect(result.headers.get("set-cookie")).toContain("Domain=.example.com");
   });
 
   it("requires an authenticated user to complete first-run onboarding", async () => {

--- a/packages/core/src/onboarding/plugin.spec.ts
+++ b/packages/core/src/onboarding/plugin.spec.ts
@@ -16,6 +16,11 @@ vi.mock("../server/auth.js", () => ({
     const domain = process.env.COOKIE_DOMAIN;
     return domain ? { domain } : {};
   },
+  crossSiteCookieAttrs: () => ({
+    sameSite: "none",
+    secure: true,
+    partitioned: true,
+  }),
   getSession: (...args: any[]) => getSessionMock(...args),
 }));
 
@@ -304,6 +309,9 @@ describe("onboarding plugin routes", () => {
       `${FIRST_RUN_ONBOARDING_COOKIE}=`,
     );
     expect(finish.headers.get("set-cookie")).toContain("Domain=.example.com");
+    expect(finish.headers.get("set-cookie")).toContain("SameSite=None");
+    expect(finish.headers.get("set-cookie")).toContain("Secure");
+    expect(finish.headers.get("set-cookie")).toContain("Partitioned");
   });
 
   it("does not show first-run onboarding to a member of an existing organization", async () => {

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -24,7 +24,7 @@ import {
 
 import { appStateGet, appStatePut } from "../application-state/store.js";
 import { getOrgContext } from "../org/context.js";
-import { getSession } from "../server/auth.js";
+import { cookieDomainAttrs, getSession } from "../server/auth.js";
 import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
 import {
   awaitBootstrap,
@@ -322,7 +322,10 @@ export function createOnboardingPlugin(
             FIRST_RUN_ONBOARDING_COMPLETED_KEY,
           );
           if (completed?.completed === true) {
-            deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, { path: "/" });
+            deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
+              path: "/",
+              ...cookieDomainAttrs(),
+            });
             return { firstRun: false };
           }
 
@@ -338,7 +341,10 @@ export function createOnboardingPlugin(
           const firstRun =
             orgContext.orgId !== null && eligible?.orgId === orgContext.orgId;
           if (!firstRun) {
-            deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, { path: "/" });
+            deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
+              path: "/",
+              ...cookieDomainAttrs(),
+            });
           }
           return {
             firstRun,
@@ -402,7 +408,10 @@ export function createOnboardingPlugin(
           { completed: true, at: new Date().toISOString() },
           { requestSource: "agent" },
         );
-        deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, { path: "/" });
+        deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
+          path: "/",
+          ...cookieDomainAttrs(),
+        });
         return { ok: true };
       }),
     );

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -24,7 +24,11 @@ import {
 
 import { appStateGet, appStatePut } from "../application-state/store.js";
 import { getOrgContext } from "../org/context.js";
-import { cookieDomainAttrs, getSession } from "../server/auth.js";
+import {
+  cookieDomainAttrs,
+  crossSiteCookieAttrs,
+  getSession,
+} from "../server/auth.js";
 import { CredentialStoreUnavailableError } from "../server/credential-provider.js";
 import {
   awaitBootstrap,
@@ -323,8 +327,9 @@ export function createOnboardingPlugin(
           );
           if (completed?.completed === true) {
             deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
-              path: "/",
+              ...crossSiteCookieAttrs(event),
               ...cookieDomainAttrs(),
+              path: "/",
             });
             return { firstRun: false };
           }
@@ -342,8 +347,9 @@ export function createOnboardingPlugin(
             orgContext.orgId !== null && eligible?.orgId === orgContext.orgId;
           if (!firstRun) {
             deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
-              path: "/",
+              ...crossSiteCookieAttrs(event),
               ...cookieDomainAttrs(),
+              path: "/",
             });
           }
           return {
@@ -409,8 +415,9 @@ export function createOnboardingPlugin(
           { requestSource: "agent" },
         );
         deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
-          path: "/",
+          ...crossSiteCookieAttrs(event),
           ...cookieDomainAttrs(),
+          path: "/",
         });
         return { ok: true };
       }),

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -4468,6 +4468,9 @@ describe("server/auth", () => {
       await baHandler(event);
 
       expect(forwardedPath).toBe("/_agent-native/auth/ba/sign-in/email");
+      expect(event.res.headers.get("set-cookie")).toContain(
+        "agent-native-first-run=1",
+      );
     });
 
     it("carries browser signup attribution through the direct Better Auth handler", async () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -3622,6 +3622,9 @@ describe("server/auth", () => {
       expect(signInEmail).toHaveBeenCalledWith({
         body: { email: "user@example.com", password: "secret-password" },
       });
+      expect(event.res.headers.get("set-cookie")).toContain(
+        "agent-native-first-run=1",
+      );
     });
 
     it("rejects register emails that Better Auth would reject before signup", async () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1358,6 +1358,7 @@ describe("server/auth", () => {
     it("opts the current browser out and forwards Better Auth logout cookies", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("AUTH_DISABLED", "1");
+      vi.stubEnv("COOKIE_DOMAIN", ".example.com");
       delete process.env.ACCESS_TOKEN;
       delete process.env.ACCESS_TOKENS;
 
@@ -1406,6 +1407,9 @@ describe("server/auth", () => {
 
       const setCookie = event.res.headers.get("set-cookie") ?? "";
       expect(setCookie).toContain("agent-native-first-run=; Max-Age=0");
+      expect(setCookie).toContain(
+        "agent-native-first-run=; Max-Age=0; Domain=.example.com",
+      );
       expect(setCookie).toContain("_auth_disabled_opt_out=1");
       expect(setCookie).toContain("HttpOnly");
       expect(setCookie).toContain("SameSite=None");
@@ -3310,6 +3314,13 @@ describe("server/auth", () => {
       const results = (await Promise.all([first, second])) as Response[];
 
       expect(results.every((result) => result.status === 302)).toBe(true);
+      expect(
+        results.every((result) =>
+          (result.headers.get("set-cookie") ?? "").includes(
+            "agent-native-first-run=1",
+          ),
+        ),
+      ).toBe(true);
       expect(results.map((result) => result.headers.get("location"))).toEqual([
         "/dispatch/overview",
         "/dispatch/overview",
@@ -7688,6 +7699,7 @@ describe("server/auth", () => {
   describe("local dev auth convenience", () => {
     it("mounts the route and reuses the existing auto dev account session", async () => {
       vi.stubEnv("NODE_ENV", "development");
+      vi.stubEnv("COOKIE_DOMAIN", ".example.com");
       delete process.env.AUTH_DISABLED;
       delete process.env.AGENT_NATIVE_BUILD_DEPLOY_CONTEXT;
 
@@ -7754,6 +7766,9 @@ describe("server/auth", () => {
       expect(signUpEmail).not.toHaveBeenCalled();
       expect(event.res.headers.get("set-cookie")).toContain(
         "better-auth-dev-session",
+      );
+      expect(event.res.headers.get("set-cookie")).toContain(
+        "agent-native-first-run=1; Max-Age=86400; Domain=.example.com",
       );
 
       mockExecute.mockImplementation(async (query: { sql?: string }) => ({

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -3684,6 +3684,7 @@ function createLocalDevAuthHandler(config?: BetterAuthConfig) {
         return { error: "Local development sign-in is unavailable" };
       }
       setFrameworkSessionCookie(event, session.token);
+      setFirstRunOnboardingCookie(event);
       await addSession(session.token, session.email);
       return authLoginResponse(event, session.token, session.email);
     } catch {
@@ -3776,6 +3777,7 @@ async function maybeAutoCreateDevSession(
     if (!result?.token) return null;
 
     setFrameworkSessionCookie(event, result.token);
+    setFirstRunOnboardingCookie(event);
     await addSession(result.token, AUTO_DEV_ACCOUNT_EMAIL);
 
     // Emit the session cookie ON the 302 itself. Returning a bare
@@ -4038,6 +4040,7 @@ function desktopOAuthBrowserBindingCookieAttrs(event: H3Event): {
 function setFirstRunOnboardingCookie(event: H3Event): void {
   setCookie(event, FIRST_RUN_ONBOARDING_COOKIE, "1", {
     ...crossSiteCookieAttrs(event),
+    ...cookieDomainAttrs(),
     httpOnly: false,
     path: "/",
     maxAge: FIRST_RUN_ONBOARDING_MAX_AGE,
@@ -4047,6 +4050,7 @@ function setFirstRunOnboardingCookie(event: H3Event): void {
 function clearFirstRunOnboardingCookie(event: H3Event): void {
   deleteCookie(event, FIRST_RUN_ONBOARDING_COOKIE, {
     ...crossSiteCookieAttrs(event),
+    ...cookieDomainAttrs(),
     path: "/",
   });
 }

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -5441,7 +5441,8 @@ async function mountBetterAuthRoutes(
       }
 
       if (
-        reqPath.includes("/sign-up/email") &&
+        (reqPath.includes("/sign-up/email") ||
+          reqPath.includes("/sign-in/email")) &&
         isResponse &&
         (response as Response).status >= 200 &&
         (response as Response).status < 300
@@ -5489,6 +5490,7 @@ async function mountBetterAuthRoutes(
         });
         if (result?.token) {
           setFrameworkSessionCookie(event, result.token);
+          setFirstRunOnboardingCookie(event);
           await addSession(result.token, email);
           if (isElectronRequest(event)) {
             await writeDesktopSso({
@@ -5917,6 +5919,7 @@ function mountAuthFallbackRoutes(app: H3App): void {
         });
         if (result?.token) {
           setFrameworkSessionCookie(event, result.token);
+          setFirstRunOnboardingCookie(event);
           await addSession(result.token, email);
           if (isElectronRequest(event)) {
             await writeDesktopSso({

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -4011,7 +4011,7 @@ function isReadMethod(event: H3Event): boolean {
  * dev keeps the default `SameSite=Lax`; `None` requires Secure, and
  * `Partitioned` only takes effect alongside `Secure`.
  */
-function crossSiteCookieAttrs(event: H3Event): {
+export function crossSiteCookieAttrs(event: H3Event): {
   sameSite: "lax" | "none";
   secure: boolean;
   partitioned?: boolean;

--- a/templates/slides/app/components/layout/Layout.tsx
+++ b/templates/slides/app/components/layout/Layout.tsx
@@ -8,7 +8,6 @@ import { IconMenu2 } from "@tabler/icons-react";
 import { useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router";
 
-import { useDecks } from "@/context/DeckContext";
 import { useSidebarCollapsed } from "@/hooks/use-sidebar-collapsed";
 import {
   hasCurrentSlideSelection,
@@ -60,9 +59,6 @@ export function Layout({ children }: LayoutProps) {
     useState<EditorSidebarOverride | null>(null);
   const { collapsed: sidebarCollapsed, setCollapsed: setSidebarCollapsed } =
     useSidebarCollapsed();
-  const { decks, loading: decksLoading } = useDecks();
-  const isEmptyDecksState =
-    location.pathname === "/" && !decksLoading && decks.length === 0;
 
   useEffect(() => {
     const onSelectionChanged = (event: Event) => {
@@ -155,7 +151,7 @@ export function Layout({ children }: LayoutProps) {
         }
       >
         <div className="agent-layout-shell flex h-screen w-full overflow-hidden bg-background text-foreground">
-          {!isEmptyDecksState && showAppSidebar && (
+          {showAppSidebar && (
             <>
               {sidebarOpen && (
                 <div
@@ -186,7 +182,7 @@ export function Layout({ children }: LayoutProps) {
           )}
           <div className="agent-layout-main-surface flex h-full min-w-0 flex-1 flex-col overflow-hidden">
             {/* Mobile-only nav strip with hamburger — only when there's no page toolbar */}
-            {!isEmptyDecksState && !ownToolbar && (
+            {!ownToolbar && (
               <div className="flex h-12 items-center border-b border-border px-4 md:hidden shrink-0">
                 <button
                   onClick={() => setSidebarOpen(true)}
@@ -197,8 +193,8 @@ export function Layout({ children }: LayoutProps) {
                 </button>
               </div>
             )}
-            {!isEmptyDecksState && !ownToolbar && <Header />}
-            {!isEmptyDecksState && <InvitationBanner />}
+            {!ownToolbar && <Header />}
+            <InvitationBanner />
             <main
               className={cn(
                 "agent-native-app-main min-h-0 flex-1",

--- a/templates/slides/changelog/2026-08-28-standard-empty-home-layout.md
+++ b/templates/slides/changelog/2026-08-28-standard-empty-home-layout.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-08-28
+---
+Keep the standard app layout visible when a Slides workspace has no decks.


### PR DESCRIPTION
## Summary

- Preserve the standard first-run onboarding handoff through email verification and password sign-in redirects.
- Keep the Slides sidebar, header, invitation banner, and standard empty-state create button visible when no decks exist.
- Add the Slides changelog entry and core changeset.

## Verification

- Core auth and onboarding tests
- Slides route/onboarding tests
- Slides production build and typechecks
- `pnpm guards` (65 checks)