### PR TITLE
fix: make Google OAuth deploy verification capability-aware

### DIFF
--- a/.changeset/declare-google-oauth-capability.md
+++ b/.changeset/declare-google-oauth-capability.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Declare managed Google OAuth capability in app health contracts so deploy verification checks only apps that own the managed connection.

--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -662,8 +662,7 @@ jobs:
         id: previous
         if: >-
           inputs.deploy && inputs.smoke && inputs.deploy_mode == 'production' &&
-          steps.target.outputs.source_template != '@agent-native/docs' &&
-          steps.target.outputs.source_template != 'macros'
+          steps.target.outputs.source_template != '@agent-native/docs'
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
@@ -821,8 +820,9 @@ jobs:
           curl --fail --silent --show-error --location --max-time 60 "${url%/}/_agent-native/health" >/dev/null
           echo "Health check passed: ${url%/}/_agent-native/health"
 
-      # The active managed client is observable only from the live host, so this
-      # is a post-publish verification. If Google rejects the callback, the
+      # The active managed client and its capability are observable only from
+      # the live host, so this is a post-publish verification. If the declared
+      # managed callback is unregistered or the check is inconclusive, the
       # immediately following step restores the deploy captured above before
       # leaving the job failed. Draft deploy URLs are intentionally excluded
       # because they are not registered OAuth origins.
@@ -830,14 +830,13 @@ jobs:
         id: google_redirect
         if: >-
           inputs.deploy && inputs.smoke && inputs.deploy_mode == 'production' &&
-          steps.target.outputs.source_template != '@agent-native/docs' &&
-          steps.target.outputs.source_template != 'macros'
+          steps.target.outputs.source_template != '@agent-native/docs'
         continue-on-error: true
         env:
           HOST: ${{ steps.target.outputs.host }}
         run: |
           set +e
-          pnpm check:google-redirect-uris -- --host "$HOST" --paths auto
+          node --experimental-strip-types scripts/check-google-redirect-uris.ts --host "$HOST" --paths auto
           status=$?
           echo "exit_code=$status" >> "$GITHUB_OUTPUT"
           exit "$status"
@@ -845,7 +844,7 @@ jobs:
       - name: Roll back after Google callback verification failure
         if: >-
           steps.google_redirect.outcome == 'failure' &&
-          steps.google_redirect.outputs.exit_code == '1'
+          steps.google_redirect.outputs.exit_code != '0'
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1393,6 +1393,12 @@ export interface CoreRoutesPluginOptions {
   googleOAuthCallbackPaths?: string[];
   /** Whether the managed Google client is deployment- or user-scoped. */
   googleOAuthCredentialMode?: "managed" | "user";
+  /**
+   * Whether this app exposes deployment-level Google workspace OAuth. Custom
+   * core-route plugins must declare this; the framework default declares that
+   * managed OAuth is not applicable.
+   */
+  googleOAuthManagedConnection?: "required" | "not_applicable";
   /** Disable the /_agent-native/application-state routes. */
   disableAppState?: boolean;
   /** Disable the /_agent-native/open deep-link route. */
@@ -1643,6 +1649,8 @@ export function createCoreRoutesPlugin(
   );
   const googleOAuthCredentialMode =
     options.googleOAuthCredentialMode ?? "managed";
+  const googleOAuthManagedConnection =
+    options.googleOAuthManagedConnection ?? "unknown";
   return async (nitroApp: any) => {
     markDefaultPluginProvided(nitroApp, "core-routes");
     // No-op when called from inside the bootstrap (auto-mount path).
@@ -1743,17 +1751,27 @@ export function createCoreRoutesPlugin(
             setResponseHeader(event, "cache-control", "no-store");
             const result =
               event.url?.searchParams.get("client") === "managed"
-                ? googleOAuthCredentialMode === "user"
+                ? googleOAuthManagedConnection === "not_applicable"
                   ? {
                       status: "unconfigured" as const,
                       clientId: null,
                       mismatchedPairs: false,
-                      credentialSource: "user" as const,
+                      credentialSource: "none" as const,
                       reason:
-                        "user-scoped OAuth credentials are checked after authentication",
+                        "this app does not expose deployment-level Google OAuth",
                       checkedAt: Date.now(),
                     }
-                  : await checkGoogleManagedCredential()
+                  : googleOAuthCredentialMode === "user"
+                    ? {
+                        status: "unconfigured" as const,
+                        clientId: null,
+                        mismatchedPairs: false,
+                        credentialSource: "user" as const,
+                        reason:
+                          "user-scoped OAuth credentials are checked after authentication",
+                        checkedAt: Date.now(),
+                      }
+                    : await checkGoogleManagedCredential()
                 : await checkGoogleSignInCredential();
             // `invalid` is the fleet-wide outage shape: the deploy is up and
             // healthy while nobody can sign in. Page on it.
@@ -1762,6 +1780,7 @@ export function createCoreRoutesPlugin(
               ...result,
               callbackPaths: googleOAuthCallbackPaths,
               credentialMode: googleOAuthCredentialMode,
+              managedConnection: googleOAuthManagedConnection,
             };
           }),
         );
