### PR TITLE
Make Clips transactional email notifications work in hosted deployments

### DIFF
--- a/scripts/guard-db-tool-scoping.mjs
+++ b/scripts/guard-db-tool-scoping.mjs
@@ -97,6 +97,10 @@ const INTENTIONAL_RAW_DB_DENYLIST = {
   "clips:recording_viewers": "viewer link rows scoped through recordings",
   "clips:space_members": "membership join rows scoped through spaces",
   "clips:spaces": "workspace child rows scoped through workspaces",
+  "clips:clips_transactional_email_configs":
+    "internal transactional-email worker configuration and cursors",
+  "clips:clips_transactional_email_jobs":
+    "internal transactional-email queue and delivery history",
   "clips:workspace_members": "membership join rows scoped through workspaces",
   "plan:plan_comments": "child rows scoped through plans",
   "plan:plan_assets": "child rows scoped through plans",

--- a/templates/clips/server/db/schema.ts
+++ b/templates/clips/server/db/schema.ts
@@ -7,6 +7,7 @@ import {
   ownableColumns,
   createSharesTable,
   uniqueIndex,
+  index,
 } from "@agent-native/core/db/schema";
 
 // -----------------------------------------------------------------------------
@@ -735,3 +736,64 @@ export const recordingEvents = table("recording_events", {
   payload: text("payload").notNull().default("{}"),
   createdAt: text("created_at").notNull().default(now()),
 });
+
+export const transactionalEmailJobs = table(
+  "clips_transactional_email_jobs",
+  {
+    logicalKey: text("logical_key").primaryKey(),
+    type: text("type", {
+      enum: [
+        "first-view",
+        "unviewed-reminder",
+        "first-agent-view",
+        "first-import",
+        "monthly-recap",
+        "two-clips",
+      ],
+    }).notNull(),
+    state: text("state", {
+      enum: [
+        "pending",
+        "awaiting_ai",
+        "ai_dispatched",
+        "ready",
+        "sending",
+        "sent",
+        "cancelled",
+        "failed",
+      ],
+    }).notNull(),
+    recipient: text("recipient").notNull(),
+    recordingIdsJson: text("recording_ids_json").notNull(),
+    shareId: text("share_id"),
+    requestedBy: text("requested_by"),
+    month: text("month"),
+    generatedSummary: text("generated_summary"),
+    attempts: integer("attempts").notNull().default(0),
+    createdAt: text("created_at").notNull().default(now()),
+    updatedAt: text("updated_at").notNull().default(now()),
+    aiDispatchedAt: text("ai_dispatched_at"),
+    aiClaimedBy: text("ai_claimed_by"),
+    readyAt: text("ready_at"),
+    sendingAt: text("sending_at"),
+    sentAt: text("sent_at"),
+    cancelledAt: text("cancelled_at"),
+    failedAt: text("failed_at"),
+    lastError: text("last_error"),
+    leaseUntil: text("lease_until"),
+    leaseToken: text("lease_token"),
+  },
+  (job) => ({
+    transactionalEmailJobsStateCreatedIndex: index(
+      "clips_transactional_email_jobs_state_created_idx",
+    ).on(job.state, job.createdAt),
+  }),
+);
+
+export const transactionalEmailConfigs = table(
+  "clips_transactional_email_configs",
+  {
+    id: text("id").primaryKey(),
+    configJson: text("config_json").notNull(),
+  },
+);

--- a/templates/clips/server/jobs/transactional-emails.test.ts
+++ b/templates/clips/server/jobs/transactional-emails.test.ts
@@ -1,5 +1,3 @@
-import { mkdtemp, rm } from "node:fs/promises";
-
 import { createClient, type Client } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/templates/clips/server/jobs/transactional-emails.test.ts
+++ b/templates/clips/server/jobs/transactional-emails.test.ts
@@ -1,8 +1,16 @@
 import { mkdtemp, rm } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { createClient, type Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let db: ReturnType<typeof drizzle>;
+let sqlite: Client;
+
+vi.mock("../db/index.js", async () => {
+  const schema = await import("../db/schema.js");
+  return { getDb: () => db, schema };
+});
 
 import type { MonthlyRecap } from "../lib/recap-metrics.js";
 import { createTransactionalEmailStore } from "../lib/transactional-email-store.js";
@@ -21,13 +29,26 @@ type AgentView = NonNullable<
   Awaited<ReturnType<TransactionalEmailRepository["getFirstOwnerAgentView"]>>
 >;
 
-const roots: string[] = [];
-
-async function testRoot(): Promise<string> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "clips-email-worker-"));
-  roots.push(root);
-  return root;
+async function createTables() {
+  await sqlite.execute(`CREATE TABLE clips_transactional_email_jobs (
+    logical_key TEXT PRIMARY KEY, type TEXT NOT NULL, state TEXT NOT NULL,
+    recipient TEXT NOT NULL, recording_ids_json TEXT NOT NULL, share_id TEXT,
+    requested_by TEXT, month TEXT, generated_summary TEXT, attempts INTEGER NOT NULL,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL, ai_dispatched_at TEXT,
+    ai_claimed_by TEXT, ready_at TEXT, sending_at TEXT, sent_at TEXT,
+    cancelled_at TEXT, failed_at TEXT, last_error TEXT, lease_until TEXT,
+    lease_token TEXT
+  )`);
+  await sqlite.execute(`CREATE TABLE clips_transactional_email_configs (
+    id TEXT PRIMARY KEY, config_json TEXT NOT NULL
+  )`);
 }
