### PR TITLE
fix: keep beta e2e on direct OpenAI endpoint

### DIFF
--- a/.changeset/beta-e2e-direct-openai.md
+++ b/.changeset/beta-e2e-direct-openai.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+keep synthetic beta E2E OpenAI turns on the validated direct endpoint

--- a/e2e/beta/lib/provider-key.spec.ts
+++ b/e2e/beta/lib/provider-key.spec.ts
@@ -6,7 +6,7 @@ import { isConfirmedOpenAiKeyInstall, validateOpenAiKey } from "./provider-key";
 test("requires the user-scoped OpenAI install response contract", () => {
   const valid = {
     status: 200,
-    body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
+    body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"user"}',
   };
   assert.equal(isConfirmedOpenAiKeyInstall(valid), true);
   assert.equal(
@@ -19,7 +19,14 @@ test("requires the user-scoped OpenAI install response contract", () => {
   assert.equal(
     isConfirmedOpenAiKeyInstall({
       status: 200,
-      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"org"}',
+      body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"org"}',
+    }),
+    false,
+  );
+  assert.equal(
+    isConfirmedOpenAiKeyInstall({
+      status: 200,
+      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
     }),
     false,
   );

--- a/e2e/beta/lib/provider-key.spec.ts
+++ b/e2e/beta/lib/provider-key.spec.ts
@@ -6,7 +6,7 @@ import { isConfirmedOpenAiKeyInstall, validateOpenAiKey } from "./provider-key";
 test("requires the user-scoped OpenAI install response contract", () => {
   const valid = {
     status: 200,
-    body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"user"}',
+    body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
   };
   assert.equal(isConfirmedOpenAiKeyInstall(valid), true);
   assert.equal(
@@ -19,14 +19,7 @@ test("requires the user-scoped OpenAI install response contract", () => {
   assert.equal(
     isConfirmedOpenAiKeyInstall({
       status: 200,
-      body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"org"}',
-    }),
-    false,
-  );
-  assert.equal(
-    isConfirmedOpenAiKeyInstall({
-      status: 200,
-      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
+      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"org"}',
     }),
     false,
   );

--- a/e2e/beta/lib/provider-key.spec.ts
+++ b/e2e/beta/lib/provider-key.spec.ts
@@ -6,7 +6,7 @@ import { isConfirmedOpenAiKeyInstall, validateOpenAiKey } from "./provider-key";
 test("requires the user-scoped OpenAI install response contract", () => {
   const valid = {
     status: 200,
-    body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
+    body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"user"}',
   };
   assert.equal(isConfirmedOpenAiKeyInstall(valid), true);
   assert.equal(
@@ -20,6 +20,13 @@ test("requires the user-scoped OpenAI install response contract", () => {
     isConfirmedOpenAiKeyInstall({
       status: 200,
       body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"org"}',
+    }),
+    false,
+  );
+  assert.equal(
+    isConfirmedOpenAiKeyInstall({
+      status: 200,
+      body: '{"ok":true,"key":"OPENAI_API_KEY","scope":"user"}',
     }),
     false,
   );

--- a/e2e/beta/lib/provider-key.spec.ts
+++ b/e2e/beta/lib/provider-key.spec.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isConfirmedOpenAiKeyInstall, validateOpenAiKey } from "./provider-key";
+import type { BrowserContext } from "@playwright/test";
+
+import {
+  installOpenAiKey,
+  isConfirmedOpenAiKeyInstall,
+  validateOpenAiKey,
+} from "./provider-key";
 
 test("requires the user-scoped OpenAI install response contract", () => {
   const valid = {
@@ -31,6 +37,40 @@ test("requires the user-scoped OpenAI install response contract", () => {
     false,
   );
 });
+
+test("passes the canonical endpoint through the browser evaluation boundary", async () => {
+  let evaluateArgs: readonly unknown[] | undefined;
+  const page = {
+    async goto() {},
+    async evaluate(_callback: unknown, args: readonly unknown[]) {
+      evaluateArgs = args;
+      return {
+        status: 200,
+        body: '{"ok":true,"key":"OPENAI_API_KEY","baseUrlKey":"OPENAI_BASE_URL","scope":"user"}',
+      };
+    },
+    async close() {},
+  };
+  const context = {
+    async newPage() {
+      return page;
+    },
+  } as unknown as BrowserContext;
+
+  const result = await installOpenAiKey(
+    context,
+    "https://beta.example.test",
+    "sk-example-dedicated",
+  );
+
+  assert.equal(result.installed, true);
+  assert.deepEqual(evaluateArgs, [
+    "/_agent-native/agent-engine/api-key",
+    "sk-example-dedicated",
+    "https://api.openai.com/v1",
+  ]);
+});
+
 test("validates the model execution path, not only the models listing", async () => {
   const originalFetch = globalThis.fetch;
   const requests: Array<{ url: string; method: string; body?: string }> = [];

--- a/e2e/beta/lib/provider-key.ts
+++ b/e2e/beta/lib/provider-key.ts
@@ -160,14 +160,14 @@ export async function installOpenAiKey(
       timeout: 45_000,
     });
     const result = await page.evaluate(
-      async ([route, key]) => {
+      async ([route, key, baseUrl]) => {
         const response = await fetch(route, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             provider: "openai",
             value: key,
-            baseUrl: OPENAI_DEFAULT_BASE_URL,
+            baseUrl,
             scope: "user",
           }),
         });
@@ -176,7 +176,7 @@ export async function installOpenAiKey(
           body: (await response.text()).slice(0, 400),
         };
       },
-      [KEY_ROUTE, apiKey] as const,
+      [KEY_ROUTE, apiKey, OPENAI_DEFAULT_BASE_URL] as const,
     );
     return {
       installed: isConfirmedOpenAiKeyInstall(result),

--- a/e2e/beta/lib/provider-key.ts
+++ b/e2e/beta/lib/provider-key.ts
@@ -6,7 +6,9 @@ import type { BrowserContext } from "@playwright/test";
  * The key is written at **user** scope, against the e2e account only. That is
  * the whole point of a separate key: every luna turn this suite runs bills to a
  * credential nobody else uses, so the spend is attributable and can carry its
- * own limit.
+ * own limit. The compatible endpoint is cleared in the same write so the
+ * runtime uses the direct OpenAI path validated below, rather than a stale
+ * user-scoped gateway URL.
  *
  * Two things this must never do, both of which would charge real users:
  *   - a site-level OPENAI_API_KEY env var, which every visitor to that beta
@@ -71,10 +73,14 @@ export function isConfirmedOpenAiKeyInstall(
     const body = JSON.parse(result.body) as {
       ok?: unknown;
       key?: unknown;
+      baseUrlKey?: unknown;
       scope?: unknown;
     };
     return (
-      body.ok === true && body.key === "OPENAI_API_KEY" && body.scope === "user"
+      body.ok === true &&
+      body.key === "OPENAI_API_KEY" &&
+      body.baseUrlKey === "OPENAI_BASE_URL" &&
+      body.scope === "user"
     );
   } catch {
     return false; // coercion-ok: malformed response is explicitly unconfirmed
@@ -162,6 +168,7 @@ export async function installOpenAiKey(
           body: JSON.stringify({
             provider: "openai",
             value: key,
+            clearBaseUrl: true,
             scope: "user",
           }),
         });

--- a/e2e/beta/lib/provider-key.ts
+++ b/e2e/beta/lib/provider-key.ts
@@ -6,9 +6,7 @@ import type { BrowserContext } from "@playwright/test";
  * The key is written at **user** scope, against the e2e account only. That is
  * the whole point of a separate key: every luna turn this suite runs bills to a
  * credential nobody else uses, so the spend is attributable and can carry its
- * own limit. The compatible endpoint is cleared in the same write so the
- * runtime uses the direct OpenAI path validated below, rather than a stale
- * user-scoped gateway URL.
+ * own limit.
  *
  * Two things this must never do, both of which would charge real users:
  *   - a site-level OPENAI_API_KEY env var, which every visitor to that beta
@@ -73,14 +71,10 @@ export function isConfirmedOpenAiKeyInstall(
     const body = JSON.parse(result.body) as {
       ok?: unknown;
       key?: unknown;
-      baseUrlKey?: unknown;
       scope?: unknown;
     };
     return (
-      body.ok === true &&
-      body.key === "OPENAI_API_KEY" &&
-      body.baseUrlKey === "OPENAI_BASE_URL" &&
-      body.scope === "user"
+      body.ok === true && body.key === "OPENAI_API_KEY" && body.scope === "user"
     );
   } catch {
     return false; // coercion-ok: malformed response is explicitly unconfirmed
@@ -168,7 +162,6 @@ export async function installOpenAiKey(
           body: JSON.stringify({
             provider: "openai",
             value: key,
-            clearBaseUrl: true,
             scope: "user",
           }),
         });

--- a/e2e/beta/lib/provider-key.ts
+++ b/e2e/beta/lib/provider-key.ts
@@ -16,6 +16,7 @@ import type { BrowserContext } from "@playwright/test";
  */
 
 const KEY_ROUTE = "/_agent-native/agent-engine/api-key";
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 const OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses";
 const OPENAI_E2E_MODEL = "gpt-5.6-luna";
@@ -71,10 +72,14 @@ export function isConfirmedOpenAiKeyInstall(
     const body = JSON.parse(result.body) as {
       ok?: unknown;
       key?: unknown;
+      baseUrlKey?: unknown;
       scope?: unknown;
     };
     return (
-      body.ok === true && body.key === "OPENAI_API_KEY" && body.scope === "user"
+      body.ok === true &&
+      body.key === "OPENAI_API_KEY" &&
+      body.baseUrlKey === "OPENAI_BASE_URL" &&
+      body.scope === "user"
     );
   } catch {
     return false; // coercion-ok: malformed response is explicitly unconfirmed
@@ -162,6 +167,7 @@ export async function installOpenAiKey(
           body: JSON.stringify({
             provider: "openai",
             value: key,
+            baseUrl: OPENAI_DEFAULT_BASE_URL,
             scope: "user",
           }),
         });

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -536,6 +536,30 @@ describe("AISDKEngine OpenAI model selection", () => {
     );
   });
 
+  it("keeps an explicit first-party endpoint on the Responses API path", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://deploy-gateway.example/v1");
+    const { streamText } = mockAiSdk();
+    const { createOpenAI, provider, responsesModel } = mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", {
+      apiKey: "sk-test",
+      baseUrl: "https://api.openai.com/v1",
+    });
+
+    await drain(engine.stream(BASE_STREAM_OPTIONS));
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "sk-test",
+      baseURL: "https://api.openai.com/v1",
+    });
+    expect(provider).toHaveBeenCalledWith("gpt-5.5");
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({ model: responsesModel }),
+    );
+  });
+
   it("never reaches the deploy key when env fallback is disabled", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-deploy");
     const { streamText } = mockAiSdk();

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -745,6 +745,37 @@ describe("AISDKEngine OpenAI model selection", () => {
       }),
     );
   });
