### PR TITLE
test: expand delegated work before beta assertion

### DIFF
--- a/e2e/beta/specs/a2a.spec.ts
+++ b/e2e/beta/specs/a2a.spec.ts
@@ -85,7 +85,7 @@ test.describe("slides -> analytics delegation", () => {
       // the assertion inspects the delegated-agent row, not just the final
       // answer that remains visible when the details are closed.
       const workSummary = page.getByRole("button", {
-        name: /^Worked for\b/i,
+        name: /^Worked(?: for\b)?/i,
       });
       await expect(workSummary).toBeVisible({ timeout: 20_000 });
       await workSummary.click();

--- a/e2e/beta/specs/a2a.spec.ts
+++ b/e2e/beta/specs/a2a.spec.ts
@@ -81,6 +81,15 @@ test.describe("slides -> analytics delegation", () => {
 
       chat.assertOnlyLuna();
 
+      // Completed tool work is collapsed by default. Open the disclosure so
+      // the assertion inspects the delegated-agent row, not just the final
+      // answer that remains visible when the details are closed.
+      const workSummary = page.getByRole("button", {
+        name: /^Worked for\b/i,
+      });
+      await expect(workSummary).toBeVisible({ timeout: 20_000 });
+      await workSummary.click();
+
       const transcript = await renderedText(
         page,
         "beta.slides delegation transcript",


### PR DESCRIPTION
## Summary\n\nExpand the completed agent work disclosure before asserting the Slides-to-Analytics delegation row. The failing beta run had a successful Analytics response, but the delegated row was hidden inside the collapsed Worked for disclosure.\n\n## Verification\n\n- E2E typecheck\n- oxfmt check\n- beta E2E suite guard\n- all 65 repository guards\n- targeted beta run will be rerun after merge