### PR TITLE
fix: use compatible changesets release action

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Create stable Release PR or publish to npm
         id: changesets
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
+        uses: changesets/action@3841a0683d3cfa6dae0f9bb335290003010fe3f0 # v1.9.0, compatible with Changesets CLI v2
         with:
           # When changesets/action finds no pending changesets, it runs
           # `publish`. @changesets/cli publishes packages concurrently, which

--- a/templates/slides/changelog/2026-08-28-standard-empty-home-layout.md
+++ b/templates/slides/changelog/2026-08-28-standard-empty-home-layout.md
@@ -2,4 +2,5 @@
 type: fixed
 date: 2026-08-28
 ---
+
 Keep the standard app layout visible when a Slides workspace has no decks.


### PR DESCRIPTION
## Summary
- pin the stable release workflow to Changesets action v1.9.0, which supports this repository's Changesets CLI v2
- restore the daily stable release path that currently fails before creating the release PR

## Verification
- `corepack pnpm test:package-release-workflow`
- `corepack pnpm guards`
- confirmed in production run 33207725407 that action v2.1.1 rejects CLI v2
