### PR TITLE
test: target the visible beta chat composer

### DIFF
--- a/e2e/beta/lib/chat.ts
+++ b/e2e/beta/lib/chat.ts
@@ -204,20 +204,45 @@ export const COMPOSER = {
   model: '[data-agent-composer-slot="model-button"]',
 } as const;
 
+/**
+ * Apps may keep responsive composer trees mounted together. Browser actions
+ * must target the rendered tree, not whichever hidden tree happens to come
+ * first in the DOM.
+ */
+export const VISIBLE_COMPOSER = {
+  input: `${COMPOSER.input}:visible`,
+  send: `${COMPOSER.send}:visible`,
+  stop: `${COMPOSER.stop}:visible`,
+  model: `${COMPOSER.model}:visible`,
+} as const;
+
 export async function readComposerRuntimeState(page: Page): Promise<unknown> {
   return page.evaluate(() => {
-    const input = document.querySelector<HTMLElement>(
-      '[data-agent-composer-slot="editor-input"]',
+    const inputs = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        '[data-agent-composer-slot="editor-input"]',
+      ),
     );
-    const send = document.querySelector<HTMLButtonElement>(
-      '[data-agent-composer-slot="send-button"]',
+    const sends = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[data-agent-composer-slot="send-button"]',
+      ),
     );
+    const isVisible = (element: Element): boolean => {
+      const style = window.getComputedStyle(element);
+      return (
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        element.getClientRects().length > 0
+      );
+    };
+    const input = inputs.find(isVisible) ?? inputs[0];
+    const send = sends.find(isVisible) ?? sends[0];
     const panel = document.querySelector<HTMLElement>(".agent-sidebar-panel");
     return {
       href: window.location.href,
-      inputCount: document.querySelectorAll(
-        '[data-agent-composer-slot="editor-input"]',
-      ).length,
+      inputCount: inputs.length,
+      visibleInputCount: inputs.filter(isVisible).length,
       input: input
         ? {
             textContent: input.textContent,
@@ -227,6 +252,8 @@ export async function readComposerRuntimeState(page: Page): Promise<unknown> {
             active: document.activeElement === input,
           }
         : null,
+      sendCount: sends.length,
+      visibleSendCount: sends.filter(isVisible).length,
       send: send
         ? {
             disabled: send.disabled,
@@ -290,14 +317,14 @@ export async function sendPromptAndAwaitTurn(
   prompt: string,
   { turnTimeoutMs = 180_000 }: { turnTimeoutMs?: number } = {},
 ): Promise<void> {
-  const input = page.locator(COMPOSER.input).first();
+  const input = page.locator(VISIBLE_COMPOSER.input).first();
   await input.waitFor({ state: "visible", timeout: 60_000 });
   await input.click();
   // The composer is a ProseMirror surface; `fill()` does not produce the input
   // events it needs to enable the send button.
   await input.pressSequentially(prompt, { delay: 8 });
 
-  const send = page.locator(COMPOSER.send).first();
+  const send = page.locator(VISIBLE_COMPOSER.send).first();
   await send.waitFor({ state: "visible", timeout: 30_000 });
   try {
     await send.click();
@@ -307,7 +334,7 @@ export async function sendPromptAndAwaitTurn(
     );
   }
 
-  const stop = page.locator(COMPOSER.stop).first();
+  const stop = page.locator(VISIBLE_COMPOSER.stop).first();
   // A turn short enough to finish before the stop button paints is still a
   // completed turn, so a missed appearance is not itself a failure.
   await stop

--- a/e2e/beta/lib/chat.ts
+++ b/e2e/beta/lib/chat.ts
@@ -205,29 +205,23 @@ export const COMPOSER = {
 } as const;
 
 /**
- * Apps may keep responsive composer trees mounted together. Browser actions
- * must target the rendered tree, not whichever hidden tree happens to come
- * first in the DOM.
+ * The suite opens the AgentSidebar, but some apps also render a page-level
+ * composer and chat keeps inactive tabs mounted. Scope actions to the open
+ * sidebar root before selecting its visible controls.
  */
+const VISIBLE_AGENT_COMPOSER_ROOT =
+  '.agent-sidebar-panel[data-agent-sidebar-state="open"] [data-agent-composer-slot="root"]:visible';
+
 export const VISIBLE_COMPOSER = {
-  input: `${COMPOSER.input}:visible`,
-  send: `${COMPOSER.send}:visible`,
-  stop: `${COMPOSER.stop}:visible`,
-  model: `${COMPOSER.model}:visible`,
+  root: VISIBLE_AGENT_COMPOSER_ROOT,
+  input: `${VISIBLE_AGENT_COMPOSER_ROOT} ${COMPOSER.input}:visible`,
+  send: `${VISIBLE_AGENT_COMPOSER_ROOT} ${COMPOSER.send}:visible`,
+  stop: `${VISIBLE_AGENT_COMPOSER_ROOT} ${COMPOSER.stop}:visible`,
+  model: `${VISIBLE_AGENT_COMPOSER_ROOT} ${COMPOSER.model}:visible`,
 } as const;
 
 export async function readComposerRuntimeState(page: Page): Promise<unknown> {
   return page.evaluate(() => {
-    const inputs = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        '[data-agent-composer-slot="editor-input"]',
-      ),
-    );
-    const sends = Array.from(
-      document.querySelectorAll<HTMLButtonElement>(
-        '[data-agent-composer-slot="send-button"]',
-      ),
-    );
     const isVisible = (element: Element): boolean => {
       const style = window.getComputedStyle(element);
       return (
@@ -236,11 +230,32 @@ export async function readComposerRuntimeState(page: Page): Promise<unknown> {
         element.getClientRects().length > 0
       );
     };
+    const panel = document.querySelector<HTMLElement>(
+      '.agent-sidebar-panel[data-agent-sidebar-state="open"]',
+    );
+    const roots = Array.from(
+      (panel ?? document).querySelectorAll<HTMLElement>(
+        '[data-agent-composer-slot="root"]',
+      ),
+    );
+    const root = roots.find(isVisible) ?? roots[0];
+    const surface = root ?? panel ?? document;
+    const inputs = Array.from(
+      surface.querySelectorAll<HTMLElement>(
+        '[data-agent-composer-slot="editor-input"]',
+      ),
+    );
+    const sends = Array.from(
+      surface.querySelectorAll<HTMLButtonElement>(
+        '[data-agent-composer-slot="send-button"]',
+      ),
+    );
     const input = inputs.find(isVisible) ?? inputs[0];
     const send = sends.find(isVisible) ?? sends[0];
-    const panel = document.querySelector<HTMLElement>(".agent-sidebar-panel");
     return {
       href: window.location.href,
+      composerRootCount: roots.length,
+      visibleComposerRootCount: roots.filter(isVisible).length,
       inputCount: inputs.length,
       visibleInputCount: inputs.filter(isVisible).length,
       input: input

--- a/e2e/beta/specs/a2a.spec.ts
+++ b/e2e/beta/specs/a2a.spec.ts
@@ -8,8 +8,8 @@ import {
 } from "../lib/authed";
 import {
   assertNoChatFailure,
-  COMPOSER,
   sendPromptAndAwaitTurn,
+  VISIBLE_COMPOSER,
   watchChatRequests,
 } from "../lib/chat";
 import {
@@ -67,7 +67,7 @@ test.describe("slides -> analytics delegation", () => {
           timeout: 45_000,
         },
       );
-      await expect(page.locator(COMPOSER.input).first()).toBeVisible({
+      await expect(page.locator(VISIBLE_COMPOSER.input).first()).toBeVisible({
         timeout: 60_000,
       });
 

--- a/e2e/beta/specs/chat.spec.ts
+++ b/e2e/beta/specs/chat.spec.ts
@@ -8,11 +8,11 @@ import {
 } from "../lib/authed";
 import {
   assertNoChatFailure,
-  COMPOSER,
   formatChatRequestDiagnostics,
   MISSING_FINAL_RESPONSE,
   readComposerRuntimeState,
   sendPromptAndAwaitTurn,
+  VISIBLE_COMPOSER,
   watchChatRequests,
 } from "../lib/chat";
 import { authenticatedEntryPath, chatSites, originFor } from "../lib/fleet";
@@ -54,7 +54,7 @@ async function expectComposerVisible(
   siteHost: string,
 ): Promise<void> {
   await expect(
-    page.locator(COMPOSER.input).first(),
+    page.locator(VISIBLE_COMPOSER.input).first(),
     `${siteHost} rendered no agent composer for a signed-in user`,
   ).toBeVisible({ timeout: 60_000 });
 }
@@ -143,7 +143,7 @@ for (const site of sites) {
           });
           try {
             await expect(
-              page.locator(COMPOSER.input).first(),
+              page.locator(VISIBLE_COMPOSER.input).first(),
               `${site.host} did not restore the composer after reloading a completed chat`,
             ).toBeVisible({ timeout: 60_000 });
           } catch (error) {
@@ -171,7 +171,7 @@ for (const site of sites) {
             `${site.host} restored a completed thread with a missing-final marker`,
           ).toHaveCount(0);
           await expect(
-            page.locator(COMPOSER.stop),
+            page.locator(VISIBLE_COMPOSER.stop),
             `${site.host} restored a completed thread in the stuck "Thinking" state`,
           ).toBeHidden();
         });
@@ -206,11 +206,11 @@ for (const site of sites) {
           chat.assertOnlyLuna();
 
           await expect(
-            page.locator(COMPOSER.stop),
+            page.locator(VISIBLE_COMPOSER.stop),
             `${site.host} still shows the stop button after the turn ended — the composer is stuck in the "Thinking" state users reported`,
           ).toBeHidden();
           await expect(
-            page.locator(COMPOSER.send).first(),
+            page.locator(VISIBLE_COMPOSER.send).first(),
             `${site.host} left the composer with neither a send nor a stop control after the turn`,
           ).toBeVisible();
         });
@@ -235,7 +235,7 @@ for (const site of sites) {
             timeout: 45_000,
           },
         );
-        const send = page.locator(COMPOSER.send).first();
+        const send = page.locator(VISIBLE_COMPOSER.send).first();
         await expect(send).toBeVisible({ timeout: 60_000 });
 
         const badge = page.locator(


### PR DESCRIPTION
## Summary

- Target the visible composer instance in beta chat and A2A browser helpers.
- Include visible and total composer counts in failure diagnostics.

The beta fleet can mount responsive composer trees together. The previous `.first()` selectors could select the hidden tree, producing false failures after a completed turn or reload even though the authenticated agent request succeeded.

## Verification

- `corepack pnpm typecheck:e2e`
- `corepack pnpm guard:beta-e2e-suite`
- `corepack pnpm exec oxfmt --check e2e/beta/lib/chat.ts e2e/beta/specs/chat.spec.ts e2e/beta/specs/a2a.spec.ts`
- `corepack pnpm guards`