### PR TITLE
Clips: simplify library empty state

### DIFF
--- a/templates/clips/app/components/library/empty-state.tsx
+++ b/templates/clips/app/components/library/empty-state.tsx
@@ -63,9 +63,7 @@ export function EmptyState({
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center py-20 px-8 text-center">
-      <div className="relative mb-6 flex h-20 w-20 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/15 to-primary/5 shadow-md">
-        <Icon className="h-10 w-10 text-primary" />
-      </div>
+      <Icon className="mb-6 h-10 w-10 text-primary" />
       <h2 className="text-base font-semibold text-foreground mb-1">
         {t(`empty.${kind}.title`)}
       </h2>

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -23,7 +23,6 @@ import {
   IconFolderPlus,
   IconPlayerRecord,
   IconAppWindow,
-  IconX,
   IconMenu2,
   IconLayoutSidebarLeftCollapse,
   IconLayoutSidebarLeftExpand,
@@ -38,10 +37,7 @@ import { ReactNode, useEffect, useMemo, useState } from "react";
 import { NavLink, useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "sonner";
 
-import {
-  CaptureInstallButton,
-  CaptureInstallInlineLink,
-} from "@/components/capture-install-options";
+import { CaptureInstallInlineLink } from "@/components/capture-install-options";
 import { ImportMenu } from "@/components/import-menu";
 import {
   AlertDialog,
@@ -123,7 +119,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
     spaceId?: string;
   }>();
 
-  const { shouldShowPromo, shouldShowSidebarLink, dismiss } = useDesktopPromo();
+  const { shouldShowSidebarLink } = useDesktopPromo();
   usePrefetchVideoStorageStatus();
 
   const { org, canManageOrg } = useOrgRole();
@@ -733,41 +729,6 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
             </header>
           )}
           <InvitationBanner />
-          {shouldShowPromo && (
-            <div className="flex items-center gap-3 border-b border-border bg-primary/5 px-5 py-2.5 text-sm">
-              <IconAppWindow className="h-4 w-4 shrink-0 text-primary" />
-              <div className="min-w-0 flex-1">
-                <span className="font-medium">
-                  {t("navigation.desktopTitle")}
-                </span>{" "}
-                <span className="text-muted-foreground">
-                  {t("navigation.desktopBody")}
-                </span>
-              </div>
-              <CaptureInstallButton
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-              >
-                Download
-              </CaptureInstallButton>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                    onClick={dismiss}
-                  >
-                    <IconX className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t("clipsFinalRaw.alreadyHaveIt")}
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          )}
           <main className="agent-native-app-main flex min-h-0 flex-1 flex-col overflow-y-auto">
             <PageHeaderSlotProvider
               slot={headerSlot}

--- a/templates/clips/app/hooks/use-desktop-promo.ts
+++ b/templates/clips/app/hooks/use-desktop-promo.ts
@@ -1,10 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useIsMobile } from "@/hooks/use-mobile";
-import {
-  hasDownloadedDesktopApp,
-  markDesktopAppDownloaded,
-} from "@/lib/capture-install-options";
 
 function detectDesktopApp(): boolean {
   if (typeof navigator === "undefined") return false;
@@ -24,27 +20,17 @@ export function useDesktopPromo() {
   const isMobile = useIsMobile();
   const [isDesktopApp, setIsDesktopApp] = useState(false);
   const [runtimeDetected, setRuntimeDetected] = useState(false);
-  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     setIsDesktopApp(detectDesktopApp());
-    setDismissed(hasDownloadedDesktopApp());
-    // Keep desktop prompts hidden until the client runtime is known. This
-    // prevents the web CTA from flashing in the desktop shell's first render.
+    // Keep the web CTA hidden until the client runtime is known. This prevents
+    // it from flashing in the desktop shell's first render.
     setRuntimeDetected(true);
-  }, []);
-
-  const dismiss = useCallback(() => {
-    setDismissed(true);
-    markDesktopAppDownloaded();
   }, []);
 
   return {
     isDesktopApp,
     isMobile,
-    shouldShowPromo:
-      runtimeDetected && !isMobile && !isDesktopApp && !dismissed,
     shouldShowSidebarLink: runtimeDetected && !isMobile && !isDesktopApp,
-    dismiss,
   };
 }


### PR DESCRIPTION
## Summary
- remove the persistent desktop-app promo ribbon from the library shell
- simplify the empty-state illustration to a standalone video icon
- remove the unused promo dismissal state

## Validation
Local checks and live screenshot verification are running after handoff.