### PR TITLE
Keep Slides text editing active on repeated Enter

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -42,7 +42,6 @@ import {
   exitEmptyBulletAtCaret,
   findEnclosingList,
   insertBulletAfterCaret,
-  isBulletList,
   removeEmptyBulletAtCaret,
   ZERO_WIDTH_SPACE,
 } from "@/components/editor/bullet-editing";

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -195,7 +195,6 @@ import {
   findSmartBlock,
   isInlineTextElement,
   isSlideTextEditingTarget,
-  isTextLeaf,
   shouldStampBuilderId,
 } from "./slide-text-targets";
 import { SlideContextToolbar } from "./SlideContextToolbar";
@@ -367,9 +366,6 @@ function getBuilderSelector(el: HTMLElement): string | null {
   if (id) return `[data-builder-id="${id}"]`;
   return null;
 }
-
-/** Block tags that can hold rich multi-paragraph content */
-const RICH_BLOCK_TAGS = new Set(["P", "DIV", "BLOCKQUOTE", "LI", "UL", "OL"]);
 
 /** Strip renderer/editor-only attributes from an HTML string before saving */
 function stripBuilderIds(html: string): string {
@@ -2339,15 +2335,6 @@ export default function SlideEditor({
   // Global keyboard handling while inline-editing
   useEffect(() => {
     if (!editingEl) return;
-    // Determine "multi-line capable" once at entry time. contentEditable's
-    // default Enter behavior inserts block-level children (e.g. <div><br></div>)
-    // after a couple of presses, which would otherwise flip isTextLeaf to false
-    // mid-edit and incorrectly commit the user out of the block. The user's
-    // intent (rich-block edit vs single-line commit) doesn't change while
-    // they're editing the same node, so latch it.
-    const isMultiLineLeaf =
-      (isTextLeaf(editingEl) && RICH_BLOCK_TAGS.has(editingEl.tagName)) ||
-      isBulletList(editingEl);
     const onKey = (e: KeyboardEvent) => {
       const isSelectAll =
         (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "a";
@@ -2413,10 +2400,8 @@ export default function SlideEditor({
         //  - Inside a styled bullet list, Enter clones the current row so a
         //    new bullet (marker + empty text) appears — contentEditable's
         //    native split can't recreate the marker glyph.
-        //  - A single <p> or <div> leaf is multi-line capable — Enter
-        //    creates a new line via contentEditable's default behavior.
-        //  - Headings, inline leaves, and smart groups commit on Enter
-        //    so the slide layout can never be broken by a stray new node.
+        //  - Enter remains native for every text block, so repeated presses
+        //    never end the editing session.
         if (e.shiftKey) return;
 
         // Re-derive the list from the LIVE caret so a re-render that swapped
@@ -2435,11 +2420,6 @@ export default function SlideEditor({
           e.preventDefault();
           captureInlineEditDraft(slide.id);
           return;
-        }
-
-        if (!isMultiLineLeaf) {
-          e.preventDefault();
-          exitInlineEdit();
         }
       }
     };

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -2461,11 +2461,16 @@ export default function SlideEditor({
         }
 
         if (!isMultiLineLeaf) {
-          e.preventDefault();
           const editing = editingElRef.current;
-          if (editing && insertLineBreak(editing)) {
-            captureInlineEditDraft(slide.id);
+          const inserted = editing ? insertLineBreak(editing) : false;
+          if (!inserted) {
+            // Keep an unsupported cross-leaf selection in edit mode rather
+            // than letting native Enter split the smart group into blocks.
+            e.preventDefault();
+            return;
           }
+          e.preventDefault();
+          captureInlineEditDraft(slide.id);
         }
       }
     };

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -42,6 +42,7 @@ import {
   exitEmptyBulletAtCaret,
   findEnclosingList,
   insertBulletAfterCaret,
+  isBulletList,
   removeEmptyBulletAtCaret,
   ZERO_WIDTH_SPACE,
 } from "@/components/editor/bullet-editing";
@@ -194,6 +195,7 @@ import {
   findSmartBlock,
   isInlineTextElement,
   isSlideTextEditingTarget,
+  isTextLeaf,
   shouldStampBuilderId,
 } from "./slide-text-targets";
 import { SlideContextToolbar } from "./SlideContextToolbar";
@@ -364,6 +366,31 @@ function getBuilderSelector(el: HTMLElement): string | null {
   const id = el.getAttribute("data-builder-id");
   if (id) return `[data-builder-id="${id}"]`;
   return null;
+}
+
+/** Block tags that can hold rich multi-paragraph content */
+const RICH_BLOCK_TAGS = new Set(["P", "DIV", "BLOCKQUOTE", "LI", "UL", "OL"]);
+
+/** Insert a soft line break without creating a new layout block. */
+function insertLineBreak(editable: HTMLElement) {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount !== 1) return false;
+  const range = selection.getRangeAt(0);
+  if (
+    !editable.contains(range.startContainer) ||
+    !editable.contains(range.endContainer)
+  ) {
+    return false;
+  }
+
+  range.deleteContents();
+  const lineBreak = document.createElement("br");
+  range.insertNode(lineBreak);
+  range.setStartAfter(lineBreak);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
 }
 
 /** Strip renderer/editor-only attributes from an HTML string before saving */
@@ -2334,6 +2361,15 @@ export default function SlideEditor({
   // Global keyboard handling while inline-editing
   useEffect(() => {
     if (!editingEl) return;
+    // Determine "multi-line capable" once at entry time. contentEditable's
+    // default Enter behavior inserts block-level children (e.g. <div><br></div>)
+    // after a couple of presses, which would otherwise flip isTextLeaf to false
+    // mid-edit and incorrectly commit the user out of the block. The user's
+    // intent (rich-block edit vs single-line commit) doesn't change while
+    // they're editing the same node, so latch it.
+    const isMultiLineLeaf =
+      (isTextLeaf(editingEl) && RICH_BLOCK_TAGS.has(editingEl.tagName)) ||
+      isBulletList(editingEl);
     const onKey = (e: KeyboardEvent) => {
       const isSelectAll =
         (e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "a";
@@ -2399,8 +2435,9 @@ export default function SlideEditor({
         //  - Inside a styled bullet list, Enter clones the current row so a
         //    new bullet (marker + empty text) appears — contentEditable's
         //    native split can't recreate the marker glyph.
-        //  - Enter remains native for every text block, so repeated presses
-        //    never end the editing session.
+        //  - Rich block leaves keep contentEditable's native multi-line edit.
+        //  - Other text blocks get a <br> so repeated presses stay within the
+        //    existing layout instead of creating new block children.
         if (e.shiftKey) return;
 
         // Re-derive the list from the LIVE caret so a re-render that swapped
@@ -2419,6 +2456,14 @@ export default function SlideEditor({
           e.preventDefault();
           captureInlineEditDraft(slide.id);
           return;
+        }
+
+        if (!isMultiLineLeaf) {
+          e.preventDefault();
+          const editing = editingElRef.current;
+          if (editing && insertLineBreak(editing)) {
+            captureInlineEditDraft(slide.id);
+          }
         }
       }
     };

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -371,26 +371,28 @@ function getBuilderSelector(el: HTMLElement): string | null {
 /** Block tags that can hold rich multi-paragraph content */
 const RICH_BLOCK_TAGS = new Set(["P", "DIV", "BLOCKQUOTE", "LI", "UL", "OL"]);
 
-/** Insert a soft line break without creating a new layout block. */
+/** Insert a soft line break inside one text leaf through native edit history. */
 function insertLineBreak(editable: HTMLElement) {
   const selection = window.getSelection();
   if (!selection || selection.rangeCount !== 1) return false;
   const range = selection.getRangeAt(0);
-  if (
-    !editable.contains(range.startContainer) ||
-    !editable.contains(range.endContainer)
-  ) {
+
+  const textLeafFor = (node: Node) => {
+    let element = node instanceof HTMLElement ? node : node.parentElement;
+    while (element && element !== editable) {
+      if (isTextLeaf(element)) return element;
+      element = element.parentElement;
+    }
+    return isTextLeaf(editable) ? editable : null;
+  };
+
+  const startLeaf = textLeafFor(range.startContainer);
+  const endLeaf = textLeafFor(range.endContainer);
+  if (!startLeaf || startLeaf !== endLeaf) {
     return false;
   }
 
-  range.deleteContents();
-  const lineBreak = document.createElement("br");
-  range.insertNode(lineBreak);
-  range.setStartAfter(lineBreak);
-  range.collapse(true);
-  selection.removeAllRanges();
-  selection.addRange(range);
-  return true;
+  return document.execCommand("insertLineBreak");
 }
 
 /** Strip renderer/editor-only attributes from an HTML string before saving */

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -378,12 +378,21 @@ function insertLineBreak(editable: HTMLElement) {
   const range = selection.getRangeAt(0);
 
   const textLeafFor = (node: Node) => {
+    if (!editable.contains(node)) return null;
     let element = node instanceof HTMLElement ? node : node.parentElement;
     while (element && element !== editable) {
       if (isTextLeaf(element)) return element;
       element = element.parentElement;
     }
-    return isTextLeaf(editable) ? editable : null;
+    const canUseEditableFallback =
+      isTextLeaf(editable) ||
+      (editable.tagName !== "IMG" &&
+        !editable.classList.contains("fmd-img-placeholder") &&
+        (editable.classList.contains("fmd-text-box") ||
+          Array.from(editable.children).every((child) =>
+            isInlineTextElement(child),
+          )));
+    return canUseEditableFallback ? editable : null;
   };
 
   const startLeaf = textLeafFor(range.startContainer);


### PR DESCRIPTION
## Summary
- keep inline Slides text editing active when Enter is pressed repeatedly
- keep native multiline behavior for rich text blocks and use soft breaks for headings and smart groups
- preserve list-specific Enter behavior and Escape/click-outside exit behavior

## Validation
- corepack pnpm --filter slides exec vitest --run app/components/editor/bullet-editing.test.tsx app/components/editor/slide-text-targets.test.ts app/components/editor/SlideEditor.render-phase.test.ts app/components/editor/SlideEditor.panel-layout.test.ts
- corepack pnpm --filter slides typecheck
- corepack pnpm exec oxfmt --check templates/slides/app/components/editor/SlideEditor.tsx
- corepack pnpm exec oxlint --config .oxlintrc.json --no-error-on-unmatched-pattern templates/slides/app/components/editor/SlideEditor.tsx
- corepack pnpm guards
- git diff --check