### PR TITLE
fix: align Slides deck search bar height

### DIFF
--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1859,7 +1859,7 @@ function DeckSearchInput({
   const t = useT();
   return (
     <label
-      className={`flex h-8 min-w-0 items-center gap-2 rounded-lg border border-border bg-card px-2.5 text-muted-foreground ${className}`}
+      className={`flex h-9 min-w-0 items-center gap-2 rounded-lg border border-border bg-card px-2.5 text-muted-foreground ${className}`}
     >
       <IconSearch className="size-3.5 shrink-0" aria-hidden="true" />
       <Input


### PR DESCRIPTION
## Summary

- Set the Slides deck search bar wrapper to Tailwind `h-9` so it aligns with the surrounding controls.

## Validation

- `git diff --check`
- Focused source check confirms the `DeckSearchInput` wrapper uses `h-9`.
- Local formatter and test binaries are unavailable in this clean worktree; CI is the remote validation gate.