### PR TITLE
Make skeleton shimmer more subtle

### DIFF
--- a/.changeset/soften-skeleton-shine-further.md
+++ b/.changeset/soften-skeleton-shine-further.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make the shared skeleton loading shine more subtle.

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -550,7 +550,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--foreground, var(--ui-foreground)) / 0.072) 50%,
+    hsl(var(--foreground, var(--ui-foreground)) / 0.043) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/packages/core/src/styles/agent-native.spec.ts
+++ b/packages/core/src/styles/agent-native.spec.ts
@@ -132,7 +132,7 @@ describe("agent-native shell surface tokens", () => {
       /@keyframes skeleton-shimmer[\s\S]*?background-position: 150% 0;[\s\S]*?background-position: -50% 0;/s,
     );
     expect(css).toContain(
-      "hsl(var(--foreground, var(--ui-foreground)) / 0.072)",
+      "hsl(var(--foreground, var(--ui-foreground)) / 0.043)",
     );
     expect(css).not.toContain("skeleton-pulse");
   });

--- a/templates/analytics/changelog/2026-08-29-analytics-loading-shine-is-more-subtle.md
+++ b/templates/analytics/changelog/2026-08-29-analytics-loading-shine-is-more-subtle.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-29
+---
+
+Analytics loading states now use an even more subtle whole-surface shine.

--- a/templates/clips/changelog/2026-08-29-clips-loading-shine-is-more-subtle.md
+++ b/templates/clips/changelog/2026-08-29-clips-loading-shine-is-more-subtle.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-29
+---
+
+Clips loading states now use an even more subtle whole-surface shine.

--- a/templates/clips/desktop/src/tailwind.css
+++ b/templates/clips/desktop/src/tailwind.css
@@ -27,7 +27,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--ui-foreground) / 0.072) 50%,
+    hsl(var(--ui-foreground) / 0.043) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/plan/app/components/plan/wireframe/html-artboard.css
+++ b/templates/plan/app/components/plan/wireframe/html-artboard.css
@@ -271,7 +271,7 @@
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    hsl(var(--foreground) / 0.072) 50%,
+    hsl(var(--foreground) / 0.043) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/plan/changelog/2026-08-29-plan-loading-shine-is-more-subtle.md
+++ b/templates/plan/changelog/2026-08-29-plan-loading-shine-is-more-subtle.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-29
+---
+
+Plan loading states now use an even more subtle whole-surface shine.

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -1181,7 +1181,7 @@ button[title="Open agent sidebar"] {
   background-image: linear-gradient(
     100deg,
     transparent 30%,
-    rgba(255, 255, 255, 0.096) 50%,
+    rgba(255, 255, 255, 0.058) 50%,
     transparent 70%
   );
   background-position: 150% 0;

--- a/templates/slides/changelog/2026-08-29-slides-loading-shine-is-more-subtle.md
+++ b/templates/slides/changelog/2026-08-29-slides-loading-shine-is-more-subtle.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-29
+---
+
+Slides loading states now use an even more subtle whole-surface shine.


### PR DESCRIPTION
## Summary
- Lower the shared skeleton shimmer highlight by roughly another 40%.
- Keep the smooth whole-surface sweep and reduced-motion behavior unchanged.
- Update the four affected app changelogs and the Core changeset.

## Validation
- Focused Core, Analytics, Slides, and Plan tests pass.
- All 65 repository guards pass.
- Live Slides and Analytics loading shells verified with fresh screenshots.