### PR TITLE
Clips: compact library search controls

### DIFF
--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -426,16 +426,19 @@ export function LibraryGrid({
 
       {/* Page header — rendered into the top app bar */}
       <PageHeader>
-        <div className="min-w-0 shrink-0">
+        <div className="min-w-0">
           {title && (
             <h1 className="text-base font-semibold text-foreground truncate">
               {title}
             </h1>
           )}
         </div>
-        <div className="ms-auto flex shrink-0 items-center gap-2">
+        <div className="ms-auto flex min-w-0 items-center gap-2">
           {extraActions}
-          <SearchBar side="bottom" className="hidden w-64 md:block" />
+          <SearchBar
+            side="bottom"
+            className="hidden min-w-0 max-w-64 flex-1 md:block"
+          />
           <SortMenu value={sort} onChange={setSort} />
         </div>
       </PageHeader>

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -433,12 +433,9 @@ export function LibraryGrid({
             </h1>
           )}
         </div>
-        <SearchBar
-          side="bottom"
-          className="hidden min-w-52 max-w-xl flex-1 md:block"
-        />
         <div className="ms-auto flex shrink-0 items-center gap-2">
           {extraActions}
+          <SearchBar side="bottom" className="hidden w-64 md:block" />
           <SortMenu value={sort} onChange={setSort} />
         </div>
       </PageHeader>

--- a/templates/clips/app/components/library/sort-menu.tsx
+++ b/templates/clips/app/components/library/sort-menu.tsx
@@ -33,9 +33,9 @@ export function SortMenu({ value, onChange }: SortMenuProps) {
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <Button
-              variant="outline"
+              variant="ghost"
               size="icon"
-              className="h-9 w-9"
+              className="h-8 w-8 text-muted-foreground hover:bg-accent/40 hover:text-foreground"
               aria-label={LABELS[value]}
             >
               <IconArrowsSort className="h-3.5 w-3.5" />

--- a/templates/clips/app/components/library/sort-menu.tsx
+++ b/templates/clips/app/components/library/sort-menu.tsx
@@ -35,7 +35,7 @@ export function SortMenu({ value, onChange }: SortMenuProps) {
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:bg-accent/40 hover:text-foreground"
               aria-label={LABELS[value]}
             >
               <IconArrowsSort className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- move library recording search into the right-side header actions
- cap the search field at 16rem
- make the sort/filter trigger a muted, borderless ghost icon

## Validation
- `corepack pnpm --dir templates/clips test -- app/components/library/search-bar.test.tsx app/components/library/library-grid-layout.test.ts` (258 files, 1,645 tests passed)
- `corepack pnpm --dir templates/clips typecheck`
- `corepack pnpm guards` (65 checks passed)
- Playwright check at 1440px and 390px, including sort menu interaction and no horizontal overflow