### PR TITLE
fix: stabilize desktop auth and CLI workbench

### DIFF
--- a/.changeset/desktop-auth-and-chat-surface.md
+++ b/.changeset/desktop-auth-and-chat-surface.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep side app surfaces from stealing the active chat while desktop terminal and app tabs are open.

--- a/packages/core/src/client/chat-first.spec.ts
+++ b/packages/core/src/client/chat-first.spec.ts
@@ -367,6 +367,26 @@ describe("chat-first session watch contract", () => {
     store.closeAll();
   });
 
+  it("keeps the main chat active when opening a side app", () => {
+    const scope = "side-app-focus-test";
+    const store = getChatFirstSurfaceTabsStore(scope);
+    store.closeAll();
+
+    store.open({
+      id: "app:mail:/",
+      kind: "app",
+      title: "Mail",
+      appId: "mail",
+      placement: "side",
+    });
+
+    expect(store.getSnapshot()).toMatchObject({
+      activeTabId: null,
+      tabs: [{ id: "app:mail:/", placement: "side" }],
+    });
+    store.closeAll();
+  });
+
   it("restores a valid app placement and rejects malformed persisted values", () => {
     const scope = "placement-test";
     const storage = createStorage();

--- a/packages/core/src/client/chat-first.spec.ts
+++ b/packages/core/src/client/chat-first.spec.ts
@@ -387,6 +387,36 @@ describe("chat-first session watch contract", () => {
     store.closeAll();
   });
 
+  it("activates a later side app without replacing the first side surface", () => {
+    const scope = "multiple-side-app-focus-test";
+    const store = getChatFirstSurfaceTabsStore(scope);
+    store.closeAll();
+
+    store.open({
+      id: "app:mail:/",
+      kind: "app",
+      title: "Mail",
+      appId: "mail",
+      placement: "side",
+    });
+    store.open({
+      id: "app:calendar:/",
+      kind: "app",
+      title: "Calendar",
+      appId: "calendar",
+      placement: "side",
+    });
+
+    expect(store.getSnapshot()).toMatchObject({
+      activeTabId: "app:calendar:/",
+      tabs: [
+        { id: "app:mail:/", placement: "side" },
+        { id: "app:calendar:/", placement: "side" },
+      ],
+    });
+    store.closeAll();
+  });
+
   it("restores a valid app placement and rejects malformed persisted values", () => {
     const scope = "placement-test";
     const storage = createStorage();

--- a/packages/core/src/client/chat-first.ts
+++ b/packages/core/src/client/chat-first.ts
@@ -882,9 +882,13 @@ function createChatFirstSurfaceTabsStore(
     open: (tab) => {
       const existingIndex = activeIndex(tab.id);
       const keepMainChatActive =
+        existingIndex < 0 &&
         tab.kind === "app" &&
         tab.placement === "side" &&
-        state.activeTabId === null;
+        state.activeTabId === null &&
+        !state.tabs.some(
+          (current) => current.kind === "app" && current.placement === "side",
+        );
       const nextActiveTabId = keepMainChatActive ? null : tab.id;
       if (existingIndex >= 0) {
         const tabs = state.tabs.map((current, index) =>

--- a/packages/core/src/client/chat-first.ts
+++ b/packages/core/src/client/chat-first.ts
@@ -881,16 +881,21 @@ function createChatFirstSurfaceTabsStore(
     },
     open: (tab) => {
       const existingIndex = activeIndex(tab.id);
+      const keepMainChatActive =
+        tab.kind === "app" &&
+        tab.placement === "side" &&
+        state.activeTabId === null;
+      const nextActiveTabId = keepMainChatActive ? null : tab.id;
       if (existingIndex >= 0) {
         const tabs = state.tabs.map((current, index) =>
           index === existingIndex ? tab : current,
         );
-        publish({ tabs, activeTabId: tab.id });
+        publish({ tabs, activeTabId: nextActiveTabId });
         return;
       }
       publish({
         tabs: [...state.tabs, tab],
-        activeTabId: tab.id,
+        activeTabId: nextActiveTabId,
       });
     },
     activate: (tabId) => {

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -9,6 +9,7 @@ files:
   - out/**
   - "!node_modules/**"
   - node_modules/node-pty/**
+  - "!node_modules/node-pty/build/**"
   - "!src/**"
   - "!shared/**"
   - "!electron.vite.config.*"

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -8,11 +8,15 @@ directories:
 files:
   - out/**
   - "!node_modules/**"
+  - node_modules/node-pty/**
   - "!src/**"
   - "!shared/**"
   - "!electron.vite.config.*"
   - "!{.env,.env.*,.npmrc,pnpm-lock.yaml}"
   - "!{tsconfig.json,tsconfig.*.json}"
+
+asarUnpack:
+  - node_modules/node-pty/prebuilds/**
 
 extraResources:
   - from: ../agent-chrome-extension/dist

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -9,7 +9,6 @@ files:
   - out/**
   - "!node_modules/**"
   - node_modules/node-pty/**
-  - "!node_modules/node-pty/build/**"
   - "!src/**"
   - "!shared/**"
   - "!electron.vite.config.*"
@@ -34,6 +33,8 @@ protocols:
       - agentnative
 
 mac:
+  files:
+    - "!node_modules/node-pty/build/**"
   extraResources:
     - from: native/bin/agent-native-computer-helper
       to: native/agent-native-computer-helper
@@ -64,6 +65,8 @@ dmg:
   artifactName: ${productName}-${arch}.${ext}
 
 win:
+  files:
+    - "!node_modules/node-pty/build/**"
   icon: build/icon.png
   target:
     - target: nsis

--- a/packages/desktop-app/electron.vite.config.ts
+++ b/packages/desktop-app/electron.vite.config.ts
@@ -237,7 +237,7 @@ export default defineConfig({
     },
     build: {
       rollupOptions: {
-        external: ["electron", /^electron\/.+/],
+        external: ["electron", /^electron\/.+/, "node-pty"],
         input: {
           index: resolve("src/main/index.ts"),
           "browser-control-host": resolve(

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -45,6 +45,7 @@
     "@tanstack/react-query": "5.101.2",
     "electron-log": "5.4.4",
     "electron-updater": "^6.8.3",
+    "node-pty": "^1.1.0",
     "react-router": "^8.3.0",
     "sonner": "^2.0.7",
     "zod": "^4.4.3"

--- a/packages/desktop-app/src/main/code-agent-worktree-reclaim.spec.ts
+++ b/packages/desktop-app/src/main/code-agent-worktree-reclaim.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPermanentCodeAgentWorktreeReclaimError,
+  nextCodeAgentWorktreeReclaimAttempt,
+} from "./code-agent-worktree-reclaim.js";
+
+describe("Code Agent worktree reclaim", () => {
+  it("recognizes missing Git references as permanently unreclaimable", () => {
+    expect(
+      isPermanentCodeAgentWorktreeReclaimError(
+        new Error(
+          "fatal: ambiguous argument 'base..agent-native/run': unknown revision",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isPermanentCodeAgentWorktreeReclaimError(
+        new Error("Could not inspect commits in the Code Agent worktree."),
+      ),
+    ).toBe(false);
+  });
+
+  it("backs off retries and caps the delay", () => {
+    const now = new Date("2026-08-29T12:00:00.000Z");
+
+    expect(nextCodeAgentWorktreeReclaimAttempt(now, undefined)).toEqual({
+      attempts: 1,
+      nextAttemptAt: "2026-08-29T12:05:00.000Z",
+    });
+    expect(nextCodeAgentWorktreeReclaimAttempt(now, 1)).toEqual({
+      attempts: 2,
+      nextAttemptAt: "2026-08-29T12:10:00.000Z",
+    });
+    expect(nextCodeAgentWorktreeReclaimAttempt(now, 99)).toEqual({
+      attempts: 100,
+      nextAttemptAt: "2026-08-30T12:00:00.000Z",
+    });
+  });
+});

--- a/packages/desktop-app/src/main/code-agent-worktree-reclaim.ts
+++ b/packages/desktop-app/src/main/code-agent-worktree-reclaim.ts
@@ -1,5 +1,6 @@
 export type CodeAgentWorktreeReclaimOutcome =
   | { status: "reclaimed" }
+  | { status: "recoverable"; error: string }
   | { status: "retry"; error?: string; nextAttemptAt?: string }
   | { status: "permanently-failed"; error: string };
 

--- a/packages/desktop-app/src/main/code-agent-worktree-reclaim.ts
+++ b/packages/desktop-app/src/main/code-agent-worktree-reclaim.ts
@@ -1,0 +1,33 @@
+export type CodeAgentWorktreeReclaimOutcome =
+  | { status: "reclaimed" }
+  | { status: "retry"; error?: string; nextAttemptAt?: string }
+  | { status: "permanently-failed"; error: string };
+
+export const CODE_AGENT_WORKTREE_RECLAIM_RETRY_BASE_MS = 5 * 60 * 1000;
+export const CODE_AGENT_WORKTREE_RECLAIM_RETRY_MAX_MS = 24 * 60 * 60 * 1000;
+
+export function isPermanentCodeAgentWorktreeReclaimError(
+  error: unknown,
+): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /ambiguous argument|unknown revision|bad object|not a valid object name|refusing to clean up|unexpected branch|another repository|source repository/i.test(
+    message,
+  );
+}
+
+export function nextCodeAgentWorktreeReclaimAttempt(
+  now: Date,
+  previousAttempts: unknown,
+): { attempts: number; nextAttemptAt: string } {
+  const previous = Number(previousAttempts);
+  const attempts =
+    Number.isFinite(previous) && previous >= 0 ? Math.floor(previous) + 1 : 1;
+  const delay = Math.min(
+    CODE_AGENT_WORKTREE_RECLAIM_RETRY_BASE_MS * 2 ** Math.min(attempts - 1, 20),
+    CODE_AGENT_WORKTREE_RECLAIM_RETRY_MAX_MS,
+  );
+  return {
+    attempts,
+    nextAttemptAt: new Date(now.getTime() + delay).toISOString(),
+  };
+}

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -35,7 +35,7 @@ function cookieStore(
       return cookies.filter((cookie) => matchesUrl(cookie, filter?.url));
     }),
     set: vi.fn(async (cookie: Electron.CookiesSetDetails) => {
-      cookies.push({
+      const nextCookie: Electron.Cookie = {
         name: cookie.name!,
         value: cookie.value!,
         domain: new URL(cookie.url).hostname,
@@ -48,7 +48,15 @@ function cookieStore(
         ...(cookie.expirationDate
           ? { expirationDate: cookie.expirationDate }
           : {}),
-      });
+      };
+      const existingIndex = cookies.findIndex(
+        (candidate) =>
+          candidate.name === nextCookie.name &&
+          candidate.domain === nextCookie.domain &&
+          candidate.path === nextCookie.path,
+      );
+      if (existingIndex >= 0) cookies[existingIndex] = nextCookie;
+      else cookies.push(nextCookie);
     }),
     remove: vi.fn(async (url: string, name: string) => {
       const index = cookies.findIndex(
@@ -2321,7 +2329,8 @@ describe("DesktopIdentityBroker", () => {
               url: mail.origin,
               name: "an_embed_session",
               value: "workspace-embed-session",
-            });
+              partitionKey: "https://dispatch.agent-native.com",
+            } as Electron.CookiesSetDetails & { partitionKey: string });
             return new Response("<html></html>", { status: 200 });
           }
           return new Response(null, { status: 404 });
@@ -2347,6 +2356,12 @@ describe("DesktopIdentityBroker", () => {
 
     await expect(broker.ensureAppSession(mail.id)).resolves.toBe(true);
     await expect(broker.ensureAppSession(mail.id)).resolves.toBe(true);
+
+    const embedCookieWrites = mailCookies.set.mock.calls.filter(
+      ([cookie]) => cookie.name === "an_embed_session",
+    );
+    expect(embedCookieWrites).toHaveLength(2);
+    expect(embedCookieWrites.at(-1)?.[0]).not.toHaveProperty("partitionKey");
 
     expect(
       identityFetch.mock.calls.filter(

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -1735,13 +1735,30 @@ export class DesktopIdentityBroker {
         throw new Error(`Embed session returned ${response.status}`);
       }
       const targetCookies = await app.session.cookies.get({});
-      const sessionCookieNames = targetCookies
-        .filter(
-          (cookie) =>
-            cookieMatchesOrigin(cookie, app.origin) &&
-            app.cookieNames.includes(cookie.name),
-        )
-        .map((cookie) => cookie.name);
+      const sessionCookies = targetCookies.filter(
+        (cookie) =>
+          cookieMatchesOrigin(cookie, app.origin) &&
+          app.cookieNames.includes(cookie.name),
+      );
+      const sessionCookieNames = sessionCookies.map((cookie) => cookie.name);
+      // The embed redirect can leave a Partitioned cookie in the main-process
+      // fetch context. Mirror the allow-listed child cookies through the same
+      // app partition without a partition key so the WebView's page requests
+      // send the session too. Never copy the parent identity cookie here.
+      for (const cookie of sessionCookies) {
+        await app.session.cookies.set({
+          url: app.origin,
+          name: cookie.name,
+          value: cookie.value,
+          path: cookie.path || "/",
+          httpOnly: cookie.httpOnly,
+          secure: cookie.secure,
+          sameSite: cookie.sameSite,
+          ...(cookie.expirationDate
+            ? { expirationDate: cookie.expirationDate }
+            : {}),
+        });
+      }
       console.info("[desktop identity] workspace app session response", {
         appId: app.id,
         responseOrigin: safeResponseOrigin(response.url),

--- a/packages/desktop-app/src/main/desktop-startup.spec.ts
+++ b/packages/desktop-app/src/main/desktop-startup.spec.ts
@@ -35,7 +35,6 @@ function createDependencies(
     dependencies: {
       isPackaged: true,
       version: "0.1.150-desktop-sso-canary.20",
-      releaseChannel: "production",
       appDataPath: "/application-support",
       defaultUserDataPath: "/application-support/Agent-Native",
       pathExists: vi.fn(() => false),
@@ -175,20 +174,44 @@ describe("initializeDesktopStartup", () => {
     );
   });
 
-  it("does not reuse the stable profile for packaged Nightly", () => {
+  it("reuses the legacy stable profile for packaged Nightly", () => {
     const { dependencies, events } = createDependencies({
-      releaseChannel: "nightly",
       version: "0.1.150-nightly.296",
       defaultUserDataPath: "/application-support/Agent-Native Nightly",
-      pathExists: vi.fn(() => true),
+      pathExists: vi.fn(
+        (directoryPath) =>
+          directoryPath === "/application-support/Agent Native", // agent-native-brand-ok: preserve the legacy Electron profile directory.
+      ),
     });
 
     initializeDesktopStartup(dependencies);
 
-    expect(dependencies.pathExists).not.toHaveBeenCalled();
-    expect(dependencies.createDirectory).not.toHaveBeenCalled();
-    expect(dependencies.setUserDataPath).not.toHaveBeenCalled();
-    expect(events).toEqual(["sentry", "logger"]);
+    expect(dependencies.createDirectory).toHaveBeenCalledWith(
+      "/application-support/Agent Native", // agent-native-brand-ok: preserve the legacy Electron profile directory.
+    );
+    expect(dependencies.setUserDataPath).toHaveBeenCalledWith(
+      "/application-support/Agent Native", // agent-native-brand-ok: preserve the legacy Electron profile directory.
+    );
+    expect(events).toEqual([
+      "create-directory",
+      "set-user-data",
+      "sentry",
+      "logger",
+    ]);
+  });
+
+  it("keeps a packaged Nightly install on its default profile when no legacy profile exists", () => {
+    const { dependencies } = createDependencies({
+      version: "0.1.150-nightly.296",
+      defaultUserDataPath: "/application-support/Agent-Native Nightly",
+      pathExists: vi.fn(() => false),
+    });
+
+    initializeDesktopStartup(dependencies);
+
+    expect(dependencies.setUserDataPath).toHaveBeenCalledWith(
+      "/application-support/Agent-Native Nightly",
+    );
   });
 
   it("uses an explicit profile for packaged Desktop before profile consumers", () => {

--- a/packages/desktop-app/src/main/desktop-startup.ts
+++ b/packages/desktop-app/src/main/desktop-startup.ts
@@ -1,14 +1,11 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 
-import type { DesktopReleaseChannel } from "@shared/release-channel";
-
 import { resolveDesktopUserDataDirectoryName } from "./ipc/update-policy.js";
 
 export interface DesktopStartupDependencies {
   isPackaged: boolean;
   version: string;
-  releaseChannel: DesktopReleaseChannel;
   appDataPath: string;
   defaultUserDataPath: string;
   pathExists?: (directoryPath: string) => boolean;
@@ -71,7 +68,6 @@ export async function runDesktopStartupStep({
 export function initializeDesktopStartup({
   isPackaged,
   version,
-  releaseChannel,
   appDataPath,
   defaultUserDataPath,
   pathExists,
@@ -88,10 +84,7 @@ export function initializeDesktopStartup({
     version,
   );
   const stableUserDataPath =
-    isPackaged &&
-    releaseChannel === "production" &&
-    !requestedUserDataPath &&
-    !isolatedUserDataDirectoryName
+    isPackaged && !requestedUserDataPath && !isolatedUserDataDirectoryName
       ? resolveStableUserDataPath(appDataPath, defaultUserDataPath, pathExists)
       : null;
   const isolatedUserDataPath = requestedUserDataPath

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -4250,6 +4250,39 @@ function cleanupDueManagedCodeAgentWorktrees(): void {
   }
 }
 
+const CODE_AGENT_WORKTREE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+let codeAgentWorktreeSweepTimer: ReturnType<typeof setTimeout> | null = null;
+
+function nextCodeAgentWorktreeSweepDelay(): number {
+  const now = Date.now();
+  let delay = CODE_AGENT_WORKTREE_SWEEP_INTERVAL_MS;
+  for (const { record } of listRawCodeAgentRunRecords()) {
+    if (!isTerminalCodeAgentRun(record)) continue;
+    const metadata = isObject(record.metadata) ? record.metadata : undefined;
+    const worktree = isObject(metadata?.worktree)
+      ? metadata.worktree
+      : undefined;
+    const nextAttemptAt = firstStringValue(worktree?.reclaimNextAttemptAt);
+    if (!nextAttemptAt) continue;
+    const dueAt = new Date(nextAttemptAt).getTime();
+    if (Number.isFinite(dueAt)) delay = Math.min(delay, dueAt - now);
+  }
+  return Math.max(1000, delay);
+}
+
+function scheduleCodeAgentWorktreeSweep(): void {
+  if (codeAgentWorktreeSweepTimer) clearTimeout(codeAgentWorktreeSweepTimer);
+  codeAgentWorktreeSweepTimer = setTimeout(() => {
+    codeAgentWorktreeSweepTimer = null;
+    try {
+      reclaimTerminalCodeAgentWorktrees();
+    } finally {
+      scheduleCodeAgentWorktreeSweep();
+    }
+  }, nextCodeAgentWorktreeSweepDelay());
+  codeAgentWorktreeSweepTimer.unref?.();
+}
+
 function scheduleCodeAgentWorktreeReclaimRetry(
   runId: string,
   worktree: Record<string, unknown>,
@@ -4271,6 +4304,7 @@ function scheduleCodeAgentWorktreeReclaimRetry(
       },
     },
   });
+  scheduleCodeAgentWorktreeSweep();
   return { status: "retry", error, nextAttemptAt };
 }
 
@@ -12425,11 +12459,7 @@ registerCodeAgentsIpc({
   pairRemoteCodeAgentConnector,
 });
 
-const codeAgentWorktreeSweepTimer = setInterval(
-  reclaimTerminalCodeAgentWorktrees,
-  60 * 60 * 1000,
-);
-codeAgentWorktreeSweepTimer.unref?.();
+scheduleCodeAgentWorktreeSweep();
 
 registerQuickPromptIpc({
   createCodeAgentRun,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -4288,6 +4288,14 @@ function reclaimTerminalCodeAgentWorktree(
   if (!worktree || worktree.retain === true || worktree.keep === true) {
     return { status: "reclaimed" };
   }
+  if (worktree.state === "recoverable") {
+    return {
+      status: "recoverable",
+      error:
+        firstStringValue(worktree.lastCleanupError) ??
+        "The worktree was kept for recovery.",
+    };
+  }
   if (worktree.reclaimStatus === "permanently-failed") {
     return {
       status: "permanently-failed",
@@ -4424,12 +4432,18 @@ function reclaimTerminalCodeAgentWorktree(
         : hasCommittedChanges
           ? "Worktree contains commits after its base; it was kept for recovery."
           : "Worktree has uncommitted changes; it was kept for recovery.";
-      return scheduleCodeAgentWorktreeReclaimRetry(
-        runId,
-        worktree,
-        { state: "recoverable" },
-        message,
-      );
+      touchCodeAgentRunRecord(runId, {
+        metadata: {
+          worktree: {
+            ...worktree,
+            state: "recoverable",
+            reclaimAttempts: undefined,
+            reclaimNextAttemptAt: undefined,
+            lastCleanupError: message,
+          },
+        },
+      });
+      return { status: "recoverable", error: message };
     }
     const result = cleanupCodeAgentWorktree({
       sourcePath,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -125,10 +125,7 @@ import {
   type DesktopIdentitySettings,
   type DesktopIdentityMagicLinkRequest,
 } from "@shared/ipc-channels";
-import {
-  DESKTOP_DEEP_LINK_PROTOCOL,
-  DESKTOP_RELEASE_CHANNEL,
-} from "@shared/release-channel";
+import { DESKTOP_DEEP_LINK_PROTOCOL } from "@shared/release-channel";
 import {
   app,
   BrowserWindow,
@@ -215,6 +212,11 @@ import {
   CODE_AGENTS_UNSUBSCRIBE_TRANSCRIPT_CHANNEL,
 } from "./code-agent-transcript-ipc.js";
 import { boundedCodeAgentTranscriptEvents } from "./code-agent-transcript-window.js";
+import {
+  isPermanentCodeAgentWorktreeReclaimError,
+  nextCodeAgentWorktreeReclaimAttempt,
+  type CodeAgentWorktreeReclaimOutcome,
+} from "./code-agent-worktree-reclaim.js";
 import {
   CODE_AGENT_EPHEMERAL_WORKTREE_RETENTION_MS,
   claimCodeAgentWorktreeRun,
@@ -332,7 +334,6 @@ import { loadDesktopWorkspaceApps } from "./workspace-apps.js";
 initializeDesktopStartup({
   isPackaged: app.isPackaged,
   version: app.getVersion(),
-  releaseChannel: DESKTOP_RELEASE_CHANNEL,
   appDataPath: app.getPath("appData"),
   defaultUserDataPath: app.getPath("userData"),
   requestedUserDataPath: desktopRequestedUserDataPath(
@@ -376,6 +377,32 @@ process.on("uncaughtException", (err: NodeJS.ErrnoException) => {
 });
 
 const IS_DEV = !app.isPackaged;
+
+function desktopRendererEntryPath(): string {
+  return path.join(__dirname, "../renderer/index.html");
+}
+
+function isDesktopRendererEntryUrl(url: string): boolean {
+  if (IS_DEV && process.env["ELECTRON_RENDERER_URL"]) {
+    return url.startsWith(process.env["ELECTRON_RENDERER_URL"]);
+  }
+  try {
+    return (
+      path.resolve(fileURLToPath(new URL(url))) ===
+      path.resolve(desktopRendererEntryPath())
+    );
+  } catch {
+    return false;
+  }
+}
+
+function loadDesktopRenderer(window: BrowserWindow): void {
+  if (IS_DEV && process.env["ELECTRON_RENDERER_URL"]) {
+    void window.loadURL(process.env["ELECTRON_RENDERER_URL"]);
+    return;
+  }
+  void window.loadFile(desktopRendererEntryPath());
+}
 
 function isDesktopSsoEnabled(): boolean {
   return AppStore.loadDesktopAppPreferences().desktopSsoEnabled === true;
@@ -1775,6 +1802,37 @@ function createWindow(): BrowserWindow {
 
   // Avoid white flash — show window once content is ready
   win.once("ready-to-show", () => win.show());
+  win.webContents.on("will-navigate", (event, url) => {
+    if (IS_DEV || isDesktopRendererEntryUrl(url)) return;
+    let protocol: string;
+    try {
+      protocol = new URL(url).protocol;
+    } catch {
+      return;
+    }
+    if (protocol !== "file:") return;
+    event.preventDefault();
+    loadDesktopRenderer(win);
+  });
+  win.webContents.on(
+    "did-fail-load",
+    (_event, errorCode, _errorDescription, url, isMainFrame) => {
+      if (
+        IS_DEV ||
+        !isMainFrame ||
+        errorCode !== -6 ||
+        isDesktopRendererEntryUrl(url)
+      ) {
+        return;
+      }
+      try {
+        if (new URL(url).protocol !== "file:") return;
+      } catch {
+        return;
+      }
+      loadDesktopRenderer(win);
+    },
+  );
   win.webContents.on("did-finish-load", () => {
     // A reloaded renderer has no status yet, so the dedup cache must not
     // suppress the next send as an unchanged repeat.
@@ -1784,12 +1842,8 @@ function createWindow(): BrowserWindow {
   });
 
   // In dev, load from the Vite dev server; in prod, load built files
-  if (IS_DEV && process.env["ELECTRON_RENDERER_URL"]) {
-    void win.loadURL(process.env["ELECTRON_RENDERER_URL"]);
-    // DevTools will be opened for the active webview via Cmd+Shift+I
-  } else {
-    void win.loadFile(path.join(__dirname, "../renderer/index.html"));
-  }
+  loadDesktopRenderer(win);
+  // DevTools will be opened for the active webview via Cmd+Shift+I
 
   mainWindow = win;
   // Coming back to the window is the strongest available signal that a tab
@@ -3841,7 +3895,6 @@ function codeAgentEventFilePath(runId: string): string | null {
 
 function listDesktopCodeAgentRuns(goalId?: string): CodeAgentRun[] {
   reconcileInterruptedCodeAgentRuns("list", goalId);
-  reclaimTerminalCodeAgentWorktrees(goalId);
   const runs = desktopCodeBackgroundAgentController.list({
     goalId,
   }) as BackgroundAgentRun[];
@@ -3866,7 +3919,6 @@ function listDesktopCodeAgentRuns(goalId?: string): CodeAgentRun[] {
 
 function readDesktopCodeAgentRun(runId: string): CodeAgentRun | null {
   reconcileInterruptedCodeAgentRun(runId, "read");
-  reclaimTerminalCodeAgentWorktree(readCodeAgentRunRecord(runId));
   const run = desktopCodeBackgroundAgentController.get(
     runId,
   ) as BackgroundAgentRun | null;
@@ -4197,23 +4249,66 @@ function cleanupDueManagedCodeAgentWorktrees(): void {
   }
 }
 
+function scheduleCodeAgentWorktreeReclaimRetry(
+  runId: string,
+  worktree: Record<string, unknown>,
+  updates: Record<string, unknown> = {},
+  error?: string,
+): CodeAgentWorktreeReclaimOutcome {
+  const { attempts, nextAttemptAt } = nextCodeAgentWorktreeReclaimAttempt(
+    new Date(),
+    worktree.reclaimAttempts,
+  );
+  touchCodeAgentRunRecord(runId, {
+    metadata: {
+      worktree: {
+        ...worktree,
+        ...updates,
+        reclaimAttempts: attempts,
+        reclaimNextAttemptAt: nextAttemptAt,
+        ...(error ? { lastCleanupError: error } : {}),
+      },
+    },
+  });
+  return { status: "retry", error, nextAttemptAt };
+}
+
 function reclaimTerminalCodeAgentWorktree(
   record: Record<string, unknown> | null,
-): void {
-  if (!record || !isTerminalCodeAgentRun(record)) return;
+): CodeAgentWorktreeReclaimOutcome {
+  if (!record || !isTerminalCodeAgentRun(record)) {
+    return { status: "reclaimed" };
+  }
   const metadata = isObject(record.metadata) ? record.metadata : undefined;
   if (metadata?.retainWorktree === true || metadata?.keepWorktree === true) {
-    return;
+    return { status: "reclaimed" };
   }
   const worktree = isObject(metadata?.worktree) ? metadata.worktree : undefined;
   if (!worktree || worktree.retain === true || worktree.keep === true) {
-    return;
+    return { status: "reclaimed" };
+  }
+  if (worktree.reclaimStatus === "permanently-failed") {
+    return {
+      status: "permanently-failed",
+      error:
+        firstStringValue(worktree.lastCleanupError) ??
+        "The Code Agent worktree could not be reclaimed.",
+    };
+  }
+  const reclaimNextAttemptAt = firstStringValue(worktree.reclaimNextAttemptAt);
+  if (
+    reclaimNextAttemptAt &&
+    new Date(reclaimNextAttemptAt).getTime() > Date.now()
+  ) {
+    return { status: "retry", nextAttemptAt: reclaimNextAttemptAt };
   }
   const sourcePath = firstStringValue(worktree.sourcePath);
   const worktreePath = firstStringValue(worktree.path);
   const branch = firstStringValue(worktree.branch);
   const baseCommit = firstStringValue(worktree.baseCommit);
-  if (!sourcePath || !worktreePath || !branch) return;
+  if (!sourcePath || !worktreePath || !branch) {
+    return { status: "reclaimed" };
+  }
 
   const runId = getRecordString(record, "id");
   const managedId = firstStringValue(worktree.id);
@@ -4235,36 +4330,63 @@ function reclaimTerminalCodeAgentWorktree(
           },
         });
         void startNextQueuedCodeAgentWorktreeRun(released.id);
+        return { status: "reclaimed" };
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isPermanentCodeAgentWorktreeReclaimError(error)) {
+        touchCodeAgentRunRecord(runId, {
+          metadata: {
+            worktree: {
+              ...worktree,
+              reclaimStatus: "permanently-failed",
+              lastCleanupError: message,
+            },
+          },
+        });
+        console.warn(
+          `[code-agents] Permanently failed to release worktree for run ${runId}:`,
+          message,
+        );
+        return { status: "permanently-failed", error: message };
+      }
       console.warn(
-        `[code-agents] Could not release worktree for run ${runId}:`,
-        error instanceof Error ? error.message : error,
+        `[code-agents] Could not release worktree for run ${runId}; retrying:`,
+        message,
+      );
+      return scheduleCodeAgentWorktreeReclaimRetry(
+        runId,
+        worktree,
+        {},
+        message,
       );
     }
-    return;
+    return { status: "reclaimed" };
   }
 
   // Older runs predate the registry. Keep their worktrees recoverable for the
   // same retention window and only remove them after checking for dirty files.
-  if (!runId) return;
+  if (!runId) return { status: "reclaimed" };
   const cleanupAfter = firstStringValue(worktree.cleanupAfter);
   if (!cleanupAfter) {
+    const nextAttemptAt = new Date(
+      Date.now() + CODE_AGENT_EPHEMERAL_WORKTREE_RETENTION_MS,
+    ).toISOString();
     touchCodeAgentRunRecord(runId, {
       metadata: {
         worktree: {
           ...worktree,
           policy: "ephemeral",
           state: "cleanup-pending",
-          cleanupAfter: new Date(
-            Date.now() + CODE_AGENT_EPHEMERAL_WORKTREE_RETENTION_MS,
-          ).toISOString(),
+          cleanupAfter: nextAttemptAt,
         },
       },
     });
-    return;
+    return { status: "retry", nextAttemptAt };
   }
-  if (new Date(cleanupAfter).getTime() > Date.now()) return;
+  if (new Date(cleanupAfter).getTime() > Date.now()) {
+    return { status: "retry", nextAttemptAt: cleanupAfter };
+  }
   if (
     listRawCodeAgentRunRecords().some(({ record: candidate }) => {
       if (candidate === record || !isActiveDesktopCodeAgentRun(candidate))
@@ -4281,7 +4403,7 @@ function reclaimTerminalCodeAgentWorktree(
       );
     })
   ) {
-    return;
+    return scheduleCodeAgentWorktreeReclaimRetry(runId, worktree);
   }
 
   try {
@@ -4296,20 +4418,17 @@ function reclaimTerminalCodeAgentWorktree(
         })
       : true;
     if (hasUncommittedChanges || hasCommittedChanges) {
-      touchCodeAgentRunRecord(runId, {
-        metadata: {
-          worktree: {
-            ...worktree,
-            state: "recoverable",
-            lastCleanupError: !baseCommit
-              ? "The worktree base could not be verified; it was kept for recovery."
-              : hasCommittedChanges
-                ? "Worktree contains commits after its base; it was kept for recovery."
-                : "Worktree has uncommitted changes; it was kept for recovery.",
-          },
-        },
-      });
-      return;
+      const message = !baseCommit
+        ? "The worktree base could not be verified; it was kept for recovery."
+        : hasCommittedChanges
+          ? "Worktree contains commits after its base; it was kept for recovery."
+          : "Worktree has uncommitted changes; it was kept for recovery.";
+      return scheduleCodeAgentWorktreeReclaimRetry(
+        runId,
+        worktree,
+        { state: "recoverable" },
+        message,
+      );
     }
     const result = cleanupCodeAgentWorktree({
       sourcePath,
@@ -4317,8 +4436,15 @@ function reclaimTerminalCodeAgentWorktree(
       branch,
     });
     if (!result.worktreeRemoved || !result.branchRemoved) {
+      const message = "Git did not fully remove the worktree and branch.";
       console.warn(
-        `[code-agents] Could not fully reclaim worktree for run ${getRecordString(record, "id") ?? "unknown"}.`,
+        `[code-agents] Could not fully reclaim worktree for run ${getRecordString(record, "id") ?? "unknown"}; retrying.`,
+      );
+      return scheduleCodeAgentWorktreeReclaimRetry(
+        runId,
+        worktree,
+        {},
+        message,
       );
     } else {
       touchCodeAgentRunRecord(runId, {
@@ -4326,15 +4452,38 @@ function reclaimTerminalCodeAgentWorktree(
           worktree: {
             ...worktree,
             state: "removed",
+            reclaimStatus: undefined,
+            reclaimAttempts: undefined,
+            reclaimNextAttemptAt: undefined,
+            lastCleanupError: undefined,
           },
         },
       });
+      return { status: "reclaimed" };
     }
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (isPermanentCodeAgentWorktreeReclaimError(error)) {
+      touchCodeAgentRunRecord(runId, {
+        metadata: {
+          worktree: {
+            ...worktree,
+            reclaimStatus: "permanently-failed",
+            lastCleanupError: message,
+          },
+        },
+      });
+      console.warn(
+        `[code-agents] Permanently failed to reclaim worktree for run ${getRecordString(record, "id") ?? "unknown"}:`,
+        message,
+      );
+      return { status: "permanently-failed", error: message };
+    }
     console.warn(
-      `[code-agents] Could not reclaim worktree for run ${getRecordString(record, "id") ?? "unknown"}:`,
-      error instanceof Error ? error.message : error,
+      `[code-agents] Could not reclaim worktree for run ${getRecordString(record, "id") ?? "unknown"}; retrying:`,
+      message,
     );
+    return scheduleCodeAgentWorktreeReclaimRetry(runId, worktree, {}, message);
   }
 }
 
@@ -5801,12 +5950,8 @@ async function spawnCodeAgentRunner(
   );
   const { command, args } = invocation;
   try {
-    const runMetadata = isObject(runRecord?.metadata) ? runRecord.metadata : {};
-    const isDesktopAppCreation =
-      runMetadata.kind === "desktop-create-app" ||
-      runMetadata.kind === "desktop-local-code-change";
     const mcpEnvironment = await desktopCodeAgentMcpEnvironment(cwd, {
-      includeWorkspaceApps: !isDesktopAppCreation,
+      includeWorkspaceApps: true,
     });
     if (mcpEnvironment.remoteConfig.state === "unavailable") {
       appendCodeAgentStatusEvent(
@@ -11661,6 +11806,7 @@ function pushCodeAgentModelOptions(
     engineLabel: string;
     supportedModels: readonly string[];
     configured: boolean;
+    description?: string;
     statusLabel?: string;
     isSubscription?: boolean;
   },
@@ -11671,6 +11817,7 @@ function pushCodeAgentModelOptions(
       engineLabel: options.engineLabel,
       model,
       label: model,
+      ...(options.description ? { description: options.description } : {}),
       configured: options.configured,
       ...(options.statusLabel ? { statusLabel: options.statusLabel } : {}),
       ...(options.isSubscription ? { isSubscription: true } : {}),
@@ -11756,11 +11903,10 @@ function getCodeAgentModelList(input?: unknown): CodeAgentModelListResult {
       }
     }
     if (claude.available) {
-      models.push({
+      pushCodeAgentModelOptions(models, {
         engine: CLAUDE_CLI_ENGINE_NAME,
         engineLabel: "Anthropic",
-        model: ANTHROPIC_MODEL_CONFIG.defaultModel,
-        label: ANTHROPIC_MODEL_CONFIG.defaultModel,
+        supportedModels: ANTHROPIC_MODEL_CONFIG.supportedModels,
         description: "Run locally through your signed-in Claude subscription.",
         configured: claude.authenticated,
         ...(claude.authenticated
@@ -12265,7 +12411,7 @@ registerCodeAgentsIpc({
 });
 
 const codeAgentWorktreeSweepTimer = setInterval(
-  cleanupDueManagedCodeAgentWorktrees,
+  reclaimTerminalCodeAgentWorktrees,
   60 * 60 * 1000,
 );
 codeAgentWorktreeSweepTimer.unref?.();

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -391,6 +391,7 @@ function isDesktopRendererEntryUrl(url: string): boolean {
       path.resolve(fileURLToPath(new URL(url))) ===
       path.resolve(desktopRendererEntryPath())
     );
+    // coercion-ok: malformed navigation URLs are not the renderer entry.
   } catch {
     return false;
   }

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -19,6 +19,7 @@ import {
   desktopTerminalInfo,
   resolveTargetUrl,
   shouldForwardRequestHeader,
+  shouldForwardResponseHeader,
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
@@ -71,5 +72,14 @@ describe("desktop chat relay target URLs", () => {
         new Set(["connection", "x-internal"]),
       ),
     ).toBe(false);
+  });
+
+  it("drops stale compression and length headers from proxied responses", () => {
+    expect(shouldForwardResponseHeader("content-encoding", "gzip")).toBe(false);
+    expect(shouldForwardResponseHeader("content-length", "123")).toBe(false);
+    expect(shouldForwardResponseHeader("transfer-encoding", "chunked")).toBe(
+      false,
+    );
+    expect(shouldForwardResponseHeader("cache-control", "no-store")).toBe(true);
   });
 });

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -35,6 +35,11 @@ const RESTRICTED_REQUEST_HEADERS = new Set([
   "content-length",
   "cookie2",
 ]);
+const RESTRICTED_RESPONSE_HEADERS = new Set([
+  ...HOP_BY_HOP_HEADERS,
+  "content-encoding",
+  "content-length",
+]);
 const RELAY_FAILURE_MESSAGE =
   "Desktop app chat relay failed. Update or restart the desktop app, then try again.";
 
@@ -192,6 +197,14 @@ export function shouldForwardRequestHeader(
   );
 }
 
+export function shouldForwardResponseHeader(
+  name: string,
+  value: string | string[] | undefined,
+  blockedHeaders: ReadonlySet<string> = RESTRICTED_RESPONSE_HEADERS,
+): boolean {
+  return shouldForwardRequestHeader(name, value, blockedHeaders);
+}
+
 function corsHeaders(request: IncomingMessage): Record<string, string> {
   const origin = requestHeaderValue(request.headers.origin) ?? "*";
   const requestedHeaders =
@@ -300,7 +313,7 @@ async function proxyRequest(
       ...corsHeaders(request),
     };
     for (const [name, value] of Object.entries(upstreamResponse.headers)) {
-      if (!HOP_BY_HOP_HEADERS.has(name) && value !== undefined) {
+      if (shouldForwardResponseHeader(name, value)) {
         headers[name] = value;
       }
     }

--- a/packages/desktop-app/src/main/ipc/update-policy.spec.ts
+++ b/packages/desktop-app/src/main/ipc/update-policy.spec.ts
@@ -51,7 +51,7 @@ describe("resolveDesktopUpdateSupport", () => {
     });
   });
 
-  it("isolates development and Desktop SSO canary profiles from stable Desktop", () => {
+  it("isolates development and SSO canary profiles while leaving Nightly to startup compatibility", () => {
     expect(resolveDesktopUserDataDirectoryName(false, "0.1.150")).toBe(
       "Agent Native Dev", // agent-native-brand-ok: preserve the legacy Electron profile directory.
     );
@@ -62,6 +62,9 @@ describe("resolveDesktopUpdateSupport", () => {
       ),
     ).toBe("Agent Native SSO Canary"); // agent-native-brand-ok: preserve the legacy Electron profile directory.
     expect(resolveDesktopUserDataDirectoryName(true, "0.1.150")).toBeNull();
+    expect(
+      resolveDesktopUserDataDirectoryName(true, "0.1.150-nightly.296"),
+    ).toBeNull();
     expect(
       resolveDesktopUserDataDirectoryName(
         true,

--- a/packages/desktop-app/src/main/privacy-regressions.test.ts
+++ b/packages/desktop-app/src/main/privacy-regressions.test.ts
@@ -15,6 +15,22 @@ function between(value: string, start: string, end: string): string {
 }
 
 describe("desktop passive-access regressions", () => {
+  it("reloads the packaged shell from its entry file after SPA route changes", () => {
+    const main = source("./index.ts");
+    const createWindow = between(
+      main,
+      "function createWindow(): BrowserWindow {",
+      "// ---------- DevTools: target the active app webview ----------",
+    );
+
+    expect(createWindow).toContain('win.webContents.on("will-navigate"');
+    expect(createWindow).toContain('"did-fail-load"');
+    expect(createWindow).toContain('protocol !== "file:"');
+    expect(createWindow).toContain("event.preventDefault();");
+    expect(createWindow).toContain("loadDesktopRenderer(win);");
+    expect(main).toContain("function desktopRendererEntryPath(): string");
+  });
+
   it("keeps remote status read-only", () => {
     // The Agent-Native Code IPC handlers live in ./ipc/code-agents.ts.
     const codeAgentsIpc = source("./ipc/code-agents.ts");
@@ -287,7 +303,7 @@ describe("desktop passive-access regressions", () => {
       "const requestedName = requestedDesktopAppName(prompt);",
     );
     expect(creation).toContain("requestedName ??");
-    expect(main).toContain("includeWorkspaceApps: !isDesktopAppCreation");
+    expect(main).toContain("includeWorkspaceApps: true");
   });
 
   it("only marks the local Codex provider configured after authentication", () => {

--- a/packages/desktop-app/src/renderer/App.spec.ts
+++ b/packages/desktop-app/src/renderer/App.spec.ts
@@ -13,6 +13,8 @@ describe("desktop chat-first shell", () => {
     expect(appSource).toContain("<CodeAgentsHub");
     expect(appSource).toContain("<DesktopIdentityGate");
     expect(appSource).toContain('appName="Agent-Native Desktop"');
+    expect(appSource).not.toContain("desktopIdentityGateDismissed");
+    expect(appSource).not.toContain("onDesktopIdentitySyncFailure");
     expect(appSource).toContain(".getStatus()");
     expect(appSource).toContain("key={settingsTab}");
     expect(appSource).toContain("initialTab={settingsTab}");

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -486,9 +486,6 @@ export default function App() {
                 void handleAppRemoval(app.id);
               }}
               onChatFirstAppSelectionChange={handleChatFirstAppSelectionChange}
-              onDesktopIdentitySyncFailure={() =>
-                setDesktopIdentityStatus("failed")
-              }
             />
           </div>
         </div>

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -27,7 +27,6 @@ import {
   isDesktopIdentityAuthenticated,
   isDesktopIdentityGateEligible,
   isDesktopIdentityGateUnauthenticated,
-  shouldShowDesktopIdentityRecovery,
   shouldUseDesktopIdentityGate,
   shouldSuppressDesktopSignInPrompt,
   resolveGuestChatCommand,
@@ -98,6 +97,14 @@ describe("Desktop identity lazy child synchronization", () => {
         status: "idle",
       }),
     ).toBe(false);
+    expect(
+      shouldDeferDesktopAppWebviewLoad({
+        eligible: true,
+        enabled: true,
+        sessionReady: false,
+        status: "failed",
+      }),
+    ).toBe(false);
   });
 
   it("keeps the chat handoff pending until child synchronization completes", () => {
@@ -134,41 +141,6 @@ describe("Desktop identity lazy child synchronization", () => {
         eligible: true,
         active: false,
         enabled: null,
-      }),
-    ).toBe(false);
-  });
-
-  it("shows child-local recovery when app session synchronization fails", () => {
-    expect(
-      shouldShowDesktopIdentityRecovery({
-        eligible: true,
-        active: true,
-        showDesktopIdentityGate: false,
-        status: "failed",
-      }),
-    ).toBe(true);
-    expect(
-      shouldShowDesktopIdentityRecovery({
-        eligible: true,
-        active: true,
-        showDesktopIdentityGate: false,
-        status: "sign-in-required",
-      }),
-    ).toBe(false);
-    expect(
-      shouldShowDesktopIdentityRecovery({
-        eligible: true,
-        active: false,
-        showDesktopIdentityGate: false,
-        status: "failed",
-      }),
-    ).toBe(false);
-    expect(
-      shouldShowDesktopIdentityRecovery({
-        eligible: true,
-        active: true,
-        showDesktopIdentityGate: true,
-        status: "failed",
       }),
     ).toBe(false);
   });
@@ -1011,6 +983,9 @@ describe("AppWebview auth state", () => {
     expect(buildGuestAuthStateProbeScript()).toContain(
       "authenticated === true",
     );
+    expect(buildGuestAuthStateProbeScript()).toContain(
+      'window.location.protocol !== "http:"',
+    );
     expect(
       resolveAppWebviewAuthStateFromProbe(
         { authenticated: false, status: 200 },
@@ -1092,7 +1067,7 @@ describe("AppWebview auth state", () => {
 
   it("reports only native sign-in gate states as unauthenticated", () => {
     expect(isDesktopIdentityGateUnauthenticated("sign-in-required")).toBe(true);
-    expect(isDesktopIdentityGateUnauthenticated("failed")).toBe(true);
+    expect(isDesktopIdentityGateUnauthenticated("failed")).toBe(false);
     expect(isDesktopIdentityGateUnauthenticated("checking")).toBe(false);
     expect(isDesktopIdentityGateUnauthenticated("signed-in")).toBe(false);
     expect(isDesktopIdentityGateUnauthenticated("idle")).toBe(false);
@@ -1479,5 +1454,59 @@ describe("Recovering from a slow app load", () => {
 
     expect(container.textContent).not.toContain("Mail isn't loading");
     expect((webview!.parentElement as HTMLElement).style.display).toBe("flex");
+  });
+
+  it("loads the app URL instead of leaving an eligible app on about:blank after identity sync fails", async () => {
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      value: {
+        identity: {
+          getSettings: vi.fn(async () => ({ ssoEnabled: true })),
+          getStatus: vi.fn(async () => "failed"),
+          ensureAppSession: vi.fn(async () => false),
+          onStatusChange: vi.fn(() => () => {}),
+        },
+      },
+    });
+
+    root = createRoot(container);
+
+    const app: AppDefinition = {
+      id: "mail",
+      name: "Mail",
+      icon: "mail",
+      description: "",
+      devPort: 3000,
+    };
+    const appConfig: AppConfig = {
+      id: "mail",
+      name: "Mail",
+      icon: "mail",
+      description: "",
+      url: "https://mail.agent-native.com",
+      devPort: 3000,
+      isBuiltIn: true,
+      enabled: true,
+      mode: "prod",
+    };
+
+    await act(async () => {
+      root.render(
+        React.createElement(AppWebview, {
+          app,
+          appConfig,
+          isActive: true,
+          theme: "dark" as const,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const webview = container.querySelector("webview");
+    expect(webview).not.toBeNull();
+    expect(webview?.getAttribute("src")).toContain(
+      "https://mail.agent-native.com",
+    );
+    expect(webview?.getAttribute("src")).not.toBe("about:blank");
   });
 });

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -113,6 +113,14 @@ export function resolveAppWebviewAuthState(
 
 export function buildGuestAuthStateProbeScript(): string {
   return `(() => {
+    if (window.location.protocol !== "http:" && window.location.protocol !== "https:") {
+      return {
+        authenticated: null,
+        invalidJson: false,
+        status: 0,
+        url: window.location.href,
+      };
+    }
     const frameworkPath = "/_agent-native/auth/session";
     const config = window.__AGENT_NATIVE_CONFIG__;
     const normalizeBasePath = (value) => {
@@ -243,6 +251,7 @@ async function readAppWebviewAuthState(
     currentUrl = webview.src || "";
   }
   const fallbackState = resolveAppWebviewAuthState(currentUrl || undefined);
+  if (fallbackState === "unknown") return "unknown";
   try {
     const result = await webview.executeJavaScript(
       buildGuestAuthStateProbeScript(),
@@ -298,20 +307,6 @@ export function shouldUseDesktopIdentityGate(input: {
   return input.eligible && input.active && input.enabled !== false;
 }
 
-export function shouldShowDesktopIdentityRecovery(input: {
-  eligible: boolean;
-  active: boolean;
-  showDesktopIdentityGate: boolean;
-  status: DesktopIdentityStatus | "checking";
-}): boolean {
-  return (
-    !input.showDesktopIdentityGate &&
-    input.eligible &&
-    input.active &&
-    input.status === "failed"
-  );
-}
-
 export function shouldSuppressDesktopSignInPrompt(
   app: Pick<AppDefinition, "id">,
   appConfig: Pick<
@@ -326,7 +321,7 @@ export function shouldSuppressDesktopSignInPrompt(
 export function isDesktopIdentityGateUnauthenticated(
   status: DesktopIdentityStatus | "checking" | undefined,
 ): boolean {
-  return status === "sign-in-required" || status === "failed";
+  return status === "sign-in-required";
 }
 
 export function isDesktopIdentityAuthenticated(
@@ -360,6 +355,7 @@ export function shouldDeferDesktopAppWebviewLoad(input: {
   return (
     input.eligible &&
     input.enabled !== false &&
+    input.status !== "failed" &&
     (!input.sessionReady || input.status !== "signed-in")
   );
 }
@@ -812,14 +808,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
         active: isActive,
         enabled: desktopIdentityEnabled,
       });
-    const desktopIdentitySurfaceActive =
-      desktopIdentityGateActive ||
-      shouldShowDesktopIdentityRecovery({
-        eligible: desktopIdentityGateEligible,
-        active: isActive,
-        showDesktopIdentityGate,
-        status: desktopIdentityStatus,
-      });
+    const desktopIdentitySurfaceActive = desktopIdentityGateActive;
     const desktopIdentityRepairRef = useRef<Promise<boolean> | null>(null);
     const repairDesktopIdentitySession = useCallback(() => {
       if (
@@ -1553,14 +1542,14 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       if (!wv) return;
       let currentUrl = "";
       try {
-        currentUrl = wv.getURL() || "";
+        currentUrl = wv.getURL() || wv.src || "";
       } catch {
         currentUrl = "";
       }
       onAuthStateChangeRef.current?.("unknown");
       const sequence = ++authProbeSequenceRef.current;
       let active = true;
-      if (!currentUrl) {
+      if (!currentUrl || resolveAppWebviewAuthState(currentUrl) === "unknown") {
         return () => {
           active = false;
         };

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -275,7 +275,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain("onNewCliTab={handleNewCliTab}");
     expect(hubSource).toContain("onNewUiTab={handleNewUiTab}");
     expect(hubSource).toContain(
-      "chatEnabled={shouldUseDesktopAppChatShell(tab.path)}",
+      'shouldUseDesktopAppChatShell(tab.path) &&\n                  tab.placement !== "side"',
     );
     expect(hubSource).toContain(
       'newTabMode={terminalPreferences.enabled ? "cli" : "ui"}',
@@ -520,10 +520,30 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain(
       'terminalPreferences.enabled ? "side" : "main"',
     );
+    expect(hubSource).toContain('resolution.target.view,\n        "side",');
     expect(hubSource).toContain("<AppWebview");
     expect(hubSource).toContain("onOpenInBrowser={openChatFirstAppInBrowser}");
     expect(hubSource).toContain(
       "void window.electronAPI.shell.openExternal(url)",
+    );
+  });
+
+  it("keeps the shared sidebar reachable from an empty full-screen chat", () => {
+    const hubSource = readFileSync(
+      "src/renderer/components/CodeAgentsHub.tsx",
+      "utf8",
+    );
+
+    expect(hubSource).toContain("!showTerminalSurface");
+    expect(hubSource).toContain("chatFirstSurfacePanel.toggle");
+    expect(hubSource).toContain(
+      "onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}",
+    );
+    expect(hubSource).toContain(
+      "{chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (",
+    );
+    expect(hubSource).not.toContain(
+      "(hasChatFirstActiveChat || terminalPreferences.enabled) &&\n        chatFirstSurfacePanel.open",
     );
   });
 
@@ -833,10 +853,9 @@ describe("CodeAgentsHub desktop identity status", () => {
 
     expect(source).toContain("desktopIdentityStatusByTab");
     expect(source).toContain("handleDesktopIdentityStatusChange");
-    expect(source).toContain("onDesktopIdentitySyncFailure");
+    expect(source).not.toContain("onDesktopIdentitySyncFailure");
     expect(source).toContain('surfaceApp.id === "dispatch"');
     expect(source).toContain('app.id === "dispatch"');
-    expect(source).toContain('status === "failed"');
     expect(source).toContain("desktopIdentityStatusByTab,");
     expect(source).toContain("handleDesktopIdentityStatusChange,");
     expect(source).toContain("handleDesktopIdentityStatusChange(tab.id");

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -32,7 +32,6 @@ import {
 } from "./CodeAgentsHub.js";
 import {
   initialMultiFrontierRunAutoContinue,
-  locksMultiFrontierMode,
   providerOperationFailureNotice,
   readNewerMultiFrontierSnapshot,
 } from "./multi-frontier-renderer-state.js";
@@ -96,13 +95,6 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(persistedDefault).toEqual({ autoContinueAfterAgreement: true });
   });
 
-  it("keeps the collaboration mode selected until a run is terminal", () => {
-    expect(locksMultiFrontierMode({ phase: "implementing" })).toBe(true);
-    expect(locksMultiFrontierMode({ phase: "paused" })).toBe(true);
-    expect(locksMultiFrontierMode({ phase: "completed" })).toBe(false);
-    expect(locksMultiFrontierMode({ phase: "failed" })).toBe(false);
-  });
-
   it("reports provider-operation failures without surfacing raw provider errors", () => {
     expect(
       providerOperationFailureNotice("claude", "connect", "notice-1"),
@@ -123,7 +115,6 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
           permissionMode: "full-auto",
           subscriptions: {},
           busy: false,
-          modeLocked: false,
           autoContinueAfterAgreement: false,
           defaultAutoContinueAfterAgreement: false,
           onModeChange,
@@ -202,7 +193,6 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
           permissionMode: "full-auto",
           subscriptions: {},
           busy: false,
-          modeLocked: false,
           autoContinueAfterAgreement: false,
           defaultAutoContinueAfterAgreement: false,
           onModeChange,
@@ -545,6 +535,22 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).not.toContain(
       "(hasChatFirstActiveChat || terminalPreferences.enabled) &&\n        chatFirstSurfacePanel.open",
     );
+  });
+
+  it("keeps hidden Multi-Frontier state from restoring or locking the chat mode", () => {
+    const hubSource = readFileSync(
+      "src/renderer/components/CodeAgentsHub.tsx",
+      "utf8",
+    );
+
+    expect(hubSource).not.toContain(
+      "newSessionExtension={multiFrontierExtension}",
+    );
+    expect(hubSource).not.toContain(
+      "openDetailRequest={multiFrontierOpenDetailRequest}",
+    );
+    expect(hubSource).not.toContain('snapshot.phase === "paused"');
+    expect(hubSource).not.toContain("locksMultiFrontierMode");
   });
 
   it("keeps full-page settings on the shared query and theme contracts", () => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1982,7 +1982,7 @@ export default function CodeAgentsHub({
     [appendMultiFrontierNotice, applyMultiFrontierSnapshot],
   );
 
-  const multiFrontierExtension = useMemo<CodeAgentsNewSessionExtension>(
+  const _multiFrontierExtension = useMemo<CodeAgentsNewSessionExtension>(
     () => ({
       active: multiFrontierMode,
       disabled: multiFrontierBusy,

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -143,7 +143,6 @@ import DesktopTerminalSurface, {
 import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 import {
   initialMultiFrontierRunAutoContinue,
-  locksMultiFrontierMode,
   providerOperationFailureNotice,
   readNewerMultiFrontierSnapshot,
 } from "./multi-frontier-renderer-state.js";
@@ -938,11 +937,8 @@ export default function CodeAgentsHub({
   const [multiFrontierNotices, setMultiFrontierNotices] = useState<
     MultiFrontierNotice[]
   >([]);
-  const [multiFrontierOpenDetailRequest, setMultiFrontierOpenDetailRequest] =
-    useState<{ detailId: string; nonce: number }>();
   const multiFrontierSequence = useRef(-1);
   const multiFrontierSettingsHydrated = useRef(false);
-  const multiFrontierDetailNonce = useRef(0);
   const multiFrontierNoticeNonce = useRef(0);
   const multiFrontierActivationTracked = useRef(false);
   const multiFrontierLastPhaseTelemetry = useRef("");
@@ -951,7 +947,6 @@ export default function CodeAgentsHub({
   >({});
   const activeMultiFrontierCollaborationId =
     multiFrontierState?.collaborationId;
-  const multiFrontierModeLocked = locksMultiFrontierMode(multiFrontierState);
 
   const openChatFirstApp = useCallback(
     (
@@ -1837,31 +1832,11 @@ export default function CodeAgentsHub({
           if (!disposed) appendProviderOperationFailure(providerId, "load");
         });
     }
-    void api
-      .list()
-      .then((snapshots) => {
-        if (disposed) return;
-        const recovered = snapshots.find(
-          (snapshot) => snapshot.phase === "paused",
-        );
-        if (!recovered) return;
-        applyMultiFrontierSnapshot(recovered);
-        multiFrontierSettingsHydrated.current = true;
-        setMultiFrontierRunAutoContinue(
-          recovered.autoContinueAfterAgreement ?? false,
-        );
-        multiFrontierDetailNonce.current += 1;
-        setMultiFrontierOpenDetailRequest({
-          detailId: recovered.collaborationId,
-          nonce: multiFrontierDetailNonce.current,
-        });
-      })
-      .catch(() => undefined);
     return () => {
       disposed = true;
       unsubscribeProviderStatus();
     };
-  }, [appendProviderOperationFailure, applyMultiFrontierSnapshot, isActive]);
+  }, [appendProviderOperationFailure, isActive]);
 
   useEffect(() => {
     if (!isActive || !activeMultiFrontierCollaborationId) return;
@@ -2018,14 +1993,12 @@ export default function CodeAgentsHub({
             permissionMode={permissionMode}
             subscriptions={multiFrontierSubscriptions}
             busy={multiFrontierBusy}
-            modeLocked={multiFrontierModeLocked}
             autoContinueAfterAgreement={multiFrontierRunAutoContinue}
             defaultAutoContinueAfterAgreement={
               multiFrontierDefaultSettings.autoContinueAfterAgreement
             }
             onModeChange={(mode) => {
               if (mode === "multi-frontier") return;
-              if (multiFrontierModeLocked) return;
               setMultiFrontierMode(false);
               onPermissionModeChange(
                 mode === "plan" ? "read-only" : "full-auto",
@@ -2146,7 +2119,6 @@ export default function CodeAgentsHub({
       connectMultiFrontierSubscription,
       multiFrontierBusy,
       multiFrontierDefaultSettings.autoContinueAfterAgreement,
-      multiFrontierModeLocked,
       multiFrontierMode,
       multiFrontierNotices,
       multiFrontierRunAutoContinue,
@@ -3185,7 +3157,6 @@ export function MultiFrontierModeControl({
   permissionMode,
   subscriptions,
   busy,
-  modeLocked,
   autoContinueAfterAgreement,
   defaultAutoContinueAfterAgreement,
   onModeChange,
@@ -3198,7 +3169,6 @@ export function MultiFrontierModeControl({
   permissionMode: CodeAgentPermissionMode;
   subscriptions: Partial<Record<MultiFrontierProviderId, SubscriptionStatus>>;
   busy: boolean;
-  modeLocked: boolean;
   autoContinueAfterAgreement: boolean;
   defaultAutoContinueAfterAgreement: boolean;
   onModeChange: (mode: "plan" | "auto" | "multi-frontier") => void;
@@ -3214,11 +3184,7 @@ export function MultiFrontierModeControl({
       : "auto";
   return (
     <div className="code-agents-multi-frontier-control">
-      <Select
-        value={value}
-        disabled={busy || modeLocked}
-        onValueChange={onModeChange}
-      >
+      <Select value={value} disabled={busy} onValueChange={onModeChange}>
         <SelectTrigger
           className="desktop-select-trigger code-agents-mode-select code-agents-multi-frontier-mode-select"
           aria-label="Run mode"

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -667,7 +667,6 @@ interface CodeAgentsHubProps {
   ) => void;
   onChatFirstAppRemove?: (app: ChatFirstAppItem) => void;
   onChatFirstAppSelectionChange?: (appId?: string) => void;
-  onDesktopIdentitySyncFailure?: () => void;
 }
 
 type CodeAgentTranscriptSubscriptionBatch = {
@@ -703,7 +702,6 @@ export default function CodeAgentsHub({
   onLocalCodeChangeStarted,
   onChatFirstAppRemove,
   onChatFirstAppSelectionChange,
-  onDesktopIdentitySyncFailure,
 }: CodeAgentsHubProps) {
   const theme = useRendererTheme();
   useEffect(() => {
@@ -1485,12 +1483,7 @@ export default function CodeAgentsHub({
   useEffect(() => {
     const tabCount = visibleChatFirstSurfaceTabs.length;
     const previousTabCount = previousChatFirstSurfaceTabCountRef.current;
-    if (!hasChatFirstActiveChat && !terminalPreferences.enabled) {
-      setChatFirstSurfacePanelOpen(false);
-    } else if (
-      tabCount > 0 &&
-      (previousTabCount === null || previousTabCount === 0)
-    ) {
+    if (tabCount > 0 && (previousTabCount === null || previousTabCount === 0)) {
       setChatFirstSurfacePanelOpen(true);
     } else if (
       tabCount === 0 &&
@@ -1500,12 +1493,7 @@ export default function CodeAgentsHub({
       setChatFirstSurfacePanelOpen(false);
     }
     previousChatFirstSurfaceTabCountRef.current = tabCount;
-  }, [
-    hasChatFirstActiveChat,
-    setChatFirstSurfacePanelOpen,
-    terminalPreferences.enabled,
-    visibleChatFirstSurfaceTabs.length,
-  ]);
+  }, [setChatFirstSurfacePanelOpen, visibleChatFirstSurfaceTabs.length]);
 
   useEffect(() => {
     if (!terminalPreferences.enabled) return;
@@ -1862,7 +1850,6 @@ export default function CodeAgentsHub({
         setMultiFrontierRunAutoContinue(
           recovered.autoContinueAfterAgreement ?? false,
         );
-        setMultiFrontierMode(true);
         multiFrontierDetailNonce.current += 1;
         setMultiFrontierOpenDetailRequest({
           detailId: recovered.collaborationId,
@@ -2037,17 +2024,7 @@ export default function CodeAgentsHub({
               multiFrontierDefaultSettings.autoContinueAfterAgreement
             }
             onModeChange={(mode) => {
-              if (mode === "multi-frontier") {
-                if (!multiFrontierMode) {
-                  setMultiFrontierRunAutoContinue(
-                    initialMultiFrontierRunAutoContinue(
-                      multiFrontierDefaultSettings,
-                    ),
-                  );
-                }
-                setMultiFrontierMode(true);
-                return;
-              }
+              if (mode === "multi-frontier") return;
               if (multiFrontierModeLocked) return;
               setMultiFrontierMode(false);
               onPermissionModeChange(
@@ -2748,7 +2725,10 @@ export default function CodeAgentsHub({
                 desktopIdentityStatus={desktopIdentityStatus}
                 appAuthState={appAuthState}
                 isActive={isTabActive}
-                chatEnabled={shouldUseDesktopAppChatShell(tab.path)}
+                chatEnabled={
+                  shouldUseDesktopAppChatShell(tab.path) &&
+                  tab.placement !== "side"
+                }
                 toggleScopeId={tab.id}
                 onNewCliTab={handleNewCliTab}
                 onNewUiTab={handleNewUiTab}
@@ -2806,12 +2786,6 @@ export default function CodeAgentsHub({
                       }}
                       onDesktopIdentityStatusChange={(status) => {
                         handleDesktopIdentityStatusChange(tab.id, status);
-                        if (
-                          surfaceApp.id === "dispatch" &&
-                          status === "failed"
-                        ) {
-                          onDesktopIdentitySyncFailure?.();
-                        }
                       }}
                       onWebContentsIdChange={(webContentsId) =>
                         handleWebContentsIdChange(tab.id, webContentsId)
@@ -2876,7 +2850,6 @@ export default function CodeAgentsHub({
       isActive,
       onLocalCodeChangeStarted,
       onOpenSettings,
-      onDesktopIdentitySyncFailure,
       refreshKey,
       surfaceApps,
       terminalPreferences.agent,
@@ -2914,7 +2887,10 @@ export default function CodeAgentsHub({
           brandIconUrl={agentNativeIconUrl}
           onOpenSettings={onOpenSettings}
           mainToolbarSlot={
-            hasChatFirstActiveChat && !chatFirstAppTakesMain ? (
+            !showTerminalSurface &&
+            !chatFirstAllAppsOpen &&
+            !scheduledTasksOpen &&
+            !chatFirstAppTakesMain ? (
               <ChatFirstSurfacePanelToggle
                 open={chatFirstSurfacePanel.open}
                 onToggle={chatFirstSurfacePanel.toggle}
@@ -2965,6 +2941,7 @@ export default function CodeAgentsHub({
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
+                onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}
               />
             ) : undefined
           }
@@ -3109,8 +3086,6 @@ export default function CodeAgentsHub({
               </>
             </TooltipProvider>
           }
-          newSessionExtension={multiFrontierExtension}
-          openDetailRequest={multiFrontierOpenDetailRequest}
           renderAppSurface={({ app, urlParams, refreshKey: appRefreshKey }) => (
             <div className="code-agents-embedded-app-surface">
               <AppWebview
@@ -3120,11 +3095,6 @@ export default function CodeAgentsHub({
                 showDesktopIdentityGate={false}
                 theme={theme}
                 urlParams={urlParams}
-                onDesktopIdentityStatusChange={(status) => {
-                  if (app.id === "dispatch" && status === "failed") {
-                    onDesktopIdentitySyncFailure?.();
-                  }
-                }}
                 // Shell key folded in: a lane change remounts every hosted
                 // surface, not just the ones with their own refresh reason.
                 refreshKey={appRefreshKey + refreshKey}
@@ -3132,9 +3102,7 @@ export default function CodeAgentsHub({
             </div>
           )}
         />
-        {(hasChatFirstActiveChat || terminalPreferences.enabled) &&
-        chatFirstSurfacePanel.open &&
-        !chatFirstAppTakesMain ? (
+        {chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (
           <ChatFirstSurfacePanel
             width={chatFirstSurfaceResize.width}
             onResizePointerDown={chatFirstSurfaceResize.onPointerDown}

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.spec.ts
@@ -48,6 +48,24 @@ describe("desktop app chat shell", () => {
     expect(source).not.toContain("data-desktop-app-sign-in");
   });
 
+  it("creates an isolated query client for each mounted app shell", () => {
+    const source = readFileSync(
+      new URL("./DesktopAppChatShell.tsx", import.meta.url),
+      "utf8",
+    );
+    const componentStart = source.indexOf(
+      "export default function DesktopAppChatShell(",
+    );
+    const queryClientCreation = source.indexOf(
+      "createAgentNativeQueryClient()",
+    );
+
+    expect(queryClientCreation).toBeGreaterThan(componentStart);
+    expect(source).not.toContain(
+      "const desktopChatQueryClient = createAgentNativeQueryClient();",
+    );
+  });
+
   it("keeps the resolved chat endpoint across app tab switches", () => {
     const source = readFileSync(
       new URL("./DesktopAppChatShell.tsx", import.meta.url),
@@ -72,6 +90,9 @@ describe("desktop app chat shell", () => {
 
     expect(shellCss).toMatch(
       /\.desktop-app-webview-surface,\s*\.code-agents-embedded-app-surface\s*\{[\s\S]*?border-radius: var\(--agent-native-raised-radius, 8px\) 0 0\s+var\(--agent-native-raised-radius, 8px\);[\s\S]*?border-left: 0;[\s\S]*?box-shadow: 0 0 0 1px hsl\(var\(--border\)\);[\s\S]*?\}/,
+    );
+    expect(shellCss).not.toContain(
+      "transition: grid-template-columns 200ms var(--ease-collapse)",
     );
   });
 

--- a/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopAppChatShell.tsx
@@ -47,7 +47,6 @@ import {
   type DesktopLocalAgentId,
 } from "../lib/desktop-local-agent-runtime.js";
 import type { AppWebviewAuthState } from "./AppWebview.js";
-const desktopChatQueryClient = createAgentNativeQueryClient();
 
 type DesktopChatModelGroup = {
   engine: string;
@@ -135,9 +134,7 @@ export function shouldShowDesktopAppChatSidebar(input: {
     return false;
   }
   if (input.desktopIdentityUnauthenticated) return false;
-  return !["sign-in-required", "failed"].includes(
-    input.desktopIdentityStatus ?? "idle",
-  );
+  return input.desktopIdentityStatus !== "sign-in-required";
 }
 
 type LocalCodeChangeState =
@@ -163,6 +160,9 @@ export default function DesktopAppChatShell({
   newTabMode = "ui",
   onLocalCodeChangeStarted,
 }: DesktopAppChatShellProps) {
+  const [desktopChatQueryClient] = useState(() =>
+    createAgentNativeQueryClient(),
+  );
   const shellRootRef = useRef<HTMLDivElement>(null);
   const [apiUrl, setApiUrl] = useState<string | null>(null);
   const [localAgentModels, setLocalAgentModels] = useState<

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.spec.tsx
@@ -194,6 +194,12 @@ describe("DesktopIdentityGate", () => {
     expect(container.querySelector("form")).toBeNull();
   });
 
+  it("does not wedge the shell on a transient identity failure", () => {
+    renderGate("failed");
+    expect(container.textContent).toBe("");
+    expect(container.querySelector(".desktop-identity-gate")).toBeNull();
+  });
+
   it("renders nothing after the broker has fanned out app sessions", () => {
     renderGate("signed-in");
     expect(container.textContent).toBe("");

--- a/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopIdentityGate.tsx
@@ -83,21 +83,18 @@ export default function DesktopIdentityGate({
   const emailRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (status === "sign-in-required" || status === "failed") {
+    if (status === "sign-in-required") {
       emailRef.current?.focus();
     }
-    if (status === "failed") {
-      setMagicLinkSentEmail(null);
-      setSubmitting(false);
-      setError((current) => current ?? COPY.failedToConnect);
-    }
-    if (status === "signed-in" || status === "idle") {
+    if (status === "signed-in" || status === "idle" || status === "failed") {
       setMagicLinkSentEmail(null);
       setSubmitting(false);
     }
   }, [status]);
 
-  if (status === "idle" || status === "signed-in") return null;
+  if (status === "idle" || status === "signed-in" || status === "failed") {
+    return null;
+  }
 
   const submit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -172,7 +169,7 @@ export default function DesktopIdentityGate({
     );
   }
 
-  if (magicLinkSentEmail && status !== "failed") {
+  if (magicLinkSentEmail) {
     return (
       <div
         className="desktop-identity-gate"
@@ -204,7 +201,6 @@ export default function DesktopIdentityGate({
   const canSubmit = Boolean(
     email.trim() && (authMode === "magic-link" || password),
   );
-
   return (
     <div
       className="desktop-identity-gate"

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -60,4 +60,38 @@ describe("DesktopTerminalSurface", () => {
     await act(async () => item?.click());
     expect(onNewUiTab).toHaveBeenCalledOnce();
   });
+
+  it("opens the shared sidebar from CLI options", async () => {
+    const onOpenSidebar = vi.fn();
+    act(() => {
+      root.render(
+        <DesktopTerminalSurface
+          agent="codex"
+          theme="dark"
+          onOpenSidebar={onOpenSidebar}
+        />,
+      );
+    });
+
+    await act(async () => {
+      const trigger = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Terminal options"]',
+      );
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+    const item = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((candidate) => candidate.textContent?.includes("Open sidebar"));
+
+    expect(item).toBeDefined();
+    await act(async () => item?.click());
+    expect(onOpenSidebar).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -8,6 +8,7 @@ import {
 } from "@agent-native/toolkit/ui";
 import {
   IconDotsVertical,
+  IconLayoutSidebarRightCollapse,
   IconMessageCircle,
   IconPlus,
   IconX,
@@ -27,6 +28,7 @@ interface DesktopTerminalSurfaceProps {
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
+  onOpenSidebar?: () => void;
 }
 
 interface DesktopTerminalTab {
@@ -48,6 +50,7 @@ export default function DesktopTerminalSurface({
   submitRequest,
   onPromptSubmitted,
   onNewUiTab,
+  onOpenSidebar,
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
@@ -165,6 +168,18 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
+              {onOpenSidebar ? (
+                <>
+                  <DropdownMenuItem onSelect={onOpenSidebar}>
+                    <IconLayoutSidebarRightCollapse
+                      size={14}
+                      className="shrink-0"
+                    />
+                    Open sidebar
+                  </DropdownMenuItem>
+                  {onNewUiTab ? <DropdownMenuSeparator /> : null}
+                </>
+              ) : null}
               {onNewUiTab ? (
                 <>
                   <DropdownMenuItem onSelect={onNewUiTab}>

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -158,7 +158,18 @@ export default function DesktopTerminalTabs({
           throw new Error("The desktop terminal has no connection.");
         }
         const response = await fetch(infoUrl);
-        const info = terminalInfoFrom(await response.json());
+        const body = await response.text();
+        let payload: unknown;
+        try {
+          payload = JSON.parse(body);
+        } catch {
+          throw new Error(
+            response.ok
+              ? "The desktop terminal returned an invalid response."
+              : `The desktop terminal failed to start (${response.status}).`,
+          );
+        }
+        const info = terminalInfoFrom(payload);
         const wsUrl =
           info.wsUrl ??
           (info.wsPort ? `ws://127.0.0.1:${info.wsPort}/ws` : undefined);

--- a/packages/desktop-app/src/renderer/components/multi-frontier-renderer-state.ts
+++ b/packages/desktop-app/src/renderer/components/multi-frontier-renderer-state.ts
@@ -20,13 +20,6 @@ export function initialMultiFrontierRunAutoContinue(
   return settings.autoContinueAfterAgreement;
 }
 
-export function locksMultiFrontierMode(
-  state?: Pick<MultiFrontierRendererState, "phase">,
-): boolean {
-  if (!state) return false;
-  return !["completed", "failed", "canceled"].includes(state.phase);
-}
-
 export function providerOperationFailureNotice(
   providerId: MultiFrontierProviderId,
   operation: "connect" | "refresh" | "load",

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -287,7 +287,6 @@ body {
 .desktop-chat-first-hub > .code-agents-surface {
   min-width: 0;
   min-height: 0;
-  transition: grid-template-columns 200ms var(--ease-collapse);
 }
 
 .desktop-chat-first-hub
@@ -1063,10 +1062,6 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .desktop-chat-first-hub > .code-agents-surface {
-    transition: none;
-  }
-
   .desktop-chat-first-mac-window-controls,
   .collapsed-mac-window-controls,
   .collapsed-mac-window-controls::before,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,6 +1269,9 @@ importers:
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.9
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/scripts/qa-chat-first-workbench-smoke.ts
+++ b/scripts/qa-chat-first-workbench-smoke.ts
@@ -100,7 +100,7 @@ async function snapshot(page: Page, name: string): Promise<SurfaceSnapshot> {
       ".agent-layout-main-surface",
     );
     const chat = document.querySelector<HTMLElement>(
-      ".agent-layout-main-surface > .relative",
+      ".agent-layout-main-surface .agent-chat-scroll",
     );
     return {
       panel: document.querySelectorAll("[data-chat-first-surface-panel]")
@@ -305,7 +305,7 @@ async function runSmoke(browser: Browser): Promise<void> {
     );
     assert.ok(
       empty.chatWidth >= empty.mainWidth - 2,
-      "chat should occupy the content width without a side panel",
+      `chat should occupy the content width without a side panel (${empty.chatWidth} / ${empty.mainWidth})`,
     );
   } finally {
     await emptyContext.context.close();
@@ -927,8 +927,8 @@ async function runElectronSmoke(): Promise<void> {
     );
     assert.equal(
       empty.toggle,
-      0,
-      "Electron empty chat must not offer a right-surface toggle",
+      1,
+      "Electron empty full-screen chat should offer a right-surface toggle",
     );
     assert.ok(
       empty.mainWidth > 0,
@@ -938,13 +938,34 @@ async function runElectronSmoke(): Promise<void> {
       await page
         .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
         .count(),
-      0,
-      "Electron empty chat should not expose the surface toggle",
+      1,
+      "Electron empty chat should expose the central surface toggle",
     );
     assert.ok(
       empty.composerRight - empty.composerLeft <= 752,
       "Electron full-page composer should be no wider than 750px",
     );
+    await page
+      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .click();
+    await page
+      .locator("[data-chat-first-surface-panel]")
+      .waitFor({ state: "visible", timeout: 15_000 });
+    const emptySidebar = await electronSnapshot(
+      page,
+      "electron-01-chat-first-empty-sidebar",
+      electronApp,
+    );
+    assert.ok(
+      emptySidebar.appOptions >= 5,
+      "Electron empty chat should expose the app picker from its sidebar",
+    );
+    await page
+      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .click();
+    await page
+      .locator("[data-chat-first-surface-panel]")
+      .waitFor({ state: "detached", timeout: 15_000 });
     const defaultAppIds = await page
       .locator("[data-chat-first-app][data-app-id]")
       .evaluateAll((elements) =>
@@ -1000,7 +1021,7 @@ async function runElectronSmoke(): Promise<void> {
       "The empty chat-first center should not show a workbench before a chat is selected",
     );
     const topNavColors = await page
-      .locator(".code-agents-rail-scroll .code-agents-nav-link")
+      .locator(".code-agents-rail-scroll .code-agents-nav-list [role=tab]")
       .evaluateAll((buttons) =>
         buttons.map((button) => getComputedStyle(button).color),
       );
@@ -1095,6 +1116,13 @@ async function runElectronSmoke(): Promise<void> {
     });
 
     await installElectronAppCreationSmokeMock(electronApp);
+    const expandRailButton = page.getByRole("button", {
+      name: "Expand rail",
+      exact: true,
+    });
+    if (await expandRailButton.count()) {
+      await expandRailButton.click();
+    }
     const createAppButton = page.locator(
       '[data-chat-first-apps-rail] button[aria-label="Create app"]',
     );


### PR DESCRIPTION
## Summary
- keep Nightly on the legacy Agent-Native user-data profile and repair embedded app session continuity
- prevent failed embeds from covering the desktop shell with a sign-in gate
- support persistent CLI/UI chat tabs, Claude-only model choices, and a packaged node-pty runtime
- make app switching retain the open chat surface without replaying its animation
- move terminal worktree reclamation off read paths with bounded retries and permanent failure state
- hide Multi-Frontier from the desktop mode picker and prevent restored state from reactivating it
- recover packaged shell reloads from pushed SPA routes instead of navigating to missing `file://` paths

## Validation
- `pnpm --dir packages/desktop-app test` (569 passed)
- `pnpm --dir packages/desktop-app typecheck`
- core/toolkit picker tests (59 passed)
- `pnpm guards`
- packaged Electron PTY smoke: `packaged-ok`, exit 0
- macOS directory package built and code-signed; notarization was skipped in this local build because credentials/options were unavailable
