### PR TITLE
fix: make beta authenticated e2e signal reliable

### DIFF
--- a/.changeset/beta-e2e-authenticated-gates.md
+++ b/.changeset/beta-e2e-authenticated-gates.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep synthetic beta E2E traffic out of analytics, prevent provider-key fallback, and preserve authenticated failure semantics across background runs.

--- a/.github/workflows/beta-e2e.yml
+++ b/.github/workflows/beta-e2e.yml
@@ -88,6 +88,7 @@ on:
         type: choice
         options:
           - public
+          - authed
           - public+authed
           - signup
       signup_apps:
@@ -256,16 +257,30 @@ jobs:
           retention-days: 7
 
   authed:
-    name: Authenticated journeys
+    name: Authenticated ${{ matrix.cluster }}
     needs: [discover, advisory]
     if: ${{ always() && !cancelled() && needs.discover.result == 'success' && inputs.lane != 'public' && inputs.lane != 'signup' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      # These clusters share the e2e identity and production-backed databases.
+      # Keep them serialized while giving each failure its own gating signal.
+      max-parallel: 1
+      matrix:
+        include:
+          - cluster: registry
+            project: registry
+          - cluster: chat
+            project: chat
+          - cluster: journeys
+            project: journeys
     env:
       BETA_E2E_APPS: ${{ needs.discover.outputs.apps }}
       BETA_E2E_GREP: ${{ inputs.grep || '' }}
       BETA_E2E_AUTHED: "1"
-      BETA_E2E_REPORT_SLOT: authed
+      BETA_E2E_CLUSTER: ${{ matrix.cluster }}
+      BETA_E2E_REPORT_SLOT: authed-${{ matrix.cluster }}
       BETA_E2E_EMAIL: ${{ secrets.BETA_E2E_EMAIL }}
       BETA_E2E_SESSION_TOKENS: ${{ secrets.BETA_E2E_SESSION_TOKENS }}
       BETA_E2E_SESSION_TOKEN_MACROS: ${{ secrets.BETA_E2E_SESSION_TOKEN_MACROS }}
@@ -277,10 +292,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/beta-e2e-setup
-      - name: Authenticated journeys
+      - name: Authenticated ${{ matrix.cluster }}
         # Global setup fails loudly if a credential is missing rather than
         # degrading to an anonymous run that would pass without testing
-        # anything. Not sharded: it establishes one session per app up front.
+        # anything. The clusters are separate so a provider failure cannot
+        # hide registry or journey regressions.
         # A title filter can select only public/fleet tests, though. Ask
         # Playwright for the authenticated selection first with auth disabled;
         # --list does not run globalSetup, so an empty selection skips the
@@ -291,7 +307,7 @@ jobs:
             trap 'rm -f "$selection_file"' EXIT
             set +e
             BETA_E2E_AUTHED=0 pnpm e2e:beta \
-              --project=authed --project=journeys \
+              --project=${{ matrix.project }} \
               --grep "$BETA_E2E_GREP" --list >"$selection_file" 2>&1
             selection_status="$?"
             set -e
@@ -304,9 +320,9 @@ jobs:
               echo "Authenticated test selection failed before execution." >&2
               exit "$selection_status"
             fi
-            pnpm e2e:beta --project=authed --project=journeys --grep "$BETA_E2E_GREP" --pass-with-no-tests
+            pnpm e2e:beta --project=${{ matrix.project }} --grep "$BETA_E2E_GREP" --pass-with-no-tests
           else
-            pnpm e2e:beta --project=authed --project=journeys
+            pnpm e2e:beta --project=${{ matrix.project }}
           fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() }}
@@ -315,7 +331,7 @@ jobs:
         # publish the e2e account's live session cookie to anyone with repo
         # read access. e2e/beta/.auth is deliberately not in this list.
         with:
-          name: beta-e2e-authed-${{ github.run_id }}
+          name: beta-e2e-authed-${{ matrix.cluster }}-${{ github.run_id }}
           path: |
             e2e/beta/playwright-report/
             e2e/beta/test-results/

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -284,7 +284,7 @@ secrets only. See `e2e/beta/README.md` for how they are minted.
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BETA_E2E_APPS`                  | Comma-separated beta app ids to test, or `all`. An unknown id fails the run rather than selecting nothing.                                              |
 | `BETA_E2E_AUTHED`                | `1`/`0` to force the authenticated lane on or off. Unset means "run it when a session credential was supplied".                                         |
-| `BETA_E2E_CLUSTER`               | Authenticated cluster selected by the workflow (`registry`, `chat`, or `journeys`); internal CI wiring, not a user credential.                         |
+| `BETA_E2E_CLUSTER`               | Authenticated cluster selected by the workflow (`registry`, `chat`, or `journeys`); internal CI wiring, not a user credential.                          |
 | `BETA_E2E_GREP`                  | Optional Playwright title filter from the workflow `grep` input. Passed through the environment so a dispatch input never reaches a shell line.         |
 | `BETA_E2E_REPORT_SLOT`           | Names this invocation's report directory. The workflow sets one per lane so three sequential runs do not overwrite each other's results.                |
 | `BETA_E2E_EMAIL`                 | The identity every authenticated spec asserts it is running as. Setup fails if the resolved session is anyone else.                                     |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -284,6 +284,7 @@ secrets only. See `e2e/beta/README.md` for how they are minted.
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BETA_E2E_APPS`                  | Comma-separated beta app ids to test, or `all`. An unknown id fails the run rather than selecting nothing.                                              |
 | `BETA_E2E_AUTHED`                | `1`/`0` to force the authenticated lane on or off. Unset means "run it when a session credential was supplied".                                         |
+| `BETA_E2E_CLUSTER`               | Authenticated cluster selected by the workflow (`registry`, `chat`, or `journeys`); internal CI wiring, not a user credential.                         |
 | `BETA_E2E_GREP`                  | Optional Playwright title filter from the workflow `grep` input. Passed through the environment so a dispatch input never reaches a shell line.         |
 | `BETA_E2E_REPORT_SLOT`           | Names this invocation's report directory. The workflow sets one per lane so three sequential runs do not overwrite each other's results.                |
 | `BETA_E2E_EMAIL`                 | The identity every authenticated spec asserts it is running as. Setup fails if the resolved session is anyone else.                                     |

--- a/e2e/beta/README.md
+++ b/e2e/beta/README.md
@@ -48,13 +48,13 @@ Analytics.
 
 ## Lanes
 
-| Lane       | Gates a promotion | Credentials          | Model spend               |
-| ---------- | ----------------- | -------------------- | ------------------------- |
-| `public`   | yes               | none                 | none                      |
-| `registry` | yes               | session              | none                      |
+| Lane       | Gates a promotion | Credentials          | Model spend                                         |
+| ---------- | ----------------- | -------------------- | --------------------------------------------------- |
+| `public`   | yes               | none                 | none                                                |
+| `registry` | yes               | session              | none                                                |
 | `chat`     | yes               | session + OpenAI key | ~1 luna turn per chat app; Slides adds one A2A turn |
-| `journeys` | yes               | session              | none                      |
-| `advisory` | no                | none                 | none                      |
+| `journeys` | yes               | session              | none                                                |
+| `advisory` | no                | none                 | none                                                |
 
 `public` is the one that always runs and needs nothing set up. It already
 covers the most-reported failures, because most of them are visible before a

--- a/e2e/beta/README.md
+++ b/e2e/beta/README.md
@@ -51,13 +51,18 @@ Analytics.
 | Lane       | Gates a promotion | Credentials          | Model spend               |
 | ---------- | ----------------- | -------------------- | ------------------------- |
 | `public`   | yes               | none                 | none                      |
-| `authed`   | yes               | session + OpenAI key | ~1 luna turn per chat app |
+| `registry` | yes               | session              | none                      |
+| `chat`     | yes               | session + OpenAI key | ~1 luna turn per chat app; Slides adds one A2A turn |
 | `journeys` | yes               | session              | none                      |
 | `advisory` | no                | none                 | none                      |
 
 `public` is the one that always runs and needs nothing set up. It already
 covers the most-reported failures, because most of them are visible before a
 user finishes signing in.
+
+The workflow's `authed` lane runs the three authenticated projects above as
+separate serialized jobs, so a provider failure cannot hide a registry or
+journey regression.
 
 `advisory` reports real findings that do not stop a user — beta being
 indexable, third-party pixels that reject beta hosts, beta sharing a database

--- a/e2e/beta/capture-session.ts
+++ b/e2e/beta/capture-session.ts
@@ -24,6 +24,7 @@
 import { chromium } from "@playwright/test";
 
 import { authenticatableSites, originFor, siteById } from "./lib/fleet";
+import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./lib/test-traffic";
 
 const SESSION_COOKIE = /^an_session/;
 
