### PR TITLE
Resume agent runs interrupted during action preparation

### DIFF
--- a/.changeset/fix-action-preparation-continuation.md
+++ b/.changeset/fix-action-preparation-continuation.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resume agent runs that end while an action input is still being prepared instead of reporting a completed turn.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -11149,6 +11149,39 @@ describe("shouldChainBackgroundContinuation (server-driven background chain)", (
     expect(backgroundContinuationReasonForRun(run)).toBe("stream_ended");
   });
 
+  it("CHAINS a background run that stopped during action preparation", () => {
+    const run = makeRun([
+      { type: "text", text: "I will build the design now." },
+      {
+        type: "activity",
+        label: "Preparing generate-design action",
+        tool: "generate-design",
+        id: "call-generate-design",
+      },
+      {
+        type: "tool_input_start",
+        tool: "generate-design",
+        id: "call-generate-design",
+      },
+      {
+        type: "tool_input_delta",
+        tool: "generate-design",
+        id: "call-generate-design",
+        text: '{"files":',
+      },
+      { type: "done" },
+    ]);
+
+    expect(
+      shouldChainBackgroundContinuation({
+        isBackgroundWorker: true,
+        run,
+        continuationCount: 0,
+      }),
+    ).toBe(true);
+    expect(backgroundContinuationReasonForRun(run)).toBe("stream_ended");
+  });
+
   it("does NOT chain a background run that sent final text after completed tools", () => {
     expect(
       shouldChainBackgroundContinuation({

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -179,6 +179,7 @@ import {
   resolveRunSoftTimeoutMs,
   resolveRunToolTimeoutCeilingMs,
   endsAfterCompletedToolWithoutAssistantFinal,
+  endsDuringActionPreparation,
 } from "./run-manager.js";
 import type { ActiveRun } from "./run-manager.js";
 import {
@@ -7377,7 +7378,10 @@ export function backgroundContinuationReasonForRun(
       new EngineError(last.error, { errorCode: last.errorCode }),
     );
   }
-  if (endsAfterCompletedToolWithoutAssistantFinal(run)) {
+  if (
+    endsAfterCompletedToolWithoutAssistantFinal(run) ||
+    endsDuringActionPreparation(run)
+  ) {
     return "stream_ended";
   }
   return "run_timeout";
@@ -7533,7 +7537,8 @@ export async function runAgentLoopWithMainChatInternalContinuations(
 function endsAtContinuationBoundary(run: ActiveRun): boolean {
   return (
     endsAtInternalContinuationBoundary(run) ||
-    endsAfterCompletedToolWithoutAssistantFinal(run)
+    endsAfterCompletedToolWithoutAssistantFinal(run) ||
+    endsDuringActionPreparation(run)
   );
 }
 

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -2531,6 +2531,51 @@ describe("run manager soft timeout", () => {
     );
   });
 
+  it("auto-continues a run that ends during action preparation", async () => {
+    const events: AgentChatEvent[] = [];
+    const run = startRun(
+      "run-action-preparation-only",
+      "thread-action-preparation-only",
+      async (send) => {
+        send({ type: "text", text: "I will build the design now." });
+        send({
+          type: "activity",
+          label: "Preparing generate-design action",
+          tool: "generate-design",
+          id: "call-generate-design",
+        });
+        send({
+          type: "tool_input_start",
+          tool: "generate-design",
+          id: "call-generate-design",
+        });
+        send({
+          type: "tool_input_delta",
+          tool: "generate-design",
+          id: "call-generate-design",
+          text: '{"files":',
+        });
+        send({ type: "done" });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+    run.subscribers.add((event) => events.push(event.event));
+
+    await run.finalized;
+
+    expect(events).toContainEqual({
+      type: "auto_continue",
+      reason: "stream_ended",
+    });
+    expect(events).not.toContainEqual({ type: "done" });
+    expect(run.status).toBe("completed");
+    expect(setRunTerminalReason).toHaveBeenCalledWith(
+      "run-action-preparation-only",
+      "stream_ended",
+    );
+  });
+
   it("keeps a completed custom UI tool result terminal", async () => {
     const events: AgentChatEvent[] = [];
     const run = startRun(

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -791,6 +791,38 @@ export function endsAfterCompletedToolWithoutAssistantFinal(
   return completedToolAfterLastAssistantText;
 }
 
+/**
+ * A model can emit a lead-in before it starts assembling an action input. If
+ * the run ends in that preparation phase, `done` is not a successful turn.
+ */
+export function endsDuringActionPreparation(run: ActiveRun): boolean {
+  let preparingAction = false;
+  for (const { event } of run.events) {
+    if (
+      isPreparingActionActivityEvent(event) ||
+      event.type === "tool_input_start" ||
+      event.type === "tool_input_delta"
+    ) {
+      preparingAction = true;
+      continue;
+    }
+    if (
+      (event.type === "text" && event.text.trim().length > 0) ||
+      event.type === "tool_start" ||
+      event.type === "tool_done" ||
+      event.type === "approval_required" ||
+      event.type === "clear" ||
+      event.type === "error" ||
+      event.type === "missing_api_key" ||
+      event.type === "auto_continue" ||
+      event.type === "loop_limit"
+    ) {
+      preparingAction = false;
+    }
+  }
+  return preparingAction;
+}
+
 function terminalEventForcesErroredStatus(event: AgentChatEvent | null) {
   return event?.type === "error" || event?.type === "missing_api_key";
 }
@@ -2031,21 +2063,22 @@ export function startRun(
               terminalEventForcesErroredStatus(terminalEvent)
             ? "errored"
             : "completed";
-      const shouldAutoContinueAfterCompletedTool =
+      const shouldAutoContinueAfterUnfinishedTurn =
         finalStatus === "completed" &&
-        endsAfterCompletedToolWithoutAssistantFinal(run) &&
+        (endsAfterCompletedToolWithoutAssistantFinal(run) ||
+          endsDuringActionPreparation(run)) &&
         (!terminalEventForCompletion ||
           (terminalEventForCompletion.event.type === "done" &&
             terminalEventForCompletion.event.reason !== "user"));
-      const completedToolContinuationEvent =
-        shouldAutoContinueAfterCompletedTool
+      const unfinishedTurnContinuationEvent =
+        shouldAutoContinueAfterUnfinishedTurn
           ? ({
               type: "auto_continue" as const,
               reason: "stream_ended" as const,
             } satisfies Extract<AgentChatEvent, { type: "auto_continue" }>)
           : null;
-      if (completedToolContinuationEvent) {
-        terminalEvent = completedToolContinuationEvent;
+      if (unfinishedTurnContinuationEvent) {
+        terminalEvent = unfinishedTurnContinuationEvent;
       }
       const terminalReason = terminalReasonForRun(
         finalStatus,
@@ -2083,7 +2116,7 @@ export function startRun(
         // re-stamp the seq at emit time (max-seq+1) just below.
         const terminalEventToEmit: AgentChatEvent =
           finalStatus === "completed"
-            ? (completedToolContinuationEvent ??
+            ? (unfinishedTurnContinuationEvent ??
               terminalEventForCompletion?.event ?? { type: "done" })
             : terminalEventForCompletion?.event.type === "error" ||
                 terminalEventForCompletion?.event.type === "missing_api_key"


### PR DESCRIPTION
Summary: Treat runs that end while action input is still being prepared as recoverable stream boundaries instead of completed turns, including durable-background continuation dispatch. Added regressions for mixed lead-in and partial generate-design input. Validation: run-manager and production-agent suites, focused SSE processor tests, core typecheck, and pnpm guards.