### PR TITLE
fix: remove AI editing presence pill

### DIFF
--- a/.changeset/remove-ai-editing-pill.md
+++ b/.changeset/remove-ai-editing-pill.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Remove the separate AI editing pill so the agent presence circle carries the status tooltip.

--- a/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.spec.tsx
@@ -25,24 +25,6 @@ describe("PresenceBar", () => {
     vi.unstubAllGlobals();
   });
 
-  it("gives the integrated AI editing label space after the avatar", () => {
-    act(() => {
-      root.render(
-        <PresenceBar
-          activeUsers={[]}
-          agentPresent
-          agentActive
-          showAgentEditingDot={false}
-        />,
-      );
-    });
-
-    const label = Array.from(container.querySelectorAll("span")).find(
-      (element) => element.textContent === "AI editing",
-    );
-    expect(label?.style.padding).toBe("0px 0px 0px 2px");
-  });
-
   it("shows AI initials with an editing tooltip", () => {
     vi.useFakeTimers();
     act(() => {
@@ -53,6 +35,7 @@ describe("PresenceBar", () => {
       '[aria-label="AI is editing"]',
     );
     expect(avatar?.textContent).toBe("AI");
+    expect(container.textContent).toBe("AI");
 
     act(() => {
       avatar?.dispatchEvent(new Event("pointermove", { bubbles: true }));

--- a/packages/toolkit/src/collab-ui/PresenceBar.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.tsx
@@ -20,9 +20,6 @@ export interface PresenceBarProps {
   agentPresent?: boolean;
   /** Whether the agent is actively making edits right now. */
   agentActive?: boolean;
-  /** Whether to show the status dot beside the active agent label. When false,
-   *  the label is integrated with the avatar pill. */
-  showAgentEditingDot?: boolean;
   /** Current user's email (to exclude from the list). */
   currentUserEmail?: string;
   /** Max visible avatars before "+N" overflow. Default: 5 */
@@ -154,15 +151,12 @@ function AgentAvatar({
   active,
   onClick,
   isFollowing,
-  showAgentEditingDot,
 }: {
   active: boolean;
   onClick?: () => void;
   isFollowing?: boolean;
-  showAgentEditingDot: boolean;
 }) {
   injectStyles();
-  const integratedEditingBadge = active && !isFollowing && !showAgentEditingDot;
   const tooltipLabel = isFollowing
     ? "Following AI — click to stop"
     : active
@@ -175,12 +169,6 @@ function AgentAvatar({
         display: "flex",
         alignItems: "center",
         gap: 4,
-        ...(integratedEditingBadge && {
-          height: AVATAR_SIZE,
-          paddingRight: 8,
-          borderRadius: 9999,
-          backgroundColor: `${AGENT_COLOR}20`,
-        }),
       }}
     >
       <Tooltip>
@@ -210,12 +198,6 @@ function AgentAvatar({
         </TooltipTrigger>
         <TooltipContent side="bottom">{tooltipLabel}</TooltipContent>
       </Tooltip>
-      {active && !isFollowing && (
-        <AgentEditingChip
-          showDot={showAgentEditingDot}
-          integrated={integratedEditingBadge}
-        />
-      )}
       {isFollowing && (
         <span
           style={{
@@ -235,46 +217,6 @@ function AgentAvatar({
         </span>
       )}
     </div>
-  );
-}
-
-function AgentEditingChip({
-  showDot,
-  integrated,
-}: {
-  showDot: boolean;
-  integrated: boolean;
-}) {
-  return (
-    <span
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: showDot ? 4 : 0,
-        height: integrated ? "auto" : 20,
-        padding: integrated ? "0 0 0 2px" : "0 8px",
-        borderRadius: integrated ? 0 : 9999,
-        backgroundColor: integrated ? "transparent" : `${AGENT_COLOR}20`,
-        color: AGENT_COLOR,
-        fontSize: 11,
-        fontWeight: 600,
-        whiteSpace: "nowrap",
-      }}
-    >
-      {showDot && (
-        <span
-          style={{
-            width: 6,
-            height: 6,
-            borderRadius: "50%",
-            backgroundColor: AGENT_COLOR,
-            animation: "_anPresencePulse 2s infinite",
-            flexShrink: 0,
-          }}
-        />
-      )}
-      AI editing
-    </span>
   );
 }
 
@@ -305,7 +247,6 @@ export function PresenceBar({
   activeUsers,
   agentPresent,
   agentActive,
-  showAgentEditingDot = true,
   currentUserEmail,
   maxVisible = 5,
   className,
@@ -344,7 +285,6 @@ export function PresenceBar({
             active={!!agentActive}
             onClick={onAvatarClick ? () => onAvatarClick(null) : undefined}
             isFollowing={isFollowingAgent}
-            showAgentEditingDot={showAgentEditingDot}
           />
         )}
         {visibleUsers.length > 0 && (

--- a/packages/toolkit/src/collab-ui/PresenceBar.tsx
+++ b/packages/toolkit/src/collab-ui/PresenceBar.tsx
@@ -20,6 +20,8 @@ export interface PresenceBarProps {
   agentPresent?: boolean;
   /** Whether the agent is actively making edits right now. */
   agentActive?: boolean;
+  /** @deprecated Agent editing is represented by the AI presence circle and tooltip. */
+  showAgentEditingDot?: boolean;
   /** Current user's email (to exclude from the list). */
   currentUserEmail?: string;
   /** Max visible avatars before "+N" overflow. Default: 5 */

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -754,7 +754,6 @@ export default function EditorToolbar({
           activeUsers={activeUsers ?? []}
           agentPresent={agentPresent}
           agentActive={agentActive}
-          showAgentEditingDot={false}
           currentUserEmail={currentUserEmail}
           className="flex-shrink-0 pl-2"
         />

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -12,10 +12,7 @@ import {
   useAvatarUrl,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import {
-  AgentPresenceChip,
-  RecentEditHighlights,
-} from "@agent-native/toolkit/collab-ui";
+import { RecentEditHighlights } from "@agent-native/toolkit/collab-ui";
 import { appStateKeyForBrowserTab } from "@shared/app-state-tabs";
 import { hashSlideContent } from "@shared/slide-fit";
 import { IconX } from "@tabler/icons-react";
@@ -6834,16 +6831,11 @@ export default function SlideEditor({
                               outlineOnly
                             />
                           )}
-                          {(agentActive || passivePresentUsers.length > 0) && (
-                            <div className="absolute right-2 top-2 z-10 flex items-center gap-2">
-                              <AgentPresenceChip
-                                active={Boolean(agentActive)}
+                          {passivePresentUsers.length > 0 && (
+                            <div className="absolute right-2 top-2 z-10">
+                              <SameSlidePresenceIndicator
+                                users={passivePresentUsers}
                               />
-                              {passivePresentUsers.length > 0 && (
-                                <SameSlidePresenceIndicator
-                                  users={passivePresentUsers}
-                                />
-                              )}
                             </div>
                           )}
                           {overflowInfo &&


### PR DESCRIPTION
## Summary

- Remove the standalone AI editing pill from the shared presence bar and Slides canvas.
- Keep the AI initials in the circular presence badge with the editing tooltip.
- Preserve human same-slide presence indicators.

## Verification

- PresenceBar test
- Slides presence and toolbar tests
- Toolkit build and typecheck
- Slides typecheck
- Full repository guards
- Direct Slides browser verification: active badge text is `AI`, tooltip is `AI is editing`, and zero `AI editing` pills render.