### PR TITLE
Soften skeleton shimmer contrast

### DIFF
--- a/.changeset/soften-skeleton-shine.md
+++ b/.changeset/soften-skeleton-shine.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Soften the contrast of the shared skeleton loading shine.

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -550,7 +550,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--foreground, var(--ui-foreground)) / 0.12) 50%,
+    hsl(var(--foreground, var(--ui-foreground)) / 0.072) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/packages/core/src/styles/agent-native.spec.ts
+++ b/packages/core/src/styles/agent-native.spec.ts
@@ -129,6 +129,9 @@ describe("agent-native shell surface tokens", () => {
     expect(css).toMatch(
       /@keyframes skeleton-shimmer[\s\S]*?background-position: 150% 0;[\s\S]*?background-position: -50% 0;/s,
     );
+    expect(css).toContain(
+      "hsl(var(--foreground, var(--ui-foreground)) / 0.072)",
+    );
     expect(css).not.toContain("skeleton-pulse");
   });
 

--- a/templates/analytics/changelog/2026-08-28-analytics-loading-states-use-a-softer-whole-surfac.md
+++ b/templates/analytics/changelog/2026-08-28-analytics-loading-states-use-a-softer-whole-surfac.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Analytics loading states now use a softer whole-surface shine.

--- a/templates/clips/changelog/2026-08-28-clips-loading-skeletons-use-a-softer-whole-surface.md
+++ b/templates/clips/changelog/2026-08-28-clips-loading-skeletons-use-a-softer-whole-surface.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Clips loading placeholders now use a softer whole-surface shine.

--- a/templates/clips/desktop/src/tailwind.css
+++ b/templates/clips/desktop/src/tailwind.css
@@ -27,7 +27,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--ui-foreground) / 0.12) 50%,
+    hsl(var(--ui-foreground) / 0.072) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -271,7 +271,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--foreground) / 0.12) 50%,
+    hsl(var(--foreground) / 0.072) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/plan/changelog/2026-08-28-plan-loading-skeletons-use-a-softer-whole-surface.md
+++ b/templates/plan/changelog/2026-08-28-plan-loading-skeletons-use-a-softer-whole-surface.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Plan loading placeholders now use a softer whole-surface shine.

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1181,7 +1181,7 @@ button[title="Open agent sidebar"] {
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    rgba(255, 255, 255, 0.16) 50%,
+    rgba(255, 255, 255, 0.096) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/slides/changelog/2026-08-28-slides-loading-skeletons-use-a-softer-whole-surface.md
+++ b/templates/slides/changelog/2026-08-28-slides-loading-skeletons-use-a-softer-whole-surface.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Slides loading placeholders and AI editing previews now use a softer whole-surface shine.


### PR DESCRIPTION
## Summary
- Reduce the shared skeleton shimmer highlight alpha by 40%.
- Apply the same softer shine to Slides, Clips, and Plan isolated loaders.
- Capture the Analytics loading-state change in the changelog.

## Verification
- Focused Core, Analytics, Slides, and Plan tests pass.
- All 65 repository guards pass.
- Live Slides and Analytics loading states verified with screenshots.