### PR TITLE
feat: extend Builder activation consent popover

### DIFF
--- a/packages/core/src/client/ConnectBuilderCard.tsx
+++ b/packages/core/src/client/ConnectBuilderCard.tsx
@@ -13,6 +13,7 @@ import { BuilderBMark } from "./builder-mark.js";
 import { writeClipboardText } from "./clipboard.js";
 import { requestDesktopLocalCodeChange } from "./desktop-local-code-change.js";
 import { getCallbackOrigin } from "./frame.js";
+import { BuilderConnectPopover } from "./settings/BuilderConnectPopover.js";
 import { useBuilderConnectFlow } from "./settings/useBuilderStatus.js";
 import { cn } from "./utils.js";
 
@@ -83,6 +84,7 @@ export function ConnectBuilderCard({
   // is what catches a flow the user completed in another tab.
   const flow = useBuilderConnectFlow({
     popupUrl: initialConnectUrl,
+    provisionAccount: true,
     trackingSource: "connect_builder_card",
   });
   // Keep the server-rendered handoff state until a successful status response
@@ -539,24 +541,25 @@ export function ConnectBuilderCard({
                       : "Do locally"}
                   </button>
                 )}
-                <button
-                  type="button"
-                  onClick={() => flow.start()}
-                  disabled={connecting}
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent",
-                    connecting && "opacity-70 cursor-wait",
-                  )}
-                >
-                  {connecting ? (
-                    <>
-                      <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-                      Waiting for Builder…
-                    </>
-                  ) : (
-                    "Connect Builder"
-                  )}
-                </button>
+                <BuilderConnectPopover flow={flow}>
+                  <button
+                    type="button"
+                    disabled={connecting}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent",
+                      connecting && "opacity-70 cursor-wait",
+                    )}
+                  >
+                    {connecting ? (
+                      <>
+                        <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                        Waiting for Builder…
+                      </>
+                    ) : (
+                      "Connect Builder"
+                    )}
+                  </button>
+                </BuilderConnectPopover>
               </div>
             ) : showDesktopLocalHandoff ? (
               <button

--- a/packages/core/src/client/NewWorkspaceAppFlow.spec.ts
+++ b/packages/core/src/client/NewWorkspaceAppFlow.spec.ts
@@ -42,6 +42,7 @@ vi.mock("./settings/useBuilderStatus.js", () => ({
     configured: false,
     connecting: builderConnectFlowState.connecting,
     error: null,
+    statusResolved: true,
     start: builderConnectFlowState.start,
   }),
 }));

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -15,6 +15,7 @@ import { sendToAgentChat } from "./agent-chat.js";
 import { agentNativePath, appBasePath } from "./api-path.js";
 import { isInBuilderFrame } from "./builder-frame.js";
 import { PromptComposer } from "./composer/index.js";
+import { BuilderConnectPopover } from "./settings/BuilderConnectPopover.js";
 import { useBuilderConnectFlow } from "./settings/useBuilderStatus.js";
 import { useDevMode } from "./use-dev-mode.js";
 
