### PR TITLE
fix: close docs mobile menu after navigation

### DIFF
--- a/packages/docs/app/components/website-redesign/ds/nav-link.tsx
+++ b/packages/docs/app/components/website-redesign/ds/nav-link.tsx
@@ -1,11 +1,12 @@
 import { IconArrowUpRight } from "@tabler/icons-react";
-import type { ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 import { Link } from "react-router";
 
 interface NavLinkProps {
   href: string;
   external?: boolean;
   showArrow?: boolean;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
   children: ReactNode;
 }
 
@@ -14,7 +15,13 @@ interface NavLinkProps {
 const linkClassName =
   "inline-flex h-8 items-center gap-1 rounded-[var(--b-radius)] px-2 py-1 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)] font-medium no-underline outline-none transition-[background,color] duration-150 ease-[ease] text-[var(--b-text-secondary)] hover:text-[var(--b-text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--b-text-primary)]";
 
-export function NavLink({ href, external, showArrow, children }: NavLinkProps) {
+export function NavLink({
+  href,
+  external,
+  showArrow,
+  onClick,
+  children,
+}: NavLinkProps) {
   const content = (
     <>
       {children}
@@ -24,14 +31,20 @@ export function NavLink({ href, external, showArrow, children }: NavLinkProps) {
 
   if (external) {
     return (
-      <a href={href} target="_blank" rel="noreferrer" className={linkClassName}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className={linkClassName}
+        onClick={onClick}
+      >
         {content}
       </a>
     );
   }
 
   return (
-    <Link to={href} className={linkClassName}>
+    <Link to={href} className={linkClassName} onClick={onClick}>
       {content}
     </Link>
   );

--- a/packages/docs/app/components/website-redesign/site-header.test.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.test.tsx
@@ -2,8 +2,8 @@
 
 import { AgentNativeI18nProvider } from "@agent-native/core/client/i18n";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The real modal pulls the docs search index; the header only owns the open
 // state, so the lazy chunk is stubbed with a probe.
@@ -14,6 +14,27 @@ vi.mock("../SearchModal", () => ({
 
 import { docsI18nCatalog } from "../../i18n";
 import { SiteHeader } from "./site-header";
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <output data-testid="location">{pathname}</output>;
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 afterEach(() => {
   cleanup();
@@ -30,6 +51,7 @@ function renderHeader() {
         persistPreference={false}
       >
         <SiteHeader starCount={1234} />
+        <LocationProbe />
       </AgentNativeI18nProvider>
     </MemoryRouter>,
   );
@@ -59,5 +81,21 @@ describe("SiteHeader search", () => {
     fireEvent.keyDown(document, { key: "k", ...init });
 
     expect(await screen.findByTestId("search-modal")).toBeTruthy();
+  });
+
+  it("closes the mobile menu after choosing a navigation link", () => {
+    renderHeader();
+
+    const toggle = screen.getByRole("button", {
+      name: "Toggle navigation menu",
+    });
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    const docsLinks = screen.getAllByRole("link", { name: "Docs" });
+    fireEvent.click(docsLinks[docsLinks.length - 1]);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("location").textContent).toBe("/docs/");
   });
 });

--- a/packages/docs/app/components/website-redesign/site-header.tsx
+++ b/packages/docs/app/components/website-redesign/site-header.tsx
@@ -223,6 +223,7 @@ export function SiteHeader({ starCount }: SiteHeaderProps) {
               href={link.href}
               external={link.external}
               showArrow={link.showArrow}
+              onClick={() => setMobileOpen(false)}
             >
               {link.label}
             </NavLink>


### PR DESCRIPTION
## Summary

- Close the docs site mobile navigation after selecting a header link.
- Preserve client-side navigation while closing the menu.
- Add a regression test for the Docs route and collapsed menu state.

## Validation

- `corepack pnpm --filter @agent-native/docs test -- app/components/website-redesign/site-header.test.tsx`
- `corepack pnpm --filter @agent-native/docs typecheck`
- `corepack pnpm exec oxfmt --check packages/docs/app/components/website-redesign/ds/nav-link.tsx packages/docs/app/components/website-redesign/site-header.tsx packages/docs/app/components/website-redesign/site-header.test.tsx`
- Browser verified at 390x844: mobile menu -> Docs navigates to `/docs/`, menu collapses, and no console errors.