@@ -4857,4 +4876,6 @@ export function createCoreRoutesPlugin(
  * export { defaultCoreRoutesPlugin as default } from "@agent-native/core/server";
  * ```
  */
-export const defaultCoreRoutesPlugin: NitroPluginDef = createCoreRoutesPlugin();
+export const defaultCoreRoutesPlugin: NitroPluginDef = createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
+});

--- a/packages/core/src/server/google-credential-check.ts
+++ b/packages/core/src/server/google-credential-check.ts
@@ -39,9 +39,10 @@ export interface GoogleCredentialCheck {
    * the provider; `preferred` means auth had not initialised yet and this fell
    * back to the preferred pair; `managed` is the deployment-level pair used by
    * the unauthenticated workspace OAuth health contract; `user` means the app
-   * intentionally resolves a user-scoped pair after sign-in.
+   * intentionally resolves a user-scoped pair after sign-in; `none` means the
+   * app declared that it does not expose deployment-level Google OAuth.
    */
-  credentialSource: "active" | "preferred" | "managed" | "user";
+  credentialSource: "active" | "preferred" | "managed" | "user" | "none";
   /** Google's `error` field, or the transport failure, when there was one. */
   reason: string | null;
   checkedAt: number;

--- a/packages/dispatch/src/server/plugins/core-routes.ts
+++ b/packages/dispatch/src/server/plugins/core-routes.ts
@@ -13,7 +13,10 @@ import { createWorkspaceAppChatProxyHandler } from "../lib/workspace-app-chat-pr
 // above the auto-generated Slack/Telegram steps (order 60). Idempotent.
 registerDispatchOnboardingSteps();
 
-const corePlugin = createCoreRoutesPlugin({ envKeys });
+const corePlugin = createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "required",
+  envKeys,
+});
 
 const dispatchCoreRoutesPlugin: NitroPluginDef = (nitroApp) => {
   const coreInit = corePlugin(nitroApp);

--- a/scripts/check-google-redirect-uris.test.ts
+++ b/scripts/check-google-redirect-uris.test.ts
@@ -20,6 +20,7 @@ test("reads callback ownership from the deployed health contract", () => {
         clientId: "client-id",
         credentialSource: "managed",
         credentialMode: "managed",
+        managedConnection: "required",
         callbackPaths: ["/_agent-native/google/callback", googleDocsCallback],
       }),
       { status: 200, headers: jsonHeaders },
@@ -29,6 +30,7 @@ test("reads callback ownership from the deployed health contract", () => {
       clientId: "client-id",
       credentialSource: "managed",
       credentialMode: "managed",
+      managedConnection: "required",
       callbackPaths: ["/_agent-native/google/callback", googleDocsCallback],
     }),
   );
@@ -37,6 +39,7 @@ test("reads callback ownership from the deployed health contract", () => {
     googleDocsCallback,
   ]);
   assert.equal(result.credentialMode, "managed");
+  assert.equal(result.managedConnection, "required");
 });
 
 test("separates definitive mismatches from inconclusive probe failures", () => {
@@ -74,6 +77,52 @@ test("separates definitive mismatches from inconclusive probe failures", () => {
     }),
     0,
   );
+});
+
+test("recognizes an explicit non-managed app without treating missing credentials as a failure", () => {
+  const result = classifyGoogleHealthResponse(
+    new Response(
+      JSON.stringify({
+        status: "unconfigured",
+        credentialSource: "none",
+        credentialMode: "managed",
+        managedConnection: "not_applicable",
+      }),
+      { status: 200, headers: jsonHeaders },
+    ),
+    JSON.stringify({
+      status: "unconfigured",
+      credentialSource: "none",
+      credentialMode: "managed",
+      managedConnection: "not_applicable",
+    }),
+  );
+  assert.equal(result.status, "unconfigured");
+  assert.equal(result.credentialSource, "none");
+  assert.equal(result.managedConnection, "not_applicable");
+});
+
+test("keeps an undeclared managed capability explicit and inconclusive", () => {
+  const result = classifyGoogleHealthResponse(
+    new Response(
+      JSON.stringify({
+        status: "valid",
+        clientId: "client-id",
+        credentialSource: "managed",
+        credentialMode: "managed",
+        managedConnection: "unknown",
+      }),
+      { status: 200, headers: jsonHeaders },
+    ),
+    JSON.stringify({
+      status: "valid",
+      clientId: "client-id",
+      credentialSource: "managed",
+      credentialMode: "managed",
+      managedConnection: "unknown",
+    }),
+  );
+  assert.equal(result.managedConnection, "unknown");
 });
 
 test("classifies Google's sign-in redirect as registered", () => {
@@ -174,6 +223,7 @@ test("does not accept a success payload from an unexpected HTTP status", () => {
     mismatchedPairs: null,
     credentialSource: null,
     credentialMode: null,
+    managedConnection: null,
     callbackPaths: null,
   });
 });

--- a/scripts/check-google-redirect-uris.ts
+++ b/scripts/check-google-redirect-uris.ts
@@ -43,8 +43,14 @@ const SAFE_CREDENTIAL_SOURCES = new Set([
   "preferred",
   "managed",
   "user",
+  "none",
 ]);
 const SAFE_CREDENTIAL_MODES = new Set(["managed", "user"]);
+const SAFE_MANAGED_CONNECTIONS = new Set([
+  "required",
+  "not_applicable",
+  "unknown",
+]);
 
 setDefaultResultOrder("ipv4first");
 
@@ -74,6 +80,7 @@ export type GoogleHealthResult = {
   mismatchedPairs: boolean | null;
   credentialSource: string | null;
   credentialMode: "managed" | "user" | null;
+  managedConnection: "required" | "not_applicable" | "unknown" | null;
   callbackPaths: string[] | null;
 };
 
@@ -156,6 +163,7 @@ function emptyHealth(
     mismatchedPairs: null,
     credentialSource: null,
     credentialMode: null,
+    managedConnection: null,
     callbackPaths: null,
   };
 }
@@ -480,6 +488,11 @@ export function classifyGoogleHealthResponse(
       SAFE_CREDENTIAL_MODES.has(body.credentialMode)
         ? (body.credentialMode as "managed" | "user")
         : null,
+    managedConnection:
+      typeof body.managedConnection === "string" &&
+      SAFE_MANAGED_CONNECTIONS.has(body.managedConnection)
+        ? (body.managedConnection as "required" | "not_applicable" | "unknown")
+        : null,
     callbackPaths: advertisedCallbackPaths(body.callbackPaths),
   };
 }
@@ -502,10 +515,37 @@ async function healthOf(
       return emptyHealth("unknown", "health response exceeded 64 KiB");
     }
     const health = classifyGoogleHealthResponse(response, bodyText);
-    if (health.credentialMode === "user") {
+    if (health.managedConnection === "not_applicable") {
+      return emptyHealth(
+        "not_applicable",
+        "app does not expose deployment-level Google OAuth",
+      );
+    }
+    if (health.managedConnection === "unknown") {
+      return emptyHealth(
+        "unknown",
+        "health response declared managed OAuth capability as unknown",
+      );
+    }
+    if (health.managedConnection === null && health.credentialMode === "user") {
       return emptyHealth(
         "not_applicable",
         "OAuth credentials are user-scoped and checked after authentication",
+      );
+    }
+    if (health.managedConnection === null && !allowLegacyHealth) {
+      return emptyHealth(
+        "unknown",
+        "health response did not declare managed OAuth capability",
+      );
+    }
+    if (
+      health.managedConnection === "required" &&
+      health.credentialSource !== "managed"
+    ) {
+      return emptyHealth(
+        "unknown",
+        "required managed OAuth health did not advertise managed credentials",
       );
     }
     if (health.credentialSource === "managed") {
@@ -661,6 +701,9 @@ async function run(argv: string[]): Promise<number> {
       row.health.credentialSource
         ? `source=${row.health.credentialSource}`
         : "",
+      row.health.managedConnection
+        ? `managed=${row.health.managedConnection}`
+        : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -668,7 +711,12 @@ async function run(argv: string[]): Promise<number> {
       `HOST\t${row.lane}\t${row.host}\tclient=${row.health.clientFingerprint ?? "none"}\t${healthLabel}`,
     );
     if (row.health.status === "not_applicable") continue;
-    if (row.health.credentialSource === "managed") managedHosts += 1;
+    if (
+      row.health.credentialSource === "managed" &&
+      row.health.managedConnection !== "not_applicable"
+    ) {
+      managedHosts += 1;
+    }
     if (
       options.allowLegacyHealth &&
       row.health.credentialSource !== "managed"

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -11,6 +11,7 @@ import { parse } from "yaml";
 import {
   PRODUCTION_PURGE_CONDITION,
   PRODUCTION_SITE_GROUP,
+  validateGoogleCallbackVerificationWorkflow,
   validateProductionPurgeCondition,
   validateReusableWorkflowConcurrency,
   validateProductionSiteConcurrency,
@@ -45,6 +46,29 @@ const reusableSource = readFileSync(
 const nodeHeredocs = [
   ...reusableSource.matchAll(/node <<'NODE'\n([\s\S]*?)\n\s*NODE/g),
 ].map((match) => match[1]);
+
+describe("Google callback deploy verification guard", () => {
+  it("requires direct probe execution and fail-closed rollback", () => {
+    assert.deepEqual(
+      validateGoogleCallbackVerificationWorkflow(reusableSource),
+      [],
+    );
+    assert.match(
+      validateGoogleCallbackVerificationWorkflow(
+        reusableSource
+          .replace(
+            "node --experimental-strip-types scripts/check-google-redirect-uris.ts",
+            "pnpm check:google-redirect-uris --",
+          )
+          .replace(
+            "steps.google_redirect.outputs.exit_code != '0'",
+            "steps.google_redirect.outputs.exit_code == '1'",
+          ),
+      ).join("\n"),
+      /directly with the supported Node loader|every non-zero/,
+    );
+  });
+});
 
 describe("production Netlify site concurrency guard", () => {
   it("supports previous, N-back, and exact Netlify deploy rollbacks", () => {

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -94,6 +94,68 @@ export function validateProductionSiteConcurrency(workflows: {
   return issues;
 }
 
+export function validateGoogleCallbackVerificationWorkflow(
+  workflow: string,
+): string[] {
+  const issues: string[] = [];
+  const verifyStart = workflow.indexOf(
+    "name: Verify Google OAuth redirect registration",
+  );
+  const rollbackStart = workflow.indexOf(
+    "name: Roll back after Google callback verification failure",
+    verifyStart,
+  );
+  const failStart = workflow.indexOf(
+    "name: Fail after Google callback verification",
+    rollbackStart,
+  );
+  const verify =
+    verifyStart >= 0 && rollbackStart > verifyStart
+      ? workflow.slice(verifyStart, rollbackStart)
+      : "";
+  const rollback =
+    rollbackStart >= 0 && failStart > rollbackStart
+      ? workflow.slice(rollbackStart, failStart)
+      : "";
+
+  if (!verify) {
+    issues.push(
+      `${reusablePath} must verify Google OAuth after publishing a deploy`,
+    );
+  } else {
+    if (
+      !verify.includes(
+        "node --experimental-strip-types scripts/check-google-redirect-uris.ts",
+      )
+    ) {
+      issues.push(
+        `${reusablePath} Google OAuth verification must run the probe directly with the supported Node loader`,
+      );
+    }
+    if (verify.includes("pnpm check:google-redirect-uris")) {
+      issues.push(
+        `${reusablePath} Google OAuth verification must not depend on a package-script indirection`,
+      );
+    }
+    if (verify.includes("source_template != 'macros'")) {
+      issues.push(
+        `${reusablePath} Google OAuth verification must use the deployed capability contract instead of a template allowlist`,
+      );
+    }
+  }
+
+  if (
+    !rollback ||
+    !rollback.includes("steps.google_redirect.outcome == 'failure'") ||
+    !rollback.includes("steps.google_redirect.outputs.exit_code != '0'")
+  ) {
+    issues.push(
+      `${reusablePath} must roll back every non-zero Google OAuth verification result, including inconclusive checks`,
+    );
+  }
+  return issues;
+}
+
 try {
   for (const [path, source] of [
     [reusablePath, reusable],
@@ -231,6 +293,7 @@ const parsedResumeIndex = parsedStepIndex(
 const parsedCleanupIndex = parsedStepIndex(
   "Restore the production deploy lock after a failed cutover",
 );
+issues.push(...validateGoogleCallbackVerificationWorkflow(reusable));
 if (
   parsedPauseIndex < 0 ||
   parsedUnlockIndex < 0 ||

--- a/templates/analytics/server/plugins/core-routes.ts
+++ b/templates/analytics/server/plugins/core-routes.ts
@@ -7,6 +7,7 @@ import { createCoreRoutesPlugin } from "@agent-native/core/server";
 // in Analytics" link produced by `update-dashboard` / `save-analysis` for a
 // connected Claude Code / Codex / Cowork never opened the record.
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   extensionTools: true,
   resolveOpenPath: ({ view, params }) => {
     if (params.dashboardId) return `/dashboards/${params.dashboardId}`;

--- a/templates/brain/server/plugins/core-routes.ts
+++ b/templates/brain/server/plugins/core-routes.ts
@@ -18,6 +18,7 @@ const VIEW_PATHS: Record<string, string> = {
 };
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   envKeys: [],
   resolveOpenPath: ({ view, params }) => {
     if (view && VIEW_PATHS[view]) return VIEW_PATHS[view];

--- a/templates/calendar/server/plugins/core-routes.ts
+++ b/templates/calendar/server/plugins/core-routes.ts
@@ -3,6 +3,7 @@ import { createCoreRoutesPlugin } from "@agent-native/core/server";
 import { envKeys } from "../lib/env-config.js";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "required",
   sseRoute: "/_agent-native/sse",
   envKeys,
   // Land deep links (`/_agent-native/open?app=calendar&view=calendar&eventId=…&date=…`)

--- a/templates/clips/server/plugins/core-routes.ts
+++ b/templates/clips/server/plugins/core-routes.ts
@@ -1,8 +1,5 @@
 import { createCoreRoutesPlugin } from "@agent-native/core/server";
 
-import { envKeys } from "../lib/env-config.js";
-
 export default createCoreRoutesPlugin({
   googleOAuthManagedConnection: "required",
-  envKeys,
 });

--- a/templates/content/server/plugins/core-routes.ts
+++ b/templates/content/server/plugins/core-routes.ts
@@ -4,6 +4,7 @@ import { envKeys } from "../lib/env-config.js";
 import { resolvePublicViewerOwner } from "../lib/public-documents.js";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   envKeys,
   anonymousOwner: resolvePublicViewerOwner,
   // Land deep links (`/_agent-native/open?app=content&view=editor&documentId=…`)

--- a/templates/crm/server/plugins/core-routes.ts
+++ b/templates/crm/server/plugins/core-routes.ts
@@ -10,6 +10,7 @@ const VIEW_PATHS: Record<string, string> = {
 };
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   resolveOpenPath: ({ view, params }) => {
     if (params.recordId) return `/records/${params.recordId}`;
     return view ? (VIEW_PATHS[view] ?? null) : null;

--- a/templates/design/server/plugins/core-routes.ts
+++ b/templates/design/server/plugins/core-routes.ts
@@ -8,6 +8,7 @@ import { createCoreRoutesPlugin } from "@agent-native/core/server";
 // editor route is `design.$id.tsx` → `/design/:id`) and 404s — so an
 // "Open in Design" link for a connected external agent never opened the design.
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   resolveOpenPath: ({ view, params }) => {
     if (params.designId) return `/design/${params.designId}`;
     // `editor`/unknown with no id: there is no bare `/editor` route — send to

--- a/templates/forms/server/plugins/core-routes.ts
+++ b/templates/forms/server/plugins/core-routes.ts
@@ -1,6 +1,7 @@
 import { createCoreRoutesPlugin } from "@agent-native/core/server";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   envKeys: [
     { key: "DATABASE_URL", label: "Database URL", required: false },
     {

--- a/templates/macros/server/plugins/core-routes.ts
+++ b/templates/macros/server/plugins/core-routes.ts
@@ -1,5 +1,6 @@
 import { createCoreRoutesPlugin } from "@agent-native/core/server";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   envKeys: [{ key: "ANTHROPIC_API_KEY", label: "Anthropic API Key" }],
 });

--- a/templates/plan/server/plugins/core-routes.ts
+++ b/templates/plan/server/plugins/core-routes.ts
@@ -3,6 +3,7 @@ import { createCoreRoutesPlugin } from "@agent-native/core/server";
 import { resolvePlanAnonymousOwner } from "../lib/public-plans.js";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   anonymousOwner: resolvePlanAnonymousOwner,
   // Plan's published MCP server id is the bare `plan`, not the derived
   // `agent-native-plan`: `.agents/plugins/agent-native-visual-plans/.mcp.json`

--- a/templates/slides/server/plugins/core-routes.ts
+++ b/templates/slides/server/plugins/core-routes.ts
@@ -3,6 +3,7 @@ import { createCoreRoutesPlugin } from "@agent-native/core/server";
 import { envKeys } from "../lib/env-config.js";
 
 export default createCoreRoutesPlugin({
+  googleOAuthManagedConnection: "not_applicable",
   envKeys,
   googleOAuthCallbackPaths: [
     "/_agent-native/google/callback",


### PR DESCRIPTION
## Summary
- declare which apps require managed Google OAuth and which do not
- make the redirect verifier derive capability from live health contracts
- run the deploy gate with Node directly and roll back on any non-zero result
- add workflow guard coverage and tests

## Validation
- pnpm typecheck
- pnpm fmt:check
- pnpm guards
- focused Google verifier and workflow tests

The beta and production deploys from the earlier revision exposed the need for this follow-up: ordinary apps without managed Connect were being treated as failed OAuth targets.