### PR TITLE
fix: detect Netlify runtime engine packages

### DIFF
--- a/.changeset/netlify-runtime-site-marker.md
+++ b/.changeset/netlify-runtime-site-marker.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use Netlify's runtime site marker when detecting bundled agent-engine packages.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1037,10 +1037,30 @@ describe("AgentEngine registry", () => {
     ).toBe(true);
   });
 
+  it("accepts bundled optional packages with Netlify's runtime site marker", async () => {
+    vi.stubEnv("SITE_ID", "site");
+    const { isAgentEnginePackageInstalled } = await import("./registry.js");
+
+    expect(
+      isAgentEnginePackageInstalled({
+        name: "ai-sdk:openai",
+        label: "OpenAI",
+        description: "",
+        installPackage: "@agent-native/definitely-missing-ai-provider",
+        capabilities: {} as any,
+        defaultModel: "gpt-5.4",
+        supportedModels: [],
+        requiredEnvVars: [],
+        create: vi.fn() as any,
+      }),
+    ).toBe(true);
+  });
+
   it.each(["NETLIFY_LOCAL", "NETLIFY_DEV"])(
     "does not treat %s as a bundled runtime",
     async (localMarker) => {
       vi.stubEnv("NETLIFY_FUNCTION_NAME", "server");
+      vi.stubEnv("SITE_ID", "site");
       vi.stubEnv(localMarker, "true");
       const { isAgentEnginePackageInstalled } = await import("./registry.js");
 

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -165,6 +165,9 @@ function isBundledServerlessRuntime(): boolean {
   // Nitro's Vercel/Netlify presets inline optional peers into the function
   // bundle; these platforms always set these markers.
   if (env.VERCEL || env.NETLIFY || env.NETLIFY_FUNCTION_NAME) return true;
+  // Netlify documents SITE_ID as a runtime marker, while NETLIFY is primarily
+  // a build-time variable and may be absent once the Function executes.
+  if (env.SITE_ID) return true; // guard:allow-env-credential - Netlify runtime host marker, not a credential.
   // Otherwise require direct evidence that this module is running from inside a
   // bundle output directory (Vercel's `/var/task`, Nitro's `.output/server`,
   // inlined `_libs`). This is the real signal that `require.resolve` cannot be


### PR DESCRIPTION
## Summary\n- use Netlify's runtime SITE_ID marker when optional engine packages are bundled\n- preserve fail-closed behavior for NETLIFY_LOCAL and NETLIFY_DEV\n- add regression coverage and a core patch changeset\n\n## Validation\n- pnpm exec vitest run packages/core/src/agent/engine/registry.spec.ts packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts\n- pnpm typecheck:e2e\n- pnpm --filter @agent-native/core build\n- pnpm --filter slides build\n- pnpm guards