### PR TITLE
Remove border from Clips comment composer

### DIFF
--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -133,15 +133,13 @@ describe("CommentsPanel reply composer", () => {
     expect(container.textContent).toContain("www.example.org/help.");
   });
 
-  it("keeps the compact comment composer text inset", () => {
+  it("keeps the compact comment composer text inset without an outer border", () => {
     const composer = container.querySelector<HTMLTextAreaElement>(
       'textarea[placeholder="commentsPanel.leaveComment"]',
     );
 
     expect(composer?.className).toContain("px-3 py-2");
-    expect(composer?.parentElement?.className).toContain(
-      "border border-border",
-    );
+    expect(composer?.parentElement?.className).not.toContain("border");
   });
 
   it("renders inline Markdown while flattening headings", () => {

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -676,8 +676,7 @@ function CommentComposer({
       <div
         className={cn(
           "flex gap-2",
-          isSharePresentation &&
-            "items-start rounded-md border border-border p-3 shadow-sm",
+          isSharePresentation && "items-start rounded-md p-3 shadow-sm",
         )}
       >
         {isSharePresentation ? (

--- a/templates/clips/changelog/2026-08-28-comment-composer-no-longer-has-an-outer-border.md
+++ b/templates/clips/changelog/2026-08-28-comment-composer-no-longer-has-an-outer-border.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+The shared comment composer now has a cleaner borderless presentation.


### PR DESCRIPTION
## Summary
- Remove the outer border from the shared Clips comment composer.
- Keep the composer inset and interaction behavior unchanged.

## Validation
- `corepack pnpm exec vitest --run app/components/player/comments-panel.test.tsx --config vitest.config.ts` (9 passed)
- `corepack pnpm typecheck` from `templates/clips`
- `corepack pnpm guards` (65 passed)
- `oxfmt --check` for modified TypeScript files