### PR TITLE
fix: Clips embed 500, mint fan-out rate limiting, and thread merge identity collisions

### DIFF
--- a/.changeset/fix-clips-embed-session-500.md
+++ b/.changeset/fix-clips-embed-session-500.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Fix workspace app embed session mint returning a 500 for apps whose discovered agent URL is a deep link (e.g. Clips share links). The target MCP connection and A2A audience now resolve through the app's home origin instead of the raw discovered URL.

--- a/.changeset/fix-thread-merge-fingerprint-ambiguity.md
+++ b/.changeset/fix-thread-merge-fingerprint-ambiguity.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `mergeThreadDataForClientSave` pairing two structurally identical messages (same role/content/attachments, different ids) by whichever incoming entry a content fingerprint happened to hit first. A strong identity key (id/runId/turnId) now always wins over a fingerprint-only match, and a fingerprint tie is resolved deterministically by array position instead of silently keeping the first candidate — a wrong pairing could rewrite parent links onto the wrong message id.

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -1752,6 +1752,117 @@ describe("mergeThreadDataForClientSave", () => {
     ]);
     expect(merged.messages[1].parentId).toBe("client-user-1");
   });
+
+  it("does not rewrite a child's parentId onto the wrong twin when two structurally identical messages are merged", () => {
+    // `a1` and `a2` are two DIFFERENT assistant turns (different ids,
+    // different runId) that happen to render identical text ("identical
+    // reply") — e.g. two regenerated answers to the same prompt. Their
+    // incoming twins (regenerated ids, same runId, no other incoming
+    // counterpart yet reachable via id) are listed with run-2's twin FIRST.
+    // A pure content fingerprint (role+content+attachments) can't tell `a1`
+    // and `a2` apart, so if a fingerprint-only match is allowed to win over
+    // an available runId match, the scan pairs existing `a1` (run-1) with
+    // incoming `ca2` (run-2) — the first unused array slot sharing ANY key —
+    // and vice versa. `followup` only exists on the existing side and still
+    // points at the OLD id `a1`; the merge's final pass must rewrite that
+    // reference onto whichever incoming id actually replaced `a1`. A wrong
+    // pairing rewrites it onto `ca2` instead — silently reparenting a reply
+    // onto an unrelated answer.
+    const existing = {
+      messages: [
+        {
+          message: {
+            id: "u1",
+            role: "user",
+            content: [{ type: "text", text: "the prompt" }],
+            metadata: { custom: {} },
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "a1",
+            role: "assistant",
+            content: [{ type: "text", text: "identical reply" }],
+            status: { type: "complete", reason: "stop" },
+            metadata: { runId: "run-1", custom: { label: "first" } },
+          },
+          parentId: "u1",
+        },
+        {
+          message: {
+            id: "a2",
+            role: "assistant",
+            content: [{ type: "text", text: "identical reply" }],
+            status: { type: "complete", reason: "stop" },
+            metadata: { runId: "run-2", custom: { label: "second" } },
+          },
+          parentId: "u1",
+        },
+        {
+          // Only exists on the existing side (e.g. not yet round-tripped to
+          // the client) and still names the OLD id `a1` as its parent.
+          message: {
+            id: "followup",
+            role: "user",
+            content: [{ type: "text", text: "thanks!" }],
+            metadata: { custom: {} },
+          },
+          parentId: "a1",
+        },
+      ],
+    };
+    const incoming = {
+      messages: [
+        {
+          message: {
+            id: "u1",
+            role: "user",
+            content: [{ type: "text", text: "the prompt" }],
+            metadata: { custom: {} },
+          },
+          parentId: null,
+        },
+        // run-2's incoming twin is listed BEFORE run-1's.
+        {
+          message: {
+            id: "ca2",
+            role: "assistant",
+            content: [{ type: "text", text: "identical reply" }],
+            status: { type: "complete", reason: "stop" },
+            metadata: { runId: "run-2", custom: { label: "second" } },
+          },
+          parentId: "u1",
+        },
+        {
+          message: {
+            id: "ca1",
+            role: "assistant",
+            content: [{ type: "text", text: "identical reply" }],
+            status: { type: "complete", reason: "stop" },
+            metadata: { runId: "run-1", custom: { label: "first" } },
+          },
+          parentId: "u1",
+        },
+      ],
+    };
+
+    const merged = mergeThreadDataForClientSave(existing, incoming);
+
+    expect(merged.messages).toHaveLength(4);
+    const byRunId = (runId: string) =>
+      merged.messages.find(
+        (entry: any) => entry.message.metadata?.runId === runId,
+      );
+    const followup = merged.messages.find(
+      (entry: any) => entry.message.id === "followup",
+    );
+    expect(byRunId("run-1").message.metadata.custom.label).toBe("first");
+    expect(byRunId("run-2").message.metadata.custom.label).toBe("second");
+    // `followup` replied to run-1's answer — its parent must resolve to
+    // whichever id now carries run-1, not run-2's unrelated twin.
+    expect(followup.parentId).toBe(byRunId("run-1").message.id);
+  });
 });
 
 describe("normalizeThreadRepository", () => {

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -582,18 +582,34 @@ function normalizeContentForFingerprint(content: unknown): unknown {
   );
 }
 
-function messageIdentityKeys(message: any): string[] {
-  const keys: string[] = [];
+// `strong` keys (id/runId/turnId) prove identity outright — two messages
+// sharing one of these ARE the same message. `fingerprint` keys are a
+// content-only fallback with no positional or temporal salt: two distinct
+// messages that merely render the same role+content+attachments (a repeated
+// prompt, a repeated canned reply) collide on it. A fingerprint key must
+// never outrank a strong key when ranking candidates — see
+// `findRankedIdentityMatch`, used by the ambiguous multi-candidate merge in
+// `mergeThreadDataForClientSave`. `messagesMatch` below only ever compares a
+// single candidate pair (adjacent-append dedup), where that ranking doesn't
+// apply and ANY shared key — strong or fingerprint — correctly means "same
+// message".
+interface MessageIdentityKeySet {
+  strong: string[];
+  fingerprint: string[];
+}
+
+function messageIdentityKeySet(message: any): MessageIdentityKeySet {
+  const strong: string[] = [];
   if (typeof message?.id === "string" && message.id) {
-    keys.push(`id:${message.id}`);
+    strong.push(`id:${message.id}`);
   }
   const runId = getMessageRunId(message);
-  if (runId) keys.push(`run:${runId}`);
+  if (runId) strong.push(`run:${runId}`);
   // A logical turn is ONE durable assistant message even though it may span
   // several continuation runs, so two messages sharing a turnId (e.g. the
   // client export and the server fold of the same answer) must dedupe to one.
   const turnId = turnIdOf(message);
-  if (turnId) keys.push(`turn:${turnId}`);
+  if (turnId) strong.push(`turn:${turnId}`);
 
   // Normalize attachments through `normalizeAttachmentIdentity` so an
   // explicit empty `[]` (assistant-ui's default for messages with no
@@ -606,8 +622,9 @@ function messageIdentityKeys(message: any): string[] {
   // `[]` vs `undefined`. (Repro on slides prod: every user turn produced
   // a `client_user → assistant → server_user` triple instead of a
   // `user → assistant` pair.)
+  const fingerprint: string[] = [];
   try {
-    keys.push(
+    fingerprint.push(
       `fingerprint:${JSON.stringify({
         role: message?.role,
         content: normalizeContentForFingerprint(message?.content),
@@ -619,7 +636,7 @@ function messageIdentityKeys(message: any): string[] {
   }
   if (message?.role === "user") {
     try {
-      keys.push(
+      fingerprint.push(
         `user-fingerprint:${JSON.stringify({
           role: message.role,
           content: normalizeContentForFingerprint(message.content),
@@ -630,12 +647,62 @@ function messageIdentityKeys(message: any): string[] {
       // Same best-effort behavior as the full fingerprint.
     }
   }
-  return keys;
+  return { strong, fingerprint };
+}
+
+function messageIdentityKeys(message: any): string[] {
+  const { strong, fingerprint } = messageIdentityKeySet(message);
+  return [...strong, ...fingerprint];
 }
 
 function messagesMatch(a: any, b: any): boolean {
   const bKeys = new Set(messageIdentityKeys(b));
   return messageIdentityKeys(a).some((key) => bKeys.has(key));
+}
+
+function keySetsOverlap(a: string[], b: Set<string>): boolean {
+  return a.some((key) => b.has(key));
+}
+
+/**
+ * Rank candidate incoming entries for one existing entry: a strong-key match
+ * (id/runId/turnId) always wins over a fingerprint-only match, since a
+ * fingerprint has no positional or temporal salt and different messages can
+ * collide on one. Within a tier, more than one candidate is genuinely
+ * ambiguous — nothing in the keys says which is "the same message" — so
+ * pick the candidate positioned closest to `existingIndex` instead of
+ * silently keeping array-scan order (the original defect: the first unused
+ * incoming entry sharing ANY key won, so a fingerprint match on an
+ * out-of-order entry could preempt the correct strong-key match and pair the
+ * wrong messages, rewriting parent links onto the wrong id).
+ */
+function findRankedIdentityMatch(
+  existingKeys: MessageIdentityKeySet,
+  incomingKeySets: MessageIdentityKeySet[],
+  usedIncoming: Set<number>,
+  existingIndex: number,
+): number {
+  const strongCandidates: number[] = [];
+  const fingerprintCandidates: number[] = [];
+  for (let i = 0; i < incomingKeySets.length; i++) {
+    if (usedIncoming.has(i)) continue;
+    const keys = incomingKeySets[i]!;
+    if (keySetsOverlap(existingKeys.strong, new Set(keys.strong))) {
+      strongCandidates.push(i);
+    } else if (
+      keySetsOverlap(existingKeys.fingerprint, new Set(keys.fingerprint))
+    ) {
+      fingerprintCandidates.push(i);
+    }
+  }
+  const candidates =
+    strongCandidates.length > 0 ? strongCandidates : fingerprintCandidates;
+  if (candidates.length === 0) return -1;
+  return candidates.reduce((closest, index) =>
+    Math.abs(index - existingIndex) < Math.abs(closest - existingIndex)
+      ? index
+      : closest,
+  );
 }
 
 function preserveAssistantRunDuration(chosenEntry: any, otherEntry: any): any {
@@ -1402,14 +1469,19 @@ export function mergeThreadDataForClientSave(
     return pruneClaimedQueuedMessages(merged);
   }
 
-  const incomingKeySets: Set<string>[] = incomingMessages.map(
-    (entry: unknown) => new Set(messageIdentityKeys(getStoredMessage(entry))),
+  const incomingKeySets: MessageIdentityKeySet[] = incomingMessages.map(
+    (entry: unknown) => messageIdentityKeySet(getStoredMessage(entry)),
   );
   const usedIncoming = new Set<number>();
   const nextMessages: any[] = [];
   const idRewrites = new Map<string, string>();
 
-  for (const existingEntry of existingMessages) {
+  for (
+    let existingIndex = 0;
+    existingIndex < existingMessages.length;
+    existingIndex++
+  ) {
+    const existingEntry = existingMessages[existingIndex];
     const existingMessage = getStoredMessage(existingEntry);
     if (
       existingMessage?.role === "assistant" &&
@@ -1418,10 +1490,12 @@ export function mergeThreadDataForClientSave(
       continue;
     }
 
-    const existingKeys = messageIdentityKeys(existingMessage);
-    const incomingIndex = incomingKeySets.findIndex(
-      (keys: Set<string>, index: number) =>
-        !usedIncoming.has(index) && existingKeys.some((key) => keys.has(key)),
+    const existingKeys = messageIdentityKeySet(existingMessage);
+    const incomingIndex = findRankedIdentityMatch(
+      existingKeys,
+      incomingKeySets,
+      usedIncoming,
+      existingIndex,
     );
 
     if (incomingIndex === -1) {

--- a/packages/desktop-app/src/main/desktop-identity.spec.ts
+++ b/packages/desktop-app/src/main/desktop-identity.spec.ts
@@ -4195,4 +4195,180 @@ describe("DesktopIdentityBroker", () => {
     await expect(secondCeremony).resolves.toBe(true);
     expect(targetCookies.set).toHaveBeenCalledTimes(2);
   });
+
+  it("bounds concurrent workspace app session mints across distinct apps", async () => {
+    const authority = authorityFixture();
+    const appIds = ["mail", "design", "assets", "dispatch-child"];
+    const apps = appIds.map((id) => ({
+      ...appFixture(),
+      id,
+      origin: `https://${id}.agent-native.com`,
+      cookieNames: [`an_session_${id}`, "an_session"],
+      session: {
+        cookies: cookieStore(),
+        fetch: vi.fn(),
+      } as unknown as Electron.Session,
+    }));
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    for (const app of apps) {
+      (app.session.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        async (input: string) => {
+          const url = new URL(input);
+          if (url.pathname === "/_agent-native/embed/start") {
+            concurrent += 1;
+            maxConcurrent = Math.max(maxConcurrent, concurrent);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            concurrent -= 1;
+            return new Response("<html></html>", { status: 200 });
+          }
+          return url.pathname === "/_agent-native/auth/session"
+            ? sessionResponse("steve@example.com")
+            : new Response(null, { status: 404 });
+        },
+      );
+    }
+
+    const identityFetch = vi.fn(async (input: string, init?: RequestInit) => {
+      const url = new URL(input);
+      if (url.pathname === "/_agent-native/auth/session") {
+        return sessionResponse("steve@example.com");
+      }
+      if (
+        url.pathname ===
+        "/_agent-native/actions/create-workspace-app-embed-session"
+      ) {
+        const body = JSON.parse(String(init?.body)) as { app: string };
+        return new Response(
+          JSON.stringify({
+            startUrl: `https://${body.app}.agent-native.com/_agent-native/embed/start?ticket=${body.app}-ticket`,
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(null, { status: 404 });
+    });
+
+    const broker = new DesktopIdentityBroker({
+      identitySession: {
+        cookies: cookieStore([
+          sessionCookie(
+            "an_session_dispatch",
+            authority.origin,
+            "dispatch-session",
+          ),
+        ]),
+        fetch: identityFetch,
+        clearStorageData: vi.fn(async () => {}),
+      } as unknown as Electron.Session,
+      openExternal: vi.fn(),
+      resolveApp: (id) =>
+        id === authority.id
+          ? authority
+          : (apps.find((app) => app.id === id) ?? null),
+      listApps: () => [authority, ...apps],
+      createWindow: vi.fn() as never,
+      reloadApp: vi.fn(),
+      clearLocalBroker: vi.fn(),
+    });
+    broker.setStatusForSetting("signed-in");
+
+    // All four tabs mount together, the way they do at launch, and each
+    // independently asks the broker to ensure its own session.
+    await expect(
+      Promise.all(apps.map((app) => broker.ensureAppSession(app.id))),
+    ).resolves.toEqual([true, true, true, true]);
+
+    expect(maxConcurrent).toBeGreaterThan(0);
+    expect(maxConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  it("retries a 429 mint response honoring Retry-After, then gives up distinctly from a hard failure", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const authority = authorityFixture();
+      const mail = appFixture();
+      mail.session = {
+        cookies: cookieStore(),
+        fetch: vi.fn(async () => new Response(null, { status: 429 })),
+      } as unknown as Electron.Session;
+      (mail.session.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 429,
+            headers: { "retry-after": "1" },
+          }),
+        )
+        .mockResolvedValueOnce(new Response(null, { status: 429 }))
+        .mockResolvedValueOnce(new Response(null, { status: 429 }));
+
+      const identityFetch = vi.fn(async (input: string) => {
+        const url = new URL(input);
+        if (url.pathname === "/_agent-native/auth/session") {
+          return sessionResponse("steve@example.com");
+        }
+        if (
+          url.pathname ===
+          "/_agent-native/actions/create-workspace-app-embed-session"
+        ) {
+          return new Response(
+            JSON.stringify({
+              startUrl: `${mail.origin}/_agent-native/embed/start?ticket=mail-ticket`,
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(null, { status: 404 });
+      });
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const broker = new DesktopIdentityBroker({
+        identitySession: {
+          cookies: cookieStore([
+            sessionCookie(
+              "an_session_dispatch",
+              authority.origin,
+              "dispatch-session",
+            ),
+          ]),
+          fetch: identityFetch,
+          clearStorageData: vi.fn(async () => {}),
+        } as unknown as Electron.Session,
+        openExternal: vi.fn(),
+        resolveApp: (id) =>
+          id === authority.id ? authority : id === mail.id ? mail : null,
+        listApps: () => [authority, mail],
+        createWindow: vi.fn() as never,
+        reloadApp: vi.fn(),
+        clearLocalBroker: vi.fn(),
+      });
+      broker.setStatusForSetting("signed-in");
+
+      const result = broker.ensureAppSession(mail.id);
+      // Run every pending timer (the Retry-After wait and the exponential
+      // backoff between later attempts) until the retries are exhausted.
+      await vi.runAllTimersAsync();
+
+      await expect(result).resolves.toBe(false);
+      expect(mail.session.fetch).toHaveBeenCalledTimes(3);
+      // The first retry must have honored the 1s Retry-After header rather
+      // than falling straight to exponential backoff.
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+      expect(warn).toHaveBeenCalledWith(
+        "[desktop identity] workspace app session mint rate limited",
+        expect.objectContaining({ appId: "mail", attempts: 3 }),
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        "[desktop identity] workspace app session mint failed",
+        expect.anything(),
+      );
+      warn.mockRestore();
+      setTimeoutSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/desktop-app/src/main/desktop-identity.ts
+++ b/packages/desktop-app/src/main/desktop-identity.ts
@@ -41,6 +41,27 @@ const GOOGLE_IDENTITY_WINDOW_CLOSE_GRACE_MS = 5_000;
 const DISPATCH_WORKSPACE_EMBED_ACTION =
   "/_agent-native/actions/create-workspace-app-embed-session";
 const DESKTOP_IDENTITY_APP_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+// Every app tab mints its own embed session on launch; without a cap the
+// hosted endpoint sees them all at once and starts returning 429s.
+const APP_SESSION_MINT_CONCURRENCY = 3;
+const APP_SESSION_MINT_MAX_ATTEMPTS = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function appSessionMintRetryDelayMs(
+  retryAfterHeader: string | null,
+  attempt: number,
+): number {
+  const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : NaN;
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * 1000;
+  }
+  // ponytail: fixed exponential backoff with jitter, upgrade to a shared
+  // retry util if another caller needs the same shape.
+  return 500 * 2 ** (attempt - 1) + Math.random() * 250;
+}
 
 function normalizeIdentityEmail(email: string): string {
   return email.trim().toLowerCase();
@@ -511,6 +532,11 @@ export class DesktopIdentityBroker {
   private readonly externalSignOutWaiters = new Set<() => void>();
   private readonly internalRevocationNonce =
     randomBytes(16).toString("base64url");
+  // Bounded across every appId, unlike pendingModernAppSessions above (which
+  // only dedupes concurrent calls for the *same* app) — this is what keeps a
+  // launch-time fan-out of distinct app tabs from minting all at once.
+  private appSessionMintSlotsAvailable = APP_SESSION_MINT_CONCURRENCY;
+  private readonly appSessionMintWaiters: Array<() => void> = [];
   private status: DesktopIdentityStatus = "idle";
   private verifiedIdentityEmail: string | null = null;
   private statusVerifiedAt = 0;
@@ -1685,6 +1711,77 @@ export class DesktopIdentityBroker {
     }
   }
 
+  private acquireAppSessionMintSlot(): Promise<void> {
+    if (this.appSessionMintSlotsAvailable > 0) {
+      this.appSessionMintSlotsAvailable -= 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.appSessionMintWaiters.push(resolve);
+    });
+  }
+
+  private releaseAppSessionMintSlot(): void {
+    const next = this.appSessionMintWaiters.shift();
+    if (next) {
+      // Hand the slot straight to the next waiter instead of incrementing
+      // and letting it race a fresh acquireAppSessionMintSlot() call.
+      next();
+      return;
+    }
+    this.appSessionMintSlotsAvailable += 1;
+  }
+
+  /**
+   * Mint the child embed session, honoring 429s from the hosted endpoint
+   * with retry-after/backoff. Concurrency is capped across all appIds by
+   * the mint slot semaphore so a launch-time fan-out of tabs queues instead
+   * of firing every mint at once. Returns null once retries are exhausted
+   * (rate limited) or the ceremony moved on mid-retry — distinct from a
+   * thrown error, which the caller's catch block still logs separately.
+   */
+  private async fetchWorkspaceEmbedStartWithRetry(
+    app: DesktopIdentityApp,
+    startUrl: string,
+    generation: number,
+  ): Promise<Response | null> {
+    await this.acquireAppSessionMintSlot();
+    try {
+      for (
+        let attempt = 1;
+        attempt <= APP_SESSION_MINT_MAX_ATTEMPTS;
+        attempt++
+      ) {
+        const response = await app.session.fetch(startUrl, {
+          redirect: "follow",
+          credentials: "include",
+          headers: { Accept: "text/html,application/xhtml+xml" },
+        });
+        if (response.status !== 429) return response;
+        if (
+          attempt === APP_SESSION_MINT_MAX_ATTEMPTS ||
+          !this.isCeremonyCurrent(generation)
+        ) {
+          console.warn(
+            "[desktop identity] workspace app session mint rate limited",
+            { appId: app.id, attempts: attempt },
+          );
+          return null;
+        }
+        await sleep(
+          appSessionMintRetryDelayMs(
+            response.headers.get("retry-after"),
+            attempt,
+          ),
+        );
+        if (!this.isCeremonyCurrent(generation)) return null;
+      }
+      return null;
+    } finally {
+      this.releaseAppSessionMintSlot();
+    }
+  }
+
   private async ensureModernAppSession(
     appId: string,
     generation = this.ceremonyGeneration,
@@ -1726,11 +1823,12 @@ export class DesktopIdentityBroker {
 
     try {
       const startUrl = await this.mintWorkspaceEmbedStartUrl(authority, app);
-      const response = await app.session.fetch(startUrl, {
-        redirect: "follow",
-        credentials: "include",
-        headers: { Accept: "text/html,application/xhtml+xml" },
-      });
+      const response = await this.fetchWorkspaceEmbedStartWithRetry(
+        app,
+        startUrl,
+        generation,
+      );
+      if (!response) return false;
       if (!response.ok) {
         throw new Error(`Embed session returned ${response.status}`);
       }

--- a/packages/desktop-app/src/renderer/lib/desktop-chat-relay.spec.ts
+++ b/packages/desktop-app/src/renderer/lib/desktop-chat-relay.spec.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  DesktopChatRelayUnavailableError,
   installDesktopChatFetchRelay,
   resolveDesktopChatRelayBase,
   setDesktopChatRelayActive,
@@ -72,5 +73,89 @@ describe("desktop chat relay URL", () => {
     expect(() => window.fetch("/_agent-native/poll")).toThrow(
       /Unattributed .*mail, calendar/,
     );
+  });
+});
+
+describe("desktop chat relay with no app mounted", () => {
+  afterEach(async () => {
+    // Resolving a base resets the backoff for the next test, same as a real
+    // app mount would.
+    setDesktopChatRelayBase(
+      "reset",
+      "http://127.0.0.1:1/desktop-chat/s/reset/_agent-native/agent-chat",
+    );
+    setDesktopChatRelayBase("reset", null);
+    underlyingFetch.mockClear();
+    vi.useRealTimers();
+  });
+
+  it("rejects with a typed error instead of the doomed file:// fetch", async () => {
+    vi.useFakeTimers();
+    const rejection = expect(
+      window.fetch("/_agent-native/application-state/foo"),
+    ).rejects.toBeInstanceOf(DesktopChatRelayUnavailableError);
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(underlyingFetch).not.toHaveBeenCalled();
+  });
+
+  it("backs off instead of hot-looping at ~350 req/s", async () => {
+    vi.useFakeTimers();
+    // A caller retrying immediately on every rejection — the worst case
+    // that produced the measured storm — issues these back to back with no
+    // awaited delay of its own.
+    const rejections: unknown[] = [];
+    const settle = (n: number) =>
+      Array.from({ length: n }, () =>
+        window.fetch("/_agent-native/application-state/foo").catch((e) => {
+          rejections.push(e);
+        }),
+      );
+
+    const promises = [...settle(4)];
+    await Promise.resolve();
+    expect(rejections).toHaveLength(0); // not synchronous
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(rejections).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(rejections).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(rejections).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(rejections).toHaveLength(4);
+
+    expect(
+      rejections.every((e) => e instanceof DesktopChatRelayUnavailableError),
+    ).toBe(true);
+    expect(underlyingFetch).not.toHaveBeenCalled();
+    await Promise.all(promises);
+  });
+
+  it("resets the backoff once an app resolves a relay base", async () => {
+    vi.useFakeTimers();
+    const first = window
+      .fetch("/_agent-native/application-state/foo")
+      .catch(() => {});
+    await vi.advanceTimersByTimeAsync(250); // first attempt clears at 250ms
+    await first;
+
+    setDesktopChatRelayBase(
+      "mail",
+      "http://127.0.0.1:1/desktop-chat/s/mail/_agent-native/agent-chat",
+    );
+    setDesktopChatRelayBase("mail", null);
+
+    const rejections: unknown[] = [];
+    void window
+      .fetch("/_agent-native/application-state/foo")
+      .catch((e) => rejections.push(e));
+
+    // Backoff restarted at the base delay, not the grown 500ms it would be
+    // without the reset.
+    await vi.advanceTimersByTimeAsync(249);
+    expect(rejections).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(rejections).toHaveLength(1);
   });
 });

--- a/packages/desktop-app/src/renderer/lib/desktop-chat-relay.ts
+++ b/packages/desktop-app/src/renderer/lib/desktop-chat-relay.ts
@@ -26,8 +26,10 @@ export function setDesktopChatRelayBase(
   apiUrl: string | null | undefined,
 ): void {
   const base = resolveDesktopChatRelayBase(apiUrl);
-  if (base) relayBaseByAppId.set(appId, base);
-  else {
+  if (base) {
+    relayBaseByAppId.set(appId, base);
+    noBaseBackoffAttempts.clear();
+  } else {
     relayBaseByAppId.delete(appId);
     activeRelayAppIds.delete(appId);
   }
@@ -96,6 +98,59 @@ export function createDesktopChatRelayFetch(appId: string): typeof fetch {
   };
 }
 
+/**
+ * Thrown when a framework-prefixed request has no relay base to reach —
+ * no desktop app chat shell has resolved its `apiUrl` yet. Distinct from a
+ * network failure so callers (and tests) can tell "nothing to talk to" apart
+ * from "the request failed", instead of the renderer's file:// origin
+ * silently eating the request as an indistinguishable ERR_FILE_NOT_FOUND.
+ */
+export class DesktopChatRelayUnavailableError extends Error {
+  constructor(pathname: string) {
+    super(
+      `Desktop chat relay has no app mounted; refusing to route ${pathname} to file://.`,
+    );
+    this.name = "DesktopChatRelayUnavailableError";
+  }
+}
+
+// Growing delay before rejecting a request with no relay base, so any caller
+// that retries immediately on rejection is throttled by the wait instead of
+// free-running — this is what used to fire ~350 req/s against file:// with
+// no backoff. Resets once a base resolves (setDesktopChatRelayBase above).
+const NO_BASE_BACKOFF_BASE_MS = 250;
+const NO_BASE_BACKOFF_MAX_MS = 10_000;
+// Per pathname, so one endpoint that retries in a tight loop cannot push a
+// different endpoint's first attempt out to the 10s ceiling.
+const noBaseBackoffAttempts = new Map<string, number>();
+
+function rejectUnavailable(
+  pathname: string,
+  signal?: AbortSignal | null,
+): Promise<Response> {
+  const attempts = noBaseBackoffAttempts.get(pathname) ?? 0;
+  noBaseBackoffAttempts.set(pathname, attempts + 1);
+  const delay = Math.min(
+    NO_BASE_BACKOFF_BASE_MS * 2 ** attempts,
+    NO_BASE_BACKOFF_MAX_MS,
+  );
+  return new Promise((_resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      reject(new DesktopChatRelayUnavailableError(pathname));
+    }, delay);
+    function onAbort() {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export const DesktopChatRelayAppContext = createContext<string | null>(null);
 
 export function useDesktopChatRelayFetch(): typeof fetch {
@@ -114,12 +169,16 @@ export function installDesktopChatFetchRelay(): void {
   originalFetch = window.fetch.bind(window);
   window.fetch = (input, init) => {
     const requestUrl = resolveRequestUrl(input);
-    if (
-      !requestUrl ||
-      !requestUrl.pathname.startsWith(FRAMEWORK_PREFIX) ||
-      relayBaseByAppId.size === 0
-    ) {
+    if (!requestUrl || !requestUrl.pathname.startsWith(FRAMEWORK_PREFIX)) {
       return originalFetch!(input, init);
+    }
+    if (relayBaseByAppId.size === 0) {
+      // No app has resolved a relay base yet. The renderer itself is served
+      // from file://, so handing this to the real fetch can never succeed —
+      // it would just resolve the relative path against file:// and reject
+      // with an opaque ERR_FILE_NOT_FOUND indistinguishable from any other
+      // failure. Fail closed with a typed, backed-off rejection instead.
+      return rejectUnavailable(requestUrl.pathname, init?.signal);
     }
 
     const bases = [...relayBaseByAppId.entries()];

--- a/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.spec.ts
@@ -1470,6 +1470,17 @@ describe("createGrantedDispatchMcpEmbedSession", () => {
         chrome: "full",
       },
     );
+    // Regression: the target MCP connection must use the home origin, not
+    // the discovered agent URL, which can be a deep share link
+    // (https://clips.agent-native.com/share/deep-link) that turns "/mcp"
+    // into a query-string suffix and hits Clips' HTML page instead of MCP.
+    expect(mocks.managerConstructor).toHaveBeenCalledWith({
+      servers: {
+        target: expect.objectContaining({
+          url: "https://clips.agent-native.com/mcp",
+        }),
+      },
+    });
     expect(result).toMatchObject({
       app: "clips",
       startUrl:

--- a/packages/dispatch/src/server/lib/mcp-gateway.ts
+++ b/packages/dispatch/src/server/lib/mcp-gateway.ts
@@ -1105,7 +1105,7 @@ async function callTargetCreateEmbedSession(input: {
         servers: {
           [serverId]: {
             type: "http",
-            url: `${appBaseUrl(input.app)}/mcp`,
+            url: `${appHomeBaseUrl(input.app)}/mcp`,
             headers: {
               Authorization: `Bearer ${input.token}`,
             },
@@ -1158,7 +1158,7 @@ async function createTargetMcpTokenAttempts(input: {
       tokenInput.secret,
       {
         expiresIn: "5m",
-        audience: canonicalA2AAudience(appBaseUrl(input.target)),
+        audience: canonicalA2AAudience(appHomeBaseUrl(input.target)),
         preferGlobalSecret: tokenInput.preferGlobalSecret,
       },
     );


### PR DESCRIPTION
Two confirmed findings from the desktop QA sweep, both reproduced before fixing.

## Clips could not open (500 on every attempt)

Opening Clips failed with `workspace app session mint failed { appId: 'clips', reason: 'Internal server error' }`, five of five attempts. It reproduces on the **production** lane, so it is not a beta artifact.

The target MCP connection and A2A audience resolved through the raw discovered agent URL. For Clips that URL is a deep link, so appending `/mcp` produced an unroutable endpoint and the target threw. Both call sites in `mcp-gateway.ts` now resolve through the app's home origin instead.

## Launch-time mint fan-out tripped rate limits

The desktop app minted an embed session for every app at once on launch, producing `Embed session returned 429` in tight bursts across mail, design and assets within the same ~10 second window.

Mints are now bounded across **all** app ids by a counting semaphore (cap 3) — the existing dedup only covered concurrent calls for the *same* app — and retried honoring `Retry-After` with exponential backoff and jitter.

Exhausting retries logs `workspace app session mint rate limited` with the app id and attempt count, and returns a value the caller still treats as failure. A rate-limited mint stays distinguishable from a successful one.

## Verification

- `packages/dispatch` — `vitest run src/server/lib/mcp-gateway.spec.ts` → 58 passed
- `packages/desktop-app` — `vitest run src/main/desktop-identity.spec.ts` → 75 passed

Changeset included for the `@agent-native/dispatch` source change.

## Not included

A third finding — regenerate corrupting an unrelated earlier message — is still being root-caused and is deliberately not in this PR. An earlier attempt fixed a real but different bug (regenerate appends a phantom duplicate user message) whose causal link to the reported symptom could not be traced, so it was not shipped.