### PR TITLE
test: add scheduled full signup canary

### DIFF
--- a/.changeset/suppress-qa-signup-tracking.md
+++ b/.changeset/suppress-qa-signup-tracking.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix: suppress analytics for reserved signup canary addresses

--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -34,9 +34,19 @@ on:
         default: "all"
         type: string
       lane:
-        description: "Which lanes to run"
+        description: "Which lanes to run (public, authed, public+authed, or signup)"
         required: false
         default: "public+authed"
+        type: string
+      signup_apps:
+        description: "Apps for the signup canary"
+        required: false
+        default: "clips,design,chat"
+        type: string
+      signup_environments:
+        description: "Environments for the signup canary"
+        required: false
+        default: "beta"
         type: string
       grep:
         description: "Only run tests whose title matches this (optional)"
@@ -59,6 +69,12 @@ on:
         required: false
       OPENAI_API_KEY:
         required: false
+      MAILOSAUR_API_KEY:
+        required: false
+      MAILOSAUR_SERVER_ID:
+        required: false
+      PAGERDUTY_ROUTING_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       apps:
@@ -73,6 +89,17 @@ on:
         options:
           - public
           - public+authed
+          - signup
+      signup_apps:
+        description: "Apps for the signup canary"
+        required: false
+        default: "clips,design,chat"
+        type: string
+      signup_environments:
+        description: "Environments for the signup canary"
+        required: false
+        default: "beta"
+        type: string
       key_source:
         description: "Which OpenAI credential the agent turns bill"
         required: false
@@ -102,6 +129,7 @@ permissions:
 jobs:
   discover:
     name: Resolve host shards
+    if: ${{ inputs.lane != 'signup' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -162,7 +190,7 @@ jobs:
     # databases; always() keeps later evidence running after ordinary failure.
     name: ${{ matrix.app }} public sweep
     needs: discover
-    if: ${{ needs.discover.result == 'success' && inputs.lane != 'authed' }}
+    if: ${{ needs.discover.result == 'success' && inputs.lane != 'authed' && inputs.lane != 'signup' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -201,7 +229,7 @@ jobs:
   fleet:
     name: Fleet-wide checks
     needs: [discover, public]
-    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'authed' }}
+    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'authed' && inputs.lane != 'signup' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -230,7 +258,7 @@ jobs:
   authed:
     name: Authenticated journeys
     needs: [discover, advisory]
-    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'public' }}
+    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'public' && inputs.lane != 'signup' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -296,7 +324,7 @@ jobs:
 
   advisory:
     name: Advisory findings (non-gating)
-    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'authed' }}
+    if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'authed' && inputs.lane != 'signup' }}
     needs: [discover, fleet]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -327,3 +355,48 @@ jobs:
           path: e2e/beta/playwright-report/
           if-no-files-found: warn
           retention-days: 7
