### PR TITLE
fix: let CLI agents open desktop sidebar apps

### DIFF
--- a/.changeset/desktop-cli-sidebar-tool.md
+++ b/.changeset/desktop-cli-sidebar-tool.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow trusted desktop hosts to add CLI launch arguments to PTY sessions.

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -208,6 +208,30 @@ describe("createPtyWebSocketServer", () => {
     ws.close();
   });
 
+  it("shell-quotes trusted host command arguments", async () => {
+    const server = await createServer({
+      command: "builder",
+      getCommandArgs: () => [
+        "--mcp-config",
+        "/tmp/desktop surface.json",
+        "it's-safe",
+      ],
+    });
+    const ws = await openSocket(`ws://127.0.0.1:${server.port}/ws`);
+    await vi.waitFor(() => expect(ptys).toHaveLength(1));
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      [
+        "-l",
+        "-c",
+        "builder '--mcp-config' '/tmp/desktop surface.json' 'it'\"'\"'s-safe'",
+      ],
+      expect.objectContaining({ cwd: expect.any(String) }),
+    );
+    ws.close();
+  });
+
   it("does not write env vars sent through the terminal bridge to .env", async () => {
     const appDir = mkdtempSync(path.join(os.tmpdir(), "agent-terminal-"));
     tempDirs.push(appDir);

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -103,6 +103,8 @@ export interface PtyServerOptions {
   port?: number;
   /** Auth check for WebSocket upgrade requests. Return false to reject. */
   authCheck?: (req: IncomingMessage) => boolean | Promise<boolean>;
+  /** Trusted host arguments appended to each validated CLI command. */
+  getCommandArgs?: (command: string) => string[] | Promise<string[]>;
   /** Log prefix for console output. Defaults to '[terminal]' */
   logPrefix?: string;
 }
@@ -124,6 +126,7 @@ export async function createPtyWebSocketServer(
     command: defaultCommand = "claude",
     port = 0,
     authCheck,
+    getCommandArgs,
     logPrefix = "[terminal]",
   } = options;
 
@@ -231,14 +234,29 @@ export async function createPtyWebSocketServer(
       }
     }
 
+    let commandArgs: string[] = [];
+    try {
+      if (getCommandArgs) commandArgs = await getCommandArgs(command);
+    } catch (error) {
+      sendStatus(
+        "failed",
+        error instanceof Error
+          ? error.message
+          : "The terminal command could not be configured.",
+      );
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+      return;
+    }
+
     // Build the command — use npx if CLI not found locally
     const baseCommand = useNpx
       ? `npx --yes ${CLI_REGISTRY[command].installPackage}`
       : command;
-    const fullCommand = extraFlags
-      ? `${baseCommand} ${extraFlags}`
-      : baseCommand;
-    console.log(`${logPrefix} Spawning PTY: ${fullCommand}`);
+    const generatedFlags = commandArgs.map(shellQuote).join(" ");
+    const fullCommand = [baseCommand, generatedFlags, extraFlags]
+      .filter(Boolean)
+      .join(" ");
+    console.log(`${logPrefix} Spawning PTY for ${command}`);
 
     // Build env, stripping CLI-specific nesting vars
     const registry = CLI_REGISTRY[command];
@@ -386,4 +404,8 @@ export async function createPtyWebSocketServer(
       });
     });
   });
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -62,6 +62,8 @@ export const IPC = {
   DESKTOP_CHAT_GET_API_URL: "desktop-chat:get-api-url",
   /** Loopback relay for discovering a local app's PTY WebSocket */
   DESKTOP_CHAT_GET_TERMINAL_INFO_URL: "desktop-chat:get-terminal-info-url",
+  /** Local CLI MCP tool → renderer app-sidebar request */
+  DESKTOP_CHAT_OPEN_APP: "desktop-chat:open-app",
 
   /** Hosted Plan app local-file sync (Plan webview ↔ main) */
   PLAN_FILES_GET_FOLDER: "plan-files:get-folder",
@@ -1132,6 +1134,12 @@ export interface DesktopOpenRequest {
   path?: string;
   softOpen?: boolean;
   runId?: string;
+}
+
+export interface DesktopChatOpenAppRequest {
+  app: string;
+  path?: string;
+  view?: string;
 }
 
 export interface DesktopShortcutActivationRequest extends DesktopOpenRequest {

--- a/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
@@ -62,7 +62,9 @@ describe("DesktopSurfaceMcpBridge", () => {
       arguments: {},
     });
     const appsText = apps.content?.find((item) => item.type === "text");
-    expect(appsText?.type === "text" ? JSON.parse(appsText.text) : null).toEqual(
+    expect(
+      appsText?.type === "text" ? JSON.parse(appsText.text) : null,
+    ).toEqual(
       expect.objectContaining({
         apps: expect.arrayContaining([{ id: "mail", name: "Mail" }]),
       }),

--- a/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
@@ -1,0 +1,98 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DesktopSurfaceMcpBridge } from "./desktop-surface-mcp";
+
+const active: Array<{ bridge: DesktopSurfaceMcpBridge; client: Client }> = [];
+
+afterEach(async () => {
+  for (const { bridge, client } of active.splice(0)) {
+    await client.close().catch(() => undefined);
+    await bridge.close().catch(() => undefined);
+  }
+  vi.restoreAllMocks();
+});
+
+async function createHarness() {
+  const openApp = vi.fn();
+  const bridge = new DesktopSurfaceMcpBridge({
+    listApps: () => [
+      { id: "mail", name: "Mail" },
+      { id: "calendar", name: "Calendar" },
+    ],
+    openApp,
+  });
+  const url = await bridge.start();
+  const registration = bridge.register();
+  const client = new Client(
+    { name: "desktop-surface-test", version: "1.0.0" },
+    { versionNegotiation: { mode: "auto" } },
+  );
+  await client.connect(
+    new StreamableHTTPClientTransport(new URL(url), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${registration.bearerToken}` },
+      },
+    }),
+  );
+  active.push({ bridge, client });
+  return { bridge, client, openApp, registration };
+}
+
+describe("DesktopSurfaceMcpBridge", () => {
+  it("exposes the sidebar app tool behind a loopback bearer", async () => {
+    const harness = await createHarness();
+    const unauthorized = await fetch(harness.registration.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const tools = await harness.client.listTools();
+    expect(tools.tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["list_apps", "open_app"]),
+    );
+
+    const apps = await harness.client.callTool({
+      name: "list_apps",
+      arguments: {},
+    });
+    const appsText = apps.content?.find((item) => item.type === "text");
+    expect(appsText?.type === "text" ? JSON.parse(appsText.text) : null).toEqual(
+      expect.objectContaining({
+        apps: expect.arrayContaining([{ id: "mail", name: "Mail" }]),
+      }),
+    );
+
+    const opened = await harness.client.callTool({
+      name: "open_app",
+      arguments: { app: "mail", path: "/inbox", view: "inbox" },
+    });
+    expect(opened.isError).not.toBe(true);
+    expect(harness.openApp).toHaveBeenCalledWith({
+      app: "mail",
+      path: "/inbox",
+      view: "inbox",
+    });
+  });
+
+  it("rejects unknown apps and unsafe paths without opening anything", async () => {
+    const harness = await createHarness();
+    const unknown = await harness.client.callTool({
+      name: "open_app",
+      arguments: { app: "notes" },
+    });
+    expect(unknown.isError).toBe(true);
+
+    const unsafe = await harness.client.callTool({
+      name: "open_app",
+      arguments: { app: "mail", path: "https://example.com" },
+    });
+    expect(unsafe.isError).toBe(true);
+    expect(harness.openApp).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-app/src/main/desktop-surface-mcp.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.ts
@@ -1,0 +1,217 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from "node:http";
+
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import { createMcpHandler, McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+
+const DESKTOP_SURFACE_MCP_PATH = "/mcp";
+
+export interface DesktopSurfaceApp {
+  id: string;
+  name: string;
+}
+
+export interface DesktopSurfaceOpenAppRequest {
+  app: string;
+  path?: string;
+  view?: string;
+}
+
+export interface DesktopSurfaceMcpBridgeOptions {
+  listApps: () => readonly DesktopSurfaceApp[];
+  openApp: (request: DesktopSurfaceOpenAppRequest) => void;
+}
+
+export interface DesktopSurfaceMcpRegistration {
+  url: string;
+  bearerToken: string;
+}
+
+function textResult(value: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+  };
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("base64url");
+}
+
+function readBearerToken(value: string | undefined): string | undefined {
+  return /^Bearer ([A-Za-z0-9_-]{32,})$/.exec(value ?? "")?.[1];
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return (
+    address === "127.0.0.1" ||
+    address === "::1" ||
+    address === "::ffff:127.0.0.1"
+  );
+}
+
+function isSafeAppPath(value: string): boolean {
+  if (!value.startsWith("/") || value.startsWith("//")) return false;
+  return (
+    URL.canParse(value, "http://desktop-app.invalid") &&
+    new URL(value, "http://desktop-app.invalid").origin ===
+      "http://desktop-app.invalid"
+  );
+}
+
+export class DesktopSurfaceMcpBridge {
+  private readonly tokenHashes = new Set<string>();
+  private readonly mcpHandler = createMcpHandler(
+    () => {
+      const mcp = new McpServer({
+        name: "agent-native-desktop",
+        version: "1.0.0",
+      });
+      this.registerTools(mcp);
+      return mcp;
+    },
+    {
+      legacy: "stateless",
+      responseMode: "json",
+      onerror: (error) => {
+        console.warn("[desktop-surface] MCP request failed:", error.message);
+      },
+    },
+  );
+  private readonly handleMcpNodeRequest = toNodeHandler(this.mcpHandler, {
+    onerror: (error) => {
+      console.warn("[desktop-surface] MCP adapter failed:", error.message);
+    },
+  });
+  private httpServer?: HttpServer;
+  private url?: string;
+
+  constructor(private readonly options: DesktopSurfaceMcpBridgeOptions) {}
+
+  async start(): Promise<string> {
+    if (this.url) return this.url;
+    const httpServer = createServer((request, response) => {
+      void this.handleHttpRequest(request, response);
+    });
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once("error", reject);
+      httpServer.listen(0, "127.0.0.1", () => {
+        httpServer.off("error", reject);
+        resolve();
+      });
+    });
+    const address = httpServer.address();
+    if (!address || typeof address === "string") {
+      httpServer.close();
+      throw new Error("Desktop surface MCP did not receive a TCP address.");
+    }
+    this.httpServer = httpServer;
+    this.url = `http://127.0.0.1:${address.port}${DESKTOP_SURFACE_MCP_PATH}`;
+    return this.url;
+  }
+
+  register(): DesktopSurfaceMcpRegistration {
+    if (!this.url) throw new Error("Desktop surface MCP bridge is not ready.");
+    const bearerToken = randomBytes(32).toString("base64url");
+    this.tokenHashes.add(hashToken(bearerToken));
+    return { url: this.url, bearerToken };
+  }
+
+  async close(): Promise<void> {
+    this.tokenHashes.clear();
+    await this.mcpHandler.close();
+    const server = this.httpServer;
+    this.httpServer = undefined;
+    this.url = undefined;
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  private async handleHttpRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    if (
+      request.url !== DESKTOP_SURFACE_MCP_PATH ||
+      !isLoopbackAddress(request.socket.remoteAddress)
+    ) {
+      response.writeHead(404).end();
+      return;
+    }
+    const token = readBearerToken(request.headers.authorization);
+    if (!token || !this.tokenHashes.has(hashToken(token))) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    try {
+      await this.handleMcpNodeRequest(request, response);
+    } catch (error) {
+      console.warn(
+        "[desktop-surface] MCP request failed:",
+        error instanceof Error ? error.message : "unknown error",
+      );
+      if (!response.headersSent) response.writeHead(500);
+      response.end();
+    }
+  }
+
+  private registerTools(mcp: McpServer): void {
+    mcp.registerTool(
+      "list_apps",
+      {
+        description:
+          "List workspace apps that can be opened in the desktop sidebar.",
+        annotations: { readOnlyHint: true, openWorldHint: false },
+      },
+      async () => textResult({ apps: this.options.listApps() }),
+    );
+    mcp.registerTool(
+      "open_app",
+      {
+        description:
+          "Open a workspace app in the Agent-Native desktop sidebar. Use the app id from list_apps. This changes the desktop UI and returns after the app tab is requested.",
+        inputSchema: {
+          app: z.string().trim().min(1).max(80),
+          path: z
+            .string()
+            .trim()
+            .min(1)
+            .max(2_000)
+            .refine(isSafeAppPath, "path must be a same-origin app path")
+            .optional(),
+          view: z.string().trim().min(1).max(200).optional(),
+        },
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+      async ({ app, path, view }) => {
+        const target = this.options
+          .listApps()
+          .find((candidate) => candidate.id === app);
+        if (!target) throw new Error(`Desktop app "${app}" is not available.`);
+        this.options.openApp({
+          app: target.id,
+          ...(path ? { path } : {}),
+          ...(view ? { view } : {}),
+        });
+        return textResult({
+          opened: true,
+          app: target.id,
+          ...(path ? { path } : {}),
+          ...(view ? { view } : {}),
+        });
+      },
+    );
+  }
+}

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -16,6 +16,7 @@ vi.mock("../app-store", () => ({
 }));
 
 import {
+  desktopTerminalMcpArgs,
   desktopTerminalInfo,
   resolveTargetUrl,
   shouldForwardRequestHeader,
@@ -23,6 +24,32 @@ import {
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
+  it("configures the desktop sidebar tool for supported CLI agents", () => {
+    const registration = {
+      url: "http://127.0.0.1:3456/mcp",
+      bearerToken: "a".repeat(43),
+    };
+
+    expect(
+      desktopTerminalMcpArgs(
+        "claude",
+        registration,
+        "/tmp/desktop config.json",
+      ),
+    ).toEqual(["--mcp-config", "/tmp/desktop config.json"]);
+    expect(
+      desktopTerminalMcpArgs("codex", registration, "/tmp/unused.json"),
+    ).toEqual([
+      "-c",
+      'mcp_servers.agent-native-desktop.url="http://127.0.0.1:3456/mcp"',
+      "-c",
+      `mcp_servers.agent-native-desktop.http_headers={"Authorization"="Bearer ${registration.bearerToken}"}`,
+    ]);
+    expect(
+      desktopTerminalMcpArgs("builder", registration, "/tmp/unused.json"),
+    ).toEqual([]);
+  });
+
   it("returns an authenticated desktop-owned terminal endpoint", () => {
     expect(desktopTerminalInfo(4567, "a token")).toEqual({
       available: true,

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -1,21 +1,35 @@
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import {
   createServer,
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
+import path from "node:path";
 
 import { createPtyWebSocketServer } from "@agent-native/core/terminal/server";
 import {
+  getDesktopVisibleApps,
   getDesktopTemplateGatewayAppUrl,
   isDefaultDesktopTemplateDevTarget,
   type AppConfig,
 } from "@shared/app-registry";
 import { IPC } from "@shared/ipc-channels";
-import { app, ipcMain, net, session, type IpcMainInvokeEvent } from "electron";
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  net,
+  session,
+  type IpcMainInvokeEvent,
+} from "electron";
 
 import * as AppStore from "../app-store";
 import { readCookieHeaderForUrl } from "../cookie-header";
+import {
+  DesktopSurfaceMcpBridge,
+  type DesktopSurfaceMcpRegistration,
+} from "../desktop-surface-mcp";
 
 const RELAY_ROOT = "/desktop-chat";
 const DESKTOP_TERMINAL_INFO_ROOT = "/desktop-terminal-info";
@@ -58,26 +72,136 @@ let desktopTerminalPromise: ReturnType<typeof createDesktopTerminal> | null =
   null;
 let ipcRegistered = false;
 
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function tomlInlineTable(headers: Record<string, string>): string {
+  return `{${Object.entries(headers)
+    .map(([key, value]) => `${tomlString(key)}=${tomlString(value)}`)
+    .join(",")}}`;
+}
+
+export function desktopTerminalMcpArgs(
+  command: string,
+  registration: DesktopSurfaceMcpRegistration,
+  claudeConfigPath: string,
+): string[] {
+  if (command === "claude") {
+    return ["--mcp-config", claudeConfigPath];
+  }
+  if (command === "codex") {
+    return [
+      "-c",
+      `mcp_servers.agent-native-desktop.url=${tomlString(registration.url)}`,
+      "-c",
+      `mcp_servers.agent-native-desktop.http_headers=${tomlInlineTable({
+        Authorization: `Bearer ${registration.bearerToken}`,
+      })}`,
+    ];
+  }
+  return [];
+}
+
+function removeDesktopTerminalConfig(filePath: string | undefined): void {
+  if (!filePath) return;
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    console.warn(
+      "[desktop-terminal] Could not remove temporary MCP config:",
+      error instanceof Error ? error.message : "unknown error",
+    );
+  }
+}
+
+function reportDesktopTerminalCleanupFailure(error: unknown): void {
+  console.warn(
+    "[desktop-terminal] Could not close the desktop surface bridge:",
+    error instanceof Error ? error.message : "unknown error",
+  );
+}
+
 async function createDesktopTerminal() {
   const token = randomUUID().replaceAll("-", "");
-  const terminal = await createPtyWebSocketServer({
-    appDir: app.getPath("home"),
-    authCheck: (request) => {
-      try {
-        const url = new URL(
-          request.url ?? "",
-          `http://${request.headers.host ?? "127.0.0.1"}`,
-        );
-        return url.searchParams.get("token") === token;
-      } catch {
-        // coercion-ok: malformed websocket URLs are authentication denials, never success.
-        return false;
-      }
+  const surfaceMcp = new DesktopSurfaceMcpBridge({
+    listApps: () =>
+      getDesktopVisibleApps(AppStore.loadApps())
+        .filter((appConfig) => appConfig.enabled !== false)
+        .map(({ id, name }) => ({ id, name })),
+    openApp: (request) => {
+      const win = BrowserWindow.getAllWindows().find(
+        (candidate) => !candidate.isDestroyed(),
+      );
+      if (!win) throw new Error("The desktop shell is not available.");
+      win.webContents.send(IPC.DESKTOP_CHAT_OPEN_APP, request);
     },
-    logPrefix: "[desktop-terminal]",
   });
-  app.once("before-quit", terminal.close);
-  return { terminal, token };
+  let claudeConfigPath: string | undefined;
+  try {
+    const surfaceMcpUrl = await surfaceMcp.start();
+    const surfaceMcpRegistration = surfaceMcp.register();
+    claudeConfigPath = path.join(
+      app.getPath("temp"),
+      `agent-native-desktop-${randomUUID()}.json`,
+    );
+    fs.writeFileSync(
+      claudeConfigPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            "agent-native-desktop": {
+              type: "http",
+              url: surfaceMcpUrl,
+              headers: {
+                Authorization: `Bearer ${surfaceMcpRegistration.bearerToken}`,
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+    const terminal = await createPtyWebSocketServer({
+      appDir: app.getPath("home"),
+      authCheck: (request) => {
+        try {
+          const url = new URL(
+            request.url ?? "",
+            `http://${request.headers.host ?? "127.0.0.1"}`,
+          );
+          return url.searchParams.get("token") === token;
+        } catch {
+          // coercion-ok: malformed websocket URLs are authentication denials, never success.
+          return false;
+        }
+      },
+      getCommandArgs: (command) =>
+        desktopTerminalMcpArgs(
+          command,
+          surfaceMcpRegistration,
+          claudeConfigPath!,
+        ),
+      logPrefix: "[desktop-terminal]",
+    });
+    const close = () => {
+      terminal.close();
+      void surfaceMcp.close().catch(reportDesktopTerminalCleanupFailure);
+      removeDesktopTerminalConfig(claudeConfigPath);
+    };
+    app.once("before-quit", close);
+    return { terminal, token };
+  } catch (error) {
+    removeDesktopTerminalConfig(claudeConfigPath);
+    try {
+      await surfaceMcp.close();
+    } catch (closeError) {
+      reportDesktopTerminalCleanupFailure(closeError);
+    }
+    throw error;
+  }
 }
 
 function ensureDesktopTerminal() {

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -65,6 +65,7 @@ import {
   type DesktopAppCreationSettings,
   type DesktopAppCreationSettingsUpdateResult,
   type DesktopAppRuntimeStatus,
+  type DesktopChatOpenAppRequest,
   type DesktopIdentityAuthRequest,
   type DesktopIdentityAuthResult,
   type DesktopIdentityMagicLinkRequest,
@@ -259,6 +260,17 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_API_URL, appId),
     getTerminalInfoUrl: (appId?: string): Promise<string | null> =>
       ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL, appId),
+    onOpenApp: (
+      cb: (request: DesktopChatOpenAppRequest) => void,
+    ): (() => void) => {
+      const handler = (
+        _: Electron.IpcRendererEvent,
+        request: DesktopChatOpenAppRequest,
+      ) => cb(request);
+      ipcRenderer.on(IPC.DESKTOP_CHAT_OPEN_APP, handler);
+      return () =>
+        ipcRenderer.removeListener(IPC.DESKTOP_CHAT_OPEN_APP, handler);
+    },
   },
 
   /** Workspace identity commands expose intent and status, never credentials. */

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -526,8 +526,9 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
 
     expect(hubSource).toContain("!showTerminalSurface");
     expect(hubSource).toContain("chatFirstSurfacePanel.toggle");
+    expect(hubSource).toContain("sidebarOpen={chatFirstSurfacePanel.open}");
     expect(hubSource).toContain(
-      "onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}",
+      "onToggleSidebar={chatFirstSurfacePanel.toggle}",
     );
     expect(hubSource).toContain(
       "{chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -511,6 +511,9 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       'terminalPreferences.enabled ? "side" : "main"',
     );
     expect(hubSource).toContain('resolution.target.view,\n        "side",');
+    expect(hubSource).toContain(
+      "window.electronAPI?.desktopChat?.onOpenApp(resolveChatFirstOpenApp)",
+    );
     expect(hubSource).toContain("<AppWebview");
     expect(hubSource).toContain("onOpenInBrowser={openChatFirstAppInBrowser}");
     expect(hubSource).toContain(

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -15,7 +15,6 @@ import {
   type CodeAgentsNewSessionExtension,
 } from "@agent-native/code-agents-ui";
 import {
-  ChatFirstSurfacePanelToggle,
   chatFirstSurfaceTabId,
   closeChatFirstSessionWatch,
   emitChatFirstOpenApp,
@@ -136,6 +135,7 @@ import CodeAgentsAppIcon from "./CodeAgentsAppIcon.js";
 import CodeAgentSchedulesPanel from "./CodeAgentSchedulesPanel.js";
 import CreateAppPromptPopover from "./CreateAppPromptPopover.js";
 import DesktopAppChatShell from "./DesktopAppChatShell.js";
+import DesktopChatFirstSurfaceMenu from "./DesktopChatFirstSurfaceMenu.js";
 import DesktopIntegrationsPage from "./DesktopIntegrationsPage.js";
 import DesktopTerminalSurface, {
   type DesktopTerminalPromptRequest,
@@ -2863,10 +2863,15 @@ export default function CodeAgentsHub({
             !chatFirstAllAppsOpen &&
             !scheduledTasksOpen &&
             !chatFirstAppTakesMain ? (
-              <ChatFirstSurfacePanelToggle
-                open={chatFirstSurfacePanel.open}
-                onToggle={chatFirstSurfacePanel.toggle}
-                className="static"
+              <DesktopChatFirstSurfaceMenu
+                sidebarOpen={chatFirstSurfacePanel.open}
+                apps={chatFirstAppItems}
+                onToggleSidebar={chatFirstSurfacePanel.toggle}
+                onOpenApp={(app) =>
+                  openChatFirstApp(app.id, undefined, undefined, "side")
+                }
+                renderAppIcon={renderChatFirstAppIcon}
+                onNewCliTab={handleNewCliTab}
               />
             ) : undefined
           }
@@ -2914,6 +2919,11 @@ export default function CodeAgentsHub({
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
                 onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}
+                apps={chatFirstAppItems}
+                onOpenApp={(app) =>
+                  openChatFirstApp(app.id, undefined, undefined, "side")
+                }
+                renderAppIcon={renderChatFirstAppIcon}
               />
             ) : undefined
           }

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1450,11 +1450,15 @@ export default function CodeAgentsHub({
     setChatFirstBrowserSelection(null);
     setChatFirstNotice(null);
     const unsubscribeApp = subscribeChatFirstOpenApp(resolveChatFirstOpenApp);
+    const unsubscribeDesktopApp =
+      window.electronAPI?.desktopChat?.onOpenApp(resolveChatFirstOpenApp) ??
+      (() => undefined);
     const unsubscribeBrowser = subscribeChatFirstOpenBrowser(
       resolveChatFirstOpenBrowser,
     );
     return () => {
       unsubscribeApp();
+      unsubscribeDesktopApp();
       unsubscribeBrowser();
     };
   }, [

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2918,7 +2918,8 @@ export default function CodeAgentsHub({
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
-                onOpenSidebar={() => setChatFirstSurfacePanelOpen(true)}
+                sidebarOpen={chatFirstSurfacePanel.open}
+                onToggleSidebar={chatFirstSurfacePanel.toggle}
                 apps={chatFirstAppItems}
                 onOpenApp={(app) =>
                   openChatFirstApp(app.id, undefined, undefined, "side")

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import DesktopChatFirstSurfaceMenu from "./DesktopChatFirstSurfaceMenu.js";
+
+describe("DesktopChatFirstSurfaceMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes sidebar, app, and CLI actions from the full-screen menu", async () => {
+    const onToggleSidebar = vi.fn();
+    const onOpenApp = vi.fn();
+    const onNewCliTab = vi.fn();
+
+    act(() => {
+      root.render(
+        <DesktopChatFirstSurfaceMenu
+          apps={[{ id: "mail", name: "Mail" }]}
+          onToggleSidebar={onToggleSidebar}
+          onOpenApp={onOpenApp}
+          onNewCliTab={onNewCliTab}
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Surface options"]',
+    );
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const menuItems = () =>
+      Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      );
+    expect(
+      menuItems().some((item) => item.textContent?.includes("Open sidebar")),
+    ).toBe(true);
+    expect(
+      menuItems().some((item) =>
+        item.textContent?.includes("Open app in sidebar"),
+      ),
+    ).toBe(true);
+    expect(
+      menuItems().some((item) => item.textContent?.includes("New CLI tab")),
+    ).toBe(true);
+
+    const sidebarItem = menuItems().find((item) =>
+      item.textContent?.includes("Open sidebar"),
+    );
+    await act(async () => sidebarItem?.click());
+    expect(onToggleSidebar).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
@@ -1,0 +1,118 @@
+import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@agent-native/toolkit/ui";
+import {
+  IconApps,
+  IconDotsVertical,
+  IconLayoutSidebarRightCollapse,
+  IconMessageCircle,
+  IconTerminal2,
+} from "@tabler/icons-react";
+import type { ReactNode } from "react";
+
+export interface DesktopChatFirstSurfaceMenuProps {
+  sidebarOpen?: boolean;
+  apps?: readonly ChatFirstAppItem[];
+  onToggleSidebar?: () => void;
+  onOpenApp?: (app: ChatFirstAppItem) => void;
+  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
+  onNewCliTab?: () => void;
+  onNewUiTab?: () => void;
+}
+
+export function DesktopChatFirstSurfaceMenuItems({
+  sidebarOpen = false,
+  apps = [],
+  onToggleSidebar,
+  onOpenApp,
+  renderAppIcon,
+  onNewCliTab,
+  onNewUiTab,
+}: DesktopChatFirstSurfaceMenuProps) {
+  const hasAppPicker = apps.length > 0 && Boolean(onOpenApp);
+  if (!onToggleSidebar && !hasAppPicker && !onNewCliTab && !onNewUiTab) {
+    return null;
+  }
+
+  return (
+    <>
+      {onToggleSidebar ? (
+        <DropdownMenuItem onSelect={onToggleSidebar}>
+          <IconLayoutSidebarRightCollapse size={14} className="shrink-0" />
+          {sidebarOpen ? "Hide sidebar" : "Open sidebar"}
+        </DropdownMenuItem>
+      ) : null}
+      {hasAppPicker ? (
+        <>
+          {onToggleSidebar ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <IconApps size={14} className="shrink-0" />
+              Open app in sidebar
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-56">
+              {apps.map((app) => (
+                <DropdownMenuItem
+                  key={app.id}
+                  onSelect={() => onOpenApp?.(app)}
+                >
+                  {renderAppIcon?.(app) ?? (
+                    <IconApps size={14} className="shrink-0" />
+                  )}
+                  <span className="min-w-0 truncate">{app.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </>
+      ) : null}
+      {onNewCliTab || onNewUiTab ? (
+        <>
+          {(onToggleSidebar || hasAppPicker) && <DropdownMenuSeparator />}
+          {onNewCliTab ? (
+            <DropdownMenuItem onSelect={onNewCliTab}>
+              <IconTerminal2 size={14} className="shrink-0" />
+              New CLI tab
+            </DropdownMenuItem>
+          ) : null}
+          {onNewUiTab ? (
+            <DropdownMenuItem onSelect={onNewUiTab}>
+              <IconMessageCircle size={14} className="shrink-0" />
+              New UI tab
+            </DropdownMenuItem>
+          ) : null}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+export default function DesktopChatFirstSurfaceMenu({
+  ...props
+}: DesktopChatFirstSurfaceMenuProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex size-7 items-center justify-center rounded-md border border-border bg-card/95 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Surface options"
+          title="Surface options"
+        >
+          <IconDotsVertical size={15} aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="w-56">
+        <DesktopChatFirstSurfaceMenuItems {...props} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -61,14 +61,15 @@ describe("DesktopTerminalSurface", () => {
     expect(onNewUiTab).toHaveBeenCalledOnce();
   });
 
-  it("opens the shared sidebar from CLI options", async () => {
-    const onOpenSidebar = vi.fn();
+  it("toggles the shared sidebar from CLI options", async () => {
+    const onToggleSidebar = vi.fn();
     act(() => {
       root.render(
         <DesktopTerminalSurface
           agent="codex"
           theme="dark"
-          onOpenSidebar={onOpenSidebar}
+          sidebarOpen
+          onToggleSidebar={onToggleSidebar}
         />,
       );
     });
@@ -88,10 +89,10 @@ describe("DesktopTerminalSurface", () => {
     });
     const item = Array.from(
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
-    ).find((candidate) => candidate.textContent?.includes("Open sidebar"));
+    ).find((candidate) => candidate.textContent?.includes("Hide sidebar"));
 
     expect(item).toBeDefined();
     await act(async () => item?.click());
-    expect(onOpenSidebar).toHaveBeenCalledOnce();
+    expect(onToggleSidebar).toHaveBeenCalledOnce();
   });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -28,7 +28,8 @@ interface DesktopTerminalSurfaceProps {
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
-  onOpenSidebar?: () => void;
+  sidebarOpen?: boolean;
+  onToggleSidebar?: () => void;
   apps?: readonly ChatFirstAppItem[];
   onOpenApp?: DesktopChatFirstSurfaceMenuProps["onOpenApp"];
   renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
@@ -53,7 +54,8 @@ export default function DesktopTerminalSurface({
   submitRequest,
   onPromptSubmitted,
   onNewUiTab,
-  onOpenSidebar,
+  sidebarOpen,
+  onToggleSidebar,
   apps = [],
   onOpenApp,
   renderAppIcon,
@@ -174,11 +176,14 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
-              {onOpenSidebar || (apps.length > 0 && onOpenApp) || onNewUiTab ? (
+              {onToggleSidebar ||
+              (apps.length > 0 && onOpenApp) ||
+              onNewUiTab ? (
                 <>
                   <DesktopChatFirstSurfaceMenuItems
+                    sidebarOpen={sidebarOpen}
                     apps={apps}
-                    onToggleSidebar={onOpenSidebar}
+                    onToggleSidebar={onToggleSidebar}
                     onOpenApp={onOpenApp}
                     renderAppIcon={renderAppIcon}
                     onNewUiTab={onNewUiTab}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -1,3 +1,4 @@
+import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
 import type { AgentTerminalSubmitRequest } from "@agent-native/core/terminal";
 import {
   DropdownMenu,
@@ -6,17 +7,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui";
-import {
-  IconDotsVertical,
-  IconLayoutSidebarRightCollapse,
-  IconMessageCircle,
-  IconPlus,
-  IconX,
-} from "@tabler/icons-react";
+import { IconDotsVertical, IconPlus, IconX } from "@tabler/icons-react";
+import type { ReactNode } from "react";
 import { useCallback, useRef, useState } from "react";
 
 import { type DesktopTerminalAgentId } from "../lib/desktop-terminal-preferences.js";
 import type { RendererTheme } from "../lib/theme.js";
+import {
+  DesktopChatFirstSurfaceMenuItems,
+  type DesktopChatFirstSurfaceMenuProps,
+} from "./DesktopChatFirstSurfaceMenu.js";
 import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 
 export interface DesktopTerminalPromptRequest extends AgentTerminalSubmitRequest {}
@@ -29,6 +29,9 @@ interface DesktopTerminalSurfaceProps {
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
   onOpenSidebar?: () => void;
+  apps?: readonly ChatFirstAppItem[];
+  onOpenApp?: DesktopChatFirstSurfaceMenuProps["onOpenApp"];
+  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
 }
 
 interface DesktopTerminalTab {
@@ -51,6 +54,9 @@ export default function DesktopTerminalSurface({
   onPromptSubmitted,
   onNewUiTab,
   onOpenSidebar,
+  apps = [],
+  onOpenApp,
+  renderAppIcon,
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
@@ -168,24 +174,15 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
-              {onOpenSidebar ? (
+              {onOpenSidebar || (apps.length > 0 && onOpenApp) || onNewUiTab ? (
                 <>
-                  <DropdownMenuItem onSelect={onOpenSidebar}>
-                    <IconLayoutSidebarRightCollapse
-                      size={14}
-                      className="shrink-0"
-                    />
-                    Open sidebar
-                  </DropdownMenuItem>
-                  {onNewUiTab ? <DropdownMenuSeparator /> : null}
-                </>
-              ) : null}
-              {onNewUiTab ? (
-                <>
-                  <DropdownMenuItem onSelect={onNewUiTab}>
-                    <IconMessageCircle size={14} className="shrink-0" />
-                    New UI tab
-                  </DropdownMenuItem>
+                  <DesktopChatFirstSurfaceMenuItems
+                    apps={apps}
+                    onToggleSidebar={onOpenSidebar}
+                    onOpenApp={onOpenApp}
+                    renderAppIcon={renderAppIcon}
+                    onNewUiTab={onNewUiTab}
+                  />
                   <DropdownMenuSeparator />
                 </>
               ) : null}

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -682,6 +682,12 @@ type DesktopOpenRequest = {
   runId?: string;
 };
 
+type DesktopChatOpenAppRequest = {
+  app: string;
+  path?: string;
+  view?: string;
+};
+
 type DesktopShortcutActivationRequest = DesktopOpenRequest & {
   requestId: string;
 };
@@ -1113,6 +1119,7 @@ interface ElectronAPI {
   desktopChat: {
     getApiUrl(appId: string): Promise<string | null>;
     getTerminalInfoUrl(appId?: string): Promise<string | null>;
+    onOpenApp(cb: (request: DesktopChatOpenAppRequest) => void): () => void;
   };
 
   mcpServers: {

--- a/scripts/qa-chat-first-workbench-smoke.ts
+++ b/scripts/qa-chat-first-workbench-smoke.ts
@@ -925,28 +925,44 @@ async function runElectronSmoke(): Promise<void> {
       0,
       "Electron launcher should be closed by default",
     );
-    assert.equal(
-      empty.toggle,
-      1,
-      "Electron empty full-screen chat should offer a right-surface toggle",
-    );
     assert.ok(
       empty.mainWidth > 0,
       "Electron Agent content should be measurable",
     );
     assert.equal(
-      await page
-        .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
-        .count(),
+      await page.getByRole("button", { name: "Surface options" }).count(),
       1,
-      "Electron empty chat should expose the central surface toggle",
+      "Electron empty chat should expose surface options",
     );
     assert.ok(
       empty.composerRight - empty.composerLeft <= 752,
       "Electron full-page composer should be no wider than 750px",
     );
+    await page.getByRole("button", { name: "Surface options" }).click();
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "Open sidebar", exact: true })
+        .count(),
+      1,
+      "Electron surface options should open the shared sidebar",
+    );
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "Open app in sidebar", exact: true })
+        .count(),
+      1,
+      "Electron surface options should expose the app picker",
+    );
+    assert.equal(
+      await page
+        .getByRole("menuitem", { name: "New CLI tab", exact: true })
+        .count(),
+      1,
+      "Electron surface options should expose a new CLI tab",
+    );
+    await saveElectronScreenshot(electronApp, "electron-surface-options");
     await page
-      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .getByRole("menuitem", { name: "Open sidebar", exact: true })
       .click();
     await page
       .locator("[data-chat-first-surface-panel]")
@@ -960,8 +976,9 @@ async function runElectronSmoke(): Promise<void> {
       emptySidebar.appOptions >= 5,
       "Electron empty chat should expose the app picker from its sidebar",
     );
+    await page.getByRole("button", { name: "Surface options" }).click();
     await page
-      .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
+      .getByRole("menuitem", { name: "Hide sidebar", exact: true })
       .click();
     await page
       .locator("[data-chat-first-surface-panel]")
@@ -1046,16 +1063,9 @@ async function runElectronSmoke(): Promise<void> {
       electronApp,
     );
     assert.equal(
-      active.toggle,
+      await page.getByRole("button", { name: "Surface options" }).count(),
       1,
-      "Electron active chat should expose the surface toggle",
-    );
-    assert.equal(
-      await page
-        .locator(".code-agents-main-toolbar [data-chat-first-surface-toggle]")
-        .count(),
-      1,
-      "Electron active chat should expose the central surface toggle",
+      "Electron active chat should expose surface options",
     );
     assert.ok(
       active.composerRight - active.composerLeft <= 752,
@@ -1110,18 +1120,24 @@ async function runElectronSmoke(): Promise<void> {
       sideApp.chatWidth < active.chatWidth - 1,
       "Electron agent-opened apps should leave the full-page chat visible beside them",
     );
-    await page.getByRole("button", { name: "Hide side surface" }).click();
+    await page.getByRole("button", { name: "Surface options" }).click();
+    await page
+      .getByRole("menuitem", { name: "Hide sidebar", exact: true })
+      .click();
+    await page.keyboard.press("Escape");
     await page.locator("[data-chat-first-surface-panel]").waitFor({
       state: "detached",
     });
 
     await installElectronAppCreationSmokeMock(electronApp);
-    const expandRailButton = page.getByRole("button", {
-      name: "Expand rail",
-      exact: true,
-    });
-    if (await expandRailButton.count()) {
-      await expandRailButton.click();
+    const collapseRailButton = page.locator("[data-chat-first-rail-collapse]");
+    if (await collapseRailButton.count()) {
+      await collapseRailButton.evaluate((button) =>
+        (button as HTMLButtonElement).click(),
+      );
+      await page
+        .locator(".code-agents-rail:not(.code-agents-rail--collapsed)")
+        .waitFor({ state: "visible" });
     }
     const createAppButton = page.locator(
       '[data-chat-first-apps-rail] button[aria-label="Create app"]',


### PR DESCRIPTION
## Summary
- expose a loopback, bearer-authenticated desktop MCP bridge to CLI terminal sessions
- inject the bridge into Claude Code and Codex without changing user config files
- route `open_app` through the existing chat-first app resolver so CLI and UI share sidebar tabs and app context
- shell-quote trusted PTY arguments and avoid logging MCP credentials

## Validation
- `pnpm --filter @agent-native/desktop-app test`
- `pnpm --filter @agent-native/desktop-app typecheck`
- `pnpm --filter @agent-native/desktop-app build`
- `pnpm --filter @agent-native/core exec vitest run src/terminal/pty-server.spec.ts`
- `pnpm guards`
- packaged runner smoke: `start-cancel-resume-ok`
