### PR TITLE
fix: preserve desktop surface tabs and scope dispatch connections

### DIFF
--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -253,6 +253,15 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
   });
 
+  it("preserves persisted chat-first tabs when the desktop hub mounts", () => {
+    const hubSource = readFileSync(
+      "src/renderer/components/CodeAgentsHub.tsx",
+      "utf8",
+    );
+
+    expect(hubSource).not.toContain("chatFirstDefaultInitializedRef");
+  });
+
   it("moves the active app beside CLI tabs and restores it for UI tabs", () => {
     const hubSource = readFileSync(
       "src/renderer/components/CodeAgentsHub.tsx",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -862,14 +862,9 @@ export default function CodeAgentsHub({
       ) ?? null,
     [visibleActiveChatFirstSurfaceTabId, visibleChatFirstSurfaceTabs],
   );
-  const chatFirstDefaultInitializedRef = useRef(false);
   useEffect(() => {
-    if (chatFirstDefaultInitializedRef.current) return;
-    chatFirstDefaultInitializedRef.current = true;
     closeChatFirstSessionWatch();
-    chatFirstSurfaceTabsStore.closeAll();
-    setChatFirstSurfacePanelOpen(false);
-  }, [chatFirstSurfaceTabsStore, setChatFirstSurfacePanelOpen]);
+  }, []);
   const chatFirstAppTakesMain =
     activeChatFirstSurfaceTab?.kind === "app" &&
     activeChatFirstSurfaceTab.placement === "main";

--- a/templates/dispatch/actions/list-workspace-connections.ts
+++ b/templates/dispatch/actions/list-workspace-connections.ts
@@ -16,7 +16,7 @@ import {
 import {
   getWorkspaceConnectionAppAccess,
   listWorkspaceConnectionGrants,
-  listWorkspaceConnections,
+  listWorkspaceConnectionsForUser,
   summarizeWorkspaceConnectionProviderReadiness,
 } from "@agent-native/core/workspace-connections";
 import { dispatchActions } from "@agent-native/dispatch/actions";
@@ -144,9 +144,10 @@ export default defineAction({
     const googleOAuthConfigured = googleOAuthAvailability === "configured";
     const providers = catalogProviders.filter(
       (provider) =>
-        googleOAuthConfigured || !isGoogleWorkspaceOAuthProvider(provider.id),
+        (!args.provider || provider.id === args.provider) &&
+        (googleOAuthConfigured || !isGoogleWorkspaceOAuthProvider(provider.id)),
     );
-    const allConnections = await listWorkspaceConnections({
+    const allConnections = await listWorkspaceConnectionsForUser({
       provider: args.provider,
       appId: args.appId,
       includeDisabled: args.includeDisabled,
@@ -160,10 +161,14 @@ export default defineAction({
       provider: args.provider,
       appId: args.appId,
     });
+    const visibleConnectionIds = new Set(
+      connections.map((connection) => connection.id),
+    );
     const explicitGrants = allExplicitGrants.filter(
       (grant) =>
-        googleOAuthConfigured ||
-        !isGoogleWorkspaceOAuthProvider(grant.provider),
+        visibleConnectionIds.has(grant.connectionId) &&
+        (googleOAuthConfigured ||
+          !isGoogleWorkspaceOAuthProvider(grant.provider)),
     );
     const grantApps = await listGrantApps();
     const legacyGrants = connections.flatMap<GrantSummary>((connection) => {

--- a/templates/dispatch/server/actions/list-workspace-connections.spec.ts
+++ b/templates/dispatch/server/actions/list-workspace-connections.spec.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
     listProviderApiCatalog: vi.fn(() => []),
     listWorkspaceConnectionGrants: vi.fn(),
     listWorkspaceConnectionProviders: vi.fn(),
-    listWorkspaceConnections: vi.fn(),
+    listWorkspaceConnectionsForUser: vi.fn(),
     summarizeWorkspaceConnectionProviderReadiness: vi.fn(() => ({
       status: "ready",
       connectionCount: 1,
@@ -55,7 +55,7 @@ vi.mock("@agent-native/core/server", () => ({
 vi.mock("@agent-native/core/workspace-connections", () => ({
   getWorkspaceConnectionAppAccess: mocks.getWorkspaceConnectionAppAccess,
   listWorkspaceConnectionGrants: mocks.listWorkspaceConnectionGrants,
-  listWorkspaceConnections: mocks.listWorkspaceConnections,
+  listWorkspaceConnectionsForUser: mocks.listWorkspaceConnectionsForUser,
   summarizeWorkspaceConnectionProviderReadiness:
     mocks.summarizeWorkspaceConnectionProviderReadiness,
 }));
@@ -83,7 +83,7 @@ describe("list-workspace-connections", () => {
       { id: "gmail", label: "Gmail" },
       { id: "slack", label: "Slack" },
     ]);
-    mocks.listWorkspaceConnections.mockResolvedValue([
+    mocks.listWorkspaceConnectionsForUser.mockResolvedValue([
       { id: "google-1", provider: "gmail", allowedApps: [] },
       { id: "slack-1", provider: "slack", allowedApps: [] },
     ]);
@@ -117,6 +117,43 @@ describe("list-workspace-connections", () => {
     expect(result.grants.map((grant) => grant.id)).toEqual([
       "slack-1:all-apps",
       "slack-grant",
+    ]);
+  });
+
+  it("scopes provider catalogs and grants to the requested provider and visible connections", async () => {
+    mocks.listWorkspaceConnectionProviders.mockReturnValue([
+      { id: "slack", label: "Slack" },
+      { id: "github", label: "GitHub" },
+    ]);
+    mocks.listWorkspaceConnectionsForUser.mockResolvedValue([
+      { id: "slack-1", provider: "slack", allowedApps: [] },
+    ]);
+    mocks.listWorkspaceConnectionGrants.mockResolvedValue([
+      {
+        id: "visible-grant",
+        connectionId: "slack-1",
+        provider: "slack",
+        appId: "dispatch",
+      },
+      {
+        id: "hidden-grant",
+        connectionId: "hidden",
+        provider: "slack",
+        appId: "dispatch",
+      },
+    ]);
+
+    const result = await action.run({ provider: "slack" });
+
+    expect(mocks.listWorkspaceConnectionsForUser).toHaveBeenCalledWith({
+      provider: "slack",
+      appId: undefined,
+      includeDisabled: undefined,
+    });
+    expect(result.providers.map((provider) => provider.id)).toEqual(["slack"]);
+    expect(result.grants.map((grant) => grant.id)).toEqual([
+      "slack-1:all-apps",
+      "visible-grant",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- preserve persisted desktop chat-first tabs and panel state when the hub mounts
- keep session-watch cleanup without clearing user tabs
- align the Dispatch template connection action with caller scoping, provider filtering, and visible-grant filtering

## Validation
- desktop focused tests: 80 passed
- core focused tests: 235 passed
- Dispatch package action tests: 6 passed
- Dispatch template action tests: 2 passed
- desktop and Dispatch typecheck passed
- repository guards: 65 passed