### PR TITLE
fix(desktop): show integrations natively without loading flash

### DIFF
--- a/.changeset/native-integrations-immediate.md
+++ b/.changeset/native-integrations-immediate.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Render the shared integrations catalog immediately while saved connections load.

--- a/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.spec.tsx
@@ -22,7 +22,20 @@ vi.mock("../resources/McpIntegrationDialog.js", () => ({
 }));
 
 vi.mock("../resources/mcp-integration-catalog.js", () => ({
-  getDefaultMcpIntegrations: () => [],
+  getDefaultMcpIntegrations: () => [
+    {
+      id: "context7",
+      name: "Context7",
+      provider: "context7",
+      description: "Fetch current library docs in agent chats.",
+      useCase: "documentation",
+      url: "https://mcp.context7.com/mcp",
+      authMode: "none",
+      connectionMode: "direct",
+      availability: "ready",
+      logoUrl: "",
+    },
+  ],
 }));
 
 vi.mock("../resources/use-mcp-servers.js", () => mcpMocks);
@@ -127,5 +140,21 @@ describe("IntegrationsPanel MCP connection errors", () => {
       id: "fullstory-1",
       scope: "org",
     });
+  });
+
+  it("renders the catalog while saved connections are still loading", async () => {
+    mcpMocks.useMcpServers.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isLoading: true,
+    });
+
+    await act(async () => {
+      root.render(<IntegrationsPanel />);
+    });
+
+    expect(container.textContent).toContain("Available integrations");
+    expect(container.textContent).toContain("Context7");
+    expect(container.querySelector(".animate-pulse")).toBeNull();
   });
 });

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -968,11 +968,6 @@ export function McpIntegrationsSection({
           Could not load connected agent integrations. The catalog is still
           available.
         </p>
-      ) : serversQuery.isLoading ? (
-        <div className="space-y-3 rounded-xl border border-border/70 bg-card px-4 py-4">
-          <div className="h-5 w-1/2 animate-pulse rounded bg-muted" />
-          <div className="h-5 w-3/4 animate-pulse rounded bg-muted" />
-        </div>
       ) : servers.length > 0 && !normalizedQuery ? (
         <section className="space-y-2">
           <h3 className="text-sm font-semibold text-foreground">Installed</h3>

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -763,6 +763,7 @@ export interface McpIntegrationsSectionProps {
   showHeader?: boolean;
   className?: string;
   onOAuthStart?: (url: string) => void | Promise<void>;
+  oauthReady?: boolean;
   oauthReturnPath?: string;
 }
 
@@ -775,6 +776,7 @@ export function McpIntegrationsSection({
   showHeader = true,
   className,
   onOAuthStart,
+  oauthReady,
   oauthReturnPath,
 }: McpIntegrationsSectionProps) {
   const t = useT();
@@ -1097,6 +1099,7 @@ export function McpIntegrationsSection({
         hasOrg={hasOrg}
         onCreateMcpServer={(args) => createServer.mutateAsync(args)}
         onOAuthStart={onOAuthStart}
+        oauthReady={oauthReady}
         oauthReturnPath={oauthReturnPath}
       />
     </section>

--- a/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.spec.tsx
@@ -99,6 +99,37 @@ describe("McpIntegrationDialog", () => {
     ).toBe("user");
   });
 
+  it("waits for the desktop OAuth target before connecting", () => {
+    const linear = DEFAULT_MCP_INTEGRATIONS.find(
+      (integration) => integration.id === "linear",
+    )!;
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <McpIntegrationDialog
+            open
+            onOpenChange={() => {}}
+            initialIntegrationId="linear"
+            defaultScope="user"
+            canCreateOrgMcp
+            hasOrg
+            onCreateMcpServer={vi.fn()}
+            integrations={[linear]}
+            oauthReady={false}
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const connect = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Connect",
+    );
+    expect(connect).toHaveProperty("disabled", true);
+    act(() => connect?.click());
+    expect(mocks.navigateToMcpOAuthStart).not.toHaveBeenCalled();
+  });
+
   it("offers a shared scope for an integration that supports it", () => {
     const context7 = DEFAULT_MCP_INTEGRATIONS.find(
       (integration) => integration.id === "context7",

--- a/packages/core/src/client/resources/McpIntegrationDialog.tsx
+++ b/packages/core/src/client/resources/McpIntegrationDialog.tsx
@@ -58,6 +58,7 @@ export interface McpIntegrationDialogProps {
   hasOrg: boolean;
   onCreateMcpServer: (args: CreateMcpServerArgs) => Promise<unknown>;
   onOAuthStart?: (url: string) => void | Promise<void>;
+  oauthReady?: boolean;
   oauthReturnPath?: string;
   onCreated?: () => void;
   integrations?: DefaultMcpIntegration[];
@@ -131,6 +132,7 @@ export function McpIntegrationDialog({
   hasOrg,
   onCreateMcpServer,
   onOAuthStart,
+  oauthReady = true,
   oauthReturnPath,
   onCreated,
   integrations,
@@ -294,6 +296,7 @@ export function McpIntegrationDialog({
     },
     options?: { scope?: McpServerScope },
   ) => {
+    if (!oauthReady) return;
     const validationError = getMcpUrlValidationError(args.url);
     if (validationError) {
       setError(validationError);
@@ -463,6 +466,7 @@ export function McpIntegrationDialog({
       (candidate) => candidate.id === quickConnectIntegrationId,
     );
     if (!integration) return;
+    if (integration.authMode === "oauth" && !oauthReady) return;
     quickConnectAttemptedRef.current = quickConnectIntegrationId;
     quickConnectRef.current?.(integration);
   }, [
@@ -471,6 +475,7 @@ export function McpIntegrationDialog({
     mcpServersQuery.isError,
     mcpServersQuery.isSuccess,
     open,
+    oauthReady,
     quickConnectIntegrationId,
   ]);
 
@@ -482,6 +487,7 @@ export function McpIntegrationDialog({
       (candidate) => candidate.id === connectIntegrationId,
     );
     if (!integration) return;
+    if (integration.authMode === "oauth" && !oauthReady) return;
     const attemptKey = `connect:${connectIntegrationId}`;
     if (quickConnectAttemptedRef.current === attemptKey) return;
     quickConnectAttemptedRef.current = attemptKey;
@@ -503,6 +509,7 @@ export function McpIntegrationDialog({
     mcpServersQuery.isError,
     mcpServersQuery.isSuccess,
     open,
+    oauthReady,
   ]);
 
   const connectPersonal = (integration: DefaultMcpIntegration) => {
@@ -1065,7 +1072,7 @@ export function McpIntegrationDialog({
                 <button
                   type="button"
                   onClick={connectCustomWithOAuth}
-                  disabled={!name.trim() || !url.trim() || busy}
+                  disabled={!oauthReady || !name.trim() || !url.trim() || busy}
                   aria-busy={busy}
                   className="rounded-md border border-border bg-background px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-40"
                 >
@@ -1081,7 +1088,7 @@ export function McpIntegrationDialog({
                     <button
                       type="button"
                       onClick={() => connectWithOAuth(selected)}
-                      disabled={busy}
+                      disabled={!oauthReady || busy}
                       aria-busy={busy}
                       className="inline-flex min-w-[132px] items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
                     >
@@ -1096,7 +1103,7 @@ export function McpIntegrationDialog({
                 <button
                   type="button"
                   onClick={() => connectWithOAuth(selected)}
-                  disabled={!name.trim() || !url.trim() || busy}
+                  disabled={!oauthReady || !name.trim() || !url.trim() || busy}
                   aria-busy={busy}
                   className="inline-flex min-w-[92px] items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
                 >

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -614,35 +614,23 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(isNativeDesktopIntegrationsPath("/integrations/slack")).toBe(false);
   });
 
-  it("only exposes native integrations after both app and desktop auth are ready", () => {
+  it("exposes native integrations before guest auth finishes loading", () => {
     expect(
       shouldShowNativeDesktopIntegrations({
         appId: "dispatch",
         path: "/integrations",
-        appAuthState: "authenticated",
-        desktopIdentityStatus: "signed-in",
       }),
     ).toBe(true);
-    for (const desktopIdentityStatus of [
-      undefined,
-      "idle",
-      "checking",
-    ] as const) {
-      expect(
-        shouldShowNativeDesktopIntegrations({
-          appId: "dispatch",
-          path: "/integrations",
-          appAuthState: "authenticated",
-          desktopIdentityStatus,
-        }),
-      ).toBe(false);
-    }
+    expect(
+      shouldShowNativeDesktopIntegrations({
+        appId: "calendar",
+        path: "/integrations",
+      }),
+    ).toBe(false);
     expect(
       shouldShowNativeDesktopIntegrations({
         appId: "dispatch",
-        path: "/integrations",
-        appAuthState: "unauthenticated",
-        desktopIdentityStatus: "signed-in",
+        path: "/integrations/slack",
       }),
     ).toBe(false);
   });

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -619,8 +619,23 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       shouldShowNativeDesktopIntegrations({
         appId: "dispatch",
         path: "/integrations",
+        appAuthState: "unknown",
       }),
     ).toBe(true);
+    expect(
+      shouldShowNativeDesktopIntegrations({
+        appId: "dispatch",
+        path: "/integrations",
+        appAuthState: "authenticated",
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowNativeDesktopIntegrations({
+        appId: "dispatch",
+        path: "/integrations",
+        appAuthState: "unauthenticated",
+      }),
+    ).toBe(false);
     expect(
       shouldShowNativeDesktopIntegrations({
         appId: "calendar",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -351,9 +351,12 @@ export function shouldUseDesktopAppChatShell(path?: string): boolean {
 export function shouldShowNativeDesktopIntegrations(input: {
   appId: string;
   path?: string;
+  appAuthState?: AppWebviewAuthState;
 }): boolean {
   return (
-    input.appId === "dispatch" && isNativeDesktopIntegrationsPath(input.path)
+    input.appId === "dispatch" &&
+    isNativeDesktopIntegrationsPath(input.path) &&
+    input.appAuthState !== "unauthenticated"
   );
 }
 
@@ -2674,8 +2677,10 @@ export default function CodeAgentsHub({
         const showNativeIntegrations = shouldShowNativeDesktopIntegrations({
           appId: surfaceApp.id,
           path: tab.path,
+          appAuthState,
         });
         const nativeOAuthActive =
+          appAuthState !== "unauthenticated" &&
           surfaceApp.id === "dispatch" &&
           isNativeDesktopIntegrationsPath(tab.path) &&
           nativeOAuthActiveByTab[tab.id] === true;

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -351,14 +351,9 @@ export function shouldUseDesktopAppChatShell(path?: string): boolean {
 export function shouldShowNativeDesktopIntegrations(input: {
   appId: string;
   path?: string;
-  appAuthState?: AppWebviewAuthState;
-  desktopIdentityStatus?: DesktopIdentityStatus | "checking";
 }): boolean {
   return (
-    input.appId === "dispatch" &&
-    isNativeDesktopIntegrationsPath(input.path) &&
-    input.appAuthState === "authenticated" &&
-    input.desktopIdentityStatus === "signed-in"
+    input.appId === "dispatch" && isNativeDesktopIntegrationsPath(input.path)
   );
 }
 
@@ -2679,8 +2674,6 @@ export default function CodeAgentsHub({
         const showNativeIntegrations = shouldShowNativeDesktopIntegrations({
           appId: surfaceApp.id,
           path: tab.path,
-          appAuthState,
-          desktopIdentityStatus,
         });
         const nativeOAuthActive =
           surfaceApp.id === "dispatch" &&

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2771,6 +2771,7 @@ export default function CodeAgentsHub({
                       aria-hidden={nativeOAuthActive}
                     >
                       <DesktopIntegrationsPage
+                        appAuthState={appAuthState}
                         targetWebContentsId={webContentsIdByTab[tab.id]}
                         onOAuthActiveChange={(active) =>
                           handleNativeOAuthActiveChange(tab.id, active)

--- a/packages/desktop-app/src/renderer/components/DesktopIntegrationsPage.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIntegrationsPage.tsx
@@ -5,16 +5,24 @@ import {
   type McpServersApi,
 } from "@agent-native/core/client/resources";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { AppWebviewAuthState } from "./AppWebview.js";
 
 export default function DesktopIntegrationsPage({
+  appAuthState,
   targetWebContentsId,
   onOAuthActiveChange,
 }: {
+  appAuthState?: AppWebviewAuthState;
   targetWebContentsId?: number;
   onOAuthActiveChange?: (active: boolean) => void;
 }) {
   const [queryClient] = useState(() => createAgentNativeQueryClient());
+  useEffect(() => {
+    if (appAuthState !== "authenticated") return;
+    void queryClient.invalidateQueries({ queryKey: ["mcp-servers"] });
+  }, [appAuthState, queryClient]);
   const startOAuth = useCallback(
     async (url: string) => {
       const handler = window.electronAPI?.mcpServers

--- a/packages/desktop-app/src/renderer/components/DesktopIntegrationsPage.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIntegrationsPage.tsx
@@ -69,6 +69,7 @@ export default function DesktopIntegrationsPage({
               <McpIntegrationsLanding
                 title="Integrations"
                 onOAuthStart={startOAuth}
+                oauthReady={targetWebContentsId !== undefined}
                 oauthReturnPath="/integrations"
               />
             </McpServersApiProvider>


### PR DESCRIPTION
## Summary

- Reveal the native Dispatch integrations surface as soon as the route opens.
- Keep the shared integrations catalog visible while connected-server data loads.
- Preserve the hosted Dispatch webview in the background for auth and OAuth.

## Verification

- Focused core and desktop tests
- Core and desktop typechecks
- 65 repository guards
- Desktop build
- Direct Electron click probe: native catalog visible at 0 ms, 100 ms, 300 ms, and 1 s with no panel loading pulses

## Known limitation

The existing broad Electron smoke harness still fails its pre-existing top-navigation color assertion.