### PR TITLE
fix: keep OAuth probe uncertainty from rolling back deploys

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -822,10 +822,11 @@ jobs:
 
       # The active managed client and its capability are observable only from
       # the live host, so this is a post-publish verification. If the declared
-      # managed callback is unregistered or the check is inconclusive, the
-      # immediately following step restores the deploy captured above before
-      # leaving the job failed. Draft deploy URLs are intentionally excluded
-      # because they are not registered OAuth origins.
+      # managed callback is definitively unregistered, the immediately
+      # following step restores the deploy captured above before leaving the
+      # job failed. Inconclusive checks fail loudly without destructive
+      # rollback. Draft deploy URLs are intentionally excluded because they
+      # are not registered OAuth origins.
       - name: Verify Google OAuth redirect registration
         id: google_redirect
         if: >-
@@ -844,7 +845,7 @@ jobs:
       - name: Roll back after Google callback verification failure
         if: >-
           steps.google_redirect.outcome == 'failure' &&
-          steps.google_redirect.outputs.exit_code != '0'
+          steps.google_redirect.outputs.exit_code == '1'
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ steps.target.outputs.site_id }}

--- a/scripts/check-google-redirect-uris.test.ts
+++ b/scripts/check-google-redirect-uris.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   classifyGoogleAuthorizeResponse,
   classifyGoogleHealthResponse,
+  fetchWithRetry,
   googleRedirectProbeExitCode,
 } from "./check-google-redirect-uris.ts";
 
@@ -185,6 +186,37 @@ test("keeps incomplete and changed provider responses unknown", () => {
     ).state,
     "unknown",
   );
