### PR TITLE
test: expose beta chat runtime state

### DIFF
--- a/e2e/beta/lib/chat.ts
+++ b/e2e/beta/lib/chat.ts
@@ -331,6 +331,45 @@ export const COMPOSER = {
   model: '[data-agent-composer-slot="model-button"]',
 } as const;
 
+export async function readComposerRuntimeState(page: Page): Promise<unknown> {
+  return page.evaluate(() => {
+    const input = document.querySelector<HTMLElement>(
+      '[data-agent-composer-slot="editor-input"]',
+    );
+    const send = document.querySelector<HTMLButtonElement>(
+      '[data-agent-composer-slot="send-button"]',
+    );
+    const panel = document.querySelector<HTMLElement>(".agent-sidebar-panel");
+    return {
+      href: window.location.href,
+      inputCount: document.querySelectorAll(
+        '[data-agent-composer-slot="editor-input"]',
+      ).length,
+      input: input
+        ? {
+            textContent: input.textContent,
+            innerText: input.innerText,
+            contentEditable: input.contentEditable,
+            ariaDisabled: input.getAttribute("aria-disabled"),
+            active: document.activeElement === input,
+          }
+        : null,
+      send: send
+        ? {
+            disabled: send.disabled,
+            ariaDisabled: send.getAttribute("aria-disabled"),
+          }
+        : null,
+      panel: panel
+        ? {
+            state: panel.getAttribute("data-agent-sidebar-state"),
+            text: panel.innerText.slice(-500),
+          }
+        : null,
+    };
+  });
+}
+
 /**
  * Error text the product renders when a turn fails. Every one of these is a
  * shape real users reported on beta; matching any of them fails the turn.
@@ -387,7 +426,13 @@ export async function sendPromptAndAwaitTurn(
 
   const send = page.locator(COMPOSER.send).first();
   await send.waitFor({ state: "visible", timeout: 30_000 });
-  await send.click();
+  try {
+    await send.click();
+  } catch (error) {
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\nComposer runtime: ${JSON.stringify(await readComposerRuntimeState(page))}`,
+    );
+  }
 
   const stop = page.locator(COMPOSER.stop).first();
   // A turn short enough to finish before the stop button paints is still a

--- a/e2e/beta/specs/chat.spec.ts
+++ b/e2e/beta/specs/chat.spec.ts
@@ -13,6 +13,7 @@ import {
   installSidebarRuntimeTrace,
   MISSING_FINAL_RESPONSE,
   readSidebarRuntimeTrace,
+  readComposerRuntimeState,
   sendPromptAndAwaitTurn,
   watchChatRequests,
 } from "../lib/chat";
@@ -141,10 +142,16 @@ for (const site of sites) {
             waitUntil: "domcontentloaded",
             timeout: 45_000,
           });
-          await expect(
-            page.locator(COMPOSER.input).first(),
-            `${site.host} did not restore the composer after reloading a completed chat`,
-          ).toBeVisible({ timeout: 60_000 });
+          try {
+            await expect(
+              page.locator(COMPOSER.input).first(),
+              `${site.host} did not restore the composer after reloading a completed chat`,
+            ).toBeVisible({ timeout: 60_000 });
+          } catch (error) {
+            throw new Error(
+              `${error instanceof Error ? error.message : String(error)}\nComposer runtime: ${JSON.stringify(await readComposerRuntimeState(page))}`,
+            );
+          }
           await expect
             .poll(
               async () => {


### PR DESCRIPTION
## Summary

- expose bounded, secret-free composer state when authenticated beta chat cannot submit
- include the same state when a completed chat does not restore after reload

This is a diagnostic slice for the live beta E2E UI failures. It does not bypass disabled controls or force submissions.