### PR TITLE
fix(calendar): compact workspace picker footer

### DIFF
--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -1190,15 +1190,15 @@ export function Sidebar({
         </nav>
 
         {!collapsed ? (
-          <div className="shrink-0">
+          <>
             <div className="px-3 py-2">
-              <OrgSwitcher reserveSpace />
+              <OrgSwitcher />
             </div>
 
-            <div className="flex items-center gap-1 px-1.5 py-1.5">
+            <div className="px-3 py-2 empty:hidden">
               <DevDatabaseLink />
             </div>
-          </div>
+          </>
         ) : null}
         <SidebarFooterActions
           collapsed={collapsed}

--- a/templates/calendar/changelog/2026-08-28-the-calendar-sidebar-keeps-the-workspace-picker-compact.md
+++ b/templates/calendar/changelog/2026-08-28-the-calendar-sidebar-keeps-the-workspace-picker-compact.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-28
+---
+
+The Calendar sidebar keeps the workspace picker compact


### PR DESCRIPTION
## Summary
- match Calendar workspace picker footer spacing to sibling apps
- remove the padded empty database-link row and reserved org spacer
- add a Calendar changelog entry

## Validation
- `corepack pnpm --filter calendar exec oxfmt --check app/components/layout/Sidebar.tsx`
- `corepack pnpm --filter calendar typecheck`
- `corepack pnpm --filter calendar exec vitest --run app/components/layout/AppLayout.spec.ts --config vitest.config.ts`
- Playwright browser check at local Calendar route in dark mode: no console errors or failed requests; screenshot captured locally

Production/beta deployment is not claimed here.