### PR TITLE
fix: open chat threads in workspace

### DIFF
--- a/scripts/qa-template-route-matrix.ts
+++ b/scripts/qa-template-route-matrix.ts
@@ -101,6 +101,14 @@ for (const template of publicMarketingTemplates) {
   );
 }
 
+for (const template of ["assets", "chat"]) {
+  assertContains(
+    `templates/${template}/app/routes/chat.$threadId.tsx`,
+    'from "./home"',
+    `${template} chat thread routes must render the private chat home, not the public marketing route`,
+  );
+}
+
 assertFilesExist("slides", [
   "_index.tsx",
   "deck.$id.tsx",

--- a/templates/assets/app/routes/chat.$threadId.tsx
+++ b/templates/assets/app/routes/chat.$threadId.tsx
@@ -1,1 +1,1 @@
-export { default, meta } from "./_index";
+export { default, meta } from "./home";

--- a/templates/chat/app/routes/chat.$threadId.tsx
+++ b/templates/chat/app/routes/chat.$threadId.tsx
@@ -1,1 +1,1 @@
-export { default, meta } from "./_index";
+export { default, meta } from "./home";


### PR DESCRIPTION
Fixes Assets and Chat app chat threads rendering the public sign-in screen. Adds route regression coverage

<img width="3136" height="1768" alt="image" src="https://github.com/user-attachments/assets/5bfa33eb-7d26-4a84-9da8-c1675788933f" />
