### PR TITLE
fix: show Connect AI above shared chat composers

### DIFF
--- a/.changeset/quiet-provider-setup.md
+++ b/.changeset/quiet-provider-setup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show the Connect AI setup card above shared chat composers when provider credentials fail.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1552,9 +1552,11 @@ describe("missing agent engine setup", () => {
     expect(source).toContain("modelCatalogConfirmsMissing");
     expect(source).toContain('agentEngineConfigured.state === "missing" &&');
     expect(source).toContain("isProviderAuthenticationError(");
+    expect(source).toContain("!isBuilderReconnectRunError(visibleRunError)");
     expect(source).toContain("!showProviderAuthSetup");
     expect(source).toContain("retryAfterRunError();");
     expect(source).toContain("onConnected={handleProviderSetupConnected}");
+    expect(source).toContain("onRetry={");
     expect(source).toMatch(
       /willQueue=\{\s*engineSetupRequired \|\| isRunning\s*\}/,
     );

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1552,7 +1552,8 @@ describe("missing agent engine setup", () => {
     expect(source).toContain("modelCatalogConfirmsMissing");
     expect(source).toContain('agentEngineConfigured.state === "missing" &&');
     expect(source).toContain("isProviderAuthenticationError(");
-    expect(source).toContain("showRunningInUI || !shouldShowRunError");
+    expect(source).toContain("!showProviderAuthSetup");
+    expect(source).toContain("retryAfterRunError();");
     expect(source).toContain("onConnected={handleProviderSetupConnected}");
     expect(source).toMatch(
       /willQueue=\{\s*engineSetupRequired \|\| isRunning\s*\}/,

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1555,7 +1555,9 @@ describe("missing agent engine setup", () => {
     expect(source).toContain("!isBuilderReconnectRunError(visibleRunError)");
     expect(source).toContain("!showProviderAuthSetup");
     expect(source).toContain("retryAfterRunError();");
+    expect(source).toContain("handleProviderSetupDismiss");
     expect(source).toContain("onConnected={handleProviderSetupConnected}");
+    expect(source).toContain("onDismiss={");
     expect(source).toContain("onRetry={");
     expect(source).toMatch(
       /willQueue=\{\s*engineSetupRequired \|\| isRunning\s*\}/,

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -143,6 +143,7 @@ import {
   getLoopLimitMetadata,
   getRunErrorMetadata,
   getRequestModeMetadata,
+  isBuilderReconnectRunError,
   runErrorKey,
   type BuilderSetupCardLayout,
   type LoopLimitInfo,
@@ -5840,6 +5841,7 @@ const AssistantChatInner = forwardRef<
     : null;
   const providerAuthErrorKey =
     visibleRunError &&
+    !isBuilderReconnectRunError(visibleRunError) &&
     isProviderAuthenticationError(
       [visibleRunError.message, visibleRunError.details]
         .filter(Boolean)
@@ -6614,6 +6616,11 @@ const AssistantChatInner = forwardRef<
                                 bouncePulse={missingKeyBouncePulse}
                                 layout={missingApiKeySetupLayout}
                                 onConnected={handleProviderSetupConnected}
+                                onRetry={
+                                  providerAuthErrorKey !== null
+                                    ? retryAfterRunError
+                                    : undefined
+                                }
                               />
                             ) : null}
                             {/* Input area */}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -5838,16 +5838,6 @@ const AssistantChatInner = forwardRef<
   const visibleRunErrorKey = visibleRunError
     ? runErrorKey(visibleRunError)
     : null;
-  const shouldShowRunError =
-    !!visibleRunError &&
-    !showRunningInUI &&
-    visibleRunErrorKey !== dismissedRunErrorKey &&
-    !matchesUserStoppedRun(
-      userStoppedRunRef.current,
-      threadId,
-      visibleRunError.runId,
-      visibleRunError.turnId,
-    );
   const providerAuthErrorKey =
     visibleRunError &&
     isProviderAuthenticationError(
@@ -5861,8 +5851,18 @@ const AssistantChatInner = forwardRef<
   const showProviderAuthSetup =
     providerAuthErrorKey !== null &&
     providerAuthErrorKey !== dismissedProviderAuthErrorKey &&
-    !authError &&
-    (showRunningInUI || !shouldShowRunError);
+    !authError;
+  const shouldShowRunError =
+    !!visibleRunError &&
+    !showRunningInUI &&
+    visibleRunErrorKey !== dismissedRunErrorKey &&
+    !showProviderAuthSetup &&
+    !matchesUserStoppedRun(
+      userStoppedRunRef.current,
+      threadId,
+      visibleRunError.runId,
+      visibleRunError.turnId,
+    );
   const showMissingKeySetup =
     (engineSetupRequired || showProviderAuthSetup) && !authError;
   const handleProviderSetupConnected = useCallback(() => {
@@ -5871,7 +5871,8 @@ const AssistantChatInner = forwardRef<
     setDismissedProviderAuthErrorKey(providerAuthErrorKey);
     setDismissedRunErrorKey(providerAuthErrorKey);
     setRunErrorInfo(null);
-  }, [handleBuilderConnected, providerAuthErrorKey]);
+    retryAfterRunError();
+  }, [handleBuilderConnected, providerAuthErrorKey, retryAfterRunError]);
   // The banner covers one run; every failed turn it does not cover keeps its own
   // inline marker, so a failure stays visible after the next prompt.
   const messageActionsCtx = useMemo(

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -5867,6 +5867,12 @@ const AssistantChatInner = forwardRef<
     );
   const showMissingKeySetup =
     (engineSetupRequired || showProviderAuthSetup) && !authError;
+  const handleProviderSetupDismiss = useCallback(() => {
+    if (providerAuthErrorKey === null) return;
+    setDismissedProviderAuthErrorKey(providerAuthErrorKey);
+    setDismissedRunErrorKey(providerAuthErrorKey);
+    setRunErrorInfo(null);
+  }, [providerAuthErrorKey]);
   const handleProviderSetupConnected = useCallback(() => {
     handleBuilderConnected();
     if (providerAuthErrorKey === null) return;
@@ -6611,10 +6617,16 @@ const AssistantChatInner = forwardRef<
                             )}
                             {showMissingKeySetup ? (
                               <BuilderSetupCard
+                                key={providerAuthErrorKey ?? "missing-provider"}
                                 fullWidth
                                 attached
                                 bouncePulse={missingKeyBouncePulse}
                                 layout={missingApiKeySetupLayout}
+                                onDismiss={
+                                  providerAuthErrorKey !== null
+                                    ? handleProviderSetupDismiss
+                                    : undefined
+                                }
                                 onConnected={handleProviderSetupConnected}
                                 onRetry={
                                   providerAuthErrorKey !== null

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -438,8 +438,36 @@ describe("run recovery surfaces", () => {
 
     await act(async () => {
       retryButton?.click();
+      retryButton?.click();
     });
     expect(onRetry).toHaveBeenCalledTimes(1);
+    expect((retryButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("keeps provider setup dismissible when requested", async () => {
+    const onDismiss = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <AgentNativeI18nProvider
+          initialLocale="en-US"
+          initialPreference="en-US"
+          persistPreference={false}
+        >
+          <BuilderSetupCard onDismiss={onDismiss} />
+        </AgentNativeI18nProvider>,
+      );
+    });
+
+    const dismissButton = container.querySelector(
+      'button[aria-label="Dismiss"]',
+    );
+    expect(dismissButton).toBeTruthy();
+
+    await act(async () => {
+      dismissButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it("formats the step limit with the selected locale", async () => {

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -173,6 +173,7 @@ vi.mock("../settings/useBuilderStatus.js", () => ({
 
 import { AgentNativeI18nProvider } from "../i18n.js";
 import {
+  BuilderSetupCard,
   BuilderSetupContent,
   LoopLimitContinueCard,
   RunErrorRecoveryCard,
@@ -328,6 +329,32 @@ describe("run recovery surfaces", () => {
     ).toBeNull();
   });
 
+  it("keeps Builder credential failures in reconnect recovery", async () => {
+    await act(async () => {
+      root.render(
+        <AgentNativeI18nProvider
+          initialLocale="en-US"
+          initialPreference="en-US"
+          persistPreference={false}
+        >
+          <RunErrorRecoveryCard
+            info={{
+              message: "Invalid token",
+              errorCode: "authentication_error",
+            }}
+            onContinue={vi.fn()}
+            onRetry={vi.fn()}
+            onDismiss={vi.fn()}
+          />
+        </AgentNativeI18nProvider>,
+      );
+    });
+
+    expect(container.textContent).toContain("Reconnect Builder.io");
+    expect(container.textContent).not.toContain("Connect AI");
+    expect(container.textContent).not.toContain("Custom keys");
+  });
+
   it("shows the searchable provider setup while disclosing API keys", async () => {
     await act(async () => {
       root.render(
@@ -387,6 +414,32 @@ describe("run recovery surfaces", () => {
     expect(actions).not.toBeNull();
     expect(actions?.className).toContain("flex-row");
     expect(actions?.className).not.toContain("flex-col");
+  });
+
+  it("keeps retry available on the shared provider setup card", async () => {
+    const onRetry = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <AgentNativeI18nProvider
+          initialLocale="en-US"
+          initialPreference="en-US"
+          persistPreference={false}
+        >
+          <BuilderSetupCard onRetry={onRetry} />
+        </AgentNativeI18nProvider>,
+      );
+    });
+
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Retry",
+    );
+    expect(retryButton).toBeTruthy();
+
+    await act(async () => {
+      retryButton?.click();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it("formats the step limit with the selected locale", async () => {

--- a/packages/core/src/client/chat/run-recovery.spec.tsx
+++ b/packages/core/src/client/chat/run-recovery.spec.tsx
@@ -217,8 +217,7 @@ describe("run recovery surfaces", () => {
         >
           <RunErrorRecoveryCard
             info={{
-              message:
-                "The model provider rejected the saved API key. Update the key in Settings → Integrations → API keys, then retry.",
+              message: "The agent connection was interrupted.",
               errorCode: "connection_error",
               runId: "run-123",
               details: "attempted_runs: run-1, run-2",
@@ -234,9 +233,6 @@ describe("run recovery surfaces", () => {
 
     await vi.waitFor(() => {
       expect(container.textContent).toContain("Debug-Informationen kopieren");
-      expect(container.textContent).toContain(
-        "Der Modellanbieter hat den gespeicherten API-Schlüssel abgelehnt.",
-      );
     });
     const copyButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent?.includes("Debug-Informationen kopieren"),
@@ -424,9 +420,7 @@ describe("run recovery surfaces", () => {
   // once a 401 started fingerprinting and skipping that credential, so the
   // setup flow and a retry now ship together.
   //
-  // Asserted through `aria-label`: the retry control is an icon-only button, so
-  // the previous `textContent` check read "" and passed no matter what
-  // rendered.
+  // The setup state keeps the retry action available below the card.
   it("shows the AI setup flow AND a retry button for a rejected provider key", async () => {
     const onRetry = vi.fn();
     await act(async () => {
@@ -453,8 +447,8 @@ describe("run recovery surfaces", () => {
     expect(container.textContent).toContain("Connect Builder.io");
     expect(container.textContent).toContain("Custom keys");
 
-    const retryButton = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Retry"]',
+    const retryButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Retry",
     );
     expect(retryButton).toBeTruthy();
     await act(async () => {
@@ -610,7 +604,7 @@ describe("run recovery surfaces", () => {
     expect(container.textContent).not.toContain("The agent hit an error");
   });
 
-  it("keeps invalid provider keys on the authentication recovery path", async () => {
+  it("renders invalid provider keys as setup without the warning", async () => {
     await act(async () => {
       root.render(
         <AgentNativeI18nProvider
@@ -631,8 +625,9 @@ describe("run recovery surfaces", () => {
       );
     });
 
-    expect(container.textContent).toContain("The agent hit an error");
+    expect(container.textContent).toContain("Connect AI");
     expect(container.textContent).toContain("Connect Builder.io");
+    expect(container.textContent).not.toContain("The agent hit an error");
   });
 
   it("dismisses the recovery card after saving a provider key", async () => {
@@ -659,6 +654,9 @@ describe("run recovery surfaces", () => {
         </AgentNativeI18nProvider>,
       );
     });
+
+    expect(container.textContent).toContain("Connect AI");
+    expect(container.textContent).not.toContain("The agent hit an error");
 
     const addKeysButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent?.includes("Custom keys"),

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -428,6 +428,7 @@ export function BuilderSetupContent({
 
 export function BuilderSetupCard({
   onConnected,
+  onDismiss,
   onRetry,
   bouncePulse,
   attached = false,
@@ -435,6 +436,7 @@ export function BuilderSetupCard({
   layout = "default",
 }: {
   onConnected?: () => void;
+  onDismiss?: () => void;
   onRetry?: () => void;
   bouncePulse?: number;
   attached?: boolean;
@@ -443,6 +445,15 @@ export function BuilderSetupCard({
 }) {
   const sidebarLayout = layout === "sidebar";
   const t = useT();
+  const retryRequestedRef = useRef(false);
+  const [retryRequested, setRetryRequested] = useState(false);
+
+  const handleRetry = useCallback(() => {
+    if (!onRetry || retryRequestedRef.current) return;
+    retryRequestedRef.current = true;
+    setRetryRequested(true);
+    onRetry();
+  }, [onRetry]);
 
   const cardRef = useRef<HTMLDivElement>(null);
   // Replay the bounce keyframe each time bouncePulse increments. Toggling the
@@ -477,14 +488,31 @@ export function BuilderSetupCard({
           sidebarLayout ? "p-2.5" : "p-3",
         )}
       >
-        <BuilderSetupContent onConnected={onConnected} layout={layout} />
+        {onDismiss ? (
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              <BuilderSetupContent onConnected={onConnected} layout={layout} />
+            </div>
+            <button
+              type="button"
+              onClick={onDismiss}
+              aria-label={t("agentChat.common.dismiss")}
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <IconX size={14} />
+            </button>
+          </div>
+        ) : (
+          <BuilderSetupContent onConnected={onConnected} layout={layout} />
+        )}
       </div>
       {onRetry ? (
         <div className="flex justify-center px-3 pt-1">
           <button
             type="button"
-            onClick={onRetry}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90"
+            onClick={handleRetry}
+            disabled={retryRequested}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
           >
             <IconRefresh size={13} />
             {t("agentChat.common.retry")}

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -511,12 +511,14 @@ export function RunErrorRecoveryCard({
   });
   const canRecover = info.recoverable === true;
   const shouldShowBuilderReconnect = isBuilderReconnectRunError(info);
-  const shouldShowProviderSetup =
-    isMissingLlmProviderRunError(info) || isDesktopChatRelayRunError(info);
   const isProviderAuthError = isProviderAuthenticationError(
     [info.message, info.details].filter(Boolean).join("\n"),
     info.errorCode,
   );
+  const shouldShowProviderSetup =
+    isMissingLlmProviderRunError(info) ||
+    isDesktopChatRelayRunError(info) ||
+    isProviderAuthError;
   // Blocked on something the reader goes and fixes elsewhere, then comes back
   // to. Recoverable runs and email verification keep a retry path; rejected
   // provider credentials use the setup flow below so the same bad key is not
@@ -612,7 +614,11 @@ export function RunErrorRecoveryCard({
         <BuilderSetupCard
           fullWidth
           layout="sidebar"
-          onConnected={handleMissingProviderConnected}
+          onConnected={
+            isProviderAuthError
+              ? handleProviderConnected
+              : handleMissingProviderConnected
+          }
         />
         {/*
           Deliberately not gated on `providerConnected`. That gate assumed
@@ -658,14 +664,6 @@ export function RunErrorRecoveryCard({
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             {localizeKnownChatErrorText(info.message, t)}
           </p>
-          {isProviderAuthError && (
-            <div className="mt-3 rounded-md border border-border/70 bg-background/60 p-2.5">
-              <BuilderSetupContent
-                layout="sidebar"
-                onConnected={handleProviderConnected}
-              />
-            </div>
-          )}
           {shouldShowBuilderReconnect && !builderReconnectResolved && (
             <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
               {t("agentChat.recovery.credentialRejected")}

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -155,7 +155,7 @@ export function getRequestModeMetadata(
 
 // ─── Run error classifiers ────────────────────────────────────────────────────
 
-function isBuilderReconnectRunError(info: RunErrorInfo): boolean {
+export function isBuilderReconnectRunError(info: RunErrorInfo): boolean {
   const code = (info.errorCode ?? "").toLowerCase();
   const message = info.message.toLowerCase();
   const isAuthCode =
@@ -428,18 +428,21 @@ export function BuilderSetupContent({
 
 export function BuilderSetupCard({
   onConnected,
+  onRetry,
   bouncePulse,
   attached = false,
   fullWidth,
   layout = "default",
 }: {
   onConnected?: () => void;
+  onRetry?: () => void;
   bouncePulse?: number;
   attached?: boolean;
   fullWidth?: boolean;
   layout?: BuilderSetupCardLayout;
 }) {
   const sidebarLayout = layout === "sidebar";
+  const t = useT();
 
   const cardRef = useRef<HTMLDivElement>(null);
   // Replay the bounce keyframe each time bouncePulse increments. Toggling the
@@ -476,6 +479,18 @@ export function BuilderSetupCard({
       >
         <BuilderSetupContent onConnected={onConnected} layout={layout} />
       </div>
+      {onRetry ? (
+        <div className="flex justify-center px-3 pt-1">
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90"
+          >
+            <IconRefresh size={13} />
+            {t("agentChat.common.retry")}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -518,7 +533,7 @@ export function RunErrorRecoveryCard({
   const shouldShowProviderSetup =
     isMissingLlmProviderRunError(info) ||
     isDesktopChatRelayRunError(info) ||
-    isProviderAuthError;
+    (isProviderAuthError && !shouldShowBuilderReconnect);
   // Blocked on something the reader goes and fixes elsewhere, then comes back
   // to. Recoverable runs and email verification keep a retry path; rejected
   // provider credentials use the setup flow below so the same bad key is not


### PR DESCRIPTION
## Summary
- Render the Connect AI setup card above shared chat composers when provider credentials are missing or rejected.
- Keep provider failures out of the yellow run-error warning and preserve retry behavior after setup.
- Cover shared recovery and composer display behavior with focused tests.

## Verification
- Core focused tests: 161 passed.
- Toolkit composer test: 6 passed.
- Core typecheck and build passed.
- Slides browser flow verified at desktop and narrow widths with one setup card, zero yellow warnings, and the card attached above the composer.

Source context: Slack report linked in the issue.