### PR TITLE
Fix desktop shortcut focus and Calendar avatars

### DIFF
--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -74,6 +74,7 @@ export default function App() {
     appId: string;
     path?: string;
     nonce: number;
+    focusNonce?: number;
   }>();
   const [pendingDesktopOpenRequest, setPendingDesktopOpenRequest] =
     useState<DesktopOpenRequest | null>(null);
@@ -327,10 +328,12 @@ export default function App() {
       }
 
       const path = safeDesktopOpenPath(request.path);
+      const nonce = Date.now();
       setChatFirstAppOpenRequest({
         appId,
-        nonce: Date.now(),
+        nonce,
         ...(path ? { path } : {}),
+        ...("requestId" in request ? { focusNonce: nonce } : {}),
       });
       setShowSettings(false);
       setShowAddApp(false);

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -250,6 +250,48 @@ describe("Desktop identity activation", () => {
     }
   });
 
+  it("focuses an active webview for an explicit app-open request", () => {
+    root = createRoot(container);
+    const app = {
+      id: "custom-calendar",
+      name: "Calendar",
+      icon: "calendar",
+      description: "",
+      devPort: 3000,
+    };
+    const appConfig = {
+      ...app,
+      url: "https://calendar.agent-native.com",
+      isBuiltIn: false,
+      enabled: true,
+      mode: "prod" as const,
+    };
+    const props = {
+      app,
+      appConfig,
+      isActive: true,
+      theme: "dark" as const,
+    };
+
+    act(() => {
+      root.render(React.createElement(AppWebview, props));
+    });
+
+    const webview = container.querySelector("webview");
+    expect(webview).not.toBeNull();
+    const focus = vi.fn();
+    Object.defineProperty(webview!, "focus", {
+      configurable: true,
+      value: focus,
+    });
+
+    act(() => {
+      root.render(React.createElement(AppWebview, { ...props, focusNonce: 1 }));
+    });
+
+    expect(focus).toHaveBeenCalledOnce();
+  });
+
   it("reveals a loaded tab without reloading it after switching away", async () => {
     root = createRoot(container);
     const app = {

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -409,6 +409,8 @@ interface AppWebviewProps {
   /** Full app config with URL overrides (optional for backward compat) */
   appConfig?: AppConfig;
   isActive: boolean;
+  /** Changes when a desktop shortcut explicitly opens this app. */
+  focusNonce?: number;
   /**
    * Set when the host hides this guest while it is still the active tab, e.g.
    * behind a full-surface overlay. An Electron guest never observes CSS
@@ -696,6 +698,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       app,
       appConfig,
       isActive,
+      focusNonce,
       surfaceHidden = false,
       showDesktopIdentityGate = true,
       theme,
@@ -1684,7 +1687,8 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     ]);
 
     // Auto-focus the webview when it becomes active so keyboard events
-    // (e.g. Tab to cycle mail filters) go to the app, not the shell.
+    // (e.g. Tab to cycle mail filters) go to the app, not the shell. The
+    // explicit nonce also handles shortcuts that reopen the active app.
     useEffect(() => {
       if (isActive && !app.placeholder && !error) {
         const wv = webviewRef.current;
@@ -1692,12 +1696,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           // Focus once after the slot becomes visible. Repeated focus calls
           // trigger focus-aware data refreshes in embedded apps.
           const frame = requestAnimationFrame(() => {
-            if (document.activeElement !== wv) wv.focus();
+            if (focusNonce !== undefined || document.activeElement !== wv) {
+              wv.focus();
+            }
           });
           return () => cancelAnimationFrame(frame);
         }
       }
-    }, [isActive, app.placeholder, error]);
+    }, [isActive, app.placeholder, error, focusNonce]);
 
     useEffect(() => {
       reportActiveWebview();

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -651,7 +651,12 @@ interface CodeAgentsHubProps {
   workspaceAppList?: DesktopWorkspaceAppListResult;
   isActive?: boolean;
   openRequest?: { goalId?: string; runId?: string; nonce: number };
-  chatFirstAppOpenRequest?: { appId: string; path?: string; nonce: number };
+  chatFirstAppOpenRequest?: {
+    appId: string;
+    path?: string;
+    nonce: number;
+    focusNonce?: number;
+  };
   chatFirstPreviewRequest?: { appId: string; nonce: number };
   chatFirstPreviewStatus?: "starting" | "ready" | "error";
   chatFirstPreviewStatusMessage?: string;
@@ -2674,6 +2679,10 @@ export default function CodeAgentsHub({
           tabId: tab.id,
           activeTabId: activeChatFirstSurfaceTab?.id,
         });
+        const shouldFocusRequestedTab =
+          isTabActive &&
+          chatFirstAppOpenRequest?.appId === tab.appId &&
+          chatFirstAppOpenRequest.path === tab.path;
         const appAuthState = appAuthStateByTab[tab.id];
         const desktopIdentityStatus = desktopIdentityStatusByTab[tab.id];
         const showNativeIntegrations = shouldShowNativeDesktopIntegrations({
@@ -2739,6 +2748,11 @@ export default function CodeAgentsHub({
                       app={toAppDefinition(surfaceApp)}
                       appConfig={surfaceApp}
                       isActive={isTabActive}
+                      focusNonce={
+                        shouldFocusRequestedTab
+                          ? chatFirstAppOpenRequest.focusNonce
+                          : undefined
+                      }
                       showDesktopIdentityGate={false}
                       surfaceHidden={!showNativeIntegrationsGuest}
                       refreshKey={refreshKey}

--- a/templates/calendar/app/lib/mcp-embed.spec.ts
+++ b/templates/calendar/app/lib/mcp-embed.spec.ts
@@ -21,6 +21,13 @@ describe("isMcpEmbedSurface (calendar)", () => {
     expect(isMcpEmbedSurface()).toBe(true);
   });
 
+  it("keeps Electron chat-first surfaces out of the MCP embed path", () => {
+    vi.stubGlobal("window", {
+      location: { search: "?embedded=1&chatFirst=1" },
+    });
+    expect(isMcpEmbedSurface()).toBe(false);
+  });
+
   it("ignores ordinary in-app routes without the embed flag", () => {
     vi.stubGlobal("window", { location: { search: "?date=2026-05-23" } });
     expect(isMcpEmbedSurface()).toBe(false);

--- a/templates/calendar/app/lib/mcp-embed.ts
+++ b/templates/calendar/app/lib/mcp-embed.ts
@@ -15,6 +15,12 @@
  */
 export function isMcpEmbedSurface(): boolean {
   if (typeof window === "undefined") return false;
-  const value = new URLSearchParams(window.location.search).get("embedded");
-  return value === "1" || value === "true";
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get("embedded");
+  const chatFirst = params.get("chatFirst");
+  return (
+    (value === "1" || value === "true") &&
+    chatFirst !== "1" &&
+    chatFirst !== "true"
+  );
 }

--- a/templates/calendar/changelog/2026-08-28-calendar-shows-google-profile-photos-in-the-desktop-app.md
+++ b/templates/calendar/changelog/2026-08-28-calendar-shows-google-profile-photos-in-the-desktop-app.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-28
+---
+
+Calendar shows Google profile photos in the desktop app


### PR DESCRIPTION
## Summary
- Focus the active app webview after every desktop shortcut app open, including reopening the current app.
- Keep Electron chat-first Calendar surfaces out of the MCP avatar fallback.
- Add focused regression coverage and a Calendar changelog entry.

## Validation
- Desktop renderer tests: 82 passed
- Calendar tests: 538 passed
- Desktop typecheck: passed
- Calendar typecheck: passed
- Repository guards: 65 passed