### PR TITLE
fix: unify app loading indicators

### DIFF
--- a/.changeset/shared-cube-loading.md
+++ b/.changeset/shared-cube-loading.md
@@ -1,0 +1,7 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+"@agent-native/toolkit": patch
+---
+
+Use the cube spinner for shared loading indicators and the worded loader for full-page states across apps.

--- a/packages/core/src/client/DefaultSpinner.spec.tsx
+++ b/packages/core/src/client/DefaultSpinner.spec.tsx
@@ -99,4 +99,14 @@ describe("DefaultSpinner", () => {
       container.querySelector('[role="status"]')?.getAttribute("aria-label"),
     ).toBe("Mail is reloading");
   });
+
+  it("can fill a dynamic viewport container", () => {
+    act(() => {
+      root.render(<DefaultSpinner height="100%" />);
+    });
+
+    expect((container.firstElementChild as HTMLElement).style.height).toBe(
+      "100%",
+    );
+  });
 });

--- a/packages/core/src/client/DefaultSpinner.tsx
+++ b/packages/core/src/client/DefaultSpinner.tsx
@@ -1,5 +1,11 @@
 import { CubeLoader } from "@agent-native/toolkit/ui/cube-loader";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import { LOADING_LABELS } from "../shared/loading-labels.js";
 
