### PR TITLE
Polish loading labels and active tool loaders

### DIFF
--- a/.changeset/spinning-cube-labels.md
+++ b/.changeset/spinning-cube-labels.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add shared shine and rotating loading labels to the app shell, and slightly enlarge active tool-call cube loaders.

--- a/packages/core/src/client/DefaultSpinner.spec.tsx
+++ b/packages/core/src/client/DefaultSpinner.spec.tsx
@@ -30,10 +30,34 @@ describe("DefaultSpinner", () => {
     });
 
     expect(container.querySelector("span")?.textContent).toBe("Churning");
+    expect(container.querySelector(".agent-running-shimmer")).not.toBeNull();
     expect(
       container.querySelectorAll("[data-agent-native-cube-loader] rect"),
     ).toHaveLength(9);
     expect(container.textContent).not.toContain("2m");
+  });
+
+  it("rotates through playful loading labels", () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        root.render(<DefaultSpinner />);
+      });
+
+      expect(
+        container.querySelector(".agent-running-shimmer")?.textContent,
+      ).toBe("Churning");
+
+      act(() => {
+        vi.advanceTimersByTime(3_000);
+      });
+
+      expect(
+        container.querySelector(".agent-running-shimmer")?.textContent,
+      ).toBe("Accomplishing");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses a caller-provided accessible loading label", () => {

--- a/packages/core/src/client/DefaultSpinner.tsx
+++ b/packages/core/src/client/DefaultSpinner.tsx
@@ -1,4 +1,63 @@
 import { CubeLoader } from "@agent-native/toolkit/ui/cube-loader";
+import { useEffect, useState } from "react";
+
+const LOADING_LABELS = [
+  "Churning",
+  "Accomplishing",
+  "Actioning",
+  "Actualizing",
+  "Architecting",
+  "Baking",
+  "Befuddling",
+  "Booping",
+  "Brewing",
+  "Calculating",
+  "Canoodling",
+  "Cerebrating",
+  "Clauding",
+  "Cogitating",
+  "Combobulating",
+  "Concocting",
+  "Considering",
+  "Cooking",
+  "Crafting",
+  "Creating",
+  "Crystallizing",
+  "Deciphering",
+  "Discombobulating",
+  "Doodling",
+  "Finagling",
+  "Flibbertigibbeting",
+  "Generating",
+  "Gesticulating",
+  "Hatching",
+  "Hullaballooing",
+  "Ideating",
+  "Lollygagging",
+  "Manifesting",
+  "Meandering",
+  "Mulling",
+  "Noodling",
+  "Percolating",
+  "Pondering",
+  "Pontificating",
+  "Puzzling",
+  "Razzmatazzing",
+  "Recombobulating",
+  "Ruminating",
+  "Sautéing",
+  "Schlepping",
+  "Spelunking",
+  "Tinkering",
+  "Tomfoolering",
+  "Topsy-turvying",
+  "Vibing",
+  "Wibbling",
+  "Wrangling",
+  "Zigzagging",
+] as const;
+
+const LOADING_LABEL_INTERVAL_MS = 3_000;
 
 /**
  * Full-screen loading spinner rendered during SSR and initial hydration.
@@ -11,6 +70,15 @@ export function DefaultSpinner({
 }: {
   ariaLabel?: string;
 }) {
+  const [loadingLabelIndex, setLoadingLabelIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setLoadingLabelIndex((index) => (index + 1) % LOADING_LABELS.length);
+    }, LOADING_LABEL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, []);
+
   return (
     <div
       style={{
@@ -25,6 +93,7 @@ export function DefaultSpinner({
       <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
         <CubeLoader aria-label={ariaLabel} className="size-6" />
         <span
+          className="agent-running-shimmer"
           style={{
             fontFamily: "ui-sans-serif, system-ui, sans-serif",
             fontSize: 16,
@@ -32,7 +101,7 @@ export function DefaultSpinner({
             opacity: 0.65,
           }}
         >
-          Churning
+          {LOADING_LABELS[loadingLabelIndex]}
         </span>
       </div>
       <style>{`

--- a/packages/core/src/client/chat/tool-call-display.spec.tsx
+++ b/packages/core/src/client/chat/tool-call-display.spec.tsx
@@ -331,6 +331,9 @@ describe("ToolCallDisplay native renderers", () => {
     expect(
       container.querySelector("[data-agent-native-cube-loader]"),
     ).not.toBeNull();
+    expect(
+      container.querySelector("[data-agent-native-cube-loader]")?.className,
+    ).toContain("size-3.5");
   });
 
   it("keeps a remote pending delegation out of the terminal state", () => {

--- a/packages/core/src/client/chat/tool-call-display.tsx
+++ b/packages/core/src/client/chat/tool-call-display.tsx
@@ -1089,7 +1089,7 @@ function ToolCallDisplayGeneric({
       >
         <span className="relative flex size-4 shrink-0 items-center justify-center">
           {isRunning ? (
-            <CubeLoader aria-hidden="true" className="size-3" />
+            <CubeLoader aria-hidden="true" className="size-3.5" />
           ) : isAgentError ? (
             <IconCircleX className="size-3.5 text-destructive" />
           ) : isUnknownOutcome ? (
@@ -1296,7 +1296,7 @@ function AgentCallCell({
         className="flex w-full items-center gap-2 rounded-md py-0.5 text-left text-[13px] text-muted-foreground transition-colors hover:text-foreground"
       >
         {isRunning ? (
-          <CubeLoader aria-hidden="true" className="size-3" />
+          <CubeLoader aria-hidden="true" className="size-3.5" />
         ) : isError ? (
           <IconCircleX className="size-3.5 text-destructive" />
         ) : (
@@ -1368,7 +1368,7 @@ function AgentActivityToolCallRow({
       <div className="my-0.5 flex w-full items-center gap-2 rounded-md py-0.5 text-left text-[13px] text-muted-foreground">
         <span className="flex size-4 shrink-0 items-center justify-center">
           {isRunning ? (
-            <CubeLoader aria-hidden="true" className="size-3" />
+            <CubeLoader aria-hidden="true" className="size-3.5" />
           ) : (
             <ToolIcon className="size-3.5" />
           )}

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1971,7 +1971,7 @@ const STATIC_SHELL_LOADING_MARKUP = [
     (delay, index) =>
       `<rect class="an-cube-cell" x="${2.5 + (index % 3) * 7}" y="${2.5 + Math.floor(index / 3) * 7}" width="5" height="5" rx="1" style="animation-delay:${delay}ms"></rect>`,
   ),
-  '</svg><span style="font-family:ui-sans-serif, system-ui, sans-serif;font-size:16px;font-weight:500;opacity:0.65">Churning</span>',
+  '</svg><span class="agent-running-shimmer" style="font-family:ui-sans-serif, system-ui, sans-serif;font-size:16px;font-weight:500;opacity:0.65">Churning</span>',
   `<\/div><style>
         html {
           background: hsl(var(--background, 0 0% 100%));


### PR DESCRIPTION
## Summary
- reuse the Agent Chat shimmer for the shell loader label
- rotate the shell label through playful loading verbs, starting with Churning
- slightly enlarge active tool-call cube loaders

## Validation
- focused Vitest: 244 tests passed
- @agent-native/core typecheck passed
- pnpm guards: all 65 checks passed
- rendered Playwright screenshot check: 9 cells, shell label Churning, tool loader 14x14