### PR TITLE
fix(clips): keep recording pill visible through countdown

### DIFF
--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1044,7 +1044,6 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
         set_capture_excluded(&existing);
         configure_overlay_behavior(&existing);
         raise_to_status_level(&existing);
-        crate::util::show_without_activation(&existing);
         return Ok(());
     }
     #[allow(unused_mut)]

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1029,7 +1029,7 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     // lands on the tray monitor (clamped so a monitor change can't strand
     // the pill off-screen).
     let default_x: i32 = mx + (mw as i32 - w as i32) / 2;
-    let default_y: i32 = my + mh as i32 - h as i32 - (48.0 * scale).round() as i32;
+    let default_y: i32 = my + mh as i32 - h as i32 - (20.0 * scale).round() as i32;
     let (x, y) = match load_toolbar_position(&app) {
         Some((sx, sy)) => (
             sx.clamp(mx, mx + mw as i32 - w as i32),
@@ -1044,6 +1044,7 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
         set_capture_excluded(&existing);
         configure_overlay_behavior(&existing);
         raise_to_status_level(&existing);
+        crate::util::show_without_activation(&existing);
         return Ok(());
     }
     #[allow(unused_mut)]
@@ -1080,19 +1081,18 @@ pub async fn show_toolbar(app: AppHandle) -> Result<(), String> {
     set_capture_excluded(&win);
     configure_overlay_behavior(&win);
     raise_to_status_level(&win);
-    // Deliberately NOT shown here. The pill owns its visibility through
-    // `toolbar_set_visible`: it stays hidden through pre-record and the
-    // countdown and appears only once the recorder reports capture live —
-    // recording controls before recording exists read as a broken state.
-    dlog!("[clips-tray] toolbar created (hidden until capture is live)");
+    // Deliberately NOT shown here. The renderer owns visibility through
+    // `toolbar_set_visible` so the window can mount in its disabled state
+    // before capture is live.
+    dlog!("[clips-tray] toolbar created (hidden until renderer is ready)");
 
     Ok(())
 }
 
 /// Show or hide the recording pill without activating it. Visibility is
-/// driven entirely by the pill renderer: hidden while the recorder is
-/// preparing or counting down, visible while capture is live or the
-/// completion card is up.
+/// driven entirely by the pill renderer: visible while the recorder is
+/// preparing, counting down, or capturing, and while the completion card is
+/// up.
 #[tauri::command]
 pub async fn toolbar_set_visible(app: AppHandle, visible: bool) -> Result<(), String> {
     let Some(win) = app.get_webview_window(TOOLBAR_LABEL) else {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -6008,8 +6008,6 @@ function Setup({
     featureConfig?.screenMemory ?? DEFAULT_SCREEN_MEMORY_CONFIG;
   const [screenMemory, setScreenMemory] = useState(observedScreenMemory);
   const [rewindConsentOpen, setRewindConsentOpen] = useState(false);
-  const [rewindManageOpen, setRewindManageOpen] = useState(false);
-  const [rewindShowAdvanced, setRewindShowAdvanced] = useState(false);
   const screenMemoryRef = useRef(observedScreenMemory);
   const screenMemoryMutationRef = useRef(0);
   const screenMemoryMutationVersionRef = useRef(0);
@@ -7134,6 +7132,19 @@ function Setup({
     return (
       <div className="mx-auto grid w-full max-w-[620px] gap-7 pb-4">
         <SettingsGroup>
+          {/* A confirmation, so a dialog rather than a takeover: the user is
+              answering one question about the screen behind it, not moving to
+              a new place. What it remembers is chosen afterwards, in the row
+              below — asking before they have agreed puts the options in front
+              of the decision.
+
+              The copy names what is captured and what can leave, and nothing
+              else. Two claims are tempting and both are false: this buffer
+              holds screen *video* (hence the GB disk limit below), not app
+              and window notes; and it cannot promise "never leaves this Mac"
+              because the agent-handoff path uploads an approved range. A
+              consent screen is the one place a comforting simplification is
+              indistinguishable from a lie. */}
           <UiAlertDialog
             open={rewindConsentOpen}
             onOpenChange={setRewindConsentOpen}
@@ -7178,397 +7189,24 @@ function Setup({
             label="Rewind"
             description="Keeps a rolling record of your recent screen on this device"
             control={
-              <div className="flex items-center gap-2">
-                <SettingsPopover
-                  title="Rewind settings"
-                  open={rewindManageOpen}
-                  onOpenChange={setRewindManageOpen}
-                  className="w-[480px] max-w-[calc(100vw-24px)]"
-                  trigger={
-                    <SettingsActionButton
-                      aria-expanded={rewindManageOpen}
-                      aria-haspopup="dialog"
-                    >
-                      Manage
-                    </SettingsActionButton>
+              <SettingsSwitch
+                checked={rewindOn}
+                onCheckedChange={(next) => {
+                  // Turning it on starts continuously capturing the screen, so
+                  // it routes through consent rather than flipping silently.
+                  // Turning it off needs no confirmation — stopping is safe.
+                  if (next) {
+                    setRewindConsentOpen(true);
+                    return;
                   }
-                >
-                  <div className="grid max-h-[min(620px,calc(100vh-80px))] gap-3 overflow-y-auto pr-1">
-                    {rewindOn ? (
-                      <>
-                        <SettingsGroup label="Capture">
-                          <SettingsRow
-                            label="Remember"
-                            description="Choose what Rewind captures"
-                            control={
-                              <SettingsSelect
-                                ariaLabel="What Rewind remembers"
-                                value={screenMemory.captureMode ?? "visuals"}
-                                onValueChange={(value) => {
-                                  void setScreenMemoryConfig({
-                                    captureMode: value as RewindCaptureMode,
-                                  });
-                                }}
-                                disabled={
-                                  screenMemoryConfigBusy ||
-                                  captureControlsLocked
-                                }
-                                options={[
-                                  { value: "visuals", label: "Screen only" },
-                                  {
-                                    value: "visuals-audio",
-                                    label: "Screen + audio",
-                                  },
-                                ]}
-                              />
-                            }
-                          />
-                          <SettingsRow
-                            label="Time limit"
-                            description="Choose how long Rewind keeps your screen history"
-                            control={
-                              <SettingsSelect
-                                ariaLabel="Rewind time limit"
-                                placeholder={`${screenMemory.retentionHours} hours`}
-                                value={String(screenMemory.retentionHours)}
-                                onValueChange={(value) => {
-                                  void setScreenMemoryConfig({
-                                    retentionHours: Number(value),
-                                  });
-                                }}
-                                disabled={screenMemoryConfigBusy}
-                                options={[
-                                  { value: "8", label: "8 hours" },
-                                  { value: "24", label: "24 hours" },
-                                ]}
-                              />
-                            }
-                          />
-                          <SettingsRow
-                            label="Storage limit"
-                            description="Choose how much space Rewind can use on this device"
-                            control={
-                              <SettingsSelect
-                                ariaLabel="Rewind storage limit"
-                                placeholder={formatStorageBytes(
-                                  screenMemory.maxBytes,
-                                )}
-                                value={String(screenMemory.maxBytes)}
-                                onValueChange={(value) => {
-                                  void setScreenMemoryConfig({
-                                    maxBytes: Number(value),
-                                  });
-                                }}
-                                disabled={screenMemoryConfigBusy}
-                                options={[
-                                  {
-                                    value: String(5 * 1024 * 1024 * 1024),
-                                    label: "5 GB",
-                                  },
-                                  {
-                                    value: String(20 * 1024 * 1024 * 1024),
-                                    label: "20 GB",
-                                  },
-                                  {
-                                    value: String(50 * 1024 * 1024 * 1024),
-                                    label: "50 GB",
-                                  },
-                                ]}
-                              />
-                            }
-                          />
-                        </SettingsGroup>
-                        <SettingsActionButton
-                          emphasis="quiet"
-                          className="justify-self-start"
-                          aria-expanded={rewindShowAdvanced}
-                          onClick={() =>
-                            setRewindShowAdvanced((current) => !current)
-                          }
-                        >
-                          {rewindShowAdvanced
-                            ? "Hide advanced"
-                            : "Show advanced"}
-                        </SettingsActionButton>
-                        {rewindShowAdvanced ? (
-                          <>
-                            <SettingsGroup label="Privacy">
-                              <SettingsRow
-                                label="Excluded apps"
-                                description="Apps Rewind never captures"
-                                control={
-                                  <SettingsActionButton
-                                    onClick={() =>
-                                      void chooseExcludedApplications()
-                                    }
-                                    disabled={excludedAppsBusy}
-                                  >
-                                    Choose apps
-                                  </SettingsActionButton>
-                                }
-                              >
-                                {excludedAppGroups.length > 0 ? (
-                                  <div className="grid gap-1">
-                                    {excludedAppGroups.map((app) => (
-                                      <div
-                                        key={app.bundleIds.join(",")}
-                                        className="flex items-center justify-between gap-2"
-                                      >
-                                        <span className="truncate">
-                                          {app.name}
-                                        </span>
-                                        <SettingsActionButton
-                                          emphasis="quiet"
-                                          onClick={() =>
-                                            removeExcludedApplications(
-                                              app.bundleIds,
-                                            )
-                                          }
-                                        >
-                                          Remove
-                                        </SettingsActionButton>
-                                      </div>
-                                    ))}
-                                  </div>
-                                ) : null}
-                              </SettingsRow>
-                              <SettingsRow
-                                label="Review before sending"
-                                description="Approve each visual or audio range before an agent receives it"
-                                control={
-                                  <SettingsSwitch
-                                    checked={
-                                      screenMemory.reviewBeforeSending !== false
-                                    }
-                                    onCheckedChange={(next) => {
-                                      void setScreenMemoryConfig({
-                                        reviewBeforeSending: next,
-                                      });
-                                    }}
-                                    disabled={screenMemoryConfigBusy}
-                                    label="Review before sending"
-                                  />
-                                }
-                              />
-                              <SettingsRow
-                                label="Preview before sending"
-                                description="Open the range locally so you see exactly what is sent"
-                                control={
-                                  <SettingsSwitch
-                                    checked={
-                                      screenMemory.autoPreviewBeforeSending ===
-                                      true
-                                    }
-                                    onCheckedChange={(next) => {
-                                      void setScreenMemoryConfig({
-                                        autoPreviewBeforeSending: next,
-                                      });
-                                    }}
-                                    disabled={screenMemoryConfigBusy}
-                                    label="Preview before sending"
-                                  />
-                                }
-                              />
-                              <SettingsRow
-                                label="Keep agent Clips"
-                                description="Choose how long Clips made for agents stay in your library"
-                                control={
-                                  <SettingsSelect
-                                    ariaLabel="How long agent-created Clips are kept"
-                                    value={screenMemory.agentClipRetention}
-                                    onValueChange={(value) => {
-                                      void setScreenMemoryConfig({
-                                        agentClipRetention:
-                                          value as ScreenMemoryStatus["config"]["agentClipRetention"],
-                                      });
-                                    }}
-                                    disabled={screenMemoryConfigBusy}
-                                    options={[
-                                      {
-                                        value: "forever",
-                                        label: "Forever",
-                                      },
-                                      {
-                                        value: "24-hours",
-                                        label: "24 hours",
-                                      },
-                                      {
-                                        value: "7-days",
-                                        label: "7 days",
-                                      },
-                                      {
-                                        value: "30-days",
-                                        label: "30 days",
-                                      },
-                                    ]}
-                                  />
-                                }
-                              />
-                              <SettingsRow
-                                label="Agent activity"
-                                description="Each time an agent searched this device's memory, newest first"
-                              >
-                                {rewindEgressEvents.length === 0 ? (
-                                  <p>No agent has searched it yet.</p>
-                                ) : (
-                                  <div className="grid gap-1">
-                                    {rewindEgressEvents
-                                      .slice(0, 10)
-                                      .map((event) => (
-                                        <div
-                                          key={`${event.requestId}-${event.state}`}
-                                          className="flex items-center justify-between gap-2"
-                                        >
-                                          <span className="truncate">
-                                            {new Date(
-                                              event.occurredAt,
-                                            ).toLocaleString()}
-                                          </span>
-                                          <span className="shrink-0">
-                                            {event.state} ·{" "}
-                                            {`${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
-                                          </span>
-                                        </div>
-                                      ))}
-                                  </div>
-                                )}
-                              </SettingsRow>
-                            </SettingsGroup>
-
-                            <SettingsGroup label="Agents">
-                              <SettingsRow
-                                label="Setup prompt"
-                                description="Paste it into an agent once to install Rewind's instructions"
-                                control={
-                                  <>
-                                    <SettingsActionButton
-                                      emphasis="quiet"
-                                      onClick={onOpenRewindDocs}
-                                    >
-                                      Learn more
-                                    </SettingsActionButton>
-                                    <SettingsActionButton
-                                      onClick={onCopyRewindAgentPrompt}
-                                    >
-                                      {rewindAgentPromptCopied
-                                        ? "Copied"
-                                        : "Copy"}
-                                    </SettingsActionButton>
-                                  </>
-                                }
-                              />
-                              <SettingsRow
-                                label="Connect an agent"
-                                description="Gives a local agent access to this device's Rewind memory"
-                                control={
-                                  <>
-                                    <SettingsActionButton
-                                      onClick={() =>
-                                        void installRewindAgentConnection(
-                                          "codex",
-                                        )
-                                      }
-                                      disabled={agentConnectionBusy !== null}
-                                    >
-                                      Codex
-                                    </SettingsActionButton>
-                                    <SettingsActionButton
-                                      onClick={() =>
-                                        void installRewindAgentConnection(
-                                          "claude-code",
-                                        )
-                                      }
-                                      disabled={agentConnectionBusy !== null}
-                                    >
-                                      Claude Code
-                                    </SettingsActionButton>
-                                  </>
-                                }
-                              >
-                                {agentConnectionMessage ? (
-                                  <p
-                                    className={
-                                      agentConnectionMessage.kind === "ok"
-                                        ? "text-xs text-success"
-                                        : "text-xs text-destructive"
-                                    }
-                                  >
-                                    {agentConnectionMessage.text}
-                                  </p>
-                                ) : null}
-                              </SettingsRow>
-                            </SettingsGroup>
-
-                            <SettingsGroup label="Storage">
-                              <SettingsRow
-                                label="Search memory"
-                                description="Find and replay a recent moment yourself"
-                                control={
-                                  <SettingsActionButton onClick={onOpenMemory}>
-                                    Search
-                                  </SettingsActionButton>
-                                }
-                              />
-                              <SettingsRow
-                                label="Save last 5 minutes"
-                                description="Exports recent memory as video files on this device. Nothing is uploaded."
-                                control={
-                                  <SettingsActionButton
-                                    onClick={() =>
-                                      void exportScreenMemoryRecent()
-                                    }
-                                    disabled={screenMemoryBusy}
-                                  >
-                                    Save
-                                  </SettingsActionButton>
-                                }
-                              />
-                              <SettingsRow
-                                label="On this device"
-                                description={`${screenMemorySegments.length} ${screenMemorySegments.length === 1 ? "segment" : "segments"} · ${formatStorageBytes(screenMemoryTotalBytes)}`}
-                                control={
-                                  <>
-                                    <SettingsActionButton
-                                      onClick={openScreenMemoryFolder}
-                                    >
-                                      Open folder
-                                    </SettingsActionButton>
-                                    <SettingsActionButton
-                                      emphasis="destructive"
-                                      onClick={() => void clearScreenMemory()}
-                                      disabled={screenMemoryBusy}
-                                    >
-                                      Delete all
-                                    </SettingsActionButton>
-                                  </>
-                                }
-                              />
-                            </SettingsGroup>
-                          </>
-                        ) : null}
-                      </>
-                    ) : (
-                      <SettingsGroup>
-                        <div className="p-3 text-sm text-muted-foreground">
-                          Turn on Rewind to manage what it remembers.
-                        </div>
-                      </SettingsGroup>
-                    )}
-                  </div>
-                </SettingsPopover>
-                <SettingsSwitch
-                  checked={rewindOn}
-                  onCheckedChange={(next) => {
-                    if (next) {
-                      setRewindConsentOpen(true);
-                      return;
-                    }
-                    void setScreenMemoryConfig({ enabled: false });
-                  }}
-                  disabled={screenMemoryConfigBusy || captureControlsLocked}
-                  label="Rewind"
-                />
-              </div>
+                  void setScreenMemoryConfig({ enabled: false });
+                }}
+                /* Rust rejects Rewind capture changes mid-Clip
+                   (config.rs `set_feature_config` guard); disabling here
+                   turns that hard error into a visible lock. */
+                disabled={screenMemoryConfigBusy || captureControlsLocked}
+                label="Rewind"
+              />
             }
           >
             {screenMemoryMessage ? (
@@ -7587,7 +7225,294 @@ function Setup({
               </p>
             ) : null}
           </SettingsRow>
+          {rewindOn ? (
+            <>
+              <SettingsRow
+                label="Remember"
+                description="Choose what Rewind captures"
+                control={
+                  <SettingsSelect
+                    ariaLabel="What Rewind remembers"
+                    value={screenMemory.captureMode ?? "visuals"}
+                    onValueChange={(value) => {
+                      void setScreenMemoryConfig({
+                        captureMode: value as RewindCaptureMode,
+                      });
+                    }}
+                    disabled={screenMemoryConfigBusy || captureControlsLocked}
+                    options={[
+                      { value: "visuals", label: "Screen only" },
+                      { value: "visuals-audio", label: "Screen + audio" },
+                    ]}
+                  />
+                }
+              />
+              <SettingsRow
+                label="Time limit"
+                description="Choose how long Rewind keeps your screen history"
+                control={
+                  <SettingsSelect
+                    ariaLabel="Rewind time limit"
+                    placeholder={`${screenMemory.retentionHours} hours`}
+                    value={String(screenMemory.retentionHours)}
+                    onValueChange={(value) => {
+                      void setScreenMemoryConfig({
+                        retentionHours: Number(value),
+                      });
+                    }}
+                    disabled={screenMemoryConfigBusy}
+                    options={[
+                      { value: "8", label: "8 hours" },
+                      { value: "24", label: "24 hours" },
+                    ]}
+                  />
+                }
+              />
+              <SettingsRow
+                label="Storage limit"
+                description="Choose how much space Rewind can use on this device"
+                control={
+                  <SettingsSelect
+                    ariaLabel="Rewind storage limit"
+                    placeholder={formatStorageBytes(screenMemory.maxBytes)}
+                    value={String(screenMemory.maxBytes)}
+                    onValueChange={(value) => {
+                      void setScreenMemoryConfig({ maxBytes: Number(value) });
+                    }}
+                    disabled={screenMemoryConfigBusy}
+                    options={[
+                      { value: String(5 * 1024 * 1024 * 1024), label: "5 GB" },
+                      {
+                        value: String(20 * 1024 * 1024 * 1024),
+                        label: "20 GB",
+                      },
+                      {
+                        value: String(50 * 1024 * 1024 * 1024),
+                        label: "50 GB",
+                      },
+                    ]}
+                  />
+                }
+              />
+            </>
+          ) : null}
         </SettingsGroup>
+
+        {rewindOn ? (
+          <>
+            <SettingsGroup label="Privacy">
+              <SettingsRow
+                label="Excluded apps"
+                description={"Apps Rewind never captures"}
+                control={
+                  <SettingsActionButton
+                    onClick={() => void chooseExcludedApplications()}
+                    disabled={excludedAppsBusy}
+                  >
+                    Choose apps
+                  </SettingsActionButton>
+                }
+              >
+                {excludedAppGroups.length > 0 ? (
+                  <div className="grid gap-1">
+                    {excludedAppGroups.map((app) => (
+                      <div
+                        key={app.bundleIds.join(",")}
+                        className="flex items-center justify-between gap-2"
+                      >
+                        <span className="truncate">{app.name}</span>
+                        <SettingsActionButton
+                          emphasis="quiet"
+                          onClick={() =>
+                            removeExcludedApplications(app.bundleIds)
+                          }
+                        >
+                          Remove
+                        </SettingsActionButton>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </SettingsRow>
+              <SettingsRow
+                label="Review before sending"
+                description="Approve each visual or audio range before an agent receives it"
+                control={
+                  <SettingsSwitch
+                    checked={screenMemory.reviewBeforeSending !== false}
+                    onCheckedChange={(next) => {
+                      void setScreenMemoryConfig({
+                        reviewBeforeSending: next,
+                      });
+                    }}
+                    disabled={screenMemoryConfigBusy}
+                    label="Review before sending"
+                  />
+                }
+              />
+              <SettingsRow
+                label="Preview before sending"
+                description="Open the range locally so you see exactly what is sent"
+                control={
+                  <SettingsSwitch
+                    checked={screenMemory.autoPreviewBeforeSending === true}
+                    onCheckedChange={(next) => {
+                      void setScreenMemoryConfig({
+                        autoPreviewBeforeSending: next,
+                      });
+                    }}
+                    disabled={screenMemoryConfigBusy}
+                    label="Preview before sending"
+                  />
+                }
+              />
+              <SettingsRow
+                label="Keep agent Clips"
+                description="Choose how long Clips made for agents stay in your library"
+                control={
+                  <SettingsSelect
+                    ariaLabel="How long agent-created Clips are kept"
+                    value={screenMemory.agentClipRetention}
+                    onValueChange={(value) => {
+                      void setScreenMemoryConfig({
+                        agentClipRetention:
+                          value as ScreenMemoryStatus["config"]["agentClipRetention"],
+                      });
+                    }}
+                    disabled={screenMemoryConfigBusy}
+                    options={[
+                      { value: "forever", label: "Forever" },
+                      { value: "24-hours", label: "24 hours" },
+                      { value: "7-days", label: "7 days" },
+                      { value: "30-days", label: "30 days" },
+                    ]}
+                  />
+                }
+              />
+              <SettingsRow
+                label="Agent activity"
+                description="Each time an agent searched this device's memory, newest first"
+              >
+                {rewindEgressEvents.length === 0 ? (
+                  <p>No agent has searched it yet.</p>
+                ) : (
+                  <div className="grid gap-1">
+                    {rewindEgressEvents.slice(0, 10).map((event) => (
+                      <div
+                        key={`${event.requestId}-${event.state}`}
+                        className="flex items-center justify-between gap-2"
+                      >
+                        <span className="truncate">
+                          {new Date(event.occurredAt).toLocaleString()}
+                        </span>
+                        <span className="shrink-0">
+                          {event.state} ·{" "}
+                          {`${event.evidenceCount} item${event.evidenceCount === 1 ? "" : "s"}`}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </SettingsRow>
+            </SettingsGroup>
+
+            <SettingsGroup label="Agents">
+              <SettingsRow
+                label="Setup prompt"
+                description="Paste it into an agent once to install Rewind's instructions"
+                control={
+                  <>
+                    <SettingsActionButton
+                      emphasis="quiet"
+                      onClick={onOpenRewindDocs}
+                    >
+                      Learn more
+                    </SettingsActionButton>
+                    <SettingsActionButton onClick={onCopyRewindAgentPrompt}>
+                      {rewindAgentPromptCopied ? "Copied" : "Copy"}
+                    </SettingsActionButton>
+                  </>
+                }
+              />
+              <SettingsRow
+                label="Connect an agent"
+                description="Gives a local agent access to this device's Rewind memory"
+                control={
+                  <>
+                    <SettingsActionButton
+                      onClick={() => void installRewindAgentConnection("codex")}
+                      disabled={agentConnectionBusy !== null}
+                    >
+                      Codex
+                    </SettingsActionButton>
+                    <SettingsActionButton
+                      onClick={() =>
+                        void installRewindAgentConnection("claude-code")
+                      }
+                      disabled={agentConnectionBusy !== null}
+                    >
+                      Claude Code
+                    </SettingsActionButton>
+                  </>
+                }
+              >
+                {agentConnectionMessage ? (
+                  <p
+                    className={
+                      agentConnectionMessage.kind === "ok"
+                        ? "text-xs text-success"
+                        : "text-xs text-destructive"
+                    }
+                  >
+                    {agentConnectionMessage.text}
+                  </p>
+                ) : null}
+              </SettingsRow>
+            </SettingsGroup>
+
+            <SettingsGroup label="Storage">
+              <SettingsRow
+                label="Search memory"
+                description="Find and replay a recent moment yourself"
+                control={
+                  <SettingsActionButton onClick={onOpenMemory}>
+                    Search
+                  </SettingsActionButton>
+                }
+              />
+              <SettingsRow
+                label="Save last 5 minutes"
+                description="Exports recent memory as video files on this device. Nothing is uploaded."
+                control={
+                  <SettingsActionButton
+                    onClick={() => void exportScreenMemoryRecent()}
+                    disabled={screenMemoryBusy}
+                  >
+                    Save
+                  </SettingsActionButton>
+                }
+              />
+              <SettingsRow
+                label="On this device"
+                description={`${screenMemorySegments.length} ${screenMemorySegments.length === 1 ? "segment" : "segments"} · ${formatStorageBytes(screenMemoryTotalBytes)}`}
+                control={
+                  <>
+                    <SettingsActionButton onClick={openScreenMemoryFolder}>
+                      Open folder
+                    </SettingsActionButton>
+                    <SettingsActionButton
+                      emphasis="destructive"
+                      onClick={() => void clearScreenMemory()}
+                      disabled={screenMemoryBusy}
+                    >
+                      Delete all
+                    </SettingsActionButton>
+                  </>
+                }
+              />
+            </SettingsGroup>
+          </>
+        ) : null}
       </div>
     );
   }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2760,9 +2760,8 @@ export function App({
   });
 
   bubbleActiveRef.current = bubbleActive;
-  // The toolbar is recording chrome, not pre-record chrome. Showing it while
-  // the popover is merely open leaves a disabled 0:00 Stop/Pause pill on the
-  // desktop, which reads as a stuck recorder and can trap accessibility clicks.
+  // The toolbar is recording chrome. It is created once the recording flow
+  // starts, then stays visible but disabled until capture is live.
   const toolbarActive = isRecording || recordingFlowActive;
 
   useEffect(() => {
@@ -3493,8 +3492,7 @@ export function App({
     // Tell Rust we're entering the recording flow NOW, not after the
     // handle arrives. The macOS screen-picker dialog steals focus from
     // the popover, which would otherwise trigger the blur-auto-hide
-    // mid-setup — so the countdown and toolbar render behind a hidden
-    // popover and the user sees nothing happen.
+    // mid-setup — so the countdown and toolbar can render during setup.
     invoke("set_recording_state", { active: true }).catch(() => {});
 
     // Hand the live camera stream to the recorder so it doesn't

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2779,6 +2779,9 @@ export function App({
     // otherwise arrive after the recorder's enabled event and strand the
     // toolbar at 0:00.
     emit("clips:toolbar-enabled", false).catch(() => {});
+    // Tell a reused pill to reappear in its disabled state for the next
+    // preparation/countdown after a restart.
+    emit("clips:toolbar-preparing").catch(() => {});
     return () => {
       cancelled = true;
       // In screen-only mode the bubble effect never runs, so its

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2467,6 +2467,7 @@ async function runRecordingCountdown(
     console.log(`[rewind-latency] countdown completion cause=${cause}`);
   } catch (err) {
     if (isCountdownCancelledError(err)) {
+      await emit("clips:toolbar-hidden").catch(() => {});
       await invoke("hide_recording_chrome").catch(() => {});
       throw err;
     }

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -2454,6 +2454,9 @@ async function runRecordingCountdown(
   let countdownGeneration: number;
   try {
     countdownGeneration = await invoke<number>("show_countdown");
+    // The countdown is a focused full-screen window. Re-show the disabled pill
+    // after it appears so it remains above that overlay while the count runs.
+    await invoke("toolbar_set_visible", { visible: true }).catch(() => {});
   } catch (err) {
     console.error("[clips-recorder] show_countdown failed:", err);
     countdown.cleanup();

--- a/templates/clips/desktop/src/overlays/countdown.tsx
+++ b/templates/clips/desktop/src/overlays/countdown.tsx
@@ -80,14 +80,6 @@ export function Countdown() {
           <IconPlayerSkipForwardFilled size={28} />
         </button>
       </div>
-      <div className="countdown-hint" aria-label="Countdown shortcuts">
-        <span>
-          <kbd>Esc</kbd> cancel
-        </span>
-        <span>
-          <kbd>Return</kbd> start now
-        </span>
-      </div>
     </div>
   );
 }

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -403,6 +403,7 @@ export function RecordingPill() {
         getCurrentWindow()
           .close()
           .catch(() => {});
+      else resetToRest();
     });
   }
 

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -645,13 +645,10 @@ export function RecordingPill() {
     if (!hasTauri) return;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let unlisten: (() => void) | null = null;
+    let lastDraggedPosition: { x: number; y: number } | null = null;
 
     function saveDraggedPosition() {
       if (!userDragActiveRef.current) return;
-      if (modeRef.current !== "recording") {
-        userDragActiveRef.current = false;
-        return;
-      }
       const saveGeneration = userDragGenerationRef.current;
       const saveChange = userDragChangeRef.current;
       const remainingGuardMs = animatingUntilRef.current - Date.now();
@@ -659,23 +656,20 @@ export function RecordingPill() {
         timer = setTimeout(saveDraggedPosition, remainingGuardMs + 1);
         return;
       }
-      void getCurrentWindow()
-        .outerPosition()
-        .then((pos) =>
-          safeInvoke("toolbar_save_position", { x: pos.x, y: pos.y }),
-        )
-        .finally(() => {
-          if (
-            userDragGenerationRef.current === saveGeneration &&
-            userDragChangeRef.current === saveChange
-          ) {
-            userDragActiveRef.current = false;
-          }
-        });
+      const position = lastDraggedPosition;
+      if (!position) return;
+      void safeInvoke("toolbar_save_position", position).finally(() => {
+        if (
+          userDragGenerationRef.current === saveGeneration &&
+          userDragChangeRef.current === saveChange
+        ) {
+          userDragActiveRef.current = false;
+        }
+      });
     }
 
     void getCurrentWindow()
-      .onMoved(() => {
+      .onMoved(({ payload }) => {
         if (!userDragArmedRef.current && !userDragActiveRef.current) return;
         if (userDragArmedRef.current) {
           userDragArmedRef.current = false;
@@ -686,6 +680,7 @@ export function RecordingPill() {
           }
         }
         if (!userDragActiveRef.current) return;
+        lastDraggedPosition = payload;
         userDragChangeRef.current += 1;
         if (timer) clearTimeout(timer);
         timer = setTimeout(saveDraggedPosition, 600);

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -412,6 +412,19 @@ export function RecordingPill() {
     });
   }
 
+  async function openRecording(url: string) {
+    try {
+      if (hasTauri) {
+        await openExternal(url);
+      } else if (!window.open(url, "_blank")) {
+        return;
+      }
+      dismissCard();
+    } catch (err) {
+      console.warn("[record-pill] opening recording failed:", err);
+    }
+  }
+
   function handleUploadFinished(payload: NativeUploadFinished) {
     // A completion only means something to a card that is on screen. While
     // the pill is recording there is no card, and anything applied here would
@@ -471,6 +484,12 @@ export function RecordingPill() {
       safeListen("clips:toolbar-preparing", () => {
         toolbarDismissedRef.current = false;
         setToolbarVisible(true);
+      }),
+    );
+    track(
+      safeListen("clips:toolbar-hidden", () => {
+        toolbarDismissedRef.current = true;
+        setToolbarVisible(false);
       }),
     );
     track(
@@ -914,11 +933,7 @@ export function RecordingPill() {
               <>
                 <button
                   type="button"
-                  onClick={() => {
-                    if (hasTauri) void openExternal(viewUrl).catch(() => {});
-                    else window.open(viewUrl, "_blank");
-                    dismissCard();
-                  }}
+                  onClick={() => void openRecording(viewUrl)}
                   className="h-[34px] flex-1 rounded-lg bg-[var(--pill-card-ink)] text-[13px] font-semibold text-[var(--pill-on-chrome)]"
                 >
                   Open

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -728,13 +728,13 @@ export function RecordingPill() {
     };
   }, [mode]);
 
-  // The pill owns its window's visibility: hidden through pre-record and the
-  // countdown, shown the moment capture is live, and kept up while the
-  // completion card is open. Rust never shows this window itself.
+  // The pill owns its window's visibility: shown in its disabled state while
+  // preparing/counting down, enabled once capture is live, and kept up while
+  // the completion card is open. Rust never shows this window itself.
   const visibleRef = useRef(false);
   useEffect(() => {
     if (!hasTauri) return;
-    const visible = enabled || mode === "done";
+    const visible = true;
     if (visibleRef.current === visible) return;
     visibleRef.current = visible;
     if (visible) syncWindowToContent();
@@ -907,6 +907,7 @@ export function RecordingPill() {
                   onClick={() => {
                     if (hasTauri) void openExternal(viewUrl).catch(() => {});
                     else window.open(viewUrl, "_blank");
+                    dismissCard();
                   }}
                   className="h-[34px] flex-1 rounded-lg bg-[var(--pill-card-ink)] text-[13px] font-semibold text-[var(--pill-on-chrome)]"
                 >

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -128,6 +128,7 @@ export function RecordingPill() {
   const [paused, setPaused] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const [enabled, setEnabled] = useState(demoMode);
+  const [toolbarVisible, setToolbarVisible] = useState(true);
   /** Demo harness only: the meter reads capture events in the real app. */
   const [demoLevel, setDemoLevel] = useState<number | null>(null);
   const [announcement, setAnnouncement] = useState("");
@@ -158,6 +159,7 @@ export function RecordingPill() {
   const userDragMarkerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const toolbarDismissedRef = useRef(false);
   const pauseTransitionRef = useRef<"pause" | "resume" | null>(null);
   const pauseTransitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -368,10 +370,11 @@ export function RecordingPill() {
     if (intent === "restart") {
       setPendingAction("restart");
       setElapsed(0);
-      // Hide immediately — the restart teardown and fresh countdown follow,
-      // and recording controls must not sit on screen while no capture is
-      // live. The replacement session's `clips:toolbar-enabled` re-shows the
-      // pill at 0:00, reusing this window thanks to the finishing hold.
+      // Hide immediately — the restart teardown follows. The replacement
+      // session's `clips:toolbar-preparing` re-shows the disabled pill for its
+      // countdown, reusing this window when the finishing hold keeps it alive.
+      toolbarDismissedRef.current = true;
+      setToolbarVisible(false);
       setEnabled(false);
       void safeInvoke("set_toolbar_finishing", { hold: true }).then(() => {
         void safeEmit("clips:recorder-restart");
@@ -391,6 +394,8 @@ export function RecordingPill() {
     setPendingAction("cancel");
     // Vanish now — feedback must not wait on the recorder's teardown. The
     // window close (or its 3s fallback) follows behind.
+    toolbarDismissedRef.current = true;
+    setToolbarVisible(false);
     setEnabled(false);
     void safeEmit("clips:recorder-cancel").then(() =>
       scheduleCloseFallback("cancel"),
@@ -463,9 +468,18 @@ export function RecordingPill() {
       ),
     );
     track(
+      safeListen("clips:toolbar-preparing", () => {
+        toolbarDismissedRef.current = false;
+        setToolbarVisible(true);
+      }),
+    );
+    track(
       safeListen<boolean>("clips:toolbar-enabled", (payload) => {
         setEnabled(!!payload);
         setPendingAction(null);
+        if (payload && !toolbarDismissedRef.current) {
+          setToolbarVisible(true);
+        }
         if (fallbackTimerRef.current) {
           clearTimeout(fallbackTimerRef.current);
           fallbackTimerRef.current = null;
@@ -735,14 +749,14 @@ export function RecordingPill() {
   const visibleRef = useRef(false);
   useEffect(() => {
     if (!hasTauri) return;
-    const visible = true;
+    const visible = toolbarVisible;
     if (visibleRef.current === visible) return;
     visibleRef.current = visible;
     if (visible) syncWindowToContent();
     queueWindowOp(async () => {
       await invoke("toolbar_set_visible", { visible });
     });
-  }, [enabled, mode]);
+  }, [toolbarVisible]);
 
   // The pill is also the single writer of the menu bar's recording mode:
   // stop square + ticking timer exactly while capture is live, the app logo

--- a/templates/clips/desktop/src/overlays/record-pill.tsx
+++ b/templates/clips/desktop/src/overlays/record-pill.tsx
@@ -482,6 +482,21 @@ export function RecordingPill() {
     );
     track(
       safeListen("clips:toolbar-preparing", () => {
+        if (modeRef.current === "done") {
+          if (stallTimerRef.current) {
+            clearTimeout(stallTimerRef.current);
+            stallTimerRef.current = null;
+          }
+          setViewUrl(null);
+          setCopied(false);
+          setSavedLocally(false);
+          setDoneStage("finishing");
+          sessionRef.current = {};
+        }
+        setElapsed(0);
+        elapsedAnchorRef.current = null;
+        setPendingAction(null);
+        resetToRest();
         toolbarDismissedRef.current = false;
         setToolbarVisible(true);
       }),
@@ -668,6 +683,11 @@ export function RecordingPill() {
 
     function saveDraggedPosition() {
       if (!userDragActiveRef.current) return;
+      if (revealedRef.current || playheadConfirmOpenRef.current) {
+        userDragActiveRef.current = false;
+        lastDraggedPosition = null;
+        return;
+      }
       const saveGeneration = userDragGenerationRef.current;
       const saveChange = userDragChangeRef.current;
       const remainingGuardMs = animatingUntilRef.current - Date.now();
@@ -689,6 +709,16 @@ export function RecordingPill() {
 
     void getCurrentWindow()
       .onMoved(({ payload }) => {
+        if (revealedRef.current || playheadConfirmOpenRef.current) {
+          userDragArmedRef.current = false;
+          userDragActiveRef.current = false;
+          lastDraggedPosition = null;
+          if (timer) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          return;
+        }
         if (!userDragArmedRef.current && !userDragActiveRef.current) return;
         if (userDragArmedRef.current) {
           userDragArmedRef.current = false;

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2998,46 +2998,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   line-height: 1;
 }
 
-.countdown-hint {
-  position: fixed;
-  left: 50%;
-  bottom: 34px;
-  display: inline-flex;
-  align-items: center;
-  gap: 14px;
-  padding: 7px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-pill);
-  background: rgba(10, 12, 16, 0.28);
-  color: rgba(255, 255, 255, 0.58);
-  font-size: 11px;
-  font-weight: 500;
-  line-height: 1;
-  transform: translateX(-50%);
-  backdrop-filter: blur(8px);
-}
-
-.countdown-hint span {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  white-space: nowrap;
-}
-
-.countdown-hint kbd {
-  min-width: 24px;
-  padding: 3px 5px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 5px;
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.74);
-  font-family: inherit;
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1;
-  text-align: center;
-}
-
 @keyframes cd-pop {
   0% {
     transform: scale(0.6);


### PR DESCRIPTION
## Summary

- place the recording pill 20px from the bottom by default while preserving saved drag positions
- keep the disabled pill visible above the countdown and remove the countdown shortcut footer
- close the completion card after opening a saved recording

## Validation

- focused pill/session tests: 20 passed
- Clips desktop TypeScript typecheck passed
- Clips desktop Vite build passed
- native cargo fmt check and cargo check passed
- repository guards: 65 passed