### PR TITLE
fix truncated a2a artifact results

### DIFF
--- a/.changeset/preserve-a2a-artifact-receipts.md
+++ b/.changeset/preserve-a2a-artifact-receipts.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve verified artifact receipts across truncated tool results and interrupted-run recovery.

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -1847,4 +1847,341 @@ describe("appendA2AArtifactLinks", () => {
       "Image: https://assets.agent-native.com/image/asset_real",
     );
   });
+
+  it("allows the canonical Assets detail URL in downstream artifact blocks", () => {
+    const text = appendA2AArtifactLinks(
+      "Image: https://assets.agent-native.com/asset/asset_real",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            "- Image: https://assets.agent-native.com/asset/asset_real (ID: asset_real, Run: run_real)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://slides.agent-native.com" },
+    );
+
+    expect(text).toBe(
+      "Image: https://assets.agent-native.com/asset/asset_real",
+    );
+  });
+
+  it("detects image artifacts structurally without a tool-name allow-list", () => {
+    const text = appendA2AArtifactLinks(
+      "Image: https://assets.agent-native.com/asset/asset_structural",
+      [
+        {
+          tool: "generate-asset",
+          result: JSON.stringify({
+            id: "asset_structural",
+            artifactType: "image",
+            url: "/asset/asset_structural",
+          }),
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(text).not.toContain("could not verify");
+  });
+
+  it.each([
+    ["intact", JSON.stringify({ count: 1, images: [] })],
+    [
+      "ledger recovered",
+      '(Recovered from prior interrupted chunk — action already completed.)\n\n{\n  "count": 3\n...[ledger truncated at 8000 chars]',
+    ],
+    [
+      "delegated cap",
+      '{\n  "count": 6\n\n...[truncated — full result was 24,000 chars; only first 20,000 shown]',
+    ],
+  ])("verifies %s image results from typed receipts", (_label, result) => {
+    const guarded = guardA2AArtifactResponse(
+      "Images: https://assets.agent-native.com/asset/asset_receipt",
+      [
+        {
+          tool: "generate-image-batch",
+          result,
+          completedSideEffect: true,
+          artifacts: [
+            {
+              kind: "image",
+              id: "asset_receipt",
+              url: "/asset/asset_receipt",
+              runId: "run_receipt",
+            },
+          ],
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.rejectedUnverifiedArtifactReferences).toBe(false);
+    expect(guarded.text).not.toContain("no successful artifact action");
+  });
+
+  it("distinguishes unreadable truncated evidence from absent artifacts", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Images: https://assets.agent-native.com/asset/asset_unreadable",
+      [
+        {
+          tool: "generate-image-batch",
+          result:
+            '(Recovered from prior interrupted chunk — action already completed.)\n\n{\n  "count": 3\n...[ledger truncated at 8000 chars]',
+          completedSideEffect: true,
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.rejectedUnverifiedArtifactReferences).toBe(true);
+    expect(guarded.text).toContain(
+      "generate-image-batch completed, but its result was truncated",
+    );
+    expect(guarded.text).not.toContain("successful artifact action");
+  });
+
+  it.each([
+    ["document", "doc_roundtrip", "/page/doc_roundtrip"],
+    ["deck", "deck_roundtrip", "/deck/deck_roundtrip"],
+    ["dashboard", "dashboard_roundtrip", "/adhoc/dashboard_roundtrip"],
+    ["analysis", "analysis_roundtrip", "/analyses/analysis_roundtrip"],
+    ["image", "image_roundtrip", "/asset/image_roundtrip"],
+    ["design", "design_roundtrip", "/design/design_roundtrip"],
+  ] as const)(
+    "round-trips a formatted %s artifact through downstream verification",
+    (kind, id, path) => {
+      const origin = "https://artifacts.agent-native.com";
+      const downstream = appendA2AArtifactLinks(
+        "Saved the artifact.",
+        [
+          {
+            tool: "write-artifact",
+            result: "result body intentionally irrelevant",
+            artifacts: [{ kind, id, url: path, title: "Round trip" }],
+          },
+        ],
+        { baseUrl: origin },
+      );
+      const guarded = guardA2AArtifactResponse(
+        `Artifact: ${origin}${path}`,
+        [{ tool: "call-agent", result: downstream }],
+        { baseUrl: "https://caller.agent-native.com" },
+      );
+
+      expect(guarded.rejectedUnverifiedArtifactReferences).toBe(false);
+      expect(guarded.text).toContain(`${origin}${path}`);
+    },
+  );
+
+  it("parses complete wrapped JSON before treating sentinel text as truncation", () => {
+    const text = appendA2AArtifactLinks(
+      "Generated it.",
+      [
+        {
+          tool: "generate-image",
+          result: [
+            "action output:",
+            JSON.stringify({
+              id: "asset_complete",
+              title: "...[ledger truncated at is literal title text",
+            }),
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://assets.agent.test" },
+    );
+
+    expect(text).toContain("/image/asset_complete");
+    expect(text).not.toContain("result was truncated");
+  });
+
+  it("attributes truncation only when the tool can produce the referenced kind", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Document: https://content.agent-native.com/page/doc_unverified",
+      [
+        {
+          tool: "generate-image-batch",
+          result:
+            '{\n  "images": [\n...[truncated — full result was 24,000 chars]',
+        },
+      ],
+      { baseUrl: "https://slides.agent-native.com" },
+    );
+
+    expect(guarded.text).toContain("successful artifact action");
+    expect(guarded.text).not.toContain("result was truncated");
+  });
+
+  it("retains verified artifact lines in a truncation rejection", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Images: https://assets.agent-native.com/asset/asset_unverified",
+      [
+        {
+          tool: "generate-image",
+          result: JSON.stringify({ id: "asset_verified" }),
+        },
+        {
+          tool: "generate-image-batch",
+          result:
+            '{\n  "images": [\n...[truncated — full result was 24,000 chars]',
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.text).toContain("result was truncated");
+    expect(guarded.text).toContain("get-asset");
+    expect(guarded.text).toContain("Artifacts:");
+    expect(guarded.text).toContain("/image/asset_verified");
+  });
+
+  it("revalidates typed document receipts at the Content origin", () => {
+    const rejected = guardA2AArtifactResponse(
+      "Document: https://content.agent-native.com/page/doc_generic",
+      [
+        {
+          tool: "read-workspace-document",
+          result: "truncated",
+          artifacts: [
+            {
+              kind: "document",
+              id: "doc_generic",
+              url: "https://attacker.example/page/doc_generic",
+            },
+          ],
+        },
+      ],
+      { baseUrl: "https://content.agent-native.com" },
+    );
+    expect(rejected.rejectedUnverifiedArtifactReferences).toBe(true);
+
+    const accepted = appendA2AArtifactLinks(
+      "Read it.",
+      [
+        {
+          tool: "get-document",
+          result: "truncated",
+          artifacts: [
+            {
+              kind: "document",
+              id: "doc_known",
+              url: "https://attacker.example/page/doc_known",
+            },
+          ],
+        },
+      ],
+      { baseUrl: "https://content.agent-native.com" },
+    );
+    expect(accepted).toContain(
+      "https://content.agent-native.com/page/doc_known",
+    );
+    expect(accepted).not.toContain("attacker.example");
+  });
+
+  it("rejects typed receipts whose canonical URL names another artifact", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Image: https://assets.agent-native.com/asset/asset_expected",
+      [
+        {
+          tool: "generate-asset",
+          result: "truncated",
+          artifacts: [
+            {
+              kind: "image",
+              id: "asset_expected",
+              url: "/asset/asset_other",
+            },
+          ],
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.rejectedUnverifiedArtifactReferences).toBe(true);
+  });
+
+  it("keeps a known producer's artifact ID when its URL is non-canonical", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Image: https://assets.agent-native.com/asset/asset_cdn",
+      [
+        {
+          tool: "generate-asset",
+          result: "truncated",
+          artifacts: [
+            {
+              kind: "image",
+              id: "asset_cdn",
+              url: "https://cdn.example.com/generated.png",
+            },
+          ],
+        },
+      ],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.rejectedUnverifiedArtifactReferences).toBe(false);
+    expect(guarded.text).not.toContain("cdn.example.com");
+  });
+
+  it("does not demand artifact verification for Assets API collection routes", () => {
+    const guarded = guardA2AArtifactResponse(
+      "Search with https://assets.agent-native.com/api/assets/search",
+      [],
+      { baseUrl: "https://assets.agent-native.com" },
+    );
+
+    expect(guarded.rejectedUnverifiedArtifactReferences).toBe(false);
+  });
+
+  it("formats the real design file count carried by a typed receipt", () => {
+    const text = appendA2AArtifactLinks(
+      "Generated the design.",
+      [
+        {
+          tool: "generate-design",
+          result: "truncated",
+          artifacts: [{ kind: "design", id: "design_two", fileCount: 2 }],
+        },
+      ],
+      { baseUrl: "https://design.agent.test" },
+    );
+
+    expect(text).toContain("(ID: design_two, 2 files)");
+  });
+
+  it("round-trips a structurally detected generate-asset identity through a signed marker", () => {
+    vi.stubEnv("A2A_SECRET", "test-a2a-secret-for-generate-asset");
+    const downstream = appendA2AArtifactLinks(
+      "Generated it.",
+      [
+        {
+          tool: "generate-asset",
+          result: JSON.stringify({
+            id: "asset_signed",
+            pageUrl: "/assets/asset_signed",
+          }),
+        },
+      ],
+      {
+        baseUrl: "https://assets.agent-native.com",
+        includePersistedArtifactMarker: true,
+      },
+    );
+
+    expect(
+      extractA2AArtifactIdentities([
+        { tool: "call-agent", result: downstream },
+      ]),
+    ).toEqual([
+      expect.objectContaining({
+        resourceType: "image",
+        id: "asset_signed",
+        sourceAction: "call-agent",
+        url: "/assets/asset_signed",
+      }),
+    ]);
+  });
 });

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -2126,6 +2126,34 @@ describe("appendA2AArtifactLinks", () => {
     expect(guarded.text).not.toContain("cdn.example.com");
   });
 
+  it("does not emit attacker-hosted URLs from typed artifact receipts", () => {
+    const text = appendA2AArtifactLinks(
+      "Generated it.",
+      [
+        {
+          tool: "generate-asset",
+          result: "truncated",
+          artifacts: [
+            {
+              kind: "image",
+              id: "asset_hostile",
+              url: "https://attacker.example/asset/asset_hostile",
+            },
+          ],
+        },
+      ],
+      {
+        baseUrl: "https://assets.agent-native.com",
+        includeReferencedArtifacts: true,
+      },
+    );
+
+    expect(text).toContain(
+      "https://assets.agent-native.com/image/asset_hostile",
+    );
+    expect(text).not.toContain("attacker.example");
+  });
+
   it("does not demand artifact verification for Assets API collection routes", () => {
     const guarded = guardA2AArtifactResponse(
       "Search with https://assets.agent-native.com/api/assets/search",
@@ -2183,5 +2211,23 @@ describe("appendA2AArtifactLinks", () => {
         url: "/assets/asset_signed",
       }),
     ]);
+  });
+
+  it("does not sign artifact identities from unknown producer tools", () => {
+    expect(
+      extractA2AArtifactIdentities([
+        {
+          tool: "echo-user-payload",
+          result: "opaque",
+          artifacts: [
+            {
+              kind: "image",
+              id: "asset_echoed",
+              url: "/asset/asset_echoed",
+            },
+          ],
+        },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -1,5 +1,13 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import {
+  artifactKindsForTool,
+  detectArtifactReceipts,
+  parseArtifactReferenceUrl,
+  type ArtifactReceipt,
+  type ArtifactReference,
+  type ArtifactReferenceKind,
+} from "../artifacts/detect.js";
 import { readDeployCredentialEnv } from "../server/credential-provider.js";
 
 function a2aSecret(): string | undefined {
@@ -16,6 +24,7 @@ export interface A2AToolResultSummary {
   result: string;
   isError?: boolean;
   completedSideEffect?: boolean;
+  artifacts?: ArtifactReceipt[];
 }
 
 export interface A2AArtifactResponseOptions {
@@ -94,42 +103,6 @@ export interface A2APersistedMutationReceipt {
   };
   readbackVerified: true;
 }
-
-const ARTIFACT_IDENTITY_WRITE_TOOLS = new Set([
-  "save-monitor",
-  "create-form",
-  "submit-content-database-form",
-  "add-database-item",
-  "upsert-database-item-by-key",
-  "mutate-content-database-block",
-  "create-document",
-  "update-document",
-  "set-document-property",
-  "create-deck",
-  "duplicate-deck",
-  "add-slide",
-  "update-slide",
-  "patch-deck",
-  "save-deck",
-  "import-pptx",
-  "restore-deck-version",
-  "update-dashboard",
-  "rename-dashboard",
-  "save-analysis",
-  "generate-image",
-  "edit-image",
-  "refine-image",
-  "restyle-image",
-  "save-generated-image",
-  "save-generated-asset",
-  "export-image",
-  "export-asset",
-  "generate-image-batch",
-  "create-design",
-  "generate-design",
-  "create-file",
-  "duplicate-design",
-]);
 
 const PERSISTED_ARTIFACT_MARKER = "agent-native:persisted-artifacts=";
 const PERSISTED_ARTIFACT_MARKER_PATTERN =
@@ -315,18 +288,8 @@ interface CreatedFormArtifact {
   anonymous: boolean;
 }
 
-type ReferencedArtifactKind =
-  | "deck"
-  | "design"
-  | "document"
-  | "dashboard"
-  | "analysis"
-  | "image";
-
-interface ReferencedArtifact {
-  kind: ReferencedArtifactKind;
-  id: string;
-}
+type ReferencedArtifactKind = ArtifactReferenceKind;
+type ReferencedArtifact = ArtifactReference;
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -338,22 +301,43 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function parseToolResultJson(result: string): Record<string, unknown> | null {
+type ParsedToolResult =
+  | { status: "parsed"; value: Record<string, unknown> }
+  | { status: "not-json" }
+  | { status: "truncated" };
+
+function parseToolResultJson(result: string): ParsedToolResult {
   const trimmed = result.trim();
-  if (!trimmed || /^Error(?:\s|:)/i.test(trimmed)) return null;
+  if (!trimmed || /^Error(?:\s|:)/i.test(trimmed)) {
+    return { status: "not-json" };
+  }
 
   try {
-    return asRecord(JSON.parse(trimmed));
+    const value = asRecord(JSON.parse(trimmed));
+    return value ? { status: "parsed", value } : { status: "not-json" };
   } catch {
     // Dev shell wrappers may include console output before the returned JSON.
     const firstBrace = trimmed.indexOf("{");
     const lastBrace = trimmed.lastIndexOf("}");
-    if (firstBrace < 0 || lastBrace <= firstBrace) return null;
-    try {
-      return asRecord(JSON.parse(trimmed.slice(firstBrace, lastBrace + 1)));
-    } catch {
-      return null;
+    if (firstBrace >= 0 && lastBrace > firstBrace) {
+      try {
+        const value = asRecord(
+          JSON.parse(trimmed.slice(firstBrace, lastBrace + 1)),
+        );
+        if (value) return { status: "parsed", value };
+      } catch {
+        // Continue to the explicit truncation and balance checks below.
+      }
     }
+    const hasTruncationMarker =
+      trimmed.includes("...[truncated —") ||
+      trimmed.includes("...[ledger truncated at");
+    if (hasTruncationMarker) return { status: "truncated" };
+    if (firstBrace < 0) return { status: "not-json" };
+    const jsonish = trimmed.slice(firstBrace);
+    const opens = (jsonish.match(/[\[{]/g) ?? []).length;
+    const closes = (jsonish.match(/[\]}]/g) ?? []).length;
+    return opens > closes ? { status: "truncated" } : { status: "not-json" };
   }
 }
 
@@ -437,14 +421,6 @@ function dashboardIdValue(parsed: Record<string, unknown>): string | undefined {
 
 function analysisIdValue(parsed: Record<string, unknown>): string | undefined {
   return stringValue(parsed.id) ?? stringValue(parsed.analysisId);
-}
-
-function imageIdValue(parsed: Record<string, unknown>): string | undefined {
-  return (
-    stringValue(parsed.assetId) ??
-    stringValue(parsed.imageId) ??
-    stringValue(parsed.id)
-  );
 }
 
 function contentDatabaseSubmissionArtifact(
@@ -607,24 +583,6 @@ function addGenericDocumentReadArtifact(
   });
 }
 
-function addImageArtifact(
-  images: Map<string, CreatedImageArtifact>,
-  parsed: Record<string, unknown>,
-): void {
-  const id = imageIdValue(parsed);
-  if (!id) return;
-  images.set(id, {
-    id,
-    runId: stringValue(parsed.runId) ?? stringValue(parsed.generationRunId),
-    title: stringValue(parsed.title),
-    url:
-      stringValue(parsed.pageUrl) ??
-      stringValue(parsed.detailUrl) ??
-      stringValue(parsed.url) ??
-      stringValue(parsed.urlPath),
-  });
-}
-
 function addDeckArtifact(
   decks: Map<string, CreatedDeckArtifact>,
   parsed: Record<string, unknown>,
@@ -675,6 +633,111 @@ function addListedDeckArtifacts(
   }
 }
 
+function addArtifactReceipt(
+  artifact: ArtifactReceipt,
+  sourceTool: string,
+  collections: {
+    documents: Map<string, CreatedDocumentArtifact>;
+    decks: Map<string, CreatedDeckArtifact>;
+    dashboards: Map<string, CreatedDashboardArtifact>;
+    analyses: Map<string, CreatedAnalysisArtifact>;
+    images: Map<string, CreatedImageArtifact>;
+    designShells: Map<string, CreatedDesignShell>;
+    generatedDesigns: Map<string, GeneratedDesignArtifact>;
+    monitors: Map<string, CreatedMonitorArtifact>;
+    forms: Map<string, CreatedFormArtifact>;
+  },
+): void {
+  if (typeof artifact.id !== "string" || !artifact.id.trim()) return;
+  const id = artifact.id.trim();
+  const reference = artifact.url
+    ? parseArtifactReferenceUrl(artifact.url)
+    : null;
+  const validatedUrl =
+    artifact.url && reference?.kind === artifact.kind && reference.id === id
+      ? artifact.url
+      : undefined;
+  if (
+    artifact.url &&
+    artifact.kind !== "monitor" &&
+    artifact.kind !== "form" &&
+    ((reference !== null && !validatedUrl) ||
+      (reference === null &&
+        !artifactKindsForTool(sourceTool).includes(artifact.kind)))
+  ) {
+    return;
+  }
+
+  if (artifact.kind === "document") {
+    if (isGenericReadTool(sourceTool)) {
+      const canonicalReadUrl =
+        validatedUrl && isContentDocumentUrl(validatedUrl)
+          ? validatedUrl
+          : undefined;
+      const knownContentRead =
+        sourceTool === "get-document" ||
+        sourceTool === "get-content-document" ||
+        sourceTool === "get-content-database";
+      if (!knownContentRead && !canonicalReadUrl) return;
+      collections.documents.set(id, {
+        id,
+        title: artifact.title,
+        url: canonicalReadUrl,
+      });
+      return;
+    }
+    collections.documents.set(id, {
+      id,
+      title: artifact.title,
+      url: validatedUrl,
+    });
+  } else if (artifact.kind === "deck") {
+    collections.decks.set(id, { id, url: validatedUrl });
+  } else if (artifact.kind === "dashboard") {
+    collections.dashboards.set(id, {
+      id,
+      title: artifact.title,
+      url: validatedUrl,
+    });
+  } else if (artifact.kind === "analysis") {
+    collections.analyses.set(id, {
+      id,
+      title: artifact.title,
+      url: validatedUrl,
+    });
+  } else if (artifact.kind === "image") {
+    collections.images.set(id, {
+      id,
+      title: artifact.title,
+      runId: artifact.runId,
+      url: validatedUrl,
+    });
+  } else if (artifact.kind === "design") {
+    if (artifact.fileCount !== undefined && artifact.fileCount > 0) {
+      collections.generatedDesigns.set(id, {
+        id,
+        url: validatedUrl,
+        fileCount: artifact.fileCount,
+      });
+    } else {
+      collections.designShells.set(id, { id, title: artifact.title });
+    }
+  } else if (artifact.kind === "monitor" && artifact.url) {
+    collections.monitors.set(id, {
+      id,
+      name: artifact.title,
+      url: artifact.url,
+    });
+  } else if (artifact.kind === "form" && artifact.url) {
+    collections.forms.set(id, {
+      id,
+      title: artifact.title,
+      url: artifact.url,
+      anonymous: false,
+    });
+  }
+}
+
 function collectArtifacts(results: A2AToolResultSummary[]): {
   documents: CreatedDocumentArtifact[];
   decks: CreatedDeckArtifact[];
@@ -685,6 +748,10 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
   generatedDesigns: GeneratedDesignArtifact[];
   monitors: CreatedMonitorArtifact[];
   forms: CreatedFormArtifact[];
+  truncatedTools: Array<{
+    tool: string;
+    kinds: ReferencedArtifactKind[];
+  }>;
 } {
   const documents = new Map<string, CreatedDocumentArtifact>();
   const decks = new Map<string, CreatedDeckArtifact>();
@@ -695,10 +762,28 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
   const generatedDesigns = new Map<string, GeneratedDesignArtifact>();
   const monitors = new Map<string, CreatedMonitorArtifact>();
   const forms = new Map<string, CreatedFormArtifact>();
+  const truncatedTools = new Map<string, ReferencedArtifactKind[]>();
+  const collections = {
+    documents,
+    decks,
+    dashboards,
+    analyses,
+    images,
+    designShells,
+    generatedDesigns,
+    monitors,
+    forms,
+  };
 
   for (const toolResult of results) {
     if (toolResult.isError === true || toolResult.completedSideEffect === false)
       continue;
+    if (toolResult.artifacts !== undefined) {
+      for (const artifact of toolResult.artifacts) {
+        addArtifactReceipt(artifact, toolResult.tool, collections);
+      }
+      continue;
+    }
     if (toolResult.tool === "call-agent") {
       for (const artifact of parseDownstreamArtifactBlock(toolResult.result)) {
         if (artifact.kind === "deck") {
@@ -742,8 +827,27 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
       continue;
     }
 
-    const parsed = parseToolResultJson(toolResult.result);
-    if (!parsed) continue;
+    const parsedResult = parseToolResultJson(toolResult.result);
+    if (parsedResult.status !== "parsed") {
+      if (
+        parsedResult.status === "truncated" &&
+        !isGenericReadTool(toolResult.tool)
+      ) {
+        const kinds = artifactKindsForTool(toolResult.tool).filter(
+          (kind): kind is ReferencedArtifactKind =>
+            kind !== "monitor" && kind !== "form",
+        );
+        if (kinds.length > 0) truncatedTools.set(toolResult.tool, [...kinds]);
+      }
+      continue;
+    }
+    const parsed = parsedResult.value;
+
+    for (const artifact of detectArtifactReceipts(parsed, toolResult.tool)) {
+      if (artifact.kind === "image") {
+        addArtifactReceipt(artifact, toolResult.tool, collections);
+      }
+    }
 
     addDeckArtifactFromAnyResult(decks, parsed);
 
@@ -905,38 +1009,6 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
       continue;
     }
 
-    if (
-      toolResult.tool === "generate-image" ||
-      toolResult.tool === "edit-image" ||
-      toolResult.tool === "refine-image" ||
-      toolResult.tool === "restyle-image" ||
-      toolResult.tool === "get-asset" ||
-      toolResult.tool === "save-generated-image" ||
-      toolResult.tool === "save-generated-asset" ||
-      toolResult.tool === "export-image"
-    ) {
-      addImageArtifact(images, parsed);
-      continue;
-    }
-
-    if (toolResult.tool === "export-asset") {
-      if (stringValue(parsed.artifactType) === "image") {
-        addImageArtifact(images, parsed);
-      }
-      continue;
-    }
-
-    if (toolResult.tool === "generate-image-batch") {
-      if (Array.isArray(parsed.images)) {
-        for (const item of parsed.images) {
-          const image = asRecord(item);
-          if (!image || image.ok === false) continue;
-          addImageArtifact(images, image);
-        }
-      }
-      continue;
-    }
-
     if (toolResult.tool === "create-design") {
       const id = stringValue(parsed.id);
       if (id) {
@@ -1027,6 +1099,10 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
     generatedDesigns: [...generatedDesigns.values()],
     monitors: [...monitors.values()],
     forms: [...forms.values()],
+    truncatedTools: [...truncatedTools].map(([tool, kinds]) => ({
+      tool,
+      kinds,
+    })),
   };
 }
 
@@ -1057,7 +1133,7 @@ export function extractA2AArtifactIdentities(
       }
       continue;
     }
-    if (!ARTIFACT_IDENTITY_WRITE_TOOLS.has(result.tool)) continue;
+    if (isGenericReadTool(result.tool)) continue;
     const artifacts = collectArtifacts([result]);
     for (const document of artifacts.documents) {
       remember({
@@ -1310,7 +1386,7 @@ export function extractA2APersistedMutationReceipts(
     }
     const parsedResult = parseToolResultJson(result.result);
     const receipt = parsePersistedMutationReceipt(
-      parsedResult?.receipt,
+      parsedResult.status === "parsed" ? parsedResult.value.receipt : undefined,
       result.tool,
     );
     if (receipt) receipts.set(receipt.receiptId, receipt);
@@ -1477,46 +1553,6 @@ function artifactUrlReferencesId(
   return reference?.kind === kind && reference.id === id;
 }
 
-function parseArtifactReferenceUrl(rawUrl: string): ReferencedArtifact | null {
-  let url: URL;
-  try {
-    url = new URL(rawUrl, "https://agent-native-artifact.invalid");
-  } catch {
-    return null;
-  }
-
-  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
-
-  const path = url.pathname.replace(/\/+$/, "");
-  const deck = path.match(/(?:^|\/)deck\/([A-Za-z0-9_-]+)(?:\/present)?$/);
-  if (deck) return { kind: "deck", id: deck[1] };
-
-  const design = path.match(/(?:^|\/)design\/([A-Za-z0-9_-]+)$/);
-  if (design) return { kind: "design", id: design[1] };
-
-  const document = path.match(/(?:^|\/)page\/([A-Za-z0-9_-]+)$/);
-  if (document) return { kind: "document", id: document[1] };
-
-  const dashboard = path.match(/(?:^|\/)adhoc\/([A-Za-z0-9_-]+)$/);
-  if (dashboard) return { kind: "dashboard", id: dashboard[1] };
-
-  const analysis = path.match(/(?:^|\/)analyses\/([A-Za-z0-9_-]+)$/);
-  if (analysis) return { kind: "analysis", id: analysis[1] };
-
-  const image = path.match(/(?:^|\/)image\/([A-Za-z0-9_-]+)$/);
-  if (image) return { kind: "image", id: image[1] };
-
-  const imageEmbed = path.match(/(?:^|\/)asset\/([A-Za-z0-9_-]+)\/embed$/);
-  if (imageEmbed) return { kind: "image", id: imageEmbed[1] };
-
-  const imageContent = path.match(
-    /(?:^|\/)api\/assets\/([A-Za-z0-9_-]+)\/content$/,
-  );
-  if (imageContent) return { kind: "image", id: imageContent[1] };
-
-  return null;
-}
-
 function formatDocumentLine(
   document: CreatedDocumentArtifact,
   baseUrl: string | undefined,
@@ -1599,22 +1635,14 @@ function collectReferencedArtifacts(
 
   for (const match of text.matchAll(artifactUrlPattern)) {
     const origin = safeOrigin(match[1]);
-    const route = match[2];
-    const id = match[3];
-    const kind: ReferencedArtifactKind =
-      route === "deck"
-        ? "deck"
-        : route === "design"
-          ? "design"
-          : route === "page"
-            ? "document"
-            : route === "adhoc"
-              ? "dashboard"
-              : route === "analyses"
-                ? "analysis"
-                : "image";
-    if (!shouldValidateArtifactReference(origin, baseOrigin, kind)) continue;
-    refs.set(`${kind}:${id}`, { kind, id });
+    const reference = parseArtifactReferenceUrl(match[0]);
+    if (
+      !reference ||
+      !shouldValidateArtifactReference(origin, baseOrigin, reference.kind)
+    ) {
+      continue;
+    }
+    refs.set(`${reference.kind}:${reference.id}`, reference);
   }
 
   return [...refs.values()];
@@ -1664,8 +1692,7 @@ function shouldValidateArtifactReference(
 }
 
 function findUnverifiedArtifactReferences(
-  text: string,
-  baseUrl: string | undefined,
+  references: ReferencedArtifact[],
   documents: CreatedDocumentArtifact[],
   decks: CreatedDeckArtifact[],
   dashboards: CreatedDashboardArtifact[],
@@ -1680,7 +1707,7 @@ function findUnverifiedArtifactReferences(
   const imageIds = new Set(images.map((image) => image.id));
   const designIds = new Set(generatedDesigns.map((design) => design.id));
 
-  return collectReferencedArtifacts(text, baseUrl).filter((ref) => {
+  return references.filter((ref) => {
     if (ref.kind === "document") return !documentIds.has(ref.id);
     if (ref.kind === "deck") return !deckIds.has(ref.id);
     if (ref.kind === "dashboard") return !dashboardIds.has(ref.id);
@@ -1721,7 +1748,31 @@ function formatUnverifiedArtifactMessage(
               : "artifact URL";
   const plural = refs.length === 1 ? label : `${label}s`;
   const message = `I could not verify the ${plural} in the final answer against a successful artifact action that saved app data, so I cannot return it.`;
-  const verifiedLines = [
+  const verifiedLines = formatVerifiedArtifactLines(
+    documents,
+    decks,
+    dashboards,
+    analyses,
+    images,
+    generatedDesigns,
+    baseUrl,
+  );
+
+  return verifiedLines.length > 0
+    ? `${message}\n\nArtifacts:\n${verifiedLines.join("\n")}`
+    : message;
+}
+
+function formatVerifiedArtifactLines(
+  documents: CreatedDocumentArtifact[],
+  decks: CreatedDeckArtifact[],
+  dashboards: CreatedDashboardArtifact[],
+  analyses: CreatedAnalysisArtifact[],
+  images: CreatedImageArtifact[],
+  generatedDesigns: GeneratedDesignArtifact[],
+  baseUrl: string | undefined,
+): string[] {
+  return [
     ...documents.map((document) => formatDocumentLine(document, baseUrl)),
     ...decks.map((deck) => formatDeckLine(deck, baseUrl)),
     ...dashboards.map((dashboard) => formatDashboardLine(dashboard, baseUrl)),
@@ -1729,7 +1780,28 @@ function formatUnverifiedArtifactMessage(
     ...images.map((image) => formatImageLine(image, baseUrl)),
     ...generatedDesigns.map((design) => formatDesignLine(design, baseUrl)),
   ];
+}
 
+const ARTIFACT_READ_ACTION: Record<ReferencedArtifactKind, string> = {
+  document: "get-document",
+  deck: "get-deck",
+  dashboard: "get-dashboard",
+  analysis: "get-analysis",
+  image: "get-asset",
+  design: "get-design",
+};
+
+function formatTruncatedArtifactMessage(
+  tools: string[],
+  refs: ReferencedArtifact[],
+  verifiedLines: string[],
+): string {
+  const toolLabel = tools.join(", ");
+  const readActions = [
+    ...new Set(refs.map((ref) => ARTIFACT_READ_ACTION[ref.kind])),
+  ];
+  const reread = readActions.join(" or ");
+  const message = `${toolLabel} completed, but its result was truncated before the artifact IDs could be read, so I cannot confirm these URLs. Re-read the artifact with ${reread} and answer again.`;
   return verifiedLines.length > 0
     ? `${message}\n\nArtifacts:\n${verifiedLines.join("\n")}`
     : message;
@@ -1768,6 +1840,7 @@ export function guardA2AArtifactResponse(
     generatedDesigns,
     monitors,
     forms,
+    truncatedTools,
   } = collectArtifacts(toolResults);
   const generatedDesignIds = new Set(
     generatedDesigns.map((design) => design.id),
@@ -1777,6 +1850,14 @@ export function guardA2AArtifactResponse(
   );
 
   let text = responseText.trim() === "(no response)" ? "" : responseText.trim();
+  const referencedArtifacts = collectReferencedArtifacts(text, baseUrl);
+  const responseMentionsArtifact = (
+    kind: ReferencedArtifactKind,
+    id: string,
+  ): boolean =>
+    referencedArtifacts.some(
+      (reference) => reference.kind === kind && reference.id === id,
+    );
 
   if (
     generatedDesigns.length === 0 &&
@@ -1794,8 +1875,7 @@ export function guardA2AArtifactResponse(
   }
 
   const unverifiedRefs = findUnverifiedArtifactReferences(
-    text,
-    baseUrl,
+    referencedArtifacts,
     documents,
     decks,
     dashboards,
@@ -1804,18 +1884,38 @@ export function guardA2AArtifactResponse(
     generatedDesigns,
   );
   if (unverifiedRefs.length > 0) {
+    const relevantTruncatedTools = truncatedTools
+      .filter(({ kinds }) =>
+        unverifiedRefs.some((reference) => kinds.includes(reference.kind)),
+      )
+      .map(({ tool }) => tool);
+    const verifiedLines = formatVerifiedArtifactLines(
+      documents,
+      decks,
+      dashboards,
+      analyses,
+      images,
+      generatedDesigns,
+      baseUrl,
+    );
     return {
       text: finalize(
-        formatUnverifiedArtifactMessage(
-          unverifiedRefs,
-          documents,
-          decks,
-          dashboards,
-          analyses,
-          images,
-          generatedDesigns,
-          baseUrl,
-        ),
+        relevantTruncatedTools.length > 0
+          ? formatTruncatedArtifactMessage(
+              relevantTruncatedTools,
+              unverifiedRefs,
+              verifiedLines,
+            )
+          : formatUnverifiedArtifactMessage(
+              unverifiedRefs,
+              documents,
+              decks,
+              dashboards,
+              analyses,
+              images,
+              generatedDesigns,
+              baseUrl,
+            ),
       ),
       rejectedUnverifiedArtifactReferences: true,
     };
@@ -1823,55 +1923,49 @@ export function guardA2AArtifactResponse(
 
   const missingLines: string[] = [];
   for (const document of documents) {
-    const path = `/page/${document.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("document", document.id)
     ) {
       missingLines.push(formatDocumentLine(document, baseUrl));
     }
   }
   for (const deck of decks) {
-    const path = `/deck/${deck.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("deck", deck.id)
     ) {
       missingLines.push(formatDeckLine(deck, baseUrl));
     }
   }
   for (const dashboard of dashboards) {
-    const path = `/adhoc/${dashboard.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("dashboard", dashboard.id)
     ) {
       missingLines.push(formatDashboardLine(dashboard, baseUrl));
     }
   }
   for (const analysis of analyses) {
-    const path = `/analyses/${analysis.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("analysis", analysis.id)
     ) {
       missingLines.push(formatAnalysisLine(analysis, baseUrl));
     }
   }
   for (const image of images) {
-    const path = `/image/${image.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("image", image.id)
     ) {
       missingLines.push(formatImageLine(image, baseUrl));
     }
   }
   for (const design of generatedDesigns) {
-    const path = `/design/${design.id}`;
     if (
       includeReferencedArtifacts ||
-      !responseAlreadyMentionsPath(text, path)
+      !responseMentionsArtifact("design", design.id)
     ) {
       missingLines.push(formatDesignLine(design, baseUrl));
     }

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   artifactKindsForTool,
   detectArtifactReceipts,
+  isArtifactReceipt,
   parseArtifactReferenceUrl,
   type ArtifactReceipt,
   type ArtifactReference,
@@ -43,6 +44,7 @@ export interface GuardedA2AArtifactResponse {
 export interface A2AArtifactIdentityOptions {
   persistedArtifactSecrets?: readonly string[];
   expectedDelegatedTaskId?: string;
+  baseUrl?: string;
 }
 
 export interface A2AArtifactIdentity {
@@ -203,6 +205,7 @@ function withPersistedArtifactMarker(
   toolResults: A2AToolResultSummary[],
   secret = a2aSecret(),
   delegatedTaskId?: string,
+  baseUrl?: string,
 ): string {
   const verificationSecrets = [secret, a2aSecret()].filter(
     (value, index, values): value is string =>
@@ -210,6 +213,7 @@ function withPersistedArtifactMarker(
   );
   const identities = extractA2AArtifactIdentities(toolResults, {
     persistedArtifactSecrets: verificationSecrets,
+    baseUrl,
   }).slice(0, 12);
   const mutationReceipts = extractA2APersistedMutationReceipts(toolResults, {
     persistedArtifactSecrets: secret ? [secret] : [],
@@ -633,9 +637,36 @@ function addListedDeckArtifacts(
   }
 }
 
+function artifactReceiptOriginAllowed(
+  rawUrl: string,
+  kind: ArtifactReceipt["kind"],
+  baseUrl: string | undefined,
+): boolean {
+  const origin = safeOrigin(rawUrl);
+  if (!origin) return true;
+  const baseOrigin = safeOrigin(baseUrl);
+  if (baseOrigin && origin === baseOrigin) return true;
+  const hostname = safeHostnameFromOrigin(origin);
+  return !!hostname && KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS[kind].has(hostname);
+}
+
+function verifiedArtifactReceiptUrl(
+  rawUrl: string | undefined,
+  kind: ArtifactReferenceKind,
+  id: string,
+  baseUrl: string | undefined,
+): string | undefined {
+  if (!rawUrl || !artifactReceiptOriginAllowed(rawUrl, kind, baseUrl)) {
+    return undefined;
+  }
+  const reference = parseArtifactReferenceUrl(rawUrl);
+  return reference?.kind === kind && reference.id === id ? rawUrl : undefined;
+}
+
 function addArtifactReceipt(
-  artifact: ArtifactReceipt,
+  value: unknown,
   sourceTool: string,
+  baseUrl: string | undefined,
   collections: {
     documents: Map<string, CreatedDocumentArtifact>;
     decks: Map<string, CreatedDeckArtifact>;
@@ -648,22 +679,36 @@ function addArtifactReceipt(
     forms: Map<string, CreatedFormArtifact>;
   },
 ): void {
-  if (typeof artifact.id !== "string" || !artifact.id.trim()) return;
+  if (!isArtifactReceipt(value)) return;
+  const artifact = value;
   const id = artifact.id.trim();
   const reference = artifact.url
     ? parseArtifactReferenceUrl(artifact.url)
     : null;
+  const sourceCanProduceKind = artifactKindsForTool(sourceTool).includes(
+    artifact.kind,
+  );
+  const originAllowed =
+    !artifact.url ||
+    artifactReceiptOriginAllowed(artifact.url, artifact.kind, baseUrl);
   const validatedUrl =
-    artifact.url && reference?.kind === artifact.kind && reference.id === id
-      ? artifact.url
-      : undefined;
+    artifact.kind === "monitor" || artifact.kind === "form"
+      ? undefined
+      : verifiedArtifactReceiptUrl(artifact.url, artifact.kind, id, baseUrl);
+  if (
+    artifact.url &&
+    (artifact.kind === "monitor" || artifact.kind === "form") &&
+    !originAllowed
+  ) {
+    return;
+  }
   if (
     artifact.url &&
     artifact.kind !== "monitor" &&
     artifact.kind !== "form" &&
-    ((reference !== null && !validatedUrl) ||
-      (reference === null &&
-        !artifactKindsForTool(sourceTool).includes(artifact.kind)))
+    ((reference !== null &&
+      (reference.kind !== artifact.kind || reference.id !== id)) ||
+      ((!reference || !originAllowed) && !sourceCanProduceKind))
   ) {
     return;
   }
@@ -738,7 +783,10 @@ function addArtifactReceipt(
   }
 }
 
-function collectArtifacts(results: A2AToolResultSummary[]): {
+function collectArtifacts(
+  results: A2AToolResultSummary[],
+  baseUrl?: string,
+): {
   documents: CreatedDocumentArtifact[];
   decks: CreatedDeckArtifact[];
   dashboards: CreatedDashboardArtifact[];
@@ -780,7 +828,7 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
       continue;
     if (toolResult.artifacts !== undefined) {
       for (const artifact of toolResult.artifacts) {
-        addArtifactReceipt(artifact, toolResult.tool, collections);
+        addArtifactReceipt(artifact, toolResult.tool, baseUrl, collections);
       }
       continue;
     }
@@ -845,7 +893,7 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
 
     for (const artifact of detectArtifactReceipts(parsed, toolResult.tool)) {
       if (artifact.kind === "image") {
-        addArtifactReceipt(artifact, toolResult.tool, collections);
+        addArtifactReceipt(artifact, toolResult.tool, baseUrl, collections);
       }
     }
 
@@ -1134,52 +1182,85 @@ export function extractA2AArtifactIdentities(
       continue;
     }
     if (isGenericReadTool(result.tool)) continue;
-    const artifacts = collectArtifacts([result]);
+    const trustedKinds = new Set(artifactKindsForTool(result.tool));
+    if (trustedKinds.size === 0) continue;
+    const artifacts = collectArtifacts([result], options.baseUrl);
     for (const document of artifacts.documents) {
+      if (!trustedKinds.has("document")) continue;
       remember({
         resourceType: "document",
         id: document.id,
         sourceAction: result.tool,
         titleAtAction: document.title,
-        url: document.url,
+        url: verifiedArtifactReceiptUrl(
+          document.url,
+          "document",
+          document.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const deck of artifacts.decks) {
+      if (!trustedKinds.has("deck")) continue;
       remember({
         resourceType: "deck",
         id: deck.id,
         sourceAction: result.tool,
-        url: deck.url,
+        url: verifiedArtifactReceiptUrl(
+          deck.url,
+          "deck",
+          deck.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const dashboard of artifacts.dashboards) {
+      if (!trustedKinds.has("dashboard")) continue;
       remember({
         resourceType: "dashboard",
         id: dashboard.id,
         sourceAction: result.tool,
         titleAtAction: dashboard.title,
-        url: dashboard.url,
+        url: verifiedArtifactReceiptUrl(
+          dashboard.url,
+          "dashboard",
+          dashboard.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const analysis of artifacts.analyses) {
+      if (!trustedKinds.has("analysis")) continue;
       remember({
         resourceType: "analysis",
         id: analysis.id,
         sourceAction: result.tool,
         titleAtAction: analysis.title,
-        url: analysis.url,
+        url: verifiedArtifactReceiptUrl(
+          analysis.url,
+          "analysis",
+          analysis.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const image of artifacts.images) {
+      if (!trustedKinds.has("image")) continue;
       remember({
         resourceType: "image",
         id: image.id,
         sourceAction: result.tool,
         titleAtAction: image.title,
-        url: image.url,
+        url: verifiedArtifactReceiptUrl(
+          image.url,
+          "image",
+          image.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const design of artifacts.designShells) {
+      if (!trustedKinds.has("design")) continue;
       remember({
         resourceType: "design",
         id: design.id,
@@ -1188,29 +1269,45 @@ export function extractA2AArtifactIdentities(
       });
     }
     for (const design of artifacts.generatedDesigns) {
+      if (!trustedKinds.has("design")) continue;
       remember({
         resourceType: "design",
         id: design.id,
         sourceAction: result.tool,
-        url: design.url,
+        url: verifiedArtifactReceiptUrl(
+          design.url,
+          "design",
+          design.id,
+          options.baseUrl,
+        ),
       });
     }
     for (const monitor of artifacts.monitors) {
+      if (!trustedKinds.has("monitor")) continue;
       remember({
         resourceType: "monitor",
         id: monitor.id,
         sourceAction: result.tool,
         titleAtAction: monitor.name,
-        url: monitor.url,
+        url: artifactReceiptOriginAllowed(
+          monitor.url,
+          "monitor",
+          options.baseUrl,
+        )
+          ? monitor.url
+          : undefined,
       });
     }
     for (const form of artifacts.forms) {
+      if (!trustedKinds.has("form")) continue;
       remember({
         resourceType: "form",
         id: form.id,
         sourceAction: result.tool,
         titleAtAction: form.title,
-        url: form.url,
+        url: artifactReceiptOriginAllowed(form.url, "form", options.baseUrl)
+          ? form.url
+          : undefined,
       });
     }
   }
@@ -1658,7 +1755,7 @@ function safeOrigin(url: string | undefined): string | undefined {
 }
 
 const KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS: Record<
-  ReferencedArtifactKind,
+  ArtifactReceipt["kind"],
   ReadonlySet<string>
 > = {
   deck: new Set(["slides.agent-native.com"]),
@@ -1667,6 +1764,8 @@ const KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS: Record<
   dashboard: new Set(["analytics.agent-native.com"]),
   analysis: new Set(["analytics.agent-native.com"]),
   image: new Set(["assets.agent-native.com", "images.agent-native.com"]),
+  monitor: new Set(["analytics.agent-native.com"]),
+  form: new Set(["forms.agent-native.com"]),
 };
 
 function safeHostnameFromOrigin(
@@ -1683,7 +1782,7 @@ function safeHostnameFromOrigin(
 function shouldValidateArtifactReference(
   origin: string | undefined,
   baseOrigin: string | undefined,
-  kind: ReferencedArtifactKind,
+  kind: ArtifactReceipt["kind"],
 ): boolean {
   if (!origin || !baseOrigin || origin === baseOrigin) return true;
 
@@ -1827,6 +1926,7 @@ export function guardA2AArtifactResponse(
           toolResults,
           options.persistedArtifactSecret ?? a2aSecret(),
           options.delegatedTaskId,
+          baseUrl,
         )
       : withReceipts;
   };
@@ -1841,7 +1941,7 @@ export function guardA2AArtifactResponse(
     monitors,
     forms,
     truncatedTools,
-  } = collectArtifacts(toolResults);
+  } = collectArtifacts(toolResults, baseUrl);
   const generatedDesignIds = new Set(
     generatedDesigns.map((design) => design.id),
   );
@@ -2023,7 +2123,7 @@ export function buildA2ARecoverableArtifactMessage(
     generatedDesigns,
     monitors,
     forms,
-  } = collectArtifacts(toolResults);
+  } = collectArtifacts(toolResults, baseUrl);
   const lines = [
     ...documents.map((document) => formatDocumentLine(document, baseUrl)),
     ...decks.map((deck) => formatDeckLine(deck, baseUrl)),

--- a/packages/core/src/agent/engine/tool-call-journal-seed.ts
+++ b/packages/core/src/agent/engine/tool-call-journal-seed.ts
@@ -1,3 +1,7 @@
+import {
+  isArtifactReceipt,
+  type ArtifactReceipt,
+} from "../../artifacts/detect.js";
 import { getCurrentTurnEventsForThread } from "../run-store.js";
 import {
   classifyToolCallJournal,
@@ -29,6 +33,7 @@ export interface PriorTurnToolResultSummary {
   input?: unknown;
   content: string;
   isError: boolean;
+  artifacts?: ArtifactReceipt[];
 }
 
 /**
@@ -129,11 +134,13 @@ export async function loadPriorTurnToolCallJournal(
       else openInputsByTool.set(event.tool, [event.input]);
     } else if (event.type === "tool_done") {
       const fifoInput = openInputsByTool.get(event.tool)?.shift();
+      const artifacts = event.artifacts?.filter(isArtifactReceipt);
       priorToolResults.push({
         name: event.tool,
         input: event.input ?? fifoInput,
         content: event.result,
         isError: event.isError === true,
+        ...(artifacts && artifacts.length > 0 ? { artifacts } : {}),
       });
     }
   }

--- a/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
+++ b/packages/core/src/agent/production-agent-journal-hard-block.spec.ts
@@ -138,10 +138,11 @@ function completedLedger(
   tool: string,
   input: Record<string, string>,
   result: string,
+  artifacts?: unknown[],
 ): unknown[] {
   return [
     { type: "tool_start", tool, input },
-    { type: "tool_done", tool, result },
+    { type: "tool_done", tool, result, ...(artifacts ? { artifacts } : {}) },
   ];
 }
 
@@ -157,6 +158,13 @@ describe("tool-call journal hard-block", () => {
         "bigquery",
         { sql: "select count(*)" },
         '{"rows":[{"count":3}]}',
+        [
+          {
+            kind: "analysis",
+            id: "analysis-prior",
+            url: "/analyses/analysis-prior",
+          },
+        ],
       ),
     );
     const guard = vi.fn(() => null);
@@ -192,14 +200,24 @@ describe("tool-call journal hard-block", () => {
         input: { sql: "select count(*)" },
         content: '{"rows":[{"count":3}]}',
         isError: false,
+        artifacts: [
+          {
+            kind: "analysis",
+            id: "analysis-prior",
+            url: "/analyses/analysis-prior",
+          },
+        ],
       },
     ]);
   });
 
   it("does NOT re-execute a journaled-complete write call on resume", async () => {
     const PRIOR_RESULT = "email-sent-id-42";
+    const artifacts = [
+      { kind: "image", id: "asset-journal", url: "/asset/asset-journal" },
+    ];
     currentTurnEventsMock.mockResolvedValue(
-      completedLedger("send-email", { to: "a@b.com" }, PRIOR_RESULT),
+      completedLedger("send-email", { to: "a@b.com" }, PRIOR_RESULT, artifacts),
     );
 
     const action = makeWriteAction();
@@ -229,6 +247,7 @@ describe("tool-call journal hard-block", () => {
     expect(toolDone?.result).toContain(PRIOR_RESULT);
     expect(toolDone?.result).toContain("Already completed");
     expect(toolDone?.completedSideEffect).toBe(true);
+    expect(toolDone?.artifacts).toEqual(artifacts);
   });
 
   it("executes a fresh call normally when the journal is empty", async () => {

--- a/packages/core/src/agent/production-agent-ledger.spec.ts
+++ b/packages/core/src/agent/production-agent-ledger.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { MCP_ACTION_RESULT_MARKER } from "../mcp-client/app-result.js";
+import { assembleA2AFinalResponse } from "../server/agent-chat/action-filters-a2a.js";
 import type { AgentEngine, EngineEvent } from "./engine/types.js";
 import {
   AGENT_INTERNAL_CONTINUE_PROMPT,
@@ -19,9 +20,28 @@ import {
 
 // ─── Mock run-store so DB is never touched ───────────────────────────────────
 
-const writeLedgerMock = vi.hoisted(() => vi.fn<() => Promise<void>>());
+const writeLedgerMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      threadId: string,
+      toolKey: string,
+      result: string,
+      artifacts: unknown[],
+    ) => Promise<void>
+  >(),
+);
 const readLedgerMock = vi.hoisted(() =>
-  vi.fn<() => Promise<string | null>>(() => Promise.resolve(null)),
+  vi.fn<
+    () => Promise<{
+      result: string;
+      artifacts: Array<{
+        kind: "image";
+        id: string;
+        url?: string;
+        runId?: string;
+      }>;
+    } | null>
+  >(() => Promise.resolve(null)),
 );
 const clearLedgerMock = vi.hoisted(() => vi.fn<() => Promise<void>>());
 const currentTurnEventsMock = vi.hoisted(() =>
@@ -154,6 +174,7 @@ describe("tool-call result ledger", () => {
       "thread-zombie",
       expect.stringContaining("save-data"),
       "zombie-result",
+      [],
     );
   });
 
@@ -184,10 +205,73 @@ describe("tool-call result ledger", () => {
     expect(writeLedgerMock).not.toHaveBeenCalled();
   });
 
+  it("emits and ledgers artifact receipts before the tool result is capped", async () => {
+    const action = makeWriteAction();
+    action.maxResultChars = 80;
+    (action.run as ReturnType<typeof vi.fn>).mockResolvedValue({
+      artifactType: "image",
+      id: "asset-large",
+      url: "/asset/asset-large",
+      runId: "generation-large",
+      payload: "X".repeat(500),
+      _agentImages: [
+        { url: "https://cdn.example.com/asset-large.png", label: "result" },
+      ],
+    });
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine: singleToolEngine("generate-asset", { prompt: "large image" }),
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: { "generate-asset": action },
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      threadId: "thread-artifact",
+    });
+
+    const receipt = {
+      kind: "image",
+      id: "asset-large",
+      url: "/asset/asset-large",
+      runId: "generation-large",
+    };
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_done",
+        tool: "generate-asset",
+        result: expect.stringContaining("...[truncated"),
+        artifacts: [receipt],
+      }),
+    );
+    expect(writeLedgerMock).toHaveBeenCalledWith(
+      "thread-artifact",
+      expect.stringContaining("generate-asset"),
+      expect.stringContaining('"payload"'),
+      [receipt],
+    );
+    const zombieWrite = writeLedgerMock.mock.calls.find(
+      ([threadId]) => threadId === "thread-artifact",
+    );
+    expect(zombieWrite?.[2]).not.toContain("_agentImages");
+  });
+
   it("returns the ledger result without re-executing on continuation match", async () => {
     // readLedgerEntry returns a cached result — the action must NOT run again.
-    const PRIOR_RESULT = "previously completed result";
-    readLedgerMock.mockResolvedValue(PRIOR_RESULT);
+    const PRIOR_RESULT =
+      `{"payload":"${"x".repeat(8_000)}` +
+      "\n...[ledger truncated at 8000 chars]";
+    const artifacts = [
+      {
+        kind: "image" as const,
+        id: "asset-recovered",
+        url: "/asset/asset-recovered",
+        runId: "generation-recovered",
+      },
+    ];
+    readLedgerMock.mockResolvedValue({ result: PRIOR_RESULT, artifacts });
 
     const action = makeWriteAction();
     const events: any[] = [];
@@ -257,12 +341,35 @@ describe("tool-call result ledger", () => {
       "Recovered from prior interrupted chunk",
     );
     expect(toolDone?.completedSideEffect).toBe(true);
+    expect(toolDone?.artifacts).toEqual(artifacts);
+
+    const toolResults = events
+      .filter(
+        (
+          event,
+        ): event is Extract<(typeof events)[number], { type: "tool_done" }> =>
+          event.type === "tool_done",
+      )
+      .map((event) => ({
+        tool: event.tool,
+        result: event.result,
+        isError: event.isError,
+        completedSideEffect: event.completedSideEffect,
+        artifacts: event.artifacts,
+      }));
+    const assembled = assembleA2AFinalResponse(events, toolResults, {
+      baseUrl: "https://assets.agent-native.com",
+    });
+    expect(assembled.finalText).toContain("Artifacts:");
+    expect(assembled.finalText).toContain(
+      "https://assets.agent-native.com/asset/asset-recovered",
+    );
   });
 
   it("waits briefly for a late zombie ledger result before re-executing", async () => {
     readLedgerMock
       .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce("late zombie result");
+      .mockResolvedValueOnce({ result: "late zombie result", artifacts: [] });
 
     const action = makeWriteAction();
     const events: any[] = [];
@@ -500,7 +607,10 @@ describe("tool-call result ledger", () => {
   it("never consults the ledger for read-only tools", async () => {
     // Even if readLedger were to return something, read-only tools should
     // bypass the ledger entirely — they have no side effects to protect.
-    readLedgerMock.mockResolvedValue("should-not-be-used");
+    readLedgerMock.mockResolvedValue({
+      result: "should-not-be-used",
+      artifacts: [],
+    });
 
     const action = makeReadAction();
     const events: any[] = [];

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -28,6 +28,10 @@ import {
   MAX_TURN_WALL_CLOCK_MS,
 } from "../app-config/run-lifecycle-invariants.js";
 import { readAppState } from "../application-state/script-helpers.js";
+import {
+  detectArtifactReceipts,
+  type ArtifactReceipt,
+} from "../artifacts/detect.js";
 import { isReadOnlyShellCommand } from "../coding-tools/index.js";
 import type { AgentNativeHarnessSetting } from "../config.js";
 import { getDbExec, isTransientDatabaseError } from "../db/client.js";
@@ -3818,7 +3822,7 @@ async function waitForInterruptedToolLedgerEntry(opts: {
   timeoutMs: number;
   signal: AbortSignal;
   send: (event: AgentChatEvent) => void;
-}): Promise<string | null> {
+}): Promise<{ result: string; artifacts: ArtifactReceipt[] } | null> {
   const pollMs = INTERRUPTED_TOOL_LEDGER_POLL_MS;
   // Wait up to the tool's OWN declared timeout — the abandoned zombie can keep
   // running that long (e.g. a 12-minute image generation, whose provider keeps
@@ -6337,7 +6341,7 @@ export async function runAgentLoop(opts: {
             // Zombie completed — recover the real result without re-executing.
             const result =
               `(Recovered from prior interrupted chunk — action already completed.)\n\n` +
-              ledgerResult;
+              ledgerResult.result;
             send({
               type: "tool_start",
               id: toolCall.id,
@@ -6351,6 +6355,9 @@ export async function runAgentLoop(opts: {
               input: toolCall.input as Record<string, unknown>,
               result,
               completedSideEffect: true,
+              ...(ledgerResult.artifacts.length > 0
+                ? { artifacts: ledgerResult.artifacts }
+                : {}),
               ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
             });
             recordToolResult(result, false);
@@ -6609,6 +6616,7 @@ export async function runAgentLoop(opts: {
         let toolResultImages:
           | import("./engine/types.js").EngineToolResultImagePart[]
           | undefined;
+        let toolArtifacts: ArtifactReceipt[] = [];
         try {
           // The run may have been aborted while we waited above for an
           // interrupted tool's ledger result (the wait can poll for minutes).
@@ -6692,12 +6700,23 @@ export async function runAgentLoop(opts: {
                 ) {
                   return;
                 }
-                const zombieText = zombieMcp ? zombieMcp.text : zombieRaw;
+                const zombieResultForAgent = zombieMcp
+                  ? zombieMcp.text
+                  : extractAgentImagesFromActionResult(zombieRaw).value;
                 const zombieStr =
-                  typeof zombieText === "string"
-                    ? zombieText
-                    : JSON.stringify(zombieText, null, 2);
-                void writeLedgerEntry(ledgerThreadId, ledgerToolKey, zombieStr);
+                  typeof zombieResultForAgent === "string"
+                    ? zombieResultForAgent
+                    : JSON.stringify(zombieResultForAgent, null, 2);
+                const zombieArtifacts = detectArtifactReceipts(
+                  zombieResultForAgent,
+                  toolCall.name,
+                );
+                void writeLedgerEntry(
+                  ledgerThreadId,
+                  ledgerToolKey,
+                  zombieStr,
+                  zombieArtifacts,
+                );
               })
               .catch(() => {
                 // Action errored in the zombie — no result to ledger.
@@ -6764,6 +6783,7 @@ export async function runAgentLoop(opts: {
               toolResultImages = extracted.images;
             }
           }
+          toolArtifacts = detectArtifactReceipts(resultForAgent, toolCall.name);
           if (toolResultImages) {
             imageNotes = [
               ...describeToolResultImages(toolResultImages),
@@ -6876,6 +6896,7 @@ export async function runAgentLoop(opts: {
               : {}),
           ...(mcpApp ? { mcpApp } : {}),
           ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
+          ...(toolArtifacts.length > 0 ? { artifacts: toolArtifacts } : {}),
         });
         recordToolResult(result, isError);
         if (!isError) {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -2542,6 +2542,7 @@ export interface AgentLoopToolResultSummary {
   name: string;
   content: string;
   isError: boolean;
+  artifacts?: ArtifactReceipt[];
 }
 
 export interface AgentLoopFinalResponseGuardContext {
@@ -5939,11 +5940,16 @@ export async function runAgentLoop(opts: {
         name: toolCall.name,
         input: normalizedToolInput,
       });
-      const recordToolResult = (content: string, isError: boolean) => {
+      const recordToolResult = (
+        content: string,
+        isError: boolean,
+        artifacts?: ArtifactReceipt[],
+      ) => {
         toolResultHistory.push({
           name: toolCall.name,
           content,
           isError,
+          ...(artifacts?.length ? { artifacts } : {}),
         });
       };
       const finalizeToolErrorResult = (rawResult: string): string => {
@@ -6298,8 +6304,11 @@ export async function runAgentLoop(opts: {
             input: toolCall.input as Record<string, unknown>,
             result,
             completedSideEffect: true,
+            ...(journaled.artifacts?.length
+              ? { artifacts: journaled.artifacts }
+              : {}),
           });
-          recordToolResult(result, false);
+          recordToolResult(result, false, journaled.artifacts);
           noteToolCallSucceeded(actionEntry);
           return {
             type: "tool-result" as const,
@@ -6360,7 +6369,7 @@ export async function runAgentLoop(opts: {
                 : {}),
               ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
             });
-            recordToolResult(result, false);
+            recordToolResult(result, false, ledgerResult.artifacts);
             noteToolCallSucceeded(actionEntry);
             return {
               type: "tool-result" as const,
@@ -6898,7 +6907,7 @@ export async function runAgentLoop(opts: {
           ...(actionEntry.chatUI ? { chatUI: actionEntry.chatUI } : {}),
           ...(toolArtifacts.length > 0 ? { artifacts: toolArtifacts } : {}),
         });
-        recordToolResult(result, isError);
+        recordToolResult(result, isError, toolArtifacts);
         if (!isError) {
           noteToolCallSucceeded(actionEntry);
           if (cacheKey) {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -148,8 +148,12 @@ const mockDb = {
     if (/UPDATE agent_runs SET status = 'aborted'/i.test(rawSql)) {
       return { rows: [], rowsAffected: abortRowsAffected };
     }
-    // Tool-call result ledger: SELECT result_summary FROM agent_tool_ledger
-    if (/SELECT result_summary FROM agent_tool_ledger/i.test(rawSql)) {
+    // Tool-call result ledger: SELECT result_summary, artifacts_json FROM ...
+    if (
+      /SELECT result_summary, artifacts_json FROM agent_tool_ledger/i.test(
+        rawSql,
+      )
+    ) {
       return { rows: ledgerRows, rowsAffected: 0 };
     }
     // readRunDispatchPayload: SELECT dispatch_payload FROM agent_runs WHERE id = ?
@@ -246,7 +250,10 @@ const {
 } = await import("./run-store.js");
 
 // Mock storage for ledger SELECT responses, keyed by toolKey
-let ledgerRows: Array<{ result_summary: string }> = [];
+let ledgerRows: Array<{
+  result_summary: string;
+  artifacts_json?: string | null;
+}> = [];
 
 describe("run store", () => {
   beforeEach(() => {
@@ -1074,7 +1081,31 @@ describe("run store", () => {
     expect(insert?.args[0]).toBe("thread-abc");
     expect(insert?.args[1]).toBe("my-tool:{}");
     expect(insert?.args[2]).toBe("the result");
+    expect(insert?.args[3]).toBe("[]");
     expect(insert?.sql).toContain("ON CONFLICT");
+  });
+
+  it("writeLedgerEntry preserves artifact receipts outside the capped result", async () => {
+    const artifacts = [
+      {
+        kind: "image" as const,
+        id: "asset-1",
+        url: "/asset/asset-1",
+        runId: "run-1",
+      },
+    ];
+    await writeLedgerEntry(
+      "thread-artifacts",
+      "generate-image:{}",
+      "X".repeat(8_500),
+      artifacts,
+    );
+
+    const insert = execCalls.find((call) =>
+      /INSERT INTO agent_tool_ledger/i.test(call.sql),
+    );
+    expect(insert?.args[2]).toContain("ledger truncated");
+    expect(JSON.parse(insert?.args[3] as string)).toEqual(artifacts);
   });
 
   it("writeLedgerEntry caps result at 8 000 chars and appends truncation marker", async () => {
@@ -1091,15 +1122,60 @@ describe("run store", () => {
   });
 
   it("readLedgerEntry returns the result when an entry exists", async () => {
-    ledgerRows = [{ result_summary: "cached output" }];
+    ledgerRows = [
+      {
+        result_summary: "cached output",
+        artifacts_json:
+          '[{"kind":"image","id":"asset-1","url":"/asset/asset-1"}]',
+      },
+    ];
     const result = await readLedgerEntry("thread-abc", "my-tool:{}");
 
-    expect(result).toBe("cached output");
+    expect(result).toEqual({
+      result: "cached output",
+      artifacts: [{ kind: "image", id: "asset-1", url: "/asset/asset-1" }],
+    });
     const select = execCalls.find((call) =>
-      /SELECT result_summary FROM agent_tool_ledger/i.test(call.sql),
+      /SELECT result_summary, artifacts_json FROM agent_tool_ledger/i.test(
+        call.sql,
+      ),
     );
     expect(select?.args[0]).toBe("thread-abc");
     expect(select?.args[1]).toBe("my-tool:{}");
+  });
+
+  it("readLedgerEntry backfills empty receipts for pre-column entries", async () => {
+    ledgerRows = [{ result_summary: "legacy output", artifacts_json: null }];
+
+    await expect(
+      readLedgerEntry("thread-legacy", "old-tool:{}"),
+    ).resolves.toEqual({ result: "legacy output", artifacts: [] });
+  });
+
+  it("readLedgerEntry preserves a completed result when receipt JSON is malformed", async () => {
+    ledgerRows = [
+      { result_summary: "completed output", artifacts_json: "{truncated" },
+    ];
+
+    await expect(
+      readLedgerEntry("thread-malformed", "write-tool:{}"),
+    ).resolves.toEqual({ result: "completed output", artifacts: [] });
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.any(SyntaxError),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          operation: "parse-tool-ledger-artifacts",
+        }),
+      }),
+    );
+  });
+
+  it("readLedgerEntry preserves a completed result when receipts are undefined", async () => {
+    ledgerRows = [{ result_summary: "pre-receipt output" }];
+
+    await expect(
+      readLedgerEntry("thread-undefined", "legacy-tool:{}"),
+    ).resolves.toEqual({ result: "pre-receipt output", artifacts: [] });
   });
 
   it("readLedgerEntry returns null when no entry exists", async () => {

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -1170,6 +1170,38 @@ describe("run store", () => {
     );
   });
 
+  it("readLedgerEntry filters malformed receipt elements without hiding the completed result", async () => {
+    ledgerRows = [
+      {
+        result_summary: "completed with one valid receipt",
+        artifacts_json: JSON.stringify([
+          null,
+          {},
+          { kind: "image", id: "asset-valid", url: "/asset/asset-valid" },
+        ]),
+      },
+    ];
+
+    await expect(
+      readLedgerEntry("thread-invalid-elements", "write-tool:{}"),
+    ).resolves.toEqual({
+      result: "completed with one valid receipt",
+      artifacts: [
+        { kind: "image", id: "asset-valid", url: "/asset/asset-valid" },
+      ],
+    });
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("contains invalid receipts"),
+      }),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          operation: "parse-tool-ledger-artifacts",
+        }),
+      }),
+    );
+  });
+
   it("readLedgerEntry preserves a completed result when receipts are undefined", async () => {
     ledgerRows = [{ result_summary: "pre-receipt output" }];
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -7,7 +7,10 @@ import {
   MAX_BACKGROUND_RUN_CONTINUATIONS,
   TURN_RUN_LEDGER_SLACK,
 } from "../app-config/run-lifecycle-invariants.js";
-import type { ArtifactReceipt } from "../artifacts/detect.js";
+import {
+  isArtifactReceipt,
+  type ArtifactReceipt,
+} from "../artifacts/detect.js";
 import type { DbExec } from "../db/client.js";
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
@@ -739,8 +742,23 @@ function parseLedgerArtifacts(
   if (artifactsJson === null || artifactsJson === undefined) return [];
   try {
     const parsed: unknown = JSON.parse(artifactsJson);
-    if (Array.isArray(parsed)) return parsed as ArtifactReceipt[];
-    throw new Error("agent_tool_ledger.artifacts_json is not an array");
+    if (!Array.isArray(parsed)) {
+      throw new Error("agent_tool_ledger.artifacts_json is not an array");
+    }
+    const artifacts = parsed.filter(isArtifactReceipt);
+    if (artifacts.length !== parsed.length) {
+      captureError(
+        new Error("agent_tool_ledger.artifacts_json contains invalid receipts"),
+        {
+          tags: {
+            component: "agent-run-store",
+            operation: "parse-tool-ledger-artifacts",
+          },
+          extra: { threadId, toolKey },
+        },
+      );
+    }
+    return artifacts;
   } catch (error) {
     captureError(error, {
       tags: {

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -7,6 +7,7 @@ import {
   MAX_BACKGROUND_RUN_CONTINUATIONS,
   TURN_RUN_LEDGER_SLACK,
 } from "../app-config/run-lifecycle-invariants.js";
+import type { ArtifactReceipt } from "../artifacts/detect.js";
 import type { DbExec } from "../db/client.js";
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 import { ensureColumnExists, ensureTableExists } from "../db/ddl-guard.js";
@@ -414,6 +415,7 @@ export async function ensureRunTables(): Promise<void> {
           thread_id TEXT NOT NULL,
           tool_key TEXT NOT NULL,
           result_summary TEXT NOT NULL,
+          artifacts_json TEXT,
           completed_at ${intType()} NOT NULL,
           PRIMARY KEY (thread_id, tool_key)
         )
@@ -506,6 +508,11 @@ export async function ensureRunTables(): Promise<void> {
           `ALTER TABLE agent_run_events ADD COLUMN IF NOT EXISTS event_at ${intType()}`,
         );
         await ensureTableExists("agent_tool_ledger", agentToolLedgerCreateSql);
+        await ensureColumnExists(
+          "agent_tool_ledger",
+          "artifacts_json",
+          `ALTER TABLE agent_tool_ledger ADD COLUMN IF NOT EXISTS artifacts_json TEXT`,
+        );
         await ensureTableExists(
           "agent_run_outcome_daily",
           agentRunOutcomeDailyCreateSql,
@@ -612,6 +619,16 @@ export async function ensureRunTables(): Promise<void> {
         // Column already exists — ignore
       }
       await client.execute(agentToolLedgerCreateSql);
+      try {
+        await client.execute(
+          `ALTER TABLE agent_tool_ledger ADD COLUMN artifacts_json TEXT`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!/duplicate column name|column .* already exists/i.test(message)) {
+          throw error;
+        }
+      }
       await client.execute(agentRunOutcomeDailyCreateSql);
       // Widen millisecond-timestamp columns that older deployments created as
       // 32-bit `INTEGER`. `insertRun()` writes `Date.now()` into `started_at`
@@ -661,6 +678,7 @@ export async function writeLedgerEntry(
   threadId: string,
   toolKey: string,
   resultSummary: string,
+  artifacts: ArtifactReceipt[] = [],
 ): Promise<void> {
   try {
     await ensureRunTables();
@@ -671,12 +689,13 @@ export async function writeLedgerEntry(
           `\n...[ledger truncated at ${LEDGER_RESULT_MAX_CHARS} chars]`
         : resultSummary;
     await client.execute({
-      sql: `INSERT INTO agent_tool_ledger (thread_id, tool_key, result_summary, completed_at)
-            VALUES (?, ?, ?, ?)
+      sql: `INSERT INTO agent_tool_ledger (thread_id, tool_key, result_summary, artifacts_json, completed_at)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT (thread_id, tool_key) DO UPDATE SET
               result_summary = excluded.result_summary,
+              artifacts_json = excluded.artifacts_json,
               completed_at = excluded.completed_at`,
-      args: [threadId, toolKey, capped, Date.now()],
+      args: [threadId, toolKey, capped, JSON.stringify(artifacts), Date.now()],
     });
   } catch {
     // Ledger is best-effort; never surface failures to the caller.
@@ -690,19 +709,47 @@ export async function writeLedgerEntry(
 export async function readLedgerEntry(
   threadId: string,
   toolKey: string,
-): Promise<string | null> {
+): Promise<{ result: string; artifacts: ArtifactReceipt[] } | null> {
   try {
     await ensureRunTables();
     const client = getDbExec();
     const { rows } = await client.execute({
-      sql: `SELECT result_summary FROM agent_tool_ledger WHERE thread_id = ? AND tool_key = ?`,
+      sql: `SELECT result_summary, artifacts_json FROM agent_tool_ledger WHERE thread_id = ? AND tool_key = ?`,
       args: [threadId, toolKey],
     });
     if (rows.length === 0) return null;
-    const row = rows[0] as { result_summary: string };
-    return row.result_summary;
+    const row = rows[0] as {
+      result_summary: string;
+      artifacts_json?: string | null;
+    };
+    return {
+      result: row.result_summary,
+      artifacts: parseLedgerArtifacts(row.artifacts_json, threadId, toolKey),
+    };
   } catch {
     return null;
+  }
+}
+
+function parseLedgerArtifacts(
+  artifactsJson: string | null | undefined,
+  threadId: string,
+  toolKey: string,
+): ArtifactReceipt[] {
+  if (artifactsJson === null || artifactsJson === undefined) return [];
+  try {
+    const parsed: unknown = JSON.parse(artifactsJson);
+    if (Array.isArray(parsed)) return parsed as ArtifactReceipt[];
+    throw new Error("agent_tool_ledger.artifacts_json is not an array");
+  } catch (error) {
+    captureError(error, {
+      tags: {
+        component: "agent-run-store",
+        operation: "parse-tool-ledger-artifacts",
+      },
+      extra: { threadId, toolKey },
+    });
+    return [];
   }
 }
 

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -49,6 +49,52 @@ describe("buildAssistantMessage", () => {
     });
   });
 
+  it("persists typed artifact receipts with the completed tool part", () => {
+    const artifacts = [
+      {
+        kind: "image" as const,
+        id: "asset-1",
+        url: "/asset/asset-1",
+        title: "Launch illustration",
+        runId: "generation-1",
+      },
+    ];
+    const message = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: {
+            type: "tool_start",
+            id: "call_generate",
+            tool: "generate-image",
+          },
+        },
+        {
+          seq: 1,
+          event: {
+            type: "tool_done",
+            id: "call_generate",
+            tool: "generate-image",
+            result: "...[truncated]",
+            completedSideEffect: true,
+            artifacts,
+          },
+        },
+      ],
+      "run-artifact-receipt",
+    );
+
+    expect(message?.content).toContainEqual(
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "generate-image",
+        result: "...[truncated]",
+        completedSideEffect: true,
+        artifacts,
+      }),
+    );
+  });
+
   it("folds a replayed tool_start onto the original card instead of persisting a second one", () => {
     // Journal / zombie-ledger recovery re-emits tool_start + tool_done for a
     // call that already ran in an interrupted chunk. The live client coalesces

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -1,4 +1,5 @@
 import type { ActionChatUIConfig } from "../action-ui.js";
+import type { ArtifactReceipt } from "../artifacts/detect.js";
 import {
   formatChatErrorText,
   normalizeChatError,
@@ -30,6 +31,7 @@ interface ContentPart {
   /** Mirrors the client ContentPart marker in client/sse-event-processor.ts. */
   outcome?: "unknown";
   completedSideEffect?: boolean;
+  artifacts?: ArtifactReceipt[];
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
   activity?: boolean;
@@ -291,6 +293,7 @@ export function buildAssistantMessage(
         if (event.completedSideEffect !== undefined) {
           part.completedSideEffect = event.completedSideEffect;
         }
+        if (event.artifacts !== undefined) part.artifacts = event.artifacts;
         if (event.mcpApp) part.mcpApp = event.mcpApp;
         if (event.chatUI) part.chatUI = event.chatUI;
       }

--- a/packages/core/src/agent/tool-call-journal.spec.ts
+++ b/packages/core/src/agent/tool-call-journal.spec.ts
@@ -81,6 +81,28 @@ describe("classifyToolCallJournal", () => {
     expect(journal.interrupted[0].input).toEqual({ path: "a.ts" });
   });
 
+  it("preserves valid artifact receipts and filters malformed persisted elements", () => {
+    const events: AgentChatEvent[] = [
+      start("generate-asset", { prompt: "cover" }),
+      {
+        type: "tool_done",
+        tool: "generate-asset",
+        result: "...[truncated]",
+        artifacts: [
+          { kind: "image", id: "asset-1", url: "/asset/asset-1" },
+          null,
+          {},
+        ],
+      } as unknown as AgentChatEvent,
+    ];
+
+    const journal = classifyToolCallJournal(events);
+
+    expect(journal.completed[0].artifacts).toEqual([
+      { kind: "image", id: "asset-1", url: "/asset/asset-1" },
+    ]);
+  });
+
   it("treats all tool calls as completed when every start has a done", () => {
     const events: AgentChatEvent[] = [
       { type: "text", text: "working on it" },

--- a/packages/core/src/agent/tool-call-journal.ts
+++ b/packages/core/src/agent/tool-call-journal.ts
@@ -34,6 +34,10 @@
  * effect again. Layer 2 is the stronger guarantee.
  */
 
+import {
+  isArtifactReceipt,
+  type ArtifactReceipt,
+} from "../artifacts/detect.js";
 import type { AgentChatEvent, AgentToolInput } from "./types.js";
 
 /** A single recorded tool-call ledger entry, classified by outcome. */
@@ -53,6 +57,8 @@ export interface ToolCallJournalEntry {
   order: number;
   /** Result text from the matched `tool_done`, when the call completed. */
   result?: string;
+  /** Typed artifact evidence captured before the model-facing result was capped. */
+  artifacts?: ArtifactReceipt[];
 }
 
 /** Result of classifying one turn's ledger events. */
@@ -180,6 +186,8 @@ export function classifyToolCallJournal(
           continue;
         }
         entry.result = event.result ?? "";
+        const artifacts = event.artifacts?.filter(isArtifactReceipt);
+        if (artifacts && artifacts.length > 0) entry.artifacts = artifacts;
         completed.push(entry);
       }
       // A tool_done with no open start is ignored — it can't be re-associated

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,5 +1,6 @@
 import type { A2AAgentActivitySnapshot } from "../a2a/activity.js";
 import type { ActionChatUIConfig } from "../action-ui.js";
+import type { ArtifactReceipt } from "../artifacts/detect.js";
 import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 
@@ -367,6 +368,7 @@ export type AgentChatEvent =
       result: string;
       isError?: boolean;
       completedSideEffect?: boolean;
+      artifacts?: ArtifactReceipt[];
       mcpApp?: AgentMcpAppPayload;
       chatUI?: ActionChatUIConfig;
     }

--- a/packages/core/src/artifacts/detect.spec.ts
+++ b/packages/core/src/artifacts/detect.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import { detectArtifactReceipts, parseArtifactReferenceUrl } from "./detect.js";
+
+describe("detectArtifactReceipts", () => {
+  it.each([
+    [
+      "document",
+      "create-document",
+      { id: "doc_1", title: "Brief", url: "/page/doc_1" },
+      { kind: "document", id: "doc_1", title: "Brief", url: "/page/doc_1" },
+    ],
+    [
+      "deck",
+      "create-deck",
+      { id: "deck_1", url: "/deck/deck_1" },
+      { kind: "deck", id: "deck_1", url: "/deck/deck_1" },
+    ],
+    [
+      "dashboard",
+      "update-dashboard",
+      { id: "dash_1", name: "Funnel", url: "/adhoc/dash_1" },
+      {
+        kind: "dashboard",
+        id: "dash_1",
+        title: "Funnel",
+        url: "/adhoc/dash_1",
+      },
+    ],
+    [
+      "analysis",
+      "save-analysis",
+      { id: "analysis_1", name: "Pipeline", url: "/analyses/analysis_1" },
+      {
+        kind: "analysis",
+        id: "analysis_1",
+        title: "Pipeline",
+        url: "/analyses/analysis_1",
+      },
+    ],
+    [
+      "image",
+      "generate-asset",
+      {
+        id: "asset_1",
+        artifactType: "image",
+        url: "/asset/asset_1",
+        runId: "run_1",
+      },
+      { kind: "image", id: "asset_1", url: "/asset/asset_1", runId: "run_1" },
+    ],
+    [
+      "design",
+      "generate-design",
+      { designId: "design_1", fileCount: 2, url: "/design/design_1" },
+      {
+        kind: "design",
+        id: "design_1",
+        url: "/design/design_1",
+        fileCount: 2,
+      },
+    ],
+    [
+      "monitor",
+      "save-monitor",
+      {
+        id: "monitor_1",
+        name: "Uptime",
+        monitorAppUrl: "/monitoring?monitor=monitor_1",
+      },
+      {
+        kind: "monitor",
+        id: "monitor_1",
+        title: "Uptime",
+        url: "/monitoring?monitor=monitor_1",
+      },
+    ],
+    [
+      "form",
+      "create-form",
+      {
+        id: "form_1",
+        title: "Feedback",
+        status: "published",
+        publicUrl: "/f/feedback",
+      },
+      { kind: "form", id: "form_1", title: "Feedback", url: "/f/feedback" },
+    ],
+  ])("detects a %s receipt", (_kind, tool, result, expected) => {
+    expect(detectArtifactReceipts(result, tool)).toContainEqual(expected);
+  });
+
+  it("fans out successful image batch slots and rejects mismatched URLs", () => {
+    expect(
+      detectArtifactReceipts(
+        {
+          images: [
+            {
+              ok: true,
+              id: "asset_ok",
+              artifactType: "image",
+              url: "/asset/asset_ok",
+            },
+            {
+              ok: false,
+              id: "asset_failed",
+              artifactType: "image",
+              url: "/asset/asset_failed",
+            },
+            {
+              ok: true,
+              id: "asset_mismatch",
+              artifactType: "image",
+              url: "/asset/another_asset",
+            },
+          ],
+        },
+        "generate-image-batch",
+      ),
+    ).toEqual([
+      {
+        kind: "image",
+        id: "asset_ok",
+        url: "/asset/asset_ok",
+      },
+    ]);
+  });
+
+  it("recognizes legacy plural Assets detail URLs", () => {
+    expect(parseArtifactReferenceUrl("/assets/asset_legacy")).toEqual({
+      kind: "image",
+      id: "asset_legacy",
+    });
+    expect(
+      detectArtifactReceipts(
+        { id: "asset_legacy", pageUrl: "/assets/asset_legacy" },
+        "generate-asset",
+      ),
+    ).toEqual([
+      {
+        kind: "image",
+        id: "asset_legacy",
+        url: "/assets/asset_legacy",
+      },
+    ]);
+  });
+
+  it("does not classify Assets API collection routes as artifacts", () => {
+    expect(parseArtifactReferenceUrl("/api/assets/search")).toBeNull();
+    expect(parseArtifactReferenceUrl("/api/assets/list")).toBeNull();
+  });
+
+  it("does not retain off-origin document URLs from read actions", () => {
+    expect(
+      detectArtifactReceipts(
+        {
+          id: "doc_generic",
+          url: "https://attacker.example/page/doc_generic",
+        },
+        "read-workspace-document",
+      ),
+    ).toEqual([]);
+    expect(
+      detectArtifactReceipts(
+        {
+          id: "doc_known",
+          url: "https://attacker.example/page/doc_known",
+        },
+        "get-document",
+      ),
+    ).toEqual([{ kind: "document", id: "doc_known" }]);
+  });
+
+  it("retains real design file counts and distinguishes empty shells", () => {
+    expect(
+      detectArtifactReceipts(
+        { designId: "design_ready", fileCount: 2 },
+        "generate-design",
+      ),
+    ).toEqual([{ kind: "design", id: "design_ready", fileCount: 2 }]);
+    expect(
+      detectArtifactReceipts(
+        { id: "design_shell", title: "Draft" },
+        "create-design",
+      ),
+    ).toEqual([{ kind: "design", id: "design_shell", title: "Draft" }]);
+  });
+});

--- a/packages/core/src/artifacts/detect.ts
+++ b/packages/core/src/artifacts/detect.ts
@@ -1,0 +1,556 @@
+export interface ArtifactReceipt {
+  kind:
+    | "document"
+    | "deck"
+    | "dashboard"
+    | "analysis"
+    | "image"
+    | "design"
+    | "monitor"
+    | "form";
+  id: string;
+  url?: string;
+  title?: string;
+  runId?: string;
+  fileCount?: number;
+}
+
+type ArtifactKind = ArtifactReceipt["kind"];
+export type ArtifactReferenceKind = Exclude<ArtifactKind, "monitor" | "form">;
+
+export interface ArtifactReference {
+  kind: ArtifactReferenceKind;
+  id: string;
+}
+
+// This map attributes unreadable truncated results and preserves legacy sparse
+// image results. Missing entries fall back to the generic verification message;
+// structurally detectable receipts remain accepted independently of this list.
+const TOOL_ARTIFACT_KINDS: Readonly<Record<string, readonly ArtifactKind[]>> = {
+  "submit-content-database-form": ["document"],
+  "add-database-item": ["document"],
+  "upsert-database-item-by-key": ["document"],
+  "mutate-content-database-block": ["document"],
+  "create-document": ["document"],
+  "update-document": ["document"],
+  "set-document-property": ["document"],
+  "get-document": ["document"],
+  "get-content-document": ["document"],
+  "get-content-database": ["document"],
+  "create-deck": ["deck"],
+  "duplicate-deck": ["deck"],
+  "get-deck": ["deck"],
+  "list-decks": ["deck"],
+  "add-slide": ["deck"],
+  "update-slide": ["deck"],
+  "patch-deck": ["deck"],
+  "save-deck": ["deck"],
+  "import-pptx": ["deck"],
+  "restore-deck-version": ["deck"],
+  "update-dashboard": ["dashboard"],
+  "rename-dashboard": ["dashboard"],
+  "get-dashboard": ["dashboard"],
+  "save-analysis": ["analysis"],
+  "get-analysis": ["analysis"],
+  "generate-image": ["image"],
+  "generate-image-api": ["image"],
+  "generate-image-batch": ["image"],
+  "generate-asset": ["image"],
+  "edit-image": ["image"],
+  "refine-image": ["image"],
+  "restyle-image": ["image"],
+  "get-asset": ["image"],
+  "get-generation-run": ["image"],
+  "refresh-generation-run": ["image"],
+  "get-variant-slots": ["image"],
+  "list-assets": ["image"],
+  "save-generated-image": ["image"],
+  "save-generated-asset": ["image"],
+  "export-image": ["image"],
+  "export-asset": ["image"],
+  "save-monitor": ["monitor"],
+  "create-form": ["form"],
+  "create-design": ["design"],
+  "get-design": ["design"],
+  "generate-design": ["design"],
+  "create-file": ["design"],
+  "duplicate-design": ["design"],
+};
+
+export function artifactKindsForTool(
+  toolName: string,
+): readonly ArtifactKind[] {
+  return TOOL_ARTIFACT_KINDS[toolName] ?? [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+export function parseArtifactReferenceUrl(
+  rawUrl: string,
+): ArtifactReference | null {
+  const baseUrl = "https://agent-native-artifact.invalid";
+  if (!URL.canParse(rawUrl, baseUrl)) return null;
+  const url = new URL(rawUrl, baseUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  const path = url.pathname.replace(/\/+$/, "");
+  const patterns: Array<[ArtifactReferenceKind, RegExp]> = [
+    ["deck", /(?:^|\/)deck\/([A-Za-z0-9_-]+)(?:\/present)?$/],
+    ["design", /(?:^|\/)design\/([A-Za-z0-9_-]+)$/],
+    ["document", /(?:^|\/)page\/([A-Za-z0-9_-]+)$/],
+    ["dashboard", /(?:^|\/)adhoc\/([A-Za-z0-9_-]+)$/],
+    ["analysis", /(?:^|\/)analyses\/([A-Za-z0-9_-]+)$/],
+    ["image", /(?:^|\/)image\/([A-Za-z0-9_-]+)$/],
+    ["image", /(?:^|\/)asset\/([A-Za-z0-9_-]+)\/embed$/],
+    ["image", /(?:^|\/)asset\/([A-Za-z0-9_-]+)$/],
+    ["image", /(?:^|\/)api\/assets\/([A-Za-z0-9_-]+)\/content$/],
+  ];
+  for (const [kind, pattern] of patterns) {
+    const match = path.match(pattern);
+    if (match) return { kind, id: match[1] };
+  }
+  const legacyAsset = path.match(/(?:^|\/)assets\/([A-Za-z0-9_-]+)$/);
+  if (legacyAsset && !/(?:^|\/)api\/assets\//.test(path)) {
+    return { kind: "image", id: legacyAsset[1] };
+  }
+  return null;
+}
+
+function resultUrl(record: Record<string, unknown>): string | undefined {
+  return (
+    stringValue(record.pageUrl) ??
+    stringValue(record.detailUrl) ??
+    stringValue(record.url) ??
+    stringValue(record.urlPath) ??
+    stringValue(record.monitorAppUrl) ??
+    stringValue(record.publicUrl)
+  );
+}
+
+function receipt(
+  kind: ArtifactKind,
+  id: string | undefined,
+  record: Record<string, unknown>,
+  url: string | null = resultUrl(record) ?? null,
+): ArtifactReceipt | null {
+  if (!id) return null;
+  return {
+    kind,
+    id,
+    ...(url ? { url } : {}),
+    ...((stringValue(record.title) ?? stringValue(record.name))
+      ? { title: stringValue(record.title) ?? stringValue(record.name) }
+      : {}),
+    ...((stringValue(record.runId) ?? stringValue(record.generationRunId))
+      ? {
+          runId:
+            stringValue(record.runId) ?? stringValue(record.generationRunId),
+        }
+      : {}),
+  };
+}
+
+function imageReceipt(
+  record: Record<string, unknown>,
+  assumeImage = false,
+): ArtifactReceipt | null {
+  const id =
+    stringValue(record.assetId) ??
+    stringValue(record.imageId) ??
+    stringValue(record.id);
+  const url = resultUrl(record);
+  const reference = url ? parseArtifactReferenceUrl(url) : null;
+  const explicitlyImage = stringValue(record.artifactType) === "image";
+  const explicitlyOtherKind =
+    stringValue(record.artifactType) !== undefined && !explicitlyImage;
+  if (explicitlyOtherKind) return null;
+  if (!assumeImage && !explicitlyImage && reference?.kind !== "image") {
+    return null;
+  }
+  if (reference?.kind === "image" && id && reference.id !== id) return null;
+  return receipt("image", id ?? reference?.id, record, url);
+}
+
+function isContentDocumentUrl(rawUrl: string): boolean {
+  return (
+    URL.canParse(rawUrl) &&
+    new URL(rawUrl).origin === "https://content.agent-native.com"
+  );
+}
+
+function documentReceipt(
+  record: Record<string, unknown>,
+  options: {
+    allowWithoutUrl: boolean;
+    requireContentOrigin: boolean;
+    additionalUrls?: Array<string | undefined>;
+  },
+): ArtifactReceipt | null {
+  const id = stringValue(record.documentId) ?? stringValue(record.id);
+  if (!id) return null;
+  const candidates = [
+    resultUrl(record),
+    ...(options.additionalUrls ?? []),
+  ].filter((value): value is string => !!value);
+  const url = candidates.find((candidate) => {
+    const reference = parseArtifactReferenceUrl(candidate);
+    return (
+      reference?.kind === "document" &&
+      reference.id === id &&
+      (!options.requireContentOrigin || isContentDocumentUrl(candidate))
+    );
+  });
+  if (!url && !options.allowWithoutUrl) return null;
+  return receipt("document", id, record, url ?? null);
+}
+
+function designReceipt(
+  id: string | undefined,
+  record: Record<string, unknown>,
+  fileCount?: number,
+): ArtifactReceipt | null {
+  const candidate = receipt("design", id, record);
+  return candidate && fileCount !== undefined
+    ? { ...candidate, fileCount }
+    : candidate;
+}
+
+function renderableDesignFile(value: unknown): boolean {
+  const file = asRecord(value);
+  if (!file) return false;
+  const filename = stringValue(file.filename);
+  const fileType = stringValue(file.fileType);
+  return (
+    fileType === "html" ||
+    fileType === "jsx" ||
+    filename?.endsWith(".html") === true ||
+    filename?.endsWith(".jsx") === true
+  );
+}
+
+function remember(
+  receipts: Map<string, ArtifactReceipt>,
+  candidate: ArtifactReceipt | null,
+): void {
+  if (candidate) receipts.set(`${candidate.kind}:${candidate.id}`, candidate);
+}
+
+function detectFromRecord(
+  result: Record<string, unknown>,
+  toolName: string,
+  receipts: Map<string, ArtifactReceipt>,
+): void {
+  const url = resultUrl(result);
+  const reference = url ? parseArtifactReferenceUrl(url) : null;
+
+  if (toolName === "generate-image-batch" && Array.isArray(result.images)) {
+    for (const value of result.images) {
+      const image = asRecord(value);
+      if (!image || image.ok === false) continue;
+      remember(receipts, imageReceipt(image, true));
+    }
+    return;
+  }
+
+  remember(
+    receipts,
+    imageReceipt(result, artifactKindsForTool(toolName).includes("image")),
+  );
+
+  const deckId = stringValue(result.deckId);
+  if (deckId) {
+    remember(
+      receipts,
+      receipt(
+        "deck",
+        deckId,
+        result,
+        reference?.kind === "deck" && reference.id === deckId ? url : null,
+      ),
+    );
+  } else if (reference?.kind === "deck") {
+    remember(receipts, receipt("deck", reference.id, result, url));
+  } else if (
+    toolName === "create-deck" ||
+    toolName === "duplicate-deck" ||
+    toolName === "get-deck"
+  ) {
+    remember(receipts, receipt("deck", stringValue(result.id), result));
+  }
+
+  if (
+    toolName === "submit-content-database-form" ||
+    toolName === "add-database-item"
+  ) {
+    const id = stringValue(result.createdDocumentId);
+    remember(
+      receipts,
+      receipt("document", id, {
+        ...result,
+        title: result.createdDocumentTitle,
+      }),
+    );
+    return;
+  }
+
+  if (
+    toolName === "upsert-database-item-by-key" ||
+    toolName === "mutate-content-database-block"
+  ) {
+    const mutationReceipt = asRecord(result.receipt);
+    const row = asRecord(mutationReceipt?.row);
+    const target = asRecord(mutationReceipt?.target);
+    const rowLink = asRecord(mutationReceipt?.rowLink);
+    const id =
+      stringValue(row?.documentId) ?? stringValue(target?.rowDocumentId);
+    remember(
+      receipts,
+      receipt(
+        "document",
+        id,
+        result,
+        stringValue(row?.urlPath) ?? stringValue(rowLink?.urlPath),
+      ),
+    );
+    return;
+  }
+
+  if (
+    toolName === "create-document" ||
+    toolName === "update-document" ||
+    toolName === "set-document-property"
+  ) {
+    if (result.conflict === true) return;
+    const document = asRecord(result.document) ?? result;
+    remember(
+      receipts,
+      receipt(
+        "document",
+        stringValue(document.documentId) ?? stringValue(document.id),
+        document,
+        resultUrl(document) ?? url,
+      ),
+    );
+    return;
+  }
+
+  if (toolName === "get-document" || toolName === "get-content-document") {
+    const document = asRecord(result.document) ?? result;
+    remember(
+      receipts,
+      documentReceipt(document, {
+        allowWithoutUrl: true,
+        requireContentOrigin: true,
+        additionalUrls: [url],
+      }),
+    );
+    return;
+  }
+
+  if (toolName === "get-content-database") {
+    const database = asRecord(result.database);
+    if (database) {
+      remember(
+        receipts,
+        documentReceipt(database, {
+          allowWithoutUrl: true,
+          requireContentOrigin: true,
+          additionalUrls: [url],
+        }),
+      );
+    } else if (result.available !== false) {
+      remember(
+        receipts,
+        documentReceipt(result, {
+          allowWithoutUrl: true,
+          requireContentOrigin: true,
+        }),
+      );
+    }
+    const candidates = Array.isArray(result.items) ? result.items : [];
+    for (const value of candidates) {
+      const item = asRecord(value);
+      const document = asRecord(item?.document) ?? item;
+      if (!document) continue;
+      remember(
+        receipts,
+        documentReceipt(document, {
+          allowWithoutUrl: true,
+          requireContentOrigin: true,
+          additionalUrls: [resultUrl(item ?? {}), url],
+        }),
+      );
+    }
+    return;
+  }
+
+  if (toolName === "list-decks" && Array.isArray(result.decks)) {
+    for (const value of result.decks) {
+      const deck = asRecord(value);
+      if (!deck) continue;
+      remember(
+        receipts,
+        receipt("deck", stringValue(deck.deckId) ?? stringValue(deck.id), deck),
+      );
+    }
+    return;
+  }
+
+  if (/^(?:find|get|list|query|read|search)-/i.test(toolName)) {
+    remember(
+      receipts,
+      documentReceipt(result, {
+        allowWithoutUrl: false,
+        requireContentOrigin: true,
+      }),
+    );
+    const document = asRecord(result.document);
+    if (document) {
+      remember(
+        receipts,
+        documentReceipt(document, {
+          allowWithoutUrl: false,
+          requireContentOrigin: true,
+          additionalUrls: [url],
+        }),
+      );
+    }
+  }
+
+  if (
+    toolName === "update-dashboard" ||
+    toolName === "rename-dashboard" ||
+    toolName === "get-dashboard"
+  ) {
+    remember(
+      receipts,
+      receipt(
+        "dashboard",
+        stringValue(result.dashboardId) ?? stringValue(result.id),
+        result,
+      ),
+    );
+    return;
+  }
+
+  if (toolName === "save-analysis" || toolName === "get-analysis") {
+    remember(
+      receipts,
+      receipt(
+        "analysis",
+        stringValue(result.analysisId) ?? stringValue(result.id),
+        result,
+      ),
+    );
+    return;
+  }
+
+  if (toolName === "save-monitor") {
+    remember(
+      receipts,
+      receipt(
+        "monitor",
+        stringValue(result.id),
+        result,
+        stringValue(result.monitorAppUrl),
+      ),
+    );
+    return;
+  }
+
+  if (
+    toolName === "create-form" &&
+    stringValue(result.status) === "published"
+  ) {
+    remember(
+      receipts,
+      receipt(
+        "form",
+        stringValue(result.id),
+        result,
+        stringValue(result.publicUrl),
+      ),
+    );
+    return;
+  }
+
+  if (toolName === "create-design") {
+    remember(receipts, designReceipt(stringValue(result.id), result));
+    return;
+  }
+
+  if (toolName === "get-design") {
+    const files = Array.isArray(result.files) ? result.files : [];
+    if (files.some(renderableDesignFile)) {
+      remember(
+        receipts,
+        designReceipt(stringValue(result.id), result, files.length),
+      );
+    }
+    return;
+  }
+
+  if (toolName === "generate-design") {
+    const savedFiles = Array.isArray(result.savedFiles)
+      ? result.savedFiles
+      : [];
+    const fileCount = numberValue(result.fileCount) ?? savedFiles.length;
+    if (fileCount > 0) {
+      remember(
+        receipts,
+        designReceipt(stringValue(result.designId), result, fileCount),
+      );
+    }
+    return;
+  }
+
+  if (toolName === "create-file") {
+    const renderable =
+      result.renderable === true ||
+      stringValue(result.fileType) === "html" ||
+      stringValue(result.fileType) === "jsx";
+    if (renderable) {
+      remember(
+        receipts,
+        designReceipt(stringValue(result.designId), result, 1),
+      );
+    }
+    return;
+  }
+
+  if (toolName === "duplicate-design" && numberValue(result.fileCount)) {
+    remember(
+      receipts,
+      designReceipt(
+        stringValue(result.id),
+        result,
+        numberValue(result.fileCount),
+      ),
+    );
+  }
+}
+
+export function detectArtifactReceipts(
+  result: unknown,
+  toolName: string,
+): ArtifactReceipt[] {
+  const record = asRecord(result);
+  if (!record) return [];
+  const receipts = new Map<string, ArtifactReceipt>();
+  detectFromRecord(record, toolName, receipts);
+  return [...receipts.values()];
+}

--- a/packages/core/src/artifacts/detect.ts
+++ b/packages/core/src/artifacts/detect.ts
@@ -18,9 +18,44 @@ export interface ArtifactReceipt {
 type ArtifactKind = ArtifactReceipt["kind"];
 export type ArtifactReferenceKind = Exclude<ArtifactKind, "monitor" | "form">;
 
+const ARTIFACT_KINDS: ReadonlySet<ArtifactKind> = new Set([
+  "document",
+  "deck",
+  "dashboard",
+  "analysis",
+  "image",
+  "design",
+  "monitor",
+  "form",
+]);
+
 export interface ArtifactReference {
   kind: ArtifactReferenceKind;
   id: string;
+}
+
+export function isArtifactReceipt(value: unknown): value is ArtifactReceipt {
+  const candidate = asRecord(value);
+  if (!candidate) return false;
+  if (
+    typeof candidate.kind !== "string" ||
+    !ARTIFACT_KINDS.has(candidate.kind as ArtifactKind) ||
+    typeof candidate.id !== "string" ||
+    !candidate.id.trim()
+  ) {
+    return false;
+  }
+  for (const key of ["url", "title", "runId"] as const) {
+    if (candidate[key] !== undefined && typeof candidate[key] !== "string") {
+      return false;
+    }
+  }
+  return (
+    candidate.fileCount === undefined ||
+    (typeof candidate.fileCount === "number" &&
+      Number.isInteger(candidate.fileCount) &&
+      candidate.fileCount >= 0)
+  );
 }
 
 // This map attributes unreadable truncated results and preserves legacy sparse

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -4505,12 +4505,20 @@ describe("journal-recovery tool replay coalescing", () => {
       // Continuation chunk replays the same call via the tool-call journal
       // (id-less re-emit with the marker result).
       { type: "tool_start", tool: "edit-screen", input: { a: 1 } },
-      { type: "tool_done", tool: "edit-screen", result: JOURNAL_MARKER },
+      {
+        type: "tool_done",
+        tool: "edit-screen",
+        result: JOURNAL_MARKER,
+        artifacts: [{ kind: "design", id: "design_replayed", fileCount: 3 }],
+      },
     ]);
 
     const toolCards = content.filter((p) => p.type === "tool-call");
     expect(toolCards).toHaveLength(1);
     expect(toolCards[0].result).toBe("real result");
+    expect(toolCards[0].artifacts).toEqual([
+      { kind: "design", id: "design_replayed", fileCount: 3 },
+    ]);
   });
 
   it("resolves an interrupted spinner with the ledger-recovered result and removes the replay artifact", async () => {
@@ -4520,13 +4528,27 @@ describe("journal-recovery tool replay coalescing", () => {
       // Next chunk replays it; the id-less tool_done name-matches the original
       // pending card, leaving the replay's own start as a stuck spinner.
       { type: "tool_start", tool: "edit-screen", input: { a: 1 } },
-      { type: "tool_done", tool: "edit-screen", result: LEDGER_MARKER },
+      {
+        type: "tool_done",
+        tool: "edit-screen",
+        result: LEDGER_MARKER,
+        artifacts: [
+          {
+            kind: "design",
+            id: "design_recovered",
+            fileCount: 2,
+          },
+        ],
+      },
     ]);
 
     const toolCards = content.filter((p) => p.type === "tool-call");
     expect(toolCards).toHaveLength(1);
     expect(toolCards[0].result).toBe(LEDGER_MARKER);
     expect(toolCards[0].toolCallId).toBe("srv_1");
+    expect(toolCards[0].artifacts).toEqual([
+      { kind: "design", id: "design_recovered", fileCount: 2 },
+    ]);
   });
 
   it("keeps genuinely repeated identical calls that are not journal replays", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -7,6 +7,7 @@ import {
   LLM_MISSING_CREDENTIALS_MESSAGE,
 } from "../agent/engine/credential-errors.js";
 import { BUILDER_GATEWAY_INTERNAL_ERROR_CODE } from "../agent/engine/error-detail.js";
+import type { ArtifactReceipt } from "../artifacts/detect.js";
 import type { AgentMcpAppPayload } from "../mcp-client/app-result.js";
 import { emitChatFirstOpenApp } from "./chat-first.js";
 import { formatChatErrorText, normalizeChatError } from "./error-format.js";
@@ -45,6 +46,7 @@ export type ContentPart =
        */
       outcome?: "unknown";
       completedSideEffect?: boolean;
+      artifacts?: ArtifactReceipt[];
       mcpApp?: AgentMcpAppPayload;
       chatUI?: ActionChatUIConfig;
       activity?: boolean;
@@ -85,6 +87,7 @@ export interface SSEEvent {
   result?: string;
   isError?: boolean;
   completedSideEffect?: boolean;
+  artifacts?: ArtifactReceipt[];
   mcpApp?: AgentMcpAppPayload;
   chatUI?: ActionChatUIConfig;
   /** Stable key the client echoes back in `approvedToolCalls` to approve a
@@ -1018,12 +1021,29 @@ function contentSnapshot(content: ContentPart[]): ContentPart[] {
       args: { ...part.args },
       ...(part.mcpApp ? { mcpApp: { ...part.mcpApp } } : {}),
       ...(part.chatUI ? { chatUI: { ...part.chatUI } } : {}),
+      ...(part.artifacts
+        ? { artifacts: part.artifacts.map((artifact) => ({ ...artifact })) }
+        : {}),
       ...(part.approval ? { approval: { ...part.approval } } : {}),
       ...(part.structuredMeta
         ? { structuredMeta: { ...part.structuredMeta } }
         : {}),
     };
   });
+}
+
+function mergeArtifactReceipts(
+  current: ArtifactReceipt[] | undefined,
+  incoming: ArtifactReceipt[],
+): ArtifactReceipt[] {
+  const receipts = new Map<string, ArtifactReceipt>();
+  for (const artifact of current ?? []) {
+    receipts.set(`${artifact.kind}:${artifact.id}`, artifact);
+  }
+  for (const artifact of incoming) {
+    receipts.set(`${artifact.kind}:${artifact.id}`, artifact);
+  }
+  return [...receipts.values()];
 }
 
 function repeatSignatureValue(value: unknown): string {
@@ -1122,6 +1142,12 @@ function coalesceJournalRecoveredTool(
       if (current.chatUI) prior.chatUI = current.chatUI;
       if (current.approval) prior.approval = { ...current.approval };
     }
+    if (current.artifacts !== undefined) {
+      prior.artifacts = mergeArtifactReceipts(
+        prior.artifacts,
+        current.artifacts,
+      );
+    }
     content.splice(completedIndex, 1);
     return true;
   }
@@ -1167,6 +1193,12 @@ function coalesceCompletedToolRepeat(
 
   previous.repeatCount =
     (previous.repeatCount ?? 1) + (current.repeatCount ?? 1);
+  if (current.artifacts !== undefined) {
+    previous.artifacts = mergeArtifactReceipts(
+      previous.artifacts,
+      current.artifacts,
+    );
+  }
   content.splice(completedIndex, 1);
 }
 
@@ -1712,6 +1744,9 @@ export function processEvent(
         if (ev.isError !== undefined) part.isError = ev.isError;
         if (ev.completedSideEffect !== undefined) {
           part.completedSideEffect = ev.completedSideEffect;
+        }
+        if (ev.artifacts !== undefined) {
+          part.artifacts = mergeArtifactReceipts(part.artifacts, ev.artifacts);
         }
         if (ev.mcpApp) part.mcpApp = ev.mcpApp;
         if (ev.chatUI) part.chatUI = ev.chatUI;

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -49,6 +49,7 @@ import {
 } from "../agent/thread-data-builder.js";
 import { attachToolSearch } from "../agent/tool-search.js";
 import type { ContinuationReason } from "../agent/types.js";
+import type { ArtifactReceipt } from "../artifacts/detect.js";
 import {
   createThread,
   getThread,
@@ -197,6 +198,7 @@ type ToolDoneEvent = {
   result: string;
   isError?: boolean;
   completedSideEffect?: boolean;
+  artifacts?: ArtifactReceipt[];
 };
 
 export type IntegrationResponseDeliveryTaskPayload = {
@@ -350,6 +352,7 @@ function collectToolResultSummaries(
       result: event.result,
       isError: event.isError,
       completedSideEffect: event.completedSideEffect,
+      artifacts: event.artifacts,
     }));
 }
 
@@ -364,7 +367,11 @@ function collectCompletedMutationToolResultSummaries(
         event.completedSideEffect === true &&
         event.isError !== true,
     )
-    .map((event) => ({ tool: event.tool, result: event.result }));
+    .map((event) => ({
+      tool: event.tool,
+      result: event.result,
+      artifacts: event.artifacts,
+    }));
 }
 
 export type ResolvedIntegrationApiKey = ResolvedOwnerApiKey;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2256,6 +2256,7 @@ export function createAgentChatPlugin(
                     result: event.result,
                     isError: event.isError,
                     completedSideEffect: event.completedSideEffect,
+                    artifacts: event.artifacts,
                   });
                   const artifactBaseUrl = resolveArtifactBaseUrl(context.event);
                   const recoverableArtifactMessage =
@@ -2733,6 +2734,7 @@ export function createAgentChatPlugin(
                       result: event.result,
                       isError: event.isError,
                       completedSideEffect: event.completedSideEffect,
+                      artifacts: event.artifacts,
                     });
                   }
                 },


### PR DESCRIPTION
Bug:
Slides asks Assets to generate slide images over A2A. Assets generates them successfully — the images exist in the DB, the logs show the runs completing — but the reply Slides gets back is:
```
I could not verify the image URLs in the final answer against a successful artifact action that saved app data, so I cannot return it.
```

No images reach the deck. It looks like a generation failure and gets reported as one, but nothing failed: the answer was discarded after the work was done.

**Why it happened**
The A2A final-answer guard exists to stop an agent returning URLs it never created. Its only evidence was the tool result string, re-parsed with JSON.parse at response time — and that string is size-capped twice: 20,000 chars for delegated runs, and 8,000 chars when a result is recovered from the zombie ledger after the run's soft timeout abandoned a long tool call. Image generation hits both: a generate-image-batch result is ~3.7 KB per image because it returns the whole asset row including metadata.compiledPrompt, so three images is 11 KB.

Cut mid-JSON, the parse fails, and the parse failure returned null — the same value as "this tool produced no artifacts." So the guard concluded no artifact existed and replaced a correct answer with a refusal. Absent and unreadable were the same value, which is the failure mode CLAUDE.md calls out as the longest-running class of repeat reports in this repo.

Two adjacent defects in the same path, found while tracing it:

Assets emits - Image: <base>/asset/<id> in its artifact block, but the downstream parser only accepted /image/<id>, /asset/<id>/embed, and /api/assets/<id>/content — so any caller re-verifying an Assets reply dropped every image line and then rejected its own answer.
Image detection was gated on a hardcoded list of ten tool names, so generate-asset, get-generation-run, and friends produced artifacts the guard could not see.

**What changed**
Artifact receipts are captured from the raw action result before stringify and truncation and carried on the tool_done event, so verification no longer depends on re-parsing a capped string. New packages/core/src/artifacts/detect.ts owns detection.
Receipts survive interrupted runs: new additive agent_tool_ledger.artifacts_json column, written outside the result cap and replayed on zombie recovery. A malformed value degrades to "no receipts" and still returns the recovered result, instead of nulling the entry and re-running a billable generation.
Unreadable is now distinct from absent. parseToolResultJson returns parsed | not-json | truncated, and a truncated artifact-producing result gets its own message naming the tool and pointing at the right re-read action, instead of claiming nothing was saved.
One URL vocabulary. parseArtifactReferenceUrl is shared by the detector, the downstream-block parser, and the answer scanner, and now accepts the canonical /asset/<id> and legacy /assets/<id> forms.
Structural detection replaces the tool-name allow-lists for images and for artifact identities in the signed cross-app marker; receipts are admitted through the same per-kind checks as before (id/URL agreement, Content-origin gate on document reads, real design file counts).
