### PR TITLE
fix(calendar): tighten settings footer spacing

### DIFF
--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -1154,7 +1154,7 @@ export function Sidebar({
             "shrink-0",
             collapsed
               ? "flex flex-col items-center gap-1 px-1 py-2"
-              : "space-y-0.5 p-2.5",
+              : "space-y-0.5 px-2.5 pt-2.5",
           )}
         >
           {bottomNavItems.map((item) => {

--- a/templates/calendar/changelog/2026-08-28-the-calendar-sidebar-keeps-the-settings-link-compact.md
+++ b/templates/calendar/changelog/2026-08-28-the-calendar-sidebar-keeps-the-settings-link-compact.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-28
+---
+
+The Calendar sidebar keeps the settings link compact


### PR DESCRIPTION
## Summary
- Remove the bottom inset from the Calendar settings navigation container.
- Keep the settings link aligned with the compact workspace picker footer.
- Add a user-facing Calendar changelog entry.

## Validation
- Focused Calendar formatting, typecheck, test, and browser visual verification will run locally and in CI.