### PR TITLE
fix: keep chat and CLI surfaces accessible

### DIFF
--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -526,8 +526,9 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
 
     expect(hubSource).toContain("!showTerminalSurface");
     expect(hubSource).toContain("chatFirstSurfacePanel.toggle");
+    expect(hubSource).toContain("sidebarOpen={chatFirstSurfacePanel.open}");
     expect(hubSource).toContain(
-      "onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}",
+      "onToggleSidebar={chatFirstSurfacePanel.toggle}",
     );
     expect(hubSource).toContain(
       "{chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -15,7 +15,6 @@ import {
   type CodeAgentsNewSessionExtension,
 } from "@agent-native/code-agents-ui";
 import {
-  ChatFirstSurfacePanelToggle,
   chatFirstSurfaceTabId,
   closeChatFirstSessionWatch,
   emitChatFirstOpenApp,
@@ -136,6 +135,7 @@ import CodeAgentsAppIcon from "./CodeAgentsAppIcon.js";
 import CodeAgentSchedulesPanel from "./CodeAgentSchedulesPanel.js";
 import CreateAppPromptPopover from "./CreateAppPromptPopover.js";
 import DesktopAppChatShell from "./DesktopAppChatShell.js";
+import DesktopChatFirstSurfaceMenu from "./DesktopChatFirstSurfaceMenu.js";
 import DesktopIntegrationsPage from "./DesktopIntegrationsPage.js";
 import DesktopTerminalSurface, {
   type DesktopTerminalPromptRequest,
@@ -2863,10 +2863,15 @@ export default function CodeAgentsHub({
             !chatFirstAllAppsOpen &&
             !scheduledTasksOpen &&
             !chatFirstAppTakesMain ? (
-              <ChatFirstSurfacePanelToggle
-                open={chatFirstSurfacePanel.open}
-                onToggle={chatFirstSurfacePanel.toggle}
-                className="static"
+              <DesktopChatFirstSurfaceMenu
+                sidebarOpen={chatFirstSurfacePanel.open}
+                apps={chatFirstAppItems}
+                onToggleSidebar={chatFirstSurfacePanel.toggle}
+                onOpenApp={(app) =>
+                  openChatFirstApp(app.id, undefined, undefined, "side")
+                }
+                renderAppIcon={renderChatFirstAppIcon}
+                onNewCliTab={handleNewCliTab}
               />
             ) : undefined
           }
@@ -2914,6 +2919,11 @@ export default function CodeAgentsHub({
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
                 onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}
+                apps={chatFirstAppItems}
+                onOpenApp={(app) =>
+                  openChatFirstApp(app.id, undefined, undefined, "side")
+                }
+                renderAppIcon={renderChatFirstAppIcon}
               />
             ) : undefined
           }

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2918,7 +2918,8 @@ export default function CodeAgentsHub({
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
-                onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}
+                sidebarOpen={chatFirstSurfacePanel.open}
+                onToggleSidebar={chatFirstSurfacePanel.toggle}
                 apps={chatFirstAppItems}
                 onOpenApp={(app) =>
                   openChatFirstApp(app.id, undefined, undefined, "side")

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DesktopChatFirstSurfaceMenu from "./DesktopChatFirstSurfaceMenu.js";
+
+describe("DesktopChatFirstSurfaceMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes sidebar, app, and CLI actions from the full-screen menu", async () => {
+    const onToggleSidebar = vi.fn();
+    const onOpenApp = vi.fn();
+    const onNewCliTab = vi.fn();
+
+    act(() => {
+      root.render(
+        <DesktopChatFirstSurfaceMenu
+          apps={[{ id: "mail", name: "Mail" }]}
+          onToggleSidebar={onToggleSidebar}
+          onOpenApp={onOpenApp}
+          onNewCliTab={onNewCliTab}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Surface options"]',
+    );
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const menuItems = () =>
+      Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      );
+    expect(
+      menuItems().some((item) => item.textContent?.includes("Open sidebar")),
+    ).toBe(true);
+    expect(
+      menuItems().some((item) =>
+        item.textContent?.includes("Open app in sidebar"),
+      ),
+    ).toBe(true);
+    expect(
+      menuItems().some((item) => item.textContent?.includes("New CLI tab")),
+    ).toBe(true);
+
+    const sidebarItem = menuItems().find((item) =>
+      item.textContent?.includes("Open sidebar"),
+    );
+    await act(async () => sidebarItem?.click());
+    expect(onToggleSidebar).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
@@ -1,0 +1,118 @@
+import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@agent-native/toolkit/ui";
+import {
+  IconApps,
+  IconDotsVertical,
+  IconLayoutSidebarRightCollapse,
+  IconMessageCircle,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import type { ReactNode } from "react";
+
+export interface DesktopChatFirstSurfaceMenuProps {
+  sidebarOpen?: boolean;
+  apps?: readonly ChatFirstAppItem[];
+  onToggleSidebar?: () => void;
+  onOpenApp?: (app: ChatFirstAppItem) => void;
+  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
+  onNewCliTab?: () => void;
+  onNewUiTab?: () => void;
+}
+
+export function DesktopChatFirstSurfaceMenuItems({
+  sidebarOpen = false,
+  apps = [],
+  onToggleSidebar,
+  onOpenApp,
+  renderAppIcon,
+  onNewCliTab,
+  onNewUiTab,
+}: DesktopChatFirstSurfaceMenuProps) {
+  const hasAppPicker = apps.length > 0 && Boolean(onOpenApp);
+  if (!onToggleSidebar && !hasAppPicker && !onNewCliTab && !onNewUiTab) {
+    return null;
+  }
+
+  return (
+    <>
+      {onToggleSidebar ? (
+        <DropdownMenuItem onSelect={onToggleSidebar}>
+          <IconLayoutSidebarRightCollapse size={14} className="shrink-0" />
+          {sidebarOpen ? "Hide sidebar" : "Open sidebar"}
+        </DropdownMenuItem>
+      ) : null}
+      {hasAppPicker ? (
+        <>
+          {onToggleSidebar ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <IconApps size={14} className="shrink-0" />
+              Open app in sidebar
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-56">
+              {apps.map((app) => (
+                <DropdownMenuItem
+                  key={app.id}
+                  onSelect={() => onOpenApp?.(app)}
+                >
+                  {renderAppIcon?.(app) ?? (
+                    <IconApps size={14} className="shrink-0" />
+                  )}
+                  <span className="min-w-0 truncate">{app.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </>
+      ) : null}
+      {onNewCliTab || onNewUiTab ? (
+        <>
+          {(onToggleSidebar || hasAppPicker) && <DropdownMenuSeparator />}
+          {onNewCliTab ? (
+            <DropdownMenuItem onSelect={onNewCliTab}>
+              <IconTerminal2 size={14} className="shrink-0" />
+              New CLI tab
+            </DropdownMenuItem>
+          ) : null}
+          {onNewUiTab ? (
+            <DropdownMenuItem onSelect={onNewUiTab}>
+              <IconMessageCircle size={14} className="shrink-0" />
+              New UI tab
+            </DropdownMenuItem>
+          ) : null}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+export default function DesktopChatFirstSurfaceMenu({
+  ...props
+}: DesktopChatFirstSurfaceMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex size-7 items-center justify-center rounded-md border border-border bg-card/95 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Surface options"
+          title="Surface options"
+        >
+          <IconDotsVertical size={15} aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="w-56">
+        <DesktopChatFirstSurfaceMenuItems {...props} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -61,14 +61,15 @@ describe("DesktopTerminalSurface", () => {
     expect(onNewUiTab).toHaveBeenCalledOnce();
   });
 
-  it("opens the shared sidebar from CLI options", async () => {
-    const onOpenSidebar = vi.fn();
+  it("toggles the shared sidebar from CLI options", async () => {
+    const onToggleSidebar = vi.fn();
     act(() => {
       root.render(
         <DesktopTerminalSurface
           agent="codex"
           theme="dark"
-          onOpenSidebar={onOpenSidebar}
+          sidebarOpen
+          onToggleSidebar={onToggleSidebar}
         />,
       );
     });
@@ -88,10 +89,10 @@ describe("DesktopTerminalSurface", () => {
     });
     const item = Array.from(
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
-    ).find((candidate) => candidate.textContent?.includes("Open sidebar"));
+    ).find((candidate) => candidate.textContent?.includes("Hide sidebar"));
 
     expect(item).toBeDefined();
     await act(async () => item?.click());
-    expect(onOpenSidebar).toHaveBeenCalledOnce();
+    expect(onToggleSidebar).toHaveBeenCalledOnce();
   });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -28,7 +28,8 @@ interface DesktopTerminalSurfaceProps {
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
-  onOpenSidebar?: () => void;
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
   apps?: readonly ChatFirstAppItem[];
   onOpenApp?: DesktopChatFirstSurfaceMenuProps["onOpenApp"];
   renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
@@ -53,7 +54,8 @@ export default function DesktopTerminalSurface({
   submitRequest,
   onPromptSubmitted,
   onNewUiTab,
-  onOpenSidebar,
+  sidebarOpen,
+  onToggleSidebar,
   apps = [],
   onOpenApp,
   renderAppIcon,
@@ -174,11 +176,14 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
-              {onOpenSidebar || (apps.length > 0 && onOpenApp) || onNewUiTab ? (
+              {onToggleSidebar ||
+              (apps.length > 0 && onOpenApp) ||
+              onNewUiTab ? (
                 <>
                   <DesktopChatFirstSurfaceMenuItems
+                    sidebarOpen={sidebarOpen}
                     apps={apps}
-                    onToggleSidebar={onOpenSidebar}
+                    onToggleSidebar={onToggleSidebar}
                     onOpenApp={onOpenApp}
                     renderAppIcon={renderAppIcon}
                     onNewUiTab={onNewUiTab}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -1,3 +1,4 @@
+import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
 import type { AgentTerminalSubmitRequest } from "@agent-native/core/terminal";
 import {
   DropdownMenu,
@@ -6,17 +7,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui";
-import {
-  IconDotsVertical,
-  IconLayoutSidebarRightCollapse,
-  IconMessageCircle,
-  IconPlus,
-  IconX,
-} from "@tabler/icons-react";
+import { IconDotsVertical, IconPlus, IconX } from "@tabler/icons-react";
+import type { ReactNode } from "react";
 import { useCallback, useRef, useState } from "react";
 
 import { type DesktopTerminalAgentId } from "../lib/desktop-terminal-preferences.js";
 import type { RendererTheme } from "../lib/theme.js";
+import {
+  DesktopChatFirstSurfaceMenuItems,
+  type DesktopChatFirstSurfaceMenuProps,
+} from "./DesktopChatFirstSurfaceMenu.js";
 import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 
 export interface DesktopTerminalPromptRequest extends AgentTerminalSubmitRequest {}
@@ -29,6 +29,9 @@ interface DesktopTerminalSurfaceProps {
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
   onOpenSidebar?: () => void;
+  apps?: readonly ChatFirstAppItem[];
+  onOpenApp?: DesktopChatFirstSurfaceMenuProps["onOpenApp"];
+  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
 }
 
 interface DesktopTerminalTab {
@@ -51,6 +54,9 @@ export default function DesktopTerminalSurface({
   onPromptSubmitted,
   onNewUiTab,
   onOpenSidebar,
+  apps = [],
+  onOpenApp,
+  renderAppIcon,
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
@@ -168,24 +174,15 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
-              {onOpenSidebar ? (
+              {onOpenSidebar || (apps.length > 0 && onOpenApp) || onNewUiTab ? (
                 <>
-                  <DropdownMenuItem onSelect={onOpenSidebar}>
-                    <IconLayoutSidebarRightCollapse
-                      size={14}
-                      className="shrink-0"
-                    />
-                    Open sidebar
-                  </DropdownMenuItem>
-                  {onNewUiTab ? <DropdownMenuSeparator /> : null}
-                </>
-              ) : null}
-              {onNewUiTab ? (
-                <>
-                  <DropdownMenuItem onSelect={onNewUiTab}>
-                    <IconMessageCircle size={14} className="shrink-0" />
-                    New UI tab
-                  </DropdownMenuItem>
+                  <DesktopChatFirstSurfaceMenuItems
+                    apps={apps}
+                    onToggleSidebar={onOpenSidebar}
+                    onOpenApp={onOpenApp}
+                    renderAppIcon={renderAppIcon}
+                    onNewUiTab={onNewUiTab}
+                  />
                   <DropdownMenuSeparator />
                 </>
               ) : null}

--- a/scripts/qa-chat-first-workbench-smoke.ts
+++ b/scripts/qa-chat-first-workbench-smoke.ts
@@ -925,28 +925,44 @@ async function runElectronSmoke(): Promise<void> {
       0,
       "Electron launcher should be closed by default",
     );
-    assert.equal(
-      empty.toggle,
-      1,
-      "Electron empty full-screen chat should offer a right-surface toggle",
-    );
     assert.ok(
       empty.mainWidth > 0,
       "Electron Agent content should be measurable",
     );
     assert.equal(
-      await page
-        .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
-        .count(),
+      await page.getByRole("button", { name: "Surface options" }).count(),
       1,
-      "Electron empty chat should expose the central surface toggle",
+      "Electron empty chat should expose surface options",
     );
     assert.ok(
       empty.composerRight - empty.composerLeft <= 752,
       "Electron full-page composer should be no wider than 750px",
     );
+    await page.getByRole("button", { name: "Surface options" }).click();
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "Open sidebar", exact: true })
+        .count(),
+      1,
+      "Electron surface options should open the shared sidebar",
+    );
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "Open app in sidebar", exact: true })
+        .count(),
+      1,
+      "Electron surface options should expose the app picker",
+    );
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "New CLI tab", exact: true })
+        .count(),
+      1,
+      "Electron surface options should expose a new CLI tab",
+    );
+    await saveElectronScreenshot(electronApp, "electron-surface-options");
     await page
-      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .getByRole("menuitem", { name: "Open sidebar", exact: true })
       .click();
     await page
       .locator("[data-chat-first-surface-panel]")
@@ -960,8 +976,9 @@ async function runElectronSmoke(): Promise<void> {
       emptySidebar.appOptions >= 5,
       "Electron empty chat should expose the app picker from its sidebar",
     );
+    await page.getByRole("button", { name: "Surface options" }).click();
     await page
-      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .getByRole("menuitem", { name: "Hide sidebar", exact: true })
       .click();
     await page
       .locator("[data-chat-first-surface-panel]")
@@ -1046,16 +1063,9 @@ async function runElectronSmoke(): Promise<void> {
       electronApp,
     );
     assert.equal(
-      active.toggle,
+      await page.getByRole("button", { name: "Surface options" }).count(),
       1,
-      "Electron active chat should expose the surface toggle",
-    );
-    assert.equal(
-      await page
-        .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
-        .count(),
-      1,
-      "Electron active chat should expose the central surface toggle",
+      "Electron active chat should expose surface options",
     );
     assert.ok(
       active.composerRight - active.composerLeft <= 752,
@@ -1110,18 +1120,24 @@ async function runElectronSmoke(): Promise<void> {
       sideApp.chatWidth < active.chatWidth - 1,
       "Electron agent-opened apps should leave the full-page chat visible beside them",
     );
-    await page.getByRole("button", { name: "Hide side surface" }).click();
+    await page.getByRole("button", { name: "Surface options" }).click();
+    await page
+      .getByRole("menuitem", { name: "Hide sidebar", exact: true })
+      .click();
+    await page.keyboard.press("Escape");
     await page.locator("[data-chat-first-surface-panel]").waitFor({
       state: "detached",
     });
 
     await installElectronAppCreationSmokeMock(electronApp);
-    const expandRailButton = page.getByRole("button", {
-      name: "Expand rail",
-      exact: true,
-    });
-    if (await expandRailButton.count()) {
-      await expandRailButton.click();
+    const collapseRailButton = page.locator("[data-chat-first-rail-collapse]");
+    if (await collapseRailButton.count()) {
+      await collapseRailButton.evaluate((button) =>
+        (button as HTMLButtonElement).click(),
+      );
+      await page
+        .locator(".code-agents-rail:not(.code-agents-rail--collapsed)")
+        .waitFor({ state: "visible" });
     }
     const createAppButton = page.locator(
       '[data-chat-first-apps-rail] button[aria-label="Create app"]',


### PR DESCRIPTION
## Summary
- add a shared surface-options menu to full-screen chat
- expose sidebar app picker and new CLI tab from UI chat
- expose the same app picker and new UI tab from terminal options
- update Electron smoke coverage for the new menu

## Verification
- 570 desktop tests passed
- desktop typecheck passed
- desktop build passed
- all 65 repository guards passed
- packaged Electron smoke reached and verified the new menu, sidebar, app picker entry, and CLI-tab entry with a rendered screenshot

The existing smoke harness still has a later app-creation fixture failure after these assertions; it is outside this change.