### PR TITLE
fix(core): preserve custom OpenRouter model IDs

### DIFF
--- a/.changeset/preserve-openrouter-models.md
+++ b/.changeset/preserve-openrouter-models.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve custom OpenRouter model IDs selected in Agent settings.

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -583,6 +583,24 @@ describe("AISDKEngine OpenAI model selection", () => {
     expect(engine.preserveCustomModels).toBe(true);
   });
 
+  it("passes arbitrary OpenRouter model ids through runtime execution", async () => {
+    const { streamText } = mockAiSdk();
+    const provider = vi.fn().mockReturnValue({ id: "openrouter-model" });
+    const createOpenRouter = vi.fn().mockReturnValue(provider);
+    vi.doMock("@openrouter/ai-sdk-provider", () => ({ createOpenRouter }));
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const { normalizeModelForEngine } = await import("./registry.js");
+    const engine = createAISDKEngine("openrouter", { apiKey: "sk-or-test" });
+    const model = normalizeModelForEngine(engine, "z-ai/glm-5.3-flash");
+
+    await drain(engine.stream({ ...BASE_STREAM_OPTIONS, model }));
+
+    expect(engine.preserveCustomModels).toBe(true);
+    expect(provider).toHaveBeenCalledWith("z-ai/glm-5.3-flash");
+    expect(streamText).toHaveBeenCalled();
+  });
+
   // Real prod incident (Sentry AGENT-NATIVE-BROWSER-94, gpt-5.6-terra): OpenAI
   // rejects `reasoning_effort` together with function tools on the legacy
   // Chat Completions surface — "Function tools with reasoning_effort are not

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -244,6 +244,7 @@ class AISDKEngine implements AgentEngine {
     this.supportedModels = PROVIDER_SUPPORTED_MODELS[provider];
     this.preserveCustomModels =
       provider === "ollama" ||
+      provider === "openrouter" ||
       (provider === "openai" && Boolean(config.baseUrl));
     this.capabilities = PROVIDER_CAPABILITIES[provider];
     this.apiKey =

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -578,6 +578,15 @@ describe("AgentEngine registry", () => {
       ).resolves.toBe(true);
     });
 
+    it("preserves arbitrary OpenRouter model ids", async () => {
+      const { resolveEnginePreservesCustomModels } =
+        await import("./registry.js");
+
+      await expect(
+        resolveEnginePreservesCustomModels({ name: "ai-sdk:openrouter" }),
+      ).resolves.toBe(true);
+    });
+
     it("falls back an unrecognized first-party OpenAI model to the default without a gateway", async () => {
       const { normalizeModelForEngine } = await import("./registry.js");
       const engine = {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -269,7 +269,7 @@ export interface NormalizeModelOptions {
    * The settings actions call `normalizeModelForEngine` with a static registry
    * ENTRY, which never carries the runtime `preserveCustomModels` flag — that
    * is only set on the engine INSTANCE created with an OpenAI-compatible
-   * `baseUrl`. They resolve the capability with
+   * `baseUrl` or the OpenRouter provider. They resolve the capability with
    * {@link resolveEnginePreservesCustomModels} and pass it here so a gateway
    * model (e.g. an Ollama `gemma4`) is not rewritten to the OpenAI default on
    * save/read. First-party OpenAI (no gateway) leaves this unset, so an unknown
@@ -392,7 +392,9 @@ export function resolveDelegatedRunModel(
 export async function resolveEnginePreservesCustomModels(
   entry: Pick<AgentEngineEntry, "name">,
 ): Promise<boolean> {
-  if (entry.name === "ai-sdk:ollama") return true;
+  if (entry.name === "ai-sdk:ollama" || entry.name === "ai-sdk:openrouter") {
+    return true;
+  }
   if (entry.name !== "ai-sdk:openai") return false;
   try {
     return Boolean(await resolveProviderBaseUrl(OPENAI_BASE_URL_ENV_VAR));


### PR DESCRIPTION
## Summary

- Preserve arbitrary OpenRouter model IDs through shared Agent settings normalization.
- Preserve arbitrary OpenRouter model IDs on the live `AISDKEngine` execution path.
- Add a regression test and patch changeset for `@agent-native/core`.
- Review and disposition the latest Agent-Native feedback sweep without duplicating existing ownership.

## Feedback review

- OpenRouter persistence: [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787939702737949), fixed at the shared normalization boundary.
- Sign-up and auth reports remain under the active auth investigation; the magic-link session fix is [PR #3870](https://github.com/BuilderIO/agent-native/pull/3870).
- Design System indexing and generation safety remain owned by [PR #3830](https://github.com/BuilderIO/agent-native/pull/3830).
- Analytics export and Design selection reports are covered by merged [PR #3816](https://github.com/BuilderIO/agent-native/pull/3816) and [PR #3822](https://github.com/BuilderIO/agent-native/pull/3822).
- Browser capture, Fusion ACL, external Slides MCP, and unreachable user MCP reports were dispositioned as external; subjective or already-resolved reports were deferred or marked informational.
- Full Slack dispositions are recorded in the task clarification ledger outside the repository. Sentry was not connected in this session, so no Sentry result is inferred.

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest --run src/agent/engine/ai-sdk-engine.spec.ts src/agent/engine/registry.spec.ts` (117 passed)
- Focused Design tests (10 passed)
- Focused Calendar tests (2 passed)
- `corepack pnpm guards` (64 passed, 1 pre-existing `guard:i18n-catalogs` baseline-drift failure)
- `git diff --check` (clean)

The full core build remains blocked by pre-existing workspace UI wrapper/export and implicit-any errors after the required local dependency builds; the focused registry path is green.