+});
+
+test("retries transient provider responses before classifying the result", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return new Response(null, {
+        status: 429,
+        headers: { "retry-after": "0" },
+      });
+    }
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: "https://accounts.google.com/v3/signin/identifier",
+      },
+    });
+  };
+  try {
+    const response = await fetchWithRetry(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+      { redirect: "manual" },
+      Date.now() + 1_000,
+    );
+    assert.equal(response.status, 302);
+    assert.equal(attempts, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("keeps a client fingerprint alongside the id needed for the probe", () => {

--- a/scripts/check-google-redirect-uris.test.ts
+++ b/scripts/check-google-redirect-uris.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   classifyGoogleAuthorizeResponse,
@@ -12,6 +14,9 @@ const redirectUri =
   "https://calendar.agent-native.com/_agent-native/google/callback";
 const jsonHeaders = { "content-type": "application/json" };
 const googleDocsCallback = "/_agent-native/google-docs/callback";
+const probePath = fileURLToPath(
+  new URL("./check-google-redirect-uris.ts", import.meta.url),
+);
 
 test("reads callback ownership from the deployed health contract", () => {
   const result = classifyGoogleHealthResponse(
@@ -77,6 +82,25 @@ test("separates definitive mismatches from inconclusive probe failures", () => {
       allowNoCoverage: true,
     }),
     0,
+  );
+});
+
+test("maps unexpected CLI failures to the inconclusive exit code", () => {
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        ["--experimental-strip-types", probePath, "--budget-seconds", "bad"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    (error: unknown) => {
+      assert.equal((error as { status?: number }).status, 2);
+      assert.match(
+        String((error as { stderr?: string }).stderr),
+        /Google redirect probe could not run: --budget-seconds must be a positive integer/,
+      );
+      return true;
+    },
   );
 });
 

--- a/scripts/check-google-redirect-uris.test.ts
+++ b/scripts/check-google-redirect-uris.test.ts
@@ -243,6 +243,28 @@ test("retries transient provider responses before classifying the result", async
   }
 });
 
+test("does not fetch after the probe deadline", async () => {
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    return new Response(null, { status: 302 });
+  };
+  try {
+    await assert.rejects(
+      fetchWithRetry(
+        "https://accounts.google.com/o/oauth2/v2/auth",
+        { redirect: "manual" },
+        Date.now() - 1,
+      ),
+      /Google probe request deadline exceeded/,
+    );
+    assert.equal(attempts, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("keeps a client fingerprint alongside the id needed for the probe", () => {
   const result = classifyGoogleHealthResponse(
     new Response(JSON.stringify({ status: "valid", clientId: "ignored" }), {

--- a/scripts/check-google-redirect-uris.ts
+++ b/scripts/check-google-redirect-uris.ts
@@ -20,6 +20,10 @@ const HOST_TIMEOUT_MS = 90_000;
 const DEFAULT_RUN_TIMEOUT_MS = 15 * 60_000;
 const HOST_CONCURRENCY = 12;
 const MAX_HEALTH_BYTES = 64 * 1024;
+const MAX_TRANSIENT_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 10_000;
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
 const CALLBACK_PATHS = {
   root: "/_agent-native/google/callback",
   // This callback is owned by the Slides template, not the framework fleet.
@@ -53,6 +57,9 @@ const SAFE_MANAGED_CONNECTIONS = new Set([
 ]);
 
 setDefaultResultOrder("ipv4first");
+
+const sleep = (milliseconds: number) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 export type GoogleRedirectProbeState =
   | "registered"
@@ -336,6 +343,71 @@ function requestSignal(deadline: number): AbortSignal {
   );
 }
 
+function retryDelayMilliseconds(response: Response, attempt: number): number {
+  const retryAfter = response.headers.get("retry-after");
+  const seconds = retryAfter === null ? Number.NaN : Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(MAX_RETRY_DELAY_MS, seconds * 1000);
+  }
+
+  const retryAt = retryAfter === null ? Number.NaN : Date.parse(retryAfter);
+  if (Number.isFinite(retryAt)) {
+    return Math.min(MAX_RETRY_DELAY_MS, Math.max(0, retryAt - Date.now()));
+  }
+
+  return Math.min(MAX_RETRY_DELAY_MS, RETRY_BACKOFF_MS * 2 ** attempt);
+}
+
+export async function fetchWithRetry(
+  input: string | URL,
+  init: RequestInit,
+  deadline: number,
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: requestSignal(deadline),
+      });
+      if (
+        !RETRYABLE_STATUSES.has(response.status) ||
+        attempt === MAX_TRANSIENT_ATTEMPTS - 1
+      ) {
+        return response;
+      }
+      const delay = Math.min(
+        retryDelayMilliseconds(response, attempt),
+        Math.max(0, deadline - Date.now()),
+      );
+      await response.body?.cancel().catch(() => undefined);
+      if (Date.now() >= deadline) return response;
+      console.warn(
+        `Google probe request returned HTTP ${response.status}; retrying in ${Math.ceil(delay / 1000)}s.`,
+      );
+      await sleep(delay);
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_TRANSIENT_ATTEMPTS - 1 || Date.now() >= deadline) {
+        throw error;
+      }
+      const delay = Math.min(
+        RETRY_BACKOFF_MS * 2 ** attempt,
+        MAX_RETRY_DELAY_MS,
+        Math.max(0, deadline - Date.now()),
+      );
+      if (delay <= 0) throw error;
+      console.warn(
+        `Google probe request failed transiently; retrying in ${Math.ceil(delay / 1000)}s.`,
+      );
+      await sleep(delay);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Google probe request exhausted its transient retries.");
+}
+
 async function probeRedirect(
   clientId: string,
   redirectUri: string,
@@ -350,10 +422,13 @@ async function probeRedirect(
   url.searchParams.set("response_type", "code");
   url.searchParams.set("scope", "openid");
   try {
-    const response = await fetch(url, {
-      redirect: "manual",
-      signal: requestSignal(deadline),
-    });
+    const response = await fetchWithRetry(
+      url,
+      {
+        redirect: "manual",
+      },
+      deadline,
+    );
     try {
       return classifyGoogleAuthorizeResponse(response, redirectUri, url.href);
     } finally {
@@ -506,9 +581,10 @@ async function healthOf(
     return emptyHealth("unknown", "host probe budget exhausted");
   }
   try {
-    const response = await fetch(
+    const response = await fetchWithRetry(
       `https://${host}/_agent-native/health/google?client=managed`,
-      { redirect: "manual", signal: requestSignal(deadline) },
+      { redirect: "manual" },
+      deadline,
     );
     const bodyText = await readBoundedText(response, MAX_HEALTH_BYTES);
     if (bodyText === null) {

--- a/scripts/check-google-redirect-uris.ts
+++ b/scripts/check-google-redirect-uris.ts
@@ -866,7 +866,17 @@ async function run(argv: string[]): Promise<number> {
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : undefined;
 if (invokedPath === fileURLToPath(import.meta.url)) {
-  run(process.argv.slice(2)).then((code) => {
-    process.exitCode = code;
-  });
+  run(process.argv.slice(2)).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(
+        `Google redirect probe could not run: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      process.exitCode = 2;
+    },
+  );
 }

--- a/scripts/check-google-redirect-uris.ts
+++ b/scripts/check-google-redirect-uris.ts
@@ -365,6 +365,9 @@ export async function fetchWithRetry(
 ): Promise<Response> {
   let lastError: unknown;
   for (let attempt = 0; attempt < MAX_TRANSIENT_ATTEMPTS; attempt += 1) {
+    if (Date.now() >= deadline) {
+      throw new Error("Google probe request deadline exceeded.");
+    }
     try {
       const response = await fetch(input, {
         ...init,

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -51,7 +51,7 @@ const nodeHeredocs = [
 ].map((match) => match[1]);
 
 describe("Google callback deploy verification guard", () => {
-  it("requires direct probe execution and fail-closed rollback", () => {
+  it("requires direct probe execution and rolls back only definitive mismatches", () => {
     assert.deepEqual(
       validateGoogleCallbackVerificationWorkflow(reusableSource),
       [],
@@ -64,11 +64,11 @@ describe("Google callback deploy verification guard", () => {
             "pnpm check:google-redirect-uris --",
           )
           .replace(
-            "steps.google_redirect.outputs.exit_code != '0'",
             "steps.google_redirect.outputs.exit_code == '1'",
+            "steps.google_redirect.outputs.exit_code == '2'",
           ),
       ).join("\n"),
-      /directly with the supported Node loader|every non-zero/,
+      /directly with the supported Node loader|only definitive/,
     );
   });
 });

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -147,10 +147,10 @@ export function validateGoogleCallbackVerificationWorkflow(
   if (
     !rollback ||
     !rollback.includes("steps.google_redirect.outcome == 'failure'") ||
-    !rollback.includes("steps.google_redirect.outputs.exit_code != '0'")
+    !rollback.includes("steps.google_redirect.outputs.exit_code == '1'")
   ) {
     issues.push(
-      `${reusablePath} must roll back every non-zero Google OAuth verification result, including inconclusive checks`,
+      `${reusablePath} must roll back only definitive Google OAuth mismatches (exit code 1); inconclusive checks must not roll back`,
     );
   }
   return issues;


### PR DESCRIPTION
## What changed

- Roll back a published deploy only when the Google redirect probe returns definitive exit code 1.
- Keep exit code 2 as a loud, non-destructive gate failure so transient or inconclusive checks do not roll back a healthy deploy.
- Retry bounded transient Google health and authorize requests, honoring Retry-After.
- Add focused retry and workflow guard coverage.

## Validation

- `pnpm exec tsx --test scripts/check-google-redirect-uris.test.ts`
- `pnpm exec tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts`
- `pnpm guards` (65 checks)
- `pnpm guard:google-auth-redirects`
- `pnpm exec oxfmt --check ...`

The separate beta managed-credential issue is intentionally not masked or changed in this code PR.