### PR TITLE
fix: isolate stable package release lanes

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -66,7 +66,9 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Stable preparation and publication must not wait behind, or be replaced
+  # by, the ordinary push-driven nightly lane.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && 'stable-preparation' || (github.event_name == 'push' && contains(github.event.head_commit.message, '[stable-release]') && 'stable-publication' || 'nightly') }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-everything.yml
+++ b/.github/workflows/release-everything.yml
@@ -118,7 +118,9 @@ jobs:
             async function waitForAutoPublishIdle(deadline) {
               while (Date.now() < deadline) {
                 const activeRuns = (await listAutoPublishRuns()).filter(
-                  (run) => run.status !== "completed",
+                  (run) =>
+                    run.status !== "completed" &&
+                    run.event === "workflow_dispatch",
                 );
                 if (activeRuns.length === 0) return true;
                 core.info(
@@ -155,7 +157,7 @@ jobs:
                   const candidateCreatedAt = Date.parse(candidate.created_at || "");
                   return (
                     candidate.id !== run.id &&
-                    candidate.event === "push" &&
+                    candidate.event === run.event &&
                     Number.isFinite(candidateCreatedAt) &&
                     candidateCreatedAt >= runCreatedAt &&
                     candidateCreatedAt <= runUpdatedAt

--- a/scripts/release-everything-workflow.test.ts
+++ b/scripts/release-everything-workflow.test.ts
@@ -9,6 +9,9 @@ type Workflow = Record<string, unknown>;
 const workflow = parse(
   readFileSync(".github/workflows/release-everything.yml", "utf8"),
 ) as Workflow;
+const autoPublishWorkflow = parse(
+  readFileSync(".github/workflows/auto-publish.yml", "utf8"),
+) as Workflow;
 const desktopWorkflow = parse(
   readFileSync(".github/workflows/desktop-release.yml", "utf8"),
 ) as Workflow;
@@ -130,6 +133,18 @@ describe("release everything workflow", () => {
     assert.match(source, /Promise\.allSettled/);
   });
 
+  it("isolates stable auto-publish lanes from nightly pushes", () => {
+    const group = String((autoPublishWorkflow.concurrency as Workflow).group);
+    assert.match(group, /github\.event_name == 'workflow_dispatch'/);
+    assert.match(group, /stable-preparation/);
+    assert.match(group, /stable-publication/);
+    assert.match(group, /stable-release/);
+
+    const source = String((coordinator.with as Workflow).script);
+    assert.match(source, /run\.event === "workflow_dispatch"/);
+    assert.match(source, /candidate\.event === run\.event/);
+  });
+
   it("survives auto-publish pending-run replacement", () => {
     const source = String((coordinator.with as Workflow).script);
 
@@ -152,7 +167,7 @@ describe("release everything workflow", () => {
     assert.match(source, /wasSupersededPendingRun/);
     assert.match(source, /retryIfSupersededPending/);
     assert.match(source, /candidate\.id !== run\.id/);
-    assert.match(source, /candidate\.event === "push"/);
+    assert.match(source, /candidate\.event === run\.event/);
     assert.match(source, /candidateCreatedAt >= runCreatedAt/);
     assert.match(source, /candidateCreatedAt <= runUpdatedAt/);
     assert.match(source, /Number\.isFinite\(runCreatedAt\)/);


### PR DESCRIPTION
## Summary
- keep stable package preparation in its own workflow-dispatch concurrency lane
- keep stable package publication separate from ordinary nightly pushes
- make the release coordinator wait only on competing stable-preparation runs
- cover the lane routing and same-event supersession behavior in the workflow tests

## Verification
- `corepack pnpm test:package-release-workflow`
- `corepack pnpm guards`
- production run 33210379055 reached its coordinator timeout after continuous nightly pushes occupied the shared lane