+
+beforeEach(async () => {
+  sqlite = createClient({ url: ":memory:" });
+  db = drizzle(sqlite);
+  await createTables();
+});
 
 function recording(id: string, ownerEmail = "sender@example.com"): Recording {
   return {
@@ -288,10 +309,7 @@ function createRepository(state: {
 
 async function setup(enabledAt = "2026-08-01T00:00:00.000Z") {
   let currentTime = new Date(enabledAt);
-  const store = createTransactionalEmailStore({
-    root: await testRoot(),
-    now: () => currentTime,
-  });
+  const store = createTransactionalEmailStore({ now: () => currentTime });
   await store.ensureEnabledAt();
   return {
     store,
@@ -304,9 +322,7 @@ async function setup(enabledAt = "2026-08-01T00:00:00.000Z") {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-  );
+  await sqlite.close();
 });
 
 describe("transactional email worker", () => {

--- a/templates/clips/server/jobs/transactional-emails.ts
+++ b/templates/clips/server/jobs/transactional-emails.ts
@@ -1292,6 +1292,8 @@ export async function runTransactionalEmailsOnce(
 }
 
 export default function registerTransactionalEmailsJob(): void {
+  if (process.env.NETLIFY === "true") return;
+
   const isProd = process.env.NODE_ENV === "production";
   const flag = process.env.RUN_BACKGROUND_JOBS;
   const enabled = flag === "1" || (isProd && flag !== "0");

--- a/templates/clips/server/jobs/transactional-emails.ts
+++ b/templates/clips/server/jobs/transactional-emails.ts
@@ -1157,7 +1157,7 @@ export async function runTransactionalEmailsOnce(
       currentTime,
     );
 
-    const jobs = await store.listJobs();
+    const jobs = await store.listJobs(["pending", "ai_dispatched"]);
     const warn = dependencies.warn ?? console.warn;
     for (const job of jobs) {
       const dispatchedAt = job.aiDispatchedAt ?? job.updatedAt;
@@ -1188,7 +1188,7 @@ export async function runTransactionalEmailsOnce(
       return result;
     }
 
-    const deliveryCandidates = (await store.listJobs())
+    const deliveryCandidates = (await store.listJobs(["ready", "sending"]))
       .filter(
         (job) =>
           (job.state === "ready" || job.state === "sending") &&

--- a/templates/clips/server/lib/transactional-email-store.test.ts
+++ b/templates/clips/server/lib/transactional-email-store.test.ts
@@ -70,6 +70,20 @@ describe("transactional email store", () => {
     expect(await store.listJobs()).toEqual([]);
   });
 
+  it("lists only requested job states", async () => {
+    const store = createTransactionalEmailStore();
+    await store.enqueue("first-view:pending", firstViewPayload);
+    await store.enqueue(
+      "first-view:awaiting-ai",
+      firstViewPayload,
+      "awaiting_ai",
+    );
+
+    await expect(store.listJobs(["pending"])).resolves.toMatchObject([
+      { logicalKey: "first-view:pending", state: "pending" },
+    ]);
+  });
+
   it("claims AI work once and enforces valid transitions", async () => {
     const store = createTransactionalEmailStore();
     await store.enqueue("first-view:share-1", firstViewPayload, "awaiting_ai");
@@ -163,6 +177,28 @@ describe("transactional email store", () => {
     ).resolves.toMatchObject({ reminderCursor: { id: "share-100" } });
   });
 
+  it("preserves concurrent reconciliation cursor updates", async () => {
+    const store = createTransactionalEmailStore();
+    await store.ensureEnabledAt();
+
+    await expect(
+      Promise.all([
+        store.updateReconciliationCursor("reminderCursor", {
+          createdAt: "2026-08-03T10:00:00.000Z",
+          id: "share-100",
+        }),
+        store.updateReconciliationCursor("firstViewCursor", {
+          createdAt: "2026-08-03T10:00:00.000Z",
+          id: "view-100",
+        }),
+      ]),
+    ).resolves.toHaveLength(2);
+    await expect(store.readConfig()).resolves.toMatchObject({
+      reminderCursor: { id: "share-100" },
+      firstViewCursor: { id: "view-100" },
+    });
+  });
+
   it("converges an unsent first-import job", async () => {
     const store = createTransactionalEmailStore();
     await store.enqueue("first-import:owner@example.com", {
@@ -187,5 +223,29 @@ describe("transactional email store", () => {
       created: false,
       job: { state: "pending", recordingIds: ["recording-older"] },
     });
+  });
+
+  it("does not overwrite a concurrently converged first-import job", async () => {
+    const store = createTransactionalEmailStore();
+    await store.enqueue("first-import:owner@example.com", {
+      type: "first-import",
+      recipient: "owner@example.com",
+      recordingIds: ["recording-original"],
+      requestedBy: "owner@example.com",
+    });
+
+    const results = await Promise.all([
+      store.enqueueOrConvergeFirstImport(
+        "owner@example.com",
+        "recording-first",
+        "owner@example.com",
+      ),
+      store.enqueueOrConvergeFirstImport(
+        "owner@example.com",
+        "recording-second",
+        "owner@example.com",
+      ),
+    ]);
+    expect(results[0].job).toEqual(results[1].job);
   });
 });

--- a/templates/clips/server/lib/transactional-email-store.test.ts
+++ b/templates/clips/server/lib/transactional-email-store.test.ts
@@ -1,31 +1,16 @@
-import { createHash } from "node:crypto";
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  readdir,
-  rm,
-  utimes,
-  writeFile,
-} from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { afterEach, describe, expect, it } from "vitest";
+let db: ReturnType<typeof drizzle>;
+let sqlite: Client;
+
+vi.mock("../db/index.js", async () => {
+  const schema = await import("../db/schema.js");
+  return { getDb: () => db, schema };
+});
 
 import { createTransactionalEmailStore } from "./transactional-email-store";
-
-const roots: string[] = [];
-
-async function testRoot(): Promise<string> {
-  const root = await mkdtemp(path.join(os.tmpdir(), "clips-email-store-"));
-  roots.push(root);
-  return root;
-}
-
-function filenameFor(logicalKey: string): string {
-  return `${createHash("sha256").update(logicalKey).digest("hex")}.json`;
-}
 
 const firstViewPayload = {
   type: "first-view" as const,
@@ -35,17 +20,34 @@ const firstViewPayload = {
   requestedBy: "owner@example.com",
 };
 
+async function createTables() {
+  await sqlite.execute(`CREATE TABLE clips_transactional_email_jobs (
+    logical_key TEXT PRIMARY KEY, type TEXT NOT NULL, state TEXT NOT NULL,
+    recipient TEXT NOT NULL, recording_ids_json TEXT NOT NULL, share_id TEXT,
+    requested_by TEXT, month TEXT, generated_summary TEXT, attempts INTEGER NOT NULL,
+    created_at TEXT NOT NULL, updated_at TEXT NOT NULL, ai_dispatched_at TEXT,
+    ai_claimed_by TEXT, ready_at TEXT, sending_at TEXT, sent_at TEXT,
+    cancelled_at TEXT, failed_at TEXT, last_error TEXT, lease_until TEXT,
+    lease_token TEXT
+  )`);
+  await sqlite.execute(`CREATE TABLE clips_transactional_email_configs (
+    id TEXT PRIMARY KEY, config_json TEXT NOT NULL
+  )`);
+}
+
+beforeEach(async () => {
+  sqlite = createClient({ url: ":memory:" });
+  db = drizzle(sqlite);
+  await createTables();
+});
+
 afterEach(async () => {
-  await Promise.all(
-    roots.splice(0).map((root) => rm(root, { recursive: true })),
-  );
+  await sqlite.close();
 });
 
 describe("transactional email store", () => {
-  it("uses exclusive creation to make enqueue idempotent", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-
+  it("uses SQL uniqueness to make enqueue idempotent", async () => {
+    const store = createTransactionalEmailStore();
     const results = await Promise.all([
       store.enqueue("first-view:share-1", firstViewPayload),
       store.enqueue("first-view:share-1", firstViewPayload),
@@ -54,42 +56,10 @@ describe("transactional email store", () => {
     expect(results.filter((result) => result.created)).toHaveLength(1);
     expect(results[0].job).toEqual(results[1].job);
     expect(await store.listJobs()).toHaveLength(1);
-    expect(
-      await readFile(
-        path.join(root, "jobs", filenameFor("first-view:share-1")),
-        "utf8",
-      ),
-    ).toContain("first-view:share-1");
   });
 
-  it("never exposes an interrupted initial publication as a final job", async () => {
-    const root = await testRoot();
-    const interruptedStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterInitialJobTempSynced: async () => {
-          throw new Error("simulated publication interruption");
-        },
-      },
-    });
-
-    await expect(
-      interruptedStore.enqueue("first-view:share-1", firstViewPayload),
-    ).rejects.toThrow("simulated publication interruption");
-    await expect(interruptedStore.listJobs()).resolves.toEqual([]);
-    expect(await readdir(path.join(root, "jobs"))).toEqual([]);
-
-    const recoveredStore = createTransactionalEmailStore({ root });
-    await expect(
-      recoveredStore.enqueue("first-view:share-1", firstViewPayload),
-    ).resolves.toMatchObject({ created: true });
-    await expect(recoveredStore.listJobs()).resolves.toHaveLength(1);
-  });
-
-  it("validates payload shape and never accepts transcript excerpts", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-
+  it("validates payloads before persisting a job", async () => {
+    const store = createTransactionalEmailStore();
     await expect(
       store.enqueue("two-clips:owner", {
         type: "two-clips",
@@ -97,133 +67,26 @@ describe("transactional email store", () => {
         recordingIds: ["recording-1"],
       }),
     ).rejects.toThrow();
-
-    await expect(
-      store.enqueue("first-import:owner@example.com", {
-        type: "first-import",
-        recipient: "owner@example.com",
-        recordingIds: ["recording-1", "recording-2"],
-      }),
-    ).rejects.toThrow();
-
-    await expect(
-      store.enqueue("first-view:transcript", {
-        ...firstViewPayload,
-        transcriptExcerpt: "This must not be persisted",
-      } as typeof firstViewPayload),
-    ).rejects.toThrow();
     expect(await store.listJobs()).toEqual([]);
   });
 
-  it("rejects corrupted and schema-invalid job files", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-    await store.enqueue("first-view:share-1", firstViewPayload);
-    const file = path.join(root, "jobs", filenameFor("first-view:share-1"));
-
-    await writeFile(file, "{not-json", "utf8");
-    await expect(store.readJob("first-view:share-1")).rejects.toThrow(
-      "Invalid transactional email job JSON",
-    );
-
-    await writeFile(
-      file,
-      JSON.stringify({ logicalKey: "first-view:share-1", state: "unknown" }),
-      "utf8",
-    );
-    await expect(store.listJobs()).rejects.toThrow(
-      "Invalid transactional email job",
-    );
-  });
-
-  it("allows only explicit state transitions and atomically claims AI work", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
+  it("claims AI work once and enforces valid transitions", async () => {
+    const store = createTransactionalEmailStore();
     await store.enqueue("first-view:share-1", firstViewPayload, "awaiting_ai");
 
     await expect(
       store.transition("first-view:share-1", ["awaiting_ai"], "sent"),
     ).rejects.toThrow("Invalid transactional email transition");
-
     const [firstClaim, secondClaim] = await Promise.all([
       store.claimNextAwaitingAi(),
       store.claimNextAwaitingAi(),
     ]);
     expect([firstClaim, secondClaim].filter(Boolean)).toHaveLength(1);
-    expect((firstClaim ?? secondClaim)?.state).toBe("ai_dispatched");
-
-    const ready = await store.transition(
-      "first-view:share-1",
-      ["ai_dispatched"],
-      "ready",
-      { generatedSummary: "A concise generated summary." },
-    );
-    expect(ready).toMatchObject({
-      state: "ready",
-      generatedSummary: "A concise generated summary.",
-      leaseUntil: null,
-    });
-    expect(ready?.readyAt).toBeTruthy();
-    await expect(
-      store.transition("first-view:share-1", ["pending"], "cancelled"),
-    ).resolves.toBeNull();
   });
 
-  it("allows one claimant-scoped AI completion without reclaiming", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-    await store.enqueue(
-      "two-clips:recipient@example.com",
-      {
-        type: "two-clips",
-        recipient: "recipient@example.com",
-        recordingIds: ["recording-1", "recording-2"],
-        requestedBy: "sender@example.com",
-      },
-      "awaiting_ai",
-    );
-
-    await expect(
-      store.claimAwaitingAi(
-        "two-clips:recipient@example.com",
-        "claimant@example.com",
-      ),
-    ).resolves.toMatchObject({
-      state: "ai_dispatched",
-      aiClaimedBy: "claimant@example.com",
-    });
-    await expect(
-      store.claimAwaitingAi(
-        "two-clips:recipient@example.com",
-        "other@example.com",
-      ),
-    ).resolves.toBeNull();
-    await expect(
-      store.completeClaimedAi(
-        "two-clips:recipient@example.com",
-        "other@example.com",
-        "One sentence.",
-      ),
-    ).resolves.toBeNull();
-    await expect(
-      store.completeClaimedAi(
-        "two-clips:recipient@example.com",
-        "claimant@example.com",
-        "One sentence.",
-      ),
-    ).resolves.toMatchObject({
-      state: "ready",
-      generatedSummary: "One sentence.",
-    });
-  });
-
-  it("reclaims only stale AI dispatches", async () => {
-    const root = await testRoot();
+  it("preserves claimant fencing and reclaims only stale AI dispatches", async () => {
     let currentTime = new Date("2026-08-01T12:00:00.000Z");
-    const store = createTransactionalEmailStore({
-      root,
-      now: () => currentTime,
-    });
+    const store = createTransactionalEmailStore({ now: () => currentTime });
     const logicalKey = "two-clips:recipient@example.com";
     await store.enqueue(
       logicalKey,
@@ -238,13 +101,8 @@ describe("transactional email store", () => {
     await store.claimAwaitingAi(logicalKey, "first@example.com");
 
     await expect(
-      store.reclaimStaleAiDispatch(
-        logicalKey,
-        "second@example.com",
-        new Date("2026-08-01T11:59:59.999Z"),
-      ),
+      store.completeClaimedAi(logicalKey, "other@example.com", "One sentence."),
     ).resolves.toBeNull();
-
     currentTime = new Date("2026-08-01T12:30:00.000Z");
     await expect(
       store.reclaimStaleAiDispatch(
@@ -255,343 +113,58 @@ describe("transactional email store", () => {
     ).resolves.toMatchObject({
       state: "ai_dispatched",
       aiClaimedBy: "second@example.com",
-      aiDispatchedAt: "2026-08-01T12:30:00.000Z",
     });
   });
 
-  it("acquires a sending lease and reclaims only expired leases", async () => {
-    const root = await testRoot();
+  it("fences stale sending leases", async () => {
     let currentTime = new Date("2026-08-01T12:00:00.000Z");
-    const store = createTransactionalEmailStore({
-      root,
-      now: () => currentTime,
-    });
+    const store = createTransactionalEmailStore({ now: () => currentTime });
     await store.enqueue("first-view:share-1", firstViewPayload);
     await store.transition("first-view:share-1", ["pending"], "ready");
-
     const firstLease = await store.acquireSendingLease(
       "first-view:share-1",
       60_000,
     );
-    expect(firstLease).toMatchObject({
-      state: "sending",
-      attempts: 1,
-      leaseUntil: "2026-08-01T12:01:00.000Z",
-      leaseToken: expect.any(String),
-    });
-    const firstLeaseToken = firstLease?.leaseToken;
-    expect(firstLeaseToken).toBeTruthy();
-
-    currentTime = new Date("2026-08-01T12:00:59.999Z");
-    await expect(
-      store.acquireSendingLease("first-view:share-1", 60_000),
-    ).resolves.toBeNull();
 
     currentTime = new Date("2026-08-01T12:01:00.000Z");
     const reclaimed = await store.acquireSendingLease(
       "first-view:share-1",
       30_000,
     );
-    expect(reclaimed).toMatchObject({
-      state: "sending",
-      attempts: 2,
-      leaseUntil: "2026-08-01T12:01:30.000Z",
-      leaseToken: expect.any(String),
-    });
-    const reclaimedLeaseToken = reclaimed?.leaseToken;
-    expect(reclaimedLeaseToken).toBeTruthy();
-    expect(reclaimedLeaseToken).not.toBe(firstLeaseToken);
-
+    expect(reclaimed).toMatchObject({ state: "sending", attempts: 2 });
     await expect(
-      store.transition("first-view:share-1", ["sending"], "sent"),
+      store.transitionSending(
+        "first-view:share-1",
+        firstLease!.leaseToken!,
+        "sent",
+      ),
     ).resolves.toBeNull();
-    for (const nextState of ["sent", "ready", "failed", "cancelled"] as const) {
-      await expect(
-        store.transitionSending(
-          "first-view:share-1",
-          firstLeaseToken!,
-          nextState,
-          nextState === "failed" ? { lastError: "stale failure" } : {},
-        ),
-      ).resolves.toBeNull();
-    }
-    await expect(store.readJob("first-view:share-1")).resolves.toMatchObject({
-      state: "sending",
-      leaseToken: reclaimedLeaseToken,
-    });
-
-    const sent = await store.transitionSending(
-      "first-view:share-1",
-      reclaimedLeaseToken!,
-      "sent",
-    );
-    expect(sent).toMatchObject({
-      state: "sent",
-      leaseUntil: null,
-      leaseToken: null,
-    });
-    expect(sent?.sentAt).toBe("2026-08-01T12:01:00.000Z");
-  });
-
-  it("recovers a stale filesystem lock after a crashed writer", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-    await store.enqueue("first-view:share-1", firstViewPayload);
-    const locksDirectory = path.join(root, "locks");
-    await mkdir(locksDirectory, { recursive: true });
-    const lock = path.join(
-      locksDirectory,
-      `${createHash("sha256").update("first-view:share-1").digest("hex")}.lock`,
-    );
-    await writeFile(lock, "", "utf8");
-    const staleTime = new Date(Date.now() - 31_000);
-    await utimes(lock, staleTime, staleTime);
-
     await expect(
-      store.transition("first-view:share-1", ["pending"], "ready"),
-    ).resolves.toMatchObject({ state: "ready" });
+      store.transitionSending(
+        "first-view:share-1",
+        reclaimed!.leaseToken!,
+        "sent",
+      ),
+    ).resolves.toMatchObject({ state: "sent", leaseToken: null });
   });
 
-  it("recovers a stale takeover marker after a crashed reclaimer", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
-    await store.enqueue("first-view:share-1", firstViewPayload);
-    const locksDirectory = path.join(root, "locks");
-    const lock = path.join(
-      locksDirectory,
-      `${createHash("sha256").update("first-view:share-1").digest("hex")}.lock`,
-    );
-    const takeover = `${lock}.takeover`;
-    await writeFile(takeover, "crashed reclaimer", "utf8");
-    const staleTime = new Date(Date.now() - 31_000);
-    await utimes(takeover, staleTime, staleTime);
-
-    await expect(
-      store.transition("first-view:share-1", ["pending"], "ready"),
-    ).resolves.toMatchObject({ state: "ready" });
-    expect(await readdir(locksDirectory)).toEqual([]);
-  });
-
-  it("allows only one of two stale-lock reclaimers to enter", async () => {
-    const root = await testRoot();
-    const setupStore = createTransactionalEmailStore({ root });
-    await setupStore.enqueue("first-view:share-1", firstViewPayload);
-    const locksDirectory = path.join(root, "locks");
-    await mkdir(locksDirectory, { recursive: true });
-    const lock = path.join(
-      locksDirectory,
-      `${createHash("sha256").update("first-view:share-1").digest("hex")}.lock`,
-    );
-    await writeFile(lock, "stale owner", "utf8");
-    const staleTime = new Date(Date.now() - 31_000);
-    await utimes(lock, staleTime, staleTime);
-
-    let releaseFirstSnapshot: (() => void) | undefined;
-    const firstSnapshotPaused = new Promise<void>((resolve) => {
-      releaseFirstSnapshot = resolve;
-    });
-    let firstSawStaleLock: (() => void) | undefined;
-    const firstSawStaleLockPromise = new Promise<void>((resolve) => {
-      firstSawStaleLock = resolve;
-    });
-    let entered = 0;
-    const firstStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterStaleLockSnapshot: async () => {
-          firstSawStaleLock?.();
-          await firstSnapshotPaused;
-        },
-        afterJobLockAcquired: async () => {
-          entered += 1;
-        },
-      },
-    });
-    const secondStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterJobLockAcquired: async () => {
-          entered += 1;
-        },
-      },
-    });
-
-    const first = firstStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    await firstSawStaleLockPromise;
-    const second = await secondStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    releaseFirstSnapshot?.();
-
-    await expect(first).resolves.toMatchObject({ state: "ready" });
-    expect(second).toBeNull();
-    expect(entered).toBe(1);
-    expect(await readdir(locksDirectory)).toEqual([]);
-  });
-
-  it("releases a held lock after a fresh contender exits", async () => {
-    const root = await testRoot();
-    const setupStore = createTransactionalEmailStore({ root });
-    await setupStore.enqueue("first-view:share-1", firstViewPayload);
-
-    let releaseHolder: (() => void) | undefined;
-    const holderPaused = new Promise<void>((resolve) => {
-      releaseHolder = resolve;
-    });
-    let holderAcquired: (() => void) | undefined;
-    const holderAcquiredPromise = new Promise<void>((resolve) => {
-      holderAcquired = resolve;
-    });
-    const holderStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterJobLockAcquired: async () => {
-          holderAcquired?.();
-          await holderPaused;
-        },
-      },
-    });
-
-    let releaseContender: (() => void) | undefined;
-    const contenderPaused = new Promise<void>((resolve) => {
-      releaseContender = resolve;
-    });
-    let freshContention: (() => void) | undefined;
-    const freshContentionPromise = new Promise<void>((resolve) => {
-      freshContention = resolve;
-    });
-    const contenderStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterFreshLockContention: async () => {
-          freshContention?.();
-          await contenderPaused;
-        },
-      },
-    });
-
-    const holder = holderStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    await holderAcquiredPromise;
-    const contender = contenderStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    await freshContentionPromise;
-
-    releaseHolder?.();
-    await expect(holder).resolves.toMatchObject({ state: "ready" });
-    releaseContender?.();
-    await expect(contender).resolves.toBeNull();
-    await expect(
-      setupStore.transition("first-view:share-1", ["ready"], "cancelled"),
-    ).resolves.toMatchObject({ state: "cancelled" });
-  });
-
-  it("does not release a replacement lock owned by a stale reclaimer", async () => {
-    const root = await testRoot();
-    const setupStore = createTransactionalEmailStore({ root });
-    await setupStore.enqueue("first-view:share-1", firstViewPayload);
-    const lock = path.join(
-      root,
-      "locks",
-      `${createHash("sha256").update("first-view:share-1").digest("hex")}.lock`,
-    );
-
-    let releaseOriginal: (() => void) | undefined;
-    const originalPaused = new Promise<void>((resolve) => {
-      releaseOriginal = resolve;
-    });
-    let originalAcquired: (() => void) | undefined;
-    const originalAcquiredPromise = new Promise<void>((resolve) => {
-      originalAcquired = resolve;
-    });
-    const originalStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterJobLockAcquired: async () => {
-          originalAcquired?.();
-          await originalPaused;
-        },
-      },
-    });
-    const original = originalStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    await originalAcquiredPromise;
-    const staleTime = new Date(Date.now() - 31_000);
-    await utimes(lock, staleTime, staleTime);
-
-    let releaseReplacement: (() => void) | undefined;
-    const replacementPaused = new Promise<void>((resolve) => {
-      releaseReplacement = resolve;
-    });
-    let replacementAcquired: (() => void) | undefined;
-    const replacementAcquiredPromise = new Promise<void>((resolve) => {
-      replacementAcquired = resolve;
-    });
-    const replacementStore = createTransactionalEmailStore({
-      root,
-      testHooks: {
-        afterJobLockAcquired: async () => {
-          replacementAcquired?.();
-          await replacementPaused;
-        },
-      },
-    });
-    const replacement = replacementStore.transition(
-      "first-view:share-1",
-      ["pending"],
-      "ready",
-    );
-    await replacementAcquiredPromise;
-
-    releaseOriginal?.();
-    await expect(original).resolves.toBeNull();
-    await expect(
-      setupStore.transition("first-view:share-1", ["pending"], "cancelled"),
-    ).resolves.toBeNull();
-
-    releaseReplacement?.();
-    await expect(replacement).resolves.toMatchObject({ state: "ready" });
-  });
-
-  it("creates enabledAt exclusively and preserves the first timestamp", async () => {
-    const root = await testRoot();
-    const firstStore = createTransactionalEmailStore({
-      root,
+  it("persists enabledAt and reconciliation cursors in SQL", async () => {
+    const store = createTransactionalEmailStore({
       now: () => new Date("2026-08-02T10:00:00.000Z"),
     });
-    const laterStore = createTransactionalEmailStore({
-      root,
-      now: () => new Date("2026-08-02T11:00:00.000Z"),
+    await expect(store.ensureEnabledAt()).resolves.toEqual({
+      enabledAt: "2026-08-02T10:00:00.000Z",
     });
-
-    const [first, second] = await Promise.all([
-      firstStore.ensureEnabledAt(),
-      laterStore.ensureEnabledAt(),
-    ]);
-
-    expect(first).toEqual(second);
-    expect(await laterStore.ensureEnabledAt()).toEqual(first);
-    expect(await firstStore.readConfig()).toEqual(first);
+    await expect(
+      store.updateReconciliationCursor("reminderCursor", {
+        createdAt: "2026-08-03T10:00:00.000Z",
+        id: "share-100",
+      }),
+    ).resolves.toMatchObject({ reminderCursor: { id: "share-100" } });
   });
 
-  it("converges an unsent first-import job on the canonical recording", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({ root });
+  it("converges an unsent first-import job", async () => {
+    const store = createTransactionalEmailStore();
     await store.enqueue("first-import:owner@example.com", {
       type: "first-import",
       recipient: "owner@example.com",
@@ -604,68 +177,15 @@ describe("transactional email store", () => {
       "cancelled",
     );
 
-    const converged = await store.enqueueOrConvergeFirstImport(
-      "owner@example.com",
-      "recording-older",
-      "owner@example.com",
-    );
-
-    expect(converged).toMatchObject({
+    await expect(
+      store.enqueueOrConvergeFirstImport(
+        "owner@example.com",
+        "recording-older",
+        "owner@example.com",
+      ),
+    ).resolves.toMatchObject({
       created: false,
-      job: {
-        state: "pending",
-        recordingIds: ["recording-older"],
-        attempts: 0,
-        cancelledAt: undefined,
-      },
+      job: { state: "pending", recordingIds: ["recording-older"] },
     });
-  });
-
-  it("validates and atomically persists the reconciliation cursor", async () => {
-    const root = await testRoot();
-    const store = createTransactionalEmailStore({
-      root,
-      now: () => new Date("2026-08-02T10:00:00.000Z"),
-    });
-    await store.ensureEnabledAt();
-
-    await expect(
-      store.updateReconciliationCursor("reminderCursor", {
-        createdAt: "2026-08-03T10:00:00.000Z",
-        id: "share-100",
-      }),
-    ).resolves.toEqual({
-      enabledAt: "2026-08-02T10:00:00.000Z",
-      reminderCursor: {
-        createdAt: "2026-08-03T10:00:00.000Z",
-        id: "share-100",
-      },
-    });
-
-    await expect(
-      store.updateReconciliationCursor("reminderCursor", {
-        createdAt: "invalid",
-        id: "",
-      }),
-    ).rejects.toThrow();
-    expect(await store.readConfig()).toEqual({
-      enabledAt: "2026-08-02T10:00:00.000Z",
-      reminderCursor: {
-        createdAt: "2026-08-03T10:00:00.000Z",
-        id: "share-100",
-      },
-    });
-  });
-
-  it("rejects corrupted enabledAt configuration instead of replacing it", async () => {
-    const root = await testRoot();
-    await mkdir(root, { recursive: true });
-    await writeFile(path.join(root, "config.json"), "{}", "utf8");
-    const store = createTransactionalEmailStore({ root });
-
-    await expect(store.ensureEnabledAt()).rejects.toThrow(
-      "Invalid transactional email config",
-    );
-    expect(await readFile(path.join(root, "config.json"), "utf8")).toBe("{}");
   });
 });

--- a/templates/clips/server/lib/transactional-email-store.ts
+++ b/templates/clips/server/lib/transactional-email-store.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { and, asc, eq, isNull, lte, or, type SQL } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lte, or, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../db/index.js";
@@ -341,11 +341,18 @@ export function createTransactionalEmailStore(
     return row ? databaseJobToJob(row) : null;
   }
 
-  async function listJobs(): Promise<TransactionalEmailJob[]> {
+  async function listJobs(
+    states?: readonly TransactionalEmailState[],
+  ): Promise<TransactionalEmailJob[]> {
     return (
       await getDb()
         .select()
         .from(schema.transactionalEmailJobs)
+        .where(
+          states?.length
+            ? inArray(schema.transactionalEmailJobs.state, states)
+            : undefined,
+        )
         .orderBy(asc(schema.transactionalEmailJobs.createdAt))
     ).map(databaseJobToJob);
   }
@@ -437,6 +444,10 @@ export function createTransactionalEmailStore(
       and(
         eq(schema.transactionalEmailJobs.logicalKey, logicalKey),
         eq(schema.transactionalEmailJobs.state, job.state),
+        eq(
+          schema.transactionalEmailJobs.recordingIdsJson,
+          JSON.stringify(job.recordingIds),
+        ),
       ),
     );
     return {
@@ -698,29 +709,33 @@ export function createTransactionalEmailStore(
     const parsedCursorName =
       transactionalEmailCursorNameSchema.parse(cursorName);
     const parsedCursor = reconciliationCursorSchema.parse(reconciliationCursor);
-    const config = await readConfig();
-    if (!config)
-      throw new Error("Transactional email config is not initialized");
-    const nextConfig = transactionalEmailConfigSchema.parse({
-      ...config,
-      [parsedCursorName]: parsedCursor,
-    });
-    const [updated] = await getDb()
-      .update(schema.transactionalEmailConfigs)
-      .set({ configJson: JSON.stringify(nextConfig) })
-      .where(
-        and(
-          eq(schema.transactionalEmailConfigs.id, "default"),
-          eq(
-            schema.transactionalEmailConfigs.configJson,
-            JSON.stringify(config),
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const config = await readConfig();
+      if (!config)
+        throw new Error("Transactional email config is not initialized");
+      const nextConfig = transactionalEmailConfigSchema.parse({
+        ...config,
+        [parsedCursorName]: parsedCursor,
+      });
+      const [updated] = await getDb()
+        .update(schema.transactionalEmailConfigs)
+        .set({ configJson: JSON.stringify(nextConfig) })
+        .where(
+          and(
+            eq(schema.transactionalEmailConfigs.id, "default"),
+            eq(
+              schema.transactionalEmailConfigs.configJson,
+              JSON.stringify(config),
+            ),
           ),
-        ),
-      )
-      .returning();
-    if (!updated)
-      throw new Error("Transactional email config is being updated");
-    return transactionalEmailConfigSchema.parse(JSON.parse(updated.configJson));
+        )
+        .returning();
+      if (updated)
+        return transactionalEmailConfigSchema.parse(
+          JSON.parse(updated.configJson),
+        );
+    }
+    throw new Error("Transactional email config is being updated");
   }
 
   return {

--- a/templates/clips/server/lib/transactional-email-store.ts
+++ b/templates/clips/server/lib/transactional-email-store.ts
@@ -1,19 +1,9 @@
-import { createHash, randomUUID } from "node:crypto";
-import {
-  link,
-  mkdir,
-  open,
-  readFile,
-  readdir,
-  rename,
-  rm,
-  stat,
-  unlink,
-  writeFile,
-} from "node:fs/promises";
-import path from "node:path";
+import { randomUUID } from "node:crypto";
 
+import { and, asc, eq, isNull, lte, or, type SQL } from "drizzle-orm";
 import { z } from "zod";
+
+import { getDb, schema } from "../db/index.js";
 
 const timestampSchema = z.string().datetime({ offset: true });
 const nonEmptyStringSchema = z.string().trim().min(1);
@@ -213,17 +203,8 @@ export function isAiBackedType(type: TransactionalEmailJob["type"]): boolean {
 }
 
 export type TransactionalEmailStoreOptions = {
-  root?: string;
   now?: () => Date;
-  testHooks?: {
-    afterInitialJobTempSynced?: () => Promise<void>;
-    afterStaleLockSnapshot?: () => Promise<void>;
-    afterJobLockAcquired?: () => Promise<void>;
-    afterFreshLockContention?: () => Promise<void>;
-  };
 };
-
-const LOCK_STALE_MS = 30_000;
 export const AI_DISPATCH_STALE_MS = 30 * 60 * 1000;
 
 const allowedTransitions: Record<
@@ -240,18 +221,6 @@ const allowedTransitions: Record<
   failed: new Set(),
 };
 
-function isNodeError(error: unknown, code: string): boolean {
-  return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as NodeJS.ErrnoException).code === code
-  );
-}
-
-function jobHash(logicalKey: string): string {
-  return createHash("sha256").update(logicalKey).digest("hex");
-}
-
 function stateTimestampField(
   state: TransactionalEmailState,
 ): keyof TransactionalEmailJob | null {
@@ -264,296 +233,142 @@ function stateTimestampField(
   return null;
 }
 
+function databaseJobToJob(
+  row: typeof schema.transactionalEmailJobs.$inferSelect,
+): TransactionalEmailJob {
+  let recordingIds: unknown;
+  try {
+    recordingIds = JSON.parse(row.recordingIdsJson);
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : "";
+    throw new Error(
+      `Invalid transactional email job recording ids for ${row.logicalKey}${detail}`,
+    );
+  }
+  return transactionalEmailJobSchema.parse({
+    logicalKey: row.logicalKey,
+    type: row.type,
+    state: row.state,
+    recipient: row.recipient,
+    recordingIds,
+    attempts: row.attempts,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    lastError: row.lastError,
+    leaseUntil: row.leaseUntil,
+    leaseToken: row.leaseToken,
+    shareId: row.shareId ?? undefined,
+    requestedBy: row.requestedBy ?? undefined,
+    month: row.month ?? undefined,
+    generatedSummary: row.generatedSummary ?? undefined,
+    aiDispatchedAt: row.aiDispatchedAt ?? undefined,
+    aiClaimedBy: row.aiClaimedBy ?? undefined,
+    readyAt: row.readyAt ?? undefined,
+    sendingAt: row.sendingAt ?? undefined,
+    sentAt: row.sentAt ?? undefined,
+    cancelledAt: row.cancelledAt ?? undefined,
+    failedAt: row.failedAt ?? undefined,
+  });
+}
+
+function jobToDatabaseValues(job: TransactionalEmailJob) {
+  return {
+    logicalKey: job.logicalKey,
+    type: job.type,
+    state: job.state,
+    recipient: job.recipient,
+    recordingIdsJson: JSON.stringify(job.recordingIds),
+    shareId: job.shareId ?? null,
+    requestedBy: job.requestedBy ?? null,
+    month: job.month ?? null,
+    generatedSummary: job.generatedSummary ?? null,
+    attempts: job.attempts,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    aiDispatchedAt: job.aiDispatchedAt ?? null,
+    aiClaimedBy: job.aiClaimedBy ?? null,
+    readyAt: job.readyAt ?? null,
+    sendingAt: job.sendingAt ?? null,
+    sentAt: job.sentAt ?? null,
+    cancelledAt: job.cancelledAt ?? null,
+    failedAt: job.failedAt ?? null,
+    lastError: job.lastError,
+    leaseUntil: job.leaseUntil,
+    leaseToken: job.leaseToken,
+  };
+}
+
 export function createTransactionalEmailStore(
   options: TransactionalEmailStoreOptions = {},
 ) {
-  const root =
-    options.root ??
-    path.join(process.cwd(), "data", "clips-transactional-emails");
-  const jobsDirectory = path.join(root, "jobs");
-  const locksDirectory = path.join(root, "locks");
-  const configFile = path.join(root, "config.json");
   const now = options.now ?? (() => new Date());
-  const testHooks = options.testHooks;
 
-  const jobFile = (logicalKey: string) =>
-    path.join(jobsDirectory, `${jobHash(logicalKey)}.json`);
-  const lockFile = (logicalKey: string) =>
-    path.join(locksDirectory, `${jobHash(logicalKey)}.lock`);
-
-  async function ensureDirectories(): Promise<void> {
-    await Promise.all([
-      mkdir(jobsDirectory, { recursive: true, mode: 0o700 }),
-      mkdir(locksDirectory, { recursive: true, mode: 0o700 }),
-    ]);
+  function normalizeRecipient(email: string) {
+    return recipientSchema.parse(email.trim().toLowerCase());
   }
 
-  async function parseJsonFile<T>(
-    file: string,
-    schema: z.ZodType<T>,
-    description: string,
-  ): Promise<T> {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(await readFile(file, "utf8"));
-    } catch (error) {
-      if (isNodeError(error, "ENOENT")) throw error;
-      const detail = error instanceof Error ? `: ${error.message}` : "";
-      throw new Error(`Invalid ${description} JSON at ${file}${detail}`);
-    }
-    const result = schema.safeParse(parsed);
-    if (!result.success) {
-      throw new Error(
-        `Invalid ${description} at ${file}: ${result.error.message}`,
-      );
-    }
-    return result.data;
-  }
-
-  async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
-    const temporaryFile = path.join(
-      path.dirname(file),
-      `.${path.basename(file)}.${process.pid}.${randomUUID()}.tmp`,
-    );
-    try {
-      await writeFile(temporaryFile, `${JSON.stringify(value, null, 2)}\n`, {
-        encoding: "utf8",
-        flag: "wx",
-        mode: 0o600,
-      });
-      await rename(temporaryFile, file);
-    } catch (error) {
-      await rm(temporaryFile, { force: true }).catch(() => undefined);
-      throw error;
-    }
-  }
-
-  async function publishJsonExclusive(
-    file: string,
-    value: unknown,
-  ): Promise<boolean> {
-    const temporaryFile = path.join(
-      path.dirname(file),
-      `.${path.basename(file)}.${process.pid}.${randomUUID()}.tmp`,
-    );
-    let handle;
-    try {
-      handle = await open(temporaryFile, "wx", 0o600);
-      await handle.writeFile(`${JSON.stringify(value, null, 2)}\n`, "utf8");
-      await handle.sync();
-      await handle.close();
-      handle = undefined;
-      await testHooks?.afterInitialJobTempSynced?.();
-      try {
-        await link(temporaryFile, file);
-        const directoryHandle = await open(path.dirname(file), "r");
-        try {
-          await directoryHandle.sync();
-        } finally {
-          await directoryHandle.close();
-        }
-        return true;
-      } catch (error) {
-        if (isNodeError(error, "EEXIST")) return false;
-        throw error;
-      }
-    } finally {
-      await handle?.close().catch(() => undefined);
-      await rm(temporaryFile, { force: true }).catch(() => undefined);
-    }
+  function transitionedJob(
+    job: TransactionalEmailJob,
+    nextState: TransactionalEmailState,
+    changes: { generatedSummary?: string; lastError?: string | null } = {},
+  ) {
+    const timestamp = now().toISOString();
+    const timestampField = stateTimestampField(nextState);
+    return transactionalEmailJobSchema.parse({
+      ...job,
+      ...changes,
+      state: nextState,
+      updatedAt: timestamp,
+      leaseUntil: null,
+      leaseToken: null,
+      ...(timestampField ? { [timestampField]: timestamp } : {}),
+    });
   }
 
   async function readJob(
     logicalKey: string,
   ): Promise<TransactionalEmailJob | null> {
-    const file = jobFile(logicalKey);
-    try {
-      const job = await parseJsonFile(
-        file,
-        transactionalEmailJobSchema,
-        "transactional email job",
-      );
-      if (job.logicalKey !== logicalKey) {
-        throw new Error(`Transactional email job key mismatch at ${file}`);
-      }
-      return job;
-    } catch (error) {
-      if (isNodeError(error, "ENOENT")) return null;
-      throw error;
-    }
+    const [row] = await getDb()
+      .select()
+      .from(schema.transactionalEmailJobs)
+      .where(
+        eq(
+          schema.transactionalEmailJobs.logicalKey,
+          nonEmptyStringSchema.parse(logicalKey),
+        ),
+      )
+      .limit(1);
+    return row ? databaseJobToJob(row) : null;
   }
 
   async function listJobs(): Promise<TransactionalEmailJob[]> {
-    await ensureDirectories();
-    const files = (await readdir(jobsDirectory))
-      .filter((file) => file.endsWith(".json"))
-      .sort();
-    const jobs = await Promise.all(
-      files.map(async (filename) => {
-        const file = path.join(jobsDirectory, filename);
-        const job = await parseJsonFile(
-          file,
-          transactionalEmailJobSchema,
-          "transactional email job",
-        );
-        if (filename !== `${jobHash(job.logicalKey)}.json`) {
-          throw new Error(`Transactional email job key mismatch at ${file}`);
-        }
-        return job;
-      }),
-    );
-    return jobs.sort((left, right) =>
-      left.createdAt.localeCompare(right.createdAt),
-    );
-  }
-
-  type FileIdentity = { dev: number; ino: number };
-
-  function identityOf(value: { dev: number; ino: number }): FileIdentity {
-    return { dev: value.dev, ino: value.ino };
-  }
-
-  function sameIdentity(
-    left: FileIdentity | null,
-    right: FileIdentity | null,
-  ): boolean {
     return (
-      left !== null &&
-      right !== null &&
-      left.dev === right.dev &&
-      left.ino === right.ino
-    );
+      await getDb()
+        .select()
+        .from(schema.transactionalEmailJobs)
+        .orderBy(asc(schema.transactionalEmailJobs.createdAt))
+    ).map(databaseJobToJob);
   }
 
-  async function fileIdentity(file: string): Promise<FileIdentity | null> {
-    const value = await stat(file).catch((error: unknown) => {
-      if (isNodeError(error, "ENOENT")) return null;
-      throw error;
-    });
-    return value ? identityOf(value) : null;
-  }
-
-  async function unlinkIfIdentity(
-    file: string,
-    expected: FileIdentity,
-  ): Promise<boolean> {
-    if (!sameIdentity(await fileIdentity(file), expected)) return false;
-    try {
-      await unlink(file);
-      return true;
-    } catch (error) {
-      if (isNodeError(error, "ENOENT")) return false;
-      throw error;
-    }
-  }
-
-  async function createLockOwner(file: string): Promise<FileIdentity> {
-    const handle = await open(file, "wx", 0o600);
-    try {
-      await handle.sync();
-      return identityOf(await handle.stat());
-    } finally {
-      await handle.close();
-    }
-  }
-
-  async function takeoverMarkerBlocks(file: string): Promise<boolean> {
-    const existing = await stat(file).catch((error: unknown) => {
-      if (isNodeError(error, "ENOENT")) return null;
-      throw error;
-    });
-    if (!existing) return false;
-    if (Date.now() - existing.mtimeMs <= LOCK_STALE_MS) return true;
-    return !(await unlinkIfIdentity(file, identityOf(existing)));
-  }
-
-  async function acquireTakeoverMarker(
-    ownerFile: string,
-    takeoverFile: string,
-  ): Promise<boolean> {
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        await link(ownerFile, takeoverFile);
-        return true;
-      } catch (error) {
-        if (!isNodeError(error, "EEXIST")) throw error;
-        if (await takeoverMarkerBlocks(takeoverFile)) return false;
-      }
-    }
-    return false;
-  }
-
-  async function withJobLock<T>(
-    logicalKey: string,
-    operation: () => Promise<T>,
-  ): Promise<T | null> {
-    await ensureDirectories();
-    const file = lockFile(logicalKey);
-    const ownerFile = `${file}.${process.pid}.${randomUUID()}.owner`;
-    const takeoverFile = `${file}.takeover`;
-    const ownerIdentity = await createLockOwner(ownerFile);
-    let acquired = false;
-    let ownsTakeover = false;
-    try {
-      if (await takeoverMarkerBlocks(takeoverFile)) return null;
-      try {
-        await link(ownerFile, file);
-        acquired = true;
-        if (await takeoverMarkerBlocks(takeoverFile)) return null;
-      } catch (error) {
-        if (!isNodeError(error, "EEXIST")) throw error;
-        const existingLock = await stat(file).catch((statError: unknown) => {
-          if (isNodeError(statError, "ENOENT")) return null;
-          throw statError;
-        });
-        if (
-          existingLock &&
-          Date.now() - existingLock.mtimeMs <= LOCK_STALE_MS
-        ) {
-          await testHooks?.afterFreshLockContention?.();
-          return null;
-        }
-        ownsTakeover = await acquireTakeoverMarker(ownerFile, takeoverFile);
-        if (!ownsTakeover) return null;
-        const lockStat = await stat(file).catch(() => null);
-        if (!lockStat || Date.now() - lockStat.mtimeMs <= LOCK_STALE_MS) {
-          return null;
-        }
-        const staleIdentity = identityOf(lockStat);
-        await testHooks?.afterStaleLockSnapshot?.();
-        if (!sameIdentity(await fileIdentity(file), staleIdentity)) return null;
-        if (!(await unlinkIfIdentity(file, staleIdentity))) return null;
-        try {
-          await link(ownerFile, file);
-          acquired = true;
-        } catch (retryError) {
-          if (isNodeError(retryError, "EEXIST")) return null;
-          throw retryError;
-        }
-      }
-      await testHooks?.afterJobLockAcquired?.();
-      if (!sameIdentity(await fileIdentity(file), ownerIdentity)) return null;
-      return await operation();
-    } finally {
-      // A holder only releases the inode it acquired. A stale reclaimer may
-      // replace that inode while the original holder is paused; identity-based
-      // release preserves the replacement without a cleanup-time takeover race.
-      if (acquired) await unlinkIfIdentity(file, ownerIdentity);
-      if (ownsTakeover) {
-        await unlinkIfIdentity(takeoverFile, ownerIdentity);
-      }
-      await rm(ownerFile, { force: true });
-    }
+  async function replaceJob(
+    job: TransactionalEmailJob,
+    condition: SQL | undefined,
+  ) {
+    const [updated] = await getDb()
+      .update(schema.transactionalEmailJobs)
+      .set(jobToDatabaseValues(job))
+      .where(condition)
+      .returning();
+    return updated ? databaseJobToJob(updated) : null;
   }
 
   async function enqueue(
     logicalKey: string,
     payload: TransactionalEmailPayload,
     initialState: "pending" | "awaiting_ai" = "pending",
-  ): Promise<{ created: boolean; job: TransactionalEmailJob }> {
+  ) {
     const parsedKey = nonEmptyStringSchema.parse(logicalKey);
     const parsedPayload = transactionalEmailPayloadSchema.parse(payload);
-    await ensureDirectories();
     const timestamp = now().toISOString();
     const job = transactionalEmailJobSchema.parse({
       logicalKey: parsedKey,
@@ -566,9 +381,12 @@ export function createTransactionalEmailStore(
       leaseUntil: null,
       leaseToken: null,
     });
-    if (await publishJsonExclusive(jobFile(parsedKey), job)) {
-      return { created: true, job };
-    }
+    const [created] = await getDb()
+      .insert(schema.transactionalEmailJobs)
+      .values(jobToDatabaseValues(job))
+      .onConflictDoNothing()
+      .returning({ logicalKey: schema.transactionalEmailJobs.logicalKey });
+    if (created) return { created: true, job };
     const existing = await readJob(parsedKey);
     if (!existing) {
       throw new Error(`Transactional email job disappeared for ${parsedKey}`);
@@ -580,7 +398,7 @@ export function createTransactionalEmailStore(
     recipient: string,
     recordingId: string,
     requestedBy: string,
-  ): Promise<{ created: boolean; job: TransactionalEmailJob }> {
+  ) {
     const logicalKey = `first-import:${recipient.trim().toLowerCase()}`;
     const enqueued = await enqueue(logicalKey, {
       type: "first-import",
@@ -589,160 +407,170 @@ export function createTransactionalEmailStore(
       requestedBy,
     });
     if (enqueued.created || enqueued.job.state === "sent") return enqueued;
-
-    const converged = await withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (
-        !job ||
-        job.type !== "first-import" ||
-        !["pending", "ready", "cancelled"].includes(job.state)
-      ) {
-        return null;
-      }
-      if (job.recordingIds[0] === recordingId) return job;
-      const timestamp = now().toISOString();
-      const updated = transactionalEmailJobSchema.parse({
-        ...job,
-        recipient,
-        recordingIds: [recordingId],
-        requestedBy,
-        state: "pending",
-        attempts: 0,
-        updatedAt: timestamp,
-        readyAt: undefined,
-        sendingAt: undefined,
-        cancelledAt: undefined,
-        failedAt: undefined,
-        lastError: null,
-        leaseUntil: null,
-        leaseToken: null,
-      });
-      await writeJsonAtomic(jobFile(logicalKey), updated);
-      return updated;
+    const job = enqueued.job;
+    if (
+      job.type !== "first-import" ||
+      !["pending", "ready", "cancelled"].includes(job.state) ||
+      job.recordingIds[0] === recordingId
+    ) {
+      return enqueued;
+    }
+    const timestamp = now().toISOString();
+    const candidate = transactionalEmailJobSchema.parse({
+      ...job,
+      recipient,
+      recordingIds: [recordingId],
+      requestedBy,
+      state: "pending",
+      attempts: 0,
+      updatedAt: timestamp,
+      readyAt: undefined,
+      sendingAt: undefined,
+      cancelledAt: undefined,
+      failedAt: undefined,
+      lastError: null,
+      leaseUntil: null,
+      leaseToken: null,
     });
-    return { created: false, job: converged ?? enqueued.job };
+    const updated = await replaceJob(
+      candidate,
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, logicalKey),
+        eq(schema.transactionalEmailJobs.state, job.state),
+      ),
+    );
+    return {
+      created: false,
+      job: updated ?? (await readJob(logicalKey)) ?? job,
+    };
   }
 
   async function transition(
     logicalKey: string,
     expectedStates: readonly TransactionalEmailState[],
     nextState: TransactionalEmailState,
-    changes: {
-      generatedSummary?: string;
-      lastError?: string | null;
-    } = {},
+    changes: { generatedSummary?: string; lastError?: string | null } = {},
   ): Promise<TransactionalEmailJob | null> {
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (!job || !expectedStates.includes(job.state)) return null;
-      if (job.state === "sending") return null;
-      if (!allowedTransitions[job.state].has(nextState)) {
-        throw new Error(
-          `Invalid transactional email transition: ${job.state} -> ${nextState}`,
-        );
-      }
-      const timestamp = now().toISOString();
-      const timestampField = stateTimestampField(nextState);
-      const updated = transactionalEmailJobSchema.parse({
-        ...job,
-        ...changes,
-        state: nextState,
-        updatedAt: timestamp,
-        leaseUntil: null,
-        leaseToken: null,
-        ...(timestampField ? { [timestampField]: timestamp } : {}),
-      });
-      await writeJsonAtomic(jobFile(logicalKey), updated);
-      return updated;
-    });
+    const job = await readJob(logicalKey);
+    if (
+      !job ||
+      !expectedStates.includes(job.state) ||
+      job.state === "sending"
+    ) {
+      return null;
+    }
+    if (!allowedTransitions[job.state].has(nextState)) {
+      throw new Error(
+        `Invalid transactional email transition: ${job.state} -> ${nextState}`,
+      );
+    }
+    return replaceJob(
+      transitionedJob(job, nextState, changes),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        eq(schema.transactionalEmailJobs.state, job.state),
+        isNull(schema.transactionalEmailJobs.leaseToken),
+      ),
+    );
   }
 
-  async function claimAwaitingAi(
-    logicalKey: string,
-    claimantEmail: string,
-  ): Promise<TransactionalEmailJob | null> {
-    const claimant = recipientSchema.parse(claimantEmail.trim().toLowerCase());
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (!job || !isAiBackedType(job.type) || job.state !== "awaiting_ai") {
-        return null;
-      }
-      const timestamp = now().toISOString();
-      const claimed = transactionalEmailJobSchema.parse({
+  async function claimAwaitingAi(logicalKey: string, claimantEmail: string) {
+    const claimant = normalizeRecipient(claimantEmail);
+    const job = await readJob(logicalKey);
+    if (!job || !isAiBackedType(job.type) || job.state !== "awaiting_ai") {
+      return null;
+    }
+    const timestamp = now().toISOString();
+    return replaceJob(
+      transactionalEmailJobSchema.parse({
         ...job,
         state: "ai_dispatched",
         aiClaimedBy: claimant,
         aiDispatchedAt: timestamp,
         updatedAt: timestamp,
-      });
-      await writeJsonAtomic(jobFile(logicalKey), claimed);
-      return claimed;
-    });
+      }),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        eq(schema.transactionalEmailJobs.state, "awaiting_ai"),
+      ),
+    );
   }
 
   async function reclaimStaleAiDispatch(
     logicalKey: string,
     claimantEmail: string,
     staleBefore: Date,
-  ): Promise<TransactionalEmailJob | null> {
-    const claimant = recipientSchema.parse(claimantEmail.trim().toLowerCase());
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      const dispatchedAt = job?.aiDispatchedAt ?? job?.updatedAt;
-      if (
-        !job ||
-        !isAiBackedType(job.type) ||
-        job.state !== "ai_dispatched" ||
-        !dispatchedAt ||
-        Date.parse(dispatchedAt) > staleBefore.getTime()
-      ) {
-        return null;
-      }
-      const timestamp = now().toISOString();
-      const reclaimed = transactionalEmailJobSchema.parse({
+  ) {
+    const claimant = normalizeRecipient(claimantEmail);
+    const job = await readJob(logicalKey);
+    const dispatchedAt = job?.aiDispatchedAt ?? job?.updatedAt;
+    if (
+      !job ||
+      !isAiBackedType(job.type) ||
+      job.state !== "ai_dispatched" ||
+      !dispatchedAt ||
+      Date.parse(dispatchedAt) > staleBefore.getTime()
+    ) {
+      return null;
+    }
+    const timestamp = now().toISOString();
+    return replaceJob(
+      transactionalEmailJobSchema.parse({
         ...job,
         aiClaimedBy: claimant,
         aiDispatchedAt: timestamp,
         updatedAt: timestamp,
-      });
-      await writeJsonAtomic(jobFile(logicalKey), reclaimed);
-      return reclaimed;
-    });
+      }),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        eq(schema.transactionalEmailJobs.state, "ai_dispatched"),
+        lte(
+          schema.transactionalEmailJobs.aiDispatchedAt,
+          staleBefore.toISOString(),
+        ),
+      ),
+    );
   }
 
   async function completeClaimedAi(
     logicalKey: string,
     claimantEmail: string,
     generatedSummary: string,
-  ): Promise<TransactionalEmailJob | null> {
-    const claimant = recipientSchema.parse(claimantEmail.trim().toLowerCase());
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (
-        !job ||
-        job.type !== "two-clips" ||
-        job.state !== "ai_dispatched" ||
-        job.aiClaimedBy !== claimant
-      ) {
-        return null;
-      }
-      const timestamp = now().toISOString();
-      const completed = transactionalEmailJobSchema.parse({
+  ) {
+    const claimant = normalizeRecipient(claimantEmail);
+    const summary = z.string().max(20_000).parse(generatedSummary);
+    const job = await readJob(logicalKey);
+    if (
+      !job ||
+      job.type !== "two-clips" ||
+      job.state !== "ai_dispatched" ||
+      job.aiClaimedBy !== claimant
+    ) {
+      return null;
+    }
+    const timestamp = now().toISOString();
+    return replaceJob(
+      transactionalEmailJobSchema.parse({
         ...job,
         state: "ready",
-        generatedSummary,
+        generatedSummary: summary,
         readyAt: timestamp,
         updatedAt: timestamp,
-      });
-      await writeJsonAtomic(jobFile(logicalKey), completed);
-      return completed;
-    });
+      }),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        eq(schema.transactionalEmailJobs.state, "ai_dispatched"),
+        eq(schema.transactionalEmailJobs.aiClaimedBy, claimant),
+      ),
+    );
   }
 
-  async function claimNextAwaitingAi(): Promise<TransactionalEmailJob | null> {
-    const candidates = (await listJobs()).filter(
-      (job) => job.state === "awaiting_ai",
-    );
+  async function claimNextAwaitingAi() {
+    const candidates = await getDb()
+      .select({ logicalKey: schema.transactionalEmailJobs.logicalKey })
+      .from(schema.transactionalEmailJobs)
+      .where(eq(schema.transactionalEmailJobs.state, "awaiting_ai"))
+      .orderBy(asc(schema.transactionalEmailJobs.createdAt));
     for (const candidate of candidates) {
       const claimed = await transition(
         candidate.logicalKey,
@@ -757,22 +585,24 @@ export function createTransactionalEmailStore(
   async function acquireSendingLease(
     logicalKey: string,
     leaseDurationMs: number,
-  ): Promise<TransactionalEmailJob | null> {
+  ) {
     if (!Number.isInteger(leaseDurationMs) || leaseDurationMs <= 0) {
       throw new Error("leaseDurationMs must be a positive integer");
     }
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (!job) return null;
-      const currentTime = now();
-      const canAcquire =
-        job.state === "ready" ||
-        (job.state === "sending" &&
-          job.leaseUntil !== null &&
-          Date.parse(job.leaseUntil) <= currentTime.getTime());
-      if (!canAcquire) return null;
-      const timestamp = currentTime.toISOString();
-      const updated = transactionalEmailJobSchema.parse({
+    const job = await readJob(logicalKey);
+    if (!job) return null;
+    const currentTime = now();
+    const timestamp = currentTime.toISOString();
+    if (
+      job.state !== "ready" &&
+      (job.state !== "sending" ||
+        job.leaseUntil === null ||
+        Date.parse(job.leaseUntil) > currentTime.getTime())
+    ) {
+      return null;
+    }
+    return replaceJob(
+      transactionalEmailJobSchema.parse({
         ...job,
         state: "sending",
         attempts: job.attempts + 1,
@@ -783,10 +613,18 @@ export function createTransactionalEmailStore(
           currentTime.getTime() + leaseDurationMs,
         ).toISOString(),
         leaseToken: randomUUID(),
-      });
-      await writeJsonAtomic(jobFile(logicalKey), updated);
-      return updated;
-    });
+      }),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        or(
+          eq(schema.transactionalEmailJobs.state, "ready"),
+          and(
+            eq(schema.transactionalEmailJobs.state, "sending"),
+            lte(schema.transactionalEmailJobs.leaseUntil, timestamp),
+          ),
+        ),
+      ),
+    );
   }
 
   async function transitionSending(
@@ -794,58 +632,61 @@ export function createTransactionalEmailStore(
     leaseToken: string,
     nextState: "sent" | "ready" | "cancelled" | "failed",
     changes: { lastError?: string | null } = {},
-  ): Promise<TransactionalEmailJob | null> {
+  ) {
     const parsedLeaseToken = nonEmptyStringSchema.parse(leaseToken);
-    return withJobLock(logicalKey, async () => {
-      const job = await readJob(logicalKey);
-      if (
-        !job ||
-        job.state !== "sending" ||
-        job.leaseToken !== parsedLeaseToken
-      ) {
-        return null;
-      }
-      if (!allowedTransitions.sending.has(nextState)) {
-        throw new Error(
-          `Invalid transactional email transition: sending -> ${nextState}`,
-        );
-      }
-      const timestamp = now().toISOString();
-      const timestampField = stateTimestampField(nextState);
-      const updated = transactionalEmailJobSchema.parse({
-        ...job,
-        ...changes,
-        state: nextState,
-        updatedAt: timestamp,
-        leaseUntil: null,
-        leaseToken: null,
-        ...(timestampField ? { [timestampField]: timestamp } : {}),
-      });
-      await writeJsonAtomic(jobFile(logicalKey), updated);
-      return updated;
-    });
+    const job = await readJob(logicalKey);
+    if (
+      !job ||
+      job.state !== "sending" ||
+      job.leaseToken !== parsedLeaseToken
+    ) {
+      return null;
+    }
+    if (!allowedTransitions.sending.has(nextState)) {
+      throw new Error(
+        `Invalid transactional email transition: sending -> ${nextState}`,
+      );
+    }
+    return replaceJob(
+      transitionedJob(job, nextState, changes),
+      and(
+        eq(schema.transactionalEmailJobs.logicalKey, job.logicalKey),
+        eq(schema.transactionalEmailJobs.state, "sending"),
+        eq(schema.transactionalEmailJobs.leaseToken, parsedLeaseToken),
+      ),
+    );
+  }
+
+  async function readConfig(): Promise<TransactionalEmailConfig | null> {
+    const [row] = await getDb()
+      .select()
+      .from(schema.transactionalEmailConfigs)
+      .where(eq(schema.transactionalEmailConfigs.id, "default"))
+      .limit(1);
+    if (!row) return null;
+    let config: unknown;
+    try {
+      config = JSON.parse(row.configJson);
+    } catch (error) {
+      const detail = error instanceof Error ? `: ${error.message}` : "";
+      throw new Error(`Invalid transactional email config JSON${detail}`);
+    }
+    return transactionalEmailConfigSchema.parse(config);
   }
 
   async function ensureEnabledAt(): Promise<TransactionalEmailConfig> {
-    await ensureDirectories();
     const config = transactionalEmailConfigSchema.parse({
       enabledAt: now().toISOString(),
     });
-    try {
-      await writeFile(configFile, `${JSON.stringify(config, null, 2)}\n`, {
-        encoding: "utf8",
-        flag: "wx",
-        mode: 0o600,
-      });
-      return config;
-    } catch (error) {
-      if (!isNodeError(error, "EEXIST")) throw error;
-      return parseJsonFile(
-        configFile,
-        transactionalEmailConfigSchema,
-        "transactional email config",
-      );
-    }
+    const [created] = await getDb()
+      .insert(schema.transactionalEmailConfigs)
+      .values({ id: "default", configJson: JSON.stringify(config) })
+      .onConflictDoNothing()
+      .returning({ id: schema.transactionalEmailConfigs.id });
+    if (created) return config;
+    const existing = await readConfig();
+    if (!existing) throw new Error("Transactional email config disappeared");
+    return existing;
   }
 
   async function updateReconciliationCursor(
@@ -857,43 +698,32 @@ export function createTransactionalEmailStore(
     const parsedCursorName =
       transactionalEmailCursorNameSchema.parse(cursorName);
     const parsedCursor = reconciliationCursorSchema.parse(reconciliationCursor);
-    const updated = await withJobLock(
-      "transactional-email-config",
-      async () => {
-        const config = await parseJsonFile(
-          configFile,
-          transactionalEmailConfigSchema,
-          "transactional email config",
-        );
-        const nextConfig = transactionalEmailConfigSchema.parse({
-          ...config,
-          [parsedCursorName]: parsedCursor,
-        });
-        await writeJsonAtomic(configFile, nextConfig);
-        return nextConfig;
-      },
-    );
-    if (!updated) {
+    const config = await readConfig();
+    if (!config)
+      throw new Error("Transactional email config is not initialized");
+    const nextConfig = transactionalEmailConfigSchema.parse({
+      ...config,
+      [parsedCursorName]: parsedCursor,
+    });
+    const [updated] = await getDb()
+      .update(schema.transactionalEmailConfigs)
+      .set({ configJson: JSON.stringify(nextConfig) })
+      .where(
+        and(
+          eq(schema.transactionalEmailConfigs.id, "default"),
+          eq(
+            schema.transactionalEmailConfigs.configJson,
+            JSON.stringify(config),
+          ),
+        ),
+      )
+      .returning();
+    if (!updated)
       throw new Error("Transactional email config is being updated");
-    }
-    return updated;
-  }
-
-  async function readConfig(): Promise<TransactionalEmailConfig | null> {
-    try {
-      return await parseJsonFile(
-        configFile,
-        transactionalEmailConfigSchema,
-        "transactional email config",
-      );
-    } catch (error) {
-      if (isNodeError(error, "ENOENT")) return null;
-      throw error;
-    }
+    return transactionalEmailConfigSchema.parse(JSON.parse(updated.configJson));
   }
 
   return {
-    root,
     enqueue,
     enqueueOrConvergeFirstImport,
     readJob,

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1164,6 +1164,41 @@ export const migrations = runMigrations(
       name: "recording-comment-mentions",
       sql: `ALTER TABLE recording_comments ADD COLUMN IF NOT EXISTS mentions_json TEXT`,
     },
+    {
+      version: 67,
+      name: "clips-transactional-email-sql-store",
+      sql: [
+        `CREATE TABLE IF NOT EXISTS clips_transactional_email_jobs (
+          logical_key TEXT PRIMARY KEY,
+          type TEXT NOT NULL,
+          state TEXT NOT NULL,
+          recipient TEXT NOT NULL,
+          recording_ids_json TEXT NOT NULL,
+          share_id TEXT,
+          requested_by TEXT,
+          month TEXT,
+          generated_summary TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          ai_dispatched_at TEXT,
+          ai_claimed_by TEXT,
+          ready_at TEXT,
+          sending_at TEXT,
+          sent_at TEXT,
+          cancelled_at TEXT,
+          failed_at TEXT,
+          last_error TEXT,
+          lease_until TEXT,
+          lease_token TEXT
+        )`,
+        `CREATE INDEX IF NOT EXISTS clips_transactional_email_jobs_state_created_idx ON clips_transactional_email_jobs (state, created_at)`,
+        `CREATE TABLE IF NOT EXISTS clips_transactional_email_configs (
+          id TEXT PRIMARY KEY,
+          config_json TEXT NOT NULL
+        )`,
+      ].join("; "),
+    },
   ],
   { table: "clips_migrations" },
 );

--- a/templates/clips/server/routes/api/clips/brain-export/run.post.ts
+++ b/templates/clips/server/routes/api/clips/brain-export/run.post.ts
@@ -47,7 +47,12 @@ export default defineEventHandler(async (event) => {
   // clock Clips has. Run it first so Brain discovery/export failures cannot
   // starve cleanup or strand SQL scratch payloads.
   const uploads = await reapExpiredUploads();
-  const transactionalEmails = await runTransactionalEmailsOnce();
+  const transactionalEmails = await runTransactionalEmailsOnce().catch(
+    (error) => {
+      console.error("[transactional-emails] scheduled run failed:", error);
+      return null;
+    },
+  );
   await runBrainExportSweepOnce();
   return { ok: true, uploads, transactionalEmails };
 });

--- a/templates/clips/server/routes/api/clips/brain-export/run.post.ts
+++ b/templates/clips/server/routes/api/clips/brain-export/run.post.ts
@@ -3,6 +3,7 @@ import { timingSafeEqual } from "node:crypto";
 import { createError, defineEventHandler, getHeader } from "h3";
 
 import { runBrainExportSweepOnce } from "../../../../jobs/brain-export.js";
+import { runTransactionalEmailsOnce } from "../../../../jobs/transactional-emails.js";
 import { reapExpiredUploads } from "../../../../lib/upload-lease.js";
 
 declare global {
@@ -46,6 +47,7 @@ export default defineEventHandler(async (event) => {
   // clock Clips has. Run it first so Brain discovery/export failures cannot
   // starve cleanup or strand SQL scratch payloads.
   const uploads = await reapExpiredUploads();
+  const transactionalEmails = await runTransactionalEmailsOnce();
   await runBrainExportSweepOnce();
-  return { ok: true, uploads };
+  return { ok: true, uploads, transactionalEmails };
 });


### PR DESCRIPTION
Moves Clips transactional email notifications from local filesystem storage to the application database, so queued emails are not lost or blocked in hosted environments. The same database records now provide the pending and sent-email history for these notifications.

Runs email processing through the existing Netlify scheduled job for hosted deployments. Local development can opt in to the recurring email worker with `RUN_BACKGROUND_JOBS=1`.

Removes the retired filesystem email implementation and updates the related tests to use an in-memory SQL database.