### PR TITLE
Stabilize shared Personal page recovery coverage

### DIFF
--- a/templates/content/e2e/shared-personal-page.spec.ts
+++ b/templates/content/e2e/shared-personal-page.spec.ts
@@ -104,6 +104,22 @@ async function crossFailureDurabilityBoundary(page: Page) {
   await page.waitForTimeout(1_000);
 }
 
+async function retryOrAwaitPropertyRecovery(page: Page) {
+  const retryButton = page.getByRole("button", { name: "Retry" });
+  const editor = page.locator(".ProseMirror");
+  await expect
+    .poll(
+      async () => {
+        if (await editor.isVisible()) return "recovered";
+        if (await retryButton.isVisible()) return "retry";
+        return "pending";
+      },
+      { timeout: 30_000 },
+    )
+    .not.toBe("pending");
+  if (await retryButton.isVisible()) await retryButton.click();
+}
+
 async function registerRecipient(
   context: BrowserContext,
   baseURL: string,
@@ -388,7 +404,7 @@ test("an editor can read and edit one shared Personal page without gaining its p
         persistedCollabBaseline,
       );
       propertyFailureActive = false;
-      await recipient.getByRole("button", { name: "Retry" }).click();
+      await retryOrAwaitPropertyRecovery(recipient);
       await expect(
         recipient.locator('[data-block-fields-state="error"]'),
       ).toHaveCount(0);


### PR DESCRIPTION
Follow-up to #3676.

The shared Personal Content fix is already merged in #3676. This follow-up removes a race in the two-identity browser regression: after an injected property failure is released, the query may recover automatically before the test clicks Retry. The test now accepts either the explicit retry state or successful editor recovery while retaining the body and persistence assertions.

Verification:
- `corepack pnpm exec vitest --run app/components/editor/DocumentBlockFields.test.ts app/components/editor/DocumentEditor.layout.test.ts`
- `CONTENT_BASE_URL=http://127.0.0.1:8085 corepack pnpm exec playwright test e2e/shared-personal-page.spec.ts --config=e2e/playwright.config.ts --retries=0 --workers=1`

The isolated browser run passed the complete two-identity shared Personal flow.