### PR TITLE
fix: hide empty sidebar slots

### DIFF
--- a/.changeset/fix-empty-sidebar-slots.md
+++ b/.changeset/fix-empty-sidebar-slots.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Hide empty optional sidebar slots when organization controls are unavailable.

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -1223,7 +1223,10 @@ export function NavContent({
   );
   const organizationPicker = (
     <div
-      className={cn("py-2", collapsed ? "flex justify-center px-1" : "px-3")}
+      className={cn(
+        "py-2 empty:hidden",
+        collapsed ? "flex justify-center px-1" : "px-3",
+      )}
     >
       <OrgSwitcher compact={collapsed} reserveSpace currentAppId="dispatch" />
     </div>

--- a/templates/assets/app/components/layout/Sidebar.tsx
+++ b/templates/assets/app/components/layout/Sidebar.tsx
@@ -536,13 +536,13 @@ export function Sidebar() {
           </nav>
 
           {!collapsed && (
-            <div className="px-3 py-2">
+            <div className="px-3 py-2 empty:hidden">
               <OrgSwitcher />
             </div>
           )}
 
           {!collapsed && (
-            <div className="px-3 py-2">
+            <div className="px-3 py-2 empty:hidden">
               <DevDatabaseLink />
             </div>
           )}

--- a/templates/brain/app/components/layout/Sidebar.tsx
+++ b/templates/brain/app/components/layout/Sidebar.tsx
@@ -446,13 +446,13 @@ export function Sidebar({
 
       <div className="mt-auto shrink-0">
         {!collapsed ? (
-          <div className="px-3 py-2">
+          <div className="px-3 py-2 empty:hidden">
             <OrgSwitcher />
           </div>
         ) : null}
 
         {!collapsed ? (
-          <div className="px-3 py-2">
+          <div className="px-3 py-2 empty:hidden">
             <DevDatabaseLink />
           </div>
         ) : null}

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -1179,7 +1179,7 @@ export function Sidebar({
 
         {!collapsed ? (
           <>
-            <div className="px-3 py-2">
+            <div className="px-3 py-2 empty:hidden">
               <OrgSwitcher />
             </div>
 

--- a/templates/chat/app/components/layout/Sidebar.tsx
+++ b/templates/chat/app/components/layout/Sidebar.tsx
@@ -493,7 +493,11 @@ export function Sidebar({
           })}
         </nav>
 
-        <div className={cn(collapsed ? "px-1 py-1" : "px-3 py-2")}>
+        <div
+          className={cn(
+            collapsed ? "px-1 py-1 empty:hidden" : "px-3 py-2 empty:hidden",
+          )}
+        >
           <OrgSwitcher
             reserveSpace
             className={

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -686,7 +686,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
               {(isMobile || !pageHasHeaderSearch) && <SearchBar />}
             </div>
 
-            <div className="shrink-0 space-y-2 px-3 py-2">
+            <div className="shrink-0 space-y-2 px-3 py-2 empty:hidden">
               <OrgSwitcher settingsPath="/settings/organization" />
               <DevDatabaseLink />
             </div>

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -2425,7 +2425,7 @@ export function DocumentSidebar({
         />
       </div>
 
-      <div className="shrink-0 px-3 py-2">
+      <div className="shrink-0 px-3 py-2 empty:hidden">
         <OrgSwitcher reserveSpace />
       </div>
 

--- a/templates/crm/app/components/layout/CrmSidebar.tsx
+++ b/templates/crm/app/components/layout/CrmSidebar.tsx
@@ -376,7 +376,7 @@ export function CrmSidebar({ onNavigate }: { onNavigate?: () => void }) {
           </div>
 
           {!collapsed && (
-            <div className="mt-2 grid gap-2 px-1">
+            <div className="mt-2 grid gap-2 px-1 empty:hidden">
               <OrgSwitcher reserveSpace />
               <DevDatabaseLink />
             </div>

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -230,10 +230,10 @@ export function Sidebar() {
 
           {!collapsed && (
             <div className="mt-auto shrink-0">
-              <div className="px-3 py-2">
+              <div className="px-3 py-2 empty:hidden">
                 <OrgSwitcher reserveSpace />
               </div>
-              <div className="px-3 py-2">
+              <div className="px-3 py-2 empty:hidden">
                 <DevDatabaseLink />
               </div>
             </div>

--- a/templates/factory/app/components/layout/Sidebar.tsx
+++ b/templates/factory/app/components/layout/Sidebar.tsx
@@ -517,7 +517,11 @@ export function Sidebar({
           })}
         </nav>
 
-        <div className={cn(collapsed ? "px-1 py-1" : "px-3 py-2")}>
+        <div
+          className={cn(
+            collapsed ? "px-1 py-1 empty:hidden" : "px-3 py-2 empty:hidden",
+          )}
+        >
           <OrgSwitcher
             reserveSpace
             className={

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -334,7 +334,7 @@ function SidebarContent({
 
       {!collapsed && (
         <>
-          <div className="space-y-2 px-3 py-2">
+          <div className="space-y-2 px-3 py-2 empty:hidden">
             <DevDatabaseLink />
             <OrgSwitcher />
           </div>

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1826,7 +1826,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                   </div>
 
                   <div className="shrink-0">
-                    <div className="px-3 py-2">
+                    <div className="px-3 py-2 empty:hidden">
                       <OrgSwitcher />
                     </div>
 
@@ -2256,7 +2256,7 @@ function StandardLayout({ children }: AppLayoutProps) {
           </div>
 
           <div className="shrink-0">
-            <div className="px-3 py-2">
+            <div className="px-3 py-2 empty:hidden">
               <OrgSwitcher />
             </div>
 

--- a/templates/plan/app/components/layout/Sidebar.tsx
+++ b/templates/plan/app/components/layout/Sidebar.tsx
@@ -718,7 +718,7 @@ export function Sidebar({
       </nav>
 
       {!collapsed && session ? (
-        <div className="space-y-2 px-3 py-2">
+        <div className="space-y-2 px-3 py-2 empty:hidden">
           <DevDatabaseLink />
           <OrgSwitcher />
         </div>

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -261,7 +261,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
             })}
           </nav>
 
-          <div className="px-3 py-2">
+          <div className="px-3 py-2 empty:hidden">
             <OrgSwitcher />
           </div>
 

--- a/templates/tasks/app/components/layout/Sidebar.tsx
+++ b/templates/tasks/app/components/layout/Sidebar.tsx
@@ -213,8 +213,8 @@ export function Sidebar({
           className={cn(
             "grid gap-1",
             collapsed
-              ? "px-1 py-1"
-              : "border-t border-sidebar-border px-3 py-2",
+              ? "px-1 py-1 empty:hidden"
+              : "border-t border-sidebar-border px-3 py-2 empty:hidden",
           )}
         >
           {BOTTOM_NAV_ITEMS.map((item) => {


### PR DESCRIPTION
## Summary
- Hide padded sidebar wrappers when optional organization or developer controls render nothing.
- Apply the shared fix across app sidebars, including Design and Dispatch.
- Preserve reserved space while organization state is loading.

## Validation
- Shared OrgSwitcher tests
- Dispatch typecheck
- Design bridge typecheck
- All repository guards
- Local Design browser DOM and screenshot verification