### PR TITLE
Restore Chrome extension help on Clips download page

### DIFF
--- a/templates/clips/app/routes/download.test.tsx
+++ b/templates/clips/app/routes/download.test.tsx
@@ -28,6 +28,9 @@ vi.mock("@agent-native/core/client/i18n", () => ({
       "downloadRoute.nightly": "Nightly",
       "downloadRoute.switchToNightly": "Switch to Nightly builds",
       "downloadRoute.switchToStable": "Switch to stable builds",
+      "downloadRoute.chromeTitle": "Chrome extension for browser logs",
+      "captureInstall.chromeDescription":
+        "Best when you want redacted console and network diagnostics from the browser tab.",
     };
     return (messages[key] ?? key).replace(
       "{{platform}}",
@@ -37,9 +40,9 @@ vi.mock("@agent-native/core/client/i18n", () => ({
 }));
 
 vi.mock("@/lib/capture-install-options", () => ({
-  clipsChromeExtensionUrl: null,
+  clipsChromeExtensionUrl: "https://chromewebstore.google.com/detail/example",
   markDesktopAppDownloaded: markDownloaded,
-  useClipsChromeExtensionEnabled: () => false,
+  useClipsChromeExtensionEnabled: () => true,
 }));
 
 vi.mock("@/lib/download-release-channel", () => ({
@@ -188,5 +191,18 @@ describe("Clips download page", () => {
     expect(container.textContent).toContain(
       "Didn't work? Try downloading again",
     );
+  });
+
+  it("keeps the extension explanation compact and links to its docs", () => {
+    expect(container.textContent).toContain(
+      "Best when you want redacted console and network diagnostics from the browser tab.",
+    );
+    const docsLink = container.querySelector<HTMLAnchorElement>(
+      'a[aria-label="Chrome extension for browser logs"]',
+    );
+    expect(docsLink?.getAttribute("href")).toBe(
+      "https://www.agent-native.com/docs/template-clips-capture-everywhere#browser-logs-with-the-chrome-extension",
+    );
+    expect(docsLink?.querySelector("svg")).toBeTruthy();
   });
 });

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -1,11 +1,13 @@
 import { appBasePath, appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
+import { docsUrl } from "@agent-native/core/shared";
 import {
   IconBrandChrome,
   IconBrandApple,
   IconBrandWindows,
   IconCheck,
   IconExternalLink,
+  IconHelpCircle,
   IconTerminal2,
 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
@@ -52,6 +54,9 @@ interface PlatformVariant {
 
 const LATEST_JSON_URL = `${appBasePath()}/api/clips-latest.json`;
 const MANIFEST_STORAGE_KEY = "clips-download-manifest-v1";
+const CHROME_EXTENSION_DOCS_URL = docsUrl("template-clips-capture-everywhere", {
+  hash: "browser-logs-with-the-chrome-extension",
+});
 
 const VARIANTS: PlatformVariant[] = [
   {
@@ -475,7 +480,20 @@ export default function DownloadPage() {
                   <h2 className="text-sm font-semibold text-foreground">
                     {t("downloadRoute.chromeTitle")}
                   </h2>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {t("captureInstall.chromeDescription")}
+                  </p>
                 </div>
+                <a
+                  href={CHROME_EXTENSION_DOCS_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t("downloadRoute.chromeTitle")}
+                  title={t("downloadRoute.chromeTitle")}
+                  className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <IconHelpCircle className="size-3" aria-hidden="true" />
+                </a>
               </div>
               <Button
                 asChild={Boolean(clipsChromeExtensionUrl)}

--- a/templates/clips/changelog/2026-08-28-chrome-extension-download-help.md
+++ b/templates/clips/changelog/2026-08-28-chrome-extension-download-help.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+The Chrome extension download option keeps a concise browser-log explanation and links to setup docs.


### PR DESCRIPTION
## Summary
- Restore a concise explanation beneath the Chrome extension download option.
- Add a subtle help icon linking to the browser logs setup documentation.
- Cover the copy and documentation link with focused route tests.
- Record the user-facing Clips improvement in the app changelog.

## Verification
- NODE_OPTIONS=--localstorage-file=/tmp/codex-clips-download-test.local-storage corepack pnpm exec vitest run app/routes/download.test.tsx --config vitest.config.ts
- corepack pnpm typecheck (templates/clips)
- Live localhost route checked with no browser console errors.