### PR TITLE
fix: label AI presence avatars consistently

### DIFF
--- a/.changeset/ai-presence-avatar.md
+++ b/.changeset/ai-presence-avatar.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Show the AI initials in collaborator presence avatars and expose the editing status on hover.

--- a/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
@@ -21,6 +21,7 @@ describe("PresenceBar", () => {
     act(() => root.unmount());
     container.remove();
     vi.restoreAllMocks();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -40,5 +41,28 @@ describe("PresenceBar", () => {
       (element) => element.textContent === "AI editing",
     );
     expect(label?.style.padding).toBe("0px 0px 0px 2px");
+  });
+
+  it("shows AI initials with an editing tooltip", () => {
+    vi.useFakeTimers();
+    act(() => {
+      root.render(<PresenceBar activeUsers={[]} agentPresent />);
+    });
+
+    const avatar = container.querySelector<HTMLElement>(
+      '[aria-label="AI is editing"]',
+    );
+    expect(avatar?.textContent).toBe("AI");
+
+    act(() => {
+      avatar?.dispatchEvent(new Event("pointermove", { bubbles: true }));
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(
+      document
+        .querySelector('[data-agent-native-tooltip="true"]')
+        ?.textContent?.includes("AI is editing"),
+    ).toBe(true);
   });
 });

--- a/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
@@ -46,7 +46,7 @@ describe("PresenceBar", () => {
   it("shows AI initials with an editing tooltip", () => {
     vi.useFakeTimers();
     act(() => {
-      root.render(<PresenceBar activeUsers={[]} agentPresent />);
+      root.render(<PresenceBar activeUsers={[]} agentActive agentPresent />);
     });
 
     const avatar = container.querySelector<HTMLElement>(
@@ -64,5 +64,10 @@ describe("PresenceBar", () => {
         .querySelector('[data-agent-native-tooltip="true"]')
         ?.textContent?.includes("AI is editing"),
     ).toBe(true);
+
+    act(() => {
+      root.render(<PresenceBar activeUsers={[]} agentPresent />);
+    });
+    expect(container.querySelector('[aria-label="AI agent"]')).not.toBeNull();
   });
 });

--- a/packages/toolkit/src/collab-ui/PresenceBar.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.tsx
@@ -165,7 +165,9 @@ function AgentAvatar({
   const integratedEditingBadge = active && !isFollowing && !showAgentEditingDot;
   const tooltipLabel = isFollowing
     ? "Following AI — click to stop"
-    : "AI is editing";
+    : active
+      ? "AI is editing"
+      : "AI agent";
 
   return (
     <div

--- a/packages/toolkit/src/collab-ui/PresenceBar.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.tsx
@@ -163,6 +163,9 @@ function AgentAvatar({
 }) {
   injectStyles();
   const integratedEditingBadge = active && !isFollowing && !showAgentEditingDot;
+  const tooltipLabel = isFollowing
+    ? "Following AI — click to stop"
+    : "AI is editing";
 
   return (
     <div
@@ -178,33 +181,33 @@ function AgentAvatar({
         }),
       }}
     >
-      <div
-        style={{
-          ...baseAvatarStyle,
-          backgroundColor: AGENT_COLOR,
-          marginLeft: 0,
-          animation: active ? "_anPresencePulse 2s infinite" : undefined,
-          cursor: onClick ? "pointer" : "default",
-          boxShadow: isFollowing
-            ? `0 0 0 2px #3b82f6, 0 0 0 4px #fff`
-            : undefined,
-        }}
-        title={
-          isFollowing
-            ? "Following AI — click to stop"
-            : active
-              ? "AI is editing"
-              : "AI agent"
-        }
-        onClick={onClick}
-        tabIndex={onClick ? 0 : undefined}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") onClick?.();
-        }}
-        role={onClick ? "button" : undefined}
-      >
-        A
-      </div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            style={{
+              ...baseAvatarStyle,
+              backgroundColor: AGENT_COLOR,
+              marginLeft: 0,
+              animation: active ? "_anPresencePulse 2s infinite" : undefined,
+              cursor: onClick ? "pointer" : "default",
+              boxShadow: isFollowing
+                ? // guard:allow-raw-color -- existing follow-mode ring color
+                  `0 0 0 2px #3b82f6, 0 0 0 4px #fff`
+                : undefined,
+            }}
+            aria-label={tooltipLabel}
+            onClick={onClick}
+            tabIndex={onClick ? 0 : undefined}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") onClick?.();
+            }}
+            role={onClick ? "button" : undefined}
+          >
+            AI
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{tooltipLabel}</TooltipContent>
+      </Tooltip>
       {active && !isFollowing && (
         <AgentEditingChip
           showDot={showAgentEditingDot}


### PR DESCRIPTION
The shared collaborator presence avatar now renders AI initials and exposes the editing status through the existing tooltip primitive.

Focused verification:
- @agent-native/toolkit PresenceBar spec
- @agent-native/toolkit typecheck and build
- @agent-native/core build
- Slides editor visual hover check

The full local guard suite still has unrelated workspace failures for missing recap-cli build output, existing i18n baseline/import debt, and is otherwise clean.