### PR TITLE
fix: invalidate stale agent engine status after key writes

### DIFF
--- a/.changeset/invalidate-stale-engine-status.md
+++ b/.changeset/invalidate-stale-engine-status.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Invalidate stale in-flight agent engine status lookups after provider credential writes.

--- a/.changeset/invalidate-status-on-all-engine-writes.md
+++ b/.changeset/invalidate-status-on-all-engine-writes.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Invalidate agent engine status lookups after every successful provider credential mutation.

--- a/packages/core/src/oauth-tokens/store.spec.ts
+++ b/packages/core/src/oauth-tokens/store.spec.ts
@@ -13,6 +13,7 @@ interface ExecCall {
 }
 
 const execCalls: ExecCall[] = [];
+const mockInvalidateAgentEngineStatusLookups = vi.hoisted(() => vi.fn());
 let existingOwner: string | null = null;
 let existingTokens: Record<string, unknown> | null = null;
 let existingRevision = 100;
@@ -122,6 +123,10 @@ vi.mock("../db/client.js", () => ({
   getDbExec: () => mockDb,
   intType: () => (mockPostgres ? "BIGINT" : "INTEGER"),
   isPostgres: () => mockPostgres,
+}));
+
+vi.mock("../server/agent-engine-status-cache.js", () => ({
+  invalidateAgentEngineStatusLookups: mockInvalidateAgentEngineStatusLookups,
 }));
 
 const {
@@ -284,6 +289,17 @@ describe("oauth token store", () => {
       "mcp_oauth:test",
       "org:org-test",
     ]);
+  });
+
+  it("invalidates status when Builder OAuth credentials are saved", async () => {
+    await saveOAuthTokens(
+      "mcp",
+      "mcp_oauth:test",
+      { access_token: "new-token" },
+      "org:org-test",
+    );
+
+    expect(mockInvalidateAgentEngineStatusLookups).toHaveBeenCalledTimes(1);
   });
 
   it("reads and conditionally replaces one exact owner-bound revision", async () => {

--- a/packages/core/src/oauth-tokens/store.ts
+++ b/packages/core/src/oauth-tokens/store.ts
@@ -6,6 +6,7 @@ import {
   decryptSecretValue,
   isEncryptedSecretValue,
 } from "../secrets/crypto.js";
+import { invalidateAgentEngineStatusLookups } from "../server/agent-engine-status-cache.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -269,7 +270,9 @@ export async function replaceOAuthTokensIfRevision(
       expectedStorageVersion,
     ],
   });
-  return result.rowsAffected === 1;
+  const replaced = result.rowsAffected === 1;
+  if (replaced && provider === "mcp") invalidateAgentEngineStatusLookups();
+  return replaced;
 }
 
 /** Delete only the exact credential revision the caller inspected. */
@@ -295,7 +298,9 @@ export async function deleteOAuthTokensIfRevision(
       expectedStorageVersion,
     ],
   });