@@ -194,6 +195,7 @@ export function NewWorkspaceAppFlow({
   // status read for anyone already connected.
   const connectFlow = useBuilderConnectFlow({
     enabled: failureReason === "builder-not-connected",
+    provisionAccount: true,
     trackingSource: "new_workspace_app_flow",
     trackingFlow: "create_app",
     onConnected: () => {
@@ -416,16 +418,17 @@ export function NewWorkspaceAppFlow({
               </div>
               {failureReason === "builder-not-connected" ? (
                 <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => connectFlow.start()}
-                    disabled={connectFlow.connecting}
-                    className="inline-flex w-fit cursor-pointer items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground hover:bg-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {connectFlow.connecting
-                      ? "Connecting..."
-                      : "Connect Builder"}
-                  </button>
+                  <BuilderConnectPopover flow={connectFlow}>
+                    <button
+                      type="button"
+                      disabled={connectFlow.connecting}
+                      className="inline-flex w-fit cursor-pointer items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground hover:bg-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {connectFlow.connecting
+                        ? "Connecting..."
+                        : "Connect Builder"}
+                    </button>
+                  </BuilderConnectPopover>
                   <a
                     href={LOCAL_APP_DOCS_URL}
                     target="_blank"

--- a/packages/core/src/client/chat/run-recovery.tsx
+++ b/packages/core/src/client/chat/run-recovery.tsx
@@ -28,6 +28,7 @@ import {
   localizeKnownChatErrorText,
 } from "../error-format.js";
 import { useFormatters, useT } from "../i18n.js";
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
 import { AgentProviderSetupForm } from "../settings/ProviderSetupForm.js";
 import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
 import { cn } from "../utils.js";
@@ -240,11 +241,12 @@ export function BuilderConnectCta({
   onConnected?: () => void;
 }) {
   const t = useT();
-  const { configured, orgName, connecting, error, start } =
-    useBuilderConnectFlow({
-      trackingSource: "assistant_chat_builder_cta",
-      onConnected,
-    });
+  const flow = useBuilderConnectFlow({
+    provisionAccount: true,
+    trackingSource: "assistant_chat_builder_cta",
+    onConnected,
+  });
+  const { configured, orgName, connecting, error } = flow;
 
   if (variant === "compact") {
     if (configured) {
@@ -260,22 +262,23 @@ export function BuilderConnectCta({
 
     return (
       <div className="agent-builder-setup-card__builder-cta flex min-w-0 flex-col items-start gap-1 sm:items-end">
-        <button
-          type="button"
-          onClick={() => start()}
-          disabled={connecting}
-          className="agent-builder-setup-card__builder-button inline-flex h-8 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-foreground px-3 text-[11px] font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
-          aria-busy={connecting}
-        >
-          {connecting ? (
-            <>
-              <IconLoader2 size={10} className="animate-spin" />
-              {t("agentChat.common.waiting")}
-            </>
-          ) : (
-            t("agentChat.setup.connectBuilder")
-          )}
-        </button>
+        <BuilderConnectPopover flow={flow}>
+          <button
+            type="button"
+            disabled={connecting}
+            className="agent-builder-setup-card__builder-button inline-flex h-8 shrink-0 items-center gap-1 whitespace-nowrap rounded-md bg-foreground px-3 text-[11px] font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+            aria-busy={connecting}
+          >
+            {connecting ? (
+              <>
+                <IconLoader2 size={10} className="animate-spin" />
+                {t("agentChat.common.waiting")}
+              </>
+            ) : (
+              t("agentChat.setup.connectBuilder")
+            )}
+          </button>
+        </BuilderConnectPopover>
         {error && (
           <p className="max-w-[13rem] text-[10px] leading-snug text-destructive sm:text-end">
             {error}
@@ -320,22 +323,23 @@ export function BuilderConnectCta({
         </p>
         {error && <p className="mt-1 text-[10px] text-destructive">{error}</p>}
       </div>
-      <button
-        type="button"
-        onClick={() => start()}
-        disabled={connecting}
-        className="ms-auto inline-flex items-center gap-1 shrink-0 rounded-md bg-foreground px-3 py-1.5 text-[11px] font-medium no-underline text-background hover:opacity-90 disabled:opacity-60 disabled:cursor-wait"
-        aria-busy={connecting}
-      >
-        {connecting ? (
-          <>
-            <IconLoader2 size={10} className="animate-spin" />
-            {t("agentChat.common.waiting")}
-          </>
-        ) : (
-          t("agentChat.common.connect")
-        )}
-      </button>
+      <BuilderConnectPopover flow={flow}>
+        <button
+          type="button"
+          disabled={connecting}
+          className="ms-auto inline-flex items-center gap-1 shrink-0 rounded-md bg-foreground px-3 py-1.5 text-[11px] font-medium no-underline text-background hover:opacity-90 disabled:opacity-60 disabled:cursor-wait"
+          aria-busy={connecting}
+        >
+          {connecting ? (
+            <>
+              <IconLoader2 size={10} className="animate-spin" />
+              {t("agentChat.common.waiting")}
+            </>
+          ) : (
+            t("agentChat.common.connect")
+          )}
+        </button>
+      </BuilderConnectPopover>
     </div>
   );
 }
@@ -550,6 +554,7 @@ export function RunErrorRecoveryCard({
   const retryRequestedRef = useRef(false);
   const [retryRequested, setRetryRequested] = useState(false);
   const builderReconnect = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource: "assistant_chat_reconnect_error",
   });
   const canRecover = info.recoverable === true;
@@ -756,19 +761,20 @@ export function RunErrorRecoveryCard({
       </div>
       <div className="mt-3 flex min-w-0 items-center gap-2">
         {shouldShowBuilderReconnect && !builderReconnectResolved && (
-          <button
-            type="button"
-            onClick={() => builderReconnect.start()}
-            disabled={builderReconnect.connecting}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
-          >
-            {builderReconnect.connecting ? (
-              <IconLoader2 size={13} className="animate-spin" />
-            ) : null}
-            {builderReconnect.connecting
-              ? t("agentChat.recovery.connectingBuilder")
-              : t("agentChat.recovery.reconnectBuilder")}
-          </button>
+          <BuilderConnectPopover flow={builderReconnect}>
+            <button
+              type="button"
+              disabled={builderReconnect.connecting}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-70"
+            >
+              {builderReconnect.connecting ? (
+                <IconLoader2 size={13} className="animate-spin" />
+              ) : null}
+              {builderReconnect.connecting
+                ? t("agentChat.recovery.connectingBuilder")
+                : t("agentChat.recovery.reconnectBuilder")}
+            </button>
+          </BuilderConnectPopover>
         )}
         {canRecover && (
           <button

--- a/packages/core/src/client/components/CodeRequiredDialog.tsx
+++ b/packages/core/src/client/components/CodeRequiredDialog.tsx
@@ -8,10 +8,10 @@ import {
 import { useEffect, useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { trackEvent } from "../analytics.js";
 import { agentNativePath } from "../api-path.js";
 import { useT } from "../i18n.js";
-import { withBuilderConnectTrackingParams } from "../settings/useBuilderStatus.js";
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
+import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
 
 const DESKTOP_DOWNLOAD_URL = "https://www.agent-native.com/download";
 
@@ -20,31 +20,6 @@ export interface CodeRequiredDialogProps {
   onClose: () => void;
   /** Label describing the feature that requires code changes */
   featureLabel?: string;
-}
-
-function useBuilderConnected() {
-  const [connected, setConnected] = useState(false);
-  const [cloudAgentsAvailable, setCloudAgentsAvailable] = useState(false);
-  const [connectUrl, setConnectUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch(agentNativePath("/_agent-native/builder/status"))
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (data) {
-          setConnected(!!data.configured);
-          setCloudAgentsAvailable(
-            !!data.builderEnabled &&
-              !!data.privateKeyConfigured &&
-              !!data.publicKeyConfigured,
-          );
-          setConnectUrl(data.connectUrl || null);
-        }
-      })
-      .catch(() => {});
-  }, []);
-
-  return { connected, cloudAgentsAvailable, connectUrl };
 }
 
 /**
@@ -59,18 +34,19 @@ export function CodeRequiredDialog({
   featureLabel,
 }: CodeRequiredDialogProps) {
   const t = useT();
-  const {
-    connected: builderConnected,
-    cloudAgentsAvailable,
-    connectUrl,
-  } = useBuilderConnected();
+  const builderFlow = useBuilderConnectFlow({
+    provisionAccount: true,
+    trackingSource: "code_required_dialog",
+    trackingFlow: "background_agent",
+  });
+  const builderConnected = builderFlow.statusResolved && builderFlow.configured;
+  const cloudAgentsAvailable =
+    builderFlow.statusResolved &&
+    builderFlow.builderEnabled &&
+    builderFlow.codeChangeConfigured;
   const [submitting, setSubmitting] = useState(false);
   const [branchUrl, setBranchUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const builderHref = withBuilderConnectTrackingParams(
-    connectUrl || agentNativePath("/_agent-native/builder/connect"),
-    { source: "code_required_dialog", flow: "background_agent" },
-  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -243,44 +219,45 @@ export function CodeRequiredDialog({
               <span style={s.badge}>{t("codeRequired.codeChangeBadge")}</span>
             </div>
           ) : (
-            <a
-              href={builderHref}
-              target="_blank"
-              rel="noreferrer"
-              onClick={() => {
-                trackEvent("builder connect clicked", {
-                  feature: "builder",
-                  stage: "client",
-                  source: "code_required_dialog",
-                  flow: "background_agent",
-                  connect_url_kind: connectUrl ? "provided" : "default",
-                });
-              }}
-              style={{ ...s.optionCard, ...s.optionLink }}
-              onMouseEnter={(e) =>
-                Object.assign(e.currentTarget.style, s.optionCardHover)
-              }
-              onMouseLeave={(e) =>
-                Object.assign(e.currentTarget.style, {
-                  borderColor: "hsl(var(--border))",
-                })
-              }
-            >
-              <div style={s.optionIcon}>
-                <IconExternalLink size={24} />
-              </div>
-              <div style={s.optionText}>
-                <span style={s.optionTitle}>
-                  {t("codeRequired.connectBuilderTitle")}
-                </span>
-                <span style={s.optionDesc}>
-                  {t("codeRequired.connectBuilderDescription")}
-                </span>
-              </div>
-              {!connectUrl && (
+            <BuilderConnectPopover flow={builderFlow}>
+              <button
+                type="button"
+                disabled={builderFlow.connecting}
+                style={{
+                  ...s.optionCard,
+                  ...s.optionLink,
+                  ...(builderFlow.connecting ? s.optionCardDisabled : {}),
+                }}
+                onMouseEnter={(e) =>
+                  Object.assign(e.currentTarget.style, s.optionCardHover)
+                }
+                onMouseLeave={(e) =>
+                  Object.assign(e.currentTarget.style, {
+                    borderColor: "hsl(var(--border))",
+                  })
+                }
+              >
+                <div style={s.optionIcon}>
+                  {builderFlow.connecting ? (
+                    <IconLoader2
+                      size={24}
+                      style={{ animation: "spin 1s linear infinite" }}
+                    />
+                  ) : (
+                    <IconExternalLink size={24} />
+                  )}
+                </div>
+                <div style={s.optionText}>
+                  <span style={s.optionTitle}>
+                    {t("codeRequired.connectBuilderTitle")}
+                  </span>
+                  <span style={s.optionDesc}>
+                    {t("codeRequired.connectBuilderDescription")}
+                  </span>
+                </div>
                 <span style={s.badge}>{t("codeRequired.setupRequired")}</span>
-              )}
-            </a>
+              </button>
+            </BuilderConnectPopover>
           )}
         </div>
 
@@ -404,6 +381,10 @@ const s: Record<string, React.CSSProperties> = {
   },
   optionCardHover: {
     borderColor: "hsl(var(--ring))",
+  },
+  optionCardDisabled: {
+    opacity: 0.7,
+    cursor: "wait",
   },
   optionLink: {
     textDecoration: "none",

--- a/packages/core/src/client/composer/runtime-adapters.tsx
+++ b/packages/core/src/client/composer/runtime-adapters.tsx
@@ -34,6 +34,7 @@ import { useOrg } from "../org/hooks.js";
 import { isMcpIntegrationCatalogAvailable } from "../resources/mcp-integration-catalog.js";
 import { McpIntegrationDialog } from "../resources/McpIntegrationDialog.js";
 import { useCreateMcpServer } from "../resources/use-mcp-servers.js";
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
 import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
 import {
   fetchAgentEngineConfiguredState,
@@ -82,6 +83,7 @@ const coreComposerAdapters: Omit<ComposerRuntimeAdapters, "translate"> = {
   },
   builder: {
     useConnectFlow: useBuilderConnectFlow,
+    BuilderConnectPopover,
     tryDelegateBuildRequest: tryDelegateBuildRequestToBuilder,
     isTrustedBuilderMessage,
     isTrustedFrameMessage,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -56,6 +56,7 @@ export {
   SettingsPanel,
   SettingsTabsPage,
   SecretsSection,
+  BuilderConnectPopover,
   getAgentSettingsSearchTabs,
   openBuilderConnectPopup,
   useAgentSettingsTabs,
@@ -75,6 +76,7 @@ export {
   type SettingsSearchEntry,
   type SettingsTabItem,
   type SettingsTabsPageProps,
+  type BuilderConnectPopoverProps,
 } from "./settings/index.js";
 export {
   DevDatabaseLink,

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -185,6 +185,7 @@ describe("FirstRunOnboarding", () => {
   it("shows one-click account consent in a popover and its loading state when enabled", () => {
     const flow = {
       hasFetchedStatus: true,
+      statusResolved: true,
       configured: false,
       agentNativeProvisioningEnabled: true,
       connecting: false,
@@ -266,6 +267,7 @@ describe("FirstRunOnboarding", () => {
     const start = vi.fn();
     mocks.useBuilderConnectFlow.mockReturnValue({
       hasFetchedStatus: true,
+      statusResolved: true,
       configured: false,
       agentNativeProvisioningEnabled: true,
       connecting: false,

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -183,15 +183,18 @@ describe("FirstRunOnboarding", () => {
   });
 
   it("shows one-click account consent in a popover and its loading state when enabled", () => {
-    const start = vi.fn();
-    mocks.useBuilderConnectFlow.mockReturnValue({
+    const flow = {
       hasFetchedStatus: true,
       configured: false,
       agentNativeProvisioningEnabled: true,
-      connecting: true,
+      connecting: false,
       error: null,
-      start,
+      start: vi.fn(),
+    };
+    flow.start.mockImplementation(() => {
+      flow.connecting = true;
     });
+    mocks.useBuilderConnectFlow.mockReturnValue(flow);
 
     act(() => {
       root.render(
@@ -256,7 +259,7 @@ describe("FirstRunOnboarding", () => {
     expect(
       document.body.querySelector('[role="status"][aria-busy="true"]'),
     ).toBeTruthy();
-    expect(start).toHaveBeenCalledOnce();
+    expect(flow.start).toHaveBeenCalledOnce();
   });
 
   it("uses the existing-account connection flow from the consent popover", () => {
@@ -265,7 +268,7 @@ describe("FirstRunOnboarding", () => {
       hasFetchedStatus: true,
       configured: false,
       agentNativeProvisioningEnabled: true,
-      connecting: true,
+      connecting: false,
       error: null,
       start,
     });

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.spec.tsx
@@ -65,10 +65,12 @@ describe("FirstRunOnboarding", () => {
     mocks.useOnboardingPreviewMode.mockReturnValue(false);
     mocks.useBuilderConnectFlow.mockReturnValue({
       hasFetchedStatus: false,
+      statusResolved: true,
       configured: false,
       agentNativeProvisioningEnabled: false,
       error: null,
       start: vi.fn(),
+      retry: vi.fn(),
     });
     mocks.useMcpServers.mockReturnValue({
       data: { user: [], org: [], orgId: null, role: null },
@@ -307,6 +309,75 @@ describe("FirstRunOnboarding", () => {
     expect(document.body.textContent).toContain(
       "Connecting Builder.io free credits",
     );
+  });
+
+  it("offers login when provisioning finds an existing Builder account", () => {
+    const start = vi.fn();
+    const retry = vi.fn();
+    const flow = {
+      hasFetchedStatus: true,
+      statusResolved: true,
+      configured: false,
+      agentNativeProvisioningEnabled: true,
+      accountExists: false,
+      connecting: false,
+      error: null,
+      retry,
+      start,
+    };
+    mocks.useBuilderConnectFlow.mockReturnValue(flow);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => {
+      [...document.body.querySelectorAll("button")]
+        .find((button) => button.textContent === "Continue")
+        ?.click();
+    });
+    act(() => {
+      document.body
+        .querySelector('[data-testid="first-run-connect-builder"]')
+        ?.click();
+    });
+    act(() => {
+      document.body
+        .querySelector('[data-testid="first-run-builder-create-and-activate"]')
+        ?.click();
+    });
+
+    mocks.useBuilderConnectFlow.mockReturnValue({
+      ...flow,
+      accountExists: true,
+    });
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <FirstRunOnboarding />
+        </TooltipProvider>,
+      );
+    });
+
+    expect(document.body.textContent).toContain(
+      "You already have a Builder.io account",
+    );
+    const logIn = [...document.body.querySelectorAll("button")].find(
+      (button) => button.textContent === "Log in",
+    );
+    expect(logIn).toBeTruthy();
+
+    act(() => logIn?.click());
+
+    expect(start).toHaveBeenLastCalledWith({
+      trackingSource: "first_run_onboarding",
+      trackingFlow: "connect_llm",
+      provisionAccount: false,
+    });
   });
 
   it("shows the searchable integration catalog and keeps onboarding open after connecting", async () => {

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -601,36 +601,28 @@ export function FirstRunOnboarding({
                   </Tooltip>
                 </div>
               </div>
-              {canActivateBuilderFreeCredits ? (
-                <BuilderConnectPopover
-                  flow={connectFlow}
-                  onConnect={(provisionAccount) =>
-                    handleBuilder(provisionAccount)
-                  }
-                  contentTestId="first-run-builder-consent"
-                  primaryTestId="first-run-builder-create-and-activate"
-                  secondaryTestId="first-run-builder-existing-account"
-                >
-                  <button
-                    type="button"
-                    data-testid="first-run-connect-builder"
-                    className={cn(primaryButtonClass, "mt-5 w-full")}
-                  >
-                    {t("agentChat.onboarding.builderActivateCredits")}
-                    <IconArrowRight size={15} />
-                  </button>
-                </BuilderConnectPopover>
-              ) : (
+              <BuilderConnectPopover
+                flow={connectFlow}
+                onConnect={(provisionAccount) =>
+                  handleBuilder(provisionAccount)
+                }
+                contentTestId="first-run-builder-consent"
+                primaryTestId="first-run-builder-create-and-activate"
+                secondaryTestId="first-run-builder-existing-account"
+              >
                 <button
                   type="button"
                   data-testid="first-run-connect-builder"
                   className={cn(primaryButtonClass, "mt-5 w-full")}
-                  onClick={() => handleBuilder()}
                 >
-                  {t("agentChat.onboarding.builderConnectCredits")}
+                  {t(
+                    canActivateBuilderFreeCredits
+                      ? "agentChat.onboarding.builderActivateCredits"
+                      : "agentChat.onboarding.builderConnectCredits",
+                  )}
                   <IconArrowRight size={15} />
                 </button>
-              )}
+              </BuilderConnectPopover>
             </section>
 
             <div
@@ -963,7 +955,9 @@ export function FirstRunOnboarding({
   }
 
   if (screen === "connecting") {
-    const provisioning = builderConnectionMode === "provision";
+    const accountExists = connectFlow.accountExists;
+    const provisioning =
+      builderConnectionMode === "provision" && !accountExists;
     return (
       <OnboardingShell profile={profile} screen="choice">
         <div
@@ -973,41 +967,65 @@ export function FirstRunOnboarding({
           aria-busy={connectFlow.connecting}
         >
           <div className="flex size-10 items-center justify-center rounded-full bg-primary/10 text-primary">
-            <IconLoader2 className="animate-spin" size={19} />
+            {accountExists ? (
+              <IconKey size={19} />
+            ) : (
+              <IconLoader2 className="animate-spin" size={19} />
+            )}
           </div>
           <h1 className="mt-5 text-xl font-semibold tracking-[-0.04em]">
-            {provisioning
-              ? t("agentChat.onboarding.builderActivating")
-              : t("agentChat.onboarding.builderConnecting")}
+            {accountExists
+              ? t("agentChat.onboarding.builderAccountExistsTitle")
+              : provisioning
+                ? t("agentChat.onboarding.builderActivating")
+                : t("agentChat.onboarding.builderConnecting")}
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">
-            {provisioning
-              ? t("agentChat.onboarding.builderProvisioningDescription")
-              : t("agentChat.onboarding.builderConnectionDescription")}
+            {accountExists
+              ? t("agentChat.onboarding.builderAccountExistsDescription")
+              : provisioning
+                ? t("agentChat.onboarding.builderProvisioningDescription")
+                : t("agentChat.onboarding.builderConnectionDescription")}
           </p>
-          <div className="mt-7 w-full rounded-xl bg-muted/35 p-4 text-left">
-            <div className="flex items-center justify-between gap-3">
-              <Skeleton className="h-3 w-28" />
-              <Skeleton className="h-5 w-16 rounded-full" />
-            </div>
-            <Skeleton className="mt-4 h-8 w-full" />
-            <div className="mt-3 grid grid-cols-3 gap-2">
-              <Skeleton className="h-7 w-full" />
-              <Skeleton className="h-7 w-full" />
-              <Skeleton className="h-7 w-full" />
-            </div>
-          </div>
-          {connectFlow.error && (
-            <div className="mt-4 flex flex-col items-center gap-2">
-              <p className="text-xs text-destructive">{connectFlow.error}</p>
-              <button
-                type="button"
-                className={secondaryButtonClass}
-                onClick={() => setScreen("choice")}
-              >
-                Try again
-              </button>
-            </div>
+          {accountExists ? (
+            <button
+              type="button"
+              className={cn(primaryButtonClass, "mt-7 w-full")}
+              onClick={() => handleBuilder(false)}
+              disabled={connectFlow.connecting}
+            >
+              {t("agentChat.auth.logIn")}
+              <IconArrowRight size={15} />
+            </button>
+          ) : (
+            <>
+              <div className="mt-7 w-full rounded-xl bg-muted/35 p-4 text-left">
+                <div className="flex items-center justify-between gap-3">
+                  <Skeleton className="h-3 w-28" />
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </div>
+                <Skeleton className="mt-4 h-8 w-full" />
+                <div className="mt-3 grid grid-cols-3 gap-2">
+                  <Skeleton className="h-7 w-full" />
+                  <Skeleton className="h-7 w-full" />
+                  <Skeleton className="h-7 w-full" />
+                </div>
+              </div>
+              {connectFlow.error && (
+                <div className="mt-4 flex flex-col items-center gap-2">
+                  <p className="text-xs text-destructive">
+                    {connectFlow.error}
+                  </p>
+                  <button
+                    type="button"
+                    className={secondaryButtonClass}
+                    onClick={() => setScreen("choice")}
+                  >
+                    Try again
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </OnboardingShell>

--- a/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
+++ b/packages/core/src/client/onboarding/FirstRunOnboarding.tsx
@@ -24,11 +24,6 @@ import type {
 import { docsUrl } from "../../shared/docs-url.js";
 import { appPath } from "../api-path.js";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../components/ui/popover.js";
-import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -50,6 +45,7 @@ import {
   useCreateMcpServer,
   useMcpServers,
 } from "../resources/use-mcp-servers.js";
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
 import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
 import { cn } from "../utils.js";
 import { shouldSkipFirstRunIntegrations } from "./first-run-enabled.js";
@@ -152,7 +148,6 @@ export function FirstRunOnboarding({
     string | null
   >(null);
   const [connectError, setConnectError] = useState<string | null>(null);
-  const [builderActivationOpen, setBuilderActivationOpen] = useState(false);
   const [builderConnectionMode, setBuilderConnectionMode] = useState<
     "existing" | "provision"
   >("existing");
@@ -607,85 +602,24 @@ export function FirstRunOnboarding({
                 </div>
               </div>
               {canActivateBuilderFreeCredits ? (
-                <Popover
-                  open={builderActivationOpen}
-                  onOpenChange={setBuilderActivationOpen}
+                <BuilderConnectPopover
+                  flow={connectFlow}
+                  onConnect={(provisionAccount) =>
+                    handleBuilder(provisionAccount)
+                  }
+                  contentTestId="first-run-builder-consent"
+                  primaryTestId="first-run-builder-create-and-activate"
+                  secondaryTestId="first-run-builder-existing-account"
                 >
-                  <PopoverTrigger asChild>
-                    <button
-                      type="button"
-                      data-testid="first-run-connect-builder"
-                      className={cn(primaryButtonClass, "mt-5 w-full")}
-                    >
-                      {t("agentChat.onboarding.builderActivateCredits")}
-                      <IconArrowRight size={15} />
-                    </button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    align="end"
-                    side="bottom"
-                    sideOffset={-40}
-                    aria-labelledby="first-run-builder-consent-title"
-                    data-testid="first-run-builder-consent"
-                    className="w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] p-3 text-left"
+                  <button
+                    type="button"
+                    data-testid="first-run-connect-builder"
+                    className={cn(primaryButtonClass, "mt-5 w-full")}
                   >
-                    <div className="space-y-2.5">
-                      <h2
-                        id="first-run-builder-consent-title"
-                        className="text-sm font-semibold text-foreground"
-                      >
-                        {t("agentChat.onboarding.builderActivateTitle")}
-                      </h2>
-                      <p className="text-xs leading-5 text-muted-foreground">
-                        {t("agentChat.onboarding.builderActivationDescription")}
-                      </p>
-                      <button
-                        type="button"
-                        data-testid="first-run-builder-create-and-activate"
-                        className={cn(primaryButtonClass, "w-full")}
-                        onClick={() => {
-                          setBuilderActivationOpen(false);
-                          handleBuilder();
-                        }}
-                      >
-                        {t("agentChat.onboarding.builderCreateAndActivate")}
-                        <IconArrowRight size={15} />
-                      </button>
-                      <p className="text-[11px] leading-4 text-muted-foreground">
-                        {t("agentChat.onboarding.builderConsentPrefix")}{" "}
-                        <a
-                          href="https://www.builder.io/legal/terms"
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          {t("agentChat.onboarding.builderTerms")}
-                        </a>{" "}
-                        {t("agentChat.onboarding.builderConsentAnd")}{" "}
-                        <a
-                          href="https://www.builder.io/legal/privacy"
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        >
-                          {t("agentChat.onboarding.builderPrivacy")}
-                        </a>
-                        .
-                      </p>
-                      <button
-                        type="button"
-                        data-testid="first-run-builder-existing-account"
-                        className="inline-flex min-h-9 w-full items-center justify-center rounded-lg px-4 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
-                        onClick={() => {
-                          setBuilderActivationOpen(false);
-                          handleBuilder(false);
-                        }}
-                      >
-                        {t("agentChat.onboarding.builderExistingAccount")}
-                      </button>
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                    {t("agentChat.onboarding.builderActivateCredits")}
+                    <IconArrowRight size={15} />
+                  </button>
+                </BuilderConnectPopover>
               ) : (
                 <button
                   type="button"

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -28,7 +28,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
-import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
+import {
+  BuilderConnectPopover,
+  useBuilderConnectFlow,
+} from "../settings/index.js";
 import { useDevMode } from "../use-dev-mode.js";
 import { trackOnboardingEvent, useOnboarding } from "./use-onboarding.js";
 import { useOnboardingPreviewMode } from "./use-preview-mode.js";
@@ -695,32 +698,35 @@ function BuilderCliAuthMethod({
   onCompleted: () => Promise<void>;
   primary?: boolean;
 }) {
-  const { connecting, error, start } = useBuilderConnectFlow({
+  const connectFlow = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource: "onboarding_builder_cli_auth",
     onConnected: onCompleted,
   });
+  const { connecting, error } = connectFlow;
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => start()}
-        disabled={connecting}
-        style={{ ...buttonPrimary(primary), opacity: connecting ? 0.7 : 1 }}
-      >
-        {connecting ? (
-          <>
-            <IconLoader2
-              size={12}
-              style={{ marginInlineEnd: 4 }}
-              className="animate-spin"
-            />
-            Waiting for Builder...
-          </>
-        ) : (
-          "Connect Builder"
-        )}
-      </button>
+      <BuilderConnectPopover flow={connectFlow}>
+        <button
+          type="button"
+          disabled={connecting}
+          style={{ ...buttonPrimary(primary), opacity: connecting ? 0.7 : 1 }}
+        >
+          {connecting ? (
+            <>
+              <IconLoader2
+                size={12}
+                style={{ marginInlineEnd: 4 }}
+                className="animate-spin"
+              />
+              Waiting for Builder...
+            </>
+          ) : (
+            "Connect Builder"
+          )}
+        </button>
+      </BuilderConnectPopover>
       {connecting && (
         <p style={styles.methodHint}>
           A Builder tab opened. Choose your team or app space there; setup will

--- a/packages/core/src/client/settings/BuilderConnectPopover.tsx
+++ b/packages/core/src/client/settings/BuilderConnectPopover.tsx
@@ -19,6 +19,8 @@ export interface BuilderConnectPopoverProps {
   flow: Pick<BuilderConnectFlow, "connecting" | "start"> & {
     agentNativeProvisioningEnabled?: boolean;
     accountExists?: boolean;
+    /** Retry the status request without bypassing provisioning consent. */
+    retry?: () => void;
     statusResolved?: boolean;
   };
   children: BuilderConnectTrigger;
@@ -71,6 +73,7 @@ export function BuilderConnectPopover({
       if (!capabilityResolved) {
         event.preventDefault();
         event.stopPropagation();
+        flow.retry?.();
         return;
       }
       children.props.onClick?.(event);

--- a/packages/core/src/client/settings/BuilderConnectPopover.tsx
+++ b/packages/core/src/client/settings/BuilderConnectPopover.tsx
@@ -104,7 +104,7 @@ export function BuilderConnectPopover({
               <IconLoader2 size={14} className="animate-spin" />
             ) : null}
             {accountExists
-              ? t("auth.logIn")
+              ? t("agentChat.auth.logIn")
               : flow.connecting
                 ? t("agentChat.onboarding.builderActivating")
                 : t("agentChat.onboarding.builderCreateAndActivate")}

--- a/packages/core/src/client/settings/BuilderConnectPopover.tsx
+++ b/packages/core/src/client/settings/BuilderConnectPopover.tsx
@@ -1,0 +1,153 @@
+import { IconArrowRight, IconLoader2 } from "@tabler/icons-react";
+import React, { useEffect, useState } from "react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
+import { useT } from "../i18n.js";
+import { cn } from "../utils.js";
+import type { BuilderConnectFlow } from "./useBuilderStatus.js";
+
+type BuilderConnectTrigger = React.ReactElement<{
+  onClick?: React.MouseEventHandler<HTMLElement>;
+}>;
+
+export interface BuilderConnectPopoverProps {
+  flow: Pick<BuilderConnectFlow, "connecting" | "start"> & {
+    agentNativeProvisioningEnabled?: boolean;
+    accountExists?: boolean;
+  };
+  children: BuilderConnectTrigger;
+  /** Preserve a surface-specific tracking source or callback when choosing a path. */
+  onConnect?: (provisionAccount: boolean) => void;
+  /** Preserve parent-row click behavior for compact setup controls. */
+  onTriggerClick?: React.MouseEventHandler<HTMLElement>;
+  contentTestId?: string;
+  primaryTestId?: string;
+  secondaryTestId?: string;
+}
+
+export function BuilderConnectPopover({
+  flow,
+  children,
+  onConnect,
+  onTriggerClick,
+  contentTestId,
+  primaryTestId,
+  secondaryTestId,
+}: BuilderConnectPopoverProps) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const showPopover = flow.agentNativeProvisioningEnabled;
+  const accountExists = showPopover && flow.accountExists;
+
+  useEffect(() => {
+    if (accountExists) setOpen(true);
+  }, [accountExists]);
+
+  const start = (provisionAccount: boolean) => {
+    setOpen(false);
+    if (onConnect) {
+      onConnect(provisionAccount);
+      return;
+    }
+    flow.start({ provisionAccount });
+  };
+
+  const trigger = React.cloneElement(children, {
+    onClick: (event) => {
+      children.props.onClick?.(event);
+      onTriggerClick?.(event);
+      if (!showPopover && !event.defaultPrevented) start(false);
+    },
+  });
+
+  if (!showPopover) return trigger;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        sideOffset={-40}
+        aria-labelledby="builder-connect-popover-title"
+        data-testid={contentTestId}
+        className="z-50 w-80 max-w-[calc(100vw-2rem)] p-3 text-left"
+      >
+        <div className="space-y-2.5">
+          <h2
+            id="builder-connect-popover-title"
+            className="text-sm font-semibold text-foreground"
+          >
+            {accountExists
+              ? t("agentChat.onboarding.builderAccountExistsTitle")
+              : t("agentChat.onboarding.builderActivateTitle")}
+          </h2>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {accountExists
+              ? t("agentChat.onboarding.builderAccountExistsDescription")
+              : t("agentChat.onboarding.builderActivationDescription")}
+          </p>
+          <button
+            type="button"
+            data-testid={primaryTestId}
+            className={cn(
+              "inline-flex min-h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-foreground px-4 text-xs font-medium text-background transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-60",
+            )}
+            onClick={() => start(accountExists ? false : true)}
+            disabled={flow.connecting}
+          >
+            {flow.connecting ? (
+              <IconLoader2 size={14} className="animate-spin" />
+            ) : null}
+            {accountExists
+              ? t("auth.logIn")
+              : flow.connecting
+                ? t("agentChat.onboarding.builderActivating")
+                : t("agentChat.onboarding.builderCreateAndActivate")}
+            {!accountExists && !flow.connecting ? (
+              <IconArrowRight size={15} />
+            ) : null}
+          </button>
+          {!accountExists && (
+            <>
+              <p className="text-[11px] leading-4 text-muted-foreground">
+                {t("agentChat.onboarding.builderConsentPrefix")}{" "}
+                <a
+                  href="https://www.builder.io/legal/terms"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {t("agentChat.onboarding.builderTerms")}
+                </a>{" "}
+                {t("agentChat.onboarding.builderConsentAnd")}{" "}
+                <a
+                  href="https://www.builder.io/legal/privacy"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {t("agentChat.onboarding.builderPrivacy")}
+                </a>
+                .
+              </p>
+              <button
+                type="button"
+                data-testid={secondaryTestId}
+                className="inline-flex min-h-9 w-full items-center justify-center rounded-lg px-4 text-xs font-normal text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-60"
+                onClick={() => start(false)}
+                disabled={flow.connecting}
+              >
+                {t("agentChat.onboarding.builderExistingAccount")}
+              </button>
+            </>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/core/src/client/settings/BuilderConnectPopover.tsx
+++ b/packages/core/src/client/settings/BuilderConnectPopover.tsx
@@ -1,5 +1,5 @@
 import { IconArrowRight, IconLoader2 } from "@tabler/icons-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import {
   Popover,
@@ -12,12 +12,14 @@ import type { BuilderConnectFlow } from "./useBuilderStatus.js";
 
 type BuilderConnectTrigger = React.ReactElement<{
   onClick?: React.MouseEventHandler<HTMLElement>;
+  "aria-disabled"?: boolean;
 }>;
 
 export interface BuilderConnectPopoverProps {
   flow: Pick<BuilderConnectFlow, "connecting" | "start"> & {
     agentNativeProvisioningEnabled?: boolean;
     accountExists?: boolean;
+    statusResolved?: boolean;
   };
   children: BuilderConnectTrigger;
   /** Preserve a surface-specific tracking source or callback when choosing a path. */
@@ -40,14 +42,21 @@ export function BuilderConnectPopover({
 }: BuilderConnectPopoverProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  const showPopover = flow.agentNativeProvisioningEnabled;
+  const capabilityResolved = flow.statusResolved === true;
+  const showPopover =
+    capabilityResolved && flow.agentNativeProvisioningEnabled === true;
   const accountExists = showPopover && flow.accountExists;
+  const initiatedByThisTriggerRef = useRef(false);
 
   useEffect(() => {
-    if (accountExists) setOpen(true);
+    if (accountExists && initiatedByThisTriggerRef.current) {
+      initiatedByThisTriggerRef.current = false;
+      setOpen(true);
+    }
   }, [accountExists]);
 
   const start = (provisionAccount: boolean) => {
+    initiatedByThisTriggerRef.current = true;
     setOpen(false);
     if (onConnect) {
       onConnect(provisionAccount);
@@ -57,7 +66,13 @@ export function BuilderConnectPopover({
   };
 
   const trigger = React.cloneElement(children, {
+    "aria-disabled": capabilityResolved ? undefined : true,
     onClick: (event) => {
+      if (!capabilityResolved) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       children.props.onClick?.(event);
       onTriggerClick?.(event);
       if (!showPopover && !event.defaultPrevented) start(false);

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -100,6 +100,7 @@ import {
 } from "./agent-settings-search.js";
 import { AgentsSection } from "./AgentsSection.js";
 import { AutomationsSection } from "./AutomationsSection.js";
+import { BuilderConnectPopover } from "./BuilderConnectPopover.js";
 import { DemoModeSection } from "./DemoModeSection.js";
 import { ExtensionsSettingsContent } from "./ExtensionsSettingsContent.js";
 import { FileStorageSettingsForm } from "./FileStorageSettingsForm.js";
@@ -518,22 +519,33 @@ function UseBuilderCard({
         {connectUrl || credentialSource !== "env" ? (
           <div className="flex items-center gap-2 mt-2.5">
             {connectUrl && (
-              <Button
-                type="button"
-                intent="neutral"
-                emphasis="ghost"
-                onClick={() =>
-                  builderFlow.start({ trackingSource, trackingFlow })
+              <BuilderConnectPopover
+                flow={builderFlow}
+                onConnect={(provisionAccount) =>
+                  builderFlow.start({
+                    trackingSource,
+                    trackingFlow,
+                    provisionAccount,
+                  })
                 }
-                disabled={builderFlow.connecting}
-                className={cn(pillButtonClass(isPage, "ghost"), "no-underline")}
               >
-                {builderFlow.connecting
-                  ? "Connecting..."
-                  : credentialSource === "env"
-                    ? "Connect account"
-                    : "Reconnect"}
-              </Button>
+                <Button
+                  type="button"
+                  intent="neutral"
+                  emphasis="ghost"
+                  disabled={builderFlow.connecting}
+                  className={cn(
+                    pillButtonClass(isPage, "ghost"),
+                    "no-underline",
+                  )}
+                >
+                  {builderFlow.connecting
+                    ? "Connecting..."
+                    : credentialSource === "env"
+                      ? "Connect account"
+                      : "Reconnect"}
+                </Button>
+              </BuilderConnectPopover>
             )}
             {credentialSource !== "env" ? <DisconnectBuilderButton /> : null}
           </div>
@@ -544,19 +556,29 @@ function UseBuilderCard({
 
   if (compact) {
     return (
-      <Button
-        type="button"
-        intent="primary"
-        emphasis="solid"
-        onClick={() => builderFlow.start({ trackingSource, trackingFlow })}
-        disabled={builderFlow.connecting}
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+      <BuilderConnectPopover
+        flow={builderFlow}
+        onConnect={(provisionAccount) =>
+          builderFlow.start({
+            trackingSource,
+            trackingFlow,
+            provisionAccount,
+          })
+        }
       >
-        {builderFlow.connecting ? "Connecting…" : "Connect Builder.io"}
-        {builderFlow.connecting ? (
-          <IconLoader2 size={14} className="animate-spin" />
-        ) : null}
-      </Button>
+        <Button
+          type="button"
+          intent="primary"
+          emphasis="solid"
+          disabled={builderFlow.connecting}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-70"
+        >
+          {builderFlow.connecting ? "Connecting…" : "Connect Builder.io"}
+          {builderFlow.connecting ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : null}
+        </Button>
+      </BuilderConnectPopover>
     );
   }
 
@@ -609,22 +631,32 @@ function UseBuilderCard({
           )}
         </div>
       </div>
-      <Button
-        type="button"
-        intent="neutral"
-        emphasis="outline"
-        onClick={() => builderFlow.start({ trackingSource, trackingFlow })}
-        disabled={builderFlow.connecting}
-        className={cn(
-          "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-medium text-foreground hover:bg-accent/40 disabled:cursor-wait disabled:opacity-70",
-          isPage ? "text-sm" : "text-[11px]",
-        )}
+      <BuilderConnectPopover
+        flow={builderFlow}
+        onConnect={(provisionAccount) =>
+          builderFlow.start({
+            trackingSource,
+            trackingFlow,
+            provisionAccount,
+          })
+        }
       >
-        {builderFlow.connecting ? "Connecting…" : "Connect Builder.io"}
-        {builderFlow.connecting ? (
-          <IconLoader2 size={isPage ? 14 : 12} className="animate-spin" />
-        ) : null}
-      </Button>
+        <Button
+          type="button"
+          intent="neutral"
+          emphasis="outline"
+          disabled={builderFlow.connecting}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-medium text-foreground hover:bg-accent/40 disabled:cursor-wait disabled:opacity-70",
+            isPage ? "text-sm" : "text-[11px]",
+          )}
+        >
+          {builderFlow.connecting ? "Connecting…" : "Connect Builder.io"}
+          {builderFlow.connecting ? (
+            <IconLoader2 size={isPage ? 14 : 12} className="animate-spin" />
+          ) : null}
+        </Button>
+      </BuilderConnectPopover>
     </div>
   );
 }
@@ -3051,6 +3083,7 @@ function SettingsPanelContent({
   const builderFlow = useBuilderConnectFlow({
     enabled: !builderConnectionOwnedExternally,
     popupUrl: connectUrl,
+    provisionAccount: true,
     trackingSource: "settings_panel_builder_card",
   });
 

--- a/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
+++ b/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
@@ -342,7 +342,7 @@ export function VoiceTranscriptionSection({
       if (!googleRealtimeConfigured) {
         focusKey("GOOGLE_APPLICATION_CREDENTIALS");
       } else if (!builderRealtimeReady) {
-        builderConnect.start();
+        builderConnect.start({ provisionAccount: false });
       }
       return;
     }

--- a/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
+++ b/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
@@ -23,12 +23,10 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import { buildSettingsRoute } from "../../navigation/index.js";
 import { agentNativePath } from "../api-path.js";
+import { BuilderConnectPopover } from "./BuilderConnectPopover.js";
 import { SettingsRow } from "./SettingsRow.js";
 import { SettingsSkeleton } from "./SettingsSkeleton.js";
-import {
-  openBuilderConnectPopup,
-  useBuilderStatus,
-} from "./useBuilderStatus.js";
+import { useBuilderConnectFlow, useBuilderStatus } from "./useBuilderStatus.js";
 
 type TranscriptionMode = "mac-native" | "google-realtime" | "batch";
 
@@ -141,7 +139,17 @@ export function VoiceTranscriptionSection({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [cleanupEnabled, setCleanupEnabled] = useState<boolean | null>(null);
-  const { status: builderStatus } = useBuilderStatus();
+  const { status: builderStatus, refetch: refetchBuilderStatus } =
+    useBuilderStatus();
+  const builderConnect = useBuilderConnectFlow({
+    popupUrl: builderStatus?.connectUrl,
+    provisionAccount: true,
+    trackingSource: "voice_transcription_settings",
+    trackingFlow: "voice_transcription",
+    onConnected: () => {
+      void refetchBuilderStatus();
+    },
+  });
   const builderRealtimeReady =
     !!builderStatus?.privateKeyConfigured &&
     !!builderStatus?.publicKeyConfigured;
@@ -334,7 +342,7 @@ export function VoiceTranscriptionSection({
       if (!googleRealtimeConfigured) {
         focusKey("GOOGLE_APPLICATION_CREDENTIALS");
       } else if (!builderRealtimeReady) {
-        openBuilderConnect();
+        builderConnect.start();
       }
       return;
     }
@@ -343,14 +351,6 @@ export function VoiceTranscriptionSection({
     setTranscriptionMode(next);
     setProvider(nextProvider);
     void persist(next, nextProvider, instructions, previous);
-  };
-
-  const openBuilderConnect = () => {
-    openBuilderConnectPopup({
-      url: builderStatus?.connectUrl,
-      source: "voice_transcription_settings",
-      features: "noopener,noreferrer,width=600,height=700",
-    });
   };
 
   const chooseBatchProvider = (next: Provider) => {
@@ -461,16 +461,17 @@ export function VoiceTranscriptionSection({
                   Ready
                 </span>
               ) : googleRealtimeConfigured ? (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openBuilderConnect();
-                  }}
-                  className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+                <BuilderConnectPopover
+                  flow={builderConnect}
+                  onTriggerClick={(event) => event.stopPropagation()}
                 >
-                  Connect Builder.io
-                </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+                  >
+                    Connect Builder.io
+                  </button>
+                </BuilderConnectPopover>
               ) : (
                 <button
                   type="button"
@@ -568,16 +569,17 @@ export function VoiceTranscriptionSection({
                     Ready
                   </span>
                 ) : googleRealtimeConfigured ? (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openBuilderConnect();
-                    }}
-                    className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent/40"
+                  <BuilderConnectPopover
+                    flow={builderConnect}
+                    onTriggerClick={(event) => event.stopPropagation()}
                   >
-                    Connect Builder.io
-                  </button>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent/40"
+                    >
+                      Connect Builder.io
+                    </button>
+                  </BuilderConnectPopover>
                 ) : (
                   <button
                     type="button"
@@ -622,16 +624,17 @@ export function VoiceTranscriptionSection({
                     Connected
                   </span>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openBuilderConnect();
-                    }}
-                    className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent/40"
+                  <BuilderConnectPopover
+                    flow={builderConnect}
+                    onTriggerClick={(event) => event.stopPropagation()}
                   >
-                    Connect Builder.io
-                  </button>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent/40"
+                    >
+                      Connect Builder.io
+                    </button>
+                  </BuilderConnectPopover>
                 )
               }
             />

--- a/packages/core/src/client/settings/index.ts
+++ b/packages/core/src/client/settings/index.ts
@@ -35,6 +35,10 @@ export {
   type BuilderStatus,
   type OpenBuilderConnectPopupOptions,
 } from "./useBuilderStatus.js";
+export {
+  BuilderConnectPopover,
+  type BuilderConnectPopoverProps,
+} from "./BuilderConnectPopover.js";
 export { SecretsSection, type SecretsSectionProps } from "./SecretsSection.js";
 export {
   SettingsGroup,

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { openMcpAppHostLink } from "../mcp-app-host.js";
+import { BuilderConnectPopover } from "./BuilderConnectPopover.js";
 import {
   useBuilderStatus,
   useBuilderConnectFlow,
@@ -75,6 +76,15 @@ function BuilderConnectProbe({
   );
 }
 
+function BuilderConnectPopoverProbe() {
+  const flow = useBuilderConnectFlow();
+  return (
+    <BuilderConnectPopover flow={flow}>
+      <button type="button">Connect</button>
+    </BuilderConnectPopover>
+  );
+}
+
 function BuilderStatusProbe() {
   const { status, loading, stale, error } = useBuilderStatus();
   return (
@@ -111,6 +121,14 @@ const refreshedConnectUrl = signedConnectUrl.replace(
   "_an_connect=refreshed",
 );
 const provisioningToken = "nonce.email.session.1700000000000.mac";
+
+function popupAttemptId(popup: Window): string {
+  const attemptId = new URL(popup.location.href).searchParams.get(
+    "_an_connect_attempt",
+  );
+  if (!attemptId) throw new Error("Builder connect attempt ID was not set");
+  return attemptId;
+}
 
 const connectedBuilderStatus = {
   configured: true,
@@ -569,6 +587,65 @@ describe("useBuilderConnectFlow", () => {
     expect(container.textContent).toContain("not-configured idle resolved");
   });
 
+  it("retries status from a connect trigger without bypassing consent", async () => {
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new Error("status unavailable"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          configured: false,
+          agentNativeProvisioningEnabled: true,
+          agentNativeProvisioningToken: provisioningToken,
+          envManaged: false,
+          builderEnabled: true,
+          orgName: null,
+          connectUrl: signedConnectUrl,
+        }),
+      );
+
+    await act(async () => {
+      root.render(<BuilderConnectPopoverProbe />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(
+      container.querySelector("[data-radix-popper-content-wrapper]"),
+    ).toBeNull();
+  });
+
+  it("keeps surface callbacks on the legacy connection path", async () => {
+    const flow = {
+      connecting: false,
+      statusResolved: true,
+      agentNativeProvisioningEnabled: false,
+      retry: vi.fn(),
+      start: vi.fn(),
+    };
+    const onConnect = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <BuilderConnectPopover flow={flow} onConnect={onConnect}>
+          <button type="button">Connect</button>
+        </BuilderConnectPopover>,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    expect(onConnect).toHaveBeenCalledWith(false);
+    expect(flow.start).not.toHaveBeenCalled();
+  });
+
   it("refreshes an un-timestamped signed prop URL before navigating web popups", async () => {
     setUserAgent("Mozilla/5.0 Chrome/140.0");
     const popup = createPopupStub();
@@ -659,7 +736,23 @@ describe("useBuilderConnectFlow", () => {
 
   it("refreshes status when a Builder preview callback posts success", async () => {
     setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
     vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          configured: false,
+          envManaged: false,
+          builderEnabled: true,
+          orgName: null,
+          connectUrl:
+            "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed",
+          appHost: "https://builder.io",
+          apiHost: "https://api.builder.io",
+          publicKeyConfigured: false,
+          privateKeyConfigured: false,
+        }),
+      )
       .mockResolvedValueOnce(
         jsonResponse({
           configured: false,
@@ -697,11 +790,18 @@ describe("useBuilderConnectFlow", () => {
     expect(container.textContent).toContain("not-configured");
 
     await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const attemptId = popupAttemptId(popup);
+    await act(async () => {
       window.dispatchEvent(
         new MessageEvent("message", {
           origin:
             "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
-          data: { type: "builder-connect-success" },
+          data: { type: "builder-connect-success", attemptId },
         }),
       );
       await Promise.resolve();
@@ -709,6 +809,42 @@ describe("useBuilderConnectFlow", () => {
     });
 
     expect(container.textContent).toContain("configured");
+  });
+
+  it("ignores a success message from another connect attempt", async () => {
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse({ configured: false }))
+      .mockResolvedValueOnce(jsonResponse({ configured: false }));
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: "https://agent-workspace.builder.io",
+          data: {
+            type: "builder-connect-success",
+            attemptId: "stale-attempt",
+          },
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("not-configured connecting");
   });
 
   it("keeps polling when callback confirmation status is unknown", async () => {
@@ -734,10 +870,11 @@ describe("useBuilderConnectFlow", () => {
     });
 
     await act(async () => {
+      const attemptId = popupAttemptId(popup);
       window.dispatchEvent(
         new MessageEvent("message", {
           origin: "https://agent-workspace.builder.io",
-          data: { type: "builder-connect-success" },
+          data: { type: "builder-connect-success", attemptId },
         }),
       );
       await vi.advanceTimersByTimeAsync(5000);
@@ -773,9 +910,10 @@ describe("useBuilderConnectFlow", () => {
     });
 
     await act(async () => {
+      const attemptId = popupAttemptId(popup);
       const message = new MessageEvent("message", {
         origin: "https://agent-workspace.builder.io",
-        data: { type: "builder-connect-success" },
+        data: { type: "builder-connect-success", attemptId },
       });
       window.dispatchEvent(message);
       window.dispatchEvent(message);
@@ -823,10 +961,11 @@ describe("useBuilderConnectFlow", () => {
     expect(container.textContent).toContain("not-configured connecting");
 
     await act(async () => {
+      const attemptId = popupAttemptId(popup);
       window.dispatchEvent(
         new MessageEvent("message", {
           origin: "https://agent-workspace.builder.io",
-          data: { type: "builder-connect-success" },
+          data: { type: "builder-connect-success", attemptId },
         }),
       );
       await vi.advanceTimersByTimeAsync(5000);

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -283,7 +283,9 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
     expect(container.textContent).not.toContain("Popup blocked");
   });
 
@@ -388,7 +390,9 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
   });
 
   it("allows an existing-account click to bypass provisioning mode", async () => {
@@ -421,7 +425,9 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
   });
 
   it("surfaces a provisioning account collision as an existing-account state", async () => {
@@ -491,7 +497,9 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
     expect(container.textContent).not.toContain(
       "Couldn't start Builder connect",
     );
@@ -602,7 +610,9 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe(expectedConnectUrl(refreshedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(refreshedConnectUrl),
+    );
 
     resolveInitialFetch(jsonResponse({ configured: false }));
   });
@@ -637,7 +647,9 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
     expect(container.textContent).not.toContain(
       "Couldn't start Builder connect",
     );
@@ -887,11 +899,17 @@ describe("useBuilderConnectFlow", () => {
       container.querySelector("button")?.click();
     });
 
-    expect(openSpy).toHaveBeenCalledWith(
+    const openedUrl = String(openSpy.mock.calls[0]?.[0]);
+    expect(withoutConnectAttempt(openedUrl)).toBe(
       expectedConnectUrl(signedConnectUrl),
+    );
+    expect(new URL(openedUrl).searchParams.get("_an_connect_attempt")).toMatch(
+      /^[0-9a-f-]{36}$/,
+    );
+    expect(openSpy.mock.calls[0]?.slice(1)).toEqual([
       "_blank",
       "noopener,noreferrer",
-    );
+    ]);
     expect(window.location.href).toBe("http://localhost:3000/settings");
     expect(container.textContent).not.toContain("Popup blocked");
   });
@@ -948,8 +966,12 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(openMcpAppHostLink).toHaveBeenCalledWith(
+    const hostUrl = String(vi.mocked(openMcpAppHostLink).mock.calls[0]?.[0]);
+    expect(withoutConnectAttempt(hostUrl)).toBe(
       expectedConnectUrl(refreshedConnectUrl),
+    );
+    expect(new URL(hostUrl).searchParams.get("_an_connect_attempt")).toMatch(
+      /^[0-9a-f-]{36}$/,
     );
     expect(container.textContent).toContain("not-configured connecting");
     expect(container.textContent).not.toContain("Allow popups");
@@ -1001,7 +1023,9 @@ describe("useBuilderConnectFlow", () => {
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
+      expectedConnectUrl(signedConnectUrl),
+    );
     expect(container.textContent).toContain("not-configured connecting");
     expect(container.textContent).not.toContain(
       "Private key does not match spaceId",

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -67,7 +67,8 @@ function BuilderConnectProbe({
       <output data-testid="status">
         {flow.configured ? "configured" : "not-configured"}{" "}
         {flow.connecting ? "connecting" : "idle"}{" "}
-        {flow.statusResolved ? "resolved" : "unresolved"}
+        {flow.statusResolved ? "resolved" : "unresolved"}{" "}
+        {flow.accountExists ? "account-exists" : "no-account-exists"}
       </output>
       <output>{flow.error ?? ""}</output>
     </div>
@@ -409,6 +410,34 @@ describe("useBuilderConnectFlow", () => {
     });
 
     expect(popup.location.href).toBe(expectedConnectUrl(signedConnectUrl));
+  });
+
+  it("surfaces a provisioning account collision as an existing-account state", async () => {
+    vi.mocked(fetch).mockImplementation(async () =>
+      jsonResponse({
+        configured: false,
+        agentNativeProvisioningEnabled: true,
+        agentNativeProvisioningToken: provisioningToken,
+        envManaged: false,
+        builderEnabled: true,
+        orgName: null,
+        connectUrl: signedConnectUrl,
+        connectError: {
+          message:
+            "A Builder account already exists for this email. Log in to connect it.",
+          code: "account_exists",
+          at: Date.now(),
+        },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe provisionAccount />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("account-exists");
   });
 
   it("falls back to the cached signed URL when the click-time status refresh fails", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -139,6 +139,12 @@ function expectedProvisionedConnectUrl(url: string): string {
   return expectedConnectUrl(parsed.toString());
 }
 
+function withoutConnectAttempt(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.delete("_an_connect_attempt");
+  return parsed.toString();
+}
+
 describe("useBuilderStatus", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -309,9 +315,12 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
-    expect(popup.location.href).toBe(
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
       expectedProvisionedConnectUrl(signedConnectUrl),
     );
+    expect(
+      new URL(popup.location.href).searchParams.get("_an_connect_attempt"),
+    ).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it("uses the click-time provisioning capability instead of a stale closure", async () => {
@@ -354,9 +363,12 @@ describe("useBuilderConnectFlow", () => {
       await Promise.resolve();
     });
 
-    expect(popup.location.href).toBe(
+    expect(withoutConnectAttempt(popup.location.href)).toBe(
       expectedProvisionedConnectUrl(signedConnectUrl),
     );
+    expect(
+      new URL(popup.location.href).searchParams.get("_an_connect_attempt"),
+    ).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it("keeps account provisioning dormant when the server does not advertise it", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -48,7 +48,7 @@ export interface BuilderStatus {
    * Surfaced as a one-shot row by the server so the connect-flow polling
    * can stop with a clear message instead of timing out at 5min.
    */
-  connectError?: { message: string; at: number };
+  connectError?: { message: string; at: number; code?: string };
   /**
    * Set when the currently effective Builder credential was rejected by
    * Builder's API. Unlike connectError, this describes the old credential pair
@@ -206,6 +206,8 @@ export interface BuilderConnectFlow {
   orgName: string | null;
   connecting: boolean;
   error: string | null;
+  /** True when account provisioning found an existing Builder account. */
+  accountExists: boolean;
   /**
    * True once the first Builder connection-status fetch has completed (successfully
    * or not). Consumers that accept an `initialConfigured` prop (e.g. agent
@@ -591,6 +593,7 @@ export function useBuilderConnectFlow(
   const [orgName, setOrgName] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [accountExists, setAccountExists] = useState(false);
   const [hasFetchedStatus, setHasFetchedStatus] = useState(false);
   const [statusResolved, setStatusResolved] = useState(false);
   const [statusConnectUrl, setStatusConnectUrl] = useState<string | null>(null);
@@ -682,6 +685,7 @@ export function useBuilderConnectFlow(
       setOrgName(null);
       setConnecting(false);
       setError(null);
+      setAccountExists(false);
       setHasFetchedStatus(false);
       setStatusResolved(false);
       setStatusConnectUrl(null);
@@ -704,6 +708,7 @@ export function useBuilderConnectFlow(
       setEnvManaged(!!s.envManaged);
       setAgentNativeProvisioningEnabled(!!s.agentNativeProvisioningEnabled);
       setAgentNativeProvisioningToken(s.agentNativeProvisioningToken ?? null);
+      setAccountExists(s.connectError?.code === "account_exists");
       setBuilderEnabled(!!s.builderEnabled);
       const nextConnectUrl = s.connectUrl ?? null;
       setStatusConnectUrl(nextConnectUrl);
@@ -769,6 +774,7 @@ export function useBuilderConnectFlow(
       };
       setConnecting(true);
       setError(null);
+      setAccountExists(false);
 
       // Open SYNCHRONOUSLY inside the caller's click handler — any await
       // before window.open lets the user-gesture token expire, which causes
@@ -856,6 +862,7 @@ export function useBuilderConnectFlow(
               setAgentNativeProvisioningToken(
                 s.agentNativeProvisioningToken ?? null,
               );
+              setAccountExists(s.connectError?.code === "account_exists");
               setBuilderEnabled(!!s.builderEnabled);
               const nextConnectUrl = s.connectUrl ?? null;
               setStatusConnectUrl(nextConnectUrl);
@@ -907,6 +914,7 @@ export function useBuilderConnectFlow(
               setAgentNativeProvisioningToken(
                 s.agentNativeProvisioningToken ?? null,
               );
+              setAccountExists(s.connectError?.code === "account_exists");
               setBuilderEnabled(!!s.builderEnabled);
               const nextConnectUrl = s.connectUrl ?? null;
               setStatusConnectUrl(nextConnectUrl);
@@ -983,6 +991,7 @@ export function useBuilderConnectFlow(
         setEnvManaged(!!s.envManaged);
         setAgentNativeProvisioningEnabled(!!s.agentNativeProvisioningEnabled);
         setAgentNativeProvisioningToken(s.agentNativeProvisioningToken ?? null);
+        setAccountExists(false);
         setBuilderEnabled(!!s.builderEnabled);
         const nextConnectUrl = s.connectUrl ?? null;
         setStatusConnectUrl(nextConnectUrl);
@@ -1005,8 +1014,11 @@ export function useBuilderConnectFlow(
         // real error instead of letting the user wait 5 minutes for timeout.
         connectStartedAtRef.current = null;
         setConnecting(false);
+        setAccountExists(s.connectError.code === "account_exists");
         setError(
-          `Couldn't save Builder credentials: ${s.connectError.message}. Try again or contact support.`,
+          s.connectError.code === "account_exists"
+            ? null
+            : `Couldn't save Builder credentials: ${s.connectError.message}. Try again or contact support.`,
         );
       } else if (Date.now() - started > POLL_TIMEOUT_MS) {
         connectStartedAtRef.current = null;
@@ -1042,10 +1054,15 @@ export function useBuilderConnectFlow(
   // by the setConnecting(false) call, which is idempotent.
   useEffect(() => {
     let channel: BroadcastChannel | null = null;
-    const handleError = (message: string) => {
+    const handleError = (message: string, code?: string) => {
       connectStartedAtRef.current = null;
       setConnecting(false);
-      setError(`Couldn't save Builder credentials: ${message}.`);
+      setAccountExists(code === "account_exists");
+      setError(
+        code === "account_exists"
+          ? null
+          : `Couldn't save Builder credentials: ${message}.`,
+      );
     };
     const handleSuccess = async () => {
       const started = connectStartedAtRef.current;
@@ -1084,6 +1101,7 @@ export function useBuilderConnectFlow(
           setAgentNativeProvisioningToken(
             s.agentNativeProvisioningToken ?? null,
           );
+          setAccountExists(s.connectError?.code === "account_exists");
           setBuilderEnabled(!!s.builderEnabled);
           const nextConnectUrl = s.connectUrl ?? null;
           setStatusConnectUrl(nextConnectUrl);
@@ -1093,8 +1111,11 @@ export function useBuilderConnectFlow(
         if (connectError) {
           connectStartedAtRef.current = null;
           setConnecting(false);
+          setAccountExists(connectError.code === "account_exists");
           setError(
-            `Couldn't save Builder credentials: ${connectError.message}. Try again or contact support.`,
+            connectError.code === "account_exists"
+              ? null
+              : `Couldn't save Builder credentials: ${connectError.message}. Try again or contact support.`,
           );
         }
         return;
@@ -1106,6 +1127,7 @@ export function useBuilderConnectFlow(
       setEnvManaged(!!s.envManaged);
       setAgentNativeProvisioningEnabled(!!s.agentNativeProvisioningEnabled);
       setAgentNativeProvisioningToken(s.agentNativeProvisioningToken ?? null);
+      setAccountExists(false);
       setBuilderEnabled(!!s.builderEnabled);
       const nextConnectUrl = s.connectUrl ?? null;
       setStatusConnectUrl(nextConnectUrl);
@@ -1126,14 +1148,16 @@ export function useBuilderConnectFlow(
     try {
       channel = new BroadcastChannel(`builder-connect:${window.location.host}`);
       channel.onmessage = (e: MessageEvent) => {
-        const data = e.data as { type?: string; message?: string } | undefined;
+        const data = e.data as
+          | { type?: string; message?: string; code?: string }
+          | undefined;
         if (data?.type === "builder-connect-success") {
           void handleSuccess();
           return;
         }
         if (data?.type === "builder-connect-error") {
           if (typeof data.message !== "string" || !data.message) return;
-          handleError(data.message);
+          handleError(data.message, data.code);
         }
       };
     } catch {
@@ -1142,14 +1166,16 @@ export function useBuilderConnectFlow(
 
     const handler = (e: MessageEvent) => {
       if (!isTrustedBuilderConnectMessageOrigin(e.origin)) return;
-      const data = e.data as { type?: string; message?: string } | undefined;
+      const data = e.data as
+        | { type?: string; message?: string; code?: string }
+        | undefined;
       if (data?.type === "builder-connect-success") {
         void handleSuccess();
         return;
       }
       if (data?.type === "builder-connect-error") {
         if (typeof data.message !== "string" || !data.message) return;
-        handleError(data.message);
+        handleError(data.message, data.code);
       }
     };
     window.addEventListener("message", handler);
@@ -1170,6 +1196,7 @@ export function useBuilderConnectFlow(
     orgName,
     connecting,
     error,
+    accountExists,
     hasFetchedStatus,
     start,
   };

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -233,6 +233,7 @@ const BUILDER_CONNECT_PARAM = "_an_connect";
 const BUILDER_CONNECT_MODE_PARAM = "_an_mode";
 const BUILDER_AGENT_NATIVE_PROVISION_MODE = "agent-native";
 const BUILDER_PROVISIONING_TOKEN_PARAM = "_an_provision";
+const BUILDER_CONNECT_ATTEMPT_PARAM = "_an_connect_attempt";
 const BUILDER_SIGNUP_SOURCE_PARAM = "signupSource";
 const BUILDER_AGENT_NATIVE_FLOW_PARAM = "agentNativeFlow";
 const BUILDER_AGENT_NATIVE_CONNECT_SOURCE_PARAM = "agentNativeConnectSource";
@@ -399,6 +400,16 @@ function isFreshSignedConnectUrl(
     typeof fetchedAt === "number" &&
     Date.now() - fetchedAt < STATUS_CONNECT_URL_TTL_MS
   );
+}
+
+function createBuilderConnectAttemptId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function isCurrentConnectError(
@@ -604,6 +615,7 @@ export function useBuilderConnectFlow(
   // gesture path (browser/editor embeds).
   const statusConnectUrlAtRef = useRef<number | null>(null);
   const connectStartedAtRef = useRef<number | null>(null);
+  const connectAttemptIdRef = useRef<string | null>(null);
   const callbackSuccessStartedAtRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
   const notifiedConnectedRef = useRef(false);
@@ -624,7 +636,7 @@ export function useBuilderConnectFlow(
   // own (the initial status fetch, the popup-open branches in `start`) keep
   // the internal fallback timeout.
   const fetchStatus = useCallback(
-    async (signal?: AbortSignal) => {
+    async (signal?: AbortSignal, connectAttemptId?: string) => {
       if (!enabled) return null;
       const origin = getCallbackOrigin() || window.location.origin;
       const ownController =
@@ -635,13 +647,19 @@ export function useBuilderConnectFlow(
         ? setTimeout(() => ownController.abort(), STATUS_FETCH_ABORT_MS)
         : null;
       try {
-        const r = await fetch(
-          new URL(
-            agentNativePath("/_agent-native/connection-status/builder"),
-            origin,
-          ).href,
-          { signal: signal ?? ownController?.signal },
+        const statusUrl = new URL(
+          agentNativePath("/_agent-native/connection-status/builder"),
+          origin,
         );
+        if (connectAttemptId) {
+          statusUrl.searchParams.set(
+            BUILDER_CONNECT_ATTEMPT_PARAM,
+            connectAttemptId,
+          );
+        }
+        const r = await fetch(statusUrl.href, {
+          signal: signal ?? ownController?.signal,
+        });
         if (!r.ok) return null;
         return (await r.json()) as Pick<
           BuilderStatus,
@@ -690,6 +708,7 @@ export function useBuilderConnectFlow(
       setStatusResolved(false);
       setStatusConnectUrl(null);
       statusConnectUrlAtRef.current = null;
+      connectAttemptIdRef.current = null;
       return;
     }
     mountedRef.current = true;
@@ -761,12 +780,14 @@ export function useBuilderConnectFlow(
     (startOptions?: BuilderConnectStartOptions) => {
       if (!enabled) return;
       const started = Date.now();
+      const connectAttemptId = createBuilderConnectAttemptId();
       const clickTrackingSource =
         startOptions?.trackingSource ?? trackingSource;
       const clickTrackingFlow = startOptions?.trackingFlow ?? trackingFlow;
       const provisionAccountForStart =
         startOptions?.provisionAccount ?? provisionAccount;
       connectStartedAtRef.current = started;
+      connectAttemptIdRef.current = connectAttemptId;
       callbackSuccessStartedAtRef.current = null;
       activeTrackingRef.current = {
         source: clickTrackingSource,
@@ -816,6 +837,10 @@ export function useBuilderConnectFlow(
           BUILDER_PROVISIONING_TOKEN_PARAM,
           provisioningToken,
         );
+        provisionUrl.searchParams.set(
+          BUILDER_CONNECT_ATTEMPT_PARAM,
+          connectAttemptId,
+        );
         return provisionUrl.toString();
       };
       const directUrl = withProvisionMode(
@@ -848,7 +873,7 @@ export function useBuilderConnectFlow(
           }
 
           void (async () => {
-            const s = await fetchStatus();
+            const s = await fetchStatus(undefined, connectAttemptId);
             if (!mountedRef.current) return;
             if (s) {
               setHasFetchedStatus(true);
@@ -893,7 +918,7 @@ export function useBuilderConnectFlow(
         } else {
           showBuilderConnectPopupPlaceholder(opened);
           void (async () => {
-            const s = await fetchStatus();
+            const s = await fetchStatus(undefined, connectAttemptId);
             if (!mountedRef.current) {
               try {
                 opened.close();
@@ -982,7 +1007,10 @@ export function useBuilderConnectFlow(
     async (signal) => {
       const started = connectStartedAtRef.current;
       if (started == null) return;
-      const s = await fetchStatus(signal);
+      const s = await fetchStatus(
+        signal,
+        connectAttemptIdRef.current ?? undefined,
+      );
       if (!mountedRef.current) return;
       if (s) setStatusResolved(true);
       if (s?.configured) {
@@ -1072,7 +1100,10 @@ export function useBuilderConnectFlow(
       callbackSuccessStartedAtRef.current = started;
       let s: Awaited<ReturnType<typeof fetchStatus>> = null;
       for (let i = 0; i < CALLBACK_SUCCESS_STATUS_RETRIES; i += 1) {
-        s = await fetchStatus();
+        s = await fetchStatus(
+          undefined,
+          connectAttemptIdRef.current ?? undefined,
+        );
         if (!mountedRef.current || connectStartedAtRef.current !== started) {
           return;
         }

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -219,6 +219,8 @@ export interface BuilderConnectFlow {
   hasFetchedStatus: boolean;
   /** Open the popup and begin polling. Must be called from a user-gesture handler. */
   start: (options?: BuilderConnectStartOptions) => void;
+  /** Retry the status request before choosing a connection path. */
+  retry: () => void;
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -617,6 +619,7 @@ export function useBuilderConnectFlow(
   const connectStartedAtRef = useRef<number | null>(null);
   const connectAttemptIdRef = useRef<string | null>(null);
   const callbackSuccessStartedAtRef = useRef<number | null>(null);
+  const retryStatusRef = useRef<() => void>(() => {});
   const mountedRef = useRef(true);
   const notifiedConnectedRef = useRef(false);
   // Keep onConnected in a ref so start() doesn't need to re-create when the
@@ -709,6 +712,7 @@ export function useBuilderConnectFlow(
       setStatusConnectUrl(null);
       statusConnectUrlAtRef.current = null;
       connectAttemptIdRef.current = null;
+      retryStatusRef.current = () => {};
       return;
     }
     mountedRef.current = true;
@@ -760,6 +764,7 @@ export function useBuilderConnectFlow(
         setError(null);
       }
     };
+    retryStatusRef.current = () => void refresh();
     void refresh();
     const onVisible = () => {
       if (document.visibilityState === "visible") void refresh();
@@ -770,11 +775,16 @@ export function useBuilderConnectFlow(
     return () => {
       cancelled = true;
       mountedRef.current = false;
+      retryStatusRef.current = () => {};
       window.removeEventListener("focus", refresh);
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("agent-engine:configured-changed", refresh);
     };
   }, [enabled, fetchStatus]);
+
+  const retry = useCallback(() => {
+    retryStatusRef.current();
+  }, []);
 
   const start = useCallback(
     (startOptions?: BuilderConnectStartOptions) => {
@@ -1101,7 +1111,8 @@ export function useBuilderConnectFlow(
           : `Couldn't save Builder credentials: ${message}.`,
       );
     };
-    const handleSuccess = async () => {
+    const handleSuccess = async (attemptId: string | undefined) => {
+      if (!isCurrentConnectAttempt(attemptId)) return;
       const started = connectStartedAtRef.current;
       if (started == null || callbackSuccessStartedAtRef.current === started) {
         return;
@@ -1197,7 +1208,7 @@ export function useBuilderConnectFlow(
             }
           | undefined;
         if (data?.type === "builder-connect-success") {
-          void handleSuccess();
+          void handleSuccess(data.attemptId);
           return;
         }
         if (data?.type === "builder-connect-error") {
@@ -1220,7 +1231,7 @@ export function useBuilderConnectFlow(
           }
         | undefined;
       if (data?.type === "builder-connect-success") {
-        void handleSuccess();
+        void handleSuccess(data.attemptId);
         return;
       }
       if (data?.type === "builder-connect-error") {
@@ -1249,5 +1260,6 @@ export function useBuilderConnectFlow(
     accountExists,
     hasFetchedStatus,
     start,
+    retry,
   };
 }

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -821,27 +821,27 @@ export function useBuilderConnectFlow(
         provisioningEnabled = agentNativeProvisioningEnabled,
         provisioningToken = agentNativeProvisioningToken,
       ): string => {
+        const connectUrl = new URL(url, origin);
+        connectUrl.searchParams.set(
+          BUILDER_CONNECT_ATTEMPT_PARAM,
+          connectAttemptId,
+        );
         if (
           !provisionAccountForStart ||
           !provisioningEnabled ||
           !provisioningToken
         ) {
-          return url;
+          return connectUrl.toString();
         }
-        const provisionUrl = new URL(url, origin);
-        provisionUrl.searchParams.set(
+        connectUrl.searchParams.set(
           BUILDER_CONNECT_MODE_PARAM,
           BUILDER_AGENT_NATIVE_PROVISION_MODE,
         );
-        provisionUrl.searchParams.set(
+        connectUrl.searchParams.set(
           BUILDER_PROVISIONING_TOKEN_PARAM,
           provisioningToken,
         );
-        provisionUrl.searchParams.set(
-          BUILDER_CONNECT_ATTEMPT_PARAM,
-          connectAttemptId,
-        );
-        return provisionUrl.toString();
+        return connectUrl.toString();
       };
       const directUrl = withProvisionMode(
         cachedFreshUrl ?? signedPropUrl ?? fallbackUrl,
@@ -1082,7 +1082,16 @@ export function useBuilderConnectFlow(
   // by the setConnecting(false) call, which is idempotent.
   useEffect(() => {
     let channel: BroadcastChannel | null = null;
-    const handleError = (message: string, code?: string) => {
+    const isCurrentConnectAttempt = (attemptId: string | undefined): boolean =>
+      typeof attemptId === "string" &&
+      attemptId === connectAttemptIdRef.current &&
+      connectStartedAtRef.current !== null;
+    const handleError = (
+      message: string,
+      code: string | undefined,
+      attemptId: string | undefined,
+    ) => {
+      if (!isCurrentConnectAttempt(attemptId)) return;
       connectStartedAtRef.current = null;
       setConnecting(false);
       setAccountExists(code === "account_exists");
@@ -1180,7 +1189,12 @@ export function useBuilderConnectFlow(
       channel = new BroadcastChannel(`builder-connect:${window.location.host}`);
       channel.onmessage = (e: MessageEvent) => {
         const data = e.data as
-          | { type?: string; message?: string; code?: string }
+          | {
+              type?: string;
+              message?: string;
+              code?: string;
+              attemptId?: string;
+            }
           | undefined;
         if (data?.type === "builder-connect-success") {
           void handleSuccess();
@@ -1188,7 +1202,7 @@ export function useBuilderConnectFlow(
         }
         if (data?.type === "builder-connect-error") {
           if (typeof data.message !== "string" || !data.message) return;
-          handleError(data.message, data.code);
+          handleError(data.message, data.code, data.attemptId);
         }
       };
     } catch {
@@ -1198,7 +1212,12 @@ export function useBuilderConnectFlow(
     const handler = (e: MessageEvent) => {
       if (!isTrustedBuilderConnectMessageOrigin(e.origin)) return;
       const data = e.data as
-        | { type?: string; message?: string; code?: string }
+        | {
+            type?: string;
+            message?: string;
+            code?: string;
+            attemptId?: string;
+          }
         | undefined;
       if (data?.type === "builder-connect-success") {
         void handleSuccess();
@@ -1206,7 +1225,7 @@ export function useBuilderConnectFlow(
       }
       if (data?.type === "builder-connect-error") {
         if (typeof data.message !== "string" || !data.message) return;
-        handleError(data.message, data.code);
+        handleError(data.message, data.code, data.attemptId);
       }
     };
     window.addEventListener("message", handler);

--- a/packages/core/src/client/setup-connections/BuilderConnectCard.tsx
+++ b/packages/core/src/client/setup-connections/BuilderConnectCard.tsx
@@ -7,6 +7,7 @@ import {
 import { IconCheck, IconPlugConnected } from "@tabler/icons-react";
 import type { ReactNode } from "react";
 
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
 import { cn } from "../utils.js";
 import {
   useBuilderConnectCardController,
@@ -87,18 +88,37 @@ export function DefaultBuilderConnectCardView({
           ) : null}
           {action ? (
             <div className="mt-3">
-              <ActionButton
-                type="button"
-                intent="primary"
-                size="compact"
-                pending={action.pending}
-                disabled={action.disabled}
-                className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-foreground px-3 text-xs font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
-                leadingIcon={<IconPlugConnected className="size-3.5" />}
-                onPress={action.onPress}
-              >
-                {action.label}
-              </ActionButton>
+              {viewModel.connectFlow ? (
+                <BuilderConnectPopover
+                  flow={viewModel.connectFlow}
+                  onConnect={action.onPress}
+                >
+                  <ActionButton
+                    type="button"
+                    intent="primary"
+                    size="compact"
+                    pending={action.pending}
+                    disabled={action.disabled}
+                    className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-foreground px-3 text-xs font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    leadingIcon={<IconPlugConnected className="size-3.5" />}
+                  >
+                    {action.label}
+                  </ActionButton>
+                </BuilderConnectPopover>
+              ) : (
+                <ActionButton
+                  type="button"
+                  intent="primary"
+                  size="compact"
+                  pending={action.pending}
+                  disabled={action.disabled}
+                  className="inline-flex h-8 items-center gap-2 rounded-md border border-border bg-foreground px-3 text-xs font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  leadingIcon={<IconPlugConnected className="size-3.5" />}
+                  onPress={() => action.onPress()}
+                >
+                  {action.label}
+                </ActionButton>
+              )}
             </div>
           ) : null}
         </div>

--- a/packages/core/src/client/setup-connections/useBuilderConnectCardController.ts
+++ b/packages/core/src/client/setup-connections/useBuilderConnectCardController.ts
@@ -1,6 +1,9 @@
 import { useCallback } from "react";
 
-import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
+import {
+  useBuilderConnectFlow,
+  type BuilderConnectFlow,
+} from "../settings/useBuilderStatus.js";
 
 const DEFAULT_TITLE = "Builder connect";
 const DEFAULT_DESCRIPTION =
@@ -23,7 +26,7 @@ export interface BuilderConnectCardAction {
   label: "Connect Builder.io";
   pending: boolean;
   disabled: boolean;
-  onPress: () => void;
+  onPress: (provisionAccount?: boolean) => void;
 }
 
 export interface BuilderConnectCardViewModel {
@@ -34,6 +37,7 @@ export interface BuilderConnectCardViewModel {
   pending: boolean;
   error: string | null;
   orgName: string | null;
+  connectFlow?: BuilderConnectFlow;
   action: BuilderConnectCardAction | null;
 }
 
@@ -48,10 +52,14 @@ export function useBuilderConnectCardController({
     [onConnected],
   );
   const flow = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource,
     onConnected: handleConnected,
   });
-  const handlePress = useCallback(() => flow.start(), [flow.start]);
+  const handlePress = useCallback(
+    (provisionAccount = false) => flow.start({ provisionAccount }),
+    [flow.start],
+  );
 
   const status: BuilderConnectCardStatus = !flow.hasFetchedStatus
     ? { kind: "checking", label: "Checking" }
@@ -70,6 +78,7 @@ export function useBuilderConnectCardController({
     pending: flow.connecting,
     error: flow.error,
     orgName: flow.orgName,
+    connectFlow: flow,
     action: flow.configured
       ? null
       : {

--- a/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
+++ b/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
@@ -20,9 +20,10 @@ export function BuilderTranscriptionCta() {
   const configured = flow.statusResolved
     ? flow.configured || flow.envManaged
     : null;
+  const statusUnavailable = flow.hasFetchedStatus && !flow.statusResolved;
 
-  // Already connected or still loading — render nothing
-  if (configured === null || configured) return null;
+  // Keep a retry path visible after an unreadable status response.
+  if (configured || (configured === null && !statusUnavailable)) return null;
 
   return (
     <div className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
@@ -34,11 +35,14 @@ export function BuilderTranscriptionCta() {
       <span className="flex-1">
         {flow.connecting
           ? "Waiting for Builder.io…"
-          : "Connect Builder.io for higher-quality transcription — free credits, no API key needed."}
+          : statusUnavailable
+            ? "Builder status unavailable. Try again."
+            : "Connect Builder.io for higher-quality transcription — free credits, no API key needed."}
       </span>
-      {flow.error ? (
+      {flow.error && (
         <span className="text-destructive text-[10px]">{flow.error}</span>
-      ) : flow.connecting ? (
+      )}
+      {flow.connecting ? (
         <IconLoader2 size={12} className="shrink-0 animate-spin" />
       ) : (
         <BuilderConnectPopover flow={flow}>
@@ -47,7 +51,7 @@ export function BuilderTranscriptionCta() {
             disabled={flow.connecting}
             className="ml-auto shrink-0 inline-flex items-center gap-1 rounded bg-foreground px-2 py-1 text-[10px] font-semibold text-background transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
           >
-            Connect
+            {statusUnavailable || flow.error ? "Retry" : "Connect"}
           </button>
         </BuilderConnectPopover>
       )}

--- a/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
+++ b/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
@@ -7,82 +7,19 @@
  */
 
 import { IconBolt, IconLoader2 } from "@tabler/icons-react";
-import { useCallback, useEffect, useRef, useState } from "react";
 
-import { agentNativePath } from "../api-path.js";
-import { openBuilderConnectPopup } from "../settings/useBuilderStatus.js";
-import { usePollLoop } from "../use-poll-loop.js";
-
-const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+import { BuilderConnectPopover } from "../settings/BuilderConnectPopover.js";
+import { useBuilderConnectFlow } from "../settings/useBuilderStatus.js";
 
 export function BuilderTranscriptionCta() {
-  const [configured, setConfigured] = useState<boolean | null>(null);
-  const [connectUrl, setConnectUrl] = useState<string | null>(null);
-  const [connecting, setConnecting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const connectStartedAtRef = useRef<number | null>(null);
-  const mountedRef = useRef(true);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    fetch(agentNativePath("/_agent-native/builder/status"))
-      .then((r) =>
-        r.ok
-          ? (r.json() as Promise<{
-              configured: boolean;
-              envManaged?: boolean;
-              connectUrl?: string;
-            }>)
-          : null,
-      )
-      .then((s) => {
-        if (!mountedRef.current) return;
-        // Env-managed mode counts as configured for the CTA — the deploy
-        // already routes transcription through Builder, no per-user prompt.
-        setConfigured(!!(s?.configured || s?.envManaged));
-        setConnectUrl(s?.connectUrl || null);
-      })
-      .catch(() => {
-        if (mountedRef.current) setConfigured(false);
-      });
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  const handleConnect = useCallback(() => {
-    connectStartedAtRef.current = Date.now();
-    setConnecting(true);
-    setError(null);
-
-    openBuilderConnectPopup({
-      url: connectUrl ?? undefined,
-      source: "builder_transcription_cta",
-    });
-  }, [connectUrl]);
-
-  usePollLoop(
-    async (signal) => {
-      const started = connectStartedAtRef.current;
-      if (started == null) return;
-      const r = await fetch(agentNativePath("/_agent-native/builder/status"), {
-        signal,
-      });
-      if (!r.ok || !mountedRef.current) return;
-      const s = (await r.json()) as { configured: boolean };
-      if (!mountedRef.current) return;
-      if (s.configured) {
-        connectStartedAtRef.current = null;
-        setConfigured(true);
-        setConnecting(false);
-      } else if (Date.now() - started > POLL_TIMEOUT_MS) {
-        connectStartedAtRef.current = null;
-        setConnecting(false);
-        setError("Didn't hear back from Builder. Allow popups and try again.");
-      }
-    },
-    { intervalMs: 2000, leading: false, enabled: connecting },
-  );
+  const flow = useBuilderConnectFlow({
+    provisionAccount: true,
+    trackingSource: "builder_transcription_cta",
+    trackingFlow: "transcription",
+  });
+  const configured = flow.statusResolved
+    ? flow.configured || flow.envManaged
+    : null;
 
   // Already connected or still loading — render nothing
   if (configured === null || configured) return null;
@@ -95,22 +32,24 @@ export function BuilderTranscriptionCta() {
         aria-hidden="true"
       />
       <span className="flex-1">
-        {connecting
+        {flow.connecting
           ? "Waiting for Builder.io…"
           : "Connect Builder.io for higher-quality transcription — free credits, no API key needed."}
       </span>
-      {error ? (
-        <span className="text-destructive text-[10px]">{error}</span>
-      ) : connecting ? (
+      {flow.error ? (
+        <span className="text-destructive text-[10px]">{flow.error}</span>
+      ) : flow.connecting ? (
         <IconLoader2 size={12} className="shrink-0 animate-spin" />
       ) : (
-        <button
-          type="button"
-          onClick={handleConnect}
-          className="ml-auto shrink-0 inline-flex items-center gap-1 rounded bg-foreground px-2 py-1 text-[10px] font-semibold text-background hover:opacity-90 transition-opacity"
-        >
-          Connect
-        </button>
+        <BuilderConnectPopover flow={flow}>
+          <button
+            type="button"
+            disabled={flow.connecting}
+            className="ml-auto shrink-0 inline-flex items-center gap-1 rounded bg-foreground px-2 py-1 text-[10px] font-semibold text-background transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+          >
+            Connect
+          </button>
+        </BuilderConnectPopover>
       )}
     </div>
   );

--- a/packages/core/src/localization/core-messages/ar-SA.ts
+++ b/packages/core/src/localization/core-messages/ar-SA.ts
@@ -53,6 +53,8 @@ const messages: AgentChatTranslation = {
     "مضمّنة مع أرصدة Builder.io المجانية النشطة",
   "onboarding.builderCredits": "مضمّنة مع أرصدة Builder.io المجانية",
   "onboarding.builderActivateTitle": "تفعيل الأرصدة المجانية",
+  "onboarding.builderAccountExistsTitle": "لديك حساب Builder.io بالفعل",
+  "onboarding.builderAccountExistsDescription": "سجّل الدخول لربطه.",
   "onboarding.builderActivationDescription":
     "سننشئ حساب Builder.io الخاص بك تلقائيًا بنقرة واحدة.",
   "onboarding.builderCreateAndActivate": "إنشاء وتفعيل",

--- a/packages/core/src/localization/core-messages/de-DE.ts
+++ b/packages/core/src/localization/core-messages/de-DE.ts
@@ -57,6 +57,10 @@ const messages: AgentChatTranslation = {
     "In aktiven Builder.io-Gratiscredits enthalten",
   "onboarding.builderCredits": "In Builder.io-Gratiscredits enthalten",
   "onboarding.builderActivateTitle": "Gratiscredits aktivieren",
+  "onboarding.builderAccountExistsTitle":
+    "Du hast bereits ein Builder.io-Konto",
+  "onboarding.builderAccountExistsDescription":
+    "Melde dich an, um es zu verbinden.",
   "onboarding.builderActivationDescription":
     "Wir erstellen dein Builder.io-Konto automatisch für dich mit einem Klick.",
   "onboarding.builderCreateAndActivate": "Erstellen und aktivieren",

--- a/packages/core/src/localization/core-messages/en-US.ts
+++ b/packages/core/src/localization/core-messages/en-US.ts
@@ -51,6 +51,9 @@ const messages = {
     "Included with active Builder.io free credits",
   "onboarding.builderCredits": "Included with Builder.io free credits",
   "onboarding.builderActivateTitle": "Activate free credits",
+  "onboarding.builderAccountExistsTitle":
+    "You already have a Builder.io account",
+  "onboarding.builderAccountExistsDescription": "Log in to connect it.",
   "onboarding.builderActivationDescription":
     "We'll automatically create your Builder.io account for you in one click.",
   "onboarding.builderCreateAndActivate": "Create and activate",

--- a/packages/core/src/localization/core-messages/es-ES.ts
+++ b/packages/core/src/localization/core-messages/es-ES.ts
@@ -57,6 +57,9 @@ const messages: AgentChatTranslation = {
   "onboarding.builderCredits":
     "Incluido con los créditos gratuitos de Builder.io",
   "onboarding.builderActivateTitle": "Activar créditos gratuitos",
+  "onboarding.builderAccountExistsTitle": "Ya tienes una cuenta de Builder.io",
+  "onboarding.builderAccountExistsDescription":
+    "Inicia sesión para conectarla.",
   "onboarding.builderActivationDescription":
     "Crearemos automáticamente tu cuenta de Builder.io con un solo clic.",
   "onboarding.builderCreateAndActivate": "Crear y activar",

--- a/packages/core/src/localization/core-messages/fr-FR.ts
+++ b/packages/core/src/localization/core-messages/fr-FR.ts
@@ -59,6 +59,9 @@ const messages: AgentChatTranslation = {
     "Inclus avec les crédits gratuits Builder.io actifs",
   "onboarding.builderCredits": "Inclus avec les crédits gratuits Builder.io",
   "onboarding.builderActivateTitle": "Activer les crédits gratuits",
+  "onboarding.builderAccountExistsTitle": "Vous avez déjà un compte Builder.io",
+  "onboarding.builderAccountExistsDescription":
+    "Connectez-vous pour l’associer.",
   "onboarding.builderActivationDescription":
     "Nous créerons automatiquement votre compte Builder.io en un clic.",
   "onboarding.builderCreateAndActivate": "Créer et activer",

--- a/packages/core/src/localization/core-messages/hi-IN.ts
+++ b/packages/core/src/localization/core-messages/hi-IN.ts
@@ -52,6 +52,8 @@ const messages: AgentChatTranslation = {
   "onboarding.builderActiveCredits": "सक्रिय Builder.io मुफ़्त क्रेडिट में शामिल",
   "onboarding.builderCredits": "Builder.io के मुफ़्त क्रेडिट में शामिल",
   "onboarding.builderActivateTitle": "मुफ़्त क्रेडिट सक्रिय करें",
+  "onboarding.builderAccountExistsTitle": "आपके पास पहले से Builder.io खाता है",
+  "onboarding.builderAccountExistsDescription": "इसे कनेक्ट करने के लिए लॉग इन करें।",
   "onboarding.builderActivationDescription":
     "हम एक क्लिक में आपके लिए Builder.io खाता अपने-आप बनाएँगे।",
   "onboarding.builderCreateAndActivate": "बनाएँ और सक्रिय करें",

--- a/packages/core/src/localization/core-messages/ja-JP.ts
+++ b/packages/core/src/localization/core-messages/ja-JP.ts
@@ -54,6 +54,10 @@ const messages: AgentChatTranslation = {
     "有効な Builder.io 無料クレジットに含まれるもの",
   "onboarding.builderCredits": "Builder.io 無料クレジットに含まれるもの",
   "onboarding.builderActivateTitle": "無料クレジットを有効化",
+  "onboarding.builderAccountExistsTitle":
+    "Builder.io アカウントをすでにお持ちです",
+  "onboarding.builderAccountExistsDescription":
+    "接続するにはログインしてください。",
   "onboarding.builderActivationDescription":
     "ワンクリックで Builder.io アカウントを自動的に作成します。",
   "onboarding.builderCreateAndActivate": "作成して有効化",

--- a/packages/core/src/localization/core-messages/ko-KR.ts
+++ b/packages/core/src/localization/core-messages/ko-KR.ts
@@ -53,6 +53,8 @@ const messages: AgentChatTranslation = {
   "onboarding.builderActiveCredits": "활성 Builder.io 무료 크레딧에 포함",
   "onboarding.builderCredits": "Builder.io 무료 크레딧에 포함",
   "onboarding.builderActivateTitle": "무료 크레딧 활성화",
+  "onboarding.builderAccountExistsTitle": "이미 Builder.io 계정이 있습니다",
+  "onboarding.builderAccountExistsDescription": "연결하려면 로그인하세요.",
   "onboarding.builderActivationDescription":
     "한 번의 클릭으로 Builder.io 계정을 자동으로 생성합니다.",
   "onboarding.builderCreateAndActivate": "생성 및 활성화",

--- a/packages/core/src/localization/core-messages/pt-BR.ts
+++ b/packages/core/src/localization/core-messages/pt-BR.ts
@@ -55,6 +55,8 @@ const messages: AgentChatTranslation = {
     "Incluído nos créditos gratuitos ativos do Builder.io",
   "onboarding.builderCredits": "Incluído nos créditos gratuitos do Builder.io",
   "onboarding.builderActivateTitle": "Ativar créditos gratuitos",
+  "onboarding.builderAccountExistsTitle": "Você já tem uma conta do Builder.io",
+  "onboarding.builderAccountExistsDescription": "Faça login para conectá-la.",
   "onboarding.builderActivationDescription":
     "Criaremos automaticamente sua conta do Builder.io com um clique.",
   "onboarding.builderCreateAndActivate": "Criar e ativar",

--- a/packages/core/src/localization/core-messages/zh-CN.ts
+++ b/packages/core/src/localization/core-messages/zh-CN.ts
@@ -51,6 +51,8 @@ const messages: AgentChatTranslation = {
   "onboarding.builderActiveCredits": "包含在有效的 Builder.io 免费额度中",
   "onboarding.builderCredits": "包含在 Builder.io 免费额度中",
   "onboarding.builderActivateTitle": "激活免费额度",
+  "onboarding.builderAccountExistsTitle": "您已有 Builder.io 账户",
+  "onboarding.builderAccountExistsDescription": "登录以连接该账户。",
   "onboarding.builderActivationDescription":
     "我们会一键自动为您创建 Builder.io 账户。",
   "onboarding.builderCreateAndActivate": "创建并激活",

--- a/packages/core/src/localization/core-messages/zh-TW.ts
+++ b/packages/core/src/localization/core-messages/zh-TW.ts
@@ -51,6 +51,8 @@ const messages: AgentChatTranslation = {
   "onboarding.builderActiveCredits": "包含於有效的 Builder.io 免費額度",
   "onboarding.builderCredits": "包含於 Builder.io 免費額度",
   "onboarding.builderActivateTitle": "啟用免費額度",
+  "onboarding.builderAccountExistsTitle": "您已有 Builder.io 帳戶",
+  "onboarding.builderAccountExistsDescription": "登入以連接該帳戶。",
   "onboarding.builderActivationDescription":
     "我們會按一下自動為您建立 Builder.io 帳戶。",
   "onboarding.builderCreateAndActivate": "建立並啟用",

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -67,6 +67,7 @@ import {
   getBuilderBrowserConnectUrlForOwner,
   getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
+  BuilderAccountProvisioningError,
   isBuilderAccountProvisioningEnabled,
   isBuilderBranchingEnabled,
   isBuilderConnectCallbackUrlAllowed,
@@ -165,6 +166,34 @@ describe("Builder account provisioning", () => {
       "test-builder-sso-secret-with-at-least-32-chars",
     );
     expect(isBuilderAccountProvisioningEnabled()).toBe(true);
+  });
+
+  it("preserves Builder's existing-account code for the login fallback", async () => {
+    vi.stubEnv(
+      BUILDER_ACCOUNT_PROVISIONING_SECRET_ENV,
+      "test-builder-sso-secret-with-at-least-32-chars",
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: "account_incomplete",
+              message: "An account already exists for this email.",
+            }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    await expect(
+      provisionBuilderAccount({ email: "owner@example.com" }),
+    ).rejects.toMatchObject({
+      name: "BuilderAccountProvisioningError",
+      message: "An account already exists for this email.",
+      code: "account_incomplete",
+    });
   });
 });
 

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1860,9 +1860,10 @@ function safeOriginFromUrl(value: string | null | undefined): string | null {
 
 export function createBuilderBrowserCallbackPage(
   previewUrl: string,
-  opts: { parentOrigin?: string } = {},
+  opts: { parentOrigin?: string; attemptId?: string } = {},
 ): string {
   const escapedUrl = JSON.stringify(previewUrl);
+  const escapedAttemptId = JSON.stringify(opts.attemptId ?? null);
   const parentOrigin =
     safeOriginFromUrl(opts.parentOrigin) ?? safeOriginFromUrl(previewUrl);
   // postMessage requires a specific target origin for cross-origin opener
@@ -1905,13 +1906,13 @@ export function createBuilderBrowserCallbackPage(
       // mirror the parent-side listener in useBuilderStatus / useBuilderConnectUrl.
       try {
         var bc = new BroadcastChannel("builder-connect:" + window.location.host);
-        bc.postMessage({ type: "builder-connect-success" });
+        bc.postMessage({ type: "builder-connect-success", attemptId: ${escapedAttemptId} || undefined });
         bc.close();
       } catch (e) {}
       try {
         if (window.opener && !window.opener.closed) {
           window.opener.postMessage(
-            { type: "builder-connect-success" },
+            { type: "builder-connect-success", attemptId: ${escapedAttemptId} || undefined },
             ${escapedTargetOrigin},
           );
         }
@@ -1955,10 +1956,12 @@ export function createBuilderBrowserCallbackErrorPage(
     closeHint?: string;
     parentOrigin?: string;
     code?: string;
+    attemptId?: string;
   } = {},
 ): string {
   const escapedMessage = JSON.stringify(message);
   const escapedCode = JSON.stringify(opts.code ?? null);
+  const escapedAttemptId = JSON.stringify(opts.attemptId ?? null);
   const parentOrigin = safeOriginFromUrl(opts.parentOrigin);
   const escapedTargetOrigin = JSON.stringify(parentOrigin ?? "*");
   const title = opts.title ?? "Couldn't save Builder connection";
@@ -2005,13 +2008,13 @@ export function createBuilderBrowserCallbackErrorPage(
         // fallback for non-BroadcastChannel environments.
         try {
           var bc = new BroadcastChannel("builder-connect:" + window.location.host);
-          bc.postMessage({ type: "builder-connect-error", message: msg, code: code || undefined });
+          bc.postMessage({ type: "builder-connect-error", message: msg, code: code || undefined, attemptId: ${escapedAttemptId} || undefined });
           bc.close();
         } catch (e) {}
         if (window.opener && !window.opener.closed) {
           try {
             window.opener.postMessage(
-              { type: "builder-connect-error", message: msg, code: code || undefined },
+              { type: "builder-connect-error", message: msg, code: code || undefined, attemptId: ${escapedAttemptId} || undefined },
               ${escapedTargetOrigin},
             );
           } catch (e) {}

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -84,6 +84,23 @@ export interface BuilderRelayRequestBody {
   credentials: BuilderRelayCredentials;
 }
 
+export class BuilderAccountProvisioningError extends Error {
+  readonly code: string | null;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "BuilderAccountProvisioningError";
+    this.code = code ?? null;
+  }
+}
+
+export function isBuilderAccountAlreadyExistsError(error: unknown): boolean {
+  return (
+    error instanceof BuilderAccountProvisioningError &&
+    (error.code === "account_incomplete" || error.code === "account_exists")
+  );
+}
+
 function builderRelaySecret(): string {
   const secret = process.env[BUILDER_RELAY_SECRET_ENV]?.trim();
   if (!secret) {
@@ -744,7 +761,7 @@ export interface BuilderBrowserStatus {
    * in-progress cli-auth callback.
    */
   authError?: { message: string; at: number };
-  connectError?: { message: string; at: number };
+  connectError?: { message: string; at: number; code?: string };
   appHost: string;
   apiHost: string;
   /**
@@ -1936,9 +1953,11 @@ export function createBuilderBrowserCallbackErrorPage(
     body?: string;
     closeHint?: string;
     parentOrigin?: string;
+    code?: string;
   } = {},
 ): string {
   const escapedMessage = JSON.stringify(message);
+  const escapedCode = JSON.stringify(opts.code ?? null);
   const parentOrigin = safeOriginFromUrl(opts.parentOrigin);
   const escapedTargetOrigin = JSON.stringify(parentOrigin ?? "*");
   const title = opts.title ?? "Couldn't save Builder connection";
@@ -1972,6 +1991,7 @@ export function createBuilderBrowserCallbackErrorPage(
     <script>
       try {
         var msg = ${escapedMessage};
+        var code = ${escapedCode};
         document.getElementById("msg").textContent = msg;
         // Notify the parent tab immediately so its polling loop stops
         // without waiting for the next /builder/status tick.
@@ -1984,13 +2004,13 @@ export function createBuilderBrowserCallbackErrorPage(
         // fallback for non-BroadcastChannel environments.
         try {
           var bc = new BroadcastChannel("builder-connect:" + window.location.host);
-          bc.postMessage({ type: "builder-connect-error", message: msg });
+          bc.postMessage({ type: "builder-connect-error", message: msg, code: code || undefined });
           bc.close();
         } catch (e) {}
         if (window.opener && !window.opener.closed) {
           try {
             window.opener.postMessage(
-              { type: "builder-connect-error", message: msg },
+              { type: "builder-connect-error", message: msg, code: code || undefined },
               ${escapedTargetOrigin},
             );
           } catch (e) {}
@@ -2349,11 +2369,12 @@ export async function provisionBuilderAccount(input: {
   );
   const parsed = await readBuilderApiObject(response, "account provisioning");
   if (!response.ok) {
-    throw new Error(
+    throw new BuilderAccountProvisioningError(
       builderApiErrorMessage(
         parsed,
         `Builder account provisioning failed (${response.status})`,
       ),
+      typeof parsed.code === "string" ? parsed.code : undefined,
     );
   }
   return parseBuilderAccountProvisioningResponse(parsed);

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -614,6 +614,7 @@ export const BUILDER_AGENT_NATIVE_TEMPLATE_PARAM = "agentNativeTemplate";
 export const BUILDER_CONNECT_MODE_PARAM = "_an_mode";
 export const BUILDER_AGENT_NATIVE_PROVISION_MODE = "agent-native";
 export const BUILDER_PROVISIONING_TOKEN_PARAM = "_an_provision";
+export const BUILDER_CONNECT_ATTEMPT_PARAM = "_an_connect_attempt";
 
 const BUILDER_CONNECT_STATE_COOKIE_MAX_ENTRIES = 4;
 

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -136,6 +136,7 @@ import {
   BUILDER_CONNECT_MODE_PARAM,
   BUILDER_AGENT_NATIVE_PROVISION_MODE,
   BUILDER_PROVISIONING_TOKEN_PARAM,
+  BUILDER_CONNECT_ATTEMPT_PARAM,
   BUILDER_CONNECT_STATE_COOKIE,
   BUILDER_ENV_KEYS,
   BUILDER_OPENER_PARAM,
@@ -2334,6 +2335,10 @@ export function createCoreRoutesPlugin(
         return runWithRequestContext(
           { userEmail, orgId: orgId ?? undefined },
           async () => {
+            const requestUrl = getFrameworkRouteRequestUrl(event);
+            const connectAttemptId = requestUrl.searchParams.get(
+              BUILDER_CONNECT_ATTEMPT_PARAM,
+            );
             const projectId = await resolveBuilderBranchProjectId();
             const requestStatus = {
               ...envStatus,
@@ -2350,8 +2355,19 @@ export function createCoreRoutesPlugin(
               if (userEmail) {
                 const errKey = `builder-connect-error:${userEmail}`;
                 const errRow = await getSetting(errKey);
-                if (errRow && typeof errRow.message === "string") {
-                  await deleteSetting(errKey).catch(() => {});
+                const isCorrelatedProvisioningError =
+                  errRow?.code === "account_exists" &&
+                  typeof connectAttemptId === "string" &&
+                  errRow.attemptId === connectAttemptId;
+                const isLegacyConnectError = errRow?.code !== "account_exists";
+                if (
+                  errRow &&
+                  typeof errRow.message === "string" &&
+                  (isCorrelatedProvisioningError || isLegacyConnectError)
+                ) {
+                  if (isLegacyConnectError) {
+                    await deleteSetting(errKey).catch(() => {});
+                  }
                   return withConnectToken({
                     ...requestStatus,
                     configured: false,
@@ -2673,6 +2689,9 @@ export function createCoreRoutesPlugin(
           }
 
           const requestUrl = getFrameworkRouteRequestUrl(event);
+          const connectAttemptId = requestUrl.searchParams.get(
+            BUILDER_CONNECT_ATTEMPT_PARAM,
+          );
           const connectToken = requestUrl.searchParams.get(
             BUILDER_CONNECT_PARAM,
           );
@@ -2748,6 +2767,7 @@ export function createCoreRoutesPlugin(
                 message,
                 at: Date.now(),
                 ...(code ? { code } : {}),
+                ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
               }).catch(() => {});
               await trackBuilderLifecycle(
                 event,

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -153,6 +153,7 @@ import {
   getBuilderConnectTrackingParams,
   getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
+  isBuilderAccountAlreadyExistsError,
   isBuilderAccountProvisioningEnabled,
   isBuilderConnectCallbackUrlAllowed,
   isSignedBuilderConnectState,
@@ -2370,6 +2371,9 @@ export function createCoreRoutesPlugin(
                         typeof errRow.at === "number"
                           ? (errRow.at as number)
                           : Date.now(),
+                      ...(typeof errRow.code === "string"
+                        ? { code: errRow.code }
+                        : {}),
                     },
                   });
                 }
@@ -2738,10 +2742,12 @@ export function createCoreRoutesPlugin(
               status: number,
               message: string,
               reason: string,
+              code?: string,
             ) => {
               await putSetting(`builder-connect-error:${ownerEmail}`, {
                 message,
                 at: Date.now(),
+                ...(code ? { code } : {}),
               }).catch(() => {});
               await trackBuilderLifecycle(
                 event,
@@ -2761,6 +2767,7 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackErrorPage(message, {
                 parentOrigin: getBuilderBrowserOriginForEvent(event),
+                ...(code ? { code } : {}),
               });
             };
 
@@ -2838,6 +2845,14 @@ export function createCoreRoutesPlugin(
                 "[builder] Agent-Native account provisioning failed:",
                 error instanceof Error ? error.message : error,
               );
+              if (isBuilderAccountAlreadyExistsError(error)) {
+                return failProvisioning(
+                  409,
+                  "A Builder account already exists for this email. Log in to connect it.",
+                  "account_exists",
+                  "account_exists",
+                );
+              }
               return failProvisioning(
                 502,
                 "Couldn't create your Builder account. Try again or connect an existing account.",

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -2659,6 +2659,10 @@ export function createCoreRoutesPlugin(
       getH3App(nitroApp).use(
         `${P}/builder/connect`,
         defineEventHandler(async (event) => {
+          const requestUrl = getFrameworkRouteRequestUrl(event);
+          const connectAttemptId = requestUrl.searchParams.get(
+            BUILDER_CONNECT_ATTEMPT_PARAM,
+          );
           const ownerContext = await resolveBuilderOwnerContext(
             event,
             "connect",
@@ -2684,14 +2688,11 @@ export function createCoreRoutesPlugin(
                 title: "Sign in required",
                 body: "Builder OAuth is tied to a signed-in account. Sign in, then try Connect Builder again.",
                 parentOrigin: getBuilderBrowserOriginForEvent(event),
+                ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
               },
             );
           }
 
-          const requestUrl = getFrameworkRouteRequestUrl(event);
-          const connectAttemptId = requestUrl.searchParams.get(
-            BUILDER_CONNECT_ATTEMPT_PARAM,
-          );
           const connectToken = requestUrl.searchParams.get(
             BUILDER_CONNECT_PARAM,
           );
@@ -2731,6 +2732,7 @@ export function createCoreRoutesPlugin(
             await putSetting(`builder-connect-error:${ownerEmail}`, {
               message: crossOriginMessage,
               at: Date.now(),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             }).catch(() => {});
             console.warn("[builder-connect] rejected cross-origin connect", {
               hasConnectToken: Boolean(connectToken),
@@ -2750,6 +2752,7 @@ export function createCoreRoutesPlugin(
               closeHint:
                 "Close this popup, refresh the app, and try Connect account again.",
               parentOrigin: getBuilderBrowserOriginForEvent(event),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             });
           }
 
@@ -2787,6 +2790,7 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackErrorPage(message, {
                 parentOrigin: getBuilderBrowserOriginForEvent(event),
+                ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
                 ...(code ? { code } : {}),
               });
             };
@@ -2858,7 +2862,10 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackPage(
                 `${parentOrigin}${getAppBasePath() || "/"}`,
-                { parentOrigin },
+                {
+                  parentOrigin,
+                  ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
+                },
               );
             } catch (error) {
               console.error(
@@ -2908,6 +2915,7 @@ export function createCoreRoutesPlugin(
               title: "Builder connection is unavailable here",
               body: "Open this app on its public HTTPS URL, then try again.",
               parentOrigin: getBuilderBrowserOriginForEvent(event),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             });
           }
           const { orgId: connectOrgId, deny: orgConnectDenied } =
@@ -2933,6 +2941,7 @@ export function createCoreRoutesPlugin(
               title: "Not allowed to connect Builder for this organization",
               body: "Ask an organization owner or admin to connect Builder.",
               parentOrigin: getBuilderBrowserOriginForEvent(event),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             });
           }
           // The standard OAuth client discovers Builder's protected-resource
@@ -2956,6 +2965,7 @@ export function createCoreRoutesPlugin(
               redirectUri: callbackUrl,
               expiresAt: Date.now() + BUILDER_CONNECT_PENDING_TTL_MS,
               tracking: connectTracking,
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             });
             await purgeExpiredBuilderConnectPendingStates().catch(() => 0); // coercion-ok: connect already persisted the new pending row; purge of abandoned rows must not fail OAuth start
             setCookie(
@@ -2995,6 +3005,7 @@ export function createCoreRoutesPlugin(
             await putSetting(`builder-connect-error:${ownerEmail}`, {
               message: msg,
               at: Date.now(),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             }).catch(() => {});
             setResponseStatus(event, 503);
             setResponseHeader(
@@ -3004,6 +3015,7 @@ export function createCoreRoutesPlugin(
             );
             return createBuilderBrowserCallbackErrorPage(msg, {
               parentOrigin: getBuilderBrowserOriginForEvent(event),
+              ...(connectAttemptId ? { attemptId: connectAttemptId } : {}),
             });
           }
           await trackBuilderLifecycle(
@@ -3264,6 +3276,9 @@ export function createCoreRoutesPlugin(
           setResponseHeader(event, "Referrer-Policy", "no-referrer");
 
           const requestUrl = getFrameworkRouteRequestUrl(event);
+          const requestConnectAttemptId = requestUrl.searchParams.get(
+            BUILDER_CONNECT_ATTEMPT_PARAM,
+          );
           const relayStateRaw = requestUrl.searchParams.get(
             BUILDER_RELAY_STATE_PARAM,
           );
@@ -3285,6 +3300,9 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackErrorPage(
                 "Builder preview relay state is invalid or expired.",
+                requestConnectAttemptId
+                  ? { attemptId: requestConnectAttemptId }
+                  : undefined,
               );
             }
 
@@ -3306,7 +3324,12 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackErrorPage(
                 "Builder didn't return credentials. Restart the connect flow from settings.",
-                { parentOrigin: relayParentOrigin },
+                {
+                  parentOrigin: relayParentOrigin,
+                  ...(requestConnectAttemptId
+                    ? { attemptId: requestConnectAttemptId }
+                    : {}),
+                },
               );
             }
 
@@ -3363,6 +3386,9 @@ export function createCoreRoutesPlugin(
               );
               return createBuilderBrowserCallbackErrorPage(message, {
                 parentOrigin: relayParentOrigin,
+                ...(requestConnectAttemptId
+                  ? { attemptId: requestConnectAttemptId }
+                  : {}),
               });
             }
 
@@ -3373,7 +3399,12 @@ export function createCoreRoutesPlugin(
             );
             return createBuilderBrowserCallbackPage(
               `${relayParentOrigin}${relayPayload.basePath || "/"}`,
-              { parentOrigin: relayParentOrigin },
+              {
+                parentOrigin: relayParentOrigin,
+                ...(requestConnectAttemptId
+                  ? { attemptId: requestConnectAttemptId }
+                  : {}),
+              },
             );
           }
 
@@ -3386,6 +3417,7 @@ export function createCoreRoutesPlugin(
             getCookie(event, BUILDER_CONNECT_STATE_COOKIE),
           );
           const parentOrigin = getBuilderBrowserOriginForEvent(event);
+          let callbackAttemptId = requestConnectAttemptId;
           const fail = async (
             status: number,
             message: string,
@@ -3397,6 +3429,7 @@ export function createCoreRoutesPlugin(
               await putSetting(`builder-connect-error:${ownerEmail}`, {
                 message,
                 at: Date.now(),
+                ...(callbackAttemptId ? { attemptId: callbackAttemptId } : {}),
               }).catch(() => {});
               await trackBuilderLifecycle(
                 event,
@@ -3417,6 +3450,7 @@ export function createCoreRoutesPlugin(
             );
             return createBuilderBrowserCallbackErrorPage(message, {
               parentOrigin,
+              ...(callbackAttemptId ? { attemptId: callbackAttemptId } : {}),
             });
           };
 
@@ -3434,6 +3468,11 @@ export function createCoreRoutesPlugin(
               "No active Builder connect flow found. Restart the connection from Settings.",
             );
           }
+
+          callbackAttemptId =
+            typeof pending.attemptId === "string"
+              ? pending.attemptId
+              : callbackAttemptId;
 
           const ownerEmail =
             typeof pending.ownerEmail === "string" ? pending.ownerEmail : null;
@@ -3596,7 +3635,10 @@ export function createCoreRoutesPlugin(
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackPage(
             `${parentOrigin}${getAppBasePath() || "/"}`,
-            { parentOrigin },
+            {
+              parentOrigin,
+              ...(callbackAttemptId ? { attemptId: callbackAttemptId } : {}),
+            },
           );
         }),
       );

--- a/packages/dispatch/src/components/create-app-popover.spec.tsx
+++ b/packages/dispatch/src/components/create-app-popover.spec.tsx
@@ -36,6 +36,7 @@ vi.mock("@agent-native/core/client/settings/useBuilderStatus", () => ({
     configured: false,
     connecting: builderConnectFlowState.connecting,
     error: null,
+    statusResolved: true,
     start: builderConnectFlowState.start,
   }),
 }));

--- a/packages/dispatch/src/components/create-app-popover.tsx
+++ b/packages/dispatch/src/components/create-app-popover.tsx
@@ -6,6 +6,7 @@ import {
 } from "@agent-native/core/client/api-path";
 import { PromptComposer } from "@agent-native/core/client/composer";
 import { isInBuilderFrame } from "@agent-native/core/client/host";
+import { BuilderConnectPopover } from "@agent-native/core/client/settings";
 import { useBuilderConnectFlow } from "@agent-native/core/client/settings/useBuilderStatus";
 import {
   buildChatFirstAppCreationPrompt,
@@ -141,6 +142,7 @@ export function CreateAppFlow({
   // its first status read for anyone already connected.
   const connectFlow = useBuilderConnectFlow({
     enabled: failureReason === "builder-not-connected",
+    provisionAccount: true,
     trackingSource: "dispatch_create_app",
     trackingFlow: "create_app",
     onConnected: () => {
@@ -604,16 +606,17 @@ export function CreateAppFlow({
           </div>
           {failureReason === "builder-not-connected" ? (
             <div className="flex flex-wrap items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => connectFlow.start()}
-                disabled={connectFlow.connecting}
-                className="w-fit"
-              >
-                {connectFlow.connecting ? "Connecting..." : "Connect Builder"}
-              </Button>
+              <BuilderConnectPopover flow={connectFlow}>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={connectFlow.connecting}
+                  className="w-fit"
+                >
+                  {connectFlow.connecting ? "Connecting..." : "Connect Builder"}
+                </Button>
+              </BuilderConnectPopover>
               <a
                 href={LOCAL_APP_DOCS_URL}
                 target="_blank"

--- a/packages/toolkit/src/composer/RealtimeVoiceMode.tsx
+++ b/packages/toolkit/src/composer/RealtimeVoiceMode.tsx
@@ -20,6 +20,7 @@ import {
   IconVolume,
 } from "@tabler/icons-react";
 import {
+  type ComponentType,
   type MouseEvent,
   useCallback,
   useEffect,
@@ -41,6 +42,10 @@ import {
   createRealtimeVoiceAudioLevelStore,
   type RealtimeVoiceAudioLevelStore,
 } from "./realtime-voice-audio-level.js";
+import type {
+  ComposerBuilderConnectFlow,
+  ComposerBuilderConnectPopoverProps,
+} from "./runtime-adapters.js";
 
 export type RealtimeVoiceModeState =
   | "connecting"
@@ -120,7 +125,9 @@ export interface RealtimeVoiceModeEntryProps {
   setupRequired?: boolean;
   openAiConfigured?: boolean;
   connectingBuilder?: boolean;
-  onConnectBuilder?: () => void;
+  onConnectBuilder?: (options?: { provisionAccount?: boolean }) => void;
+  builderConnectFlow?: ComposerBuilderConnectFlow;
+  builderConnectPopover?: ComponentType<ComposerBuilderConnectPopoverProps>;
   onUseOpenAiKey?: () => void;
   className?: string;
 }
@@ -146,6 +153,8 @@ export function RealtimeVoiceModeEntry({
   openAiConfigured = false,
   connectingBuilder = false,
   onConnectBuilder,
+  builderConnectFlow,
+  builderConnectPopover: BuilderConnectPopover,
   onUseOpenAiKey,
   className,
 }: RealtimeVoiceModeEntryProps) {
@@ -272,22 +281,49 @@ export function RealtimeVoiceModeEntry({
           >
             {setupRequired ? (
               <>
-                <Button
-                  type="button"
-                  size="sm"
-                  className="w-full justify-start px-3"
-                  disabled={connectingBuilder}
-                  onClick={() =>
-                    choose("realtime", onConnectBuilder ?? onStartVoiceMode)
-                  }
-                >
-                  {connectingBuilder ? (
-                    <IconLoader2 className="animate-spin" />
-                  ) : (
-                    <IconPlugConnected aria-hidden="true" />
-                  )}
-                  {copy.connectBuilder}
-                </Button>
+                {BuilderConnectPopover && builderConnectFlow ? (
+                  <BuilderConnectPopover
+                    flow={builderConnectFlow}
+                    onConnect={(provisionAccount) =>
+                      choose("realtime", () =>
+                        onConnectBuilder
+                          ? onConnectBuilder({ provisionAccount })
+                          : onStartVoiceMode(),
+                      )
+                    }
+                  >
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="w-full justify-start px-3"
+                      disabled={connectingBuilder}
+                    >
+                      {connectingBuilder ? (
+                        <IconLoader2 className="animate-spin" />
+                      ) : (
+                        <IconPlugConnected aria-hidden="true" />
+                      )}
+                      {copy.connectBuilder}
+                    </Button>
+                  </BuilderConnectPopover>
+                ) : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="w-full justify-start px-3"
+                    disabled={connectingBuilder}
+                    onClick={() =>
+                      choose("realtime", onConnectBuilder ?? onStartVoiceMode)
+                    }
+                  >
+                    {connectingBuilder ? (
+                      <IconLoader2 className="animate-spin" />
+                    ) : (
+                      <IconPlugConnected aria-hidden="true" />
+                    )}
+                    {copy.connectBuilder}
+                  </Button>
+                )}
                 <Button
                   type="button"
                   variant="outline"

--- a/packages/toolkit/src/composer/TiptapComposer.tsx
+++ b/packages/toolkit/src/composer/TiptapComposer.tsx
@@ -1503,8 +1503,10 @@ function ModelSelector({
   // provider or local agent is ready.
   const builderFlow = adapters.builder!.useConnectFlow!({
     enabled: providerConnectStatusEnabled,
+    provisionAccount: true,
     trackingSource: "composer_builder_cta",
   });
+  const BuilderConnectPopover = adapters.builder?.BuilderConnectPopover;
   const hasConfiguredBuilderModels = providerGroups.some(
     (group) => group.engine === "builder" && group.configured,
   );
@@ -1866,39 +1868,77 @@ function ModelSelector({
                       <>
                         {showBuilderAction && (
                           <>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                if (onConnectProvider) {
-                                  onConnectProvider();
-                                } else {
-                                  builderFlow.start();
-                                }
-                              }}
-                              disabled={
-                                !onConnectProvider && builderFlow.connecting
-                              }
-                              className="flex w-full items-start gap-2 rounded-md px-2 py-2 text-start hover:bg-accent/50 disabled:opacity-60"
-                            >
-                              <IconPlugConnected className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                              <span className="min-w-0 flex-1">
-                                <span className="block text-[12px] font-medium text-foreground">
-                                  {!onConnectProvider && builderFlow.connecting
-                                    ? t("agentPanel.connectingBuilder", {
-                                        defaultValue: "Connecting Builder.io…",
-                                      })
-                                    : t("agentPanel.connectBuilderIo", {
-                                        defaultValue: "Connect Builder.io",
+                            {BuilderConnectPopover ? (
+                              <BuilderConnectPopover
+                                flow={builderFlow}
+                                onConnect={(provisionAccount) => {
+                                  if (onConnectProvider && !provisionAccount) {
+                                    onConnectProvider();
+                                  } else {
+                                    builderFlow.start({ provisionAccount });
+                                  }
+                                }}
+                              >
+                                <button
+                                  type="button"
+                                  disabled={builderFlow.connecting}
+                                  className="flex w-full items-start gap-2 rounded-md px-2 py-2 text-start hover:bg-accent/50 disabled:opacity-60"
+                                >
+                                  <IconPlugConnected className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                  <span className="min-w-0 flex-1">
+                                    <span className="block text-[12px] font-medium text-foreground">
+                                      {builderFlow.connecting
+                                        ? t("agentPanel.connectingBuilder", {
+                                            defaultValue:
+                                              "Connecting Builder.io…",
+                                          })
+                                        : t("agentPanel.connectBuilderIo", {
+                                            defaultValue: "Connect Builder.io",
+                                          })}
+                                    </span>
+                                    <span className="block text-[11px] text-muted-foreground">
+                                      {t("agentPanel.builderModelCredits", {
+                                        defaultValue:
+                                          "Free credits for Claude, OpenAI & Gemini",
                                       })}
+                                    </span>
+                                  </span>
+                                </button>
+                              </BuilderConnectPopover>
+                            ) : (
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  if (onConnectProvider) {
+                                    onConnectProvider();
+                                  } else {
+                                    builderFlow.start();
+                                  }
+                                }}
+                                disabled={builderFlow.connecting}
+                                className="flex w-full items-start gap-2 rounded-md px-2 py-2 text-start hover:bg-accent/50 disabled:opacity-60"
+                              >
+                                <IconPlugConnected className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                <span className="min-w-0 flex-1">
+                                  <span className="block text-[12px] font-medium text-foreground">
+                                    {builderFlow.connecting
+                                      ? t("agentPanel.connectingBuilder", {
+                                          defaultValue:
+                                            "Connecting Builder.io…",
+                                        })
+                                      : t("agentPanel.connectBuilderIo", {
+                                          defaultValue: "Connect Builder.io",
+                                        })}
+                                  </span>
+                                  <span className="block text-[11px] text-muted-foreground">
+                                    {t("agentPanel.builderModelCredits", {
+                                      defaultValue:
+                                        "Free credits for Claude, OpenAI & Gemini",
+                                    })}
+                                  </span>
                                 </span>
-                                <span className="block text-[11px] text-muted-foreground">
-                                  {t("agentPanel.builderModelCredits", {
-                                    defaultValue:
-                                      "Free credits for Claude, OpenAI & Gemini",
-                                  })}
-                                </span>
-                              </span>
-                            </button>
+                              </button>
+                            )}
                             {!onConnectProvider && builderFlow.error && (
                               <p
                                 role="alert"

--- a/packages/toolkit/src/composer/VoiceButton.tsx
+++ b/packages/toolkit/src/composer/VoiceButton.tsx
@@ -72,6 +72,7 @@ export function VoiceButton({ voice, isMac, disabled }: VoiceButtonProps) {
   const realtimeCopy = useRealtimeVoiceModeCopy();
   const voiceProviders = adapters.voice!.useProviderStatus!();
   const builderConnect = adapters.builder!.useConnectFlow!({
+    provisionAccount: true,
     trackingSource: "realtime_voice",
     trackingFlow: "voice_transcription",
     onConnected: () => voiceProviders.refresh(),
@@ -132,6 +133,8 @@ export function VoiceButton({ voice, isMac, disabled }: VoiceButtonProps) {
         openAiConfigured={voiceProviders.status?.openai === true}
         connectingBuilder={builderConnect.connecting}
         onConnectBuilder={builderConnect.start}
+        builderConnectFlow={builderConnect}
+        builderConnectPopover={adapters.builder?.BuilderConnectPopover}
         onUseOpenAiKey={() => {
           if (voiceProviders.status?.openai) void realtimeVoice.start();
           else openOpenAiKeySettings();

--- a/packages/toolkit/src/composer/runtime-adapters.tsx
+++ b/packages/toolkit/src/composer/runtime-adapters.tsx
@@ -3,6 +3,8 @@ import {
   useContext,
   useMemo,
   type ComponentType,
+  type MouseEventHandler,
+  type ReactElement,
   type ReactNode,
 } from "react";
 
@@ -51,7 +53,18 @@ export interface ComposerBuilderConnectFlow {
   connecting: boolean;
   statusResolved: boolean;
   error: string | null;
-  start: () => void;
+  agentNativeProvisioningEnabled?: boolean;
+  accountExists?: boolean;
+  start: (options?: { provisionAccount?: boolean }) => void;
+}
+
+export interface ComposerBuilderConnectPopoverProps {
+  flow: ComposerBuilderConnectFlow;
+  children: ReactElement<{
+    onClick?: MouseEventHandler<HTMLElement>;
+  }>;
+  onConnect?: (provisionAccount: boolean) => void;
+  onTriggerClick?: MouseEventHandler<HTMLElement>;
 }
 
 export interface AgentChatContextItem {
@@ -80,6 +93,7 @@ export interface ComposerAgentChatOpenThreadRequest {
 export interface ComposerBuilderConnectFlowOptions {
   enabled?: boolean;
   popupUrl?: string;
+  provisionAccount?: boolean;
   trackingSource?: string;
   trackingFlow?: string;
   onConnected?: (state: { orgName: string | null }) => void | Promise<void>;
@@ -147,6 +161,7 @@ export interface ComposerRuntimeAdapters {
     useConnectFlow?: (
       options: ComposerBuilderConnectFlowOptions,
     ) => ComposerBuilderConnectFlow;
+    BuilderConnectPopover?: ComponentType<ComposerBuilderConnectPopoverProps>;
     tryDelegateBuildRequest?: (text: string) => boolean;
     isTrustedFrameMessage?: (event: MessageEvent) => boolean;
     isTrustedBuilderMessage?: (event: MessageEvent) => boolean;
@@ -222,6 +237,8 @@ const fallbackBuilderFlow = {
   connecting: false,
   statusResolved: false,
   error: null,
+  agentNativeProvisioningEnabled: false,
+  accountExists: false,
   start: () => {},
 };
 

--- a/templates/analytics/app/pages/sessions/SessionsPage.tsx
+++ b/templates/analytics/app/pages/sessions/SessionsPage.tsx
@@ -3,6 +3,7 @@ import { agentNativePath } from "@agent-native/core/client/api-path";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
+  BuilderConnectPopover,
   useBuilderConnectFlow,
   useBuilderStatus,
 } from "@agent-native/core/client/settings";
@@ -526,6 +527,7 @@ export function ReplayStorageHint({
   const builderStatus = useBuilderStatus();
   const builderConnect = useBuilderConnectFlow({
     popupUrl: builderStatus.status?.connectUrl,
+    provisionAccount: true,
     trackingSource: "analytics_sessions_storage_hint",
     trackingFlow: "replay_storage",
     onConnected: async () => {
@@ -601,31 +603,27 @@ export function ReplayStorageHint({
             </div>
           ) : null}
           <div className="flex max-w-full flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              size="sm"
-              className="shrink-0"
-              onClick={() =>
-                builderConnect.start({
-                  trackingSource: "analytics_sessions_storage_hint",
-                  trackingFlow: "replay_storage",
-                })
-              }
-              disabled={
-                builderConnect.connecting ||
-                builderStatusLoading ||
-                builderConnected
-              }
-            >
-              {builderConnect.connecting ? (
-                <IconLoader2 className="h-4 w-4 animate-spin" />
-              ) : builderConnected ? (
-                <IconCheck className="h-4 w-4" />
-              ) : null}
-              {builderConnected
-                ? t("sessions.storageConnected")
-                : t("sessions.connectBuilder")}
-            </Button>
+            <BuilderConnectPopover flow={builderConnect}>
+              <Button
+                type="button"
+                size="sm"
+                className="shrink-0"
+                disabled={
+                  builderConnect.connecting ||
+                  builderStatusLoading ||
+                  builderConnected
+                }
+              >
+                {builderConnect.connecting ? (
+                  <IconLoader2 className="h-4 w-4 animate-spin" />
+                ) : builderConnected ? (
+                  <IconCheck className="h-4 w-4" />
+                ) : null}
+                {builderConnected
+                  ? t("sessions.storageConnected")
+                  : t("sessions.connectBuilder")}
+              </Button>
+            </BuilderConnectPopover>
             <CollapsibleTrigger asChild>
               <Button type="button" variant="ghost" size="sm">
                 <IconServer className="h-3.5 w-3.5" />

--- a/templates/assets/app/routes/settings.tsx
+++ b/templates/assets/app/routes/settings.tsx
@@ -10,6 +10,7 @@ import {
 import { TeamPage } from "@agent-native/core/client/org";
 import {
   AccountSettingsCard,
+  BuilderConnectPopover,
   SettingsGroup,
   SettingsRow,
   SettingsTabsPage,
@@ -228,6 +229,7 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
   };
 
   const flow = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource: "assets_settings_connections",
     trackingFlow: "image_generation",
     onConnected: refreshSetup,
@@ -307,31 +309,32 @@ function AssetsSetupCard({ libraryCount }: { libraryCount: number }) {
           }
           control={
             builderEnabled ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => flow.start()}
-                disabled={flow.connecting}
-                className="shrink-0"
-              >
-                {flow.connecting ? (
-                  <>
-                    <IconLoader2 className="size-3.5 animate-spin" />
-                    {t("settings.connecting")}
-                  </>
-                ) : builderConnected ? (
-                  <>
-                    {t("settings.reconnect")}
-                    <IconExternalLink className="size-3.5" />
-                  </>
-                ) : (
-                  <>
-                    {t("settings.connect")}
-                    <IconExternalLink className="size-3.5" />
-                  </>
-                )}
-              </Button>
+              <BuilderConnectPopover flow={flow}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={flow.connecting}
+                  className="shrink-0"
+                >
+                  {flow.connecting ? (
+                    <>
+                      <IconLoader2 className="size-3.5 animate-spin" />
+                      {t("settings.connecting")}
+                    </>
+                  ) : builderConnected ? (
+                    <>
+                      {t("settings.reconnect")}
+                      <IconExternalLink className="size-3.5" />
+                    </>
+                  ) : (
+                    <>
+                      {t("settings.connect")}
+                      <IconExternalLink className="size-3.5" />
+                    </>
+                  )}
+                </Button>
+              </BuilderConnectPopover>
             ) : null
           }
         />

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -1,6 +1,9 @@
-import { agentNativePath, appPath } from "@agent-native/core/client/api-path";
+import { appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
-import { openBuilderConnectPopup } from "@agent-native/core/client/settings";
+import {
+  BuilderConnectPopover,
+  useBuilderConnectFlow,
+} from "@agent-native/core/client/settings";
 import {
   BUILDER_CREDITS_UPGRADE_URL,
   isBuilderCreditsExhaustedMessage,
@@ -15,7 +18,7 @@ import {
   IconBolt,
   IconRefresh,
 } from "@tabler/icons-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -617,118 +620,19 @@ function TranscriptSetupCard({
   onRetry?: () => void;
 }) {
   const t = useT();
-  const [builderConfigured, setBuilderConfigured] = useState<boolean | null>(
-    null,
-  );
-  const [connecting, setConnecting] = useState(false);
-  const [connectError, setConnectError] = useState<string | null>(null);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const mountedRef = useRef(true);
-  const inFlightRef = useRef(false);
-  const visibilityHandlerRef = useRef<(() => void) | null>(null);
-
-  const autoRetryRef = useRef(false);
-  const onRetryRef = useRef(onRetry);
-
-  useEffect(() => {
-    onRetryRef.current = onRetry;
-  }, [onRetry]);
-
-  const stopVisibilityHandler = useCallback(() => {
-    if (visibilityHandlerRef.current) {
-      document.removeEventListener(
-        "visibilitychange",
-        visibilityHandlerRef.current,
-      );
-      visibilityHandlerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    fetch(agentNativePath("/_agent-native/builder/status"))
-      .then((r) =>
-        r.ok ? (r.json() as Promise<{ configured: boolean }>) : null,
-      )
-      .then((s) => {
-        if (mountedRef.current) setBuilderConfigured(s?.configured ?? false);
-      })
-      .catch(() => {
-        if (mountedRef.current) setBuilderConfigured(false);
-      });
-    return () => {
-      mountedRef.current = false;
-      if (pollRef.current) clearInterval(pollRef.current);
-      stopVisibilityHandler();
-    };
-  }, [stopVisibilityHandler]);
-
-  useEffect(() => {
-    if (!builderConfigured || autoRetryRef.current) return;
-    if (!isConnectedBuilderRetryable(failureReason)) return;
-    autoRetryRef.current = true;
-    const handle = window.setTimeout(() => onRetryRef.current?.(), 250);
-    return () => window.clearTimeout(handle);
-  }, [builderConfigured, failureReason]);
-
-  const handleConnect = useCallback(() => {
-    if (pollRef.current) clearInterval(pollRef.current);
-    stopVisibilityHandler();
-    inFlightRef.current = false;
-    setConnecting(true);
-    setConnectError(null);
-
-    openBuilderConnectPopup({ source: "clips_transcript_panel" });
-
-    const start = Date.now();
-    const tick = async () => {
-      if (document.hidden || inFlightRef.current) return;
-      inFlightRef.current = true;
-      const controller = new AbortController();
-      const abortTimer = setTimeout(
-        () => controller.abort(),
-        Math.max(10_000, 2000 * 4),
-      );
-      try {
-        const r = await fetch(
-          agentNativePath("/_agent-native/builder/status"),
-          {
-            signal: controller.signal,
-          },
-        );
-        if (!r.ok) return;
-        const s = (await r.json()) as { configured: boolean };
-        if (!mountedRef.current) {
-          clearInterval(pollRef.current!);
-          stopVisibilityHandler();
-          return;
-        }
-        if (s.configured) {
-          clearInterval(pollRef.current!);
-          stopVisibilityHandler();
-          setBuilderConfigured(true);
-          setConnecting(false);
-          onRetry?.();
-        } else if (Date.now() - start > 5 * 60 * 1000) {
-          clearInterval(pollRef.current!);
-          stopVisibilityHandler();
-          setConnecting(false);
-          setConnectError(t("transcriptPanel.builderNoResponse"));
-        }
-      } catch {
-        // coercion-ok: a transient poll error keeps the loop running; the
-        // 5-minute bound above surfaces builderNoResponse if it never succeeds.
-      } finally {
-        clearTimeout(abortTimer);
-        inFlightRef.current = false;
-      }
-    };
-    pollRef.current = setInterval(() => void tick(), 2000);
-    visibilityHandlerRef.current = () => {
-      if (!document.hidden) void tick();
-    };
-    document.addEventListener("visibilitychange", visibilityHandlerRef.current);
-  }, [onRetry, stopVisibilityHandler, t]);
+  const builderConnect = useBuilderConnectFlow({
+    provisionAccount: true,
+    trackingSource: "clips_transcript_panel",
+    trackingFlow: "transcription",
+    onConnected: () => {
+      if (isConnectedBuilderRetryable(failureReason)) onRetry?.();
+    },
+  });
+  const builderConfigured = builderConnect.statusResolved
+    ? builderConnect.configured
+    : null;
+  const connecting = builderConnect.connecting;
+  const connectError = builderConnect.error;
 
   const isProviderError =
     !isBuilderCreditsExhaustedMessage(failureReason) &&
@@ -805,24 +709,25 @@ function TranscriptSetupCard({
                 ) : null}
               </div>
             ) : (
-              <button
-                type="button"
-                onClick={handleConnect}
-                disabled={connecting || builderConfigured === null}
-                className="shrink-0 inline-flex items-center gap-1 text-[11px] font-medium border border-border rounded px-2 py-1 bg-background hover:bg-accent disabled:opacity-50 transition-colors"
-              >
-                {connecting ? (
-                  <>
-                    <IconLoader2 className="h-3 w-3 animate-spin" />
-                    {t("transcriptPanel.waiting")}
-                  </>
-                ) : (
-                  <>
-                    <IconExternalLink className="h-3 w-3" />
-                    Connect
-                  </>
-                )}
-              </button>
+              <BuilderConnectPopover flow={builderConnect}>
+                <button
+                  type="button"
+                  disabled={connecting || builderConfigured === null}
+                  className="shrink-0 inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-1 text-[11px] font-medium transition-colors hover:bg-accent disabled:opacity-50"
+                >
+                  {connecting ? (
+                    <>
+                      <IconLoader2 className="h-3 w-3 animate-spin" />
+                      {t("transcriptPanel.waiting")}
+                    </>
+                  ) : (
+                    <>
+                      <IconExternalLink className="h-3 w-3" />
+                      Connect
+                    </>
+                  )}
+                </button>
+              </BuilderConnectPopover>
             )}
           </div>
           {connectError && (

--- a/templates/clips/app/components/recorder/storage-setup-card.tsx
+++ b/templates/clips/app/components/recorder/storage-setup-card.tsx
@@ -1,6 +1,9 @@
 import { agentNativePath, appPath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
-import { openBuilderConnectPopup } from "@agent-native/core/client/settings";
+import {
+  BuilderConnectPopover,
+  useBuilderConnectFlow,
+} from "@agent-native/core/client/settings";
 import {
   IconCheck,
   IconCloud,
@@ -73,19 +76,7 @@ export function StorageSetupCard({
     }
   }, []);
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-      stopVisibilityHandler();
-    };
-  }, [stopVisibilityHandler]);
-
-  const handleConnect = useCallback(() => {
+  const startFileUploadPoll = useCallback(() => {
     if (pollRef.current) {
       clearInterval(pollRef.current);
       pollRef.current = null;
@@ -94,11 +85,6 @@ export function StorageSetupCard({
     inFlightRef.current = false;
     setConnecting(true);
     setErr(null);
-
-    openBuilderConnectPopup({
-      source: connectSource,
-      flow: connectFlow,
-    });
 
     const start = Date.now();
     const timeoutMs = 5 * 60 * 1000;
@@ -154,7 +140,26 @@ export function StorageSetupCard({
       if (!document.hidden) void tick();
     };
     document.addEventListener("visibilitychange", visibilityHandlerRef.current);
-  }, [onConfigured, connectSource, connectFlow, stopVisibilityHandler, t]);
+  }, [onConfigured, stopVisibilityHandler, t]);
+
+  const builderConnect = useBuilderConnectFlow({
+    provisionAccount: true,
+    trackingSource: connectSource,
+    trackingFlow: connectFlow,
+    onConnected: startFileUploadPoll,
+  });
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      stopVisibilityHandler();
+    };
+  }, [stopVisibilityHandler]);
 
   return (
     <div className="mx-auto flex w-full max-w-md flex-col gap-5 rounded-2xl border border-border bg-card p-6 shadow-lg">
@@ -167,55 +172,56 @@ export function StorageSetupCard({
       </div>
 
       {/* Builder.io — primary option, one-click Connect flow. */}
-      <button
-        type="button"
-        onClick={handleConnect}
-        disabled={connecting || connected}
-        className={
-          "flex items-start gap-3 rounded-xl border px-4 py-3.5 text-start transition-colors " +
-          (connected
-            ? "border-primary/50 bg-primary/5"
-            : "border-primary bg-primary text-primary-foreground hover:bg-primary/90")
-        }
-      >
-        <div
+      <BuilderConnectPopover flow={builderConnect}>
+        <button
+          type="button"
+          disabled={connecting || connected}
           className={
-            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg " +
+            "flex items-start gap-3 rounded-xl border px-4 py-3.5 text-start transition-colors " +
             (connected
-              ? "bg-foreground text-background"
-              : "bg-primary-foreground/15 text-primary-foreground")
+              ? "border-primary/50 bg-primary/5"
+              : "border-primary bg-primary text-primary-foreground hover:bg-primary/90")
           }
         >
-          {connected ? (
-            <IconCheck className="h-5 w-5" />
-          ) : connecting ? (
-            <IconLoader2 className="h-5 w-5 animate-spin" />
-          ) : (
-            <BuilderBMark className="h-5 w-5" />
-          )}
-        </div>
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">
-              {connected
-                ? t("storageSetup.builderConnected")
-                : connecting
-                  ? t("storageSetup.waitingForBuilder")
-                  : t("storageSetup.connectBuilder")}
-            </span>
-          </div>
-          <span
+          <div
             className={
-              "mt-0.5 block text-xs " +
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg " +
               (connected
-                ? "text-muted-foreground"
-                : "text-primary-foreground/80")
+                ? "bg-foreground text-background"
+                : "bg-primary-foreground/15 text-primary-foreground")
             }
           >
-            {connected ? connectedDescription : connectDescription}
-          </span>
-        </div>
-      </button>
+            {connected ? (
+              <IconCheck className="h-5 w-5" />
+            ) : connecting ? (
+              <IconLoader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <BuilderBMark className="h-5 w-5" />
+            )}
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">
+                {connected
+                  ? t("storageSetup.builderConnected")
+                  : connecting
+                    ? t("storageSetup.waitingForBuilder")
+                    : t("storageSetup.connectBuilder")}
+              </span>
+            </div>
+            <span
+              className={
+                "mt-0.5 block text-xs " +
+                (connected
+                  ? "text-muted-foreground"
+                  : "text-primary-foreground/80")
+              }
+            >
+              {connected ? connectedDescription : connectDescription}
+            </span>
+          </div>
+        </button>
+      </BuilderConnectPopover>
 
       {err && <p className="text-xs text-muted-foreground">{err}</p>}
 

--- a/templates/clips/app/components/recorder/storage-setup-card.tsx
+++ b/templates/clips/app/components/recorder/storage-setup-card.tsx
@@ -65,6 +65,7 @@ export function StorageSetupCard({
   const mountedRef = useRef(true);
   const inFlightRef = useRef(false);
   const visibilityHandlerRef = useRef<(() => void) | null>(null);
+  const connectRequestedRef = useRef(false);
 
   const stopVisibilityHandler = useCallback(() => {
     if (visibilityHandlerRef.current) {
@@ -142,12 +143,25 @@ export function StorageSetupCard({
     document.addEventListener("visibilitychange", visibilityHandlerRef.current);
   }, [onConfigured, stopVisibilityHandler, t]);
 
+  const handleBuilderConnected = useCallback(() => {
+    if (!connectRequestedRef.current) return;
+    connectRequestedRef.current = false;
+    startFileUploadPoll();
+  }, [startFileUploadPoll]);
+
   const builderConnect = useBuilderConnectFlow({
     provisionAccount: true,
     trackingSource: connectSource,
     trackingFlow: connectFlow,
-    onConnected: startFileUploadPoll,
+    onConnected: handleBuilderConnected,
   });
+  const handleBuilderConnect = useCallback(
+    (provisionAccount: boolean) => {
+      connectRequestedRef.current = true;
+      builderConnect.start({ provisionAccount });
+    },
+    [builderConnect.start],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -172,7 +186,10 @@ export function StorageSetupCard({
       </div>
 
       {/* Builder.io — primary option, one-click Connect flow. */}
-      <BuilderConnectPopover flow={builderConnect}>
+      <BuilderConnectPopover
+        flow={builderConnect}
+        onConnect={handleBuilderConnect}
+      >
         <button
           type="button"
           disabled={connecting || connected}

--- a/templates/clips/app/components/settings/ai-setup-section.tsx
+++ b/templates/clips/app/components/settings/ai-setup-section.tsx
@@ -3,6 +3,7 @@ import { useT } from "@agent-native/core/client/i18n";
 import {
   AGENT_PROVIDER_CATALOG,
   AgentProviderSetupForm,
+  BuilderConnectPopover,
   SettingsGroup,
   SettingsRow,
   type AgentProviderId,
@@ -104,23 +105,28 @@ export function AiSetupSection({ builder, secrets }: AiSetupSectionProps) {
                   Builder.io
                 </span>
               ) : (
-                <Button
-                  type="button"
-                  variant="default"
-                  size="sm"
-                  onClick={() =>
+                <BuilderConnectPopover
+                  flow={builder.connectFlow}
+                  onConnect={(provisionAccount) =>
                     builder.start({
+                      provisionAccount,
                       trackingSource: "clips_settings_ai_setup",
                       trackingFlow: "connect_llm",
                     })
                   }
-                  disabled={builder.connecting || builder.loading}
                 >
-                  {builder.connecting ? (
-                    <IconLoader2 className="h-4 w-4 animate-spin" />
-                  ) : null}
-                  {t("settings.connectBuilder")}
-                </Button>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    disabled={builder.connecting || builder.loading}
+                  >
+                    {builder.connecting ? (
+                      <IconLoader2 className="h-4 w-4 animate-spin" />
+                    ) : null}
+                    {t("settings.connectBuilder")}
+                  </Button>
+                </BuilderConnectPopover>
               )}
               <CollapsibleTrigger asChild>
                 <Button type="button" variant="outline" size="sm">

--- a/templates/clips/app/components/settings/types.ts
+++ b/templates/clips/app/components/settings/types.ts
@@ -1,4 +1,7 @@
-import type { BuilderConnectStartOptions } from "@agent-native/core/client/settings";
+import type {
+  BuilderConnectFlow,
+  BuilderConnectStartOptions,
+} from "@agent-native/core/client/settings";
 
 /**
  * The Builder.io connection as the settings sections need it. Video storage
@@ -11,4 +14,5 @@ export interface BuilderConnection {
   connecting: boolean;
   orgName: string | null;
   start: (options?: BuilderConnectStartOptions) => void;
+  connectFlow: BuilderConnectFlow;
 }

--- a/templates/clips/app/components/settings/video-storage-section.tsx
+++ b/templates/clips/app/components/settings/video-storage-section.tsx
@@ -1,6 +1,10 @@
 import { agentNativePath } from "@agent-native/core/client/api-path";
 import { useT } from "@agent-native/core/client/i18n";
-import { SettingsGroup, SettingsRow } from "@agent-native/core/client/settings";
+import {
+  BuilderConnectPopover,
+  SettingsGroup,
+  SettingsRow,
+} from "@agent-native/core/client/settings";
 import { IconCheck, IconLoader2, IconTrash } from "@tabler/icons-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -242,23 +246,28 @@ export function VideoStorageSection({
                   {t("common.connected")}
                 </span>
               ) : (
-                <Button
-                  type="button"
-                  variant="default"
-                  size="sm"
-                  onClick={() =>
+                <BuilderConnectPopover
+                  flow={builder.connectFlow}
+                  onConnect={(provisionAccount) =>
                     builder.start({
+                      provisionAccount,
                       trackingSource: "clips_settings_video_storage",
                       trackingFlow: "video_storage",
                     })
                   }
-                  disabled={builder.connecting || builder.loading}
                 >
-                  {builder.connecting ? (
-                    <IconLoader2 className="h-4 w-4 animate-spin" />
-                  ) : null}
-                  {t("settings.connectBuilder")}
-                </Button>
+                  <Button
+                    type="button"
+                    variant="default"
+                    size="sm"
+                    disabled={builder.connecting || builder.loading}
+                  >
+                    {builder.connecting ? (
+                      <IconLoader2 className="h-4 w-4 animate-spin" />
+                    ) : null}
+                    {t("settings.connectBuilder")}
+                  </Button>
+                </BuilderConnectPopover>
               )}
               <CollapsibleTrigger asChild>
                 <Button type="button" variant="outline" size="sm">

--- a/templates/clips/app/routes/_app.settings._index.tsx
+++ b/templates/clips/app/routes/_app.settings._index.tsx
@@ -108,6 +108,7 @@ export default function SettingsIndexRoute() {
   const connectRequestedRef = useRef(false);
   const builderConnect = useBuilderConnectFlow({
     popupUrl: builderStatus.status?.connectUrl,
+    provisionAccount: true,
     trackingSource: "clips_settings",
     trackingFlow: "clips_setup",
     onConnected: async () => {
@@ -166,6 +167,7 @@ export default function SettingsIndexRoute() {
       connecting: builderConnect.connecting,
       orgName: builderConnect.orgName ?? builderStatus.status?.orgName ?? null,
       start: startBuilderConnect,
+      connectFlow: builderConnect,
     }),
     [builderConnect, builderStatus, startBuilderConnect, storageStatus],
   );

--- a/templates/content/app/components/editor/database/DatabaseView.tsx
+++ b/templates/content/app/components/editor/database/DatabaseView.tsx
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import {
+  BuilderConnectPopover,
   useBuilderConnectFlow,
   useBuilderStatus,
 } from "@agent-native/core/client/settings";
@@ -8366,6 +8367,7 @@ function DatabaseSettingsSourcePanel({
         : [{ id: "builder-space", name: dbText("builderSpace") }];
   const builderSpaceLabel = builderSpaces[0]?.name ?? builderOrgName;
   const connect = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource: "database_source_panel",
     onConnected: () => {
       void builderStatus.refetch();
@@ -8571,19 +8573,20 @@ function DatabaseSettingsSourcePanel({
             {dbText("connectYourBuilderAccountToBrowseItsSpaces")}
           </div>
           <div>
-            <Button
-              type="button"
-              size="sm"
-              disabled={!canEdit || connect.connecting}
-              onClick={() => connect.start()}
-            >
-              {connect.connecting ? (
-                <Spinner className="mr-1.5 size-3.5" />
-              ) : (
-                <IconExternalLink className="mr-1.5 size-3.5" />
-              )}
-              Connect Builder
-            </Button>
+            <BuilderConnectPopover flow={connect}>
+              <Button
+                type="button"
+                size="sm"
+                disabled={!canEdit || connect.connecting}
+              >
+                {connect.connecting ? (
+                  <Spinner className="mr-1.5 size-3.5" />
+                ) : (
+                  <IconExternalLink className="mr-1.5 size-3.5" />
+                )}
+                Connect Builder
+              </Button>
+            </BuilderConnectPopover>
           </div>
         </div>
       );

--- a/templates/content/app/components/editor/database/settings.tsx
+++ b/templates/content/app/components/editor/database/settings.tsx
@@ -1,5 +1,6 @@
 import { useCodeMode } from "@agent-native/core/client/agent-chat";
 import {
+  BuilderConnectPopover,
   useBuilderConnectFlow,
   useBuilderStatus,
 } from "@agent-native/core/client/settings";
@@ -702,6 +703,7 @@ function DatabaseSettingsSourcePanel({
         : [{ id: "builder-space", name: dbText("builderSpace") }];
   const builderSpaceLabel = builderSpaces[0]?.name ?? builderOrgName;
   const connect = useBuilderConnectFlow({
+    provisionAccount: true,
     trackingSource: "database_source_panel",
     onConnected: () => {
       void builderStatus.refetch();
@@ -869,19 +871,20 @@ function DatabaseSettingsSourcePanel({
             {dbText("connectYourBuilderAccountToBrowseItsSpaces")}
           </div>
           <div>
-            <Button
-              type="button"
-              size="sm"
-              disabled={!canEdit || connect.connecting}
-              onClick={() => connect.start()}
-            >
-              {connect.connecting ? (
-                <Spinner className="mr-1.5 size-3.5" />
-              ) : (
-                <IconExternalLink className="mr-1.5 size-3.5" />
-              )}
-              Connect Builder
-            </Button>
+            <BuilderConnectPopover flow={connect}>
+              <Button
+                type="button"
+                size="sm"
+                disabled={!canEdit || connect.connecting}
+              >
+                {connect.connecting ? (
+                  <Spinner className="mr-1.5 size-3.5" />
+                ) : (
+                  <IconExternalLink className="mr-1.5 size-3.5" />
+                )}
+                Connect Builder
+              </Button>
+            </BuilderConnectPopover>
           </div>
         </div>
       );

--- a/templates/design/app/components/design/edit-panel/component-section.tsx
+++ b/templates/design/app/components/design/edit-panel/component-section.tsx
@@ -3,6 +3,10 @@ import {
   useActionQuery,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
+import {
+  BuilderConnectPopover,
+  useBuilderConnectFlow,
+} from "@agent-native/core/client/settings";
 import { withBuilderUtmTrackingParams } from "@agent-native/core/shared";
 import { propNameToDataAttribute } from "@shared/component-model";
 import {
@@ -110,10 +114,25 @@ function MakeItRealCard({
   featureLabel: string;
 }) {
   const t = useT();
+  const queryClient = useQueryClient();
   const { data, isLoading } = useActionQuery<ConnectBuilderAppResult>(
     "connect-builder-app",
     { designId },
   );
+  const builderConnect = useBuilderConnectFlow({
+    popupUrl:
+      data?.cta?.kind === "connect-builder" ? data.cta.connectUrl : undefined,
+    provisionAccount: true,
+    trackingSource: "design_editor_make_real",
+    trackingFlow: "design_migration",
+    onConnected: () => {
+      if (data?.cta?.kind === "connect-builder") {
+        void queryClient.invalidateQueries({
+          queryKey: ["action", "connect-builder-app", { designId }],
+        });
+      }
+    },
+  });
 
   const migrateMutation = useActionMutation("migrate-inline-design-to-app");
 
@@ -139,12 +158,6 @@ function MakeItRealCard({
 
   // "Make it real" primary action: open the connect URL or migrate.
   const handlePrimary = () => {
-    if (cta.kind === "connect-builder") {
-      // Open the Builder OAuth connect flow in a new tab.  The user completes
-      // it there and comes back; the card will re-query on next render.
-      window.open(cta.connectUrl, "_blank", "noopener,noreferrer");
-      return;
-    }
     if (cta.kind === "configure-project") {
       window.open(cta.connectUrl, "_blank", "noopener,noreferrer");
       return;
@@ -211,16 +224,30 @@ function MakeItRealCard({
         >
           {summary}
         </p>
-        <Button
-          type="button"
-          size="sm"
-          onClick={handlePrimary}
-          title={cta.primaryAction}
-          className="h-6 shrink-0 gap-1 rounded-md bg-[var(--design-editor-accent-color)] px-1.5 text-[10px] font-semibold text-white hover:bg-[var(--design-editor-accent-hover-color)]"
-        >
-          {primaryLabel}
-          <IconArrowRight className="size-2.5" />
-        </Button>
+        {cta.kind === "connect-builder" ? (
+          <BuilderConnectPopover flow={builderConnect}>
+            <Button
+              type="button"
+              size="sm"
+              title={cta.primaryAction}
+              className="h-6 shrink-0 gap-1 rounded-md bg-[var(--design-editor-accent-color)] px-1.5 text-[10px] font-semibold text-primary-foreground hover:bg-[var(--design-editor-accent-hover-color)]"
+            >
+              {primaryLabel}
+              <IconArrowRight className="size-2.5" />
+            </Button>
+          </BuilderConnectPopover>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            onClick={handlePrimary}
+            title={cta.primaryAction}
+            className="h-6 shrink-0 gap-1 rounded-md bg-[var(--design-editor-accent-color)] px-1.5 text-[10px] font-semibold text-primary-foreground hover:bg-[var(--design-editor-accent-hover-color)]"
+          >
+            {primaryLabel}
+            <IconArrowRight className="size-2.5" />
+          </Button>
+        )}
 
         {/* When Builder is fully connected, also offer direct migration */}
         {data.connected && data.builderEnabled && (

--- a/templates/design/app/components/design/editor/MakeRealDialog.tsx
+++ b/templates/design/app/components/design/editor/MakeRealDialog.tsx
@@ -1,3 +1,7 @@
+import {
+  BuilderConnectPopover,
+  useBuilderConnectFlow,
+} from "@agent-native/core/client/settings";
 import { withBuilderUtmTrackingParams } from "@agent-native/core/shared";
 import {
   IconCircleCheck,
@@ -46,6 +50,18 @@ export function MakeRealDialog({
   pending: boolean;
   onConfirm: () => void;
 }) {
+  const builderConnect = useBuilderConnectFlow({
+    enabled: open,
+    popupUrl:
+      result?.status === "not-configured" &&
+      result.cta?.kind === "connect-builder"
+        ? result.cta.connectUrl
+        : undefined,
+    provisionAccount: true,
+    trackingSource: "design_make_real_dialog",
+    trackingFlow: "design_migration",
+  });
+
   return (
     <Dialog
       open={open}
@@ -75,16 +91,25 @@ export function MakeRealDialog({
                 Cancel
               </Button>
               {result.cta.connectUrl ? (
-                <Button asChild className="cursor-pointer">
-                  <a
-                    href={result.cta.connectUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {result.cta.primaryAction}
-                    <IconExternalLink className="ml-1.5 size-3.5" />
-                  </a>
-                </Button>
+                result.cta.kind === "connect-builder" ? (
+                  <BuilderConnectPopover flow={builderConnect}>
+                    <Button className="cursor-pointer">
+                      {result.cta.primaryAction}
+                      <IconExternalLink className="ml-1.5 size-3.5" />
+                    </Button>
+                  </BuilderConnectPopover>
+                ) : (
+                  <Button asChild className="cursor-pointer">
+                    <a
+                      href={result.cta.connectUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {result.cta.primaryAction}
+                      <IconExternalLink className="ml-1.5 size-3.5" />
+                    </a>
+                  </Button>
+                )
               ) : null}
             </DialogFooter>
           </>


### PR DESCRIPTION
## What this changes

This extends the Builder activation consent popover from onboarding to every
web product surface that offers a Builder connection, including setup cards,
settings, recovery, uploads, transcription, voice, the composer, Dispatch,
Analytics, Clips, Content, and Design.

The new path is strictly opt-in. A deployment only advertises it when
`AGENT_NATIVE_BUILDER_SSO_SECRET` is configured and the current signed-in
session has a verified email. With the secret unset, the existing Builder OAuth
flow and UI remain unchanged.

When enabled, the popover offers:

- `Create and activate`, which provisions or reuses the signed-in user's
  Builder account, activates the free credits, shows a loading state, and
  records the normal signup/Amplitude attribution with `agent-native` use-case
  metadata.
- `I have a Builder.io account`, which continues through the existing login
  flow.

If provisioning reports that an account already exists for the verified email,
the popover changes to a simple `Log in` CTA instead of attempting to create a
duplicate account.

## Verification

- 65 repository guards pass.
- Core and toolkit typechecks pass.
- 118 focused core tests pass.
- Browser verification confirms the popover covers the clicked trigger so only
  one Builder action is visible.
