### PR TITLE
fix: let beta synthetic checks use dedicated engine keys

### DIFF
--- a/.changeset/synthetic-engine-status-fallback.md
+++ b/.changeset/synthetic-engine-status-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow synthetic browser checks to verify a user-scoped engine when the deploy-selected engine is intentionally unavailable to synthetic traffic.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1235,7 +1235,7 @@ describe("AgentEngine registry", () => {
     });
 
     it("lets synthetic requests resolve a user engine when the env engine is unusable", async () => {
-      process.env.AGENT_ENGINE = "builder";
+      vi.stubEnv("AGENT_ENGINE", "builder");
       vi.doUnmock("../../server/request-context.js");
       vi.doMock(
         "../../server/credential-provider.js",

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("../../server/builder-oauth.js", () => ({
   BUILDER_OAUTH_SCOPE: "builder:ai:invoke",
@@ -1212,6 +1212,10 @@ describe("AgentEngine registry", () => {
       vi.doMock("../../org/context.js", () => ({
         resolveOrgIdForEmail: vi.fn().mockResolvedValue(null),
       }));
+    });
+
+    afterEach(() => {
+      vi.doUnmock("../../server/credential-provider.js");
     });
 
     it("selects builder from the Builder-credits pair alone on a hosted app", async () => {

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1232,11 +1232,7 @@ describe("AgentEngine registry", () => {
 
     it("lets synthetic requests resolve a user engine when the env engine is unusable", async () => {
       process.env.AGENT_ENGINE = "builder";
-      vi.doMock("../../server/request-context.js", () => ({
-        getRequestContext: () => ({ isSyntheticTraffic: true }),
-        getRequestUserEmail: () => "visitor@example.com",
-        getRequestOrgId: () => undefined,
-      }));
+      vi.doUnmock("../../server/request-context.js");
       vi.doMock(
         "../../server/credential-provider.js",
         async (importOriginal) => ({
@@ -1265,6 +1261,8 @@ describe("AgentEngine registry", () => {
 
       const { registerAgentEngine, resolveEngine } =
         await import("./registry.js");
+      const { runWithRequestContext } =
+        await import("../../server/request-context.js");
       const builderCreate = vi.fn().mockReturnValue({
         name: "builder",
         stream: vi.fn(),
@@ -1293,7 +1291,10 @@ describe("AgentEngine registry", () => {
         create: openAiCreate,
       });
 
-      const resolved = await resolveEngine({});
+      const resolved = await runWithRequestContext(
+        { userEmail: "visitor@example.com", isSyntheticTraffic: true },
+        () => resolveEngine({}),
+      );
 
       expect(resolved).toBe(openAiEngine);
       expect(builderCreate).not.toHaveBeenCalled();

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1230,6 +1230,79 @@ describe("AgentEngine registry", () => {
       expect((await detectEngineFromEnvForRequest())?.name).toBe("builder");
     });
 
+    it("lets synthetic requests resolve a user engine when the env engine is unusable", async () => {
+      process.env.AGENT_ENGINE = "builder";
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => ({ isSyntheticTraffic: true }),
+        getRequestUserEmail: () => "visitor@example.com",
+        getRequestOrgId: () => undefined,
+      }));
+      vi.doMock(
+        "../../server/credential-provider.js",
+        async (importOriginal) => ({
+          ...(await importOriginal<
+            typeof import("../../server/credential-provider.js")
+          >()),
+          canUseDeployCredentialFallbackForRequest: () => false,
+          getProviderCredentialAuthFailure: vi.fn(async () => null),
+          resolveBuilderCredentialsDetailed: vi.fn(async () => ({
+            privateKey: null,
+            publicKey: null,
+            lookupFailed: false,
+            lane: null,
+          })),
+          resolveBuilderGatewayCredentialsDetailed: vi.fn(async () => ({
+            privateKey: null,
+            publicKey: null,
+            lookupFailed: false,
+            lane: null,
+          })),
+          resolveSecret: vi.fn(async (key: string) =>
+            key === "OPENAI_API_KEY" ? "sk-openai-user" : null,
+          ),
+        }),
+      );
+
+      const { registerAgentEngine, resolveEngine } =
+        await import("./registry.js");
+      const builderCreate = vi.fn().mockReturnValue({
+        name: "builder",
+        stream: vi.fn(),
+      } as any);
+      const openAiEngine = { name: "ai-sdk:openai", stream: vi.fn() } as any;
+      const openAiCreate = vi.fn().mockReturnValue(openAiEngine);
+
+      registerAgentEngine({
+        name: "builder",
+        label: "Builder",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "builder-model",
+        supportedModels: ["builder-model"],
+        requiredEnvVars: ["BUILDER_GATEWAY_TOKEN", "BUILDER_GATEWAY_SPACE_ID"],
+        create: builderCreate,
+      });
+      registerAgentEngine({
+        name: "ai-sdk:openai",
+        label: "OpenAI",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "gpt-5.6-luna",
+        supportedModels: ["gpt-5.6-luna"],
+        requiredEnvVars: ["OPENAI_API_KEY"],
+        create: openAiCreate,
+      });
+
+      const resolved = await resolveEngine({});
+
+      expect(resolved).toBe(openAiEngine);
+      expect(builderCreate).not.toHaveBeenCalled();
+      expect(openAiCreate).toHaveBeenCalledWith({
+        apiKey: "sk-openai-user",
+        allowEnvFallback: false,
+      });
+    });
+
     it("does not select builder from a gateway token without its space id", async () => {
       vi.stubEnv("NODE_ENV", "production");
       process.env.BUILDER_GATEWAY_TOKEN = "btk-site-token"; // guard:allow-env-credential — fixture: the deployment's Builder-credits pair is the credential under test

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -29,6 +29,7 @@ import {
 } from "../../server/credential-provider.js";
 import {
   getRequestOrgId,
+  getRequestContext,
   getRequestUserEmail,
 } from "../../server/request-context.js";
 import { getSetting } from "../../settings/store.js";
@@ -1309,16 +1310,25 @@ export async function resolveEngine(
     const entry = _registry.get(envEngine);
     if (entry) {
       assertAgentEnginePackageInstalled(entry);
-      return entry.create(
-        await engineCreateConfigForEntry(
-          entry,
-          apiKey,
-          undefined,
-          "automatic",
-          apiKeyEnvVar,
+      // Synthetic checks cannot use deploy-wide credentials, but may validate
+      // the dedicated user-scoped credential they install for the request.
+      const canUseConfiguredEngine =
+        getRequestContext()?.isSyntheticTraffic !== true ||
+        (await isStoredEngineUsableForRequest({ engine: entry.name }, entry, {
           credentialIdentity,
-        ),
-      );
+        }));
+      if (canUseConfiguredEngine) {
+        return entry.create(
+          await engineCreateConfigForEntry(
+            entry,
+            apiKey,
+            undefined,
+            "automatic",
+            apiKeyEnvVar,
+            credentialIdentity,
+          ),
+        );
+      }
     }
   }
 

--- a/packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts
+++ b/packages/core/src/server/core-routes-plugin.agent-engine-status.spec.ts
@@ -7,6 +7,7 @@ import {
   type AgentEngineStatusDeps,
   type AgentEngineStatusResult,
 } from "./core-routes-plugin.js";
+import { runWithRequestContext } from "./request-context.js";
 
 type TestEntry = {
   name: string;
@@ -20,6 +21,13 @@ const openAiEntry: TestEntry = {
   defaultModel: "gpt-5",
   supportedModels: ["gpt-5"],
   requiredEnvVars: ["OPENAI_API_KEY"],
+};
+
+const builderEntry: TestEntry = {
+  name: "builder",
+  defaultModel: "gpt-5",
+  supportedModels: ["gpt-5"],
+  requiredEnvVars: ["BUILDER_GATEWAY_TOKEN", "BUILDER_GATEWAY_SPACE_ID"],
 };
 
 function deferred<T>() {
@@ -153,5 +161,29 @@ describe("resolveAgentEngineStatus", () => {
         createDeps({ readOpenAiBaseUrlConfigured: () => true }),
       ),
     ).resolves.toEqual({ configured: false, openAiBaseUrlConfigured: true });
+  });
+
+  it("lets synthetic checks fall through an unusable deploy engine to user secrets", async () => {
+    process.env.AGENT_ENGINE = "builder";
+
+    const result = await runWithRequestContext(
+      { isSyntheticTraffic: true },
+      () =>
+        resolveAgentEngineStatus(
+          createDeps({
+            lookupEntry: (name) =>
+              name === "builder" ? builderEntry : openAiEntry,
+            isStoredEngineUsable: (stored) =>
+              (stored as { engine?: string }).engine !== "builder",
+            detectFromUserSecrets: async () => openAiEntry,
+          }),
+        ),
+    );
+
+    expect(result).toMatchObject({
+      configured: true,
+      engine: "ai-sdk:openai",
+      source: "app_secrets",
+    });
   });
 });

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -334,16 +334,19 @@ export async function resolveAgentEngineStatus<
   const configuredEngine = getAppConfig().agent.engine;
   const envEntry = configuredEngine ? lookupEntry(configuredEngine) : undefined;
   if (envEntry) {
-    if (!(await deps.isStoredEngineUsable({ engine: envEntry.name }, envEntry)))
+    if (await deps.isStoredEngineUsable({ engine: envEntry.name }, envEntry)) {
+      return {
+        configured: true,
+        engine: envEntry.name,
+        model: envEntry.defaultModel ?? DEFAULT_MODEL,
+        source: "env",
+        envVar: "AGENT_ENGINE",
+        openAiBaseUrlConfigured,
+      };
+    }
+    if (getRequestContext()?.isSyntheticTraffic !== true) {
       return { configured: false, openAiBaseUrlConfigured };
-    return {
-      configured: true,
-      engine: envEntry.name,
-      model: envEntry.defaultModel ?? DEFAULT_MODEL,
-      source: "env",
-      envVar: "AGENT_ENGINE",
-      openAiBaseUrlConfigured,
-    };
+    }
   }
 
   // Stored provider selections win over an existing Builder connection, so


### PR DESCRIPTION
Synthetic beta browser checks intentionally cannot use deploy-wide Builder credentials. When beta selected AGENT_ENGINE=builder, the agent-engine status route treated that synthetic-unavailable Builder engine as authoritative unconfigured and never checked the dedicated user-scoped OpenAI key installed by the E2E setup.

This keeps normal request precedence unchanged and lets synthetic requests continue to user-scoped detection only after the deploy-selected engine is unavailable. Adds a focused regression test.