### PR TITLE
fix: retry transient Netlify API rate limits

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -318,18 +318,18 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           (async () => {
           const fs = require("node:fs");
+          const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
           const api = "https://api.netlify.com/api/v1";
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
             "User-Agent": "agent-native-prebuilt-production-build-pause",
           };
-          const request = (url, options = {}) => fetch(url, {
+          const request = (url, options = {}) => requestNetlifyApi(url, {
             ...options,
             headers: { ...headers, ...(options.headers || {}) },
-            signal: AbortSignal.timeout(30_000),
           });
 
           async function readJson(response, label) {
@@ -415,8 +415,9 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           (async () => {
+          const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
           const api = "https://api.netlify.com/api/v1";
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
@@ -444,10 +445,9 @@ jobs:
           if (!siteId) throw new Error("Netlify site id is required to unlock production.");
 
           const request = (url, options = {}) =>
-            fetch(url, {
+            requestNetlifyApi(url, {
               ...options,
               headers: { ...headers, ...(options.headers || {}) },
-              signal: AbortSignal.timeout(30_000),
             });
           const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
           const ACTIVE_PRODUCTION_DEPLOY_STATES = [
@@ -668,15 +668,15 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           (async () => {
             const fs = require("node:fs");
+            const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
             const siteId = process.env.NETLIFY_SITE_ID;
-            const response = await fetch(`https://api.netlify.com/api/v1/sites/${siteId}`, {
+            const response = await requestNetlifyApi(`https://api.netlify.com/api/v1/sites/${siteId}`, {
               headers: {
                 Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
               },
-              signal: AbortSignal.timeout(30_000),
             });
             const text = await response.text();
             const site = text ? JSON.parse(text) : null;
@@ -750,15 +750,15 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           const api = "https://api.netlify.com/api/v1";
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
           };
-          const request = (url) => fetch(url, {
-            headers,
-            signal: AbortSignal.timeout(30_000),
-          });
+          const request = (url) =>
+            import("./scripts/netlify-api-request.ts").then(({ requestNetlifyApi }) =>
+              requestNetlifyApi(url, { headers }),
+            );
           const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
           async function readJson(response, label) {
@@ -852,16 +852,16 @@ jobs:
           PREVIOUS_DEPLOY_ID: ${{ steps.previous.outputs.published_deploy_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           (async () => {
+            const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
             const api = "https://api.netlify.com/api/v1";
             const headers = {
               Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
             };
-            const request = (url, options = {}) => fetch(url, {
+            const request = (url, options = {}) => requestNetlifyApi(url, {
               ...options,
               headers: { ...headers, ...(options.headers || {}) },
-              signal: AbortSignal.timeout(30_000),
             });
             const readJson = async (response, label) => {
               const text = await response.text();
@@ -953,10 +953,11 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           const api = "https://api.netlify.com/api/v1";
+          const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
           (async () => {
-            const response = await fetch(`${api}/purge`, {
+            const response = await requestNetlifyApi(`${api}/purge`, {
               method: "POST",
               headers: {
                 Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
@@ -964,7 +965,6 @@ jobs:
                 "User-Agent": "agent-native-prebuilt-production-cache-purge",
               },
               body: JSON.stringify({ site_id: process.env.NETLIFY_SITE_ID }),
-              signal: AbortSignal.timeout(30_000),
             });
             const text = await response.text();
             let body = null;
@@ -991,16 +991,16 @@ jobs:
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           const api = "https://api.netlify.com/api/v1";
+          const { requestNetlifyApi } = await import("./scripts/netlify-api-request.ts");
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
             "User-Agent": "agent-native-prebuilt-production-lock",
           };
-          const request = (url, options = {}) => fetch(url, {
+          const request = (url, options = {}) => requestNetlifyApi(url, {
             ...options,
             headers: { ...headers, ...(options.headers || {}) },
-            signal: AbortSignal.timeout(30_000),
           });
 
           async function readJson(response, label) {
@@ -1046,17 +1046,19 @@ jobs:
           cutoverHasGitConnectedBuild: ${{ steps.pause.outputs.has_git_connected_build }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           const api = "https://api.netlify.com/api/v1";
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
             "User-Agent": "agent-native-prebuilt-production-build-resume",
           };
-          const request = (url, options = {}) => fetch(url, {
-            ...options,
-            headers: { ...headers, ...(options.headers || {}) },
-            signal: AbortSignal.timeout(30_000),
-          });
+          const request = (url, options = {}) =>
+            import("./scripts/netlify-api-request.ts").then(({ requestNetlifyApi }) =>
+              requestNetlifyApi(url, {
+                ...options,
+                headers: { ...headers, ...(options.headers || {}) },
+              }),
+            );
 
           async function readJson(response, label) {
             const text = await response.text();
@@ -1120,17 +1122,19 @@ jobs:
           cutoverWasPaused: ${{ steps.pause.outputs.cutover_acquired }}
         run: |
           set -euo pipefail
-          node <<'NODE'
+          node --experimental-strip-types <<'NODE'
           const api = "https://api.netlify.com/api/v1";
           const headers = {
             Authorization: `Bearer ${process.env.NETLIFY_AUTH_TOKEN}`,
             "User-Agent": "agent-native-prebuilt-production-failure-cleanup",
           };
-          const request = (url, options = {}) => fetch(url, {
-            ...options,
-            headers: { ...headers, ...(options.headers || {}) },
-            signal: AbortSignal.timeout(30_000),
-          });
+          const request = (url, options = {}) =>
+            import("./scripts/netlify-api-request.ts").then(({ requestNetlifyApi }) =>
+              requestNetlifyApi(url, {
+                ...options,
+                headers: { ...headers, ...(options.headers || {}) },
+              }),
+            );
 
           async function readJson(response, label) {
             const text = await response.text();

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -12,6 +12,7 @@ import {
   PRODUCTION_PURGE_CONDITION,
   PRODUCTION_SITE_GROUP,
   validateGoogleCallbackVerificationWorkflow,
+  validateNetlifyApiRateLimitHandling,
   validateProductionPurgeCondition,
   validateReusableWorkflowConcurrency,
   validateProductionSiteConcurrency,
@@ -44,7 +45,9 @@ const reusableSource = readFileSync(
   "utf8",
 );
 const nodeHeredocs = [
-  ...reusableSource.matchAll(/node <<'NODE'\n([\s\S]*?)\n\s*NODE/g),
+  ...reusableSource.matchAll(
+    /node(?: --experimental-strip-types)? <<'NODE'\n([\s\S]*?)\n\s*NODE/g,
+  ),
 ].map((match) => match[1]);
 
 describe("Google callback deploy verification guard", () => {
@@ -66,6 +69,21 @@ describe("Google callback deploy verification guard", () => {
           ),
       ).join("\n"),
       /directly with the supported Node loader|every non-zero/,
+    );
+  });
+});
+
+describe("Netlify API rate-limit guard", () => {
+  it("routes all reusable-workflow API calls through the bounded helper", () => {
+    assert.deepEqual(validateNetlifyApiRateLimitHandling(reusableSource), []);
+    assert.match(
+      validateNetlifyApiRateLimitHandling(
+        reusableSource.replace(
+          "requestNetlifyApi(`https://api.netlify.com/api/v1/sites/${siteId}`",
+          "fetch(`https://api.netlify.com/api/v1/sites/${siteId}`",
+        ),
+      ).join("\n"),
+      /raw Netlify fetch calls/,
     );
   });
 });
@@ -199,6 +217,11 @@ describe("production Netlify site concurrency guard", () => {
 
   it("executes every reusable workflow heredoc under the pinned Node loader", () => {
     assert.equal(nodeHeredocs.length, 9);
+    assert.equal(
+      (reusableSource.match(/node --experimental-strip-types <<'NODE'/g) ?? [])
+        .length,
+      9,
+    );
     const directory = mkdtempSync(
       join(tmpdir(), "agent-native-netlify-heredocs-"),
     );
@@ -247,7 +270,7 @@ describe("production Netlify site concurrency guard", () => {
       String(purge.run),
       /const api = "https:\/\/api\.netlify\.com\/api\/v1"/,
     );
-    assert.match(String(purge.run), /fetch\(`\$\{api\}\/purge`/);
+    assert.match(String(purge.run), /requestNetlifyApi\(`\$\{api\}\/purge`/);
     assert.match(String(purge.run), /method: "POST"/);
     assert.match(
       String(purge.run),

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -156,6 +156,23 @@ export function validateGoogleCallbackVerificationWorkflow(
   return issues;
 }
 
+export function validateNetlifyApiRateLimitHandling(
+  workflow: string,
+): string[] {
+  const issues: string[] = [];
+  if (!workflow.includes("scripts/netlify-api-request.ts")) {
+    issues.push(
+      `${reusablePath} Netlify API calls must use the bounded rate-limit helper`,
+    );
+  }
+  if (workflow.includes("fetch(")) {
+    issues.push(
+      `${reusablePath} must not make raw Netlify fetch calls outside the rate-limit helper`,
+    );
+  }
+  return issues;
+}
+
 try {
   for (const [path, source] of [
     [reusablePath, reusable],
@@ -294,6 +311,7 @@ const parsedCleanupIndex = parsedStepIndex(
   "Restore the production deploy lock after a failed cutover",
 );
 issues.push(...validateGoogleCallbackVerificationWorkflow(reusable));
+issues.push(...validateNetlifyApiRateLimitHandling(reusable));
 if (
   parsedPauseIndex < 0 ||
   parsedUnlockIndex < 0 ||
@@ -426,7 +444,7 @@ if (purgeStart < 0 || purgeEnd <= purgeStart) {
   const purge = reusable.slice(purgeStart, purgeEnd);
   if (
     !purge.includes('const api = "https://api.netlify.com/api/v1"') ||
-    !purge.includes("fetch(`${api}/purge`") ||
+    !purge.includes("requestNetlifyApi(`${api}/purge`") ||
     !purge.includes('method: "POST"') ||
     !purge.includes(
       "JSON.stringify({ site_id: process.env.NETLIFY_SITE_ID })",

--- a/scripts/netlify-api-request.test.ts
+++ b/scripts/netlify-api-request.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { requestNetlifyApi } from "./netlify-api-request.ts";
+
+describe("requestNetlifyApi", () => {
+  it("retries a rate-limited request before returning success", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response(null, {
+            status: 429,
+            headers: { "retry-after": "0" },
+          })
+        : new Response("ok", { status: 200 });
+    };
+
+    try {
+      const response = await requestNetlifyApi("https://example.test");
+      assert.equal(response.status, 200);
+      assert.equal(calls, 2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns the final rate-limit response after bounded retries", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return new Response(null, {
+        status: 429,
+        headers: { "retry-after": "0" },
+      });
+    };
+
+    try {
+      const response = await requestNetlifyApi("https://example.test");
+      assert.equal(response.status, 429);
+      assert.equal(calls, 6);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/scripts/netlify-api-request.ts
+++ b/scripts/netlify-api-request.ts
@@ -1,0 +1,48 @@
+const MAX_RATE_LIMIT_ATTEMPTS = 6;
+const RATE_LIMIT_BACKOFF_MS = 30_000;
+const MAX_RATE_LIMIT_DELAY_MS = 120_000;
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+function retryDelayMilliseconds(response: Response, attempt: number): number {
+  const retryAfter = response.headers.get("retry-after");
+  const seconds = retryAfter === null ? Number.NaN : Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(MAX_RATE_LIMIT_DELAY_MS, seconds * 1000);
+  }
+
+  const retryAt = retryAfter === null ? Number.NaN : Date.parse(retryAfter);
+  if (Number.isFinite(retryAt)) {
+    return Math.min(MAX_RATE_LIMIT_DELAY_MS, Math.max(0, retryAt - Date.now()));
+  }
+
+  return Math.min(
+    MAX_RATE_LIMIT_DELAY_MS,
+    RATE_LIMIT_BACKOFF_MS * 2 ** attempt,
+  );
+}
+
+export async function requestNetlifyApi(
+  url: string,
+  options: RequestInit = {},
+): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_RATE_LIMIT_ATTEMPTS; attempt += 1) {
+    const response = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (response.status !== 429) return response;
+
+    await response.arrayBuffer();
+    if (attempt === MAX_RATE_LIMIT_ATTEMPTS - 1) return response;
+
+    const delay = retryDelayMilliseconds(response, attempt);
+    console.warn(
+      `Netlify API rate limited; retrying in ${Math.ceil(delay / 1000)}s.`,
+    );
+    await sleep(delay);
+  }
+
+  throw new Error("Netlify API request exhausted its rate-limit retries.");
+}


### PR DESCRIPTION
## Summary
- route prebuilt Netlify API calls through bounded 429 Retry-After backoff
- keep callback verification and production cleanup fail-closed
- add workflow guard and focused retry tests

## Validation
- pnpm typecheck
- pnpm fmt:check
- pnpm guards
- pnpm exec tsx --test scripts/netlify-api-request.test.ts scripts/guard-netlify-prebuilt-workflow.test.ts