### PR TITLE
fix: retry transient HTML gateway responses for workspace app embeds

### DIFF
--- a/.changeset/preserve-mcp-http-status.md
+++ b/.changeset/preserve-mcp-http-status.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve typed HTTP status codes when formatting MCP connection errors.

--- a/.changeset/retry-html-gateway-responses.md
+++ b/.changeset/retry-html-gateway-responses.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Retry transient 502–504 gateway responses from workspace app MCP hosts, including HTML error pages.

--- a/packages/core/src/mcp-client/errors.ts
+++ b/packages/core/src/mcp-client/errors.ts
@@ -18,44 +18,69 @@ function stringifyError(error: unknown): string {
   }
 }
 
+function httpStatusFromError(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as Record<string, unknown>;
+  const nested = record.data;
+  const status =
+    record.status ??
+    (nested && typeof nested === "object"
+      ? (nested as Record<string, unknown>).status
+      : undefined);
+  return typeof status === "number" && status >= 100 && status <= 599
+    ? status
+    : undefined;
+}
+
 export function formatMcpConnectError(error: unknown): string {
   const raw = stringifyError(error);
   const text = raw.trim();
-  if (!text) return "Could not connect to that MCP server.";
+  const status = httpStatusFromError(error);
+  const statusPrefix =
+    status !== undefined &&
+    !new RegExp(`\\bHTTP(?:\\/\\d+(?:\\.\\d+)?)?\\s+${status}\\b`, "i").test(
+      text,
+    )
+      ? `HTTP ${status}: `
+      : "";
+  const formattedText = `${statusPrefix}${text}`;
+  if (!formattedText) return "Could not connect to that MCP server.";
   if (
     /<!doctype|<html[\s>]|<\/html>|unexpected token '<'|is not valid json/i.test(
       text,
     )
   ) {
-    return "That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.";
+    return `${statusPrefix}That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.`;
   }
   if (
     /invalid_union|unrecognized_keys|invalid_type|invalid_value/i.test(text) &&
     /jsonrpc|method|unrecognized keys|args|origin|url/i.test(text)
   ) {
-    return "That URL returned JSON, but not an MCP JSON-RPC response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.";
+    return `${statusPrefix}That URL returned JSON, but not an MCP JSON-RPC response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.`;
   }
   if (/401|403|unauthorized|forbidden/i.test(text)) {
-    return "The MCP server rejected the request. Reconnect or update the required Authorization header.";
+    return `${statusPrefix}The MCP server rejected the request. Reconnect or update the required Authorization header.`;
   }
   if (
     /streamable http/i.test(text) &&
     /error|failed|non-200|status/i.test(text)
   ) {
-    return "The server did not complete the Streamable HTTP MCP handshake. Check the URL and any required authorization headers.";
+    return `${statusPrefix}The server did not complete the Streamable HTTP MCP handshake. Check the URL and any required authorization headers.`;
   }
   if (
     /failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out/i.test(
       text,
     )
   ) {
-    return "Could not reach that MCP server. Check the URL and make sure it is publicly reachable from this app.";
+    return `${statusPrefix}Could not reach that MCP server. Check the URL and make sure it is publicly reachable from this app.`;
   }
   if (/404|not found|405|method not allowed/i.test(text)) {
-    return "That URL is reachable, but it does not look like the MCP endpoint. Check the server's Streamable HTTP path.";
+    return `${statusPrefix}That URL is reachable, but it does not look like the MCP endpoint. Check the server's Streamable HTTP path.`;
   }
   if (text === "[object ErrorEvent]" || text === "error") {
     return "The MCP server connection failed while opening its event stream. Check the URL and any required authorization headers.";
   }
-  return text.length > 240 ? `${text.slice(0, 237).trimEnd()}...` : text;
+  return formattedText.length > 240
+    ? `${formattedText.slice(0, 237).trimEnd()}...`
+    : formattedText;
 }

