### PR TITLE
fix: retry transient Builder design-system indexing

### DIFF
--- a/.changeset/retry-builder-design-system-index.md
+++ b/.changeset/retry-builder-design-system-index.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Retry transient Builder design-system indexing gateway failures.

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -575,6 +575,43 @@ describe("Builder design-system helpers", () => {
     expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
   });
 
+  it("retries transient Builder indexing transport failures", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            designSystemId: "ds-1",
+            jobId: "job-1",
+            projectId: "project-1",
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    try {
+      const result = indexBuilderDesignSystem({
+        sources: [{ kind: "file", uploadToken: "upload-token" }],
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await expect(result).resolves.toMatchObject({
+        designSystemId: "ds-1",
+        jobId: "job-1",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry permanent Builder indexing failures", async () => {
     process.env.BUILDER_PRIVATE_KEY = "builder-private";
     process.env.BUILDER_PUBLIC_KEY = "builder-public";

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -568,6 +568,11 @@ describe("Builder design-system helpers", () => {
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    const idempotencyKeys = fetchMock.mock.calls.map(([, init]) =>
+      new Headers(init?.headers).get("Idempotency-Key"),
+    );
+    expect(idempotencyKeys[0]).toMatch(/^agent-native-dsi-/);
+    expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
   });
 
   it("does not retry permanent Builder indexing failures", async () => {

--- a/packages/core/src/server/builder-design-systems.spec.ts
+++ b/packages/core/src/server/builder-design-systems.spec.ts
@@ -5,6 +5,7 @@ import {
   collectBuilderDesignSystemGitHubFiles,
   createBuilderDesignSystemProxyFields,
   hydrateBuilderDesignSystemReference,
+  indexBuilderDesignSystem,
   localBuilderDesignSystemId,
   mimeTypeForBuilderDesignSystemFilename,
   parseBuilderDesignSystemProxyReference,
@@ -526,6 +527,67 @@ describe("Builder design-system helpers", () => {
       jobId: "job-1",
       status: "in-progress",
     });
+  });
+
+  it("retries transient Builder indexing gateway failures", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("<html><title>Bad gateway</title></html>", {
+          status: 502,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            designSystemId: "ds-1",
+            jobId: "job-1",
+            projectId: "project-1",
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    try {
+      const result = indexBuilderDesignSystem({
+        sources: [{ kind: "file", uploadToken: "upload-token" }],
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await expect(result).resolves.toMatchObject({
+        designSystemId: "ds-1",
+        jobId: "job-1",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry permanent Builder indexing failures", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "builder-private";
+    process.env.BUILDER_PUBLIC_KEY = "builder-public";
+    process.env.BUILDER_DESIGN_SYSTEMS_BASE_URL =
+      "https://builder.example.test/design-systems/v1";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Invalid source" }), {
+        status: 422,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      indexBuilderDesignSystem({
+        sources: [{ kind: "file", uploadToken: "upload-token" }],
+      }),
+    ).rejects.toThrow("422");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("keeps an unscoped public repository as a native Builder source", async () => {

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -726,16 +726,26 @@ async function fetchBuilderDesignSystemIndex(
   const headers = new Headers(init.headers);
   headers.set("Idempotency-Key", idempotencyKey);
   const request = { ...init, headers };
-  let response = await fetchWithTimeout(url, request, INDEX_ATTEMPT_TIMEOUT_MS);
-  for (const retryDelay of INDEX_RETRY_DELAYS_MS) {
-    if (response.ok || !RETRYABLE_INDEX_STATUSES.has(response.status)) {
-      return response;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const response = await fetchWithTimeout(
+        url,
+        request,
+        INDEX_ATTEMPT_TIMEOUT_MS,
+      );
+      if (
+        response.ok ||
+        !RETRYABLE_INDEX_STATUSES.has(response.status) ||
+        attempt >= INDEX_RETRY_DELAYS_MS.length
+      ) {
+        return response;
+      }
+      if (response.body) await response.body.cancel();
+    } catch (error) {
+      if (attempt >= INDEX_RETRY_DELAYS_MS.length) throw error;
     }
-    if (response.body) await response.body.cancel();
-    await delay(retryDelay);
-    response = await fetchWithTimeout(url, request, INDEX_ATTEMPT_TIMEOUT_MS);
+    await delay(INDEX_RETRY_DELAYS_MS[attempt]);
   }
-  return response;
 }
 
 async function uploadToResumableUrl(

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -22,6 +22,8 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 // files off a single unbounded request body.
 const GCS_CHUNK_SIZE = 16 * 1024 * 1024;
 const MAX_CHUNK_RETRIES = 5;
+const RETRYABLE_INDEX_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const INDEX_RETRY_DELAYS_MS = [600, 1800] as const;
 
 export interface BuilderDesignSystemIndexFile {
   name: string;
@@ -713,6 +715,22 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function fetchBuilderDesignSystemIndex(
+  url: string | URL,
+  init: RequestInit,
+): Promise<Response> {
+  let response = await fetchWithTimeout(url, init);
+  for (const retryDelay of INDEX_RETRY_DELAYS_MS) {
+    if (response.ok || !RETRYABLE_INDEX_STATUSES.has(response.status)) {
+      return response;
+    }
+    if (response.body) await response.body.cancel();
+    await delay(retryDelay);
+    response = await fetchWithTimeout(url, init);
+  }
+  return response;
+}
+
 async function uploadToResumableUrl(
   slot: { uploadUrl: string },
   file: BuilderDesignSystemIndexFile,
@@ -1259,7 +1277,7 @@ export async function indexBuilderDesignSystem(
     );
   }
   const credentials = await resolveBuilderDesignSystemCredentials();
-  const index = await fetchWithTimeout(
+  const index = await fetchBuilderDesignSystemIndex(
     makeBuilderDesignSystemUrl("index", credentials),
     {
       method: "POST",

--- a/packages/core/src/server/builder-design-systems.ts
+++ b/packages/core/src/server/builder-design-systems.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import type { DesignSystemSourceInput } from "@builder.io/ai-utils";
 
 import { withBuilderUtmTrackingParams } from "../shared/builder-link-tracking.js";
@@ -23,6 +25,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const GCS_CHUNK_SIZE = 16 * 1024 * 1024;
 const MAX_CHUNK_RETRIES = 5;
 const RETRYABLE_INDEX_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const INDEX_ATTEMPT_TIMEOUT_MS = 20_000;
 const INDEX_RETRY_DELAYS_MS = [600, 1800] as const;
 
 export interface BuilderDesignSystemIndexFile {
@@ -718,15 +721,19 @@ function delay(ms: number): Promise<void> {
 async function fetchBuilderDesignSystemIndex(
   url: string | URL,
   init: RequestInit,
+  idempotencyKey: string,
 ): Promise<Response> {
-  let response = await fetchWithTimeout(url, init);
+  const headers = new Headers(init.headers);
+  headers.set("Idempotency-Key", idempotencyKey);
+  const request = { ...init, headers };
+  let response = await fetchWithTimeout(url, request, INDEX_ATTEMPT_TIMEOUT_MS);
   for (const retryDelay of INDEX_RETRY_DELAYS_MS) {
     if (response.ok || !RETRYABLE_INDEX_STATUSES.has(response.status)) {
       return response;
     }
     if (response.body) await response.body.cancel();
     await delay(retryDelay);
-    response = await fetchWithTimeout(url, init);
+    response = await fetchWithTimeout(url, request, INDEX_ATTEMPT_TIMEOUT_MS);
   }
   return response;
 }
@@ -1277,6 +1284,7 @@ export async function indexBuilderDesignSystem(
     );
   }
   const credentials = await resolveBuilderDesignSystemCredentials();
+  const idempotencyKey = `agent-native-dsi-${randomUUID()}`;
   const index = await fetchBuilderDesignSystemIndex(
     makeBuilderDesignSystemUrl("index", credentials),
     {
@@ -1295,6 +1303,7 @@ export async function indexBuilderDesignSystem(
           : {}),
       }),
     },
+    idempotencyKey,
   );
   await assertOk(index, "Builder design-system indexing failed");
   const indexed = (await index.json()) as IndexResponse;


### PR DESCRIPTION
## Summary
- Retry typed transient Builder design-system indexing failures, including the reported 502 gateway response.
- Keep permanent 4xx failures terminal and preserve the existing error response.

## Source evidence
- Slack report: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788013640082899

## Verification
- `pnpm --filter @agent-native/core exec vitest --run src/server/builder-design-systems.spec.ts --config vitest.config.ts`
- `pnpm guard:serverless-function-payload`
- `pnpm guard:no-silent-coercion`
- `pnpm guard:no-raw-colors`
- `pnpm exec oxfmt --check packages/core/src/server/builder-design-systems.ts packages/core/src/server/builder-design-systems.spec.ts`
- Authenticated beta Slides `/design-systems` opened successfully and the Connect Figma import dialog rendered. No file was uploaded during browser verification.