### PR TITLE
Move dashboard certification into overflow menu

### DIFF
--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1899,28 +1899,6 @@ function SqlDashboardPageContent({
         {dashboardId && (
           <ViewsMenu dashboardId={dashboardId} canEdit={canEdit} />
         )}
-        {dashboardId && dashboardUpdatedAt && canCertify && !archivedAt ? (
-          <Button
-            size="sm"
-            variant={dashboardCertified ? "secondary" : "outline"}
-            onClick={() => void handleCertify()}
-            disabled={certificationPending}
-            aria-label={t(
-              dashboardCertified
-                ? "sqlDashboard.certifiedForAi"
-                : "sqlDashboard.certifyForAi",
-            )}
-          >
-            <IconShieldCheck className="mr-1 h-4 w-4" />
-            <span className="hidden sm:inline">
-              {t(
-                dashboardCertified
-                  ? "sqlDashboard.certifiedForAi"
-                  : "sqlDashboard.certifyForAi",
-              )}
-            </span>
-          </Button>
-        ) : null}
         {dashboardId ? (
           <ShareButton
             resourceType="dashboard"
@@ -2058,6 +2036,23 @@ function SqlDashboardPageContent({
                   <IconHistory className="mr-2 h-3.5 w-3.5" />
                   {t("dashboard.historyTitle")}
                 </DropdownMenuItem>
+                {dashboardUpdatedAt && canCertify && !archivedAt ? (
+                  <DropdownMenuItem
+                    disabled={dashboardCertified || certificationPending}
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      setDashboardActionsOpen(false);
+                      void handleCertify();
+                    }}
+                  >
+                    <IconShieldCheck className="mr-2 h-3.5 w-3.5" />
+                    {t(
+                      dashboardCertified
+                        ? "sqlDashboard.certifiedForAi"
+                        : "sqlDashboard.certifyForAi",
+                    )}
+                  </DropdownMenuItem>
+                ) : null}
               </>
             ) : null}
             {canArchive && !archivedAt ? (

--- a/templates/analytics/changelog/2026-08-29-dashboard-certification-lives-in-the-overflow-menu.md
+++ b/templates/analytics/changelog/2026-08-29-dashboard-certification-lives-in-the-overflow-menu.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-29
+---
+
+Dashboard certification lives in the overflow menu


### PR DESCRIPTION
## Summary\n- Move dashboard AI certification from the header into the existing three-dots menu.\n- Keep the certified shield as a compact title status and disable recertification while the current dashboard version is certified.\n- Add an Analytics changelog entry.\n\n## Validation\n- Targeted oxlint on the changed dashboard page.\n- no-default-chrome and i18n-changed-copy guards.\n- Local Playwright smoke: admin menu visibility, certification click, toast, persistence, and compact status.\n\nAnalytics typecheck is currently blocked by existing production-config errors and the googleOAuthManagedConnection type error in server/plugins/core-routes.ts.