### PR TITLE
fix(deploy): assemble starter with masked runtime credentials

### DIFF
--- a/.github/workflows/deploy-netlify-prebuilt.yml
+++ b/.github/workflows/deploy-netlify-prebuilt.yml
@@ -257,7 +257,19 @@ jobs:
             agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
             export agentNativePrebuiltAuthSecret
           fi
+          if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "chat" ]]; then
+            # Starter's runtime database and auth secret are Netlify secrets.
+            # The external prebuilt runner receives masked values, so use
+            # build-only shapes and let the deployed Functions read the real
+            # site-scoped values at runtime.
+            export agentNativePrebuiltBuild=true
+            agentNativePrebuiltAuthSecret="$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')"
+            export agentNativePrebuiltAuthSecret
+          fi
           if [[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]; then
+            export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
+          fi
+          if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "chat" ]]; then
             export agentNativePrebuiltDatabaseUrl="postgresql://build-only.invalid/agent_native"
           fi
           netlify build --context "$BUILD_CONTEXT" --filter "$SOURCE_TEMPLATE"

--- a/scripts/guard-netlify-prebuilt-workflow.test.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.test.ts
@@ -358,6 +358,33 @@ describe("production Netlify site concurrency guard", () => {
     assert.match(migration, /pnpm --filter clips migrate:production/);
   });
 
+  it("keeps production Chat assembly independent of masked runtime secrets", () => {
+    const workflow = readFileSync(
+      ".github/workflows/deploy-netlify-prebuilt.yml",
+      "utf8",
+    );
+    const chatNetlify = readFileSync("templates/chat/netlify.toml", "utf8");
+    const buildStart = workflow.indexOf(
+      "name: Build with the Netlify project configuration",
+    );
+    const buildEnd = workflow.indexOf(
+      "name: Verify deploy directories",
+      buildStart,
+    );
+    const build = workflow.slice(buildStart, buildEnd);
+
+    assert.match(
+      build,
+      /if \[\[ \"\$TARGET\" == \"production\" && \"\$SOURCE_TEMPLATE\" == \"chat\" \]\];/,
+    );
+    assert.match(chatNetlify, /agentNativePrebuiltDatabaseUrl/);
+    assert.match(chatNetlify, /agentNativePrebuiltAuthSecret/);
+    assert.match(
+      chatNetlify,
+      /agentNativePrebuiltBuild:-\}.*!= \\\"true\\\".*migrate:production/,
+    );
+  });
+
   it("only verifies static cache artifacts for prerendered prebuilt targets", () => {
     const workflow = readWorkflow(
       ".github/workflows/deploy-netlify-prebuilt.yml",

--- a/scripts/guard-netlify-prebuilt-workflow.ts
+++ b/scripts/guard-netlify-prebuilt-workflow.ts
@@ -4,6 +4,7 @@ import { parse } from "yaml";
 
 const reusablePath = ".github/workflows/deploy-netlify-prebuilt.yml";
 const clipsNetlifyPath = "templates/clips/netlify.toml";
+const chatNetlifyPath = "templates/chat/netlify.toml";
 const productionPath = ".github/workflows/deploy-production-sites-prebuilt.yml";
 const betaPath = ".github/workflows/deploy-beta-sites-prebuilt.yml";
 const manageProductionPath = ".github/workflows/manage-production-sites.yml";
@@ -18,6 +19,7 @@ export const PRODUCTION_PURGE_CONDITION =
 
 const reusable = readFileSync(reusablePath, "utf8");
 const clipsNetlify = readFileSync(clipsNetlifyPath, "utf8");
+const chatNetlify = readFileSync(chatNetlifyPath, "utf8");
 const production = readFileSync(productionPath, "utf8");
 const beta = readFileSync(betaPath, "utf8");
 const manageProduction = readFileSync(manageProductionPath, "utf8");
@@ -222,6 +224,18 @@ const clipsBuild =
   buildStepStart >= 0 && buildStepEnd > buildStepStart
     ? reusable.slice(buildStepStart, buildStepEnd)
     : "";
+const hasProductionChatBuildOverride =
+  clipsBuild.includes(
+    'if [[ "$TARGET" == "production" && "$SOURCE_TEMPLATE" == "chat" ]];',
+  ) &&
+  chatNetlify.includes("agentNativePrebuiltBuild") &&
+  chatNetlify.includes("agentNativePrebuiltDatabaseUrl") &&
+  chatNetlify.includes("agentNativePrebuiltAuthSecret");
+if (!hasProductionChatBuildOverride) {
+  issues.push(
+    `${reusablePath} and ${chatNetlifyPath} must provide a production Chat build-only override for masked Netlify secrets`,
+  );
+}
 const hasClipsAndPlanBuildOverride = clipsBuild.includes(
   '[[ "$SOURCE_TEMPLATE" == "clips" || "$SOURCE_TEMPLATE" == "plan" ]]',
 );

--- a/templates/chat/netlify.toml
+++ b/templates/chat/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 ignore = "node ./scripts/netlify-ignore-build.mjs chat"
-command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter chat build && if [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; then pnpm --filter chat migrate:production; fi"
+command = "if [ \"${agentNativePrebuiltBuild:-}\" = \"true\" ]; then export DATABASE_URL=\"${agentNativePrebuiltDatabaseUrl:?}\" BETTER_AUTH_SECRET=\"${agentNativePrebuiltAuthSecret:?}\"; else export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}; fi && pnpm install && NITRO_PRESET=netlify pnpm --filter chat build && if { [ \"${CONTEXT:-}\" = \"production\" ] || [ \"${AGENT_NATIVE_RUN_RELEASE_MIGRATIONS:-}\" = \"1\" ]; } && [ \"${agentNativePrebuiltBuild:-}\" != \"true\" ]; then pnpm --filter chat migrate:production; fi"
 publish = "templates/chat/dist"
 functions = "templates/chat/.netlify/functions-internal"
 


### PR DESCRIPTION
## Summary
- provide build-only database and auth shapes when the production Chat site is assembled by the external prebuilt lane
- skip only the duplicate release migration in that flagged prebuilt build; ordinary Netlify production builds still use the real database and migrate
- add workflow guard coverage without changing beta behavior

## Validation
- `corepack pnpm exec tsx --test scripts/guard-netlify-prebuilt-workflow.test.ts`
- `corepack pnpm exec tsx scripts/guard-netlify-prebuilt-workflow.ts`
- `corepack pnpm exec tsx scripts/guard-netlify-release-migrations.ts`
- `corepack pnpm exec tsx scripts/guard-netlify-private-env.ts`
- `corepack pnpm exec oxfmt --check scripts/guard-netlify-prebuilt-workflow.ts scripts/guard-netlify-prebuilt-workflow.test.ts`
- `git diff HEAD^ --check`