### PR TITLE
Remove blue accent from Nightly heading on /download

### DIFF
--- a/packages/docs/app/components/DownloadPage.test.tsx
+++ b/packages/docs/app/components/DownloadPage.test.tsx
@@ -141,8 +141,8 @@ describe("DownloadPage", () => {
     expect(
       screen
         .getByRole("heading", { name: "Download Agent-Native Nightly" })
-        .querySelector("span")?.className,
-    ).toContain("b-text-eyebrow");
+        .querySelector("span"),
+    ).toBeNull();
     expect(
       screen
         .getByRole("radio", { name: "Nightly" })

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -469,14 +469,7 @@ export default function DownloadPage() {
         <GridInner className="relative flex flex-col items-center gap-[var(--spacing-6)] border-t border-solid border-[var(--b-border-default)] px-[var(--spacing-10)] pt-[var(--spacing-40)] pb-[var(--spacing-24)] text-center">
           <h1 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-1)] font-medium leading-[1.05] tracking-[-0.02em] text-[var(--b-text-primary)] mobile:leading-[1.2]">
             {t("downloadPage.title")}
-            {isNightly && (
-              <>
-                {" "}
-                <span className="text-[var(--b-text-eyebrow)]">
-                  {t("downloadPage.nightly")}
-                </span>
-              </>
-            )}
+            {isNightly && <> {t("downloadPage.nightly")}</>}
           </h1>
           <p className="m-0 max-w-[560px] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-1)] leading-[1.4] text-[var(--b-text-secondary)]">
             {t("downloadPage.body")}


### PR DESCRIPTION
## Summary
- The Nightly variant of the `/download` hero heading used `--b-text-eyebrow` (a cyan accent color) on the word "Nightly." That's inconsistent with the rest of the redesigned site — the homepage doesn't use that accent anywhere anymore.
- "Nightly" now renders as plain text inline in the heading, inheriting the same color as the rest of it (no color override).
- Updates the corresponding unit test to assert there's no longer a colored `<span>` wrapping "Nightly."

## Test plan
- [x] `packages/docs` full test suite — 408/408 pass
- [x] `pnpm guards` — all 65 checks pass
- [x] Manually verified in browser: toggled to Nightly, confirmed the heading renders in a single uniform color

🤖 Generated with [Claude Code](https://claude.com/claude-code)