### PR TITLE
fix: align Design provider availability and recovery

### DIFF
--- a/.changeset/fix-provider-selection-and-tool-cap.md
+++ b/.changeset/fix-provider-selection-and-tool-cap.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix provider-aware model selection, shared Builder reconnect access, and provider tool limits.

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -51,6 +51,14 @@ function mockAnthropicProvider() {
   return { createAnthropic, provider, anthropicModel };
 }
 
+function makeTool(name: string) {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object" as const, properties: {} },
+  };
+}
+
 describe("AISDKEngine Anthropic thinking-budget headroom", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -599,6 +607,30 @@ describe("AISDKEngine OpenAI model selection", () => {
     expect(engine.preserveCustomModels).toBe(true);
     expect(provider).toHaveBeenCalledWith("z-ai/glm-5.3-flash");
     expect(streamText).toHaveBeenCalled();
+  });
+
+  it("caps AI SDK provider tools at 128 and keeps tool-search", async () => {
+    const { streamText } = mockAiSdk();
+    mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", { apiKey: "sk-test" });
+    const tools = Array.from({ length: 129 }, (_, index) =>
+      makeTool(index === 128 ? "tool-search" : `tool-${index}`),
+    );
+
+    await drain(
+      engine.stream({
+        ...BASE_STREAM_OPTIONS,
+        tools,
+      }),
+    );
+
+    const call = streamText.mock.calls[0][0];
+    const toolNames = Object.keys(call.tools);
+    expect(toolNames).toHaveLength(128);
+    expect(toolNames).toContain("tool-search");
+    expect(toolNames).not.toContain("tool-127");
   });
 
   // Real prod incident (Sentry AGENT-NATIVE-BROWSER-94, gpt-5.6-terra): OpenAI

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -33,6 +33,7 @@ import {
   describeErrorWithCauses,
 } from "./error-detail.js";
 import { createFirstEventAbortController } from "./first-event-timeout.js";
+import { limitProviderTools } from "./limit-provider-tools.js";
 import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
@@ -312,9 +313,10 @@ class AISDKEngine implements AgentEngine {
     }
 
     const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
+    const providerTools = limitProviderTools(opts.tools);
     const aiSdkTools =
-      opts.tools.length > 0
-        ? engineToolsToAISDK(opts.tools, jsonSchema, toolNameMap)
+      providerTools.length > 0
+        ? engineToolsToAISDK(providerTools, jsonSchema, toolNameMap)
         : undefined;
     const messages = engineMessagesToAISDK(opts.messages, {
       // Vision-capable provider translators (anthropic/openai/google/

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -26,6 +26,7 @@ import {
 } from "./credential-errors.js";
 import { describeErrorWithCauses } from "./error-detail.js";
 import { createFirstEventAbortController } from "./first-event-timeout.js";
+import { limitProviderTools } from "./limit-provider-tools.js";
 import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
@@ -85,7 +86,10 @@ class AnthropicEngine implements AgentEngine {
     const client = new Anthropic({ apiKey: this.apiKey, maxRetries: 1 });
 
     const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
-    const tools = engineToolsToAnthropic(opts.tools, toolNameMap);
+    const tools = engineToolsToAnthropic(
+      limitProviderTools(opts.tools),
+      toolNameMap,
+    );
     const messages = engineMessagesToAnthropic(opts.messages, toolNameMap);
     const anthropicOpts = opts.providerOptions?.anthropic;
 

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -216,6 +216,7 @@ describe("createBuilderEngine", () => {
     expect(oauthState.resolveAccess).toHaveBeenCalledWith({
       ownerEmail: "person@example.com",
       requiredScope: "builder:ai:invoke",
+      orgId: null,
     });
     const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe("https://test.example/gateway/v1/messages");
@@ -897,6 +898,13 @@ describe("createBuilderEngine", () => {
 
     await collectEvents(createBuilderEngine().stream(BASE_OPTS));
 
+    expect(oauthState.hasSession).toHaveBeenCalledWith(
+      "person@example.com",
+      "org-request",
+    );
+    expect(oauthState.resolveAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: "org-request" }),
+    );
     expect(oauthState.markReconnect).toHaveBeenCalledWith(
       "person@example.com",
       "org",

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -112,6 +112,14 @@ function jsonErrorResponse(status: number, body: unknown): Response {
   });
 }
 
+function makeTool(name: string) {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
 const BASE_OPTS: EngineStreamOptions = {
   model: CLAUDE_SONNET_MODEL_ID,
   systemPrompt: "You are helpful.",
@@ -1870,6 +1878,32 @@ describe("createBuilderEngine", () => {
     const sentBody = (globalThis.fetch as any).mock.calls[0][1].body as string;
     expect(stop?.requestShape?.payloadBytes).toBe(
       new TextEncoder().encode(sentBody).length,
+    );
+  });
+
+  it("caps Builder provider tools at 128 and keeps tool-search", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonlResponse([{ type: "stop", reason: "end_turn" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    await collectEvents(
+      engine.stream({
+        ...BASE_OPTS,
+        tools: Array.from({ length: 129 }, (_, index) =>
+          makeTool(index === 128 ? "tool-search" : `tool-${index}`),
+        ),
+      }),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.tools).toHaveLength(128);
+    expect(body.tools.map((tool: { name: string }) => tool.name)).toContain(
+      "tool-search",
+    );
+    expect(body.tools.map((tool: { name: string }) => tool.name)).not.toContain(
+      "tool-127",
     );
   });
 

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -23,7 +23,9 @@ const credentialState = vi.hoisted(() => ({
 
 const oauthState = vi.hoisted(() => ({
   ownerEmail: undefined as string | undefined,
+  orgId: undefined as string | undefined,
   accessToken: null as string | null,
+  scope: undefined as "user" | "org" | undefined,
   stored: false,
   resolveAccess: vi.fn(),
   hasSession: vi.fn(),
@@ -81,6 +83,7 @@ vi.mock("../../server/builder-oauth.js", () => ({
 }));
 
 vi.mock("../../server/request-context.js", () => ({
+  getRequestOrgId: vi.fn(() => oauthState.orgId),
   getRequestUserEmail: vi.fn(() => oauthState.ownerEmail),
 }));
 
@@ -137,7 +140,9 @@ describe("createBuilderEngine", () => {
     credentialState.lane = "identity";
     credentialState.recordBuilderGatewayAuthFailure.mockClear();
     oauthState.ownerEmail = undefined;
+    oauthState.orgId = undefined;
     oauthState.accessToken = null;
+    oauthState.scope = undefined;
     oauthState.stored = false;
     oauthState.resolveAccess.mockReset().mockImplementation(async () =>
       oauthState.accessToken
@@ -145,6 +150,7 @@ describe("createBuilderEngine", () => {
             accessToken: oauthState.accessToken,
             ownerEmail: oauthState.ownerEmail,
             scopes: ["builder:ai:invoke"],
+            scope: oauthState.scope,
           }
         : null,
     );
@@ -871,6 +877,31 @@ describe("createBuilderEngine", () => {
       credentialState.recordBuilderGatewayAuthFailure,
     ).not.toHaveBeenCalled();
     expect(oauthState.markReconnect).toHaveBeenCalledWith("person@example.com");
+  });
+
+  it("marks the OAuth grant in the request organization", async () => {
+    oauthState.ownerEmail = "person@example.com";
+    oauthState.orgId = "org-request";
+    oauthState.scope = "org";
+    oauthState.accessToken = "oauth-access-token";
+    oauthState.stored = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonErrorResponse(401, {
+          code: "unauthorized",
+          message: "Invalid token",
+        }),
+      ),
+    );
+
+    await collectEvents(createBuilderEngine().stream(BASE_OPTS));
+
+    expect(oauthState.markReconnect).toHaveBeenCalledWith(
+      "person@example.com",
+      "org",
+      "org-request",
+    );
   });
 
   it("maps 403 invalid token to Builder auth stop-error", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -57,6 +57,7 @@ import {
   isProviderConnectionErrorMessage,
 } from "./error-detail.js";
 import { FIRST_STREAM_EVENT_TIMEOUT_MS } from "./first-event-timeout.js";
+import { limitProviderTools } from "./limit-provider-tools.js";
 import { resolveMaxOutputTokensForEngine } from "./output-tokens.js";
 import {
   splitSystemPromptForCache,
@@ -265,11 +266,12 @@ class BuilderEngine implements AgentEngine {
         ? BUILDER_DEFAULT_MODEL
         : requestedModel;
     const toolNameMap = createProviderToolNameMap(opts.tools, opts.messages);
+    const providerTools = limitProviderTools(opts.tools);
     const messages = engineMessagesToBuilderGatewayAnthropic(
       opts.messages,
       toolNameMap,
     );
-    const tools = engineToolsToAnthropic(opts.tools, toolNameMap);
+    const tools = engineToolsToAnthropic(providerTools, toolNameMap);
     const thinkingBudget =
       opts.providerOptions?.anthropic?.thinking?.budgetTokens;
     const reasoningEffort = normalizeReasoningEffortForModel(

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -221,17 +221,19 @@ class BuilderEngine implements AgentEngine {
       this.configuredCredentials ??
       (await resolveBuilderGatewayCredentialsDetailed());
     const ownerEmail = getRequestUserEmail();
+    const orgId = getRequestOrgId() ?? null;
     let oauthAccess: Awaited<
       ReturnType<typeof resolveBuilderOAuthRequestAccess>
     > = null;
     let hasStoredOAuth = false;
     if (ownerEmail) {
-      hasStoredOAuth = await hasBuilderOAuthSession(ownerEmail);
+      hasStoredOAuth = await hasBuilderOAuthSession(ownerEmail, orgId);
       if (hasStoredOAuth) {
         try {
           oauthAccess = await resolveBuilderOAuthRequestAccess({
             ownerEmail,
             requiredScope: BUILDER_OAUTH_SCOPE,
+            orgId,
           });
         } catch {
           // coercion-ok: unusable OAuth custody must not fall back to legacy keys.

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -471,6 +471,7 @@ class BuilderEngine implements AgentEngine {
           creditsLane,
           requestShape,
           recordLegacyCredentialFailure: !oauthAccess,
+          oauthScope: oauthAccess?.scope,
         });
         return;
       }
@@ -541,6 +542,7 @@ class BuilderEngine implements AgentEngine {
         requestStartedAt: tStart,
         requestShape,
         recordLegacyCredentialFailure: !oauthAccess,
+        oauthScope: oauthAccess?.scope,
       });
     } finally {
       gatewayAbort.cleanup();
@@ -621,6 +623,7 @@ function gatewayErrorStop(
 
 async function recordAuthFailureForCurrentLane(opts: {
   recordLegacyCredentialFailure?: boolean;
+  oauthScope?: "user" | "org";
   status?: number;
   code?: string;
   message?: string;
@@ -634,7 +637,13 @@ async function recordAuthFailureForCurrentLane(opts: {
     return;
   }
   const ownerEmail = getRequestUserEmail();
-  if (ownerEmail) await markBuilderOAuthReconnectRequired(ownerEmail);
+  if (ownerEmail) {
+    if (opts.oauthScope) {
+      await markBuilderOAuthReconnectRequired(ownerEmail, opts.oauthScope);
+    } else {
+      await markBuilderOAuthReconnectRequired(ownerEmail);
+    }
+  }
 }
 
 async function* emitHttpError(
@@ -643,6 +652,7 @@ async function* emitHttpError(
     creditsLane: boolean;
     requestShape?: EngineRequestShape;
     recordLegacyCredentialFailure?: boolean;
+    oauthScope?: "user" | "org";
   },
 ): AsyncIterable<EngineEvent> {
   const status = response.status;
@@ -683,6 +693,7 @@ async function* emitHttpError(
   if (status === 401 || code === "unauthorized") {
     await recordAuthFailureForCurrentLane({
       recordLegacyCredentialFailure: opts.recordLegacyCredentialFailure,
+      oauthScope: opts.oauthScope,
       status,
       code,
       message,
@@ -697,6 +708,7 @@ async function* emitHttpError(
   if (status === 403 && isBuilderCredentialAuthError(message)) {
     await recordAuthFailureForCurrentLane({
       recordLegacyCredentialFailure: opts.recordLegacyCredentialFailure,
+      oauthScope: opts.oauthScope,
       status,
       code,
       message,
@@ -784,6 +796,7 @@ async function* parseJsonlStream(
     creditsLane?: boolean;
     requestShape?: EngineRequestShape;
     recordLegacyCredentialFailure?: boolean;
+    oauthScope?: "user" | "org";
   } = {},
 ): AsyncIterable<EngineEvent> {
   const parts: EngineContentPart[] = [];
@@ -1037,6 +1050,7 @@ async function* parseJsonlStream(
               await recordAuthFailureForCurrentLane({
                 recordLegacyCredentialFailure:
                   captureContext.recordLegacyCredentialFailure,
+                oauthScope: captureContext.oauthScope,
                 code:
                   typeof gatewayErrCode === "string" ? gatewayErrCode : errCode,
                 message: String(errMsg),

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -31,7 +31,10 @@ import {
   recordBuilderGatewayAuthFailure,
   type BuilderGatewayLane,
 } from "../../server/credential-provider.js";
-import { getRequestUserEmail } from "../../server/request-context.js";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "../../server/request-context.js";
 import { applyBuilderUtmTrackingParams } from "../../shared/builder-link-tracking.js";
 import {
   allowsSamplingParams,
@@ -638,8 +641,14 @@ async function recordAuthFailureForCurrentLane(opts: {
   }
   const ownerEmail = getRequestUserEmail();
   if (ownerEmail) {
-    if (opts.oauthScope) {
-      await markBuilderOAuthReconnectRequired(ownerEmail, opts.oauthScope);
+    if (opts.oauthScope === "org") {
+      await markBuilderOAuthReconnectRequired(
+        ownerEmail,
+        "org",
+        getRequestOrgId(),
+      );
+    } else if (opts.oauthScope === "user") {
+      await markBuilderOAuthReconnectRequired(ownerEmail, "user");
     } else {
       await markBuilderOAuthReconnectRequired(ownerEmail);
     }

--- a/packages/core/src/agent/engine/limit-provider-tools.spec.ts
+++ b/packages/core/src/agent/engine/limit-provider-tools.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  limitProviderTools,
+  MAX_PROVIDER_TOOLS,
+} from "./limit-provider-tools.js";
+import type { EngineTool } from "./types.js";
+
+function makeTool(name: string): EngineTool {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object", properties: {} },
+  };
+}
+
+describe("limitProviderTools", () => {
+  it("caps provider tool arrays at 128 while preserving tool-search", () => {
+    const tools = Array.from({ length: MAX_PROVIDER_TOOLS + 1 }, (_, index) =>
+      makeTool(index === MAX_PROVIDER_TOOLS ? "tool-search" : `tool-${index}`),
+    );
+
+    const limited = limitProviderTools(tools);
+
+    expect(limited).toHaveLength(MAX_PROVIDER_TOOLS);
+    expect(limited.map((tool) => tool.name)).toContain("tool-search");
+    expect(limited.map((tool) => tool.name)).not.toContain("tool-127");
+  });
+});

--- a/packages/core/src/agent/engine/limit-provider-tools.ts
+++ b/packages/core/src/agent/engine/limit-provider-tools.ts
@@ -1,0 +1,29 @@
+import type { EngineTool } from "./types.js";
+
+export const MAX_PROVIDER_TOOLS = 128;
+const DEFAULT_PRESERVED_TOOL_NAMES = ["tool-search"] as const;
+
+export function limitProviderTools(
+  tools: readonly EngineTool[],
+  preserveNames: readonly string[] = DEFAULT_PRESERVED_TOOL_NAMES,
+): EngineTool[] {
+  if (tools.length <= MAX_PROVIDER_TOOLS) return tools as EngineTool[];
+
+  const preservedNames = new Set(preserveNames);
+  const seen = new Set<string>();
+  const limited: EngineTool[] = [];
+
+  for (const tool of tools) {
+    if (!preservedNames.has(tool.name) || seen.has(tool.name)) continue;
+    limited.push(tool);
+    seen.add(tool.name);
+  }
+
+  for (const tool of tools) {
+    if (seen.has(tool.name)) continue;
+    limited.push(tool);
+    if (limited.length === MAX_PROVIDER_TOOLS) return limited;
+  }
+
+  return limited.slice(0, MAX_PROVIDER_TOOLS);
+}

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1386,12 +1386,30 @@ describe("AgentEngine registry", () => {
       const { builderEngine } =
         registerBuilderAndAnthropic(registerAgentEngine);
       const entry = getAgentEngineEntry("builder")!;
+      const identity = {
+        userEmail: "visitor@example.com",
+        orgId: "org-request",
+      };
 
       await expect(
-        isResolvedEngineUsableForRequest(builderEngine),
+        isResolvedEngineUsableForRequest(builderEngine, {
+          credentialIdentity: identity,
+        }),
       ).resolves.toBe(true);
-      await expect(isStoredEngineUsableForRequest(null, entry)).resolves.toBe(
-        true,
+      await expect(
+        isStoredEngineUsableForRequest(null, entry, {
+          credentialIdentity: identity,
+        }),
+      ).resolves.toBe(true);
+      expect(hasBuilderOAuthSession).toHaveBeenCalledWith(
+        identity.userEmail,
+        identity.orgId,
+      );
+      expect(resolveBuilderOAuthRequestAccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerEmail: identity.userEmail,
+          orgId: identity.orgId,
+        }),
       );
     });
 

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -27,7 +27,10 @@ import {
   resolveSecret,
   type BuilderCredentialLookupIdentity,
 } from "../../server/credential-provider.js";
-import { getRequestUserEmail } from "../../server/request-context.js";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "../../server/request-context.js";
 import { getSetting } from "../../settings/store.js";
 import { getAgentAppModelDefaultForCurrentRequest } from "../app-model-defaults.js";
 import {
@@ -775,12 +778,17 @@ async function builderOAuthLaneUsable(
 ): Promise<boolean | null> {
   const ownerEmail =
     identity?.userEmail?.trim().toLowerCase() || getRequestUserEmail();
-  if (!ownerEmail || !(await hasBuilderOAuthSession(ownerEmail))) return null;
+  const orgId =
+    identity?.orgId !== undefined ? identity.orgId : getRequestOrgId();
+  const requestOrgId = orgId ?? null;
+  if (!ownerEmail || !(await hasBuilderOAuthSession(ownerEmail, requestOrgId)))
+    return null;
   try {
     return Boolean(
       await resolveBuilderOAuthRequestAccess({
         ownerEmail,
         requiredScope: BUILDER_OAUTH_SCOPE,
+        orgId: requestOrgId,
       }),
     );
   } catch {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -2395,6 +2395,88 @@ describe("runAgentLoop", () => {
     expect(seenTools[2]).toContain("hidden-tool");
   });
 
+  it("prioritizes tool-search matches before the provider tool cap", async () => {
+    const actions = attachToolSearch(
+      Object.fromEntries([
+        ...Array.from({ length: 128 }, (_, index) => [
+          `starter-${index}`,
+          actionEntry({
+            description: `Starter tool ${index}`,
+            readOnly: true,
+          }),
+        ]),
+        [
+          "late-tool",
+          actionEntry({
+            description: "The late tool that search should load",
+            readOnly: true,
+          }),
+        ],
+      ] as const),
+    );
+    const allTools = actionsToEngineTools(actions);
+    const initialTools = allTools.filter(
+      (tool) =>
+        tool.name === "tool-search" ||
+        (tool.name.startsWith("starter-") && Number(tool.name.slice(8)) < 127),
+    );
+    const seenTools: string[][] = [];
+    let streamCalls = 0;
+
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(opts): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        seenTools.push(opts.tools.map((tool) => tool.name));
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-search-late-tool",
+                name: "tool-search",
+                input: { query: "late tool" },
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: initialTools,
+      availableTools: allTools,
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions,
+      send: () => {},
+      signal: new AbortController().signal,
+    });
+
+    expect(seenTools[0]?.indexOf("late-tool")).toBe(-1);
+    expect(seenTools[1]?.indexOf("late-tool")).toBeLessThan(127);
+  });
+
   it("expands the full authorized tool surface for a guarded corrective retry", async () => {
     const actions = attachToolSearch({
       starter: actionEntry({

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4800,9 +4800,16 @@ export async function runAgentLoop(opts: {
       added.push(name);
     }
     if (added.length > 0) {
-      activeTools = (availableTools ?? tools).filter((tool) =>
+      const expandedTools = (availableTools ?? tools).filter((tool) =>
         activeToolNames.has(tool.name),
       );
+      const prioritizedNames = new Set(names);
+      // Provider adapters cap the schema list; keep search results in the
+      // prefix so the next request can actually call what it discovered.
+      activeTools = [
+        ...expandedTools.filter((tool) => prioritizedNames.has(tool.name)),
+        ...expandedTools.filter((tool) => !prioritizedNames.has(tool.name)),
+      ];
     }
     if (
       !reportedExpandedToolSchemaBytes &&

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -207,6 +207,10 @@ async function mountWithCatalog(
       el
         .querySelector("[data-testid='assistant-chat']")
         ?.getAttribute("data-selected-engine") ?? null,
+    modelOf: () =>
+      el
+        .querySelector("[data-testid='assistant-chat']")
+        ?.getAttribute("data-selected-model") ?? null,
     catalogOf: () =>
       el
         .querySelector("[data-testid='assistant-chat']")
@@ -590,6 +594,29 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
       await Promise.resolve();
     });
     expect(view.engineOf()).toBe("anthropic");
+    await view.cleanup();
+  });
+
+  it("heals a persisted selection when its provider is hidden as unconfigured", async () => {
+    window.localStorage.setItem(
+      "agent-native:chat-models:selection:catalog-test",
+      JSON.stringify({ model: "z-ai/glm-5.2", engine: "ai-sdk:openrouter" }),
+    );
+    const view = await mountWithCatalog(
+      [
+        ...ANTHROPIC_ENGINES,
+        {
+          name: "ai-sdk:openrouter",
+          label: "OpenRouter",
+          supportedModels: ["z-ai/glm-5.2"],
+          requiredEnvVars: ["OPENROUTER_API_KEY"],
+        },
+      ],
+      ["ANTHROPIC_API_KEY"],
+    );
+
+    expect(view.engineOf()).toBe("anthropic");
+    expect(view.modelOf()).toBe("claude-sonnet-5");
     await view.cleanup();
   });
 

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -217,19 +217,36 @@ function resolveModelSelection(
   const suppliedEngine = selection.engine?.trim()
     ? selection.engine
     : undefined;
-  const engine =
-    (groups.some((group) => group.engine === suppliedEngine)
-      ? suppliedEngine
-      : undefined) ??
-    groups.find((group) => group.models.includes(selection.model))?.engine ??
-    suppliedEngine;
-  if (!engine && groups.length > 0) return undefined;
-
-  const effort = resolveReasoningEffortSelection(
-    selection.model,
-    selection.effort,
+  const suppliedEngineGroup = suppliedEngine
+    ? groups.find((group) => group.engine === suppliedEngine)
+    : undefined;
+  const matchingConfiguredGroup = groups.find(
+    (group) => group.configured && group.models.includes(selection.model),
   );
-  const resolved: ModelSelection = { model: selection.model, effort };
+  const fallbackConfiguredGroup = groups.find((group) => group.configured);
+  const fallbackGroup = matchingConfiguredGroup ?? fallbackConfiguredGroup;
+  const engine = suppliedEngineGroup?.engine ?? fallbackGroup?.engine;
+  const model = suppliedEngineGroup
+    ? selection.model
+    : matchingConfiguredGroup?.models.includes(selection.model)
+      ? selection.model
+      : fallbackGroup?.models[0];
+  // A non-empty catalog is an availability boundary: do not keep routing a
+  // stale selection through a provider group hidden for missing credentials.
+  if (!engine || !model) {
+    if (groups.length > 0) return undefined;
+    return {
+      model: selection.model,
+      ...(suppliedEngine ? { engine: suppliedEngine } : {}),
+      effort: resolveReasoningEffortSelection(
+        selection.model,
+        selection.effort,
+      ),
+    };
+  }
+
+  const effort = resolveReasoningEffortSelection(model, selection.effort);
+  const resolved: ModelSelection = { model, effort };
   if (engine) resolved.engine = engine;
   return resolved;
 }

--- a/packages/core/src/client/chat-model-groups.spec.ts
+++ b/packages/core/src/client/chat-model-groups.spec.ts
@@ -114,7 +114,7 @@ describe("buildChatModelGroups", () => {
         },
         {
           name: "ai-sdk:google",
-          label: "Gemini",
+          label: "Google AI",
           supportedModels: ["gemini-3.5-flash"],
           requiredEnvVars: ["GOOGLE_GENERATIVE_AI_API_KEY"],
         },
@@ -126,7 +126,7 @@ describe("buildChatModelGroups", () => {
         },
         {
           name: "ai-sdk:openrouter",
-          label: "OpenRouter",
+          label: "Router",
           supportedModels: ["z-ai/glm-5.2"],
           requiredEnvVars: ["OPENROUTER_API_KEY"],
         },
@@ -178,6 +178,29 @@ describe("buildChatModelGroups", () => {
     });
   });
 
+  it("hides unconfigured Gemini and OpenRouter, including stale selections", () => {
+    const groups = buildChatModelGroups({
+      currentEngineName: "ai-sdk:openrouter",
+      currentModel: "z-ai/glm-5.2",
+      engines: [
+        {
+          name: "ai-sdk:google",
+          label: "Gemini",
+          supportedModels: ["gemini-3.5-flash"],
+          requiredEnvVars: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+        },
+        {
+          name: "ai-sdk:openrouter",
+          label: "OpenRouter",
+          supportedModels: ["z-ai/glm-5.2"],
+          requiredEnvVars: ["OPENROUTER_API_KEY"],
+        },
+      ],
+    });
+
+    expect(groups).toEqual([]);
+  });
+
   it("keeps a hidden provider visible when it is the current engine", () => {
     const groups = buildChatModelGroups({
       currentEngineName: "ai-sdk:groq",
@@ -202,7 +225,7 @@ describe("buildChatModelGroups", () => {
     ]);
   });
 
-  it("puts OpenRouter after other installed custom providers", () => {
+  it("keeps custom providers visible when OpenRouter is unavailable", () => {
     const groups = buildChatModelGroups({
       engines: [
         {
@@ -220,10 +243,7 @@ describe("buildChatModelGroups", () => {
       ],
     });
 
-    expect(groups.map((group) => group.label)).toEqual([
-      "Custom",
-      "OpenRouter",
-    ]);
+    expect(groups.map((group) => group.label)).toEqual(["Custom"]);
   });
 
   it("keeps the current engine visible without re-adding unsupported current models", () => {

--- a/packages/core/src/client/chat-model-groups.spec.ts
+++ b/packages/core/src/client/chat-model-groups.spec.ts
@@ -154,10 +154,10 @@ describe("buildChatModelGroups", () => {
     expect(groups.map((group) => group.label)).toEqual([
       "OpenAI",
       "Claude",
-      "Gemini",
-      "OpenRouter",
+      "Google AI",
+      "Router",
     ]);
-    expect(groups.find((group) => group.label === "Gemini")).toMatchObject({
+    expect(groups.find((group) => group.label === "Google AI")).toMatchObject({
       engine: "ai-sdk:google",
       configured: true,
     });
@@ -171,7 +171,7 @@ describe("buildChatModelGroups", () => {
     expect(groups.find((group) => group.label === "Claude")).toMatchObject({
       models: ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-4-8"],
     });
-    expect(groups.find((group) => group.label === "OpenRouter")).toMatchObject({
+    expect(groups.find((group) => group.label === "Router")).toMatchObject({
       engine: "ai-sdk:openrouter",
       models: ["z-ai/glm-5.2"],
       configured: true,

--- a/packages/core/src/client/chat-model-groups.ts
+++ b/packages/core/src/client/chat-model-groups.ts
@@ -56,6 +56,11 @@ const HIDDEN_CHAT_MODEL_ENGINES = new Set([
   "ai-sdk:cohere",
 ]);
 
+const HIDDEN_UNCONFIGURED_CHAT_MODEL_ENGINES = new Set([
+  "ai-sdk:google",
+  "ai-sdk:openrouter",
+]);
+
 function addCurrentModel(
   models: readonly string[],
   engineName: string,
@@ -197,6 +202,11 @@ function sortModelPickerEngines(
   return modelPickerEngineRank(a) - modelPickerEngineRank(b);
 }
 
+function shouldShowConfiguredGroup(group: EngineModelGroup): boolean {
+  if (group.configured) return true;
+  return !HIDDEN_UNCONFIGURED_CHAT_MODEL_ENGINES.has(group.engine);
+}
+
 export function buildChatModelGroups({
   engines,
   configuredKeys,
@@ -240,5 +250,6 @@ export function buildChatModelGroups({
             requiredEnvVars.some((key) => configured.has(key))),
       };
     })
-    .filter((group) => group.models.length > 0);
+    .filter((group) => group.models.length > 0)
+    .filter(shouldShowConfiguredGroup);
 }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -3849,6 +3849,106 @@ describe("SSE event processor error classification", () => {
     expect(terminal?.metadata?.custom?.runError?.recoverable).toBe(true);
   });
 
+  it("does not auto-continue a terminal stop message without an abort code", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "error",
+            error: "The agent stopped before finishing.",
+            recoverable: true,
+          },
+        ]),
+        [],
+        { value: 0 },
+        "tab-stop-message",
+      ),
+    );
+
+    const terminal = results.at(-1) as
+      | {
+          status?: { type: string; reason: string };
+          metadata?: { custom?: { runError?: { recoverable?: boolean } } };
+        }
+      | undefined;
+    expect(terminal?.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(terminal?.metadata?.custom?.runError?.recoverable).toBe(true);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          message: "The agent stopped before finishing.",
+          recoverable: true,
+        }),
+      }),
+    );
+  });
+
+  it("does not auto-continue provider credential rejection", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const results = await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "error",
+            error:
+              "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+            recoverable: true,
+          },
+        ]),
+        [],
+        { value: 0 },
+        "tab-provider-credential",
+      ),
+    );
+
+    const terminal = results.at(-1) as
+      | {
+          status?: { type: string; reason: string };
+          metadata?: { custom?: { runError?: { recoverable?: boolean } } };
+        }
+      | undefined;
+    expect(terminal?.status).toEqual({ type: "incomplete", reason: "error" });
+    expect(terminal?.metadata?.custom?.runError?.recoverable).toBe(true);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:run-error",
+        detail: expect.objectContaining({
+          message:
+            "The provider rejected the credential used for this request; it is skipped on the next attempt. Retry, or update your provider key if it keeps failing.",
+          recoverable: true,
+        }),
+      }),
+    );
+  });
+
   it("does not auto-continue a breaker stop that preserved its underlying transient code", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -800,6 +800,19 @@ function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
   // flag re-POSTs the exact chain the server just refused to continue.
   if (ev.recoverable === false) return false;
 
+  // These messages can carry `recoverable: true` for banner rendering, but
+  // repeating the request would retry the same rejected credential or a run
+  // the user already stopped.
+  if (
+    msg.includes(
+      "the provider rejected the credential used for this request",
+    ) ||
+    msg.includes("stopped before finishing") ||
+    msg.includes("stopped before it finished")
+  ) {
+    return false;
+  }
+
   if (
     code === "context_length_exceeded" ||
     code === "input_too_long" ||

--- a/packages/core/src/client/use-chat-models.ts
+++ b/packages/core/src/client/use-chat-models.ts
@@ -315,10 +315,11 @@ export function useChatModels({
           // Default only to a CONFIGURED group, and to nothing when there is
           // none. `DEFAULT_MODEL` is a builder-gateway id that no group carries
           // unless Builder is connected, and unconfigured groups are kept in the
-          // list for their connect affordance — so both `?? DEFAULT_MODEL` and
-          // `?? groups[0]` yield a selection the app cannot route, which the
-          // server silently replaces with its own default. An empty selection
-          // hides the picker instead of showing a model that will not be used.
+          // list for their connect affordance where that is useful — so both
+          // `?? DEFAULT_MODEL` and `?? groups[0]` yield a selection the app
+          // cannot route, which the server silently replaces with its own
+          // default. An empty selection hides the picker instead of showing a
+          // model that will not be used.
           const configuredGroups = groups.filter((g) => g.configured);
           const resolveRoutableSelection = () => {
             const group =

--- a/packages/core/src/server/builder-api-auth.spec.ts
+++ b/packages/core/src/server/builder-api-auth.spec.ts
@@ -60,6 +60,11 @@ describe("resolveBuilderApiAuthorization", () => {
     await expect(resolveBuilderApiAuthorization(ASSETS_WRITE)).resolves.toBe(
       "Bearer <OAUTH_TOKEN_EXAMPLE>",
     );
+    expect(getBuilderOAuthSessionMock).toHaveBeenCalledWith(
+      "user@example.com",
+      null,
+      ASSETS_WRITE,
+    );
     // OAuth wins outright — the legacy key is never even consulted.
     expect(resolveBuilderPrivateKeyMock).not.toHaveBeenCalled();
   });
@@ -144,6 +149,7 @@ describe("resolveBuilderApiAuthorization", () => {
     expect(getBuilderOAuthSessionMock).toHaveBeenCalledWith(
       "user@example.com",
       "org-recording",
+      ASSETS_WRITE,
     );
   });
 
@@ -168,6 +174,11 @@ describe("canAuthorizeBuilderApiRequest", () => {
 
     await expect(canAuthorizeBuilderApiRequest(ASSETS_WRITE)).resolves.toBe(
       false,
+    );
+    expect(getBuilderOAuthSessionMock).toHaveBeenCalledWith(
+      "user@example.com",
+      null,
+      ASSETS_WRITE,
     );
   });
 

--- a/packages/core/src/server/builder-api-auth.ts
+++ b/packages/core/src/server/builder-api-auth.ts
@@ -55,7 +55,7 @@ export async function resolveBuilderApiAuthorization(
   // the grant is org-scoped, and a recording that finalizes after the user
   // switched org must still authorize against the org it belongs to. The
   // legacy private-key path already resolves this way.
-  const orgId = getRequestOrgId();
+  const orgId = getRequestOrgId() ?? null;
 
   if (ownerEmail && (await readOAuthCustody(ownerEmail, orgId))) {
     const session = await readCredentialStore(() =>
@@ -91,7 +91,8 @@ export async function resolveBuilderApiAuthorization(
  */
 export async function hasBuilderApiCredentialCustody(): Promise<boolean> {
   const ownerEmail = getRequestUserEmail();
-  if (ownerEmail && (await readOAuthCustody(ownerEmail, getRequestOrgId()))) {
+  const orgId = getRequestOrgId() ?? null;
+  if (ownerEmail && (await readOAuthCustody(ownerEmail, orgId))) {
     return true;
   }
   return !!(await resolveBuilderPrivateKey());
@@ -105,7 +106,7 @@ export async function canAuthorizeBuilderApiRequest(
   requiredScope?: string,
 ): Promise<boolean> {
   const ownerEmail = getRequestUserEmail();
-  const orgId = getRequestOrgId();
+  const orgId = getRequestOrgId() ?? null;
 
   if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail, orgId))) {
     const session = await getBuilderOAuthSession(ownerEmail, orgId);

--- a/packages/core/src/server/builder-api-auth.ts
+++ b/packages/core/src/server/builder-api-auth.ts
@@ -58,9 +58,24 @@ export async function resolveBuilderApiAuthorization(
   const orgId = getRequestOrgId() ?? null;
 
   if (ownerEmail && (await readOAuthCustody(ownerEmail, orgId))) {
-    const session = await readCredentialStore(() =>
-      getBuilderOAuthSession(ownerEmail, orgId),
-    );
+    let session: Awaited<ReturnType<typeof getBuilderOAuthSession>>;
+    try {
+      session = await readCredentialStore(() =>
+        getBuilderOAuthSession(ownerEmail, orgId, requiredScope),
+      );
+    } catch (err) {
+      if (
+        requiredScope &&
+        err instanceof Error &&
+        err.message ===
+          `Builder OAuth connection does not grant ${requiredScope}`
+      ) {
+        throw new Error(
+          `Builder.io access needs re-authorizing to grant ${requiredScope}. Open Settings and authorize Builder.io again.`,
+        );
+      }
+      throw err;
+    }
     if (!session) {
       throw new Error(
         "Builder.io access expired. Re-authorize Builder.io in Settings to continue.",
@@ -109,10 +124,26 @@ export async function canAuthorizeBuilderApiRequest(
   const orgId = getRequestOrgId() ?? null;
 
   if (ownerEmail && (await hasBuilderOAuthSession(ownerEmail, orgId))) {
-    const session = await getBuilderOAuthSession(ownerEmail, orgId);
-    return (
-      !!session && (!requiredScope || session.scopes.includes(requiredScope))
-    );
+    try {
+      const session = await getBuilderOAuthSession(
+        ownerEmail,
+        orgId,
+        requiredScope,
+      );
+      return (
+        !!session && (!requiredScope || session.scopes.includes(requiredScope))
+      );
+    } catch (err) {
+      if (
+        requiredScope &&
+        err instanceof Error &&
+        err.message ===
+          `Builder OAuth connection does not grant ${requiredScope}`
+      ) {
+        return false;
+      }
+      throw err;
+    }
   }
 
   return !!(await resolveBuilderPrivateKey());

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -339,6 +339,18 @@ describe("Builder hosted user OAuth", () => {
     );
   });
 
+  it("does not fall back to the active org when the caller has no org", async () => {
+    resolveOrgMock.mockResolvedValue("org-acme");
+
+    await expect(hasBuilderOAuthSession(ownerEmail, null)).resolves.toBe(false);
+    expect(getRawTokensMock).toHaveBeenCalledTimes(1);
+    expect(getRawTokensMock).toHaveBeenCalledWith(
+      "mcp",
+      perUserKey(ownerEmail),
+      "user:alice@example.com",
+    );
+  });
+
   it("shares one org-scoped credential across members of the same org", async () => {
     resolveOrgMock.mockResolvedValue("org-acme");
     getRawTokensMock.mockImplementation(

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -57,6 +57,13 @@ function perOrgKey(orgId: string): string {
   return `${BASE_KEY}:o:${digest}`;
 }
 
+function perUserKey(email: string): string {
+  const digest = createHash("sha256")
+    .update(email.trim().toLowerCase())
+    .digest("hex");
+  return `${BASE_KEY}:u:${digest}`;
+}
+
 function credentials(overrides: Record<string, unknown> = {}) {
   return {
     serverUrl: BUILDER_OAUTH_RESOURCE,
@@ -93,6 +100,7 @@ beforeEach(() => {
   markReconnectMock.mockResolvedValue(true);
   validateIssuerMock.mockReset();
   getRawTokensMock.mockReset();
+  getRawTokensMock.mockResolvedValue(null);
   resolveOrgMock.mockReset();
   // Every user belongs to an org; individual tests override the org id.
   resolveOrgMock.mockResolvedValue(DEFAULT_ORG);
@@ -171,6 +179,7 @@ describe("Builder hosted user OAuth", () => {
     await saveBuilderOAuthCredentials({
       ownerEmail,
       orgId: DEFAULT_ORG,
+      role: "owner",
       credentials: exchanged,
     });
     expect(saveMock).toHaveBeenCalledWith({
@@ -199,9 +208,9 @@ describe("Builder hosted user OAuth", () => {
     });
 
     expect(saveMock).toHaveBeenCalledWith({
-      key: perOrgKey(DEFAULT_ORG),
-      scope: "org",
-      scopeId: DEFAULT_ORG,
+      key: perUserKey(ownerEmail),
+      scope: "user",
+      scopeId: ownerEmail,
       serverUrl: BUILDER_OAUTH_RESOURCE,
       credentials: finished,
     });
@@ -330,6 +339,10 @@ describe("Builder hosted user OAuth", () => {
 
   it("shares one org-scoped credential across members of the same org", async () => {
     resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-acme" ? {} : null,
+    );
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(credentials());
 
@@ -350,6 +363,7 @@ describe("Builder hosted user OAuth", () => {
 
     await finishBuilderOAuthAuthorization({
       ownerEmail,
+      role: "owner",
       code: "<AUTHORIZATION_CODE_EXAMPLE>",
       iss: BUILDER_OAUTH_ISSUER,
       pending: {
@@ -369,6 +383,33 @@ describe("Builder hosted user OAuth", () => {
     });
   });
 
+  it("keeps member OAuth credentials in personal custody", async () => {
+    const finished = credentials();
+    finishMock.mockResolvedValue({ credentials: finished });
+
+    await finishBuilderOAuthAuthorization({
+      ownerEmail,
+      orgId: "org-acme",
+      role: "member",
+      code: "<AUTHORIZATION_CODE_EXAMPLE>",
+      iss: BUILDER_OAUTH_ISSUER,
+      pending: {
+        codeVerifier: "<PKCE_VERIFIER_EXAMPLE>",
+        clientInformation: { client_id: "<CLIENT_ID_EXAMPLE>" },
+        discoveryState: finished.discoveryState,
+        redirectUri: "https://app.example.com/_agent-native/builder/callback",
+      },
+    });
+
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: perUserKey(ownerEmail),
+        scope: "user",
+        scopeId: ownerEmail,
+      }),
+    );
+  });
+
   it("stores under the org captured at start, not the active org at callback", async () => {
     // A switched active org must not win over the org authorized at start.
     resolveOrgMock.mockResolvedValue("org-switched");
@@ -378,6 +419,7 @@ describe("Builder hosted user OAuth", () => {
     await finishBuilderOAuthAuthorization({
       ownerEmail,
       orgId: "org-started",
+      role: "owner",
       code: "<AUTHORIZATION_CODE_EXAMPLE>",
       iss: BUILDER_OAUTH_ISSUER,
       pending: {
@@ -400,6 +442,10 @@ describe("Builder hosted user OAuth", () => {
 
   it("reports the requesting user's email even when the token is org-scoped", async () => {
     resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-acme" ? {} : null,
+    );
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(credentials());
 
@@ -421,6 +467,10 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("marks reconnect required for a revoked OAuth grant", async () => {
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-default" ? {} : null,
+    );
     await markBuilderOAuthReconnectRequired(ownerEmail);
     expect(markReconnectMock).toHaveBeenCalledWith({
       key: perOrgKey(DEFAULT_ORG),
@@ -438,6 +488,7 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("accepts custody whose serverUrl was canonicalized with a trailing slash", async () => {
+    getRawTokensMock.mockResolvedValue({});
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(
       credentials({
@@ -451,6 +502,7 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("parses scopes for status and rejects an insufficient requested scope", async () => {
+    getRawTokensMock.mockResolvedValue({});
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(
       credentials({
@@ -477,6 +529,7 @@ describe("Builder hosted user OAuth", () => {
   // Crediting it with the upload scope would trade a clear local error for an
   // opaque 403 from Builder.
   it("keeps a scope-less legacy credential AI-only", async () => {
+    getRawTokensMock.mockResolvedValue({});
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(
       credentials({
@@ -499,6 +552,7 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("fails closed for a credential whose issuer or resource binding changed", async () => {
+    getRawTokensMock.mockResolvedValue({});
     getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
     readMock.mockResolvedValue(
       credentials({
@@ -522,6 +576,10 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("delegates expiring bundles to the guarded generic OAuth refresher", async () => {
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-default" ? {} : null,
+    );
     let stored = credentials({ tokenExpiresAt: Date.now() + 1_000 });
     readMock.mockImplementation(async () => stored);
     getAccessTokenMock.mockImplementation(async () => {
@@ -560,6 +618,10 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("revokes remotely on disconnect and always deletes local custody", async () => {
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-default" ? {} : null,
+    );
     revokeMock.mockResolvedValue({
       local: "deleted",
       remote: "succeeded",
@@ -578,6 +640,10 @@ describe("Builder hosted user OAuth", () => {
   });
 
   it("deletes local custody even when Builder revocation fails", async () => {
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-default" ? {} : null,
+    );
     revokeMock.mockResolvedValue({
       local: "deleted",
       remote: "failed",

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -41,6 +41,7 @@ import {
   exchangeBuilderOAuthAuthorization,
   finishBuilderOAuthAuthorization,
   getBuilderOAuthConnectionScope,
+  getBuilderOAuthStoredScope,
   getBuilderOAuthSession,
   hasBuilderOAuthSession,
   markBuilderOAuthReconnectRequired,
@@ -561,6 +562,17 @@ describe("Builder hosted user OAuth", () => {
     await expect(getBuilderOAuthConnectionScope(ownerEmail)).resolves.toBe(
       "org",
     );
+  });
+
+  it("reports stored custody for disconnect even when its token is unusable", async () => {
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-default" ? {} : null,
+    );
+    getAccessTokenMock.mockResolvedValue(null);
+
+    await expect(getBuilderOAuthStoredScope(ownerEmail)).resolves.toBe("org");
+    expect(getAccessTokenMock).not.toHaveBeenCalled();
   });
 
   // A stored credential with no `scope` claim predates both Builder always

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -40,6 +40,7 @@ import {
   deleteBuilderOAuthSession,
   exchangeBuilderOAuthAuthorization,
   finishBuilderOAuthAuthorization,
+  getBuilderOAuthConnectionScope,
   getBuilderOAuthSession,
   hasBuilderOAuthSession,
   markBuilderOAuthReconnectRequired,
@@ -522,6 +523,44 @@ describe("Builder hosted user OAuth", () => {
         requiredScope: "builder:assets:write",
       }),
     ).rejects.toThrow("does not grant builder:assets:write");
+  });
+
+  it("falls back to an org grant when a personal grant lacks the requested scope", async () => {
+    resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockResolvedValue({});
+    getAccessTokenMock.mockResolvedValue("<ACCESS_TOKEN_EXAMPLE>");
+    readMock.mockImplementation(async (options: { scope: "user" | "org" }) =>
+      options.scope === "user"
+        ? credentials()
+        : credentials({
+            tokens: {
+              access_token: "<ACCESS_TOKEN_EXAMPLE>",
+              scope: BUILDER_OAUTH_SCOPES.join(" "),
+              issuer: BUILDER_OAUTH_ISSUER,
+            },
+          }),
+    );
+
+    await expect(
+      resolveBuilderOAuthRequestAccess({
+        ownerEmail,
+        requiredScope: "builder:assets:write",
+      }),
+    ).resolves.toMatchObject({ scope: "org", scopes: BUILDER_OAUTH_SCOPES });
+  });
+
+  it("reports the usable org grant when personal custody needs reconnect", async () => {
+    resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockResolvedValue({});
+    getAccessTokenMock.mockImplementation(
+      async (options: { scope: "user" | "org" }) =>
+        options.scope === "user" ? null : "<ACCESS_TOKEN_EXAMPLE>",
+    );
+    readMock.mockResolvedValue(credentials());
+
+    await expect(getBuilderOAuthConnectionScope(ownerEmail)).resolves.toBe(
+      "org",
+    );
   });
 
   // A stored credential with no `scope` claim predates both Builder always

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -42,50 +42,82 @@ export type BuilderOAuthPendingFlow = {
   redirectUri: string;
 };
 
+export type BuilderOAuthScope = "user" | "org";
+
 export type BuilderOAuthSession = {
   accessToken: string;
   expiresAt?: number;
   scopes: string[];
+  scope: BuilderOAuthScope;
 };
 
 export type BuilderOAuthRequestAccess = BuilderOAuthSession & {
   ownerEmail: string;
 };
 
-// The Builder connection is shared by everyone in the caller's org: the
-// credential is scoped to the org so every member reads the same token. Every
-// user belongs to an org, so a missing org is a broken invariant, not a case
-// to fall back on.
+// Builder connections follow the same scope policy as legacy Builder keys:
+// owner/admin writes are shared with the org, while a member's connection is
+// personal and cannot replace the org grant.
 function normalizeOwnerEmail(ownerEmail: string): string {
   const email = ownerEmail.trim().toLowerCase();
   if (!email) throw new Error("Builder OAuth owner email is required");
   return email;
 }
 
-// Read paths use this: a caller with no org simply has no Builder session, so
-// engine detection and status checks get null instead of an exception.
-//
-// An explicit orgId wins over the user's active org. The grant is org-scoped,
-// so work that carries its own organization — a recording finalizing after the
-// user switched active org, a background run — must authorize against that org
-// rather than whichever one the user happens to be looking at now.
-async function resolveOwnerOptions(ownerEmail: string, orgId?: string | null) {
-  const email = normalizeOwnerEmail(ownerEmail);
-  const resolvedOrgId = orgId?.trim() || (await resolveOrgIdForEmail(email));
-  if (!resolvedOrgId) return null;
-  return orgOwnerOptions(resolvedOrgId);
+function userOAuthKey(ownerEmail: string): string {
+  const digest = createHash("sha256")
+    .update(normalizeOwnerEmail(ownerEmail))
+    .digest("hex");
+  return `${BUILDER_OAUTH_KEY}:u:${digest}`;
 }
 
-// Write paths use this: storing a Builder credential without an org is a broken
-// invariant, so a missing org fails loudly rather than silently dropping it.
-async function ownerOptions(ownerEmail: string) {
-  const options = await resolveOwnerOptions(ownerEmail);
-  if (!options) {
-    throw new Error(
-      `Builder OAuth requires an organization for ${normalizeOwnerEmail(ownerEmail)}`,
-    );
+function userOwnerOptions(ownerEmail: string) {
+  const scopeId = normalizeOwnerEmail(ownerEmail);
+  return {
+    key: userOAuthKey(scopeId),
+    scope: "user" as const,
+    scopeId,
+    serverUrl: BUILDER_OAUTH_RESOURCE,
+  };
+}
+
+// Read paths try a member's personal grant first, then the org grant. An
+// explicit orgId wins over the user's active org so background work stays
+// bound to the organization that authorized it.
+async function resolveBuilderOAuthOptions(
+  ownerEmail: string,
+  orgId?: string | null,
+) {
+  const email = normalizeOwnerEmail(ownerEmail);
+  const userOptions = userOwnerOptions(email);
+  const resolvedOrgId = orgId?.trim() || (await resolveOrgIdForEmail(email));
+  return resolvedOrgId
+    ? [userOptions, orgOwnerOptions(resolvedOrgId)]
+    : [userOptions];
+}
+
+async function resolveBuilderOAuthOptionsForScope(
+  ownerEmail: string,
+  scope: BuilderOAuthScope,
+  orgId?: string | null,
+) {
+  if (scope === "user") return [userOwnerOptions(ownerEmail)];
+  const resolvedOrgId =
+    orgId?.trim() || (await resolveOrgIdForEmail(ownerEmail));
+  return resolvedOrgId ? [orgOwnerOptions(resolvedOrgId)] : [];
+}
+
+async function writeBuilderOAuthOptions(input: {
+  ownerEmail: string;
+  orgId?: string | null;
+  role?: string | null;
+}) {
+  if (input.role === "owner" || input.role === "admin") {
+    const orgId =
+      input.orgId?.trim() || (await resolveOrgIdForEmail(input.ownerEmail));
+    if (orgId) return orgOwnerOptions(orgId);
   }
-  return options;
+  return userOwnerOptions(input.ownerEmail);
 }
 
 function orgOwnerOptions(orgId: string) {
@@ -217,20 +249,22 @@ export async function exchangeBuilderOAuthAuthorization(input: {
 
 export async function saveBuilderOAuthCredentials(input: {
   ownerEmail: string;
-  orgId?: string;
+  orgId?: string | null;
+  role?: string | null;
   credentials: McpOAuthCredentialBundle;
-}): Promise<void> {
+}): Promise<BuilderOAuthScope> {
+  const options = await writeBuilderOAuthOptions(input);
   await saveMcpOAuthCredentials({
-    ...(input.orgId
-      ? orgOwnerOptions(input.orgId)
-      : await ownerOptions(input.ownerEmail)),
+    ...options,
     credentials: input.credentials,
   });
+  return options.scope;
 }
 
 export async function finishBuilderOAuthAuthorization(input: {
   ownerEmail: string;
-  orgId?: string;
+  orgId?: string | null;
+  role?: string | null;
   code: string;
   iss?: string;
   pending: BuilderOAuthPendingFlow;
@@ -239,57 +273,97 @@ export async function finishBuilderOAuthAuthorization(input: {
   await saveBuilderOAuthCredentials({
     ownerEmail: input.ownerEmail,
     orgId: input.orgId,
+    role: input.role,
     credentials,
   });
 }
 
 export async function markBuilderOAuthReconnectRequired(
   ownerEmail: string,
+  scope?: BuilderOAuthScope,
+  orgId?: string | null,
 ): Promise<void> {
-  const options = await resolveOwnerOptions(ownerEmail);
-  if (!options) return;
-  await markMcpOAuthReconnectRequired(options);
+  const options = scope
+    ? await resolveBuilderOAuthOptionsForScope(ownerEmail, scope, orgId)
+    : await resolveBuilderOAuthOptions(ownerEmail, orgId);
+  for (const candidate of options) {
+    if (
+      (await getOAuthTokens(
+        "mcp",
+        candidate.key,
+        `${candidate.scope}:${candidate.scopeId}`,
+      )) !== null
+    ) {
+      await markMcpOAuthReconnectRequired(candidate);
+      return;
+    }
+  }
 }
 
 export async function getBuilderOAuthSession(
   ownerEmail: string,
   orgId?: string | null,
 ): Promise<BuilderOAuthSession | null> {
-  const options = await resolveOwnerOptions(ownerEmail, orgId);
-  if (!options) return null;
-  // Delegates refresh single-flight and reconnect latching to the shared
-  // credential lifecycle; a null token covers missing, expired-unrefreshable,
-  // and reconnect_required alike.
-  const accessToken = await getMcpOAuthAccessToken(options);
-  if (!accessToken) return null;
-  const credentials = await readMcpOAuthCredentials(options);
-  if (!credentials || !isBuilderCredential(credentials)) return null;
-  return {
-    accessToken,
-    expiresAt: credentials.tokenExpiresAt,
-    scopes: scopesFrom(credentials),
-  };
+  for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
+    const stored = await getOAuthTokens(
+      "mcp",
+      options.key,
+      `${options.scope}:${options.scopeId}`,
+    );
+    if (stored === null) continue;
+    // Delegates refresh single-flight and reconnect latching to the shared
+    // credential lifecycle; a null token covers expired-unrefreshable and
+    // reconnect_required alike, so an org fallback can still be used.
+    const accessToken = await getMcpOAuthAccessToken(options);
+    if (!accessToken) continue;
+    const credentials = await readMcpOAuthCredentials(options);
+    if (!credentials || !isBuilderCredential(credentials)) continue;
+    return {
+      accessToken,
+      expiresAt: credentials.tokenExpiresAt,
+      scopes: scopesFrom(credentials),
+      scope: options.scope,
+    };
+  }
+  return null;
 }
 
 export async function hasBuilderOAuthSession(
   ownerEmail: string,
   orgId?: string | null,
 ): Promise<boolean> {
-  const options = await resolveOwnerOptions(ownerEmail, orgId);
-  if (!options) return false;
-  const stored = await getOAuthTokens(
-    "mcp",
-    options.key,
-    `${options.scope}:${options.scopeId}`,
-  );
-  return stored !== null;
+  for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
+    const stored = await getOAuthTokens(
+      "mcp",
+      options.key,
+      `${options.scope}:${options.scopeId}`,
+    );
+    if (stored !== null) return true;
+  }
+  return false;
+}
+
+export async function getBuilderOAuthConnectionScope(
+  ownerEmail: string,
+  orgId?: string | null,
+): Promise<BuilderOAuthScope | null> {
+  for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
+    const stored = await getOAuthTokens(
+      "mcp",
+      options.key,
+      `${options.scope}:${options.scopeId}`,
+    );
+    if (stored !== null) return options.scope;
+  }
+  return null;
 }
 
 export async function resolveBuilderOAuthRequestAccess(input: {
   ownerEmail: string;
   requiredScope: string;
+  orgId?: string | null;
 }): Promise<BuilderOAuthRequestAccess | null> {
-  const session = await getBuilderOAuthSession(input.ownerEmail);
+  const session = await getBuilderOAuthSession(input.ownerEmail, input.orgId);
   if (!session) return null;
   if (!session.scopes.includes(input.requiredScope)) {
     throw new Error(
@@ -301,10 +375,27 @@ export async function resolveBuilderOAuthRequestAccess(input: {
 
 export async function deleteBuilderOAuthSession(
   ownerEmail: string,
+  scope?: BuilderOAuthScope,
+  orgId?: string | null,
 ): Promise<{ localDeleted: boolean; remoteRevoked: boolean }> {
-  const options = await resolveOwnerOptions(ownerEmail);
-  if (!options) return { localDeleted: false, remoteRevoked: false };
-  const result = await revokeMcpOAuthCredentials(options);
+  const options = scope
+    ? await resolveBuilderOAuthOptionsForScope(ownerEmail, scope, orgId)
+    : await resolveBuilderOAuthOptions(ownerEmail, orgId);
+  let selected: (typeof options)[number] | null = null;
+  for (const candidate of options) {
+    if (
+      (await getOAuthTokens(
+        "mcp",
+        candidate.key,
+        `${candidate.scope}:${candidate.scopeId}`,
+      )) !== null
+    ) {
+      selected = candidate;
+      break;
+    }
+  }
+  if (!selected) return { localDeleted: false, remoteRevoked: false };
+  const result = await revokeMcpOAuthCredentials(selected);
   return {
     localDeleted: result.local === "deleted",
     remoteRevoked: result.remote === "succeeded",

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -90,7 +90,10 @@ async function resolveBuilderOAuthOptions(
 ) {
   const email = normalizeOwnerEmail(ownerEmail);
   const userOptions = userOwnerOptions(email);
-  const resolvedOrgId = orgId?.trim() || (await resolveOrgIdForEmail(email));
+  const resolvedOrgId =
+    orgId === undefined
+      ? await resolveOrgIdForEmail(email)
+      : orgId?.trim() || null;
   return resolvedOrgId
     ? [userOptions, orgOwnerOptions(resolvedOrgId)]
     : [userOptions];
@@ -103,7 +106,9 @@ async function resolveBuilderOAuthOptionsForScope(
 ) {
   if (scope === "user") return [userOwnerOptions(ownerEmail)];
   const resolvedOrgId =
-    orgId?.trim() || (await resolveOrgIdForEmail(ownerEmail));
+    orgId === undefined
+      ? await resolveOrgIdForEmail(ownerEmail)
+      : orgId?.trim() || null;
   return resolvedOrgId ? [orgOwnerOptions(resolvedOrgId)] : [];
 }
 

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -361,6 +361,21 @@ export async function getBuilderOAuthConnectionScope(
   return session?.scope ?? null;
 }
 
+export async function getBuilderOAuthStoredScope(
+  ownerEmail: string,
+  orgId?: string | null,
+): Promise<BuilderOAuthScope | null> {
+  for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
+    const stored = await getOAuthTokens(
+      "mcp",
+      options.key,
+      `${options.scope}:${options.scopeId}`,
+    );
+    if (stored !== null) return options.scope;
+  }
+  return null;
+}
+
 export async function resolveBuilderOAuthRequestAccess(input: {
   ownerEmail: string;
   requiredScope: string;

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -303,7 +303,9 @@ export async function markBuilderOAuthReconnectRequired(
 export async function getBuilderOAuthSession(
   ownerEmail: string,
   orgId?: string | null,
+  requiredScope?: string,
 ): Promise<BuilderOAuthSession | null> {
+  let missingRequiredScope = false;
   for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
     const stored = await getOAuthTokens(
       "mcp",
@@ -318,12 +320,20 @@ export async function getBuilderOAuthSession(
     if (!accessToken) continue;
     const credentials = await readMcpOAuthCredentials(options);
     if (!credentials || !isBuilderCredential(credentials)) continue;
+    const scopes = scopesFrom(credentials);
+    if (requiredScope && !scopes.includes(requiredScope)) {
+      missingRequiredScope = true;
+      continue;
+    }
     return {
       accessToken,
       expiresAt: credentials.tokenExpiresAt,
-      scopes: scopesFrom(credentials),
+      scopes,
       scope: options.scope,
     };
+  }
+  if (requiredScope && missingRequiredScope) {
+    throw new Error(`Builder OAuth connection does not grant ${requiredScope}`);
   }
   return null;
 }
@@ -347,15 +357,8 @@ export async function getBuilderOAuthConnectionScope(
   ownerEmail: string,
   orgId?: string | null,
 ): Promise<BuilderOAuthScope | null> {
-  for (const options of await resolveBuilderOAuthOptions(ownerEmail, orgId)) {
-    const stored = await getOAuthTokens(
-      "mcp",
-      options.key,
-      `${options.scope}:${options.scopeId}`,
-    );
-    if (stored !== null) return options.scope;
-  }
-  return null;
+  const session = await getBuilderOAuthSession(ownerEmail, orgId);
+  return session?.scope ?? null;
 }
 
 export async function resolveBuilderOAuthRequestAccess(input: {
@@ -363,13 +366,12 @@ export async function resolveBuilderOAuthRequestAccess(input: {
   requiredScope: string;
   orgId?: string | null;
 }): Promise<BuilderOAuthRequestAccess | null> {
-  const session = await getBuilderOAuthSession(input.ownerEmail, input.orgId);
+  const session = await getBuilderOAuthSession(
+    input.ownerEmail,
+    input.orgId,
+    input.requiredScope,
+  );
   if (!session) return null;
-  if (!session.scopes.includes(input.requiredScope)) {
-    throw new Error(
-      `Builder OAuth connection does not grant ${input.requiredScope}`,
-    );
-  }
   return { ...session, ownerEmail: input.ownerEmail.trim().toLowerCase() };
 }
 

--- a/packages/core/src/server/core-routes-plugin.builder-connect.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.builder-connect.spec.ts
@@ -1,0 +1,68 @@
+import type { H3Event } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getOrgContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../org/context.js", () => ({
+  getOrgContext: getOrgContextMock,
+}));
+
+import { resolveBuilderOrgMutation } from "./core-routes-plugin.js";
+
+function createMockEvent(): H3Event {
+  return {
+    req: {
+      method: "POST",
+      url: "https://example.com/_agent-native/builder/connect",
+      headers: new Headers({ host: "example.com" }),
+    },
+    url: new URL("https://example.com/_agent-native/builder/connect"),
+    node: {
+      req: {
+        headers: { host: "example.com" },
+        method: "POST",
+        socket: { remoteAddress: "203.0.113.10" },
+        url: "/_agent-native/builder/connect",
+      },
+    },
+    headers: new Headers({ host: "example.com" }),
+    context: {},
+    path: "/_agent-native/builder/connect",
+  } as unknown as H3Event;
+}
+
+beforeEach(() => {
+  getOrgContextMock.mockReset();
+});
+
+describe("resolveBuilderOrgMutation", () => {
+  it("allows any authenticated org member to start Builder connect", async () => {
+    getOrgContextMock.mockResolvedValue({
+      orgId: "org-123",
+      role: "member",
+    });
+
+    await expect(
+      resolveBuilderOrgMutation(createMockEvent(), {
+        allowMemberInitiation: true,
+      }),
+    ).resolves.toEqual({
+      orgId: "org-123",
+      deny: null,
+    });
+  });
+
+  it("keeps shared Builder revocation owner/admin protected", async () => {
+    getOrgContextMock.mockResolvedValue({
+      orgId: "org-123",
+      role: "member",
+    });
+
+    await expect(resolveBuilderOrgMutation(createMockEvent())).resolves.toEqual(
+      {
+        orgId: "org-123",
+        deny: "Only an organization owner or admin can change the shared Builder connection.",
+      },
+    );
+  });
+});

--- a/packages/core/src/server/core-routes-plugin.builder-connect.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.builder-connect.spec.ts
@@ -48,6 +48,7 @@ describe("resolveBuilderOrgMutation", () => {
       }),
     ).resolves.toEqual({
       orgId: "org-123",
+      role: "member",
       deny: null,
     });
   });
@@ -61,6 +62,7 @@ describe("resolveBuilderOrgMutation", () => {
     await expect(resolveBuilderOrgMutation(createMockEvent())).resolves.toEqual(
       {
         orgId: "org-123",
+        role: "member",
         deny: "Only an organization owner or admin can change the shared Builder connection.",
       },
     );

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -178,7 +178,7 @@ import {
   BUILDER_OAUTH_SCOPE,
   deleteBuilderOAuthSession,
   exchangeBuilderOAuthAuthorization,
-  getBuilderOAuthConnectionScope,
+  getBuilderOAuthStoredScope,
   hasBuilderOAuthSession,
   resolveBuilderOAuthRequestAccess,
   saveBuilderOAuthCredentials,
@@ -3618,9 +3618,7 @@ export function createCoreRoutesPlugin(
           }
 
           try {
-            const oauthScope = await getBuilderOAuthConnectionScope(
-              session.email,
-            );
+            const oauthScope = await getBuilderOAuthStoredScope(session.email);
             const hadOAuth = oauthScope !== null;
             // Revoking an org-scoped grant takes the connection offline for
             // every member, so require org owner/admin before doing so.

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -3505,13 +3505,27 @@ export function createCoreRoutesPlugin(
           // PKCE proves the callback belongs to this flow before its pending
           // row is consumed. Persist first so a transient credential-store
           // failure does not strand an otherwise valid pending flow.
+          let callbackRole: string | null = null;
+          if (pending.role === "owner" || pending.role === "admin") {
+            // Re-check authority after the external OAuth round trip. A role
+            // captured at connect start must not authorize a later org write.
+            const currentOrg = await resolveBuilderOrgMutation(event, {
+              allowMemberInitiation: true,
+            });
+            if (
+              currentOrg.orgId === pending.orgId &&
+              (currentOrg.role === "owner" || currentOrg.role === "admin")
+            ) {
+              callbackRole = currentOrg.role;
+            }
+          }
           let credentialScope: "user" | "org" = "user";
           try {
             credentialScope = await saveBuilderOAuthCredentials({
               ownerEmail,
               orgId:
                 typeof pending.orgId === "string" ? pending.orgId : undefined,
-              role: typeof pending.role === "string" ? pending.role : null,
+              role: callbackRole,
               credentials,
             });
           } catch {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -178,6 +178,7 @@ import {
   BUILDER_OAUTH_SCOPE,
   deleteBuilderOAuthSession,
   exchangeBuilderOAuthAuthorization,
+  getBuilderOAuthConnectionScope,
   hasBuilderOAuthSession,
   resolveBuilderOAuthRequestAccess,
   saveBuilderOAuthCredentials,
@@ -472,7 +473,11 @@ async function resolveAgentEngineStatusIdentity(
 export async function resolveBuilderOrgMutation(
   event: H3Event,
   options: { allowMemberInitiation?: boolean } = {},
-): Promise<{ orgId: string | null; deny: string | null }> {
+): Promise<{
+  orgId: string | null;
+  role: string | null;
+  deny: string | null;
+}> {
   let orgId: string | null = null;
   let role: string | null = null;
   try {
@@ -483,19 +488,21 @@ export async function resolveBuilderOrgMutation(
     // coercion-ok: org is missing, it will fail closed
   }
   if (options.allowMemberInitiation) {
-    if (orgId) return { orgId, deny: null };
+    if (orgId) return { orgId, role, deny: null };
     return {
       orgId,
+      role,
       deny: "Only signed-in organization members can connect Builder.",
     };
   }
   if (role !== "owner" && role !== "admin") {
     return {
       orgId,
+      role,
       deny: "Only an organization owner or admin can change the shared Builder connection.",
     };
   }
-  return { orgId, deny: null };
+  return { orgId, role, deny: null };
 }
 
 export function getFrameworkEnvKeys(): EnvKeyConfig[] {
@@ -2881,10 +2888,13 @@ export function createCoreRoutesPlugin(
               parentOrigin: getBuilderBrowserOriginForEvent(event),
             });
           }
-          const { orgId: connectOrgId, deny: orgConnectDenied } =
-            await resolveBuilderOrgMutation(event, {
-              allowMemberInitiation: true,
-            });
+          const {
+            orgId: connectOrgId,
+            role: connectRole,
+            deny: orgConnectDenied,
+          } = await resolveBuilderOrgMutation(event, {
+            allowMemberInitiation: true,
+          });
           if (orgConnectDenied) {
             await trackBuilderLifecycle(
               event,
@@ -2924,7 +2934,7 @@ export function createCoreRoutesPlugin(
             await putSetting(`builder-connect-pending:${state}`, {
               ownerEmail,
               orgId: connectOrgId,
-              role: null,
+              role: connectRole,
               encryptedOAuthFlow: encryptSecretValue(JSON.stringify(oauthFlow)),
               redirectUri: callbackUrl,
               expiresAt: Date.now() + BUILDER_CONNECT_PENDING_TTL_MS,
@@ -3495,11 +3505,13 @@ export function createCoreRoutesPlugin(
           // PKCE proves the callback belongs to this flow before its pending
           // row is consumed. Persist first so a transient credential-store
           // failure does not strand an otherwise valid pending flow.
+          let credentialScope: "user" | "org" = "user";
           try {
-            await saveBuilderOAuthCredentials({
+            credentialScope = await saveBuilderOAuthCredentials({
               ownerEmail,
               orgId:
                 typeof pending.orgId === "string" ? pending.orgId : undefined,
+              role: typeof pending.role === "string" ? pending.role : null,
               credentials,
             });
           } catch {
@@ -3563,7 +3575,7 @@ export function createCoreRoutesPlugin(
             {
               ...builderConnectTrackingProperties(tracking),
               stage: "callback",
-              credential_scope: "user",
+              credential_scope: credentialScope,
             },
           );
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
@@ -3592,18 +3604,21 @@ export function createCoreRoutesPlugin(
           }
 
           try {
-            const hadOAuth = await hasBuilderOAuthSession(session.email);
+            const oauthScope = await getBuilderOAuthConnectionScope(
+              session.email,
+            );
+            const hadOAuth = oauthScope !== null;
             // Revoking an org-scoped grant takes the connection offline for
             // every member, so require org owner/admin before doing so.
-            if (hadOAuth) {
+            if (oauthScope === "org") {
               const { deny } = await resolveBuilderOrgMutation(event);
               if (deny) {
                 setResponseStatus(event, 403);
                 return { error: deny };
               }
             }
-            const oauthResult = hadOAuth
-              ? await deleteBuilderOAuthSession(session.email)
+            const oauthResult = oauthScope
+              ? await deleteBuilderOAuthSession(session.email, oauthScope)
               : { localDeleted: false, remoteRevoked: false };
             const { deleteBuilderCredentials } =
               await import("./credential-provider.js");
@@ -3619,7 +3634,7 @@ export function createCoreRoutesPlugin(
             }
             await deleteBuilderCredentials(
               session.email,
-              hadOAuth ? undefined : { orgId, role },
+              oauthScope ? undefined : { orgId, role },
             );
             await trackBuilderLifecycle(
               event,

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -464,15 +464,14 @@ async function resolveAgentEngineStatusIdentity(
 }
 
 /**
- * A Builder grant is shared by everyone in the caller's org, so establishing,
- * overwriting, or revoking one requires org owner/admin authority. Returns the
- * authorized org id and a denial message (null when allowed). The org id is
- * captured at connect start so the grant is stored under the org that was
- * authorized, not one re-resolved after the OAuth round trip. Fails closed: an
- * unreadable owner/admin role is denied.
+ * Shared Builder grants stay org-scoped, but connect initiation can come from
+ * any authenticated member. Revocation still needs owner/admin authority.
+ * Capture the org id at connect start so the grant is stored under the org
+ * that was authorized, not one re-resolved after the OAuth round trip.
  */
-async function resolveBuilderOrgMutation(
+export async function resolveBuilderOrgMutation(
   event: H3Event,
+  options: { allowMemberInitiation?: boolean } = {},
 ): Promise<{ orgId: string | null; deny: string | null }> {
   let orgId: string | null = null;
   let role: string | null = null;
@@ -482,6 +481,13 @@ async function resolveBuilderOrgMutation(
     role = orgCtx.role ?? null;
   } catch {
     // coercion-ok: org is missing, it will fail closed
+  }
+  if (options.allowMemberInitiation) {
+    if (orgId) return { orgId, deny: null };
+    return {
+      orgId,
+      deny: "Only signed-in organization members can connect Builder.",
+    };
   }
   if (role !== "owner" && role !== "admin") {
     return {
@@ -2876,7 +2882,9 @@ export function createCoreRoutesPlugin(
             });
           }
           const { orgId: connectOrgId, deny: orgConnectDenied } =
-            await resolveBuilderOrgMutation(event);
+            await resolveBuilderOrgMutation(event, {
+              allowMemberInitiation: true,
+            });
           if (orgConnectDenied) {
             await trackBuilderLifecycle(
               event,
@@ -2896,7 +2904,7 @@ export function createCoreRoutesPlugin(
             );
             return createBuilderBrowserCallbackErrorPage(orgConnectDenied, {
               title: "Not allowed to connect Builder for this organization",
-              body: "Ask an organization owner or admin to connect Builder.",
+              body: orgConnectDenied,
               parentOrigin: getBuilderBrowserOriginForEvent(event),
             });
           }

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2397,7 +2397,10 @@ export function createCoreRoutesPlugin(
               > = null;
               let hasOAuthCustody = false;
               try {
-                hasOAuthCustody = await hasBuilderOAuthSession(userEmail);
+                hasOAuthCustody = await hasBuilderOAuthSession(
+                  userEmail,
+                  orgId,
+                );
               } catch {
                 return withConnectToken({
                   ...requestStatus,
@@ -2417,6 +2420,7 @@ export function createCoreRoutesPlugin(
                   oauthAccess = await resolveBuilderOAuthRequestAccess({
                     ownerEmail: userEmail,
                     requiredScope: BUILDER_OAUTH_SCOPE,
+                    orgId,
                   });
                 } catch {
                   oauthAccess = null;
@@ -3618,20 +3622,6 @@ export function createCoreRoutesPlugin(
           }
 
           try {
-            const oauthScope = await getBuilderOAuthStoredScope(session.email);
-            const hadOAuth = oauthScope !== null;
-            // Revoking an org-scoped grant takes the connection offline for
-            // every member, so require org owner/admin before doing so.
-            if (oauthScope === "org") {
-              const { deny } = await resolveBuilderOrgMutation(event);
-              if (deny) {
-                setResponseStatus(event, 403);
-                return { error: deny };
-              }
-            }
-            const oauthResult = oauthScope
-              ? await deleteBuilderOAuthSession(session.email, oauthScope)
-              : { localDeleted: false, remoteRevoked: false };
             const { deleteBuilderCredentials } =
               await import("./credential-provider.js");
             let orgId: string | null = null;
@@ -3644,6 +3634,27 @@ export function createCoreRoutesPlugin(
             } catch {
               // coercion-ok: org module is optional; disconnect still clears user-scoped custody.
             }
+            const oauthScope = await getBuilderOAuthStoredScope(
+              session.email,
+              orgId,
+            );
+            const hadOAuth = oauthScope !== null;
+            // Revoking an org-scoped grant takes the connection offline for
+            // every member, so require org owner/admin before doing so.
+            if (oauthScope === "org") {
+              const { deny } = await resolveBuilderOrgMutation(event);
+              if (deny) {
+                setResponseStatus(event, 403);
+                return { error: deny };
+              }
+            }
+            const oauthResult = oauthScope
+              ? await deleteBuilderOAuthSession(
+                  session.email,
+                  oauthScope,
+                  orgId,
+                )
+              : { localDeleted: false, remoteRevoked: false };
             await deleteBuilderCredentials(
               session.email,
               oauthScope ? undefined : { orgId, role },


### PR DESCRIPTION
## Summary

- hide unconfigured direct Gemini and OpenRouter model groups while keeping Builder catalog support authoritative
- allow any signed-in organization member to initiate the shared Builder connection, while keeping org-scoped grant revocation owner/admin-only
- cap provider tool payloads at 128 and preserve tool-search
- prevent rejected credentials and user-stopped runs from entering automatic reconnect recovery

The only real local OpenRouter key found was removed from the unrelated benchmark .env. Framework env files, process env, and Design production/beta/account deployment env names contain no matching OpenRouter or Gemini credentials.

## Validation

- focused core Vitest: 244 passed
- toolkit build passed
- git diff --check passed
- guards: all changed-line/code-specific checks passed; four existing checkout/baseline checks remain blocked by missing recap artifacts, existing i18n baseline/import debt, and the intentionally untracked file before staging
- core typecheck remains blocked by unrelated sparse-checkout baseline module-resolution errors; changed files were not reported

Slack feedback addressed:
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787958894058039
- https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1787959878313049