+
+  signup:
+    name: Signup canary
+    if: ${{ inputs.lane == 'signup' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      SIGNUP_E2E_APPS: ${{ inputs.signup_apps || 'clips,design,chat' }}
+      SIGNUP_E2E_ENVIRONMENTS: ${{ inputs.signup_environments || 'beta' }}
+      MAILOSAUR_API_KEY: ${{ secrets.MAILOSAUR_API_KEY }}
+      MAILOSAUR_SERVER_ID: ${{ secrets.MAILOSAUR_SERVER_ID }}
+      PAGERDUTY_ROUTING_KEY: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/beta-e2e-setup
+      - name: Typecheck signup suite
+        run: pnpm typecheck:e2e:signup
+      - name: Run full signup flow
+        id: signup
+        run: pnpm e2e:signup
+      - name: Page signup health on-call
+        if: ${{ steps.signup.outcome == 'failure' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PAGERDUTY_ROUTING_KEY:-}" ]; then
+            echo "::warning::PAGERDUTY_ROUTING_KEY is not configured; the GitHub issue fallback is active but no page was sent."
+            exit 0
+          fi
+          jq -n \
+            --arg routing_key "$PAGERDUTY_ROUTING_KEY" \
+            --arg dedup_key "agent-native-signup-e2e" \
+            --arg source "${{ github.repository }}" \
+            --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{routing_key: $routing_key, event_action: "trigger", dedup_key: $dedup_key, payload: {summary: "Agent-Native signup E2E is failing", source: $source, severity: "critical", custom_details: {run_url: $run_url, apps: env.SIGNUP_E2E_APPS, environments: env.SIGNUP_E2E_ENVIRONMENTS}}}' \
+            | curl --fail-with-body --connect-timeout 10 --max-time 20 --silent --show-error \
+                --header 'Content-Type: application/json' \
+                --data-binary @- \
+                https://events.pagerduty.com/v2/enqueue
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ always() }}
+        with:
+          name: signup-e2e-${{ github.run_id }}
+          path: e2e/signup/test-results/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -41,7 +41,7 @@ on:
       signup_apps:
         description: "Apps for the signup canary"
         required: false
-        default: "clips,design,chat"
+        default: "all"
         type: string
       signup_environments:
         description: "Environments for the signup canary"
@@ -93,7 +93,7 @@ on:
       signup_apps:
         description: "Apps for the signup canary"
         required: false
-        default: "clips,design,chat"
+        default: "all"
         type: string
       signup_environments:
         description: "Environments for the signup canary"
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      SIGNUP_E2E_APPS: ${{ inputs.signup_apps || 'clips,design,chat' }}
+      SIGNUP_E2E_APPS: ${{ inputs.signup_apps || 'all' }}
       SIGNUP_E2E_ENVIRONMENTS: ${{ inputs.signup_environments || 'beta' }}
       MAILOSAUR_API_KEY: ${{ secrets.MAILOSAUR_API_KEY }}
       MAILOSAUR_SERVER_ID: ${{ secrets.MAILOSAUR_SERVER_ID }}

--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -360,7 +360,7 @@ jobs:
     name: Signup canary
     if: ${{ inputs.lane == 'signup' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 180
     env:
       SIGNUP_E2E_APPS: ${{ inputs.signup_apps || 'all' }}
       SIGNUP_E2E_ENVIRONMENTS: ${{ inputs.signup_environments || 'beta' }}

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   issues: write
 
@@ -39,6 +40,59 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
+
+      - name: Check signup canary dead-man
+        run: |
+          set -o pipefail
+          node <<'NODE' | tee /tmp/agent-native-signup-deadman.log
+          (async () => {
+            const repository = process.env.GITHUB_REPOSITORY;
+            const token = process.env.GH_TOKEN;
+            const url = `https://api.github.com/repos/${repository}/actions/workflows/signup-e2e-scheduled.yml/runs?event=schedule&per_page=20`;
+            const response = await fetch(url, {
+              headers: {
+                accept: "application/vnd.github+json",
+                authorization: `Bearer ${token}`,
+                "x-github-api-version": "2022-11-28",
+              },
+            });
+            if (!response.ok) {
+              console.error(`FAIL\tsignup-e2e\tGitHub Actions API HTTP ${response.status}`);
+              process.exitCode = 1;
+            } else {
+              const body = await response.json();
+              const completed = (body.workflow_runs ?? []).filter(
+                (run) => run.status === "completed",
+              );
+              const successful = completed.find(
+                (run) => run.conclusion === "success",
+              );
+              if (completed.length === 0) {
+                console.log("INFO\tsignup-e2e\tno completed scheduled run yet");
+              } else if (!successful) {
+                console.error(
+                  "FAIL\tsignup-e2e\tno successful scheduled run exists",
+                );
+                process.exitCode = 1;
+              } else {
+                const ageMs = Date.now() - Date.parse(successful.created_at);
+                if (!Number.isFinite(ageMs) || ageMs > 48 * 60 * 60 * 1_000) {
+                  console.error(
+                    `FAIL\tsignup-e2e\tlast successful scheduled run is ${Math.round(ageMs / 3_600_000)}h old`,
+                  );
+                  process.exitCode = 1;
+                } else {
+                  console.log(
+                    `PASS\tsignup-e2e\tlast successful scheduled run is ${Math.round(ageMs / 3_600_000)}h old`,
+                  );
+                }
+              }
+            }
+          })().catch((error) => {
+            console.error(`FAIL\tsignup-e2e\t${error?.message ?? error}`);
+            process.exitCode = 1;
+          });
+          NODE
 
       - name: Probe every public host
         id: probe
@@ -548,6 +602,10 @@ jobs:
           FAILING="$(grep '^FAIL[[:space:]]' /tmp/agent-native-site-availability.log || true)"
           GOOGLE_FAILING="$(grep -E '^(FAIL|INCONCLUSIVE)' /tmp/agent-native-google-credentials.log || true)"
           REDIRECT_FAILING="$(grep -E '^(FAIL|UNKNOWN|UNPROBEABLE)' /tmp/agent-native-google-redirects.log || true)"
+          SIGNUP_DEADMAN_FAILING="$(grep '^FAIL[[:space:]].*signup-e2e' /tmp/agent-native-signup-deadman.log || true)"
+          if [ -n "$SIGNUP_DEADMAN_FAILING" ]; then
+            FAILING="$SIGNUP_DEADMAN_FAILING${FAILING:+$'\n'}$FAILING"
+          fi
           if [ -n "$GOOGLE_FAILING" ]; then
             if [ -n "$FAILING" ]; then
               FAILING="$(printf '%s\n%s' "$FAILING" "$GOOGLE_FAILING")"

--- a/.github/workflows/monitor-agent-native-sites.yml
+++ b/.github/workflows/monitor-agent-native-sites.yml
@@ -48,27 +48,62 @@ jobs:
           (async () => {
             const repository = process.env.GITHUB_REPOSITORY;
             const token = process.env.GH_TOKEN;
-            const url = `https://api.github.com/repos/${repository}/actions/workflows/signup-e2e-scheduled.yml/runs?event=schedule&per_page=20`;
-            const response = await fetch(url, {
-              headers: {
-                accept: "application/vnd.github+json",
-                authorization: `Bearer ${token}`,
-                "x-github-api-version": "2022-11-28",
-              },
-            });
+            const headers = {
+              accept: "application/vnd.github+json",
+              authorization: `Bearer ${token}`,
+              "x-github-api-version": "2022-11-28",
+            };
+            const runsUrl = `https://api.github.com/repos/${repository}/actions/workflows/signup-e2e-scheduled.yml/runs?event=schedule&per_page=20`;
+            const workflowUrl = `https://api.github.com/repos/${repository}/actions/workflows/signup-e2e-scheduled.yml`;
+            const [response, workflowResponse] = await Promise.all([
+              fetch(runsUrl, { headers }),
+              fetch(workflowUrl, { headers }),
+            ]);
             if (!response.ok) {
               console.error(`FAIL\tsignup-e2e\tGitHub Actions API HTTP ${response.status}`);
               process.exitCode = 1;
+            } else if (!workflowResponse.ok) {
+              console.error(
+                `FAIL\tsignup-e2e\tGitHub Actions workflow API HTTP ${workflowResponse.status}`,
+              );
+              process.exitCode = 1;
             } else {
               const body = await response.json();
+              const workflow = await workflowResponse.json();
+              if (workflow.state !== "active") {
+                console.error(
+                  `FAIL\tsignup-e2e\tscheduled workflow state is ${workflow.state ?? "unknown"}`,
+                );
+                process.exitCode = 1;
+                return;
+              }
+              const workflowUpdatedAt = Date.parse(
+                workflow.updated_at ?? workflow.created_at,
+              );
+              const workflowAgeMs = Date.now() - workflowUpdatedAt;
+              const maxAgeMs = 48 * 60 * 60 * 1_000;
+              if (!Number.isFinite(workflowAgeMs)) {
+                console.error(
+                  "FAIL\tsignup-e2e\tscheduled workflow has no valid activation timestamp",
+                );
+                process.exitCode = 1;
+                return;
+              }
               const completed = (body.workflow_runs ?? []).filter(
                 (run) => run.status === "completed",
               );
               const successful = completed.find(
                 (run) => run.conclusion === "success",
               );
-              if (completed.length === 0) {
-                console.log("INFO\tsignup-e2e\tno completed scheduled run yet");
+              if (completed.length === 0 && workflowAgeMs > maxAgeMs) {
+                console.error(
+                  `FAIL\tsignup-e2e\tno completed scheduled run exists and workflow has been active for ${Math.round(workflowAgeMs / 3_600_000)}h`,
+                );
+                process.exitCode = 1;
+              } else if (completed.length === 0) {
+                console.log(
+                  `INFO\tsignup-e2e\tno completed scheduled run yet; ${Math.max(0, Math.round((maxAgeMs - workflowAgeMs) / 3_600_000))}h rollout grace remains`,
+                );
               } else if (!successful) {
                 console.error(
                   "FAIL\tsignup-e2e\tno successful scheduled run exists",
@@ -76,7 +111,7 @@ jobs:
                 process.exitCode = 1;
               } else {
                 const ageMs = Date.now() - Date.parse(successful.created_at);
-                if (!Number.isFinite(ageMs) || ageMs > 48 * 60 * 60 * 1_000) {
+                if (!Number.isFinite(ageMs) || ageMs > maxAgeMs) {
                   console.error(
                     `FAIL\tsignup-e2e\tlast successful scheduled run is ${Math.round(ageMs / 3_600_000)}h old`,
                   );
@@ -95,6 +130,7 @@ jobs:
           NODE
 
       - name: Probe every public host
+        if: ${{ always() }}
         id: probe
         run: |
           set -o pipefail

--- a/.github/workflows/signup-e2e-scheduled.yml
+++ b/.github/workflows/signup-e2e-scheduled.yml
@@ -1,0 +1,109 @@
+name: Signup E2E (scheduled)
+
+on:
+  schedule:
+    - cron: "15 16 * * *"
+  workflow_dispatch:
+    inputs:
+      apps:
+        description: "Comma-separated apps or all"
+        required: false
+        default: "clips,design,chat"
+      environments:
+        description: "Comma-separated environments: beta,production"
+        required: false
+        default: "beta"
+
+concurrency:
+  group: signup-e2e-scheduled
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  signup-e2e:
+    name: Full signup flow
+    uses: ./.github/workflows/beta-e2e.yml
+    with:
+      apps: ${{ inputs.apps || 'clips,design,chat' }}
+      lane: signup
+      grep: ""
+      key_source: dedicated
+      signup_apps: ${{ inputs.apps || 'clips,design,chat' }}
+      signup_environments: ${{ inputs.environments || 'beta' }}
+    secrets:
+      MAILOSAUR_API_KEY: ${{ secrets.MAILOSAUR_API_KEY }}
+      MAILOSAUR_SERVER_ID: ${{ secrets.MAILOSAUR_SERVER_ID }}
+      PAGERDUTY_ROUTING_KEY: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
+    permissions:
+      contents: read
+
+  report:
+    name: Report signup E2E status
+    if: ${{ always() }}
+    needs: signup-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      PAGERDUTY_ROUTING_KEY: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
+      SIGNUP_E2E_APPS: ${{ inputs.apps || 'clips,design,chat' }}
+      SIGNUP_E2E_ENVIRONMENTS: ${{ inputs.environments || 'beta' }}
+    steps:
+      - name: Update one open issue for a failed run
+        if: ${{ needs.signup-e2e.result == 'failure' || needs.signup-e2e.result == 'cancelled' }}
+        run: |
+          set -euo pipefail
+
+          issue_title="[signup-e2e] Scheduled signup health check failing"
+          issue_number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 --json number,title | jq -r --arg title "$issue_title" '[.[] | select(.title == $title) | .number] | first // empty')"
+          failed_jobs="$(gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --json jobs --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "cancelled") | .name] | join(", ")')"
+          body="$(cat <<EOF
+          The scheduled full signup E2E check failed.
+
+          Run: $RUN_URL
+          Failed jobs: $failed_jobs
+          Targets: $SIGNUP_E2E_APPS on $SIGNUP_E2E_ENVIRONMENTS
+
+          The Playwright artifact contains failure screenshots without auth traces or videos.
+          This issue is reused while open; a successful run comments with the recovery run and closes it.
+          EOF
+          )"
+
+          if [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$issue_title" --body "$body"
+          fi
+
+      - name: Close the open issue after recovery
+        if: ${{ needs.signup-e2e.result == 'success' }}
+        run: |
+          set -euo pipefail
+
+          issue_title="[signup-e2e] Scheduled signup health check failing"
+          issue_number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 --json number,title | jq -r --arg title "$issue_title" '[.[] | select(.title == $title) | .number] | first // empty')"
+          if [ -n "$issue_number" ]; then
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "The scheduled signup E2E check recovered: $RUN_URL"
+            gh issue close "$issue_number" --repo "$GITHUB_REPOSITORY"
+          fi
+
+      - name: Resolve PagerDuty after recovery
+        if: ${{ needs.signup-e2e.result == 'success' && env.PAGERDUTY_ROUTING_KEY != '' }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg routing_key "$PAGERDUTY_ROUTING_KEY" \
+            --arg dedup_key "agent-native-signup-e2e" \
+            --arg source "${{ github.repository }}" \
+            '{routing_key: $routing_key, event_action: "resolve", dedup_key: $dedup_key, payload: {summary: "Agent-Native signup E2E recovered", source: $source}}' \
+            | curl --fail-with-body --connect-timeout 10 --max-time 20 --silent --show-error \
+                --header 'Content-Type: application/json' \
+                --data-binary @- \
+                https://events.pagerduty.com/v2/enqueue

--- a/.github/workflows/signup-e2e-scheduled.yml
+++ b/.github/workflows/signup-e2e-scheduled.yml
@@ -8,7 +8,7 @@ on:
       apps:
         description: "Comma-separated apps or all"
         required: false
-        default: "clips,design,chat"
+        default: "all"
       environments:
         description: "Comma-separated environments: beta,production"
         required: false
@@ -26,11 +26,11 @@ jobs:
     name: Full signup flow
     uses: ./.github/workflows/beta-e2e.yml
     with:
-      apps: ${{ inputs.apps || 'clips,design,chat' }}
+      apps: ${{ inputs.apps || 'all' }}
       lane: signup
       grep: ""
       key_source: dedicated
-      signup_apps: ${{ inputs.apps || 'clips,design,chat' }}
+      signup_apps: ${{ inputs.apps || 'all' }}
       signup_environments: ${{ inputs.environments || 'beta' }}
     secrets:
       MAILOSAUR_API_KEY: ${{ secrets.MAILOSAUR_API_KEY }}
@@ -53,7 +53,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       PAGERDUTY_ROUTING_KEY: ${{ secrets.PAGERDUTY_ROUTING_KEY }}
-      SIGNUP_E2E_APPS: ${{ inputs.apps || 'clips,design,chat' }}
+      SIGNUP_E2E_APPS: ${{ inputs.apps || 'all' }}
       SIGNUP_E2E_ENVIRONMENTS: ${{ inputs.environments || 'beta' }}
     steps:
       - name: Update one open issue for a failed run

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -263,14 +263,14 @@ production deployment:
 
 ## CI-only variables
 
-| Variable                      | Purpose                                                                                                                                                                 |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POSTGRES_DB`                 | Database name for the ephemeral Postgres service container used by the Content DB test lane.                                                                            |
-| `POSTGRES_HOST_AUTH_METHOD`   | Auth method for that same throwaway container; `trust` keeps the lane password-free.                                                                                    |
-| `S2573_PGLITE_INSTALL_PREFIX` | Install prefix for the PGlite build used by the Content database row-migration lock test.                                                                               |
-| `CI_FULL`                     | Change-scope classifier output selecting the full CI suite instead of targeted jobs.                                                                                    |
-| `CI_WORKSPACE_FILTERS`        | JSON-encoded pnpm workspace selectors emitted by the change-scope classifier.                                                                                           |
-| `PAGERDUTY_ROUTING_KEY`       | Optional GitHub Actions secret used to page the production health on-call when the keep-warm audit fails; GitHub issue reporting remains the fallback when it is unset. |
+| Variable                      | Purpose                                                                                                                                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_DB`                 | Database name for the ephemeral Postgres service container used by the Content DB test lane.                                                                                            |
+| `POSTGRES_HOST_AUTH_METHOD`   | Auth method for that same throwaway container; `trust` keeps the lane password-free.                                                                                                    |
+| `S2573_PGLITE_INSTALL_PREFIX` | Install prefix for the PGlite build used by the Content database row-migration lock test.                                                                                               |
+| `CI_FULL`                     | Change-scope classifier output selecting the full CI suite instead of targeted jobs.                                                                                                    |
+| `CI_WORKSPACE_FILTERS`        | JSON-encoded pnpm workspace selectors emitted by the change-scope classifier.                                                                                                           |
+| `PAGERDUTY_ROUTING_KEY`       | Optional GitHub Actions secret used to page the production health on-call when keep-warm or scheduled signup checks fail; GitHub issue reporting remains the fallback when it is unset. |
 
 ### Beta E2E browser suite
 
@@ -295,6 +295,19 @@ secrets only. See `e2e/beta/README.md` for how they are minted.
 | `BETA_E2E_ALLOW_SHARED_KEY`      | Set by the workflow when the dispatch chooses `key_source=shared`. Opts a run into billing the shared key instead of the dedicated one.                 |
 | `BETA_E2E_MODEL`                 | Overrides the luna model id. Rejected unless it is a luna model — the suite is budgeted for luna.                                                       |
 | `BETA_E2E_ENGINE`                | Engine for the model selection (`ai-sdk:openai` by default, or `builder`). Decides which luna spelling is used.                                         |
+
+### Scheduled signup E2E canary
+
+Read by `.github/workflows/signup-e2e-scheduled.yml` and `e2e/signup/`, never
+by application runtime code. Mailosaur credentials are live service secrets:
+store them only as GitHub Actions secrets. See `e2e/signup/README.md`.
+
+| Variable                  | Purpose                                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `MAILOSAUR_API_KEY`       | Mailosaur API key used to read the verification message delivered to the signup canary inbox. |
+| `MAILOSAUR_SERVER_ID`     | Mailosaur server whose generated domain receives the canary verification messages.            |
+| `SIGNUP_E2E_APPS`         | Comma-separated app ids, or `all`, for the full email signup canary.                          |
+| `SIGNUP_E2E_ENVIRONMENTS` | Comma-separated `beta` and/or `production` environments for the canary.                       |
 
 GitHub Actions also creates short-lived step handoff variables such as
 `HEAD_SHA`, `MATRIX`, `PLAN_JSON`, `PLAN_URL`, `PR_NUMBER`, `RUN_URL`,

--- a/e2e/signup/README.md
+++ b/e2e/signup/README.md
@@ -5,11 +5,14 @@ follows the link delivered by Mailosaur, proves the
 authenticated Better Auth session before a refresh, then proves it again after
 the refresh that exposed the reported outage.
 
-The scheduled targets are `clips`, `design`, and `chat` on beta, using a fresh
-reserved address per run to exercise new-user creation. Production is opt-in
-through `workflow_dispatch` and also uses a fresh reserved address. The
-workflow is serial so one run creates a bounded number of canary accounts
-instead of multiplying them across a matrix.
+The scheduled target is `all` email-capable sites on beta. That currently covers
+12 of the 16 fleet apps; Google-only apps (`mail` and `calendar`) and apps
+without the Better Auth email magic-link flow (`factory` and `macros`) are
+intentionally excluded. Every target uses a fresh reserved address per run to
+exercise new-user creation. Production is opt-in through `workflow_dispatch`
+and also uses a fresh reserved address. The workflow is serial so one run
+creates a bounded number of canary accounts instead of multiplying them across
+a matrix.
 
 ## GitHub Actions setup
 

--- a/e2e/signup/README.md
+++ b/e2e/signup/README.md
@@ -1,0 +1,53 @@
+# Scheduled signup E2E
+
+This lane exercises the real email magic-link flow on the selected apps. It
+follows the link delivered by Mailosaur, proves the
+authenticated Better Auth session before a refresh, then proves it again after
+the refresh that exposed the reported outage.
+
+The scheduled targets are `clips`, `design`, and `chat` on beta, using a fresh
+reserved address per run to exercise new-user creation. Production is opt-in
+through `workflow_dispatch` and also uses a fresh reserved address. The
+workflow is serial so one run creates a bounded number of canary accounts
+instead of multiplying them across a matrix.
+
+## GitHub Actions setup
+
+Add these repository secrets before enabling the scheduled workflow:
+
+- `MAILOSAUR_API_KEY`
+- `MAILOSAUR_SERVER_ID`
+- `PAGERDUTY_ROUTING_KEY` (optional; the existing PagerDuty service delivers
+  email, text, or push notifications according to its escalation policy)
+
+Create one Mailosaur server for the lane. Mailosaur accepts arbitrary local
+parts on the server domain, so each run uses an address like
+`signup+qa-test-bot-123-beta-clips-abc123@SERVER_ID.mailosaur.net`.
+
+The workflow runs daily at 16:15 UTC on beta and can also be started manually
+with comma-separated `apps` and `environments` inputs for beta or production. A
+failed run opens or updates one GitHub issue. If PagerDuty is configured, it
+also triggers the existing signup canary incident and resolves it after a
+successful recovery run.
+
+## Local run
+
+```sh
+MAILOSAUR_API_KEY=... \
+MAILOSAUR_SERVER_ID=... \
+SIGNUP_E2E_APPS=clips \
+SIGNUP_E2E_ENVIRONMENTS=beta \
+pnpm e2e:signup
+```
+
+The reserved `+qa-test-bot-` address marker is suppressed by the shared
+tracking registry, including `track()` and `identify()` calls. The marker is
+stable enough to filter canary accounts from signup data by local-part pattern,
+while the full address remains unique for every run.
+`SIGNUP_E2E_APPS=all` intentionally excludes Google-only apps and Macros,
+which do not expose the Better Auth email magic-link flow.
+
+The existing `Beta E2E (scheduled)` workflow already runs the Luna agentic chat
+journey. This lane stays deterministic and focuses on the email, redirect,
+session, and refresh boundaries that a model-driven journey cannot reliably
+assert.

--- a/e2e/signup/README.md
+++ b/e2e/signup/README.md
@@ -10,9 +10,10 @@ The scheduled target is `all` email-capable sites on beta. That currently covers
 without the Better Auth email magic-link flow (`factory` and `macros`) are
 intentionally excluded. Every target uses a fresh reserved address per run to
 exercise new-user creation. Production is opt-in through `workflow_dispatch`
-and also uses a fresh reserved address. The workflow is serial so one run
-creates a bounded number of canary accounts instead of multiplying them across
-a matrix.
+and also uses a fresh reserved address. The runner uses four workers against
+different hosts, so a fleet-wide outage reaches the alert path promptly while
+one run still creates a bounded number of canary accounts instead of
+multiplying them across a matrix.
 
 ## GitHub Actions setup
 

--- a/e2e/signup/lib/mailosaur.ts
+++ b/e2e/signup/lib/mailosaur.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from "node:crypto";
+
+const MAILOSAUR_API = "https://mailosaur.com/api";
+const MAILOSAUR_DOMAIN_SUFFIX = ".mailosaur.net";
+const EMAIL_WAIT_TIMEOUT_MS = 180_000;
+const EMAIL_POLL_INTERVAL_MS = 2_000;
+
+interface MailosaurRecipient {
+  email?: string;
+}
+
+interface MailosaurLink {
+  href?: string;
+  text?: string;
+}
+
+interface MailosaurMessageSummary {
+  id: string;
+  subject?: string;
+  to?: MailosaurRecipient[];
+  received?: string;
+}
+
+interface MailosaurMessageList {
+  items?: MailosaurMessageSummary[];
+}
+
+export interface MailosaurMessage extends MailosaurMessageSummary {
+  html?: { body?: string; links?: MailosaurLink[] };
+  text?: { body?: string; links?: MailosaurLink[] };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for signup E2E.`);
+  return value;
+}
+
+function serverId(): string {
+  const value = requiredEnv("MAILOSAUR_SERVER_ID");
+  if (!/^[a-z0-9][a-z0-9-]{1,62}$/i.test(value)) {
+    throw new Error("MAILOSAUR_SERVER_ID has an invalid format.");
+  }
+  return value;
+}
+
+function authorizationHeader(): string {
+  const apiKey = requiredEnv("MAILOSAUR_API_KEY");
+  return `Basic ${Buffer.from(`${apiKey}:`).toString("base64")}`;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/json",
+      Authorization: authorizationHeader(),
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Mailosaur API returned HTTP ${response.status}.`);
+  }
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new Error("Mailosaur API returned invalid JSON.");
+  }
+}
+
+function normalizeEmail(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function messageIsForEmail(
+  message: MailosaurMessageSummary,
+  email: string,
+): boolean {
+  return (message.to ?? []).some(
+    (recipient) => normalizeEmail(recipient.email) === normalizeEmail(email),
+  );
+}
+
+function isAuthMessage(message: MailosaurMessageSummary): boolean {
+  return /sign[\s-]?in|verif/i.test(message.subject ?? "");
+}
+
+async function listMessages(receivedAfter: number) {
+  const params = new URLSearchParams({
+    server: serverId(),
+    receivedAfter: new Date(receivedAfter).toISOString(),
+    itemsPerPage: "100",
+    dir: "Received",
+  });
+  const result = await getJson<
+    MailosaurMessageList | MailosaurMessageSummary[]
+  >(`${MAILOSAUR_API}/messages?${params.toString()}`);
+  return Array.isArray(result) ? result : (result.items ?? []);
+}
+
+export function createQaEmail(app: string, environment: string): string {
+  const run = (process.env.GITHUB_RUN_ID ?? Date.now().toString(36))
+    .replace(/[^a-z0-9]/gi, "")
+    .toLowerCase();
+  const attempt = (process.env.GITHUB_RUN_ATTEMPT ?? "1").replace(
+    /[^a-z0-9]/gi,
+    "",
+  );
+  const nonce = randomUUID().replace(/-/g, "").slice(0, 10);
+  return `signup+qa-test-bot-${run || "local"}-${attempt || "1"}-${environment}-${app}-${nonce}@${serverId()}${MAILOSAUR_DOMAIN_SUFFIX}`;
+}
+
+export async function waitForVerificationEmail(
+  email: string,
+  receivedAfter: number,
+): Promise<MailosaurMessage> {
+  const deadline = Date.now() + EMAIL_WAIT_TIMEOUT_MS;
+  while (Date.now() <= deadline) {
+    const summaries = await listMessages(receivedAfter);
+    const summary = summaries.find(
+      (message) => messageIsForEmail(message, email) && isAuthMessage(message),
+    );
+    if (summary) {
+      return getJson<MailosaurMessage>(
+        `${MAILOSAUR_API}/messages/${encodeURIComponent(summary.id)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, EMAIL_POLL_INTERVAL_MS));
+  }
+  throw new Error(
+    `No verification email for ${email} arrived within ${EMAIL_WAIT_TIMEOUT_MS / 1000}s.`,
+  );
+}
+
+function linksFromMessage(message: MailosaurMessage): string[] {
+  const structured = [
+    ...(message.html?.links ?? []),
+    ...(message.text?.links ?? []),
+  ]
+    .map((link) => link.href?.trim())
+    .filter((href): href is string => Boolean(href));
+  const bodies = [message.html?.body, message.text?.body].filter(
+    (body): body is string => Boolean(body),
+  );
+  const plainText = bodies.flatMap(
+    (body) =>
+      body.replace(/&amp;/g, "&").match(/https?:\/\/[^\s"'<>]+/gi) ?? [],
+  );
+  return [...new Set([...structured, ...plainText])];
+}
+
+function linkOrigin(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "invalid-url";
+  }
+}
+
+export function verificationLinkFor(
+  message: MailosaurMessage,
+  expectedOrigin: string,
+): string {
+  const links = linksFromMessage(message);
+  const expected = new URL(expectedOrigin);
+  const secureSameOrigin = links.find((href) => {
+    try {
+      const url = new URL(href, expectedOrigin);
+      return url.protocol === "https:" && url.origin === expected.origin;
+    } catch {
+      return false;
+    }
+  });
+  if (!secureSameOrigin) {
+    const observed = links.map(linkOrigin).join(", ") || "none";
+    throw new Error(
+      `Verification email contained no HTTPS link back to ${expected.origin}; observed origins: ${observed}.`,
+    );
+  }
+  return secureSameOrigin;
+}

--- a/e2e/signup/lib/mailosaur.ts
+++ b/e2e/signup/lib/mailosaur.ts
@@ -166,6 +166,7 @@ export function verificationLinkFor(
     try {
       const url = new URL(href, expectedOrigin);
       return url.protocol === "https:" && url.origin === expected.origin;
+      // coercion-ok: malformed candidate links are rejected before the required-link check.
     } catch {
       return false;
     }

--- a/e2e/signup/lib/targets.ts
+++ b/e2e/signup/lib/targets.ts
@@ -1,0 +1,82 @@
+import {
+  ALL_SITES,
+  isGoogleOnly,
+  originFor,
+  productionHostFor,
+  siteById,
+} from "../../beta/lib/fleet";
+
+export type SignupEnvironment = "beta" | "production";
+
+export interface SignupTarget {
+  app: string;
+  environment: SignupEnvironment;
+  origin: string;
+}
+
+const DEFAULT_APPS = ["clips", "design", "chat"];
+const EMAIL_SIGNUP_UNSUPPORTED_APPS = new Set(["factory", "macros"]);
+
+function supportsEmailSignup(app: string): boolean {
+  return !isGoogleOnly(app) && !EMAIL_SIGNUP_UNSUPPORTED_APPS.has(app);
+}
+
+function requestedValues(name: string, fallback: string): string[] {
+  const raw = process.env[name]?.trim() || fallback;
+  if (raw.toLowerCase() === "all") return ["all"];
+  const values = [
+    ...new Set(
+      raw
+        .split(",")
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+  if (values.length === 0) {
+    throw new Error(`${name} resolved to no targets.`);
+  }
+  return values;
+}
+
+function selectedApps() {
+  const requested = requestedValues("SIGNUP_E2E_APPS", DEFAULT_APPS.join(","));
+  if (requested[0] === "all")
+    return ALL_SITES.filter((site) => supportsEmailSignup(site.id));
+  const known = new Set(ALL_SITES.map((site) => site.id));
+  const unknown = requested.filter((app) => !known.has(app));
+  if (unknown.length > 0) {
+    throw new Error(
+      `SIGNUP_E2E_APPS names unknown app(s): ${unknown.join(", ")}.`,
+    );
+  }
+  const unsupported = requested.filter((app) => !supportsEmailSignup(app));
+  if (unsupported.length > 0) {
+    throw new Error(
+      `SIGNUP_E2E_APPS includes app(s) without email signup: ${unsupported.join(", ")}.`,
+    );
+  }
+  return requested.map(siteById);
+}
+
+function selectedEnvironments(): SignupEnvironment[] {
+  return requestedValues("SIGNUP_E2E_ENVIRONMENTS", "beta").map((value) => {
+    if (value === "beta") return "beta";
+    if (value === "prod" || value === "production") return "production";
+    throw new Error(
+      `SIGNUP_E2E_ENVIRONMENTS contains ${value}; use beta or production.`,
+    );
+  });
+}
+
+export function selectedSignupTargets(): SignupTarget[] {
+  return selectedEnvironments().flatMap((environment) =>
+    selectedApps().map((site) => ({
+      app: site.id,
+      environment,
+      origin:
+        environment === "beta"
+          ? originFor(site)
+          : `https://${productionHostFor(site)}`,
+    })),
+  );
+}

--- a/e2e/signup/lib/targets.ts
+++ b/e2e/signup/lib/targets.ts
@@ -14,7 +14,7 @@ export interface SignupTarget {
   origin: string;
 }
 
-const DEFAULT_APPS = ["clips", "design", "chat"];
+const DEFAULT_APPS = "all";
 const EMAIL_SIGNUP_UNSUPPORTED_APPS = new Set(["factory", "macros"]);
 
 function supportsEmailSignup(app: string): boolean {
@@ -39,7 +39,7 @@ function requestedValues(name: string, fallback: string): string[] {
 }
 
 function selectedApps() {
-  const requested = requestedValues("SIGNUP_E2E_APPS", DEFAULT_APPS.join(","));
+  const requested = requestedValues("SIGNUP_E2E_APPS", DEFAULT_APPS);
   if (requested[0] === "all")
     return ALL_SITES.filter((site) => supportsEmailSignup(site.id));
   const known = new Set(ALL_SITES.map((site) => site.id));

--- a/e2e/signup/playwright.config.ts
+++ b/e2e/signup/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const isCi = Boolean(process.env.CI);
+
+export default defineConfig({
+  testDir: "./specs",
+  fullyParallel: false,
+  forbidOnly: isCi,
+  retries: isCi ? 1 : 0,
+  workers: 1,
+  timeout: 360_000,
+  expect: { timeout: 30_000 },
+  reporter: isCi ? [["github"], ["list"]] : [["list"]],
+  outputDir: "test-results/signup",
+  use: {
+    ...devices["Desktop Chrome"],
+    trace: "off",
+    screenshot: "only-on-failure",
+    video: "off",
+    actionTimeout: 20_000,
+    navigationTimeout: 60_000,
+  },
+});

--- a/e2e/signup/playwright.config.ts
+++ b/e2e/signup/playwright.config.ts
@@ -4,10 +4,10 @@ const isCi = Boolean(process.env.CI);
 
 export default defineConfig({
   testDir: "./specs",
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: isCi,
   retries: isCi ? 1 : 0,
-  workers: 1,
+  workers: 4,
   timeout: 360_000,
   expect: { timeout: 30_000 },
   reporter: isCi ? [["github"], ["list"]] : [["list"]],

--- a/e2e/signup/specs/signup.spec.ts
+++ b/e2e/signup/specs/signup.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { isQaTestEmail } from "../../../packages/core/src/shared/qa-test-email";
+import { collectAppPageErrors, renderedText } from "../../beta/lib/app";
+import {
+  createQaEmail,
+  verificationLinkFor,
+  waitForVerificationEmail,
+} from "../lib/mailosaur";
+import { selectedSignupTargets } from "../lib/targets";
+
+interface SessionResult {
+  status: number;
+  body: unknown;
+}
+
+async function readSession(page: Page) {
+  return page.evaluate(async (): Promise<SessionResult> => {
+    const response = await fetch("/_agent-native/auth/session", {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const raw = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = raw;
+    }
+    return { status: response.status, body };
+  });
+}
+
+async function readBetterAuthSession(page: Page) {
+  return page.evaluate(async (): Promise<SessionResult> => {
+    const response = await fetch("/_agent-native/auth/ba/get-session", {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const raw = await response.text();
+    let body: unknown;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      body = raw;
+    }
+    return { status: response.status, body };
+  });
+}
+
+function assertSession(session: SessionResult, email: string, label: string) {
+  expect(session.status, `${label} returned HTTP ${session.status}`).toBe(200);
+  expect(
+    (session.body as { email?: unknown }).email,
+    `${label} did not identify the canary account`,
+  ).toBe(email);
+}
+
+function assertBetterAuthSession(
+  session: SessionResult,
+  email: string,
+  label: string,
+) {
+  expect(session.status, `${label} returned HTTP ${session.status}`).toBe(200);
+  expect(
+    (session.body as { user?: { email?: unknown } }).user?.email,
+    `${label} did not identify the canary account`,
+  ).toBe(email);
+}
+
+const targets = selectedSignupTargets();
+
+test.describe.configure({ mode: "serial" });
+
+for (const target of targets) {
+  test(`${target.environment} ${target.app} completes email signup without a refresh`, async ({
+    page,
+  }) => {
+    test.setTimeout(360_000);
+    const { errors, thirdParty } = collectAppPageErrors(page, target.origin);
+    const failedRequests: string[] = [];
+    page.on("requestfailed", (request) => {
+      const failure = request.failure()?.errorText ?? "unknown";
+      if (
+        /aborted/i.test(failure) ||
+        !request.url().startsWith(target.origin)
+      ) {
+        return;
+      }
+      failedRequests.push(`${request.url()} (${failure})`);
+    });
+
+    const email = createQaEmail(target.app, target.environment);
+    expect(
+      isQaTestEmail(email),
+      `${email} must be suppressed by tracking`,
+    ).toBe(true);
+    const signInUrl = `${target.origin}/sign-in?signup_e2e=${Date.now()}`;
+    const emailRequestedAt = Date.now() - 5_000;
+    const magicLinkStatuses: number[] = [];
+    page.on("response", (response) => {
+      const request = response.request();
+      if (
+        request.method() === "POST" &&
+        new URL(response.url()).pathname === "/_agent-native/auth/magic-link"
+      ) {
+        magicLinkStatuses.push(response.status());
+      }
+    });
+
+    await test.step("open the real sign-in page", async () => {
+      const response = await page.goto(signInUrl, {
+        waitUntil: "domcontentloaded",
+      });
+      expect(response, `${signInUrl} produced no response`).toBeTruthy();
+      expect(response!.status(), `${signInUrl} returned an error`).toBeLessThan(
+        400,
+      );
+      await renderedText(page, signInUrl);
+      await expect(page.locator("#magic-link-form")).toBeVisible();
+    });
+
+    await test.step("request a fresh magic link", async () => {
+      const emailPromise = waitForVerificationEmail(email, emailRequestedAt);
+      await page.locator("#m-email").fill(email);
+      await page.locator("#magic-link-submit").click();
+      await expect(page.locator("#magic-link-success")).toBeVisible();
+      await expect(page.locator("#magic-link-success-email")).toHaveText(email);
+      expect(
+        magicLinkStatuses,
+        "magic-link request was not observed",
+      ).not.toEqual([]);
+      expect(magicLinkStatuses.at(-1)).toBe(200);
+      const message = await emailPromise;
+
+      await test.step("use the secure same-origin link from the inbox", async () => {
+        const verificationLink = verificationLinkFor(message, target.origin);
+        const response = await page.goto(verificationLink, {
+          waitUntil: "domcontentloaded",
+        });
+        expect(
+          response,
+          `${target.app} verification produced no response`,
+        ).toBeTruthy();
+        expect(
+          response!.status(),
+          `${target.app} verification returned an error`,
+        ).toBeLessThan(400);
+        expect(new URL(page.url()).origin).toBe(target.origin);
+        expect(new URL(page.url()).pathname).not.toMatch(/sign-in|login/i);
+      });
+    });
+
+    await test.step("prove the session works before any refresh", async () => {
+      assertSession(
+        await readSession(page),
+        email,
+        `${target.app} immediate session`,
+      );
+      assertBetterAuthSession(
+        await readBetterAuthSession(page),
+        email,
+        `${target.app} immediate Better Auth session`,
+      );
+    });
+
+    await test.step("prove the session survives a browser refresh", async () => {
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .not.toMatch(/sign-in|login/i);
+      assertSession(
+        await readSession(page),
+        email,
+        `${target.app} refreshed session`,
+      );
+      assertBetterAuthSession(
+        await readBetterAuthSession(page),
+        email,
+        `${target.app} refreshed Better Auth session`,
+      );
+    });
+
+    if (thirdParty.length > 0) {
+      test.info().annotations.push({
+        type: "third-party-noise",
+        description: [...new Set(thirdParty)].join("; "),
+      });
+    }
+    expect(
+      errors,
+      `${target.origin} threw an uncaught error during signup`,
+    ).toEqual([]);
+    expect(
+      failedRequests,
+      `${target.origin} had failed same-origin requests during signup`,
+    ).toEqual([]);
+  });
+}

--- a/e2e/signup/specs/signup.spec.ts
+++ b/e2e/signup/specs/signup.spec.ts
@@ -70,8 +70,6 @@ function assertBetterAuthSession(
 
 const targets = selectedSignupTargets();
 
-test.describe.configure({ mode: "serial" });
-
 for (const target of targets) {
   test(`${target.environment} ${target.app} completes email signup without a refresh`, async ({
     page,

--- a/e2e/signup/tsconfig.json
+++ b/e2e/signup/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "typeRoots": ["../../packages/core/node_modules/@types"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["**/*.ts", "../beta/lib/fleet.ts"],
+  "exclude": ["node_modules", "test-results", "playwright-report", ".auth"]
+}

--- a/package.json
+++ b/package.json
@@ -163,7 +163,9 @@
     "dev:electron:apps": "node scripts/dev-electron.ts --apps",
     "e2e:beta": "playwright test --config e2e/beta/playwright.config.ts",
     "e2e:beta:capture": "tsx e2e/beta/capture-session.ts",
+    "e2e:signup": "playwright test --config e2e/signup/playwright.config.ts",
     "typecheck:e2e": "tsc --noEmit -p e2e/beta/tsconfig.json",
+    "typecheck:e2e:signup": "tsc --noEmit -p e2e/signup/tsconfig.json",
     "guard:beta-e2e-suite": "tsx scripts/guard-beta-e2e-suite.ts"
   },
   "devDependencies": {

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -440,6 +440,58 @@ describe("browser analytics pageviews", () => {
     });
   });
 
+  it("suppresses browser telemetry for QA signup identities", async () => {
+    const { gtag } = installBrowser();
+    const { analyticsCalls } = installFetch();
+    vi.stubEnv("VITE_AMPLITUDE_API_KEY", "amplitude_test");
+    (window as any).__AGENT_NATIVE_CONFIG__ = {
+      sentryDsn: "https://public@example/4511270423822336",
+    };
+    const {
+      captureClientException,
+      configureTracking,
+      setTrackingIdentity,
+      trackAgentChatLifecycle,
+      trackEvent,
+    } = await freshAnalytics();
+
+    configureTracking({
+      key: "anpk_configured",
+      endpoint: "https://analytics.example.test/api/analytics/track",
+      pageviewTracking: false,
+      sessionReplay: true,
+      errorCapture: false,
+    });
+    await tick();
+    analyticsCalls.length = 0;
+    gtag.mockClear();
+    amplitudeMock.track.mockClear();
+    sentryMock.setUser.mockClear();
+    sentryMock.captureException.mockClear();
+
+    setTrackingIdentity(
+      {
+        id: "auth-user-qa",
+        email: "signup+qa-test-bot-run-1@example.com",
+      },
+      "org_qa",
+    );
+    trackEvent("signup completed");
+    trackAgentChatLifecycle({ phase: "surface-mounted", surface: "signup" });
+    expect(
+      captureClientException(new Error("QA canary failure")),
+    ).toBeUndefined();
+    await tick();
+
+    expect(analyticsCalls).toHaveLength(0);
+    expect(gtag).not.toHaveBeenCalled();
+    expect(amplitudeMock.track).not.toHaveBeenCalled();
+    expect(sentryMock.setUser).toHaveBeenLastCalledWith(null);
+    expect(sentryMock.captureException).not.toHaveBeenCalled();
+    expect(replayMock.startSessionReplay).not.toHaveBeenCalled();
+    expect(replayMock.emitSessionReplayAgentChatEvent).not.toHaveBeenCalled();
+  });
+
   it("tracks client-side URL changes once per URL", async () => {
     const { history } = installBrowser();
     const { analyticsCalls } = installFetch();

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -9,6 +9,7 @@ import {
   llmConnectionTrackingProperties,
   type LlmConnectionStatus,
 } from "../shared/llm-connection.js";
+import { isQaTestEmail } from "../shared/qa-test-email.js";
 import { toPostHogExceptionProperties } from "../tracking/posthog-exception.js";
 import { getAnalyticsClientPlatform } from "./analytics-platform.js";
 import {
@@ -380,6 +381,17 @@ function installLlmConnectionRefresh(): void {
 
 function readTrackingString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isQaTrackingIdentity(identity: TrackingIdentity | null): boolean {
+  return Boolean(
+    identity &&
+    (isQaTestEmail(identity.userId) || isQaTestEmail(identity.userEmail)),
+  );
+}
+
+function isQaTrackingUser(user: TrackingIdentityUser | null): boolean {
+  return Boolean(user && (isQaTestEmail(user.id) || isQaTestEmail(user.email)));
 }
 
 function stopSessionReplayForAuthClear(
@@ -1079,6 +1091,8 @@ export function setSentryUser(
   user: TrackingIdentityUser | null,
   orgId?: string | null,
 ): void {
+  const previousIdentity = _trackingIdentity;
+  const suppressTracking = isQaTrackingUser(user);
   let shouldRetryReplay = false;
   if (user) {
     const userId = user.email || user.id;
@@ -1092,9 +1106,13 @@ export function setSentryUser(
     } else {
       clearTrackingIdentity();
     }
-    shouldRetryReplay = Boolean(user.email);
+    shouldRetryReplay = Boolean(user.email) && !suppressTracking;
   } else {
     clearTrackingIdentity();
+  }
+  if (suppressTracking) {
+    _pendingSentryCaptures = [];
+    stopSessionReplayForAuthClear(previousIdentity);
   }
   _trackingIdentityResolved = true;
   if (
@@ -1105,13 +1123,13 @@ export function setSentryUser(
     void startConfiguredSessionReplay(_sessionReplayOptions);
   }
   if (_sentryInitialized && _sentryModule) {
-    _sentryModule.setUser(user);
+    _sentryModule.setUser(suppressTracking ? null : user);
     if (orgId !== undefined) {
       _sentryModule.setTag("orgId", orgId ?? null);
     }
     return;
   }
-  _pendingSentryUser = user;
+  _pendingSentryUser = suppressTracking ? null : user;
   if (orgId !== undefined) {
     _pendingSentryOrgId = orgId ?? null;
   }
@@ -1155,6 +1173,7 @@ export function captureClientException(
   context: ClientCaptureContext = {},
 ): string | undefined {
   if (typeof window === "undefined") return undefined;
+  if (isQaTrackingIdentity(_trackingIdentity)) return undefined;
   try {
     ensureSentry(true);
     if (_sentryModule) return captureWithSentry(_sentryModule, error, context);
@@ -1258,13 +1277,15 @@ export function trackAgentChatLifecycle(input: AgentChatLifecycleEvent): void {
         : (replayResult?.reason ?? "not-configured"),
     };
     trackEvent("agent_chat_lifecycle", properties);
-    _sessionReplayModuleForCapture?.emitSessionReplayAgentChatEvent?.({
-      phase: input.phase,
-      surface,
-      ...(input.threadId ? { threadId: input.threadId } : {}),
-      ...(input.runId ? { runId: input.runId } : {}),
-      ...(input.tabId ? { tabId: input.tabId } : {}),
-    });
+    if (!isQaTrackingIdentity(_trackingIdentity)) {
+      _sessionReplayModuleForCapture?.emitSessionReplayAgentChatEvent?.({
+        phase: input.phase,
+        surface,
+        ...(input.threadId ? { threadId: input.threadId } : {}),
+        ...(input.runId ? { runId: input.runId } : {}),
+        ...(input.tabId ? { tabId: input.tabId } : {}),
+      });
+    }
   })();
 }
 
@@ -1480,6 +1501,7 @@ function sendPostHogExceptionEvent(event: CapturedExceptionEvent): void {
 }
 
 function sendExceptionEvent(event: CapturedExceptionEvent): void {
+  if (isQaTrackingIdentity(_trackingIdentity)) return;
   // Route through the existing first-party analytics ingest as a dedicated
   // `$exception` event. This reuses the public-key auth + sendBeacon/keepalive
   // transport; the server forks it into error_issues/error_events and still
@@ -1492,6 +1514,7 @@ function sendExceptionEvent(event: CapturedExceptionEvent): void {
 }
 
 function emitExceptionToReplay(event: CapturedExceptionEvent): void {
+  if (isQaTrackingIdentity(_trackingIdentity)) return;
   _sessionReplayModuleForCapture?.emitSessionReplayException?.({
     type: event.type,
     message: event.message,
@@ -1640,9 +1663,10 @@ function replayExtraPropertiesWithDefaults(
           : {};
     const props = rawProps && typeof rawProps === "object" ? rawProps : {};
     const withDefaults = _getDefaultProps?.("session_replay", props) ?? props;
+    const identity = _trackingIdentity ?? _sessionReplayIdentitySnapshot;
     return applyTrackingIdentity(
       withDefaults,
-      _trackingIdentity ?? _sessionReplayIdentitySnapshot,
+      isQaTrackingIdentity(identity) ? null : identity,
     );
   };
 }
@@ -1688,6 +1712,7 @@ function maybeInstallSessionReplay(
 async function waitForSessionReplayAuthIfRequired(
   options: SessionReplayOptions,
 ): Promise<boolean> {
+  if (isQaTrackingIdentity(_trackingIdentity)) return false;
   if (!options.requireSignedInUser) return true;
   if (_trackingIdentity?.userEmail) return true;
   try {
@@ -1699,7 +1724,9 @@ async function waitForSessionReplayAuthIfRequired(
   } catch {
     // best-effort; missing identity below keeps replay off
   }
-  return !!_trackingIdentity?.userEmail;
+  return (
+    !!_trackingIdentity?.userEmail && !isQaTrackingIdentity(_trackingIdentity)
+  );
 }
 
 async function startConfiguredSessionReplay(
@@ -1724,7 +1751,9 @@ async function startConfiguredSessionReplay(
     return mod.startSessionReplay({
       ...options,
       shouldStart: () =>
-        _trackingContentCaptureEnabled && (options.shouldStart?.() ?? true),
+        _trackingContentCaptureEnabled &&
+        !isQaTrackingIdentity(_trackingIdentity) &&
+        (options.shouldStart?.() ?? true),
     });
   })()
     .catch(() => ({ started: false, reason: "import-failed" as const }))
@@ -1749,7 +1778,9 @@ export async function startSessionReplay(
   return mod.startSessionReplay({
     ...configured,
     shouldStart: () =>
-      _trackingContentCaptureEnabled && (configured.shouldStart?.() ?? true),
+      _trackingContentCaptureEnabled &&
+      !isQaTrackingIdentity(_trackingIdentity) &&
+      (configured.shouldStart?.() ?? true),
   });
 }
 
@@ -1767,7 +1798,9 @@ export async function maybeStartSessionReplay(
   return mod.maybeStartSessionReplay({
     ...configured,
     shouldStart: () =>
-      _trackingContentCaptureEnabled && (configured.shouldStart?.() ?? true),
+      _trackingContentCaptureEnabled &&
+      !isQaTrackingIdentity(_trackingIdentity) &&
+      (configured.shouldStart?.() ?? true),
   });
 }
 
@@ -1993,6 +2026,7 @@ export function trackEvent(
   params?: Record<string, unknown>,
 ): void {
   if (typeof window === "undefined") return;
+  if (isQaTrackingIdentity(_trackingIdentity)) return;
   ensureSentry();
   const props = resolveProps(name, params);
   const amplitudeProps = amplitudeEventProperties(name, props);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -210,6 +210,7 @@ export {
 // Shared (isomorphic)
 export {
   agentChat,
+  isQaTestEmail,
   type AgentChatCallOptions,
   type AgentChatResponse,
 } from "./shared/index.js";

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -115,6 +115,7 @@ export {
   type ChatFirstAppCreationResource,
   type ChatFirstAppCreationVaultAccessMode,
 } from "./chat-first-app-creation.js";
+export { isQaTestEmail } from "./qa-test-email.js";
 export {
   NATIVE_AUTH_COPY,
   resolveNativeAuthCopy,

--- a/packages/core/src/shared/qa-test-email.ts
+++ b/packages/core/src/shared/qa-test-email.ts
@@ -1,0 +1,5 @@
+const QA_TEST_EMAIL_PATTERN = /\+qa-test-bot-[^@\s]+@/i;
+
+export function isQaTestEmail(value: unknown): boolean {
+  return typeof value === "string" && QA_TEST_EMAIL_PATTERN.test(value);
+}

--- a/packages/core/src/tracking/registry.spec.ts
+++ b/packages/core/src/tracking/registry.spec.ts
@@ -99,6 +99,8 @@ describe("tracking registry", () => {
     track("client_event", undefined, { userId: email });
     track("property_event", { userEmail: email });
     identify(email, { email });
+    identify("auth-user-qa", { email });
+    identify("auth-user-qa", { userEmail: email });
 
     expect(events).toEqual([]);
     expect(identified).toEqual([]);

--- a/packages/core/src/tracking/registry.spec.ts
+++ b/packages/core/src/tracking/registry.spec.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { runWithRequestContext } from "../server/request-context.js";
+import { isQaTestEmail } from "../shared/qa-test-email.js";
 import {
   flushTracking,
+  identify,
   registerTrackingProvider,
   track,
   unregisterTrackingProvider,
@@ -25,6 +27,7 @@ describe("tracking registry", () => {
     unregisterTrackingProvider("qa-throwing-track");
     unregisterTrackingProvider("qa-rejecting-flush");
     unregisterTrackingProvider("qa-capture");
+    unregisterTrackingProvider("qa-identify");
     vi.restoreAllMocks();
   });
 
@@ -77,6 +80,38 @@ describe("tracking registry", () => {
     });
 
     expect(events[0]?.sessionId).toBe("session-2");
+  });
+
+  it("suppresses reserved QA identities before track or identify reaches providers", () => {
+    const events = captureEvents();
+    const identified: string[] = [];
+    registerTrackingProvider({
+      name: "qa-identify",
+      track() {},
+      identify(userId) {
+        identified.push(userId);
+      },
+    });
+    const email = "signup+qa-test-bot-123@example.com";
+
+    expect(isQaTestEmail(email)).toBe(true);
+    track("signup", { email }, { userId: email });
+    track("client_event", undefined, { userId: email });
+    track("property_event", { userEmail: email });
+    identify(email, { email });
+
+    expect(events).toEqual([]);
+    expect(identified).toEqual([]);
+  });
+
+  it("keeps ordinary plus-addresses trackable", () => {
+    const events = captureEvents();
+    const email = "signup+experiment-123@example.com";
+
+    expect(isQaTestEmail(email)).toBe(false);
+    track("signup", { email }, { userId: email });
+
+    expect(events).toHaveLength(1);
   });
 
   it("leaves the session absent for callers with no browser", () => {

--- a/packages/core/src/tracking/registry.ts
+++ b/packages/core/src/tracking/registry.ts
@@ -152,7 +152,7 @@ export function identify(
   userId: string,
   traits?: Record<string, unknown>,
 ): void {
-  if (isQaTestEmail(userId)) return;
+  if (isTrackingSuppressed(userId, traits)) return;
   for (const provider of getRegistry().values()) {
     if (!provider.identify) continue;
     try {

--- a/packages/core/src/tracking/registry.ts
+++ b/packages/core/src/tracking/registry.ts
@@ -2,11 +2,25 @@ import type { ActionRunContext } from "../action.js";
 import { resolveDeployEnvironment } from "../server/deploy-environment.js";
 import { getRequestContext } from "../server/request-context.js";
 import { ANALYTICS_CLIENT_PLATFORM_PROPERTY } from "../shared/analytics-platform.js";
+import { isQaTestEmail } from "../shared/qa-test-email.js";
 import type { TrackingProvider, TrackingEvent } from "./types.js";
+
+export { isQaTestEmail } from "../shared/qa-test-email.js";
 
 const REGISTRY_KEY = Symbol.for("@agent-native/core/tracking.registry");
 interface GlobalWithRegistry {
   [REGISTRY_KEY]?: Map<string, TrackingProvider>;
+}
+
+function isTrackingSuppressed(
+  userId: string | undefined,
+  properties?: Record<string, unknown>,
+): boolean {
+  return (
+    isQaTestEmail(userId) ||
+    isQaTestEmail(properties?.email) ||
+    isQaTestEmail(properties?.userEmail)
+  );
 }
 
 function getRegistry(): Map<string, TrackingProvider> {
@@ -97,6 +111,7 @@ export function track(
 ): void {
   const { userId, anonymousId, sessionId, occurredAt } =
     resolveTrackingSource(source);
+  if (isTrackingSuppressed(userId, properties)) return;
   const clientPlatform = getRequestContext()?.clientPlatform;
   const trackedProperties = {
     ...(properties ?? {}),
@@ -137,6 +152,7 @@ export function identify(
   userId: string,
   traits?: Record<string, unknown>,
 ): void {
+  if (isQaTestEmail(userId)) return;
   for (const provider of getRegistry().values()) {
     if (!provider.identify) continue;
     try {


### PR DESCRIPTION
## Summary

- Add a four-worker Playwright canary for the real email magic-link signup flow across every eligible fleet app, including the verification redirect, framework session, Better Auth session, and browser refresh assertions.
- Use Mailosaur server inboxes with unique `signup+qa-test-bot-...` addresses and suppress those addresses in core `track()` and `identify()` delivery plus the shared browser analytics boundary.
- Run the signup lane daily on beta with the `all` email-capable app set; production is an explicit workflow dispatch and also uses unique addresses so it always exercises net-new signup.
- Reuse the existing PagerDuty and GitHub issue alert paths, with a bounded dead-man check in the five-minute site monitor.

## Validation

- `pnpm typecheck:e2e:signup`
- `pnpm --filter @agent-native/core exec vitest --run src/client/analytics.spec.ts src/tracking/registry.spec.ts --config vitest.config.ts`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm guard:beta-e2e-suite`
- `pnpm guard:env-documentation`
- `pnpm guards` (all 65 checks passed)
- Playwright target listing, YAML parsing, full target selection including CRM, QA-address uniqueness, suppression coupling, and oxfmt checks

## Operations

- GitHub Actions requires `MAILOSAUR_API_KEY` and `MAILOSAUR_SERVER_ID`; `PAGERDUTY_ROUTING_KEY` enables email/text/push through the existing PagerDuty policy.
- The signup job allows 180 minutes for a valid beta-plus-production dispatch, uses `fullyParallel: true` with four workers, continues later targets after an individual failure, and uploads failure artifacts. The scheduled 12-target beta run reaches a fleet-wide email failure in roughly 18 minutes instead of the roughly 72-minute serial path; a 24-target beta-plus-production dispatch is roughly 36 minutes.
- No live signup run was possible in this checkout because the Mailosaur secrets are not provisioned yet.
- The existing scheduled beta E2E continues to provide the Luna agentic journey; this signup lane remains deterministic for reliable auth-boundary assertions.
- Live production handoff: Chat production reportedly accepts the real `/_agent-native/auth/magic-link` request but sends net-new verification links to `starter.agent-native.com`. Correct Chat production auth-origin configuration outside this diff.
- Live production handoff: CRM production reportedly returns HTTP 500 from the real magic-link endpoint while beta CRM returns 200. Diagnose the unhandled production exception outside this diff.
- The earlier Chat 403 observation was against the wrong `/ba/sign-in/magic-link` endpoint and is retracted. The auth error sanitizer also hides the underlying Better Auth error and is a separate follow-up.