@@ -81,7 +82,9 @@ async function capture(): Promise<void> {
       // A fresh context per app: these are host-scoped sessions, and reusing
       // one jar would make it impossible to tell which host actually issued
       // a cookie.
-      const context = await browser.newContext();
+      const context = await browser.newContext({
+        extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
+      });
       const page = await context.newPage();
       await page.goto(`${origin}/sign-in`, { waitUntil: "domcontentloaded" });
 

--- a/e2e/beta/capture-session.ts
+++ b/e2e/beta/capture-session.ts
@@ -24,7 +24,10 @@
 import { chromium } from "@playwright/test";
 
 import { authenticatableSites, originFor, siteById } from "./lib/fleet";
-import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./lib/test-traffic";
+import {
+  BETA_E2E_TEST_TRAFFIC_HEADERS,
+  installBetaE2ETrafficMarker,
+} from "./lib/test-traffic";
 
 const SESSION_COOKIE = /^an_session/;
 
@@ -85,6 +88,7 @@ async function capture(): Promise<void> {
       const context = await browser.newContext({
         extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
       });
+      await installBetaE2ETrafficMarker(context);
       const page = await context.newPage();
       await page.goto(`${origin}/sign-in`, { waitUntil: "domcontentloaded" });
 

--- a/e2e/beta/global-setup.ts
+++ b/e2e/beta/global-setup.ts
@@ -21,7 +21,10 @@ import {
   markAuthedLaneReady,
   missingCredentialsMessage,
 } from "./lib/session";
-import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./lib/test-traffic";
+import {
+  BETA_E2E_TEST_TRAFFIC_HEADERS,
+  installBetaE2ETrafficMarker,
+} from "./lib/test-traffic";
 
 function providerKeyRequired(): boolean {
   return process.env.BETA_E2E_CLUSTER?.trim().toLowerCase() === "chat";
@@ -137,6 +140,7 @@ async function globalSetup(): Promise<void> {
             storageState: authStatePath(site.id),
             extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
           });
+          await installBetaE2ETrafficMarker(context);
           try {
             if (!apiKey) {
               throw new Error("No validated OpenAI credential is available.");

--- a/e2e/beta/global-setup.ts
+++ b/e2e/beta/global-setup.ts
@@ -7,7 +7,11 @@ import {
   selectedSites,
 } from "./lib/fleet";
 import { warm } from "./lib/http";
-import { installOpenAiKey, resolveOpenAiKey } from "./lib/provider-key";
+import {
+  installOpenAiKey,
+  resolveOpenAiKey,
+  validateOpenAiKey,
+} from "./lib/provider-key";
 import {
   authStatePath,
   bootstrapAppSession,
@@ -17,13 +21,18 @@ import {
   markAuthedLaneReady,
   missingCredentialsMessage,
 } from "./lib/session";
+import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./lib/test-traffic";
+
+function providerKeyRequired(): boolean {
+  return process.env.BETA_E2E_CLUSTER?.trim().toLowerCase() === "chat";
+}
 
 /**
  * Prepare the run.
  *
  * Two jobs: warm every host so a cold start does not read as a failure, and —
  * when the authenticated lane is in play — establish one signed-in session per
- * app and install the dedicated OpenAI key against it.
+ * app and, for the chat cluster, install the dedicated OpenAI key against it.
  *
  * The authenticated lane either works or the run stops here. Degrading to an
  * anonymous session would leave every authed assertion passing against a
@@ -71,8 +80,9 @@ async function globalSetup(): Promise<void> {
   if (!hasSessionCredentials()) throw new Error(missingCredentialsMessage());
 
   const email = expectedEmail();
-  const resolvedKey = resolveOpenAiKey();
-  if (!resolvedKey) {
+  const needsProviderKey = providerKeyRequired();
+  const resolvedKey = needsProviderKey ? resolveOpenAiKey() : undefined;
+  if (needsProviderKey && !resolvedKey) {
     throw new Error(
       [
         "The authenticated lane was requested but no OpenAI credential was supplied.",
@@ -83,14 +93,16 @@ async function globalSetup(): Promise<void> {
       ].join("\n"),
     );
   }
-  const apiKey = resolvedKey.key;
-  if (resolvedKey.source === "shared") {
+  const apiKey = resolvedKey?.key;
+  if (resolvedKey?.source === "shared") {
     console.warn(
       "[beta-e2e] billing the SHARED OPENAI_API_KEY. This run's agent-turn spend is pooled with every other consumer of that key and cannot be attributed to the suite. Create BETA_E2E_OPENAI_API_KEY to separate it.",
     );
-  } else {
+  } else if (resolvedKey) {
     console.log("[beta-e2e] billing the dedicated BETA_E2E_OPENAI_API_KEY.");
   }
+
+  if (apiKey) await validateOpenAiKey(apiKey);
 
   const targets = authenticatableSites();
   if (targets.length === 0) {
@@ -120,15 +132,19 @@ async function globalSetup(): Promise<void> {
       try {
         const identity = await bootstrapAppSession(browser, site);
 
-        if (needsKey.has(site.id)) {
+        if (needsProviderKey && needsKey.has(site.id)) {
           const context = await browser.newContext({
             storageState: authStatePath(site.id),
+            extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
           });
           try {
+            if (!apiKey) {
+              throw new Error("No validated OpenAI credential is available.");
+            }
             const install = await installOpenAiKey(context, origin, apiKey);
             if (!install.installed) {
               failures.push(
-                `${site.id}: signed in as ${identity.email} but the dedicated OpenAI key was rejected (HTTP ${install.status}: ${install.body}). Turns here would bill an unintended credential.`,
+                `${site.id}: signed in as ${identity.email} but the dedicated OpenAI key was rejected (HTTP ${install.status}). Turns here would bill an unintended credential.`,
               );
               continue;
             }
@@ -138,7 +154,7 @@ async function globalSetup(): Promise<void> {
         }
 
         console.log(
-          `[beta-e2e]   ${site.id}: session ok as ${identity.email}${needsKey.has(site.id) ? `, ${resolvedKey.source} OpenAI key installed` : ""}`,
+          `[beta-e2e]   ${site.id}: session ok as ${identity.email}${needsProviderKey && needsKey.has(site.id) ? `, ${resolvedKey?.source} OpenAI key installed` : ""}`,
         );
       } catch (error) {
         failures.push(

--- a/e2e/beta/lib/authed.ts
+++ b/e2e/beta/lib/authed.ts
@@ -3,8 +3,14 @@ import { existsSync } from "node:fs";
 import { test, type Browser, type BrowserContext } from "@playwright/test";
 
 import { seedModelSelection } from "./chat";
-import { type BetaSite, originFor } from "./fleet";
-import { authStatePath, authedLaneReady, expectedEmail } from "./session";
+import { authenticatedEntryPath, type BetaSite, originFor } from "./fleet";
+import {
+  authStatePath,
+  authedLaneReady,
+  expectedEmail,
+  sessionFailureReason,
+} from "./session";
+import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./test-traffic";
 
 /**
  * Shared setup for the authenticated lane.
@@ -28,7 +34,7 @@ export function authedLaneEnabled(): boolean {
 export function skipUnlessAuthed(): void {
   test.skip(
     !authedLaneEnabled(),
-    "authenticated lane not requested (set BETA_E2E_SESSION_TOKENS and BETA_E2E_OPENAI_API_KEY, or BETA_E2E_AUTHED=1)",
+    "authenticated lane not requested (set session credentials; chat also needs BETA_E2E_OPENAI_API_KEY, or BETA_E2E_AUTHED=1)",
   );
 }
 
@@ -44,7 +50,10 @@ export async function signedInContext(
       `No stored session for ${site.id} at ${statePath}. Global setup should have created it; running this spec signed out would assert nothing.`,
     );
   }
-  const context = await browser.newContext({ storageState: statePath });
+  const context = await browser.newContext({
+    storageState: statePath,
+    extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
+  });
   if (seedModel) {
     const namespaces =
       site.id === "chat" || site.id === "analytics" || site.id === "dispatch"
@@ -70,7 +79,7 @@ export async function assertSignedInOnBeta(
   const origin = originFor(site);
   const page = await context.newPage();
   try {
-    await page.goto(`${origin}/`, {
+    await page.goto(`${origin}${authenticatedEntryPath(site)}`, {
       waitUntil: "domcontentloaded",
       timeout: 45_000,
     });
@@ -90,7 +99,7 @@ export async function assertSignedInOnBeta(
 
     if (!email) {
       throw new Error(
-        `${site.host} does not consider this context signed in (HTTP ${session.status}: ${session.body.slice(0, 200)}). The stored session has probably expired — re-run \`pnpm e2e:beta:capture\`.`,
+        `${site.host} does not consider this context signed in (HTTP ${session.status}: ${session.body.slice(0, 200)}). ${sessionFailureReason({ status: session.status, body: session.body, tokenProvided: false })}`,
       );
     }
     const expected = expectedEmail();

--- a/e2e/beta/lib/authed.ts
+++ b/e2e/beta/lib/authed.ts
@@ -10,7 +10,10 @@ import {
   expectedEmail,
   sessionFailureReason,
 } from "./session";
-import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./test-traffic";
+import {
+  BETA_E2E_TEST_TRAFFIC_HEADERS,
+  installBetaE2ETrafficMarker,
+} from "./test-traffic";
 
 /**
  * Shared setup for the authenticated lane.
@@ -54,6 +57,7 @@ export async function signedInContext(
     storageState: statePath,
     extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
   });
+  await installBetaE2ETrafficMarker(context);
   if (seedModel) {
     const namespaces =
       site.id === "chat" || site.id === "analytics" || site.id === "dispatch"

--- a/e2e/beta/lib/fleet.ts
+++ b/e2e/beta/lib/fleet.ts
@@ -37,6 +37,10 @@ const GOOGLE_ONLY_APPS = new Set(["mail", "calendar"]);
  * so it should be a decision someone makes, not a side effect of deploying.
  */
 const CHAT_APPS = ["chat", "slides", "analytics", "content", "dispatch"];
+const AUTHENTICATED_ENTRY_PATHS: Record<string, string> = {
+  content: "/home",
+  slides: "/home",
+};
 
 function readSites(): BetaSite[] {
   const file = path.join(repoRoot, "scripts", "netlify-beta-sites.json");
@@ -106,6 +110,11 @@ export function siteById(id: string): BetaSite {
 export function originFor(site: BetaSite | string): string {
   const host = typeof site === "string" ? siteById(site).host : site.host;
   return `https://${host}`;
+}
+
+export function authenticatedEntryPath(site: BetaSite | string): string {
+  const id = typeof site === "string" ? site : site.id;
+  return AUTHENTICATED_ENTRY_PATHS[id] ?? "/";
 }
 
 /** The production twin of a beta host, used for isolation checks. */

--- a/e2e/beta/lib/provider-key.spec.ts
+++ b/e2e/beta/lib/provider-key.spec.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isConfirmedOpenAiKeyInstall } from "./provider-key";
+
+test("requires the user-scoped OpenAI install response contract", () => {
+  const valid = {
+    status: 200,
+    body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
+  };
+  assert.equal(isConfirmedOpenAiKeyInstall(valid), true);
+  assert.equal(
+    isConfirmedOpenAiKeyInstall({
+      status: 204,
+      body: "",
+    }),
+    false,
+  );
+  assert.equal(
+    isConfirmedOpenAiKeyInstall({
+      status: 200,
+      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"org"}',
+    }),
+    false,
+  );
+});

--- a/e2e/beta/lib/provider-key.ts
+++ b/e2e/beta/lib/provider-key.ts
@@ -16,6 +16,8 @@ import type { BrowserContext } from "@playwright/test";
  */
 
 const KEY_ROUTE = "/_agent-native/agent-engine/api-key";
+const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
+const OPENAI_VALIDATION_TIMEOUT_MS = 15_000;
 
 export type KeySource = "dedicated" | "shared";
 
@@ -59,6 +61,49 @@ export interface KeyInstallResult {
   body: string;
 }
 
+export function isConfirmedOpenAiKeyInstall(
+  result: Pick<KeyInstallResult, "status" | "body">,
+): boolean {
+  if (result.status < 200 || result.status >= 300) return false;
+  try {
+    const body = JSON.parse(result.body) as {
+      ok?: unknown;
+      key?: unknown;
+      scope?: unknown;
+    };
+    return (
+      body.ok === true && body.key === "OPENAI_API_KEY" && body.scope === "user"
+    );
+  } catch {
+    return false; // coercion-ok: malformed response is explicitly unconfirmed
+  }
+}
+
+/** Validate the exact credential once before installing it on any beta host. */
+export async function validateOpenAiKey(apiKey: string): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch(OPENAI_MODELS_ENDPOINT, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(OPENAI_VALIDATION_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(
+      `Could not validate the selected OpenAI credential: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.ok) return;
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(
+      `OpenAI rejected the selected credential (HTTP ${response.status}).`,
+    );
+  }
+  throw new Error(
+    `OpenAI credential validation was inconclusive (HTTP ${response.status}).`,
+  );
+}
+
 /**
  * POST the key from inside a loaded page on the target origin. Same-origin is
  * required: the framework rejects a cross-origin credential write.
@@ -93,7 +138,7 @@ export async function installOpenAiKey(
       [KEY_ROUTE, apiKey] as const,
     );
     return {
-      installed: result.status >= 200 && result.status < 300,
+      installed: isConfirmedOpenAiKeyInstall(result),
       status: result.status,
       body: result.body,
     };

--- a/e2e/beta/lib/session.spec.ts
+++ b/e2e/beta/lib/session.spec.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   hasSessionCredentials,
+  sessionFailureReason,
   sessionTokenFor,
   shouldRetrySessionExchange,
 } from "./session";
@@ -55,4 +56,39 @@ test("recognizes a per-app token as an authenticated credential", () => {
       delete process.env.BETA_E2E_STORAGE_STATE_FILE;
     else process.env.BETA_E2E_STORAGE_STATE_FILE = previousStorageStateFile;
   }
+});
+
+test("classifies session failures without guessing that a credential expired", () => {
+  assert.match(
+    sessionFailureReason({
+      status: 503,
+      body: '{"error":"Session lookup timed out"}',
+      tokenProvided: true,
+    }),
+    /endpoint was unavailable/,
+  );
+  assert.match(
+    sessionFailureReason({
+      status: 200,
+      body: '{"error":"Not authenticated"}',
+      tokenProvided: true,
+    }),
+    /did not honor/,
+  );
+  assert.match(
+    sessionFailureReason({
+      status: 200,
+      body: "not json",
+      tokenProvided: false,
+    }),
+    /unreadable/,
+  );
+  assert.doesNotMatch(
+    sessionFailureReason({
+      status: 200,
+      body: '{"error":"Not authenticated"}',
+      tokenProvided: true,
+    }),
+    /expire|30 days/i,
+  );
 });

--- a/e2e/beta/lib/session.ts
+++ b/e2e/beta/lib/session.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from "node:url";
 import type { Browser, BrowserContext } from "@playwright/test";
 
 import { type BetaSite, originFor } from "./fleet";
+import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./test-traffic";
 
 /**
  * Authenticated-session bootstrap for the beta fleet.
@@ -176,6 +177,35 @@ export function missingCredentialsMessage(): string {
   ].join("\n");
 }
 
+export function sessionFailureReason(options: {
+  status: number;
+  body: string;
+  tokenProvided: boolean;
+}): string {
+  const credential = options.tokenProvided
+    ? "supplied session token"
+    : "stored session cookie";
+  if (options.status >= 500) {
+    return `The beta host's session endpoint was unavailable (HTTP ${options.status}); retry the host.`;
+  }
+  if (options.status === 401 || options.status === 403) {
+    return `The ${credential} was rejected by this host (HTTP ${options.status}).`;
+  }
+
+  try {
+    const parsed = JSON.parse(options.body) as { error?: unknown } | null;
+    if (
+      typeof parsed?.error === "string" &&
+      /not authenticated/i.test(parsed.error)
+    ) {
+      return "The host answered successfully but did not honor the supplied session credential.";
+    }
+  } catch {
+    return `The beta host returned an unreadable session response (HTTP ${options.status}).`;
+  }
+  return `The beta host returned no authenticated identity (HTTP ${options.status}).`;
+}
+
 /** Read the live session the way the app itself would, from inside the page. */
 async function readSessionIdentity(
   context: BrowserContext,
@@ -223,7 +253,12 @@ export async function bootstrapAppSession(
   if (!blob && !token) throw new Error(missingCredentialsMessage());
 
   const context = await browser.newContext(
-    blob ? { storageState: JSON.parse(blob) } : {},
+    blob
+      ? {
+          storageState: JSON.parse(blob),
+          extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
+        }
+      : { extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS },
   );
 
   try {
@@ -286,9 +321,11 @@ export async function bootstrapAppSession(
         [
           `Beta session bootstrap failed for ${site.id} (${origin}).`,
           `GET /_agent-native/auth/session returned HTTP ${status}: ${body}`,
-          token
-            ? "The supplied session token was rejected. Framework sessions expire after 30 days — re-run `pnpm e2e:beta:capture`."
-            : "The supplied storage state carried no session cookie this host accepts.",
+          sessionFailureReason({
+            status,
+            body,
+            tokenProvided: Boolean(token),
+          }),
         ].join("\n"),
       );
     }

--- a/e2e/beta/lib/session.ts
+++ b/e2e/beta/lib/session.ts
@@ -11,7 +11,10 @@ import { fileURLToPath } from "node:url";
 import type { Browser, BrowserContext } from "@playwright/test";
 
 import { type BetaSite, originFor } from "./fleet";
-import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./test-traffic";
+import {
+  BETA_E2E_TEST_TRAFFIC_HEADERS,
+  installBetaE2ETrafficMarker,
+} from "./test-traffic";
 
 /**
  * Authenticated-session bootstrap for the beta fleet.
@@ -260,6 +263,7 @@ export async function bootstrapAppSession(
         }
       : { extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS },
   );
+  await installBetaE2ETrafficMarker(context);
 
   try {
     if (token) {

--- a/e2e/beta/lib/test-traffic.ts
+++ b/e2e/beta/lib/test-traffic.ts
@@ -1,0 +1,3 @@
+export const BETA_E2E_TEST_TRAFFIC_HEADERS = {
+  "X-Agent-Native-Test-Traffic": "beta-e2e",
+} as const;

--- a/e2e/beta/lib/test-traffic.ts
+++ b/e2e/beta/lib/test-traffic.ts
@@ -1,3 +1,20 @@
+import type { BrowserContext } from "@playwright/test";
+
 export const BETA_E2E_TEST_TRAFFIC_HEADERS = {
   "X-Agent-Native-Test-Traffic": "beta-e2e",
 } as const;
+
+/** Mark browser code before any document script can initialize telemetry. */
+export function installBetaE2ETrafficMarker(
+  context: BrowserContext,
+): Promise<void> {
+  return context
+    .addInitScript((marker) => {
+      (
+        window as Window & {
+          __AGENT_NATIVE_SYNTHETIC_TRAFFIC__?: string;
+        }
+      ).__AGENT_NATIVE_SYNTHETIC_TRAFFIC__ = marker;
+    }, "beta-e2e")
+    .then(() => undefined);
+}

--- a/e2e/beta/playwright.config.ts
+++ b/e2e/beta/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { BETA_E2E_TEST_TRAFFIC_HEADERS } from "./lib/test-traffic";
+
 /**
  * Browser E2E against the deployed Agent-Native beta fleet.
  *
@@ -10,10 +12,9 @@ import { defineConfig, devices } from "@playwright/test";
  *
  * Two lanes:
  *   public  no credentials, every host, zero model spend. Always runs.
- *   authed  needs BETA_E2E_SESSION_TOKENS (or BETA_E2E_STORAGE_STATE) and
- *           BETA_E2E_OPENAI_API_KEY. Spends luna tokens. Skipped only when the
- *           run was not asked for it — never when it was asked for and the
- *           credential is absent, which fails in global setup instead.
+ *   authenticated  needs BETA_E2E_SESSION_TOKENS (or BETA_E2E_STORAGE_STATE)
+ *                  and BETA_E2E_OPENAI_API_KEY for chat. Spends
+ *                  luna tokens only in those clusters.
  *
  * `ignoreHTTPSErrors` is deliberately left unset: "the connection isn't
  * private" was a real beta report, and only a browser that still checks
@@ -88,6 +89,7 @@ export default defineConfig({
   outputDir: `test-results/${REPORT_SLOT}`,
   use: {
     ...devices["Desktop Chrome"],
+    extraHTTPHeaders: BETA_E2E_TEST_TRAFFIC_HEADERS,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -113,10 +115,16 @@ export default defineConfig({
       testMatch: /specs\/fleet-wide\.spec\.ts$/,
     },
     {
-      name: "authed",
-      testMatch: /specs\/(registry|chat|a2a)\.spec\.ts$/,
-      // One retry, not two: each retry of a chat spec is another paid agent
-      // turn, and a turn that fails twice is a finding rather than a flake.
+      name: "registry",
+      testMatch: /specs\/registry\.spec\.ts$/,
+      // Registry checks do not spend model tokens, but one retry still
+      // separates a cold host from a deterministic authentication failure.
+      retries: 1,
+      use: { ...AUTHED_ARTIFACTS },
+    },
+    {
+      name: "chat",
+      testMatch: /specs\/(chat|a2a)\.spec\.ts$/,
       retries: 1,
       use: { ...AUTHED_ARTIFACTS },
     },

--- a/e2e/beta/specs/a2a.spec.ts
+++ b/e2e/beta/specs/a2a.spec.ts
@@ -12,7 +12,12 @@ import {
   sendPromptAndAwaitTurn,
   watchChatRequests,
 } from "../lib/chat";
-import { originFor, selectedSites, siteById } from "../lib/fleet";
+import {
+  authenticatedEntryPath,
+  originFor,
+  selectedSites,
+  siteById,
+} from "../lib/fleet";
 
 /**
  * Cross-app delegation: Slides asking Analytics for data.
@@ -55,10 +60,13 @@ test.describe("slides -> analytics delegation", () => {
       const page = await context.newPage();
       const chat = watchChatRequests(page);
 
-      await page.goto(`${origin}/?agentSidebar=open`, {
-        waitUntil: "domcontentloaded",
-        timeout: 45_000,
-      });
+      await page.goto(
+        `${origin}${authenticatedEntryPath(slides)}?agentSidebar=open`,
+        {
+          waitUntil: "domcontentloaded",
+          timeout: 45_000,
+        },
+      );
       await expect(page.locator(COMPOSER.input).first()).toBeVisible({
         timeout: 60_000,
       });
@@ -111,7 +119,7 @@ test.describe("A2A reachability between deployed peers", () => {
     });
     try {
       const page = await context.newPage();
-      await page.goto(`${originFor(slides)}/`, {
+      await page.goto(`${originFor(slides)}${authenticatedEntryPath(slides)}`, {
         waitUntil: "domcontentloaded",
         timeout: 45_000,
       });

--- a/e2e/beta/specs/advisory.spec.ts
+++ b/e2e/beta/specs/advisory.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import { originFor, productionHostFor, selectedSites } from "../lib/fleet";
 import { mustRespond, parseJson } from "../lib/http";
+import { installBetaE2ETrafficMarker } from "../lib/test-traffic";
 
 /**
  * Findings worth surfacing that should not block a promotion.
@@ -16,6 +17,10 @@ import { mustRespond, parseJson } from "../lib/http";
  */
 
 const sites = selectedSites();
+
+test.beforeEach(async ({ page }) => {
+  await installBetaE2ETrafficMarker(page.context());
+});
 
 test.describe.configure({ mode: "parallel" });
 

--- a/e2e/beta/specs/apps/data-visibility.spec.ts
+++ b/e2e/beta/specs/apps/data-visibility.spec.ts
@@ -6,7 +6,13 @@ import {
   signedInContext,
   skipUnlessAuthed,
 } from "../../lib/authed";
-import { chatSites, originFor, selectedSites, siteById } from "../../lib/fleet";
+import {
+  authenticatedEntryPath,
+  chatSites,
+  originFor,
+  selectedSites,
+  siteById,
+} from "../../lib/fleet";
 
 /**
  * "My things are gone."
@@ -48,7 +54,7 @@ test.describe("slides deck list", () => {
       const page = await context.newPage();
       const { errors } = collectAppPageErrors(page, origin);
 
-      await page.goto(`${origin}/`, {
+      await page.goto(`${origin}${authenticatedEntryPath(site)}`, {
         waitUntil: "domcontentloaded",
         timeout: 90_000,
       });
@@ -111,7 +117,7 @@ test.describe("content workspace", () => {
       const page = await context.newPage();
       const { errors } = collectAppPageErrors(page, origin);
 
-      await page.goto(`${origin}/`, {
+      await page.goto(`${origin}${authenticatedEntryPath(site)}`, {
         waitUntil: "domcontentloaded",
         timeout: 90_000,
       });
@@ -335,10 +341,13 @@ test.describe("app-local chat history", () => {
       try {
         await assertSignedInOnBeta(context, site);
         const page = await context.newPage();
-        await page.goto(`${origin}/?agentSidebar=open`, {
-          waitUntil: "domcontentloaded",
-          timeout: 90_000,
-        });
+        await page.goto(
+          `${origin}${authenticatedEntryPath(site)}?agentSidebar=open`,
+          {
+            waitUntil: "domcontentloaded",
+            timeout: 90_000,
+          },
+        );
 
         const result = await page.evaluate(async () => {
           const response = await fetch(

--- a/e2e/beta/specs/auth-surface.spec.ts
+++ b/e2e/beta/specs/auth-surface.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { settleAuthGate } from "../lib/app";
 import { originFor, productionHostFor, selectedSites } from "../lib/fleet";
 import { mustRespond, parseJson } from "../lib/http";
+import { installBetaE2ETrafficMarker } from "../lib/test-traffic";
 
 /**
  * The signed-out auth surface, in the shapes users actually hit it.
@@ -13,6 +14,10 @@ import { mustRespond, parseJson } from "../lib/http";
  */
 
 const sites = selectedSites();
+
+test.beforeEach(async ({ page }) => {
+  await installBetaE2ETrafficMarker(page.context());
+});
 
 test.describe.configure({ mode: "parallel" });
 

--- a/e2e/beta/specs/chat.spec.ts
+++ b/e2e/beta/specs/chat.spec.ts
@@ -13,7 +13,7 @@ import {
   sendPromptAndAwaitTurn,
   watchChatRequests,
 } from "../lib/chat";
-import { chatSites, originFor } from "../lib/fleet";
+import { authenticatedEntryPath, chatSites, originFor } from "../lib/fleet";
 
 /**
  * One real agent turn per chat-bearing app, on luna.
@@ -65,10 +65,13 @@ for (const site of sites) {
 
         // The sidebar is collapsed by default on some entry paths; asking for
         // it explicitly is what guarantees a composer to type into.
-        await page.goto(`${origin}/?agentSidebar=open`, {
-          waitUntil: "domcontentloaded",
-          timeout: 45_000,
-        });
+        await page.goto(
+          `${origin}${authenticatedEntryPath(site)}?agentSidebar=open`,
+          {
+            waitUntil: "domcontentloaded",
+            timeout: 45_000,
+          },
+        );
 
         await expect(
           page.locator(COMPOSER.input).first(),
@@ -141,10 +144,13 @@ for (const site of sites) {
       try {
         const page = await context.newPage();
         const chat = watchChatRequests(page);
-        await page.goto(`${origin}/?agentSidebar=open`, {
-          waitUntil: "domcontentloaded",
-          timeout: 45_000,
-        });
+        await page.goto(
+          `${origin}${authenticatedEntryPath(site)}?agentSidebar=open`,
+          {
+            waitUntil: "domcontentloaded",
+            timeout: 45_000,
+          },
+        );
         await expect(page.locator(COMPOSER.input).first()).toBeVisible({
           timeout: 60_000,
         });
@@ -178,10 +184,13 @@ for (const site of sites) {
       const context = await signedInContext(browser, site);
       try {
         const page = await context.newPage();
-        await page.goto(`${origin}/?agentSidebar=open`, {
-          waitUntil: "domcontentloaded",
-          timeout: 45_000,
-        });
+        await page.goto(
+          `${origin}${authenticatedEntryPath(site)}?agentSidebar=open`,
+          {
+            waitUntil: "domcontentloaded",
+            timeout: 45_000,
+          },
+        );
         const send = page.locator(COMPOSER.send).first();
         await expect(send).toBeVisible({ timeout: 60_000 });
 

--- a/e2e/beta/specs/fleet-public.spec.ts
+++ b/e2e/beta/specs/fleet-public.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "../lib/app";
 import { originFor, productionHostFor, selectedSites } from "../lib/fleet";
 import { mustRespond, parseJson, probe, warm } from "../lib/http";
+import { installBetaE2ETrafficMarker } from "../lib/test-traffic";
 
 /**
  * The unauthenticated fleet sweep.
@@ -31,6 +32,10 @@ interface HealthSample {
 const SAMPLE_COUNT = 4;
 
 const sites = selectedSites();
+
+test.beforeEach(async ({ page }) => {
+  await installBetaE2ETrafficMarker(page.context());
+});
 
 test.describe.configure({ mode: "parallel" });
 

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -1,6 +1,11 @@
 import * as jose from "jose";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { runWithRequestContext } from "../server/request-context.js";
+import {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+} from "../shared/test-traffic.js";
 import {
   A2AClient,
   A2ATaskTerminalError,
@@ -84,6 +89,61 @@ describe("A2AClient", () => {
       .filter(([, init]) => init?.method === "POST")
       .map(([url]) => url);
     expect(postUrls).toEqual(["https://agent.test/a2a"]);
+  });
+
+  it("carries trusted transport headers on A2A requests", async () => {
+    let requestHeaders: HeadersInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestHeaders = init?.headers;
+        return completedResponse(
+          JSON.parse(String(init?.body)),
+          "transport header ok",
+        );
+      }),
+    );
+
+    await expect(
+      callAgent("https://agent.test/_agent-native/a2a", "hello", {
+        async: false,
+        transportHeaders: {
+          [SYNTHETIC_TRAFFIC_HEADER]: SYNTHETIC_TRAFFIC_BETA_E2E,
+        },
+      }),
+    ).resolves.toBe("transport header ok");
+
+    expect(new Headers(requestHeaders).get(SYNTHETIC_TRAFFIC_HEADER)).toBe(
+      SYNTHETIC_TRAFFIC_BETA_E2E,
+    );
+  });
+
+  it("inherits the synthetic marker for direct A2A clients", async () => {
+    let requestHeaders: HeadersInit | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requestHeaders = init?.headers;
+        return completedResponse(
+          JSON.parse(String(init?.body)),
+          "request-context marker ok",
+        );
+      }),
+    );
+
+    await runWithRequestContext({ isSyntheticTraffic: true }, () =>
+      new A2AClient("https://agent.test/_agent-native/a2a").sendAndWait(
+        {
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        },
+        { timeoutMs: 1_000 },
+      ),
+    );
+
+    expect(new Headers(requestHeaders).get(SYNTHETIC_TRAFFIC_HEADER)).toBe(
+      SYNTHETIC_TRAFFIC_BETA_E2E,
+    );
   });
 
   it("falls back to /a2a when the agent-native endpoint is absent", async () => {

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -4,7 +4,24 @@ import * as jose from "jose";
 
 import { getAppConfig } from "../app-config/index.js";
 import { ssrfSafeFetch } from "../extensions/url-safety.js";
+import { getRequestContext } from "../server/request-context.js";
+import {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+} from "../shared/test-traffic.js";
 import { canonicalA2AAudience } from "./audience.js";
+import { sanitizeA2ACorrelationMetadata } from "./correlation.js";
+import type {
+  A2AApprovedAction,
+  A2ACorrelationMetadata,
+  A2ASourceContextReference,
+  A2AReadOnlyActionResult,
+  AgentCard,
+  JsonRpcRequest,
+  JsonRpcResponse,
+  Message,
+  Task,
+} from "./types.js";
 
 /**
  * A workspace serves every app from one gateway on loopback, so sibling A2A
@@ -48,18 +65,6 @@ function workspacePrivateOrigins(): string[] {
   }
   return origins;
 }
-import { sanitizeA2ACorrelationMetadata } from "./correlation.js";
-import type {
-  A2AApprovedAction,
-  A2ACorrelationMetadata,
-  A2ASourceContextReference,
-  A2AReadOnlyActionResult,
-  AgentCard,
-  JsonRpcRequest,
-  JsonRpcResponse,
-  Message,
-  Task,
-} from "./types.js";
 
 const DEFAULT_A2A_POLL_REQUEST_TIMEOUT_MS = 15_000;
 const DEFAULT_A2A_DISCOVERY_TIMEOUT_MS = 3_000;
@@ -200,11 +205,16 @@ export class A2AClient {
   private endpointCandidates: string[] = [];
   private endpointResolved = false;
   private requestTimeoutMs?: number;
+  private transportHeaders?: Record<string, string>;
 
   constructor(
     baseUrl: string,
     apiKey?: string,
-    options?: { requestTimeoutMs?: number; fallbackApiKeys?: string[] },
+    options?: {
+      requestTimeoutMs?: number;
+      fallbackApiKeys?: string[];
+      transportHeaders?: Record<string, string>;
+    },
   ) {
     const normalized = baseUrl.replace(/\/$/, "");
     const explicitEndpoint = splitExplicitA2AEndpoint(normalized);
@@ -219,6 +229,12 @@ export class A2AClient {
       ...(options?.fallbackApiKeys ?? []),
     ]);
     this.requestTimeoutMs = options?.requestTimeoutMs;
+    this.transportHeaders = {
+      ...(options?.transportHeaders ?? {}),
+      ...(getRequestContext()?.isSyntheticTraffic === true
+        ? { [SYNTHETIC_TRAFFIC_HEADER]: SYNTHETIC_TRAFFIC_BETA_E2E }
+        : {}),
+    };
   }
 
   /**
@@ -265,7 +281,10 @@ export class A2AClient {
   }
 
   private headers(apiKey = this.apiKey): Record<string, string> {
-    const h: Record<string, string> = { "Content-Type": "application/json" };
+    const h: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...(this.transportHeaders ?? {}),
+    };
     if (apiKey) {
       h["Authorization"] = `Bearer ${apiKey}`;
     }
@@ -1021,6 +1040,8 @@ export async function callAgent(
     apiKeyFallbacks?: string[];
     /** Additional transport metadata. Receivers must not use it as identity. */
     metadata?: Record<string, unknown>;
+    /** Trusted server-side headers to carry across the A2A transport. */
+    transportHeaders?: Record<string, string>;
     contextId?: string;
     userEmail?: string;
     orgDomain?: string;
@@ -1103,6 +1124,7 @@ export async function callAgent(
         .filter((token): token is string => token !== undefined);
       const client = new A2AClient(url, apiKeyAttempts[i], {
         fallbackApiKeys,
+        transportHeaders: opts?.transportHeaders,
       });
       let task: Task;
       if (useAsync) {

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -83,6 +83,7 @@ vi.mock("../../server/builder-oauth.js", () => ({
 }));
 
 vi.mock("../../server/request-context.js", () => ({
+  getRequestContext: vi.fn(() => undefined),
   getRequestOrgId: vi.fn(() => oauthState.orgId),
   getRequestUserEmail: vi.fn(() => oauthState.ownerEmail),
 }));

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -449,6 +449,7 @@ describe("AgentEngine registry", () => {
 
     it("prefers a current app default model over the global model", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "owner@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -882,6 +883,7 @@ describe("AgentEngine registry", () => {
 
   it("resolveEngine honors a usable app default before the global setting", async () => {
     vi.doMock("../../server/request-context.js", () => ({
+      getRequestContext: () => undefined,
       getRequestUserEmail: () => "owner@example.com",
       getRequestOrgId: () => undefined,
     }));
@@ -1082,6 +1084,7 @@ describe("AgentEngine registry", () => {
         deleteSetting: vi.fn(),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "visitor@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -1481,6 +1484,7 @@ describe("AgentEngine registry", () => {
 
     it("returns null when no request user is set", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => undefined,
         getRequestOrgId: () => undefined,
       }));
@@ -1492,6 +1496,7 @@ describe("AgentEngine registry", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
       try {
         vi.doMock("../../server/request-context.js", () => ({
+          getRequestContext: () => undefined,
           getRequestUserEmail: () => undefined,
           getRequestOrgId: () => undefined,
         }));
@@ -1506,6 +1511,7 @@ describe("AgentEngine registry", () => {
 
     it("returns null for the local-dev session", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "local@localhost",
         getRequestOrgId: () => undefined,
       }));
@@ -1515,6 +1521,7 @@ describe("AgentEngine registry", () => {
 
     it("surfaces an unreadable credential store instead of reporting no engine", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "tim@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1546,6 +1553,7 @@ describe("AgentEngine registry", () => {
 
     it("picks the Builder engine when the user has Builder keys in app_secrets", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "brent@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -1593,6 +1601,7 @@ describe("AgentEngine registry", () => {
 
     it("picks the Builder engine when the active org has shared Builder credentials", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "member@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1663,6 +1672,7 @@ describe("AgentEngine registry", () => {
 
     it("picks the Builder engine from org credentials when the user has only a partial stale Builder row", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "member@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1721,6 +1731,7 @@ describe("AgentEngine registry", () => {
 
     it("resolveEngine routes to Builder when the user has Builder creds in app_secrets and no env-level keys", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "brent@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -1781,6 +1792,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "member@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1854,6 +1866,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1929,6 +1942,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -1987,6 +2001,7 @@ describe("AgentEngine registry", () => {
 
     it("pairs an explicitly selected provider with its saved key when the caller has none", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2037,6 +2052,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2078,6 +2094,7 @@ describe("AgentEngine registry", () => {
     it("does not pass an unrelated active key to an env-selected provider", async () => {
       vi.stubEnv("AGENT_ENGINE", "ai-sdk:openai");
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2134,6 +2151,7 @@ describe("AgentEngine registry", () => {
       // key it carries (plugin `options.apiKey`) matches no stored secret, so
       // only the declared env var can prove it belongs to Anthropic.
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2173,6 +2191,7 @@ describe("AgentEngine registry", () => {
 
     it("keeps a declared key on the provider it was issued for", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2215,6 +2234,7 @@ describe("AgentEngine registry", () => {
         getSetting: vi.fn().mockResolvedValue(null),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => "builder_org",
       }));
@@ -2290,6 +2310,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -2366,6 +2387,7 @@ describe("AgentEngine registry", () => {
         ),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -2422,6 +2444,7 @@ describe("AgentEngine registry", () => {
         }),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -2499,6 +2522,7 @@ describe("AgentEngine registry", () => {
 
     it("passes a scoped OpenAI-compatible endpoint into the OpenAI engine", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -2585,6 +2609,7 @@ describe("AgentEngine registry", () => {
 
     it("does not pass the scoped OpenAI endpoint into non-OpenAI engines", async () => {
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
@@ -2634,6 +2659,7 @@ describe("AgentEngine registry", () => {
         getSetting: vi.fn().mockResolvedValue(null),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "new@example.com",
         getRequestOrgId: () => "org-1",
       }));
@@ -2697,6 +2723,7 @@ describe("AgentEngine registry", () => {
       vi.stubEnv("NODE_ENV", "production");
       process.env.OPENAI_API_KEY = "sk-deploy"; // guard:allow-env-credential — fixture: explicit app-level LLM engine selection can inherit hosted env
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "new@example.com",
         getRequestOrgId: () => "org-1",
       }));
@@ -2762,6 +2789,7 @@ describe("AgentEngine registry", () => {
         deleteSetting: vi.fn(),
       }));
       vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "new@example.com",
         getRequestOrgId: () => "org-1",
       }));

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -71,6 +71,10 @@ import {
   stepDownReasoningEffort,
   type ReasoningEffort,
 } from "../shared/reasoning-effort.js";
+import {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+} from "../shared/test-traffic.js";
 import { actionPreparationContinuationNote } from "./action-continuation-guidance.js";
 import {
   drainAgentWarnings,
@@ -2375,6 +2379,13 @@ export async function callConnectedAgentReference(input: {
       userEmail: callerAuth.userEmail,
       orgDomain: callerAuth.orgDomain,
       orgSecret: callerAuth.orgSecret,
+      ...(getRequestContext()?.isSyntheticTraffic === true
+        ? {
+            transportHeaders: {
+              [SYNTHETIC_TRAFFIC_HEADER]: SYNTHETIC_TRAFFIC_BETA_E2E,
+            },
+          }
+        : {}),
       onUpdate: relay.observePollUpdate,
     });
     const responseText =

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -228,6 +228,30 @@ describe("browser analytics pageviews", () => {
     expect(getCookie()).toContain(`an_aid=${body.anonymousId}`);
   });
 
+  it("suppresses browser analytics for synthetic E2E traffic", async () => {
+    const { gtag } = installBrowser();
+    (
+      window as Window & {
+        __AGENT_NATIVE_SYNTHETIC_TRAFFIC__?: string;
+      }
+    ).__AGENT_NATIVE_SYNTHETIC_TRAFFIC__ = "beta-e2e";
+    const { analyticsCalls } = installFetch();
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv("VITE_AMPLITUDE_API_KEY", "amp_test");
+
+    const { captureClientException, configureTracking, trackEvent } =
+      await freshAnalytics();
+    configureTracking({ errorCapture: true, sessionReplay: true });
+    trackEvent("synthetic_event", { value: "must-not-send" });
+    captureClientException(new Error("synthetic failure"));
+    await tick();
+
+    expect(analyticsCalls).toHaveLength(0);
+    expect(gtag).not.toHaveBeenCalled();
+    expect(amplitudeMock.init).not.toHaveBeenCalled();
+    expect(sentryMock.init).not.toHaveBeenCalled();
+  });
+
   it("uses the configured native client platform for every pageview", async () => {
     installBrowser("https://mail.agent-native.com/inbox");
     const { analyticsCalls } = installFetch();

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -10,6 +10,7 @@ import {
   type LlmConnectionStatus,
 } from "../shared/llm-connection.js";
 import { isQaTestEmail } from "../shared/qa-test-email.js";
+import { isSyntheticTrafficValue } from "../shared/test-traffic.js";
 import { toPostHogExceptionProperties } from "../tracking/posthog-exception.js";
 import { getAnalyticsClientPlatform } from "./analytics-platform.js";
 import {
@@ -63,6 +64,8 @@ export {
 declare global {
   interface Window {
     gtag?: (...args: any[]) => void;
+    /** Set by synthetic E2E contexts before the first app script runs. */
+    __AGENT_NATIVE_SYNTHETIC_TRAFFIC__?: string;
     __AGENT_NATIVE_CONFIG__?: {
       /**
        * This app's origins, projected by server/app-origin-config.ts. These
@@ -673,7 +676,15 @@ function isLocalAnalyticsHostname(hostname: string | undefined): boolean {
   );
 }
 
+function isSyntheticBrowserTraffic(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    isSyntheticTrafficValue(window.__AGENT_NATIVE_SYNTHETIC_TRAFFIC__)
+  );
+}
+
 function ensureAmplitude(): boolean {
+  if (isSyntheticBrowserTraffic()) return false;
   if (_amplitudeInitialized) return true;
   const key = (import.meta.env as Record<string, string | undefined>)
     ?.VITE_AMPLITUDE_API_KEY;
@@ -1001,6 +1012,7 @@ function captureWithSentry(
 }
 
 function ensureSentry(loadWithoutDsn = false): void {
+  if (isSyntheticBrowserTraffic()) return;
   if (_sentryInitialized || _sentryLoadPromise) return;
   const dsn = getClientSentryDsn();
   if (!dsn && !loadWithoutDsn) return;
@@ -1018,6 +1030,7 @@ function ensureSentry(loadWithoutDsn = false): void {
         dsn,
         environment: resolveClientDeploymentEnvironment(),
         beforeSend(event) {
+          if (isSyntheticBrowserTraffic()) return null;
           event.tags = {
             ...event.tags,
             deployment_environment: resolveClientDeploymentEnvironment(),
@@ -1173,6 +1186,7 @@ export function captureClientException(
   context: ClientCaptureContext = {},
 ): string | undefined {
   if (typeof window === "undefined") return undefined;
+  if (isSyntheticBrowserTraffic()) return undefined;
   if (isQaTrackingIdentity(_trackingIdentity)) return undefined;
   try {
     ensureSentry(true);
@@ -1238,6 +1252,7 @@ export type AgentChatLifecycleEvent = {
  */
 export function trackAgentChatLifecycle(input: AgentChatLifecycleEvent): void {
   if (typeof window === "undefined") return;
+  if (isSyntheticBrowserTraffic()) return;
   const surface = input.surface?.trim() || "app";
   const dedupeKey = [
     input.phase,
@@ -1290,6 +1305,10 @@ export function trackAgentChatLifecycle(input: AgentChatLifecycleEvent): void {
 }
 
 export function configureTracking(options: ConfigureTrackingOptions): void {
+  if (isSyntheticBrowserTraffic()) {
+    _trackingContentCaptureEnabled = false;
+    return;
+  }
   if (options.clientPlatform) {
     _configuredAnalyticsClientPlatform = options.clientPlatform;
   }
@@ -1454,6 +1473,7 @@ function posthogErrorConfig(): { key: string; host: string } | undefined {
  * id, which `$identify` later aliases on login.
  */
 function sendPostHogExceptionEvent(event: CapturedExceptionEvent): void {
+  if (isSyntheticBrowserTraffic()) return;
   const config = posthogErrorConfig();
   if (!config) return;
 
@@ -1501,6 +1521,7 @@ function sendPostHogExceptionEvent(event: CapturedExceptionEvent): void {
 }
 
 function sendExceptionEvent(event: CapturedExceptionEvent): void {
+  if (isSyntheticBrowserTraffic()) return;
   if (isQaTrackingIdentity(_trackingIdentity)) return;
   // Route through the existing first-party analytics ingest as a dedicated
   // `$exception` event. This reuses the public-key auth + sendBeacon/keepalive
@@ -1514,6 +1535,7 @@ function sendExceptionEvent(event: CapturedExceptionEvent): void {
 }
 
 function emitExceptionToReplay(event: CapturedExceptionEvent): void {
+  if (isSyntheticBrowserTraffic()) return;
   if (isQaTrackingIdentity(_trackingIdentity)) return;
   _sessionReplayModuleForCapture?.emitSessionReplayException?.({
     type: event.type,
@@ -1732,6 +1754,9 @@ async function waitForSessionReplayAuthIfRequired(
 async function startConfiguredSessionReplay(
   options: SessionReplayOptions,
 ): Promise<SessionReplayStartResult | null> {
+  if (isSyntheticBrowserTraffic()) {
+    return { started: false, reason: "disabled" };
+  }
   if (_sessionReplayStartPromise) return _sessionReplayStartPromise;
   _sessionReplayStartPromise = (async () => {
     if (!_trackingContentCaptureEnabled) {
@@ -1766,6 +1791,9 @@ async function startConfiguredSessionReplay(
 export async function startSessionReplay(
   options: SessionReplayOptions = {},
 ): Promise<SessionReplayStartResult> {
+  if (isSyntheticBrowserTraffic()) {
+    return { started: false, reason: "disabled" };
+  }
   if (!_trackingContentCaptureEnabled) {
     return { started: false, reason: "disabled" };
   }
@@ -1787,6 +1815,9 @@ export async function startSessionReplay(
 export async function maybeStartSessionReplay(
   options: SessionReplayOptions = {},
 ): Promise<SessionReplayStartResult> {
+  if (isSyntheticBrowserTraffic()) {
+    return { started: false, reason: "disabled" };
+  }
   if (!_trackingContentCaptureEnabled) {
     return { started: false, reason: "disabled" };
   }
@@ -1978,6 +2009,7 @@ function sendAgentNativeAnalytics(
   name: string,
   properties: Record<string, unknown>,
 ): void {
+  if (isSyntheticBrowserTraffic()) return;
   if (isLocalAnalyticsHostname(window.location.hostname)) return;
 
   const publicKey =
@@ -2026,6 +2058,7 @@ export function trackEvent(
   params?: Record<string, unknown>,
 ): void {
   if (typeof window === "undefined") return;
+  if (isSyntheticBrowserTraffic()) return;
   if (isQaTrackingIdentity(_trackingIdentity)) return;
   ensureSentry();
   const props = resolveProps(name, params);

--- a/packages/core/src/client/session-replay.ts
+++ b/packages/core/src/client/session-replay.ts
@@ -7,11 +7,25 @@ import {
   type SessionReplayIframeStartMessage,
   type SessionReplayIframeStopMessage,
 } from "../session-replay-iframe-protocol.js";
+import { isSyntheticTrafficValue } from "../shared/test-traffic.js";
 import {
   getOrCreateAnalyticsAnonymousId,
   getOrCreateAnalyticsSessionId,
 } from "./analytics-session.js";
 import { scrubUrl } from "./url-scrub.js";
+
+function isSyntheticBrowserTraffic(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    isSyntheticTrafficValue(
+      (
+        window as Window & {
+          __AGENT_NATIVE_SYNTHETIC_TRAFFIC__?: unknown;
+        }
+      ).__AGENT_NATIVE_SYNTHETIC_TRAFFIC__,
+    )
+  );
+}
 
 type ReplayEvent = Record<string, unknown>;
 type QueuedReplayEvent = {
@@ -2065,6 +2079,7 @@ function rollbackReplaySequenceReservation(
 }
 
 export async function flushSessionReplay(reason = "manual"): Promise<void> {
+  if (isSyntheticBrowserTraffic()) return;
   const state = getState();
   if (!state.options) return;
   if (state.pendingReplayUpload) {
@@ -3310,6 +3325,9 @@ function installCaptureInterceptors(state: SessionReplayState): void {
 export async function startSessionReplay(
   options: SessionReplayOptions = {},
 ): Promise<SessionReplayStartResult> {
+  if (isSyntheticBrowserTraffic()) {
+    return { started: false, reason: "disabled" };
+  }
   if (options.enabled === false) return { started: false, reason: "disabled" };
   if (options.shouldStart && !options.shouldStart()) {
     return { started: false, reason: "disabled" };

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1752,7 +1752,7 @@ async function getHandler() {
         headers: {
           "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-User-Timezone,X-Agent-Native-Session-Id,X-Agent-Native-Client-Platform,X-Agent-Native-Desktop-Verifier,X-Agent-Native-Tool-Bridge,X-Agent-Native-Tool-Id,X-Agent-Native-Frontend,X-Agent-Native-Client-Compatibility,X-Agent-Native-Build-Id,X-Agent-Native-Embed-Target",
+          "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Requested-With,X-Request-Source,X-Agent-Native-CSRF,X-User-Timezone,X-Agent-Native-Session-Id,X-Agent-Native-Client-Platform,X-Agent-Native-Desktop-Verifier,X-Agent-Native-Test-Traffic,X-Agent-Native-Tool-Bridge,X-Agent-Native-Tool-Id,X-Agent-Native-Frontend,X-Agent-Native-Client-Compatibility,X-Agent-Native-Build-Id,X-Agent-Native-Embed-Target",
         },
       });
     }

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -116,6 +116,7 @@ vi.mock("../org/context.js", () => ({
 }));
 
 vi.mock("../server/request-context.js", () => ({
+  getRequestContext: vi.fn(() => undefined),
   hasRequestContext: vi.fn(() => false),
   markRequestBoundaryInstalled: vi.fn(),
   runWithRequestContext: runWithRequestContextMock,

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -26,6 +26,7 @@ import { actionCallIsReadOnly, notifyActionChange } from "./action-change.js";
 import {
   readBrowserSessionIdHeader,
   readAnalyticsClientPlatformHeader,
+  readSyntheticTrafficHeader,
   seedAgentRunOwnerContext,
   type AgentRunOwnerContext,
 } from "./agent-run-context.js";
@@ -590,6 +591,7 @@ function mountActionRoutesInternal(
         const timezone = readTimezoneHeader(event);
         const browserSessionId = readBrowserSessionIdHeader(event);
         const clientPlatform = readAnalyticsClientPlatformHeader(event);
+        const isSyntheticTraffic = readSyntheticTrafficHeader(event);
 
         return runWithRequestContext(
           {
@@ -600,6 +602,7 @@ function mountActionRoutesInternal(
             timezone,
             browserSessionId,
             clientPlatform,
+            ...(isSyntheticTraffic ? { isSyntheticTraffic: true } : {}),
             requestOrigin: getForwardedRequestOrigin(event),
             // Captured here because this is the last layer that still holds
             // the h3 event; everything below reads it off the request store.

--- a/packages/core/src/server/agent-run-context.ts
+++ b/packages/core/src/server/agent-run-context.ts
@@ -6,6 +6,10 @@ import {
   ANALYTICS_CLIENT_PLATFORM_HEADER,
   normalizeAnalyticsClientPlatform,
 } from "../shared/analytics-platform.js";
+import {
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "../shared/test-traffic.js";
 import { getSession } from "./auth.js";
 import {
   runWithRequestContext,
@@ -122,6 +126,12 @@ export function readAnalyticsClientPlatformHeader(
         ANALYTICS_CLIENT_PLATFORM_BODY_FIELD
       ],
     )
+  );
+}
+
+export function readSyntheticTrafficHeader(event: H3Event): boolean {
+  return isSyntheticTrafficValue(
+    readHeaderValue(event, SYNTHETIC_TRAFFIC_HEADER),
   );
 }
 
@@ -244,6 +254,7 @@ export async function resolveAgentRunRequestContext(options: {
   const timezone = readAgentRunTimezone(options.event);
   const browserSessionId = readBrowserSessionIdHeader(options.event);
   const clientPlatform = readAnalyticsClientPlatformHeader(options.event);
+  const isSyntheticTraffic = readSyntheticTrafficHeader(options.event);
   const waitUntil = requestWaitUntil(options.event);
   const run = {
     ...(options.isBackgroundWorker ? { isBackgroundWorker: true } : {}),
@@ -256,6 +267,7 @@ export async function resolveAgentRunRequestContext(options: {
     timezone,
     ...(browserSessionId ? { browserSessionId } : {}),
     ...(clientPlatform ? { clientPlatform } : {}),
+    ...(isSyntheticTraffic ? { isSyntheticTraffic: true } : {}),
     ...(Object.keys(run).length > 0 ? { run } : {}),
   };
 }

--- a/packages/core/src/server/analytics.spec.ts
+++ b/packages/core/src/server/analytics.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { injectAnalyticsIntoHtml, wrapWithAnalytics } from "./analytics.js";
+import { runWithRequestContext } from "./request-context.js";
 
 const previousGaMeasurementId = process.env.GA_MEASUREMENT_ID;
 const previousBakedGaMeasurementId =
@@ -174,6 +175,19 @@ describe("wrapWithAnalytics", () => {
 });
 
 describe("injectAnalyticsIntoHtml", () => {
+  it("omits analytics injection for synthetic traffic", () => {
+    process.env.GA_MEASUREMENT_ID = "G-UNITTEST123";
+    process.env.GTM_CONTAINER_ID = "GTM-AUTH123";
+    process.env.AGENT_NATIVE_ANALYTICS_PUBLIC_KEY = "anpk_test";
+
+    const source = "<html><head></head><body>synthetic</body></html>";
+    const html = runWithRequestContext({ isSyntheticTraffic: true }, () =>
+      injectAnalyticsIntoHtml(source),
+    );
+
+    expect(html).toBe(source);
+  });
+
   it("injects first-party analytics config for public auth events", () => {
     process.env.AGENT_NATIVE_ANALYTICS_PUBLIC_KEY = "anpk_auth_test";
     process.env.AGENT_NATIVE_ANALYTICS_ENDPOINT =

--- a/packages/core/src/server/analytics.ts
+++ b/packages/core/src/server/analytics.ts
@@ -1,4 +1,5 @@
 import { getAppConfig } from "../app-config/index.js";
+import { getRequestContext } from "./request-context.js";
 
 /**
  * Opt-in analytics injection for SSR streams.
@@ -146,6 +147,8 @@ type AnalyticsInjection = {
 };
 
 function getAnalyticsInjection(): AnalyticsInjection | null {
+  if (getRequestContext()?.isSyntheticTraffic) return null;
+
   const agentNativeAnalytics = getAgentNativeAnalyticsConfigScript();
   const containerId = getGtmContainerId();
   if (containerId) {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -2423,6 +2423,7 @@ function applyCorsHeaders(
           "X-Agent-Native-CSRF",
           "X-User-Timezone",
           "X-Agent-Native-Desktop-Verifier",
+          "X-Agent-Native-Test-Traffic",
           EMBED_TARGET_HEADER,
         ].join(","),
   );

--- a/packages/core/src/server/capture-error.spec.ts
+++ b/packages/core/src/server/capture-error.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { captureError, registerErrorCaptureProvider } from "./capture-error.js";
+import { runWithRequestContext } from "./request-context.js";
 
 describe("server captureError", () => {
   it("no-ops when no capture provider is registered", () => {
@@ -47,5 +48,19 @@ describe("server captureError", () => {
     expect(result).toBe("evt_ok");
     expect(throwing).toHaveBeenCalledTimes(1);
     expect(working).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not forward synthetic traffic to observability providers", () => {
+    const provider = vi.fn(() => "evt_test");
+    const unregister = registerErrorCaptureProvider("synthetic-test", provider);
+
+    const result = runWithRequestContext({ isSyntheticTraffic: true }, () =>
+      captureError(new Error("synthetic failure")),
+    );
+
+    unregister();
+
+    expect(result).toBeUndefined();
+    expect(provider).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/server/capture-error.ts
+++ b/packages/core/src/server/capture-error.ts
@@ -1,3 +1,5 @@
+import { getRequestContext } from "./request-context.js";
+
 export interface CaptureErrorContext {
   /** The request path or logical route, when known. */
   route?: string;
@@ -55,6 +57,8 @@ export function captureError(
   error: unknown,
   context: CaptureErrorContext = {},
 ): string | undefined {
+  if (getRequestContext()?.isSyntheticTraffic) return undefined;
+
   let eventId: string | undefined;
   for (const provider of providers.values()) {
     try {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -9,6 +9,10 @@ const mockPutSetting = vi.fn();
 const mockDeleteSetting = vi.fn();
 const mockGetRequestUserEmail = vi.fn<[], string | undefined>();
 const mockGetRequestOrgId = vi.fn<[], string | undefined>();
+const mockGetRequestContext = vi.fn<
+  [],
+  { isSyntheticTraffic?: boolean } | undefined
+>();
 const mockIsLocalDatabase = vi.fn<[], boolean>();
 const mockResolveOrgIdForEmail = vi.fn<[string], Promise<string | null>>();
 const mockGetDbExec = vi.fn();
@@ -20,6 +24,7 @@ vi.mock("../secrets/storage.js", () => ({
   deleteAppSecret: (...args: any[]) => mockDeleteAppSecret(...args),
 }));
 vi.mock("./request-context.js", () => ({
+  getRequestContext: () => mockGetRequestContext(),
   getRequestUserEmail: () => mockGetRequestUserEmail(),
   getRequestOrgId: () => mockGetRequestOrgId(),
 }));
@@ -164,6 +169,7 @@ beforeEach(() => {
   mockDeleteSetting.mockResolvedValue(true);
   mockGetRequestUserEmail.mockReturnValue(undefined);
   mockGetRequestOrgId.mockReturnValue(undefined);
+  mockGetRequestContext.mockReturnValue(undefined);
   mockIsLocalDatabase.mockReturnValue(true);
   mockResolveOrgIdForEmail.mockResolvedValue(null);
   mockGetDbExec.mockReturnValue({
@@ -778,6 +784,21 @@ describe("resolveBuilderCredential", () => {
     expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
     expect(canUseDeployCredentialFallbackForRequest("ANTHROPIC_API_KEY")).toBe(
       true,
+    );
+  });
+
+  it("never uses deploy provider keys for synthetic traffic", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.OPENAI_API_KEY = "openai-deploy-key";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestContext.mockReturnValue({ isSyntheticTraffic: true });
+    mockGetRequestUserEmail.mockReturnValue("e2e@example.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
+    expect(canUseDeployCredentialFallbackForRequest("OPENAI_API_KEY")).toBe(
+      false,
     );
   });
 

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -32,7 +32,11 @@ import {
 } from "../db/client.js";
 import { getOrgSetting } from "../settings/org-settings.js";
 import { isTruthyRuntimeValue } from "../shared/runtime-config.js";
-import { getRequestUserEmail, getRequestOrgId } from "./request-context.js";
+import {
+  getRequestContext,
+  getRequestUserEmail,
+  getRequestOrgId,
+} from "./request-context.js";
 
 const DISPATCH_VAULT_ACCESS_SETTINGS_KEY = "dispatch-vault-access-settings";
 
@@ -233,6 +237,10 @@ export function isDeployCredentialFallbackAllowed(): boolean {
 export function canUseDeployCredentialFallbackForRequest(
   key?: string,
 ): boolean {
+  // Synthetic checks must never fall through to a deploy-wide provider key.
+  // If the dedicated test credential is rejected, using the site's shared key
+  // would make a green retry both misleading and billable to real traffic.
+  if (getRequestContext()?.isSyntheticTraffic === true) return false;
   const email = getRequestUserEmail();
   if (!email) return true;
   if (isAppProvidedDeployCredentialKey(key)) return true;

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -12,7 +12,7 @@
  * first call to `getH3App()` per nitroApp instance.
  */
 import type { EventHandler, H3Event } from "h3";
-import { setResponseHeader, setResponseStatus } from "h3";
+import { getHeader, setResponseHeader, setResponseStatus } from "h3";
 
 import { AppConfigurationError } from "../app-config/index.js";
 import { getMissingDefaultPlugins } from "../deploy/route-discovery.js";
@@ -21,6 +21,10 @@ import {
   SIGN_IN_ENTRY_PATH,
   SIGN_IN_LEGACY_ENTRY_PATH,
 } from "../shared/sign-in-journey.js";
+import {
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "../shared/test-traffic.js";
 import { getConfiguredAppBasePath } from "./app-base-path.js";
 import { captureError } from "./capture-error.js";
 import { createCsrfMiddleware } from "./csrf.js";
@@ -320,9 +324,16 @@ function registerRequestContextBoundary(nitroApp: any): void {
   if (!h3 || !Array.isArray(h3["~middleware"])) return;
   if (h3[REQUEST_CONTEXT_BOUNDARY_KEY]) return;
 
-  const middleware = (_event: H3Event, next: () => unknown) => {
+  const middleware = (event: H3Event, next: () => unknown) => {
     if (hasRequestContext()) return next();
-    return runWithRequestContext({}, () => next());
+    return runWithRequestContext(
+      {
+        isSyntheticTraffic: isSyntheticTrafficValue(
+          getHeader(event, SYNTHETIC_TRAFFIC_HEADER),
+        ),
+      },
+      () => next(),
+    );
   };
 
   h3[REQUEST_CONTEXT_BOUNDARY_KEY] = middleware;

--- a/packages/core/src/server/request-context.spec.ts
+++ b/packages/core/src/server/request-context.spec.ts
@@ -157,6 +157,14 @@ describe("server/request-context", () => {
       });
     });
 
+    it("inherits synthetic traffic through nested request contexts", () => {
+      runWithRequestContext({ isSyntheticTraffic: true }, () => {
+        runWithRequestContext({ userEmail: "alice@example.com" }, () => {
+          expect(getRequestContext()?.isSyntheticTraffic).toBe(true);
+        });
+      });
+    });
+
     it("marks contexts when authenticated request identity is read", () => {
       runWithRequestContext({ userEmail: "alice@example.com" }, () => {
         const ctx = getRequestContext();

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -146,6 +146,8 @@ export interface RequestRunContext {
 }
 
 export interface RequestContext {
+  /** True for synthetic browser checks whose telemetry must not be recorded. */
+  isSyntheticTraffic?: boolean;
   userEmail?: string;
   userName?: string;
   orgId?: string;
@@ -321,10 +323,16 @@ export function runWithRequestContext<T>(
   ctx: RequestContext,
   fn: () => T | Promise<T>,
 ): T | Promise<T> {
-  if (ctx.run?.allowedActionNames !== undefined) {
+  const inheritedSyntheticTraffic = als.getStore()?.isSyntheticTraffic;
+  const context =
+    ctx.isSyntheticTraffic === undefined &&
+    inheritedSyntheticTraffic !== undefined
+      ? { ...ctx, isSyntheticTraffic: inheritedSyntheticTraffic }
+      : ctx;
+  if (context.run?.allowedActionNames !== undefined) {
     assertRequestActionSurfaceIsolation();
   }
-  return als.run(ctx, () => {
+  return als.run(context, () => {
     if (observers.length > 0) {
       for (const obs of observers) {
         try {

--- a/packages/core/src/server/self-dispatch.spec.ts
+++ b/packages/core/src/server/self-dispatch.spec.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+} from "../shared/test-traffic.js";
+import { runWithRequestContext } from "./request-context.js";
+import {
   fireInternalDispatch,
   resolveSelfDispatchBaseUrl,
 } from "./self-dispatch.js";
@@ -99,6 +104,32 @@ describe("fireInternalDispatch", () => {
     // The /starter base path must be stripped for the host-root function url.
     expect(calledUrl).toBe(
       "https://workspace.example.test/.netlify/functions/starter-agent-background",
+    );
+  });
+
+  it("carries the synthetic marker into a background handoff", async () => {
+    let requestHeaders: HeadersInit | undefined;
+    globalThis.fetch = vi.fn(async (_url: string, init?: RequestInit) => {
+      requestHeaders = init?.headers;
+      return {
+        ok: true,
+        status: 202,
+        statusText: "Accepted",
+        text: async () => "",
+      };
+    }) as unknown as typeof fetch;
+
+    await runWithRequestContext({ isSyntheticTraffic: true }, () =>
+      fireInternalDispatch({
+        baseUrl: "https://slides.example.test",
+        path: "/.netlify/functions/server-agent-background",
+        taskId: "task-synthetic",
+        awaitResponse: true,
+      }),
+    );
+
+    expect(new Headers(requestHeaders).get(SYNTHETIC_TRAFFIC_HEADER)).toBe(
+      SYNTHETIC_TRAFFIC_BETA_E2E,
     );
   });
 

--- a/packages/core/src/server/self-dispatch.ts
+++ b/packages/core/src/server/self-dispatch.ts
@@ -1,6 +1,10 @@
 import { getAppConfig } from "../app-config/index.js";
 import { isLocalDatabase } from "../db/client.js";
 import { signInternalToken } from "../integrations/internal-token.js";
+import {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+} from "../shared/test-traffic.js";
 /**
  * Shared self-dispatch helper for the framework's serverless background-work
  * pattern: enqueue a unit of work to SQL, then fire a fresh HTTP POST back to
@@ -27,6 +31,7 @@ import {
   getConfiguredAppBasePath,
   withConfiguredAppBasePath,
 } from "./app-base-path.js";
+import { getRequestContext } from "./request-context.js";
 
 /**
  * On serverless, returning from the dispatching handler before the outbound
@@ -178,6 +183,9 @@ export async function fireInternalDispatch(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
+  if (getRequestContext()?.isSyntheticTraffic === true) {
+    headers[SYNTHETIC_TRAFFIC_HEADER] = SYNTHETIC_TRAFFIC_BETA_E2E;
+  }
   try {
     headers["Authorization"] = `Bearer ${signInternalToken(options.taskId)}`;
   } catch (err) {

--- a/packages/core/src/server/sentry.ts
+++ b/packages/core/src/server/sentry.ts
@@ -27,6 +27,7 @@ import {
   errorSignalFromSentryEvent,
   shouldReportErrorSignal,
 } from "./error-noise-filter.js";
+import { getRequestContext } from "./request-context.js";
 import { resolveServerSentryDsn } from "./sentry-config.js";
 
 let _initStarted = false;
@@ -232,6 +233,7 @@ export function captureAuthError(
     email?: string;
   },
 ): string | undefined {
+  if (getRequestContext()?.isSyntheticTraffic) return undefined;
   if (!_initSucceeded) return undefined;
   try {
     return Sentry.withScope((scope) => {
@@ -280,6 +282,7 @@ export function captureRouteError(
   error: unknown,
   context: RouteErrorContext = {},
 ): string | undefined {
+  if (getRequestContext()?.isSyntheticTraffic) return undefined;
   if (!_initSucceeded) return undefined;
   try {
     return Sentry.withScope((scope) => {

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -117,6 +117,11 @@ export {
 } from "./chat-first-app-creation.js";
 export { isQaTestEmail } from "./qa-test-email.js";
 export {
+  SYNTHETIC_TRAFFIC_BETA_E2E,
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "./test-traffic.js";
+export {
   NATIVE_AUTH_COPY,
   resolveNativeAuthCopy,
   type NativeAuthCopy,

--- a/packages/core/src/shared/test-traffic.ts
+++ b/packages/core/src/shared/test-traffic.ts
@@ -1,7 +1,7 @@
 /**
  * Header used by synthetic browser checks to keep their telemetry out of
- * production analytics. The value is intentionally explicit so an arbitrary
- * caller cannot suppress events by sending a truthy header.
+ * production analytics. The exact value avoids accidental suppression from
+ * unrelated truthy headers; it is an operational marker, not a credential.
  */
 export const SYNTHETIC_TRAFFIC_HEADER = "X-Agent-Native-Test-Traffic";
 export const SYNTHETIC_TRAFFIC_BETA_E2E = "beta-e2e";

--- a/packages/core/src/shared/test-traffic.ts
+++ b/packages/core/src/shared/test-traffic.ts
@@ -1,0 +1,14 @@
+/**
+ * Header used by synthetic browser checks to keep their telemetry out of
+ * production analytics. The value is intentionally explicit so an arbitrary
+ * caller cannot suppress events by sending a truthy header.
+ */
+export const SYNTHETIC_TRAFFIC_HEADER = "X-Agent-Native-Test-Traffic";
+export const SYNTHETIC_TRAFFIC_BETA_E2E = "beta-e2e";
+
+export function isSyntheticTrafficValue(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    value.trim().toLowerCase() === SYNTHETIC_TRAFFIC_BETA_E2E
+  );
+}

--- a/packages/core/src/tracking/registry.spec.ts
+++ b/packages/core/src/tracking/registry.spec.ts
@@ -106,6 +106,19 @@ describe("tracking registry", () => {
     expect(identified).toEqual([]);
   });
 
+  it("suppresses synthetic browser traffic before providers", async () => {
+    const events = captureEvents();
+    await runWithRequestContext(
+      { isSyntheticTraffic: true, userEmail: "alice@example.com" },
+      () => {
+        track("synthetic_event", { source: "beta-e2e" });
+        identify("alice@example.com");
+      },
+    );
+
+    expect(events).toEqual([]);
+  });
+
   it("keeps ordinary plus-addresses trackable", () => {
     const events = captureEvents();
     const email = "signup+experiment-123@example.com";

--- a/packages/core/src/tracking/registry.ts
+++ b/packages/core/src/tracking/registry.ts
@@ -17,6 +17,7 @@ function isTrackingSuppressed(
   properties?: Record<string, unknown>,
 ): boolean {
   return (
+    getRequestContext()?.isSyntheticTraffic === true ||
     isQaTestEmail(userId) ||
     isQaTestEmail(properties?.email) ||
     isQaTestEmail(properties?.userEmail)

--- a/scripts/guard-beta-e2e-suite.ts
+++ b/scripts/guard-beta-e2e-suite.ts
@@ -201,7 +201,7 @@ if (workflow) {
     );
   }
   const hasAuthSelectionCommandWithStatus =
-    /set \+e[\s\\]+BETA_E2E_AUTHED=0 pnpm e2e:beta[\s\\]+--project=authed --project=journeys[\s\\]+--grep "\$BETA_E2E_GREP" --list >"\$selection_file" 2>&1\s+selection_status="\$\?"\s+set -e/.test(
+    /set \+e[\s\\]+BETA_E2E_AUTHED=0 pnpm e2e:beta[\s\\]+--project=\$\{\{\s*matrix\.project\s*\}\}[\s\\]+--grep "\$BETA_E2E_GREP" --list >"\$selection_file" 2>&1\s+selection_status="\$\?"\s+set -e/.test(
       workflow,
     );
   const selectionStatusCapture = workflow.indexOf('selection_status="$?"');
@@ -278,7 +278,12 @@ if (workflow) {
     type WorkflowJob = {
       needs?: string | string[];
       if?: string;
-      strategy?: { "max-parallel"?: unknown };
+      strategy?: {
+        "max-parallel"?: unknown;
+        matrix?: {
+          include?: Array<{ project?: unknown }>;
+        };
+      };
     };
     const parsed = parse(workflow) as {
       jobs?: Record<string, WorkflowJob>;
@@ -308,6 +313,40 @@ if (workflow) {
       issues.push(
         `${workflowPath} must cap the public matrix at four runners so the sharded sweep cannot burst shared backend capacity.`,
       );
+    }
+
+    const authenticatedProjects =
+      jobs.authed?.strategy?.matrix?.include?.map((entry) => entry.project) ??
+      [];
+    const configuredProjects = new Set(
+      [...config.matchAll(/\bname:\s*["']([^"']+)["']/g)].map(
+        (match) => match[1],
+      ),
+    );
+    if (authenticatedProjects.length === 0) {
+      issues.push(
+        `${workflowPath} authed must declare authenticated matrix projects so registry, chat, and journey failures remain independently visible.`,
+      );
+    }
+    const seenAuthenticatedProjects = new Set<string>();
+    for (const project of authenticatedProjects) {
+      if (typeof project !== "string" || !project) {
+        issues.push(
+          `${workflowPath} authed contains an authenticated matrix entry without a project name.`,
+        );
+        continue;
+      }
+      if (seenAuthenticatedProjects.has(project)) {
+        issues.push(
+          `${workflowPath} authed lists authenticated project ${project} more than once.`,
+        );
+      }
+      seenAuthenticatedProjects.add(project);
+      if (!configuredProjects.has(project)) {
+        issues.push(
+          `${workflowPath} authed matrix project ${project} is not configured in ${configPath}.`,
+        );
+      }
     }
 
     if (

--- a/templates/analytics/server/handlers/events.ts
+++ b/templates/analytics/server/handlers/events.ts
@@ -1,5 +1,9 @@
 import { readBody } from "@agent-native/core/server";
-import { defineEventHandler, setResponseStatus } from "h3";
+import {
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "@agent-native/core/shared";
+import { defineEventHandler, getHeader, setResponseStatus } from "h3";
 
 import { getAppEventsTable } from "../lib/bigquery";
 import { resolveCredential } from "../lib/credentials";
@@ -13,6 +17,11 @@ import { getAccessToken } from "../lib/gcloud";
  * Used for tracking metric views, user actions, etc.
  */
 export const handleTrackEvent = defineEventHandler(async (event) => {
+  if (isSyntheticTrafficValue(getHeader(event, SYNTHETIC_TRAFFIC_HEADER))) {
+    setResponseStatus(event, 202);
+    return { success: true, accepted: 0 };
+  }
+
   try {
     const { event: eventName, data, userId, timestamp } = await readBody(event);
 

--- a/templates/analytics/server/handlers/first-party-analytics.ts
+++ b/templates/analytics/server/handlers/first-party-analytics.ts
@@ -1,5 +1,9 @@
 import { readBody } from "@agent-native/core/server";
 import {
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "@agent-native/core/shared";
+import {
   defineEventHandler,
   getHeader,
   setResponseHeader,
@@ -17,7 +21,7 @@ function setCors(event: any): void {
   setResponseHeader(
     event,
     "Access-Control-Allow-Headers",
-    "content-type, x-agent-native-analytics-key",
+    `content-type, x-agent-native-analytics-key, ${SYNTHETIC_TRAFFIC_HEADER.toLowerCase()}`,
   );
   setResponseHeader(event, "Access-Control-Max-Age", "86400");
 }
@@ -30,6 +34,10 @@ export const handleAnalyticsTrackOptions = defineEventHandler((event) => {
 
 export const handleAnalyticsTrack = defineEventHandler(async (event) => {
   setCors(event);
+  if (isSyntheticTrafficValue(getHeader(event, SYNTHETIC_TRAFFIC_HEADER))) {
+    setResponseStatus(event, 202);
+    return { success: true, accepted: 0 };
+  }
   try {
     const headerKey = getHeader(event, "x-agent-native-analytics-key");
     let body = await readBody(event);

--- a/templates/analytics/server/handlers/session-replay.ts
+++ b/templates/analytics/server/handlers/session-replay.ts
@@ -1,6 +1,10 @@
 import { gunzipSync } from "node:zlib";
 
 import {
+  SYNTHETIC_TRAFFIC_HEADER,
+  isSyntheticTrafficValue,
+} from "@agent-native/core/shared";
+import {
   defineEventHandler,
   getHeader,
   getQuery,
@@ -58,7 +62,7 @@ function setCors(event: any): void {
   setResponseHeader(
     event,
     "Access-Control-Allow-Headers",
-    "content-type, content-encoding, x-agent-native-analytics-key",
+    `content-type, content-encoding, x-agent-native-analytics-key, ${SYNTHETIC_TRAFFIC_HEADER.toLowerCase()}`,
   );
   setResponseHeader(event, "Access-Control-Max-Age", "86400");
 }
@@ -274,6 +278,11 @@ export const handleSessionReplayOptions = defineEventHandler((event) => {
 
 export const handleSessionReplayIngest = defineEventHandler(async (event) => {
   setCors(event);
+  if (isSyntheticTrafficValue(getHeader(event, SYNTHETIC_TRAFFIC_HEADER))) {
+    setResponseStatus(event, 202);
+    return { success: true, accepted: 0 };
+  }
+
   try {
     const query = getQuery(event);
     if (hasQueryKey(query)) {

--- a/templates/content/app/routes/_app.home.tsx
+++ b/templates/content/app/routes/_app.home.tsx
@@ -2,7 +2,7 @@ import { useActionMutation } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import type { ContentLandingResult } from "@shared/content-landing";
 import { useCallback, useEffect, useRef } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { toast } from "sonner";
 
 import { QueryErrorState } from "@/components/QueryErrorState";
@@ -48,6 +48,7 @@ function DocumentSkeleton() {
 
 export default function HomeRoute() {
   const t = useT();
+  const location = useLocation();
   const navigate = useNavigate();
   const startedRef = useRef(false);
   const resolveLanding = useActionMutation<
@@ -63,13 +64,20 @@ export default function HomeRoute() {
       if (result.fallbackReason === "saved-document-unavailable") {
         toast.info(t("landing.previousPageUnavailable"));
       }
-      void navigate(`/page/${result.documentId}`, { replace: true });
+      void navigate(
+        {
+          pathname: `/page/${result.documentId}`,
+          search: location.search,
+          hash: location.hash,
+        },
+        { replace: true },
+      );
     } catch (error) {
       // Keep the typed mutation error available to QueryErrorState. Retrying
       // starts a fresh resolver attempt rather than pretending arrival worked.
       console.error("Failed to resolve the Content landing page", error);
     }
-  }, [navigate, resolveLanding, t]);
+  }, [location.hash, location.search, navigate, resolveLanding, t]);
 
   useEffect(() => {
     void openLanding();

--- a/templates/macros/server/plugins/auth.ts
+++ b/templates/macros/server/plugins/auth.ts
@@ -15,7 +15,7 @@ import {
   setFrameworkSessionCookie,
 } from "@agent-native/core/server";
 import { createClient } from "@supabase/supabase-js";
-import { defineEventHandler, getMethod } from "h3";
+import { createError, defineEventHandler, getMethod } from "h3";
 
 // Above a normal Neon serverless cold-wake (~1-2s) but well under both the
 // core DB op timeout and Netlify's function limit, so a slow-but-fine lookup
@@ -114,11 +114,12 @@ export default (nitroApp: any) => {
       for (const cookie of cookies) {
         const email = await getSessionEmailWithTimeout(cookie);
         if (email === "timeout") {
-          // Transient slow/cold DB — do NOT destroy a possibly-valid
-          // session. Treat this request as unauthenticated (the framework
-          // serves the login page instead of hanging), but keep the cookie
-          // so the next request succeeds once the DB warms.
-          return null;
+          // Keep the cookie and make the retryable infrastructure failure
+          // visible. Returning null turns an unreadable session into a guest.
+          throw createError({
+            statusCode: 503,
+            statusMessage: "Session lookup timed out",
+          });
         }
         if (email) return { email, token: cookie };
       }


### PR DESCRIPTION
## Summary

- Split authenticated beta E2E coverage into independent registry, chat, and journeys gates while keeping shared state serialized.
- Surface macros session lookup timeouts as HTTP 503 and classify session failures without inventing expiry diagnoses.
- Validate the selected OpenAI credential once before installation and fail synthetic requests closed instead of falling back to a deploy-wide key.
- Mark beta E2E traffic across browser, action, A2A, and background requests so server tracking and first-party analytics accept zero synthetic events.
- Preserve the agent-sidebar query through Content landing navigation and use the authenticated entry path for Slides and Content journeys.

## Validation

- `pnpm guards`
- `pnpm typecheck:e2e`
- `pnpm --filter @agent-native/core exec vitest --run src/server/request-context.spec.ts src/tracking/registry.spec.ts src/server/credential-provider.spec.ts src/server/self-dispatch.spec.ts src/a2a/client.spec.ts --config vitest.config.ts`
- `pnpm --filter @agent-native/core exec tsc --noEmit`
- macros and Content TypeScript checks
- `git diff --cached --check`
