### PR TITLE
Tighten Analytics sidebar spacing

### DIFF
--- a/templates/analytics/app/components/layout/Layout.spec.ts
+++ b/templates/analytics/app/components/layout/Layout.spec.ts
@@ -24,7 +24,7 @@ describe("Analytics layout sidebar route policy", () => {
     );
   });
 
-  it("keeps sidebar navigation scrolling separate from its pinned footer", () => {
+  it("keeps sidebar navigation compact and separate from its pinned footer", () => {
     const source = readFileSync(
       new URL("./Sidebar.tsx", import.meta.url),
       "utf8",
@@ -34,11 +34,14 @@ describe("Analytics layout sidebar route policy", () => {
       'className="flex min-h-0 flex-1 flex-col overflow-hidden py-2"',
     );
     expect(source).toContain(
-      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium lg:px-4"',
+      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium"',
     );
     expect(source).toContain('className="flex min-w-0 flex-col gap-1 pb-1"');
     expect(source).toContain(
-      'className="shrink-0 min-w-0 px-2 pt-2 text-sm font-medium lg:px-4"',
+      'className="shrink-0 min-w-0 px-2 pt-2 text-sm font-medium"',
+    );
+    expect(source).toContain(
+      'className="flex h-12 shrink-0 items-center border-b border-border px-4"',
     );
     expect(source).not.toContain(
       'className="flex min-h-0 flex-1 flex-col overflow-y-auto overflow-x-hidden py-2"',
@@ -79,7 +82,7 @@ describe("Analytics layout sidebar route policy", () => {
     );
   });
 
-  it("keeps the collapsed rail compact without changing expanded spacing", () => {
+  it("keeps both collapsed and expanded sidebar spacing compact", () => {
     const source = readFileSync(
       new URL("./Sidebar.tsx", import.meta.url),
       "utf8",
@@ -92,7 +95,7 @@ describe("Analytics layout sidebar route policy", () => {
       '"flex h-9 w-9 items-center justify-center rounded-md transition-colors"',
     );
     expect(source).toContain(
-      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium lg:px-4"',
+      'className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium"',
     );
   });
 });

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2350,7 +2350,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
         </>
       ) : (
         <>
-          <div className="flex h-12 shrink-0 items-center border-b border-border px-4 lg:px-6">
+          <div className="flex h-12 shrink-0 items-center border-b border-border px-4">
             <Link
               to="/"
               className="flex min-w-0 flex-1 items-center gap-2 font-semibold"
@@ -2365,7 +2365,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
             </Link>
           </div>
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden py-2">
-            <nav className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium lg:px-4">
+            <nav className="min-h-0 min-w-0 flex flex-1 flex-col gap-1 overflow-x-hidden overflow-y-auto px-2 text-sm font-medium">
               {/* Ask section */}
               <div className="order-1 group/section min-w-0 space-y-1">
                 <div
@@ -2673,7 +2673,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
               </div>
             </nav>
 
-            <div className="shrink-0 min-w-0 px-2 pt-2 text-sm font-medium lg:px-4">
+            <div className="shrink-0 min-w-0 px-2 pt-2 text-sm font-medium">
               <nav className="flex min-w-0 flex-col gap-1 pb-1">
                 {bottomItems.map((item) => {
                   const Icon = item.icon;

--- a/templates/analytics/changelog/2026-08-28-analytics-sidebar-horizontal-spacing-is-tighter.md
+++ b/templates/analytics/changelog/2026-08-28-analytics-sidebar-horizontal-spacing-is-tighter.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-28
+---
+
+Analytics sidebar navigation now matches sibling sidebars with tighter horizontal spacing.


### PR DESCRIPTION
## Summary
- tighten the Analytics left sidebar horizontal padding to match sibling sidebars
- keep the spacing assertion and user-facing changelog in sync

## Validation
- `git diff --check` passed
- focused test and typecheck pending in the worktree