### PR TITLE
Fix Mail label tabs and empty states

### DIFF
--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -74,6 +74,14 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain("{mobileInboxTabs.map((tab) => {");
   });
 
+  it("uses mailbox-wide counts for regular label tabs", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      "if (!isInboxScopedAppLabel(label?.id ?? pinnedId)) continue;",
+    );
+  });
+
   it("does not let loaded pages inflate server-backed label badges", () => {
     const source = appLayoutSource();
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -87,7 +87,15 @@ describe("AppLayout inbox rail count", () => {
 
     expect(source).not.toContain("Math.max(serverCount, localCount)");
     expect(source).toContain(
-      'typeof serverCount === "number" && useServerLabelCounts',
+      'typeof serverCount === "number" ? serverCount : localCount',
+    );
+  });
+
+  it("scopes label counts to the selected accounts", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      "useLabels(activeAccounts.size > 0 ? [...activeAccounts] : undefined)",
     );
   });
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -318,15 +318,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     }
     prevSearchQueryRef.current = activeSearchQuery;
   }, [activeSearchQuery]);
-  const {
-    data: labelsData,
-    isLoading: labelsLoading,
-    isError: labelsError,
-    error: labelsQueryError,
-    isFetching: labelsFetching,
-    refetch: refetchLabels,
-  } = useLabels();
-  const labels = labelsData ?? EMPTY_LABELS;
   const { data: settings, isLoading: settingsLoading } = useSettings();
   const updateSettings = useUpdateSettings();
   const googleStatus = useGoogleAuthStatus();
@@ -363,6 +354,15 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       );
     }
   }, [activeAccounts]);
+  const {
+    data: labelsData,
+    isLoading: labelsLoading,
+    isError: labelsError,
+    error: labelsQueryError,
+    isFetching: labelsFetching,
+    refetch: refetchLabels,
+  } = useLabels(activeAccounts.size > 0 ? [...activeAccounts] : undefined);
+  const labels = labelsData ?? EMPTY_LABELS;
   const [tabSettingsOpen, setTabSettingsOpen] = useState(false);
   const [labelSearch, setLabelSearch] = useState("");
   // Spin the refresh icon only when the user clicked the button — background
@@ -1049,8 +1049,6 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     );
   };
 
-  const useServerLabelCounts = activeAccounts.size === 0;
-
   // Gmail category tabs partition the inbox; regular labels span the mailbox.
   // Keep only the former tied to the loaded inbox partition.
   const inboxPartitionTabIds = new Set<string>([OTHER_INBOX_TAB_ID]);
@@ -1076,9 +1074,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     const localCounts = localCountsForKind(kind);
     const serverCount = inboxLabel?.[countField];
     const localCount = localCounts["__inboxTotal"] ?? 0;
-    return typeof serverCount === "number" && useServerLabelCounts
-      ? serverCount
-      : localCount;
+    return typeof serverCount === "number" ? serverCount : localCount;
   };
 
   const getOtherCount = (kind: CountKind) => {
@@ -1102,9 +1098,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       localCounts[viewId] ?? (label ? (localCounts[label.id] ?? 0) : 0);
     if (inboxPartitionTabIds.has(viewId)) return localCount;
     const serverCount = label?.[countField];
-    return typeof serverCount === "number" && useServerLabelCounts
-      ? serverCount
-      : localCount;
+    return typeof serverCount === "number" ? serverCount : localCount;
   };
   const getTopBarCount = (viewId: string) => getTabCount(viewId, "total");
   const getUnreadCount = (viewId: string) => getTabCount(viewId, "unread");

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1051,12 +1051,13 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
   const useServerLabelCounts = activeAccounts.size === 0;
 
