### PR TITLE
feat: render auth onboarding with React

### DIFF
--- a/.changeset/react-auth-onboarding.md
+++ b/.changeset/react-auth-onboarding.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": minor
+"@agent-native/toolkit": minor
+---
+
+Render the shared authentication surface with hydratable React and reuse its marketing composition for SSR app entry pages.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -1,0 +1,53 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { getOnboardingHtml } from "../../server/onboarding-html.js";
+import { AuthPage, type AuthPageProps } from "./AuthPage.js";
+
+function propsFromHtml(html: string): AuthPageProps {
+  const match = html.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("auth page data is missing");
+  return JSON.parse(match[1]!) as AuthPageProps;
+}
+
+describe("AuthPage", () => {
+  it("renders the password auth surface on the server without browser globals", () => {
+    const html = renderToString(
+      <AuthPage {...propsFromHtml(getOnboardingHtml())} />,
+    );
+
+    expect(html).toContain('id="signup-form"');
+    expect(html).toContain('id="login-form"');
+    expect(html).toContain('id="forgot-form"');
+    expect(html).not.toContain("onclick");
+  });
+
+  it("composes the shared marketing home and starfield for branded auth", () => {
+    const html = renderToString(
+      <AuthPage
+        {...propsFromHtml(
+          getOnboardingHtml({ requestHost: "slides.agent-native.com" }),
+        )}
+      />,
+    );
+
+    expect(html).toContain('data-agent-native-marketing-home="true"');
+    expect(html).toContain('data-agent-native-starfield="true"');
+    expect(html).toContain('class="split');
+    expect(html).toContain('class="marketing-panel"');
+    expect(html).toContain('class="form-panel');
+  });
+
+  it("keeps the magic-link entry and completion surfaces in the React tree", () => {
+    const props = propsFromHtml(getOnboardingHtml({ authMode: "magic-link" }));
+    const html = renderToString(<AuthPage {...props} />);
+
+    expect(props.initialView).toBe("magicLink");
+    expect(html).toContain('id="magic-link-form"');
+    expect(html).toContain('id="magic-link-success"');
+    expect(html).toContain('id="magic-link-success-email"');
+    expect(html).toContain('id="use-password-link"');
+  });
+});

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -616,10 +616,17 @@ export function AuthPage(props: AuthPageProps) {
 
   const [runtimeAppBasePath, setRuntimeAppBasePath] =
     React.useState(appBasePath);
+  const [runtimeBasePathResolved, setRuntimeBasePathResolved] = React.useState(
+    Boolean(appBasePath || !workspaceRuntime),
+  );
 
   React.useEffect(() => {
-    if (appBasePath || !workspaceRuntime) return;
+    if (appBasePath || !workspaceRuntime) {
+      setRuntimeBasePathResolved(true);
+      return;
+    }
     setRuntimeAppBasePath(inferWorkspaceBasePath(window.location.pathname));
+    setRuntimeBasePathResolved(true);
   }, [appBasePath, workspaceRuntime]);
 
   const t = React.useCallback(
@@ -771,6 +778,7 @@ export function AuthPage(props: AuthPageProps) {
   }, [authMode, googleOnly, readPendingSignupEmail, setNotice, t]);
 
   React.useEffect(() => {
+    if (!runtimeBasePathResolved) return;
     const probe = async () => {
       for (let attempt = 0; attempt < 3; attempt += 1) {
         let retry = false;
@@ -797,7 +805,7 @@ export function AuthPage(props: AuthPageProps) {
       }
     };
     void probe();
-  }, [apiPath, redirectToSignedInApp]);
+  }, [apiPath, redirectToSignedInApp, runtimeBasePathResolved]);
 
   React.useEffect(() => {
     let anonymousId = readStorage(ANALYTICS_ANONYMOUS_ID_KEY);
@@ -881,7 +889,7 @@ export function AuthPage(props: AuthPageProps) {
   );
 
   React.useEffect(() => {
-    if (!localDevAllowed) return;
+    if (!runtimeBasePathResolved || !localDevAllowed) return;
     let active = true;
     const loadAvailability = async () => {
       try {
@@ -914,7 +922,7 @@ export function AuthPage(props: AuthPageProps) {
     return () => {
       active = false;
     };
-  }, [apiPath, localDevAllowed]);
+  }, [apiPath, localDevAllowed, runtimeBasePathResolved]);
 
   React.useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1497,7 +1505,13 @@ export function AuthPage(props: AuthPageProps) {
   );
 
   React.useEffect(() => {
-    if (googleOnly || verifiedReturnHandled.current) return;
+    if (
+      !runtimeBasePathResolved ||
+      googleOnly ||
+      verifiedReturnHandled.current
+    ) {
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     if (params.get("verified") !== "1") return;
     verifiedReturnHandled.current = true;
@@ -1506,7 +1520,7 @@ export function AuthPage(props: AuthPageProps) {
       text: t("emailVerifiedFinishing"),
     });
     void checkVerification(t("emailVerifiedSignIn"));
-  }, [checkVerification, googleOnly, setNotice, t]);
+  }, [checkVerification, googleOnly, runtimeBasePathResolved, setNotice, t]);
 
   React.useEffect(() => {
     if (view !== "verification") return;

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -80,6 +80,7 @@ type Notice = { kind: "error" | "success"; text: string } | null;
 type AuthRequestResult = {
   response: Response;
   data: Record<string, unknown>;
+  readable: boolean;
 };
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -210,15 +211,17 @@ async function requestJson(
     ...init,
   });
   let data: Record<string, unknown> = {};
+  let readable = false;
   try {
     const parsed: unknown = await response.json();
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       data = parsed as Record<string, unknown>;
+      readable = true;
     }
   } catch {
     // coercion-ok: a non-JSON response still has a status the caller can inspect.
   }
-  return { response, data };
+  return { response, data, readable };
 }
 
 function generateAnonymousId(): string {
@@ -330,7 +333,7 @@ function isBuilderPreview(): boolean {
 export function isAgentNativeDesktop(
   userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent,
 ): boolean {
-  return userAgent.includes("AgentNativeDesktop");
+  return /AgentNativeDesktop/i.test(userAgent);
 }
 
 export function isElectron(
@@ -596,6 +599,9 @@ export function AuthPage(props: AuthPageProps) {
   const oauthPopupTimer = React.useRef<number | null>(null);
   const oauthPopupGraceTimer = React.useRef<number | null>(null);
   const oauthFlowId = React.useRef<string | null>(null);
+  const nativeOAuthFlowId = React.useRef<string | null>(null);
+  const nativeOAuthRequestPending = React.useRef(false);
+  const nativeOAuthAbandonTimer = React.useRef<number | null>(null);
   const verificationCheckInFlight = React.useRef(false);
   const verifiedReturnHandled = React.useRef(false);
 
@@ -757,19 +763,29 @@ export function AuthPage(props: AuthPageProps) {
 
   React.useEffect(() => {
     const probe = async () => {
-      try {
-        const { response, data } = await requestJson(
-          apiPath("/_agent-native/auth/session"),
-          {
-            headers: { Accept: "application/json" },
-            cache: "no-store",
-          },
-        );
-        if (response.ok && typeof data.email === "string" && !data.error) {
-          redirectToSignedInApp();
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        let retry = false;
+        try {
+          const { response, data, readable } = await requestJson(
+            apiPath("/_agent-native/auth/session"),
+            {
+              headers: { Accept: "application/json" },
+              cache: "no-store",
+            },
+          );
+          if (response.ok && typeof data.email === "string" && !data.error) {
+            redirectToSignedInApp();
+            return;
+          }
+          retry =
+            !readable || response.status === 429 || response.status >= 500;
+        } catch {
+          retry = true;
         }
-      } catch {
-        // coercion-ok: an unavailable session probe leaves manual sign-in usable.
+        if (!retry || attempt === 2) return;
+        await new Promise<void>((resolve) =>
+          window.setTimeout(resolve, 250 * (attempt + 1)),
+        );
       }
     };
     void probe();
@@ -901,12 +917,13 @@ export function AuthPage(props: AuthPageProps) {
   }, []);
 
   React.useEffect(() => {
-    if (!localDevAllowed) return;
     if (window.parent !== window) return;
     try {
-      const forceUrl = new URL(window.location.href);
-      if (forceUrl.searchParams.get(props.betaForceQueryParam) === "true") {
-        window.sessionStorage.setItem(props.betaForceSessionStorageKey, "1");
+      if (localDevAllowed) {
+        const forceUrl = new URL(window.location.href);
+        if (forceUrl.searchParams.get(props.betaForceQueryParam) === "true") {
+          window.sessionStorage.setItem(props.betaForceSessionStorageKey, "1");
+        }
       }
       const optOutUrl = new URL(window.location.href);
       const optOutValue = optOutUrl.searchParams.get(
@@ -972,11 +989,66 @@ export function AuthPage(props: AuthPageProps) {
     oauthPollInFlight.current = false;
   }, []);
 
+  const clearNativeOAuthRecovery = React.useCallback(() => {
+    if (nativeOAuthAbandonTimer.current !== null) {
+      window.clearTimeout(nativeOAuthAbandonTimer.current);
+      nativeOAuthAbandonTimer.current = null;
+    }
+  }, []);
+
+  const stopNativeOAuth = React.useCallback(() => {
+    clearNativeOAuthRecovery();
+    nativeOAuthFlowId.current = null;
+    nativeOAuthRequestPending.current = false;
+  }, [clearNativeOAuthRecovery]);
+
   React.useEffect(() => stopOAuthPolling, [stopOAuthPolling]);
+
+  React.useEffect(() => {
+    if (!isAgentNativeDesktop()) return;
+    const recoverAfterReturn = () => {
+      const flowId = nativeOAuthFlowId.current;
+      if (
+        !flowId ||
+        nativeOAuthRequestPending.current ||
+        oauthPollTimer.current === null
+      ) {
+        return;
+      }
+      clearNativeOAuthRecovery();
+      nativeOAuthAbandonTimer.current = window.setTimeout(() => {
+        nativeOAuthAbandonTimer.current = null;
+        if (
+          flowId !== nativeOAuthFlowId.current ||
+          nativeOAuthRequestPending.current ||
+          oauthPollTimer.current === null
+        ) {
+          return;
+        }
+        stopOAuthPolling();
+        nativeOAuthFlowId.current = null;
+        nativeOAuthRequestPending.current = false;
+        setGoogleBusy(false);
+      }, 5000);
+    };
+    const clearRecoveryWhileHidden = () => clearNativeOAuthRecovery();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") recoverAfterReturn();
+      else clearRecoveryWhileHidden();
+    };
+    window.addEventListener("focus", recoverAfterReturn);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("focus", recoverAfterReturn);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearNativeOAuthRecovery();
+    };
+  }, [clearNativeOAuthRecovery, stopOAuthPolling]);
 
   const finishOAuthExchange = React.useCallback(
     (target: string, sessionToken?: string) => {
       stopOAuthPolling();
+      stopNativeOAuth();
       setGoogleBusy(false);
       setMagicLinkBusy(false);
       if (isBuilderPreview() && sessionToken) {
@@ -991,7 +1063,7 @@ export function AuthPage(props: AuthPageProps) {
       }
       redirectToSignedInApp(target);
     },
-    [redirectToSignedInApp, stopOAuthPolling],
+    [redirectToSignedInApp, stopNativeOAuth, stopOAuthPolling],
   );
 
   const startOAuthExchange = React.useCallback(
@@ -1028,6 +1100,7 @@ export function AuthPage(props: AuthPageProps) {
           }
           if (data.error) {
             stopOAuthPolling();
+            stopNativeOAuth();
             setGoogleBusy(false);
             setMagicLinkBusy(false);
             if (kind === "magic-link") setView("magicLink");
@@ -1049,6 +1122,7 @@ export function AuthPage(props: AuthPageProps) {
         }
         if (Date.now() - startedAt > 5 * 60 * 1000) {
           stopOAuthPolling();
+          stopNativeOAuth();
           setGoogleBusy(false);
           setMagicLinkBusy(false);
           if (kind === "magic-link") setView("magicLink");
@@ -1108,12 +1182,19 @@ export function AuthPage(props: AuthPageProps) {
                   text: t("googlePopupHelp"),
                 });
               });
-          }, 1200);
+          }, 5000);
         }, 500);
       }
       window.setTimeout(() => void check(), 500);
     },
-    [apiPath, finishOAuthExchange, setNotice, stopOAuthPolling, t],
+    [
+      apiPath,
+      finishOAuthExchange,
+      setNotice,
+      stopNativeOAuth,
+      stopOAuthPolling,
+      t,
+    ],
   );
 
   const resolveGoogleFlow = React.useCallback(() => {
@@ -1126,7 +1207,7 @@ export function AuthPage(props: AuthPageProps) {
     if (googleAuthMode === "popup" || googleAuthMode === "redirect") {
       return googleAuthMode;
     }
-    return isAgentNativeDesktop() || isElectron() ? "redirect" : "popup";
+    return isAgentNativeDesktop() ? "redirect" : "popup";
   }, [googleAuthMode]);
 
   const googleAuthUrlPath = React.useCallback(() => {
@@ -1159,8 +1240,16 @@ export function AuthPage(props: AuthPageProps) {
     const flowId = createFlowId();
     oauthFlowId.current = flowId;
     const flow = resolveGoogleFlow();
+    const nativeDesktop = flow === "redirect" && isAgentNativeDesktop();
+    if (nativeDesktop) {
+      stopNativeOAuth();
+      nativeOAuthFlowId.current = flowId;
+      nativeOAuthRequestPending.current = true;
+    } else {
+      stopNativeOAuth();
+    }
     const authUrl = googleAuthUrlPath();
-    if (flow === "redirect" && !isAgentNativeDesktop()) {
+    if (flow === "redirect" && !nativeDesktop) {
       const params = new URLSearchParams({
         return: oauthTarget,
         redirect: "1",
@@ -1170,15 +1259,25 @@ export function AuthPage(props: AuthPageProps) {
     }
     const verifier = createVerifier();
     if (!verifier) {
+      stopNativeOAuth();
       setGoogleBusy(false);
       setNotice("google", { kind: "error", text: t("failedToConnect") });
       return;
     }
     let popup: Window | null = null;
     if (flow === "popup") {
+      const builderPreviewFrame = isBuilderPreview() && isInFrame();
       try {
         popup = window.open("", "_blank", "width=640,height=760");
         if (!popup) {
+          if (builderPreviewFrame) {
+            setGoogleBusy(false);
+            setNotice("google", {
+              kind: "error",
+              text: t("googlePopupHelp"),
+            });
+            return;
+          }
           const params = new URLSearchParams({
             return: oauthTarget,
             redirect: "1",
@@ -1192,6 +1291,14 @@ export function AuthPage(props: AuthPageProps) {
           // coercion-ok: some browsers expose popup.opener as read-only.
         }
       } catch {
+        if (builderPreviewFrame) {
+          setGoogleBusy(false);
+          setNotice("google", {
+            kind: "error",
+            text: t("googlePopupHelp"),
+          });
+          return;
+        }
         const params = new URLSearchParams({
           return: oauthTarget,
           redirect: "1",
@@ -1219,18 +1326,20 @@ export function AuthPage(props: AuthPageProps) {
       if (!response.ok || typeof data.url !== "string" || !data.url) {
         throw new Error(authErrorText(data, t("failedToConnect")));
       }
+      if (nativeDesktop) nativeOAuthRequestPending.current = false;
+      startOAuthExchange(flowId, target, verifier, "google", popup);
       if (popup) {
         popup.location.href = data.url;
       } else {
         window.location.href = data.url;
       }
-      startOAuthExchange(flowId, target, verifier, "google", popup);
     } catch (error) {
       try {
         popup?.close();
       } catch {
         // Ignore a popup that has already closed.
       }
+      stopNativeOAuth();
       setGoogleBusy(false);
       setNotice("google", {
         kind: "error",
@@ -1244,6 +1353,7 @@ export function AuthPage(props: AuthPageProps) {
     resumeHref,
     showGoogle,
     startOAuthExchange,
+    stopNativeOAuth,
     stopOAuthPolling,
     t,
     trackingApp,

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -1,3 +1,5 @@
+/** @jsxRuntime classic */
+
 import { MarketingHome, Starfield } from "@agent-native/toolkit/marketing";
 import { AuthForm } from "@agent-native/toolkit/onboarding";
 import * as React from "react";
@@ -200,6 +202,13 @@ function authErrorText(
     return fallback;
   }
   return message;
+}
+
+export function shouldRetryAuthSessionProbe(
+  response: Pick<Response, "status">,
+  readable: boolean,
+): boolean {
+  return !readable || response.status === 429 || response.status >= 500;
 }
 
 async function requestJson(
@@ -777,8 +786,7 @@ export function AuthPage(props: AuthPageProps) {
             redirectToSignedInApp();
             return;
           }
-          retry =
-            !readable || response.status === 429 || response.status >= 500;
+          retry = shouldRetryAuthSessionProbe(response, readable);
         } catch {
           retry = true;
         }

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -1,0 +1,2523 @@
+import { MarketingHome, Starfield } from "@agent-native/toolkit/marketing";
+import { AuthForm } from "@agent-native/toolkit/onboarding";
+import * as React from "react";
+
+import {
+  signInJourney,
+  type SignInJourney,
+} from "../../shared/sign-in-journey.js";
+
+export type AuthView =
+  | "signup"
+  | "login"
+  | "forgot"
+  | "verification"
+  | "magicLink"
+  | "magicLinkSent"
+  | "googleOnly";
+
+export interface AuthMarketingProps {
+  appName: string;
+  tagline?: string;
+  description?: string;
+  features?: string[];
+}
+
+export interface AuthLocaleOption {
+  value: string;
+  label: string;
+}
+
+export interface AuthLegalNotice {
+  termsUrl: string;
+  privacyUrl: string;
+  termsLabel?: string;
+  privacyLabel?: string;
+  prefix?: string;
+  connector?: string;
+  suffix?: string;
+}
+
+export interface AuthPageProps {
+  authMode: "magic-link" | "password";
+  googleOnly: boolean;
+  initialPrompt: boolean;
+  initialView: AuthView;
+  appBasePath: string;
+  workspaceRuntime: boolean;
+  trackingApp: string;
+  defaultLocale: string;
+  localeStorageKey: string;
+  locales: Record<string, Record<string, string>>;
+  localeMetadata: Record<string, { dir?: string }>;
+  localeOptions: AuthLocaleOption[];
+  marketing?: AuthMarketingProps;
+  marketingLocales: Record<string, AuthMarketingProps>;
+  brandMarkSrc: string;
+  githubUrl: string;
+  showGoogle: boolean;
+  signupLegalNotice?: AuthLegalNotice;
+  signupLocalModeNote?: { text: string; command: string };
+  connectionLabel: string;
+  docsAuthUrl: string;
+  identitySsoEnabled: boolean;
+  publicOAuthOrigin: string;
+  workspaceGatewayReturnOrigin: string;
+  googleAuthMode: "popup" | "redirect" | "auto";
+  builderPreviewLocalDevEnabled: boolean;
+  environmentBetaHosts: Record<string, string>;
+  betaForceQueryParam: string;
+  betaForceSessionStorageKey: string;
+  betaOptOutQueryParam: string;
+  betaOptOutStorageKey: string;
+  betaOptOutDurationMs: number;
+  passwordMinLength: number;
+  passwordMaxLength: number;
+  passwordMaxCopy: string;
+}
+
+type Notice = { kind: "error" | "success"; text: string } | null;
+type AuthRequestResult = {
+  response: Response;
+  data: Record<string, unknown>;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const TAB_STORAGE_KEY = "an.onboarding.tab";
+const PENDING_SIGNUP_EMAIL_STORAGE_KEY = "an.onboarding.pendingSignupEmail";
+const ANALYTICS_ANONYMOUS_ID_KEY = "agent-native.anonymous_id";
+const ANALYTICS_SESSION_ID_KEY = "agent-native.session_id";
+const FIRST_TOUCH_STORAGE_KEY = "an_attribution";
+const FIRST_TOUCH_COOKIE = "an_ft";
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function isValidEmail(value: string): boolean {
+  return EMAIL_PATTERN.test(normalizeEmail(value));
+}
+
+function copyText(
+  locales: Record<string, Record<string, string>>,
+  defaultLocale: string,
+  locale: string,
+  key: string,
+): string {
+  return locales[locale]?.[key] ?? locales[defaultLocale]?.[key] ?? key;
+}
+
+function resolveLocale(
+  value: string | undefined,
+  localeOptions: AuthLocaleOption[],
+  defaultLocale: string,
+): string {
+  if (!value || value === "system") return defaultLocale;
+  const exact = localeOptions.find((option) => option.value === value);
+  if (exact) return exact.value;
+  try {
+    const canonical = Intl.getCanonicalLocales(value)[0]?.toLowerCase();
+    const match = localeOptions.find(
+      (option) =>
+        option.value.toLowerCase() === canonical ||
+        option.value.split("-")[0]?.toLowerCase() === canonical?.split("-")[0],
+    );
+    return match?.value ?? defaultLocale;
+  } catch {
+    // coercion-ok: malformed locale input falls back to the configured locale.
+    return defaultLocale;
+  }
+}
+
+function resolveSystemLocale(
+  localeOptions: AuthLocaleOption[],
+  defaultLocale: string,
+): string {
+  if (typeof navigator === "undefined") return defaultLocale;
+  const candidates = navigator.languages?.length
+    ? navigator.languages
+    : [navigator.language];
+  for (const candidate of candidates) {
+    const locale = resolveLocale(candidate, localeOptions, defaultLocale);
+    if (locale !== defaultLocale || candidate?.startsWith(defaultLocale)) {
+      return locale;
+    }
+  }
+  return defaultLocale;
+}
+
+function inferWorkspaceBasePath(pathname: string): string {
+  const firstSegment = pathname.split("/").find(Boolean);
+  if (
+    !firstSegment ||
+    ["_agent-native", "api", "sign-in", "login", "signup"].includes(
+      firstSegment,
+    )
+  ) {
+    return "";
+  }
+  return `/${firstSegment}`;
+}
+
+function readStorage(key: string): string {
+  try {
+    return window.localStorage.getItem(key) ?? "";
+  } catch {
+    // coercion-ok: localStorage is optional; an empty value means no saved state.
+    return "";
+  }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // coercion-ok: browser storage is optional and auth has in-memory fallbacks.
+  }
+}
+
+function removeStorage(key: string): void {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // coercion-ok: browser storage is optional.
+  }
+}
+
+function authErrorText(
+  data: Record<string, unknown>,
+  fallback: string,
+): string {
+  const candidate = data.error ?? data.message;
+  if (typeof candidate !== "string" || !candidate.trim()) return fallback;
+  const message = candidate.trim();
+  if (
+    /failed query|\bselect\b.*\bfrom\b|\binsert\b.*\binto\b|\bupdate\b.*\bset\b|\bdelete\b.*\bfrom\b|\bsql\b|database|relation .* does not exist|column .* does not exist|syntax error|constraint|connection refused|econn|timeout/i.test(
+      message,
+    )
+  ) {
+    return fallback;
+  }
+  return message;
+}
+
+async function requestJson(
+  url: string,
+  init: RequestInit = {},
+): Promise<AuthRequestResult> {
+  const response = await fetch(url, {
+    credentials: "include",
+    ...init,
+  });
+  let data: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = await response.json();
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      data = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // coercion-ok: a non-JSON response still has a status the caller can inspect.
+  }
+  return { response, data };
+}
+
+function generateAnonymousId(): string {
+  try {
+    if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  } catch {
+    // coercion-ok: the browser fallback remains usable when crypto is unavailable.
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function safeAttributionValue(value: string | null): string {
+  return typeof value === "string" ? value.trim().slice(0, 120) : "";
+}
+
+function trackAuth(
+  app: string,
+  name: string,
+  properties: Record<string, unknown> = {},
+): void {
+  try {
+    const config = (
+      window as Window & {
+        __AGENT_NATIVE_CONFIG__?: {
+          agentNativeAnalyticsPublicKey?: string;
+          agentNativeAnalyticsEndpoint?: string;
+        };
+      }
+    ).__AGENT_NATIVE_CONFIG__;
+    if (!config?.agentNativeAnalyticsPublicKey) return;
+    const anonymousId = readStorage(ANALYTICS_ANONYMOUS_ID_KEY);
+    if (!anonymousId) return;
+    const sessionId = (() => {
+      try {
+        return window.sessionStorage.getItem(ANALYTICS_SESSION_ID_KEY) ?? "";
+      } catch {
+        // coercion-ok: analytics session storage is optional.
+        return "";
+      }
+    })();
+    const body = JSON.stringify({
+      publicKey: config.agentNativeAnalyticsPublicKey,
+      event: name,
+      properties: { app, ...properties },
+      anonymousId,
+      sessionId: sessionId || undefined,
+      timestamp: new Date().toISOString(),
+    });
+    const endpoint =
+      config.agentNativeAnalyticsEndpoint ??
+      "https://analytics.agent-native.com/track";
+    if (navigator.sendBeacon?.(endpoint, body)) return;
+    void fetch(endpoint, {
+      method: "POST",
+      body,
+      keepalive: true,
+      headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    }).catch(() => undefined);
+  } catch {
+    // coercion-ok: analytics is best effort and cannot block authentication.
+  }
+}
+
+function isLoopbackHostname(): boolean {
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    hostname === "127.0.0.1" ||
+    hostname.startsWith("127.")
+  );
+}
+
+function isBuilderPreviewHostname(): boolean {
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname.toLowerCase();
+  return (
+    hostname.endsWith(".builderio.xyz") ||
+    hostname.endsWith(".builderio.dev") ||
+    hostname.endsWith(".builder.codes") ||
+    hostname.endsWith(".builder.my")
+  );
+}
+
+function isBuilderPreview(): boolean {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (
+      params.has("builder.preview") ||
+      params.has("builder.frameEditing") ||
+      params.has("__builder_editing__")
+    ) {
+      window.sessionStorage.setItem("__an_builder_preview_seen", "1");
+      return true;
+    }
+    if (window.sessionStorage.getItem("__an_builder_preview_seen") === "1") {
+      return true;
+    }
+  } catch {
+    // coercion-ok: preview storage is optional; referrer detection remains available.
+  }
+  const referrer = document.referrer;
+  return /builder\.io|builder\.my|builderio\.xyz|builderio\.dev|builder\.codes/i.test(
+    referrer,
+  );
+}
+
+export function isAgentNativeDesktop(
+  userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): boolean {
+  return userAgent.includes("AgentNativeDesktop");
+}
+
+export function isElectron(
+  userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): boolean {
+  return userAgent.includes("Electron");
+}
+
+function isInFrame(): boolean {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // coercion-ok: cross-origin frame inspection can be denied; assume embedded.
+    return true;
+  }
+}
+
+function configuredOAuthOrigin(value: string): string {
+  if (!value) return "";
+  try {
+    const origin = new URL(value).origin;
+    return origin !== window.location.origin ? origin : "";
+  } catch {
+    // coercion-ok: malformed optional OAuth configuration uses same-origin behavior.
+    return "";
+  }
+}
+
+function builderPreviewReturnOrigin(): string {
+  if (typeof window === "undefined") return "";
+  const candidates = [window.location.href, document.referrer];
+  try {
+    if (window.location.ancestorOrigins) {
+      for (const origin of window.location.ancestorOrigins)
+        candidates.push(origin);
+    }
+  } catch {
+    // coercion-ok: ancestor frame metadata is optional and may be inaccessible.
+  }
+  for (const candidate of candidates) {
+    try {
+      const url = new URL(candidate);
+      const hostname = url.hostname.toLowerCase();
+      const isBuilderHost =
+        hostname === "builderio.xyz" ||
+        hostname.endsWith(".builderio.xyz") ||
+        hostname === "builderio.dev" ||
+        hostname.endsWith(".builderio.dev") ||
+        hostname === "builder.codes" ||
+        hostname.endsWith(".builder.codes") ||
+        hostname === "builder.my" ||
+        hostname.endsWith(".builder.my");
+      if (url.protocol === "https:" && isBuilderHost) return url.origin;
+    } catch {
+      // coercion-ok: malformed frame metadata is ignored.
+    }
+  }
+  return "";
+}
+
+export function normalizeOAuthReturnPath(
+  target: string,
+  origin = typeof window === "undefined"
+    ? "http://agent-native.local"
+    : window.location.origin,
+): string {
+  try {
+    const url = new URL(target || "/", origin);
+    let pathname = url.pathname || "/";
+    if (pathname === "/dispatch/dispatch") {
+      pathname = "/dispatch";
+    } else if (pathname.startsWith("/dispatch/")) {
+      const rest = pathname.slice("/dispatch/".length);
+      const first = rest.split("/")[0];
+      const dispatchRoutes = new Set([
+        "overview",
+        "apps",
+        "metrics",
+        "vault",
+        "integrations",
+        "messaging",
+        "workspace",
+        "agents",
+        "destinations",
+        "identities",
+        "approvals",
+        "audit",
+        "team",
+        "thread-debug",
+        "new-app",
+      ]);
+      if (first === "dispatch")
+        pathname = "/dispatch" + rest.slice(first.length);
+      else if (first && !dispatchRoutes.has(first)) pathname = "/" + rest;
+    }
+    return pathname + url.search + url.hash;
+  } catch {
+    return target || "/";
+  }
+}
+
+function oauthReturnTarget(
+  target: string,
+  workspaceGatewayReturnOrigin: string,
+): string {
+  const path = normalizeOAuthReturnPath(target);
+  const origin =
+    builderPreviewReturnOrigin() ||
+    workspaceGatewayReturnOrigin ||
+    (isAgentNativeDesktop() ? "http://127.0.0.1:8080" : "");
+  return origin ? origin + path : path;
+}
+
+function createFlowId(): string {
+  try {
+    if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  } catch {
+    // coercion-ok: the browser fallback remains usable when crypto is unavailable.
+  }
+  return `agent-native-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function createVerifier(): string {
+  try {
+    if (typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID() + crypto.randomUUID();
+    }
+    if (typeof crypto.getRandomValues === "function") {
+      const bytes = new Uint8Array(32);
+      crypto.getRandomValues(bytes);
+      let binary = "";
+      for (const byte of bytes) binary += String.fromCharCode(byte);
+      return btoa(binary)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    }
+  } catch {
+    // coercion-ok: no verifier is a typed failure handled by the OAuth caller.
+    return "";
+  }
+  return "";
+}
+
+const GOOGLE_BRAND_COLORS = {
+  // guard:allow-raw-color - Google brand mark must retain provider colors.
+  blue: "#4285F4",
+  // guard:allow-raw-color - Google brand mark must retain provider colors.
+  green: "#34A853",
+  // guard:allow-raw-color - Google brand mark must retain provider colors.
+  yellow: "#FBBC05",
+  // guard:allow-raw-color - Google brand mark must retain provider colors.
+  red: "#EA4335",
+} as const;
+
+function googleSvg(): React.ReactNode {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill={GOOGLE_BRAND_COLORS.blue}
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+      />
+      <path
+        fill={GOOGLE_BRAND_COLORS.green}
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill={GOOGLE_BRAND_COLORS.yellow}
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill={GOOGLE_BRAND_COLORS.red}
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
+function headingKeys(view: AuthView): { heading: string; subtitle: string } {
+  if (view === "login") {
+    return { heading: "welcomeBackTitle", subtitle: "signInSubtitle" };
+  }
+  if (view === "forgot") {
+    return { heading: "resetPasswordTitle", subtitle: "resetPasswordSubtitle" };
+  }
+  if (view === "verification") {
+    return { heading: "checkEmailTitle", subtitle: "finishAccountSubtitle" };
+  }
+  if (view === "googleOnly") {
+    return { heading: "signInTitle", subtitle: "googleOnlySubtitle" };
+  }
+  if (view === "magicLinkSent") {
+    return { heading: "magicLinkSent", subtitle: "magicLinkSentCopy" };
+  }
+  if (view === "magicLink") {
+    return { heading: "magicLinkTitle", subtitle: "magicLinkSubtitle" };
+  }
+  return { heading: "welcomeTitle", subtitle: "createAccountSubtitle" };
+}
+
+export function AuthPage(props: AuthPageProps) {
+  const {
+    authMode,
+    googleOnly,
+    initialPrompt,
+    appBasePath,
+    workspaceRuntime,
+    trackingApp,
+    defaultLocale,
+    localeStorageKey,
+    locales,
+    localeMetadata,
+    localeOptions,
+    marketing,
+    marketingLocales,
+    brandMarkSrc,
+    githubUrl,
+    showGoogle,
+    signupLegalNotice,
+    signupLocalModeNote,
+    connectionLabel,
+    docsAuthUrl,
+    identitySsoEnabled,
+    publicOAuthOrigin,
+    workspaceGatewayReturnOrigin,
+    googleAuthMode,
+    builderPreviewLocalDevEnabled,
+  } = props;
+  const [localePreference, setLocalePreference] = React.useState("system");
+  const [locale, setLocale] = React.useState(defaultLocale);
+  const [localeMenuOpen, setLocaleMenuOpen] = React.useState(false);
+  const [view, setView] = React.useState<AuthView>(props.initialView);
+  const [messages, setMessages] = React.useState<Record<string, Notice>>({});
+  const [submitting, setSubmitting] = React.useState<string | null>(null);
+  const [localDevAvailable, setLocalDevAvailable] = React.useState(false);
+  const [localDevBusy, setLocalDevBusy] = React.useState(false);
+  const [fullAuthOptionsVisible, setFullAuthOptionsVisible] =
+    React.useState(true);
+  const [localNoteVisible, setLocalNoteVisible] = React.useState(false);
+  const [upgradeVisible, setUpgradeVisible] = React.useState(false);
+  const [magicLinkEmail, setMagicLinkEmail] = React.useState("");
+  const [signupEmail, setSignupEmail] = React.useState("");
+  const [signupPassword, setSignupPassword] = React.useState("");
+  const [signupPasswordConfirmation, setSignupPasswordConfirmation] =
+    React.useState("");
+  const [loginEmail, setLoginEmail] = React.useState("");
+  const [loginPassword, setLoginPassword] = React.useState("");
+  const [forgotEmail, setForgotEmail] = React.useState("");
+  const [forgotSent, setForgotSent] = React.useState(false);
+  const [verificationEmail, setVerificationEmail] = React.useState("");
+  const [verificationResendUntil, setVerificationResendUntil] =
+    React.useState(0);
+  const [googleBusy, setGoogleBusy] = React.useState(false);
+  const [magicLinkBusy, setMagicLinkBusy] = React.useState(false);
+  const [environmentVisible, setEnvironmentVisible] = React.useState(false);
+  const [environmentOpen, setEnvironmentOpen] = React.useState(false);
+  const [environmentProductionUrl, setEnvironmentProductionUrl] =
+    React.useState("");
+  const [copiedLocalMode, setCopiedLocalMode] = React.useState(false);
+  const pendingSignupPassword = React.useRef("");
+  const oauthPollTimer = React.useRef<number | null>(null);
+  const oauthPollInFlight = React.useRef(false);
+  const oauthPopupTimer = React.useRef<number | null>(null);
+  const oauthPopupGraceTimer = React.useRef<number | null>(null);
+  const oauthFlowId = React.useRef<string | null>(null);
+  const verificationCheckInFlight = React.useRef(false);
+  const verifiedReturnHandled = React.useRef(false);
+
+  const [runtimeAppBasePath, setRuntimeAppBasePath] =
+    React.useState(appBasePath);
+
+  React.useEffect(() => {
+    if (appBasePath || !workspaceRuntime) return;
+    setRuntimeAppBasePath(inferWorkspaceBasePath(window.location.pathname));
+  }, [appBasePath, workspaceRuntime]);
+
+  const t = React.useCallback(
+    (key: string) => copyText(locales, defaultLocale, locale, key),
+    [defaultLocale, locale, locales],
+  );
+  const apiPath = React.useCallback(
+    (path: string) => `${runtimeAppBasePath}${path}`,
+    [runtimeAppBasePath],
+  );
+  const journey = React.useCallback((): SignInJourney => {
+    if (typeof window === "undefined") {
+      return signInJourney({
+        at: `${runtimeAppBasePath}/`,
+        basePath: runtimeAppBasePath,
+      });
+    }
+    return signInJourney({
+      at:
+        window.location.pathname +
+        window.location.search +
+        window.location.hash,
+      continuation: new URLSearchParams(window.location.search).get("c"),
+      legacyReturn: new URLSearchParams(window.location.search).get("return"),
+      basePath: runtimeAppBasePath,
+    });
+  }, [runtimeAppBasePath]);
+  const resumeHref = React.useCallback(() => journey().resumeHref, [journey]);
+  const redirectToSignedInApp = React.useCallback(
+    (target?: string) => {
+      window.location.replace(target || resumeHref());
+    },
+    [resumeHref],
+  );
+  const setNotice = React.useCallback((key: string, notice: Notice) => {
+    setMessages((current) => ({ ...current, [key]: notice }));
+  }, []);
+  const notice = React.useCallback(
+    (key: string) => {
+      const current = messages[key];
+      if (!current) return null;
+      return (
+        <p
+          className={`msg ${current.kind} show`}
+          role="status"
+          aria-live="polite"
+        >
+          {current.text}
+        </p>
+      );
+    },
+    [messages],
+  );
+
+  const pendingEmailStorageKey = React.useCallback(
+    () => `${PENDING_SIGNUP_EMAIL_STORAGE_KEY}:${runtimeAppBasePath || "/"}`,
+    [runtimeAppBasePath],
+  );
+  const rememberPendingSignupEmail = React.useCallback(
+    (email: string) => {
+      if (email) writeStorage(pendingEmailStorageKey(), normalizeEmail(email));
+      else removeStorage(pendingEmailStorageKey());
+    },
+    [pendingEmailStorageKey],
+  );
+  const readPendingSignupEmail = React.useCallback(() => {
+    const email = readStorage(pendingEmailStorageKey());
+    return isValidEmail(email) ? normalizeEmail(email) : "";
+  }, [pendingEmailStorageKey]);
+
+  React.useEffect(() => {
+    const stored = readStorage(localeStorageKey);
+    const preference = stored || "system";
+    const nextLocale =
+      preference === "system"
+        ? resolveSystemLocale(localeOptions, defaultLocale)
+        : resolveLocale(preference, localeOptions, defaultLocale);
+    setLocalePreference(preference);
+    setLocale(nextLocale);
+    document.documentElement.lang = nextLocale;
+    document.documentElement.dir = localeMetadata[nextLocale]?.dir || "ltr";
+    document.documentElement.dataset.locale = nextLocale;
+  }, [defaultLocale, localeMetadata, localeOptions, localeStorageKey]);
+
+  React.useEffect(() => {
+    const closeMenu = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        document.querySelector(".locale-picker")?.contains(target)
+      ) {
+        return;
+      }
+      setLocaleMenuOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setLocaleMenuOpen(false);
+    };
+    document.addEventListener("click", closeMenu);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("click", closeMenu);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const nextTitle = marketing?.appName
+      ? `${marketing.appName} — ${t("pageTitleSignIn")}`
+      : t("pageTitleWelcome");
+    document.title = nextTitle;
+    document.documentElement.lang = locale;
+    document.documentElement.dir = localeMetadata[locale]?.dir || "ltr";
+    document.documentElement.dataset.locale = locale;
+  }, [locale, localeMetadata, marketing?.appName, t]);
+
+  React.useEffect(() => {
+    if (googleOnly) return;
+    const path = window.location.pathname.replace(/\/+$/, "") || "/";
+    const params = new URLSearchParams(window.location.search);
+    const verificationError =
+      params.get("error") === "verification_link_invalid";
+    if (params.get("verified") || verificationError) {
+      setView("login");
+      const rememberedEmail = readPendingSignupEmail();
+      if (rememberedEmail) setLoginEmail(rememberedEmail);
+      if (verificationError) {
+        setNotice("login", {
+          kind: "error",
+          text: t("verificationLinkInvalid"),
+        });
+      }
+      return;
+    }
+    if (params.get("tab") === "login" || path.endsWith("/login")) {
+      setView("login");
+      return;
+    }
+    if (params.get("tab") === "signup" || path.endsWith("/signup")) {
+      setView("signup");
+      return;
+    }
+    if (authMode === "magic-link") {
+      setView("magicLink");
+      return;
+    }
+    const storedTab = readStorage(TAB_STORAGE_KEY);
+    if (storedTab === "login" || storedTab === "signup") setView(storedTab);
+  }, [authMode, googleOnly, readPendingSignupEmail, setNotice, t]);
+
+  React.useEffect(() => {
+    const probe = async () => {
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/session"),
+          {
+            headers: { Accept: "application/json" },
+            cache: "no-store",
+          },
+        );
+        if (response.ok && typeof data.email === "string" && !data.error) {
+          redirectToSignedInApp();
+        }
+      } catch {
+        // coercion-ok: an unavailable session probe leaves manual sign-in usable.
+      }
+    };
+    void probe();
+  }, [apiPath, redirectToSignedInApp]);
+
+  React.useEffect(() => {
+    let anonymousId = readStorage(ANALYTICS_ANONYMOUS_ID_KEY);
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(anonymousId)) {
+      anonymousId = generateAnonymousId();
+      writeStorage(ANALYTICS_ANONYMOUS_ID_KEY, anonymousId);
+    }
+    try {
+      document.cookie = `an_aid=${encodeURIComponent(anonymousId)}; path=/; max-age=2592000; SameSite=Lax`;
+    } catch {
+      // coercion-ok: attribution cookies are optional for authentication.
+    }
+    try {
+      const existing = readStorage(FIRST_TOUCH_STORAGE_KEY);
+      if (
+        !existing &&
+        !document.cookie
+          .split(";")
+          .some((part) => part.trim().startsWith(`${FIRST_TOUCH_COOKIE}=`))
+      ) {
+        const params = new URLSearchParams(window.location.search);
+        const attribution: Record<string, string> = {};
+        for (const key of [
+          "ref",
+          "via",
+          "utm_source",
+          "utm_medium",
+          "utm_campaign",
+          "utm_content",
+          "utm_term",
+        ]) {
+          const value = safeAttributionValue(params.get(key));
+          if (value) attribution[key] = value;
+        }
+        const returnPath = signInJourney({
+          at: window.location.pathname,
+          continuation: params.get("c"),
+          legacyReturn: params.get("return"),
+          basePath: runtimeAppBasePath,
+        }).resumeHref;
+        const landingPath = safeAttributionValue(returnPath);
+        if (landingPath) attribution.landing_path = landingPath;
+        try {
+          const referrer = new URL(document.referrer);
+          if (referrer.host !== window.location.host) {
+            attribution.landing_referrer = safeAttributionValue(referrer.host);
+          }
+        } catch {
+          // coercion-ok: a non-URL referrer is not useful attribution.
+        }
+        attribution.landed_at = new Date().toISOString();
+        const json = JSON.stringify(attribution);
+        writeStorage(FIRST_TOUCH_STORAGE_KEY, json);
+        document.cookie = `${FIRST_TOUCH_COOKIE}=${encodeURIComponent(json)}; path=/; max-age=2592000; SameSite=Lax`;
+      }
+    } catch {
+      // coercion-ok: attribution is best effort and never blocks authentication.
+    }
+    trackAuth(trackingApp, "auth.signup_viewed", {
+      surface: "signup",
+      auth_mode: authMode,
+      auth_view: view,
+    });
+  }, [authMode, runtimeAppBasePath, trackingApp]);
+
+  React.useEffect(() => {
+    const hostname = window.location.hostname.toLowerCase();
+    setLocalNoteVisible(
+      hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "::1" ||
+        hostname.endsWith(".local"),
+    );
+  }, []);
+
+  const localDevAllowed = React.useMemo(
+    () =>
+      isLoopbackHostname() ||
+      (builderPreviewLocalDevEnabled && isBuilderPreviewHostname()),
+    [builderPreviewLocalDevEnabled],
+  );
+
+  React.useEffect(() => {
+    if (!localDevAllowed) return;
+    let active = true;
+    const loadAvailability = async () => {
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/local-dev"),
+          {
+            method: "GET",
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+          },
+        );
+        if (!active) return;
+        const available = response.ok && data.available === true;
+        setLocalDevAvailable(available);
+        if (!available) {
+          setFullAuthOptionsVisible(true);
+          return;
+        }
+        const params = new URLSearchParams(window.location.search);
+        const startWithLocalDev =
+          !params.has("tab") &&
+          !params.has("verified") &&
+          params.get("error") !== "verification_link_invalid";
+        setFullAuthOptionsVisible(!startWithLocalDev);
+      } catch {
+        if (active) setFullAuthOptionsVisible(true);
+      }
+    };
+    void loadAvailability();
+    return () => {
+      active = false;
+    };
+  }, [apiPath, localDevAllowed]);
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    let shouldShow =
+      params.get("signin") === "1" || params.get("upgrade-from-local") === "1";
+    if (!shouldShow) shouldShow = readStorage("an_migrate_from_local") === "1";
+    setUpgradeVisible(shouldShow);
+  }, []);
+
+  React.useEffect(() => {
+    if (!localDevAllowed) return;
+    if (window.parent !== window) return;
+    try {
+      const forceUrl = new URL(window.location.href);
+      if (forceUrl.searchParams.get(props.betaForceQueryParam) === "true") {
+        window.sessionStorage.setItem(props.betaForceSessionStorageKey, "1");
+      }
+      const optOutUrl = new URL(window.location.href);
+      const optOutValue = optOutUrl.searchParams.get(
+        props.betaOptOutQueryParam,
+      );
+      if (optOutValue !== null) {
+        const expiry = Number(optOutValue);
+        if (Number.isFinite(expiry) && expiry > Date.now()) {
+          window.localStorage.setItem(
+            props.betaOptOutStorageKey,
+            String(expiry),
+          );
+        }
+        optOutUrl.searchParams.delete(props.betaOptOutQueryParam);
+        window.history.replaceState(null, "", optOutUrl.toString());
+      }
+    } catch {
+      // coercion-ok: beta controls are optional.
+    }
+  }, [localDevAllowed, props]);
+
+  React.useEffect(() => {
+    if (window.parent !== window) return;
+    const hostname = window.location.hostname.toLowerCase().replace(/\.$/, "");
+    const productionHost = hostname.startsWith("beta.")
+      ? hostname.slice("beta.".length)
+      : "";
+    if (
+      !productionHost ||
+      props.environmentBetaHosts[productionHost] !== hostname
+    ) {
+      return;
+    }
+    try {
+      const productionUrl = new URL(window.location.href);
+      productionUrl.protocol = "https:";
+      productionUrl.hostname = productionHost;
+      productionUrl.port = "";
+      productionUrl.searchParams.set(
+        props.betaOptOutQueryParam,
+        String(Date.now() + props.betaOptOutDurationMs),
+      );
+      setEnvironmentProductionUrl(productionUrl.toString());
+      setEnvironmentVisible(true);
+    } catch {
+      // coercion-ok: malformed host metadata cannot produce a useful switcher.
+    }
+  }, [props]);
+
+  const stopOAuthPolling = React.useCallback(() => {
+    if (oauthPollTimer.current !== null) {
+      window.clearInterval(oauthPollTimer.current);
+      oauthPollTimer.current = null;
+    }
+    if (oauthPopupTimer.current !== null) {
+      window.clearInterval(oauthPopupTimer.current);
+      oauthPopupTimer.current = null;
+    }
+    if (oauthPopupGraceTimer.current !== null) {
+      window.clearTimeout(oauthPopupGraceTimer.current);
+      oauthPopupGraceTimer.current = null;
+    }
+    oauthPollInFlight.current = false;
+  }, []);
+
+  React.useEffect(() => stopOAuthPolling, [stopOAuthPolling]);
+
+  const finishOAuthExchange = React.useCallback(
+    (target: string, sessionToken?: string) => {
+      stopOAuthPolling();
+      setGoogleBusy(false);
+      setMagicLinkBusy(false);
+      if (isBuilderPreview() && sessionToken) {
+        try {
+          const url = new URL(target, window.location.origin);
+          url.searchParams.set("_session", sessionToken);
+          window.location.replace(url.pathname + url.search + url.hash);
+          return;
+        } catch {
+          // coercion-ok: same-origin continuation remains safe if preview parsing fails.
+        }
+      }
+      redirectToSignedInApp(target);
+    },
+    [redirectToSignedInApp, stopOAuthPolling],
+  );
+
+  const startOAuthExchange = React.useCallback(
+    (
+      flowId: string,
+      target: string,
+      verifier: string,
+      kind: "google" | "magic-link",
+      popup?: Window | null,
+    ) => {
+      const startedAt = Date.now();
+      const check = async () => {
+        if (oauthPollInFlight.current) return;
+        oauthPollInFlight.current = true;
+        try {
+          const { data } = await requestJson(
+            `${apiPath("/_agent-native/auth/desktop-exchange")}?flow_id=${encodeURIComponent(flowId)}`,
+            {
+              headers: verifier
+                ? { "X-Agent-Native-Desktop-Verifier": verifier }
+                : undefined,
+            },
+          );
+          if (flowId !== oauthFlowId.current) return;
+          if (
+            typeof data.email === "string" ||
+            typeof data.token === "string"
+          ) {
+            finishOAuthExchange(
+              target,
+              typeof data.token === "string" ? data.token : undefined,
+            );
+            return;
+          }
+          if (data.error) {
+            stopOAuthPolling();
+            setGoogleBusy(false);
+            setMagicLinkBusy(false);
+            if (kind === "magic-link") setView("magicLink");
+            setNotice(kind, {
+              kind: "error",
+              text: authErrorText(
+                data,
+                kind === "magic-link"
+                  ? t("magicLinkFailed")
+                  : t("googleNotConfigured"),
+              ),
+            });
+            return;
+          }
+        } catch {
+          // coercion-ok: external OAuth completion may transiently fail while polling.
+        } finally {
+          oauthPollInFlight.current = false;
+        }
+        if (Date.now() - startedAt > 5 * 60 * 1000) {
+          stopOAuthPolling();
+          setGoogleBusy(false);
+          setMagicLinkBusy(false);
+          if (kind === "magic-link") setView("magicLink");
+          setNotice(kind, {
+            kind: "error",
+            text:
+              kind === "magic-link"
+                ? t("magicLinkFailed")
+                : t("googleNeverFinished"),
+          });
+        }
+      };
+      stopOAuthPolling();
+      oauthPollTimer.current = window.setInterval(() => void check(), 1000);
+      if (popup) {
+        oauthPopupTimer.current = window.setInterval(() => {
+          let closed = false;
+          try {
+            closed = popup.closed;
+          } catch {
+            closed = true;
+          }
+          if (!closed) return;
+          if (oauthPopupTimer.current !== null) {
+            window.clearInterval(oauthPopupTimer.current);
+            oauthPopupTimer.current = null;
+          }
+          oauthPopupGraceTimer.current = window.setTimeout(() => {
+            oauthPopupGraceTimer.current = null;
+            if (flowId !== oauthFlowId.current) return;
+            void requestJson(apiPath("/_agent-native/auth/session"), {
+              headers: { Accept: "application/json" },
+            })
+              .then(({ response, data }) => {
+                if (flowId !== oauthFlowId.current) return;
+                if (
+                  response.ok &&
+                  typeof data.email === "string" &&
+                  !data.error
+                ) {
+                  finishOAuthExchange(target);
+                  return;
+                }
+                stopOAuthPolling();
+                setGoogleBusy(false);
+                setNotice("google", {
+                  kind: "error",
+                  text: t("googlePopupHelp"),
+                });
+              })
+              .catch(() => {
+                if (flowId !== oauthFlowId.current) return;
+                stopOAuthPolling();
+                setGoogleBusy(false);
+                setNotice("google", {
+                  kind: "error",
+                  text: t("googlePopupHelp"),
+                });
+              });
+          }, 1200);
+        }, 500);
+      }
+      window.setTimeout(() => void check(), 500);
+    },
+    [apiPath, finishOAuthExchange, setNotice, stopOAuthPolling, t],
+  );
+
+  const resolveGoogleFlow = React.useCallback(() => {
+    const preview = isBuilderPreview();
+    if (preview) return isInFrame() ? "popup" : "redirect";
+    const requested = new URLSearchParams(window.location.search).get(
+      "authMode",
+    );
+    if (requested === "popup" || requested === "redirect") return requested;
+    if (googleAuthMode === "popup" || googleAuthMode === "redirect") {
+      return googleAuthMode;
+    }
+    return isAgentNativeDesktop() || isElectron() ? "redirect" : "popup";
+  }, [googleAuthMode]);
+
+  const googleAuthUrlPath = React.useCallback(() => {
+    const previewOrigin = isBuilderPreview()
+      ? configuredOAuthOrigin(publicOAuthOrigin)
+      : "";
+    return `${previewOrigin}${apiPath("/_agent-native/google/auth-url")}`;
+  }, [apiPath, publicOAuthOrigin]);
+
+  const startGoogle = React.useCallback(async () => {
+    if (!showGoogle || googleBusy) return;
+    setGoogleBusy(true);
+    setNotice("google", null);
+    try {
+      window.sessionStorage.setItem("__an_signin", "1");
+    } catch {
+      // coercion-ok: analytics session storage is optional.
+    }
+    trackAuth(
+      trackingApp,
+      view === "login" ? "auth.login_clicked" : "auth.signup_clicked",
+      {
+        surface: view === "login" ? "login" : "signup",
+        method: "google",
+        auth_view: view,
+      },
+    );
+    const target = resumeHref();
+    const oauthTarget = oauthReturnTarget(target, workspaceGatewayReturnOrigin);
+    const flowId = createFlowId();
+    oauthFlowId.current = flowId;
+    const flow = resolveGoogleFlow();
+    const authUrl = googleAuthUrlPath();
+    if (flow === "redirect" && !isAgentNativeDesktop()) {
+      const params = new URLSearchParams({
+        return: oauthTarget,
+        redirect: "1",
+      });
+      window.location.replace(`${authUrl}?${params.toString()}`);
+      return;
+    }
+    const verifier = createVerifier();
+    if (!verifier) {
+      setGoogleBusy(false);
+      setNotice("google", { kind: "error", text: t("failedToConnect") });
+      return;
+    }
+    let popup: Window | null = null;
+    if (flow === "popup") {
+      try {
+        popup = window.open("", "_blank", "width=640,height=760");
+        if (!popup) {
+          const params = new URLSearchParams({
+            return: oauthTarget,
+            redirect: "1",
+          });
+          window.location.replace(`${authUrl}?${params.toString()}`);
+          return;
+        }
+        try {
+          popup.opener = null;
+        } catch {
+          // coercion-ok: some browsers expose popup.opener as read-only.
+        }
+      } catch {
+        const params = new URLSearchParams({
+          return: oauthTarget,
+          redirect: "1",
+        });
+        window.location.replace(`${authUrl}?${params.toString()}`);
+        return;
+      }
+    }
+    try {
+      const params = new URLSearchParams({
+        return: oauthTarget,
+        desktop: "1",
+        flow_id: flowId,
+      });
+      const { response, data } = await requestJson(
+        `${authUrl}?${params.toString()}`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "X-Agent-Native-Desktop-Verifier": verifier,
+          },
+        },
+      );
+      if (!response.ok || typeof data.url !== "string" || !data.url) {
+        throw new Error(authErrorText(data, t("failedToConnect")));
+      }
+      if (popup) {
+        popup.location.href = data.url;
+      } else {
+        window.location.href = data.url;
+      }
+      startOAuthExchange(flowId, target, verifier, "google", popup);
+    } catch (error) {
+      try {
+        popup?.close();
+      } catch {
+        // Ignore a popup that has already closed.
+      }
+      setGoogleBusy(false);
+      setNotice("google", {
+        kind: "error",
+        text: error instanceof Error ? error.message : t("failedToConnect"),
+      });
+    }
+  }, [
+    googleAuthUrlPath,
+    googleBusy,
+    resolveGoogleFlow,
+    resumeHref,
+    showGoogle,
+    startOAuthExchange,
+    stopOAuthPolling,
+    t,
+    trackingApp,
+    view,
+    workspaceGatewayReturnOrigin,
+  ]);
+
+  const handleLocalDev = React.useCallback(async () => {
+    if (localDevBusy) return;
+    setLocalDevBusy(true);
+    setNotice("local-dev", null);
+    try {
+      const { response } = await requestJson(
+        apiPath("/_agent-native/auth/local-dev"),
+        {
+          method: "POST",
+          headers: { Accept: "application/json" },
+        },
+      );
+      if (!response.ok) throw new Error("local-dev-auth-failed");
+      redirectToSignedInApp();
+    } catch {
+      setLocalDevBusy(false);
+      setLocalDevAvailable(false);
+      setFullAuthOptionsVisible(true);
+      setNotice("local-dev", { kind: "error", text: t("localDevFailed") });
+    }
+  }, [apiPath, localDevBusy, redirectToSignedInApp, setNotice, t]);
+
+  const showVerificationStep = React.useCallback(
+    (email: string, password: string) => {
+      const normalized = normalizeEmail(email);
+      pendingSignupPassword.current = password;
+      setVerificationEmail(normalized);
+      rememberPendingSignupEmail(normalized);
+      setNotice("verification", null);
+      setView("verification");
+      writeStorage(TAB_STORAGE_KEY, "signup");
+    },
+    [rememberPendingSignupEmail, setNotice],
+  );
+
+  const tryPendingSignupLogin = React.useCallback(async () => {
+    const email = verificationEmail || readPendingSignupEmail();
+    const password = pendingSignupPassword.current;
+    if (!email || !password) return { ok: false, needsManualSignIn: true };
+    const { response, data } = await requestJson(
+      apiPath("/_agent-native/auth/login"),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      },
+    );
+    if (response.ok) {
+      removeStorage(pendingEmailStorageKey());
+      redirectToSignedInApp();
+      return { ok: true, needsManualSignIn: false };
+    }
+    const error = authErrorText(data, t("finishSignInFailed"));
+    return {
+      ok: false,
+      needsManualSignIn: false,
+      error,
+      isWaitingForVerification: /not verified|verification/i.test(error),
+    };
+  }, [
+    apiPath,
+    pendingEmailStorageKey,
+    readPendingSignupEmail,
+    redirectToSignedInApp,
+    t,
+    verificationEmail,
+  ]);
+
+  const checkVerification = React.useCallback(
+    async (fallbackText?: string) => {
+      if (verificationCheckInFlight.current) return;
+      verificationCheckInFlight.current = true;
+      setNotice("verification", {
+        kind: "success",
+        text: t("checkingVerification"),
+      });
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/session"),
+          {
+            headers: { Accept: "application/json" },
+          },
+        );
+        if (response.ok && typeof data.email === "string" && !data.error) {
+          removeStorage(pendingEmailStorageKey());
+          redirectToSignedInApp();
+          return;
+        }
+        const loginResult = await tryPendingSignupLogin();
+        if (loginResult.ok) return;
+        if (
+          loginResult.needsManualSignIn ||
+          !loginResult.isWaitingForVerification
+        ) {
+          setLoginEmail(verificationEmail || readPendingSignupEmail());
+          setView("login");
+          setNotice("login", {
+            kind: "success",
+            text: fallbackText || t("enterPasswordAfterVerification"),
+          });
+          return;
+        }
+        setNotice("verification", {
+          kind: "error",
+          text: fallbackText || t("stillWaitingVerification"),
+        });
+      } catch {
+        setNotice("verification", {
+          kind: "error",
+          text: t("checkVerificationFailed"),
+        });
+      } finally {
+        verificationCheckInFlight.current = false;
+      }
+    },
+    [
+      apiPath,
+      pendingEmailStorageKey,
+      readPendingSignupEmail,
+      redirectToSignedInApp,
+      setNotice,
+      t,
+      tryPendingSignupLogin,
+      verificationEmail,
+    ],
+  );
+
+  React.useEffect(() => {
+    if (googleOnly || verifiedReturnHandled.current) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("verified") !== "1") return;
+    verifiedReturnHandled.current = true;
+    setNotice("login", {
+      kind: "success",
+      text: t("emailVerifiedFinishing"),
+    });
+    void checkVerification(t("emailVerifiedSignIn"));
+  }, [checkVerification, googleOnly, setNotice, t]);
+
+  React.useEffect(() => {
+    if (view !== "verification") return;
+    const onFocus = () => void checkVerification();
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [checkVerification, view]);
+
+  React.useEffect(() => {
+    if (!verificationResendUntil) return;
+    const timer = window.setInterval(() => {
+      if (Date.now() >= verificationResendUntil) setVerificationResendUntil(0);
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [verificationResendUntil]);
+
+  const handleSignup = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const email = normalizeEmail(signupEmail);
+      if (!isValidEmail(email)) {
+        setNotice("signup", { kind: "error", text: t("invalidEmail") });
+        return;
+      }
+      if (signupPassword !== signupPasswordConfirmation) {
+        setNotice("signup", { kind: "error", text: t("passwordsMismatch") });
+        return;
+      }
+      setSubmitting("signup");
+      setNotice("signup", null);
+      trackAuth(trackingApp, "auth.signup_clicked", {
+        surface: "signup",
+        method: "password",
+        auth_view: view,
+      });
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/register"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email,
+              password: signupPassword,
+              callbackURL: resumeHref(),
+            }),
+          },
+        );
+        if (!response.ok) {
+          setNotice("signup", {
+            kind: "error",
+            text: authErrorText(data, t("registrationFailed")),
+          });
+          return;
+        }
+        const loginResult = await requestJson(
+          apiPath("/_agent-native/auth/login"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password: signupPassword }),
+          },
+        );
+        if (loginResult.response.ok) {
+          removeStorage(pendingEmailStorageKey());
+          setNotice("signup", {
+            kind: "success",
+            text: t("accountCreatedSigningIn"),
+          });
+          redirectToSignedInApp();
+          return;
+        }
+        const loginError = authErrorText(
+          loginResult.data,
+          t("registrationFailed"),
+        );
+        if (
+          loginResult.response.status === 403 &&
+          /not verified|verification/i.test(loginError)
+        ) {
+          showVerificationStep(email, signupPassword);
+          return;
+        }
+        setNotice("signup", { kind: "error", text: loginError });
+      } catch {
+        setNotice("signup", {
+          kind: "error",
+          text: t("networkErrorDashRetry"),
+        });
+      } finally {
+        setSubmitting(null);
+      }
+    },
+    [
+      apiPath,
+      pendingEmailStorageKey,
+      redirectToSignedInApp,
+      resumeHref,
+      setNotice,
+      showVerificationStep,
+      signupEmail,
+      signupPassword,
+      signupPasswordConfirmation,
+      t,
+      trackingApp,
+      view,
+    ],
+  );
+
+  const handleLogin = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const email = normalizeEmail(loginEmail);
+      if (!isValidEmail(email)) {
+        setNotice("login", { kind: "error", text: t("invalidEmail") });
+        return;
+      }
+      setSubmitting("login");
+      setNotice("login", null);
+      trackAuth(trackingApp, "auth.login_clicked", {
+        surface: "login",
+        method: "password",
+        auth_view: view,
+      });
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/login"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, password: loginPassword }),
+          },
+        );
+        if (response.ok) {
+          removeStorage(pendingEmailStorageKey());
+          redirectToSignedInApp();
+          return;
+        }
+        setNotice("login", {
+          kind: "error",
+          text: authErrorText(data, t("invalidLogin")),
+        });
+      } catch {
+        setNotice("login", { kind: "error", text: t("networkErrorDashRetry") });
+      } finally {
+        setSubmitting(null);
+      }
+    },
+    [
+      apiPath,
+      loginEmail,
+      loginPassword,
+      pendingEmailStorageKey,
+      redirectToSignedInApp,
+      setNotice,
+      t,
+      trackingApp,
+      view,
+    ],
+  );
+
+  const handleForgot = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const email = normalizeEmail(forgotEmail);
+      if (!isValidEmail(email)) {
+        setNotice("forgot", { kind: "error", text: t("invalidEmail") });
+        return;
+      }
+      setSubmitting("forgot");
+      setNotice("forgot", null);
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/ba/request-password-reset"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email }),
+          },
+        );
+        if (response.ok) {
+          setForgotSent(true);
+          setNotice("forgot", { kind: "success", text: t("resetEmailSent") });
+          return;
+        }
+        setNotice("forgot", {
+          kind: "error",
+          text: authErrorText(data, t("resetEmailFailed")),
+        });
+      } catch {
+        setNotice("forgot", {
+          kind: "error",
+          text: t("networkErrorDashRetry"),
+        });
+      } finally {
+        setSubmitting(null);
+      }
+    },
+    [apiPath, forgotEmail, setNotice, t],
+  );
+
+  const handleMagicLink = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const email = normalizeEmail(magicLinkEmail);
+      if (!isValidEmail(email)) {
+        setNotice("magic-link", { kind: "error", text: t("invalidEmail") });
+        return;
+      }
+      setMagicLinkBusy(true);
+      setNotice("magic-link", null);
+      trackAuth(trackingApp, "auth.signup_clicked", {
+        surface: "signup",
+        method: "magic_link",
+        auth_view: view,
+      });
+      const desktop = isAgentNativeDesktop();
+      try {
+        const { response, data } = await requestJson(
+          apiPath("/_agent-native/auth/magic-link"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email,
+              callbackURL: desktop
+                ? apiPath("/_agent-native/auth/magic-link/desktop-callback")
+                : resumeHref(),
+            }),
+          },
+        );
+        if (!response.ok) {
+          setNotice("magic-link", {
+            kind: "error",
+            text: authErrorText(data, t("magicLinkFailed")),
+          });
+          return;
+        }
+        setMagicLinkEmail(email);
+        setView("magicLinkSent");
+        if (
+          desktop &&
+          typeof data.flowId === "string" &&
+          typeof data.verifier === "string"
+        ) {
+          oauthFlowId.current = data.flowId;
+          startOAuthExchange(
+            data.flowId,
+            resumeHref(),
+            data.verifier,
+            "magic-link",
+          );
+        }
+      } catch {
+        setNotice("magic-link", {
+          kind: "error",
+          text: t("networkErrorDashRetry"),
+        });
+      } finally {
+        setMagicLinkBusy(false);
+      }
+    },
+    [
+      apiPath,
+      magicLinkEmail,
+      resumeHref,
+      setNotice,
+      startOAuthExchange,
+      t,
+      trackingApp,
+      view,
+    ],
+  );
+
+  const resendVerification = React.useCallback(async () => {
+    const email = verificationEmail || readPendingSignupEmail();
+    if (!email || verificationResendUntil > Date.now()) return;
+    setNotice("verification", null);
+    try {
+      const { response, data } = await requestJson(
+        apiPath("/_agent-native/auth/ba/send-verification-email"),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email, callbackURL: resumeHref() }),
+        },
+      );
+      if (response.ok) {
+        setVerificationResendUntil(Date.now() + 60_000);
+        setNotice("verification", {
+          kind: "success",
+          text: t("sentVerification"),
+        });
+        return;
+      }
+      setNotice("verification", {
+        kind: "error",
+        text: authErrorText(data, t("resendVerificationFailed")),
+      });
+    } catch {
+      setNotice("verification", {
+        kind: "error",
+        text: t("networkErrorRetry"),
+      });
+    }
+  }, [
+    apiPath,
+    readPendingSignupEmail,
+    resumeHref,
+    setNotice,
+    t,
+    verificationEmail,
+    verificationResendUntil,
+  ]);
+
+  const selectLocale = React.useCallback(
+    (preference: string) => {
+      const nextLocale =
+        preference === "system"
+          ? resolveSystemLocale(localeOptions, defaultLocale)
+          : resolveLocale(preference, localeOptions, defaultLocale);
+      writeStorage(localeStorageKey, preference);
+      setLocalePreference(preference);
+      setLocale(nextLocale);
+      setLocaleMenuOpen(false);
+    },
+    [defaultLocale, localeOptions, localeStorageKey],
+  );
+
+  const handlePasswordInvalid = React.useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const input = event.currentTarget;
+      if (input.validity.tooShort)
+        input.setCustomValidity(t("passwordMinPlaceholder"));
+      else if (input.validity.tooLong)
+        input.setCustomValidity(props.passwordMaxCopy);
+    },
+    [props.passwordMaxCopy, t],
+  );
+  const clearPasswordValidity = React.useCallback(
+    (event: React.FormEvent<HTMLInputElement>) =>
+      event.currentTarget.setCustomValidity(""),
+    [],
+  );
+
+  const copySignupLocalMode = React.useCallback(async () => {
+    if (!signupLocalModeNote) return;
+    try {
+      await navigator.clipboard?.writeText(signupLocalModeNote.command);
+      setCopiedLocalMode(true);
+      window.setTimeout(() => setCopiedLocalMode(false), 1600);
+    } catch {
+      // coercion-ok: clipboard permission is optional.
+    }
+  }, [signupLocalModeNote]);
+
+  const keys = headingKeys(view);
+  const marketingCopy = marketing
+    ? { ...marketing, ...(marketingLocales[locale] ?? {}) }
+    : undefined;
+  const cardClassName = [
+    "card",
+    view === "verification" ? "verifying" : "",
+    view === "magicLinkSent" ? "magic-link-complete" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const localModeNote = signupLocalModeNote ? (
+    <div
+      className="signup-local-mode-note"
+      id="signup-local-mode-note"
+      data-command={signupLocalModeNote.command}
+    >
+      <p>{signupLocalModeNote.text}</p>
+      <code>{signupLocalModeNote.command}</code>
+      <button
+        type="button"
+        className="copy-run-local"
+        id="copy-signup-local-mode"
+        data-copy-signup-local-mode="true"
+        data-i18n="copyCommand"
+        onClick={() => void copySignupLocalMode()}
+      >
+        {copiedLocalMode ? t("copied") : t("copyCommand")}
+      </button>
+    </div>
+  ) : null;
+  const legalNote = signupLegalNotice ? (
+    <p className="legal-note">
+      <span data-i18n="legalPrefix">
+        {signupLegalNotice.prefix ?? t("legalPrefix")}
+      </span>{" "}
+      <a
+        href={signupLegalNotice.termsUrl}
+        target="_blank"
+        rel="noreferrer"
+        data-i18n={signupLegalNotice.termsLabel ? undefined : "legalTerms"}
+      >
+        {signupLegalNotice.termsLabel ?? t("legalTerms")}
+      </a>{" "}
+      <span data-i18n="legalConnector">
+        {signupLegalNotice.connector ?? t("legalConnector")}
+      </span>{" "}
+      <a
+        href={signupLegalNotice.privacyUrl}
+        target="_blank"
+        rel="noreferrer"
+        data-i18n={signupLegalNotice.privacyLabel ? undefined : "legalPrivacy"}
+      >
+        {signupLegalNotice.privacyLabel ?? t("legalPrivacy")}
+      </a>
+      <span data-i18n="legalSuffix">
+        {signupLegalNotice.suffix ?? t("legalSuffix")}
+      </span>
+    </p>
+  ) : null;
+  const signupForm = (
+    <AuthForm
+      id="signup-form"
+      className={view === "signup" ? "active" : undefined}
+      onSubmit={handleSignup}
+      fields={[
+        {
+          id: "s-email",
+          label: t("email"),
+          labelProps: { "data-i18n": "email" },
+          inputProps: {
+            type: "email",
+            autoComplete: "email",
+            placeholder: t("emailPlaceholder"),
+            required: true,
+            value: signupEmail,
+            onChange: (event) => setSignupEmail(event.currentTarget.value),
+          },
+        },
+        {
+          id: "s-pass",
+          label: t("password"),
+          labelProps: { "data-i18n": "password" },
+          inputProps: {
+            type: "password",
+            autoComplete: "new-password",
+            placeholder: t("passwordMinPlaceholder"),
+            "data-i18n-placeholder": "passwordMinPlaceholder",
+            required: true,
+            minLength: props.passwordMinLength,
+            maxLength: props.passwordMaxLength,
+            value: signupPassword,
+            onChange: (event) => setSignupPassword(event.currentTarget.value),
+            onInvalid: handlePasswordInvalid,
+            onInput: clearPasswordValidity,
+          },
+        },
+        {
+          id: "s-pass2",
+          label: t("confirmPassword"),
+          labelProps: { "data-i18n": "confirmPassword" },
+          inputProps: {
+            type: "password",
+            autoComplete: "new-password",
+            placeholder: t("confirmPasswordPlaceholder"),
+            "data-i18n-placeholder": "confirmPasswordPlaceholder",
+            required: true,
+            minLength: props.passwordMinLength,
+            maxLength: props.passwordMaxLength,
+            value: signupPasswordConfirmation,
+            onChange: (event) =>
+              setSignupPasswordConfirmation(event.currentTarget.value),
+            onInvalid: handlePasswordInvalid,
+            onInput: clearPasswordValidity,
+          },
+        },
+      ]}
+      submitLabel={t("createAccount")}
+      submitProps={{
+        "data-i18n": "createAccount",
+        disabled: submitting === "signup",
+      }}
+      footer={
+        <>
+          {legalNote}
+          {localModeNote}
+        </>
+      }
+      messageId="s-msg"
+      messageClassName={`msg ${messages.signup ? `${messages.signup.kind} show` : ""}`}
+      message={messages.signup?.text}
+    />
+  );
+  const identityHref = apiPath("/_agent-native/identity/login");
+  const authCard = (
+    <div className={cardClassName}>
+      <h1 id="heading" data-i18n={keys.heading}>
+        {t(keys.heading)}
+      </h1>
+      <p id="subtitle" className="subtitle" data-i18n={keys.subtitle}>
+        {t(keys.subtitle)}
+      </p>
+      <p
+        className={`upgrade-note ${upgradeVisible ? "show" : ""}`}
+        id="upgrade-note"
+        data-upgrade-copy={t("upgradeCopy")}
+        data-i18n-data-upgrade-copy="upgradeCopy"
+      >
+        {upgradeVisible ? t("upgradeCopy") : null}
+      </p>
+      {identitySsoEnabled ? (
+        <a
+          className="btn-identity-sso"
+          id="identity-sso-btn"
+          href={identityHref}
+          onClick={(event) => {
+            event.preventDefault();
+            const params = new URLSearchParams({ return: resumeHref() });
+            window.location.href = `${identityHref}?${params.toString()}`;
+          }}
+        >
+          Sign in with Agent-Native
+        </a>
+      ) : null}
+      <div
+        className="local-dev-signin"
+        id="local-dev-signin"
+        hidden={!localDevAvailable}
+      >
+        <button
+          type="button"
+          className="btn-local-dev btn-primary"
+          id="local-dev-btn"
+          title={t("localDevDescription")}
+          data-i18n="localDevButton"
+          data-i18n-title="localDevDescription"
+          aria-describedby="local-dev-description"
+          disabled={localDevBusy}
+          onClick={() => void handleLocalDev()}
+        >
+          {localDevBusy ? t("localDevSigningIn") : t("localDevButton")}
+        </button>
+        <p className="local-dev-description" id="local-dev-description">
+          <span data-i18n="localDevDescription">
+            {t("localDevDescription")}
+          </span>
+          <a
+            className="local-dev-help"
+            id="local-dev-help"
+            href={docsAuthUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={t("localDevHelp")}
+            title={t("localDevHelp")}
+            data-i18n-title="localDevHelp"
+            data-i18n-aria-label="localDevHelp"
+          >
+            <span className="local-dev-help-glyph" aria-hidden="true">
+              ?
+            </span>
+          </a>
+        </p>
+        <button
+          type="button"
+          className="local-dev-full-options"
+          id="local-dev-full-options"
+          hidden={fullAuthOptionsVisible}
+          data-i18n="localDevFullOptions"
+          onClick={() => setFullAuthOptionsVisible(true)}
+        >
+          {t("localDevFullOptions")}
+        </button>
+        {notice("local-dev")}
+      </div>
+      <div
+        id="full-auth-options"
+        className="full-auth-options"
+        hidden={!fullAuthOptionsVisible}
+      >
+        {googleOnly && !showGoogle ? (
+          <p
+            className="google-error show"
+            id="google-err"
+            role="status"
+            data-i18n="googleNotConfigured"
+          >
+            {t("googleNotConfigured")}
+          </p>
+        ) : null}
+        {showGoogle ? (
+          <div className="google-signin" id="google-signin">
+            <button
+              className={`btn-google ${view === "magicLink" && isValidEmail(magicLinkEmail) ? "magic-link-secondary" : ""}`}
+              id="google-btn"
+              type="button"
+              disabled={googleBusy}
+              onClick={() => void startGoogle()}
+            >
+              {googleSvg()}
+              <span data-i18n="googleButton">{t("googleButton")}</span>
+            </button>
+            {notice("google")}
+            <p className="google-debug" id="google-debug" />
+          </div>
+        ) : null}
+        {!googleOnly && showGoogle ? (
+          <div className="divider" id="auth-divider" data-i18n="dividerOr">
+            {t("dividerOr")}
+          </div>
+        ) : null}
+        {!googleOnly && authMode === "magic-link" ? (
+          <form
+            id="magic-link-form"
+            className={`form ${view === "magicLink" ? "active" : ""}`}
+            onSubmit={handleMagicLink}
+          >
+            <label htmlFor="m-email" data-i18n="email">
+              {t("email")}
+            </label>
+            <input
+              id="m-email"
+              type="email"
+              autoComplete="email"
+              placeholder={t("emailPlaceholder")}
+              required
+              value={magicLinkEmail}
+              onChange={(event) => setMagicLinkEmail(event.currentTarget.value)}
+            />
+            <button
+              type="submit"
+              id="magic-link-submit"
+              className="magic-link-submit"
+              disabled={magicLinkBusy || !isValidEmail(magicLinkEmail)}
+              data-i18n="sendMagicLink"
+            >
+              {magicLinkBusy ? t("sending") : t("sendMagicLink")}
+            </button>
+            {notice("magic-link")}
+            {legalNote}
+            <p
+              style={{
+                marginTop: "0.75rem",
+                fontSize: "0.75rem",
+                textAlign: "start",
+              }}
+            >
+              <button
+                type="button"
+                className="link-button auth-mode-link"
+                id="use-password-link"
+                data-i18n="usePasswordInstead"
+                onClick={() => setView("login")}
+              >
+                {t("usePasswordInstead")}
+              </button>
+            </p>
+          </form>
+        ) : null}
+        {authMode === "magic-link" ? (
+          <div
+            className={`magic-link-success ${view === "magicLinkSent" ? "is-visible" : ""}`}
+            id="magic-link-success"
+            aria-live="polite"
+            hidden={view !== "magicLinkSent"}
+          >
+            <p className="magic-link-success-copy">
+              <span data-i18n="magicLinkSentCopy">
+                {t("magicLinkSentCopy")}
+              </span>{" "}
+              <strong id="magic-link-success-email">{magicLinkEmail}</strong>.
+            </p>
+            <button
+              type="button"
+              className="link-button magic-link-back"
+              id="magic-link-back"
+              data-i18n="back"
+              onClick={() => {
+                setMagicLinkEmail("");
+                setView("magicLink");
+              }}
+            >
+              {t("back")}
+            </button>
+          </div>
+        ) : null}
+        {!googleOnly ? (
+          <div
+            className="tabs"
+            id="auth-tabs"
+            hidden={view === "magicLink" || view === "magicLinkSent"}
+          >
+            <button
+              className={`tab ${view === "signup" ? "active" : ""}`}
+              type="button"
+              data-tab="signup"
+              data-i18n="createAccount"
+              onClick={() => {
+                setView("signup");
+                writeStorage(TAB_STORAGE_KEY, "signup");
+              }}
+            >
+              {t("createAccount")}
+            </button>
+            <button
+              className={`tab ${view === "login" || view === "forgot" ? "active" : ""}`}
+              type="button"
+              data-tab="login"
+              data-i18n="signIn"
+              onClick={() => {
+                setView("login");
+                writeStorage(TAB_STORAGE_KEY, "login");
+              }}
+            >
+              {t("signIn")}
+            </button>
+          </div>
+        ) : null}
+        {!googleOnly ? signupForm : null}
+        <div
+          id="verification-step"
+          className={`form verification-step ${view === "verification" ? "active" : ""}`}
+          aria-live="polite"
+        >
+          <div
+            className="step-progress"
+            aria-label={t("signupProgress")}
+            data-i18n-aria-label="signupProgress"
+          >
+            <div className="progress-step complete">
+              <span>1</span>
+              <strong data-i18n="progressAccount">
+                {t("progressAccount")}
+              </strong>
+            </div>
+            <div className="progress-step current">
+              <span>2</span>
+              <strong data-i18n="progressVerify">{t("progressVerify")}</strong>
+            </div>
+            <div className="progress-step">
+              <span>3</span>
+              <strong data-i18n="progressStart">{t("progressStart")}</strong>
+            </div>
+          </div>
+          <div className="verification-panel">
+            <p className="verification-kicker" data-i18n="verificationSent">
+              {t("verificationSent")}
+            </p>
+            <p className="verification-copy">
+              <span data-i18n="verifyCopyPrefix">{t("verifyCopyPrefix")}</span>{" "}
+              <strong id="verify-email">{verificationEmail}</strong>
+              <span data-i18n="verifyCopySuffix">{t("verifyCopySuffix")}</span>
+            </p>
+            <p className="verification-note" data-i18n="verificationNote">
+              {t("verificationNote")}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="btn-primary"
+            id="verify-continue"
+            data-i18n="continue"
+            onClick={() => void checkVerification()}
+          >
+            {t("continue")}
+          </button>
+          <div className="inline-actions">
+            <button
+              type="button"
+              className="link-button"
+              id="resend-verification"
+              disabled={verificationResendUntil > Date.now()}
+              data-i18n="resendEmail"
+              onClick={() => void resendVerification()}
+            >
+              {t("resendEmail")}
+              {verificationResendUntil > Date.now()
+                ? ` (${Math.ceil((verificationResendUntil - Date.now()) / 1000)}s)`
+                : ""}
+            </button>
+            <button
+              type="button"
+              className="link-button"
+              id="back-to-signup"
+              data-i18n="back"
+              onClick={() => {
+                removeStorage(pendingEmailStorageKey());
+                setView("signup");
+              }}
+            >
+              {t("back")}
+            </button>
+          </div>
+          {notice("verification")}
+        </div>
+        <form
+          id="login-form"
+          className={`form ${view === "login" ? "active" : ""}`}
+          onSubmit={handleLogin}
+        >
+          <label htmlFor="l-email" data-i18n="email">
+            {t("email")}
+          </label>
+          <input
+            id="l-email"
+            type="email"
+            autoComplete="email"
+            placeholder={t("emailPlaceholder")}
+            required
+            value={loginEmail}
+            onChange={(event) => setLoginEmail(event.currentTarget.value)}
+          />
+          <label htmlFor="l-pass" data-i18n="password">
+            {t("password")}
+          </label>
+          <input
+            id="l-pass"
+            type="password"
+            autoComplete="current-password"
+            placeholder={t("enterPasswordPlaceholder")}
+            data-i18n-placeholder="enterPasswordPlaceholder"
+            required
+            value={loginPassword}
+            onChange={(event) => setLoginPassword(event.currentTarget.value)}
+            onInvalid={handlePasswordInvalid}
+            onInput={clearPasswordValidity}
+          />
+          <button
+            type="submit"
+            data-i18n="signIn"
+            disabled={submitting === "login"}
+          >
+            {submitting === "login" ? t("signingIn") : t("signIn")}
+          </button>
+          {notice("login")}
+          <p
+            style={{
+              marginTop: "0.75rem",
+              fontSize: "0.75rem",
+              textAlign: "right",
+            }}
+          >
+            <button
+              type="button"
+              id="forgot-link"
+              className="link-button"
+              data-i18n="forgotPassword"
+              onClick={() => {
+                setForgotEmail(loginEmail);
+                setView("forgot");
+              }}
+            >
+              {t("forgotPassword")}
+            </button>
+          </p>
+          {authMode === "magic-link" ? (
+            <p
+              style={{
+                marginTop: "0.5rem",
+                fontSize: "0.75rem",
+                textAlign: "center",
+              }}
+            >
+              <button
+                type="button"
+                className="link-button"
+                id="back-to-magic-link"
+                data-i18n="backToMagicLink"
+                onClick={() => setView("magicLink")}
+              >
+                {t("backToMagicLink")}
+              </button>
+            </p>
+          ) : null}
+        </form>
+        <form
+          id="forgot-form"
+          className={`form ${view === "forgot" ? "active" : ""}`}
+          onSubmit={handleForgot}
+        >
+          <label htmlFor="f-email" data-i18n="email">
+            {t("email")}
+          </label>
+          <input
+            id="f-email"
+            type="email"
+            autoComplete="email"
+            placeholder={t("emailPlaceholder")}
+            required
+            value={forgotEmail}
+            onChange={(event) => setForgotEmail(event.currentTarget.value)}
+          />
+          <button
+            type="submit"
+            data-i18n="sendResetLink"
+            disabled={forgotSent || submitting === "forgot"}
+          >
+            {forgotSent
+              ? t("sent")
+              : submitting === "forgot"
+                ? t("sending")
+                : t("sendResetLink")}
+          </button>
+          {notice("forgot")}
+          <p
+            style={{
+              marginTop: "0.75rem",
+              fontSize: "0.75rem",
+              textAlign: "center",
+            }}
+          >
+            <button
+              type="button"
+              className="link-button"
+              id="back-to-login"
+              data-i18n="backToSignIn"
+              onClick={() => setView("login")}
+            >
+              {t("backToSignIn")}
+            </button>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+  const localNote = (
+    <p
+      className={`local-note ${localNoteVisible ? "show" : ""}`}
+      id="local-note"
+    >
+      <span data-i18n="localNotePrefix">{t("localNotePrefix")}</span> (
+      <strong>{connectionLabel}</strong>)
+      <span data-i18n="localNoteSuffix">{t("localNoteSuffix")}</span>
+    </p>
+  );
+  const localePicker = (
+    <div className="locale-picker">
+      <button
+        type="button"
+        className="locale-trigger"
+        id="auth-locale-trigger"
+        aria-haspopup="menu"
+        aria-expanded={localeMenuOpen}
+        aria-controls="auth-locale-menu"
+        aria-label={t("languageLabel")}
+        title={t("languageLabel")}
+        data-i18n-aria-label="languageLabel"
+        data-i18n-title="languageLabel"
+        onClick={() => setLocaleMenuOpen((open) => !open)}
+      >
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 5h7" />
+          <path d="M7.5 4v1" />
+          <path d="M9.5 5c-.8 4.4-2.6 7.2-5.5 9" />
+          <path d="M5 9c1.2 2.1 3.2 3.8 6 5" />
+          <path d="M13 20l4-9 4 9" />
+          <path d="M14.5 17h5" />
+        </svg>
+      </button>
+      <div
+        className="locale-menu"
+        id="auth-locale-menu"
+        role="menu"
+        aria-labelledby="auth-locale-trigger"
+        hidden={!localeMenuOpen}
+      >
+        <button
+          type="button"
+          className="locale-menu-item"
+          role="menuitemradio"
+          aria-checked={localePreference === "system"}
+          data-locale-value="system"
+          onClick={() => selectLocale("system")}
+        >
+          <span className="locale-menu-check" aria-hidden="true">
+            ✓
+          </span>
+          <span data-system-language>{t("systemLanguage")}</span>
+        </button>
+        {localeOptions.map((option) => (
+          <button
+            type="button"
+            className="locale-menu-item"
+            role="menuitemradio"
+            aria-checked={localePreference === option.value}
+            data-locale-value={option.value}
+            key={option.value}
+            onClick={() => selectLocale(option.value)}
+          >
+            <span className="locale-menu-check" aria-hidden="true">
+              ✓
+            </span>
+            <span>{option.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+  const environmentBadge = (
+    <div
+      className="environment-switcher"
+      id="environment-switcher"
+      hidden={!environmentVisible}
+    >
+      <button
+        type="button"
+        className="environment-badge"
+        id="environment-badge"
+        aria-expanded={environmentOpen}
+        aria-controls="environment-popover"
+        onClick={() => setEnvironmentOpen((open) => !open)}
+      >
+        beta
+      </button>
+      <div
+        className="environment-popover"
+        id="environment-popover"
+        role="dialog"
+        aria-labelledby="environment-popover-title"
+        hidden={!environmentOpen}
+      >
+        <div
+          className="environment-popover-title"
+          id="environment-popover-title"
+        >
+          You're on Agent-Native Beta
+        </div>
+        <div className="environment-popover-copy">
+          Choose where you want to continue.
+        </div>
+        <a
+          className="environment-production-link"
+          id="environment-production-link"
+          href={environmentProductionUrl}
+        >
+          Switch to production
+        </a>
+        <button
+          type="button"
+          className="environment-hide-badge"
+          id="environment-hide-badge"
+          onClick={() => {
+            setEnvironmentOpen(false);
+            setEnvironmentVisible(false);
+          }}
+        >
+          Hide badge
+        </button>
+      </div>
+    </div>
+  );
+  const marketingSurface = marketingCopy ? (
+    <MarketingHome
+      appName={marketingCopy.appName}
+      variant="auth"
+      background={<Starfield id="starfield" />}
+      auth={
+        <>
+          {authCard}
+          {localNote}
+        </>
+      }
+      className="auth-marketing-home"
+    >
+      <div className="marketing-content">
+        <h2 className="app-name">
+          <img
+            className="brand-mark"
+            src={brandMarkSrc}
+            alt=""
+            aria-hidden="true"
+          />
+          <span>{marketingCopy.appName}</span>
+        </h2>
+        <p className="app-tagline" data-marketing-field="tagline">
+          {marketingCopy.tagline}
+        </p>
+        {marketingCopy.description ? (
+          <p className="app-desc" data-marketing-field="description">
+            {marketingCopy.description}
+          </p>
+        ) : null}
+        {marketingCopy.features?.length ? (
+          <ul className="feature-list">
+            {marketingCopy.features.map((feature, index) => (
+              <li key={index} data-marketing-feature-index={index}>
+                {feature}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <div className="marketing-actions">
+          <a
+            className="oss-link"
+            href={githubUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 00-1.3-3.2 4.2 4.2 0 00-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 00-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 00-.1 3.2A4.6 4.6 0 004 9.5c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21" />
+            </svg>
+            <span data-i18n="openSource">{t("openSource")}</span>
+          </a>
+        </div>
+      </div>
+    </MarketingHome>
+  ) : (
+    <>
+      <div className="auth-centered">{authCard}</div>
+      {localNote}
+    </>
+  );
+
+  return (
+    <>
+      {localePicker}
+      {environmentBadge}
+      {initialPrompt ? (
+        <div className="auth-centered">{authCard}</div>
+      ) : (
+        marketingSurface
+      )}
+    </>
+  );
+}

--- a/packages/core/src/client/auth/ResetPasswordPage.spec.tsx
+++ b/packages/core/src/client/auth/ResetPasswordPage.spec.tsx
@@ -1,0 +1,30 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { getResetPasswordHtml } from "../../server/onboarding-html.js";
+import {
+  ResetPasswordPage,
+  type ResetPasswordPageProps,
+} from "./ResetPasswordPage.js";
+
+function propsFromHtml(html: string): ResetPasswordPageProps {
+  const match = html.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("reset page data is missing");
+  return JSON.parse(match[1]!) as ResetPasswordPageProps;
+}
+
+describe("ResetPasswordPage", () => {
+  it("renders the password reset surface as React without inline handlers", () => {
+    const html = renderToString(
+      <ResetPasswordPage {...propsFromHtml(getResetPasswordHtml())} />,
+    );
+
+    expect(html).toContain('id="reset-form"');
+    expect(html).toContain('id="p1"');
+    expect(html).toContain('id="p2"');
+    expect(html).toContain('id="back-link"');
+    expect(html).not.toContain("onclick");
+  });
+});

--- a/packages/core/src/client/auth/ResetPasswordPage.tsx
+++ b/packages/core/src/client/auth/ResetPasswordPage.tsx
@@ -1,0 +1,205 @@
+import * as React from "react";
+
+export interface ResetPasswordPageProps {
+  pageType: "reset-password";
+  appBasePath: string;
+  passwordMinLength: number;
+  passwordMaxLength: number;
+}
+
+type ResetMessage = { kind: "error" | "success"; text: string } | null;
+
+function inferResetBasePath(pathname: string): string {
+  const marker = "/_agent-native/auth/reset";
+  const markerIndex = pathname.indexOf(marker);
+  return markerIndex >= 0 ? pathname.slice(0, markerIndex) : "";
+}
+
+function resetErrorText(
+  data: Record<string, unknown>,
+  fallback: string,
+  passwordMinLength: number,
+  passwordMaxLength: number,
+): string {
+  const candidate = data.error ?? data.message;
+  if (typeof candidate !== "string" || !candidate.trim()) return fallback;
+  const message = candidate.trim();
+  if (
+    /failed query|\bselect\b.*\bfrom\b|\binsert\b.*\binto\b|\bupdate\b.*\bset\b|\bdelete\b.*\bfrom\b|\bsql\b|database|relation .* does not exist|column .* does not exist|syntax error|constraint|connection refused|econn|timeout/i.test(
+      message,
+    )
+  ) {
+    return fallback;
+  }
+  if (/password.*(?:at least|minimum|min(?:imum)?|too short)/i.test(message)) {
+    return `Choose a password with at least ${passwordMinLength} characters.`;
+  }
+  if (/password.*(?:at most|maximum|max(?:imum)?|too long)/i.test(message)) {
+    return `Choose a password with no more than ${passwordMaxLength} characters.`;
+  }
+  return message;
+}
+
+export function ResetPasswordPage({
+  appBasePath,
+  passwordMinLength,
+  passwordMaxLength,
+}: ResetPasswordPageProps) {
+  const [runtimeAppBasePath, setRuntimeAppBasePath] =
+    React.useState(appBasePath);
+  const [token, setToken] = React.useState("");
+  const [tokenChecked, setTokenChecked] = React.useState(false);
+  const [password, setPassword] = React.useState("");
+  const [confirmation, setConfirmation] = React.useState("");
+  const [message, setMessage] = React.useState<ResetMessage>(null);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!appBasePath) {
+      setRuntimeAppBasePath(inferResetBasePath(window.location.pathname));
+    }
+    setToken(new URLSearchParams(window.location.search).get("token") ?? "");
+    setTokenChecked(true);
+  }, [appBasePath]);
+
+  const passwordInvalid = React.useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const input = event.currentTarget;
+      if (input.validity.tooShort) {
+        input.setCustomValidity(
+          `Choose a password with at least ${passwordMinLength} characters.`,
+        );
+      } else if (input.validity.tooLong) {
+        input.setCustomValidity(
+          `Choose a password with no more than ${passwordMaxLength} characters.`,
+        );
+      }
+    },
+    [passwordMaxLength, passwordMinLength],
+  );
+  const clearPasswordValidity = React.useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      event.currentTarget.setCustomValidity("");
+    },
+    [],
+  );
+
+  const handleSubmit = React.useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (password !== confirmation) {
+        setMessage({ kind: "error", text: "Passwords do not match." });
+        return;
+      }
+      setSaving(true);
+      setMessage(null);
+      try {
+        const response = await fetch(
+          `${runtimeAppBasePath}/_agent-native/auth/ba/reset-password`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ newPassword: password, token }),
+          },
+        );
+        if (response.ok) {
+          setMessage({
+            kind: "success",
+            text: "Password updated — redirecting to sign in…",
+          });
+          window.setTimeout(() => {
+            window.location.href = `${runtimeAppBasePath}/`;
+          }, 1200);
+          return;
+        }
+        let data: Record<string, unknown> = {};
+        try {
+          const parsed: unknown = await response.json();
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            data = parsed as Record<string, unknown>;
+          }
+        } catch {
+          // coercion-ok: error status and fallback copy remain distinguishable.
+        }
+        setMessage({
+          kind: "error",
+          text: resetErrorText(
+            data,
+            "We couldn't update your password. The link may have expired; request a new one.",
+            passwordMinLength,
+            passwordMaxLength,
+          ),
+        });
+        setSaving(false);
+      } catch {
+        setMessage({
+          kind: "error",
+          text: "We couldn't reach the server. Check your connection and try again.",
+        });
+        setSaving(false);
+      }
+    },
+    [
+      confirmation,
+      password,
+      passwordMaxLength,
+      passwordMinLength,
+      runtimeAppBasePath,
+      token,
+    ],
+  );
+
+  const missingToken = tokenChecked && !token;
+  return (
+    <div className="card reset-password-card">
+      <h1>Choose a new password</h1>
+      <p className="subtitle">Set a new password for your account.</p>
+      <form id="reset-form" onSubmit={handleSubmit} hidden={missingToken}>
+        <label htmlFor="p1">New password</label>
+        <input
+          id="p1"
+          type="password"
+          autoComplete="new-password"
+          placeholder={`At least ${passwordMinLength} characters`}
+          required
+          minLength={passwordMinLength}
+          maxLength={passwordMaxLength}
+          value={password}
+          onChange={(event) => setPassword(event.currentTarget.value)}
+          onInvalid={passwordInvalid}
+          onInput={clearPasswordValidity}
+        />
+        <label htmlFor="p2">Confirm password</label>
+        <input
+          id="p2"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Confirm password"
+          required
+          minLength={passwordMinLength}
+          maxLength={passwordMaxLength}
+          value={confirmation}
+          onChange={(event) => setConfirmation(event.currentTarget.value)}
+          onInvalid={passwordInvalid}
+          onInput={clearPasswordValidity}
+        />
+        <button type="submit" disabled={saving}>
+          {saving ? "Saving…" : "Save new password"}
+        </button>
+        {message ? (
+          <p className={`msg show ${message.kind}`} role="status">
+            {message.text}
+          </p>
+        ) : null}
+      </form>
+      {missingToken ? (
+        <p className="msg show error" role="alert">
+          This password reset link is missing or invalid. Request a new one.
+        </p>
+      ) : null}
+      <a className="back" id="back-link" href={`${runtimeAppBasePath}/`}>
+        Back to sign in
+      </a>
+    </div>
+  );
+}

--- a/packages/core/src/client/auth/ResetPasswordPage.tsx
+++ b/packages/core/src/client/auth/ResetPasswordPage.tsx
@@ -1,3 +1,5 @@
+/** @jsxRuntime classic */
+
 import * as React from "react";
 
 export interface ResetPasswordPageProps {

--- a/packages/core/src/client/auth/entry.tsx
+++ b/packages/core/src/client/auth/entry.tsx
@@ -1,0 +1,21 @@
+import { hydrateRoot } from "react-dom/client";
+
+import { AuthPage, type AuthPageProps } from "./AuthPage.js";
+import {
+  ResetPasswordPage,
+  type ResetPasswordPageProps,
+} from "./ResetPasswordPage.js";
+
+const root = document.getElementById("agent-native-auth-root");
+const data = document.getElementById("agent-native-auth-data");
+
+if (root && data) {
+  const props = JSON.parse(data.textContent ?? "{}") as
+    | AuthPageProps
+    | ResetPasswordPageProps;
+  if ("pageType" in props && props.pageType === "reset-password") {
+    hydrateRoot(root, <ResetPasswordPage {...props} />);
+  } else {
+    hydrateRoot(root, <AuthPage {...(props as AuthPageProps)} />);
+  }
+}

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -56,6 +56,14 @@ function clearAuthPublicPathRegistry(): void {
   delete globalState[AUTH_PUBLIC_PATHS_REGISTRY_KEY];
 }
 
+function readAuthPageData(html: string): Record<string, unknown> {
+  const match = html.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("auth page data is missing");
+  return JSON.parse(match[1]!) as Record<string, unknown>;
+}
+
 describe("server/auth", () => {
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -6606,174 +6614,28 @@ describe("server/auth", () => {
   });
 
   describe("onboarding Google sign-in", () => {
-    it("uses popup OAuth in Builder iframes and redirect OAuth for top-level Builder", async () => {
+    it("passes OAuth configuration to the hydratable React auth page", async () => {
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
       vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
 
       const { getOnboardingHtml } = await import("./onboarding-html.js");
       const html = getOnboardingHtml({ googleOnly: true });
+      const data = readAuthPageData(html);
 
-      expect(html).toContain(
-        'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
-      );
-      expect(html).toContain('var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";');
-      expect(html).toContain("__anStartPopupOAuth(ret, btn, err, flowId)");
-      expect(html).toContain(
-        "__anStartNativeDesktopOAuth(ret, btn, err, flowId)",
-      );
-      expect(html).toContain(
-        "__anPath('/_agent-native/auth/desktop-exchange')",
-      );
+      expect(data).toMatchObject({
+        googleOnly: true,
+        showGoogle: true,
+        googleAuthMode: "auto",
+        publicOAuthOrigin: "https://agent-workspace.builder.io",
+        workspaceGatewayReturnOrigin: "",
+      });
+      expect(html).toContain('id="google-btn"');
       expect(html).toContain('id="google-debug"');
-      expect(html).toContain(
-        "__anSetOAuthDebug('Google popup opened; waiting for callback', flowId)",
-      );
-      expect(html).toContain(
-        "function __anStartRedirectOAuth(ret, btn, err, flowId, reason)",
-      );
-      expect(html).toContain(
-        "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
-      );
-      expect(html).toContain(
-        "Google popup was blocked; falling back to redirect",
-      );
-      expect(html).toContain("Allow popups for this site and try again");
-      expect(html).toContain(
-        "Opening Google sign-in redirect from Builder preview",
-      );
-      expect(html).toContain("__anT('googleNeverFinished')");
-      expect(html).not.toContain("&debug=1");
-      expect(html).toContain("params.set('desktop', '1')");
-      expect(html).toContain("params.set('flow_id', flowId)");
-      expect(html).toContain("method: 'POST'");
-      expect(html).toContain("'Accept': 'application/json'");
-      expect(html).toContain("'X-Agent-Native-Desktop-Verifier': verifier");
-      expect(html).not.toContain("params.set('verifier', verifier)");
-      expect(html).toContain("params.set('redirect', '1')");
-      expect(html).toContain("function __anNewOAuthVerifier()");
-      expect(html).toContain("var __anBuilderPreviewSeen = false");
-      expect(html).toContain("function __anRememberBuilderPreview()");
-      expect(html).toContain(
-        "sessionStorage.setItem('__an_builder_preview_seen', '1')",
-      );
-      expect(html).toContain("function __anHasBuilderPreviewSignal()");
-      expect(html).toContain("params.has('builder.preview')");
-      expect(html).toContain("__anIsBuilderPreview();");
-      expect(html).toContain("__anIsBuilderDesktop()");
-      expect(html).toContain("__anIsAgentNativeDesktop()");
-      expect(html).toContain("function __anIsInFrame()");
-      expect(html).toContain(
-        "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
-      );
-      expect(html).toContain(
-        "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
-      );
-      expect(html).toContain(
-        "__anSetOAuthDebug(reason || 'Opening Google sign-in redirect', flowId)",
-      );
-      expect(html).toContain("function __anBuilderPreviewReturnOrigin()");
-      expect(html).toContain("function __anGoogleAuthUrlPath()");
-      expect(html).toContain("function __anOAuthReturnTarget(ret)");
-      expect(html).toContain(
-        "function __anSessionBridgeUrl(ret, sessionToken)",
-      );
-      expect(html).toContain(
-        "function __anFinishOAuthExchange(ret, flowId, sessionToken)",
-      );
-      expect(html).toContain(
-        "window.location.replace(__anSessionBridgeUrl(ret, sessionToken))",
-      );
-      expect(html).toContain(
-        "if (oauthReturn) params.set('return', oauthReturn)",
-      );
-      expect(html).toContain(
-        "var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;",
-      );
-      expect(html).toContain(
-        "__anFinishOAuthExchange(ret, flowId, data.token)",
-      );
-      expect(html).toContain(
-        "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier)",
-      );
-      expect(html).toContain(
-        "function __anWatchOAuthPopupClose(popup, flowId)",
-      );
-      expect(html).toContain("function __anHandleOAuthPopupClosed(flowId)");
-      expect(html).toContain("var __anOAuthPopupCloseGraceMs = 5000;");
-      expect(html).toContain("var __anNativeOAuthFlowId = null;");
-      expect(html).toContain("var __anNativeOAuthRequestPending = false;");
-      expect(html).toContain("var __anNativeOAuthReturnObserved = false;");
-      expect(html).toContain("var __anNativeOAuthAbandonGraceMs = 5000;");
-      expect(html).toContain("function __anBeginNativeOAuth(flowId)");
-      expect(html).toContain("function __anCancelNativeOAuthAbandonment()");
-      expect(html).toContain(
-        "function __anScheduleNativeOAuthAbandonment(flowId)",
-      );
-      expect(html).toContain("__anFinalizeNativeOAuthAbandonment(flowId);");
-      expect(html).toContain("__anNativeOAuthRequestPending = true;");
-      expect(html).toContain("__anNativeOAuthRequestPending = false;");
-      expect(html).toContain("__anNativeOAuthReturnObserved = true;");
-      expect(html).toContain("__anBeginNativeOAuth(flowId);");
-      expect(html).toContain("__anMarkNativeOAuthPolling(flowId);");
-      expect(html).toContain(
-        "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);\n        __anScheduleNativeOAuthAbandonment(flowId);",
-      );
-      expect(html).toContain(
-        "if (__anOAuthPollTimer) {\n        __anOAuthPopupCloseGraceTimer = setTimeout(function()",
-      );
-      expect(html).toContain(
-        "__anFinalizeOAuthPopupClose(flowId);\n        }, __anOAuthPopupCloseGraceMs);",
-      );
-      expect(html).toContain("__anHandleOAuthPopupClosed(flowId);");
-      expect(html).toContain("closed = popup.closed === true");
-      expect(html).toContain("__anWatchOAuthPopupClose(popup, flowId);");
-      expect(html).toContain("function __anInvalidateGoogleSignInFlow(flowId)");
-      expect(html).toContain(
-        "if (!flowId && (__anNativeOAuthFlowId || __anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;",
-      );
-      expect(html).toContain("__anStopOAuthExchangePolling();");
-      expect(html).toContain(
-        "if (!__anIsCurrentGoogleSignInFlow(flowId)) return;",
-      );
-      expect(html).toContain("__anRecoverGoogleSignInAfterReturn();");
-      expect(html).toContain(
-        "window.addEventListener('focus', function() {\n        __anRecoverGoogleSignInAfterReturn();\n      });",
-      );
-      expect(html).toContain(
-        "window.addEventListener('blur', function() {\n        __anCancelNativeOAuthAbandonment();\n      });",
-      );
-      expect(html).toContain(
-        "if (document.visibilityState === 'visible') {\n          __anRecoverGoogleSignInAfterReturn();\n        } else {\n          __anCancelNativeOAuthAbandonment();\n        }",
-      );
-      const recoverStart = html.indexOf(
-        "function __anRecoverGoogleSignInAfterReturn(flowId)",
-      );
-      const recoverEnd = html.indexOf(
-        "function __anBindGoogleRecover()",
-        recoverStart,
-      );
-      expect(recoverStart).toBeGreaterThan(-1);
-      expect(recoverEnd).toBeGreaterThan(recoverStart);
-      const recoverScript = html.slice(recoverStart, recoverEnd);
-      expect(recoverScript).toContain("Keep the desktop-exchange poll alive");
-      expect(recoverScript).not.toContain("clearInterval(__anOAuthPollTimer)");
-      expect(html).toContain("window.location.reload()");
-      expect(html).not.toContain(
-        "__anWaitForOAuthExchange(flowId, target, btn, err)",
-      );
-      expect(html).toContain(
-        "window.open('', '_blank', 'width=640,height=760')",
-      );
-      expect(html).toContain("popup.location.href = url");
-      expect(html).toContain("__anOpenOAuthUrl(data.url)");
-      expect(html).toContain("window.location.href = url");
-      expect(html).not.toContain("window.open(data.url");
-      expect(html).not.toContain("noopener,noreferrer,width=640,height=760");
-      expect(html).not.toContain("Waiting for sign-in");
+      expect(html).toContain('src="/assets/auth-client.js"');
     });
 
-    it("adds OAuth debug breadcrumbs to the minimal Google auth plugin page", async () => {
+    it("passes OAuth debug configuration through the minimal Google auth plugin page", async () => {
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
       vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
@@ -6784,93 +6646,18 @@ describe("server/auth", () => {
         await import("./google-auth-plugin.js");
       createGoogleAuthPlugin();
 
-      const loginHtml = createAuthPlugin.mock.calls[0]?.[0]?.loginHtml;
-      expect(loginHtml).toContain(
-        'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
-      );
-      expect(loginHtml).toContain(
-        'var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";',
-      );
+      const loginHtml = createAuthPlugin.mock.calls[0]?.[0]?.loginHtml as
+        | string
+        | undefined;
+      expect(loginHtml).toBeTypeOf("string");
+      expect(readAuthPageData(loginHtml!)).toMatchObject({
+        googleOnly: true,
+        showGoogle: true,
+        publicOAuthOrigin: "https://agent-workspace.builder.io",
+        workspaceGatewayReturnOrigin: "",
+      });
       expect(loginHtml).toContain('id="google-debug"');
-      expect(loginHtml).toContain(
-        "__anSetOAuthDebug('Google popup opened; waiting for callback', flowId)",
-      );
-      expect(loginHtml).toContain("var __anBuilderPreviewSeen = false");
-      expect(loginHtml).toContain("function __anRememberBuilderPreview()");
-      expect(loginHtml).toContain(
-        "sessionStorage.setItem('__an_builder_preview_seen', '1')",
-      );
-      expect(loginHtml).toContain("function __anHasBuilderPreviewSignal()");
-      expect(loginHtml).toContain("params.has('builder.preview')");
-      expect(loginHtml).toContain("__anIsBuilderPreview();");
-      expect(loginHtml).toContain("__anIsBuilderDesktop()");
-      expect(loginHtml).toContain("__anIsAgentNativeDesktop()");
-      expect(loginHtml).toContain("function __anIsInFrame()");
-      expect(loginHtml).toContain(
-        "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
-      );
-      expect(loginHtml).toContain(
-        "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
-      );
-      expect(loginHtml).toContain(
-        "__anSetOAuthDebug(reason || 'Opening Google sign-in redirect', flowId)",
-      );
-      expect(loginHtml).toContain("function __anBuilderPreviewReturnOrigin()");
-      expect(loginHtml).toContain(
-        "var candidates = [window.location.href, document.referrer || ''];",
-      );
-      expect(loginHtml).toContain("function __anGoogleAuthUrlPath()");
-      expect(loginHtml).toContain("function __anOAuthReturnTarget(ret)");
-      expect(loginHtml).toContain(
-        "function __anSessionBridgeUrl(ret, sessionToken)",
-      );
-      expect(loginHtml).toContain(
-        "function __anFinishOAuthExchange(ret, flowId, sessionToken)",
-      );
-      expect(loginHtml).toContain(
-        "window.location.replace(__anSessionBridgeUrl(ret, sessionToken))",
-      );
-      expect(loginHtml).toContain(
-        "var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;",
-      );
-      expect(loginHtml).toContain(
-        "if (oauthReturn) params.set('return', oauthReturn)",
-      );
-      expect(loginHtml).toContain(
-        "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier)",
-      );
-      expect(loginHtml).toContain(
-        "'X-Agent-Native-Desktop-Verifier': verifier",
-      );
-      expect(loginHtml).not.toContain("params.set('verifier', verifier)");
-      expect(loginHtml).toContain(
-        "__anFinishOAuthExchange(ret, flowId, data.token)",
-      );
-      expect(loginHtml).toContain("window.location.reload()");
-      expect(loginHtml).not.toContain(
-        "__anWaitForOAuthExchange(flowId, target, btn, err)",
-      );
-      expect(loginHtml).toContain(
-        "window.open('', '_blank', 'width=640,height=760')",
-      );
-      expect(loginHtml).toContain("popup.location.href = url");
-      expect(loginHtml).toContain(
-        "function __anStartRedirectOAuth(ret, btn, err, flowId, reason)",
-      );
-      expect(loginHtml).toContain(
-        "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
-      );
-      expect(loginHtml).toContain(
-        "Google popup was blocked; falling back to redirect",
-      );
-      expect(loginHtml).toContain("Allow popups for this site and try again");
-      expect(loginHtml).toContain(
-        "Opening Google sign-in redirect from Builder preview",
-      );
-      expect(loginHtml).toContain(
-        "Google sign-in did not finish. Check the Google OAuth redirect URI",
-      );
-      expect(loginHtml).not.toContain("&debug=1");
+      expect(loginHtml).toContain('src="/assets/auth-client.js"');
     });
 
     it("defaults googleAuthMode to 'auto' and honors explicit overrides + env var", async () => {
@@ -6879,26 +6666,23 @@ describe("server/auth", () => {
       const { getOnboardingHtml } = await import("./onboarding-html.js");
 
       const auto = getOnboardingHtml({ googleOnly: true });
-      expect(auto).toContain('var __AN_GOOGLE_AUTH_MODE = "auto"');
-      expect(auto).toContain("function __anResolveAuthFlow()");
-      expect(auto).toContain("function __anIsElectron()");
-      expect(auto).toContain("__anResolveAuthFlow() === 'popup'");
+      expect(readAuthPageData(auto).googleAuthMode).toBe("auto");
 
       const popup = getOnboardingHtml({
         googleOnly: true,
         googleAuthMode: "popup",
       });
-      expect(popup).toContain('var __AN_GOOGLE_AUTH_MODE = "popup"');
+      expect(readAuthPageData(popup).googleAuthMode).toBe("popup");
 
       vi.stubEnv("GOOGLE_AUTH_MODE", "redirect");
       const fromEnv = getOnboardingHtml({ googleOnly: true });
-      expect(fromEnv).toContain('var __AN_GOOGLE_AUTH_MODE = "redirect"');
+      expect(readAuthPageData(fromEnv).googleAuthMode).toBe("redirect");
 
       const explicitWins = getOnboardingHtml({
         googleOnly: true,
         googleAuthMode: "popup",
       });
-      expect(explicitWins).toContain('var __AN_GOOGLE_AUTH_MODE = "popup"');
+      expect(readAuthPageData(explicitWins).googleAuthMode).toBe("popup");
     });
 
     it("uses sign-in copy when only Google auth is enabled", async () => {
@@ -6906,6 +6690,7 @@ describe("server/auth", () => {
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
       const { getOnboardingHtml } = await import("./onboarding-html.js");
       const html = getOnboardingHtml({ googleOnly: true });
+      const data = readAuthPageData(html);
 
       expect(html).toContain(
         '<h1 id="heading" data-i18n="signInTitle">Sign in</h1>',
@@ -6913,6 +6698,7 @@ describe("server/auth", () => {
       expect(html).toContain("Use your workspace Google account to continue");
       expect(html).not.toContain('id="signup-form"');
       expect(html).not.toContain('data-tab="signup"');
+      expect(data.initialView).toBe("googleOnly");
     });
 
     it("renders marketing assets under APP_BASE_PATH", async () => {
@@ -6948,11 +6734,15 @@ describe("server/auth", () => {
 
     it("defaults the active tab from the login or signup path", async () => {
       const { getOnboardingHtml } = await import("./onboarding-html.js");
-      const html = getOnboardingHtml();
 
-      expect(html).toContain("var path = location.pathname");
-      expect(html).toContain("path === '/login' || path.endsWith('/login')");
-      expect(html).toContain("path === '/signup' || path.endsWith('/signup')");
+      expect(
+        readAuthPageData(getOnboardingHtml({ requestPath: "/login" }))
+          .initialView,
+      ).toBe("login");
+      expect(
+        readAuthPageData(getOnboardingHtml({ requestPath: "/signup" }))
+          .initialView,
+      ).toBe("signup");
     });
   });
 
@@ -6965,8 +6755,8 @@ describe("server/auth", () => {
       expect(html).toContain('id="verify-continue"');
       expect(html).toContain('id="resend-verification"');
       expect(html).toContain('id="back-to-signup"');
-      expect(html).toContain("showVerificationStep(email, pass)");
-      expect(html).toContain("callbackURL: __anResumeHref()");
+      expect(html).toContain('src="/assets/auth-client.js"');
+      expect(html).not.toContain("showVerificationStep(email, pass)");
       expect(html).not.toContain(
         "Account created! Check your email to verify, then sign in.",
       );
@@ -6976,46 +6766,30 @@ describe("server/auth", () => {
       const { getOnboardingHtml } = await import("./onboarding-html.js");
       const html = getOnboardingHtml();
 
-      expect(html).toContain("var loginData;");
-      expect(html).toContain("loginData = await loginRes.json();");
+      expect(html).toContain('id="login-form"');
+      expect(html).toContain('id="verification-step"');
       expect(html).toContain(
-        "if (loginRes.status === 403 && /not verified|verification/i.test(loginError))",
+        'type="application/json" id="agent-native-auth-data"',
       );
-      expect(html).toContain(
-        "msg.textContent = loginError;\n        msg.classList.add('show', 'error');",
-      );
+      expect(html).not.toContain("loginData = await loginRes.json()");
     });
 
     it("silently signs in after verification completes outside the app", async () => {
       const { getOnboardingHtml } = await import("./onboarding-html.js");
-      const html = getOnboardingHtml();
+      const html = getOnboardingHtml({ requestPath: "/sign-in?verified=1" });
 
-      expect(html).toContain("var pendingSignupPassword = ''");
-      expect(html).toContain("function __anIsVerifiedRedirectSuccess()");
-      expect(html).toContain(
-        "return params.has('verified') && !params.has('error');",
-      );
-      expect(html).toContain("async function signInWithPendingSignup()");
-      expect(html).toContain("__anPath('/_agent-native/auth/login')");
-      expect(html).toContain(
-        "window.addEventListener('focus', maybeCompleteVerificationAfterReturn)",
-      );
-      expect(html).toContain(
-        "checkVerificationSession(null, { silent: true })",
-      );
+      expect(readAuthPageData(html).initialView).toBe("login");
+      expect(html).toContain('id="login-form"');
+      expect(html).toContain('src="/assets/auth-client.js"');
     });
 
     it("keeps resend verification on a visible cooldown after sending", async () => {
       const { getOnboardingHtml } = await import("./onboarding-html.js");
       const html = getOnboardingHtml();
 
-      expect(html).toContain("var RESEND_VERIFICATION_COOLDOWN_SECONDS = 60");
-      expect(html).toContain(
-        "startResendVerificationCooldown(RESEND_VERIFICATION_COOLDOWN_SECONDS)",
-      );
-      expect(html).toContain(
-        "btn.textContent = __anT('resendEmail') + ' (' + remaining + 's)'",
-      );
+      expect(html).toContain('id="resend-verification"');
+      expect(html).toContain('data-i18n="resendEmail"');
+      expect(html).toContain('src="/assets/auth-client.js"');
     });
   });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -6042,7 +6042,12 @@ async function mountBetterAuthRoutes(
         setResponseStatus(event, 405);
         return { error: "Method not allowed" };
       }
-      return new Response(getResetPasswordHtml(), {
+      const requestPath =
+        (event as any).context?._mountedPathname ??
+        event.node?.req?.url ??
+        event.path ??
+        "/";
+      return new Response(getResetPasswordHtml(requestPath), {
         headers: { "Content-Type": "text/html; charset=utf-8" },
       });
     }),

--- a/packages/core/src/server/login-document-session-probe.spec.ts
+++ b/packages/core/src/server/login-document-session-probe.spec.ts
@@ -1,105 +1,23 @@
-/**
- * The login document's "is there already a session?" probe.
- *
- * Extracted from the emitted document and run for real, the way
- * onboarding-html.spec.ts already exercises the sign-in journey runtime: the
- * script is a string, so a stale copy of this logic cannot be caught by
- * typechecking.
- *
- * The signed-out answer from /_agent-native/auth/session is a 200 carrying
- * `{ error }`. Anything else — a non-ok status, an unparseable body, a failed
- * fetch — means the question went unanswered, and reading that as signed-out
- * leaves a signed-in visitor parked on the login form with nothing to retry
- * it. That is what the /chatapp leg of the sign-in matrix reported as being
- * "stuck at /chatapp/sign-in".
- */
 import { describe, expect, it } from "vitest";
 
+import { shouldRetryAuthSessionProbe } from "../client/auth/AuthPage.js";
 import { getOnboardingHtml } from "./onboarding-html.js";
 
-type SessionResponse = () => unknown;
-
-interface Probe {
-  calls: number;
-  redirected: string[];
-  run: () => Promise<boolean>;
-}
-
-function probeScript(): string {
-  const html = getOnboardingHtml();
-  const start = html.indexOf("var __AN_SESSION_PROBE_ATTEMPTS");
-  const end = html.indexOf("function __anIsLoopbackHostname");
-  expect(start).toBeGreaterThan(-1);
-  expect(end).toBeGreaterThan(start);
-  return html.slice(start, end);
-}
-
-function buildProbe(script: string, responses: SessionResponse[]): Probe {
-  const probe: Probe = {
-    calls: 0,
-    redirected: [],
-    run: () => Promise.resolve(false),
-  };
-  function fetchStub() {
-    const next = responses[Math.min(probe.calls, responses.length - 1)];
-    probe.calls += 1;
-    return Promise.resolve(next ? next() : null);
-  }
-  const maybeRedirect = new Function(
-    "fetch",
-    "__anPath",
-    "__anRedirectToSignedInApp",
-    script + " return __anMaybeRedirectSignedIn;",
-  )(
-    fetchStub,
-    (path: string) => path,
-    (ret: string) => probe.redirected.push(ret),
-  ) as (ret: string) => Promise<boolean>;
-  probe.run = () => maybeRedirect("/inbox");
-  return probe;
-}
-
-const signedIn: SessionResponse = () => ({
-  ok: true,
-  json: () => Promise.resolve({ email: "someone@example.test" }),
-});
-
-const serverError: SessionResponse = () => ({
-  ok: false,
-  json: () => Promise.reject(new Error("not json")),
-});
-
-/** Real `fetch` rejects on a transport failure rather than throwing. */
-const networkFailure: SessionResponse = () =>
-  Promise.reject(new Error("fetch failed"));
-
-const signedOut: SessionResponse = () => ({
-  ok: true,
-  json: () => Promise.resolve({ error: "Not authenticated" }),
-});
-
 describe("login document session probe", () => {
-  it("resumes after a blip instead of standing the visitor down", async () => {
-    const probe = buildProbe(probeScript(), [
-      serverError,
-      networkFailure,
-      signedIn,
-    ]);
-    await expect(probe.run()).resolves.toBe(true);
-    expect(probe.redirected).toEqual(["/inbox"]);
+  it("retries unreadable and transient session responses", () => {
+    expect(shouldRetryAuthSessionProbe({ status: 200 }, false)).toBe(true);
+    expect(shouldRetryAuthSessionProbe({ status: 429 }, true)).toBe(true);
+    expect(shouldRetryAuthSessionProbe({ status: 503 }, true)).toBe(true);
   });
 
-  it("does not redirect when the session stays unreadable", async () => {
-    const probe = buildProbe(probeScript(), [serverError]);
-    await expect(probe.run()).resolves.toBe(false);
-    expect(probe.redirected).toEqual([]);
-    expect(probe.calls).toBe(3);
+  it("stops on a readable signed-out or client-error response", () => {
+    expect(shouldRetryAuthSessionProbe({ status: 200 }, true)).toBe(false);
+    expect(shouldRetryAuthSessionProbe({ status: 401 }, true)).toBe(false);
   });
 
-  it("treats a 200 carrying error as final, and does not retry it", async () => {
-    const probe = buildProbe(probeScript(), [signedOut]);
-    await expect(probe.run()).resolves.toBe(false);
-    expect(probe.calls).toBe(1);
-    expect(probe.redirected).toEqual([]);
+  it("ships a hydratable React auth root", () => {
+    const html = getOnboardingHtml();
+    expect(html).toContain('id="agent-native-auth-root"');
+    expect(html).toContain('src="/assets/auth-client.js"');
   });
 });

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { AuthPageProps } from "../client/auth/AuthPage.js";
 import { LOCALE_STORAGE_KEY } from "../localization/shared.js";
 import {
   PASSWORD_MAX_LENGTH,
@@ -11,6 +12,14 @@ import {
 } from "../shared/social-meta.js";
 import { BUILT_IN_AUTH_MARKETING } from "./auth-marketing.js";
 import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
+
+function readAuthPageData(html: string): AuthPageProps {
+  const match = html.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
+  if (!match) throw new Error("auth page data is missing");
+  return JSON.parse(match[1]!) as AuthPageProps;
+}
 
 describe("getOnboardingHtml", () => {
   afterEach(() => {
@@ -31,16 +40,13 @@ describe("getOnboardingHtml", () => {
     });
 
     expect(html).toContain('id="environment-badge"');
-    expect(html).toContain("You're on Agent-Native Beta");
+    expect(html).toContain("You&#x27;re on Agent-Native Beta");
     expect(html).toContain("Switch to production");
     expect(html).toContain('id="environment-hide-badge"');
-    expect(html).toContain("switcher.hidden = true");
-    expect(html).toContain("__anInitEnvironmentBadge");
-    expect(html).toContain("agentNativeBetaOptOut");
-    expect(html).toContain("agent-native:beta-opt-out-until");
-    expect(html).toContain("agent-native:force-production");
-    expect(html).toContain("window.localStorage.setItem");
-    expect(html).toContain("window.history.replaceState");
+    expect(readAuthPageData(html).environmentBetaHosts).toHaveProperty(
+      "analytics.agent-native.com",
+    );
+    expect(html).toContain('src="/assets/auth-client.js"');
     expect(html).toContain("left: max(0.75rem, env(safe-area-inset-left));");
     expect(html).toContain("left: 0;");
     expect(html).toContain(
@@ -52,12 +58,27 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain('id="environment-badge" aria-expanded="false"');
   });
 
-  it("redirects signed-in visitors without a cache-buster query loop", () => {
+  it("ships a hydratable React auth surface without inline auth handlers", () => {
     const html = getOnboardingHtml();
 
-    expect(html).toContain("window.location.replace(ret || __anResumeHref())");
-    expect(html).not.toContain("__anWithAuthCacheBypass");
-    expect(html).not.toContain("__an_auth_redirect");
+    expect(html).toContain('id="agent-native-auth-root"');
+    expect(html).toContain('src="/assets/auth-client.js"');
+    expect(html).toContain(
+      'type="application/json" id="agent-native-auth-data"',
+    );
+    expect(html).not.toContain('onclick="signInWithGoogle()"');
+    expect(html).not.toContain("__anAuthView");
+  });
+
+  it("renders deep-link tab selection in the initial SSR view", () => {
+    expect(
+      readAuthPageData(getOnboardingHtml({ requestPath: "/sign-in?tab=login" }))
+        .initialView,
+    ).toBe("login");
+    expect(
+      readAuthPageData(getOnboardingHtml({ requestPath: "/signup?tab=signup" }))
+        .initialView,
+    ).toBe("signup");
   });
 
   it("keeps the local-dev CTA hidden in cached HTML and reveals it only for loopback hosts", () => {
@@ -81,17 +102,10 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain("width: 0.625rem;");
     expect(html).toContain("height: 0.625rem;");
     expect(html).toContain(".full-auth-options { margin-top: 1rem; }");
-    expect(html).toContain("function __anIsLoopbackHostname()");
-    expect(html).toContain("function __anSetFullAuthOptionsVisible(visible)");
-    expect(html).toContain("fetch(__anPath('/_agent-native/auth/local-dev')");
-    expect(html).toContain("method: 'GET'");
-    expect(html).toContain("cache: 'no-store'");
-    expect(html).toContain("data.available === true");
-    expect(html).toContain("hostname.indexOf('127.') === 0");
-    expect(html).toContain(
-      "var __AN_BUILDER_PREVIEW_LOCAL_DEV_ENABLED = false;",
+    expect(readAuthPageData(html).builderPreviewLocalDevEnabled).toBe(false);
+    expect(readAuthPageData(html).docsAuthUrl).toContain(
+      "local-development-sign-in",
     );
-    expect(html).not.toContain("NODE_ENV");
   });
 
   it("enables the local-dev CTA on Builder previews only with explicit opt-in", () => {
@@ -99,17 +113,12 @@ describe("getOnboardingHtml", () => {
 
     const html = getOnboardingHtml();
 
-    expect(html).toContain(
-      "var __AN_BUILDER_PREVIEW_LOCAL_DEV_ENABLED = true;",
-    );
-    expect(html).toContain("function __anIsBuilderPreviewHost()");
-    expect(html).toContain("function __anCanUseLocalDevSignin()");
-    expect(html).toContain("hostname.endsWith('.builder.my')");
+    expect(readAuthPageData(html).builderPreviewLocalDevEnabled).toBe(true);
 
     vi.stubEnv("NODE_ENV", "production");
-    expect(getOnboardingHtml()).toContain(
-      "var __AN_BUILDER_PREVIEW_LOCAL_DEV_ENABLED = false;",
-    );
+    expect(
+      readAuthPageData(getOnboardingHtml()).builderPreviewLocalDevEnabled,
+    ).toBe(false);
   });
 
   describe("federated SSO button (AGENT_NATIVE_IDENTITY_HUB_URL)", () => {
@@ -145,17 +154,9 @@ describe("getOnboardingHtml", () => {
       expect(html).toContain('id="identity-sso-btn"');
       expect(html).toContain('href="/_agent-native/identity/login"');
       expect(html).toContain("Sign in with Agent-Native");
-      expect(html).toContain("function __anIdentitySsoUrl()");
-      expect(html).toContain("params.set('return', __anResumeHref())");
-      expect(html).toContain(
-        "identity.addEventListener('click', __anStartIdentitySso)",
-      );
       expect(html).toContain("data-agent-native-embedded-init");
       expect(html).toContain(
         'params.get("embedded") === "1" || window.self !== window.top',
-      );
-      expect(html).toContain(
-        'html[data-agent-native-embedded="1"] #identity-sso-btn { display: none !important; }',
       );
       // Exactly one rendered element — not duplicated across layout branches.
       expect(html.split('id="identity-sso-btn"').length - 1).toBe(1);
@@ -180,7 +181,6 @@ describe("getOnboardingHtml", () => {
       const html = getOnboardingHtml({ googleOnly: true });
 
       expect(html).not.toContain('id="google-btn"');
-      expect(html).not.toContain("async function signInWithGoogle()");
       expect(html).toContain('id="google-err"');
       expect(html).toContain('class="google-error show"');
       expect(html).toContain('data-i18n="googleNotConfigured"');
@@ -206,10 +206,7 @@ describe("getOnboardingHtml", () => {
       const html = getOnboardingHtml({ googleOnly: true });
 
       expect(html).toContain('id="google-btn"');
-      expect(html).toContain("async function signInWithGoogle()");
-      expect(html).toContain(
-        "surface: __anAuthView === 'login' ? 'login' : 'signup'",
-      );
+      expect(readAuthPageData(html).showGoogle).toBe(true);
       expect(html).not.toContain('class="google-error show"');
     });
   });
@@ -217,11 +214,8 @@ describe("getOnboardingHtml", () => {
   it("reveals the upgrade note only from explicit upgrade markers", () => {
     const html = getOnboardingHtml();
 
-    expect(html).toContain("upgrade-from-local");
-    expect(html).toContain("an_migrate_from_local");
-    expect(html).toContain(
-      "Continue signing in to attach this app to your account and migrate local data.",
-    );
+    expect(html).toContain('data-i18n-data-upgrade-copy="upgradeCopy"');
+    expect(readAuthPageData(html).initialPrompt).toBe(false);
   });
 
   it("injects APP_BASE_PATH so mounted login pages call app-scoped auth endpoints", () => {
@@ -231,14 +225,8 @@ describe("getOnboardingHtml", () => {
 
     const html = getOnboardingHtml();
 
-    expect(html).toContain('var configured = "/starter";');
-    expect(html).toContain("__anPath('/_agent-native/auth/session')");
-    expect(html).toContain("__anPath('/_agent-native/auth/register')");
-    expect(html).toContain("__anPath('/_agent-native/auth/login')");
-    expect(html).toContain(
-      "__anPath('/_agent-native/auth/ba/request-password-reset')",
-    );
-    expect(html).toContain("__anPath('/_agent-native/google/auth-url')");
+    expect(html).toContain('src="/starter/assets/auth-client.js"');
+    expect(readAuthPageData(html).appBasePath).toBe("/starter");
   });
 
   it("derives the workspace mount for request-specific and cached login HTML", () => {
@@ -249,74 +237,34 @@ describe("getOnboardingHtml", () => {
     const requestHtml = getOnboardingHtml({
       requestPath: "/dispatch/sign-in?c=continuation",
     });
-    expect(requestHtml).toContain('var configured = "/dispatch";');
+    expect(readAuthPageData(requestHtml).appBasePath).toBe("/dispatch");
+    expect(requestHtml).toContain('src="/dispatch/assets/auth-client.js"');
 
     const cachedHtml = getOnboardingHtml();
-    expect(cachedHtml).toContain('var configured = "";');
-    const start = cachedHtml.indexOf("function __anBasePath()");
-    const end = cachedHtml.indexOf("function __anPath", start);
-    const basePath = new Function(
-      "window",
-      `${cachedHtml.slice(start, end)} return __anBasePath();`,
-    )({ location: { pathname: "/dispatch/sign-in" } });
-    expect(basePath).toBe("/dispatch");
-
-    const rootBasePath = new Function(
-      "window",
-      `${cachedHtml.slice(start, end)} return __anBasePath();`,
-    )({ location: { pathname: "/sign-in" } });
-    expect(rootBasePath).toBe("");
+    expect(readAuthPageData(cachedHtml).appBasePath).toBe("");
+    expect(readAuthPageData(cachedHtml).workspaceRuntime).toBe(true);
+    expect(cachedHtml).toContain('src="/assets/auth-client.js"');
   });
 
   it("validates email/password auth emails before submitting forms", () => {
     const html = getOnboardingHtml();
 
-    expect(html).toContain("function __anIsValidAuthEmail(value)");
-    expect(html).toContain("/^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/");
-    expect(html).toContain(
-      "Enter a valid email address, like you@example.com.",
-    );
-    expect(html).toContain(
-      "body: JSON.stringify({ email: email, password: pass })",
-    );
-    expect(html).toContain("password: document.getElementById('l-pass').value");
+    expect(html).toContain('id="signup-form"');
+    expect(html).toContain('id="login-form"');
+    expect(html).toContain('type="email"');
+    expect(readAuthPageData(html).passwordMinLength).toBe(PASSWORD_MIN_LENGTH);
   });
 
   it("uses clear client-side validation and hides technical auth errors", () => {
     const html = getOnboardingHtml();
     const resetHtml = getResetPasswordHtml();
 
-    expect(html).toContain("function __anAuthErrorText(data, fallback)");
-    expect(html).toContain("function __anBindPasswordValidation(input)");
-    expect(html).toContain(
-      "input.setCustomValidity(__anT('passwordMinPlaceholder'))",
-    );
     expect(html).toContain(`maxLength="${PASSWORD_MAX_LENGTH}"`);
-    expect(html).toContain(
-      "We couldn't create your account. Please try again.",
-    );
-    expect(html).toContain(
-      "We couldn't reach the server. Check your connection and try again.",
-    );
-    expect(html).toContain("function __anVerificationRedirectError()");
-    expect(html).toContain("verification_link_invalid");
-    expect(html).toContain(
-      "This verification link is invalid or expired. Request a new one.",
-    );
-    expect(resetHtml).toContain(
-      "This password reset link is missing or invalid. Request a new one.",
-    );
-    expect(resetHtml).toContain(
-      "We couldn't update your password. The link may have expired; request a new one.",
-    );
-    expect(resetHtml).toContain(`maxlength="${PASSWORD_MAX_LENGTH}"`);
-
-    const onboardingScript = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
-    const resetScript = resetHtml.match(/<script>([\s\S]*)<\/script>/)?.[1];
-    expect(onboardingScript).toBeTruthy();
-    expect(resetScript).toBeTruthy();
-    expect(() => new Function(onboardingScript!)).not.toThrow();
-    expect(() => new Function(resetScript!)).not.toThrow();
+    expect(resetHtml).toContain('id="agent-native-auth-root"');
+    expect(resetHtml).toContain('pageType":"reset-password"');
+    expect(resetHtml).toContain('src="/assets/auth-client.js"');
+    expect(resetHtml).toContain("Choose a new password");
+    expect(resetHtml).toContain(`maxLength="${PASSWORD_MAX_LENGTH}"`);
   });
 
   it("does not render a run-local CTA in the auth marketing panel", () => {
@@ -332,14 +280,12 @@ describe("getOnboardingHtml", () => {
       },
     });
 
-    const onboardingScript = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
-    expect(onboardingScript).toBeTruthy();
     expect(html).not.toContain('id="run-local-button"');
     expect(html).not.toContain('id="run-local-panel"');
     expect(html).not.toContain("Run Locally");
     expect(html).not.toContain("function __anCopyRunLocalCommand()");
-    expect(html).toContain('onclick="signInWithGoogle()"');
-    expect(() => new Function(onboardingScript!)).not.toThrow();
+    expect(html).toContain('id="google-btn"');
+    expect(readAuthPageData(html).showGoogle).toBe(true);
   });
 
   it("renders the policy password minimum in signup and reset forms", () => {
@@ -350,8 +296,8 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain(`maxLength="${PASSWORD_MAX_LENGTH}"`);
     expect(html).toContain(`At least ${PASSWORD_MIN_LENGTH} characters`);
     expect(html).not.toContain('minlength="8"');
-    expect(resetHtml).toContain(`minlength="${PASSWORD_MIN_LENGTH}"`);
-    expect(resetHtml).toContain(`maxlength="${PASSWORD_MAX_LENGTH}"`);
+    expect(resetHtml).toContain(`minLength="${PASSWORD_MIN_LENGTH}"`);
+    expect(resetHtml).toContain(`maxLength="${PASSWORD_MAX_LENGTH}"`);
     expect(resetHtml).toContain(`At least ${PASSWORD_MIN_LENGTH} characters`);
     expect(resetHtml).not.toContain('minlength="8"');
   });
@@ -362,7 +308,7 @@ describe("getOnboardingHtml", () => {
     expect(html).not.toContain('id="magic-link-form"');
     expect(html).toContain('id="signup-form"');
     expect(html).toContain('id="login-form"');
-    expect(html).toContain("/_agent-native/auth/login");
+    expect(readAuthPageData(html).authMode).toBe("password");
   });
 
   it("does not autofocus auth inputs on initial load", () => {
@@ -381,94 +327,32 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain('id="magic-link-submit"');
     expect(html).toContain('class="magic-link-submit"');
     expect(html).toContain(".magic-link-submit { display: block; }");
+    expect(readAuthPageData(html).initialView).toBe("magicLink");
     expect(html).toContain('id="magic-link-success"');
     expect(html).toContain('id="magic-link-success-email"');
-    expect(html).toContain("function showMagicLinkSuccess(email)");
-    expect(html).toContain("button.disabled = !isValid");
-    expect(html).toContain(
-      "googleButton.classList.toggle('magic-link-secondary', isValid)",
-    );
     expect(html).toContain(".btn-google.magic-link-secondary");
     expect(html).toContain("margin-top: 0.375rem;");
     expect(html).toContain("margin-bottom: 0.875rem;");
     expect(html).toContain("text-align: start;");
-    expect(html).toContain(
-      "magicLinkEmail.addEventListener('input', updateMagicLinkSubmitState)",
-    );
     expect(html).toContain('id="use-password-link"');
     expect(html).toContain('class="link-button auth-mode-link"');
     expect(html).toContain(
       'style="margin-top:0.75rem;font-size:0.75rem;text-align:start"',
     );
     expect(html).toContain('id="back-to-magic-link"');
-    expect(html).toContain("/_agent-native/auth/magic-link");
-    expect(html).toContain("callbackURL: isDesktopMagicLink");
-    expect(html).toContain("/_agent-native/auth/magic-link/desktop-callback");
-    expect(html).toContain(
-      "__anWaitForOAuthExchange(magicFlowId, __anResumeHref(), btn, msg, 'magic-link', magicVerifier)",
-    );
-    expect(html).toContain(
-      "var initial = __AN_AUTH_MODE === 'magic-link' ? 'magicLink' : 'signup';",
-    );
-    expect(html).toContain("} else if (__AN_AUTH_MODE !== 'magic-link') {");
-    expect(html).toContain("if (initial === 'magicLink') showMagicLinkForm();");
-    expect(html).toContain('class="tabs" id="auth-tabs"');
-    expect(html).not.toContain('class="tabs" id="auth-tabs" hidden');
-    expect(html).toContain(
-      '<h1 id="heading" data-i18n="welcomeTitle">Welcome</h1>',
-    );
+    expect(html).toContain('id="auth-tabs"');
+    expect(html).toContain('data-i18n="magicLinkTitle">Welcome</h1>');
     expect(html).toContain("Create an account or sign in");
-    expect(html).not.toContain("Email me a sign-in link");
     expect(html).toContain("Continue with email");
-    expect(html).toContain("magicLinkTitle");
-    expect(html).toContain("magicLinkSubtitle");
+    expect(html).not.toContain("onclick=");
   });
 
   it("does not let a remembered password tab override the magic-link entry view", () => {
-    const html = getOnboardingHtml({ authMode: "magic-link" });
-    const start = html.indexOf("    var initial = __AN_AUTH_MODE");
-    const end = html.indexOf("    if (initial === 'magicLink')", start);
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-
-    const resolveInitialView = new Function(
-      "__AN_AUTH_MODE",
-      "location",
-      "localStorage",
-      "TAB_STORAGE_KEY",
-      "__anVerificationRedirectError",
-      "__anIsVerifiedRedirectSuccess",
-      `${html.slice(start, end)} return initial;`,
-    ) as (
-      authMode: "magic-link" | "password",
-      location: { search: string; pathname: string },
-      localStorage: { getItem: (key: string) => string | null },
-      storageKey: string,
-      verificationError: () => string | null,
-      verifiedRedirect: () => boolean,
-    ) => string;
-
-    const storage = { getItem: () => "signup" };
     expect(
-      resolveInitialView(
-        "magic-link",
-        { search: "", pathname: "/" },
-        storage,
-        "an.onboarding.tab",
-        () => null,
-        () => false,
-      ),
+      readAuthPageData(getOnboardingHtml({ authMode: "magic-link" }))
+        .initialView,
     ).toBe("magicLink");
-    expect(
-      resolveInitialView(
-        "password",
-        { search: "", pathname: "/" },
-        storage,
-        "an.onboarding.tab",
-        () => null,
-        () => false,
-      ),
-    ).toBe("signup");
+    expect(readAuthPageData(getOnboardingHtml()).initialView).toBe("signup");
   });
 
   it("renders a quiet centered auth surface for an initial prompt", () => {
@@ -517,77 +401,25 @@ describe("getOnboardingHtml", () => {
   it("keeps the pending verification email across a redirect without storing its password", () => {
     const html = getOnboardingHtml();
 
-    expect(html).toContain(
-      "var PENDING_SIGNUP_EMAIL_STORAGE_KEY = 'an.onboarding.pendingSignupEmail'",
-    );
-    expect(html).toContain(
-      "localStorage.setItem(pendingSignupEmailStorageKey(), email)",
-    );
-    expect(html).toContain("rememberPendingSignupEmail(pendingSignupEmail)");
-    expect(html).toContain(
-      "pendingSignupEmail || readRememberedPendingSignupEmail()",
-    );
-    expect(html).toContain(
-      "if (loginEmail && rememberedEmail) loginEmail.value = rememberedEmail",
-    );
+    expect(html).toContain('id="verification-step"');
+    expect(html).toContain('id="verify-email"');
+    expect(html).not.toContain("pendingSignupPassword");
   });
 
   it("normalizes and rehydrates the stored verification email at runtime", () => {
     const html = getOnboardingHtml();
-    const start = html.indexOf(
-      "var PENDING_SIGNUP_EMAIL_STORAGE_KEY = 'an.onboarding.pendingSignupEmail'",
-    );
-    const end = html.indexOf("function setActiveTab", start);
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-
-    const values = new Map<string, string>();
-    const storage = {
-      getItem: (key: string) => values.get(key) ?? null,
-      setItem: (key: string, value: string) => values.set(key, value),
-      removeItem: (key: string) => values.delete(key),
-    };
-    const runtime = new Function(
-      "localStorage",
-      "__anBasePath",
-      "__anIsValidAuthEmail",
-      "__anNormalizeAuthEmail",
-      `${html.slice(start, end)}
-return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
-    )(
-      storage,
-      () => "/design",
-      (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
-      (value: string) => value.trim().toLowerCase(),
-    ) as {
-      rememberPendingSignupEmail: (email: string) => void;
-      readRememberedPendingSignupEmail: () => string;
-    };
-
-    runtime.rememberPendingSignupEmail("URVI28@OUTLOOK.COM");
-    expect(runtime.readRememberedPendingSignupEmail()).toBe(
-      "urvi28@outlook.com",
-    );
-    expect(values.has("an.onboarding.pendingSignupEmail:/design")).toBe(true);
-
-    runtime.rememberPendingSignupEmail("");
-    expect(runtime.readRememberedPendingSignupEmail()).toBe("");
+    expect(html).toContain('id="agent-native-auth-data"');
+    expect(html).toContain('id="verification-step"');
+    expect(html).toContain('id="resend-verification"');
+    expect(html).toContain('id="back-to-signup"');
   });
 
   it("captures first-touch attribution on the standalone auth page", () => {
     const html = getOnboardingHtml();
 
-    expect(html).toContain("function __anCaptureSignupAttribution()");
-    expect(html).toContain("localStorage.getItem('an_attribution')");
-    expect(html).toContain("document.cookie = 'an_ft='");
-    expect(html).toContain("'utm_source'");
-    expect(html).toContain("var returnPath = __anJourney.normalizeAppPath");
-    expect(html).toContain("__anExternalReferrerHost(document.referrer || '')");
-    expect(html).toContain("function __anSyncAnalyticsAnonymousId()");
-    expect(html).toContain("localStorage.getItem('agent-native.anonymous_id')");
-    expect(html).toContain("document.cookie = 'an_aid='");
-    expect(html).toContain("auth.signup_viewed");
-    expect(html).toContain("auth.signup_clicked");
+    expect(html).toContain('id="agent-native-auth-root"');
+    expect(html).toContain('src="/assets/auth-client.js"');
+    expect(html).not.toContain("document.cookie = 'an_ft='");
   });
 
   it("omits hosted terms and privacy links on unhosted email signup", () => {
@@ -620,19 +452,14 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
 
     expect(html).toContain('id="auth-locale-trigger"');
     expect(html).toContain('id="auth-locale-menu"');
-    expect(html).toContain(
-      `var __AN_AUTH_LOCALE_STORAGE_KEY = "${LOCALE_STORAGE_KEY}"`,
-    );
+    expect(readAuthPageData(html).localeStorageKey).toBe(LOCALE_STORAGE_KEY);
     expect(html).toContain('data-locale-value="es-ES"');
     expect(html).toContain("Español");
     expect(html).not.toContain("Español (Spanish)");
     expect(html).not.toContain("English (en-US)");
-    expect(html).toContain("<span data-system-language>System</span>");
+    expect(html).toContain('data-system-language="true">System</span>');
     expect(html).toContain('data-i18n="createAccount"');
     expect(html).toContain("Crear cuenta");
-    expect(html).toContain("function __anApplyAuthLocale");
-    expect(html).toContain("function __anSetAuthLocaleMenuOpen");
-    expect(html).toContain("root.setAttribute('dir', meta.dir || 'ltr')");
   });
 
   it("localizes built-in Forms auth marketing copy from the locale picker", () => {
@@ -644,8 +471,9 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
     expect(html).toContain('data-marketing-feature-index="0"');
     expect(html).toContain("你的 AI 代理会与你一起构建、发布和分析表单。");
     expect(html).toContain("用一句话创建完整表单");
-    expect(html).toContain("function __anApplyAuthMarketingCopy");
-    expect(html).toContain('var __AN_AUTH_MARKETING_SLUG = "forms"');
+    expect(readAuthPageData(html).marketingLocales["zh-CN"]?.tagline).toContain(
+      "构建、发布和分析表单",
+    );
   });
 
   it("keeps built-in marketing on beta template subdomains", () => {
@@ -653,7 +481,6 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
       requestHost: "beta.clips.agent-native.com",
     });
 
-    expect(html).toContain('var __AN_AUTH_MARKETING_SLUG = "clips"');
     expect(html).toContain("你的 AI 代理会转录、总结并搜索你记录的所有内容。");
   });
 
@@ -673,12 +500,10 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
       },
     });
 
-    expect(html).toContain('var __AN_AUTH_MARKETING_SLUG = "";');
     expect(html).toContain(
       "One-click screen recording (Loom-style) with auto titles, summaries, and chapters",
     );
-    expect(html).toContain("var __AN_AUTH_MARKETING_LOCALES = {};");
-    expect(html).toContain("function __anResolveAuthSystemLocale()");
+    expect(readAuthPageData(html).marketingLocales).toEqual({});
     expect(html).not.toContain("var rootLocale =");
   });
 
@@ -729,7 +554,9 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
       "npx @agent-native/core@latest skills add visual-plan --mode local-files --scope user",
     );
     expect(html).toContain('id="copy-signup-local-mode"');
-    expect(html).toContain("function __anCopySignupLocalModeCommand()");
+    expect(readAuthPageData(html).signupLocalModeNote?.command).toContain(
+      "skills add visual-plan --mode local-files",
+    );
   });
 
   it("keeps the local-files escape hatch off other hosted signup pages", () => {
@@ -744,64 +571,9 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
   it("normalizes sign-in return targets through the one shared primitive", () => {
     const html = getOnboardingHtml();
 
-    // The document must not carry its own return-path validator: the whole
-    // point of the shared runtime is that there is nothing here to drift.
-    expect(html).toContain("var __anCreateSignInJourney =");
-    expect(html).toContain(
-      "var __anJourney = __anCreateSignInJourney(__anBasePath());",
-    );
-    expect(html).toContain("function __anResumeHref()");
+    expect(html).toContain('src="/assets/auth-client.js"');
+    expect(readAuthPageData(html).appBasePath).toBe("");
     expect(html).not.toContain("function __anNormalizeReturnPath");
-    expect(html).not.toContain("function __anIsAuthEntryPath");
-    expect(html).not.toContain("function __anGetSignedInReturnPath");
-
-    // …and the embedded runtime really behaves, hashes and all.
-    const script = html.slice(
-      html.indexOf("var __anCreateSignInJourney ="),
-      html.indexOf("var __anJourney = __anCreateSignInJourney"),
-    );
-    const journey = new Function(
-      `${script} return __anCreateSignInJourney("");`,
-    )() as {
-      signInJourney: (input: {
-        at: string;
-        continuation?: string | null;
-        legacyReturn?: string | null;
-      }) => { signInHref: string | null; resumeHref: string };
-      normalizeAppPath: (raw: string) => string | null;
-    };
-    expect(journey.normalizeAppPath("/inbox?a=1#top")).toBe("/inbox?a=1#top");
-    expect(journey.normalizeAppPath("//evil.com")).toBeNull();
-    expect(journey.normalizeAppPath("https://evil.com/x")).toBeNull();
-    expect(journey.signInJourney({ at: "/login" })).toEqual({
-      signInHref: null,
-      resumeHref: "/home",
-    });
-    expect(
-      journey.signInJourney({
-        at: "/sign-in",
-        legacyReturn: "/inbox#x",
-      }).resumeHref,
-    ).toBe("/inbox#x");
-
-    const mountedJourney = new Function(
-      `${script} return __anCreateSignInJourney("/dispatch");`,
-    )() as {
-      encodeContinuation: (path: string) => string;
-      signInJourney: (input: {
-        at: string;
-        continuation?: string | null;
-        legacyReturn?: string | null;
-      }) => { resumeHref: string };
-    };
-    const mountedTarget = "/dispatch/apps/feedback-leaderboard";
-    const mountedToken = mountedJourney.encodeContinuation(mountedTarget);
-    expect(
-      mountedJourney.signInJourney({
-        at: `/dispatch/sign-in?c=${mountedToken}`,
-        continuation: mountedToken,
-      }).resumeHref,
-    ).toBe(mountedTarget);
   });
 
   it("uses branded first-party marketing from the request host", () => {
@@ -876,9 +648,8 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
       },
     });
 
-    expect(html).toContain('var __AN_AUTH_MARKETING_SLUG = "";');
     expect(html).toContain("Plan your team's work with a custom calendar.");
-    expect(html).toContain("var __AN_AUTH_MARKETING_LOCALES = {};");
+    expect(readAuthPageData(html).marketingLocales).toEqual({});
   });
 
   it("does not localize custom marketing from a built-in request host", () => {
@@ -890,9 +661,8 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
       },
     });
 
-    expect(html).toContain('var __AN_AUTH_MARKETING_SLUG = "";');
     expect(html).toContain("Route your own work with a custom dispatch flow.");
-    expect(html).toContain("var __AN_AUTH_MARKETING_LOCALES = {};");
+    expect(readAuthPageData(html).marketingLocales).toEqual({});
   });
 
   it("embeds the public OAuth origin for Builder desktop redirects", () => {
@@ -902,65 +672,10 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
 
     const html = getOnboardingHtml();
 
-    expect(html).toContain(
-      'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
-    );
-    expect(html).toContain('var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";');
-    expect(html).toContain(
-      "__anSetOAuthDebug(reason || 'Opening Google sign-in redirect', flowId)",
-    );
-    expect(html).toContain(
-      "function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage)",
-    );
-    expect(html).toContain("Allow popups for this site and try again");
-    expect(html).toContain(
-      "Opening Google sign-in redirect from Builder preview",
-    );
-    expect(html).toContain(
-      "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
-    );
-    expect(html).toContain("function __anBuilderPreviewReturnOrigin()");
-    expect(html).toContain("var __anBuilderPreviewSeen = false");
-    expect(html).toContain("function __anRememberBuilderPreview()");
-    expect(html).toContain(
-      "sessionStorage.setItem('__an_builder_preview_seen', '1')",
-    );
-    expect(html).toContain("function __anHasBuilderPreviewSignal()");
-    expect(html).toContain("params.has('builder.preview')");
-    expect(html).toContain("__anIsBuilderPreview();");
-    expect(html).toContain("function __anIsInFrame()");
-    expect(html).toContain(
-      "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
-    );
-    expect(html).toContain(
-      "var candidates = [window.location.href, document.referrer || ''];",
-    );
-    expect(html).toContain("function __anIsAgentNativeDesktop()");
-    expect(html).toContain("function __anGoogleAuthUrlPath()");
-    expect(html).toContain("function __anOAuthReturnTarget(ret)");
-    expect(html).toContain("function __anSessionBridgeUrl(ret, sessionToken)");
-    expect(html).toContain(
-      "function __anFinishOAuthExchange(ret, flowId, sessionToken)",
-    );
-    expect(html).toContain("function __anMaybeRedirectSignedIn(ret)");
-    expect(html).toContain("__anMaybeRedirectSignedIn();");
-    expect(html).toContain(
-      "__anMaybeRedirectSignedIn(__anResumeHref()).then(function(redirected)",
-    );
-    expect(html).toContain(
-      "window.location.replace(__anSessionBridgeUrl(ret, sessionToken))",
-    );
-    expect(html).toContain(
-      "var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;",
-    );
-    expect(html).toContain("__anFinishOAuthExchange(ret, flowId, data.token)");
-    expect(html).toContain(
-      "__anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier)",
-    );
-    expect(html).toContain("window.location.reload()");
-    expect(html).toContain(
-      "if (oauthReturn) params.set('return', oauthReturn)",
-    );
+    const data = readAuthPageData(html);
+    expect(data.publicOAuthOrigin).toBe("https://agent-workspace.builder.io");
+    expect(data.workspaceGatewayReturnOrigin).toBe("");
+    expect(html).toContain('src="/assets/auth-client.js"');
   });
 
   it("embeds the local workspace gateway return origin when configured", () => {
@@ -971,11 +686,8 @@ return { rememberPendingSignupEmail, readRememberedPendingSignupEmail };`,
 
     const html = getOnboardingHtml();
 
-    expect(html).toContain('var __AN_PUBLIC_OAUTH_ORIGIN = "";');
-    expect(html).toContain(
-      'var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "http://127.0.0.1:8080";',
-    );
-    expect(html).toContain("function __anNormalizeWorkspaceReturnPath(ret)");
-    expect(html).toContain("path === '/dispatch/dispatch'");
+    const data = readAuthPageData(html);
+    expect(data.publicOAuthOrigin).toBe("");
+    expect(data.workspaceGatewayReturnOrigin).toBe("http://127.0.0.1:8080");
   });
 });

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -246,6 +246,20 @@ describe("getOnboardingHtml", () => {
     expect(cachedHtml).toContain('src="/assets/auth-client.js"');
   });
 
+  it("derives the workspace mount for the reset page asset", () => {
+    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+    delete process.env.APP_BASE_PATH;
+    delete process.env.VITE_APP_BASE_PATH;
+
+    const resetHtml = getResetPasswordHtml(
+      "/dispatch/_agent-native/auth/reset?token=reset-token",
+    );
+
+    expect(readAuthPageData(resetHtml).appBasePath).toBe("/dispatch");
+    expect(resetHtml).toContain('src="/dispatch/assets/auth-client.js"');
+    expect(resetHtml).toContain('href="/dispatch/favicon.svg"');
+  });
+
   it("validates email/password auth emails before submitting forms", () => {
     const html = getOnboardingHtml();
 

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -229,6 +229,25 @@ describe("getOnboardingHtml", () => {
     expect(readAuthPageData(html).appBasePath).toBe("/starter");
   });
 
+  it("uses the Vite base for mounted auth assets and metadata", () => {
+    vi.stubEnv("VITE_APP_BASE_PATH", "/viteapp");
+    delete process.env.APP_BASE_PATH;
+
+    const html = getOnboardingHtml({
+      requestHost: "slides.agent-native.com",
+      requestOrigin: "https://slides.agent-native.com",
+    });
+
+    expect(readAuthPageData(html).appBasePath).toBe("/viteapp");
+    expect(html).toContain('src="/viteapp/assets/auth-client.js"');
+    expect(html).toContain('src="/viteapp/agent-native-icon-dark.svg"');
+    expect(html).toContain('href="/viteapp/favicon.svg"');
+    expect(html).toContain('href="/viteapp/icon-180.svg"');
+    expect(html).toContain(
+      "https://slides.agent-native.com/viteapp/_agent-native/og-image.png",
+    );
+  });
+
   it("derives the workspace mount for request-specific and cached login HTML", () => {
     vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
     delete process.env.APP_BASE_PATH;

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1174,9 +1174,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   const googleOnly = !!opts.googleOnly;
   const authMode = opts.authMode ?? "password";
   const simplifiedAuth = opts.initialPrompt === true;
-  const configuredAppBasePath = normalizeAppBasePath(
-    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
-  );
+  const configuredAppBasePath = getAppBasePathFromViteEnv();
   const appBasePath =
     configuredAppBasePath || workspaceBasePathFromRequest(opts.requestPath);
   const workspaceRuntime = isWorkspaceRuntime();
@@ -1229,11 +1227,14 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
           command: marketing.signupLocalModeNote.command.trim(),
         }
       : undefined;
-  const brandMarkSrc = withAppBasePath("/agent-native-icon-dark.svg");
+  const brandMarkSrc = withAppBasePath(
+    "/agent-native-icon-dark.svg",
+    appBasePath,
+  );
   const socialImageUrl = withAgentNativeSocialImageCacheBuster(
     opts.requestOrigin
-      ? `${opts.requestOrigin}${withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH)}`
-      : withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH),
+      ? `${opts.requestOrigin}${withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH, appBasePath)}`
+      : withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH, appBasePath),
   );
   const t = (key: keyof typeof EN_AUTH_COPY) => EN_AUTH_COPY[key];
   const hostedSignupLegalNotice: SignupLegalNoticeOptions | undefined =
@@ -2103,11 +2104,11 @@ ${embeddedAuthCss}
         createElement("link", {
           rel: "icon",
           type: "image/svg+xml",
-          href: withAppBasePath("/favicon.svg"),
+          href: withAppBasePath("/favicon.svg", appBasePath),
         }),
         createElement("link", {
           rel: "apple-touch-icon",
-          href: withAppBasePath("/icon-180.svg"),
+          href: withAppBasePath("/icon-180.svg", appBasePath),
         }),
         hasMarketing
           ? [

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -111,11 +111,9 @@ function workspaceBasePathFromRequest(requestPath: string | undefined): string {
   return normalizeAppBasePath(`/${firstSegment}`);
 }
 
-function withAppBasePath(path: string): string {
+function withAppBasePath(path: string, explicitBasePath?: string): string {
   const cleanPath = path.startsWith("/") ? path : `/${path}`;
-  const basePath = normalizeAppBasePath(
-    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
-  );
+  const basePath = explicitBasePath ?? getAppBasePathFromViteEnv();
   return `${basePath}${cleanPath}`;
 }
 
@@ -2236,8 +2234,10 @@ const RESET_PASSWORD_STYLES = `
 `;
 
 /** React document for the password reset page linked from auth email. */
-export function getResetPasswordHtml(): string {
-  const appBasePath = getAppBasePathFromViteEnv();
+export function getResetPasswordHtml(requestPath?: string): string {
+  const configuredAppBasePath = getAppBasePathFromViteEnv();
+  const appBasePath =
+    configuredAppBasePath || workspaceBasePathFromRequest(requestPath);
   const resetPageProps = {
     pageType: "reset-password" as const,
     appBasePath,
@@ -2261,11 +2261,11 @@ export function getResetPasswordHtml(): string {
         createElement("link", {
           rel: "icon",
           type: "image/svg+xml",
-          href: withAppBasePath("/favicon.svg"),
+          href: withAppBasePath("/favicon.svg", appBasePath),
         }),
         createElement("link", {
           rel: "apple-touch-icon",
-          href: withAppBasePath("/icon-180.svg"),
+          href: withAppBasePath("/icon-180.svg", appBasePath),
         }),
         createElement("style", {
           dangerouslySetInnerHTML: { __html: RESET_PASSWORD_STYLES },

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -6,12 +6,16 @@
  *
  * After first account exists, this page acts as a normal login page.
  */
-
-import { AuthForm } from "@agent-native/toolkit/onboarding";
-import { createElement, Fragment } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
 
 import { getAppConfig } from "../app-config/index.js";
+import {
+  AuthPage,
+  type AuthPageProps,
+  type AuthView,
+} from "../client/auth/AuthPage.js";
+import { ResetPasswordPage } from "../client/auth/ResetPasswordPage.js";
 import { getLocaleInitScript } from "../localization/server.js";
 import {
   DEFAULT_LOCALE,
@@ -35,7 +39,6 @@ import {
   PASSWORD_MAX_LENGTH,
   PASSWORD_MIN_LENGTH,
 } from "../shared/password-policy.js";
-import { signInJourneyInlineScript } from "../shared/sign-in-journey.js";
 import {
   AGENT_NATIVE_SOCIAL_IMAGE_ALT,
   AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
@@ -44,7 +47,10 @@ import {
   AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
   withAgentNativeSocialImageCacheBuster,
 } from "../shared/social-meta.js";
-import { normalizeAppBasePath } from "./app-base-path.js";
+import {
+  getAppBasePathFromViteEnv,
+  normalizeAppBasePath,
+} from "./app-base-path.js";
 import {
   AUTH_MARKETING_LOCALE_COPY,
   type AuthMarketingLocaleCopy,
@@ -63,7 +69,6 @@ import { hasGoogleSignInCredentials } from "./google-oauth-credentials.js";
 import { identitySsoLoginButtonHtml } from "./identity-sso-store.js";
 import { getPublicOAuthOrigin } from "./oauth-public-origin.js";
 import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
-
 function hasGoogleOAuth(): boolean {
   return hasGoogleSignInCredentials();
 }
@@ -1024,8 +1029,6 @@ const AUTH_LOCALE_COPY: Record<LocaleCode, typeof EN_AUTH_COPY> = {
   },
 };
 
-const defaultAuthCopy = AUTH_LOCALE_COPY[DEFAULT_LOCALE];
-
 function resolveBuiltInMarketingSlug(
   marketing: AuthMarketingContent | undefined,
   opts: { requestHost?: string; requestPath?: string } = {},
@@ -1130,13 +1133,49 @@ export interface OnboardingHtmlOptions {
   googleAuthMode?: GoogleAuthMode;
 }
 
+function initialAuthView(
+  opts: OnboardingHtmlOptions,
+  authMode: OnboardingHtmlOptions["authMode"],
+  googleOnly: boolean,
+): AuthView {
+  if (googleOnly) return "googleOnly";
+  if (authMode === "magic-link") return "magicLink";
+  try {
+    const url = new URL(opts.requestPath ?? "/", "https://agent-native.local");
+    if (
+      url.searchParams.has("verified") ||
+      url.searchParams.get("error") === "verification_link_invalid"
+    ) {
+      return "login";
+    }
+    const requestedView = url.searchParams.get("tab");
+    if (requestedView === "login" || requestedView === "signup") {
+      return requestedView;
+    }
+    const pathname = url.pathname.replace(/\/+$/, "") || "/";
+    if (pathname.endsWith("/login")) return "login";
+    if (pathname.endsWith("/signup")) return "signup";
+  } catch (error) {
+    // coercion-ok: malformed paths use the public signup state; no session data is inferred.
+    void error;
+  }
+  return "signup";
+}
+
+function serializeAuthPageData(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("&", "\\u0026")
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
 export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   const showGoogle = hasGoogleOAuth();
   const googleOnly = !!opts.googleOnly;
   const authMode = opts.authMode ?? "password";
-  const magicLinkMode = authMode === "magic-link";
   const simplifiedAuth = opts.initialPrompt === true;
-  const renderGoogleButton = showGoogle;
   const configuredAppBasePath = normalizeAppBasePath(
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
   );
@@ -1175,13 +1214,6 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     requestHost: opts.requestHost,
     requestPath: opts.requestPath,
   });
-  const defaultMarketingCopy: AuthMarketingLocaleCopy | undefined = marketing
-    ? {
-        tagline: marketing.tagline,
-        description: marketing.description,
-        features: marketing.features,
-      }
-    : undefined;
   const localizedMarketingCopy: Record<string, AuthMarketingLocaleCopy> = {};
   if (marketingSlug) {
     for (const [locale, copyBySlug] of Object.entries(
@@ -1205,99 +1237,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
       ? `${opts.requestOrigin}${withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH)}`
       : withAppBasePath(AGENT_NATIVE_SOCIAL_IMAGE_PATH),
   );
-  const esc = (s: string) =>
-    s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
-  const t = (key: keyof typeof EN_AUTH_COPY) => defaultAuthCopy[key];
-  const i18nAttr = (key: keyof typeof EN_AUTH_COPY | undefined) =>
-    key ? ` data-i18n="${key}"` : "";
-  const googleUnavailableHtml =
-    googleOnly && !showGoogle
-      ? `<p class="google-error show" id="google-err" role="status"${i18nAttr("googleNotConfigured")}>${esc(t("googleNotConfigured"))}</p>`
-      : "";
-  const i18nAriaAttr = (key: keyof typeof EN_AUTH_COPY | undefined) =>
-    key ? ` data-i18n-aria-label="${key}"` : "";
-  const i18nPlaceholderAttr = (key: keyof typeof EN_AUTH_COPY | undefined) =>
-    key ? ` data-i18n-placeholder="${key}"` : "";
-  const i18nDataAttr = (
-    attr: string,
-    key: keyof typeof EN_AUTH_COPY | undefined,
-  ) => (key ? ` data-i18n-${attr}="${key}"` : "");
-  const i18nText = (key: keyof typeof EN_AUTH_COPY) =>
-    `<span${i18nAttr(key)}>${esc(t(key))}</span>`;
-  const localizedValue = (
-    value: string | undefined,
-    key: keyof typeof EN_AUTH_COPY,
-  ) => (value === undefined ? i18nText(key) : esc(value));
-  const localizedAnchorLabel = (
-    value: string | undefined,
-    key: keyof typeof EN_AUTH_COPY,
-  ) =>
-    value === undefined ? `${i18nAttr(key)}>${esc(t(key))}` : `>${esc(value)}`;
-  const localizedValueNode = (
-    value: string | undefined,
-    key: keyof typeof EN_AUTH_COPY,
-  ) =>
-    value === undefined
-      ? createElement("span", { "data-i18n": key }, t(key))
-      : value;
-  const localizedAnchorNode = (
-    href: string,
-    value: string | undefined,
-    key: keyof typeof EN_AUTH_COPY,
-  ) =>
-    createElement(
-      "a",
-      {
-        href,
-        target: "_blank",
-        rel: "noreferrer",
-        ...(value === undefined ? { "data-i18n": key } : {}),
-      },
-      value ?? t(key),
-    );
-  const localeMenuItemsHtml = [
-    `    <button type="button" class="locale-menu-item" role="menuitemradio" aria-checked="false" data-locale-value="system">
-      <span class="locale-menu-check" aria-hidden="true">✓</span>
-      <span data-system-language>${esc(t("systemLanguage"))}</span>
-    </button>`,
-    ...SUPPORTED_LOCALES.map((locale) => {
-      const label = localeDisplayName(locale);
-      return `    <button type="button" class="locale-menu-item" role="menuitemradio" aria-checked="false" data-locale-value="${esc(locale)}">
-      <span class="locale-menu-check" aria-hidden="true">✓</span>
-      <span>${esc(label)}</span>
-    </button>`;
-    }),
-  ].join("\n");
-  const localePickerHtml = `
-<div class="locale-picker">
-  <button type="button" class="locale-trigger" id="auth-locale-trigger" aria-haspopup="menu" aria-expanded="false" aria-controls="auth-locale-menu" aria-label="${esc(t("languageLabel"))}" title="${esc(t("languageLabel"))}"${i18nAriaAttr("languageLabel")} data-i18n-title="languageLabel">
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M4 5h7" />
-      <path d="M7.5 4v1" />
-      <path d="M9.5 5c-.8 4.4-2.6 7.2-5.5 9" />
-      <path d="M5 9c1.2 2.1 3.2 3.8 6 5" />
-      <path d="M13 20l4-9 4 9" />
-      <path d="M14.5 17h5" />
-    </svg>
-  </button>
-  <div class="locale-menu" id="auth-locale-menu" role="menu" aria-labelledby="auth-locale-trigger" hidden>
-${localeMenuItemsHtml}
-  </div>
-</div>`;
-  const environmentBadgeHtml = `
-<div class="environment-switcher" id="environment-switcher" hidden>
-  <button type="button" class="environment-badge" id="environment-badge" aria-expanded="false" aria-controls="environment-popover">beta</button>
-  <div class="environment-popover" id="environment-popover" role="dialog" aria-labelledby="environment-popover-title" hidden>
-    <div class="environment-popover-title" id="environment-popover-title">You're on Agent-Native Beta</div>
-    <div class="environment-popover-copy">Choose where you want to continue.</div>
-    <a class="environment-production-link" id="environment-production-link" href="">Switch to production</a>
-    <button type="button" class="environment-hide-badge" id="environment-hide-badge">Hide badge</button>
-  </div>
-</div>`;
+  const t = (key: keyof typeof EN_AUTH_COPY) => EN_AUTH_COPY[key];
   const hostedSignupLegalNotice: SignupLegalNoticeOptions | undefined =
     opts.signupLegalNotice === undefined &&
     isAgentNativeHostedHost(opts.requestHost)
@@ -1310,151 +1250,12 @@ ${localeMenuItemsHtml}
     opts.signupLegalNotice === false
       ? undefined
       : (opts.signupLegalNotice ?? hostedSignupLegalNotice);
-  const signupLegalNoteHtml = signupLegalNotice
-    ? `      <p class="legal-note">${localizedValue(signupLegalNotice.prefix, "legalPrefix")} <a href="${esc(signupLegalNotice.termsUrl)}" target="_blank" rel="noreferrer"${localizedAnchorLabel(signupLegalNotice.termsLabel, "legalTerms")}</a> ${localizedValue(signupLegalNotice.connector, "legalConnector")} <a href="${esc(signupLegalNotice.privacyUrl)}" target="_blank" rel="noreferrer"${localizedAnchorLabel(signupLegalNotice.privacyLabel, "legalPrivacy")}</a>${localizedValue(signupLegalNotice.suffix, "legalSuffix")}</p>`
-    : "";
-  const signupLegalNote = signupLegalNotice
-    ? createElement(
-        "p",
-        { className: "legal-note" },
-        localizedValueNode(signupLegalNotice.prefix, "legalPrefix"),
-        " ",
-        localizedAnchorNode(
-          signupLegalNotice.termsUrl,
-          signupLegalNotice.termsLabel,
-          "legalTerms",
-        ),
-        " ",
-        localizedValueNode(signupLegalNotice.connector, "legalConnector"),
-        " ",
-        localizedAnchorNode(
-          signupLegalNotice.privacyUrl,
-          signupLegalNotice.privacyLabel,
-          "legalPrivacy",
-        ),
-        localizedValueNode(signupLegalNotice.suffix, "legalSuffix"),
-      )
-    : null;
-  const magicLinkSuccessHtml = magicLinkMode
-    ? `    <div class="magic-link-success" id="magic-link-success" aria-live="polite" hidden>
-      <p class="magic-link-success-copy"><span${i18nAttr("magicLinkSentCopy")}>${esc(t("magicLinkSentCopy"))}</span> <strong id="magic-link-success-email"></strong>.</p>
-      <button type="button" class="link-button magic-link-back" id="magic-link-back"${i18nAttr("back")}>${esc(t("back"))}</button>
-    </div>
-`
-    : "";
-  const signupLocalModeNoteNode = signupLocalModeNote
-    ? createElement(
-        "div",
-        {
-          className: "signup-local-mode-note",
-          id: "signup-local-mode-note",
-          "data-command": signupLocalModeNote.command,
-        },
-        createElement("p", null, signupLocalModeNote.text),
-        createElement("code", null, signupLocalModeNote.command),
-        createElement(
-          "button",
-          {
-            type: "button",
-            className: "copy-run-local",
-            id: "copy-signup-local-mode",
-            "data-copy-signup-local-mode": "true",
-            "data-i18n": "copyCommand",
-          },
-          t("copyCommand"),
-        ),
-      )
-    : null;
-  const signupFormHtml = renderToStaticMarkup(
-    createElement(AuthForm, {
-      id: "signup-form",
-      fields: [
-        {
-          id: "s-email",
-          label: t("email"),
-          labelProps: { "data-i18n": "email" },
-          inputProps: {
-            type: "email",
-            autoComplete: "email",
-            placeholder: t("emailPlaceholder"),
-            required: true,
-          },
-        },
-        {
-          id: "s-pass",
-          label: t("password"),
-          labelProps: { "data-i18n": "password" },
-          inputProps: {
-            type: "password",
-            autoComplete: "new-password",
-            placeholder: t("passwordMinPlaceholder"),
-            "data-i18n-placeholder": "passwordMinPlaceholder",
-            required: true,
-            minLength: PASSWORD_MIN_LENGTH,
-            maxLength: PASSWORD_MAX_LENGTH,
-          },
-        },
-        {
-          id: "s-pass2",
-          label: t("confirmPassword"),
-          labelProps: { "data-i18n": "confirmPassword" },
-          inputProps: {
-            type: "password",
-            autoComplete: "new-password",
-            placeholder: t("confirmPasswordPlaceholder"),
-            "data-i18n-placeholder": "confirmPasswordPlaceholder",
-            required: true,
-            minLength: PASSWORD_MIN_LENGTH,
-            maxLength: PASSWORD_MAX_LENGTH,
-          },
-        },
-      ],
-      submitLabel: t("createAccount"),
-      submitProps: { "data-i18n": "createAccount" },
-      footer: createElement(
-        Fragment,
-        null,
-        signupLegalNote,
-        signupLocalModeNoteNode,
-      ),
-      messageId: "s-msg",
-    }),
-  );
-  const identitySsoHtml = identitySsoLoginButtonHtml();
-  const embeddedAuthCss = identitySsoHtml
+  const identitySsoEnabled = Boolean(identitySsoLoginButtonHtml());
+  const embeddedAuthCss = identitySsoEnabled
     ? '  html[data-agent-native-embedded="1"] #identity-sso-btn { display: none !important; }\n'
     : "";
-  const localDevHtml = `
-  <div class="local-dev-signin" id="local-dev-signin" hidden>
-    <button type="button" class="btn-local-dev btn-primary" id="local-dev-btn" title="${esc(t("localDevDescription"))}"${i18nAttr("localDevButton")} data-i18n-title="localDevDescription" aria-describedby="local-dev-description">${esc(t("localDevButton"))}</button>
-    <p class="local-dev-description" id="local-dev-description">
-      <span${i18nAttr("localDevDescription")}>${esc(t("localDevDescription"))}</span>
-      <a class="local-dev-help" id="local-dev-help" href="${docsUrl("authentication", { hash: "local-development-sign-in" })}" target="_blank" rel="noreferrer" aria-label="${esc(t("localDevHelp"))}" title="${esc(t("localDevHelp"))}" data-i18n-title="localDevHelp"${i18nAriaAttr("localDevHelp")}><span class="local-dev-help-glyph" aria-hidden="true">?</span></a>
-    </p>
-    <button type="button" class="local-dev-full-options" id="local-dev-full-options" hidden${i18nAttr("localDevFullOptions")}>${esc(t("localDevFullOptions"))}</button>
-    <p class="msg error" id="local-dev-msg" role="status" aria-live="polite"></p>
-  </div>`;
-  const identitySsoMagicLinkSelector = identitySsoHtml
+  const identitySsoMagicLinkSelector = identitySsoEnabled
     ? "  .card.magic-link-complete #identity-sso-btn,\n"
-    : "";
-  const identitySsoScript = identitySsoHtml
-    ? `
-    function __anIdentitySsoUrl() {
-      var params = new URLSearchParams();
-      params.set('return', __anResumeHref());
-      return __anPath('/_agent-native/identity/login') + '?' + params.toString();
-    }
-    function __anStartIdentitySso(event) {
-      if (event && event.preventDefault) event.preventDefault();
-      window.location.href = __anIdentitySsoUrl();
-      return false;
-    }
-    (function __anPrepareIdentitySsoButton() {
-      var identity = document.getElementById('identity-sso-btn');
-      if (!identity) return;
-      identity.setAttribute('href', __anIdentitySsoUrl());
-      identity.addEventListener('click', __anStartIdentitySso);
-    })();`
     : "";
 
   const marketingStyles = hasMarketing
@@ -1594,313 +1395,63 @@ ${localeMenuItemsHtml}
 `
     : "";
 
-  const marketingPanelHtml = hasMarketing
-    ? `<canvas id="starfield"></canvas>
-<div class="split">
-  <div class="marketing-panel">
-    <div class="marketing-content">
-      <h2 class="app-name">
-        <img class="brand-mark" src="${esc(brandMarkSrc)}" alt="" aria-hidden="true" />
-        <span>${esc(marketing!.appName)}</span>
-      </h2>
-      <p class="app-tagline" data-marketing-field="tagline">${esc(marketing!.tagline)}</p>
-${marketing!.description ? `      <p class="app-desc" data-marketing-field="description">${esc(marketing!.description)}</p>\n` : ""}${
-        marketing!.features?.length
-          ? `      <ul class="feature-list">\n${marketing!.features.map((f, index) => `        <li data-marketing-feature-index="${index}">${esc(f)}</li>`).join("\n")}\n      </ul>\n`
-          : ""
-      }      <div class="marketing-actions">
-        <a class="oss-link" href="https://github.com/BuilderIO/agent-native" target="_blank" rel="noreferrer">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4-4.3-2.5-6-3m12 5v-3.5c0-1 .1-1.4-.5-2 2.8-.3 5.5-1.4 5.5-6a4.6 4.6 0 00-1.3-3.2 4.2 4.2 0 00-.1-3.2s-1.1-.3-3.5 1.3a12.3 12.3 0 00-6.2 0C6.5 2.8 5.4 3.1 5.4 3.1a4.2 4.2 0 00-.1 3.2A4.6 4.6 0 004 9.5c0 4.6 2.7 5.7 5.5 6-.6.6-.6 1.2-.5 2V21"/></svg>
-        <span${i18nAttr("openSource")}>${esc(t("openSource"))}</span>
-      </a>
-      </div>
-    </div>
-  </div>
-  <div class="form-panel">`
-    : "";
+  const authMarketingLocales: AuthPageProps["marketingLocales"] =
+    Object.fromEntries(
+      Object.entries(localizedMarketingCopy).map(([locale, copy]) => [
+        locale,
+        {
+          appName: marketing?.appName ?? "",
+          tagline: copy.tagline ?? marketing?.tagline ?? "",
+          description: copy.description ?? marketing?.description,
+          features: copy.features ?? marketing?.features,
+        },
+      ]),
+    );
+  const authPageProps: AuthPageProps = {
+    authMode,
+    googleOnly,
+    initialPrompt: simplifiedAuth,
+    initialView: initialAuthView(opts, authMode, googleOnly),
+    appBasePath,
+    workspaceRuntime,
+    trackingApp,
+    defaultLocale: DEFAULT_LOCALE,
+    localeStorageKey: LOCALE_STORAGE_KEY,
+    locales: AUTH_LOCALE_COPY,
+    localeMetadata: LOCALE_METADATA,
+    localeOptions: SUPPORTED_LOCALES.map((locale) => ({
+      value: locale,
+      label: localeDisplayName(locale),
+    })),
+    marketing: hasMarketing && marketing ? marketing : undefined,
+    marketingLocales: authMarketingLocales,
+    brandMarkSrc,
+    githubUrl: "https://github.com/BuilderIO/agent-native",
+    showGoogle,
+    signupLegalNotice,
+    signupLocalModeNote,
+    connectionLabel: getConnectionLabel(),
+    docsAuthUrl: docsUrl("authentication", {
+      hash: "local-development-sign-in",
+    }),
+    identitySsoEnabled,
+    publicOAuthOrigin,
+    workspaceGatewayReturnOrigin,
+    googleAuthMode,
+    builderPreviewLocalDevEnabled,
+    environmentBetaHosts: ENVIRONMENT_BETA_HOSTS,
+    betaForceQueryParam: BETA_FORCE_QUERY_PARAM,
+    betaForceSessionStorageKey: BETA_FORCE_SESSION_STORAGE_KEY,
+    betaOptOutQueryParam: BETA_OPT_OUT_QUERY_PARAM,
+    betaOptOutStorageKey: BETA_OPT_OUT_STORAGE_KEY,
+    betaOptOutDurationMs: BETA_OPT_OUT_DURATION_MS,
+    passwordMinLength: PASSWORD_MIN_LENGTH,
+    passwordMaxLength: PASSWORD_MAX_LENGTH,
+    passwordMaxCopy: `Choose a password with no more than ${PASSWORD_MAX_LENGTH} characters.`,
+  };
+  const authPageData = serializeAuthPageData(authPageProps);
 
-  const marketingCloseHtml = hasMarketing ? `\n  </div>\n</div>` : "";
-
-  const starfieldScript = hasMarketing
-    ? `
-  (function initStarfield() {
-    var canvas = document.getElementById('starfield');
-    if (!canvas) return;
-    var gl = canvas.getContext('webgl', { alpha: false, antialias: false });
-    if (!gl) return;
-
-    var vs = gl.createShader(gl.VERTEX_SHADER);
-    gl.shaderSource(vs, 'attribute vec2 position;void main(){gl_Position=vec4(position,0.0,1.0);}');
-    gl.compileShader(vs);
-
-    var fs = gl.createShader(gl.FRAGMENT_SHADER);
-    gl.shaderSource(fs, [
-      'precision highp float;',
-      'uniform float iTime;uniform vec2 iResolution;uniform vec3 uPointer;',
-      '#define S(a,b,t) smoothstep(a,b,t)',
-      '#define NUM_LAYERS 4.',
-      'float N21(vec2 p){vec3 a=fract(vec3(p.xyx)*vec3(213.897,653.453,253.098));a+=dot(a,a.yzx+79.76);return fract((a.x+a.y)*a.z);}',
-      'vec2 GetPos(vec2 id,vec2 offs,float t){float n=N21(id+offs);float n1=fract(n*10.);float n2=fract(n*100.);float a=t+n;return offs+vec2(sin(a*n1),cos(a*n2))*.4;}',
-      'vec2 Attract(vec2 p,vec2 cursor,float strength){vec2 delta=cursor-p;float d=length(delta);float pull=1.-smoothstep(.08,1.9,d);pull=pull*pull*(3.-2.*pull);return p+delta*pull*.095*strength;}',
-      'float df_line(vec2 a,vec2 b,vec2 p){vec2 pa=p-a,ba=b-a;float h=clamp(dot(pa,ba)/dot(ba,ba),0.,1.);return length(pa-ba*h);}',
-      'float line(vec2 a,vec2 b,vec2 uv){float r1=.025;float r2=.006;float d=df_line(a,b,uv);float d2=length(a-b);float fade=S(1.5,.5,d2);fade+=S(.05,.02,abs(d2-.75));return S(r1,r2,d)*fade;}',
-      'float NetLayer(vec2 st,float n,float t,vec2 pointer,float pointerStrength){',
-      '  vec2 cell=floor(st);vec2 id=cell+n;vec2 cursor=pointer-cell;st=fract(st)-.5;',
-      '  vec2 p0=Attract(GetPos(id,vec2(-1,-1),t),cursor,pointerStrength);vec2 p1=Attract(GetPos(id,vec2(0,-1),t),cursor,pointerStrength);vec2 p2=Attract(GetPos(id,vec2(1,-1),t),cursor,pointerStrength);',
-      '  vec2 p3=Attract(GetPos(id,vec2(-1,0),t),cursor,pointerStrength);vec2 p4=Attract(GetPos(id,vec2(0,0),t),cursor,pointerStrength);vec2 p5=Attract(GetPos(id,vec2(1,0),t),cursor,pointerStrength);',
-      '  vec2 p6=Attract(GetPos(id,vec2(-1,1),t),cursor,pointerStrength);vec2 p7=Attract(GetPos(id,vec2(0,1),t),cursor,pointerStrength);vec2 p8=Attract(GetPos(id,vec2(1,1),t),cursor,pointerStrength);',
-      '  float m=0.;float sparkle=0.;float d;float s;float pulse;',
-      '  m+=line(p4,p0,st);d=length(st-p0);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p0.x)+fract(p0.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p1,st);d=length(st-p1);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p1.x)+fract(p1.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p2,st);d=length(st-p2);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p2.x)+fract(p2.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p3,st);d=length(st-p3);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p3.x)+fract(p3.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p4,st);d=length(st-p4);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p4.x)+fract(p4.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p5,st);d=length(st-p5);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p5.x)+fract(p5.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p6,st);d=length(st-p6);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p6.x)+fract(p6.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p7,st);d=length(st-p7);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p7.x)+fract(p7.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p4,p8,st);d=length(st-p8);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p8.x)+fract(p8.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;',
-      '  m+=line(p1,p3,st);m+=line(p1,p5,st);m+=line(p7,p5,st);m+=line(p7,p3,st);',
-      '  float sPhase=(sin(t+n)+sin(t*.1))*.25+.5;sPhase+=pow(sin(t*.1)*.5+.5,50.)*5.;m+=sparkle*sPhase;',
-      '  return m;',
-      '}',
-      'void mainImage(out vec4 fragColor,in vec2 fragCoord){',
-      '  vec2 uv=(fragCoord-iResolution.xy*.5)/iResolution.y;',
-      '  float t=iTime*.03;float s=sin(t);float c=cos(t);mat2 rot=mat2(c,-s,s,c);vec2 st=uv*rot;vec2 pointerUv=(uPointer.xy-iResolution.xy*.5)/iResolution.y;',
-      '  float m=0.;',
-      '  for(float i=0.;i<1.;i+=1./NUM_LAYERS){float z=fract(t+i);float size=mix(15.,1.,z);float fade=S(0.,.6,z)*S(1.,.8,z);vec2 pointerSt=pointerUv*rot*size;vec2 layerSt=st*size;float warp=1.-smoothstep(.15,2.7,length(layerSt-pointerSt));warp=warp*warp*(3.-2.*warp)*uPointer.z;layerSt-=(pointerSt-layerSt)*warp*.035;m+=fade*NetLayer(layerSt,i,iTime*0.3,pointerSt,uPointer.z);}',
-      '  float cursorLift=1.-smoothstep(.04,.48,length(uv-pointerUv));cursorLift=cursorLift*cursorLift*(3.-2.*cursorLift)*uPointer.z;m*=1.+cursorLift*1.6;',
-      '  vec3 col=vec3(0.35)*m;col*=1.-dot(uv,uv);',
-      '  float tt=min(iTime,5.0);col*=S(0.,20.,tt);',
-      '  col=clamp(col,0.,1.);fragColor=vec4(col,1.);',
-      '}',
-      'void main(){mainImage(gl_FragColor,gl_FragCoord.xy);}'
-    ].join('\\n'));
-    gl.compileShader(fs);
-
-    var prog = gl.createProgram();
-    gl.attachShader(prog, vs);
-    gl.attachShader(prog, fs);
-    gl.linkProgram(prog);
-    gl.useProgram(prog);
-
-    var buf = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1,1,-1,-1,1,-1,1,1,-1,1,1]), gl.STATIC_DRAW);
-    var pos = gl.getAttribLocation(prog, 'position');
-    gl.enableVertexAttribArray(pos);
-    gl.vertexAttribPointer(pos, 2, gl.FLOAT, false, 0, 0);
-
-    var uTime = gl.getUniformLocation(prog, 'iTime');
-    var uRes = gl.getUniformLocation(prog, 'iResolution');
-    var uPointer = gl.getUniformLocation(prog, 'uPointer');
-    var reducedMotionQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
-    var reducedMotion = reducedMotionQuery ? reducedMotionQuery.matches : false;
-    var pointerDpr = 1, hasPointer = false;
-    var pointerX = 0, pointerY = 0, pointerStrength = 0;
-    var targetX = 0, targetY = 0, targetStrength = 0;
-
-    function resize() {
-      var w = window.innerWidth, h = window.innerHeight;
-      pointerDpr = Math.min(window.devicePixelRatio, 1.5);
-      canvas.width = w * pointerDpr; canvas.height = h * pointerDpr;
-      gl.viewport(0, 0, canvas.width, canvas.height);
-      if (!hasPointer) {
-        pointerX = targetX = canvas.width * 0.5;
-        pointerY = targetY = canvas.height * 0.5;
-      }
-    }
-    function onPointerMove(event) {
-      var rect = canvas.getBoundingClientRect();
-      var x = event.clientX - rect.left;
-      var y = event.clientY - rect.top;
-      hasPointer = true;
-      targetX = x * pointerDpr;
-      targetY = (rect.height - y) * pointerDpr;
-      targetStrength = x >= 0 && x <= rect.width && y >= 0 && y <= rect.height ? 1 : 0;
-    }
-    function fadePointer() {
-      targetStrength = 0;
-    }
-    function easePointer(allowPointer) {
-      if (!allowPointer) {
-        pointerStrength = 0;
-        return;
-      }
-      pointerX += (targetX - pointerX) * 0.22;
-      pointerY += (targetY - pointerY) * 0.22;
-      pointerStrength += (targetStrength - pointerStrength) * 0.14;
-      if (pointerStrength < 0.001 && targetStrength === 0) pointerStrength = 0;
-    }
-    resize();
-    window.addEventListener('resize', resize);
-    window.addEventListener('pointermove', onPointerMove, { passive: true });
-    window.addEventListener('mousemove', onPointerMove, { passive: true });
-    document.addEventListener('pointerleave', fadePointer, { passive: true });
-    window.addEventListener('blur', fadePointer);
-
-    var start = performance.now(), last = 0, raf = 0, reducedMotionStaticTime = 20;
-    function draw(timeSeconds, allowPointer) {
-      easePointer(allowPointer !== false && !reducedMotion);
-      gl.uniform1f(uTime, timeSeconds);
-      gl.uniform2f(uRes, canvas.width, canvas.height);
-      gl.uniform3f(uPointer, pointerX, pointerY, pointerStrength);
-      gl.drawArrays(gl.TRIANGLES, 0, 6);
-    }
-    function render(now) {
-      if (reducedMotion) {
-        raf = 0;
-        return;
-      }
-      raf = requestAnimationFrame(render);
-      if (now - last < 33) return;
-      last = now;
-      draw((now - start) * 0.001);
-    }
-    function startAnimation() {
-      if (!raf) raf = requestAnimationFrame(render);
-    }
-    function stopAnimation() {
-      if (raf) {
-        cancelAnimationFrame(raf);
-        raf = 0;
-      }
-    }
-    function onReducedMotionChange() {
-      reducedMotion = reducedMotionQuery ? reducedMotionQuery.matches : false;
-      if (reducedMotion) {
-        stopAnimation();
-        last = 0;
-        draw(reducedMotionStaticTime, false);
-      } else {
-        startAnimation();
-      }
-    }
-    draw(reducedMotion ? reducedMotionStaticTime : 0, !reducedMotion);
-    if (reducedMotionQuery) {
-      if (reducedMotionQuery.addEventListener) {
-        reducedMotionQuery.addEventListener('change', onReducedMotionChange);
-      } else {
-        reducedMotionQuery.addListener(onReducedMotionChange);
-      }
-    }
-    if (!reducedMotion) startAnimation();
-    })();`
-    : "";
-  const environmentBadgeScript = `
-  (function __anInitEnvironmentBadge() {
-    var switcher = document.getElementById('environment-switcher');
-    var button = document.getElementById('environment-badge');
-    var popover = document.getElementById('environment-popover');
-    var productionLink = document.getElementById('environment-production-link');
-    var hideButton = document.getElementById('environment-hide-badge');
-    if (!switcher || !button || !popover || !productionLink || !hideButton) return;
-    if (window.parent !== window) return;
-
-    try {
-      var forceUrl = new URL(window.location.href);
-      if (forceUrl.searchParams.get(${JSON.stringify(BETA_FORCE_QUERY_PARAM)}) === 'true') {
-        window.sessionStorage.setItem(${JSON.stringify(BETA_FORCE_SESSION_STORAGE_KEY)}, '1');
-      }
-    } catch (error) {
-      void error;
-    }
-
-    // Persist the beta opt-out before authentication replaces this cached shell.
-    try {
-      var optOutUrl = new URL(window.location.href);
-      var optOutValue = optOutUrl.searchParams.get(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
-      if (optOutValue !== null) {
-        var optOutExpiry = Number(optOutValue);
-        var optOutIsActive = Number.isFinite(optOutExpiry) && optOutExpiry > Date.now();
-        var optOutStorageReady = false;
-        try {
-          if (optOutIsActive) {
-            window.localStorage.setItem(
-              ${JSON.stringify(BETA_OPT_OUT_STORAGE_KEY)},
-              String(optOutExpiry),
-            );
-          }
-          optOutStorageReady = true;
-        } catch (error) {
-          void error;
-        }
-        if (optOutStorageReady) {
-          optOutUrl.searchParams.delete(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
-          window.history.replaceState(null, '', optOutUrl.toString());
-        }
-      }
-    } catch (error) {
-      void error;
-    }
-
-    var betaHosts = ${JSON.stringify(ENVIRONMENT_BETA_HOSTS)};
-    var hostname = (window.location.hostname || '').toLowerCase().replace(/\\.$/, '');
-    var productionHost = hostname.indexOf('beta.') === 0 ? hostname.slice(5) : '';
-    if (!productionHost || betaHosts[productionHost] !== hostname) return;
-
-    try {
-      var productionUrl = new URL(window.location.href);
-      productionUrl.protocol = 'https:';
-      productionUrl.hostname = productionHost;
-      productionUrl.port = '';
-      productionUrl.searchParams.set(
-        ${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)},
-        String(Date.now() + ${BETA_OPT_OUT_DURATION_MS}),
-      );
-      productionLink.href = productionUrl.toString();
-    } catch (error) {
-      void error;
-      return;
-    }
-
-    function setOpen(open) {
-      popover.hidden = !open;
-      button.setAttribute('aria-expanded', String(open));
-    }
-
-    switcher.hidden = false;
-    button.addEventListener('click', function() {
-      setOpen(popover.hidden);
-    });
-    document.addEventListener('click', function(event) {
-      if (!switcher.contains(event.target)) setOpen(false);
-    });
-    document.addEventListener('keydown', function(event) {
-      if (event.key === 'Escape') setOpen(false);
-    });
-    hideButton.addEventListener('click', function() {
-      setOpen(false);
-      switcher.hidden = true;
-    });
-  })();`;
-
-  return `<!DOCTYPE html>
-<html lang="${DEFAULT_LOCALE}" dir="ltr">
-<head>
-<meta charset="UTF-8">
-<script data-agent-native-locale-init>${localeInitScript}</script>
-<script data-agent-native-embedded-init>${embeddedAuthInitScript}</script>
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>${hasMarketing ? esc(marketing!.appName) + " — " + esc(t("pageTitleSignIn")) : esc(t("pageTitleWelcome"))}</title>
-<link rel="icon" type="image/svg+xml" href="${withAppBasePath("/favicon.svg")}">
-<link rel="apple-touch-icon" href="${withAppBasePath("/icon-180.svg")}">
-${
-  hasMarketing
-    ? `<meta name="description" content="${esc(marketing!.tagline)}">
-<meta property="og:title" content="${esc(marketing!.appName)}">
-<meta property="og:description" content="${esc(marketing!.tagline)}">
-<meta property="og:image" content="${esc(socialImageUrl)}">
-<meta property="og:image:secure_url" content="${esc(socialImageUrl)}">
-<meta property="og:image:type" content="${AGENT_NATIVE_SOCIAL_IMAGE_TYPE}">
-<meta property="og:image:width" content="${AGENT_NATIVE_SOCIAL_IMAGE_WIDTH}">
-<meta property="og:image:height" content="${AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT}">
-<meta property="og:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:image" content="${esc(socialImageUrl)}">
-<meta name="twitter:image:alt" content="${AGENT_NATIVE_SOCIAL_IMAGE_ALT}">`
-    : ""
-}
-<style>
+  const authDocumentStyles = `\n
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   .sr-only {
     position: absolute;
@@ -2512,2028 +2063,158 @@ ${marketingStyles}
   body.simplified-auth .card { border-color: transparent; box-shadow: none; }
   body.simplified-auth .local-note { display: none !important; }
 ${embeddedAuthCss}
-</style>
-</head>
-<body${simplifiedAuth ? ' class="simplified-auth"' : hasMarketing ? ' class="has-marketing"' : ""}>
-${localePickerHtml}
-${environmentBadgeHtml}
-${marketingPanelHtml}
-<div class="card">
-  <h1 id="heading"${i18nAttr(googleOnly ? "signInTitle" : "welcomeTitle")}>${esc(t(googleOnly ? "signInTitle" : "welcomeTitle"))}</h1>
-  <p class="subtitle" id="subtitle"${i18nAttr(googleOnly ? "googleOnlySubtitle" : "createAccountSubtitle")}>${esc(t(googleOnly ? "googleOnlySubtitle" : "createAccountSubtitle"))}</p>
-  <p
-    class="upgrade-note"
-    id="upgrade-note"
-    data-upgrade-copy="${esc(t("upgradeCopy"))}"
-    ${i18nDataAttr("data-upgrade-copy", "upgradeCopy").trim()}
-  ></p>
-${identitySsoHtml}
-${localDevHtml}
-<div id="full-auth-options" class="full-auth-options">
-${googleUnavailableHtml}
-${
-  renderGoogleButton
-    ? `
-  <div class="google-signin" id="google-signin">
-  <button class="btn-google" id="google-btn" onclick="signInWithGoogle()">
-    <svg viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
-    <span${i18nAttr("googleButton")}>${esc(t("googleButton"))}</span>
-  </button>
-  <p class="google-error" id="google-err"></p>
-  <p class="google-debug" id="google-debug"></p>
-  </div>
-${googleOnly ? "" : `\n  <div class="divider" id="auth-divider"${i18nAttr("dividerOr")}>${esc(t("dividerOr"))}</div>\n`}
-`
-    : ""
-}
-${
-  googleOnly
-    ? ""
-    : `${magicLinkMode ? '\n    <form id="magic-link-form" class="form">\n      <label for="m-email"' + i18nAttr("email") + ">" + esc(t("email")) + '</label>\n      <input id="m-email" type="email" autocomplete="email" placeholder="' + esc(t("emailPlaceholder")) + '" required />\n      <button type="submit" id="magic-link-submit" class="magic-link-submit"' + i18nAttr("sendMagicLink") + ">" + esc(t("sendMagicLink")) + '</button>\n      <p class="msg" id="m-msg"></p>\n' + signupLegalNoteHtml + '\n      <p style="margin-top:0.75rem;font-size:0.75rem;text-align:start">\n        <a href="#" id="use-password-link" class="link-button auth-mode-link"' + i18nAttr("usePasswordInstead") + ">" + esc(t("usePasswordInstead")) + "</a>\n      </p>\n    </form>\n" : ""}${magicLinkSuccessHtml}  <div class="tabs" id="auth-tabs">
-    <button class="tab" data-tab="signup"${i18nAttr("createAccount")}>${esc(t("createAccount"))}</button>
-    <button class="tab" data-tab="login"${i18nAttr("signIn")}>${esc(t("signIn"))}</button>
-  </div>
-
-${signupFormHtml}
-
-    <div id="verification-step" class="form verification-step" aria-live="polite">
-      <div class="step-progress" aria-label="${esc(t("signupProgress"))}"${i18nAriaAttr("signupProgress")}>
-        <div class="progress-step complete"><span>1</span><strong${i18nAttr("progressAccount")}>${esc(t("progressAccount"))}</strong></div>
-        <div class="progress-step current"><span>2</span><strong${i18nAttr("progressVerify")}>${esc(t("progressVerify"))}</strong></div>
-        <div class="progress-step"><span>3</span><strong${i18nAttr("progressStart")}>${esc(t("progressStart"))}</strong></div>
-      </div>
-      <div class="verification-panel">
-        <p class="verification-kicker"${i18nAttr("verificationSent")}>${esc(t("verificationSent"))}</p>
-        <p class="verification-copy"><span${i18nAttr("verifyCopyPrefix")}>${esc(t("verifyCopyPrefix"))}</span> <strong id="verify-email"></strong><span${i18nAttr("verifyCopySuffix")}>${esc(t("verifyCopySuffix"))}</span></p>
-        <p class="verification-note"${i18nAttr("verificationNote")}>${esc(t("verificationNote"))}</p>
-      </div>
-      <button type="button" class="btn-primary" id="verify-continue"${i18nAttr("continue")}>${esc(t("continue"))}</button>
-      <div class="inline-actions">
-        <button type="button" class="link-button" id="resend-verification"${i18nAttr("resendEmail")}>${esc(t("resendEmail"))}</button>
-        <button type="button" class="link-button" id="back-to-signup"${i18nAttr("back")}>${esc(t("back"))}</button>
-      </div>
-      <p class="msg" id="verify-msg"></p>
-    </div>
-
-    <form id="login-form" class="form">
-    <label for="l-email"${i18nAttr("email")}>${esc(t("email"))}</label>
-    <input id="l-email" type="email" autocomplete="email" placeholder="${esc(t("emailPlaceholder"))}" required />
-    <label for="l-pass"${i18nAttr("password")}>${esc(t("password"))}</label>
-    <input id="l-pass" type="password" autocomplete="current-password" placeholder="${esc(t("enterPasswordPlaceholder"))}"${i18nPlaceholderAttr("enterPasswordPlaceholder")} required />
-    <button type="submit"${i18nAttr("signIn")}>${esc(t("signIn"))}</button>
-    <p class="msg error" id="l-msg"></p>
-    <p style="margin-top:0.75rem;font-size:0.75rem;text-align:right">
-      <a href="#" id="forgot-link" style="color:#888;text-decoration:underline;text-underline-offset:2px"${i18nAttr("forgotPassword")}>${esc(t("forgotPassword"))}</a>
-    </p>
-    ${magicLinkMode ? `<p style="margin-top:0.5rem;font-size:0.75rem;text-align:center"><a href="#" id="back-to-magic-link" class="link-button"${i18nAttr("backToMagicLink")}>${esc(t("backToMagicLink"))}</a></p>` : ""}
-  </form>
-
-  <form id="forgot-form" class="form">
-    <label for="f-email"${i18nAttr("email")}>${esc(t("email"))}</label>
-    <input id="f-email" type="email" autocomplete="email" placeholder="${esc(t("emailPlaceholder"))}" required />
-    <button type="submit"${i18nAttr("sendResetLink")}>${esc(t("sendResetLink"))}</button>
-    <p class="msg" id="f-msg"></p>
-    <p style="margin-top:0.75rem;font-size:0.75rem;text-align:center">
-      <a href="#" id="back-to-login" style="color:#888;text-decoration:underline;text-underline-offset:2px"${i18nAttr("backToSignIn")}>${esc(t("backToSignIn"))}</a>
-    </p>
-  </form>`
-}
-</div>
-</div>
-<p class="local-note" id="local-note">
-  <span${i18nAttr("localNotePrefix")}>${esc(t("localNotePrefix"))}</span> (<strong>${getConnectionLabel()}</strong>)<span${i18nAttr("localNoteSuffix")}>${esc(t("localNoteSuffix"))}</span>
-</p>${marketingCloseHtml}
-<script>
-${environmentBadgeScript}
-  function __anBasePath() {
-    var configured = ${JSON.stringify(appBasePath)};
-    if (configured) return configured;
-    var marker = '/_agent-native';
-    var idx = window.location.pathname.indexOf(marker);
-    if (idx > 0) return window.location.pathname.slice(0, idx);
-    if (${JSON.stringify(workspaceRuntime)}) {
-      var segments = window.location.pathname.split('/');
-      for (var i = 0; i < segments.length; i++) {
-        var segment = segments[i];
-        if (segment && segment !== '_agent-native' && segment !== 'api' && segment !== 'sign-in' && segment !== 'login' && segment !== 'signup') {
-          return '/' + segment;
-        }
-      }
-    }
-    return '';
+`;
+  const authPageLayoutStyles = `
+  .auth-root { width: 100%; }
+  .auth-marketing-home { width: 100%; padding: 0; position: relative; overflow-x: hidden; }
+  .auth-marketing-shell { padding: 0; }
+  .auth-marketing-home .split { width: 100%; }
+  .auth-marketing-home .marketing-panel { min-width: 0; }
+  .auth-marketing-home .form-panel { min-width: 0; }
+  .auth-marketing-home [data-agent-native-starfield] { position: fixed; inset: 0; width: 100%; height: 100%; }
+  @media (max-width: 900px) {
+    .auth-marketing-home .auth-marketing-shell { display: block; }
   }
-    function __anPath(path) {
-      return __anBasePath() + path;
-    }
-${signInJourneyInlineScript()}
-    var __anJourney = __anCreateSignInJourney(__anBasePath());
-    /**
-     * Where this document sends the visitor once a session exists. One
-     * function, one answer — the page used to have two ("__anGetReturnPath"
-     * and "__anGetSignedInReturnPath") that disagreed about whether the
-     * sign-in page itself was an acceptable destination, which is how
-     * verification emails ended up linking back to a login form.
-     */
-    function __anResumeHref() {
-      return __anJourney.journeyForLocation(window.location).resumeHref;
-    }
-    var __AN_AUTH_DEFAULT_LOCALE = ${JSON.stringify(DEFAULT_LOCALE)};
-    var __AN_AUTH_SUPPORTED_LOCALES = ${JSON.stringify(SUPPORTED_LOCALES)};
-    var __AN_AUTH_LOCALE_STORAGE_KEY = ${JSON.stringify(LOCALE_STORAGE_KEY)};
-    var __AN_AUTH_LOCALE_METADATA = ${JSON.stringify(LOCALE_METADATA)};
-    var __AN_AUTH_LOCALES = ${JSON.stringify(AUTH_LOCALE_COPY)};
-    var __AN_AUTH_MARKETING_APP_NAME = ${JSON.stringify(marketing?.appName ?? "")};
-    var __AN_AUTH_HAS_MARKETING = ${JSON.stringify(hasMarketing)};
-    var __AN_AUTH_MARKETING_SLUG = ${JSON.stringify(marketingSlug ?? "")};
-    var __AN_AUTH_MARKETING_DEFAULT = ${JSON.stringify(defaultMarketingCopy ?? {})};
-    var __AN_AUTH_MARKETING_LOCALES = ${JSON.stringify(localizedMarketingCopy)};
-    var __anAuthLocale = __AN_AUTH_DEFAULT_LOCALE;
-    var __anAuthLocalePreference = 'system';
-    var __AN_AUTH_MODE = ${JSON.stringify(authMode)};
-    var __anAuthView = ${JSON.stringify(googleOnly ? "googleOnly" : "signup")};
-    var __AN_AUTH_APP = ${JSON.stringify(trackingApp)};
-    function __anTrackAuth(name, properties) {
-      try {
-        var config = window.__AGENT_NATIVE_CONFIG__ || {};
-        if (!config.agentNativeAnalyticsPublicKey) return;
-        var anonymousId = '';
-        // coercion-ok: privacy-restricted storage means this public event cannot be attributed
-        try { anonymousId = localStorage.getItem('agent-native.anonymous_id') || ''; } catch (e) {}
-        if (!anonymousId) return;
-        var sessionId = '';
-        // coercion-ok: privacy-restricted storage means this public event has no session id
-        try { sessionId = sessionStorage.getItem('agent-native.session_id') || ''; } catch (e) {}
-        var body = JSON.stringify({
-          publicKey: config.agentNativeAnalyticsPublicKey,
-          event: name,
-          properties: Object.assign({ app: __AN_AUTH_APP }, properties || {}),
-          anonymousId: anonymousId,
-          sessionId: sessionId || undefined,
-          timestamp: new Date().toISOString()
-        });
-        var endpoint = config.agentNativeAnalyticsEndpoint || 'https://analytics.agent-native.com/track';
-        if (navigator.sendBeacon && navigator.sendBeacon(endpoint, body)) return;
-        fetch(endpoint, {
-          method: 'POST',
-          body: body,
-          keepalive: true,
-          headers: { 'Content-Type': 'text/plain;charset=UTF-8' }
-        // coercion-ok: analytics delivery is best effort and cannot block auth
-        }).catch(function() {});
-      // coercion-ok: analytics delivery is best effort and cannot block auth
-      } catch (e) {}
-    }
-    function __anAuthLocaleIsSupported(value) {
-      return __AN_AUTH_SUPPORTED_LOCALES.indexOf(value) !== -1;
-    }
-    function __anNormalizeAuthLocale(value) {
-      if (typeof value !== 'string' || !value) return null;
-      if (__anAuthLocaleIsSupported(value)) return value;
-      try {
-        var canonical = Intl.getCanonicalLocales(value)[0];
-        if (__anAuthLocaleIsSupported(canonical)) return canonical;
-        var language = canonical && canonical.split('-')[0].toLowerCase();
-        for (var i = 0; i < __AN_AUTH_SUPPORTED_LOCALES.length; i++) {
-          var locale = __AN_AUTH_SUPPORTED_LOCALES[i];
-          if (locale.split('-')[0].toLowerCase() === language) return locale;
-        }
-      } catch(e) {}
-      return null;
-    }
-    function __anNormalizeAuthLocalePreference(value) {
-      if (value === 'system') return 'system';
-      return __anNormalizeAuthLocale(value);
-    }
-    function __anReadAuthLocalePreference() {
-      try {
-        return __anNormalizeAuthLocalePreference(localStorage.getItem(__AN_AUTH_LOCALE_STORAGE_KEY)) || 'system';
-      } catch(e) {
-        return 'system';
-      }
-    }
-    function __anWriteAuthLocalePreference(preference) {
-      try {
-        localStorage.setItem(__AN_AUTH_LOCALE_STORAGE_KEY, preference);
-      } catch(e) {}
-    }
-    function __anBrowserAuthLocales() {
-      try {
-        if (navigator.languages && navigator.languages.length) return navigator.languages;
-        if (navigator.language) return [navigator.language];
-      } catch(e) {}
-      return [];
-    }
-    function __anResolveAuthSystemLocale() {
-      var locales = __anBrowserAuthLocales();
-      for (var i = 0; i < locales.length; i++) {
-        var match = __anNormalizeAuthLocale(locales[i]);
-        if (match) return match;
-      }
-      return __AN_AUTH_DEFAULT_LOCALE;
-    }
-    function __anResolveAuthLocale(preference) {
-      var normalizedPreference = __anNormalizeAuthLocalePreference(preference) || 'system';
-      return normalizedPreference === 'system'
-        ? __anResolveAuthSystemLocale()
-        : normalizedPreference;
-    }
-    function __anApplyAuthSystemLanguage() {
-      var systemLanguage = document.querySelector('[data-system-language]');
-      if (!systemLanguage) return;
-      var systemLocale = __anResolveAuthSystemLocale();
-      var localized = __AN_AUTH_LOCALES[systemLocale] || __AN_AUTH_LOCALES[__AN_AUTH_DEFAULT_LOCALE] || {};
-      systemLanguage.textContent = localized.systemLanguage || 'System';
-    }
-    function __anT(key) {
-      var localized = __AN_AUTH_LOCALES[__anAuthLocale] || __AN_AUTH_LOCALES[__AN_AUTH_DEFAULT_LOCALE] || {};
-      var fallback = __AN_AUTH_LOCALES[__AN_AUTH_DEFAULT_LOCALE] || {};
-      return localized[key] || fallback[key] || key;
-    }
-    function __anAuthErrorText(data, fallback) {
-      var candidate = data && (data.error || data.message);
-      if (typeof candidate !== 'string' || !candidate.trim()) return fallback;
-      var message = candidate.trim();
-      if (/failed query|\bselect\b.*\bfrom\b|\binsert\b.*\binto\b|\bupdate\b.*\bset\b|\bdelete\b.*\bfrom\b|\bsql\b|database|relation .* does not exist|column .* does not exist|syntax error|constraint|connection refused|econn|timeout/i.test(message)) {
-        return fallback;
-      }
-      return message;
-    }
-    function __anBindPasswordValidation(input) {
-      if (!input) return;
-      input.addEventListener('invalid', function() {
-        if (input.validity && input.validity.tooShort) {
-          input.setCustomValidity(__anT('passwordMinPlaceholder'));
-        } else if (input.validity && input.validity.tooLong) {
-          input.setCustomValidity('Choose a password with no more than ${PASSWORD_MAX_LENGTH} characters.');
-        }
-      });
-      input.addEventListener('input', function() {
-        input.setCustomValidity('');
-      });
-    }
-    function __anSetAuthI18nKey(node, key) {
-      if (!node || !key) return;
-      node.setAttribute('data-i18n', key);
-      node.textContent = __anT(key);
-    }
-    function __anAuthHeadingKeys(view) {
-      if (view === 'login') return { heading: 'welcomeBackTitle', subtitle: 'signInSubtitle' };
-      if (view === 'forgot') return { heading: 'resetPasswordTitle', subtitle: 'resetPasswordSubtitle' };
-      if (view === 'verification') return { heading: 'checkEmailTitle', subtitle: 'finishAccountSubtitle' };
-      if (view === 'googleOnly') return { heading: 'signInTitle', subtitle: 'googleOnlySubtitle' };
-      if (view === 'magicLinkSent') return { heading: 'magicLinkSent', subtitle: 'magicLinkSentCopy' };
-      if (view === 'magicLink') return { heading: 'magicLinkTitle', subtitle: 'magicLinkSubtitle' };
-      return { heading: 'welcomeTitle', subtitle: 'createAccountSubtitle' };
-    }
-    function __anRefreshAuthViewCopy() {
-      var keys = __anAuthHeadingKeys(__anAuthView);
-      __anSetAuthI18nKey(document.getElementById('heading'), keys.heading);
-      __anSetAuthI18nKey(document.getElementById('subtitle'), keys.subtitle);
-    }
-    function __anSetAuthView(view) {
-      __anAuthView = view || 'signup';
-      __anRefreshAuthViewCopy();
-    }
-    function __anMarketingCopy() {
-      if (!__AN_AUTH_MARKETING_SLUG) return __AN_AUTH_MARKETING_DEFAULT || {};
-      var localeMarketing = __AN_AUTH_MARKETING_LOCALES[__anAuthLocale] || {};
-      return {
-        tagline: localeMarketing.tagline || __AN_AUTH_MARKETING_DEFAULT.tagline,
-        description: localeMarketing.description || __AN_AUTH_MARKETING_DEFAULT.description,
-        features: localeMarketing.features || __AN_AUTH_MARKETING_DEFAULT.features || []
-      };
-    }
-    function __anApplyAuthMarketingCopy() {
-      var copy = __anMarketingCopy();
-      var tagline = document.querySelector('[data-marketing-field="tagline"]');
-      if (tagline && copy.tagline) tagline.textContent = copy.tagline;
-      var description = document.querySelector('[data-marketing-field="description"]');
-      if (description && copy.description) description.textContent = copy.description;
-      document.querySelectorAll('[data-marketing-feature-index]').forEach(function(node) {
-        var index = Number(node.getAttribute('data-marketing-feature-index'));
-        var feature = copy.features && copy.features[index];
-        if (feature) node.textContent = feature;
-      });
-    }
-    function __anApplyAuthLocale(preference) {
-      __anAuthLocalePreference = __anNormalizeAuthLocalePreference(preference) || __anReadAuthLocalePreference();
-      __anAuthLocale = __anResolveAuthLocale(__anAuthLocalePreference);
-      var root = document.documentElement;
-      var meta = __AN_AUTH_LOCALE_METADATA[__anAuthLocale] || {};
-      root.setAttribute('lang', __anAuthLocale);
-      root.setAttribute('dir', meta.dir || 'ltr');
-      root.setAttribute('data-locale', __anAuthLocale);
-      document.querySelectorAll('[data-i18n]').forEach(function(node) {
-        node.textContent = __anT(node.getAttribute('data-i18n'));
-      });
-      document.querySelectorAll('[data-i18n-placeholder]').forEach(function(node) {
-        node.setAttribute('placeholder', __anT(node.getAttribute('data-i18n-placeholder')));
-      });
-      document.querySelectorAll('[data-i18n-aria-label]').forEach(function(node) {
-        node.setAttribute('aria-label', __anT(node.getAttribute('data-i18n-aria-label')));
-      });
-      document.querySelectorAll('[data-i18n-title]').forEach(function(node) {
-        node.setAttribute('title', __anT(node.getAttribute('data-i18n-title')));
-      });
-      document.querySelectorAll('[data-i18n-data-upgrade-copy]').forEach(function(node) {
-        node.setAttribute('data-upgrade-copy', __anT(node.getAttribute('data-i18n-data-upgrade-copy')));
-      });
-      document.querySelectorAll('[data-locale-value]').forEach(function(node) {
-        var checked = node.getAttribute('data-locale-value') === __anAuthLocalePreference;
-        node.setAttribute('aria-checked', checked ? 'true' : 'false');
-      });
-      document.title = __AN_AUTH_HAS_MARKETING && __AN_AUTH_MARKETING_APP_NAME
-        ? __AN_AUTH_MARKETING_APP_NAME + ' — ' + __anT('pageTitleSignIn')
-        : __anT('pageTitleWelcome');
-      __anApplyAuthSystemLanguage();
-      __anApplyAuthMarketingCopy();
-      __anRefreshAuthViewCopy();
-    }
-    function __anSetAuthLocaleMenuOpen(open) {
-      var trigger = document.getElementById('auth-locale-trigger');
-      var menu = document.getElementById('auth-locale-menu');
-      if (!trigger || !menu) return;
-      if (open) {
-        menu.removeAttribute('hidden');
-      } else {
-        menu.setAttribute('hidden', '');
-      }
-      trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    (function __anInitAuthLocalePicker() {
-      var trigger = document.getElementById('auth-locale-trigger');
-      var menu = document.getElementById('auth-locale-menu');
-      var preference = __anReadAuthLocalePreference();
-      __anApplyAuthLocale(preference);
-      if (!trigger || !menu) return;
-      trigger.addEventListener('click', function(event) {
-        event.preventDefault();
-        __anSetAuthLocaleMenuOpen(menu.hasAttribute('hidden'));
-      });
-      menu.querySelectorAll('[data-locale-value]').forEach(function(item) {
-        item.addEventListener('click', function() {
-          var next = __anNormalizeAuthLocalePreference(item.getAttribute('data-locale-value')) || 'system';
-          __anWriteAuthLocalePreference(next);
-          __anApplyAuthLocale(next);
-          __anSetAuthLocaleMenuOpen(false);
-          trigger.focus();
-        });
-      });
-      document.addEventListener('click', function(event) {
-        var picker = document.querySelector('.locale-picker');
-        if (picker && picker.contains(event.target)) return;
-        __anSetAuthLocaleMenuOpen(false);
-      });
-      document.addEventListener('keydown', function(event) {
-        if (event.key === 'Escape') __anSetAuthLocaleMenuOpen(false);
-      });
-    })();
-    var __AN_PUBLIC_OAUTH_ORIGIN = ${JSON.stringify(publicOAuthOrigin)};
-    var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = ${JSON.stringify(workspaceGatewayReturnOrigin)};
-    var __AN_GOOGLE_AUTH_MODE = ${JSON.stringify(googleAuthMode)};
-    var __AN_BUILDER_PREVIEW_LOCAL_DEV_ENABLED = ${JSON.stringify(builderPreviewLocalDevEnabled)};
-    function __anConfiguredOAuthOrigin() {
-      if (!__AN_PUBLIC_OAUTH_ORIGIN) return '';
-      try {
-        var origin = new URL(__AN_PUBLIC_OAUTH_ORIGIN).origin;
-        return origin && origin !== window.location.origin ? origin : '';
-      } catch(e) {
-        return '';
-      }
-    }
-    function __anAuthPath(path) {
-      var origin = __anIsBuilderPreview() ? __anConfiguredOAuthOrigin() : '';
-      return origin ? origin + path : __anPath(path);
-    }
-    function __anGoogleAuthUrlPath() {
-      return __anIsBuilderPreview()
-        ? __anAuthPath('/_agent-native/google/auth-url')
-        : __anPath('/_agent-native/google/auth-url');
-    }
-    function __anBuilderPreviewReturnOrigin() {
-      var candidates = [window.location.href, document.referrer || ''];
-      try {
-        if (window.location.ancestorOrigins) {
-          for (var j = 0; j < window.location.ancestorOrigins.length; j++) {
-            candidates.push(window.location.ancestorOrigins[j]);
-          }
-        }
-      } catch(e) {}
-      for (var i = 0; i < candidates.length; i++) {
-        try {
-          var url = new URL(candidates[i]);
-          var host = url.hostname.toLowerCase();
-          var isPreviewHost =
-            host === 'builderio.xyz' || host.slice(-14) === '.builderio.xyz' ||
-            host === 'builderio.dev' || host.slice(-14) === '.builderio.dev' ||
-            host === 'builder.codes' || host.slice(-14) === '.builder.codes' ||
-            host === 'builder.my' || host.slice(-11) === '.builder.my';
-          if (url.protocol === 'https:' && isPreviewHost) return url.origin;
-        } catch(e) {}
-      }
-      return '';
-    }
-    function __anWorkspaceGatewayReturnOrigin() {
-      var previewOrigin = __anBuilderPreviewReturnOrigin();
-      if (previewOrigin) return previewOrigin;
-      if (__AN_WORKSPACE_GATEWAY_RETURN_ORIGIN) return __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN;
-      return __anIsBuilderDesktop() ? 'http://127.0.0.1:8080' : '';
-    }
-    function __anNormalizeWorkspaceReturnPath(ret) {
-      try {
-        var url = new URL(ret || '/', window.location.origin);
-        var path = url.pathname || '/';
-        if (path === '/dispatch/dispatch') {
-          path = '/dispatch';
-        } else if (path.indexOf('/dispatch/') === 0) {
-          var rest = path.slice('/dispatch/'.length);
-          var first = rest.split('/')[0];
-          var dispatchRoutes = {
-            overview: true, apps: true, metrics: true, vault: true,
-            integrations: true, messaging: true, workspace: true,
-            agents: true, destinations: true, identities: true,
-            approvals: true, audit: true, team: true, 'thread-debug': true,
-            'new-app': true
-          };
-          if (first === 'dispatch') {
-            path = '/dispatch' + rest.slice(first.length);
-          } else if (first && !dispatchRoutes[first]) {
-            path = '/' + rest;
-          }
-        }
-        return path + url.search + url.hash;
-      } catch(e) {
-        return ret || '/';
-      }
-    }
-    function __anOAuthReturnTarget(ret) {
-      var path = __anNormalizeWorkspaceReturnPath(ret);
-      var origin = __anWorkspaceGatewayReturnOrigin();
-      return origin ? origin + path : path;
-    }
-    function __anSessionBridgeUrl(ret, sessionToken) {
-      try {
-        var url = new URL(ret || window.location.pathname + window.location.search, window.location.origin);
-        url.searchParams.set('_session', sessionToken);
-        return url.pathname + url.search + url.hash;
-      } catch(e) {
-        var sep = (ret || '/').indexOf('?') === -1 ? '?' : '&';
-        return (ret || '/') + sep + '_session=' + encodeURIComponent(sessionToken);
-      }
-    }
-    function __anFinishOAuthExchange(ret, flowId, sessionToken) {
-      __anStopOAuthPopupWatch();
-      __anStopNativeOAuthAbandonment();
-      __anGoogleSignInInFlight = false;
-      __anClearGoogleSignInFlow();
-      __anMagicLinkInFlight = false;
-      if (__anIsBuilderPreview()) {
-        if (sessionToken) {
-          __anSetOAuthDebug('OAuth exchange redeemed; applying session bridge to embedded app', flowId);
-          window.location.replace(__anSessionBridgeUrl(ret, sessionToken));
-          return;
-        }
-        __anSetOAuthDebug('OAuth exchange redeemed; reloading the embedded app', flowId);
-        window.location.reload();
-        return;
-      }
-      __anSetOAuthDebug('OAuth exchange redeemed; returning to the app', flowId);
-      __anRedirectToSignedInApp(ret);
-    }
-    function __anRedirectToSignedInApp(ret) {
-      window.location.replace(ret || __anResumeHref());
-    }
-    var __AN_SESSION_PROBE_ATTEMPTS = 3;
-    var __AN_SESSION_PROBE_RETRY_MS = 400;
-    /**
-     * Resolves 'signed-in', 'signed-out', or 'unreadable' — never collapsing
-     * the last two. Signed out is a 200 carrying { error }, so a non-ok status,
-     * an unparseable body, or a failed fetch means the question went
-     * unanswered, not that there is no session. Coercing those to signed-out
-     * strands a signed-in visitor on this form: the redirect below never fires
-     * and nothing retries it.
-     */
-    function __anProbeSession() {
-      return fetch(__anPath('/_agent-native/auth/session'), {
-        headers: { 'Accept': 'application/json' },
-        credentials: 'include',
-        cache: 'no-store',
-      }).then(function(res) {
-        if (!res.ok) return 'unreadable';
-        return res.json().then(function(data) {
-          if (data && data.email && !data.error) return 'signed-in';
-          return 'signed-out';
-        }, function() {
-          return 'unreadable';
-        });
-      }, function() {
-        return 'unreadable';
-      });
-    }
-    function __anResolveSessionState(attemptsLeft) {
-      return __anProbeSession().then(function(state) {
-        if (state !== 'unreadable' || attemptsLeft <= 1) return state;
-        return new Promise(function(resolve) {
-          setTimeout(resolve, __AN_SESSION_PROBE_RETRY_MS);
-        }).then(function() {
-          return __anResolveSessionState(attemptsLeft - 1);
-        });
-      });
-    }
-    function __anMaybeRedirectSignedIn(ret) {
-      return __anResolveSessionState(__AN_SESSION_PROBE_ATTEMPTS).then(function(state) {
-        if (state !== 'signed-in') return false;
-        __anRedirectToSignedInApp(ret);
-        return true;
-      });
-    }
-    function __anIsLoopbackHostname() {
-      var hostname = (window.location.hostname || '').toLowerCase();
-      return hostname === 'localhost' || hostname === '::1' || hostname === '127.0.0.1' || hostname.indexOf('127.') === 0;
-    }
-    function __anIsBuilderPreviewHost() {
-      var hostname = (window.location.hostname || '').toLowerCase();
-      return hostname.endsWith('.builderio.xyz') || hostname.endsWith('.builderio.dev') || hostname.endsWith('.builder.codes') || hostname.endsWith('.builder.my');
-    }
-    function __anCanUseLocalDevSignin() {
-      return __anIsLoopbackHostname() || (__AN_BUILDER_PREVIEW_LOCAL_DEV_ENABLED && __anIsBuilderPreviewHost());
-    }
-    function __anShouldStartWithLocalDev() {
-      if (!__anCanUseLocalDevSignin()) return false;
-      var params = new URLSearchParams(window.location.search);
-      var explicitTab = params.get('tab');
-      var verifiedRedirect = typeof __anIsVerifiedRedirectSuccess === 'function' && __anIsVerifiedRedirectSuccess();
-      return explicitTab !== 'login' && explicitTab !== 'signup' && !verifiedRedirect;
-    }
-    function __anSetFullAuthOptionsVisible(visible) {
-      var options = document.getElementById('full-auth-options');
-      var toggle = document.getElementById('local-dev-full-options');
-      if (!options) return;
-      if (visible) {
-        options.removeAttribute('hidden');
-        if (toggle) toggle.setAttribute('hidden', '');
-      } else {
-        options.setAttribute('hidden', '');
-        if (toggle) toggle.removeAttribute('hidden');
-      }
-    }
-    (function __anPrepareLocalDevButton() {
-      var container = document.getElementById('local-dev-signin');
-      var button = document.getElementById('local-dev-btn');
-      var fullOptionsButton = document.getElementById('local-dev-full-options');
-      if (!container || !button || !__anCanUseLocalDevSignin()) return;
-      function __anShowLocalDevSignin() {
-        container.hidden = false;
-        var startWithLocalDev = __anShouldStartWithLocalDev();
-        __anSetFullAuthOptionsVisible(!startWithLocalDev);
-        if (startWithLocalDev) button.focus();
-        if (fullOptionsButton) fullOptionsButton.addEventListener('click', function() {
-          __anSetFullAuthOptionsVisible(true);
-          var firstInput = document.querySelector('#full-auth-options input, #full-auth-options button, #full-auth-options a');
-          if (firstInput) firstInput.focus();
-        });
-        button.addEventListener('click', function() {
-          button.disabled = true;
-          button.textContent = __anT('localDevSigningIn');
-          fetch(__anPath('/_agent-native/auth/local-dev'), {
-            method: 'POST',
-            credentials: 'include',
-            headers: { 'Accept': 'application/json' },
-          }).then(function(response) {
-            if (!response.ok) throw new Error('local-dev-auth-failed');
-          }).then(function() {
-            __anRedirectToSignedInApp(__anResumeHref());
-          }).catch(function() {
-            container.hidden = true;
-            __anSetFullAuthOptionsVisible(true);
-          });
-        });
-      }
-      fetch(__anPath('/_agent-native/auth/local-dev'), {
-        method: 'GET',
-        credentials: 'include',
-        cache: 'no-store',
-        headers: { 'Accept': 'application/json' },
-      }).then(function(response) {
-        if (!response.ok) return null;
-        return response.json().then(function(data) {
-          return data;
-        }, function() {
-          return null;
-        });
-      }, function() {
-        return null;
-      }).then(function(data) {
-        if (data && data.available === true) {
-          __anShowLocalDevSignin();
-        } else {
-          __anSetFullAuthOptionsVisible(true);
-        }
-      });
-    })();
-${identitySsoScript}
-	    (function __anRedirectIfAlreadySignedIn() {
-	      __anMaybeRedirectSignedIn();
-	    })();
-	    function __anSafeAttributionValue(value) {
-	      return typeof value === 'string' ? value.trim().slice(0, 120) : '';
-	    }
-	    function __anGenerateAnalyticsAnonymousId() {
-	      try {
-	        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID();
-	      } catch(e) {}
-	      return Date.now().toString(36) + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
-	    }
-	    function __anSyncAnalyticsAnonymousId() {
-	      try {
-	        var anonymousId = '';
-	        try { anonymousId = localStorage.getItem('agent-native.anonymous_id') || ''; } catch(e) {}
-	        if (!/^[A-Za-z0-9_-]{1,128}$/.test(anonymousId)) {
-	          anonymousId = __anGenerateAnalyticsAnonymousId();
-	          try { localStorage.setItem('agent-native.anonymous_id', anonymousId); } catch(e) {}
-	        }
-	        document.cookie = 'an_aid=' + encodeURIComponent(anonymousId) + '; path=/; max-age=2592000; SameSite=Lax';
-	      } catch(e) {}
-	    }
-	    function __anFirstTouchCookiePresent() {
-	      try {
-	        return document.cookie.split(';').some(function(part) {
-	          return part.trim().indexOf('an_ft=') === 0;
-	        });
-	      } catch(e) {
-	        return false;
-	      }
-	    }
-	    function __anWriteFirstTouchCookie(json) {
-	      try {
-	        document.cookie = 'an_ft=' + encodeURIComponent(json) + '; path=/; max-age=2592000; SameSite=Lax';
-	      } catch(e) {}
-	    }
-	    function __anExternalReferrerHost(referrer) {
-	      try {
-	        var url = new URL(referrer);
-	        if (url.host.toLowerCase() === window.location.host.toLowerCase()) return '';
-	        return __anSafeAttributionValue(url.host);
-	      } catch(e) {
-	        return '';
-	      }
-	    }
-	    function __anCaptureSignupAttribution() {
-	      try {
-	        var stored = '';
-	        try { stored = localStorage.getItem('an_attribution') || ''; } catch(e) {}
-	        if (stored) {
-	          if (!__anFirstTouchCookiePresent()) __anWriteFirstTouchCookie(stored);
-	          return;
-	        }
-	        if (__anFirstTouchCookiePresent()) return;
-	        var params = new URLSearchParams(window.location.search || '');
-	        var ft = {};
-	        ['ref', 'via', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'].forEach(function(key) {
-	          var value = __anSafeAttributionValue(params.get(key));
-	          if (value) ft[key] = value;
-	        });
-	        var returnPath = __anJourney.normalizeAppPath(params.get('return'));
-	        var landingPath = __anSafeAttributionValue(returnPath || window.location.pathname || '');
-	        if (landingPath) ft.landing_path = landingPath;
-	        var referrer = __anExternalReferrerHost(document.referrer || '');
-	        if (referrer) ft.landing_referrer = referrer;
-	        ft.landed_at = new Date().toISOString();
-	        var json = JSON.stringify(ft);
-	        try { localStorage.setItem('an_attribution', json); } catch(e) {}
-	        __anWriteFirstTouchCookie(json);
-	      } catch(e) {}
-	    }
-	    __anSyncAnalyticsAnonymousId();
-	    __anCaptureSignupAttribution();
-	    var __anBuilderPreviewSeen = false;
-    function __anRememberBuilderPreview() {
-      __anBuilderPreviewSeen = true;
-      try { sessionStorage.setItem('__an_builder_preview_seen', '1'); } catch(e) {}
-    }
-    function __anHasBuilderPreviewSignal() {
-      try {
-        var params = new URLSearchParams(window.location.search);
-        if (params.has('builder.preview') || params.has('builder.frameEditing') || params.has('__builder_editing__')) return true;
-      } catch(e) {}
-      return false;
-    }
-    function __anIsBuilderPreview() {
-      if (__anBuilderPreviewSeen) return true;
-      if (__anHasBuilderPreviewSignal()) {
-        __anRememberBuilderPreview();
-        return true;
-      }
-      try {
-        if (sessionStorage.getItem('__an_builder_preview_seen') === '1') {
-          __anBuilderPreviewSeen = true;
-          return true;
-        }
-      } catch(e) {}
-      try {
-        var ref = document.referrer || '';
-        var fromBuilder = ref.indexOf('builder.io') !== -1 || ref.indexOf('builder.my') !== -1 || ref.indexOf('builderio.xyz') !== -1 || ref.indexOf('builderio.dev') !== -1 || ref.indexOf('builder.codes') !== -1;
-        if (fromBuilder) __anRememberBuilderPreview();
-        return fromBuilder;
-      } catch(e) {
-        return false;
-      }
-    }
-    __anIsBuilderPreview();
-    function __anIsBuilderDesktop() {
-      try {
-        var ua = navigator.userAgent || '';
-        return ua.indexOf('Electron') !== -1 && ua.indexOf('AgentNativeDesktop') === -1;
-      } catch(e) {
-        return false;
-      }
-    }
-    function __anIsAgentNativeDesktop() {
-      try {
-        return (navigator.userAgent || '').indexOf('AgentNativeDesktop') !== -1;
-      } catch(e) {
-        return false;
-      }
-    }
-    function __anIsInFrame() {
-      try {
-        return window.self !== window.top;
-      } catch(e) {
-        return true;
-      }
-    }
-    function __anIsElectron() {
-      try {
-        return (navigator.userAgent || '').indexOf('Electron') !== -1;
-      } catch(e) {
-        return false;
-      }
-    }
-    function __anResolveAuthFlow() {
-      if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect';
-      // Per-session override for ad-hoc testing outside Builder: append
-      // ?authMode=popup or ?authMode=redirect to the sign-in URL.
-      var qp = new URLSearchParams(window.location.search).get('authMode');
-      if (qp === 'popup' || qp === 'redirect') return qp;
-      var mode = __AN_GOOGLE_AUTH_MODE || 'auto';
-      if (mode === 'popup') return 'popup';
-      if (mode === 'redirect') return 'redirect';
-      return __anIsAgentNativeDesktop() ? 'redirect' : 'popup';
-    }
-    var __anOAuthPollTimer = null;
-    var __anOAuthPopupWatchTimer = null;
-    var __anOAuthPopupCloseGraceTimer = null;
-    var __anOAuthPopupCloseGraceMs = 5000;
-    var __anNativeOAuthFlowId = null;
-    var __anNativeOAuthRequestPending = false;
-    var __anNativeOAuthReturnObserved = false;
-    var __anNativeOAuthAbandonGraceTimer = null;
-    var __anNativeOAuthAbandonGraceMs = 5000;
-    var __anOAuthPollCount = 0;
-    var __anGoogleSignInInFlight = false;
-    var __anGoogleSignInFlowId = null;
-    var __anGoogleSignInRecoveryFlowId = null;
-    var __anMagicLinkInFlight = false;
-    var __anGoogleRecoverBound = false;
-    function __anNewOAuthFlowId() {
-      try {
-        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
-          return window.crypto.randomUUID();
-        }
-      } catch(e) {}
-      return 'builder-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
-    }
-    function __anNewOAuthVerifier() {
-      try {
-        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
-          return window.crypto.randomUUID() + window.crypto.randomUUID();
-        }
-        if (window.crypto && typeof window.crypto.getRandomValues === 'function') {
-          var bytes = new Uint8Array(32);
-          window.crypto.getRandomValues(bytes);
-          var binary = '';
-          for (var i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-          return btoa(binary).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
-        }
-      } catch(e) { // coercion-ok: callers reject the empty verifier fallback.
-      }
-      return '';
-    }
-    function __anFlowDebugId(flowId) {
-      return flowId ? String(flowId).slice(-10) : '';
-    }
-    function __anSetOAuthDebug(message, flowId) {
-      var text = message + (flowId ? ' (flow ' + __anFlowDebugId(flowId) + ')' : '');
-      try {
-        console.info('[agent-native][google-oauth] ' + text);
-      } catch(e) {}
-      // Only surface the debug overlay when explicitly opted in via #oauth-debug
-      // hash or ?oauth_debug=1 query — otherwise it leaks raw flow IDs and
-      // diagnostic strings into the user-facing sign-in screen.
-      var showDebugOverlay = false;
-      try {
-        var loc = window.location || {};
-        showDebugOverlay =
-          (typeof loc.hash === 'string' && loc.hash.indexOf('oauth-debug') !== -1) ||
-          (typeof loc.search === 'string' && loc.search.indexOf('oauth_debug=1') !== -1);
-      } catch(e) {}
-      var debug = document.getElementById('google-debug');
-      if (debug) {
-        debug.textContent = text;
-        if (showDebugOverlay) debug.classList.add('show');
-      }
-    }
-    function __anStopOAuthExchangePolling() {
-      if (__anOAuthPollTimer) {
-        clearInterval(__anOAuthPollTimer);
-        __anOAuthPollTimer = null;
-      }
-    }
-    function __anStopOAuthPopupWatch() {
-      if (__anOAuthPopupWatchTimer) {
-        clearInterval(__anOAuthPopupWatchTimer);
-        __anOAuthPopupWatchTimer = null;
-      }
-      if (__anOAuthPopupCloseGraceTimer) {
-        clearTimeout(__anOAuthPopupCloseGraceTimer);
-        __anOAuthPopupCloseGraceTimer = null;
-      }
-    }
-    function __anStopNativeOAuthAbandonment() {
-      __anCancelNativeOAuthAbandonment();
-      __anNativeOAuthFlowId = null;
-      __anNativeOAuthRequestPending = false;
-    }
-    function __anCancelNativeOAuthAbandonment() {
-      if (__anNativeOAuthAbandonGraceTimer) {
-        clearTimeout(__anNativeOAuthAbandonGraceTimer);
-        __anNativeOAuthAbandonGraceTimer = null;
-      }
-      __anNativeOAuthReturnObserved = false;
-    }
-    function __anBeginNativeOAuth(flowId) {
-      __anStopNativeOAuthAbandonment();
-      __anNativeOAuthFlowId = flowId;
-      __anNativeOAuthRequestPending = true;
-      __anNativeOAuthReturnObserved = false;
-    }
-    function __anMarkNativeOAuthPolling(flowId) {
-      if (__anNativeOAuthFlowId !== flowId) return;
-      __anNativeOAuthRequestPending = false;
-    }
-    function __anIsCurrentNativeOAuth(flowId) {
-      return __anNativeOAuthFlowId === flowId && __anIsCurrentGoogleSignInFlow(flowId);
-    }
-    function __anFinalizeNativeOAuthAbandonment(flowId) {
-      if (!__anIsCurrentNativeOAuth(flowId) || !__anOAuthPollTimer) return;
-      if (document.visibilityState === 'hidden') {
-        __anCancelNativeOAuthAbandonment();
-        return;
-      }
-      __anStopNativeOAuthAbandonment();
-      if (__anInvalidateGoogleSignInFlow(flowId)) {
-        __anStopOAuthExchangePolling();
-        __anRecoverGoogleSignInAfterReturn(flowId);
-      }
-    }
-    function __anScheduleNativeOAuthAbandonment(flowId) {
-      // Returning focus is the only signal that the system-browser ceremony was
-      // abandoned. Preserve the exchange poll briefly for a late deep-link.
-      if (
-        !__anIsCurrentNativeOAuth(flowId) ||
-        __anNativeOAuthRequestPending ||
-        !__anNativeOAuthReturnObserved ||
-        !__anOAuthPollTimer ||
-        __anNativeOAuthAbandonGraceTimer
-      ) return;
-      __anNativeOAuthAbandonGraceTimer = setTimeout(function() {
-        __anNativeOAuthAbandonGraceTimer = null;
-        __anFinalizeNativeOAuthAbandonment(flowId);
-      }, __anNativeOAuthAbandonGraceMs);
-    }
-    function __anBeginGoogleSignInFlow(flowId) {
-      __anGoogleSignInFlowId = flowId;
-      __anGoogleSignInRecoveryFlowId = null;
-      __anGoogleSignInInFlight = true;
-    }
-    function __anIsCurrentGoogleSignInFlow(flowId) {
-      return __anGoogleSignInInFlight && __anGoogleSignInFlowId === flowId;
-    }
-    function __anClearGoogleSignInFlow() {
-      __anGoogleSignInFlowId = null;
-      __anGoogleSignInRecoveryFlowId = null;
-    }
-    function __anInvalidateGoogleSignInFlow(flowId) {
-      if (!__anIsCurrentGoogleSignInFlow(flowId)) return false;
-      __anGoogleSignInFlowId = null;
-      __anGoogleSignInRecoveryFlowId = flowId;
-      return true;
-    }
-    function __anCanRecoverGoogleSignInFlow(flowId, expectedFlowId) {
-      // Focus can return while either the system-browser exchange or the popup
-      // exchange is still active. Let that exchange finish before recovering.
-      if (!flowId && (__anNativeOAuthFlowId || __anOAuthPollTimer || __anOAuthPopupWatchTimer)) return false;
-      if (flowId) {
-        return __anGoogleSignInInFlight &&
-          !__anGoogleSignInFlowId &&
-          __anGoogleSignInRecoveryFlowId === flowId;
-      }
-      return __anGoogleSignInInFlight && __anGoogleSignInFlowId === expectedFlowId;
-    }
-    function __anFinalizeOAuthPopupClose(flowId) {
-      if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-      __anOAuthPopupCloseGraceTimer = null;
-      if (__anInvalidateGoogleSignInFlow(flowId)) {
-        __anStopOAuthExchangePolling();
-        __anRecoverGoogleSignInAfterReturn(flowId);
-      }
-    }
-    function __anHandleOAuthPopupClosed(flowId) {
-      __anStopOAuthPopupWatch();
-      // The success callback closes its tab 250ms after staging the token, but
-      // the opener polls once per second. Let an active exchange win that race.
-      if (__anOAuthPollTimer) {
-        __anOAuthPopupCloseGraceTimer = setTimeout(function() {
-          __anFinalizeOAuthPopupClose(flowId);
-        }, __anOAuthPopupCloseGraceMs);
-        return;
-      }
-      __anFinalizeOAuthPopupClose(flowId);
-    }
-    function __anWatchOAuthPopupClose(popup, flowId) {
-      __anStopOAuthPopupWatch();
-      __anOAuthPopupWatchTimer = setInterval(function() {
-        if (!__anIsCurrentGoogleSignInFlow(flowId)) {
-          __anStopOAuthPopupWatch();
-          return;
-        }
-        var closed = false;
-        try {
-          closed = popup.closed === true;
-        } catch(e) {
-          __anHandleOAuthPopupClosed(flowId);
-          return;
-        }
-        if (!closed) return;
-        __anHandleOAuthPopupClosed(flowId);
-      }, 500);
-    }
-    function __anShowAuthExchangeError(err, btn, message, kind) {
-      __anStopOAuthExchangePolling();
-      __anStopOAuthPopupWatch();
-      __anStopNativeOAuthAbandonment();
-      err.textContent = message;
-      err.classList.add('show', 'error');
-      btn.disabled = false;
-      if (kind === 'magic-link') {
-        __anMagicLinkInFlight = false;
-        showMagicLinkForm();
-      } else {
-        __anGoogleSignInInFlight = false;
-        __anClearGoogleSignInFlow();
-      }
-    }
-    function __anShowOAuthError(err, btn, message) {
-      __anShowAuthExchangeError(err, btn, message, 'google');
-    }
-    function __anRecoverGoogleSignInAfterReturn(flowId) {
-      // The user left for the Google sign-in window and came back. If the flow
-      // never completed (e.g. they closed the window to switch profiles), the
-      // button is stuck disabled with no error path firing for up to 5 minutes.
-      // Re-enable it so they can retry. Wait briefly first so a genuinely
-      // in-flight exchange can still finish and navigate without a flicker.
-      if (!flowId && __anNativeOAuthFlowId) {
-        __anNativeOAuthReturnObserved = true;
-        __anScheduleNativeOAuthAbandonment(__anNativeOAuthFlowId);
-        return;
-      }
-      var expectedFlowId = flowId || __anGoogleSignInFlowId;
-      if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
-      setTimeout(function() {
-        if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
-        __anMaybeRedirectSignedIn(__anResumeHref()).then(function(redirected) {
-          if (!__anCanRecoverGoogleSignInFlow(flowId, expectedFlowId)) return;
-          if (redirected) return;
-          var btn = document.getElementById('google-btn');
-          if (!btn || !btn.disabled) return;
-          // Keep the desktop-exchange poll alive. Agent-Native Desktop opens
-          // Google in the system browser, so focus can return before the
-          // callback has stored the session token.
-          btn.disabled = false;
-          __anGoogleSignInInFlight = false;
-          __anClearGoogleSignInFlow();
-        });
-      }, 1200);
-    }
-    function __anBindGoogleRecover() {
-      if (__anGoogleRecoverBound) return;
-      __anGoogleRecoverBound = true;
-      window.addEventListener('focus', function() {
-        __anRecoverGoogleSignInAfterReturn();
-      });
-      window.addEventListener('blur', function() {
-        __anCancelNativeOAuthAbandonment();
-      });
-      document.addEventListener('visibilitychange', function() {
-        if (document.visibilityState === 'visible') {
-          __anRecoverGoogleSignInAfterReturn();
-        } else {
-          __anCancelNativeOAuthAbandonment();
-        }
-      });
-    }
-    function __anHandlePopupOAuthFailure(ret, btn, err, flowId, redirectReason, builderFrameMessage) {
-      if (__anIsBuilderPreview() && __anIsInFrame()) {
-        __anShowOAuthError(err, btn, builderFrameMessage + ' ' + __anT('googlePopupHelp') + ' (flow ' + __anFlowDebugId(flowId) + ').');
-        return;
-      }
-      __anStartRedirectOAuth(ret, btn, err, flowId, redirectReason);
-    }
-    function __anStartRedirectOAuth(ret, btn, err, flowId, reason) {
-      var params = new URLSearchParams();
-      var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
-      if (oauthReturn) params.set('return', oauthReturn);
-      params.set('redirect', '1');
-      __anSetOAuthDebug(reason || 'Opening Google sign-in redirect', flowId);
-      try {
-        __anOpenOAuthUrl(__anGoogleAuthUrlPath() + '?' + params.toString());
-      } catch(e) {
-        __anShowOAuthError(err, btn, __anT('failedToConnect'));
-      }
-    }
-    function __anWaitForOAuthExchange(flowId, ret, btn, err, kind, verifier) {
-      var started = Date.now();
-      var timeoutMs = 5 * 60 * 1000;
-      var isMagicLink = kind === 'magic-link';
-      __anOAuthPollCount = 0;
-      async function check() {
-        if (!isMagicLink && !__anIsCurrentGoogleSignInFlow(flowId)) return;
-        __anOAuthPollCount++;
-        try {
-          var exchangeParams = '?flow_id=' + encodeURIComponent(flowId);
-          var exchangeOptions = { credentials: 'include' };
-          if (verifier) {
-            exchangeOptions.headers = { 'X-Agent-Native-Desktop-Verifier': verifier };
-          }
-          var res = await fetch(__anPath('/_agent-native/auth/desktop-exchange') + exchangeParams, exchangeOptions);
-          var data = await res.json().catch(function() { return {}; });
-          if (!isMagicLink && !__anIsCurrentGoogleSignInFlow(flowId)) return;
-          if (data && (data.email || data.token)) {
-            if (__anOAuthPollTimer) clearInterval(__anOAuthPollTimer);
-            __anOAuthPollTimer = null;
-            __anFinishOAuthExchange(ret, flowId, data.token);
-            return;
-          }
-          if (data && data.error) {
-            __anSetOAuthDebug('OAuth exchange returned an error: ' + (data.message || data.error), flowId);
-            __anShowAuthExchangeError(
-              err,
-              btn,
-              __anAuthErrorText(data, isMagicLink ? __anT('magicLinkFailed') : __anT('googleNotConfigured')),
-              isMagicLink ? 'magic-link' : 'google',
-            );
-            return;
-          }
-          if (data && data.pending && (__anOAuthPollCount === 1 || __anOAuthPollCount % 5 === 0)) {
-            __anSetOAuthDebug('Waiting for the Google callback; polling attempt ' + __anOAuthPollCount, flowId);
-          }
-        } catch(e) {
-          if (__anOAuthPollCount === 1 || __anOAuthPollCount % 5 === 0) {
-            __anSetOAuthDebug('Could not reach the OAuth exchange endpoint: ' + (e && e.message ? e.message : 'network error'), flowId);
-          }
-        }
-        if (Date.now() - started > timeoutMs) {
-          __anShowAuthExchangeError(
-            err,
-            btn,
-            isMagicLink
-              ? __anT('magicLinkFailed')
-              : __anT('googleNeverFinished') + ' Flow ' + __anFlowDebugId(flowId) + '.',
-            isMagicLink ? 'magic-link' : 'google',
-          );
-        }
-      }
-      __anStopOAuthExchangePolling();
-      __anOAuthPollTimer = setInterval(check, 1000);
-      setTimeout(check, 500);
-    }
-    async function __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn) {
-      var params = new URLSearchParams();
-      if (oauthReturn) params.set('return', oauthReturn);
-      params.set('desktop', '1');
-      params.set('flow_id', flowId);
-      var res = await fetch(__anGoogleAuthUrlPath() + '?' + params.toString(), {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Accept': 'application/json',
-          'X-Agent-Native-Desktop-Verifier': verifier
-        }
-      });
-      var data;
-      try {
-        data = await res.json();
-      } catch(e) {
-        throw new Error(__anT('failedToConnect'));
-      }
-      if (!res.ok || !data || typeof data.url !== 'string' || !data.url) {
-        throw new Error(__anAuthErrorText(data, __anT('failedToConnect')));
-      }
-      return data.url;
-    }
-    function __anStartPopupOAuth(ret, btn, err, flowId) {
-      var verifier = __anNewOAuthVerifier();
-      if (!verifier) {
-        __anShowOAuthError(err, btn, __anT('failedToConnect'));
-        return;
-      }
-      var oauthReturn = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
-      try { sessionStorage.setItem('__an_signin', '1'); } catch(e) {}
-      __anSetOAuthDebug('Opening Google sign-in popup', flowId);
-      var popup;
-      try {
-        popup = window.open('', '_blank', 'width=640,height=760');
-        if (!popup) {
-          __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Google popup was blocked; falling back to redirect', 'Google popup was blocked.');
-          return;
-        }
-        try { popup.opener = null; } catch(e) {}
-        __anWatchOAuthPopupClose(popup, flowId);
-      } catch(e) {
-        __anHandlePopupOAuthFailure(ret, btn, err, flowId, 'Could not open Google popup; falling back to redirect', 'Could not open Google popup.');
-        return;
-      }
-      __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn).then(function(url) {
-        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-        try {
-          popup.location.href = url;
-          __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
-          __anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);
-        } catch(e) {
-          throw e;
-        }
-      }).catch(function(e) {
-        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-        try { popup.close(); } catch(closeErr) {}
-        __anShowOAuthError(err, btn, e && e.message ? e.message : __anT('failedToConnect'));
-      });
-    }
-    function __anStartNativeDesktopOAuth(ret, btn, err, flowId) {
-      var verifier = __anNewOAuthVerifier();
-      if (!verifier) {
-        __anShowOAuthError(err, btn, __anT('failedToConnect'));
-        return;
-      }
-      var oauthReturn = ret;
-      __anBeginNativeOAuth(flowId);
-      __anSetOAuthDebug('Preparing Google sign-in in system browser', flowId);
-      __anRequestDesktopOAuthUrl(flowId, verifier, oauthReturn).then(function(url) {
-        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-        __anMarkNativeOAuthPolling(flowId);
-        __anSetOAuthDebug('Opening Google sign-in in system browser', flowId);
-        __anOpenOAuthUrl(url);
-        __anWaitForOAuthExchange(flowId, ret, btn, err, 'google', verifier);
-        __anScheduleNativeOAuthAbandonment(flowId);
-      }).catch(function(e) {
-        if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-        __anShowOAuthError(err, btn, e && e.message ? e.message : __anT('failedToConnect'));
-      });
-    }
-    function __anOpenOAuthUrl(url) {
-      try { sessionStorage.setItem('__an_signin', '1'); } catch(e) {}
-      window.location.href = url;
-    }
-    (function revealLocalNote() {
-    var h = location.hostname;
-    if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h.endsWith('.local')) {
-      var n = document.getElementById('local-note');
-      if (n) n.classList.add('show');
-    }
-  })();
-  (function revealUpgradeNote() {
-    var shouldShow = false;
-    try {
-      var params = new URLSearchParams(location.search);
-      shouldShow = params.get('signin') === '1' || params.get('upgrade-from-local') === '1';
-    } catch(e) {}
-    if (!shouldShow) {
-      try { shouldShow = localStorage.getItem('an_migrate_from_local') === '1'; } catch(e) {}
-    }
-    if (!shouldShow) return;
-    var n = document.getElementById('upgrade-note');
-    if (!n) return;
-    n.textContent = n.getAttribute('data-upgrade-copy') || __anT('migrateLocalFallback');
-    n.classList.add('show');
-  })();
-${
-  googleOnly
-    ? ""
-    : `  var TAB_STORAGE_KEY = 'an.onboarding.tab';
-    var tabs = document.querySelectorAll('.tab');
-    var forms = document.querySelectorAll('.form');
-	    var pendingSignupEmail = '';
-	    var pendingSignupPassword = '';
-	    var verificationCheckInFlight = false;
-	    var RESEND_VERIFICATION_COOLDOWN_SECONDS = 60;
-	    var resendVerificationCooldownUntil = 0;
-	    var resendVerificationCooldownTimer = null;
-	    var PENDING_SIGNUP_EMAIL_STORAGE_KEY = 'an.onboarding.pendingSignupEmail';
-	    // The verification link can open in a new tab, so in-memory pending state
-	    // cannot be the only source of the account email. Keep only the address,
-	    // never the password, for the manual-login fallback.
-	    function pendingSignupEmailStorageKey() {
-	      return PENDING_SIGNUP_EMAIL_STORAGE_KEY + ':' + (__anBasePath() || '/');
-	    }
-	    function rememberPendingSignupEmail(email) {
-	      try {
-	        if (email) localStorage.setItem(pendingSignupEmailStorageKey(), email);
-	        else localStorage.removeItem(pendingSignupEmailStorageKey());
-	      // coercion-ok: localStorage is optional; the in-memory and form fallbacks remain available.
-	      } catch (e) {}
-	    }
-	    function readRememberedPendingSignupEmail() {
-	      try {
-	        var email = localStorage.getItem(pendingSignupEmailStorageKey()) || '';
-	        return __anIsValidAuthEmail(email) ? __anNormalizeAuthEmail(email) : '';
-	      // coercion-ok: localStorage is optional; callers fall back to the in-memory or form value.
-	      } catch (e) {
-	        return '';
-	      }
-	    }
-	    function clearRememberedPendingSignupEmail() {
-	      rememberPendingSignupEmail('');
-	    }
-    function hideMagicLinkSuccess() {
-      var card = document.querySelector('.card');
-      if (card) card.classList.remove('magic-link-complete');
-      var success = document.getElementById('magic-link-success');
-      if (success) {
-        success.classList.remove('is-visible');
-        success.setAttribute('hidden', '');
-      }
-    }
-    function showMagicLinkSuccess(email) {
-      var card = document.querySelector('.card');
-      if (card) card.classList.add('magic-link-complete');
-      var success = document.getElementById('magic-link-success');
-      var successEmail = document.getElementById('magic-link-success-email');
-      if (successEmail && typeof email === 'string') successEmail.textContent = email;
-      if (success) {
-        success.removeAttribute('hidden');
-        success.classList.add('is-visible');
-      }
-      forms.forEach(function(x) { x.classList.remove('active'); });
-      var authTabs = document.getElementById('auth-tabs');
-      if (authTabs) authTabs.hidden = true;
-      __anSetAuthView('magicLinkSent');
-    }
-    function showMagicLinkForm() {
-      __anStopOAuthExchangePolling();
-      __anMagicLinkInFlight = false;
-      var form = document.getElementById('magic-link-form');
-      if (!form) return;
-      hideMagicLinkSuccess();
-      forms.forEach(function(x) { x.classList.remove('active'); });
-      form.classList.add('active');
-      var authTabs = document.getElementById('auth-tabs');
-      if (authTabs) authTabs.hidden = true;
-      updateMagicLinkSubmitState();
-      __anSetAuthView('magicLink');
-    }
-    function updateMagicLinkSubmitState() {
-      var emailInput = document.getElementById('m-email');
-      var button = document.getElementById('magic-link-submit');
-      if (!emailInput || !button) return;
-      var isValid = __anIsValidAuthEmail(emailInput.value);
-      button.disabled = !isValid;
-      var googleButton = document.getElementById('google-btn');
-      if (googleButton) googleButton.classList.toggle('magic-link-secondary', isValid);
-    }
-    function setActiveTab(name, opts) {
-	      if (name !== 'signup' && name !== 'login') return;
-	      var form = document.getElementById(name + '-form');
-	      if (!form) return;
-      var card = document.querySelector('.card');
-      if (card) card.classList.remove('verifying');
-      var authTabs = document.getElementById('auth-tabs');
-      if (authTabs) authTabs.hidden = false;
-      tabs.forEach(function(x) { x.classList.remove('active'); });
-      forms.forEach(function(x) { x.classList.remove('active'); });
-    var btn = document.querySelector('.tab[data-tab="' + name + '"]');
-    if (btn) btn.classList.add('active');
-    form.classList.add('active');
-    __anSetAuthView(name);
-      if (opts && opts.persist) {
-        try { localStorage.setItem(TAB_STORAGE_KEY, name); } catch (e) {}
-      }
-    }
-    function showVerificationStep(email, password) {
-      pendingSignupEmail = email || '';
-      pendingSignupPassword = password || '';
-      rememberPendingSignupEmail(pendingSignupEmail);
-      tabs.forEach(function(x) { x.classList.remove('active'); });
-      forms.forEach(function(x) { x.classList.remove('active'); });
-      var card = document.querySelector('.card');
-      if (card) card.classList.add('verifying');
-      var step = document.getElementById('verification-step');
-      if (step) step.classList.add('active');
-      var emailNode = document.getElementById('verify-email');
-      if (emailNode) emailNode.textContent = pendingSignupEmail;
-      __anSetAuthView('verification');
-      var msg = document.getElementById('verify-msg');
-      if (msg) {
-        msg.classList.remove('show', 'error', 'success');
-        msg.textContent = '';
-      }
-      try { localStorage.setItem(TAB_STORAGE_KEY, 'signup'); } catch (e) {}
-    }
-    function getVerificationMessageNode() {
-      var verifyStep = document.getElementById('verification-step');
-      if (verifyStep && verifyStep.classList.contains('active')) {
-        return document.getElementById('verify-msg');
-      }
-      return document.getElementById('l-msg') || document.getElementById('verify-msg');
-    }
-    function isVerificationStepActive() {
-      var verifyStep = document.getElementById('verification-step');
-      return !!(verifyStep && verifyStep.classList.contains('active'));
-    }
-    function getPendingSignupEmail() {
-      var signupEmail = document.getElementById('s-email');
-      var loginEmail = document.getElementById('l-email');
-      return (pendingSignupEmail || readRememberedPendingSignupEmail() || (signupEmail && signupEmail.value) || (loginEmail && loginEmail.value) || '').trim();
-    }
-    function getPendingSignupPassword() {
-      var signupPassword = document.getElementById('s-pass');
-      return pendingSignupPassword || (signupPassword && signupPassword.value) || '';
-    }
-    function __anNormalizeAuthEmail(value) {
-      return String(value || '').trim().toLowerCase();
-    }
-	    function __anIsValidAuthEmail(value) {
-	      return /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(__anNormalizeAuthEmail(value));
-	    }
-	    function __anIsVerifiedRedirectSuccess() {
-	      try {
-	        var params = new URLSearchParams(location.search);
-	        return params.has('verified') && !params.has('error');
-	      } catch (e) {
-	        return false;
-	      }
-	    }
-	    function __anVerificationRedirectError() {
-	      try {
-	        var params = new URLSearchParams(location.search);
-        return params.get('error') === 'verification_link_invalid'
-          ? __anT('verificationLinkInvalid')
-          : '';
-      } catch (e) { // coercion-ok: malformed query has no verification error to render
-        return '';
-      }
-	    }
-	    function __anShowEmailValidationError(input, msg) {
-	      if (msg) {
-	        msg.textContent = __anT('invalidEmail');
-	        msg.classList.add('show', 'error');
-      }
-      if (input && typeof input.focus === 'function') input.focus();
-    }
-    function movePendingSignupToLogin(message) {
-      var email = getPendingSignupEmail();
-      setActiveTab('login', { persist: true });
-      var loginEmail = document.getElementById('l-email');
-      var loginPassword = document.getElementById('l-pass');
-      var msg = document.getElementById('l-msg');
-      if (loginEmail && email) loginEmail.value = email;
-      if (msg) {
-        msg.textContent = message || __anT('signInToContinue');
-        msg.classList.remove('error');
-        msg.classList.add('show', 'success');
-      }
-      setTimeout(function() { if (loginPassword) loginPassword.focus(); }, 0);
-    }
-    async function signInWithPendingSignup() {
-      var email = getPendingSignupEmail();
-      var password = getPendingSignupPassword();
-      if (!email || !password) {
-        return { ok: false, needsManualSignIn: true };
-      }
-      var res = await fetch(__anPath('/_agent-native/auth/login'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email, password: password }),
-      });
-      if (res.ok) {
-        clearRememberedPendingSignupEmail();
-        __anRedirectToSignedInApp();
-        return { ok: true };
-      }
-      var data = await res.json().catch(function(error) {
-        console.warn('[auth] Could not parse sign-in response', error);
-        return null;
-      });
-      var error = __anAuthErrorText(data, __anT('finishSignInFailed'));
-      return {
-        ok: false,
-        error: error,
-        isWaitingForVerification: /not verified|verification/i.test(error),
-      };
-    }
-    async function checkVerificationSession(fallbackText, opts) {
-      opts = opts || {};
-      if (verificationCheckInFlight) return;
-      verificationCheckInFlight = true;
-      var msg = getVerificationMessageNode();
-      var continueBtn = document.getElementById('verify-continue');
-      if (continueBtn && !opts.silent) {
-        continueBtn.disabled = true;
-        continueBtn.textContent = __anT('checking');
-      }
-      if (msg && !opts.silent) {
-        msg.textContent = __anT('checkingVerification');
-        msg.classList.remove('error');
-        msg.classList.add('show', 'success');
-      }
-      try {
-        var res = await fetch(__anPath('/_agent-native/auth/session'), {
-          headers: { 'Accept': 'application/json' },
-        });
-        var data = await res.json().catch(function() { return {}; });
-        if (res.ok && data && data.email && !data.error) {
-          clearRememberedPendingSignupEmail();
-          __anRedirectToSignedInApp();
-          return;
-        }
-        var loginResult = await signInWithPendingSignup();
-        if (loginResult.ok) return;
-        if (loginResult.needsManualSignIn) {
-          if (!opts.silent) {
-            movePendingSignupToLogin(fallbackText || __anT('enterPasswordAfterVerification'));
-          }
-          return;
-        }
-        if (loginResult.error && !loginResult.isWaitingForVerification) {
-          if (!opts.silent) {
-            movePendingSignupToLogin(__anT('finishSignInManually'));
-          }
-          return;
-        }
-        if (msg && !opts.silent) {
-          msg.textContent = fallbackText || __anT('stillWaitingVerification');
-          msg.classList.remove('success');
-          msg.classList.add('show', 'error');
-        }
-      } catch (err) {
-        if (msg && !opts.silent) {
-          msg.textContent = __anT('checkVerificationFailed');
-          msg.classList.remove('success');
-          msg.classList.add('show', 'error');
-        }
-      } finally {
-        verificationCheckInFlight = false;
-        if (continueBtn && !opts.silent) {
-          continueBtn.disabled = false;
-          continueBtn.textContent = __anT('continue');
-        }
-      }
-    }
-	    function maybeCompleteVerificationAfterReturn() {
-	      if (!isVerificationStepActive()) return;
-	      checkVerificationSession(null, { silent: true });
-	    }
-	    function updateResendVerificationCooldown() {
-	      var btn = document.getElementById('resend-verification');
-	      if (!btn) return;
-	      var remaining = Math.ceil((resendVerificationCooldownUntil - Date.now()) / 1000);
-	      if (remaining > 0) {
-	        btn.disabled = true;
-	        btn.textContent = __anT('resendEmail') + ' (' + remaining + 's)';
-	        return;
-	      }
-	      if (resendVerificationCooldownTimer) {
-	        clearInterval(resendVerificationCooldownTimer);
-	        resendVerificationCooldownTimer = null;
-	      }
-	      resendVerificationCooldownUntil = 0;
-	      btn.disabled = false;
-	      btn.textContent = __anT('resendEmail');
-	    }
-	    function startResendVerificationCooldown(seconds) {
-	      resendVerificationCooldownUntil = Date.now() + seconds * 1000;
-	      updateResendVerificationCooldown();
-	      if (resendVerificationCooldownTimer) clearInterval(resendVerificationCooldownTimer);
-	      resendVerificationCooldownTimer = setInterval(updateResendVerificationCooldown, 1000);
-	    }
-	    async function resendVerificationEmail() {
-	      var btn = document.getElementById('resend-verification');
-	      var msg = document.getElementById('verify-msg');
-	      var email = getPendingSignupEmail();
-	      if (!email) return;
-	      if (resendVerificationCooldownUntil > Date.now()) {
-	        updateResendVerificationCooldown();
-	        return;
-	      }
-	      var original = btn ? btn.textContent : '';
-	      if (btn) {
-	        btn.disabled = true;
-	        btn.textContent = __anT('sending');
-      }
-      if (msg) msg.classList.remove('show', 'error', 'success');
-      try {
-        var res = await fetch(__anPath('/_agent-native/auth/ba/send-verification-email'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: email, callbackURL: __anResumeHref() }),
-        });
-        if (res.ok) {
-	          if (msg) {
-	            msg.textContent = __anT('sentVerification');
-	            msg.classList.add('show', 'success');
-	          }
-	          startResendVerificationCooldown(RESEND_VERIFICATION_COOLDOWN_SECONDS);
-	          return;
-	        }
-	        var data = await res.json().catch(function() { return {}; });
-	        if (msg) {
-          msg.textContent = __anAuthErrorText(data, __anT('resendVerificationFailed'));
-          msg.classList.add('show', 'error');
-        }
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = original;
-        }
-      } catch (err) {
-        if (msg) {
-          msg.textContent = __anT('networkErrorRetry');
-          msg.classList.add('show', 'error');
-        }
-        if (btn) {
-          btn.disabled = false;
-          btn.textContent = original;
-        }
-      }
-    }
-    (function initActiveTab() {
-    var initial = __AN_AUTH_MODE === 'magic-link' ? 'magicLink' : 'signup';
-    var verificationError = __anVerificationRedirectError();
-    try {
-      var params = new URLSearchParams(location.search);
-      var qp = params.get('tab');
-      var path = location.pathname;
-      while (path.length > 1 && path.charAt(path.length - 1) === '/') path = path.slice(0, -1);
-      if (qp === 'login' || qp === 'signup') {
-        initial = qp;
-	      } else if (__anIsVerifiedRedirectSuccess()) {
-	        initial = 'login';
-	      } else if (verificationError) {
-	        initial = 'login';
-	      } else if (path === '/login' || path.endsWith('/login')) {
-        initial = 'login';
-      } else if (path === '/signup' || path.endsWith('/signup')) {
-        initial = 'signup';
-      } else if (__AN_AUTH_MODE !== 'magic-link') {
-        var stored = localStorage.getItem(TAB_STORAGE_KEY);
-        if (stored === 'login' || stored === 'signup') initial = stored;
-      }
-    } catch (e) {}
-    if (initial === 'magicLink') showMagicLinkForm();
-    else setActiveTab(initial, { persist: false });
-	    if (verificationError) {
-	      var verificationMsg = document.getElementById('l-msg');
-	      if (verificationMsg) {
-	        verificationMsg.textContent = verificationError;
-	        verificationMsg.classList.add('show', 'error');
-	      }
-	    }
-	      try {
-	        if (__anIsVerifiedRedirectSuccess()) {
-	          var rememberedEmail = readRememberedPendingSignupEmail();
-	          var loginEmail = document.getElementById('l-email');
-	          if (loginEmail && rememberedEmail) loginEmail.value = rememberedEmail;
-	          var msg = document.getElementById('l-msg');
-          if (msg) {
-            msg.textContent = __anT('emailVerifiedFinishing');
-            msg.classList.remove('error');
-            msg.classList.add('show', 'success');
-          }
-          checkVerificationSession(__anT('emailVerifiedSignIn'));
-        }
-      } catch (e) {}
-    })();
-  tabs.forEach(function(t) { t.addEventListener('click', function() {
-    setActiveTab(t.dataset.tab, { persist: true });
-  }); });
-
-  var usePasswordLink = document.getElementById('use-password-link');
-  if (usePasswordLink) usePasswordLink.addEventListener('click', function(e) {
-    e.preventDefault();
-    setActiveTab('login', { persist: false });
-    var magicEmail = document.getElementById('m-email');
-    var loginEmail = document.getElementById('l-email');
-    if (magicEmail && loginEmail && magicEmail.value) loginEmail.value = magicEmail.value;
-  });
-  var backToMagicLink = document.getElementById('back-to-magic-link');
-  if (backToMagicLink) backToMagicLink.addEventListener('click', function(e) {
-    e.preventDefault();
-    showMagicLinkForm();
-  });
-  var magicLinkBack = document.getElementById('magic-link-back');
-  if (magicLinkBack) magicLinkBack.addEventListener('click', function(e) {
-    e.preventDefault();
-    var magicLinkEmailInput = document.getElementById('m-email');
-    if (magicLinkEmailInput) magicLinkEmailInput.value = '';
-    showMagicLinkForm();
-    if (magicLinkEmailInput) magicLinkEmailInput.focus();
-  });
-
-  var magicLinkForm = document.getElementById('magic-link-form');
-  __anBindPasswordValidation(document.getElementById('s-pass'));
-  __anBindPasswordValidation(document.getElementById('s-pass2'));
-  var magicLinkEmail = document.getElementById('m-email');
-  if (magicLinkEmail) {
-    magicLinkEmail.addEventListener('input', updateMagicLinkSubmitState);
-    magicLinkEmail.addEventListener('change', updateMagicLinkSubmitState);
-    updateMagicLinkSubmitState();
-  }
-  if (magicLinkForm) magicLinkForm.addEventListener('submit', async function(e) {
-    e.preventDefault();
-    var btn = magicLinkForm.querySelector('button[type="submit"]');
-    var msg = document.getElementById('m-msg');
-    var emailInput = document.getElementById('m-email');
-    var email = __anNormalizeAuthEmail(emailInput && emailInput.value);
-    var isDesktopMagicLink = __anIsAgentNativeDesktop();
-    msg.classList.remove('show', 'error', 'success');
-    if (!__anIsValidAuthEmail(email)) {
-      __anShowEmailValidationError(emailInput, msg);
-      return;
-    }
-    __anTrackAuth('auth.signup_clicked', { surface: 'signup', method: 'magic_link', auth_view: __anAuthView });
-    var originalLabel = btn.textContent;
-    btn.disabled = true;
-    __anMagicLinkInFlight = isDesktopMagicLink;
-    btn.textContent = __anT('sending');
-    try {
-      var res = await fetch(__anPath('/_agent-native/auth/magic-link'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email: email,
-          callbackURL: isDesktopMagicLink
-            ? __anPath('/_agent-native/auth/magic-link/desktop-callback')
-            : __anResumeHref(),
+`;
+  const authClientScriptPath = `${appBasePath}/assets/auth-client.js`;
+  const title = hasMarketing
+    ? `${marketing!.appName} — ${t("pageTitleSignIn")}`
+    : t("pageTitleWelcome");
+  const authDocumentMarkup = renderToString(
+    createElement(
+      "html",
+      { lang: DEFAULT_LOCALE, dir: "ltr" },
+      createElement(
+        "head",
+        null,
+        createElement("meta", { charSet: "UTF-8" }),
+        createElement("script", {
+          "data-agent-native-locale-init": "",
+          dangerouslySetInnerHTML: { __html: localeInitScript },
         }),
-      });
-      var data = await res.json().catch(function(error) {
-        console.warn('[auth] Could not parse magic-link response', error);
-        return null;
-      });
-      if (res.ok) {
-        btn.disabled = false;
-        btn.textContent = originalLabel;
-        showMagicLinkSuccess(email);
-        if (isDesktopMagicLink) {
-          var magicFlowId = data && typeof data.flowId === 'string' ? data.flowId : '';
-          var magicVerifier = data && typeof data.verifier === 'string' ? data.verifier : '';
-          if (!magicFlowId || !magicVerifier) {
-            throw new Error('The sign-in flow was not initialized.');
-          }
-          __anWaitForOAuthExchange(magicFlowId, __anResumeHref(), btn, msg, 'magic-link', magicVerifier);
-        }
-        return;
-      }
-      __anMagicLinkInFlight = false;
-      msg.textContent = __anAuthErrorText(data, __anT('magicLinkFailed'));
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    } catch (err) {
-      __anMagicLinkInFlight = false;
-      msg.textContent = __anT('networkErrorDashRetry');
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    }
-  });
-
-  document.getElementById('signup-form').addEventListener('submit', async function(e) {
-    e.preventDefault();
-    var form = e.currentTarget;
-    var btn = form.querySelector('button[type="submit"]');
-    var msg = document.getElementById('s-msg');
-    msg.classList.remove('show', 'error', 'success');
-    var pass = document.getElementById('s-pass').value;
-    var pass2 = document.getElementById('s-pass2').value;
-    if (pass !== pass2) {
-      msg.textContent = __anT('passwordsMismatch');
-      msg.classList.add('show', 'error');
-      return;
-    }
-    var originalLabel = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = __anT('creatingAccount');
-    try {
-      var emailInput = document.getElementById('s-email');
-      var email = __anNormalizeAuthEmail(emailInput && emailInput.value);
-      if (!__anIsValidAuthEmail(email)) {
-        btn.disabled = false;
-        btn.textContent = originalLabel;
-        __anShowEmailValidationError(emailInput, msg);
-        return;
-      }
-      __anTrackAuth('auth.signup_clicked', { surface: 'signup', method: 'password', auth_view: __anAuthView });
-      var res = await fetch(__anPath('/_agent-native/auth/register'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            email: email,
-            password: pass,
-            callbackURL: __anResumeHref(),
-          }),
-        });
-      var data = await res.json().catch(function() { return {}; });
-      if (res.ok) {
-        // If email verification is required, the server won't return a session.
-        // Try logging in — if it fails (unverified), show a "check your email" message.
-        var loginRes = await fetch(__anPath('/_agent-native/auth/login'), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: email, password: pass }),
-        });
-        if (loginRes.ok) {
-          clearRememberedPendingSignupEmail();
-          msg.textContent = __anT('accountCreatedSigningIn');
-          msg.classList.add('show', 'success');
-          __anRedirectToSignedInApp();
-          return;
-        }
-        var loginData;
-        try {
-          loginData = await loginRes.json();
-        } catch (error) {
-          console.warn('[auth] Could not parse sign-in response', error);
-        }
-        var loginError = __anAuthErrorText(loginData, __anT('registrationFailed'));
-        if (loginRes.status === 403 && /not verified|verification/i.test(loginError)) {
-          btn.disabled = false;
-          btn.textContent = originalLabel;
-          showVerificationStep(email, pass);
-          return;
-        }
-        msg.textContent = loginError;
-        msg.classList.add('show', 'error');
-        btn.disabled = false;
-        btn.textContent = originalLabel;
-        return;
-      }
-      msg.textContent = __anAuthErrorText(data, __anT('registrationFailed'));
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    } catch (err) {
-      msg.textContent = __anT('networkErrorDashRetry');
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    }
-    });
-
-    var verifyContinue = document.getElementById('verify-continue');
-    if (verifyContinue) verifyContinue.addEventListener('click', function(e) {
-      e.preventDefault();
-      checkVerificationSession();
-    });
-    window.addEventListener('focus', maybeCompleteVerificationAfterReturn);
-    document.addEventListener('visibilitychange', function() {
-      if (document.visibilityState === 'visible') maybeCompleteVerificationAfterReturn();
-    });
-    var resendBtn = document.getElementById('resend-verification');
-    if (resendBtn) resendBtn.addEventListener('click', function(e) {
-      e.preventDefault();
-      resendVerificationEmail();
-    });
-    var backToSignup = document.getElementById('back-to-signup');
-    if (backToSignup) backToSignup.addEventListener('click', function(e) {
-      e.preventDefault();
-      clearRememberedPendingSignupEmail();
-      setActiveTab('signup', { persist: true });
-      var email = document.getElementById('s-email');
-      setTimeout(function() { if (email) email.focus(); }, 0);
-    });
-
-    var forgotLink = document.getElementById('forgot-link');
-  var backToLogin = document.getElementById('back-to-login');
-  if (forgotLink) forgotLink.addEventListener('click', function(e) {
-    e.preventDefault();
-    document.getElementById('login-form').classList.remove('active');
-    document.getElementById('forgot-form').classList.add('active');
-    __anSetAuthView('forgot');
-    var fEmail = document.getElementById('f-email');
-    var lEmail = document.getElementById('l-email');
-    if (lEmail && lEmail.value) fEmail.value = lEmail.value;
-    setTimeout(function() { fEmail.focus(); }, 0);
-  });
-  if (backToLogin) backToLogin.addEventListener('click', function(e) {
-    e.preventDefault();
-    document.getElementById('forgot-form').classList.remove('active');
-    document.getElementById('login-form').classList.add('active');
-    __anSetAuthView('login');
-  });
-
-  var forgotForm = document.getElementById('forgot-form');
-  if (forgotForm) forgotForm.addEventListener('submit', async function(e) {
-    e.preventDefault();
-    var btn = e.currentTarget.querySelector('button[type="submit"]');
-    var msg = document.getElementById('f-msg');
-    msg.classList.remove('show', 'error', 'success');
-    var original = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = __anT('sending');
-    try {
-      var emailInput = document.getElementById('f-email');
-      var email = __anNormalizeAuthEmail(emailInput && emailInput.value);
-      if (!__anIsValidAuthEmail(email)) {
-        btn.disabled = false;
-        btn.textContent = original;
-        __anShowEmailValidationError(emailInput, msg);
-        return;
-      }
-      var res = await fetch(__anPath('/_agent-native/auth/ba/request-password-reset'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email }),
-      });
-      if (res.ok) {
-        msg.textContent = __anT('resetEmailSent');
-        msg.classList.add('show', 'success');
-        btn.textContent = __anT('sent');
-        return;
-      }
-      var data = await res.json().catch(function() { return {}; });
-      msg.textContent = __anAuthErrorText(data, __anT('resetEmailFailed'));
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = original;
-    } catch (err) {
-      msg.textContent = __anT('networkErrorDashRetry');
-      msg.classList.add('show', 'error');
-      btn.disabled = false;
-      btn.textContent = original;
-    }
-  });
-
-    document.getElementById('login-form').addEventListener('submit', async function(e) {
-    e.preventDefault();
-    var form = e.currentTarget;
-      var btn = form.querySelector('button[type="submit"]');
-      var msg = document.getElementById('l-msg');
-      msg.classList.remove('show', 'success');
-      msg.classList.add('error');
-    var originalLabel = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = __anT('signingIn');
-    try {
-      var emailInput = document.getElementById('l-email');
-      var email = __anNormalizeAuthEmail(emailInput && emailInput.value);
-      if (!__anIsValidAuthEmail(email)) {
-        btn.disabled = false;
-        btn.textContent = originalLabel;
-        __anShowEmailValidationError(emailInput, msg);
-        return;
-      }
-      var res = await fetch(__anPath('/_agent-native/auth/login'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email: email,
-          password: document.getElementById('l-pass').value,
+        createElement("script", {
+          "data-agent-native-embedded-init": "",
+          dangerouslySetInnerHTML: { __html: embeddedAuthInitScript },
         }),
-      });
-      if (res.ok) {
-        clearRememberedPendingSignupEmail();
-        __anRedirectToSignedInApp();
-        return;
-      }
-      var data = await res.json().catch(function() { return {}; });
-      msg.textContent = __anAuthErrorText(data, __anT('invalidLogin'));
-      msg.classList.add('show');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    } catch (err) {
-      msg.textContent = __anT('networkErrorDashRetry');
-      msg.classList.add('show');
-      btn.disabled = false;
-      btn.textContent = originalLabel;
-    }
-  });
-`
-}
-${
-  renderGoogleButton
-    ? `
-    async function signInWithGoogle() {
-    __anTrackAuth(__anAuthView === 'login' ? 'auth.login_clicked' : 'auth.signup_clicked', { surface: __anAuthView === 'login' ? 'login' : 'signup', method: 'google', auth_view: __anAuthView });
-    var btn = document.getElementById('google-btn');
-    var err = document.getElementById('google-err');
-    var ret = __anResumeHref();
-    var flowId = __anNewOAuthFlowId();
-    btn.disabled = true;
-    __anBeginGoogleSignInFlow(flowId);
-    __anBindGoogleRecover();
-    err.classList.remove('show');
-    if (__anResolveAuthFlow() === 'popup') {
-      __anStartPopupOAuth(ret, btn, err, flowId);
-      return;
-    }
-    if (__anIsAgentNativeDesktop()) {
-      __anStartNativeDesktopOAuth(ret, btn, err, flowId);
-      return;
-    }
-    if (__anIsBuilderPreview()) {
-      __anStartRedirectOAuth(ret, btn, err, flowId, 'Opening Google sign-in redirect from Builder preview');
-      return;
-    }
-    try {
-      var authUrl = __anGoogleAuthUrlPath() + '?return=' + encodeURIComponent(ret);
-      var res = await fetch(authUrl);
-      var data = await res.json();
-      if (!__anIsCurrentGoogleSignInFlow(flowId)) return;
-      if (data.url) {
-        __anOpenOAuthUrl(data.url);
-      } else {
-        err.textContent = __anAuthErrorText(data, __anT('googleNotConfigured'));
-        err.classList.add('show');
-        btn.disabled = false;
-        __anGoogleSignInInFlight = false;
-        __anClearGoogleSignInFlow();
-      }
-    } catch (e) {
-      err.textContent = __anT('failedToConnect');
-      err.classList.add('show');
-      btn.disabled = false;
-      __anGoogleSignInInFlight = false;
-      __anClearGoogleSignInFlow();
-    }
-  }`
-    : ""
-}
-${starfieldScript}
-${
-  signupLocalModeNote
-    ? `
-  function __anCopyCommandFromPanel(panelId, buttonId) {
-    var panel = document.getElementById(panelId);
-    var button = document.getElementById(buttonId);
-    if (!panel || !button) return;
-    var command = panel.getAttribute('data-command') || '';
-    var original = button.textContent || __anT('copyCommand');
-    function markCopied() {
-      button.textContent = __anT('copied');
-      setTimeout(function() { button.textContent = original; }, 1600);
-    }
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(command).then(markCopied).catch(function() {});
-    }
-  }
-  function __anCopySignupLocalModeCommand() {
-    __anCopyCommandFromPanel('signup-local-mode-note', 'copy-signup-local-mode');
-  }
-  var copySignupLocalModeButton = document.getElementById('copy-signup-local-mode');
-  if (copySignupLocalModeButton) {
-    copySignupLocalModeButton.addEventListener('click', __anCopySignupLocalModeCommand);
-  }
-  `
-    : ""
-}
-  if (__anAuthView === 'signup' || __anAuthView === 'magicLink' || __anAuthView === 'googleOnly') {
-    __anTrackAuth('auth.signup_viewed', {
-      surface: 'signup',
-      auth_mode: __AN_AUTH_MODE,
-      auth_view: __anAuthView
-    });
-  }
-</script>
-</body>
-</html>`;
+        createElement("meta", {
+          name: "viewport",
+          content:
+            "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no",
+        }),
+        createElement("title", null, title),
+        createElement("link", {
+          rel: "icon",
+          type: "image/svg+xml",
+          href: withAppBasePath("/favicon.svg"),
+        }),
+        createElement("link", {
+          rel: "apple-touch-icon",
+          href: withAppBasePath("/icon-180.svg"),
+        }),
+        hasMarketing
+          ? [
+              createElement("meta", {
+                key: "description",
+                name: "description",
+                content: marketing!.tagline,
+              }),
+              createElement("meta", {
+                key: "og-title",
+                property: "og:title",
+                content: marketing!.appName,
+              }),
+              createElement("meta", {
+                key: "og-description",
+                property: "og:description",
+                content: marketing!.tagline,
+              }),
+              createElement("meta", {
+                key: "og-image",
+                property: "og:image",
+                content: socialImageUrl,
+              }),
+              createElement("meta", {
+                key: "og-image-secure",
+                property: "og:image:secure_url",
+                content: socialImageUrl,
+              }),
+              createElement("meta", {
+                key: "og-image-type",
+                property: "og:image:type",
+                content: AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
+              }),
+              createElement("meta", {
+                key: "og-image-width",
+                property: "og:image:width",
+                content: AGENT_NATIVE_SOCIAL_IMAGE_WIDTH,
+              }),
+              createElement("meta", {
+                key: "og-image-height",
+                property: "og:image:height",
+                content: AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
+              }),
+              createElement("meta", {
+                key: "og-image-alt",
+                property: "og:image:alt",
+                content: AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+              }),
+              createElement("meta", {
+                key: "twitter-card",
+                name: "twitter:card",
+                content: "summary_large_image",
+              }),
+              createElement("meta", {
+                key: "twitter-image",
+                name: "twitter:image",
+                content: socialImageUrl,
+              }),
+              createElement("meta", {
+                key: "twitter-image-alt",
+                name: "twitter:image:alt",
+                content: AGENT_NATIVE_SOCIAL_IMAGE_ALT,
+              }),
+            ]
+          : null,
+        createElement("style", {
+          dangerouslySetInnerHTML: {
+            __html: authDocumentStyles + authPageLayoutStyles,
+          },
+        }),
+        createElement("script", {
+          type: "module",
+          src: authClientScriptPath,
+        }),
+      ),
+      createElement(
+        "body",
+        {
+          className: simplifiedAuth
+            ? "simplified-auth"
+            : hasMarketing
+              ? "has-marketing"
+              : undefined,
+        },
+        createElement(
+          "div",
+          { id: "agent-native-auth-root", className: "auth-root" },
+          createElement(AuthPage, authPageProps),
+        ),
+        createElement("script", {
+          type: "application/json",
+          id: "agent-native-auth-data",
+          dangerouslySetInnerHTML: { __html: authPageData },
+        }),
+      ),
+    ),
+  );
+  return `<!DOCTYPE html>${authDocumentMarkup}`;
 }
 
 /** @deprecated Use getOnboardingHtml() instead */
 export const ONBOARDING_HTML = getOnboardingHtml();
 
-/**
- * HTML for the password reset page — shown when the user clicks the link in
- * their reset email. Posts `{ newPassword, token }` to Better Auth's
- * `/reset-password` endpoint, then redirects to the login page.
- */
-export function getResetPasswordHtml(): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Reset password</title>
-<link rel="icon" type="image/svg+xml" href="${withAppBasePath("/favicon.svg")}">
-<link rel="apple-touch-icon" href="${withAppBasePath("/icon-180.svg")}">
-<style>
+const RESET_PASSWORD_STYLES = `
+  /* guard:allow-raw-color - standalone reset page has no app theme token layer */
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0a0a0a; color: #e5e5e5; display: flex; align-items: center; justify-content: center; min-height: 100vh; padding: 1rem; }
   .card { width: 100%; max-width: 400px; padding: 2rem; background: #141414; border: 1px solid rgba(255,255,255,0.08); border-radius: 12px; }
@@ -4552,113 +2233,65 @@ export function getResetPasswordHtml(): string {
   .msg.show { display: block; }
   .back { display: inline-block; margin-top: 1rem; font-size: 0.75rem; color: #888; text-decoration: none; }
   .back:hover { color: #bbb; }
-</style>
-</head>
-<body>
-<div class="card">
-  <h1>Choose a new password</h1>
-  <p class="subtitle">Set a new password for your account.</p>
-  <form id="reset-form">
-    <label for="p1">New password</label>
-    <input id="p1" type="password" autocomplete="new-password" placeholder="At least ${PASSWORD_MIN_LENGTH} characters" required minlength="${PASSWORD_MIN_LENGTH}" maxlength="${PASSWORD_MAX_LENGTH}" />
-    <label for="p2">Confirm password</label>
-    <input id="p2" type="password" autocomplete="new-password" placeholder="Confirm password" required minlength="${PASSWORD_MIN_LENGTH}" maxlength="${PASSWORD_MAX_LENGTH}" />
-    <button type="submit">Save new password</button>
-    <p class="msg" id="msg"></p>
-  </form>
-  <a class="back" id="back-link" href="/">Back to sign in</a>
-</div>
-<script>
-  (function() {
-    // Derive the app's base path so apps mounted under a prefix
-    // (e.g. /mail, /calendar) get sent home instead of to the root domain.
-    var RESET_PATH = '/_agent-native/auth/reset';
-    var pathname = window.location.pathname;
-    var idx = pathname.indexOf(RESET_PATH);
-    var basePath = (idx >= 0 ? pathname.slice(0, idx) : '') || '';
-    var homeHref = basePath + '/';
-    var backLink = document.getElementById('back-link');
-    if (backLink) backLink.setAttribute('href', homeHref);
-    var params = new URLSearchParams(location.search);
-    var token = params.get('token') || '';
-    var msg = document.getElementById('msg');
-    var resetForm = document.getElementById('reset-form');
-    function resetErrorText(data, fallback) {
-      var candidate = data && (data.error || data.message);
-      if (typeof candidate !== 'string' || !candidate.trim()) return fallback;
-      var message = candidate.trim();
-      if (/failed query|\bselect\b.*\bfrom\b|\binsert\b.*\binto\b|\bupdate\b.*\bset\b|\bdelete\b.*\bfrom\b|\bsql\b|database|relation .* does not exist|column .* does not exist|syntax error|constraint|connection refused|econn|timeout/i.test(message)) {
-        return fallback;
-      }
-      if (/password.*(?:at least|minimum|min(?:imum)?|too short)/i.test(message)) {
-        return 'Choose a password with at least ${PASSWORD_MIN_LENGTH} characters.';
-      }
-      if (/password.*(?:at most|maximum|max(?:imum)?|too long)/i.test(message)) {
-        return 'Choose a password with no more than ${PASSWORD_MAX_LENGTH} characters.';
-      }
-      return message;
-    }
-    function bindPasswordValidation(input) {
-      if (!input) return;
-      input.addEventListener('invalid', function() {
-        if (input.validity && input.validity.tooShort) {
-          input.setCustomValidity('Choose a password with at least ${PASSWORD_MIN_LENGTH} characters.');
-        } else if (input.validity && input.validity.tooLong) {
-          input.setCustomValidity('Choose a password with no more than ${PASSWORD_MAX_LENGTH} characters.');
-        }
-      });
-      input.addEventListener('input', function() {
-        input.setCustomValidity('');
-      });
-    }
-    bindPasswordValidation(document.getElementById('p1'));
-    bindPasswordValidation(document.getElementById('p2'));
-    if (!token) {
-      msg.textContent = 'This password reset link is missing or invalid. Request a new one.';
-      msg.classList.add('show', 'error');
-      resetForm.style.display = 'none';
-      return;
-    }
-    resetForm.addEventListener('submit', async function(e) {
-      e.preventDefault();
-      var btn = e.currentTarget.querySelector('button[type="submit"]');
-      var p1 = document.getElementById('p1').value;
-      var p2 = document.getElementById('p2').value;
-      msg.classList.remove('show', 'error', 'success');
-      if (p1 !== p2) {
-        msg.textContent = 'Passwords do not match.';
-        msg.classList.add('show', 'error');
-        return;
-      }
-      var original = btn.textContent;
-      btn.disabled = true;
-      btn.textContent = 'Saving…';
-      try {
-        var res = await fetch(basePath + '/_agent-native/auth/ba/reset-password', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ newPassword: p1, token: token }),
-        });
-        if (res.ok) {
-          msg.textContent = 'Password updated — redirecting to sign in…';
-          msg.classList.add('show', 'success');
-          setTimeout(function() { window.location.href = homeHref; }, 1200);
-          return;
-        }
-        var data = await res.json().catch(function() { return {}; });
-        msg.textContent = resetErrorText(data, "We couldn't update your password. The link may have expired; request a new one.");
-        msg.classList.add('show', 'error');
-        btn.disabled = false;
-        btn.textContent = original;
-      } catch (err) {
-        msg.textContent = "We couldn't reach the server. Check your connection and try again.";
-        msg.classList.add('show', 'error');
-        btn.disabled = false;
-        btn.textContent = original;
-      }
-    });
-  })();
-</script>
-</body>
-</html>`;
+`;
+
+/** React document for the password reset page linked from auth email. */
+export function getResetPasswordHtml(): string {
+  const appBasePath = getAppBasePathFromViteEnv();
+  const resetPageProps = {
+    pageType: "reset-password" as const,
+    appBasePath,
+    passwordMinLength: PASSWORD_MIN_LENGTH,
+    passwordMaxLength: PASSWORD_MAX_LENGTH,
+  };
+  const resetDocumentMarkup = renderToString(
+    createElement(
+      "html",
+      { lang: "en", dir: "ltr" },
+      createElement(
+        "head",
+        null,
+        createElement("meta", { charSet: "UTF-8" }),
+        createElement("meta", {
+          name: "viewport",
+          content:
+            "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no",
+        }),
+        createElement("title", null, "Reset password"),
+        createElement("link", {
+          rel: "icon",
+          type: "image/svg+xml",
+          href: withAppBasePath("/favicon.svg"),
+        }),
+        createElement("link", {
+          rel: "apple-touch-icon",
+          href: withAppBasePath("/icon-180.svg"),
+        }),
+        createElement("style", {
+          dangerouslySetInnerHTML: { __html: RESET_PASSWORD_STYLES },
+        }),
+        createElement("script", {
+          type: "module",
+          src: `${appBasePath}/assets/auth-client.js`,
+        }),
+      ),
+      createElement(
+        "body",
+        null,
+        createElement(
+          "div",
+          { id: "agent-native-auth-root" },
+          createElement(ResetPasswordPage, resetPageProps),
+        ),
+        createElement("script", {
+          type: "application/json",
+          id: "agent-native-auth-data",
+          dangerouslySetInnerHTML: {
+            __html: serializeAuthPageData(resetPageProps),
+          },
+        }),
+      ),
+    ),
+  );
+  return `<!DOCTYPE html>${resetDocumentMarkup}`;
 }

--- a/packages/core/src/server/sign-in-matrix.spec.ts
+++ b/packages/core/src/server/sign-in-matrix.spec.ts
@@ -413,10 +413,12 @@ describe("sign-in matrix", () => {
     });
 
     it("surface 5/6: desktop detection does not change where the visitor lands", () => {
-      expect(isElectron("Mozilla/5.0 Electron/32.0 BuilderDesktop")).toBe(true);
+      const genericElectron = "Mozilla/5.0 Electron/32.0 BuilderDesktop";
+      expect(isElectron(genericElectron)).toBe(true);
+      expect(isAgentNativeDesktop(genericElectron)).toBe(false);
       expect(
         isAgentNativeDesktop(
-          "Mozilla/5.0 Electron/32.0 AgentNativeDesktop/1.2",
+          "Mozilla/5.0 Electron/32.0 agentnativedesktop/1.2",
         ),
       ).toBe(true);
       // Both desktop surfaces complete sign-in outside the web cookie jar, but

--- a/packages/core/src/server/sign-in-matrix.spec.ts
+++ b/packages/core/src/server/sign-in-matrix.spec.ts
@@ -18,16 +18,14 @@
  *   D. a forged continuation cannot nest, cannot leave the origin, and cannot
  *      escape the base path into a sibling app on the same host.
  *
- * Every row is ALSO evaluated against the runtime extracted from the real
- * rendered login document, and the two answers must be identical. That
- * equality check is the drift detector: the original bug was a second login
- * document whose completion disagreed with the module, and no test compared
- * them.
+ * The React auth document loads one client bundle that imports the same
+ * journey module. The document checks below ensure the shipped shell carries
+ * that bundle and serialized props instead of embedding a second runtime.
  *
  * Browser-driven coverage (real dev server, real form, real hydration) for the
  * root deploy, the `/chatapp` base-path deploy, and a genuinely cross-origin
  * iframe lives in `scripts/qa-sign-in-matrix-smoke.ts` (`pnpm qa:sign-in`).
- * The surfaces here that a headless browser cannot reproduce — a separate
+ * The surfaces here that a headless browser cannot reproduce - a separate
  * Electron cookie jar, a custom-scheme deep link, an opaque-origin MCP frame —
  * are asserted against the shipped code rather than mimed.
  */
@@ -36,6 +34,11 @@ import path from "node:path";
 
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  isAgentNativeDesktop,
+  isElectron,
+  normalizeOAuthReturnPath,
+} from "../client/auth/AuthPage.js";
 import {
   decodeContinuation,
   encodeContinuation,
@@ -61,42 +64,23 @@ interface JourneyRuntime {
 }
 
 /**
- * The journey runtime as the browser really receives it: sliced out of the
- * rendered login document, not imported from the module under test.
+ * The React auth document's client bundle imports the shared journey module;
+ * assert the document carries that bundle and exercise the shared runtime.
  */
 function documentRuntime(
   basePath: string,
   opts: Parameters<typeof getOnboardingHtml>[0] = {},
 ): JourneyRuntime {
   const html = getOnboardingHtml(opts);
-  const start = html.indexOf("var __anCreateSignInJourney =");
-  const end = html.indexOf("var __anJourney = __anCreateSignInJourney");
-  expect(start).toBeGreaterThan(-1);
-  expect(end).toBeGreaterThan(start);
-  return new Function(
-    `${html.slice(start, end)} return __anCreateSignInJourney(${JSON.stringify(basePath)});`,
-  )() as JourneyRuntime;
-}
-
-/** Slice one named `function name(...) {...}` out of the rendered document. */
-function documentFunction<T>(name: string, extra = ""): T {
-  const html = getOnboardingHtml();
-  const start = html.indexOf(`function ${name}(`);
-  expect(start, `${name} must exist in the login document`).toBeGreaterThan(-1);
-  let depth = 0;
-  let i = html.indexOf("{", start);
-  const open = i;
-  for (; i < html.length; i++) {
-    if (html[i] === "{") depth++;
-    else if (html[i] === "}") {
-      depth--;
-      if (depth === 0) break;
-    }
-  }
-  expect(i, `${name} must have a balanced body`).toBeLessThan(html.length);
-  const source = html.slice(start, i + 1);
-  expect(open).toBeGreaterThan(start);
-  return new Function(`${extra}\n${source}\nreturn ${name};`)() as T;
+  expect(html).toContain('id="agent-native-auth-root"');
+  expect(html).toContain('id="agent-native-auth-data"');
+  expect(html).toContain("assets/auth-client.js");
+  return {
+    normalizeAppPath: (raw) => normalizeAppPath(raw, basePath),
+    encodeContinuation: (p) => encodeContinuation(p, basePath),
+    decodeContinuation: (t) => decodeContinuation(t, basePath),
+    signInJourney: (input) => signInJourney({ ...input, basePath }),
+  };
 }
 
 interface Surface {
@@ -378,7 +362,7 @@ describe("sign-in matrix", () => {
       },
     );
 
-    it("the login document and the module agree on every case", () => {
+    it("the React auth document is wired to the shared journey contract", () => {
       const [, moduleJourney] = runtimes[0];
       const cases = [
         protectedPath,
@@ -402,42 +386,39 @@ describe("sign-in matrix", () => {
 
   describe("surface-specific completion", () => {
     it("surface 3/5: the _session bridge keeps the route it was given", () => {
-      const bridge = documentFunction<(ret: string, token: string) => string>(
-        "__anSessionBridgeUrl",
-        "var window = { location: { origin: 'https://app.example', pathname: '/', search: '' } };",
+      const returned = appendSessionToOAuthReturnUrl(
+        "http://127.0.0.1:8080/decks/42?edit=1#slide-3",
+        "tok",
       );
-      expect(bridge("/decks/42?edit=1#slide-3", "tok")).toBe(
-        "/decks/42?edit=1&_session=tok#slide-3",
-      );
+      const parsed = new URL(returned);
+      expect(parsed.origin).toBe("http://127.0.0.1:8080");
+      expect(parsed.pathname).toBe("/decks/42");
+      expect(parsed.searchParams.get("edit")).toBe("1");
+      expect(parsed.searchParams.get("_session")).toBe("tok");
+      expect(parsed.hash).toBe("#slide-3");
     });
 
     it("surface 4: workspace return normalization never yields an auth entry path", () => {
-      const normalizeWorkspace = documentFunction<(ret: string) => string>(
-        "__anNormalizeWorkspaceReturnPath",
-        "var window = { location: { origin: 'https://preview.example' } };",
-      );
       // The hardcoded Dispatch route table is workspace routing, not return
       // validation — it must leave real app routes alone…
-      expect(normalizeWorkspace("/dispatch/apps")).toBe("/dispatch/apps");
-      expect(normalizeWorkspace("/dispatch/dispatch")).toBe("/dispatch");
-      expect(normalizeWorkspace("/dispatch/mail/inbox")).toBe("/mail/inbox");
+      expect(normalizeOAuthReturnPath("/dispatch/apps")).toBe("/dispatch/apps");
+      expect(normalizeOAuthReturnPath("/dispatch/dispatch")).toBe("/dispatch");
+      expect(normalizeOAuthReturnPath("/dispatch/mail/inbox")).toBe(
+        "/mail/inbox",
+      );
       // …and whatever it produces must still be a legal resume target.
       for (const ret of ["/dispatch/apps", "/dispatch/mail/inbox", "/x?y=1"]) {
-        expect(normalizeAppPath(normalizeWorkspace(ret))).not.toBeNull();
+        expect(normalizeAppPath(normalizeOAuthReturnPath(ret))).not.toBeNull();
       }
     });
 
     it("surface 5/6: desktop detection does not change where the visitor lands", () => {
-      const isBuilderDesktop = documentFunction<() => boolean>(
-        "__anIsBuilderDesktop",
-        "var navigator = { userAgent: 'Mozilla/5.0 Electron/32.0 BuilderDesktop' };",
-      );
-      const isAgentNativeDesktop = documentFunction<() => boolean>(
-        "__anIsAgentNativeDesktop",
-        "var navigator = { userAgent: 'Mozilla/5.0 Electron/32.0 AgentNativeDesktop/1.2' };",
-      );
-      expect(isBuilderDesktop()).toBe(true);
-      expect(isAgentNativeDesktop()).toBe(true);
+      expect(isElectron("Mozilla/5.0 Electron/32.0 BuilderDesktop")).toBe(true);
+      expect(
+        isAgentNativeDesktop(
+          "Mozilla/5.0 Electron/32.0 AgentNativeDesktop/1.2",
+        ),
+      ).toBe(true);
       // Both desktop surfaces complete sign-in outside the web cookie jar, but
       // the continuation they carry is the same one every other surface uses.
       // Agent-Native Desktop reloads in place, so its resume is the route it
@@ -553,33 +534,30 @@ describe("sign-in matrix", () => {
 
   describe("base path reaches the login document", () => {
     it("bakes the configured base path in, rather than sniffing it", () => {
-      // `__anBasePath()`'s marker fallback only fires for URLs containing
-      // `/_agent-native`, so on `/myapp/login` it returns "". The configured
-      // value is therefore the only thing that makes surface 2 work, and a
-      // change that stops baking it reopens the infinite bounce.
+      // The configured value is needed for a mounted auth document's asset
+      // URLs; the client still derives the request path after hydration.
       vi.stubEnv("APP_BASE_PATH", "/myapp");
       try {
         const html = getOnboardingHtml();
-        expect(html).toContain('var configured = "/myapp";');
-        expect(html).toContain(
-          "var __anJourney = __anCreateSignInJourney(__anBasePath());",
-        );
+        expect(html).toContain('src="/myapp/assets/auth-client.js"');
       } finally {
         vi.unstubAllEnvs();
       }
-      expect(getOnboardingHtml()).toContain('var configured = "";');
+      expect(getOnboardingHtml()).toContain('src="/assets/auth-client.js"');
     });
   });
 
   describe("one login document, one validator", () => {
     it("the Google-only document is the same maintained document", () => {
       const googleOnly = getOnboardingHtml({ googleOnly: true });
-      expect(googleOnly).toContain("var __anCreateSignInJourney =");
-      expect(googleOnly).toContain(
-        "var __anJourney = __anCreateSignInJourney(__anBasePath());",
+      expect(googleOnly).toContain('id="agent-native-auth-root"');
+      expect(googleOnly).toContain('id="agent-native-auth-data"');
+      expect(googleOnly).toContain("assets/auth-client.js");
+      const data = googleOnly.match(
+        /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
       );
-      // The deleted second login page completed with
-      // `window.location.href = ret || '/'` where `ret` was the sign-in page.
+      expect(data).toBeTruthy();
+      expect(JSON.parse(data?.[1] ?? "{}").googleOnly).toBe(true);
       expect(googleOnly).not.toContain("window.location.href = ret");
     });
 

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -3500,6 +3500,73 @@ function nitroPresetMarkerPlugin(
   };
 }
 
+const AUTH_CLIENT_ASSET_PATH = "assets/auth-client.js";
+
+function authClientEntryPath(): string {
+  const sourceEntry = path.resolve(__dirname, "../client/auth/entry.tsx");
+  return fs.existsSync(sourceEntry)
+    ? sourceEntry
+    : path.resolve(__dirname, "../client/auth/entry.js");
+}
+
+function authClientAssetPlugin(): Plugin {
+  const entry = authClientEntryPath();
+  let isBuild = false;
+  let hasReactRouterHmr = false;
+  return {
+    name: "agent-native-auth-client-asset",
+    applyToEnvironment(environment) {
+      return environment.name === "client";
+    },
+    configResolved(config) {
+      isBuild = config.command === "build";
+      hasReactRouterHmr = config.plugins.some((plugin) =>
+        plugin.name?.startsWith("react-router"),
+      );
+    },
+    buildStart() {
+      if (!isBuild) return;
+      this.emitFile({
+        type: "chunk",
+        id: entry,
+        fileName: AUTH_CLIENT_ASSET_PATH,
+      });
+    },
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = new URL(req.url ?? "/", "http://agent-native.local")
+          .pathname;
+        if (
+          req.method !== "GET" ||
+          !pathname.endsWith(`/${AUTH_CLIENT_ASSET_PATH}`)
+        ) {
+          next();
+          return;
+        }
+
+        void server
+          .transformRequest(entry)
+          .then((result) => {
+            if (!result?.code) {
+              res.statusCode = 500;
+              res.end("Unable to transform the auth client asset.");
+              return;
+            }
+            const authClientCode = hasReactRouterHmr
+              ? `import ${JSON.stringify(
+                  `${server.config.base.replace(/\/+$/, "")}/@id/__x00__virtual:react-router/inject-hmr-runtime`,
+                )};\n${result.code}`
+              : result.code;
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "application/javascript");
+            res.end(authClientCode);
+          })
+          .catch(next);
+      });
+    },
+  };
+}
+
 function createAgentNativePlugins(
   options: ClientConfigOptions | AgentNativeVitePluginOptions,
   {
@@ -3530,6 +3597,7 @@ function createAgentNativePlugins(
     appChangelogRawPlugin(),
     actionTypesPlugin(),
     agentsBundlePlugin({ agentNativeConfig: options.agentNativeConfig }),
+    authClientAssetPlugin(),
     autoReloadOnOptimizeDep(),
     fullReloadOnOptimizeDep504(),
     embedDevFrameHeaders(),

--- a/packages/toolkit/src/marketing/MarketingHome.spec.tsx
+++ b/packages/toolkit/src/marketing/MarketingHome.spec.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import { MarketingHome } from "./MarketingHome.js";
+import { Starfield } from "./Starfield.js";
 
 describe("MarketingHome", () => {
   it("renders the default marketing shell and action links on the server", () => {
@@ -23,6 +24,9 @@ describe("MarketingHome", () => {
     expect(html).toContain('href="/sign-in"');
     expect(html).toContain("Sign in");
     expect(html).toContain("Reusable");
+    expect(html).toContain("max-w-7xl");
+    expect(html).toContain("py-16");
+    expect(html).not.toContain("max-w-6xl");
   });
 
   it("allows a route to replace the hero while retaining the public shell", () => {
@@ -35,5 +39,32 @@ describe("MarketingHome", () => {
     expect(html).toContain("Custom hero");
     expect(html).not.toContain("Example</p>");
     expect(html).toContain("<canvas");
+  });
+
+  it("provides an opt-in auth composition without changing the default shell", () => {
+    const html = renderToStaticMarkup(
+      <MarketingHome
+        appName="Example"
+        variant="auth"
+        background={<Starfield id="auth-starfield" />}
+        auth={<div>Sign in form</div>}
+      >
+        <div>Marketing copy</div>
+      </MarketingHome>,
+    );
+
+    expect(html).toContain("Marketing copy");
+    expect(html).toContain("Sign in form");
+    expect(html).toContain('id="auth-starfield"');
+    expect(html).toContain("max-w-6xl");
+    expect(html).toContain("max-w-md");
+  });
+
+  it("renders the starfield canvas without browser APIs during SSR", () => {
+    const html = renderToStaticMarkup(<Starfield />);
+
+    expect(html).toContain('<canvas id="starfield"');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('data-agent-native-starfield="true"');
   });
 });

--- a/packages/toolkit/src/marketing/MarketingHome.tsx
+++ b/packages/toolkit/src/marketing/MarketingHome.tsx
@@ -11,6 +11,8 @@ export interface MarketingValueProp {
 export interface MarketingHomeProps {
   /** Product or app name shown in the public shell. */
   appName: React.ReactNode;
+  /** Choose the standard public shell or the split auth composition. */
+  variant?: "default" | "auth";
   /** Main value proposition. */
   tagline?: React.ReactNode;
   /** Supporting product description. */
@@ -36,6 +38,7 @@ export interface MarketingHomeProps {
 
 export function MarketingHome({
   appName,
+  variant = "default",
   tagline,
   description,
   valueProps = [],
@@ -50,6 +53,7 @@ export function MarketingHome({
   primaryActionLabel,
   secondaryActionLabel,
 }: MarketingHomeProps) {
+  const isAuthVariant = variant === "auth";
   const resolvedPrimaryAction =
     primaryAction ??
     (primaryActionHref ? (
@@ -131,15 +135,36 @@ export function MarketingHome({
           {background}
         </div>
       ) : null}
-      <div className="mx-auto flex min-h-screen w-full max-w-7xl items-center px-6 py-16 sm:px-10 lg:px-16">
+      <div
+        className={cn(
+          isAuthVariant
+            ? "auth-marketing-shell mx-auto flex min-h-screen w-full items-center px-6 py-10 sm:px-10 lg:px-16"
+            : "mx-auto flex min-h-screen w-full max-w-7xl items-center px-6 py-16 sm:px-10 lg:px-16",
+        )}
+      >
         <div
           className={cn(
-            "grid w-full items-center gap-12",
+            isAuthVariant && auth ? "split" : "grid w-full items-center gap-12",
             auth ? "lg:grid-cols-[minmax(0,1fr)_minmax(20rem,28rem)]" : "",
+            isAuthVariant && auth ? "max-w-6xl" : "",
           )}
         >
-          <section>{content}</section>
-          {auth ? <aside>{auth}</aside> : null}
+          <section
+            className={isAuthVariant && auth ? "marketing-panel" : undefined}
+          >
+            {content}
+          </section>
+          {auth ? (
+            <aside
+              className={cn(
+                isAuthVariant
+                  ? "form-panel w-full max-w-md justify-self-end"
+                  : "",
+              )}
+            >
+              {auth}
+            </aside>
+          ) : null}
         </div>
       </div>
     </main>

--- a/packages/toolkit/src/marketing/Starfield.tsx
+++ b/packages/toolkit/src/marketing/Starfield.tsx
@@ -1,0 +1,292 @@
+import * as React from "react";
+
+import { cn } from "../utils.js";
+
+const VERTEX_SHADER_SOURCE =
+  "attribute vec2 position;void main(){gl_Position=vec4(position,0.0,1.0);}";
+
+const FRAGMENT_SHADER_SOURCE = [
+  "precision highp float;",
+  "uniform float iTime;uniform vec2 iResolution;uniform vec3 uPointer;",
+  "#define S(a,b,t) smoothstep(a,b,t)",
+  "#define NUM_LAYERS 4.",
+  "float N21(vec2 p){vec3 a=fract(vec3(p.xyx)*vec3(213.897,653.453,253.098));a+=dot(a,a.yzx+79.76);return fract((a.x+a.y)*a.z);}",
+  "vec2 GetPos(vec2 id,vec2 offs,float t){float n=N21(id+offs);float n1=fract(n*10.);float n2=fract(n*100.);float a=t+n;return offs+vec2(sin(a*n1),cos(a*n2))*.4;}",
+  "vec2 Attract(vec2 p,vec2 cursor,float strength){vec2 delta=cursor-p;float d=length(delta);float pull=1.-smoothstep(.08,1.9,d);pull=pull*pull*(3.-2.*pull);return p+delta*pull*.095*strength;}",
+  "float df_line(vec2 a,vec2 b,vec2 p){vec2 pa=p-a,ba=b-a;float h=clamp(dot(pa,ba)/dot(ba,ba),0.,1.);return length(pa-ba*h);}",
+  "float line(vec2 a,vec2 b,vec2 uv){float r1=.025;float r2=.006;float d=df_line(a,b,uv);float d2=length(a-b);float fade=S(1.5,.5,d2);fade+=S(.05,.02,abs(d2-.75));return S(r1,r2,d)*fade;}",
+  "float NetLayer(vec2 st,float n,float t,vec2 pointer,float pointerStrength){",
+  "  vec2 cell=floor(st);vec2 id=cell+n;vec2 cursor=pointer-cell;st=fract(st)-.5;",
+  "  vec2 p0=Attract(GetPos(id,vec2(-1,-1),t),cursor,pointerStrength);vec2 p1=Attract(GetPos(id,vec2(0,-1),t),cursor,pointerStrength);vec2 p2=Attract(GetPos(id,vec2(1,-1),t),cursor,pointerStrength);",
+  "  vec2 p3=Attract(GetPos(id,vec2(-1,0),t),cursor,pointerStrength);vec2 p4=Attract(GetPos(id,vec2(0,0),t),cursor,pointerStrength);vec2 p5=Attract(GetPos(id,vec2(1,0),t),cursor,pointerStrength);",
+  "  vec2 p6=Attract(GetPos(id,vec2(-1,1),t),cursor,pointerStrength);vec2 p7=Attract(GetPos(id,vec2(0,1),t),cursor,pointerStrength);vec2 p8=Attract(GetPos(id,vec2(1,1),t),cursor,pointerStrength);",
+  "  float m=0.;float sparkle=0.;float d;float s;float pulse;",
+  "  m+=line(p4,p0,st);d=length(st-p0);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p0.x)+fract(p0.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p1,st);d=length(st-p1);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p1.x)+fract(p1.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p2,st);d=length(st-p2);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p2.x)+fract(p2.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p3,st);d=length(st-p3);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p3.x)+fract(p3.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p4,st);d=length(st-p4);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p4.x)+fract(p4.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p5,st);d=length(st-p5);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p5.x)+fract(p5.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p6,st);d=length(st-p6);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p6.x)+fract(p6.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p7,st);d=length(st-p7);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p7.x)+fract(p7.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p4,p8,st);d=length(st-p8);s=(.005/(d*d));s*=S(1.,.7,d);pulse=sin((fract(p8.x)+fract(p8.y)+t)*5.)*.4+.6;pulse=pow(pulse,20.);sparkle+=s*pulse;",
+  "  m+=line(p1,p3,st);m+=line(p1,p5,st);m+=line(p7,p5,st);m+=line(p7,p3,st);",
+  "  float sPhase=(sin(t+n)+sin(t*.1))*.25+.5;sPhase+=pow(sin(t*.1)*.5+.5,50.)*5.;m+=sparkle*sPhase;",
+  "  return m;",
+  "}",
+  "void mainImage(out vec4 fragColor,in vec2 fragCoord){",
+  "  vec2 uv=(fragCoord-iResolution.xy*.5)/iResolution.y;",
+  "  float t=iTime*.03;float s=sin(t);float c=cos(t);mat2 rot=mat2(c,-s,s,c);vec2 st=uv*rot;vec2 pointerUv=(uPointer.xy-iResolution.xy*.5)/iResolution.y;",
+  "  float m=0.;",
+  "  for(float i=0.;i<1.;i+=1./NUM_LAYERS){float z=fract(t+i);float size=mix(15.,1.,z);float fade=S(0.,.6,z)*S(1.,.8,z);vec2 pointerSt=pointerUv*rot*size;vec2 layerSt=st*size;float warp=1.-smoothstep(.15,2.7,length(layerSt-pointerSt));warp=warp*warp*(3.-2.*warp)*uPointer.z;layerSt-=(pointerSt-layerSt)*warp*.035;m+=fade*NetLayer(layerSt,i,iTime*0.3,pointerSt,uPointer.z);}",
+  "  float cursorLift=1.-smoothstep(.04,.48,length(uv-pointerUv));cursorLift=cursorLift*cursorLift*(3.-2.*cursorLift)*uPointer.z;m*=1.+cursorLift*1.6;",
+  "  vec3 col=vec3(0.35)*m;col*=1.-dot(uv,uv);",
+  "  float tt=min(iTime,5.0);col*=S(0.,20.,tt);",
+  "  col=clamp(col,0.,1.);fragColor=vec4(col,1.);",
+  "}",
+  "void main(){mainImage(gl_FragColor,gl_FragCoord.xy);}",
+].join("\n");
+
+function createShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string,
+): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) return null;
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+  return shader;
+}
+
+function initializeStarfield(canvas: HTMLCanvasElement): () => void {
+  let gl: WebGLRenderingContext | null = null;
+  try {
+    gl = canvas.getContext("webgl", { alpha: false, antialias: false });
+  } catch {
+    return () => undefined;
+  }
+  if (!gl) return () => undefined;
+
+  const vertexShader = createShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE);
+  if (!vertexShader) return () => undefined;
+
+  const fragmentShader = createShader(
+    gl,
+    gl.FRAGMENT_SHADER,
+    FRAGMENT_SHADER_SOURCE,
+  );
+  if (!fragmentShader) {
+    gl.deleteShader(vertexShader);
+    return () => undefined;
+  }
+
+  const program = gl.createProgram();
+  if (!program) {
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    return () => undefined;
+  }
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    return () => undefined;
+  }
+
+  const buffer = gl.createBuffer();
+  const position = gl.getAttribLocation(program, "position");
+  if (!buffer || position < 0) {
+    gl.deleteBuffer(buffer);
+    gl.deleteProgram(program);
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    return () => undefined;
+  }
+
+  gl.useProgram(program);
+  gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, -1, 1, 1, -1, 1, 1]),
+    gl.STATIC_DRAW,
+  );
+  gl.enableVertexAttribArray(position);
+  gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+  const timeUniform = gl.getUniformLocation(program, "iTime");
+  const resolutionUniform = gl.getUniformLocation(program, "iResolution");
+  const pointerUniform = gl.getUniformLocation(program, "uPointer");
+  const reducedMotionQuery = window.matchMedia?.(
+    "(prefers-reduced-motion: reduce)",
+  );
+  const listenerOptions: AddEventListenerOptions = { passive: true };
+  let reducedMotion = reducedMotionQuery?.matches ?? false;
+  let pointerDpr = 1;
+  let hasPointer = false;
+  let pointerX = 0;
+  let pointerY = 0;
+  let pointerStrength = 0;
+  let targetX = 0;
+  let targetY = 0;
+  let targetStrength = 0;
+  let animationFrame = 0;
+
+  const resize = () => {
+    const rect = canvas.getBoundingClientRect();
+    const width = Math.max(1, rect.width || window.innerWidth);
+    const height = Math.max(1, rect.height || window.innerHeight);
+    pointerDpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    canvas.width = Math.floor(width * pointerDpr);
+    canvas.height = Math.floor(height * pointerDpr);
+    gl?.viewport(0, 0, canvas.width, canvas.height);
+    if (!hasPointer) {
+      pointerX = targetX = canvas.width * 0.5;
+      pointerY = targetY = canvas.height * 0.5;
+    }
+  };
+
+  const onPointerMove = (event: Event) => {
+    const mouseEvent = event as MouseEvent;
+    const rect = canvas.getBoundingClientRect();
+    const x = mouseEvent.clientX - rect.left;
+    const y = mouseEvent.clientY - rect.top;
+    hasPointer = true;
+    targetX = x * pointerDpr;
+    targetY = (rect.height - y) * pointerDpr;
+    targetStrength =
+      x >= 0 && x <= rect.width && y >= 0 && y <= rect.height ? 1 : 0;
+  };
+  const fadePointer = () => {
+    targetStrength = 0;
+  };
+  const easePointer = (allowPointer: boolean) => {
+    if (!allowPointer) {
+      pointerStrength = 0;
+      return;
+    }
+    pointerX += (targetX - pointerX) * 0.22;
+    pointerY += (targetY - pointerY) * 0.22;
+    pointerStrength += (targetStrength - pointerStrength) * 0.14;
+    if (pointerStrength < 0.001 && targetStrength === 0) pointerStrength = 0;
+  };
+  const draw = (timeSeconds: number, allowPointer: boolean) => {
+    easePointer(allowPointer && !reducedMotion);
+    gl?.uniform1f(timeUniform, timeSeconds);
+    gl?.uniform2f(resolutionUniform, canvas.width, canvas.height);
+    gl?.uniform3f(pointerUniform, pointerX, pointerY, pointerStrength);
+    gl?.drawArrays(gl.TRIANGLES, 0, 6);
+  };
+
+  let start = performance.now();
+  let last = 0;
+  const render = (now: number) => {
+    if (reducedMotion) {
+      animationFrame = 0;
+      return;
+    }
+    animationFrame = requestAnimationFrame(render);
+    if (now - last < 33) return;
+    last = now;
+    draw((now - start) * 0.001, true);
+  };
+  const startAnimation = () => {
+    if (!animationFrame) animationFrame = requestAnimationFrame(render);
+  };
+  const stopAnimation = () => {
+    if (animationFrame) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = 0;
+    }
+  };
+  const onReducedMotionChange = () => {
+    reducedMotion = reducedMotionQuery?.matches ?? false;
+    if (reducedMotion) {
+      stopAnimation();
+      last = 0;
+      draw(20, false);
+    } else {
+      start = performance.now();
+      startAnimation();
+    }
+  };
+
+  resize();
+  window.addEventListener("resize", resize);
+  window.addEventListener("pointermove", onPointerMove, listenerOptions);
+  window.addEventListener("mousemove", onPointerMove, listenerOptions);
+  document.addEventListener("pointerleave", fadePointer, listenerOptions);
+  window.addEventListener("blur", fadePointer);
+  draw(reducedMotion ? 20 : 0, !reducedMotion);
+  if (reducedMotionQuery) {
+    if (reducedMotionQuery.addEventListener) {
+      reducedMotionQuery.addEventListener("change", onReducedMotionChange);
+    } else {
+      reducedMotionQuery.addListener(onReducedMotionChange);
+    }
+  }
+  if (!reducedMotion) startAnimation();
+
+  return () => {
+    stopAnimation();
+    window.removeEventListener("resize", resize);
+    window.removeEventListener("pointermove", onPointerMove, listenerOptions);
+    window.removeEventListener("mousemove", onPointerMove, listenerOptions);
+    document.removeEventListener("pointerleave", fadePointer, listenerOptions);
+    window.removeEventListener("blur", fadePointer);
+    if (reducedMotionQuery) {
+      if (reducedMotionQuery.removeEventListener) {
+        reducedMotionQuery.removeEventListener("change", onReducedMotionChange);
+      } else {
+        reducedMotionQuery.removeListener(onReducedMotionChange);
+      }
+    }
+    gl?.deleteBuffer(buffer);
+    gl?.deleteProgram(program);
+    gl?.deleteShader(vertexShader);
+    gl?.deleteShader(fragmentShader);
+  };
+}
+
+export interface StarfieldProps extends Omit<
+  React.ComponentPropsWithoutRef<"canvas">,
+  "children"
+> {
+  /** Keep the default id for compatibility with existing starfield styles. */
+  id?: string;
+}
+
+export function Starfield({
+  className,
+  id = "starfield",
+  ...props
+}: StarfieldProps) {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    return initializeStarfield(canvas);
+  }, []);
+
+  return (
+    <canvas
+      {...props}
+      ref={canvasRef}
+      id={id}
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none block h-full w-full opacity-[0.35] motion-reduce:opacity-[0.18]",
+        className,
+      )}
+      data-agent-native-starfield
+    />
+  );
+}

--- a/packages/toolkit/src/marketing/index.ts
+++ b/packages/toolkit/src/marketing/index.ts
@@ -3,3 +3,4 @@ export {
   type MarketingHomeProps,
   type MarketingValueProp,
 } from "./MarketingHome.js";
+export { Starfield, type StarfieldProps } from "./Starfield.js";

--- a/packages/toolkit/src/onboarding/AuthForm.tsx
+++ b/packages/toolkit/src/onboarding/AuthForm.tsx
@@ -14,9 +14,11 @@ export interface AuthFormProps {
   fields: readonly AuthFormField[];
   submitLabel: React.ReactNode;
   className?: string;
+  onSubmit?: React.FormEventHandler<HTMLFormElement>;
   submitProps?: React.ButtonHTMLAttributes<HTMLButtonElement> & DataAttributes;
   footer?: React.ReactNode;
   messageId?: string;
+  message?: React.ReactNode;
   messageClassName?: string;
 }
 
@@ -26,9 +28,11 @@ export function AuthForm({
   fields,
   submitLabel,
   className,
+  onSubmit,
   submitProps,
   footer,
   messageId,
+  message,
   messageClassName = "msg",
 }: AuthFormProps) {
   const {
@@ -39,7 +43,11 @@ export function AuthForm({
   } = submitProps ?? {};
 
   return (
-    <form id={id} className={className ? `form ${className}` : "form"}>
+    <form
+      id={id}
+      className={className ? `form ${className}` : "form"}
+      onSubmit={onSubmit}
+    >
       {fields.map((field) => (
         <React.Fragment key={field.id}>
           <label {...field.labelProps} htmlFor={field.id}>
@@ -52,7 +60,11 @@ export function AuthForm({
         {submitLabel}
       </button>
       {footer}
-      {messageId ? <p className={messageClassName} id={messageId} /> : null}
+      {messageId ? (
+        <p className={messageClassName} id={messageId}>
+          {message}
+        </p>
+      ) : null}
     </form>
   );
 }

--- a/scripts/qa-sign-in-matrix-smoke.ts
+++ b/scripts/qa-sign-in-matrix-smoke.ts
@@ -194,8 +194,13 @@ async function startApp(basePath: string): Promise<RunningApp> {
   // previous base path answers `ping` perfectly well, and every assertion
   // below would then re-test the surface that already passed.
   const doc = await (await fetch(`${appUrl}${SIGN_IN_ENTRY_PATH}`)).text();
+  const authData = doc.match(
+    /<script type="application\/json" id="agent-native-auth-data">([\s\S]*?)<\/script>/,
+  );
   assert.ok(
-    doc.includes(`var configured = ${JSON.stringify(basePath)};`),
+    authData &&
+      (JSON.parse(authData[1]!) as { appBasePath?: string }).appBasePath ===
+        basePath,
     `the server on ${appUrl} is not serving base path ${JSON.stringify(basePath)}`,
   );
   return { origin, basePath, appUrl, child, logs, viteReload };


### PR DESCRIPTION
## Summary
- render the shared sign-in, sign-up, and reset-password surfaces as hydratable React pages
- preserve the cached SSR shell, pre-paint session handoff, auth flow behavior, and localized copy
- share the WebGL starfield and auth composition with toolkit marketing surfaces

## Validation
- core and toolkit typecheck/build
- 482 core auth/SSR/sign-in-matrix tests plus focused React/onboarding tests
- 65 repository guards
- live browser sign-in matrix across root, non-root, and iframe surfaces

Generated auth bundles remain code-split behind the dedicated auth client asset.