### PR TITLE
Persist prompt drafts across refreshes

### DIFF
--- a/.changeset/persist-composer-drafts.md
+++ b/.changeset/persist-composer-drafts.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+---
+
+Persist Agent-Native prompt drafts synchronously and keep prompt surfaces isolated across refreshes.

--- a/packages/core/src/client/AgentAskPopover.tsx
+++ b/packages/core/src/client/AgentAskPopover.tsx
@@ -18,6 +18,7 @@ export interface AgentAskPopoverProps {
   context?: string;
   className?: string;
   icon?: ReactNode;
+  draftScope?: string;
 }
 
 /** A low-emphasis entry point for asking the agent without losing the current surface. */
@@ -29,6 +30,7 @@ export function AgentAskPopover({
   context,
   className,
   icon,
+  draftScope,
 }: AgentAskPopoverProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -73,6 +75,7 @@ export function AgentAskPopover({
         <PromptComposer
           autoFocus
           attachmentsEnabled={false}
+          draftScope={draftScope}
           initialText={prompt}
           initialTextKey={prompt}
           layoutVariant="compact"

--- a/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
@@ -29,14 +29,20 @@ vi.mock("./use-jobs.js", () => ({
 vi.mock("../AgentAskPopover.js", () => ({
   AgentAskPopover: ({
     context,
+    draftScope,
     label,
     title,
   }: {
     context: string;
+    draftScope?: string;
     label?: string;
     title: string;
   }) => (
-    <button type="button" data-creation-context={context}>
+    <button
+      type="button"
+      data-creation-context={context}
+      data-draft-scope={draftScope}
+    >
       {label ?? title}
     </button>
   ),
@@ -174,6 +180,33 @@ describe("AgentJobsTab organization automations", () => {
       "Scheduled and event-triggered automations shared with this organization.",
     );
     expect(container.textContent).not.toContain("personal today");
+  });
+
+  it("scopes organization creation drafts to the active organization", () => {
+    act(() => {
+      root.render(<AgentJobsTab canManageOrg organizationId="org-a" />);
+    });
+
+    expect(
+      container.querySelector(
+        '[data-draft-scope="agent-jobs:organization-create:org-a"]',
+      ),
+    ).not.toBeNull();
+
+    act(() => {
+      root.render(<AgentJobsTab canManageOrg organizationId="org-b" />);
+    });
+
+    expect(
+      container.querySelector(
+        '[data-draft-scope="agent-jobs:organization-create:org-b"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[data-draft-scope="agent-jobs:organization-create:org-a"]',
+      ),
+    ).toBeNull();
   });
 
   it("stays quiet about the scheduler when schedules actually fire", () => {

--- a/packages/core/src/client/agent-page/AgentJobsTab.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.tsx
@@ -333,6 +333,7 @@ export function AgentJobsTab({
             ) : null}
             <AgentAskPopover
               context={organizationAutomationCreationContext()}
+              draftScope="agent-jobs:organization-create"
               prompt={t("jobs.organizationPrompt", {
                 defaultValue:
                   "Create a shared organization automation that does this: ",
@@ -390,6 +391,7 @@ export function AgentJobsTab({
             organization ? null : (
               <AgentAskPopover
                 context={automationCreationContext()}
+                draftScope="agent-jobs:personal-empty-create"
                 prompt={t("jobs.automationPrompt", {
                   defaultValue: "Create an automation that does this: ",
                 })}
@@ -692,6 +694,7 @@ export function AgentJobsTab({
       actions={
         <AgentAskPopover
           context={automationCreationContext()}
+          draftScope="agent-jobs:page-create"
           prompt={t("jobs.automationPrompt", {
             defaultValue: "Create an automation that does this: ",
           })}
@@ -710,6 +713,7 @@ export function AgentJobsTab({
           <div className="flex justify-end">
             <AgentAskPopover
               context={automationCreationContext()}
+              draftScope="agent-jobs:compact-create"
               prompt={t("jobs.automationPrompt", {
                 defaultValue: "Create an automation that does this: ",
               })}

--- a/packages/core/src/client/agent-page/AgentJobsTab.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.tsx
@@ -218,7 +218,11 @@ export function organizationAutomationCreationContext(): string {
 export function AgentJobsTab({
   canManageOrg = false,
   hideHeader = false,
-}: AgentPageTabProps & { hideHeader?: boolean }) {
+  organizationId,
+}: AgentPageTabProps & {
+  hideHeader?: boolean;
+  organizationId?: string | null;
+}) {
   const t = useT();
   const formatters = useFormatters();
   const personalJobsQuery = useRecurringJobs("user");
@@ -235,6 +239,9 @@ export function AgentJobsTab({
   const organizationJobsMutation = useManageRecurringJob("org");
   const organizationAutomationsMutation = useManageAutomation("org");
   const runAutomationMutation = useRunAutomationNow();
+  const organizationDraftScope = organizationId?.trim()
+    ? `agent-jobs:organization-create:${organizationId}`
+    : undefined;
   const [deleteTarget, setDeleteTarget] = useState<ListedAutomation | null>(
     null,
   );
@@ -333,7 +340,7 @@ export function AgentJobsTab({
             ) : null}
             <AgentAskPopover
               context={organizationAutomationCreationContext()}
-              draftScope="agent-jobs:organization-create"
+              draftScope={organizationDraftScope}
               prompt={t("jobs.organizationPrompt", {
                 defaultValue:
                   "Create a shared organization automation that does this: ",

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -640,7 +640,11 @@ export function AgentTabsPage({
         keywords: "jobs scheduled automations recurring event triggers",
         content: (
           <Suspense fallback={<TabLoading />}>
-            <AgentJobsTab scope={scope} canManageOrg={canManageOrg} />
+            <AgentJobsTab
+              scope={scope}
+              canManageOrg={canManageOrg}
+              organizationId={org?.orgId}
+            />
           </Suspense>
         ),
       },
@@ -684,7 +688,7 @@ export function AgentTabsPage({
       ...extraTabs,
       ...scopedExtraTabs,
     ],
-    [appName, canManageOrg, extraTabs, scope, scopedExtraTabs],
+    [appName, canManageOrg, extraTabs, org?.orgId, scope, scopedExtraTabs],
   );
   const visibleTabs = useMemo(
     () => tabs.filter((tab) => !normalizedHiddenTabs.has(tab.id)),

--- a/packages/desktop-app/src/renderer/components/QuickPromptOverlay.tsx
+++ b/packages/desktop-app/src/renderer/components/QuickPromptOverlay.tsx
@@ -339,6 +339,7 @@ export default function QuickPromptOverlay({
         });
       } catch (error) {
         setSubmitError(error instanceof Error ? error.message : String(error));
+        throw error;
       } finally {
         setLocalSubmitting(false);
       }
@@ -395,7 +396,7 @@ export default function QuickPromptOverlay({
         className="quick-prompt-overlay__composer"
         composerRef={composerRef}
         disabled={submitting || localSubmitting}
-        initialText=""
+        draftScope="desktop:quick-prompt"
         layoutVariant="hero"
         placeholder="Ask anything…"
         showModelSelector

--- a/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
@@ -26,6 +26,7 @@ const clientState = vi.hoisted(() => ({
     onEffortChange: vi.fn(),
     refreshEngines: vi.fn(),
   })),
+  activeOrgId: "org-a" as string | null,
 }));
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({
@@ -80,6 +81,14 @@ vi.mock("@agent-native/core/client/hooks", () => ({
   useActionMutation: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
+vi.mock("@agent-native/core/client/org", () => ({
+  useOrgRole: () => ({
+    org: clientState.activeOrgId
+      ? { orgId: clientState.activeOrgId }
+      : undefined,
+  }),
+}));
+
 vi.mock("@agent-native/core/client/host", () => ({
   isInBuilderFrame: () => clientState.inBuilderFrame,
 }));
@@ -127,6 +136,7 @@ describe("DispatchControlPlane", () => {
     clientState.workspaceApps = [];
     clientState.connectedApps = [];
     clientState.curatedTemplates = [];
+    clientState.activeOrgId = "org-a";
     clientState.useChatModels.mockClear();
     queryClient = new QueryClient({
       defaultOptions: {
@@ -182,7 +192,7 @@ describe("DispatchControlPlane", () => {
     });
     expect(clientState.promptComposerProps).toMatchObject({
       availableModels: [],
-      draftScope: "dispatch:overview",
+      draftScope: "dispatch:overview:org-a",
       modelListLoading: false,
       selectedEffort: "medium",
       selectedEngine: "",
@@ -240,6 +250,40 @@ describe("DispatchControlPlane", () => {
         },
       }),
     );
+  });
+
+  it("keeps overview drafts isolated by active organization", async () => {
+    const renderOverview = async () => {
+      await act(async () => {
+        root.render(
+          <MemoryRouter initialEntries={["/overview"]}>
+            <TooltipProvider>
+              <QueryClientProvider client={queryClient}>
+                <DispatchControlPlane />
+              </QueryClientProvider>
+            </TooltipProvider>
+          </MemoryRouter>,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    };
+
+    await renderOverview();
+    expect(clientState.promptComposerProps).toMatchObject({
+      draftScope: "dispatch:overview:org-a",
+    });
+
+    clientState.activeOrgId = "org-b";
+    await renderOverview();
+    expect(clientState.promptComposerProps).toMatchObject({
+      draftScope: "dispatch:overview:org-b",
+    });
+
+    clientState.activeOrgId = null;
+    await renderOverview();
+    expect(clientState.promptComposerProps).toMatchObject({
+      draftScope: "dispatch:overview",
+    });
   });
 
   it("shows mounted and connected apps together without duplicates", async () => {

--- a/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.spec.tsx
@@ -182,6 +182,7 @@ describe("DispatchControlPlane", () => {
     });
     expect(clientState.promptComposerProps).toMatchObject({
       availableModels: [],
+      draftScope: "dispatch:overview",
       modelListLoading: false,
       selectedEffort: "medium",
       selectedEngine: "",

--- a/packages/dispatch/src/components/dispatch-control-plane.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.tsx
@@ -122,6 +122,7 @@ function CommandPanel() {
         </div>
         <PromptComposer
           availableModels={availableModels}
+          draftScope="dispatch:overview"
           modelListLoading={modelListLoading}
           placeholder={t("dispatch.pages.overviewPromptPlaceholder", {
             defaultValue: "Ask Dispatch anything...",

--- a/packages/dispatch/src/components/dispatch-control-plane.tsx
+++ b/packages/dispatch/src/components/dispatch-control-plane.tsx
@@ -6,6 +6,7 @@ import {
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { useOrgRole } from "@agent-native/core/client/org";
 import { IconChevronDown, IconClockHour4, IconPlus } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
@@ -68,6 +69,10 @@ function SectionHeader({
 
 function CommandPanel() {
   const t = useT();
+  const { org } = useOrgRole();
+  const draftScope = org?.orgId?.trim()
+    ? `dispatch:overview:${org.orgId}`
+    : "dispatch:overview";
   const {
     availableModels,
     isLoading: modelListLoading,
@@ -122,7 +127,7 @@ function CommandPanel() {
         </div>
         <PromptComposer
           availableModels={availableModels}
-          draftScope="dispatch:overview"
+          draftScope={draftScope}
           modelListLoading={modelListLoading}
           placeholder={t("dispatch.pages.overviewPromptPlaceholder", {
             defaultValue: "Ask Dispatch anything...",

--- a/packages/docs/app/components/TableOfContents.tsx
+++ b/packages/docs/app/components/TableOfContents.tsx
@@ -238,6 +238,7 @@ export default function TableOfContents({
           icon={<IconMessage aria-hidden="true" size={16} stroke={1.5} />}
           placeholder={t("agent.emptyState")}
           prompt=""
+          draftScope="docs:table-of-contents-ask"
           className="mt-4 w-full cursor-pointer border border-[var(--docs-border)] bg-transparent text-[var(--fg-secondary)] hover:bg-[var(--bg-secondary)] hover:text-[var(--fg)]"
         />
       </nav>

--- a/packages/toolkit/src/composer/ComposerPlusMenu.tsx
+++ b/packages/toolkit/src/composer/ComposerPlusMenu.tsx
@@ -43,6 +43,7 @@ export interface ComposerTerminalModeControl {
 
 interface ComposerPlusMenuProps {
   onSelectMode?: (mode: ComposerMode) => void;
+  addAttachment?: (file: File) => Promise<unknown>;
   onAttachmentError?: (message: string) => void;
   /**
    * Show the "Create Extension" entry. Extensions are optional and hidden
@@ -241,8 +242,9 @@ function MenuItemHelp({
 }
 
 function UploadOnlyAttachButton({
+  addAttachment,
   onAttachmentError,
-}: Pick<ComposerPlusMenuProps, "onAttachmentError">) {
+}: Pick<ComposerPlusMenuProps, "addAttachment" | "onAttachmentError">) {
   const composerRuntime = useComposerRuntime();
   const t = useComposerRuntimeAdapters().translate!;
   const inputRef = useRef<HTMLInputElement>(null);
@@ -250,7 +252,9 @@ function UploadOnlyAttachButton({
     if (!files || files.length === 0) return;
     try {
       await Promise.all(
-        Array.from(files).map((file) => composerRuntime.addAttachment(file)),
+        Array.from(files).map((file) =>
+          (addAttachment ?? composerRuntime.addAttachment)(file),
+        ),
       );
     } catch (error) {
       onAttachmentError?.(
@@ -301,13 +305,19 @@ function UploadOnlyAttachButton({
 
 export function ComposerPlusMenu({
   onSelectMode,
+  addAttachment,
   onAttachmentError,
   extensionTools = false,
   mode = "full",
   terminalModeControl,
 }: ComposerPlusMenuProps) {
   if (mode === "upload-only") {
-    return <UploadOnlyAttachButton onAttachmentError={onAttachmentError} />;
+    return (
+      <UploadOnlyAttachButton
+        addAttachment={addAttachment}
+        onAttachmentError={onAttachmentError}
+      />
+    );
   }
   if (mode === "terminal" && terminalModeControl) {
     return (
@@ -317,6 +327,7 @@ export function ComposerPlusMenu({
   return (
     <ComposerPlusMenuFull
       onSelectMode={onSelectMode}
+      addAttachment={addAttachment}
       onAttachmentError={onAttachmentError}
       extensionTools={extensionTools}
     />
@@ -392,11 +403,12 @@ function ComposerPlusMenuTerminal({
 
 function ComposerPlusMenuFull({
   onSelectMode,
+  addAttachment,
   onAttachmentError,
   extensionTools,
 }: Pick<
   ComposerPlusMenuProps,
-  "onSelectMode" | "onAttachmentError" | "extensionTools"
+  "addAttachment" | "onSelectMode" | "onAttachmentError" | "extensionTools"
 >) {
   const adapters = useComposerRuntimeAdapters();
   const t = adapters.translate!;
@@ -490,7 +502,9 @@ function ComposerPlusMenuFull({
     if (!files || files.length === 0) return;
     try {
       await Promise.all(
-        Array.from(files).map((file) => composerRuntime.addAttachment(file)),
+        Array.from(files).map((file) =>
+          (addAttachment ?? composerRuntime.addAttachment)(file),
+        ),
       );
     } catch (error) {
       onAttachmentError?.(

--- a/packages/toolkit/src/composer/PromptComposer.spec.ts
+++ b/packages/toolkit/src/composer/PromptComposer.spec.ts
@@ -1,11 +1,29 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildPromptComposerSubmission,
+  PromptComposer,
   shouldGateComposerForMissingEngine,
+  type PromptComposerFile,
 } from "./PromptComposer.js";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
 
 describe("shouldGateComposerForMissingEngine", () => {
   it("never disables the composer while the status check is unresolved", () => {
@@ -106,5 +124,52 @@ describe("buildPromptComposerSubmission", () => {
       expect(result.files).toEqual([file]);
       expect(result.text).not.toContain("data:image");
     }
+  });
+});
+
+describe("PromptComposer scoped runtime", () => {
+  it("does not carry attachments across draft scopes", async () => {
+    let attachedFiles: PromptComposerFile[] = [];
+    const renderComposer = (draftScope: string) =>
+      root.render(
+        React.createElement(PromptComposer, {
+          attachmentsEnabled: true,
+          draftScope,
+          includeDefaultSlashSkills: false,
+          onAttachmentsChange: (files) => {
+            attachedFiles = files;
+          },
+          onSubmit: () => {},
+          plusMenuMode: "upload-only",
+          showModelSelector: false,
+          voiceEnabled: false,
+        }),
+      );
+
+    await act(async () => {
+      renderComposer("prompt-scope-a");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    const file = new File(["pending"], "pending.txt", { type: "text/plain" });
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [file],
+    });
+
+    await act(async () => {
+      input?.dispatchEvent(new Event("change", { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(attachedFiles).toHaveLength(1);
+
+    await act(async () => {
+      renderComposer("prompt-scope-b");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(attachedFiles).toHaveLength(0);
   });
 });

--- a/packages/toolkit/src/composer/PromptComposer.tsx
+++ b/packages/toolkit/src/composer/PromptComposer.tsx
@@ -777,7 +777,7 @@ function PromptComposerInner({
  * its own minimal assistant-ui runtime so it can be dropped into any subtree
  * without needing the outer chat to be mounted.
  */
-export function PromptComposer(props: PromptComposerProps) {
+function PromptComposerRuntime(props: PromptComposerProps) {
   const StaleIndexBoundary =
     useComposerRuntimeAdapters().agentChat!.StaleIndexBoundary!;
   const attachmentAdapter = useMemo(
@@ -815,4 +815,8 @@ export function PromptComposer(props: PromptComposerProps) {
       </AssistantRuntimeProvider>
     </TooltipProvider>
   );
+}
+
+export function PromptComposer(props: PromptComposerProps) {
+  return <PromptComposerRuntime key={props.draftScope ?? ""} {...props} />;
 }

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -241,7 +241,7 @@ describe("createTiptapComposerExtensions", () => {
     const focusRef = React.createRef<TiptapComposerHandle>();
     const onTextChange = vi.fn();
 
-    function Harness({ currentScope }: { currentScope: string }) {
+    function Harness({ currentScope }: { currentScope?: string }) {
       const runtime = useLocalRuntime(emptyChatModelAdapter);
       return React.createElement(
         AssistantRuntimeProvider,
@@ -250,7 +250,6 @@ describe("createTiptapComposerExtensions", () => {
           TooltipProvider,
           null,
           React.createElement(TiptapComposer, {
-            key: currentScope,
             focusRef,
             draftScope: currentScope,
             initialText: "Seed prompt",
@@ -265,6 +264,18 @@ describe("createTiptapComposerExtensions", () => {
     }
 
     await act(async () => {
+      localStorage.setItem(getComposerDraftKey(), "<p>Legacy prompt</p>");
+      root.render(React.createElement(Harness, { currentScope: undefined }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(
+      container.querySelector(".agent-composer-prosemirror")?.textContent,
+    ).toBe("Seed prompt");
+    expect(localStorage.getItem(getComposerDraftKey())).toContain(
+      "Legacy prompt",
+    );
+
+    await act(async () => {
       root.render(React.createElement(Harness, { currentScope: scope }));
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
@@ -273,11 +284,17 @@ describe("createTiptapComposerExtensions", () => {
     ).toBe("Saved prompt");
     expect(onTextChange).toHaveBeenCalledWith("Saved prompt");
 
-    act(() =>
+    act(() => focusRef.current?.setText("Typed prompt"));
+    expect(localStorage.getItem(getComposerDraftKey(scope))).toContain(
+      "Typed prompt",
+    );
+
+    await act(async () => {
       root.render(
         React.createElement(Harness, { currentScope: "draft-recovery:other" }),
-      ),
-    );
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
     expect(
       container.querySelector(".agent-composer-prosemirror")?.textContent,
     ).toBe("Seed prompt");

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -240,9 +240,11 @@ describe("createTiptapComposerExtensions", () => {
 
     const focusRef = React.createRef<TiptapComposerHandle>();
     const onTextChange = vi.fn();
+    let harnessRuntime: ReturnType<typeof useLocalRuntime> | undefined;
 
     function Harness({ currentScope }: { currentScope?: string }) {
       const runtime = useLocalRuntime(emptyChatModelAdapter);
+      harnessRuntime = runtime;
       return React.createElement(
         AssistantRuntimeProvider,
         { runtime },
@@ -290,6 +292,18 @@ describe("createTiptapComposerExtensions", () => {
     );
 
     await act(async () => {
+      await harnessRuntime?.thread.composer.addAttachment({
+        id: "scope-a-attachment",
+        type: "document",
+        name: "scope-a.txt",
+        content: [],
+      });
+    });
+    expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
+      1,
+    );
+
+    await act(async () => {
       root.render(
         React.createElement(Harness, { currentScope: "draft-recovery:other" }),
       );
@@ -298,6 +312,9 @@ describe("createTiptapComposerExtensions", () => {
     expect(
       container.querySelector(".agent-composer-prosemirror")?.textContent,
     ).toBe("Seed prompt");
+    expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
+      0,
+    );
   });
 
   it.each([

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -364,6 +364,68 @@ describe("createTiptapComposerExtensions", () => {
     ).toBeNull();
   });
 
+  it("syncs identical text after switching draft scopes", async () => {
+    const runs: Array<ReadonlyArray<{ content?: unknown }>> = [];
+    const recordingAdapter: ChatModelAdapter = {
+      async *run({ messages }) {
+        runs.push(messages);
+      },
+    };
+    const focusRef = React.createRef<TiptapComposerHandle>();
+
+    function Harness({ currentScope }: { currentScope: string }) {
+      const runtime = useLocalRuntime(recordingAdapter);
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            focusRef,
+            draftScope: currentScope,
+            includeDefaultSlashSkills: false,
+            plusMenuMode: "hidden",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    const submit = async () => {
+      const editor = container.querySelector(
+        ".agent-composer-prosemirror",
+      ) as HTMLElement;
+      await act(async () => {
+        editor.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            bubbles: true,
+            cancelable: true,
+            key: "Enter",
+          }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    };
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { currentScope: "scope-a" }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    act(() => focusRef.current?.setText("hello"));
+    await submit();
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { currentScope: "scope-b" }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    act(() => focusRef.current?.setText("hello"));
+    await submit();
+
+    expect(runs).toHaveLength(2);
+    expect(runs[1]?.at(-1)?.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
   it.each([
     [
       "text",

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -242,7 +242,13 @@ describe("createTiptapComposerExtensions", () => {
     const onTextChange = vi.fn();
     let harnessRuntime: ReturnType<typeof useLocalRuntime> | undefined;
 
-    function Harness({ currentScope }: { currentScope?: string }) {
+    function Harness({
+      currentScope,
+      plusMenuMode = "hidden",
+    }: {
+      currentScope?: string;
+      plusMenuMode?: "full" | "hidden";
+    }) {
       const runtime = useLocalRuntime(emptyChatModelAdapter);
       harnessRuntime = runtime;
       return React.createElement(
@@ -258,7 +264,7 @@ describe("createTiptapComposerExtensions", () => {
             initialTextKey: "seed",
             includeDefaultSlashSkills: false,
             onTextChange,
-            plusMenuMode: "hidden",
+            plusMenuMode,
             voiceEnabled: false,
           }),
         ),
@@ -291,6 +297,18 @@ describe("createTiptapComposerExtensions", () => {
       "Typed prompt",
     );
 
+    act(() =>
+      focusRef.current?.insertReference({
+        label: "Pending reference",
+        refType: "file",
+        refPath: "/tmp/pending.txt",
+      }),
+    );
+    act(() => window.dispatchEvent(new Event("pagehide")));
+    expect(localStorage.getItem(getComposerDraftKey(scope))).toContain(
+      "Pending reference",
+    );
+
     await act(async () => {
       await harnessRuntime?.thread.composer.addAttachment({
         id: "scope-a-attachment",
@@ -305,7 +323,33 @@ describe("createTiptapComposerExtensions", () => {
 
     await act(async () => {
       root.render(
-        React.createElement(Harness, { currentScope: "draft-recovery:other" }),
+        React.createElement(Harness, {
+          currentScope: scope,
+          plusMenuMode: "full",
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('button[aria-label="Add..."]')
+        ?.click();
+    });
+    act(() => {
+      Array.from(document.querySelectorAll("button"))
+        .find((button) => button.textContent?.trim() === "Schedule Task")
+        ?.click();
+    });
+    expect(
+      container.querySelector('[data-agent-composer-slot="mode-row"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      root.render(
+        React.createElement(Harness, {
+          currentScope: "draft-recovery:other",
+          plusMenuMode: "full",
+        }),
       );
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
@@ -315,6 +359,9 @@ describe("createTiptapComposerExtensions", () => {
     expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
       0,
     );
+    expect(
+      container.querySelector('[data-agent-composer-slot="mode-row"]'),
+    ).toBeNull();
   });
 
   it.each([

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -16,6 +16,7 @@ vi.mock("sonner", () => ({
 }));
 
 import { TooltipProvider } from "../ui/tooltip.js";
+import { getComposerDraftKey } from "./draft-key.js";
 import {
   canSubmitComposerContent,
   canRemoveVoicePreview,
@@ -54,6 +55,7 @@ let root: Root;
 
 beforeEach(() => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  localStorage.clear();
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -221,6 +223,64 @@ describe("createTiptapComposerExtensions", () => {
     expect(editor.getHTML()).toContain('data-type="file-reference"');
 
     editor.destroy();
+  });
+
+  it("restores a scoped draft before a seeded prompt without crossing scopes", async () => {
+    const scope = "draft-recovery:test";
+    const draftEditor = new Editor({
+      element: document.createElement("div"),
+      extensions: createTiptapComposerExtensions(() => "Message agent..."),
+    });
+    draftEditor.commands.setContent("<p>Saved prompt</p>");
+    localStorage.setItem(getComposerDraftKey(scope), draftEditor.getHTML());
+    draftEditor.destroy();
+    expect(localStorage.getItem(getComposerDraftKey(scope))).toContain(
+      "Saved prompt",
+    );
+
+    const focusRef = React.createRef<TiptapComposerHandle>();
+    const onTextChange = vi.fn();
+
+    function Harness({ currentScope }: { currentScope: string }) {
+      const runtime = useLocalRuntime(emptyChatModelAdapter);
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            key: currentScope,
+            focusRef,
+            draftScope: currentScope,
+            initialText: "Seed prompt",
+            initialTextKey: "seed",
+            includeDefaultSlashSkills: false,
+            onTextChange,
+            plusMenuMode: "hidden",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { currentScope: scope }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(
+      container.querySelector(".agent-composer-prosemirror")?.textContent,
+    ).toBe("Saved prompt");
+    expect(onTextChange).toHaveBeenCalledWith("Saved prompt");
+
+    act(() =>
+      root.render(
+        React.createElement(Harness, { currentScope: "draft-recovery:other" }),
+      ),
+    );
+    expect(
+      container.querySelector(".agent-composer-prosemirror")?.textContent,
+    ).toBe("Seed prompt");
   });
 
   it.each([

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -4,6 +4,7 @@ import {
   AssistantRuntimeProvider,
   useLocalRuntime,
   type ChatModelAdapter,
+  type AttachmentAdapter,
 } from "@assistant-ui/react";
 import { Editor } from "@tiptap/core";
 import React, { act } from "react";
@@ -424,6 +425,97 @@ describe("createTiptapComposerExtensions", () => {
 
     expect(runs).toHaveLength(2);
     expect(runs[1]?.at(-1)?.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("waits for old attachment cleanup before accepting a new-scope upload", async () => {
+    let releaseCleanup!: () => void;
+    const cleanupDone = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const removeAttachment = vi.fn(() => cleanupDone);
+    const attachmentAdapter: AttachmentAdapter = {
+      accept: "*",
+      add: async ({ file }) => ({
+        id: file.name,
+        type: "document",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      }),
+      remove: removeAttachment,
+      send: async (attachment) => ({
+        ...attachment,
+        status: { type: "complete" },
+        content: [],
+      }),
+    };
+    const focusRef = React.createRef<TiptapComposerHandle>();
+    let harnessRuntime: ReturnType<typeof useLocalRuntime> | undefined;
+
+    function Harness({ currentScope }: { currentScope: string }) {
+      const runtime = useLocalRuntime(emptyChatModelAdapter, {
+        adapters: { attachments: attachmentAdapter },
+      });
+      harnessRuntime = runtime;
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            focusRef,
+            draftScope: currentScope,
+            includeDefaultSlashSkills: false,
+            plusMenuMode: "upload-only",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { currentScope: "scope-a" }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    await act(async () => {
+      await harnessRuntime?.thread.composer.addAttachment(
+        new File(["old"], "same.txt", { type: "text/plain" }),
+      );
+    });
+
+    await act(async () => {
+      root.render(React.createElement(Harness, { currentScope: "scope-b" }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
+      0,
+    );
+
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [new File(["new"], "same.txt", { type: "text/plain" })],
+    });
+    await act(async () => {
+      input?.dispatchEvent(new Event("change", { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(removeAttachment).toHaveBeenCalledTimes(1);
+    expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
+      0,
+    );
+
+    await act(async () => {
+      releaseCleanup();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(harnessRuntime?.thread.composer.getState().attachments).toHaveLength(
+      1,
+    );
   });
 
   it.each([

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -3741,8 +3741,8 @@ export function TiptapComposer({
       lastComposerRuntimeSyncRef.current = null;
       composerRuntime.setText("");
       const cleanupGeneration = draftScopeGenerationRef.current;
-      attachmentCleanupRef.current = composerRuntime
-        .clearAttachments()
+      attachmentCleanupRef.current = attachmentCleanupRef.current
+        .then(() => composerRuntime.clearAttachments())
         .catch((error) => {
           if (draftScopeGenerationRef.current === cleanupGeneration) {
             console.error(

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -431,15 +431,25 @@ function composerDocumentHasContent(doc: ComposerDocument): boolean {
 }
 
 function persistComposerDraft(
-  draftKey: string,
+  draftKey: string | null,
   editor: { getHTML(): string; state: { doc: ComposerDocument } },
 ): void {
+  if (!draftKey) return;
   try {
     if (!composerDocumentHasContent(editor.state.doc)) {
       localStorage.removeItem(draftKey);
     } else {
       localStorage.setItem(draftKey, editor.getHTML());
     }
+  } catch {
+    // coercion-ok: browser storage is optional and can be unavailable or full.
+  }
+}
+
+function clearComposerDraft(draftKey: string | null): void {
+  if (!draftKey) return;
+  try {
+    localStorage.removeItem(draftKey);
   } catch {
     // coercion-ok: browser storage is optional and can be unavailable or full.
   }
@@ -2463,7 +2473,12 @@ export function TiptapComposer({
   }, []);
 
   // Persist draft to localStorage so refreshes don't lose the prompt.
-  const draftKey = getComposerDraftKey(draftScope);
+  const hasDraftScope = Boolean(draftScope?.trim());
+  const draftKey =
+    hasDraftScope || initialText === undefined
+      ? getComposerDraftKey(draftScope)
+      : null;
+  const previousDraftKeyRef = useRef(draftKey);
   useEffect(() => {
     lastComposerRuntimeSyncRef.current = null;
   }, [composerRuntime]);
@@ -3281,11 +3296,7 @@ export function TiptapComposer({
     setEditorHasText(false);
     setSlotReferences([]);
     resetComposerRuntimeState();
-    try {
-      localStorage.removeItem(draftKey);
-    } catch {
-      // coercion-ok: browser storage is optional and can be unavailable or full.
-    }
+    clearComposerDraft(draftKey);
     closePopover();
   }, [closePopover, draftKey, editor, resetComposerRuntimeState]);
 
@@ -3403,9 +3414,7 @@ export function TiptapComposer({
         setSlotReferences([]);
         setComposerMode(null);
         composerModeRef.current = null;
-        try {
-          localStorage.removeItem(draftKey);
-        } catch {}
+        clearComposerDraft(draftKey);
         closePopover();
         return;
       }
@@ -3434,9 +3443,7 @@ export function TiptapComposer({
       if (isComposerEditorUsable(ed)) ed.commands.clearContent();
       setEditorHasText(false);
       setSlotReferences([]);
-      try {
-        localStorage.removeItem(draftKey);
-      } catch {}
+      clearComposerDraft(draftKey);
       closePopover();
     },
     [
@@ -3616,19 +3623,32 @@ export function TiptapComposer({
 
   useEffect(() => {
     if (!isComposerEditorUsable(editor)) return;
+    if (previousDraftKeyRef.current !== draftKey) return;
     if (composerText !== "") return;
     if (editor.isEmpty) return;
     editor.commands.clearContent();
-  }, [composerText, editor]);
+  }, [composerText, draftKey, editor]);
 
   useEffect(() => {
     if (!isComposerEditorUsable(editor)) return;
+    const draftKeyChanged = previousDraftKeyRef.current !== draftKey;
+    previousDraftKeyRef.current = draftKey;
+    if (draftKeyChanged) {
+      editor.commands.clearContent(false);
+      initialTextKeyRef.current = undefined;
+      setEditorHasText(false);
+      setSlotReferences([]);
+      composerRuntime.setText("");
+      onTextChangeRef.current?.("");
+    }
     const key = initialTextKey ?? initialText;
     let saved: string | null = null;
-    try {
-      saved = localStorage.getItem(draftKey);
-    } catch {
-      // coercion-ok: browser storage is optional and can be unavailable or full.
+    if (draftKey) {
+      try {
+        saved = localStorage.getItem(draftKey);
+      } catch {
+        // coercion-ok: browser storage is optional and can be unavailable or full.
+      }
     }
 
     try {

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -2488,6 +2488,12 @@ export function TiptapComposer({
       : null;
   const draftKeyRef = useRef(draftKey);
   draftKeyRef.current = draftKey;
+  const draftScopeGenerationRef = useRef(0);
+  const renderedDraftKeyRef = useRef(draftKey);
+  if (renderedDraftKeyRef.current !== draftKey) {
+    renderedDraftKeyRef.current = draftKey;
+    draftScopeGenerationRef.current += 1;
+  }
   const draftEditorRef = useRef<ComposerDraftEditor | null>(null);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelScheduledDraftPersist = useCallback(() => {
@@ -3371,6 +3377,11 @@ export function TiptapComposer({
 
       draftEditorRef.current = ed;
       flushComposerDraft();
+      const submittingDraftKey = draftKeyRef.current;
+      const submittingDraftGeneration = draftScopeGenerationRef.current;
+      const isCurrentDraftScope = () =>
+        draftKeyRef.current === submittingDraftKey &&
+        draftScopeGenerationRef.current === submittingDraftGeneration;
       const { text, references } = syncComposerState();
       const attachments = composerRuntime.getState().attachments;
       if (!text.trim() && references.length === 0 && attachments.length === 0)
@@ -3435,6 +3446,7 @@ export function TiptapComposer({
         }
       }
       if (!isComposerEditorUsable(ed)) return;
+      if (!isCurrentDraftScope()) return;
 
       // Composer mode: send with context via agent chat bridge
       if (composerMode) {
@@ -3493,6 +3505,7 @@ export function TiptapComposer({
           // available for recovery when a host rejects the submission.
           return;
         }
+        if (!isCurrentDraftScope()) return;
         // Clear any pending attachments now that the host has them.
         void composerRuntime.clearAttachments().catch(() => {});
         if (!clearOnSubmit) {

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -24,6 +24,7 @@ import React, {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -2487,13 +2488,23 @@ export function TiptapComposer({
       ? getComposerDraftKey(draftScope)
       : null;
   const draftKeyRef = useRef(draftKey);
-  draftKeyRef.current = draftKey;
   const draftScopeGenerationRef = useRef(0);
-  const renderedDraftKeyRef = useRef(draftKey);
-  if (renderedDraftKeyRef.current !== draftKey) {
-    renderedDraftKeyRef.current = draftKey;
-    draftScopeGenerationRef.current += 1;
-  }
+  const attachmentCleanupRef = useRef<Promise<void>>(Promise.resolve());
+  const addAttachmentForCurrentScope = useCallback(
+    async (file: File) => {
+      const scopeGeneration = draftScopeGenerationRef.current;
+      await attachmentCleanupRef.current;
+      if (draftScopeGenerationRef.current !== scopeGeneration) return;
+      return composerRuntime.addAttachment(file);
+    },
+    [composerRuntime],
+  );
+  useLayoutEffect(() => {
+    if (draftKeyRef.current !== draftKey) {
+      draftKeyRef.current = draftKey;
+      draftScopeGenerationRef.current += 1;
+    }
+  }, [draftKey]);
   const draftEditorRef = useRef<ComposerDraftEditor | null>(null);
   const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cancelScheduledDraftPersist = useCallback(() => {
@@ -2589,7 +2600,7 @@ export function TiptapComposer({
           }
 
           void Promise.all(
-            attachments.map((file) => composerRuntime.addAttachment(file)),
+            attachments.map((file) => addAttachmentForCurrentScope(file)),
           ).catch((error) => {
             const msg =
               error instanceof Error
@@ -2612,17 +2623,17 @@ export function TiptapComposer({
         // which cuts off mid-stream on large files and triggers a spin.
         if (shouldConvertClipboardToAttachment(paste)) {
           event.preventDefault();
-          void composerRuntime
-            .addAttachment(createPastedAttachmentFile(paste))
-            .catch((error) => {
-              const msg =
-                error instanceof Error
-                  ? error.message
-                  : t("agentChat.composer.pastedTextError", {
-                      defaultValue: "Could not attach the pasted text.",
-                    });
-              onAttachmentErrorRef.current?.(msg);
-            });
+          void addAttachmentForCurrentScope(
+            createPastedAttachmentFile(paste),
+          ).catch((error) => {
+            const msg =
+              error instanceof Error
+                ? error.message
+                : t("agentChat.composer.pastedTextError", {
+                    defaultValue: "Could not attach the pasted text.",
+                  });
+            onAttachmentErrorRef.current?.(msg);
+          });
           return true;
         }
 
@@ -2634,7 +2645,7 @@ export function TiptapComposer({
         // add the same file a second time.
         return handleComposerFileDrop({
           event: event as DragEvent,
-          addAttachment: (file) => composerRuntime.addAttachment(file),
+          addAttachment: addAttachmentForCurrentScope,
           onError: (error) => {
             const msg =
               error instanceof Error
@@ -3156,6 +3167,8 @@ export function TiptapComposer({
     onLiveUpdate: handleLiveUpdate,
     contextPack: buildVoiceContextPack,
   });
+  const voiceCancelRef = useRef(voice.cancel);
+  voiceCancelRef.current = voice.cancel;
 
   // Clean up live text if voice session ends without a final transcript (cancel/error)
   useEffect(() => {
@@ -3716,6 +3729,9 @@ export function TiptapComposer({
     const draftKeyChanged = previousDraftKeyRef.current !== draftKey;
     previousDraftKeyRef.current = draftKey;
     if (draftKeyChanged) {
+      voiceAnchorRef.current = null;
+      prevVoiceInsertRef.current = "";
+      voiceCancelRef.current();
       editor.commands.clearContent(false);
       initialTextKeyRef.current = undefined;
       setEditorHasText(false);
@@ -3724,11 +3740,17 @@ export function TiptapComposer({
       composerModeRef.current = null;
       lastComposerRuntimeSyncRef.current = null;
       composerRuntime.setText("");
-      void composerRuntime.clearAttachments().catch((error) => {
-        onAttachmentErrorRef.current?.(
-          error instanceof Error ? error.message : String(error),
-        );
-      });
+      const cleanupGeneration = draftScopeGenerationRef.current;
+      attachmentCleanupRef.current = composerRuntime
+        .clearAttachments()
+        .catch((error) => {
+          if (draftScopeGenerationRef.current === cleanupGeneration) {
+            console.error(
+              "Could not clear attachments while changing composer scope",
+              error,
+            );
+          }
+        });
       onTextChangeRef.current?.("");
     }
     const key = initialTextKey ?? initialText;
@@ -3908,6 +3930,7 @@ export function TiptapComposer({
         {attachButton ??
           (plusMenuMode === "hidden" ? null : (
             <ComposerPlusMenu
+              addAttachment={addAttachmentForCurrentScope}
               onSelectMode={handleSelectMode}
               mode={plusMenuMode}
               terminalModeControl={terminalModeControl}

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -3722,6 +3722,7 @@ export function TiptapComposer({
       setSlotReferences([]);
       setComposerMode(null);
       composerModeRef.current = null;
+      lastComposerRuntimeSyncRef.current = null;
       composerRuntime.setText("");
       void composerRuntime.clearAttachments().catch((error) => {
         onAttachmentErrorRef.current?.(

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -408,10 +408,12 @@ function uniquifyComposerImageFile(file: File): File {
   return new File([file], uniqueName, { type: file.type });
 }
 
-function composerDocumentHasContent(doc: {
+type ComposerDocument = {
   textContent: string;
   descendants: (callback: (node: any) => boolean | void) => void;
-}): boolean {
+};
+
+function composerDocumentHasContent(doc: ComposerDocument): boolean {
   if (doc.textContent.trim().length > 0) return true;
   let hasContent = false;
   doc.descendants((node: any) => {
@@ -426,6 +428,21 @@ function composerDocumentHasContent(doc: {
     return true;
   });
   return hasContent;
+}
+
+function persistComposerDraft(
+  draftKey: string,
+  editor: { getHTML(): string; state: { doc: ComposerDocument } },
+): void {
+  try {
+    if (!composerDocumentHasContent(editor.state.doc)) {
+      localStorage.removeItem(draftKey);
+    } else {
+      localStorage.setItem(draftKey, editor.getHTML());
+    }
+  } catch {
+    // coercion-ok: browser storage is optional and can be unavailable or full.
+  }
 }
 
 export function handleComposerFileDrop(options: {
@@ -1542,7 +1559,9 @@ function ModelSelector({
   const openLlmSettings = useCallback(() => {
     try {
       window.location.hash = "llm";
-    } catch {}
+    } catch {
+      // coercion-ok: browser storage is optional and can be unavailable or full.
+    }
     window.dispatchEvent(new CustomEvent("agent-panel:open-settings"));
     setPickerOpen(false);
   }, [setPickerOpen]);
@@ -2443,14 +2462,8 @@ export function TiptapComposer({
     popoverStateRef.current = null;
   }, []);
 
-  // Persist draft to localStorage so hot-reloads don't lose the prompt
+  // Persist draft to localStorage so refreshes don't lose the prompt.
   const draftKey = getComposerDraftKey(draftScope);
-  const draftTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  useEffect(() => {
-    return () => {
-      clearTimeout(draftTimerRef.current);
-    };
-  }, []);
   useEffect(() => {
     lastComposerRuntimeSyncRef.current = null;
   }, [composerRuntime]);
@@ -2468,44 +2481,14 @@ export function TiptapComposer({
   const editor = useEditor({
     extensions: createTiptapComposerExtensions(() => placeholderRef.current),
     editable: !disabled,
-    onCreate: ({ editor: ed }) => {
-      // Restore draft on mount
-      try {
-        if (initialText !== undefined) {
-          ed.commands.setContent(plainTextToDoc(initialText));
-          ed.commands.focus("end");
-          setEditorHasText(composerDocumentHasContent(ed.state.doc));
-          initialTextKeyRef.current = initialTextKey ?? initialText;
-        } else {
-          const saved = localStorage.getItem(draftKey);
-          if (saved) {
-            ed.commands.setContent(saved);
-            ed.commands.focus("end");
-            setEditorHasText(composerDocumentHasContent(ed.state.doc));
-          }
-        }
-        onTextChangeRef.current?.(ed.state.doc.textContent.trim());
-      } catch {}
-    },
     onUpdate: ({ editor: ed }) => {
       // Drive the send button's enabled state from the actual editor contents;
       // the composer runtime is only synced on submit, so its isEmpty lags.
       setEditorHasText(composerDocumentHasContent(ed.state.doc));
       onTextChangeRef.current?.(ed.state.doc.textContent.trim());
 
-      // Debounce-save draft to localStorage
-      clearTimeout(draftTimerRef.current);
-      draftTimerRef.current = setTimeout(() => {
-        try {
-          const html = ed.getHTML();
-          const isEmpty = !composerDocumentHasContent(ed.state.doc);
-          if (isEmpty) {
-            localStorage.removeItem(draftKey);
-          } else {
-            localStorage.setItem(draftKey, html);
-          }
-        } catch {}
-      }, 300);
+      // Write before an unmount can cancel a deferred save.
+      persistComposerDraft(draftKey, ed);
     },
     onSelectionUpdate: ({ editor: ed }) => {
       const { from, to } = ed.state.selection;
@@ -2929,13 +2912,7 @@ export function TiptapComposer({
       setSlotReferences([]);
       composerRuntime.setText(trimmed);
       onTextChangeRef.current?.(trimmed);
-      try {
-        if (trimmed) {
-          localStorage.setItem(draftKey, editor.getHTML());
-        } else {
-          localStorage.removeItem(draftKey);
-        }
-      } catch {}
+      persistComposerDraft(draftKey, editor);
     },
     insertReference,
   }));
@@ -3306,7 +3283,9 @@ export function TiptapComposer({
     resetComposerRuntimeState();
     try {
       localStorage.removeItem(draftKey);
-    } catch {}
+    } catch {
+      // coercion-ok: browser storage is optional and can be unavailable or full.
+    }
     closePopover();
   }, [closePopover, draftKey, editor, resetComposerRuntimeState]);
 
@@ -3643,23 +3622,38 @@ export function TiptapComposer({
   }, [composerText, editor]);
 
   useEffect(() => {
-    if (!isComposerEditorUsable(editor) || initialText === undefined) return;
+    if (!isComposerEditorUsable(editor)) return;
     const key = initialTextKey ?? initialText;
-    if (initialTextKeyRef.current === key) return;
-    initialTextKeyRef.current = key;
-    editor.commands.setContent(plainTextToDoc(initialText));
-    editor.commands.focus("end");
-    const trimmed = editor.state.doc.textContent.trim();
-    setEditorHasText(trimmed.length > 0);
-    composerRuntime.setText(trimmed);
-    onTextChangeRef.current?.(trimmed);
+    let saved: string | null = null;
     try {
-      if (trimmed) {
-        localStorage.setItem(draftKey, editor.getHTML());
+      saved = localStorage.getItem(draftKey);
+    } catch {
+      // coercion-ok: browser storage is optional and can be unavailable or full.
+    }
+
+    try {
+      if (saved && editor.isEmpty) {
+        editor.commands.setContent(saved);
+        editor.commands.focus("end");
+        if (initialText !== undefined) initialTextKeyRef.current = key;
+      } else if (initialText === undefined) {
+        onTextChangeRef.current?.(editor.state.doc.textContent.trim());
+        return;
+      } else if (initialTextKeyRef.current !== key) {
+        initialTextKeyRef.current = key;
+        editor.commands.setContent(plainTextToDoc(initialText));
+        editor.commands.focus("end");
       } else {
-        localStorage.removeItem(draftKey);
+        return;
       }
-    } catch {}
+      const trimmed = editor.state.doc.textContent.trim();
+      setEditorHasText(composerDocumentHasContent(editor.state.doc));
+      composerRuntime.setText(trimmed);
+      onTextChangeRef.current?.(trimmed);
+      persistComposerDraft(draftKey, editor);
+    } catch {
+      // coercion-ok: a stale editor during unmount should not block the refresh path.
+    }
   }, [composerRuntime, draftKey, editor, initialText, initialTextKey]);
 
   // Tiptap only reads `editable` at init; prop changes need setEditable.

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -3639,6 +3639,11 @@ export function TiptapComposer({
       setEditorHasText(false);
       setSlotReferences([]);
       composerRuntime.setText("");
+      void composerRuntime.clearAttachments().catch((error) => {
+        onAttachmentErrorRef.current?.(
+          error instanceof Error ? error.message : String(error),
+        );
+      });
       onTextChangeRef.current?.("");
     }
     const key = initialTextKey ?? initialText;

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -413,6 +413,14 @@ type ComposerDocument = {
   descendants: (callback: (node: any) => boolean | void) => void;
 };
 
+type ComposerDraftEditor = {
+  isDestroyed?: boolean;
+  getHTML(): string;
+  state: { doc: ComposerDocument };
+};
+
+const COMPOSER_DRAFT_SAVE_DELAY_MS = 300;
+
 function composerDocumentHasContent(doc: ComposerDocument): boolean {
   if (doc.textContent.trim().length > 0) return true;
   let hasContent = false;
@@ -432,7 +440,7 @@ function composerDocumentHasContent(doc: ComposerDocument): boolean {
 
 function persistComposerDraft(
   draftKey: string | null,
-  editor: { getHTML(): string; state: { doc: ComposerDocument } },
+  editor: ComposerDraftEditor,
 ): void {
   if (!draftKey) return;
   try {
@@ -2478,6 +2486,37 @@ export function TiptapComposer({
     hasDraftScope || initialText === undefined
       ? getComposerDraftKey(draftScope)
       : null;
+  const draftKeyRef = useRef(draftKey);
+  draftKeyRef.current = draftKey;
+  const draftEditorRef = useRef<ComposerDraftEditor | null>(null);
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelScheduledDraftPersist = useCallback(() => {
+    if (draftSaveTimerRef.current === null) return;
+    clearTimeout(draftSaveTimerRef.current);
+    draftSaveTimerRef.current = null;
+  }, []);
+  const flushComposerDraft = useCallback(() => {
+    cancelScheduledDraftPersist();
+    const ed = draftEditorRef.current;
+    if (!ed || !isComposerEditorUsable(ed)) return;
+    persistComposerDraft(draftKeyRef.current, ed);
+  }, [cancelScheduledDraftPersist]);
+  const scheduleComposerDraftPersist = useCallback(
+    (ed: ComposerDraftEditor) => {
+      draftEditorRef.current = ed;
+      cancelScheduledDraftPersist();
+      const key = draftKeyRef.current;
+      if (!key) return;
+      draftSaveTimerRef.current = setTimeout(() => {
+        draftSaveTimerRef.current = null;
+        if (draftKeyRef.current !== key || draftEditorRef.current !== ed) {
+          return;
+        }
+        persistComposerDraft(key, ed);
+      }, COMPOSER_DRAFT_SAVE_DELAY_MS);
+    },
+    [cancelScheduledDraftPersist],
+  );
   const previousDraftKeyRef = useRef(draftKey);
   useEffect(() => {
     lastComposerRuntimeSyncRef.current = null;
@@ -2502,8 +2541,7 @@ export function TiptapComposer({
       setEditorHasText(composerDocumentHasContent(ed.state.doc));
       onTextChangeRef.current?.(ed.state.doc.textContent.trim());
 
-      // Write before an unmount can cancel a deferred save.
-      persistComposerDraft(draftKey, ed);
+      scheduleComposerDraftPersist(ed);
     },
     onSelectionUpdate: ({ editor: ed }) => {
       const { from, to } = ed.state.selection;
@@ -2777,6 +2815,24 @@ export function TiptapComposer({
     },
   });
 
+  useEffect(() => {
+    if (!isComposerEditorUsable(editor)) return;
+    draftEditorRef.current = editor;
+    const flush = () => {
+      cancelScheduledDraftPersist();
+      persistComposerDraft(draftKey, editor);
+    };
+    window.addEventListener("pagehide", flush);
+    window.addEventListener("beforeunload", flush);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      window.removeEventListener("beforeunload", flush);
+      cancelScheduledDraftPersist();
+      persistComposerDraft(draftKey, editor);
+      if (draftEditorRef.current === editor) draftEditorRef.current = null;
+    };
+  }, [cancelScheduledDraftPersist, draftKey, editor]);
+
   // Placeholder decorations are computed by ProseMirror. Dispatching an empty
   // transaction makes a locale or composer-mode change visible immediately.
   useEffect(() => {
@@ -2927,7 +2983,7 @@ export function TiptapComposer({
       setSlotReferences([]);
       composerRuntime.setText(trimmed);
       onTextChangeRef.current?.(trimmed);
-      persistComposerDraft(draftKey, editor);
+      flushComposerDraft();
     },
     insertReference,
   }));
@@ -3293,12 +3349,19 @@ export function TiptapComposer({
     const ed = editor;
     if (!isComposerEditorUsable(ed)) return;
     ed.commands.clearContent();
+    cancelScheduledDraftPersist();
     setEditorHasText(false);
     setSlotReferences([]);
     resetComposerRuntimeState();
     clearComposerDraft(draftKey);
     closePopover();
-  }, [closePopover, draftKey, editor, resetComposerRuntimeState]);
+  }, [
+    cancelScheduledDraftPersist,
+    closePopover,
+    draftKey,
+    editor,
+    resetComposerRuntimeState,
+  ]);
 
   const submitComposer = useCallback(
     async (intent: ComposerSubmitIntent = "immediate") => {
@@ -3306,6 +3369,8 @@ export function TiptapComposer({
       if (!isComposerEditorUsable(ed)) return;
       if (submitInFlightRef.current) return;
 
+      draftEditorRef.current = ed;
+      flushComposerDraft();
       const { text, references } = syncComposerState();
       const attachments = composerRuntime.getState().attachments;
       if (!text.trim() && references.length === 0 && attachments.length === 0)
@@ -3414,6 +3479,7 @@ export function TiptapComposer({
         setSlotReferences([]);
         setComposerMode(null);
         composerModeRef.current = null;
+        cancelScheduledDraftPersist();
         clearComposerDraft(draftKey);
         closePopover();
         return;
@@ -3443,16 +3509,19 @@ export function TiptapComposer({
       if (isComposerEditorUsable(ed)) ed.commands.clearContent();
       setEditorHasText(false);
       setSlotReferences([]);
+      cancelScheduledDraftPersist();
       clearComposerDraft(draftKey);
       closePopover();
     },
     [
       closePopover,
       clearEditorAfterSubmit,
+      cancelScheduledDraftPersist,
       composerMode,
       composerRuntime,
       draftKey,
       editor,
+      flushComposerDraft,
       interceptBuildRequestsForBuilder,
       clearOnSubmit,
       onBeforeSubmit,
@@ -3638,6 +3707,8 @@ export function TiptapComposer({
       initialTextKeyRef.current = undefined;
       setEditorHasText(false);
       setSlotReferences([]);
+      setComposerMode(null);
+      composerModeRef.current = null;
       composerRuntime.setText("");
       void composerRuntime.clearAttachments().catch((error) => {
         onAttachmentErrorRef.current?.(
@@ -3675,11 +3746,18 @@ export function TiptapComposer({
       setEditorHasText(composerDocumentHasContent(editor.state.doc));
       composerRuntime.setText(trimmed);
       onTextChangeRef.current?.(trimmed);
-      persistComposerDraft(draftKey, editor);
+      scheduleComposerDraftPersist(editor);
     } catch {
       // coercion-ok: a stale editor during unmount should not block the refresh path.
     }
-  }, [composerRuntime, draftKey, editor, initialText, initialTextKey]);
+  }, [
+    composerRuntime,
+    draftKey,
+    editor,
+    initialText,
+    initialTextKey,
+    scheduleComposerDraftPersist,
+  ]);
 
   // Tiptap only reads `editable` at init; prop changes need setEditable.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- persist shared composer drafts synchronously so refreshes and quick unmounts do not lose typed prompts
- restore drafts before seeded prompt text and keep each prompt surface isolated with stable scopes
- preserve drafts when Quick Prompt submission fails

## Validation
- focused toolkit, Dispatch, Agent Jobs, and docs tests
- toolkit, core, Dispatch, and desktop package typechecks
- all 65 repository guards
- existing Dispatch browser smoke launches, but its /overview flow currently redirects to /overview/overview and 404s before assertions, so that harness result is unavailable for this change

Source report: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787953671138079