-  // Gmail totals overlap across labels, while these tabs are an exclusive
-  // partition of the loaded inbox. Keep their badges tied to that partition.
+  // Gmail category tabs partition the inbox; regular labels span the mailbox.
+  // Keep only the former tied to the loaded inbox partition.
   const inboxPartitionTabIds = new Set<string>([OTHER_INBOX_TAB_ID]);
   for (const pinnedId of pinnedTriageLabels(pinnedLabels)) {
-    inboxPartitionTabIds.add(pinnedId);
     const label = resolveLabelForCount(pinnedId);
+    if (!isInboxScopedAppLabel(label?.id ?? pinnedId)) continue;
+    inboxPartitionTabIds.add(pinnedId);
     if (label) inboxPartitionTabIds.add(label.id);
   }
 

--- a/templates/mail/app/hooks/use-emails.spec.ts
+++ b/templates/mail/app/hooks/use-emails.spec.ts
@@ -103,6 +103,12 @@ describe("useLabels", () => {
 
     expect(source).toContain("placeholderData: (previousData) => previousData");
     expect(source).toContain("export const EMPTY_LABELS: Label[] = [];");
+    expect(source).toContain(
+      "export function useLabels(accountEmails?: readonly string[])",
+    );
+    expect(source).toContain(
+      'accountEmails=${encodeURIComponent(accountFilter.join(","))}',
+    );
   });
 });
 

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -1468,10 +1468,18 @@ export function useContacts() {
 
 export const EMPTY_LABELS: Label[] = [];
 
-export function useLabels() {
+export function useLabels(accountEmails?: readonly string[]) {
+  const accountFilter = accountEmails?.length
+    ? [...new Set(accountEmails.map((email) => email.toLowerCase()))].sort()
+    : undefined;
   return useQuery<Label[]>({
-    queryKey: ["labels"],
-    queryFn: () => apiFetch("/api/labels"),
+    queryKey: ["labels", accountFilter],
+    queryFn: () => {
+      const params = accountFilter?.length
+        ? `?accountEmails=${encodeURIComponent(accountFilter.join(","))}`
+        : "";
+      return apiFetch(`/api/labels${params}`);
+    },
     // A failed background refresh must not erase the last complete label map.
     // The layout still surfaces isError so an initial failure has an explicit
     // retry path instead of looking like an empty mailbox.

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -388,7 +388,9 @@ export function InboxPage() {
     !!activeLabel &&
     view === "inbox" &&
     mailLabelsInclude(triageLabels, activeLabel);
-  const clientSliceTab = isPinnedTab && !searchQuery;
+  const mailboxWideLabelTab =
+    view === "inbox" && !!activeLabel && !isInboxScopedAppLabel(activeLabel);
+  const clientSliceTab = isPinnedTab && !searchQuery && !mailboxWideLabelTab;
   const isOtherTab =
     view === "inbox" &&
     activeInboxTab === OTHER_INBOX_TAB_PARAM &&
@@ -396,6 +398,7 @@ export function InboxPage() {
   const effectiveLabel = clientSliceTab
     ? undefined
     : (activeLabel ?? undefined);
+  const emailView = mailboxWideLabelTab ? "all" : view;
   const {
     data: rawEmails,
     isLoading,
@@ -407,7 +410,7 @@ export function InboxPage() {
     fetchNextPage,
     isFetchingNextPage,
     isFetchNextPageError,
-  } = useEmails(view, searchQuery, effectiveLabel);
+  } = useEmails(emailView, searchQuery, effectiveLabel);
   const hasEmailData = rawEmails !== undefined;
   const emailListLoading =
     isLoading ||

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -51,6 +51,18 @@ describe("Inbox navigation commands", () => {
     );
   });
 
+  it("loads legacy custom-label inbox links from the whole mailbox", () => {
+    const source = inboxSource();
+
+    expect(source).toContain("const mailboxWideLabelTab =");
+    expect(source).toContain(
+      'const emailView = mailboxWideLabelTab ? "all" : view;',
+    );
+    expect(source).toContain(
+      "useEmails(emailView, searchQuery, effectiveLabel)",
+    );
+  });
+
   it("syncs the active inbox partition into agent navigation state", () => {
     expect(navigationHookSource()).toContain("activeInboxTab?: string;");
     expect(navigationHookSource()).toContain("activeAccounts?: string[];");

--- a/templates/mail/app/pages/inbox-zero.test.tsx
+++ b/templates/mail/app/pages/inbox-zero.test.tsx
@@ -15,6 +15,12 @@ const emptyInbox: InboxZeroState = {
   hasNextPage: false,
 };
 
+const emptyLabel: InboxZeroState = {
+  ...emptyInbox,
+  view: "all",
+  activeLabel: "github",
+};
+
 function InboxZeroBoundary({ state }: { state: InboxZeroState }) {
   return shouldShowInboxZero(state) ? (
     <div data-testid="inbox-zero" />
@@ -36,6 +42,15 @@ describe("InboxZero rendering", () => {
   it("renders Inbox Zero after the final empty page", () => {
     const markup = renderToStaticMarkup(
       <InboxZeroBoundary state={emptyInbox} />,
+    );
+
+    expect(markup).toContain('data-testid="inbox-zero"');
+    expect(markup).not.toContain('data-testid="email-list"');
+  });
+
+  it("renders Inbox Zero for an empty label filter", () => {
+    const markup = renderToStaticMarkup(
+      <InboxZeroBoundary state={emptyLabel} />,
     );
 
     expect(markup).toContain('data-testid="inbox-zero"');

--- a/templates/mail/app/pages/inbox-zero.ts
+++ b/templates/mail/app/pages/inbox-zero.ts
@@ -22,8 +22,7 @@ export function shouldShowInboxZero({
   hasNextPage,
 }: InboxZeroState): boolean {
   return (
-    view === "inbox" &&
-    (!activeLabel || activeLabel === "important") &&
+    (view === "inbox" || Boolean(activeLabel)) &&
     hasEmailData &&
     !isLoading &&
     !isError &&

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -30,4 +30,18 @@ describe("emails handler Gmail label listing", () => {
     expect(source).toContain("failedAccountReads > 0");
     expect(source).toContain("Unable to load Gmail labels. Please retry.");
   });
+
+  it("filters local all-mail label reads and scopes Gmail label counts", () => {
+    const source = emailsHandlerSource();
+
+    expect(source).toContain(
+      "if (label) emails = filterLabelMessages(emails, label);",
+    );
+    expect(source).toContain(
+      "const accountTokens = await getAccountTokens(email, accountEmails);",
+    );
+    expect(source).toContain(
+      "return recomputeUnreadCounts(\n    await readEmails(email),\n    await readLabels(email),\n  );",
+    );
+  });
 });

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -9,7 +9,10 @@ import {
 import { readBody, getSession } from "@agent-native/core/server";
 import { getAppProductionUrl } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
-import { mailLabelMatches } from "@shared/gmail-labels.js";
+import {
+  isInboxScopedAppLabel,
+  mailLabelMatches,
+} from "@shared/gmail-labels.js";
 import { markdownPreviewSnippet } from "@shared/markdown.js";
 import { emailMessageMatchesSearch } from "@shared/search.js";
 import type { EmailMessage, Label, UserSettings } from "@shared/types.js";
@@ -36,7 +39,10 @@ import {
   persistTracking,
   type TrackingContext,
 } from "../lib/email-tracking.js";
-import { filterInboxScopedThreadMessages } from "../lib/gmail-query.js";
+import {
+  filterInboxScopedThreadMessages,
+  filterLabelMessages,
+} from "../lib/gmail-query.js";
 import {
   createOAuth2Client,
   gmailGetMessage,
@@ -217,8 +223,14 @@ async function getAccessToken(accountEmail: string): Promise<string | null> {
  */
 async function getAccountTokens(
   forEmail: string,
+  requestedAccountEmails?: readonly string[],
 ): Promise<Array<{ email: string; accessToken: string }>> {
-  const accounts = await listOAuthAccountsByOwner("google", forEmail);
+  const requested = requestedAccountEmails
+    ? new Set(requestedAccountEmails.map((account) => account.toLowerCase()))
+    : undefined;
+  const accounts = (await listOAuthAccountsByOwner("google", forEmail)).filter(
+    (account) => !requested || requested.has(account.accountId.toLowerCase()),
+  );
 
   const results: Array<{ email: string; accessToken: string }> = [];
 
@@ -354,8 +366,12 @@ function recomputeUnreadCounts(
   labels: Label[],
 ): Label[] {
   return labels.map((label) => {
+    const inboxScoped = label.id === "inbox" || isInboxScopedAppLabel(label.id);
     const active = emails.filter(
-      (e) => !e.isArchived && !e.isTrashed && e.labelIds.includes(label.id),
+      (e) =>
+        !e.isTrashed &&
+        (!inboxScoped || !e.isArchived) &&
+        e.labelIds.includes(label.id),
     );
     const unread = active.filter((e) => !e.isRead).length;
     return { ...label, unreadCount: unread, totalCount: active.length };
@@ -522,6 +538,7 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         emails = emails.filter((e) => e.isTrashed);
         break;
       case "all":
+        if (label) emails = filterLabelMessages(emails, label);
         break;
       default:
         // label: prefixed or raw label id
@@ -1731,7 +1748,14 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
   const email = await userEmail(_event);
   if (await isConnected(email)) {
     try {
-      const accountTokens = await getAccountTokens(email);
+      const { accountEmails: accountEmailsQuery } = getQuery(_event) as {
+        accountEmails?: string;
+      };
+      const accountEmails = accountEmailsQuery
+        ?.split(",")
+        .map((account) => account.trim())
+        .filter(Boolean);
+      const accountTokens = await getAccountTokens(email, accountEmails);
       // Deduplicate by derived short-name id (not Gmail label ID)
       const labelMap = new Map<
         string,
@@ -1848,7 +1872,10 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
       return { error: "Unable to load Gmail labels. Please retry." };
     }
   }
-  return readLabels(email);
+  return recomputeUnreadCounts(
+    await readEmails(email),
+    await readLabels(email),
+  );
 });
 
 // ─── Calendar RSVP ───────────────────────────────────────────────────────────

--- a/templates/mail/server/lib/email-state.spec.ts
+++ b/templates/mail/server/lib/email-state.spec.ts
@@ -143,13 +143,13 @@ function mockAccounts() {
   } as any);
 }
 
-function mockLocalEmails(emails = makeLocalEmails()) {
+function mockLocalEmails(
+  emails = makeLocalEmails(),
+  labels = [{ id: "inbox", name: "Inbox", unreadCount: 1, totalCount: 2 }],
+) {
   vi.mocked(getUserSetting).mockImplementation(async (_owner, key) => {
     if (key === "local-emails") return { emails } as any;
-    if (key === "labels")
-      return {
-        labels: [{ id: "inbox", name: "Inbox", unreadCount: 1, totalCount: 2 }],
-      } as any;
+    if (key === "labels") return { labels } as any;
     return undefined;
   });
   vi.mocked(putUserSetting).mockResolvedValue(undefined as any);
@@ -228,6 +228,30 @@ describe("archiveEmail", () => {
         .mocked(putUserSetting)
         .mock.calls.find(([, k]) => k === "labels");
       expect(labelCall).toBeDefined();
+    });
+
+    it("keeps archived user-label counts mailbox-wide", async () => {
+      mockConnected(false);
+      mockLocalEmails(
+        makeLocalEmails().map((email) => ({
+          ...email,
+          labelIds: ["inbox", "github"],
+        })),
+        [
+          { id: "inbox", name: "Inbox", unreadCount: 1, totalCount: 2 },
+          { id: "github", name: "Github", unreadCount: 1, totalCount: 2 },
+        ],
+      );
+
+      await archiveEmail({ id: MSG_ID, ownerEmail: OWNER });
+
+      const [, , written] = vi
+        .mocked(putUserSetting)
+        .mock.calls.find(([, key]) => key === "labels")!;
+      const github = (written as any).labels.find(
+        (label: any) => label.id === "github",
+      );
+      expect(github).toMatchObject({ unreadCount: 1, totalCount: 2 });
     });
 
     it("throws when email not found", async () => {

--- a/templates/mail/server/lib/email-state.ts
+++ b/templates/mail/server/lib/email-state.ts
@@ -4,6 +4,8 @@ import {
   saveOAuthTokens,
 } from "@agent-native/core/oauth-tokens";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { isInboxScopedAppLabel } from "@shared/gmail-labels.js";
+import type { EmailMessage, Label } from "@shared/types.js";
 /**
  * Shared server functions for email state-change operations.
  *
@@ -12,7 +14,6 @@ import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
  * superset of behaviour from the two prior implementations — see reconciliation
  * notes inline.
  */
-import type { EmailMessage, Label } from "@shared/types.js";
 
 import type { BulkMarkReadResult } from "./bulk-mark-read.js";
 import {
@@ -132,8 +133,12 @@ function recomputeUnreadCounts(
   labels: Label[],
 ): Label[] {
   return labels.map((label) => {
+    const inboxScoped = label.id === "inbox" || isInboxScopedAppLabel(label.id);
     const active = emails.filter(
-      (e) => !e.isArchived && !e.isTrashed && e.labelIds.includes(label.id),
+      (e) =>
+        !e.isTrashed &&
+        (!inboxScoped || !e.isArchived) &&
+        e.labelIds.includes(label.id),
     );
     return {
       ...label,

--- a/templates/mail/server/lib/gmail-query.spec.ts
+++ b/templates/mail/server/lib/gmail-query.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildGmailEmailSearchQuery,
   filterInboxScopedThreadMessages,
+  filterLabelMessages,
   gmailLabelSearchClause,
 } from "./gmail-query.js";
 
@@ -107,6 +108,28 @@ describe("buildGmailEmailSearchQuery", () => {
 describe("gmailLabelSearchClause", () => {
   it("quotes Gmail labels that need quoting", () => {
     expect(gmailLabelSearchClause("Team/Foo Bar")).toBe('label:"Team/Foo-Bar"');
+  });
+});
+
+describe("filterLabelMessages", () => {
+  it("keeps archived labeled mail while excluding unrelated and trashed mail", () => {
+    const archived = message({
+      id: "archived",
+      isArchived: true,
+      labelIds: ["github"],
+    });
+    const unrelated = message({ id: "unrelated", labelIds: ["inbox"] });
+    const trashed = message({
+      id: "trashed",
+      isTrashed: true,
+      labelIds: ["github"],
+    });
+
+    expect(
+      filterLabelMessages([archived, unrelated, trashed], "github").map(
+        (email) => email.id,
+      ),
+    ).toEqual(["archived"]);
   });
 });
 

--- a/templates/mail/server/lib/gmail-query.ts
+++ b/templates/mail/server/lib/gmail-query.ts
@@ -86,6 +86,16 @@ export function buildGmailEmailSearchQuery({
   return [viewQuery, searchClause].filter(Boolean).join(" ");
 }
 
+export function filterLabelMessages(
+  emails: EmailMessage[],
+  label: string,
+): EmailMessage[] {
+  return emails.filter(
+    (message) =>
+      !message.isTrashed && mailLabelsInclude(message.labelIds, label),
+  );
+}
+
 function threadKey(message: EmailMessage): string {
   return `${message.accountEmail ?? ""}:${message.threadId || message.id}`;
 }


### PR DESCRIPTION
## Summary
- Keep regular Gmail label tabs mailbox-wide, including archived messages and legacy inbox label URLs.
- Use mailbox-wide label counts for regular custom tabs while preserving inbox partition counts for Gmail triage categories.
- Show the existing Inbox Zero artwork when a label filter is empty.

A full-text search for “github” does not assign a Gmail label, and Superhuman’s private filter definition is not imported by this app. This fixes the Mail routing/count behavior without retroactively mutating messages.

## Validation
- Focused Mail tests: 43 passed
- Mail typecheck and build: passed
- Repository guards: 65 passed
- Local browser proof: empty `Github` label route renders Inbox Zero artwork