### PR TITLE
Match sidebar branding to app text

### DIFF
--- a/.changeset/match-sidebar-brand-color.md
+++ b/.changeset/match-sidebar-brand-color.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Match the Dispatch sidebar mark to its text color and tighten its size.

--- a/examples/chat-antd/app/components/layout/Sidebar.tsx
+++ b/examples/chat-antd/app/components/layout/Sidebar.tsx
@@ -338,7 +338,7 @@ export function Sidebar({
         >
           <AgentNativeIcon
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/examples/chat-mui/app/components/layout/Sidebar.tsx
+++ b/examples/chat-mui/app/components/layout/Sidebar.tsx
@@ -338,7 +338,7 @@ export function Sidebar({
         >
           <AgentNativeIcon
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/packages/dispatch/src/components/layout/Layout.spec.tsx
+++ b/packages/dispatch/src/components/layout/Layout.spec.tsx
@@ -601,8 +601,9 @@ describe("Dispatch NavContent", () => {
     const sidebarLogo = container.querySelector(
       "a[data-dispatch-logo] svg[data-agent-native-icon]",
     );
-    expect(sidebarLogo?.className).toContain("text-black");
-    expect(sidebarLogo?.className).toContain("dark:text-white");
+    expect(sidebarLogo?.className).toContain("text-foreground");
+    expect(sidebarLogo?.className).toContain("h-[17px]");
+    expect(sidebarLogo?.className).toContain("w-[30px]");
     expect(container.textContent).not.toContain("Workspace control plane");
 
     const threadButton = [...container.querySelectorAll("button")].find(

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -1257,8 +1257,8 @@ export function NavContent({
           <AgentNativeIcon
             aria-hidden="true"
             className={cn(
-              "shrink-0 text-black dark:text-white",
-              collapsed ? "h-4 w-7" : "h-5 w-[35px]",
+              "shrink-0 text-foreground",
+              collapsed ? "h-3.5 w-6" : "h-[17px] w-[30px]",
             )}
           />
           {!collapsed && (

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2356,9 +2356,8 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
               className="flex min-w-0 flex-1 items-center gap-2 font-semibold"
             >
               <AgentNativeIcon
-                size={35}
                 aria-hidden="true"
-                className="h-5 w-[35px] shrink-0 text-black dark:text-white"
+                className="h-[17px] w-[30px] shrink-0 text-sidebar-foreground"
               />
               <span className="text-lg font-bold tracking-tight">
                 {t("navigation.brand")}

--- a/templates/analytics/changelog/2026-08-28-sidebar-branding-matches-the-app-text-color-with-a-tighter-m.md
+++ b/templates/analytics/changelog/2026-08-28-sidebar-branding-matches-the-app-text-color-with-a-tighter-m.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Sidebar branding matches the app text color with a tighter mark size.

--- a/templates/assets/app/components/layout/Sidebar.tsx
+++ b/templates/assets/app/components/layout/Sidebar.tsx
@@ -394,9 +394,8 @@ export function Sidebar() {
       data-sidebar-brand-toggle
     >
       <AgentNativeIcon
-        size={28}
         aria-hidden="true"
-        className="h-4 w-7 shrink-0 text-black dark:text-white"
+        className="h-3.5 w-6 shrink-0 text-sidebar-foreground"
       />
       {!collapsed && (
         <span className="text-sm font-semibold tracking-tight">

--- a/templates/brain/app/components/layout/Sidebar.tsx
+++ b/templates/brain/app/components/layout/Sidebar.tsx
@@ -339,9 +339,8 @@ export function Sidebar({
           }
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -782,7 +782,7 @@ export function Sidebar({
               onCollapsedChange(!collapsed);
             }}
             className={cn(
-              "flex items-center gap-2 rounded outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "flex items-center gap-2 rounded text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring",
               collapsed ? "size-8 justify-center" : "flex-1",
             )}
             aria-label={
@@ -797,9 +797,8 @@ export function Sidebar({
             data-sidebar-brand-toggle
           >
             <AgentNativeIcon
-              size={28}
               aria-hidden="true"
-              className="h-4 w-7 shrink-0 text-black dark:text-white"
+              className="h-3.5 w-6 shrink-0 text-foreground"
             />
             {!collapsed && (
               <span className="text-base font-semibold tracking-tight">

--- a/templates/calendar/changelog/2026-08-28-sidebar-branding-matches-the-app-text-color-with-a-tighter-m.md
+++ b/templates/calendar/changelog/2026-08-28-sidebar-branding-matches-the-app-text-color-with-a-tighter-m.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Sidebar branding matches the app text color with a tighter mark size.

--- a/templates/chat/app/components/layout/Sidebar.tsx
+++ b/templates/chat/app/components/layout/Sidebar.tsx
@@ -387,9 +387,8 @@ export function Sidebar({
           }
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -373,7 +373,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
           >
             <AgentNativeIcon
               aria-hidden="true"
-              className="h-4 w-7 shrink-0 text-black dark:text-white"
+              className="h-3.5 w-6 shrink-0 text-foreground"
             />
             {!showCollapsedSidebar && (
               <span className="truncate text-sm font-semibold text-foreground">

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1782,9 +1782,8 @@ export function DocumentSidebar({
       data-sidebar-brand-toggle
     >
       <AgentNativeIcon
-        size={28}
         aria-hidden="true"
-        className="h-4 w-7 shrink-0 text-black dark:text-white"
+        className="h-3.5 w-6 shrink-0 text-foreground"
       />
       {!isCollapsed && (
         <span className="text-base font-semibold tracking-tight">Content</span>

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -138,9 +138,8 @@ export function Sidebar() {
           data-sidebar-brand-toggle
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-foreground"
           />
           {!collapsed && (
             <span className="text-sm font-semibold tracking-tight">

--- a/templates/factory/app/components/layout/Sidebar.tsx
+++ b/templates/factory/app/components/layout/Sidebar.tsx
@@ -408,9 +408,8 @@ export function Sidebar({
           }
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">

--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -267,9 +267,8 @@ export function Sidebar() {
               data-sidebar-brand-toggle
             >
               <AgentNativeIcon
-                size={28}
                 aria-hidden="true"
-                className="h-4 w-7 shrink-0 text-black dark:text-white"
+                className="h-3.5 w-6 shrink-0 text-foreground"
               />
             </button>
           </TooltipTrigger>
@@ -388,14 +387,13 @@ export function Sidebar() {
                     ? t("sidebar.openAskFullScreen")
                     : t("sidebar.collapseSidebar")
                 }
-                className="flex min-h-10 min-w-0 items-center gap-2 rounded-lg px-2 text-base font-semibold tracking-tight text-muted-foreground/80 active:scale-[0.96] transition-[color,transform] hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className="flex min-h-10 min-w-0 items-center gap-2 rounded-lg px-2 text-base font-semibold tracking-tight text-foreground active:scale-[0.96] transition-[color,transform] hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 onClick={handleBrandClick}
                 data-sidebar-brand-toggle
               >
                 <AgentNativeIcon
-                  size={28}
                   aria-hidden="true"
-                  className="h-4 w-7 shrink-0 text-black dark:text-white"
+                  className="h-3.5 w-6 shrink-0 text-foreground"
                 />
                 <span className="truncate">{t("navigation.brand")}</span>
               </button>

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -252,9 +252,8 @@ function SidebarContent({
         {!collapsed && (
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <AgentNativeIcon
-              size={28}
               aria-hidden="true"
-              className="h-4 w-7 shrink-0 text-black dark:text-white"
+              className="h-3.5 w-6 shrink-0 text-foreground"
             />
             <span className="font-logo truncate text-sm font-bold tracking-tight text-foreground">
               {t("navigation.brand")}

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -625,9 +625,8 @@ export function Sidebar({
           data-sidebar-brand-toggle
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-foreground"
           />
           {!collapsed && (
             <span className="truncate text-sm font-semibold tracking-tight">

--- a/templates/slides/app/components/layout/Sidebar.test.tsx
+++ b/templates/slides/app/components/layout/Sidebar.test.tsx
@@ -112,7 +112,7 @@ describe("<Sidebar collapsed>", () => {
 });
 
 describe("<Sidebar expanded>", () => {
-  it("reserves fixed dimensions for the brand marks", () => {
+  it("uses compact dimensions for the brand mark", () => {
     const { container } = renderAt(
       "/",
       <Sidebar collapsed={false} onToggleCollapsed={() => {}} />,
@@ -123,12 +123,11 @@ describe("<Sidebar expanded>", () => {
     );
 
     expect(brandMark).not.toBeNull();
-    expect(brandMark?.getAttribute("width")).toBe("28");
-    expect(brandMark?.getAttribute("height")).toBe("28");
-    expect(brandMark?.className).toContain("w-7");
-    expect(brandMark?.className).toContain("h-4");
-    expect(brandMark?.className).toContain("text-black");
-    expect(brandMark?.className).toContain("dark:text-white");
+    expect(brandMark?.getAttribute("width")).toBe("24");
+    expect(brandMark?.getAttribute("height")).toBe("24");
+    expect(brandMark?.className).toContain("w-6");
+    expect(brandMark?.className).toContain("h-3.5");
+    expect(brandMark?.className).toContain("text-sidebar-foreground");
   });
 
   it("renders the full sidebar (w-56) with the Collapse button and labelled nav", () => {

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -106,9 +106,8 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
       )}
     >
       <AgentNativeIcon
-        size={28}
         aria-hidden="true"
-        className="h-4 w-7 shrink-0 text-black dark:text-white"
+        className="h-3.5 w-6 shrink-0 text-sidebar-foreground"
       />
       {!collapsed && (
         <span className="truncate text-sm font-semibold tracking-tight">

--- a/templates/tasks/app/components/layout/Sidebar.tsx
+++ b/templates/tasks/app/components/layout/Sidebar.tsx
@@ -155,9 +155,8 @@ export function Sidebar({
           }
         >
           <AgentNativeIcon
-            size={28}
             aria-hidden="true"
-            className="h-4 w-7 shrink-0 text-black dark:text-white"
+            className="h-3.5 w-6 shrink-0 text-sidebar-accent-foreground"
           />
           <div className={cn("min-w-0", collapsed && "sr-only")}>
             <p className="truncate text-sm font-semibold text-sidebar-accent-foreground">


### PR DESCRIPTION
## Summary
- match each sidebar logo to the adjacent app brand text token
- brighten the Forms brand text and logo
- reduce sidebar mark dimensions by about 15% while preserving flex centering

## Verification
- Dispatch layout spec
- Slides sidebar test
- Forms, Calendar, Chat, and Dispatch typechecks
- Agent-Native branding and raw-color guards
- live light/dark browser screenshots across Forms, Calendar, and Chat