### PR TITLE
Fix dark-mode Clips composer contrast

### DIFF
--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -634,7 +634,7 @@ function CommentComposer({
         <button
           type="button"
           onClick={() => onUnauthenticated("comment")}
-          className="flex min-h-16 w-full items-center gap-3 rounded-md border-0 bg-transparent px-3 py-2.5 text-left text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-h-16 w-full items-center gap-3 rounded-md border-0 bg-background px-3 py-2.5 text-left text-sm text-muted-foreground shadow-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <Avatar className="size-7 shrink-0">
             <AvatarFallback className="bg-primary/15 text-xs text-primary">


### PR DESCRIPTION
## Summary
- Give the public Leave a comment control the page-body background so it contrasts with the dark activity rail.
- Preserve the existing Agent tab composer treatment and verify its light and dark contrast.

## Verification
- corepack pnpm --dir templates/clips exec vitest run app/components/player/comments-panel.test.tsx
- corepack pnpm --dir templates/clips exec tsc --noEmit
- corepack pnpm guards
- Live light and dark browser checks with screenshots