--- a/packages/core/src/mcp-client/errors.ts
+++ b/packages/core/src/mcp-client/errors.ts
@@ -35,15 +35,16 @@ export function formatMcpConnectError(error: unknown): string {
   const raw = stringifyError(error);
   const text = raw.trim();
   const status = httpStatusFromError(error);
-  const statusPrefix =
+  const statusPrefix = status !== undefined ? `HTTP ${status}: ` : "";
+  const hasStatusInText =
     status !== undefined &&
-    !new RegExp(`\\bHTTP(?:\\/\\d+(?:\\.\\d+)?)?\\s+${status}\\b`, "i").test(
+    new RegExp(`\\bHTTP(?:\\/\\d+(?:\\.\\d+)?)?\\s+${status}\\b`, "i").test(
       text,
-    )
-      ? `HTTP ${status}: `
-      : "";
-  const formattedText = `${statusPrefix}${text}`;
-  if (!formattedText) return "Could not connect to that MCP server.";
+    );
+  const formattedText = hasStatusInText ? text : `${statusPrefix}${text}`;
+  if (!text) {
+    return `${statusPrefix}Could not connect to that MCP server.`;
+  }
   if (
     /<!doctype|<html[\s>]|<\/html>|unexpected token '<'|is not valid json/i.test(
       text,

--- a/packages/core/src/mcp-client/errors.ts
+++ b/packages/core/src/mcp-client/errors.ts
@@ -78,7 +78,7 @@ export function formatMcpConnectError(error: unknown): string {
     return `${statusPrefix}That URL is reachable, but it does not look like the MCP endpoint. Check the server's Streamable HTTP path.`;
   }
   if (text === "[object ErrorEvent]" || text === "error") {
-    return "The MCP server connection failed while opening its event stream. Check the URL and any required authorization headers.";
+    return `${statusPrefix}The MCP server connection failed while opening its event stream. Check the URL and any required authorization headers.`;
   }
   return formattedText.length > 240
     ? `${formattedText.slice(0, 237).trimEnd()}...`

--- a/packages/core/src/mcp-client/errors.ts
+++ b/packages/core/src/mcp-client/errors.ts
@@ -21,12 +21,11 @@ function stringifyError(error: unknown): string {
 function httpStatusFromError(error: unknown): number | undefined {
   if (!error || typeof error !== "object") return undefined;
   const record = error as Record<string, unknown>;
-  const nested = record.data;
-  const status =
-    record.status ??
-    (nested && typeof nested === "object"
-      ? (nested as Record<string, unknown>).status
-      : undefined);
+  const nested =
+    record.data && typeof record.data === "object"
+      ? (record.data as Record<string, unknown>)
+      : undefined;
+  const status = record.status ?? nested?.status ?? record.code ?? nested?.code;
   return typeof status === "number" && status >= 100 && status <= 599
     ? status
     : undefined;

--- a/packages/core/src/mcp-client/routes.spec.ts
+++ b/packages/core/src/mcp-client/routes.spec.ts
@@ -88,6 +88,17 @@ describe("formatMcpConnectError", () => {
     );
   });
 
+  it("preserves typed HTTP status when formatting HTML responses", () => {
+    const error = Object.assign(
+      new Error("Error POSTing to endpoint: <!doctype html><html>502</html>"),
+      { data: { status: 502, statusText: "Bad Gateway" } },
+    );
+
+    expect(formatMcpConnectError(error)).toBe(
+      "HTTP 502: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.",
+    );
+  });
+
   it("explains Streamable HTTP handshake failures", () => {
     expect(
       formatMcpConnectError("Streamable HTTP error: non-200 status code"),

--- a/packages/core/src/mcp-client/routes.spec.ts
+++ b/packages/core/src/mcp-client/routes.spec.ts
@@ -120,6 +120,17 @@ describe("formatMcpConnectError", () => {
     );
   });
 
+  it.each(["error", "[object ErrorEvent]"])(
+    "preserves typed status for legacy event errors (%s)",
+    (message) => {
+      const error = Object.assign(new Error(message), { code: 502 });
+
+      expect(formatMcpConnectError(error)).toBe(
+        "HTTP 502: The MCP server connection failed while opening its event stream. Check the URL and any required authorization headers.",
+      );
+    },
+  );
+
   it("retains typed status when an HTML body contains the same status", () => {
     const error = Object.assign(
       new Error(

--- a/packages/core/src/mcp-client/routes.spec.ts
+++ b/packages/core/src/mcp-client/routes.spec.ts
@@ -99,6 +99,19 @@ describe("formatMcpConnectError", () => {
     );
   });
 
+  it("preserves HTTP status from MCP SDK error codes", () => {
+    const error = Object.assign(
+      new Error(
+        "Streamable HTTP error: Error POSTing to endpoint: <!doctype html><html>502</html>",
+      ),
+      { code: 502 },
+    );
+
+    expect(formatMcpConnectError(error)).toBe(
+      "HTTP 502: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.",
+    );
+  });
+
   it("explains Streamable HTTP handshake failures", () => {
     expect(
       formatMcpConnectError("Streamable HTTP error: non-200 status code"),

--- a/packages/core/src/mcp-client/routes.spec.ts
+++ b/packages/core/src/mcp-client/routes.spec.ts
@@ -112,6 +112,27 @@ describe("formatMcpConnectError", () => {
     );
   });
 
+  it("keeps a useful fallback for typed errors without a message", () => {
+    const error = Object.assign(new Error(), { code: 502 });
+
+    expect(formatMcpConnectError(error)).toBe(
+      "HTTP 502: Could not connect to that MCP server.",
+    );
+  });
+
+  it("retains typed status when an HTML body contains the same status", () => {
+    const error = Object.assign(
+      new Error(
+        "Error POSTing to endpoint: HTTP 502 Bad Gateway <!doctype html><html></html>",
+      ),
+      { code: 502 },
+    );
+
+    expect(formatMcpConnectError(error)).toBe(
+      "HTTP 502: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.",
+    );
+  });
+
   it("explains Streamable HTTP handshake failures", () => {
     expect(
       formatMcpConnectError("Streamable HTTP error: non-200 status code"),

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1107,12 +1107,12 @@ describe("openGrantedDispatchMcpApp", () => {
     });
   });
 
-  it("retries transient target MCP connection failures while pre-minting embeds", async () => {
+  it("retries transient target MCP gateway failures with HTML bodies", async () => {
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     mocks.managerCallTool
       .mockRejectedValueOnce(
         new Error(
-          'MCP server "target" is not connected: The server did not complete the Streamable HTTP MCP handshake.',
+          'MCP server "target" is not connected: HTTP 502 Bad Gateway <!DOCTYPE html><html><title>Cloudflare 502: Bad gateway</title></html>',
         ),
       )
       .mockResolvedValueOnce({

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1112,7 +1112,7 @@ describe("openGrantedDispatchMcpApp", () => {
     mocks.managerCallTool
       .mockRejectedValueOnce(
         new Error(
-          'MCP server "target" is not connected: HTTP 502 Bad Gateway <!DOCTYPE html><html><title>Cloudflare 502: Bad gateway</title></html>',
+          'MCP server "target" is not connected: HTTP 502: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.',
         ),
       )
       .mockResolvedValueOnce({
@@ -1145,6 +1145,29 @@ describe("openGrantedDispatchMcpApp", () => {
         "http://localhost:8086/_agent-native/embed/start?ticket=remote",
     });
     randomSpy.mockRestore();
+  });
+
+  it("does not retry an HTML 404 whose body mentions a gateway status", async () => {
+    mocks.managerCallTool.mockRejectedValueOnce(
+      new Error(
+        'MCP server "target" is not connected: HTTP 404: That URL returned a web page instead of an MCP response. Cloudflare HTTP 502 is unrelated.',
+      ),
+    );
+
+    await expect(
+      runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
+        },
+        () =>
+          createGrantedDispatchMcpEmbedSession({
+            app: "analytics",
+            path: "/dashboards",
+          }),
+      ),
+    ).rejects.toThrow(/HTTP 404/);
+    expect(mocks.managerCallTool).toHaveBeenCalledTimes(1);
   });
 
   it("returns the normal open URL when embed preminting fails", async () => {

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1111,8 +1111,11 @@ describe("openGrantedDispatchMcpApp", () => {
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
     mocks.managerCallTool
       .mockRejectedValueOnce(
-        new Error(
-          'MCP server "target" is not connected: HTTP 502: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.',
+        Object.assign(
+          new Error(
+            'MCP server "target" is not connected: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.',
+          ),
+          { code: 502 },
         ),
       )
       .mockResolvedValueOnce({
@@ -1149,8 +1152,11 @@ describe("openGrantedDispatchMcpApp", () => {
 
   it("does not retry an HTML 404 whose body mentions a gateway status", async () => {
     mocks.managerCallTool.mockRejectedValueOnce(
-      new Error(
-        'MCP server "target" is not connected: HTTP 404: That URL returned a web page instead of an MCP response. Cloudflare HTTP 502 is unrelated.',
+      Object.assign(
+        new Error(
+          'MCP server "target" is not connected: That URL returned a web page instead of an MCP response. Cloudflare HTTP 502 is unrelated.',
+        ),
+        { code: 404 },
       ),
     );
 
@@ -1166,7 +1172,7 @@ describe("openGrantedDispatchMcpApp", () => {
             path: "/dashboards",
           }),
       ),
-    ).rejects.toThrow(/HTTP 404/);
+    ).rejects.toThrow(/Cloudflare HTTP 502 is unrelated/);
     expect(mocks.managerCallTool).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1176,6 +1176,32 @@ describe("openGrantedDispatchMcpApp", () => {
     expect(mocks.managerCallTool).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry a typed permanent 4xx MCP error", async () => {
+    mocks.managerCallTool.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "Streamable HTTP error: Error POSTing to endpoint: <!doctype html><html>422</html>",
+        ),
+        { code: 422 },
+      ),
+    );
+
+    await expect(
+      runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
+        },
+        () =>
+          createGrantedDispatchMcpEmbedSession({
+            app: "analytics",
+            path: "/dashboards",
+          }),
+      ),
+    ).rejects.toThrow(/Streamable HTTP error/);
+    expect(mocks.managerCallTool).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the normal open URL when embed preminting fails", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mocks.managerCallTool.mockRejectedValueOnce(

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1107,48 +1107,51 @@ describe("openGrantedDispatchMcpApp", () => {
     });
   });
 
-  it("retries transient target MCP gateway failures with HTML bodies", async () => {
-    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
-    mocks.managerCallTool
-      .mockRejectedValueOnce(
-        Object.assign(
-          new Error(
-            'MCP server "target" is not connected: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.',
+  it.each([408, 429, 502, 503, 504])(
+    "retries transient typed HTTP %i target MCP failures with HTML bodies",
+    async (status) => {
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+      mocks.managerCallTool
+        .mockRejectedValueOnce(
+          Object.assign(
+            new Error(
+              'MCP server "target" is not connected: That URL returned a web page instead of an MCP response. Check that you pasted the Streamable HTTP endpoint, often ending in /mcp.',
+            ),
+            { code: status },
           ),
-          { code: 502 },
-        ),
-      )
-      .mockResolvedValueOnce({
-        structuredContent: {
-          startUrl:
-            "http://localhost:8086/_agent-native/embed/start?ticket=remote",
+        )
+        .mockResolvedValueOnce({
+          structuredContent: {
+            startUrl:
+              "http://localhost:8086/_agent-native/embed/start?ticket=remote",
+          },
+        });
+
+      const result = await runWithRequestContext(
+        {
+          userEmail: "owner@example.test",
+          requestOrigin: "http://localhost:8092",
         },
+        () =>
+          openGrantedDispatchMcpApp({
+            app: "analytics",
+            path: "/dashboards",
+            embed: true,
+          }),
+      );
+
+      expect(mocks.managerConstructor).toHaveBeenCalledTimes(2);
+      expect(mocks.managerStart).toHaveBeenCalledTimes(2);
+      expect(mocks.managerStop).toHaveBeenCalledTimes(2);
+      expect(mocks.managerCallTool).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({
+        app: "analytics",
+        embedStartUrl:
+          "http://localhost:8086/_agent-native/embed/start?ticket=remote",
       });
-
-    const result = await runWithRequestContext(
-      {
-        userEmail: "owner@example.test",
-        requestOrigin: "http://localhost:8092",
-      },
-      () =>
-        openGrantedDispatchMcpApp({
-          app: "analytics",
-          path: "/dashboards",
-          embed: true,
-        }),
-    );
-
-    expect(mocks.managerConstructor).toHaveBeenCalledTimes(2);
-    expect(mocks.managerStart).toHaveBeenCalledTimes(2);
-    expect(mocks.managerStop).toHaveBeenCalledTimes(2);
-    expect(mocks.managerCallTool).toHaveBeenCalledTimes(2);
-    expect(result).toMatchObject({
-      app: "analytics",
-      embedStartUrl:
-        "http://localhost:8086/_agent-native/embed/start?ticket=remote",
-    });
-    randomSpy.mockRestore();
-  });
+      randomSpy.mockRestore();
+    },
+  );
 
   it("does not retry an HTML 404 whose body mentions a gateway status", async () => {
     mocks.managerCallTool.mockRejectedValueOnce(

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -988,6 +988,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function httpStatusFromError(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as Record<string, unknown>;
+  const nested =
+    record.data && typeof record.data === "object"
+      ? (record.data as Record<string, unknown>)
+      : undefined;
+  const status = record.status ?? nested?.status ?? record.code ?? nested?.code;
+  return typeof status === "number" && status >= 100 && status <= 599
+    ? status
+    : undefined;
+}
+
 function isRetryableTargetMcpError(error: unknown): boolean {
   const message =
     error instanceof Error
@@ -995,6 +1008,13 @@ function isRetryableTargetMcpError(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : safeJson(error);
+  const status = httpStatusFromError(error);
+  if (status !== undefined) {
+    if (status === 502 || status === 503 || status === 504) return true;
+    if (status === 401 || status === 403 || status === 404 || status === 405) {
+      return false;
+    }
+  }
   if (
     /^(?:MCP server\b.*?\bnot connected:\s+)?HTTP(?:\/\d+(?:\.\d+)?)?\s+(?:502|503|504)\b/i.test(
       message,

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -995,6 +995,7 @@ function isRetryableTargetMcpError(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : safeJson(error);
+  if (/\b(?:502|503|504)\b/.test(message)) return true;
   if (
     /rejected the request|unauthorized|forbidden|401|403|404|405|html/i.test(
       message,
@@ -1002,7 +1003,7 @@ function isRetryableTargetMcpError(error: unknown): boolean {
   ) {
     return false;
   }
-  return /streamable http|handshake|failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out|timeout|502|503|504/i.test(
+  return /streamable http|handshake|failed to fetch|fetch failed|networkerror|econnrefused|enotfound|timed out|timeout/i.test(
     message,
   );
 }

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -1011,9 +1011,7 @@ function isRetryableTargetMcpError(error: unknown): boolean {
   const status = httpStatusFromError(error);
   if (status !== undefined) {
     if (status === 502 || status === 503 || status === 504) return true;
-    if (status === 401 || status === 403 || status === 404 || status === 405) {
-      return false;
-    }
+    if (status >= 400 && status < 500) return false;
   }
   if (
     /^(?:MCP server\b.*?\bnot connected:\s+)?HTTP(?:\/\d+(?:\.\d+)?)?\s+(?:502|503|504)\b/i.test(

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -995,7 +995,13 @@ function isRetryableTargetMcpError(error: unknown): boolean {
       : typeof error === "string"
         ? error
         : safeJson(error);
-  if (/\b(?:502|503|504)\b/.test(message)) return true;
+  if (
+    /^(?:MCP server\b.*?\bnot connected:\s+)?HTTP(?:\/\d+(?:\.\d+)?)?\s+(?:502|503|504)\b/i.test(
+      message,
+    )
+  ) {
+    return true;
+  }
   if (
     /rejected the request|unauthorized|forbidden|401|403|404|405|html/i.test(
       message,

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -1010,7 +1010,14 @@ function isRetryableTargetMcpError(error: unknown): boolean {
         : safeJson(error);
   const status = httpStatusFromError(error);
   if (status !== undefined) {
-    if (status === 502 || status === 503 || status === 504) return true;
+    if (
+      status === 408 ||
+      status === 429 ||
+      status === 502 ||
+      status === 503 ||
+      status === 504
+    )
+      return true;
     if (status >= 400 && status < 500) return false;
   }
   if (


### PR DESCRIPTION
## Summary

- Preserve typed HTTP status codes when normalizing MCP connection errors, including legacy event-stream errors.
- Retry transient HTTP 502, 503, and 504 target MCP responses, including typed SDK errors with HTML gateway bodies.
- Keep permanent HTML and all typed 4xx responses non-retryable, with regression coverage for an HTML 404 mentioning 502 and a typed 422 response.

## Validation

- `corepack pnpm exec vitest run packages/core/src/mcp-client/routes.spec.ts packages/dispatch/src/server/lib/mcp-gateway.spec.ts` (82 passed)
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/dispatch typecheck`
- `corepack pnpm --filter @agent-native/dispatch test` (626 passed)
- `corepack pnpm --filter @agent-native/core test` (13,485 passed, 2 skipped)
- `corepack pnpm guards` (65 passed)
- `corepack pnpm run prep` (typecheck and guards passed; unrelated `packages/docs` RootShell tests failed locally)