### PR TITLE
Prevent Clips tray popover window from being dragged

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -730,21 +730,6 @@ function openPrivacySettings(pane: MacosPrivacyPane): void {
   }
 }
 
-// Same explicit-drag pattern the toolbar/bubble overlays use —
-// `data-tauri-drag-region` has been unreliable, so we call `startDragging()`
-// directly on mousedown. Clicks on buttons/inputs still reach their handlers
-// since we only start a drag when the mousedown target isn't inside one.
-function handlePopoverHeaderMouseDown(event: React.MouseEvent) {
-  if (event.button !== 0) return;
-  const target = event.target as HTMLElement;
-  if (target.closest("button, a, input, select, textarea")) return;
-  getCurrentWindow()
-    .startDragging()
-    .catch((err) => {
-      console.warn("[clips-popover] startDragging failed:", err);
-    });
-}
-
 function nativeVoiceProvider(): VoiceProvider {
   return isMacPlatform() ? "macos-native" : "browser";
 }
@@ -4368,10 +4353,7 @@ export function App({
   if (authStatus === "unknown") {
     return (
       <div className="app" ref={appRef}>
-        <div
-          className="header header-centered"
-          onMouseDown={handlePopoverHeaderMouseDown}
-        >
+        <div className="header header-centered">
           <button
             className="icon-button header-close"
             onClick={hidePopover}
@@ -4403,10 +4385,7 @@ export function App({
             modes, Feedback, and Settings all act on an account that does not
             exist yet, so they appear after auth rather than competing with it.
             Only the window's own close control stays. */}
-        <div
-          className="header header-centered"
-          onMouseDown={handlePopoverHeaderMouseDown}
-        >
+        <div className="header header-centered">
           <button
             className="icon-button header-close"
             onClick={hidePopover}
@@ -5169,10 +5148,7 @@ function Header({
   // close button lives top-right as an absolute-positioned sibling, so the
   // tabs aren't offset by the close button's width.
   return (
-    <div
-      className="header header-centered"
-      onMouseDown={handlePopoverHeaderMouseDown}
-    >
+    <div className="header header-centered">
       <FeedbackButton submitterEmail={submitterEmail} />
       <div
         className="mode-toggle"
@@ -5571,10 +5547,7 @@ function PopoverSubViewHeader({
   action?: ReactNode;
 }) {
   return (
-    <div
-      className="setup-header popover-view-header"
-      onMouseDown={handlePopoverHeaderMouseDown}
-    >
+    <div className="setup-header popover-view-header">
       <button
         type="button"
         className="setup-back"
@@ -8239,12 +8212,7 @@ function Setup({
           className="flex min-w-0 flex-col gap-0.5 overflow-y-auto border-r border-border bg-muted/50 p-2.5 pt-3"
           aria-label="Settings sections"
         >
-          {/* The tray window is chromeless, so this header is its only drag
-              handle — without it the window cannot be moved. */}
-          <div
-            className="flex items-center pb-2"
-            onMouseDown={handlePopoverHeaderMouseDown}
-          >
+          <div className="flex items-center pb-2">
             {onCancel ? (
               <button
                 type="button"


### PR DESCRIPTION
### Summary
Removes the explicit drag handling from the Clips desktop popover headers so the tray/menubar window can no longer be moved by the user.

### Problem
The Clips desktop menu window was draggable via `startDragging()` calls wired to `onMouseDown` on several popover headers. Since this window is meant to be a tray/menubar-style popup anchored to the taskbar/menubar icon, allowing it to be dragged caused it to end up in an incorrect position, which then appeared to "jump back" when settings were updated.

### Solution
Removed the `handlePopoverHeaderMouseDown` drag handler and all of its usages so the popover headers no longer trigger window dragging, keeping the window pinned to its tray anchor.

### Key Changes
- Removed the `handlePopoverHeaderMouseDown` function in `templates/clips/desktop/src/app.tsx`, which called `getCurrentWindow().startDragging()` on mousedown.
- Removed `onMouseDown={handlePopoverHeaderMouseDown}` from the auth-unknown header, the auth-required header, the `Header` component, `PopoverSubViewHeader`, and the `Setup` settings sidebar header.
- Removed the accompanying comments explaining the now-deleted drag-handle behavior.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/silk-particle-l1yekw8w"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-silk-particle-l1yekw8w.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>



---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3881`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>silk-particle-l1yekw8w</branchName>-->