### PR TITLE
fix: keep auth email links on canonical HTTPS origins

### DIFF
--- a/.changeset/disable-auth-link-tracking.md
+++ b/.changeset/disable-auth-link-tracking.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix: keep authentication email links on their canonical HTTPS origin

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -1746,7 +1746,14 @@ async function createBetterAuthInstance(
         email,
         magicLinkUrl: deliveredMagicLinkUrl,
       });
-      await sendEmail({ to: email, subject, html, text, appSender });
+      await sendEmail({
+        to: email,
+        subject,
+        html,
+        text,
+        appSender,
+        disableClickTracking: true,
+      });
     },
   });
 
@@ -1786,6 +1793,7 @@ async function createBetterAuthInstance(
           html,
           text,
           appSender,
+          disableClickTracking: true,
           templateId: CORE_RESET_PASSWORD_EMAIL_ID,
         });
       },
@@ -1819,6 +1827,7 @@ async function createBetterAuthInstance(
           html,
           text,
           appSender,
+          disableClickTracking: true,
           templateId: CORE_VERIFY_SIGNUP_EMAIL_ID,
         });
       },

--- a/packages/core/src/server/email.spec.ts
+++ b/packages/core/src/server/email.spec.ts
@@ -53,6 +53,25 @@ describe("sendEmail", () => {
     expect(body.categories).toContain("calendar.booking-confirmed::org::org-1");
   });
 
+  it("disables click tracking for security-sensitive links", async () => {
+    vi.stubEnv("SENDGRID_API_KEY", "sendgrid-example-key");
+    vi.stubEnv("EMAIL_FROM", "Agent-Native <reports@example.com>");
+    const fetchMock = vi.fn(async () => new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await sendEmail({
+      to: "reader@example.com",
+      subject: "Verify your email",
+      html: '<a href="https://design.agent-native.com/verify">Verify</a>',
+      disableClickTracking: true,
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.tracking_settings).toEqual({
+      click_tracking: { enable: false },
+    });
+  });
+
   it("applies per-app sender branding on agent-native.com deployments", async () => {
     vi.stubEnv("SENDGRID_API_KEY", "sendgrid-example-key");
     vi.stubEnv("EMAIL_FROM", "Agent-Native <noreply@agent-native.com>");

--- a/packages/core/src/server/email.ts
+++ b/packages/core/src/server/email.ts
@@ -46,6 +46,8 @@ export interface SendEmailArgs {
   subject: string;
   html: string;
   text?: string;
+  /** Keep security-sensitive links out of provider click-tracking redirects. */
+  disableClickTracking?: boolean;
   from?: string;
   /**
    * Display-name-only override. Keeps the configured (domain-verified) sending
@@ -371,6 +373,11 @@ async function deliverEmail(
         : undefined,
     ].filter((value): value is string => Boolean(value));
     if (categories.length) sgPayload.categories = categories;
+    if (args.disableClickTracking) {
+      sgPayload.tracking_settings = {
+        click_tracking: { enable: false },
+      };
+    }
     const sgHeaders: Record<string, string> = {};
     if (args.inReplyTo) sgHeaders["In-Reply-To"] = args.inReplyTo;
     if (args.references) sgHeaders["References"] = args.references;


### PR DESCRIPTION
## Summary

- Disable SendGrid click tracking for magic-link, signup-verification, and password-reset emails.
- Preserve click tracking for ordinary transactional email.
- Add regression coverage for the SendGrid payload.

## Validation

- `corepack pnpm prep:urgent`