-  return result.rowsAffected === 1;
+  const deleted = result.rowsAffected === 1;
+  if (deleted && provider === "mcp") invalidateAgentEngineStatusLookups();
+  return deleted;
 }
 
 /**
@@ -438,7 +443,10 @@ export async function saveOAuthTokens(
       Date.now(),
     ],
   });
-  if (result.rowsAffected === 1) return;
+  if (result.rowsAffected === 1) {
+    if (provider === "mcp") invalidateAgentEngineStatusLookups();
+    return;
+  }
 
   const { rows: conflict } = await client.execute({
     sql: `SELECT owner FROM ${table} WHERE provider = ? AND account_id = ?`,
@@ -471,12 +479,18 @@ export async function deleteOAuthTokens(
       sql: `DELETE FROM ${table} WHERE provider = ? AND account_id = ?${ownerClause}`,
       args,
     });
+    if (result.rowsAffected > 0 && provider === "mcp") {
+      invalidateAgentEngineStatusLookups();
+    }
     return result.rowsAffected;
   }
   const result = await client.execute({
     sql: `DELETE FROM ${table} WHERE provider = ?`,
     args: [provider],
   });
+  if (result.rowsAffected > 0 && provider === "mcp") {
+    invalidateAgentEngineStatusLookups();
+  }
   return result.rowsAffected;
 }
 

--- a/packages/core/src/secrets/storage.spec.ts
+++ b/packages/core/src/secrets/storage.spec.ts
@@ -11,6 +11,8 @@ import {
 
 import { decryptSharedSecretValue } from "./crypto.js";
 
+const mockInvalidateAgentEngineStatusLookups = vi.fn();
+
 // A stable encryption key so values round-trip deterministically and the
 // crypto layer never falls through to the cwd-derived fallback (which would
 // warn on every run).
@@ -52,6 +54,12 @@ async function loadStorageWithSqlite() {
     isPostgres: () => false,
     isProductionServerlessFunctionRuntime: () => false,
   }));
+  vi.doMock("../server/agent-engine-status-cache.js", async () => ({
+    ...(await vi.importActual<
+      typeof import("../server/agent-engine-status-cache.js")
+    >("../server/agent-engine-status-cache.js")),
+    invalidateAgentEngineStatusLookups: mockInvalidateAgentEngineStatusLookups,
+  }));
   const mod = await import("./storage.js");
   return { sqlite, mod };
 }
@@ -66,6 +74,7 @@ describe("secrets storage bootstrap", () => {
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock("../db/client.js");
+    vi.doUnmock("../server/agent-engine-status-cache.js");
   });
 
   it("reads on the hot path without schema probes or DDL", async () => {
@@ -232,6 +241,17 @@ describe("secrets storage CRUD (real sqlite)", () => {
     sqlite.close();
     vi.resetModules();
     vi.doUnmock("../db/client.js");
+    vi.doUnmock("../server/agent-engine-status-cache.js");
+  });
+
+  it("invalidates status after shared engine credentials are written or deleted", async () => {
+    mockInvalidateAgentEngineStatusLookups.mockClear();
+
+    await mod.writeAppSecret({ ...userRef, value: "sk-live-credential" });
+    expect(mockInvalidateAgentEngineStatusLookups).toHaveBeenCalledTimes(1);
+
+    await expect(mod.deleteAppSecret(userRef)).resolves.toBe(true);
+    expect(mockInvalidateAgentEngineStatusLookups).toHaveBeenCalledTimes(2);
   });
 
   it("encrypts the value at rest and round-trips the plaintext", async () => {

--- a/packages/core/src/secrets/storage.ts
+++ b/packages/core/src/secrets/storage.ts
@@ -16,6 +16,10 @@ import { randomUUID } from "node:crypto";
 
 import { getDbExec, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
+import {
+  invalidateAgentEngineStatusLookups,
+  isAgentEngineStatusCredentialKey,
+} from "../server/agent-engine-status-cache.js";
 import { getRequestContext } from "../server/request-context.js";
 import {
   encryptSecretValue as encryptLegacyValue,
@@ -225,6 +229,9 @@ export async function writeAppSecret(args: WriteSecretArgs): Promise<string> {
       sql: `${upsertSql} RETURNING id`,
       args: upsertArgs,
     });
+    if (isAgentEngineStatusCredentialKey(key)) {
+      invalidateAgentEngineStatusLookups();
+    }
     return String(rows[0]?.id ?? id);
   }
 
@@ -234,6 +241,9 @@ export async function writeAppSecret(args: WriteSecretArgs): Promise<string> {
   // relying on it. The row is guaranteed to exist at this point, so this is
   // a plain lookup rather than a TOCTOU-prone gate on the write itself.
   await client.execute({ sql: upsertSql, args: upsertArgs });
+  if (isAgentEngineStatusCredentialKey(key)) {
+    invalidateAgentEngineStatusLookups();
+  }
   const { rows } = await client.execute({
     sql: `SELECT id FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ? LIMIT 1`,
     args: [scope, scopeId, key],
@@ -688,5 +698,8 @@ export async function deleteAppSecret(ref: SecretRef): Promise<boolean> {
     sql: `DELETE FROM app_secrets WHERE scope = ? AND scope_id = ? AND key = ?`,
     args: [scope, scopeId, key],
   });
+  if (rowsAffected > 0 && isAgentEngineStatusCredentialKey(key)) {
+    invalidateAgentEngineStatusLookups();
+  }
   return rowsAffected > 0;
 }

--- a/packages/core/src/server/agent-engine-api-key-route.spec.ts
+++ b/packages/core/src/server/agent-engine-api-key-route.spec.ts
@@ -5,6 +5,7 @@ const mockGetSession = vi.fn();
 const mockGetOrgContext = vi.fn();
 const mockIsBlockedExtensionUrlWithDns = vi.fn();
 const mockWriteAppSecret = vi.fn();
+const mockDeleteAppSecret = vi.fn();
 const mockClearProviderCredentialAuthFailure = vi.fn();
 
 vi.mock("./auth.js", () => ({
@@ -17,7 +18,7 @@ vi.mock("../org/context.js", () => ({
 
 vi.mock("../secrets/storage.js", () => ({
   writeAppSecret: (...args: unknown[]) => mockWriteAppSecret(...args),
-  deleteAppSecret: vi.fn(),
+  deleteAppSecret: (...args: unknown[]) => mockDeleteAppSecret(...args),
 }));
 
 vi.mock("../extensions/url-safety.js", () => ({
@@ -144,6 +145,54 @@ describe("agent engine api-key route helpers", () => {
       key: "OPENAI_API_KEY",
       scope: "user",
     });
+    const fresh = shareAgentEngineStatusLookup(key, compute);
+    resolveGate();
+
+    await expect(stale).resolves.toEqual({ configured: false });
+    await expect(fresh).resolves.toEqual({
+      configured: true,
+      engine: "ai-sdk:openai",
+    });
+    expect(runs).toBe(2);
+  });
+
+  it("invalidates after a key write even if the endpoint write fails", async () => {
+    mockGetSession.mockResolvedValue({ email: "alice@example.test" });
+    mockWriteAppSecret
+      .mockResolvedValueOnce("secret-id")
+      .mockRejectedValueOnce(new Error("database unavailable"));
+    const key = agentEngineStatusIdentityKey("alice@example.test", undefined);
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve;
+    });
+    let runs = 0;
+    const compute = async () => {
+      const attempt = ++runs;
+      await gate;
+      return attempt === 1
+        ? { configured: false }
+        : { configured: true, engine: "ai-sdk:openai" };
+    };
+    const stale = shareAgentEngineStatusLookup(key, compute);
+
+    const event = {
+      req: new Request("http://localhost/_agent-native/agent-engine/api-key", {
+        method: "POST",
+        body: JSON.stringify({
+          provider: "openai",
+          apiKey: "sk-example",
+          baseUrl: "https://gateway.example/v1",
+          scope: "user",
+        }),
+        headers: { "content-type": "application/json" },
+      }),
+      res: { headers: new Headers(), status: 200 },
+    };
+
+    await expect(
+      createAgentEngineApiKeyHandler()(event as any),
+    ).rejects.toThrow("database unavailable");
     const fresh = shareAgentEngineStatusLookup(key, compute);
     resolveGate();
 

--- a/packages/core/src/server/agent-engine-api-key-route.spec.ts
+++ b/packages/core/src/server/agent-engine-api-key-route.spec.ts
@@ -5,6 +5,7 @@ const mockGetSession = vi.fn();
 const mockGetOrgContext = vi.fn();
 const mockIsBlockedExtensionUrlWithDns = vi.fn();
 const mockWriteAppSecret = vi.fn();
+const mockClearProviderCredentialAuthFailure = vi.fn();
 
 vi.mock("./auth.js", () => ({
   getSession: (...args: any[]) => mockGetSession(...args),
@@ -24,6 +25,11 @@ vi.mock("../extensions/url-safety.js", () => ({
     mockIsBlockedExtensionUrlWithDns(...args),
 }));
 
+vi.mock("./credential-provider.js", () => ({
+  clearProviderCredentialAuthFailure: (...args: unknown[]) =>
+    mockClearProviderCredentialAuthFailure(...args),
+}));
+
 import { validateProviderBaseUrl } from "../agent/engine/provider-endpoint-validation.js";
 import {
   createAgentEngineApiKeyHandler,
@@ -31,6 +37,10 @@ import {
   resolveAgentEngineApiKeyWriteTarget,
   validateAgentEngineProviderKey,
 } from "./agent-engine-api-key-route.js";
+import {
+  agentEngineStatusIdentityKey,
+  shareAgentEngineStatusLookup,
+} from "./agent-engine-status-cache.js";
 
 describe("agent engine api-key route helpers", () => {
   it("validates OpenRouter keys against the authenticated key endpoint", async () => {
@@ -94,6 +104,55 @@ describe("agent engine api-key route helpers", () => {
         "OpenRouter rejected this API key. Get a new key from OpenRouter and try again.",
     });
     expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("invalidates an in-flight status lookup after saving a provider key", async () => {
+    mockGetSession.mockResolvedValue({ email: "alice@example.test" });
+    mockWriteAppSecret.mockResolvedValue("secret-id");
+    const key = agentEngineStatusIdentityKey("alice@example.test", undefined);
+    let resolveGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      resolveGate = resolve;
+    });
+    let runs = 0;
+    const compute = async () => {
+      const attempt = ++runs;
+      await gate;
+      return attempt === 1
+        ? { configured: false }
+        : { configured: true, engine: "ai-sdk:openai" };
+    };
+    const stale = shareAgentEngineStatusLookup(key, compute);
+
+    const event = {
+      req: new Request("http://localhost/_agent-native/agent-engine/api-key", {
+        method: "POST",
+        body: JSON.stringify({
+          provider: "openai",
+          apiKey: "sk-example",
+          scope: "user",
+        }),
+        headers: { "content-type": "application/json" },
+      }),
+      res: { headers: new Headers(), status: 200 },
+    };
+
+    await expect(
+      createAgentEngineApiKeyHandler()(event as any),
+    ).resolves.toEqual({
+      ok: true,
+      key: "OPENAI_API_KEY",
+      scope: "user",
+    });
+    const fresh = shareAgentEngineStatusLookup(key, compute);
+    resolveGate();
+
+    await expect(stale).resolves.toEqual({ configured: false });
+    await expect(fresh).resolves.toEqual({
+      configured: true,
+      engine: "ai-sdk:openai",
+    });
+    expect(runs).toBe(2);
   });
 
   it("rejects private provider endpoints at the server validation boundary", async () => {

--- a/packages/core/src/server/agent-engine-api-key-route.ts
+++ b/packages/core/src/server/agent-engine-api-key-route.ts
@@ -275,10 +275,12 @@ export function createAgentEngineApiKeyHandler() {
         scope: resolved.target.scope,
         scopeId: resolved.target.scopeId,
       });
+      invalidateAgentEngineStatusLookups();
       await clearProviderCredentialAuthFailure({
         key: payload.key,
         value: payload.value,
       });
+      invalidateAgentEngineStatusLookups();
     }
 
     if (payload.baseUrl) {
@@ -291,6 +293,7 @@ export function createAgentEngineApiKeyHandler() {
         scope: resolved.target.scope,
         scopeId: resolved.target.scopeId,
       });
+      invalidateAgentEngineStatusLookups();
     } else if (payload.clearBaseUrl) {
       await deleteAppSecret({
         key:
@@ -300,9 +303,6 @@ export function createAgentEngineApiKeyHandler() {
         scope: resolved.target.scope,
         scopeId: resolved.target.scopeId,
       });
-    }
-
-    if (payload.value || payload.baseUrl || payload.clearBaseUrl) {
       invalidateAgentEngineStatusLookups();
     }
 

--- a/packages/core/src/server/agent-engine-api-key-route.ts
+++ b/packages/core/src/server/agent-engine-api-key-route.ts
@@ -14,6 +14,7 @@ import {
 } from "../agent/engine/provider-env-vars.js";
 import { getOrgContext } from "../org/context.js";
 import { deleteAppSecret, writeAppSecret } from "../secrets/storage.js";
+import { invalidateAgentEngineStatusLookups } from "./agent-engine-status-cache.js";
 import { getSession } from "./auth.js";
 import { clearProviderCredentialAuthFailure } from "./credential-provider.js";
 import { readBody } from "./h3-helpers.js";
@@ -299,6 +300,10 @@ export function createAgentEngineApiKeyHandler() {
         scope: resolved.target.scope,
         scopeId: resolved.target.scopeId,
       });
+    }
+
+    if (payload.value || payload.baseUrl || payload.clearBaseUrl) {
+      invalidateAgentEngineStatusLookups();
     }
 
     return {

--- a/packages/core/src/server/agent-engine-status-cache.ts
+++ b/packages/core/src/server/agent-engine-status-cache.ts
@@ -1,0 +1,44 @@
+export interface AgentEngineStatusResult {
+  configured: boolean;
+  engine?: string;
+  model?: string;
+  source?: "settings" | "env" | "app_secrets";
+  envVar?: string;
+  openAiBaseUrlConfigured?: boolean;
+}
+
+const agentEngineStatusInFlight = new Map<
+  string,
+  Promise<AgentEngineStatusResult>
+>();
+
+/**
+ * Share concurrent status probes, but let credential mutations discard an
+ * older answer before the next probe joins it.
+ */
+export function shareAgentEngineStatusLookup(
+  identityKey: string,
+  compute: () => Promise<AgentEngineStatusResult>,
+): Promise<AgentEngineStatusResult> {
+  const existing = agentEngineStatusInFlight.get(identityKey);
+  if (existing) return existing;
+  const started = compute().finally(() => {
+    if (agentEngineStatusInFlight.get(identityKey) === started) {
+      agentEngineStatusInFlight.delete(identityKey);
+    }
+  });
+  agentEngineStatusInFlight.set(identityKey, started);
+  return started;
+}
+
+/** Drop in-flight answers that predate a provider/settings mutation. */
+export function invalidateAgentEngineStatusLookups(): void {
+  agentEngineStatusInFlight.clear();
+}
+
+export function agentEngineStatusIdentityKey(
+  userEmail: string | undefined,
+  orgId: string | undefined,
+): string {
+  return `${userEmail ?? ""}\u0000${orgId ?? ""}`;
+}

