### PR TITLE
fix: stabilize desktop auth and CLI tabs

### DIFF
--- a/.changeset/quiet-desktop-chat-tabs.md
+++ b/.changeset/quiet-desktop-chat-tabs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep desktop chat tab creation aligned with the selected UI or CLI mode.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -826,6 +826,16 @@ export interface AgentPanelProps extends Omit<
   onExitWideDrawer?: () => void;
   /** Route settings requests to a host-owned settings surface. */
   onOpenSettings?: (section?: string) => void;
+  /** Start a desktop-owned CLI tab from the chat sidebar menu. */
+  onNewCliTab?: () => void;
+  /** Return from a desktop-owned CLI tab to a UI chat tab. */
+  onNewUiTab?: () => void;
+  /** Select the mode used by the chat sidebar's new-tab affordances. */
+  newTabMode?: "ui" | "cli";
+  /** Host-owned label for the desktop CLI tab action. */
+  newCliTabLabel?: string;
+  /** Host-owned label for the desktop UI tab action. */
+  newUiTabLabel?: string;
   /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
   storageKey?: string;
   /** Restore the previously active chat thread on mount. Default: true. */
@@ -998,6 +1008,11 @@ function AgentPanelInner({
   isWideDrawer,
   onExitWideDrawer,
   onOpenSettings,
+  onNewCliTab,
+  onNewUiTab,
+  newTabMode = "ui",
+  newCliTabLabel,
+  newUiTabLabel,
   storageKey,
   restoreActiveThread = true,
   scope,
@@ -1498,10 +1513,22 @@ function AgentPanelInner({
           />
         ) : null}
         {mode === "chat" && (
-          <IconTooltip content={t("agentPanel.newChat")}>
+          <IconTooltip
+            content={
+              newTabMode === "cli" && newCliTabLabel
+                ? newCliTabLabel
+                : t("agentPanel.newChat")
+            }
+          >
             <button
-              onClick={addTab}
-              aria-label={t("agentPanel.newChat")}
+              onClick={
+                newTabMode === "cli" && onNewCliTab ? onNewCliTab : addTab
+              }
+              aria-label={
+                newTabMode === "cli" && newCliTabLabel
+                  ? newCliTabLabel
+                  : t("agentPanel.newChat")
+              }
               className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
             >
               <IconPlus size={14} />
@@ -1591,9 +1618,15 @@ function AgentPanelInner({
             ) : null}
             {onCollapse && mode === "chat" && (
               <>
-                <DropdownMenuItem onSelect={addTab}>
+                <DropdownMenuItem
+                  onSelect={
+                    newTabMode === "cli" && onNewUiTab ? onNewUiTab : addTab
+                  }
+                >
                   <IconPlus size={14} className="shrink-0" />
-                  {t("agentPanel.newChat")}
+                  {newTabMode === "cli"
+                    ? (newUiTabLabel ?? t("agentPanel.newChat"))
+                    : t("agentPanel.newChat")}
                 </DropdownMenuItem>
                 {(() => {
                   const activeTab = activeChatSessionId
@@ -1624,6 +1657,15 @@ function AgentPanelInner({
                 })()}
               </>
             )}
+            {mode === "chat" &&
+            newTabMode !== "cli" &&
+            onNewCliTab &&
+            newCliTabLabel ? (
+              <DropdownMenuItem onSelect={onNewCliTab}>
+                <IconTerminal2 size={14} className="shrink-0" />
+                {newCliTabLabel}
+              </DropdownMenuItem>
+            ) : null}
             {mode === "chat" && toggleHistory && (
               <DropdownMenuItem
                 onSelect={(event) =>
@@ -3138,6 +3180,16 @@ export interface AgentSidebarProps {
   onFullscreenRequest?: () => void;
   /** Route settings requests to a host-owned settings surface. */
   onOpenSettings?: (section?: string) => void;
+  /** Start a desktop-owned CLI tab from the chat sidebar menu. */
+  onNewCliTab?: () => void;
+  /** Return from a desktop-owned CLI tab to a UI chat tab. */
+  onNewUiTab?: () => void;
+  /** Select the mode used by the chat sidebar's new-tab affordances. */
+  newTabMode?: "ui" | "cli";
+  /** Host-owned label for the desktop CLI tab action. */
+  newCliTabLabel?: string;
+  /** Host-owned label for the desktop UI tab action. */
+  newUiTabLabel?: string;
   /** Ambient resource context rendered as a composer chip. */
   scope?: import("./use-chat-threads.js").ChatThreadScope | null;
   /** Identity used to route host-scoped sidebar toggle events. */
@@ -3208,6 +3260,11 @@ export function AgentSidebar({
   openOnChatRunning = false,
   onFullscreenRequest,
   onOpenSettings,
+  onNewCliTab,
+  onNewUiTab,
+  newTabMode = "ui",
+  newCliTabLabel,
+  newUiTabLabel,
   scope,
   toggleScopeId,
   isolateHistoryByScope = false,
@@ -4031,6 +4088,11 @@ export function AgentSidebar({
             onExitWideDrawer={isMobile ? undefined : exitWideDrawer}
             onFullViewRequest={onFullscreenRequest}
             onOpenSettings={onOpenSettings}
+            onNewCliTab={onNewCliTab}
+            onNewUiTab={onNewUiTab}
+            newTabMode={newTabMode}
+            newCliTabLabel={newCliTabLabel}
+            newUiTabLabel={newUiTabLabel}
             storageKey={storageKey}
             restoreActiveThread={restoreActiveThread}
             scope={scope}

--- a/packages/core/src/client/terminal/AgentTerminal.spec.ts
+++ b/packages/core/src/client/terminal/AgentTerminal.spec.ts
@@ -172,6 +172,18 @@ describe("AgentTerminal", () => {
     );
   });
 
+  it("keeps host authentication when adding the CLI command", async () => {
+    renderTerminal({
+      wsUrl: "ws://127.0.0.1:12345/ws?token=desktop-secret",
+      command: "codex",
+    });
+    await waitForSocketCount(1);
+
+    expect(MockWebSocket.instances[0].url).toBe(
+      "ws://127.0.0.1:12345/ws?token=desktop-secret&command=codex",
+    );
+  });
+
   it("shows setup-status errors and suppresses reconnects", async () => {
     renderTerminal({
       wsUrl: "ws://127.0.0.1:12345/ws",

--- a/packages/core/src/client/terminal/AgentTerminal.tsx
+++ b/packages/core/src/client/terminal/AgentTerminal.tsx
@@ -295,11 +295,11 @@ export function AgentTerminal({
       }
 
       // Build WebSocket URL with query params
-      const qs = new URLSearchParams();
-      if (resolvedCommand) qs.set("command", resolvedCommand);
-      if (flags) qs.set("flags", flags);
-      const qsStr = qs.toString();
-      const fullWsUrl = qsStr ? `${wsUrl}?${qsStr}` : wsUrl;
+      const fullWsUrl = new URL(wsUrl);
+      if (resolvedCommand) {
+        fullWsUrl.searchParams.set("command", resolvedCommand);
+      }
+      if (flags) fullWsUrl.searchParams.set("flags", flags);
 
       term.write(
         `\x1b[2m[terminal] Starting ${resolvedCommand || "CLI"}...\x1b[0m\r\n`,
@@ -452,7 +452,7 @@ export function AgentTerminal({
       submitPromptRef.current = submitPrompt;
       const initialRequest = pendingSubmitRequestRef.current;
       if (initialRequest) submitPrompt(initialRequest);
-      connect(fullWsUrl);
+      connect(fullWsUrl.toString());
 
       // Store cleanup references
       return () => {

--- a/packages/desktop-app/src/main/codex-login-launcher.test.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.test.ts
@@ -11,7 +11,7 @@ describe("getCodexLoginLaunchSpec", () => {
       "/usr/bin/osascript",
       [
         "-e",
-        'tell application "Terminal" to do script "codex login"',
+        'tell application "Terminal"\nset loginTab to do script "codex login"\nrepeat while busy of loginTab\ndelay 1\nend repeat\nend tell',
         "-e",
         'tell application "Terminal" to activate',
       ],
@@ -55,7 +55,7 @@ describe("getCodexLoginLaunchSpec", () => {
       command: "/usr/bin/osascript",
       args: [
         "-e",
-        'tell application "Terminal" to do script "codex login"',
+        'tell application "Terminal"\nset loginTab to do script "codex login"\nrepeat while busy of loginTab\ndelay 1\nend repeat\nend tell',
         "-e",
         'tell application "Terminal" to activate',
       ],

--- a/packages/desktop-app/src/main/codex-login-launcher.ts
+++ b/packages/desktop-app/src/main/codex-login-launcher.ts
@@ -116,7 +116,7 @@ export function getCodexLoginLaunchSpec(
       command: "/usr/bin/osascript",
       args: [
         "-e",
-        'tell application "Terminal" to do script "codex login"',
+        'tell application "Terminal"\nset loginTab to do script "codex login"\nrepeat while busy of loginTab\ndelay 1\nend repeat\nend tell',
         "-e",
         'tell application "Terminal" to activate',
       ],

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -398,7 +398,7 @@ app.userAgentFallback = `${app.userAgentFallback} AgentNativeDesktop/${app.getVe
 const DEEP_LINK_PROTOCOL = DESKTOP_DEEP_LINK_PROTOCOL;
 if (IS_DEV) {
   app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL, process.execPath, [
-    path.resolve(process.argv[1]),
+    app.getAppPath(),
   ]);
 } else {
   app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => "/tmp"), once: vi.fn() },
   ipcMain: { handle: vi.fn() },
   net: { request: vi.fn() },
   session: { fromPartition: vi.fn() },
+}));
+
+vi.mock("@agent-native/core/terminal/server", () => ({
+  createPtyWebSocketServer: vi.fn(),
 }));
 
 vi.mock("../app-store", () => ({
@@ -11,11 +16,19 @@ vi.mock("../app-store", () => ({
 }));
 
 import {
+  desktopTerminalInfo,
   resolveTargetUrl,
   shouldForwardRequestHeader,
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
+  it("returns an authenticated desktop-owned terminal endpoint", () => {
+    expect(desktopTerminalInfo(4567, "a token")).toEqual({
+      available: true,
+      wsUrl: "ws://127.0.0.1:4567/ws?token=a%20token",
+    });
+  });
+
   it("rejects dot-segment traversal after URL normalization", () => {
     expect(
       resolveTargetUrl(

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -5,18 +5,20 @@ import {
   type ServerResponse,
 } from "node:http";
 
+import { createPtyWebSocketServer } from "@agent-native/core/terminal/server";
 import {
   getDesktopTemplateGatewayAppUrl,
   isDefaultDesktopTemplateDevTarget,
   type AppConfig,
 } from "@shared/app-registry";
 import { IPC } from "@shared/ipc-channels";
-import { ipcMain, net, session, type IpcMainInvokeEvent } from "electron";
+import { app, ipcMain, net, session, type IpcMainInvokeEvent } from "electron";
 
 import * as AppStore from "../app-store";
 import { readCookieHeaderForUrl } from "../cookie-header";
 
 const RELAY_ROOT = "/desktop-chat";
+const DESKTOP_TERMINAL_INFO_ROOT = "/desktop-terminal-info";
 const RELAY_ALLOWED_PREFIX = "/_agent-native/";
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -47,7 +49,46 @@ interface RelayPath {
 }
 
 let relayPromise: Promise<RelayState> | null = null;
+let desktopTerminalPromise: ReturnType<typeof createDesktopTerminal> | null =
+  null;
 let ipcRegistered = false;
+
+async function createDesktopTerminal() {
+  const token = randomUUID().replaceAll("-", "");
+  const terminal = await createPtyWebSocketServer({
+    appDir: app.getPath("home"),
+    authCheck: (request) => {
+      try {
+        const url = new URL(
+          request.url ?? "",
+          `http://${request.headers.host ?? "127.0.0.1"}`,
+        );
+        return url.searchParams.get("token") === token;
+      } catch {
+        // coercion-ok: malformed websocket URLs are authentication denials, never success.
+        return false;
+      }
+    },
+    logPrefix: "[desktop-terminal]",
+  });
+  app.once("before-quit", terminal.close);
+  return { terminal, token };
+}
+
+function ensureDesktopTerminal() {
+  desktopTerminalPromise ??= createDesktopTerminal().catch((error) => {
+    desktopTerminalPromise = null;
+    throw error;
+  });
+  return desktopTerminalPromise;
+}
+
+export function desktopTerminalInfo(port: number, token: string) {
+  return {
+    available: true,
+    wsUrl: `ws://127.0.0.1:${port}/ws?token=${encodeURIComponent(token)}`,
+  };
+}
 
 function desktopTemplateGatewayOverridesDevUrls(): boolean {
   const value =
@@ -301,6 +342,28 @@ function ensureRelay(): Promise<RelayState> {
         sendError(request, response, 400, "Invalid relay URL");
         return;
       }
+      if (parsed.pathname === `${DESKTOP_TERMINAL_INFO_ROOT}/${secret}`) {
+        void ensureDesktopTerminal()
+          .then(({ terminal, token }) => {
+            response.writeHead(200, {
+              ...corsHeaders(request),
+              "Content-Type": "application/json; charset=utf-8",
+            });
+            response.end(
+              JSON.stringify(desktopTerminalInfo(terminal.port, token)),
+            );
+          })
+          .catch((error) => {
+            console.warn("[desktop-terminal] failed to start", error);
+            sendError(
+              request,
+              response,
+              503,
+              "The desktop terminal could not be started.",
+            );
+          });
+        return;
+      }
       const relayPath = parseRelayPath(parsed.pathname, secret);
       if (!relayPath) {
         sendError(request, response, 404, "Desktop chat relay route not found");
@@ -348,6 +411,10 @@ export function registerDesktopChatIpc(): void {
   ipcMain.handle(
     IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL,
     async (_event: IpcMainInvokeEvent, appId: unknown) => {
+      if (appId === undefined || appId === null) {
+        const relay = await ensureRelay();
+        return `http://127.0.0.1:${relay.port}${DESKTOP_TERMINAL_INFO_ROOT}/${relay.secret}`;
+      }
       if (typeof appId !== "string" || !appId.trim()) return null;
       const appConfig = AppStore.loadApps().find(
         (candidate) => candidate.id === appId,

--- a/packages/desktop-app/src/main/multi-frontier-host.spec.ts
+++ b/packages/desktop-app/src/main/multi-frontier-host.spec.ts
@@ -131,7 +131,7 @@ describe("MultiFrontierHost", () => {
 
     expect(launch.mock.calls[0]?.[1]).toEqual(
       expect.arrayContaining([
-        'tell application "Terminal" to do script "codex login"',
+        'tell application "Terminal"\nset loginTab to do script "codex login"\nrepeat while busy of loginTab\ndelay 1\nend repeat\nend tell',
       ]),
     );
     expect(launch.mock.calls[1]?.[1]).toEqual(
@@ -140,6 +140,25 @@ describe("MultiFrontierHost", () => {
       ]),
     );
     expect(launch.mock.calls.every((call) => call[2] === "/safe")).toBe(true);
+  });
+
+  it("refreshes Codex status after the macOS Terminal login completes", async () => {
+    const codex = createCodexAdapter(status("codex", "needs-sign-in"));
+    const connected = status("codex", "connected");
+    codex.refresh.mockResolvedValueOnce(connected);
+    const host = createHost({
+      codex,
+      platform: "darwin",
+      launchDetached: async (_command, _args, _cwd, options) => {
+        expect(options.waitForExit).toBe(true);
+        return { ok: true, cwd: "/safe" };
+      },
+    });
+
+    await expect(host.beginProviderLogin("codex")).resolves.toMatchObject({
+      status: { connectionState: "connected" },
+    });
+    expect(codex.refresh).toHaveBeenCalledOnce();
   });
 
   it("resolves cwd, generates request and participant ids in main, and forwards actions", async () => {

--- a/packages/desktop-app/src/main/multi-frontier-host.ts
+++ b/packages/desktop-app/src/main/multi-frontier-host.ts
@@ -212,9 +212,16 @@ export class MultiFrontierHost {
         error: { message: "The provider sign-in terminal did not open." },
       };
     }
-    return providerId === "codex"
-      ? { status: this.#codexStatus }
-      : { status: sanitizeStatus(await this.#readClaudeStatus(), "claude") };
+    if (providerId === "codex") {
+      if (this.#platform === "darwin") {
+        this.#codexStatus = sanitizeStatus(
+          await this.#codex.refresh(),
+          "codex",
+        );
+      }
+      return { status: this.#codexStatus };
+    }
+    return { status: sanitizeStatus(await this.#readClaudeStatus(), "claude") };
   }
 
   async list(): Promise<MultiFrontierRendererState[]> {

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -398,4 +398,22 @@ describe("desktop passive-access regressions", () => {
     expect(whenReady).toContain("if (pendingDeepLink) {");
     expect(whenReady).toContain("handleDeepLink(pendingDeepLink);");
   });
+
+  it("registers development deep links against the current app path", () => {
+    const main = source("./index.ts");
+    const registration = between(
+      main,
+      "const DEEP_LINK_PROTOCOL = DESKTOP_DEEP_LINK_PROTOCOL;",
+      "let pendingDeepLink: string | null = null;",
+    );
+
+    expect(registration).toContain(
+      "app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL, process.execPath, [",
+    );
+    expect(registration).toContain("app.getAppPath(),");
+    expect(registration).not.toContain("process.argv[1]");
+    expect(registration).toContain(
+      "app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);",
+    );
+  });
 });

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -257,7 +257,7 @@ const electronAPI = {
   desktopChat: {
     getApiUrl: (appId: string): Promise<string | null> =>
       ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_API_URL, appId),
-    getTerminalInfoUrl: (appId: string): Promise<string | null> =>
+    getTerminalInfoUrl: (appId?: string): Promise<string | null> =>
       ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL, appId),
   },
 

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -931,7 +931,7 @@ describe("AppWebview auth state", () => {
     );
     expect(buildGuestAuthStateProbeScript()).toContain("workspaceRuntime");
     expect(buildGuestAuthStateProbeScript()).toContain(
-      "authenticated !== false",
+      "authenticated === true",
     );
     expect(
       resolveAppWebviewAuthStateFromProbe(
@@ -945,6 +945,33 @@ describe("AppWebview auth state", () => {
         "unauthenticated",
       ),
     ).toBe("authenticated");
+    expect(
+      resolveAppWebviewAuthStateFromProbe(
+        { email: "user@example.com", status: 200 },
+        "unauthenticated",
+      ),
+    ).toBe("authenticated");
+    expect(
+      resolveAppWebviewAuthStateFromProbe(
+        { user: { email: "user@example.com" }, status: 200 },
+        "unauthenticated",
+      ),
+    ).toBe("authenticated");
+    expect(
+      resolveAppWebviewAuthStateFromProbe(
+        { user: {}, status: 200 },
+        "authenticated",
+      ),
+    ).toBe("unknown");
+    expect(
+      resolveAppWebviewAuthStateFromProbe({ status: 200 }, "authenticated"),
+    ).toBe("unknown");
+    expect(
+      resolveAppWebviewAuthStateFromProbe(
+        { ok: true, status: 200 },
+        "authenticated",
+      ),
+    ).toBe("unknown");
   });
 
   it("falls back only when the app does not expose the session endpoint", () => {

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -27,6 +27,7 @@ import {
   isDesktopIdentityAuthenticated,
   isDesktopIdentityGateEligible,
   isDesktopIdentityGateUnauthenticated,
+  shouldShowDesktopIdentityRecovery,
   shouldUseDesktopIdentityGate,
   shouldSuppressDesktopSignInPrompt,
   resolveGuestChatCommand,
@@ -133,6 +134,41 @@ describe("Desktop identity lazy child synchronization", () => {
         eligible: true,
         active: false,
         enabled: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows child-local recovery when app session synchronization fails", () => {
+    expect(
+      shouldShowDesktopIdentityRecovery({
+        eligible: true,
+        active: true,
+        showDesktopIdentityGate: false,
+        status: "failed",
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowDesktopIdentityRecovery({
+        eligible: true,
+        active: true,
+        showDesktopIdentityGate: false,
+        status: "sign-in-required",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDesktopIdentityRecovery({
+        eligible: true,
+        active: false,
+        showDesktopIdentityGate: false,
+        status: "failed",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDesktopIdentityRecovery({
+        eligible: true,
+        active: true,
+        showDesktopIdentityGate: true,
+        status: "failed",
       }),
     ).toBe(false);
   });

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -930,6 +930,9 @@ describe("AppWebview auth state", () => {
       "/_agent-native/auth/session",
     );
     expect(buildGuestAuthStateProbeScript()).toContain("workspaceRuntime");
+    expect(buildGuestAuthStateProbeScript()).toContain(
+      "authenticated !== false",
+    );
     expect(
       resolveAppWebviewAuthStateFromProbe(
         { authenticated: false, status: 200 },

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -174,7 +174,7 @@ export function buildGuestAuthStateProbeScript(): string {
       const hasSession = Boolean(
         record &&
           !Object.prototype.hasOwnProperty.call(record, "error") &&
-          (record.email || record.user || record.session),
+          record.authenticated !== false,
       );
       return {
         authenticated: hasSession,

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -298,6 +298,20 @@ export function shouldUseDesktopIdentityGate(input: {
   return input.eligible && input.active && input.enabled !== false;
 }
 
+export function shouldShowDesktopIdentityRecovery(input: {
+  eligible: boolean;
+  active: boolean;
+  showDesktopIdentityGate: boolean;
+  status: DesktopIdentityStatus | "checking";
+}): boolean {
+  return (
+    !input.showDesktopIdentityGate &&
+    input.eligible &&
+    input.active &&
+    input.status === "failed"
+  );
+}
+
 export function shouldSuppressDesktopSignInPrompt(
   app: Pick<AppDefinition, "id">,
   appConfig: Pick<
@@ -794,6 +808,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         eligible: desktopIdentityGateEligible,
         active: isActive,
         enabled: desktopIdentityEnabled,
+      });
+    const desktopIdentitySurfaceActive =
+      desktopIdentityGateActive ||
+      shouldShowDesktopIdentityRecovery({
+        eligible: desktopIdentityGateEligible,
+        active: isActive,
+        showDesktopIdentityGate,
+        status: desktopIdentityStatus,
       });
     const desktopIdentityRepairRef = useRef<Promise<boolean> | null>(null);
     const repairDesktopIdentitySession = useCallback(() => {
@@ -1844,7 +1866,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
               flex: "1 1 auto",
               display:
                 error ||
-                (desktopIdentityGateActive && !desktopIdentitySessionReady)
+                (desktopIdentitySurfaceActive && !desktopIdentitySessionReady)
                   ? "none"
                   : "flex",
               flexDirection: "column",
@@ -1853,14 +1875,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         )}
 
         {isActive &&
-          desktopIdentityGateActive &&
+          desktopIdentitySurfaceActive &&
           !desktopIdentitySessionReady &&
           (desktopIdentityStatus === "idle" ||
             desktopIdentityStatus === "signed-in") && (
             <LoadingScreen app={app} slow={false} isDev={isDevMode} />
           )}
 
-        {desktopIdentityGateActive && (
+        {desktopIdentitySurfaceActive && (
           <DesktopIdentityGate
             appName={app.name}
             status={desktopIdentityStatus}

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -174,7 +174,15 @@ export function buildGuestAuthStateProbeScript(): string {
       const hasSession = Boolean(
         record &&
           !Object.prototype.hasOwnProperty.call(record, "error") &&
-          record.authenticated !== false,
+          record.authenticated !== false &&
+          (record.authenticated === true ||
+            typeof record.email === "string" ||
+            (record.user &&
+              typeof record.user === "object" &&
+              Object.keys(record.user).length > 0) ||
+            (record.session &&
+              typeof record.session === "object" &&
+              Object.keys(record.session).length > 0)),
       );
       return {
         authenticated: hasSession,
@@ -194,9 +202,12 @@ export function resolveAppWebviewAuthStateFromProbe(
   if (!result || typeof result !== "object") return "unknown";
   const probe = result as {
     authenticated?: unknown;
+    email?: unknown;
     invalidJson?: unknown;
     status?: unknown;
+    user?: unknown;
     url?: unknown;
+    session?: unknown;
   };
   if (probe.status === 401 || probe.status === 403) {
     return "unauthenticated";
@@ -211,11 +222,15 @@ export function resolveAppWebviewAuthStateFromProbe(
   if (probe.invalidJson === true) return "unknown";
   if (probe.authenticated === true) return "authenticated";
   if (probe.authenticated === false) return "unauthenticated";
-  const responseUrl =
-    typeof probe.url === "string"
-      ? resolveAppWebviewAuthState(probe.url)
-      : "unknown";
-  return responseUrl === "unknown" ? "unknown" : responseUrl;
+  const hasSessionEvidence =
+    typeof probe.email === "string" ||
+    (probe.user !== null &&
+      typeof probe.user === "object" &&
+      Object.keys(probe.user).length > 0) ||
+    (probe.session !== null &&
+      typeof probe.session === "object" &&
+      Object.keys(probe.session).length > 0);
+  return hasSessionEvidence ? "authenticated" : "unknown";
 }
 
 async function readAppWebviewAuthState(

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -263,6 +263,23 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
   });
 
+  it("moves the active app beside CLI tabs and restores it for UI tabs", () => {
+    const hubSource = readFileSync(
+      "src/renderer/components/CodeAgentsHub.tsx",
+      "utf8",
+    );
+
+    expect(hubSource).toContain('placement: enabled ? "side" : "main"');
+    expect(hubSource).toContain("onNewCliTab={handleNewCliTab}");
+    expect(hubSource).toContain("onNewUiTab={handleNewUiTab}");
+    expect(hubSource).toContain(
+      "chatEnabled={shouldUseDesktopAppChatShell(tab.path)}",
+    );
+    expect(hubSource).toContain(
+      'newTabMode={terminalPreferences.enabled ? "cli" : "ui"}',
+    );
+  });
+
   it("declares the app guest hidden while the integrations overlay covers it", () => {
     // The guest stays isActive while the wrapper is `invisible`, and an
     // Electron guest never observes CSS hiding — without this it keeps
@@ -812,7 +829,9 @@ describe("CodeAgentsHub desktop identity status", () => {
     expect(source).toContain("desktopIdentityStatusByTab");
     expect(source).toContain("handleDesktopIdentityStatusChange");
     expect(source).toContain("onDesktopIdentitySyncFailure");
-    expect(source).toContain('if (status === "failed")');
+    expect(source).toContain('surfaceApp.id === "dispatch"');
+    expect(source).toContain('app.id === "dispatch"');
+    expect(source).toContain('status === "failed"');
     expect(source).toContain("desktopIdentityStatusByTab,");
     expect(source).toContain("handleDesktopIdentityStatusChange,");
     expect(source).toContain("handleDesktopIdentityStatusChange(tab.id");

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -270,6 +270,8 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
 
     expect(hubSource).toContain('placement: enabled ? "side" : "main"');
+    expect(hubSource).toContain('state.tabs.find((tab) => tab.kind === "app")');
+    expect(hubSource).toContain("setChatFirstSurfacePanelOpen(false)");
     expect(hubSource).toContain("onNewCliTab={handleNewCliTab}");
     expect(hubSource).toContain("onNewUiTab={handleNewUiTab}");
     expect(hubSource).toContain(

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1110,11 +1110,14 @@ export default function CodeAgentsHub({
       const activeTab = state.tabs.find(
         (tab) => tab.id === state.activeTabId && tab.kind === "app",
       );
-      if (activeTab?.kind === "app") {
+      const appTab = activeTab ?? state.tabs.find((tab) => tab.kind === "app");
+      if (appTab?.kind === "app") {
         chatFirstSurfaceTabsStore.open({
-          ...activeTab,
+          ...appTab,
           placement: enabled ? "side" : "main",
         });
+      } else if (!enabled) {
+        setChatFirstSurfacePanelOpen(false);
       }
       writeDesktopTerminalPreferences({ enabled });
       if (enabled && startSession) {
@@ -1122,7 +1125,7 @@ export default function CodeAgentsHub({
         setTerminalSessionStarted(true);
       }
     },
-    [chatFirstSurfaceTabsStore],
+    [chatFirstSurfaceTabsStore, setChatFirstSurfacePanelOpen],
   );
   const handleTerminalModeChange = useCallback(
     (enabled: boolean) => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -744,9 +744,8 @@ export default function CodeAgentsHub({
       setDesktopIdentityStatusByTab((current) =>
         updateDesktopIdentityStatusByTab(current, tabId, status),
       );
-      if (status === "failed") onDesktopIdentitySyncFailure?.();
     },
-    [onDesktopIdentitySyncFailure],
+    [],
   );
   const handleAppAuthStateChange = useCallback(
     (tabId: string, state: AppWebviewAuthState) => {
@@ -1105,10 +1104,30 @@ export default function CodeAgentsHub({
     setTerminalPromptRequest(null);
     setTerminalSessionStarted(true);
   }, []);
+  const setDesktopTerminalMode = useCallback(
+    (enabled: boolean, startSession = false) => {
+      const state = chatFirstSurfaceTabsStore.getSnapshot();
+      const activeTab = state.tabs.find(
+        (tab) => tab.id === state.activeTabId && tab.kind === "app",
+      );
+      if (activeTab?.kind === "app") {
+        chatFirstSurfaceTabsStore.open({
+          ...activeTab,
+          placement: enabled ? "side" : "main",
+        });
+      }
+      writeDesktopTerminalPreferences({ enabled });
+      if (enabled && startSession) {
+        setTerminalPromptRequest(null);
+        setTerminalSessionStarted(true);
+      }
+    },
+    [chatFirstSurfaceTabsStore],
+  );
   const handleTerminalModeChange = useCallback(
     (enabled: boolean) => {
       const wasEnabled = terminalPreferences.enabled;
-      writeDesktopTerminalPreferences({ enabled });
+      setDesktopTerminalMode(enabled);
       if (wasEnabled && !enabled) {
         toast({
           title: "Terminal mode is off",
@@ -1124,7 +1143,15 @@ export default function CodeAgentsHub({
         });
       }
     },
-    [onOpenSettings, terminalPreferences.enabled],
+    [onOpenSettings, setDesktopTerminalMode, terminalPreferences.enabled],
+  );
+  const handleNewCliTab = useCallback(
+    () => setDesktopTerminalMode(true, true),
+    [setDesktopTerminalMode],
+  );
+  const handleNewUiTab = useCallback(
+    () => setDesktopTerminalMode(false),
+    [setDesktopTerminalMode],
   );
   const openChatFirstAllApps = useCallback(() => {
     setChatFirstAllAppsOpen(true);
@@ -2654,7 +2681,6 @@ export default function CodeAgentsHub({
       if (tab.kind === "terminal") {
         return (
           <DesktopTerminalTabs
-            apps={apps}
             agent={terminalPreferences.agent}
             theme={theme}
             className="desktop-terminal-tabs--side-surface"
@@ -2714,6 +2740,9 @@ export default function CodeAgentsHub({
                 isActive={isTabActive}
                 chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
                 toggleScopeId={tab.id}
+                onNewCliTab={handleNewCliTab}
+                onNewUiTab={handleNewUiTab}
+                newTabMode={terminalPreferences.enabled ? "cli" : "ui"}
                 onLocalCodeChangeStarted={onLocalCodeChangeStarted}
               >
                 <div
@@ -2760,9 +2789,15 @@ export default function CodeAgentsHub({
                           handleAppAuthStateChange(tab.id, "unauthenticated");
                         }
                       }}
-                      onDesktopIdentityStatusChange={(status) =>
-                        handleDesktopIdentityStatusChange(tab.id, status)
-                      }
+                      onDesktopIdentityStatusChange={(status) => {
+                        handleDesktopIdentityStatusChange(tab.id, status);
+                        if (
+                          surfaceApp.id === "dispatch" &&
+                          status === "failed"
+                        ) {
+                          onDesktopIdentitySyncFailure?.();
+                        }
+                      }}
                       onWebContentsIdChange={(webContentsId) =>
                         handleWebContentsIdChange(tab.id, webContentsId)
                       }
@@ -2820,6 +2855,7 @@ export default function CodeAgentsHub({
       handleAppAuthStateChange,
       handleWebContentsIdChange,
       handleNativeOAuthActiveChange,
+      handleNewCliTab,
       host,
       isActive,
       onLocalCodeChangeStarted,
@@ -2828,6 +2864,7 @@ export default function CodeAgentsHub({
       refreshKey,
       surfaceApps,
       terminalPreferences.agent,
+      terminalPreferences.enabled,
       theme,
       nativeOAuthActiveByTab,
       webContentsIdByTab,
@@ -2907,11 +2944,11 @@ export default function CodeAgentsHub({
           renderChatFirstChatSurface={
             showTerminalSurface ? (
               <DesktopTerminalSurface
-                apps={apps}
                 agent={terminalPreferences.agent}
                 theme={theme}
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
+                onNewUiTab={handleNewUiTab}
               />
             ) : undefined
           }
@@ -3068,7 +3105,9 @@ export default function CodeAgentsHub({
                 theme={theme}
                 urlParams={urlParams}
                 onDesktopIdentityStatusChange={(status) => {
-                  if (status === "failed") onDesktopIdentitySyncFailure?.();
+                  if (app.id === "dispatch" && status === "failed") {
+                    onDesktopIdentitySyncFailure?.();
+                  }
                 }}
                 // Shell key folded in: a lane change remounts every hosted
                 // surface, not just the ones with their own refresh reason.

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   desktopSettingsTabForSection,
-  shouldAnimateDesktopAppChatSidebar,
   shouldShowDesktopAppChatSidebar,
 } from "./DesktopAppChatShell.js";
 
@@ -19,32 +18,12 @@ describe("desktop app chat shell", () => {
     expect(desktopSettingsTabForSection("voice")).toBe("general");
   });
 
-  it("animates only the first active presentation of a cached app tab", () => {
-    expect(
-      shouldAnimateDesktopAppChatSidebar({
-        isActive: true,
-        hasSwitchedAway: false,
-      }),
-    ).toBe(true);
-    expect(
-      shouldAnimateDesktopAppChatSidebar({
-        isActive: false,
-        hasSwitchedAway: false,
-      }),
-    ).toBe(false);
-    expect(
-      shouldAnimateDesktopAppChatSidebar({
-        isActive: true,
-        hasSwitchedAway: true,
-      }),
-    ).toBe(false);
-    expect(
-      shouldAnimateDesktopAppChatSidebar({
-        isActive: true,
-        hasSwitchedAway: false,
-        chatSidebarWasOpenBeforeMount: true,
-      }),
-    ).toBe(false);
+  it("keeps cached app chat sidebars mounted without replaying entrance animation", () => {
+    const source = readFileSync(
+      new URL("./DesktopAppChatShell.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("animateDesktop={false}");
   });
 
   it("keeps the shell open state shared while new app chats start empty", () => {
@@ -58,6 +37,8 @@ describe("desktop app chat shell", () => {
     expect(source).toContain('position="left"');
     expect(source).toContain('agentChatSurface="desktop"');
     expect(source).toContain("toggleScopeId={toggleScopeId}");
+    expect(source).toContain("onNewCliTab={onNewCliTab}");
+    expect(source).toContain('newCliTabLabel="New CLI tab"');
     expect(source).toContain("restoreActiveThread={false}");
     expect(source).toContain("enabled={showChatSidebar}");
     expect(source).not.toContain(
@@ -113,7 +94,7 @@ describe("desktop app chat shell", () => {
         apiUrl: "https://dispatch.example/_agent-native/agent-chat",
         appAuthState: "unauthenticated",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldShowDesktopAppChatSidebar({
         apiUrl: "https://dispatch.example/_agent-native/agent-chat",

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -94,7 +94,7 @@ describe("desktop app chat shell", () => {
         apiUrl: "https://dispatch.example/_agent-native/agent-chat",
         appAuthState: "unauthenticated",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldShowDesktopAppChatSidebar({
         apiUrl: "https://dispatch.example/_agent-native/agent-chat",

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -84,13 +84,13 @@ export interface DesktopAppChatShellProps {
   isActive?: boolean;
   chatEnabled?: boolean;
   toggleScopeId?: string;
+  onNewCliTab?: () => void;
+  onNewUiTab?: () => void;
+  newTabMode?: "ui" | "cli";
   onLocalCodeChangeStarted?: (
     result: DesktopPrepareLocalCodeChangeResult,
   ) => void;
 }
-
-const DESKTOP_APP_CHAT_OPEN_STORAGE_KEY =
-  "agent-native.desktop-app-chat.sidebar-open";
 
 export function desktopSettingsTabForSection(section?: string | null): string {
   const normalized = section?.replace(/^#/, "").trim().toLowerCase() ?? "";
@@ -120,30 +120,6 @@ export function desktopSettingsTabForSection(section?: string | null): string {
   return "general";
 }
 
-function wasDesktopAppChatSidebarOpenBeforeMount(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return (
-      window.localStorage.getItem(DESKTOP_APP_CHAT_OPEN_STORAGE_KEY) === "true"
-    );
-    // coercion-ok: localStorage may be unavailable; replaying the entrance is the safe fallback.
-  } catch {
-    return false;
-  }
-}
-
-export function shouldAnimateDesktopAppChatSidebar(input: {
-  isActive: boolean;
-  hasSwitchedAway: boolean;
-  chatSidebarWasOpenBeforeMount?: boolean;
-}): boolean {
-  return (
-    input.isActive &&
-    !input.hasSwitchedAway &&
-    !input.chatSidebarWasOpenBeforeMount
-  );
-}
-
 export function shouldShowDesktopAppChatSidebar(input: {
   apiUrl?: string | null;
   appAuthState?: AppWebviewAuthState;
@@ -151,11 +127,7 @@ export function shouldShowDesktopAppChatSidebar(input: {
   desktopIdentityUnauthenticated?: boolean;
   desktopIdentityStatus?: DesktopIdentityStatus | "checking";
 }): boolean {
-  if (
-    input.chatEnabled === false ||
-    !input.apiUrl ||
-    input.appAuthState === "unauthenticated"
-  ) {
+  if (input.chatEnabled === false || !input.apiUrl) {
     return false;
   }
   if (input.desktopIdentityUnauthenticated) return false;
@@ -182,14 +154,12 @@ export default function DesktopAppChatShell({
   isActive = true,
   chatEnabled = true,
   toggleScopeId,
+  onNewCliTab,
+  onNewUiTab,
+  newTabMode = "ui",
   onLocalCodeChangeStarted,
 }: DesktopAppChatShellProps) {
   const shellRootRef = useRef<HTMLDivElement>(null);
-  const hasBeenActiveRef = useRef(isActive);
-  const hasSwitchedAwayRef = useRef(false);
-  const chatSidebarWasOpenBeforeMountRef = useRef(
-    wasDesktopAppChatSidebarOpenBeforeMount(),
-  );
   const [apiUrl, setApiUrl] = useState<string | null>(null);
   const [localAgentModels, setLocalAgentModels] = useState<
     CodeAgentModelOption[]
@@ -199,20 +169,6 @@ export default function DesktopAppChatShell({
   const [localCodeChangePrompt, setLocalCodeChangePrompt] = useState("");
   const [localCodeChange, setLocalCodeChange] = useState<LocalCodeChangeState>({
     status: "idle",
-  });
-
-  useEffect(() => {
-    if (isActive) {
-      hasBeenActiveRef.current = true;
-    } else if (hasBeenActiveRef.current) {
-      hasSwitchedAwayRef.current = true;
-    }
-  }, [isActive]);
-
-  const animateDesktopChatSidebar = shouldAnimateDesktopAppChatSidebar({
-    isActive,
-    hasSwitchedAway: hasSwitchedAwayRef.current,
-    chatSidebarWasOpenBeforeMount: chatSidebarWasOpenBeforeMountRef.current,
   });
 
   useEffect(() => {
@@ -578,7 +534,7 @@ export default function DesktopAppChatShell({
               enabled={showChatSidebar}
               position="left"
               defaultOpen
-              animateDesktop={animateDesktopChatSidebar}
+              animateDesktop={false}
               openStorageKey="desktop-app-chat"
               storageKey={`desktop-app-chat:${appId}`}
               scope={{
@@ -595,6 +551,11 @@ export default function DesktopAppChatShell({
                     : undefined
                   : ignoreOpenSettings
               }
+              onNewCliTab={onNewCliTab}
+              onNewUiTab={onNewUiTab}
+              newTabMode={newTabMode}
+              newCliTabLabel="New CLI tab"
+              newUiTabLabel="New UI tab"
               apiUrl={showChatSidebar ? (apiUrl ?? undefined) : undefined}
               isolateHistoryByScope
               agentChatSurface="desktop"

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -127,7 +127,11 @@ export function shouldShowDesktopAppChatSidebar(input: {
   desktopIdentityUnauthenticated?: boolean;
   desktopIdentityStatus?: DesktopIdentityStatus | "checking";
 }): boolean {
-  if (input.chatEnabled === false || !input.apiUrl) {
+  if (
+    input.chatEnabled === false ||
+    !input.apiUrl ||
+    input.appAuthState === "unauthenticated"
+  ) {
     return false;
   }
   if (input.desktopIdentityUnauthenticated) return false;

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
@@ -71,6 +71,14 @@ describe("DesktopIdentityGate", () => {
     expect(container.textContent).toContain("Sign in with Google");
     expect(container.textContent).toContain("Welcome");
     expect(container.textContent).toContain("Create an account or sign in");
+    expect(
+      container.querySelector(".desktop-identity-gate__app-name"),
+    ).toBeNull();
+    expect(
+      container
+        .querySelector(".desktop-identity-gate")
+        ?.getAttribute("aria-label"),
+    ).toBe("Mail sign-in");
     expect(container.textContent).toContain("Email");
     expect(container.textContent).toContain(
       "By signing up, you accept our Terms and Privacy Policy.",

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
@@ -215,7 +215,6 @@ export default function DesktopIdentityGate({
     >
       <div className="desktop-identity-gate__panel desktop-identity-gate__panel--form">
         <div className="desktop-identity-gate__heading">
-          <span className="desktop-identity-gate__app-name">{appName}</span>
           <h1>{COPY.welcomeTitle}</h1>
           <p>{COPY.welcomeSubtitle}</p>
         </div>

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DesktopTerminalSurface from "./DesktopTerminalSurface.js";
+
+vi.mock("./DesktopTerminalTabs.js", () => ({
+  default: () => <div data-terminal-test />,
+}));
+
+describe("DesktopTerminalSurface", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("offers a new UI tab from CLI options", async () => {
+    const onNewUiTab = vi.fn();
+    act(() => {
+      root.render(
+        <DesktopTerminalSurface
+          agent="codex"
+          theme="dark"
+          onNewUiTab={onNewUiTab}
+        />,
+      );
+    });
+
+    await act(async () => {
+      const trigger = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Terminal options"]',
+      );
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+    const item = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((candidate) => candidate.textContent?.includes("New UI tab"));
+
+    expect(item).toBeDefined();
+    await act(async () => item?.click());
+    expect(onNewUiTab).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -6,8 +6,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui";
-import type { AppConfig } from "@shared/app-registry";
-import { IconDotsVertical, IconPlus, IconX } from "@tabler/icons-react";
+import {
+  IconDotsVertical,
+  IconMessageCircle,
+  IconPlus,
+  IconX,
+} from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 
 import { type DesktopTerminalAgentId } from "../lib/desktop-terminal-preferences.js";
@@ -17,12 +21,12 @@ import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 export interface DesktopTerminalPromptRequest extends AgentTerminalSubmitRequest {}
 
 interface DesktopTerminalSurfaceProps {
-  apps: readonly AppConfig[];
   agent: DesktopTerminalAgentId;
   theme: RendererTheme;
   className?: string;
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
+  onNewUiTab?: () => void;
 }
 
 interface DesktopTerminalTab {
@@ -38,12 +42,12 @@ function createTerminalTab(number: number): DesktopTerminalTab {
 }
 
 export default function DesktopTerminalSurface({
-  apps,
   agent,
   theme,
   className,
   submitRequest,
   onPromptSubmitted,
+  onNewUiTab,
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
@@ -161,6 +165,15 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
+              {onNewUiTab ? (
+                <>
+                  <DropdownMenuItem onSelect={onNewUiTab}>
+                    <IconMessageCircle size={14} className="shrink-0" />
+                    New UI tab
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </>
+              ) : null}
               <DropdownMenuItem onSelect={() => closeTab(activeTabId)}>
                 Close terminal
               </DropdownMenuItem>
@@ -187,7 +200,6 @@ export default function DesktopTerminalSurface({
             hidden={tab.id !== activeTabId}
           >
             <DesktopTerminalTabs
-              apps={apps}
               agent={agent}
               theme={theme}
               submitRequest={tab.id === activeTabId ? submitRequest : undefined}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -2,9 +2,8 @@ import {
   AgentTerminal,
   type AgentTerminalSubmitRequest,
 } from "@agent-native/core/terminal";
-import type { AppConfig } from "@shared/app-registry";
 import { IconLoader2, IconTerminal2 } from "@tabler/icons-react";
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 
 import {
   DESKTOP_TERMINAL_AGENT_OPTIONS,
@@ -13,7 +12,6 @@ import {
 import type { RendererTheme } from "../lib/theme.js";
 
 interface DesktopTerminalTabsProps {
-  apps: readonly AppConfig[];
   agent: DesktopTerminalAgentId;
   theme: RendererTheme;
   className?: string;
@@ -29,19 +27,8 @@ type TerminalConnection =
 interface TerminalInfo {
   available?: boolean;
   wsPort?: number;
+  wsUrl?: string;
   error?: string;
-}
-
-function isLocalDevApp(app: AppConfig): boolean {
-  return (
-    app.enabled !== false &&
-    app.mode === "dev" &&
-    Boolean(app.devUrl?.trim() || app.devPort || app.localPath)
-  );
-}
-
-function findTerminalApp(apps: readonly AppConfig[]): AppConfig | undefined {
-  return apps.find(isLocalDevApp);
 }
 
 function readChatSurface(): HTMLElement | null {
@@ -109,12 +96,12 @@ function terminalInfoFrom(value: unknown): TerminalInfo {
   return {
     available: info.available === true,
     wsPort: typeof info.wsPort === "number" ? info.wsPort : undefined,
+    wsUrl: typeof info.wsUrl === "string" ? info.wsUrl : undefined,
     error: typeof info.error === "string" ? info.error : undefined,
   };
 }
 
 export default function DesktopTerminalTabs({
-  apps,
   agent,
   theme,
   className,
@@ -130,7 +117,6 @@ export default function DesktopTerminalTabs({
   const [terminalForeground, setTerminalForeground] = useState(
     readSidebarForeground,
   );
-  const terminalApp = useMemo(() => findTerminalApp(apps), [apps]);
   const selectedAgent =
     DESKTOP_TERMINAL_AGENT_OPTIONS.find((option) => option.id === agent) ??
     DESKTOP_TERMINAL_AGENT_OPTIONS[0];
@@ -152,14 +138,12 @@ export default function DesktopTerminalTabs({
   useEffect(() => {
     let cancelled = false;
     const getTerminalInfoUrl = window.electronAPI?.desktopChat
-      ? (id: string) => window.electronAPI!.desktopChat!.getTerminalInfoUrl(id)
+      ? () => window.electronAPI!.desktopChat!.getTerminalInfoUrl()
       : undefined;
-    if (!terminalApp || !getTerminalInfoUrl) {
+    if (!getTerminalInfoUrl) {
       setConnection({
         state: "error",
-        message: terminalApp
-          ? "Terminal tabs are unavailable in this desktop build."
-          : "Set an app to Local in Settings to start terminal tabs.",
+        message: "Terminal tabs are unavailable in this desktop build.",
       });
       return () => {
         cancelled = true;
@@ -167,22 +151,23 @@ export default function DesktopTerminalTabs({
     }
 
     setConnection({ state: "loading" });
-    void getTerminalInfoUrl(terminalApp.id)
+    void getTerminalInfoUrl()
       .then(async (infoUrl) => {
         if (cancelled) return;
         if (!infoUrl) {
-          throw new Error("The local app has no terminal connection.");
+          throw new Error("The desktop terminal has no connection.");
         }
         const response = await fetch(infoUrl);
         const info = terminalInfoFrom(await response.json());
-        if (!response.ok || !info.available || !info.wsPort) {
-          throw new Error(
-            info.error ?? "The local app terminal is not running.",
-          );
+        const wsUrl =
+          info.wsUrl ??
+          (info.wsPort ? `ws://127.0.0.1:${info.wsPort}/ws` : undefined);
+        if (!response.ok || !info.available || !wsUrl) {
+          throw new Error(info.error ?? "The desktop terminal is not running.");
         }
         setConnection({
           state: "ready",
-          wsUrl: `ws://127.0.0.1:${info.wsPort}/ws`,
+          wsUrl,
         });
       })
       .catch((error: unknown) => {
@@ -192,14 +177,14 @@ export default function DesktopTerminalTabs({
           message:
             error instanceof Error
               ? error.message
-              : "The local app terminal could not be reached.",
+              : "The desktop terminal could not be reached.",
         });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [terminalApp]);
+  }, []);
 
   const workbenchStyle = {
     "--desktop-terminal-background": terminalBackground,

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -1112,7 +1112,7 @@ interface ElectronAPI {
 
   desktopChat: {
     getApiUrl(appId: string): Promise<string | null>;
-    getTerminalInfoUrl(appId: string): Promise<string | null>;
+    getTerminalInfoUrl(appId?: string): Promise<string | null>;
   };
 
   mcpServers: {

--- a/packages/desktop-app/src/renderer/lib/desktop-terminal-preferences.spec.ts
+++ b/packages/desktop-app/src/renderer/lib/desktop-terminal-preferences.spec.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("desktop terminal preferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("persists the last selected new-tab mode", async () => {
+    const preferences = await import("./desktop-terminal-preferences.js");
+
+    preferences.writeDesktopTerminalPreferences({ enabled: true });
+
+    expect(preferences.readDesktopTerminalPreferences().enabled).toBe(true);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          preferences.DESKTOP_TERMINAL_PREFERENCES_STORAGE_KEY,
+        )!,
+      ),
+    ).toMatchObject({ enabled: true });
+
+    preferences.writeDesktopTerminalPreferences({ enabled: false });
+
+    expect(preferences.readDesktopTerminalPreferences().enabled).toBe(false);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(
+          preferences.DESKTOP_TERMINAL_PREFERENCES_STORAGE_KEY,
+        )!,
+      ),
+    ).toMatchObject({ enabled: false });
+  });
+});

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -1203,16 +1203,6 @@ body {
   margin-bottom: 24px;
 }
 
-.desktop-identity-gate__app-name {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--label-inactive);
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
 .desktop-identity-gate__heading h1 {
   margin: 0;
   color: var(--shell-fg);

--- a/packages/toolkit/src/composer/PromptComposer.tsx
+++ b/packages/toolkit/src/composer/PromptComposer.tsx
@@ -745,6 +745,7 @@ function PromptComposerInner({
           onTextChange={onTextChange}
           draftScope={draftScope}
           selectedModel={composerModel}
+          selectedEngine={composerEngine}
           modelSelectorOpen={modelSelectorOpen}
           selectedEffort={composerEffort}
           availableModels={composerModelGroups}

--- a/packages/toolkit/src/composer/TiptapComposer.spec.ts
+++ b/packages/toolkit/src/composer/TiptapComposer.spec.ts
@@ -666,6 +666,51 @@ describe("createTiptapComposerExtensions", () => {
     expect(shouldRenderModelSelector(unconfigured, undefined)).toBe(false);
     expect(shouldRenderModelSelector(undefined, () => {})).toBe(false);
   });
+
+  it("resets a hidden model when switching to Claude Code", async () => {
+    const onModelChange = vi.fn();
+
+    function Harness() {
+      const runtime = useLocalRuntime(emptyChatModelAdapter);
+      return React.createElement(
+        AssistantRuntimeProvider,
+        { runtime },
+        React.createElement(
+          TooltipProvider,
+          null,
+          React.createElement(TiptapComposer, {
+            availableModels: [
+              {
+                engine: "openai",
+                label: "OpenAI",
+                models: ["gpt-5.6-sol"],
+                configured: true,
+              },
+              {
+                engine: "claude-cli",
+                label: "Claude Code",
+                models: ["claude-sonnet-5"],
+                configured: true,
+              },
+            ],
+            selectedModel: "gpt-5.6-sol",
+            selectedEngine: "openai",
+            selectedAgent: "claude-code",
+            onModelChange,
+            includeDefaultSlashSkills: false,
+            plusMenuMode: "hidden",
+            voiceEnabled: false,
+          }),
+        ),
+      );
+    }
+
+    act(() => root.render(React.createElement(Harness)));
+
+    await act(async () => {});
+
+    expect(onModelChange).toHaveBeenCalledWith("claude-sonnet-5", "claude-cli");
+  });
 });
 
 describe("TiptapComposer slash commands", () => {

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -48,6 +48,7 @@ import { SkillReference } from "./extensions/SkillReference.js";
 import { MentionItemMedia } from "./MentionItemMedia.js";
 import { MentionPopover, type MentionPopoverRef } from "./MentionPopover.js";
 import {
+  filterModelGroupsForAgent,
   isClaudeCodeAgentId,
   isLunaModel,
   resolvePreferredAgentModel,
@@ -1244,7 +1245,7 @@ function localizedReasoningEffortLabel(
  * Deduplicate models to only the latest version per family.
  * e.g. [opus-4-7, opus-4-6, opus-4-5] → [opus-4-7]
  */
-function latestModelsOnly(models: string[]): string[] {
+function latestModelsOnly(models: readonly string[]): string[] {
   const seen = new Set<string>();
   return models.filter((m) => {
     // Claude: family = tier (opus/sonnet/haiku)
@@ -1410,6 +1411,9 @@ function ModelSelector({
       (group) => group.engine === "codex-cli",
     );
     const groups = providerGroups.flatMap((group) => {
+      if (group.engine === "claude-cli") {
+        return isClaudeCodeAgent ? [group] : [];
+      }
       if (group.engine === "codex-cli") {
         return isCodexAgent && isOpenAiModelProviderGroup(group) ? [group] : [];
       }
@@ -1432,17 +1436,11 @@ function ModelSelector({
         : group.models.filter(isOpenAiModelId);
       return models.length > 0 ? [{ ...group, models }] : [];
     });
-    if (!isClaudeCodeAgent) return groups;
-    return groups
-      .map((group) => ({
-        ...group,
-        models: group.models.filter((candidate) => !isLunaModel(candidate)),
-      }))
-      .filter((group) => group.models.length > 0);
-  }, [isClaudeCodeAgent, isCodexAgent, providerGroups]);
+    return filterModelGroupsForAgent(selectedAgent, groups);
+  }, [isClaudeCodeAgent, isCodexAgent, providerGroups, selectedAgent]);
   const preferredAgentModel = useMemo(
-    () => resolvePreferredAgentModel(selectedAgent, providerGroups),
-    [providerGroups, selectedAgent],
+    () => resolvePreferredAgentModel(selectedAgent, modelProviderGroups),
+    [modelProviderGroups, selectedAgent],
   );
   useEffect(() => {
     if (!isClaudeCodeAgent || !isLunaModel(model) || !preferredAgentModel) {
@@ -1524,6 +1522,7 @@ function ModelSelector({
     (group) => group.configured,
   );
   const showBuilderAction =
+    !isClaudeCodeAgent &&
     !hasConfiguredCloudProviderReady &&
     (Boolean(onConnectProvider) ||
       (providerConnectStatusEnabled &&
@@ -1532,6 +1531,7 @@ function ModelSelector({
         !hasConfiguredBuilderModels &&
         !hasConnectedSubscription));
   const showAddKeysAction =
+    !isClaudeCodeAgent &&
     !hasConfiguredCloudProviderReady &&
     (hasUnconfiguredVisibleModels || showBuilderAction);
   const showProviderActions = showBuilderAction || showAddKeysAction;
@@ -1577,7 +1577,7 @@ function ModelSelector({
         >
           <span className="min-w-0 truncate">
             {selectedAgentOption?.icon ? (
-              <span className="me-1 inline-flex shrink-0 align-[-2px] text-muted-foreground">
+              <span className="me-1 inline-flex shrink-0 align-middle text-muted-foreground">
                 {selectedAgentOption.icon}
               </span>
             ) : null}

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -50,7 +50,6 @@ import { MentionPopover, type MentionPopoverRef } from "./MentionPopover.js";
 import {
   filterModelGroupsForAgent,
   isClaudeCodeAgentId,
-  isLunaModel,
   resolvePreferredAgentModel,
 } from "./model-selection.js";
 import {
@@ -764,6 +763,8 @@ export interface TiptapComposerProps {
   voiceEnabled?: boolean;
   /** Selected model override for this conversation */
   selectedModel?: string;
+  /** Selected provider engine for this conversation */
+  selectedEngine?: string;
   /** Selected effort override for this conversation */
   selectedEffort?: ReasoningEffort;
   /** Show the legacy provider-level Auto model option (default: true). */
@@ -1340,6 +1341,7 @@ function ModelSelector({
   engines,
   agents,
   selectedAgent,
+  selectedEngine,
   agentOnly = false,
   hostedHarness = false,
   showAutoModelOption = true,
@@ -1356,6 +1358,7 @@ function ModelSelector({
   imageModel,
 }: {
   model: string;
+  selectedEngine?: string;
   effort?: ReasoningEffort;
   agents?: ComposerAgentOption[];
   selectedAgent?: string;
@@ -1442,19 +1445,26 @@ function ModelSelector({
     () => resolvePreferredAgentModel(selectedAgent, modelProviderGroups),
     [modelProviderGroups, selectedAgent],
   );
+  const selectedModelIsAvailable = modelProviderGroups.some(
+    (group) =>
+      group.models.includes(model) &&
+      (selectedEngine === undefined || group.engine === selectedEngine),
+  );
   useEffect(() => {
-    if (!isClaudeCodeAgent || !isLunaModel(model) || !preferredAgentModel) {
-      return;
-    }
     if (
-      preferredAgentModel.model === model &&
-      preferredAgentModel.engine ===
-        engines.find((group) => group.models.includes(model))?.engine
+      !isClaudeCodeAgent ||
+      selectedModelIsAvailable ||
+      !preferredAgentModel
     ) {
       return;
     }
     onChange(preferredAgentModel.model, preferredAgentModel.engine);
-  }, [engines, isClaudeCodeAgent, model, onChange, preferredAgentModel]);
+  }, [
+    isClaudeCodeAgent,
+    onChange,
+    preferredAgentModel,
+    selectedModelIsAvailable,
+  ]);
   const effortOptions = agentOnly
     ? []
     : (reasoning?.getOptionsForModel?.(model) ??
@@ -2269,6 +2279,7 @@ export function TiptapComposer({
   planModeDisabledReason,
   voiceEnabled = DEFAULT_VOICE_DICTATION_ENABLED,
   selectedModel,
+  selectedEngine,
   selectedEffort,
   showAutoModelOption = true,
   modelSelectorOpen,
@@ -3809,6 +3820,7 @@ export function TiptapComposer({
         {shouldRenderModelSelector(availableModels, onModelChange) && (
           <ModelSelector
             model={selectedModel ?? ""}
+            selectedEngine={selectedEngine}
             open={modelSelectorOpen}
             effort={selectedEffort}
             engines={availableModels!}

--- a/packages/toolkit/src/composer/model-selection.spec.ts
+++ b/packages/toolkit/src/composer/model-selection.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  filterModelGroupsForAgent,
   isClaudeCodeAgentId,
+  isClaudeModelId,
   isLunaModel,
   resolvePreferredAgentModel,
 } from "./model-selection.js";
@@ -26,6 +28,17 @@ describe("composer agent model defaults", () => {
     expect(isClaudeCodeAgentId("codex")).toBe(false);
     expect(isLunaModel("gpt-5.6-luna")).toBe(true);
     expect(isLunaModel("openai/gpt-5.6-sol")).toBe(false);
+    expect(isClaudeModelId("claude-sonnet-5")).toBe(true);
+    expect(isClaudeModelId("gpt-5.6-sol")).toBe(false);
+  });
+
+  it("keeps only Claude models when Claude Code is selected", () => {
+    expect(
+      filterModelGroupsForAgent("claude-code", [
+        { engine: "claude-cli", models: ["claude-sonnet-5", "gpt-5.6-luna"] },
+        { engine: "builder", models: ["claude-opus-4-8", "gpt-5.6-sol"] },
+      ]),
+    ).toEqual([{ engine: "claude-cli", models: ["claude-sonnet-5"] }]);
   });
 
   it("defaults Claude Code to Sonnet and other agents to Luna", () => {

--- a/packages/toolkit/src/composer/model-selection.ts
+++ b/packages/toolkit/src/composer/model-selection.ts
@@ -12,6 +12,24 @@ export function isLunaModel(model: string): boolean {
   return model.toLowerCase().includes("luna");
 }
 
+export function isClaudeModelId(model: string): boolean {
+  return model.toLowerCase().startsWith("claude-");
+}
+
+export function filterModelGroupsForAgent<T extends ComposerModelGroupLike>(
+  agentId: string | undefined,
+  groups: readonly T[],
+): T[] {
+  if (!isClaudeCodeAgentId(agentId)) return [...groups];
+  return groups
+    .filter((group) => group.engine === "claude-cli")
+    .map((group) => ({
+      ...group,
+      models: group.models.filter(isClaudeModelId),
+    }))
+    .filter((group) => group.models.length > 0);
+}
+
 export function resolvePreferredAgentModel(
   agentId: string | undefined,
   groups: readonly ComposerModelGroupLike[],


### PR DESCRIPTION
Fixes the nightly desktop auth and terminal-tab regressions reported in this task.\n\n- Remove the visible desktop login eyebrow and repair dev deep-link registration so OAuth does not reopen the generic Electron starter window.\n- Wait for macOS Codex login completion, refresh provider status, and keep child app auth failures from bouncing the global desktop identity gate.\n- Run a desktop-owned authenticated terminal without requiring a Local app; support remembered CLI/UI tab actions and side-by-side CLI plus app tabs.\n- Restrict Claude Code model selection to Claude models and hide Builder/custom-key actions; keep the CLI icon vertically centered.\n- Keep the app chat sidebar mounted and still when switching app tabs.\n\nValidation: focused desktop tests 148 passed; full desktop tests 559 passed; core and toolkit typechecks/builds passed; desktop build passed; i18n changed-copy guard passed. The full prep aggregate remains blocked by pre-existing missing generated template packages, existing i18n catalog debt, and unrelated browser-test failures.