### PR TITLE
Prefetch internal routes in the viewport by default

### DIFF
--- a/.changeset/viewport-route-warmup.md
+++ b/.changeset/viewport-route-warmup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prefetch internal route data and JavaScript for links entering the viewport by default.

--- a/packages/core/src/shared/route-warmup-config.spec.ts
+++ b/packages/core/src/shared/route-warmup-config.spec.ts
@@ -12,9 +12,9 @@ describe("route warmup config normalization", () => {
     expect(isAgentNativeRouteWarmupStrategy("hover")).toBe(false);
   });
 
-  it("normalizes invalid strategy strings to the safe default", () => {
+  it("normalizes invalid strategy strings to the viewport default", () => {
     expect(normalizeAgentNativeRouteWarmupConfig("hover" as any).strategy).toBe(
-      "intent",
+      "viewport",
     );
     expect(
       normalizeAgentNativeRouteWarmupConfig({
@@ -23,9 +23,9 @@ describe("route warmup config normalization", () => {
         maxConcurrent: -1,
       }),
     ).toMatchObject({
-      strategy: "intent",
+      strategy: "viewport",
       selector: 'a[data-an-prefetch="render"][href]',
-      maxConcurrent: 4,
+      maxConcurrent: 8,
     });
   });
 

--- a/packages/core/src/shared/route-warmup-config.ts
+++ b/packages/core/src/shared/route-warmup-config.ts
@@ -45,11 +45,11 @@ export const DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_SELECTOR =
 
 export const DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_CONFIG: AgentNativeRouteWarmupResolvedConfig =
   {
-    strategy: "intent",
+    strategy: "viewport",
     data: true,
     modules: true,
     selector: DEFAULT_AGENT_NATIVE_ROUTE_WARMUP_SELECTOR,
-    maxConcurrent: 4,
+    maxConcurrent: 8,
   };
 
 export function isAgentNativeRouteWarmupStrategy(

--- a/packages/core/src/vite/client.spec.ts
+++ b/packages/core/src/vite/client.spec.ts
@@ -948,18 +948,18 @@ describe("route warmup config", () => {
     }
   });
 
-  it("enables safe React Router route warmup by default", () => {
+  it("enables viewport React Router route warmup by default", () => {
     const config = defineConfig();
     const routeWarmup = JSON.parse(
       String(config.define?.__AGENT_NATIVE_ROUTE_WARMUP_CONFIG__),
     );
 
     expect(routeWarmup).toEqual({
-      strategy: "intent",
+      strategy: "viewport",
       data: true,
       modules: true,
       selector: 'a[data-an-prefetch="render"][href]',
-      maxConcurrent: 4,
+      maxConcurrent: 8,
     });
   });
 


### PR DESCRIPTION
## Summary

- Make viewport route warmup the framework default for internal links.
- Warm route data and JavaScript with up to eight concurrent data requests.
- Preserve explicit link opt-outs and the existing save-data guard.

## Validation

- Focused route warmup and Vite config tests
- Core typecheck
- `pnpm guards`
- oxfmt check
