### PR TITLE
fix(desktop): use one native auth session across apps

### DIFF
--- a/packages/desktop-app/README.md
+++ b/packages/desktop-app/README.md
@@ -237,14 +237,14 @@ and is stored locally with the desktop settings.
 
 ## Shared sign-in for workspace apps
 
-Desktop presents the parent sign-in surface inline the first time a hosted app
-needs authentication. After that sign-in completes, eligible built-in and
-custom workspace apps receive short-lived app sessions through Dispatch and
-open without another login screen.
+Desktop presents one parent sign-in surface natively in the shell before a
+hosted app needs authentication. After that sign-in completes, eligible
+built-in and custom workspace apps receive short-lived app sessions through
+Dispatch and open without another login screen.
 
 The supported flow is:
 
-1. Open an app while signed out and complete the inline Google-first sign-in
+1. Open Desktop while signed out and complete the native Google-first sign-in
    surface. Password sign-in stays inline; Google and magic-link verification
    may complete in the system browser before returning to Desktop.
 2. Desktop stores the parent session in its persistent identity partition and

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -264,6 +264,12 @@ describe("Desktop identity navigation boundaries", () => {
     expect(
       isDesktopIdentityAppConfigEligible(custom, { canonical: true }),
     ).toBe(true);
+    expect(
+      isDesktopIdentityAppConfigEligible(
+        { id: "dispatch", enabled: false, mode: "prod" },
+        { allowDisabled: true, canonical: true },
+      ),
+    ).toBe(true);
     expect(isDesktopIdentityOriginEligible("https://custom.example")).toBe(
       true,
     );

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -2150,6 +2150,32 @@ describe("DesktopIdentityBroker", () => {
     }
   });
 
+  it("retries child sessions while the parent identity remains signed in", async () => {
+    const authority = authorityFixture();
+    const mail = appFixture();
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: cookieStore(),
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      resolveApp: (id) =>
+        id === authority.id ? authority : id === mail.id ? mail : null,
+      listApps: () => [authority, mail],
+      createWindow: vi.fn() as never,
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+    broker.setStatusForSetting("signed-in");
+    const ensureAppSession = vi
+      .spyOn(broker, "ensureAppSession")
+      .mockResolvedValue(true);
+
+    await expect(broker.retryAppSessionFanout()).resolves.toBe(true);
+
+    expect(ensureAppSession).toHaveBeenNthCalledWith(1, authority.id);
+    expect(ensureAppSession).toHaveBeenNthCalledWith(2, mail.id);
+  });
+
   it("does not remint a verified modern child on repeated status notifications", async () => {
     const authority = authorityFixture();
     const mail = appFixture();

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -794,6 +794,49 @@ export class DesktopIdentityBroker {
     return operation;
   }
 
+  async retryAppSessionFanout(): Promise<boolean> {
+    if (this.status !== "signed-in" || this.signOutOperation) return false;
+    const authority = this.options.resolveApp("dispatch");
+    if (!authority) return false;
+
+    const appsById = new Map<string, DesktopIdentityApp>([
+      [authority.id, authority],
+    ]);
+    try {
+      for (const app of this.options.listApps?.() ?? []) {
+        if (app.identityAuthority === true || app.workspaceSso === true) {
+          appsById.set(app.id, app);
+        }
+      }
+    } catch (error) {
+      console.warn("[desktop identity] retry app snapshot failed", {
+        reason: error instanceof Error ? error.message : "unknown error",
+      });
+      return false;
+    }
+
+    const generation = this.ceremonyGeneration;
+    let allSucceeded = true;
+    for (const app of appsById.values()) {
+      this.unsupportedAppIds.delete(app.id);
+      if (!this.isCeremonyCurrent(generation)) return false;
+      try {
+        if (!(await this.ensureAppSession(app.id))) allSucceeded = false;
+      } catch (error) {
+        allSucceeded = false;
+        console.warn("[desktop identity] retry app session failed", {
+          appId: app.id,
+          reason: error instanceof Error ? error.message : "unknown error",
+        });
+      }
+    }
+    return (
+      allSucceeded &&
+      this.isCeremonyCurrent(generation) &&
+      !this.signOutOperation
+    );
+  }
+
   private ensureModernAppSessionDeduped(
     appId: string,
     generation = this.ceremonyGeneration,

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -199,14 +199,21 @@ export function isDesktopIdentityAppConfigEligible<
   },
 >(
   configured: T | null | undefined,
-  options?: { canonical?: boolean; forCleanup?: boolean },
+  options?: {
+    allowDisabled?: boolean;
+    canonical?: boolean;
+    forCleanup?: boolean;
+  },
 ): configured is T {
   if (!configured || !isDesktopIdentityAppIdEligible(configured.id)) {
     return false;
   }
   const productionMode =
     configured.mode === undefined || configured.mode === "prod";
-  const enabled = options?.forCleanup ? true : configured.enabled === true;
+  const enabled =
+    options?.forCleanup || options?.allowDisabled
+      ? true
+      : configured.enabled === true;
   return Boolean(
     productionMode &&
     enabled &&

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -767,7 +767,11 @@ function getInjectionTargetForAppId(
 
 function resolveDesktopIdentityApp(
   appId: string,
-  options?: { forCleanup?: boolean; appConfigs?: AppConfig[] },
+  options?: {
+    forCleanup?: boolean;
+    allowDisabled?: boolean;
+    appConfigs?: AppConfig[];
+  },
 ): DesktopIdentityApp | null {
   if (!app.isPackaged) return null;
 

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -1585,9 +1585,7 @@ ipcMain.handle(IPC.IDENTITY_SIGN_IN, async (event) => {
   if (!broker) return false;
   const status = broker.getStatus();
   if (status !== "sign-in-required" && status !== "failed") return false;
-  const identityApp =
-    resolveDesktopIdentityApp(activeAppId) ??
-    resolveDesktopIdentityApp("dispatch");
+  const identityApp = resolveDesktopIdentityApp("dispatch");
   if (!identityApp) return false;
   return broker.signIn(identityApp.id);
 });

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -874,6 +874,10 @@ function listDesktopIdentityApps(
     .filter((candidate): candidate is DesktopIdentityApp => candidate !== null);
 }
 
+function resolveDesktopIdentityAuthority(): DesktopIdentityApp | null {
+  return resolveDesktopIdentityApp("dispatch", { allowDisabled: true });
+}
+
 function listDesktopIdentityCleanupApps(): DesktopIdentityApp[] {
   return listDesktopIdentityApps({ forCleanup: true });
 }
@@ -1349,7 +1353,7 @@ ipcMain.handle(IPC.IDENTITY_STATUS_GET, async (event) => {
   }
   if (!isDesktopSsoEnabled()) return "idle" satisfies DesktopIdentityStatus;
   const broker = ensureDesktopIdentityBroker();
-  await broker?.refreshStatus(resolveDesktopIdentityApp("dispatch"));
+  await broker?.refreshStatus(resolveDesktopIdentityAuthority());
   return broker?.getStatus() ?? "idle";
 });
 
@@ -1357,7 +1361,7 @@ ipcMain.handle(IPC.IDENTITY_AVAILABILITY_GET, async (event) => {
   if (!isShellIdentityIpc(event) || !isDesktopSsoEnabled()) return false;
   const broker = ensureDesktopIdentityBroker();
   if (!broker) return false;
-  await broker.refreshStatus(resolveDesktopIdentityApp("dispatch"));
+  await broker.refreshStatus(resolveDesktopIdentityAuthority());
   return broker.isAvailable();
 });
 
@@ -1385,7 +1389,7 @@ ipcMain.handle(IPC.IDENTITY_SSO_ENABLED_SET, async (event, enabled) => {
 
   const broker = ensureDesktopIdentityBroker();
   if (broker) {
-    await broker.refreshStatus(resolveDesktopIdentityApp("dispatch"));
+    await broker.refreshStatus(resolveDesktopIdentityAuthority());
     mainWindow?.webContents.send(
       IPC.IDENTITY_STATUS_CHANGED,
       broker.getStatus(),
@@ -1540,7 +1544,7 @@ ipcMain.handle(IPC.IDENTITY_ENVIRONMENT_LANE_GET, async (event) => {
   // persisted Builder session would load production once before switching.
   if (isDesktopSsoEnabled()) {
     const broker = ensureDesktopIdentityBroker();
-    await broker?.refreshStatus(resolveDesktopIdentityApp("dispatch"));
+    await broker?.refreshStatus(resolveDesktopIdentityAuthority());
   }
   return resolveDesktopEnvironmentLaneState();
 });
@@ -1589,8 +1593,15 @@ ipcMain.handle(IPC.IDENTITY_SIGN_IN, async (event) => {
   const broker = ensureDesktopIdentityBroker();
   if (!broker) return false;
   const status = broker.getStatus();
+  if (status === "signed-in") {
+    const recovered = await broker.retryAppSessionFanout();
+    if (recovered) {
+      mainWindow?.webContents.send(IPC.IDENTITY_STATUS_CHANGED, "signed-in");
+    }
+    return recovered;
+  }
   if (status !== "sign-in-required" && status !== "failed") return false;
-  const identityApp = resolveDesktopIdentityApp("dispatch");
+  const identityApp = resolveDesktopIdentityAuthority();
   if (!identityApp) return false;
   return broker.signIn(identityApp.id);
 });
@@ -1672,7 +1683,10 @@ function ensureDesktopIdentityBroker(): DesktopIdentityBroker | null {
     // Parent Google verification runs in the isolated identity window so its
     // browser-bound OAuth state remains in the same cookie partition. Magic
     // links may still complete through the system browser exchange path.
-    resolveApp: resolveDesktopIdentityApp,
+    resolveApp: (appId) =>
+      resolveDesktopIdentityApp(appId, {
+        allowDisabled: appId === "dispatch",
+      }),
     listApps: () => listDesktopIdentityApps(),
     openExternal: (url) => openExternalUrl(url),
     createWindow: (options) => new BrowserWindow(options),

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -802,6 +802,7 @@ function resolveDesktopIdentityApp(
     if (canonical && !isCanonical) return null;
     if (
       !isDesktopIdentityAppConfigEligible(configured, {
+        allowDisabled: appId === "dispatch" && isCanonical,
         canonical: isCanonical,
       })
     ) {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -69,6 +69,7 @@ describe("desktop passive-access regressions", () => {
     expect(resolver).toContain(
       'allowDisabled: appId === "dispatch" && isCanonical',
     );
+    expect(resolver).toContain("allowDisabled?: boolean");
   });
 
   it("keeps remembered Content folder discovery metadata-only", () => {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -58,7 +58,7 @@ describe("desktop passive-access regressions", () => {
       "ipcMain.handle(IPC.IDENTITY_AUTHENTICATE",
     );
 
-    expect(signIn).toContain('resolveDesktopIdentityApp("dispatch")');
+    expect(signIn).toContain("resolveDesktopIdentityAuthority()");
     expect(signIn).not.toContain("resolveDesktopIdentityApp(activeAppId)");
 
     const resolver = between(
@@ -70,6 +70,13 @@ describe("desktop passive-access regressions", () => {
       'allowDisabled: appId === "dispatch" && isCanonical',
     );
     expect(resolver).toContain("allowDisabled?: boolean");
+    expect(main).toContain(
+      'return resolveDesktopIdentityApp("dispatch", { allowDisabled: true });',
+    );
+    expect(main).not.toContain(
+      'refreshStatus(resolveDesktopIdentityApp("dispatch"))',
+    );
+    expect(main).toContain("retryAppSessionFanout()");
   });
 
   it("keeps remembered Content folder discovery metadata-only", () => {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -60,6 +60,15 @@ describe("desktop passive-access regressions", () => {
 
     expect(signIn).toContain('resolveDesktopIdentityApp("dispatch")');
     expect(signIn).not.toContain("resolveDesktopIdentityApp(activeAppId)");
+
+    const resolver = between(
+      main,
+      "function resolveDesktopIdentityApp(",
+      "function listDesktopIdentityApps(",
+    );
+    expect(resolver).toContain(
+      'allowDisabled: appId === "dispatch" && isCanonical',
+    );
   });
 
   it("keeps remembered Content folder discovery metadata-only", () => {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -50,6 +50,18 @@ describe("desktop passive-access regressions", () => {
     expect(signedInFastPath).toBeGreaterThan(signOutGuard);
   });
 
+  it("starts native sign-in from the Dispatch authority, not the active app", () => {
+    const main = source("./index.ts");
+    const signIn = between(
+      main,
+      "ipcMain.handle(IPC.IDENTITY_SIGN_IN",
+      "ipcMain.handle(IPC.IDENTITY_AUTHENTICATE",
+    );
+
+    expect(signIn).toContain('resolveDesktopIdentityApp("dispatch")');
+    expect(signIn).not.toContain("resolveDesktopIdentityApp(activeAppId)");
+  });
+
   it("keeps remembered Content folder discovery metadata-only", () => {
     const main = source("./index.ts");
     const normalization = between(

--- a/packages/desktop-app/src/renderer/App.spec.ts
+++ b/packages/desktop-app/src/renderer/App.spec.ts
@@ -11,6 +11,9 @@ describe("desktop chat-first shell", () => {
 
     expect(appSource).toContain("content-area content-area--chat-first");
     expect(appSource).toContain("<CodeAgentsHub");
+    expect(appSource).toContain("<DesktopIdentityGate");
+    expect(appSource).toContain('appName="Agent-Native Desktop"');
+    expect(appSource).toContain(".getStatus()");
     expect(appSource).toContain("key={settingsTab}");
     expect(appSource).toContain("initialTab={settingsTab}");
     expect(appSource).not.toContain("chatFirstMode");

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -483,6 +483,9 @@ export default function App() {
                 void handleAppRemoval(app.id);
               }}
               onChatFirstAppSelectionChange={handleChatFirstAppSelectionChange}
+              onDesktopIdentitySyncFailure={() =>
+                setDesktopIdentityStatus("failed")
+              }
             />
           </div>
         </div>

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import { Toaster, toast } from "sonner";
 
 import type {
   DesktopPrepareLocalCodeChangeResult,
+  DesktopIdentityStatus,
   DesktopWorkspaceAppListResult,
 } from "../../shared/ipc-channels.js";
 import AppSettings, { AddAppDialog } from "./components/AppSettings.js";
@@ -24,6 +25,7 @@ import {
   rememberDesktopIdentityStatus,
 } from "./components/AppWebview.js";
 import CodeAgentsHub from "./components/CodeAgentsHub.js";
+import DesktopIdentityGate from "./components/DesktopIdentityGate.js";
 import WindowControls, {
   CollapsedMacWindowControls,
 } from "./components/WindowControls.js";
@@ -43,6 +45,9 @@ export default function App() {
   const [workspaceAppList, setWorkspaceAppList] =
     useState<DesktopWorkspaceAppListResult>();
   const [loading, setLoading] = useState(true);
+  const [desktopIdentityStatus, setDesktopIdentityStatus] = useState<
+    DesktopIdentityStatus | "checking"
+  >(() => (window.electronAPI?.identity ? "checking" : "idle"));
   const [showSettings, setShowSettings] = useState(false);
   const [settingsTab, setSettingsTab] = useState("general");
   const [showAddApp, setShowAddApp] = useState(false);
@@ -132,21 +137,32 @@ export default function App() {
 
   useEffect(() => {
     void refreshWorkspaceAppList();
-    const onStatusChange = window.electronAPI?.identity
-      ? (
-          callback: Parameters<
-            typeof window.electronAPI.identity.onStatusChange
-          >[0],
-        ) => window.electronAPI!.identity!.onStatusChange(callback)
-      : undefined;
-    if (!onStatusChange) return;
-    return onStatusChange((status) => {
+    const identity = window.electronAPI?.identity;
+    if (!identity) {
+      setDesktopIdentityStatus("idle");
+      return;
+    }
+    let mounted = true;
+    const handleStatusChange = (status: DesktopIdentityStatus) => {
+      if (!mounted) return;
+      setDesktopIdentityStatus(status);
       // App is the shell-level subscriber, so sign-out invalidates the
       // renderer cache even while every individual app webview is inactive.
       rememberDesktopIdentityStatus(status);
       void refreshWorkspaceAppList();
       void refreshEnvironmentLane();
-    });
+    };
+    const unsubscribe = identity.onStatusChange(handleStatusChange);
+    void identity
+      .getStatus()
+      .then(handleStatusChange)
+      .catch(() => {
+        if (mounted) setDesktopIdentityStatus("failed");
+      });
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
   }, [refreshWorkspaceAppList, refreshEnvironmentLane]);
 
   const visibleEnabledApps = getDesktopVisibleApps(
@@ -470,6 +486,25 @@ export default function App() {
             />
           </div>
         </div>
+        <DesktopIdentityGate
+          appName="Agent-Native Desktop"
+          status={desktopIdentityStatus}
+          onSignIn={() => window.electronAPI?.identity?.signIn() ?? false}
+          onAuthenticate={(request) =>
+            window.electronAPI?.identity?.authenticate(request) ??
+            Promise.resolve({
+              ok: false,
+              error: "The desktop identity surface is unavailable.",
+            })
+          }
+          onMagicLink={(request) =>
+            window.electronAPI?.identity?.requestMagicLink(request) ??
+            Promise.resolve({
+              ok: false,
+              error: "The desktop identity surface is unavailable.",
+            })
+          }
+        />
       </div>
 
       {showSettings ? (

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -137,9 +137,9 @@ describe("Desktop identity lazy child synchronization", () => {
     ).toBe(false);
   });
 
-  it("does not demote a verified workspace session when child sync fails", () => {
+  it("reports a failed child sync to the shell-owned identity surface", () => {
     expect(resolveDesktopIdentityLazySyncStatus("signed-in", false)).toBe(
-      "signed-in",
+      "failed",
     );
     expect(resolveDesktopIdentityLazySyncStatus("signed-in", true)).toBe(
       "signed-in",

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -418,6 +418,8 @@ interface AppWebviewProps {
    * hiding, so the host has to say so or the page keeps polling underneath.
    */
   surfaceHidden?: boolean;
+  /** When false, the shell owns the single native identity sign-in surface. */
+  showDesktopIdentityGate?: boolean;
   /** Resolved shell theme to apply inside the guest document. */
   theme: RendererTheme;
   /** Only same-origin app surfaces should inherit the shell theme. */
@@ -698,6 +700,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       appConfig,
       isActive,
       surfaceHidden = false,
+      showDesktopIdentityGate = true,
       theme,
       syncTheme = true,
       sourceUrl,
@@ -773,11 +776,13 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         return false;
       }
     }, [app.id, updateDesktopIdentitySessionReady]);
-    const desktopIdentityGateActive = shouldUseDesktopIdentityGate({
-      eligible: desktopIdentityGateEligible,
-      active: isActive,
-      enabled: desktopIdentityEnabled,
-    });
+    const desktopIdentityGateActive =
+      showDesktopIdentityGate &&
+      shouldUseDesktopIdentityGate({
+        eligible: desktopIdentityGateEligible,
+        active: isActive,
+        enabled: desktopIdentityEnabled,
+      });
     const desktopIdentityRepairRef = useRef<Promise<boolean> | null>(null);
     const repairDesktopIdentitySession = useCallback(() => {
       if (

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -319,9 +319,6 @@ export function resolveDesktopIdentityLazySyncStatus(
   status: DesktopIdentityStatus,
   synchronized: boolean,
 ): DesktopIdentityStatus {
-  // Lazy child fan-out is best-effort. It must not demote a verified
-  // workspace session; the child app owns its fallback login surface.
-  if (status === "signed-in") return "signed-in";
   return synchronized ? status : "failed";
 }
 
@@ -1047,7 +1044,9 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
             // authoritative sign-out status or the next activation rechecks.
             invalidateRememberedDesktopIdentityStatus();
           }
-          updateDesktopIdentitySessionReady(true);
+          updateDesktopIdentitySessionReady(
+            preserveLoadedSession || synchronized === true,
+          );
           setDesktopIdentityStatus(
             resolveDesktopIdentityLazySyncStatus(status, synchronized === true),
           );

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -811,6 +811,8 @@ describe("CodeAgentsHub desktop identity status", () => {
 
     expect(source).toContain("desktopIdentityStatusByTab");
     expect(source).toContain("handleDesktopIdentityStatusChange");
+    expect(source).toContain("onDesktopIdentitySyncFailure");
+    expect(source).toContain('if (status === "failed")');
     expect(source).toContain("desktopIdentityStatusByTab,");
     expect(source).toContain("handleDesktopIdentityStatusChange,");
     expect(source).toContain("handleDesktopIdentityStatusChange(tab.id");

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -664,6 +664,7 @@ interface CodeAgentsHubProps {
   ) => void;
   onChatFirstAppRemove?: (app: ChatFirstAppItem) => void;
   onChatFirstAppSelectionChange?: (appId?: string) => void;
+  onDesktopIdentitySyncFailure?: () => void;
 }
 
 type CodeAgentTranscriptSubscriptionBatch = {
@@ -699,6 +700,7 @@ export default function CodeAgentsHub({
   onLocalCodeChangeStarted,
   onChatFirstAppRemove,
   onChatFirstAppSelectionChange,
+  onDesktopIdentitySyncFailure,
 }: CodeAgentsHubProps) {
   const theme = useRendererTheme();
   useEffect(() => {
@@ -742,8 +744,9 @@ export default function CodeAgentsHub({
       setDesktopIdentityStatusByTab((current) =>
         updateDesktopIdentityStatusByTab(current, tabId, status),
       );
+      if (status === "failed") onDesktopIdentitySyncFailure?.();
     },
-    [],
+    [onDesktopIdentitySyncFailure],
   );
   const handleAppAuthStateChange = useCallback(
     (tabId: string, state: AppWebviewAuthState) => {
@@ -2821,6 +2824,7 @@ export default function CodeAgentsHub({
       isActive,
       onLocalCodeChangeStarted,
       onOpenSettings,
+      onDesktopIdentitySyncFailure,
       refreshKey,
       surfaceApps,
       terminalPreferences.agent,
@@ -3063,6 +3067,9 @@ export default function CodeAgentsHub({
                 showDesktopIdentityGate={false}
                 theme={theme}
                 urlParams={urlParams}
+                onDesktopIdentityStatusChange={(status) => {
+                  if (status === "failed") onDesktopIdentitySyncFailure?.();
+                }}
                 // Shell key folded in: a lane change remounts every hosted
                 // surface, not just the ones with their own refresh reason.
                 refreshKey={appRefreshKey + refreshKey}

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2736,6 +2736,7 @@ export default function CodeAgentsHub({
                       app={toAppDefinition(surfaceApp)}
                       appConfig={surfaceApp}
                       isActive={isTabActive}
+                      showDesktopIdentityGate={false}
                       surfaceHidden={!showNativeIntegrationsGuest}
                       refreshKey={refreshKey}
                       theme={theme}
@@ -3059,6 +3060,7 @@ export default function CodeAgentsHub({
                 app={toAppDefinition(app)}
                 appConfig={app}
                 isActive={isActive}
+                showDesktopIdentityGate={false}
                 theme={theme}
                 urlParams={urlParams}
                 // Shell key folded in: a lane change remounts every hosted

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -130,6 +130,7 @@ body {
   min-height: 0;
   height: auto;
   overflow: hidden;
+  position: relative;
 }
 
 /* ─── Windows/Linux custom window controls ───────────────────── */


### PR DESCRIPTION
## Summary

- Move the Desktop identity sign-in gate to the native shell so it is shown once.
- Always start native sign-in from the Dispatch identity authority, independent of the active app.
- Keep eligible app-scoped session fanout and add regression coverage.

## Verification

- Focused desktop tests: 4 files, 68 tests passed
- Desktop typecheck passed
- oxfmt check passed

Reported in [Slack](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787937992659039).