### PR TITLE
fix: keep template roots on canonical auth shell

### DIFF
--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -650,9 +650,11 @@ export default (event) =>
       {},
       {},
     );
-    expect(await rootResponse.text()).toContain(
-      "data-agent-native-auth-redirect",
-    );
+    const rootHtml = await rootResponse.text();
+    const handoff = rootHtml.indexOf("data-agent-native-auth-redirect");
+    expect(handoff).toBeGreaterThan(rootHtml.indexOf("<head>"));
+    expect(handoff).toBeLessThan(rootHtml.indexOf("</head>"));
+    expect(handoff).toBeLessThan(rootHtml.indexOf("<body>"));
 
     const appResponse = await worker.fetch(
       new Request("https://app.test/home"),

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -52,6 +52,10 @@ import {
 } from "../server/agent-chat/recurring-jobs-runtime.js";
 import { normalizeAppBasePath } from "../server/app-base-path.js";
 import {
+  frameworkSessionHintCookieName,
+  resolveAuthCookieNamespace,
+} from "../server/cookie-namespace.js";
+import {
   DEFAULT_SPECULATION_RULES_PATH,
   resolveSsrCacheHeaders,
   resolveSsrCacheKeyHeaders,
@@ -910,7 +914,11 @@ export function generateWorkerEntry(
   // deployment-wide SSR cache policy is baked in from this build's env.
   const ssrCacheHeaders = resolveSsrCacheHeaders();
   const ssrCacheKeyHeaders = resolveSsrCacheKeyHeaders();
-  const ssrAuthRedirectScript = getSsrAuthRedirectScript();
+  const ssrAuthRedirectScript = getSsrAuthRedirectScript(
+    frameworkSessionHintCookieName(
+      resolveAuthCookieNamespace().frameworkCookieName,
+    ),
+  );
   const routeImports: string[] = [];
   const routeRegistrations: string[] = [];
 

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1414,6 +1414,12 @@ describe("server/auth", () => {
       expect(setCookie).toContain(
         `${SESSION_HINT_COOKIE}=; Max-Age=0; Domain=.example.com`,
       );
+      expect(setCookie).toContain(
+        `${SESSION_HINT_COOKIE}=; Max-Age=0; Path=/; Secure; Partitioned; SameSite=None`,
+      );
+      expect(setCookie).toContain(
+        `${SESSION_HINT_COOKIE}=; Max-Age=0; Domain=.example.com; Path=/; Secure; Partitioned; SameSite=None`,
+      );
       expect(setCookie).toContain("HttpOnly");
       expect(setCookie).toContain("SameSite=None");
       expect(setCookie).toContain("Secure");
@@ -3038,6 +3044,75 @@ describe("server/auth", () => {
       expect(handoff).toBeLessThan(html.indexOf("</head>"));
       expect(handoff).toBeLessThan(html.indexOf("<body>"));
       expect(getSession).not.toHaveBeenCalled();
+    });
+
+    it("keeps the cached root auth document independent of request host", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml:
+          "<!doctype html><HTML><HEAD><title>QA login</title></HEAD><BODY>QA login</BODY></HTML>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const first = await guard(
+        createMockEvent({
+          path: "/",
+          headers: { host: "first.example", "x-forwarded-proto": "https" },
+        }),
+      );
+      const second = await guard(
+        createMockEvent({
+          path: "/",
+          headers: { host: "second.example", "x-forwarded-proto": "https" },
+        }),
+      );
+
+      const firstHtml = await (first as Response).text();
+      const secondHtml = await (second as Response).text();
+      expect(firstHtml).toBe(secondHtml);
+      const handoff = firstHtml.indexOf("data-agent-native-auth-redirect");
+      expect(handoff).toBeGreaterThan(firstHtml.indexOf("<HEAD>"));
+      expect(handoff).toBeLessThan(firstHtml.indexOf("</HEAD>"));
+      expect(firstHtml).not.toContain("first.example");
+      expect(firstHtml).not.toContain("second.example");
+    });
+
+    it("normalizes fragment login HTML before adding the root handoff", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml: '<form id="qa-login">QA login</form>',
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(createMockEvent({ path: "/" }));
+
+      expect(result).toBeInstanceOf(Response);
+      const html = await (result as Response).text();
+      const handoff = html.indexOf("data-agent-native-auth-redirect");
+      expect(handoff).toBeGreaterThan(html.indexOf("<head>"));
+      expect(handoff).toBeLessThan(html.indexOf("</head>"));
+      expect(handoff).toBeLessThan(html.indexOf("<body>"));
+      expect(html).toContain('<form id="qa-login">QA login</form>');
     });
 
     it("promotes omitted verification for explicitly trusted BYOA providers", async () => {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1390,7 +1390,7 @@ describe("server/auth", () => {
         describeDbError: (error: unknown) => String(error),
       }));
 
-      const { autoMountAuth } = await import("./auth.js");
+      const { autoMountAuth, SESSION_HINT_COOKIE } = await import("./auth.js");
       const app = createMockApp();
       await autoMountAuth(app);
 
@@ -1411,6 +1411,9 @@ describe("server/auth", () => {
         "agent-native-first-run=; Max-Age=0; Domain=.example.com",
       );
       expect(setCookie).toContain("_auth_disabled_opt_out=1");
+      expect(setCookie).toContain(
+        `${SESSION_HINT_COOKIE}=; Max-Age=0; Domain=.example.com`,
+      );
       expect(setCookie).toContain("HttpOnly");
       expect(setCookie).toContain("SameSite=None");
       expect(setCookie).toContain("Secure");
@@ -3005,6 +3008,38 @@ describe("server/auth", () => {
       }
     });
 
+    it("serves the public home with the same cached auth document and head handoff", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const getSession = vi.fn(async () => null);
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession,
+        loginHtml:
+          "<!doctype html><html><head><title>QA login</title></head><body>QA login</body></html>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(createMockEvent({ path: "/" }));
+
+      expect(result).toBeInstanceOf(Response);
+      const response = result as Response;
+      expectLoginHtmlCacheHeaders(response);
+      const html = await response.text();
+      const handoff = html.indexOf("data-agent-native-auth-redirect");
+      expect(handoff).toBeGreaterThan(html.indexOf("<head>"));
+      expect(handoff).toBeLessThan(html.indexOf("</head>"));
+      expect(handoff).toBeLessThan(html.indexOf("<body>"));
+      expect(getSession).not.toHaveBeenCalled();
+    });
+
     it("promotes omitted verification for explicitly trusted BYOA providers", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;
@@ -3170,7 +3205,7 @@ describe("server/auth", () => {
 
       const result = await guard(
         createMockEvent({
-          path: "/",
+          path: "/home",
           headers: { host: "dispatch.agent-native.com" },
         }),
       );
@@ -4070,7 +4105,7 @@ describe("server/auth", () => {
         getBetterAuthSync: vi.fn(() => undefined),
       }));
 
-      const { autoMountAuth } = await import("./auth.js");
+      const { autoMountAuth, SESSION_HINT_COOKIE } = await import("./auth.js");
       const app = createMockApp();
       await autoMountAuth(app);
 
@@ -4103,6 +4138,9 @@ describe("server/auth", () => {
       });
       expect(event.res.headers.get("set-cookie")).toContain(
         "session-token-abc",
+      );
+      expect(event.res.headers.get("set-cookie")).toContain(
+        `${SESSION_HINT_COOKIE}=1`,
       );
     });
 

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -4701,6 +4701,48 @@ describe("server/auth", () => {
       );
     });
 
+    it("clears the session hint on direct Better Auth sign-out", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(
+            async () => new Response(JSON.stringify({ ok: true })),
+          ),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth, SESSION_HINT_COOKIE } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const baHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/ba",
+      )?.[1];
+      const response = await baHandler(
+        createJsonPostEvent(
+          "/_agent-native/auth/ba/sign-out",
+          {},
+          { cookie: `${SESSION_HINT_COOKIE}=1` },
+          "https://localhost",
+        ),
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.headers.get("set-cookie")).toContain(
+        `${SESSION_HINT_COOKIE}=; Max-Age=0; Path=/; Secure; Partitioned; SameSite=None`,
+      );
+    });
+
     it("carries browser signup attribution through the direct Better Auth handler", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -5415,6 +5415,26 @@ async function mountBetterAuthRoutes(
         typeof (response as any).headers?.get === "function";
 
       if (
+        isSignOut &&
+        isResponse &&
+        (response as Response).status >= 200 &&
+        (response as Response).status < 400
+      ) {
+        const stagedHeaders = event.res?.headers;
+        const stagedCookieCount = stagedHeaders
+          ? getSetCookieHeaders(stagedHeaders).length
+          : 0;
+        clearFrameworkSessionHintCookies(event);
+        if (stagedHeaders) {
+          for (const cookie of getSetCookieHeaders(stagedHeaders).slice(
+            stagedCookieCount,
+          )) {
+            (response as Response).headers.append("set-cookie", cookie);
+          }
+        }
+      }
+
+      if (
         isResponse &&
         (response as Response).status >= 200 &&
         (response as Response).status < 400 &&

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -123,6 +123,7 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
   withAgentNativeSocialImageCacheBuster,
 } from "../shared/social-meta.js";
+import { getSsrAuthRedirectScript } from "../shared/ssr-auth-redirect.js";
 import {
   normalizeWorkspaceAppAudience,
   workspaceAppAudienceFromEnv,
@@ -161,7 +162,10 @@ import {
   verifyBuilderConnectTokenAndGetOwner,
   verifyBuilderPreviewRelayStateForCallback,
 } from "./builder-browser.js";
-import { resolveAuthCookieNamespace } from "./cookie-namespace.js";
+import {
+  frameworkSessionHintCookieName,
+  resolveAuthCookieNamespace,
+} from "./cookie-namespace.js";
 import {
   getAllowedCorsOrigin,
   readCorsAllowedOrigins,
@@ -346,6 +350,11 @@ export interface AuthOptions {
    */
   loginHtml?: string;
   /**
+   * Serve the configured auth document at the public root. Defaults to true
+   * when the auth plugin provides marketing or custom login content.
+   */
+  rootAuth?: boolean;
+  /**
    * Hide email/password forms on the built-in login page and show only the
    * Google sign-in button. Use this for templates (mail, calendar) where
    * Google connection is required anyway. Has no effect when `loginHtml`
@@ -461,6 +470,7 @@ export function getCookieDomain(): string | undefined {
 }
 
 export const COOKIE_NAME = AUTH_COOKIE_NAMESPACE.frameworkCookieName;
+export const SESSION_HINT_COOKIE = frameworkSessionHintCookieName(COOKIE_NAME);
 export const BETTER_AUTH_COOKIE_PREFIX =
   AUTH_COOKIE_NAMESPACE.betterAuthCookiePrefix;
 const AUTH_DISABLED_OPT_OUT_COOKIE = `${COOKIE_NAME}_auth_disabled_opt_out`;
@@ -568,7 +578,14 @@ function deleteCookieFromEveryScope(event: H3Event, name: string): void {
   }
 }
 
+export function clearFrameworkSessionHintCookies(event: H3Event): void {
+  for (const name of frameworkSessionCookieNamesToClear()) {
+    deleteCookieFromEveryScope(event, frameworkSessionHintCookieName(name));
+  }
+}
+
 export function clearFrameworkSessionCookies(event: H3Event): void {
+  clearFrameworkSessionHintCookies(event);
   for (const name of frameworkSessionCookieNamesToClear()) {
     deleteCookieFromEveryScope(event, name);
   }
@@ -1582,6 +1599,7 @@ interface AuthGuardConfig {
   loginHtml: string;
   getLoginHtml?: (event: H3Event, rawPath: string) => string;
   authMode?: OnboardingHtmlOptions["authMode"];
+  rootAuth: boolean;
   publicPaths: string[];
   publicCorsPaths: string[];
   workspaceAppAudience: WorkspaceAppAudience;
@@ -1736,10 +1754,20 @@ function getAuthOnboardingHtml(
 function getOnboardingLoginHtmlConfig(
   options: AuthOptions,
   authMode?: OnboardingHtmlOptions["authMode"],
-): Pick<AuthGuardConfig, "loginHtml" | "getLoginHtml" | "authMode"> {
-  if (options.loginHtml) return { loginHtml: options.loginHtml, authMode };
+): Pick<
+  AuthGuardConfig,
+  "loginHtml" | "getLoginHtml" | "authMode" | "rootAuth"
+> {
+  if (options.loginHtml) {
+    return {
+      loginHtml: options.loginHtml,
+      authMode,
+      rootAuth: options.rootAuth ?? true,
+    };
+  }
   return {
     authMode,
+    rootAuth: options.rootAuth ?? Boolean(options.marketing),
     loginHtml: getAuthOnboardingHtml(options, undefined, undefined, authMode),
     getLoginHtml: (event, rawPath) =>
       getAuthOnboardingHtml(options, event, rawPath, authMode),
@@ -2974,26 +3002,41 @@ function injectLoginSocialImageMeta(loginHtml: string, event: H3Event): string {
   );
 }
 
-function loginHtmlResponse(loginHtml: string, event: H3Event): Response {
-  return new Response(
-    injectAnalyticsIntoHtml(
-      injectLoginSocialImageMeta(injectBetaOptOutPersistence(loginHtml), event),
-    ),
-    {
-      status: 200,
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        // The sign-in document is part of the public server shell. Keep it on the
-        // same long-fresh/long-SWR CDN policy as React Router SSR so hosted
-        // template roots do not invoke origin just to render anonymous login UI.
-        // The login markup reflects deployment-wide auth configuration; the
-        // analytics script is public build configuration, not user/session
-        // state. Never vary this per request by cookie or session.
-        ...resolveSsrCacheHeaders(),
-        "X-Robots-Tag": "noindex, nofollow",
-      },
-    },
+function injectHeadScript(html: string, script: string): string {
+  const headCloseIdx = html.indexOf("</head>");
+  if (headCloseIdx === -1) return html;
+  return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
+}
+
+function loginHtmlResponse(
+  loginHtml: string,
+  event: H3Event,
+  options: { includeRootAuthRedirect?: boolean } = {},
+): Response {
+  let html = injectLoginSocialImageMeta(
+    injectBetaOptOutPersistence(loginHtml),
+    event,
   );
+  if (options.includeRootAuthRedirect) {
+    html = injectHeadScript(
+      html,
+      getSsrAuthRedirectScript(SESSION_HINT_COOKIE),
+    );
+  }
+  return new Response(injectAnalyticsIntoHtml(html), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // The sign-in document is part of the public server shell. Keep it on the
+      // same long-fresh/long-SWR CDN policy as React Router SSR so hosted
+      // template roots do not invoke origin just to render anonymous login UI.
+      // The login markup reflects deployment-wide auth configuration; the
+      // analytics script is public build configuration, not user/session
+      // state. Never vary this per request by cookie or session.
+      ...resolveSsrCacheHeaders(),
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+  });
 }
 
 function isHtmlDocumentRequest(event: H3Event, pathname: string): boolean {
@@ -3270,6 +3313,16 @@ function createAuthGuardFn(
     // branch below; this bypass is for the upload path only.
     if (p === "/_agent-native/recap-image") {
       return;
+    }
+
+    // The public home uses the same server-rendered auth surface as the
+    // framework sign-in entry. This is unconditional and does not inspect the
+    // request session, so the cached root document stays identical for every
+    // visitor; the head handoff handles existing sessions in the browser.
+    if (config.rootAuth && p === "/" && isHtmlDocumentRequest(event, p)) {
+      return loginHtmlResponse(loginHtml, event, {
+        includeRootAuthRedirect: true,
+      });
     }
 
     // Force-sign-in entrypoint. Templates send viewers from public pages
@@ -4062,6 +4115,16 @@ function clearFirstRunOnboardingCookie(event: H3Event): void {
   });
 }
 
+function setFrameworkSessionHintCookie(event: H3Event): void {
+  setCookie(event, SESSION_HINT_COOKIE, "1", {
+    ...crossSiteCookieAttrs(event),
+    ...cookieDomainAttrs(),
+    httpOnly: false,
+    path: "/",
+    maxAge: sessionMaxAge,
+  });
+}
+
 export function setFrameworkSessionCookie(event: H3Event, token: string): void {
   clearFrameworkSessionCookies(event);
   setCookie(event, COOKIE_NAME, token, {
@@ -4071,6 +4134,7 @@ export function setFrameworkSessionCookie(event: H3Event, token: string): void {
     path: "/",
     maxAge: sessionMaxAge,
   });
+  setFrameworkSessionHintCookie(event);
 }
 
 /**
@@ -5301,6 +5365,26 @@ async function mountBetterAuthRoutes(
         typeof (response as any).status === "number" &&
         typeof (response as any).headers?.get === "function";
 
+      if (
+        isResponse &&
+        (response as Response).status >= 200 &&
+        (response as Response).status < 400 &&
+        extractSessionTokenFromSetCookies(response as Response)
+      ) {
+        const stagedHeaders = event.res?.headers;
+        const stagedCookieCount = stagedHeaders
+          ? getSetCookieHeaders(stagedHeaders).length
+          : 0;
+        setFrameworkSessionHintCookie(event);
+        if (stagedHeaders) {
+          for (const cookie of getSetCookieHeaders(stagedHeaders).slice(
+            stagedCookieCount,
+          )) {
+            (response as Response).headers.append("set-cookie", cookie);
+          }
+        }
+      }
+
       if (isMagicLinkVerification && isResponse) {
         logMagicLinkVerificationResponse(
           event,
@@ -5873,6 +5957,8 @@ async function mountBetterAuthRoutes(
         return { error: "Method not allowed" };
       }
       const session = await getSession(event);
+      if (session) setFrameworkSessionHintCookie(event);
+      else clearFrameworkSessionHintCookies(event);
       return session ?? { error: "Not authenticated" };
     }),
   );
@@ -6075,6 +6161,8 @@ function mountAuthFallbackRoutes(app: H3App): void {
         return { error: "Method not allowed" };
       }
       const session = await getSession(event);
+      if (session) setFrameworkSessionHintCookie(event);
+      else clearFrameworkSessionHintCookies(event);
       return session ?? { error: "Not authenticated" };
     }),
   );
@@ -6132,6 +6220,11 @@ export async function autoMountAuth(
         );
         _authGuardConfig.loginHtml = loginHtmlConfig.loginHtml;
         _authGuardConfig.getLoginHtml = loginHtmlConfig.getLoginHtml;
+      }
+      if (options.rootAuth !== undefined) {
+        _authGuardConfig.rootAuth = options.rootAuth;
+      } else if (options.loginHtml || options.marketing) {
+        _authGuardConfig.rootAuth = true;
       }
       if (options.publicPaths) {
         _authGuardConfig.publicPaths = [
@@ -6237,6 +6330,7 @@ export async function autoMountAuth(
         : {
             getLoginHtml: () => getCustomAuthRequiredHtml(),
           }),
+      rootAuth: options.rootAuth ?? Boolean(options.loginHtml),
       publicPaths,
       publicCorsPaths: options.publicCorsPaths ?? [],
       workspaceAppAudience,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -569,18 +569,26 @@ async function enrichLegacySessionIdentity(
   };
 }
 
-function deleteCookieFromEveryScope(event: H3Event, name: string): void {
+function deleteCookieFromEveryScope(
+  event: H3Event,
+  name: string,
+  attributes: Parameters<typeof deleteCookie>[2] = {},
+): void {
   // Clear host-only cookies first. Then clear any configured domain scope so
   // stale shared cookies stop shadowing isolated app sessions.
-  deleteCookie(event, name, { path: "/" });
+  deleteCookie(event, name, { ...attributes, path: "/" });
   for (const domain of AUTH_COOKIE_NAMESPACE.frameworkCookieDomainsToClear) {
-    deleteCookie(event, name, { path: "/", domain });
+    deleteCookie(event, name, { ...attributes, path: "/", domain });
   }
 }
 
 export function clearFrameworkSessionHintCookies(event: H3Event): void {
   for (const name of frameworkSessionCookieNamesToClear()) {
-    deleteCookieFromEveryScope(event, frameworkSessionHintCookieName(name));
+    deleteCookieFromEveryScope(
+      event,
+      frameworkSessionHintCookieName(name),
+      crossSiteCookieAttrs(event),
+    );
   }
 }
 
@@ -2954,16 +2962,22 @@ function desktopMagicLinkLandingPage(
   });
 }
 
-function injectLoginSocialImageMeta(loginHtml: string, event: H3Event): string {
-  const headCloseIdx = loginHtml.indexOf("</head>");
-  if (headCloseIdx === -1) return loginHtml;
+function injectLoginSocialImageMeta(
+  loginHtml: string,
+  event?: H3Event,
+): string {
+  const headCloseMatch = /<\/head\s*>/i.exec(loginHtml);
+  if (!headCloseMatch || headCloseMatch.index === undefined) return loginHtml;
+  const headCloseIdx = headCloseMatch.index;
 
   const hasAnySocialImage =
     LOGIN_OG_IMAGE_META_RE.test(loginHtml) ||
     LOGIN_TWITTER_IMAGE_META_RE.test(loginHtml);
   const imageUrl = escapeHtmlAttr(
     withAgentNativeSocialImageCacheBuster(
-      getAppUrl(event, AGENT_NATIVE_SOCIAL_IMAGE_PATH),
+      event
+        ? getAppUrl(event, AGENT_NATIVE_SOCIAL_IMAGE_PATH)
+        : `${getAppBasePath()}${AGENT_NATIVE_SOCIAL_IMAGE_PATH}`,
     ),
   );
   const tags: string[] = [];
@@ -3003,19 +3017,52 @@ function injectLoginSocialImageMeta(loginHtml: string, event: H3Event): string {
 }
 
 function injectHeadScript(html: string, script: string): string {
-  const headCloseIdx = html.indexOf("</head>");
-  if (headCloseIdx === -1) return html;
-  return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
+  const headCloseMatch = /<\/head\s*>/i.exec(html);
+  if (headCloseMatch?.index !== undefined) {
+    return (
+      html.slice(0, headCloseMatch.index) +
+      script +
+      html.slice(headCloseMatch.index)
+    );
+  }
+
+  const headOpenMatch = /<head\b[^>]*>/i.exec(html);
+  if (headOpenMatch?.index !== undefined) {
+    const headEnd = headOpenMatch.index + headOpenMatch[0].length;
+    return html.slice(0, headEnd) + script + html.slice(headEnd);
+  }
+
+  const bodyOpenMatch = /<body\b[^>]*>/i.exec(html);
+  if (bodyOpenMatch?.index !== undefined) {
+    return (
+      html.slice(0, bodyOpenMatch.index) +
+      `<head>${script}</head>` +
+      html.slice(bodyOpenMatch.index)
+    );
+  }
+
+  const htmlOpenMatch = /<html\b[^>]*>/i.exec(html);
+  if (htmlOpenMatch?.index !== undefined) {
+    const htmlEnd = htmlOpenMatch.index + htmlOpenMatch[0].length;
+    return (
+      html.slice(0, htmlEnd) + `<head>${script}</head>` + html.slice(htmlEnd)
+    );
+  }
+
+  return `<!doctype html><html><head>${script}</head><body>${html}</body></html>`;
 }
 
 function loginHtmlResponse(
   loginHtml: string,
   event: H3Event,
-  options: { includeRootAuthRedirect?: boolean } = {},
+  options: {
+    includeRootAuthRedirect?: boolean;
+    requestIndependent?: boolean;
+  } = {},
 ): Response {
   let html = injectLoginSocialImageMeta(
     injectBetaOptOutPersistence(loginHtml),
-    event,
+    options.requestIndependent ? undefined : event,
   );
   if (options.includeRootAuthRedirect) {
     html = injectHeadScript(
@@ -3064,7 +3111,6 @@ function createAuthGuardFn(
     const url = event.node?.req?.url ?? event.path ?? "/";
     const queryStart = url.indexOf("?");
     const rawPath = queryStart >= 0 ? url.slice(0, queryStart) : url;
-    const loginHtml = config.getLoginHtml?.(event, rawPath) ?? config.loginHtml;
     const p = stripAppBasePath(rawPath);
     const normalizedUrl = queryStart >= 0 ? `${p}${url.slice(queryStart)}` : p;
     const callbackRelay = workspaceOAuthCallbackRelayResponse(event);
@@ -3320,10 +3366,13 @@ function createAuthGuardFn(
     // request session, so the cached root document stays identical for every
     // visitor; the head handoff handles existing sessions in the browser.
     if (config.rootAuth && p === "/" && isHtmlDocumentRequest(event, p)) {
-      return loginHtmlResponse(loginHtml, event, {
+      return loginHtmlResponse(config.loginHtml, event, {
         includeRootAuthRedirect: true,
+        requestIndependent: true,
       });
     }
+
+    const loginHtml = config.getLoginHtml?.(event, rawPath) ?? config.loginHtml;
 
     // Force-sign-in entrypoint. Templates send viewers from public pages
     // (share links, embeds) here with a `?return=<path>` query. The clean

--- a/packages/core/src/server/cookie-namespace.ts
+++ b/packages/core/src/server/cookie-namespace.ts
@@ -19,6 +19,12 @@ export interface AuthCookieNamespace {
   isFirstPartyCookieDomain: boolean;
 }
 
+export function frameworkSessionHintCookieName(
+  sessionCookieName: string,
+): string {
+  return `${sessionCookieName}_hint`;
+}
+
 export function resolveAuthCookieNamespace(
   env: Record<string, string | undefined> = process.env,
   cwd = process.cwd(),

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -272,7 +272,11 @@ describe("createH3SSRHandler", () => {
     expect(response.headers.get("speculation-rules")).toBe(
       DEFAULT_SPECULATION_RULES_HEADER,
     );
-    expect(await response.text()).toContain("data-agent-native-auth-redirect");
+    const html = await response.text();
+    const handoff = html.indexOf("data-agent-native-auth-redirect");
+    expect(handoff).toBeGreaterThan(html.indexOf("<head>"));
+    expect(handoff).toBeLessThan(html.indexOf("</head>"));
+    expect(handoff).toBeLessThan(html.indexOf("<body>"));
   });
 
   it("only adds the auth handoff to the public root shell", async () => {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -40,6 +40,10 @@ import {
 } from "./app-base-path.js";
 import { getAppOriginClientConfigScript } from "./app-origin-config.js";
 import { captureError } from "./capture-error.js";
+import {
+  frameworkSessionHintCookieName,
+  resolveAuthCookieNamespace,
+} from "./cookie-namespace.js";
 import { getPostHogClientConfigScript } from "./posthog-config.js";
 import { runWithRequestContext } from "./request-context.js";
 import {
@@ -427,7 +431,13 @@ async function rewriteMountedResponse(
       getPostHogClientConfigScript(),
       getRealtimeClientConfigScript(),
       getAppOriginClientConfigScript(),
-      pathname === "/" ? getSsrAuthRedirectScript() : null,
+      pathname === "/"
+        ? getSsrAuthRedirectScript(
+            frameworkSessionHintCookieName(
+              resolveAuthCookieNamespace().frameworkCookieName,
+            ),
+          )
+        : null,
     ]
       .filter(Boolean)
       .join("") || null;

--- a/packages/core/src/shared/ssr-auth-redirect.spec.ts
+++ b/packages/core/src/shared/ssr-auth-redirect.spec.ts
@@ -2,13 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { getSsrAuthRedirectScript } from "./ssr-auth-redirect.js";
 
-function scriptBody(): string {
-  const script = getSsrAuthRedirectScript();
+function scriptBody(sessionHintCookieName?: string): string {
+  const script = getSsrAuthRedirectScript(sessionHintCookieName);
   return script.slice(script.indexOf(">") + 1, script.lastIndexOf("</script>"));
 }
 
 function runScript({
   session,
+  cookie = "",
+  sessionHintCookieName,
   pathname = "/",
   search = "",
   hash = "",
@@ -17,6 +19,8 @@ function runScript({
   homeFollowedStatus,
 }: {
   session: Record<string, unknown> | null;
+  cookie?: string;
+  sessionHintCookieName?: string;
   pathname?: string;
   search?: string;
   hash?: string;
@@ -44,12 +48,10 @@ function runScript({
       replace(value: string): void;
     };
   };
-  const fetch = async (_input: unknown, init?: { redirect?: string }) => {
+  const document = { cookie };
+  const fetch = async (_input: unknown) => {
     fetchCount += 1;
     if (fetchCount > 1) {
-      if (homeStatus === 302 && init?.redirect === "manual") {
-        return { ok: false, status: 0, type: "opaqueredirect" } as Response;
-      }
       const status = homeFollowedStatus ?? homeStatus;
       return { ok: status >= 200 && status < 400, status } as Response;
     }
@@ -59,12 +61,42 @@ function runScript({
     } as Response;
   };
 
-  new Function("window", "fetch", scriptBody())(window, fetch);
+  new Function(
+    "window",
+    "document",
+    "fetch",
+    scriptBody(sessionHintCookieName),
+  )(window, document, fetch);
 
-  return Object.assign(result, { window });
+  return Object.assign(result, { window, fetchCount });
 }
 
 describe("getSsrAuthRedirectScript", () => {
+  it("redirects synchronously from the head when the session hint is present", () => {
+    const result = runScript({
+      session: null,
+      cookie: "analytics=1; an_session_slides_hint=1",
+      sessionHintCookieName: "an_session_slides_hint",
+      pathname: "/docs/",
+      search: "?from=hero",
+      hash: "#start",
+    });
+
+    expect(result.redirectedTo).toBe("/docs/home?from=hero#start");
+    expect(result.fetchCount).toBe(0);
+  });
+
+  it("requires an exact readable hint cookie", () => {
+    const result = runScript({
+      session: null,
+      cookie: "an_session_slides_hint_extra=1; an_session_slides_hint=0",
+      sessionHintCookieName: "an_session_slides_hint",
+    });
+
+    expect(result.redirectedTo).toBeNull();
+    expect(result.fetchCount).toBe(1);
+  });
+
   it("redirects an authenticated visitor to the mounted app home", async () => {
     const result = runScript({
       session: { email: "person@example.test" },
@@ -118,6 +150,7 @@ describe("getSsrAuthRedirectScript", () => {
     expect(script).toContain('cache: "no-store"');
     expect(script).toContain("/_agent-native/auth/session");
     expect(script).toContain('method: "HEAD"');
+    expect(script).toContain("document.cookie");
     expect(script).not.toContain('redirect: "manual"');
   });
 });

--- a/packages/core/src/shared/ssr-auth-redirect.ts
+++ b/packages/core/src/shared/ssr-auth-redirect.ts
@@ -5,13 +5,31 @@
  * browser owns the session check and redirect so the shell stays anonymous and
  * safe for a shared CDN cache.
  */
-export function getSsrAuthRedirectScript(): string {
+export function getSsrAuthRedirectScript(
+  sessionHintCookieName = "an_session_hint",
+): string {
   return `<script data-agent-native-auth-redirect>(function () {
   if (window.__agentNativeAuthRedirectStarted) return;
   window.__agentNativeAuthRedirectStarted = true;
   var root = window.location.pathname.replace(/\\/+$/, "");
-  var sessionPath = (root || "") + "/_agent-native/auth/session";
   var homePath = (root || "") + "/home";
+  var sessionHintCookieName = ${JSON.stringify(sessionHintCookieName)};
+  function hasSessionHint() {
+    if (typeof document !== "object" || typeof document.cookie !== "string") return false;
+    var prefix = sessionHintCookieName + "=";
+    return document.cookie.split(";").some(function (cookie) {
+      var entry = cookie.trim();
+      return entry.indexOf(prefix) === 0 && entry.slice(prefix.length) === "1";
+    });
+  }
+  function redirectFromHint() {
+    window.location.replace(homePath + window.location.search + window.location.hash);
+  }
+  if (hasSessionHint()) {
+    redirectFromHint();
+    return;
+  }
+  var sessionPath = (root || "") + "/_agent-native/auth/session";
   function redirectToAppHome() {
     return fetch(homePath, {
       method: "HEAD",
@@ -20,7 +38,7 @@ export function getSsrAuthRedirectScript(): string {
       headers: { "Accept": "text/html" }
     }).then(function (response) {
       if (!response || !response.ok) return;
-      window.location.replace(homePath + window.location.search + window.location.hash);
+      redirectFromHint();
     });
   }
   fetch(sessionPath, {


### PR DESCRIPTION
## Summary

- Serve configured template roots from the existing server-rendered onboarding/auth document so `/` matches `/sign-in` without a parallel marketing shell.
- Add a non-sensitive readable session-presence hint and synchronous `<head>` handoff to `/home`, with the session probe retained as a fallback for older sessions.
- Keep the SSR cache contract unconditional and cover redirecting app-home routes such as Plan and Mail.

## Verification

- 428 focused core tests passed.
- All 65 repository guards passed, including `guard:ssr-cache-shell`.
- Template route matrix passed.
- Live Slides, Plan, and Chat checks passed; Plan verified `/home` resolving through its route redirect.
- `/` was byte-identical with and without a session cookie and retained public CDN headers.