@@ -38,8 +44,10 @@ function getRandomLoadingLabelIndex(): number {
 
 export function DefaultSpinner({
   ariaLabel = "Loading",
+  height = "100vh",
 }: {
   ariaLabel?: string;
+  height?: CSSProperties["height"];
 }) {
   const [loadingLabelIndex, setLoadingLabelIndex] = useState(
     getInitialLoadingLabelIndex,
@@ -81,7 +89,7 @@ export function DefaultSpinner({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        height: "100vh",
+        height,
         width: "100%",
       }}
     >

--- a/packages/core/src/client/ui/index.ts
+++ b/packages/core/src/client/ui/index.ts
@@ -35,6 +35,7 @@ export { getClientSurface, type ClientSurface } from "../client-surface.js";
 export { ErrorBoundary } from "../ErrorBoundary.js";
 export { ClientOnly } from "../ClientOnly.js";
 export { DefaultSpinner } from "../DefaultSpinner.js";
+export { Spinner } from "@agent-native/toolkit/ui/spinner";
 export { RuntimeConfigNotice } from "../RuntimeConfigNotice.js";
 export {
   EnvironmentBadge,

--- a/packages/dispatch/src/components/ui/spinner.tsx
+++ b/packages/dispatch/src/components/ui/spinner.tsx
@@ -1,17 +1,1 @@
-import { IconLoader2 } from "@tabler/icons-react";
-
-import { cn } from "../../lib/utils";
-
-export function Spinner({
-  className,
-  ...props
-}: React.ComponentProps<typeof IconLoader2>) {
-  return (
-    <IconLoader2
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
-  );
-}
+export * from "@agent-native/toolkit/ui/spinner";

--- a/packages/dispatch/src/routes/pages/$appId.spec.tsx
+++ b/packages/dispatch/src/routes/pages/$appId.spec.tsx
@@ -8,6 +8,7 @@ const routeState = vi.hoisted(() => ({
 }));
 
 vi.mock("@agent-native/core/client/api-path", () => ({
+  agentNativePath: (path: string) => path,
   appPath: (path: string) => path,
 }));
 

--- a/packages/dispatch/src/routes/pages/$appId.tsx
+++ b/packages/dispatch/src/routes/pages/$appId.tsx
@@ -1,6 +1,7 @@
 import { appPath } from "@agent-native/core/client/api-path";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { withSsrHtmlContentType } from "@agent-native/core/shared";
 import { withBuilderUtmTrackingParams } from "@agent-native/core/shared/builder-link-tracking";
 import {
@@ -22,7 +23,6 @@ import { ActionQueryError } from "../../components/action-query-error";
 import { DispatchShell } from "../../components/dispatch-shell";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
-import { Spinner } from "../../components/ui/spinner";
 import { resolveServerCatchAllTarget } from "../../lib/catch-all-target";
 import {
   navigateToWorkspaceApp,
@@ -161,11 +161,7 @@ export default function WorkspaceAppCatchAllRoute() {
     (isLoading && !app) ||
     (app && app.status !== "pending" && href && !navigationFailed)
   ) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <Spinner className="size-8" />
-      </div>
-    );
+    return <DefaultSpinner />;
   }
 
   return (

--- a/packages/dispatch/src/routes/pages/_index.tsx
+++ b/packages/dispatch/src/routes/pages/_index.tsx
@@ -1,8 +1,7 @@
 import { appPath } from "@agent-native/core/client/api-path";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { withSsrHtmlContentType } from "@agent-native/core/shared";
 import { redirect, type LoaderFunctionArgs } from "react-router";
-
-import { Spinner } from "../../components/ui/spinner";
 
 const SEO_TITLE =
   "Dispatch - Open Source workspace control plane for AI agents";
@@ -53,11 +52,7 @@ export function clientLoader({ url }: LoaderFunctionArgs) {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex items-center justify-center h-screen w-full">
-      <Spinner className="size-8" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function IndexPage() {

--- a/packages/toolkit/src/ui/cube-loader.spec.tsx
+++ b/packages/toolkit/src/ui/cube-loader.spec.tsx
@@ -7,6 +7,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CubeLoader } from "./cube-loader.js";
+import { Spinner } from "./spinner.js";
 
 describe("CubeLoader", () => {
   let container: HTMLDivElement;
@@ -47,6 +48,25 @@ describe("CubeLoader", () => {
     expect(loader).toContain('role="status"');
     expect(loader).toContain('aria-label="Loading"');
     expect(loader).toContain('class="size-4"');
+  });
+
+  it("keeps aria-hidden loaders decorative", () => {
+    const loader = renderToStaticMarkup(
+      createElement(CubeLoader, { "aria-hidden": true }),
+    );
+
+    expect(loader).not.toContain("role=");
+    expect(loader).not.toContain("aria-label=");
+  });
+
+  it("uses the cube for the shared spinner primitive", () => {
+    const spinner = renderToStaticMarkup(
+      createElement(Spinner, { className: "size-8" }),
+    );
+
+    expect(spinner).toContain('data-agent-native-cube-loader="true"');
+    expect(spinner).toContain('class="size-8"');
+    expect(spinner).not.toContain("animate-spin");
   });
 
   it("anchors its cells to the page timeline when mounted again", () => {

--- a/packages/toolkit/src/ui/cube-loader.spec.tsx
+++ b/packages/toolkit/src/ui/cube-loader.spec.tsx
@@ -69,6 +69,20 @@ describe("CubeLoader", () => {
     expect(spinner).not.toContain("animate-spin");
   });
 
+  it("keeps icon-compatible color and title props meaningful", () => {
+    const spinner = renderToStaticMarkup(
+      createElement(Spinner, {
+        absoluteStrokeWidth: true,
+        stroke: "currentColor",
+        title: "Loading clip",
+      }),
+    );
+
+    expect(spinner).toContain('stroke="currentColor"');
+    expect(spinner).toContain('vector-effect="non-scaling-stroke"');
+    expect(spinner).toContain("<title>Loading clip</title>");
+  });
+
   it("anchors its cells to the page timeline when mounted again", () => {
     expect(renderToStaticMarkup(createElement(CubeLoader))).toContain(
       "calc(90ms - var(--an-cube-loader-phase, 0ms))",

--- a/packages/toolkit/src/ui/cube-loader.tsx
+++ b/packages/toolkit/src/ui/cube-loader.tsx
@@ -39,9 +39,13 @@ export function CubeLoader({
   ...props
 }: CubeLoaderProps) {
   const hasRole = Object.prototype.hasOwnProperty.call(props, "role");
+  const isAriaHidden =
+    props["aria-hidden"] === true || props["aria-hidden"] === "true";
   const hasExplicitSize =
     size !== undefined || width !== undefined || height !== undefined;
-  const ariaLabel = props["aria-label"] ?? (hasRole ? undefined : "Loading");
+  const ariaLabel =
+    props["aria-label"] ?? (hasRole || isAriaHidden ? undefined : "Loading");
+  const role = hasRole ? props.role : isAriaHidden ? undefined : "status";
   const setRefs = useCallback(
     (svg: SVGSVGElement | null) => setCubeAnimationPhase(svg, ref),
     [ref],
@@ -51,7 +55,7 @@ export function CubeLoader({
     <svg
       {...props}
       ref={setRefs}
-      role={hasRole ? props.role : "status"}
+      role={role}
       aria-label={ariaLabel}
       width={width ?? size ?? 24}
       height={height ?? size ?? 24}

--- a/packages/toolkit/src/ui/cube-loader.tsx
+++ b/packages/toolkit/src/ui/cube-loader.tsx
@@ -25,14 +25,20 @@ function setCubeAnimationPhase(
 
 export type CubeLoaderProps = Omit<
   React.SVGProps<SVGSVGElement>,
-  "children"
+  "children" | "stroke"
 > & {
+  absoluteStrokeWidth?: boolean;
   size?: number | string;
+  stroke?: string | number;
+  title?: string;
 };
 
 export function CubeLoader({
+  absoluteStrokeWidth,
   className,
   size,
+  stroke,
+  title,
   width,
   height,
   ref,
@@ -44,12 +50,15 @@ export function CubeLoader({
   const hasExplicitSize =
     size !== undefined || width !== undefined || height !== undefined;
   const ariaLabel =
-    props["aria-label"] ?? (hasRole || isAriaHidden ? undefined : "Loading");
+    props["aria-label"] ??
+    title ??
+    (hasRole || isAriaHidden ? undefined : "Loading");
   const role = hasRole ? props.role : isAriaHidden ? undefined : "status";
   const setRefs = useCallback(
     (svg: SVGSVGElement | null) => setCubeAnimationPhase(svg, ref),
     [ref],
   );
+  const strokeColor = stroke === undefined ? undefined : String(stroke);
 
   return (
     <svg
@@ -61,9 +70,14 @@ export function CubeLoader({
       height={height ?? size ?? 24}
       viewBox="0 0 24 24"
       fill="currentColor"
+      stroke={strokeColor}
+      vectorEffect={
+        absoluteStrokeWidth ? "non-scaling-stroke" : props.vectorEffect
+      }
       className={cn(!hasExplicitSize && "size-4", className)}
       data-agent-native-cube-loader="true"
     >
+      {title ? <title>{title}</title> : null}
       <style>{`
         @keyframes an-cube-pulse {
           0%, 100% { opacity: 0.15; }

--- a/packages/toolkit/src/ui/spinner.tsx
+++ b/packages/toolkit/src/ui/spinner.tsx
@@ -1,17 +1,6 @@
-import { IconLoader2 } from "@tabler/icons-react";
-
 import { cn } from "../utils.js";
+import { CubeLoader, type CubeLoaderProps } from "./cube-loader.js";
 
-export function Spinner({
-  className,
-  ...props
-}: React.ComponentProps<typeof IconLoader2>) {
-  return (
-    <IconLoader2
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
-  );
+export function Spinner({ className, ...props }: CubeLoaderProps) {
+  return <CubeLoader className={cn("size-4", className)} {...props} />;
 }

--- a/packages/toolkit/src/ui/spinner.tsx
+++ b/packages/toolkit/src/ui/spinner.tsx
@@ -1,18 +1,6 @@
-import { IconLoader2 } from "@tabler/icons-react";
-
 import { cn } from "../utils.js";
-import { CubeLoader } from "./cube-loader.js";
+import { CubeLoader, type CubeLoaderProps } from "./cube-loader.js";
 
-type SpinnerProps = React.ComponentProps<typeof IconLoader2> & {
-  absoluteStrokeWidth?: boolean;
-};
-
-export function Spinner({
-  className,
-  absoluteStrokeWidth: _absoluteStrokeWidth,
-  stroke: _stroke,
-  title: _title,
-  ...props
-}: SpinnerProps) {
+export function Spinner({ className, ...props }: CubeLoaderProps) {
   return <CubeLoader className={cn("size-4", className)} {...props} />;
 }

--- a/packages/toolkit/src/ui/spinner.tsx
+++ b/packages/toolkit/src/ui/spinner.tsx
@@ -1,6 +1,18 @@
-import { cn } from "../utils.js";
-import { CubeLoader, type CubeLoaderProps } from "./cube-loader.js";
+import { IconLoader2 } from "@tabler/icons-react";
 
-export function Spinner({ className, ...props }: CubeLoaderProps) {
+import { cn } from "../utils.js";
+import { CubeLoader } from "./cube-loader.js";
+
+type SpinnerProps = React.ComponentProps<typeof IconLoader2> & {
+  absoluteStrokeWidth?: boolean;
+};
+
+export function Spinner({
+  className,
+  absoluteStrokeWidth: _absoluteStrokeWidth,
+  stroke: _stroke,
+  title: _title,
+  ...props
+}: SpinnerProps) {
   return <CubeLoader className={cn("size-4", className)} {...props} />;
 }

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -1,5 +1,6 @@
 import { LanguagePicker, useT } from "@agent-native/core/client/i18n";
 import {
+  DefaultSpinner,
   OpenSourceBadge,
   PoweredByBadge,
   StarfieldBackground,
@@ -27,7 +28,6 @@ import { DatePicker } from "@/components/booking/DatePicker";
 import { TimeSlotPicker } from "@/components/booking/TimeSlotPicker";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import {
   useAvailableDays,
   useAvailableSlots,
@@ -268,9 +268,7 @@ export default function BookingPage() {
   ) {
     return (
       <BookingPageShell>
-        <div className="mx-auto mt-[7.5vh] flex w-full max-w-lg justify-center">
-          <Spinner className="size-8 text-foreground" />
-        </div>
+        <DefaultSpinner />
       </BookingPageShell>
     );
   }

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -266,11 +266,7 @@ export default function BookingPage() {
     availabilityLoading ||
     isRedirecting
   ) {
-    return (
-      <BookingPageShell>
-        <DefaultSpinner />
-      </BookingPageShell>
-    );
+    return <DefaultSpinner />;
   }
 
   if ((bookingLinkError || !bookingLink) && !isLegacyBookingPage) {

--- a/templates/calendar/app/pages/ManageBookingPage.tsx
+++ b/templates/calendar/app/pages/ManageBookingPage.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import {
   IconCalendar,
   IconClock,
@@ -24,7 +25,6 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { appApiPath } from "@/lib/api-path";
 
 interface BookingInfo {
@@ -80,11 +80,7 @@ export function ManageBookingPage() {
   const isPast = booking ? new Date(booking.end) < new Date() : false;
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Spinner className="size-8 text-foreground" />
-      </div>
-    );
+    return <DefaultSpinner />;
   }
 
   if (error || !booking) {

--- a/templates/calendar/app/routes/event.tsx
+++ b/templates/calendar/app/routes/event.tsx
@@ -4,6 +4,7 @@ import {
   isInAgentEmbed,
   postNavigate,
 } from "@agent-native/core/client/navigation";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import type { CalendarEvent } from "@shared/api";
 import {
@@ -19,7 +20,6 @@ import { useEffect } from "react";
 import { useSearchParams } from "react-router";
 
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import { messagesByLocale } from "@/i18n-data";
 
 type EventPreviewResult = CalendarEvent | { error: string };
@@ -197,11 +197,7 @@ export default function EventPreviewRoute() {
   }
 
   if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <Spinner className="size-6 text-primary" />
-      </div>
-    );
+    return <DefaultSpinner />;
   }
 
   if (error || !result || "error" in result) {

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -1,5 +1,6 @@
 import { appBasePath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
@@ -9,7 +10,6 @@ import {
   VideoPlayer,
   type VideoPlayerHandle,
 } from "@/components/player/video-player";
-import { Spinner } from "@/components/ui/spinner";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { parsePlaybackSpeed } from "@/lib/playback-speed";
 import { parseTimeParam, resolveStartMs } from "@/lib/time-param";
@@ -188,8 +188,8 @@ export default function EmbedRoute() {
 
   if (dataQ.isLoading) {
     return (
-      <div className="fixed inset-0 flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black">
-        <Spinner className="h-8 w-8 text-white/70" />
+      <div className="fixed inset-0 bg-background text-foreground">
+        <DefaultSpinner />
       </div>
     );
   }

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -190,7 +190,7 @@ export default function EmbedRoute() {
     return (
       // guard:allow-raw-color — standalone embeds must match the black player backdrop
       <div className="fixed inset-0 flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black text-background/70 dark:text-foreground/70">
-        <DefaultSpinner />
+        <DefaultSpinner height="100%" />
       </div>
     );
   }

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -188,7 +188,8 @@ export default function EmbedRoute() {
 
   if (dataQ.isLoading) {
     return (
-      <div className="fixed inset-0 bg-background text-foreground">
+      // guard:allow-raw-color — standalone embeds must match the black player backdrop
+      <div className="fixed inset-0 flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black text-background/70 dark:text-foreground/70">
         <DefaultSpinner />
       </div>
     );

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -11,7 +11,10 @@ import {
   useChangeVersions,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { buildSignInReturnHref } from "@agent-native/core/client/ui";
+import {
+  buildSignInReturnHref,
+  DefaultSpinner,
+} from "@agent-native/core/client/ui";
 import {
   isHumanReadableDocumentTitle,
   normalizeDocumentTitle,
@@ -927,11 +930,7 @@ export default function RecordingPage() {
   if (!recordingId) return null;
 
   if (playerDataQ.isLoading || playerDataForbidden) {
-    return (
-      <div className="flex items-center justify-center h-screen w-full bg-background">
-        <Spinner className="h-8 w-8" />
-      </div>
-    );
+    return <DefaultSpinner />;
   }
 
   if (playerDataQ.isError || !recording) {
@@ -941,11 +940,7 @@ export default function RecordingPage() {
         ? `/r/${recordingId}`
         : window.location.pathname + window.location.search;
     if (sessionLoading) {
-      return (
-        <div className="flex items-center justify-center h-screen w-full bg-background">
-          <Spinner className="h-8 w-8" />
-        </div>
-      );
+      return <DefaultSpinner />;
     }
     return (
       <div className="flex flex-col items-center justify-center h-screen w-full bg-background px-6">

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -11,7 +11,10 @@ import {
   getBrowserTabId,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { buildSignInReturnHref } from "@agent-native/core/client/ui";
+import {
+  buildSignInReturnHref,
+  DefaultSpinner,
+} from "@agent-native/core/client/ui";
 import { docsUrl } from "@agent-native/core/shared";
 import {
   IconAlertTriangle,
@@ -877,9 +880,7 @@ export default function ShareRoute() {
     return (
       <>
         {agentDiscovery}
-        <div className="flex items-center justify-center h-screen w-full bg-background">
-          <Spinner className="h-8 w-8 text-muted-foreground" />
-        </div>
+        <DefaultSpinner />
       </>
     );
   }

--- a/templates/clips/app/routes/share.meeting.$meetingId.tsx
+++ b/templates/clips/app/routes/share.meeting.$meetingId.tsx
@@ -1,7 +1,7 @@
 import { appPath } from "@agent-native/core/client/api-path";
 import { useSession } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { PoweredByBadge } from "@agent-native/core/client/ui";
+import { DefaultSpinner, PoweredByBadge } from "@agent-native/core/client/ui";
 import {
   AGENT_ACCESS_PARAM,
   normalizeDocumentTitle,
@@ -33,7 +33,6 @@ import {
 } from "@/components/meetings/attendee-stack";
 import { TranscriptBubbles } from "@/components/meetings/transcript-bubbles";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
 import enMessages from "@/i18n/en-US";
 import {
   fetchPublicMeeting,
@@ -227,11 +226,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
 };
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center bg-background">
-      <Spinner className="size-8 text-muted-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 function formatDateTime(iso?: string | null): string {

--- a/templates/clips/desktop/src/components/ui/spinner.tsx
+++ b/templates/clips/desktop/src/components/ui/spinner.tsx
@@ -1,17 +1,1 @@
-// Tabler is this repo's icon set; the generated component ships Lucide.
-import { IconLoader2 } from "@tabler/icons-react";
-
-import { cn } from "@/lib/utils";
-
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
-  return (
-    <IconLoader2
-      role="status"
-      aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
-      {...props}
-    />
-  );
-}
-
-export { Spinner };
+export { Spinner } from "@agent-native/core/client/ui";

--- a/templates/mail/app/routes/_index.tsx
+++ b/templates/mail/app/routes/_index.tsx
@@ -1,8 +1,7 @@
 import { agentNativePath } from "@agent-native/core/client/api-path";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { withSsrHtmlContentType } from "@agent-native/core/shared";
 import { redirect, type LoaderFunctionArgs } from "react-router";
-
-import { Spinner } from "@/components/ui/spinner";
 
 const SEO_TITLE =
   "Mail - Open Source AI email client and Superhuman alternative";
@@ -62,11 +61,7 @@ export async function clientLoader(_args: LoaderFunctionArgs) {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex items-center justify-center h-screen w-full">
-      <Spinner className="size-8" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function IndexRoute() {

--- a/templates/plan/app/routes/chat.tsx
+++ b/templates/plan/app/routes/chat.tsx
@@ -1,4 +1,5 @@
-import { Spinner } from "@/components/ui/spinner";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
+
 import { APP_TITLE } from "@/lib/app-config";
 import { PlanChatPage } from "@/pages/PlanChatPage";
 
@@ -22,11 +23,7 @@ export function meta() {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function ChatRoute() {

--- a/templates/plan/app/routes/local-plans.$slug.tsx
+++ b/templates/plan/app/routes/local-plans.$slug.tsx
@@ -1,6 +1,6 @@
+import { DefaultSpinner } from "@agent-native/core/client/ui";
 import { useParams } from "react-router";
 
-import { Spinner } from "@/components/ui/spinner";
 import { APP_TITLE } from "@/lib/app-config";
 import { PlansPage } from "@/pages/PlansPage";
 
@@ -16,11 +16,7 @@ export function meta() {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function LocalPlanRoute() {

--- a/templates/plan/app/routes/plans.$id.tsx
+++ b/templates/plan/app/routes/plans.$id.tsx
@@ -1,4 +1,5 @@
-import { Spinner } from "@/components/ui/spinner";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
+
 import { APP_TITLE } from "@/lib/app-config";
 import { planDocumentTitle } from "@/lib/plan-document-title";
 import { PlansPage } from "@/pages/PlansPage";
@@ -38,11 +39,7 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 };
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function PlanRoute() {

--- a/templates/plan/app/routes/plans.tsx
+++ b/templates/plan/app/routes/plans.tsx
@@ -1,4 +1,5 @@
-import { Spinner } from "@/components/ui/spinner";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
+
 import { APP_TITLE } from "@/lib/app-config";
 import { PlansPage } from "@/pages/PlansPage";
 
@@ -14,11 +15,7 @@ export function meta() {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function PlansRoute() {

--- a/templates/plan/app/routes/recaps.$id.tsx
+++ b/templates/plan/app/routes/recaps.$id.tsx
@@ -1,4 +1,5 @@
-import { Spinner } from "@/components/ui/spinner";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
+
 import { APP_TITLE } from "@/lib/app-config";
 import { planDocumentTitle } from "@/lib/plan-document-title";
 import { PlansPage } from "@/pages/PlansPage";
@@ -38,11 +39,7 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 };
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function RecapRoute() {

--- a/templates/plan/app/routes/recaps.tsx
+++ b/templates/plan/app/routes/recaps.tsx
@@ -1,4 +1,5 @@
-import { Spinner } from "@/components/ui/spinner";
+import { DefaultSpinner } from "@agent-native/core/client/ui";
+
 import { APP_TITLE } from "@/lib/app-config";
 import { PlansPage } from "@/pages/PlansPage";
 
@@ -14,11 +15,7 @@ export function meta() {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex h-screen w-full items-center justify-center">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DefaultSpinner />;
 }
 
 export default function RecapsRoute() {


### PR DESCRIPTION
## Summary

- Route shared `Spinner` usage through the cube loader, including the Clips desktop wrapper.
- Use the worded `DefaultSpinner` for full-page loading gates across Clips, Plan, Mail, Calendar, and Dispatch.
- Preserve animation phase across remounts, randomize loading labels, and transition label width changes.

## Validation

- Focused Toolkit, Core, Dispatch, and Clips tests pass.
- Toolkit, Core, Dispatch, Clips, Mail, Plan, and Clips desktop typechecks pass where run.
- Toolkit, Dispatch, and Clips builds pass.
- Live Clips route verification shows the cube loader with a loading word.
- Full guards have one pre-existing failure: the i18n catalog baseline/import debt.