### PR TITLE
fix: page signup canary failures in GitHub Actions

### DIFF
--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -376,7 +376,7 @@ jobs:
         id: signup
         run: pnpm e2e:signup
       - name: Page signup health on-call
-        if: ${{ steps.signup.outcome == 'failure' }}
+        if: ${{ failure() && steps.signup.outcome == 'failure' }}
         run: |
           set -euo pipefail
           if [ -z "${PAGERDUTY_ROUTING_KEY:-}" ]; then


### PR DESCRIPTION
## Summary

- Allow the dedicated Agent-Native signup PagerDuty step to run after the signup step fails.
- Keep paging scoped to signup failures, while avoiding pages for typecheck failures or cancellations.

## Validation

- `pnpm guard:beta-e2e-suite`
- `git diff --check`

## Operational setup

- GitHub secrets `MAILOSAUR_API_KEY`, `MAILOSAUR_SERVER_ID`, and `PAGERDUTY_ROUTING_KEY` are provisioned without exposing values.
- PagerDuty uses a dedicated Agent-Native signup service, escalation policy, and Events API integration.
- The scheduled lane is ready to run against the full beta fleet with unique Mailosaur addresses.

Known production handoff from the signup canary investigation: chat production sends new-user magic links to the Starter host, and CRM production returns HTTP 500 from the magic-link endpoint. These remain production configuration and runtime investigations outside this workflow-condition fix.