### PR TITLE
fix: stop MCP OAuth callbacks before connection

### DIFF
--- a/.changeset/finish-mcp-oauth-connection.md
+++ b/.changeset/finish-mcp-oauth-connection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep MCP OAuth callbacks from returning to chat until the saved server is connected.

--- a/packages/core/src/mcp-client/oauth-routes.spec.ts
+++ b/packages/core/src/mcp-client/oauth-routes.spec.ts
@@ -24,6 +24,7 @@ import {
   resolveMcpOAuthStartError,
   resolveMcpOAuthScope,
   resolveManagedMcpOAuthClient,
+  resolveMcpOAuthReturnPath,
   setMcpOAuthFlowCookie,
   stripMcpOAuthAppBasePath,
   type McpOAuthFlow,
@@ -44,6 +45,18 @@ const baseFlow: McpOAuthFlow = {
 };
 
 describe("MCP OAuth callback flow validation", () => {
+  it("returns to integrations when OAuth saved credentials do not connect", () => {
+    expect(resolveMcpOAuthReturnPath(false, { ...baseFlow })).toBe(
+      "/settings/integrations",
+    );
+    expect(
+      resolveMcpOAuthReturnPath(true, {
+        ...baseFlow,
+        returnUrl: "/chat?thread=meeting-actions",
+      }),
+    ).toBe("/chat?thread=meeting-actions");
+  });
+
   it("carries staged cookies on native redirects", () => {
     const event = {
       res: { headers: new Headers() },

--- a/packages/core/src/mcp-client/oauth-routes.ts
+++ b/packages/core/src/mcp-client/oauth-routes.ts
@@ -47,6 +47,7 @@ import {
   normalizeServerName,
   replaceOAuthRemoteServer,
   validateRemoteUrl,
+  type StoredRemoteMcpServer,
   type RemoteMcpScope,
 } from "./remote-store.js";
 
@@ -103,7 +104,22 @@ export interface McpOAuthFlow {
 }
 
 export interface McpOAuthRoutesOptions {
-  reconfigure: () => Promise<void>;
+  reconfigure: (target: {
+    scope: RemoteMcpScope;
+    scopeId: string;
+    server: StoredRemoteMcpServer;
+  }) => Promise<boolean>;
+}
+
+export function resolveMcpOAuthReturnPath(
+  connected: boolean,
+  flow: Pick<McpOAuthFlow, "name" | "returnUrl">,
+): string {
+  if (!connected) return "/settings/integrations";
+  return (
+    flow.returnUrl ??
+    `/settings/integrations?connected=mcp-${encodeURIComponent(flow.name)}`
+  );
 }
 
 export function redirectWithStagedCookies(
@@ -490,10 +506,12 @@ async function handleMcpOAuthCallback(
       setResponseStatus(event, 400);
       return { error: result.error };
     }
-    await options.reconfigure();
-    const returnPath =
-      flow.returnUrl ??
-      `/settings/integrations?connected=mcp-${encodeURIComponent(flow.name)}`;
+    const connected = await options.reconfigure({
+      scope: flow.scope,
+      scopeId: flow.scopeId,
+      server: result.server,
+    });
+    const returnPath = resolveMcpOAuthReturnPath(connected, flow);
     return redirectWithStagedCookies(
       event,
       getAppUrl(event, stripMcpOAuthAppBasePath(returnPath, getAppBasePath())),

--- a/packages/core/src/mcp-client/routes.ts
+++ b/packages/core/src/mcp-client/routes.ts
@@ -454,9 +454,10 @@ export function mountMcpServersRoutes(
   mountedApps.add(nitroApp);
 
   mountMcpOAuthRoutes(nitroApp, {
-    reconfigure: async () => {
+    reconfigure: async ({ scope, scopeId, server }) => {
       await options.waitUntilReady?.();
       await reconfigureManager(manager);
+      return manager.hasServer(mergedConfigKey(scope, server, scopeId));
     },
   });
 


### PR DESCRIPTION
## Summary

MCP OAuth callbacks now return to Integrations unless the exact scoped server is connected after credentials are saved. This prevents a failed Granola handshake from redirecting back into the pending chat prompt and repeating the connection suggestion.

The change addresses the report in [Slack](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787949179628209).

## Changes

- pass the saved scoped server into the OAuth reconfigure callback
- verify the matching merged MCP server is live before resuming chat
- send failed post-OAuth connections to the Integrations status surface
- preserve the existing chat return path after a successful connection

## Verification

- `corepack pnpm --filter @agent-native/core exec vitest --run src/mcp-client/oauth-routes.spec.ts src/mcp-client/routes.spec.ts src/mcp-client/manager.spec.ts`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards`
- `corepack pnpm exec oxfmt --check packages/core/src/mcp-client/oauth-routes.ts packages/core/src/mcp-client/oauth-routes.spec.ts packages/core/src/mcp-client/routes.ts`
