### PR TITLE
fix(docs): preload visual blocks during client navigation

### DIFF
--- a/packages/docs/app/components/DocContent.tsx
+++ b/packages/docs/app/components/DocContent.tsx
@@ -38,10 +38,10 @@ export default function DocContent({
   // into the real renderer instead of painting a second Markdown tree.
   void preloadDocBlocksContent();
 
+  // Raw Markdown is not a safe fallback for MDX pages: unresolved block tags
+  // would render as visible source instead of content.
   return (
-    <Suspense
-      fallback={<MarkdownRenderer markdown={markdown} locale={locale} />}
-    >
+    <Suspense fallback={null}>
       <DocBlocksContent markdown={markdown} locale={locale} />
     </Suspense>
   );

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -247,14 +247,12 @@ export async function loadDocRespectingDraftVisibility(
   const visibleDoc =
     isDraft === Boolean(doc.draft) ? doc : { ...doc, draft: isDraft };
 
-  // Route loaders run before both SSR and client-side navigations render. Keep
-  // the optional block module out of ordinary docs requests, but resolve it
-  // before a block page can paint the Markdown fallback and then reflow.
-  if (hasDocBlockSyntax(visibleDoc.body)) {
-    await preloadDocBlocksContent();
-  }
+  return preloadDocBlocksForDoc(visibleDoc);
+}
 
-  return visibleDoc;
+export async function preloadDocBlocksForDoc(doc: DocEntry): Promise<DocEntry> {
+  if (hasDocBlockSyntax(doc.body)) await preloadDocBlocksContent();
+  return doc;
 }
 
 export function hasLocalizedDoc(locale: unknown, slug: string): boolean {

--- a/packages/docs/app/routes/$locale.docs.$slug.tsx
+++ b/packages/docs/app/routes/$locale.docs.$slug.tsx
@@ -1,1 +1,1 @@
-export { default, loader, meta } from "./docs.$locale.$slug";
+export { clientLoader, default, loader, meta } from "./docs.$locale.$slug";

--- a/packages/docs/app/routes/$locale.docs._index.tsx
+++ b/packages/docs/app/routes/$locale.docs._index.tsx
@@ -1,1 +1,1 @@
-export { default, loader, meta } from "./docs._index";
+export { clientLoader, default, loader, meta } from "./docs._index";

--- a/packages/docs/app/routes/docs.$locale.$slug.tsx
+++ b/packages/docs/app/routes/docs.$locale.$slug.tsx
@@ -3,6 +3,7 @@ import {
   redirect,
   useLoaderData,
   useParams,
+  type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
 
@@ -10,6 +11,7 @@ import DocContent from "../components/DocContent";
 import DocDraftBanner from "../components/DocDraftBanner";
 import {
   loadDocRespectingDraftVisibility,
+  preloadDocBlocksForDoc,
   type DocEntry,
 } from "../components/docs-content";
 import {
@@ -56,6 +58,11 @@ export async function loader({ params, request, url }: LoaderFunctionArgs) {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
+}
+
+export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
+  const doc = (await serverLoader()) as DocEntry;
+  return preloadDocBlocksForDoc(doc);
 }
 
 export const meta = ({

--- a/packages/docs/app/routes/docs.$slug.tsx
+++ b/packages/docs/app/routes/docs.$slug.tsx
@@ -1,10 +1,16 @@
 import { withSsrHtmlContentType } from "@agent-native/core/shared";
-import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router";
+import {
+  redirect,
+  useLoaderData,
+  type ClientLoaderFunctionArgs,
+  type LoaderFunctionArgs,
+} from "react-router";
 
 import DocContent from "../components/DocContent";
 import DocDraftBanner from "../components/DocDraftBanner";
 import {
   loadDocRespectingDraftVisibility,
+  preloadDocBlocksForDoc,
   type DocEntry,
 } from "../components/docs-content";
 import {
@@ -37,6 +43,11 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Not Found", { status: 404 });
   }
   return doc;
+}
+
+export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
+  const doc = (await serverLoader()) as DocEntry;
+  return preloadDocBlocksForDoc(doc);
 }
 
 export const meta = ({

--- a/packages/docs/app/routes/docs._index.tsx
+++ b/packages/docs/app/routes/docs._index.tsx
@@ -1,6 +1,7 @@
 import {
   useLoaderData,
   useParams,
+  type ClientLoaderFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
 
@@ -8,6 +9,7 @@ import DocContent from "../components/DocContent";
 import DocDraftBanner from "../components/DocDraftBanner";
 import {
   loadDocRespectingDraftVisibility,
+  preloadDocBlocksForDoc,
   type DocEntry,
 } from "../components/docs-content";
 import {
@@ -33,6 +35,11 @@ export async function loader({
   );
   if (!doc) throw new Response("Not Found", { status: 404 });
   return doc;
+}
+
+export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
+  const doc = (await serverLoader()) as DocEntry;
+  return preloadDocBlocksForDoc(doc);
 }
 
 export const meta = ({


### PR DESCRIPTION
## Summary
- preload docs visual-block content in browser client loaders before rendering navigated pages
- never expose unresolved MDX block tags through the loading fallback
- cover canonical and localized docs routes

## Validation
- docs focused tests: 15 passed
- docs visual block validation: 12 passed
- package TypeScript compiler: passed
- 
> agentnative@1.0.0 guards /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/run-guards.ts


[guard:hooks-registered] output

> agentnative@1.0.0 guard:hooks-registered /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-hooks-registered.mjs

guard-hooks-registered: OK (2 hook command(s) registered, 2 hook script(s) on disk).

[guard:chat-first-shared-ui] output

> agentnative@1.0.0 guard:chat-first-shared-ui /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-chat-first-shared-ui.ts

[guard:chat-first-shared-ui] clean

[guard:no-drizzle-push] output

> agentnative@1.0.0 guard:no-drizzle-push /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-drizzle-push.mjs

guard-no-drizzle-push: clean (no `drizzle-kit push` in any build/deploy path).

[guard:no-pnpm-patches] output

> agentnative@1.0.0 guard:no-pnpm-patches /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-no-pnpm-patches.ts

guard-no-pnpm-patches: clean (no pnpm package patches found).

[guard:release-schema-complete] output

> agentnative@1.0.0 guard:release-schema-complete /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-release-schema-complete.ts

Release schema list covers every store that defines tables (0 findings).

[guard:no-env-credentials] output

> agentnative@1.0.0 guard:no-env-credentials /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-env-credentials.mjs

guard-no-env-credentials: clean (no forbidden process.env reads in credential paths).

[guard:env-documentation] output

> agentnative@1.0.0 guard:env-documentation /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-env-documentation.ts

[env-doc] Covered 936 static environment variables in the maintainer inventory and curated framework docs (393 inventory entries, 83 public entries).

[guard:no-unscoped-credentials] output

> agentnative@1.0.0 guard:no-unscoped-credentials /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-unscoped-credentials.mjs

guard-no-unscoped-credentials: clean (every credential call passes context).

[guard:google-auth-redirects] output

> agentnative@1.0.0 guard:google-auth-redirects /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-google-auth-redirects.mjs

guard-google-auth-redirects: clean (11 auth-url files checked).

[guard:agent-native-brand] output

> agentnative@1.0.0 guard:agent-native-brand /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-agent-native-brand.ts

guard:agent-native-brand: clean (17734 files)

[guard:db-tool-scoping] output

> agentnative@1.0.0 guard:db-tool-scoping /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-db-tool-scoping.mjs

guard-db-tool-scoping: clean (58 intentionally denied template table(s))

[guard:template-list] output

> agentnative@1.0.0 guard:template-list /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-template-list.mjs

guard-template-list: clean (13 public templates: analytics, assets, brain, calendar, chat, clips, content, design, dispatch, forms, mail, plan, slides).

[guard:no-localhost-fallback] output

> agentnative@1.0.0 guard:no-localhost-fallback /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-localhost-fallback.mjs

guard-no-localhost-fallback: clean (no "local@localhost" literals and no ambient-identity fallbacks in production code).

[guard:no-env-mutation] output

> agentnative@1.0.0 guard:no-env-mutation /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-env-mutation.mjs

guard-no-env-mutation: clean (no process.env mutations/deletions in production code).

[guard:no-empty-migrations] output

> agentnative@1.0.0 guard:no-empty-migrations /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-no-empty-migrations.ts

No empty migration plugins found.

[guard:netlify-private-env] output

> agentnative@1.0.0 guard:netlify-private-env /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-netlify-private-env.ts

guard-netlify-private-env: clean (no Builder private key in Netlify deploy config).

[guard:netlify-release-migrations] output

> agentnative@1.0.0 guard:netlify-release-migrations /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-netlify-release-migrations.ts

guard-netlify-release-migrations: clean (published production and beta schemas have explicit owners).

[guard:netlify-prebuilt-workflow] output

> agentnative@1.0.0 guard:netlify-prebuilt-workflow /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-netlify-prebuilt-workflow.ts

Netlify prebuilt workflows preserve context and publish serialization.

[guard:beta-e2e-suite] output

> agentnative@1.0.0 guard:beta-e2e-suite /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-beta-e2e-suite.ts

guard:beta-e2e-suite passed

[guard:trusted-acceptance] output

> agentnative@1.0.0 guard:trusted-acceptance /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-trusted-acceptance-workflow.ts

Trusted acceptance workflow boundary checks passed.

[guard:content-product-conformance] output

> agentnative@1.0.0 guard:content-product-conformance /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/validate-content-product-impact-workflow.ts

Content product conformance workflow boundary checks passed.

[guard:content-product-docs] output

> agentnative@1.0.0 guard:content-product-docs /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/validate-content-product-docs.ts

[content-product-docs] Validated 6 Chapters, 32 Features, and 124 Capabilities

[guard:template-standard] output

> agentnative@1.0.0 guard:template-standard /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/template-standard/index.ts --check

[template-standard] checked 17 templates: analytics, assets, brain, calendar, chat, clips, content, crm, design, dispatch, factory, forms, macros, mail, plan, slides, tasks
[template-standard] core-routes surface: investigated, not enforced (see manifest.ts CORE_ROUTES_FINDING).
[template-standard] never-standardized surfaces (no checks by design): actions/ (app-specific operations); drizzle schema (app-specific data model); app/ UI (app-specific screens/components); app-specific skills beyond the shared set sync-workspace-core-skills.ts governs; agent-native.json / app-skill.json content; changelog/ entries

[template-standard] 10 known gap(s), accepted in the baseline (Phase 2/3 should shrink these):
  - byte-sync:learnings-defaults:mismatch :: analytics — templates/analytics/learnings.defaults.md content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:learnings-defaults:mismatch :: clips — templates/clips/learnings.defaults.md content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/learnings.defaults.md).
  - byte-sync:gitignore-source:mismatch :: assets — templates/assets/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: brain — templates/brain/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: chat — templates/chat/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: crm — templates/crm/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: design — templates/design/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: dispatch — templates/dispatch/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: plan — templates/plan/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).
  - byte-sync:gitignore-source:mismatch :: slides — templates/slides/_gitignore content differs from the canonical copy (/Users/steve/.codex/worktrees/a579/framework/scripts/template-standard/assets/_gitignore).

[template-standard] 6 version-drift warning(s) (WARN-level, does not fail the guard):
  - dep-version-band:zod :: brain — templates/brain/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: chat — templates/chat/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: factory — templates/factory/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: macros — templates/macros/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: plan — templates/plan/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".
  - dep-version-band:zod :: tasks — templates/tasks/package.json uses zod@"^4.4.3"; the majority of templates use "^4.3.6".

[template-standard] no new drift. 10 baselined gap(s) remain open.

[guard:public-packages] output

> agentnative@1.0.0 guard:public-packages /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-public-packages.ts

OK Agent-Native package publish metadata is public.

[guard:workspace-skills] output

> agentnative@1.0.0 guard:workspace-skills /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/sync-workspace-core-skills.ts --check

Workspace-core, default-template, and template shared skills are in sync.

[guard:shared-ui-singletons] output

> agentnative@1.0.0 guard:shared-ui-singletons /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-shared-ui-singletons.ts

[guard:shared-ui-singletons] clean (13 catalog-shared dependencies; 7 singleton-critical resolutions)

[guard:toolkit-must-not-import-core] output

> agentnative@1.0.0 guard:toolkit-must-not-import-core /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-toolkit-must-not-import-core.ts

[guard:toolkit-must-not-import-core] clean

[guard:controller-boundaries] output

> agentnative@1.0.0 guard:controller-boundaries /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-controller-boundaries.ts

[guard:controller-boundaries] clean

[guard:no-generated-artifacts] output

> agentnative@1.0.0 guard:no-generated-artifacts /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-generated-artifacts.mjs


[guard:template-ui-imports] output

> agentnative@1.0.0 guard:template-ui-imports /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-template-ui-imports.ts

[guard:template-ui-imports] clean

[guard:no-one-off-mcp-app-html] output

> agentnative@1.0.0 guard:no-one-off-mcp-app-html /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-one-off-mcp-app-html.mjs

[guard-no-one-off-mcp-app-html] OK - scanned 6952 template source files.

[guard:extension-no-public] output

> agentnative@1.0.0 guard:extension-no-public /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-extension-no-public.mjs

[guard-extension-no-public] OK — scanned 16476 files, no violations.

[guard:i18n-changed-copy] output

> agentnative@1.0.0 guard:i18n-changed-copy /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-i18n-changed-copy.ts

[guard:i18n-changed-copy] checked 0 changed copy surfaces

[guard:plan-skills] output

> agentnative@1.0.0 guard:plan-skills /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/sync-plan-skills.ts --check

Exported app skills are in sync with skills.ts constants.

[guard:plan-marketplace] output

> agentnative@1.0.0 guard:plan-marketplace /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/sync-plan-marketplace.ts --check

App marketplace bundles are in sync (agent-native-visual-plans 1.0.0+codex.93102d6bf147, agent-native-design 1.0.0+codex.85ef363482ba, agent-native-turn-into-app 1.0.0+codex.a8b5000e2df3).

[guard:no-core-client-barrel-imports] output

> agentnative@1.0.0 guard:no-core-client-barrel-imports /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-no-core-client-barrel-imports.ts

[guard:no-core-client-barrel-imports] clean

[guard:no-error-string-returns] output

> agentnative@1.0.0 guard:no-error-string-returns /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-error-string-returns.mjs

guard-no-error-string-returns: OK

[guard:no-action-twin-routes] output

> agentnative@1.0.0 guard:no-action-twin-routes /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-action-twin-routes.mjs

guard-no-action-twin-routes: OK (17 grandfathered routes remaining in baseline)

[guard:eject-manifests] output

> agentnative@1.0.0 guard:eject-manifests /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-eject-manifests.ts

Eject manifests cover 29 units across 4 packages and all six first-party catalogs.

[guard:provider-action-factories] output

> agentnative@1.0.0 guard:provider-action-factories /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-provider-action-factories.ts

[guard:provider-action-factories] all shared action factories are in use

[guard:ssr-cache-shell] output

> agentnative@1.0.0 guard:ssr-cache-shell /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-ssr-cache-shell.mjs

guard-ssr-cache-shell: clean (SSR HTML/.data stays a public, anonymous, hard-CDN-cached shell).

[guard:agent-chat-context] output

> agentnative@1.0.0 guard:agent-chat-context /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-agent-chat-context.ts

[guard:agent-chat-context] packages/core/src/templates/default/AGENTS.md: 5743/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] packages/core/src/templates/headless/AGENTS.md: 5598/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] packages/core/src/templates/workspace-core/AGENTS.md: 5959/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/analytics/AGENTS.md: 5503/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/assets/AGENTS.md: 5722/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/brain/AGENTS.md: 5726/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/calendar/AGENTS.md: 4875/6000 instruction chars
[guard:agent-chat-context] templates/chat/AGENTS.md: 2884/6000 instruction chars
[guard:agent-chat-context] templates/clips/AGENTS.md: 5868/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/content/AGENTS.md: 5988/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/crm/AGENTS.md: 5609/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/design/AGENTS.md: 5998/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/dispatch/AGENTS.md: 5956/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/factory/AGENTS.md: 5679/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/forms/AGENTS.md: 5865/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/macros/AGENTS.md: 1887/6000 instruction chars
[guard:agent-chat-context] templates/mail/AGENTS.md: 5680/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/plan/AGENTS.md: 4953/6000 instruction chars
[guard:agent-chat-context] templates/slides/AGENTS.md: 5963/6000 instruction chars (WARN: approaching cap)
[guard:agent-chat-context] templates/tasks/AGENTS.md: 3989/6000 instruction chars
[guard:agent-chat-context] WARNING: 15 file(s) over the 5500-character soft limit (does not fail the build):
- packages/core/src/templates/default/AGENTS.md: 5743 characters is over the 5500-character soft limit — only 257 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- packages/core/src/templates/headless/AGENTS.md: 5598 characters is over the 5500-character soft limit — only 402 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- packages/core/src/templates/workspace-core/AGENTS.md: 5959 characters is over the 5500-character soft limit — only 41 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/analytics/AGENTS.md: 5503 characters is over the 5500-character soft limit — only 497 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/assets/AGENTS.md: 5722 characters is over the 5500-character soft limit — only 278 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/brain/AGENTS.md: 5726 characters is over the 5500-character soft limit — only 274 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/clips/AGENTS.md: 5868 characters is over the 5500-character soft limit — only 132 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/content/AGENTS.md: 5988 characters is over the 5500-character soft limit — only 12 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/crm/AGENTS.md: 5609 characters is over the 5500-character soft limit — only 391 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/design/AGENTS.md: 5998 characters is over the 5500-character soft limit — only 2 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/dispatch/AGENTS.md: 5956 characters is over the 5500-character soft limit — only 44 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/factory/AGENTS.md: 5679 characters is over the 5500-character soft limit — only 321 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/forms/AGENTS.md: 5865 characters is over the 5500-character soft limit — only 135 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/mail/AGENTS.md: 5680 characters is over the 5500-character soft limit — only 320 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
- templates/slides/AGENTS.md: 5963 characters is over the 5500-character soft limit — only 37 characters of headroom before the 6000-character hard cap starts dropping content. Move detail into .agents/skills/* now.
[guard:agent-chat-context] packages/dispatch/src/server/plugins/agent-chat.ts: 27 starter tools
[guard:agent-chat-context] templates/analytics/server/plugins/agent-chat.ts: 37 starter tools
[guard:agent-chat-context] templates/assets/server/plugins/agent-chat.ts: 16 starter tools
[guard:agent-chat-context] templates/brain/server/plugins/agent-chat.ts: 25 starter tools
[guard:agent-chat-context] templates/calendar/server/plugins/agent-chat.ts: 20 starter tools
[guard:agent-chat-context] templates/chat/server/plugins/agent-chat.ts: 3 starter tools
[guard:agent-chat-context] templates/clips/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/content/server/plugins/agent-chat.ts: 4 starter tools
[guard:agent-chat-context] templates/crm/server/plugins/agent-chat.ts: 36 starter tools
[guard:agent-chat-context] templates/design/server/plugins/agent-chat.ts: 35 starter tools
[guard:agent-chat-context] templates/factory/server/plugins/agent-chat.ts: 32 starter tools
[guard:agent-chat-context] templates/forms/server/plugins/agent-chat.ts: 13 starter tools
[guard:agent-chat-context] templates/macros/server/plugins/agent-chat.ts: 9 starter tools
[guard:agent-chat-context] templates/mail/server/plugins/agent-chat.ts: 22 starter tools
[guard:agent-chat-context] templates/plan/server/plugins/agent-chat.ts: 12 starter tools
[guard:agent-chat-context] templates/slides/server/plugins/agent-chat.ts: 21 starter tools
[guard:agent-chat-context] templates/tasks/server/plugins/agent-chat.ts: 17 starter tools
[guard:agent-chat-context] clean (17 first-party agent chat plugins)

[guard:route-chunk-recovery] output

> agentnative@1.0.0 guard:route-chunk-recovery /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-route-chunk-recovery.mjs

[guard:route-chunk-recovery] OK — 17 template client entr(ies) install stale-chunk recovery.

[guard:ssr-cache-artifact] output

> agentnative@1.0.0 guard:ssr-cache-artifact /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-ssr-cache-artifact.ts

guard:ssr-cache-artifact: clean (runtime and prerendered Netlify shells share the public SWR policy).

[guard:one-sign-in] output

> agentnative@1.0.0 guard:one-sign-in /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-one-sign-in.mjs

[guard-one-sign-in] OK - scanned 5040 template source files.

[guard:additive-migrations] output

> agentnative@1.0.0 guard:additive-migrations /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-additive-migrations.mjs

guard-additive-migrations: OK (30 migration source file(s) scanned)

[guard:config-docs] output

> agentnative@1.0.0 guard:config-docs /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/sync-config-docs.ts --check

[sync-config-docs] up to date

[guard:request-storms] output

> agentnative@1.0.0 guard:request-storms /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-request-storms.ts

[guard:request-storms] clean (8056 maintained TypeScript files)

[guard:no-legacy-config] output

> agentnative@1.0.0 guard:no-legacy-config /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-legacy-config.mjs

guard-no-legacy-config: clean

[guard:no-silent-coercion] output

> agentnative@1.0.0 guard:no-silent-coercion /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-silent-coercion.mjs

guard-no-silent-coercion: OK

[guard:i18n-catalogs] output

> agentnative@1.0.0 guard:i18n-catalogs /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-i18n-catalogs.ts

[guard:i18n-catalogs] checked 20 catalog directories

[guard:no-raw-colors] output

> agentnative@1.0.0 guard:no-raw-colors /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-raw-colors.mjs

guard-no-raw-colors: OK

[guard:no-secret-literals] output

> agentnative@1.0.0 guard:no-secret-literals /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-secret-literals.mjs

guard-no-secret-literals: OK

[guard:no-default-chrome] output

> agentnative@1.0.0 guard:no-default-chrome /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-default-chrome.mjs

guard-no-default-chrome: OK (31 added line(s) across 6 file(s); no new default-surface chrome)

[guard:no-boot-data-work] output

> agentnative@1.0.0 guard:no-boot-data-work /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-boot-data-work.mjs

guard-no-boot-data-work: OK

[guard:persistent-compositing] output

> agentnative@1.0.0 guard:persistent-compositing /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-persistent-compositing.mjs

guard-persistent-compositing: OK (1 baselined, 0 new).

[guard:no-heavy-dashboard-list-reads] output
guard-no-heavy-dashboard-list-reads: OK

[guard:no-blob-column-predicate] output
guard-no-blob-column-predicate: clean

[guard:serverless-function-payload] output

> agentnative@1.0.0 guard:serverless-function-payload /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-serverless-function-payload.mjs

guard-serverless-function-payload: OK

[guard:help-icon-scale] output

> agentnative@1.0.0 guard:help-icon-scale /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-help-icon-scale.mjs

guard-help-icon-scale: OK (16 help icon elements checked; inline glyphs are at most 12px)

[guard:doc-budgets] output

> agentnative@1.0.0 guard:doc-budgets /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-doc-budgets.mjs

guard:doc-budgets: 10 standing docs within ceiling.

[guard:no-untracked-imports] output

> agentnative@1.0.0 guard:no-untracked-imports /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-untracked-imports.mjs

guard-no-untracked-imports: clean (17895 tracked files scanned).

[guard:dead-settings-keys] output

> agentnative@1.0.0 guard:dead-settings-keys /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-dead-settings-keys.mjs

guard-dead-settings-keys: OK

[guard:migration-manifest] output

> agentnative@1.0.0 guard:migration-manifest /Users/steve/.codex/worktrees/a579/framework
> tsx scripts/guard-migration-manifest.ts

[guard:migration-manifest] clean

[guard:no-unscoped-queries] output

> agentnative@1.0.0 guard:no-unscoped-queries /Users/steve/.codex/worktrees/a579/framework
> node scripts/guard-no-unscoped-queries.mjs

guard-no-unscoped-queries: clean (20 schema dirs scanned).: 65 checks passed
- browser: homepage -> Docs showed the real Getting Started callout at the first sample with no raw MDX tag or console errors