### PR TITLE
Add Clips comment formatting and mentions

### DIFF
--- a/templates/clips/actions/add-comment.ts
+++ b/templates/clips/actions/add-comment.ts
@@ -19,12 +19,18 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
+import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
 import { isRecordingExpired } from "../server/lib/recording-page-access.js";
 import { nanoid } from "../server/lib/recordings.js";
 
+const mentionSchema = z.object({
+  email: z.string().email(),
+  name: z.string().trim().min(1),
+});
+
 export default defineAction({
   description:
-    "Add a comment to a recording at a specific video timestamp. Comment text supports inline Markdown such as bold, italic, inline code, and links; headings are flattened in comment surfaces. For new threads, omit threadId/parentId. For replies, pass both.",
+    "Add a comment to a recording at a specific video timestamp. Comment text supports inline Markdown such as bold, italic, inline code, and links; headings are flattened in comment surfaces. Organization members can be mentioned with @. For new threads, omit threadId/parentId. For replies, pass both.",
   schema: z.object({
     recordingId: z.string().describe("Recording ID"),
     content: z
@@ -49,6 +55,10 @@ export default defineAction({
       .string()
       .optional()
       .describe("Display name for the author (falls back to email local part)"),
+    mentions: z
+      .union([z.string(), z.array(mentionSchema).max(20)])
+      .optional()
+      .describe("Organization members mentioned in the comment"),
   }),
   run: async (args) => {
     // Commenting is open to any signed-in viewer with access to the
@@ -83,6 +93,11 @@ export default defineAction({
 
     if (!rec) throw new Error(`Recording not found: ${args.recordingId}`);
 
+    const mentions = await resolveCommentMentions(
+      args.mentions,
+      rec.organizationId,
+    );
+
     // Floor to the nearest second so nearby comments land on the same
     // timestamp bucket for scrubber grouping and the playback overlay.
     const videoTimestampMs = Math.floor(args.videoTimestampMs / 1000) * 1000;
@@ -96,6 +111,7 @@ export default defineAction({
       authorEmail,
       authorName,
       content: args.content,
+      mentionsJson: mentions.length > 0 ? JSON.stringify(mentions) : null,
       videoTimestampMs,
       createdAt: now,
       updatedAt: now,
@@ -107,6 +123,7 @@ export default defineAction({
       authorEmail,
       authorName: authorName ?? undefined,
       content: args.content,
+      mentions,
       videoTimestampMs: args.videoTimestampMs,
       isReply: Boolean(parentId),
     });

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -421,6 +421,7 @@ export default defineAction({
         authorEmail: c.authorEmail,
         authorName: c.authorName,
         content: c.content,
+        mentionsJson: c.mentionsJson,
         videoTimestampMs: c.videoTimestampMs,
         emojiReactionsJson: c.emojiReactionsJson,
         resolved: Boolean(c.resolved),

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -47,6 +47,7 @@ import {
   CLIPS_BUILDER_CREDITS_STATE_KEY,
   normalizeBuilderCreditsStatus,
 } from "../shared/builder-credits.js";
+import { displayCommentMentions } from "../shared/comment-mentions.js";
 import {
   normalizeTranscriptSegments,
   parseTranscriptSegments,
@@ -421,7 +422,7 @@ export default defineAction({
         authorEmail: c.authorEmail,
         authorName: c.authorName,
         content: c.content,
-        mentionsJson: c.mentionsJson,
+        mentions: displayCommentMentions(c.mentionsJson),
         videoTimestampMs: c.videoTimestampMs,
         emojiReactionsJson: c.emojiReactionsJson,
         resolved: Boolean(c.resolved),

--- a/templates/clips/actions/list-comments.ts
+++ b/templates/clips/actions/list-comments.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { hydrateCommentAuthorNames } from "../server/lib/user-identities.js";
+import { parseCommentMentions } from "../shared/comment-mentions.js";
 
 export default defineAction({
   description:
@@ -45,6 +46,7 @@ export default defineAction({
         authorEmail: c.authorEmail,
         authorName: c.authorName,
         content: c.content,
+        mentions: parseCommentMentions(c.mentionsJson),
         videoTimestampMs: c.videoTimestampMs,
         emojiReactionsJson: c.emojiReactionsJson,
         resolved: Boolean(c.resolved),

--- a/templates/clips/actions/list-comments.ts
+++ b/templates/clips/actions/list-comments.ts
@@ -15,7 +15,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { hydrateCommentAuthorNames } from "../server/lib/user-identities.js";
-import { parseCommentMentions } from "../shared/comment-mentions.js";
+import { displayCommentMentions } from "../shared/comment-mentions.js";
 
 export default defineAction({
   description:
@@ -46,7 +46,7 @@ export default defineAction({
         authorEmail: c.authorEmail,
         authorName: c.authorName,
         content: c.content,
-        mentions: parseCommentMentions(c.mentionsJson),
+        mentions: displayCommentMentions(c.mentionsJson),
         videoTimestampMs: c.videoTimestampMs,
         emojiReactionsJson: c.emojiReactionsJson,
         resolved: Boolean(c.resolved),

--- a/templates/clips/actions/list-notifications.ts
+++ b/templates/clips/actions/list-notifications.ts
@@ -17,6 +17,7 @@ import { and, desc, gte, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { canReceiveRecordingActivity } from "../server/lib/recording-page-access.js";
 import {
   getCurrentOwnerEmail,
   sameOwnerEmail,
@@ -42,20 +43,30 @@ export default defineAction({
         id: schema.recordings.id,
         title: schema.recordings.title,
         ownerEmail: schema.recordings.ownerEmail,
+        password: schema.recordings.password,
+        expiresAt: schema.recordings.expiresAt,
       })
       .from(schema.recordings)
       .where(accessFilter(schema.recordings, schema.recordingShares));
-    if (visibleRecordings.length === 0) {
+    const accessibleRecordings = visibleRecordings.filter((recording) =>
+      canReceiveRecordingActivity({
+        ownerEmail: recording.ownerEmail,
+        recipientEmail: me,
+        hasPassword: Boolean(recording.password),
+        expiresAt: recording.expiresAt,
+      }),
+    );
+    if (accessibleRecordings.length === 0) {
       return { items: [], count: 0 };
     }
 
-    const myRecordingIds = visibleRecordings
+    const myRecordingIds = accessibleRecordings
       .filter((recording) => sameOwnerEmail(recording.ownerEmail, me))
       .map((recording) => recording.id);
     const myRecordingIdSet = new Set(myRecordingIds);
-    const ids = visibleRecordings.map((recording) => recording.id);
+    const ids = accessibleRecordings.map((recording) => recording.id);
     const titleById = new Map(
-      visibleRecordings.map(
+      accessibleRecordings.map(
         (recording) => [recording.id, recording.title] as const,
       ),
     );

--- a/templates/clips/actions/list-notifications.ts
+++ b/templates/clips/actions/list-notifications.ts
@@ -11,17 +11,18 @@
  */
 
 import { defineAction } from "@agent-native/core/action";
+import { accessFilter } from "@agent-native/core/sharing";
 import { getUserProfiles } from "@agent-native/core/user-profile/server";
-import { and, desc, gte, inArray } from "drizzle-orm";
+import { and, desc, gte, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
   getCurrentOwnerEmail,
-  ownerEmailMatches,
   sameOwnerEmail,
 } from "../server/lib/recordings.js";
 import { profileNameFor } from "../server/lib/user-identities.js";
+import { parseCommentMentions } from "../shared/comment-mentions.js";
 
 export default defineAction({
   description:
@@ -35,26 +36,41 @@ export default defineAction({
     const db = getDb();
     const me = getCurrentOwnerEmail();
 
-    // Recordings I own — notifications are about activity ON these.
-    const myRecordings = await db
+    // Activity on recordings I own plus mentions on recordings I can open.
+    const visibleRecordings = await db
       .select({
         id: schema.recordings.id,
         title: schema.recordings.title,
+        ownerEmail: schema.recordings.ownerEmail,
       })
       .from(schema.recordings)
-      .where(ownerEmailMatches(schema.recordings.ownerEmail, me));
-    if (myRecordings.length === 0) {
+      .where(accessFilter(schema.recordings, schema.recordingShares));
+    if (visibleRecordings.length === 0) {
       return { items: [], count: 0 };
     }
 
-    const ids = myRecordings.map((r) => r.id);
+    const myRecordingIds = visibleRecordings
+      .filter((recording) => sameOwnerEmail(recording.ownerEmail, me))
+      .map((recording) => recording.id);
+    const myRecordingIdSet = new Set(myRecordingIds);
+    const ids = visibleRecordings.map((recording) => recording.id);
     const titleById = new Map(
-      myRecordings.map((r) => [r.id, r.title] as const),
+      visibleRecordings.map(
+        (recording) => [recording.id, recording.title] as const,
+      ),
     );
 
     const cutoff = new Date(
       Date.now() - args.days * 24 * 60 * 60 * 1000,
     ).toISOString();
+
+    const mentionPattern = `%"email":"${me.toLowerCase()}"%`;
+    const commentScope = myRecordingIds.length
+      ? or(
+          inArray(schema.recordingComments.recordingId, myRecordingIds),
+          sql`lower(${schema.recordingComments.mentionsJson}) LIKE ${mentionPattern}`,
+        )
+      : sql`lower(${schema.recordingComments.mentionsJson}) LIKE ${mentionPattern}`;
 
     const [comments, reactions] = await Promise.all([
       db
@@ -64,30 +80,33 @@ export default defineAction({
           and(
             inArray(schema.recordingComments.recordingId, ids),
             gte(schema.recordingComments.createdAt, cutoff),
+            commentScope,
           ),
         )
         .orderBy(desc(schema.recordingComments.createdAt))
         .limit(args.limit),
-      db
-        .select()
-        .from(schema.recordingReactions)
-        .where(
-          and(
-            inArray(schema.recordingReactions.recordingId, ids),
-            gte(schema.recordingReactions.createdAt, cutoff),
-          ),
-        )
-        .orderBy(desc(schema.recordingReactions.createdAt))
-        .limit(args.limit),
+      myRecordingIds.length
+        ? db
+            .select()
+            .from(schema.recordingReactions)
+            .where(
+              and(
+                inArray(schema.recordingReactions.recordingId, myRecordingIds),
+                gte(schema.recordingReactions.createdAt, cutoff),
+              ),
+            )
+            .orderBy(desc(schema.recordingReactions.createdAt))
+            .limit(args.limit)
+        : Promise.resolve([]),
     ]);
 
-    const mentionRegex = new RegExp(
-      `@${me.replace(/[.+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      "i",
-    );
-
     const commentRows = comments.filter(
-      (c) => !sameOwnerEmail(c.authorEmail, me),
+      (comment) =>
+        !sameOwnerEmail(comment.authorEmail, me) &&
+        (myRecordingIdSet.has(comment.recordingId) ||
+          parseCommentMentions(comment.mentionsJson).some(
+            (mention) => mention.email === me.toLowerCase(),
+          )),
     );
     const reactionRows = reactions.filter(
       (r) => !sameOwnerEmail(r.viewerEmail, me),
@@ -100,9 +119,11 @@ export default defineAction({
     const items = [
       ...commentRows.map((c) => ({
         id: `c:${c.id}`,
-        kind: (mentionRegex.test(c.content) ? "mention" : "comment") as
-          | "mention"
-          | "comment",
+        kind: (parseCommentMentions(c.mentionsJson).some(
+          (mention) => mention.email === me.toLowerCase(),
+        )
+          ? "mention"
+          : "comment") as "mention" | "comment",
         recordingId: c.recordingId,
         recordingTitle: titleById.get(c.recordingId) ?? "Untitled",
         authorEmail: c.authorEmail,

--- a/templates/clips/actions/list-recording-mention-members.test.ts
+++ b/templates/clips/actions/list-recording-mention-members.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockResolveAccess = vi.hoisted(() => vi.fn());
+const mockOrderBy = vi.hoisted(() => vi.fn());
+const mockGetUserProfiles = vi.hoisted(() => vi.fn());
+const mockIsEmailDerivedName = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (options: unknown) => options,
+}));
+
+vi.mock("@agent-native/core/org", () => ({
+  orgMembers: {
+    email: "org_members.email",
+    orgId: "org_members.org_id",
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  ForbiddenError: class ForbiddenError extends Error {},
+  resolveAccess: (...args: unknown[]) => mockResolveAccess(...args),
+}));
+
+vi.mock("@agent-native/core/user-profile", () => ({
+  isEmailDerivedName: (...args: unknown[]) => mockIsEmailDerivedName(...args),
+}));
+
+vi.mock("@agent-native/core/user-profile/server", () => ({
+  getUserProfiles: (...args: unknown[]) => mockGetUserProfiles(...args),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  asc: (column: unknown) => ({ kind: "asc", column }),
+  eq: (column: unknown, value: unknown) => ({ kind: "eq", column, value }),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: (...args: unknown[]) => mockOrderBy(...args),
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("../server/lib/recording-page-access.js", () => ({
+  isRecordingExpired: vi.fn((expiresAt: string | null | undefined) => {
+    if (!expiresAt) return false;
+    return new Date(expiresAt).getTime() < Date.now();
+  }),
+}));
+
+import action from "./list-recording-mention-members";
+
+const baseResource = {
+  organizationId: "org-recording",
+  expiresAt: "2026-12-01T00:00:00.000Z",
+  visibility: "org" as const,
+  password: null,
+  ownerEmail: "owner@example.com",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveAccess.mockResolvedValue({
+    role: "viewer",
+    resource: baseResource,
+  });
+  mockOrderBy.mockResolvedValue([
+    { email: "alex@example.com" },
+    { email: "beta@example.com" },
+  ]);
+  mockGetUserProfiles.mockResolvedValue(
+    new Map([
+      ["alex@example.com", { name: "Alex Chen" }],
+      ["beta@example.com", { name: "Beta" }],
+    ]),
+  );
+  mockIsEmailDerivedName.mockReturnValue(false);
+});
+
+describe("list-recording-mention-members", () => {
+  it("returns the members for the recording's organization", async () => {
+    await expect(
+      action.run({ recordingId: "rec-1" } as never),
+    ).resolves.toEqual({
+      members: [
+        { email: "alex@example.com", name: "Alex Chen" },
+        { email: "beta@example.com", name: "Beta" },
+      ],
+    });
+
+    expect(mockResolveAccess).toHaveBeenCalledWith("recording", "rec-1");
+    expect(mockOrderBy).toHaveBeenCalledWith({
+      kind: "asc",
+      column: "org_members.email",
+    });
+  });
+
+  it("returns members for a password-protected recording after access is resolved", async () => {
+    mockResolveAccess.mockResolvedValue({
+      role: "viewer",
+      resource: {
+        ...baseResource,
+        visibility: "public" as const,
+        password: "secret",
+      },
+    });
+
+    await expect(
+      action.run({ recordingId: "rec-1" } as never),
+    ).resolves.toEqual(expect.objectContaining({ members: expect.any(Array) }));
+  });
+});

--- a/templates/clips/actions/list-recording-mention-members.ts
+++ b/templates/clips/actions/list-recording-mention-members.ts
@@ -1,0 +1,64 @@
+/**
+ * Return the org members for a recording's organization so comment composers
+ * can autocomplete @mentions against the right roster.
+ *
+ * Usage:
+ *   pnpm action list-recording-mention-members --recordingId=<id>
+ */
+
+import { defineAction } from "@agent-native/core/action";
+import { orgMembers } from "@agent-native/core/org";
+import { resolveAccess, ForbiddenError } from "@agent-native/core/sharing";
+import { isEmailDerivedName } from "@agent-native/core/user-profile";
+import { getUserProfiles } from "@agent-native/core/user-profile/server";
+import { asc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { getDb } from "../server/db/index.js";
+import { isRecordingExpired } from "../server/lib/recording-page-access.js";
+
+export default defineAction({
+  description:
+    "Return the organization members for a recording so comment composers can autocomplete mentions against the recording's org roster.",
+  schema: z.object({
+    recordingId: z.string().describe("Recording ID"),
+  }),
+  http: { method: "GET" },
+  run: async (args) => {
+    const access = await resolveAccess("recording", args.recordingId);
+    if (!access) {
+      throw new ForbiddenError(`No access to recording ${args.recordingId}`);
+    }
+
+    const rec = access.resource as {
+      expiresAt?: string | null;
+      organizationId: string;
+    };
+
+    if (isRecordingExpired(rec.expiresAt)) {
+      throw new ForbiddenError("Recording has expired");
+    }
+
+    const db = getDb();
+    const memberRows = await db
+      .select({
+        email: orgMembers.email,
+      })
+      .from(orgMembers)
+      .where(eq(orgMembers.orgId, rec.organizationId))
+      .orderBy(asc(orgMembers.email));
+
+    const profiles = await getUserProfiles(
+      memberRows.map((member) => member.email),
+    );
+    const members = memberRows.map((member) => {
+      const name = profiles.get(member.email.toLowerCase())?.name;
+      return {
+        email: member.email,
+        ...(name && !isEmailDerivedName(name, member.email) ? { name } : {}),
+      };
+    });
+
+    return { members };
+  },
+});

--- a/templates/clips/actions/reply-to-comment.ts
+++ b/templates/clips/actions/reply-to-comment.ts
@@ -19,12 +19,18 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { notifyRecordingComment } from "../server/lib/activity-notifications.js";
+import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
 import { isRecordingExpired } from "../server/lib/recording-page-access.js";
 import { nanoid } from "../server/lib/recordings.js";
 
+const mentionSchema = z.object({
+  email: z.string().email(),
+  name: z.string().trim().min(1),
+});
+
 export default defineAction({
   description:
-    "Reply to an existing comment with inline Markdown text (without headings). Looks up the thread and parent and delegates to add-comment.",
+    "Reply to an existing comment with inline Markdown text (without headings). Organization members can be mentioned with @. Looks up the thread and parent and delegates to add-comment.",
   schema: z.object({
     commentId: z.string().describe("Comment ID to reply to"),
     content: z
@@ -32,6 +38,10 @@ export default defineAction({
       .min(1)
       .describe("Reply text; inline Markdown is supported, without headings"),
     authorName: z.string().optional(),
+    mentions: z
+      .union([z.string(), z.array(mentionSchema).max(20)])
+      .optional()
+      .describe("Organization members mentioned in the reply"),
   }),
   run: async (args) => {
     const db = getDb();
@@ -62,6 +72,10 @@ export default defineAction({
     }
     const authorName =
       getRequestUserName()?.trim() || args.authorName?.trim() || null;
+    const mentions = await resolveCommentMentions(
+      args.mentions,
+      parent.organizationId,
+    );
 
     const id = nanoid();
     const now = new Date().toISOString();
@@ -75,6 +89,7 @@ export default defineAction({
       authorEmail,
       authorName,
       content: args.content,
+      mentionsJson: mentions.length > 0 ? JSON.stringify(mentions) : null,
       videoTimestampMs: parent.videoTimestampMs,
       createdAt: now,
       updatedAt: now,
@@ -86,6 +101,7 @@ export default defineAction({
       authorEmail,
       authorName: authorName ?? undefined,
       content: args.content,
+      mentions,
       videoTimestampMs: parent.videoTimestampMs,
       isReply: true,
     });

--- a/templates/clips/actions/update-comment.test.ts
+++ b/templates/clips/actions/update-comment.test.ts
@@ -5,6 +5,8 @@ type CommentRow = {
   recordingId: string;
   authorEmail: string;
   content: string;
+  organizationId: string;
+  mentionsJson: string | null;
   updatedAt: string;
 };
 
@@ -17,6 +19,7 @@ const mockGetUserEmail = vi.hoisted(() =>
   vi.fn<() => string | null>(() => "author@example.com"),
 );
 const mockWriteAppState = vi.hoisted(() => vi.fn());
+const mockIsOrgMember = vi.hoisted(() => vi.fn());
 const { MockForbiddenError } = vi.hoisted(() => {
   class MockForbiddenError extends Error {}
   return { MockForbiddenError };
@@ -33,6 +36,10 @@ vi.mock("@agent-native/core/server/request-context", () => ({
 
 vi.mock("@agent-native/core/application-state", () => ({
   writeAppState: (...args: unknown[]) => mockWriteAppState(...args),
+}));
+
+vi.mock("@agent-native/core/org", () => ({
+  isOrgMember: (...args: unknown[]) => mockIsOrgMember(...args),
 }));
 
 vi.mock("../server/lib/recordings.js", () => ({
@@ -77,6 +84,8 @@ vi.mock("../server/db/index.js", () => {
       recordingId: column("recordingId"),
       authorEmail: column("authorEmail"),
       content: column("content"),
+      organizationId: column("organizationId"),
+      mentionsJson: column("mentionsJson"),
       updatedAt: column("updatedAt"),
     },
   };
@@ -125,10 +134,13 @@ beforeEach(() => {
       recordingId: "recording-1",
       authorEmail: "author@example.com",
       content: "Original text",
+      organizationId: "org-1",
+      mentionsJson: null,
       updatedAt: "2026-07-29T00:00:00.000Z",
     },
   ];
   mockGetUserEmail.mockReturnValue("author@example.com");
+  mockIsOrgMember.mockResolvedValue(true);
 });
 
 describe("update-comment", () => {
@@ -166,6 +178,7 @@ describe("update-comment", () => {
     expect(result).toEqual({
       id: "comment-1",
       content: "Updated text",
+      mentions: [],
       updatedAt: expect.any(String),
     });
     expect(state.rows[0]).toMatchObject({
@@ -186,6 +199,23 @@ describe("update-comment", () => {
     expect(() =>
       action.schema.parse({ id: "comment-1", content: "   " }),
     ).toThrow();
+  });
+
+  it("preserves an existing mention when the optional field is omitted", async () => {
+    state.rows[0].content = "Original text @Member";
+    state.rows[0].mentionsJson = JSON.stringify([
+      { email: "member@example.com", name: "Member" },
+    ]);
+
+    const result = await run({
+      id: "comment-1",
+      content: "Updated text @Member",
+    });
+
+    expect(state.rows[0].mentionsJson).toBe(
+      JSON.stringify([{ email: "member@example.com", name: "Member" }]),
+    );
+    expect(result.mentions).toEqual([{ name: "Member" }]);
   });
 
   it("fails loudly when the comment changed concurrently", async () => {

--- a/templates/clips/actions/update-comment.ts
+++ b/templates/clips/actions/update-comment.ts
@@ -16,6 +16,11 @@ import { getDb, schema } from "../server/db/index.js";
 import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
 import { isRecordingExpired } from "../server/lib/recording-page-access.js";
 import { sameOwnerEmail } from "../server/lib/recordings.js";
+import {
+  displayCommentMentions,
+  mentionsForCommentText,
+  parseCommentMentions,
+} from "../shared/comment-mentions.js";
 
 const mentionSchema = z.object({
   email: z.string().email(),
@@ -73,7 +78,12 @@ export default defineAction({
     }
 
     const mentions = await resolveCommentMentions(
-      args.mentions,
+      args.mentions === undefined
+        ? mentionsForCommentText(
+            args.content,
+            parseCommentMentions(existing.mentionsJson),
+          )
+        : args.mentions,
       existing.organizationId,
     );
 
@@ -101,6 +111,11 @@ export default defineAction({
 
     await writeAppState("refresh-signal", { ts: Date.now() });
 
-    return { id: args.id, content: args.content, updatedAt };
+    return {
+      id: args.id,
+      content: args.content,
+      mentions: displayCommentMentions(mentions),
+      updatedAt,
+    };
   },
 });

--- a/templates/clips/actions/update-comment.ts
+++ b/templates/clips/actions/update-comment.ts
@@ -13,8 +13,14 @@ import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { resolveCommentMentions } from "../server/lib/comment-mentions.js";
 import { isRecordingExpired } from "../server/lib/recording-page-access.js";
 import { sameOwnerEmail } from "../server/lib/recordings.js";
+
+const mentionSchema = z.object({
+  email: z.string().email(),
+  name: z.string().trim().min(1),
+});
 
 export default defineAction({
   description:
@@ -28,6 +34,10 @@ export default defineAction({
       .describe(
         "Updated comment text; inline Markdown is supported, without headings",
       ),
+    mentions: z
+      .union([z.string(), z.array(mentionSchema).max(20)])
+      .optional()
+      .describe("Organization members mentioned in the updated comment"),
   }),
   run: async (args) => {
     const userEmail = getRequestUserEmail();
@@ -62,10 +72,19 @@ export default defineAction({
       );
     }
 
+    const mentions = await resolveCommentMentions(
+      args.mentions,
+      existing.organizationId,
+    );
+
     const updatedAt = new Date().toISOString();
     const updated = await db
       .update(schema.recordingComments)
-      .set({ content: args.content, updatedAt })
+      .set({
+        content: args.content,
+        mentionsJson: mentions.length > 0 ? JSON.stringify(mentions) : null,
+        updatedAt,
+      })
       .where(
         and(
           eq(schema.recordingComments.id, args.id),

--- a/templates/clips/app/components/player/comment-composer.tsx
+++ b/templates/clips/app/components/player/comment-composer.tsx
@@ -1,0 +1,284 @@
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+import type { CommentMention } from "../../../shared/comment-mentions";
+import type { MentionMember } from "../../hooks/use-mention-members";
+
+export type MentionEntry = CommentMention;
+
+export function mentionLabel(member: MentionMember): string {
+  return member.name?.trim() || member.email.split("@")[0];
+}
+
+interface CommentComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  onMentionAdd: (entry: MentionEntry) => void;
+  onEscape?: () => void;
+  onBlur?: () => void;
+  members: MentionMember[];
+  placeholder?: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  rows?: number;
+  className?: string;
+  submitOnEnter?: boolean;
+  "aria-label"?: string;
+}
+
+export const CommentComposer = forwardRef<
+  HTMLTextAreaElement,
+  CommentComposerProps
+>(function CommentComposer(
+  {
+    value,
+    onChange,
+    onSubmit,
+    onMentionAdd,
+    onEscape,
+    onBlur,
+    members,
+    placeholder,
+    autoFocus,
+    disabled = false,
+    rows = 2,
+    className,
+    submitOnEnter = false,
+    "aria-label": ariaLabel,
+  },
+  ref,
+) {
+  const innerRef = useRef<HTMLTextAreaElement | null>(null);
+  const [query, setQuery] = useState<string | null>(null);
+  const [highlight, setHighlight] = useState(0);
+
+  const setRefs = (element: HTMLTextAreaElement | null) => {
+    innerRef.current = element;
+    if (typeof ref === "function") ref(element);
+    else if (ref) {
+      (ref as { current: HTMLTextAreaElement | null }).current = element;
+    }
+  };
+
+  useEffect(() => {
+    if (autoFocus) innerRef.current?.focus();
+  }, [autoFocus]);
+
+  const filtered =
+    query === null
+      ? []
+      : members
+          .filter((member) => {
+            const q = query.toLowerCase();
+            return (
+              !q ||
+              (member.name ?? "").toLowerCase().includes(q) ||
+              member.email.toLowerCase().includes(q)
+            );
+          })
+          .slice(0, 6);
+
+  const refreshQuery = (element: HTMLTextAreaElement) => {
+    const caret = element.selectionStart ?? element.value.length;
+    const match = element.value.slice(0, caret).match(/(?:^|\s)@([^\s@]*)$/);
+    setQuery(match ? match[1] : null);
+    setHighlight(0);
+  };
+
+  const selectMember = (member: MentionMember) => {
+    const element = innerRef.current;
+    if (!element) return;
+    const caret = element.selectionStart ?? value.length;
+    const before = value.slice(0, caret);
+    const match = before.match(/(?:^|\s)@([^\s@]*)$/);
+    if (!match) return;
+    const label = mentionLabel(member);
+    const atStart = caret - match[1].length - 1;
+    const next = `${value.slice(0, atStart)}@${label} ${value.slice(caret)}`;
+    onChange(next);
+    onMentionAdd({ email: member.email, name: label });
+    setQuery(null);
+    requestAnimationFrame(() => {
+      const current = innerRef.current;
+      if (!current) return;
+      current.focus();
+      const nextCaret = atStart + label.length + 2;
+      current.setSelectionRange(nextCaret, nextCaret);
+    });
+  };
+
+  const applyMarkdownShortcut = (
+    event: KeyboardEvent<HTMLTextAreaElement>,
+  ): boolean => {
+    if (
+      event.nativeEvent.isComposing ||
+      (!event.metaKey && !event.ctrlKey) ||
+      event.altKey
+    ) {
+      return false;
+    }
+
+    const key = event.key.toLowerCase();
+    const marker =
+      key === "b"
+        ? "**"
+        : key === "i"
+          ? "*"
+          : key === "`"
+            ? "`"
+            : key === "x" && event.shiftKey
+              ? "~~"
+              : null;
+    if (!marker) return false;
+
+    const element = innerRef.current;
+    if (!element) return false;
+    event.preventDefault();
+    const start = element.selectionStart ?? value.length;
+    const end = element.selectionEnd ?? start;
+    const selected = value.slice(start, end);
+    const before = value.slice(0, start);
+    const after = value.slice(end);
+    const wrapped = before.endsWith(marker) && after.startsWith(marker);
+    const nextValue = wrapped
+      ? `${before.slice(0, -marker.length)}${selected}${after.slice(marker.length)}`
+      : `${before}${marker}${selected}${marker}${after}`;
+    const nextStart = wrapped ? start - marker.length : start + marker.length;
+    const nextEnd = wrapped ? end - marker.length : nextStart + selected.length;
+    onChange(nextValue);
+    requestAnimationFrame(() => {
+      const current = innerRef.current;
+      if (!current) return;
+      current.focus();
+      current.setSelectionRange(nextStart, nextEnd);
+    });
+    return true;
+  };
+
+  const menuOpen = query !== null && filtered.length > 0;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (menuOpen) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlight((current) => (current + 1) % filtered.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlight(
+          (current) => (current - 1 + filtered.length) % filtered.length,
+        );
+        return;
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        selectMember(filtered[highlight]);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setQuery(null);
+        return;
+      }
+    }
+
+    if (applyMarkdownShortcut(event)) return;
+
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      (submitOnEnter || event.metaKey || event.ctrlKey)
+    ) {
+      event.preventDefault();
+      onSubmit();
+      return;
+    }
+    if (event.key === "Escape") onEscape?.();
+  };
+
+  return (
+    <Popover
+      open={menuOpen}
+      onOpenChange={(open) => {
+        if (!open) setQuery(null);
+      }}
+    >
+      <PopoverAnchor asChild>
+        <div className="relative min-w-0 flex-1">
+          <Textarea
+            ref={setRefs}
+            value={value}
+            disabled={disabled}
+            rows={rows}
+            aria-label={ariaLabel}
+            onChange={(event) => {
+              onChange(event.target.value);
+              refreshQuery(event.target);
+            }}
+            onKeyUp={(event) => refreshQuery(event.currentTarget)}
+            onClick={(event) => refreshQuery(event.currentTarget)}
+            onKeyDown={handleKeyDown}
+            onBlur={() => {
+              setTimeout(() => setQuery(null), 120);
+              onBlur?.();
+            }}
+            placeholder={placeholder}
+            className={cn(
+              "w-full resize-none bg-transparent placeholder:text-muted-foreground focus:outline-none",
+              className,
+            )}
+          />
+        </div>
+      </PopoverAnchor>
+      {!disabled && menuOpen ? (
+        <PopoverContent
+          side="bottom"
+          align="start"
+          portalled={false}
+          className="w-80 max-w-[calc(100vw-2rem)] p-1"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
+          <div role="listbox">
+            {filtered.map((member, index) => (
+              <button
+                key={member.email}
+                type="button"
+                role="option"
+                aria-selected={index === highlight}
+                onPointerDown={(event) => event.preventDefault()}
+                onClick={() => selectMember(member)}
+                onMouseEnter={() => setHighlight(index)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-left text-[13px]",
+                  index === highlight ? "bg-accent" : "hover:bg-accent/60",
+                )}
+              >
+                <span className="font-medium text-foreground">
+                  {mentionLabel(member)}
+                </span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {member.email}
+                </span>
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      ) : null}
+    </Popover>
+  );
+});

--- a/templates/clips/app/components/player/comments-panel.test.tsx
+++ b/templates/clips/app/components/player/comments-panel.test.tsx
@@ -31,6 +31,12 @@ vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) => key,
 }));
 
+vi.mock("../../hooks/use-mention-members", () => ({
+  useMentionMembers: () => ({
+    data: [{ email: "member@example.com", name: "Member" }],
+  }),
+}));
+
 const rootComment: Comment = {
   id: "comment-1",
   threadId: "thread-1",
@@ -139,23 +145,45 @@ describe("CommentsPanel reply composer", () => {
     );
 
     expect(composer?.className).toContain("px-3 py-2");
-    expect(composer?.parentElement?.className).toContain(
-      "border border-border",
-    );
+    expect(composer?.closest(".border-border")).not.toBeNull();
   });
 
   it("renders inline Markdown while flattening headings", () => {
     renderPanel("viewer@example.com", [
       {
         ...rootComment,
-        content: "# Not a heading\n\n**Bold** and `inline code`.",
+        content: "# Not a heading\n\n**Bold**, *italic* and `inline code`.",
       },
     ]);
 
     expect(container.querySelector("h1, h2, h3, h4, h5, h6")).toBeNull();
     expect(container.querySelector("strong")?.textContent).toBe("Bold");
+    expect(container.querySelector("em")?.textContent).toBe("italic");
     expect(container.querySelector("code")?.textContent).toBe("inline code");
     expect(container.textContent).toContain("Not a heading");
+  });
+
+  it("applies Markdown formatting shortcuts to selected text", () => {
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="commentsPanel.leaveComment"]',
+    );
+    expect(composer).not.toBeNull();
+
+    act(() => {
+      if (!composer) return;
+      setTextareaValue(composer, "format this");
+      composer.setSelectionRange(0, 11);
+      composer.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "b",
+          metaKey: true,
+        }),
+      );
+    });
+
+    expect(composer?.value).toBe("**format this**");
   });
 
   it("opens and focuses a reply field inline without replacing the new-comment draft", async () => {
@@ -189,6 +217,48 @@ describe("CommentsPanel reply composer", () => {
       inlineReply!.compareDocumentPosition(newComment as Node) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+    expect(inlineReply?.closest(".ml-12")).not.toBeNull();
+  });
+
+  it("inserts organization member mentions from autocomplete", async () => {
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      'textarea[placeholder="commentsPanel.leaveComment"]',
+    );
+    expect(composer).not.toBeNull();
+
+    act(() => {
+      if (!composer) return;
+      setTextareaValue(composer, "Hi @");
+      composer.setSelectionRange(4, 4);
+      composer.dispatchEvent(
+        new KeyboardEvent("keyup", { bubbles: true, key: "@" }),
+      );
+    });
+
+    const option = document.body.querySelector<HTMLButtonElement>(
+      'button[role="option"]',
+    );
+    expect(option?.textContent).toContain("Member");
+
+    await act(async () => {
+      option?.click();
+      await Promise.resolve();
+    });
+
+    expect(composer?.value).toBe("Hi @Member ");
+    act(() =>
+      composer?.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    act(() =>
+      container.querySelector<HTMLButtonElement>("button.size-8")?.click(),
+    );
+
+    expect(actionMocks.addComment).toHaveBeenCalledWith({
+      recordingId: "recording-1",
+      content: "Hi @Member",
+      videoTimestampMs: 34_000,
+      mentions: [{ email: "member@example.com", name: "Member" }],
+    });
   });
 
   it("submits the inline reply to the selected thread", async () => {

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -35,9 +35,10 @@ import {
 import { cn } from "@/lib/utils";
 
 import {
+  displayCommentMentions,
   mentionsForCommentText,
-  parseCommentMentions,
   type CommentMention,
+  type CommentMentionDisplay,
 } from "../../../shared/comment-mentions";
 import { useMentionMembers } from "../../hooks/use-mention-members";
 import {
@@ -81,7 +82,7 @@ export interface Comment {
   authorEmail: string;
   authorName: string | null;
   content: string;
-  mentionsJson?: string | null;
+  mentions?: CommentMentionDisplay[];
   videoTimestampMs: number;
   emojiReactionsJson: string;
   resolved: boolean;
@@ -153,7 +154,14 @@ export function CommentsPanel(props: CommentsPanelProps) {
   const [editDraft, setEditDraft] = useState("");
   const [editMentions, setEditMentions] = useState<MentionEntry[]>([]);
   const replyComposerRef = useRef<HTMLTextAreaElement>(null);
-  const { data: mentionMembers = [] } = useMentionMembers(isSignedIn);
+  const { data: mentionMembers = [] } = useMentionMembers(
+    recordingId,
+    isSignedIn,
+  );
+  const selectedEditMentions = useMemo(
+    () => mentionsForCommentText(editDraft, editMentions),
+    [editDraft, editMentions],
+  );
 
   const queryClient = useQueryClient();
 
@@ -178,9 +186,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
         authorEmail: currentUserEmail ?? "",
         authorName: currentUserName ?? null,
         content: vars.content,
-        mentionsJson: vars.mentions?.length
-          ? JSON.stringify(vars.mentions)
-          : null,
+        mentions: displayCommentMentions(vars.mentions),
         videoTimestampMs: vars.videoTimestampMs ?? 0,
         emojiReactionsJson: "{}",
         resolved: false,
@@ -315,9 +321,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
             ? {
                 ...comment,
                 content: vars.content,
-                mentionsJson: vars.mentions?.length
-                  ? JSON.stringify(vars.mentions)
-                  : null,
+                ...(vars.mentions === undefined
+                  ? {}
+                  : { mentions: displayCommentMentions(vars.mentions) }),
                 updatedAt,
               }
             : comment,
@@ -339,8 +345,8 @@ export function CommentsPanel(props: CommentsPanelProps) {
             ? {
                 ...comment,
                 content: data.content,
-                ...(data.mentionsJson !== undefined
-                  ? { mentionsJson: data.mentionsJson }
+                ...(data.mentions !== undefined
+                  ? { mentions: data.mentions }
                   : {}),
                 updatedAt: data.updatedAt,
               }
@@ -426,7 +432,8 @@ export function CommentsPanel(props: CommentsPanelProps) {
     if (!canComment) return;
     setEditingId(comment.id);
     setEditDraft(comment.content);
-    setEditMentions(parseCommentMentions(comment.mentionsJson));
+    // Persisted comment data only contains display-safe mention names.
+    setEditMentions([]);
   }
 
   function cancelEditing() {
@@ -439,7 +446,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
     if (!canComment) return;
     const content = editDraft.trim();
     if (!content) return;
-    if (content === comment.content) {
+    if (content === comment.content && selectedEditMentions.length === 0) {
       cancelEditing();
       return;
     }
@@ -447,7 +454,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
     updateComment.mutate({
       id: comment.id,
       content,
-      ...mentionArgs(editDraft, editMentions),
+      ...mentionArgs(editDraft, selectedEditMentions),
     });
   }
 
@@ -510,6 +517,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
                         upsertMention(current, mention),
                       )
                     }
+                    hasSelectedEditMentions={selectedEditMentions.length > 0}
                     members={mentionMembers}
                     onStartEdit={() => startEditing(root)}
                     onCancelEdit={cancelEditing}
@@ -540,6 +548,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
                               setEditMentions((current) =>
                                 upsertMention(current, mention),
                               )
+                            }
+                            hasSelectedEditMentions={
+                              selectedEditMentions.length > 0
                             }
                             members={mentionMembers}
                             onStartEdit={() => startEditing(r)}
@@ -849,6 +860,7 @@ function InlineEditComposer({
   originalContent,
   onDraftChange,
   onMentionAdd,
+  hasSelectedMentions,
   members,
   onCancel,
   onSubmit,
@@ -857,6 +869,7 @@ function InlineEditComposer({
   originalContent: string;
   onDraftChange: (value: string) => void;
   onMentionAdd: (mention: MentionEntry) => void;
+  hasSelectedMentions: boolean;
   members: { email: string; name: string | null }[];
   onCancel: () => void;
   onSubmit: () => void;
@@ -886,7 +899,8 @@ function InlineEditComposer({
           size="sm"
           onClick={onSubmit}
           disabled={
-            !normalizedDraft || normalizedDraft === originalContent.trim()
+            !normalizedDraft ||
+            (normalizedDraft === originalContent.trim() && !hasSelectedMentions)
           }
         >
           {t("common.save")}
@@ -908,6 +922,7 @@ function CommentCard({
   onDelete,
   onEditDraftChange,
   onEditMentionAdd,
+  hasSelectedEditMentions,
   members,
   onStartEdit,
   onCancelEdit,
@@ -927,6 +942,7 @@ function CommentCard({
   onDelete: (id: string) => void;
   onEditDraftChange: (value: string) => void;
   onEditMentionAdd: (mention: MentionEntry) => void;
+  hasSelectedEditMentions: boolean;
   members: { email: string; name: string | null }[];
   onStartEdit: () => void;
   onCancelEdit: () => void;
@@ -1011,6 +1027,7 @@ function CommentCard({
             originalContent={comment.content}
             onDraftChange={onEditDraftChange}
             onMentionAdd={onEditMentionAdd}
+            hasSelectedMentions={hasSelectedEditMentions}
             members={members}
             onCancel={onCancelEdit}
             onSubmit={onSaveEdit}
@@ -1020,7 +1037,7 @@ function CommentCard({
             <InlineMarkdown
               content={comment.content}
               className="mt-0.5 text-sm text-foreground"
-              protectedSpans={commentMentionSpans(comment.mentionsJson)}
+              protectedSpans={commentMentionSpans(comment.mentions)}
             />
 
             <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
@@ -1177,10 +1194,10 @@ function mentionArgs(
 }
 
 function commentMentionSpans(
-  mentionsJson: string | null | undefined,
+  mentions: readonly CommentMentionDisplay[] | null | undefined,
 ): InlineMarkdownProtectedSpan[] {
   const labels = Array.from(
-    new Set(parseCommentMentions(mentionsJson).map((mention) => mention.name)),
+    new Set((mentions ?? []).map((mention) => mention.name)),
   ).sort((a, b) => b.length - a.length);
   return labels.map((name) => ({
     source: `@${name}`,

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -3,7 +3,10 @@ import {
   useAvatarUrl,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
-import { InlineMarkdown } from "@agent-native/core/client/markdown";
+import {
+  InlineMarkdown,
+  type InlineMarkdownProtectedSpan,
+} from "@agent-native/core/client/markdown";
 import {
   IconSend,
   IconCheck,
@@ -29,9 +32,18 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
+import {
+  mentionsForCommentText,
+  parseCommentMentions,
+  type CommentMention,
+} from "../../../shared/comment-mentions";
+import { useMentionMembers } from "../../hooks/use-mention-members";
+import {
+  CommentComposer as CommentTextComposer,
+  type MentionEntry,
+} from "./comment-composer";
 import { REACTION_EMOJIS } from "./reaction-emojis";
 import { msToClock } from "./scrubber";
 
@@ -69,6 +81,7 @@ export interface Comment {
   authorEmail: string;
   authorName: string | null;
   content: string;
+  mentionsJson?: string | null;
   videoTimestampMs: number;
   emojiReactionsJson: string;
   resolved: boolean;
@@ -134,9 +147,13 @@ export function CommentsPanel(props: CommentsPanelProps) {
   const [draft, setDraft] = useState("");
   const [replyDraft, setReplyDraft] = useState("");
   const [replyTo, setReplyTo] = useState<Comment | null>(null);
+  const [draftMentions, setDraftMentions] = useState<MentionEntry[]>([]);
+  const [replyMentions, setReplyMentions] = useState<MentionEntry[]>([]);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState("");
+  const [editMentions, setEditMentions] = useState<MentionEntry[]>([]);
   const replyComposerRef = useRef<HTMLTextAreaElement>(null);
+  const { data: mentionMembers = [] } = useMentionMembers(isSignedIn);
 
   const queryClient = useQueryClient();
 
@@ -161,6 +178,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
         authorEmail: currentUserEmail ?? "",
         authorName: currentUserName ?? null,
         content: vars.content,
+        mentionsJson: vars.mentions?.length
+          ? JSON.stringify(vars.mentions)
+          : null,
         videoTimestampMs: vars.videoTimestampMs ?? 0,
         emojiReactionsJson: "{}",
         resolved: false,
@@ -292,7 +312,14 @@ export function CommentsPanel(props: CommentsPanelProps) {
       patchComments((list) =>
         list.map((comment) =>
           comment.id === vars.id
-            ? { ...comment, content: vars.content, updatedAt }
+            ? {
+                ...comment,
+                content: vars.content,
+                mentionsJson: vars.mentions?.length
+                  ? JSON.stringify(vars.mentions)
+                  : null,
+                updatedAt,
+              }
             : comment,
         ),
       );
@@ -302,6 +329,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
       setEditingId(vars.id);
       setEditDraft(vars.content);
+      setEditMentions(vars.mentions ?? []);
     },
     onSuccess: (data: any) => {
       if (!data?.id || !data?.content || !data?.updatedAt) return;
@@ -311,6 +339,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
             ? {
                 ...comment,
                 content: data.content,
+                ...(data.mentionsJson !== undefined
+                  ? { mentionsJson: data.mentionsJson }
+                  : {}),
                 updatedAt: data.updatedAt,
               }
             : comment,
@@ -357,21 +388,25 @@ export function CommentsPanel(props: CommentsPanelProps) {
           videoTimestampMs: target.videoTimestampMs,
           threadId: target.threadId,
           parentId: target.id,
+          ...mentionArgs(value, replyMentions),
           ...(currentUserName ? { authorName: currentUserName } : {}),
         }
       : {
           recordingId,
           content: text,
           videoTimestampMs: currentMs,
+          ...mentionArgs(value, draftMentions),
           ...(currentUserName ? { authorName: currentUserName } : {}),
         };
     // Clear composer state before firing the mutation so the UI feels instant —
     // the optimistic cache patch in onMutate puts the comment in the list.
     if (target) {
       setReplyDraft("");
+      setReplyMentions([]);
       setReplyTo(null);
     } else {
       setDraft("");
+      setDraftMentions([]);
     }
     addComment.mutate(vars);
   }
@@ -383,6 +418,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return;
     }
     setReplyTo(root);
+    setReplyMentions([]);
     setTimeout(() => replyComposerRef.current?.focus(), 0);
   }
 
@@ -390,11 +426,13 @@ export function CommentsPanel(props: CommentsPanelProps) {
     if (!canComment) return;
     setEditingId(comment.id);
     setEditDraft(comment.content);
+    setEditMentions(parseCommentMentions(comment.mentionsJson));
   }
 
   function cancelEditing() {
     setEditingId(null);
     setEditDraft("");
+    setEditMentions([]);
   }
 
   function submitEdit(comment: Comment) {
@@ -406,7 +444,11 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return;
     }
     cancelEditing();
-    updateComment.mutate({ id: comment.id, content });
+    updateComment.mutate({
+      id: comment.id,
+      content,
+      ...mentionArgs(editDraft, editMentions),
+    });
   }
 
   const composer = (
@@ -420,6 +462,10 @@ export function CommentsPanel(props: CommentsPanelProps) {
       enableComments={enableComments}
       canComment={canComment}
       onDraftChange={setDraft}
+      onMentionAdd={(mention) =>
+        setDraftMentions((current) => upsertMention(current, mention))
+      }
+      members={mentionMembers}
       onSubmit={() => submitDraft(draft, null)}
       onUnauthenticated={onUnauthenticated}
     />
@@ -459,6 +505,12 @@ export function CommentsPanel(props: CommentsPanelProps) {
                     isEditing={editingId === root.id}
                     editDraft={editDraft}
                     onEditDraftChange={setEditDraft}
+                    onEditMentionAdd={(mention) =>
+                      setEditMentions((current) =>
+                        upsertMention(current, mention),
+                      )
+                    }
+                    members={mentionMembers}
                     onStartEdit={() => startEditing(root)}
                     onCancelEdit={cancelEditing}
                     onSaveEdit={() => submitEdit(root)}
@@ -484,6 +536,12 @@ export function CommentsPanel(props: CommentsPanelProps) {
                             isEditing={editingId === r.id}
                             editDraft={editDraft}
                             onEditDraftChange={setEditDraft}
+                            onEditMentionAdd={(mention) =>
+                              setEditMentions((current) =>
+                                upsertMention(current, mention),
+                              )
+                            }
+                            members={mentionMembers}
                             onStartEdit={() => startEditing(r)}
                             onCancelEdit={cancelEditing}
                             onSaveEdit={() => submitEdit(r)}
@@ -502,8 +560,15 @@ export function CommentsPanel(props: CommentsPanelProps) {
                       draft={replyDraft}
                       textareaRef={replyComposerRef}
                       onDraftChange={setReplyDraft}
+                      onMentionAdd={(mention) =>
+                        setReplyMentions((current) =>
+                          upsertMention(current, mention),
+                        )
+                      }
+                      members={mentionMembers}
                       onCancel={() => {
                         setReplyDraft("");
+                        setReplyMentions([]);
                         setReplyTo(null);
                       }}
                       onSubmit={() => submitDraft(replyDraft, replyTo)}
@@ -601,6 +666,8 @@ function CommentComposer({
   enableComments,
   canComment,
   onDraftChange,
+  onMentionAdd,
+  members,
   onSubmit,
   onUnauthenticated,
 }: {
@@ -613,6 +680,8 @@ function CommentComposer({
   enableComments: boolean;
   canComment: boolean;
   onDraftChange: (value: string) => void;
+  onMentionAdd: (mention: MentionEntry) => void;
+  members: { email: string; name: string | null }[];
   onSubmit: () => void;
   onUnauthenticated?: (intent: "comment" | "react") => void;
 }) {
@@ -693,9 +762,12 @@ function CommentComposer({
             </AvatarFallback>
           </Avatar>
         ) : null}
-        <Textarea
+        <CommentTextComposer
           value={draft}
-          onChange={(e) => onDraftChange(e.target.value)}
+          onChange={onDraftChange}
+          onMentionAdd={onMentionAdd}
+          members={members}
+          onSubmit={onSubmit}
           placeholder={t("commentsPanel.leaveComment")}
           className={cn(
             "resize-none border-0 bg-background text-sm",
@@ -703,12 +775,7 @@ function CommentComposer({
               ? "min-h-10 flex-1 border-0 px-3 py-2 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
               : "min-h-[60px]",
           )}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-              e.preventDefault();
-              onSubmit();
-            }
-          }}
+          submitOnEnter={false}
         />
         <Button
           onClick={onSubmit}
@@ -730,38 +797,35 @@ function InlineReplyComposer({
   draft,
   textareaRef,
   onDraftChange,
+  onMentionAdd,
+  members,
   onCancel,
   onSubmit,
 }: {
   draft: string;
   textareaRef: Ref<HTMLTextAreaElement>;
   onDraftChange: (value: string) => void;
+  onMentionAdd: (mention: MentionEntry) => void;
+  members: { email: string; name: string | null }[];
   onCancel: () => void;
   onSubmit: () => void;
 }) {
   const t = useT();
 
   return (
-    <div className="ml-9 mt-2 rounded-lg p-2">
-      <Textarea
+    <div className="ml-12 mt-2 rounded-lg p-2">
+      <CommentTextComposer
         ref={textareaRef}
         autoFocus
         value={draft}
-        onChange={(event) => onDraftChange(event.target.value)}
+        onChange={onDraftChange}
+        onMentionAdd={onMentionAdd}
+        members={members}
+        onSubmit={onSubmit}
         placeholder={t("commentsPanel.writeReply")}
         className="min-h-16 resize-none border-0 bg-background text-sm"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            event.preventDefault();
-            onCancel();
-          } else if (
-            event.key === "Enter" &&
-            (event.metaKey || event.ctrlKey)
-          ) {
-            event.preventDefault();
-            onSubmit();
-          }
-        }}
+        onEscape={onCancel}
+        submitOnEnter={false}
       />
       <div className="mt-2 flex justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>
@@ -785,12 +849,16 @@ function InlineEditComposer({
   draft,
   originalContent,
   onDraftChange,
+  onMentionAdd,
+  members,
   onCancel,
   onSubmit,
 }: {
   draft: string;
   originalContent: string;
   onDraftChange: (value: string) => void;
+  onMentionAdd: (mention: MentionEntry) => void;
+  members: { email: string; name: string | null }[];
   onCancel: () => void;
   onSubmit: () => void;
 }) {
@@ -799,24 +867,17 @@ function InlineEditComposer({
 
   return (
     <div className="mt-2 rounded-lg p-2">
-      <Textarea
+      <CommentTextComposer
         autoFocus
         value={draft}
-        onChange={(event) => onDraftChange(event.target.value)}
+        onChange={onDraftChange}
+        onMentionAdd={onMentionAdd}
+        members={members}
+        onSubmit={onSubmit}
         aria-label={t("commentsPanel.editComment")}
         className="min-h-16 resize-none border-0 bg-background text-sm"
-        onKeyDown={(event) => {
-          if (event.key === "Escape") {
-            event.preventDefault();
-            onCancel();
-          } else if (
-            event.key === "Enter" &&
-            (event.metaKey || event.ctrlKey)
-          ) {
-            event.preventDefault();
-            onSubmit();
-          }
-        }}
+        onEscape={onCancel}
+        submitOnEnter={false}
       />
       <div className="mt-2 flex justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>
@@ -847,6 +908,8 @@ function CommentCard({
   onResolve,
   onDelete,
   onEditDraftChange,
+  onEditMentionAdd,
+  members,
   onStartEdit,
   onCancelEdit,
   onSaveEdit,
@@ -864,6 +927,8 @@ function CommentCard({
   onResolve: (id: string, resolved: boolean) => void;
   onDelete: (id: string) => void;
   onEditDraftChange: (value: string) => void;
+  onEditMentionAdd: (mention: MentionEntry) => void;
+  members: { email: string; name: string | null }[];
   onStartEdit: () => void;
   onCancelEdit: () => void;
   onSaveEdit: () => void;
@@ -946,6 +1011,8 @@ function CommentCard({
             draft={editDraft}
             originalContent={comment.content}
             onDraftChange={onEditDraftChange}
+            onMentionAdd={onEditMentionAdd}
+            members={members}
             onCancel={onCancelEdit}
             onSubmit={onSaveEdit}
           />
@@ -954,6 +1021,7 @@ function CommentCard({
             <InlineMarkdown
               content={comment.content}
               className="mt-0.5 text-sm text-foreground"
+              protectedSpans={commentMentionSpans(comment.mentionsJson)}
             />
 
             <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
@@ -1088,6 +1156,38 @@ function parseReactions(raw: string): Record<string, string[]> {
     if (v && typeof v === "object") return v as Record<string, string[]>;
   } catch {}
   return {};
+}
+
+function upsertMention(
+  current: MentionEntry[],
+  mention: MentionEntry,
+): MentionEntry[] {
+  return current.some(
+    (entry) => entry.email.toLowerCase() === mention.email.toLowerCase(),
+  )
+    ? current
+    : [...current, mention];
+}
+
+function mentionArgs(
+  text: string,
+  mentions: readonly CommentMention[],
+): { mentions?: CommentMention[] } {
+  const present = mentionsForCommentText(text, mentions);
+  return present.length > 0 ? { mentions: present } : {};
+}
+
+function commentMentionSpans(
+  mentionsJson: string | null | undefined,
+): InlineMarkdownProtectedSpan[] {
+  const labels = Array.from(
+    new Set(parseCommentMentions(mentionsJson).map((mention) => mention.name)),
+  ).sort((a, b) => b.length - a.length);
+  return labels.map((name) => ({
+    source: `@${name}`,
+    label: `@${name}`,
+    className: "comment-mention font-medium text-primary",
+  }));
 }
 
 function displayName(c: Comment): string {

--- a/templates/clips/app/hooks/use-mention-members.ts
+++ b/templates/clips/app/hooks/use-mention-members.ts
@@ -1,0 +1,30 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+import { useQuery } from "@tanstack/react-query";
+
+export interface MentionMember {
+  email: string;
+  name: string | null;
+}
+
+export function useMentionMembers(enabled = true) {
+  return useQuery<MentionMember[]>({
+    queryKey: ["clips-comment-mention-members"],
+    enabled,
+    retry: false,
+    staleTime: 60_000,
+    queryFn: async () => {
+      const response = await fetch(
+        agentNativePath("/_agent-native/org/members"),
+      );
+      if (!response.ok) return [];
+      const data = await response.json();
+      const members = Array.isArray(data?.members) ? data.members : [];
+      return members
+        .map((member: any) => ({
+          email: typeof member?.email === "string" ? member.email : "",
+          name: typeof member?.name === "string" ? member.name : null,
+        }))
+        .filter((member: MentionMember) => member.email);
+    },
+  });
+}

--- a/templates/clips/app/hooks/use-mention-members.ts
+++ b/templates/clips/app/hooks/use-mention-members.ts
@@ -1,30 +1,24 @@
-import { agentNativePath } from "@agent-native/core/client/api-path";
-import { useQuery } from "@tanstack/react-query";
+import { useActionQuery } from "@agent-native/core/client/hooks";
 
 export interface MentionMember {
   email: string;
   name: string | null;
 }
 
-export function useMentionMembers(enabled = true) {
-  return useQuery<MentionMember[]>({
-    queryKey: ["clips-comment-mention-members"],
-    enabled,
-    retry: false,
-    staleTime: 60_000,
-    queryFn: async () => {
-      const response = await fetch(
-        agentNativePath("/_agent-native/org/members"),
-      );
-      if (!response.ok) return [];
-      const data = await response.json();
-      const members = Array.isArray(data?.members) ? data.members : [];
-      return members
-        .map((member: any) => ({
-          email: typeof member?.email === "string" ? member.email : "",
-          name: typeof member?.name === "string" ? member.name : null,
-        }))
-        .filter((member: MentionMember) => member.email);
+type MentionMembersResponse = { members: MentionMember[] };
+
+export function useMentionMembers(
+  recordingId?: string,
+  enabled = true,
+): { data: MentionMember[] } {
+  const query = useActionQuery<MentionMembersResponse>(
+    "list-recording-mention-members",
+    recordingId ? { recordingId } : undefined,
+    {
+      enabled: enabled && Boolean(recordingId),
+      retry: false,
+      staleTime: 60_000,
     },
-  });
+  );
+  return { data: query.data?.members ?? [] };
 }

--- a/templates/clips/app/routes/_app.notifications.tsx
+++ b/templates/clips/app/routes/_app.notifications.tsx
@@ -44,7 +44,10 @@ export default function NotificationsRoute() {
   const [replyFor, setReplyFor] = useState<NotificationItem | null>(null);
   const [replyText, setReplyText] = useState("");
   const [replyMentions, setReplyMentions] = useState<MentionEntry[]>([]);
-  const { data: mentionMembers = [] } = useMentionMembers(true);
+  const { data: mentionMembers = [] } = useMentionMembers(
+    replyFor?.recordingId,
+    !!replyFor,
+  );
 
   const qc = useQueryClient();
   const {

--- a/templates/clips/app/routes/_app.notifications.tsx
+++ b/templates/clips/app/routes/_app.notifications.tsx
@@ -9,15 +9,21 @@ import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/library/page-header";
+import {
+  CommentComposer,
+  type MentionEntry,
+} from "@/components/player/comment-composer";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   NotificationsList,
   type NotificationItem,
   type NotificationKind,
 } from "@/components/workspace/notifications-list";
+import { useMentionMembers } from "@/hooks/use-mention-members";
 import enMessages from "@/i18n/en-US";
+
+import { mentionsForCommentText } from "../../shared/comment-mentions";
 
 export function meta() {
   return [{ title: enMessages.notificationsRoute.pageTitle }];
@@ -37,6 +43,8 @@ export default function NotificationsRoute() {
   const [filter, setFilter] = useState<"all" | NotificationKind>("all");
   const [replyFor, setReplyFor] = useState<NotificationItem | null>(null);
   const [replyText, setReplyText] = useState("");
+  const [replyMentions, setReplyMentions] = useState<MentionEntry[]>([]);
+  const { data: mentionMembers = [] } = useMentionMembers(true);
 
   const qc = useQueryClient();
   const {
@@ -66,6 +74,7 @@ export default function NotificationsRoute() {
       threadId?: string;
       parentId?: string;
       videoTimestampMs?: number;
+      mentions?: MentionEntry[];
     }
   >("add-comment");
 
@@ -78,9 +87,11 @@ export default function NotificationsRoute() {
         recordingId: replyFor.recordingId,
         content,
         threadId: replyFor.id.replace(/^c:/, ""),
+        mentions: mentionsForCommentText(content, replyMentions),
       });
       toast.success(t("notificationsRoute.replySent"));
       setReplyText("");
+      setReplyMentions([]);
       setReplyFor(null);
       void qc.invalidateQueries({ queryKey: ["action", "list-notifications"] });
       void qc.invalidateQueries({ queryKey: ["action", "list-comments"] });
@@ -142,7 +153,14 @@ export default function NotificationsRoute() {
               </Button>
             </div>
           ) : (
-            <NotificationsList items={filtered} onReply={setReplyFor} />
+            <NotificationsList
+              items={filtered}
+              onReply={(item) => {
+                setReplyText("");
+                setReplyMentions([]);
+                setReplyFor(item);
+              }}
+            />
           )}
         </div>
 
@@ -156,18 +174,23 @@ export default function NotificationsRoute() {
                 {replyFor.recordingTitle}
               </span>
             </div>
-            <div className="flex items-center gap-2">
-              <Input
+            <div className="flex items-end gap-2">
+              <CommentComposer
                 value={replyText}
-                onChange={(e) => setReplyText(e.target.value)}
+                onChange={setReplyText}
+                onMentionAdd={(mention) =>
+                  setReplyMentions((current) =>
+                    current.some((entry) => entry.email === mention.email)
+                      ? current
+                      : [...current, mention],
+                  )
+                }
+                members={mentionMembers}
+                onSubmit={() => void handleSendReply()}
                 placeholder={t("notificationsRoute.replyPlaceholder")}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault();
-                    void handleSendReply();
-                  }
-                }}
                 autoFocus
+                submitOnEnter
+                className="min-h-10 flex-1 resize-none bg-background text-sm"
               />
               <Button
                 onClick={handleSendReply}
@@ -176,7 +199,14 @@ export default function NotificationsRoute() {
               >
                 <IconSend className="size-4" />
               </Button>
-              <Button variant="ghost" onClick={() => setReplyFor(null)}>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setReplyText("");
+                  setReplyMentions([]);
+                  setReplyFor(null);
+                }}
+              >
                 {t("common.cancel")}
               </Button>
             </div>

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -341,6 +341,7 @@ export const recordingComments = table("recording_comments", {
   authorEmail: text("author_email").notNull(),
   authorName: text("author_name"),
   content: text("content").notNull(),
+  mentionsJson: text("mentions_json"),
   videoTimestampMs: integer("video_timestamp_ms").notNull().default(0),
   // JSON map of emoji -> [emails]
   emojiReactionsJson: text("emoji_reactions_json").notNull().default("{}"),

--- a/templates/clips/server/lib/activity-notifications.spec.ts
+++ b/templates/clips/server/lib/activity-notifications.spec.ts
@@ -44,6 +44,8 @@ vi.mock("../db/index.js", () => ({
       title: "title",
       ownerEmail: "owner_email",
       orgId: "org_id",
+      password: "password",
+      expiresAt: "expires_at",
     },
     recordingComments: {
       recordingId: "recording_id",
@@ -69,6 +71,8 @@ const RECORDING = {
   title: "Sprint demo",
   ownerEmail: "owner@example.com",
   orgId: null,
+  password: null as string | null,
+  expiresAt: null as string | null,
 };
 
 /**
@@ -177,6 +181,43 @@ describe("clips activity notifications", () => {
         wasMentioned: true,
       }),
     );
+  });
+
+  it("keeps comment bodies out of password-protected recordings for viewers", async () => {
+    stubDb({
+      recording: {
+        ...RECORDING,
+        password: "stored-password-hash",
+      },
+    });
+
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Private note",
+      mentions: [{ email: "member@example.com", name: "Member" }],
+    });
+
+    expect(notifyArgs().candidates).toEqual(["owner@example.com"]);
+  });
+
+  it("drops all comment activity after a recording expires", async () => {
+    stubDb({
+      recording: {
+        ...RECORDING,
+        expiresAt: "2026-07-15T11:59:59.999Z",
+      },
+    });
+
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      content: "Expired note",
+    });
+
+    expect(notifyArgs().candidates).toEqual([]);
   });
 
   it("builds the reaction email for each recipient", async () => {

--- a/templates/clips/server/lib/activity-notifications.spec.ts
+++ b/templates/clips/server/lib/activity-notifications.spec.ts
@@ -153,6 +153,32 @@ describe("clips activity notifications", () => {
     ]);
   });
 
+  it("adds mentioned organization members and marks their email", async () => {
+    await notifyRecordingComment({
+      recordingId: "rec_1",
+      threadId: "thread_1",
+      authorEmail: "viewer@example.com",
+      authorName: "Viewer",
+      content: "Can you review this, @Tagged?",
+      mentions: [{ email: "Tagged@Example.com", name: "Tagged" }],
+    });
+
+    expect(notifyArgs().candidates).toEqual([
+      "owner@example.com",
+      "tagged@example.com",
+    ]);
+
+    await notifyArgs().send("tagged@example.com");
+
+    expect(mocks.sendClipsTransactionalEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "activity-comment",
+        to: "tagged@example.com",
+        wasMentioned: true,
+      }),
+    );
+  });
+
   it("builds the reaction email for each recipient", async () => {
     await notifyRecordingReaction({
       recordingId: "rec_1",

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -73,6 +73,7 @@ export interface RecordingCommentNotificationInput {
   authorEmail: string;
   authorName?: string | null;
   content: string;
+  mentions?: { email: string; name: string }[];
   videoTimestampMs?: number | null;
   isReply?: boolean;
 }
@@ -94,7 +95,11 @@ async function deliverRecordingCommentEmails(
     return RECORDING_MISSING;
   }
 
-  const candidates = [recording.ownerEmail];
+  const mentions = input.mentions ?? [];
+  const mentioned = new Set(
+    mentions.map((mention) => mention.email.trim().toLowerCase()),
+  );
+  const candidates = [recording.ownerEmail, ...mentioned];
   if (input.isReply) {
     candidates.push(
       ...(await threadParticipants(input.recordingId, input.threadId)),
@@ -126,6 +131,7 @@ async function deliverRecordingCommentEmails(
         content: input.content,
         videoTimestampMs: input.videoTimestampMs ?? null,
         isReply: input.isReply ?? false,
+        ...(mentioned.has(to) ? { wasMentioned: true } : {}),
       }),
   });
 }

--- a/templates/clips/server/lib/activity-notifications.ts
+++ b/templates/clips/server/lib/activity-notifications.ts
@@ -18,6 +18,7 @@ import { and, eq } from "drizzle-orm";
 
 import { CLIPS_USER_PREFS_KEY } from "../../shared/clips-ai-prefs.js";
 import { getDb, schema } from "../db/index.js";
+import { canReceiveRecordingActivity } from "./recording-page-access.js";
 import { sendClipsTransactionalEmail } from "./transactional-email-templates.js";
 
 /**
@@ -44,6 +45,8 @@ async function getRecording(recordingId: string) {
       title: schema.recordings.title,
       ownerEmail: schema.recordings.ownerEmail,
       orgId: schema.recordings.orgId,
+      password: schema.recordings.password,
+      expiresAt: schema.recordings.expiresAt,
     })
     .from(schema.recordings)
     .where(eq(schema.recordings.id, recordingId))
@@ -108,10 +111,18 @@ async function deliverRecordingCommentEmails(
 
   // Thread rows are history, not an access grant: a viewer whose share was
   // revoked must stop receiving the recording's comment bodies.
+  const clipsAllowed = candidates.filter((email) =>
+    canReceiveRecordingActivity({
+      ownerEmail: recording.ownerEmail,
+      recipientEmail: email,
+      hasPassword: Boolean(recording.password),
+      expiresAt: recording.expiresAt,
+    }),
+  );
   const allowed = await filterRecipientsByResourceAccess({
     resourceType: "recording",
     resourceId: recording.id,
-    emails: candidates,
+    emails: clipsAllowed,
     orgId: recording.orgId,
   });
 
@@ -162,12 +173,20 @@ async function deliverRecordingReactionEmails(
     return RECORDING_MISSING;
   }
 
+  const clipsAllowed = [recording.ownerEmail, ...(input.extraRecipients ?? [])]
+    .filter((email): email is string => Boolean(email))
+    .filter((email) =>
+      canReceiveRecordingActivity({
+        ownerEmail: recording.ownerEmail,
+        recipientEmail: email,
+        hasPassword: Boolean(recording.password),
+        expiresAt: recording.expiresAt,
+      }),
+    );
   const allowed = await filterRecipientsByResourceAccess({
     resourceType: "recording",
     resourceId: recording.id,
-    emails: [recording.ownerEmail, ...(input.extraRecipients ?? [])].filter(
-      (email): email is string => Boolean(email),
-    ),
+    emails: clipsAllowed,
     orgId: recording.orgId,
   });
 

--- a/templates/clips/server/lib/comment-mentions.test.ts
+++ b/templates/clips/server/lib/comment-mentions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+const isOrgMember = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/org", () => ({ isOrgMember }));
+
+import { resolveCommentMentions } from "./comment-mentions";
+
+describe("resolveCommentMentions", () => {
+  it("normalizes mentions and keeps only organization members", async () => {
+    isOrgMember.mockImplementation(
+      async (_organizationId: string, email: string) =>
+        email === "member@example.com",
+    );
+
+    await expect(
+      resolveCommentMentions(
+        [
+          { email: "Member@Example.com", name: "Member" },
+          { email: "outsider@example.com", name: "Outsider" },
+        ],
+        "org-1",
+      ),
+    ).resolves.toEqual([{ email: "member@example.com", name: "Member" }]);
+  });
+});

--- a/templates/clips/server/lib/comment-mentions.test.ts
+++ b/templates/clips/server/lib/comment-mentions.test.ts
@@ -4,6 +4,10 @@ const isOrgMember = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/org", () => ({ isOrgMember }));
 
+import {
+  displayCommentMentions,
+  mentionsForCommentText,
+} from "../../shared/comment-mentions";
 import { resolveCommentMentions } from "./comment-mentions";
 
 describe("resolveCommentMentions", () => {
@@ -22,5 +26,21 @@ describe("resolveCommentMentions", () => {
         "org-1",
       ),
     ).resolves.toEqual([{ email: "member@example.com", name: "Member" }]);
+  });
+});
+
+describe("comment mention display and matching", () => {
+  it("returns display names without recipient emails", () => {
+    expect(
+      displayCommentMentions([{ email: "member@example.com", name: "Member" }]),
+    ).toEqual([{ name: "Member" }]);
+  });
+
+  it("does not match a shorter name inside a longer mention", () => {
+    const mention = { email: "alex@example.com", name: "Alex" };
+    expect(mentionsForCommentText("Thanks @Alexander", [mention])).toEqual([]);
+    expect(mentionsForCommentText("Thanks @Alex!", [mention])).toEqual([
+      mention,
+    ]);
   });
 });

--- a/templates/clips/server/lib/comment-mentions.ts
+++ b/templates/clips/server/lib/comment-mentions.ts
@@ -1,0 +1,23 @@
+import { isOrgMember } from "@agent-native/core/org";
+
+import {
+  normalizeCommentMentions,
+  type CommentMention,
+} from "../../shared/comment-mentions.js";
+
+export async function resolveCommentMentions(
+  value: unknown,
+  organizationId: string,
+): Promise<CommentMention[]> {
+  const mentions = normalizeCommentMentions(value);
+  if (!organizationId || mentions.length === 0) return [];
+
+  const membership = await Promise.all(
+    mentions.map(async (mention) =>
+      (await isOrgMember(organizationId, mention.email)) ? mention : null,
+    ),
+  );
+  return membership.filter(
+    (mention): mention is CommentMention => mention !== null,
+  );
+}

--- a/templates/clips/server/lib/emails.ts
+++ b/templates/clips/server/lib/emails.ts
@@ -222,9 +222,9 @@ function registerClipsEmailDefinitions(): void {
     name: "Clip comment",
     trigger:
       "Someone comments or replies on a Clip. Subject and copy differ slightly for a reply; both send under this id.",
-    recipientLabel: "Owner and thread authors",
+    recipientLabel: "Owner, mentioned members, and thread authors",
     recipient:
-      "The recording owner, plus every prior author in the thread when the comment is a reply. The list is re-checked against the recording's live ACL and filtered by each user's `emailNotifications` preference; the comment's own author never receives it.",
+      "The recording owner, mentioned organization members, plus every prior author in the thread when the comment is a reply. The list is re-checked against the recording's live ACL and filtered by each user's `emailNotifications` preference; the comment's own author never receives it.",
     senderLabel: "Agent-Native Clips",
     sender: CLIPS_SENDER,
     preview: () =>

--- a/templates/clips/server/lib/recording-page-access.test.ts
+++ b/templates/clips/server/lib/recording-page-access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  canReceiveRecordingActivity,
   canOpenDirectRecordingPage,
   isRecordingExpired,
 } from "./recording-page-access.js";
@@ -78,5 +79,40 @@ describe("canOpenDirectRecordingPage", () => {
         hasExplicitShare: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("canReceiveRecordingActivity", () => {
+  const now = Date.parse("2026-07-15T12:00:00.000Z");
+  const recording = {
+    ownerEmail: "owner@example.com",
+    recipientEmail: "viewer@example.com",
+    hasPassword: false,
+    now,
+  };
+
+  it("rejects activity for expired recordings", () => {
+    expect(
+      canReceiveRecordingActivity({
+        ...recording,
+        expiresAt: "2026-07-15T11:59:59.999Z",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps password-protected activity with the owner", () => {
+    expect(
+      canReceiveRecordingActivity({
+        ...recording,
+        recipientEmail: "OWNER@example.com",
+        hasPassword: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects password-protected activity for non-owners", () => {
+    expect(
+      canReceiveRecordingActivity({ ...recording, hasPassword: true }),
+    ).toBe(false);
   });
 });

--- a/templates/clips/server/lib/recording-page-access.ts
+++ b/templates/clips/server/lib/recording-page-access.ts
@@ -38,3 +38,19 @@ export function canOpenDirectRecordingPage(input: {
   if (input.visibility === "public") return input.hasExplicitShare;
   return true;
 }
+
+/** Comment activity follows the same expiry and password boundary as the player. */
+export function canReceiveRecordingActivity(input: {
+  ownerEmail: string;
+  recipientEmail: string;
+  hasPassword: boolean;
+  expiresAt?: string | null;
+  now?: number;
+}): boolean {
+  if (isRecordingExpired(input.expiresAt, input.now)) return false;
+  if (!input.hasPassword) return true;
+  return (
+    input.ownerEmail.trim().toLowerCase() ===
+    input.recipientEmail.trim().toLowerCase()
+  );
+}

--- a/templates/clips/server/lib/transactional-email-templates.ts
+++ b/templates/clips/server/lib/transactional-email-templates.ts
@@ -75,6 +75,7 @@ export type ClipsTransactionalEmailInput =
       content: string;
       videoTimestampMs?: number | null;
       isReply?: boolean;
+      wasMentioned?: boolean;
     })
   | (TransactionalEmailBase & {
       kind: "activity-reaction";
@@ -547,17 +548,23 @@ export function renderClipsTransactionalEmail(
         typeof input.videoTimestampMs === "number" && input.videoTimestampMs > 0
           ? ` at ${formatTimestamp(input.videoTimestampMs)}`
           : "";
-      const subject = input.isReply
-        ? `${author} replied on “${title}”`
-        : `${author} commented on “${title}”`;
+      const subject = input.wasMentioned
+        ? `${author} mentioned you on “${title}”`
+        : input.isReply
+          ? `${author} replied on “${title}”`
+          : `${author} commented on “${title}”`;
       const rendered = renderEmail({
         brandName: CLIPS_BRAND_NAME,
         preheader: subject,
-        heading: input.isReply
-          ? `${author} replied on your Clip`
-          : `${author} commented on your Clip`,
+        heading: input.wasMentioned
+          ? `${author} mentioned you on your Clip`
+          : input.isReply
+            ? `${author} replied on your Clip`
+            : `${author} commented on your Clip`,
         paragraphs: [
-          `${emailStrong(author)} left a ${input.isReply ? "reply" : "comment"} on ${emailStrong(title!)}${at}.`,
+          input.wasMentioned
+            ? `${emailStrong(author)} mentioned you in a comment on ${emailStrong(title!)}${at}.`
+            : `${emailStrong(author)} left a ${input.isReply ? "reply" : "comment"} on ${emailStrong(title!)}${at}.`,
           `“${quotedExcerpt(input.content)}”`,
         ],
         cta: {

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1159,6 +1159,11 @@ export const migrations = runMigrations(
       name: "recording-media-updated-at",
       sql: `ALTER TABLE recordings ADD COLUMN IF NOT EXISTS media_updated_at TEXT NOT NULL DEFAULT (datetime('now'))`,
     },
+    {
+      version: 66,
+      name: "recording-comment-mentions",
+      sql: `ALTER TABLE recording_comments ADD COLUMN IF NOT EXISTS mentions_json TEXT`,
+    },
   ],
   { table: "clips_migrations" },
 );

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -36,6 +36,7 @@ import {
   buildAgentApiUrls,
   CLIP_AGENT_ACCESS_TOKEN_PREFIX,
 } from "../../../shared/agent-context.js";
+import { displayCommentMentions } from "../../../shared/comment-mentions.js";
 import {
   normalizeTranscriptSegments,
   parseTranscriptSegments,
@@ -331,6 +332,12 @@ export default defineEventHandler(async (event) => {
         )
     : [];
   const hydratedComments = await hydrateCommentAuthorNames(comments);
+  const commentMentions = new Map(
+    hydratedComments.map((comment) => [
+      comment.id,
+      displayCommentMentions(comment.mentionsJson),
+    ]),
+  );
   for (const comment of hydratedComments) {
     Reflect.deleteProperty(comment, "mentionsJson");
   }
@@ -522,6 +529,7 @@ export default defineEventHandler(async (event) => {
       authorEmail: c.authorEmail,
       authorName: c.authorName,
       content: c.content,
+      mentions: commentMentions.get(c.id) ?? [],
       videoTimestampMs: c.videoTimestampMs,
       emojiReactionsJson: c.emojiReactionsJson,
       resolved: Boolean(c.resolved),

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -331,6 +331,9 @@ export default defineEventHandler(async (event) => {
         )
     : [];
   const hydratedComments = await hydrateCommentAuthorNames(comments);
+  for (const comment of hydratedComments) {
+    Reflect.deleteProperty(comment, "mentionsJson");
+  }
 
   const reactions = rec.enableReactions
     ? await db

--- a/templates/clips/shared/comment-mentions.ts
+++ b/templates/clips/shared/comment-mentions.ts
@@ -3,6 +3,10 @@ export interface CommentMention {
   name: string;
 }
 
+export interface CommentMentionDisplay {
+  name: string;
+}
+
 export function normalizeCommentMentions(value: unknown): CommentMention[] {
   let raw = value;
   if (typeof raw === "string") {
@@ -44,11 +48,24 @@ export function parseCommentMentions(
   return normalizeCommentMentions(value);
 }
 
+export function displayCommentMentions(
+  value: unknown,
+): CommentMentionDisplay[] {
+  return normalizeCommentMentions(value).map(({ name }) => ({ name }));
+}
+
+function hasMentionToken(text: string, name: string): boolean {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|\\s)@${escapedName}(?=$|[^\\p{L}\\p{N}_])`, "u").test(
+    text,
+  );
+}
+
 export function mentionsForCommentText(
   text: string,
   mentions: readonly CommentMention[],
 ): CommentMention[] {
   return normalizeCommentMentions(
-    mentions.filter((mention) => text.includes(`@${mention.name}`)),
+    mentions.filter((mention) => hasMentionToken(text, mention.name)),
   );
 }

--- a/templates/clips/shared/comment-mentions.ts
+++ b/templates/clips/shared/comment-mentions.ts
@@ -1,0 +1,54 @@
+export interface CommentMention {
+  email: string;
+  name: string;
+}
+
+export function normalizeCommentMentions(value: unknown): CommentMention[] {
+  let raw = value;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      raw = JSON.parse(trimmed);
+    } catch {
+      // coercion-ok: malformed optional mention metadata is treated as absent.
+      return [];
+    }
+  }
+  if (!Array.isArray(raw)) return [];
+
+  const seen = new Set<string>();
+  const mentions: CommentMention[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Record<string, unknown>;
+    const email =
+      typeof candidate.email === "string"
+        ? candidate.email.trim().toLowerCase()
+        : "";
+    if (!email || !email.includes("@") || seen.has(email)) continue;
+    const name =
+      typeof candidate.name === "string" ? candidate.name.trim() : "";
+    seen.add(email);
+    mentions.push({
+      email,
+      name: name || email.split("@")[0] || email,
+    });
+  }
+  return mentions;
+}
+
+export function parseCommentMentions(
+  value: string | null | undefined,
+): CommentMention[] {
+  return normalizeCommentMentions(value);
+}
+
+export function mentionsForCommentText(
+  text: string,
+  mentions: readonly CommentMention[],
+): CommentMention[] {
+  return normalizeCommentMentions(
+    mentions.filter((mention) => text.includes(`@${mention.name}`)),
+  );
+}


### PR DESCRIPTION
Summary: add Cmd/Ctrl Markdown shortcuts, organization-member mention autocomplete and notifications, safer mention persistence, and deeper nested reply composers. Validation: focused Clips tests passed (259 files, 1,650 tests), Clips typecheck passed, repository guards passed, and Playwright browser proof covered mention selection, Cmd+B, and nested replies.