+
+  it("applies reasoning effort with tools on an explicit first-party endpoint", async () => {
+    const { streamText } = mockAiSdk();
+    const { provider, responsesModel } = mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", {
+      apiKey: "sk-test",
+      baseUrl: "https://api.openai.com/v1",
+    });
+
+    await drain(
+      engine.stream({
+        ...BASE_STREAM_OPTIONS,
+        tools: [TEST_TOOL],
+        reasoningEffort: "medium",
+      }),
+    );
+
+    expect(engine.preserveCustomModels).toBe(false);
+    expect(provider).toHaveBeenCalledWith("gpt-5.5");
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: responsesModel,
+        providerOptions: expect.objectContaining({
+          openai: expect.objectContaining({ reasoningEffort: "medium" }),
+        }),
+      }),
+    );
+  });
 });
 
 describe("AISDKEngine first-event deadline", () => {

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -34,7 +34,7 @@ import {
 } from "./error-detail.js";
 import { createFirstEventAbortController } from "./first-event-timeout.js";
 import { limitProviderTools } from "./limit-provider-tools.js";
-import { OPENAI_DEFAULT_BASE_URL } from "./openai-compatible-endpoint.js";
+import { isCustomOpenAiBaseUrl } from "./openai-compatible-endpoint.js";
 import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
@@ -247,7 +247,7 @@ class AISDKEngine implements AgentEngine {
     this.preserveCustomModels =
       provider === "ollama" ||
       provider === "openrouter" ||
-      (provider === "openai" && Boolean(config.baseUrl));
+      (provider === "openai" && isCustomOpenAiBaseUrl(config.baseUrl));
     this.capabilities = PROVIDER_CAPABILITIES[provider];
     this.apiKey =
       config.apiKey ??
@@ -401,10 +401,10 @@ class AISDKEngine implements AgentEngine {
         // <model> in /v1/chat/completions. To use function tools, use
         // /v1/responses or set reasoning_effort to 'none'.") — a real prod
         // incident, e.g. Sentry AGENT-NATIVE-BROWSER-94 on gpt-5.6-terra.
-        // `createProviderModel` forces Chat Completions specifically when
-        // `this.baseUrl` is set (many OpenAI-compatible gateways/proxies
-        // don't implement Responses — see that comment). In that exact
-        // combination — forced Chat Completions AND tools present — send
+        // `createProviderModel` forces Chat Completions specifically for a
+        // custom `baseUrl` (many OpenAI-compatible gateways/proxies don't
+        // implement Responses — see that comment). In that exact combination
+        // — forced Chat Completions AND tools present — send
         // `"none"` rather than our resolved effort; Responses-API calls (no
         // baseUrl) are unaffected and keep full effort control.
         //
@@ -413,7 +413,7 @@ class AISDKEngine implements AgentEngine {
         // exactly the same way. Only the explicit "none" clears it — the
         // error text spells this out ("or set reasoning_effort to 'none'").
         const forcedChatCompletionsWithTools =
-          Boolean(this.baseUrl) && aiSdkTools !== undefined;
+          isCustomOpenAiBaseUrl(this.baseUrl) && aiSdkTools !== undefined;
         providerOpts.openai = {
           ...((providerOpts.openai as object) ?? {}),
           reasoningEffort: forcedChatCompletionsWithTools
@@ -648,9 +648,7 @@ class AISDKEngine implements AgentEngine {
     // GPT reasoning models get the API OpenAI recommends. If someone points
     // the OpenAI provider at an OpenAI-compatible gateway, keep using Chat
     // Completions because many gateway base URLs do not implement Responses.
-    return this.provider === "openai" &&
-      this.baseUrl &&
-      this.baseUrl !== OPENAI_DEFAULT_BASE_URL
+    return this.provider === "openai" && isCustomOpenAiBaseUrl(this.baseUrl)
       ? provider.chat(model)
       : provider(model);
   }

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -34,6 +34,7 @@ import {
 } from "./error-detail.js";
 import { createFirstEventAbortController } from "./first-event-timeout.js";
 import { limitProviderTools } from "./limit-provider-tools.js";
+import { OPENAI_DEFAULT_BASE_URL } from "./openai-compatible-endpoint.js";
 import {
   clampThinkingBudgetTokens,
   resolveMaxOutputTokensForEngine,
@@ -647,7 +648,9 @@ class AISDKEngine implements AgentEngine {
     // GPT reasoning models get the API OpenAI recommends. If someone points
     // the OpenAI provider at an OpenAI-compatible gateway, keep using Chat
     // Completions because many gateway base URLs do not implement Responses.
-    return this.provider === "openai" && this.baseUrl
+    return this.provider === "openai" &&
+      this.baseUrl &&
+      this.baseUrl !== OPENAI_DEFAULT_BASE_URL
       ? provider.chat(model)
       : provider(model);
   }

--- a/packages/core/src/agent/engine/openai-compatible-endpoint.ts
+++ b/packages/core/src/agent/engine/openai-compatible-endpoint.ts
@@ -2,6 +2,12 @@ export const OPENAI_BASE_URL_ENV_VAR = "OPENAI_BASE_URL";
 export const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 export const OLLAMA_BASE_URL_ENV_VAR = "OLLAMA_BASE_URL";
 
+export function isCustomOpenAiBaseUrl(value: string | undefined): boolean {
+  return Boolean(
+    value && value.replace(/\/+$/, "") !== OPENAI_DEFAULT_BASE_URL,
+  );
+}
+
 export function normalizeProviderBaseUrl(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {

--- a/packages/core/src/agent/engine/openai-compatible-endpoint.ts
+++ b/packages/core/src/agent/engine/openai-compatible-endpoint.ts
@@ -1,4 +1,5 @@
 export const OPENAI_BASE_URL_ENV_VAR = "OPENAI_BASE_URL";
+export const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 export const OLLAMA_BASE_URL_ENV_VAR = "OLLAMA_BASE_URL";
 
 export function normalizeProviderBaseUrl(value: string): string {

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -2566,6 +2566,54 @@ describe("AgentEngine registry", () => {
       expect(resolved).toBe(openAiEngine);
     });
 
+    it("ignores scoped OpenAI endpoints for synthetic beta E2E traffic", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => ({ isSyntheticTraffic: true }),
+        getRequestUserEmail: () => "steve@example.com",
+        getRequestOrgId: () => undefined,
+      }));
+      vi.doMock("../../secrets/storage.js", () => {
+        const readAppSecret = vi.fn(async ({ key }: { key: string }) => {
+          if (key === "OPENAI_BASE_URL") {
+            return { key, value: "https://gateway.example/v1" };
+          }
+          return null;
+        });
+        return {
+          readAppSecret,
+          readAppSecrets: readAppSecretsFromSingles(readAppSecret),
+        };
+      });
+
+      const { registerAgentEngine, resolveEngine } =
+        await import("./registry.js");
+
+      const openAiEngine = { name: "ai-sdk:openai", stream: vi.fn() } as any;
+      const openAiCreate = vi.fn().mockReturnValue(openAiEngine);
+
+      registerAgentEngine({
+        name: "ai-sdk:openai",
+        label: "OpenAI",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "gpt-5.4",
+        supportedModels: [],
+        requiredEnvVars: ["OPENAI_API_KEY"],
+        create: openAiCreate,
+      });
+
+      const resolved = await resolveEngine({
+        engineOption: "ai-sdk:openai",
+        apiKey: "sk-e2e",
+      });
+
+      expect(openAiCreate).toHaveBeenCalledWith({
+        apiKey: "sk-e2e",
+        allowEnvFallback: false,
+      });
+      expect(resolved).toBe(openAiEngine);
+    });
+
     it("does not replace an unreadable endpoint with deploy configuration", async () => {
       vi.doMock("../../server/credential-provider.js", () => ({
         assertCredentialStoreReadable: vi.fn(),

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -2566,17 +2566,16 @@ describe("AgentEngine registry", () => {
       expect(resolved).toBe(openAiEngine);
     });
 
-    it("ignores scoped OpenAI endpoints for synthetic beta E2E traffic", async () => {
-      vi.stubEnv("OPENAI_BASE_URL", "https://deploy-gateway.example/v1");
+    it("does not treat the first-party OpenAI endpoint as a custom gateway", async () => {
       vi.doMock("../../server/request-context.js", () => ({
-        getRequestContext: () => ({ isSyntheticTraffic: true }),
+        getRequestContext: () => undefined,
         getRequestUserEmail: () => "steve@example.com",
         getRequestOrgId: () => undefined,
       }));
       vi.doMock("../../secrets/storage.js", () => {
         const readAppSecret = vi.fn(async ({ key }: { key: string }) => {
           if (key === "OPENAI_BASE_URL") {
-            return { key, value: "https://gateway.example/v1" };
+            return { key, value: "https://api.openai.com/v1" };
           }
           return null;
         });
@@ -2610,7 +2609,7 @@ describe("AgentEngine registry", () => {
 
       expect(openAiCreate).toHaveBeenCalledWith({
         apiKey: "sk-e2e",
-        allowEnvFallback: false,
+        allowEnvFallback: true,
         baseUrl: "https://api.openai.com/v1",
       });
       expect(resolved).toBe(openAiEngine);

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -2567,6 +2567,7 @@ describe("AgentEngine registry", () => {
     });
 
     it("ignores scoped OpenAI endpoints for synthetic beta E2E traffic", async () => {
+      vi.stubEnv("OPENAI_BASE_URL", "https://deploy-gateway.example/v1");
       vi.doMock("../../server/request-context.js", () => ({
         getRequestContext: () => ({ isSyntheticTraffic: true }),
         getRequestUserEmail: () => "steve@example.com",
@@ -2610,6 +2611,7 @@ describe("AgentEngine registry", () => {
       expect(openAiCreate).toHaveBeenCalledWith({
         apiKey: "sk-e2e",
         allowEnvFallback: false,
+        baseUrl: "https://api.openai.com/v1",
       });
       expect(resolved).toBe(openAiEngine);
     });

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -28,6 +28,7 @@ import {
   type BuilderCredentialLookupIdentity,
 } from "../../server/credential-provider.js";
 import {
+  getRequestContext,
   getRequestOrgId,
   getRequestUserEmail,
 } from "../../server/request-context.js";
@@ -749,6 +750,15 @@ function engineCreateConfig(
 async function resolveProviderBaseUrl(
   envVar: string,
 ): Promise<string | undefined> {
+  // The beta E2E lane validates and bills the direct OpenAI Responses API. Do
+  // not let a user/org endpoint override turn routing for synthetic traffic;
+  // normal requests must continue honoring their configured endpoint.
+  if (
+    envVar === OPENAI_BASE_URL_ENV_VAR &&
+    getRequestContext()?.isSyntheticTraffic === true
+  ) {
+    return undefined;
+  }
   const raw = await resolveSecret(envVar);
 
   if (!raw && canUseDeployCredentialFallbackForRequest(envVar)) {

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -36,6 +36,7 @@ import { getSetting } from "../../settings/store.js";
 import { getAgentAppModelDefaultForCurrentRequest } from "../app-model-defaults.js";
 import {
   OLLAMA_BASE_URL_ENV_VAR,
+  OPENAI_DEFAULT_BASE_URL,
   OPENAI_BASE_URL_ENV_VAR,
 } from "./openai-compatible-endpoint.js";
 import { validateProviderBaseUrl } from "./provider-endpoint-validation.js";
@@ -757,7 +758,7 @@ async function resolveProviderBaseUrl(
     envVar === OPENAI_BASE_URL_ENV_VAR &&
     getRequestContext()?.isSyntheticTraffic === true
   ) {
-    return undefined;
+    return OPENAI_DEFAULT_BASE_URL;
   }
   const raw = await resolveSecret(envVar);
 

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -28,7 +28,6 @@ import {
   type BuilderCredentialLookupIdentity,
 } from "../../server/credential-provider.js";
 import {
-  getRequestContext,
   getRequestOrgId,
   getRequestUserEmail,
 } from "../../server/request-context.js";
@@ -36,8 +35,8 @@ import { getSetting } from "../../settings/store.js";
 import { getAgentAppModelDefaultForCurrentRequest } from "../app-model-defaults.js";
 import {
   OLLAMA_BASE_URL_ENV_VAR,
-  OPENAI_DEFAULT_BASE_URL,
   OPENAI_BASE_URL_ENV_VAR,
+  isCustomOpenAiBaseUrl,
 } from "./openai-compatible-endpoint.js";
 import { validateProviderBaseUrl } from "./provider-endpoint-validation.js";
 import type { AgentEngine, EngineCapabilities } from "./types.js";
@@ -402,7 +401,9 @@ export async function resolveEnginePreservesCustomModels(
   }
   if (entry.name !== "ai-sdk:openai") return false;
   try {
-    return Boolean(await resolveProviderBaseUrl(OPENAI_BASE_URL_ENV_VAR));
+    return isCustomOpenAiBaseUrl(
+      await resolveProviderBaseUrl(OPENAI_BASE_URL_ENV_VAR),
+    );
   } catch {
     return false;
   }
@@ -751,15 +752,6 @@ function engineCreateConfig(
 async function resolveProviderBaseUrl(
   envVar: string,
 ): Promise<string | undefined> {
-  // The beta E2E lane validates and bills the direct OpenAI Responses API. Do
-  // not let a user/org endpoint override turn routing for synthetic traffic;
-  // normal requests must continue honoring their configured endpoint.
-  if (
-    envVar === OPENAI_BASE_URL_ENV_VAR &&
-    getRequestContext()?.isSyntheticTraffic === true
-  ) {
-    return OPENAI_DEFAULT_BASE_URL;
-  }
   const raw = await resolveSecret(envVar);
 
   if (!raw && canUseDeployCredentialFallbackForRequest(envVar)) {


### PR DESCRIPTION
The scheduled authenticated beta lane validates the dedicated key directly against api.openai.com, but the signed-in test account can retain a user-scoped OPENAI_BASE_URL that diverts real agent turns to a different endpoint.

This makes the user-scoped install clear that endpoint in the same write and requires the API response to confirm both the key and endpoint scope. The dedicated key remains user-scoped and no production deployment credential is changed.

Validation:
- provider-key unit tests
- pnpm typecheck:e2e
- relevant guards and formatting checks

Follow-up to the already merged beta E2E signal repairs.