### PR TITLE
Use monochrome sidebar branding

### DIFF
--- a/.changeset/monochrome-sidebar-branding.md
+++ b/.changeset/monochrome-sidebar-branding.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Use a monochrome Agent-Native mark in app sidebars.

--- a/examples/chat-antd/app/components/layout/Sidebar.tsx
+++ b/examples/chat-antd/app/components/layout/Sidebar.tsx
@@ -3,10 +3,9 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import {
   ChatHistoryRail,
   type ChatHistoryItem,
@@ -337,21 +336,9 @@ export function Sidebar({
           )}
           aria-label={collapsed ? APP_TITLE : undefined}
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/examples/chat-mui/app/components/layout/Sidebar.tsx
+++ b/examples/chat-mui/app/components/layout/Sidebar.tsx
@@ -3,10 +3,9 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import {
   ChatHistoryRail,
   type ChatHistoryItem,
@@ -337,21 +336,9 @@ export function Sidebar({
           )}
           aria-label={collapsed ? APP_TITLE : undefined}
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/packages/core/src/client/components/icons/AgentNativeIcon.tsx
+++ b/packages/core/src/client/components/icons/AgentNativeIcon.tsx
@@ -12,9 +12,9 @@ interface AgentNativeIconProps extends Omit<SVGProps<SVGSVGElement>, "fill"> {
 
 /**
  * Monochrome agent-native "A" mark. Source paths are taken from the Tauri
- * menu-bar icon at `packages/core/src/assets/branding/tray-icon.svg`, with the
- * padded tray viewBox cropped for toolbar use and `fill="white"` swapped for
- * `fill="currentColor"` so the icon inherits the surrounding text color.
+ * menu-bar icon at `packages/core/src/assets/branding/tray-icon.svg`, with
+ * `fill="white"` swapped for `fill="currentColor"` so the icon inherits the
+ * surrounding text color.
  */
 export function AgentNativeIcon({
   size = 24,
@@ -26,21 +26,19 @@ export function AgentNativeIcon({
       xmlns="http://www.w3.org/2000/svg"
       width={size}
       height={size}
-      viewBox="0 0 114 114"
+      viewBox="0 0 114 66"
       fill="none"
       className={className}
       {...rest}
     >
-      <g transform="translate(0 24)">
-        <path
-          d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z"
-          fill="currentColor"
-        />
-        <path
-          d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z"
-          fill="currentColor"
-        />
-      </g>
+      <path
+        d="M24.5537 65.7695H0L15.0859 39.4619L37.708 0L60.4912 39.4619H39.6396L24.5537 65.7695Z"
+        fill="currentColor"
+      />
+      <path
+        d="M89.446 0H114L76.2921 65.7704H51.7383L89.446 0Z"
+        fill="currentColor"
+      />
     </svg>
   );
 }

--- a/packages/dispatch/src/components/layout/Layout.spec.tsx
+++ b/packages/dispatch/src/components/layout/Layout.spec.tsx
@@ -102,6 +102,9 @@ vi.mock("@agent-native/core/client/navigation", () => ({
 }));
 
 vi.mock("@agent-native/core/client/ui", () => ({
+  AgentNativeIcon: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-agent-native-icon {...props} />
+  ),
   FeedbackButton: () => <div>Feedback</div>,
 }));
 
@@ -595,10 +598,11 @@ describe("Dispatch NavContent", () => {
       '[data-agent-native="chat-history-list"]',
     );
     expect(historyList?.className).toContain("an-chat-history--rail");
-    expect(
-      container.querySelector('img[src="/agent-native-icon-light.svg"]')
-        ?.parentElement?.className,
-    ).not.toContain("border");
+    const sidebarLogo = container.querySelector(
+      "a[data-dispatch-logo] svg[data-agent-native-icon]",
+    );
+    expect(sidebarLogo?.className).toContain("text-black");
+    expect(sidebarLogo?.className).toContain("dark:text-white");
     expect(container.textContent).not.toContain("Workspace control plane");
 
     const threadButton = [...container.querySelectorAll("button")].find(

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -63,7 +63,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { InvitationBanner, OrgSwitcher } from "@agent-native/core/client/org";
 import { RunsTray } from "@agent-native/core/client/progress";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   ChatHistoryRail,
@@ -1254,25 +1254,10 @@ export function NavContent({
             collapsed ? "justify-center" : "gap-2",
           )}
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
             aria-hidden="true"
-            width={35}
-            height={20}
             className={cn(
-              "block shrink-0 object-contain object-center dark:hidden",
-              collapsed ? "h-4 w-7" : "h-5 w-[35px]",
-            )}
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={35}
-            height={20}
-            className={cn(
-              "hidden shrink-0 object-contain object-center dark:block",
+              "shrink-0 text-black dark:text-white",
               collapsed ? "h-4 w-7" : "h-5 w-[35px]",
             )}
           />

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -91,7 +91,6 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import {
   callAction,
@@ -2355,21 +2354,10 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
               to="/"
               className="flex min-w-0 flex-1 items-center gap-2 font-semibold"
             >
-              <img
-                src={appPath("/agent-native-icon-light.svg")}
-                alt=""
+              <AgentNativeIcon
+                size={35}
                 aria-hidden="true"
-                width={35}
-                height={20}
-                className="block h-5 w-[35px] shrink-0 object-contain object-center dark:hidden"
-              />
-              <img
-                src={appPath("/agent-native-icon-dark.svg")}
-                alt=""
-                aria-hidden="true"
-                width={35}
-                height={20}
-                className="hidden h-5 w-[35px] shrink-0 object-contain object-center dark:block"
+                className="h-5 w-[35px] shrink-0 text-black dark:text-white"
               />
               <span className="text-lg font-bold tracking-tight">
                 {t("navigation.brand")}

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { AgentNativeIcon } from "@agent-native/core/client/ui";
 import {
   IconChartBar,
   IconChevronDown,

--- a/templates/analytics/changelog/2026-08-28-sidebar-branding-uses-a-monochrome-agent-native-mark.md
+++ b/templates/analytics/changelog/2026-08-28-sidebar-branding-uses-a-monochrome-agent-native-mark.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Sidebar branding uses a monochrome Agent-Native mark.

--- a/templates/assets/app/components/layout/Sidebar.tsx
+++ b/templates/assets/app/components/layout/Sidebar.tsx
@@ -4,13 +4,12 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   ChatHistoryRail,
@@ -394,21 +393,10 @@ export function Sidebar() {
       )}
       data-sidebar-brand-toggle
     >
-      <img
-        src={appPath("/agent-native-icon-light.svg")}
-        alt=""
+      <AgentNativeIcon
+        size={28}
         aria-hidden="true"
-        width={28}
-        height={16}
-        className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-      />
-      <img
-        src={appPath("/agent-native-icon-dark.svg")}
-        alt=""
-        aria-hidden="true"
-        width={28}
-        height={16}
-        className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+        className="h-4 w-7 shrink-0 text-black dark:text-white"
       />
       {!collapsed && (
         <span className="text-sm font-semibold tracking-tight">

--- a/templates/brain/app/components/layout/Sidebar.tsx
+++ b/templates/brain/app/components/layout/Sidebar.tsx
@@ -3,12 +3,11 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   ChatHistoryRail,
@@ -339,21 +338,10 @@ export function Sidebar({
                 : undefined
           }
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -1,10 +1,9 @@
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { startWorkspaceProviderOAuth } from "@agent-native/core/client/integrations";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import { getWeekdayOrder, getWeekStartsOn } from "@shared/calendar-week";
 import {
@@ -797,21 +796,10 @@ export function Sidebar({
             }
             data-sidebar-brand-toggle
           >
-            <img
-              src={appPath("/agent-native-icon-light.svg")}
-              alt=""
+            <AgentNativeIcon
+              size={28}
               aria-hidden="true"
-              width={28}
-              height={16}
-              className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-            />
-            <img
-              src={appPath("/agent-native-icon-dark.svg")}
-              alt=""
-              aria-hidden="true"
-              width={28}
-              height={16}
-              className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+              className="h-4 w-7 shrink-0 text-black dark:text-white"
             />
             {!collapsed && (
               <span className="text-base font-semibold tracking-tight">

--- a/templates/calendar/changelog/2026-08-28-sidebar-branding-uses-a-monochrome-agent-native-mark.md
+++ b/templates/calendar/changelog/2026-08-28-sidebar-branding-uses-a-monochrome-agent-native-mark.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Sidebar branding uses a monochrome Agent-Native mark.

--- a/templates/chat/app/components/layout/Sidebar.tsx
+++ b/templates/chat/app/components/layout/Sidebar.tsx
@@ -3,11 +3,10 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   ChatHistoryRail,
@@ -387,21 +386,10 @@ export function Sidebar({
                 : undefined
           }
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -2,7 +2,6 @@ import {
   AgentSidebar,
   AgentToggleButton,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { getBrowserTabId } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
@@ -12,7 +11,7 @@ import {
   OrgSwitcher,
   useOrgRole,
 } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconInbox,
@@ -372,21 +371,9 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
             )}
             data-sidebar-brand-toggle
           >
-            <img
-              src={appPath("/agent-native-icon-light.svg")}
-              alt=""
+            <AgentNativeIcon
               aria-hidden="true"
-              width={28}
-              height={16}
-              className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-            />
-            <img
-              src={appPath("/agent-native-icon-dark.svg")}
-              alt=""
-              aria-hidden="true"
-              width={28}
-              height={16}
-              className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+              className="h-4 w-7 shrink-0 text-black dark:text-white"
             />
             {!showCollapsedSidebar && (
               <span className="truncate text-sm font-semibold text-foreground">

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,5 +1,4 @@
 import { useCodeMode } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { ExtensionSlot } from "@agent-native/core/client/extensions";
 import {
@@ -9,7 +8,7 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import type {
   ContentDatabaseItem,
@@ -1782,21 +1781,10 @@ export function DocumentSidebar({
       )}
       data-sidebar-brand-toggle
     >
-      <img
-        src={appPath("/agent-native-icon-light.svg")}
-        alt=""
+      <AgentNativeIcon
+        size={28}
         aria-hidden="true"
-        width={28}
-        height={16}
-        className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-      />
-      <img
-        src={appPath("/agent-native-icon-dark.svg")}
-        alt=""
-        aria-hidden="true"
-        width={28}
-        height={16}
-        className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+        className="h-4 w-7 shrink-0 text-black dark:text-white"
       />
       {!isCollapsed && (
         <span className="text-base font-semibold tracking-tight">Content</span>

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -1,9 +1,8 @@
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconPencil,
@@ -138,21 +137,10 @@ export function Sidebar() {
           )}
           data-sidebar-brand-toggle
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           {!collapsed && (
             <span className="text-sm font-semibold tracking-tight">

--- a/templates/factory/app/components/layout/Sidebar.tsx
+++ b/templates/factory/app/components/layout/Sidebar.tsx
@@ -3,11 +3,10 @@ import {
   useChatThreads,
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   ChatHistoryRail,
@@ -408,21 +407,10 @@ export function Sidebar({
                 : undefined
           }
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -3,12 +3,11 @@ import {
   focusAgentChat,
   navigateWithAgentChatViewTransition,
 } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconArrowUp,
@@ -267,21 +266,10 @@ export function Sidebar() {
               className="flex size-8 shrink-0 items-center justify-center rounded-lg outline-none transition-[background-color,box-shadow,transform] hover:bg-accent/50 focus-visible:ring-2 focus-visible:ring-ring"
               data-sidebar-brand-toggle
             >
-              <img
-                src={appPath("/agent-native-icon-light.svg")}
-                alt=""
+              <AgentNativeIcon
+                size={28}
                 aria-hidden="true"
-                width={28}
-                height={16}
-                className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-              />
-              <img
-                src={appPath("/agent-native-icon-dark.svg")}
-                alt=""
-                aria-hidden="true"
-                width={28}
-                height={16}
-                className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+                className="h-4 w-7 shrink-0 text-black dark:text-white"
               />
             </button>
           </TooltipTrigger>
@@ -404,21 +392,10 @@ export function Sidebar() {
                 onClick={handleBrandClick}
                 data-sidebar-brand-toggle
               >
-                <img
-                  src={appPath("/agent-native-icon-light.svg")}
-                  alt=""
+                <AgentNativeIcon
+                  size={28}
                   aria-hidden="true"
-                  width={28}
-                  height={16}
-                  className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-                />
-                <img
-                  src={appPath("/agent-native-icon-dark.svg")}
-                  alt=""
-                  aria-hidden="true"
-                  width={28}
-                  height={16}
-                  className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+                  className="h-4 w-7 shrink-0 text-black dark:text-white"
                 />
                 <span className="truncate">{t("navigation.brand")}</span>
               </button>

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -1,10 +1,10 @@
 import { AgentSidebar } from "@agent-native/core/client/agent-chat";
-import { agentNativePath, appPath } from "@agent-native/core/client/api-path";
+import { agentNativePath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import {
   HeaderActionsProvider,
   SidebarFooterActions,
@@ -251,21 +251,10 @@ function SidebarContent({
       >
         {!collapsed && (
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <img
-              src={appPath("/agent-native-icon-light.svg")}
-              alt=""
+            <AgentNativeIcon
+              size={28}
               aria-hidden="true"
-              width={28}
-              height={16}
-              className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-            />
-            <img
-              src={appPath("/agent-native-icon-dark.svg")}
-              alt=""
-              aria-hidden="true"
-              width={28}
-              height={16}
-              className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+              className="h-4 w-7 shrink-0 text-black dark:text-white"
             />
             <span className="font-logo truncate text-sm font-bold tracking-tight text-foreground">
               {t("navigation.brand")}

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
 import {
+  AgentNativeIcon,
   buildSignInReturnHref,
   FeedbackButton,
 } from "@agent-native/core/client/ui";

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -6,7 +6,6 @@ import {
   type ChatThreadSummary,
 } from "@agent-native/core/client/agent-chat";
 import { useCodeMode } from "@agent-native/core/client/agent-chat";
-import { appPath } from "@agent-native/core/client/api-path";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useSession } from "@agent-native/core/client/hooks";
@@ -624,21 +623,10 @@ export function Sidebar({
           disabled={!collapsible || !onCollapsedChange}
           data-sidebar-brand-toggle
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           {!collapsed && (
             <span className="truncate text-sm font-semibold tracking-tight">

--- a/templates/slides/app/components/layout/Sidebar.test.tsx
+++ b/templates/slides/app/components/layout/Sidebar.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@agent-native/core/client/db-admin", () => ({
 }));
 
 vi.mock("@agent-native/core/client/ui", () => ({
+  AgentNativeIcon: ({
+    size = 24,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & { size?: number }) => (
+    <svg data-agent-native-icon width={size} height={size} {...props} />
+  ),
   FeedbackButton: () => null,
 }));
 
@@ -112,17 +118,17 @@ describe("<Sidebar expanded>", () => {
       <Sidebar collapsed={false} onToggleCollapsed={() => {}} />,
     );
 
-    const brandMarks = container.querySelectorAll(
-      'img[src="/agent-native-icon-light.svg"], img[src="/agent-native-icon-dark.svg"]',
+    const brandMark = container.querySelector(
+      'button[data-sidebar-brand-toggle] svg[aria-hidden="true"]',
     );
 
-    expect(brandMarks).toHaveLength(2);
-    for (const brandMark of brandMarks) {
-      expect(brandMark.getAttribute("width")).toBe("28");
-      expect(brandMark.getAttribute("height")).toBe("16");
-      expect(brandMark.className).toContain("w-7");
-      expect(brandMark.className).toContain("object-contain");
-    }
+    expect(brandMark).not.toBeNull();
+    expect(brandMark?.getAttribute("width")).toBe("28");
+    expect(brandMark?.getAttribute("height")).toBe("28");
+    expect(brandMark?.className).toContain("w-7");
+    expect(brandMark?.className).toContain("h-4");
+    expect(brandMark?.className).toContain("text-black");
+    expect(brandMark?.className).toContain("dark:text-white");
   });
 
   it("renders the full sidebar (w-56) with the Collapse button and labelled nav", () => {

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -1,9 +1,8 @@
-import { appPath } from "@agent-native/core/client/api-path";
 import { DevDatabaseLink } from "@agent-native/core/client/db-admin";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconLayoutGrid,
@@ -106,21 +105,10 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
         collapsed ? "size-8 justify-center" : "min-w-0 flex-1",
       )}
     >
-      <img
-        src={appPath("/agent-native-icon-light.svg")}
-        alt=""
+      <AgentNativeIcon
+        size={28}
         aria-hidden="true"
-        width={28}
-        height={16}
-        className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-      />
-      <img
-        src={appPath("/agent-native-icon-dark.svg")}
-        alt=""
-        aria-hidden="true"
-        width={28}
-        height={16}
-        className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+        className="h-4 w-7 shrink-0 text-black dark:text-white"
       />
       {!collapsed && (
         <span className="truncate text-sm font-semibold tracking-tight">

--- a/templates/tasks/app/components/layout/Sidebar.tsx
+++ b/templates/tasks/app/components/layout/Sidebar.tsx
@@ -1,8 +1,7 @@
-import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
 import { openCommandMenu } from "@agent-native/core/client/navigation";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client/ui";
+import { AgentNativeIcon, FeedbackButton } from "@agent-native/core/client/ui";
 import { SidebarFooterActions } from "@agent-native/toolkit/app-shell";
 import {
   IconCheckbox,
@@ -155,21 +154,10 @@ export function Sidebar({
                 : undefined
           }
         >
-          <img
-            src={appPath("/agent-native-icon-light.svg")}
-            alt=""
+          <AgentNativeIcon
+            size={28}
             aria-hidden="true"
-            width={28}
-            height={16}
-            className="block h-4 w-7 shrink-0 object-contain object-center dark:hidden"
-          />
-          <img
-            src={appPath("/agent-native-icon-dark.svg")}
-            alt=""
-            aria-hidden="true"
-            width={28}
-            height={16}
-            className="hidden h-4 w-7 shrink-0 object-contain object-center dark:block"
+            className="h-4 w-7 shrink-0 text-black dark:text-white"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">


### PR DESCRIPTION
## Summary
- replace repeated light/dark image pairs in app sidebars with the shared monochrome Agent-Native mark
- use currentColor with black in light mode and white in dark mode
- preserve sidebar sizing and update focused coverage plus changelog metadata

## Verification
- Dispatch layout tests: 27 passed
- Slides sidebar tests: 9 passed
- Dispatch and Slides typechecks passed
- agent-native-brand and no-raw-colors guards passed
- live Forms browser check passed in light and dark themes