--- a/packages/core/src/server/agent-engine-status-cache.ts
+++ b/packages/core/src/server/agent-engine-status-cache.ts
@@ -1,3 +1,9 @@
+import {
+  OLLAMA_BASE_URL_ENV_VAR,
+  OPENAI_BASE_URL_ENV_VAR,
+  PROVIDER_ENV_VARS,
+} from "../agent/engine/provider-env-vars.js";
+
 export interface AgentEngineStatusResult {
   configured: boolean;
   engine?: string;
@@ -11,6 +17,14 @@ const agentEngineStatusInFlight = new Map<
   string,
   Promise<AgentEngineStatusResult>
 >();
+
+const AGENT_ENGINE_STATUS_CREDENTIAL_KEYS = new Set([
+  ...PROVIDER_ENV_VARS,
+  OPENAI_BASE_URL_ENV_VAR,
+  OLLAMA_BASE_URL_ENV_VAR,
+  "BUILDER_PRIVATE_KEY",
+  "BUILDER_PUBLIC_KEY",
+]);
 
 /**
  * Share concurrent status probes, but let credential mutations discard an
@@ -34,6 +48,10 @@ export function shareAgentEngineStatusLookup(
 /** Drop in-flight answers that predate a provider/settings mutation. */
 export function invalidateAgentEngineStatusLookups(): void {
   agentEngineStatusInFlight.clear();
+}
+
+export function isAgentEngineStatusCredentialKey(key: string): boolean {
+  return AGENT_ENGINE_STATUS_CREDENTIAL_KEYS.has(key);
 }
 
 export function agentEngineStatusIdentityKey(

--- a/packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   agentEngineStatusIdentityKey,
+  invalidateAgentEngineStatusLookups,
   resolveAgentEngineStatus,
   shareAgentEngineStatusLookup,
   type AgentEngineStatusDeps,
@@ -49,6 +50,7 @@ function createDeps(
 const originalAgentEngine = process.env.AGENT_ENGINE;
 
 afterEach(() => {
+  invalidateAgentEngineStatusLookups();
   if (originalAgentEngine === undefined) delete process.env.AGENT_ENGINE;
   else process.env.AGENT_ENGINE = originalAgentEngine;
 });
@@ -194,6 +196,26 @@ describe("shareAgentEngineStatusLookup", () => {
     await expect(shareAgentEngineStatusLookup(key, compute)).resolves.toEqual({
       configured: false,
     });
+    expect(runs).toBe(2);
+  });
+
+  it("does not let a provider write leave a pre-write lookup in flight", async () => {
+    const key = agentEngineStatusIdentityKey("a@example.com", "org-1");
+    const gate = deferred<void>();
+    let runs = 0;
+    const compute = async () => {
+      const attempt = ++runs;
+      await gate.promise;
+      return attempt === 1 ? { configured: false } : answer("ai-sdk:openai");
+    };
+
+    const stale = shareAgentEngineStatusLookup(key, compute);
+    invalidateAgentEngineStatusLookups();
+    const fresh = shareAgentEngineStatusLookup(key, compute);
+    gate.resolve();
+
+    await expect(stale).resolves.toEqual({ configured: false });
+    await expect(fresh).resolves.toEqual(answer("ai-sdk:openai"));
     expect(runs).toBe(2);
   });
 

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -122,6 +122,17 @@ import { validateTrackPayload } from "../tracking/route.js";
 import { createAutomationsHandler } from "../triggers/routes.js";
 import { createAgentEngineApiKeyHandler } from "./agent-engine-api-key-route.js";
 import {
+  agentEngineStatusIdentityKey,
+  shareAgentEngineStatusLookup,
+  type AgentEngineStatusResult,
+} from "./agent-engine-status-cache.js";
+export {
+  agentEngineStatusIdentityKey,
+  invalidateAgentEngineStatusLookups,
+  shareAgentEngineStatusLookup,
+  type AgentEngineStatusResult,
+} from "./agent-engine-status-cache.js";
+import {
   readAnalyticsClientPlatformHeader,
   readBrowserSessionIdHeader,
 } from "./agent-run-context.js";
@@ -277,15 +288,6 @@ type AgentEngineStatusEntry = {
   requiredEnvVars: readonly string[];
 };
 
-export interface AgentEngineStatusResult {
-  configured: boolean;
-  engine?: string;
-  model?: string;
-  source?: "settings" | "env" | "app_secrets";
-  envVar?: string;
-  openAiBaseUrlConfigured?: boolean;
-}
-
 export interface AgentEngineStatusDeps<
   E extends AgentEngineStatusEntry = AgentEngineStatusEntry,
 > {
@@ -390,40 +392,6 @@ export async function resolveAgentEngineStatus<
   }
 
   return { configured: false, openAiBaseUrlConfigured };
-}
-
-const _agentEngineStatusInFlight = new Map<
-  string,
-  Promise<AgentEngineStatusResult>
->();
-
-/**
- * Share one in-flight status resolution between concurrent probes of the same
- * identity. Several client surfaces probe this route on mount and the client
- * retries after its own timeout; without this each probe re-ran the whole
- * credential sweep. The entry is dropped as soon as the lookup settles, so a
- * joiner never sees an answer older than one lookup — no TTL, nothing to
- * invalidate when a provider is added or removed. The key carries the identity
- * that decides the answer, so no tenant can read another's result.
- */
-export function shareAgentEngineStatusLookup(
-  identityKey: string,
-  compute: () => Promise<AgentEngineStatusResult>,
-): Promise<AgentEngineStatusResult> {
-  const existing = _agentEngineStatusInFlight.get(identityKey);
-  if (existing) return existing;
-  const started = compute().finally(() => {
-    _agentEngineStatusInFlight.delete(identityKey);
-  });
-  _agentEngineStatusInFlight.set(identityKey, started);
-  return started;
-}
-
-export function agentEngineStatusIdentityKey(
-  userEmail: string | undefined,
-  orgId: string | undefined,
-): string {
-  return `${userEmail ?? ""}\u0000${orgId ?? ""}`;
 }
 
 function requestAgentEngineStatusDeps(): AgentEngineStatusDeps<AgentEngineEntry> {

--- a/packages/core/src/server/scoped-key-storage.spec.ts
+++ b/packages/core/src/server/scoped-key-storage.spec.ts
@@ -4,6 +4,7 @@ const mockGetSession = vi.fn();
 const mockGetOrgContext = vi.fn();
 const mockGetRequiredSecret = vi.fn();
 const mockWriteAppSecret = vi.fn();
+const mockInvalidateAgentEngineStatusLookups = vi.fn();
 
 vi.mock("./auth.js", () => ({
   getSession: (...args: any[]) => mockGetSession(...args),
@@ -19,6 +20,11 @@ vi.mock("../secrets/register.js", () => ({
 
 vi.mock("../secrets/storage.js", () => ({
   writeAppSecret: (...args: any[]) => mockWriteAppSecret(...args),
+}));
+
+vi.mock("./agent-engine-status-cache.js", () => ({
+  invalidateAgentEngineStatusLookups: (...args: any[]) =>
+    mockInvalidateAgentEngineStatusLookups(...args),
 }));
 
 import {
@@ -39,6 +45,28 @@ describe("saveKeyValuesToScopedSecrets", () => {
     });
     mockGetRequiredSecret.mockReturnValue(undefined);
     mockWriteAppSecret.mockResolvedValue("sec_1");
+  });
+
+  it("invalidates status after each provider secret write", async () => {
+    await saveKeyValuesToScopedSecrets(event, [
+      { key: "OPENAI_API_KEY", value: "sk-example" },
+    ]);
+
+    expect(mockInvalidateAgentEngineStatusLookups).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates before a later partial save can fail", async () => {
+    mockWriteAppSecret
+      .mockResolvedValueOnce("sec_1")
+      .mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      saveKeyValuesToScopedSecrets(event, [
+        { key: "OPENAI_API_KEY", value: "sk-first" },
+        { key: "ANTHROPIC_API_KEY", value: "sk-second" },
+      ]),
+    ).rejects.toThrow("database unavailable");
+    expect(mockInvalidateAgentEngineStatusLookups).toHaveBeenCalledTimes(1);
   });
 
   it("saves arbitrary keys to the current user by default", async () => {

--- a/packages/core/src/server/scoped-key-storage.spec.ts
+++ b/packages/core/src/server/scoped-key-storage.spec.ts
@@ -22,7 +22,8 @@ vi.mock("../secrets/storage.js", () => ({
   writeAppSecret: (...args: any[]) => mockWriteAppSecret(...args),
 }));
 
-vi.mock("./agent-engine-status-cache.js", () => ({
+vi.mock("./agent-engine-status-cache.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent-engine-status-cache.js")>()),
   invalidateAgentEngineStatusLookups: (...args: any[]) =>
     mockInvalidateAgentEngineStatusLookups(...args),
 }));

--- a/packages/core/src/server/scoped-key-storage.ts
+++ b/packages/core/src/server/scoped-key-storage.ts
@@ -1,5 +1,10 @@
 import type { H3Event } from "h3";
 
+import {
+  OLLAMA_BASE_URL_ENV_VAR,
+  OPENAI_BASE_URL_ENV_VAR,
+  PROVIDER_ENV_VARS,
+} from "../agent/engine/provider-env-vars.js";
 import { getOrgContext } from "../org/context.js";
 import {
   getRequiredSecret,
@@ -7,9 +12,15 @@ import {
   type SecretScope,
 } from "../secrets/register.js";
 import { writeAppSecret } from "../secrets/storage.js";
+import { invalidateAgentEngineStatusLookups } from "./agent-engine-status-cache.js";
 import { getSession } from "./auth.js";
 
 const KEY_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const AGENT_ENGINE_STATUS_KEYS = new Set([
+  ...PROVIDER_ENV_VARS,
+  OPENAI_BASE_URL_ENV_VAR,
+  OLLAMA_BASE_URL_ENV_VAR,
+]);
 
 export type ScopedKeySaveRequestScope =
   | "app"
@@ -216,6 +227,9 @@ export async function saveKeyValuesToScopedSecrets(
       scope,
       scopeId,
     });
+    if (AGENT_ENGINE_STATUS_KEYS.has(entry.key)) {
+      invalidateAgentEngineStatusLookups();
+    }
     rows.push({ key: entry.key, scope, scopeId });
   }
 

--- a/packages/core/src/server/scoped-key-storage.ts
+++ b/packages/core/src/server/scoped-key-storage.ts
@@ -1,10 +1,5 @@
 import type { H3Event } from "h3";
 
-import {
-  OLLAMA_BASE_URL_ENV_VAR,
-  OPENAI_BASE_URL_ENV_VAR,
-  PROVIDER_ENV_VARS,
-} from "../agent/engine/provider-env-vars.js";
 import { getOrgContext } from "../org/context.js";
 import {
   getRequiredSecret,
@@ -12,15 +7,13 @@ import {
   type SecretScope,
 } from "../secrets/register.js";
 import { writeAppSecret } from "../secrets/storage.js";
-import { invalidateAgentEngineStatusLookups } from "./agent-engine-status-cache.js";
+import {
+  invalidateAgentEngineStatusLookups,
+  isAgentEngineStatusCredentialKey,
+} from "./agent-engine-status-cache.js";
 import { getSession } from "./auth.js";
 
 const KEY_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const AGENT_ENGINE_STATUS_KEYS = new Set([
-  ...PROVIDER_ENV_VARS,
-  OPENAI_BASE_URL_ENV_VAR,
-  OLLAMA_BASE_URL_ENV_VAR,
-]);
 
 export type ScopedKeySaveRequestScope =
   | "app"
@@ -227,7 +220,7 @@ export async function saveKeyValuesToScopedSecrets(
       scope,
       scopeId,
     });
-    if (AGENT_ENGINE_STATUS_KEYS.has(entry.key)) {
+    if (isAgentEngineStatusCredentialKey(entry.key)) {
       invalidateAgentEngineStatusLookups();
     }
     rows.push({ key: entry.key, scope, scopeId });


### PR DESCRIPTION
## Summary\n\n- invalidate in-flight agent-engine status lookups after provider credential writes\n- keep concurrent status probes deduplicated without allowing a stale promise to delete a newer lookup\n- add route and cache regression coverage\n\n## Validation\n\n- focused core tests: 26 passed\n- core typecheck\n- E2E typecheck\n- 65 repository guards passed