### PR TITLE
fix: detect bundled engine packages on Netlify

### DIFF
--- a/.changeset/netlify-bundled-engine-detection.md
+++ b/.changeset/netlify-bundled-engine-detection.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Treat Netlify function bundles as having their inlined agent-engine packages when resolving runtime availability.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1018,6 +1018,25 @@ describe("AgentEngine registry", () => {
     expect(detectEngineFromEnv()).toBeNull();
   });
 
+  it("accepts bundled optional packages on a Netlify function runtime", async () => {
+    vi.stubEnv("NETLIFY_FUNCTION_NAME", "server");
+    const { isAgentEnginePackageInstalled } = await import("./registry.js");
+
+    expect(
+      isAgentEnginePackageInstalled({
+        name: "ai-sdk:openai",
+        label: "OpenAI",
+        description: "",
+        installPackage: "@agent-native/definitely-missing-ai-provider",
+        capabilities: {} as any,
+        defaultModel: "gpt-5.4",
+        supportedModels: [],
+        requiredEnvVars: [],
+        create: vi.fn() as any,
+      }),
+    ).toBe(true);
+  });
+
   it("registers the builder engine with both credential shapes", async () => {
     const { registerBuiltinEngines } = await import("./builtin.js");
     const { getAgentEngineEntry } = await import("./registry.js");

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1037,6 +1037,29 @@ describe("AgentEngine registry", () => {
     ).toBe(true);
   });
 
+  it.each(["NETLIFY_LOCAL", "NETLIFY_DEV"])(
+    "does not treat %s as a bundled runtime",
+    async (localMarker) => {
+      vi.stubEnv("NETLIFY_FUNCTION_NAME", "server");
+      vi.stubEnv(localMarker, "true");
+      const { isAgentEnginePackageInstalled } = await import("./registry.js");
+
+      expect(
+        isAgentEnginePackageInstalled({
+          name: "ai-sdk:openai",
+          label: "OpenAI",
+          description: "",
+          installPackage: "@agent-native/definitely-missing-ai-provider",
+          capabilities: {} as any,
+          defaultModel: "gpt-5.4",
+          supportedModels: [],
+          requiredEnvVars: [],
+          create: vi.fn() as any,
+        }),
+      ).toBe(false);
+    },
+  );
+
   it("registers the builder engine with both credential shapes", async () => {
     const { registerBuiltinEngines } = await import("./builtin.js");
     const { getAgentEngineEntry } = await import("./registry.js");

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -158,7 +158,7 @@ function isBundledServerlessRuntime(): boolean {
   const env = process.env;
   // Nitro's Vercel/Netlify presets inline optional peers into the function
   // bundle; these platforms always set these markers.
-  if (env.VERCEL || env.NETLIFY) return true;
+  if (env.VERCEL || env.NETLIFY || env.NETLIFY_FUNCTION_NAME) return true;
   // Otherwise require direct evidence that this module is running from inside a
   // bundle output directory (Vercel's `/var/task`, Nitro's `.output/server`,
   // inlined `_libs`). This is the real signal that `require.resolve` cannot be

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -156,6 +156,12 @@ function packageNameFromInstallSpecifier(specifier: string): string | null {
  */
 function isBundledServerlessRuntime(): boolean {
   const env = process.env;
+  if (
+    /^(1|true)$/i.test(env.NETLIFY_LOCAL ?? "") ||
+    /^(1|true)$/i.test(env.NETLIFY_DEV ?? "")
+  ) {
+    return false;
+  }
   // Nitro's Vercel/Netlify presets inline optional peers into the function
   // bundle; these platforms always set these markers.
   if (env.VERCEL || env.NETLIFY || env.NETLIFY_FUNCTION_NAME) return true;


### PR DESCRIPTION
## Summary
- recognize Netlify function runtime markers when optional agent-engine packages are inlined into the bundle
- add a regression test for the runtime package gate

## Validation
- pnpm exec vitest run packages/core/src/agent/engine/registry.spec.ts packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts
- pnpm exec tsx --test e2e/beta/lib/provider-key.spec.ts
- pnpm typecheck:e2e
- pnpm guards
- pnpm --filter slides build

This fixes the beta E2E preflight that could read the user-scoped OpenAI base URL while incorrectly reporting the bundled AI SDK packages as unavailable on Slides.