### PR TITLE
fix: keep Design chat and toast surfaces clear

### DIFF
--- a/.changeset/clear-design-chat-overflow.md
+++ b/.changeset/clear-design-chat-overflow.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep shared agent chat scrollers inside their flex boundaries.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -1541,6 +1541,9 @@ describe("missing agent engine setup", () => {
       "if (!hideUserMessage) resumeFollowingRef.current()",
     );
     expect(messageScroller).toContain('"agentChat.composer.scrollToBottom"');
+    expect(messageScroller).toContain(
+      '"relative flex min-h-0 flex-1 flex-col overflow-hidden"',
+    );
     expect(source).toContain("<MessageScrollerButton />");
     expect(source).toMatch(/<MessageScrollerProvider[\s\S]*?\bautoScroll\b/);
     expect(source).not.toContain("autoScroll={false}");

--- a/packages/core/src/client/components/ui/message-scroller.tsx
+++ b/packages/core/src/client/components/ui/message-scroller.tsx
@@ -41,7 +41,10 @@ function MessageScrollerProvider(props: MessageScrollerProviderProps) {
 function MessageScroller({ className, ...props }: MessageScrollerRootProps) {
   return (
     <ShadcnMessageScroller.Root
-      className={cn("relative flex min-h-0 flex-1 flex-col", className)}
+      className={cn(
+        "relative flex min-h-0 flex-1 flex-col overflow-hidden",
+        className,
+      )}
       {...props}
     />
   );

--- a/templates/design/app/global.shell.spec.ts
+++ b/templates/design/app/global.shell.spec.ts
@@ -30,6 +30,16 @@ describe("Design app shell", () => {
     );
   });
 
+  it("keeps toasts clear of the editor chat column", () => {
+    const root = readFileSync(new URL("./root.tsx", import.meta.url), {
+      encoding: "utf8",
+    });
+
+    expect(root).toContain('position="bottom-right"');
+    expect(root).toContain("offset={{ bottom: 44, right: 32 }}");
+    expect(root).toContain("mobileOffset={{ bottom: 44, right: 16 }}");
+  });
+
   it("defines one baseline contract for the editor shell and fixed action rail", () => {
     const css = readFileSync(new URL("./global.css", import.meta.url), {
       encoding: "utf8",

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -188,7 +188,9 @@ function DesignToaster() {
   return (
     <Toaster
       richColors
-      position={isBuilderHostEmbed() ? "bottom-right" : "bottom-left"}
+      position="bottom-right"
+      offset={{ bottom: 44, right: 32 }}
+      mobileOffset={{ bottom: 44, right: 16 }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- move Design toasts to the bottom-right with the shared safe bottom offsets
- contain the shared assistant chat scroller so long error content cannot create a second page scrollbar
- add focused regression coverage and a core patch changeset

## Validation
- `corepack pnpm --filter @agent-native/core exec vitest --run src/client/AssistantChat.display.spec.ts`
- `corepack pnpm --filter design exec vitest --run app/global.shell.spec.ts`
- `corepack pnpm --filter design typecheck`
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm guards` (65 checks)
- authenticated Chromium verification at the reported 2x viewport, including a rendered toast and long chat error state
