### PR TITLE
fix: evaluate analytics alerts from BigQuery

### DIFF
--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -418,7 +418,7 @@ describe("analytics alert evaluation", () => {
     const page = Array.from({ length: 5_000 }, (_, index) => ({
       id: `evt-${index}`,
       event_name: "agent_run_terminal",
-      timestamp: "2026-08-31T12:00:00.000Z",
+      timestamp: "2026-08-31T12:00:00.123456Z",
       properties: "{}",
       context: "{}",
     }));
@@ -478,7 +478,13 @@ describe("analytics alert evaluation", () => {
     expect(result.observedValue).toBe(1);
     expect(firstPartyMocks.query).toHaveBeenCalledTimes(2);
     expect(firstPartyMocks.query.mock.calls[1]?.[0]).toContain(
+      "TIMESTAMP('2026-08-31T12:00:00.123456Z')",
+    );
+    expect(firstPartyMocks.query.mock.calls[1]?.[0]).toContain(
       "id < 'evt-4999'",
+    );
+    expect(firstPartyMocks.query.mock.calls[1]?.[0]).toContain(
+      ") AS analytics_alert_page WHERE (timestamp < TIMESTAMP('",
     );
   });
 

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -341,6 +341,62 @@ describe("analytics alert evaluation", () => {
     );
   });
 
+  it("normalizes personal BigQuery alert scope by email case", () => {
+    const query = buildBigQueryAlertQuery(
+      {
+        eventName: "agent_run_terminal",
+        filters: [],
+        ownerEmail: "Owner@Example.Test",
+        orgId: null,
+      },
+      "2026-08-31T12:00:00.000Z",
+      "2026-08-31T12:10:00.000Z",
+    );
+
+    expect(query).toContain("LOWER(owner_email) = LOWER('Owner@Example.Test')");
+  });
+
+  it("fails loudly when BigQuery returns truncated alert results", async () => {
+    backendMocks.get.mockResolvedValue({ sink: "bigquery", table: null });
+    firstPartyMocks.query.mockResolvedValue({
+      rows: [],
+      schema: [],
+      truncated: true,
+    });
+
+    await expect(
+      evaluateAndNotifyAnalyticsAlertRule(
+        {
+          id: "rule-1",
+          name: "Production chat errors",
+          description: "",
+          eventName: "agent_run_terminal",
+          filters: [],
+          thresholdMode: "event_count",
+          distinctBy: null,
+          threshold: 1,
+          windowMinutes: 10,
+          cooldownMinutes: 60,
+          severity: "critical",
+          channels: ["inbox"],
+          emailRecipients: [],
+          slackWebhookUrl: null,
+          webhookUrl: null,
+          enabled: true,
+          lastEvaluatedAt: null,
+          lastTriggeredAt: null,
+          lastStatus: null,
+          lastError: null,
+          createdAt: "2026-08-31T12:00:00.000Z",
+          updatedAt: "2026-08-31T12:00:00.000Z",
+          ownerEmail: "owner@example.test",
+          orgId: "org-1",
+        },
+        new Date("2026-08-31T12:05:00.000Z"),
+      ),
+    ).rejects.toThrow("refusing to evaluate partial data");
+  });
+
   it("keeps sweep ordering fair instead of cycling only recently evaluated rules", () => {
     const source = readFileSync(
       new URL("./analytics-alerts.ts", import.meta.url),

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -356,6 +356,57 @@ describe("analytics alert evaluation", () => {
     expect(query).toContain("LOWER(owner_email) = LOWER('Owner@Example.Test')");
   });
 
+  it("preserves null and structured JSON filter semantics in BigQuery", () => {
+    const query = buildBigQueryAlertQuery(
+      {
+        eventName: "agent_run_terminal",
+        filters: [
+          { field: "user_id", value: null },
+          { field: "properties.tags", op: "exists", value: true },
+          { field: "properties.status", op: "in", value: [null, "errored"] },
+        ],
+        ownerEmail: "owner@example.test",
+        orgId: "org-1",
+      },
+      "2026-08-31T12:00:00.000Z",
+      "2026-08-31T12:10:00.000Z",
+    );
+
+    expect(query).toContain("user_id IS NULL");
+    expect(query).toContain("JSON_QUERY(properties, '$.tags')");
+    expect(query).toContain("JSON_VALUE(properties, '$.status') IS NULL");
+  });
+
+  it("fails closed for unsupported BigQuery alert filters", () => {
+    expect(() =>
+      buildBigQueryAlertQuery(
+        {
+          eventName: "agent_run_terminal",
+          filters: [
+            { field: "properties.message", op: "contains", value: "bug" },
+          ],
+          ownerEmail: "owner@example.test",
+          orgId: "org-1",
+        },
+        "2026-08-31T12:00:00.000Z",
+        "2026-08-31T12:10:00.000Z",
+      ),
+    ).toThrow("unsupported operator");
+
+    expect(() =>
+      buildBigQueryAlertQuery(
+        {
+          eventName: "agent_run_terminal",
+          filters: [{ field: "properties.message[0]", value: "bug" }],
+          ownerEmail: "owner@example.test",
+          orgId: "org-1",
+        },
+        "2026-08-31T12:00:00.000Z",
+        "2026-08-31T12:10:00.000Z",
+      ),
+    ).toThrow("unsupported field");
+  });
+
   it("fails loudly when BigQuery returns truncated alert results", async () => {
     backendMocks.get.mockResolvedValue({ sink: "bigquery", table: null });
     firstPartyMocks.query.mockResolvedValue({

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -375,25 +375,31 @@ describe("analytics alert evaluation", () => {
 
     expect(query).toContain("user_id IS NULL");
     expect(query).toContain("JSON_QUERY(properties, '$.tags')");
-    expect(query).toContain("JSON_VALUE(properties, '$.status') IS NULL");
+    expect(query).not.toContain("JSON_VALUE(properties, '$.status')");
   });
 
-  it("fails closed for unsupported BigQuery alert filters", () => {
-    expect(() =>
-      buildBigQueryAlertQuery(
-        {
-          eventName: "agent_run_terminal",
-          filters: [
-            { field: "properties.message", op: "contains", value: "bug" },
-          ],
-          ownerEmail: "owner@example.test",
-          orgId: "org-1",
-        },
-        "2026-08-31T12:00:00.000Z",
-        "2026-08-31T12:10:00.000Z",
-      ),
-    ).toThrow("unsupported operator");
+  it("keeps JSON filters for the in-memory evaluator and pushes string contains", () => {
+    const query = buildBigQueryAlertQuery(
+      {
+        eventName: "agent_run_terminal",
+        filters: [
+          { field: "app", op: "contains", value: "chat" },
+          { field: "properties.message", op: "contains", value: "bug" },
+          { field: "properties.payload", value: { kind: "bug" } },
+        ],
+        ownerEmail: "owner@example.test",
+        orgId: "org-1",
+      },
+      "2026-08-31T12:00:00.000Z",
+      "2026-08-31T12:10:00.000Z",
+    );
 
+    expect(query).toContain("STRPOS(COALESCE(app, ''), 'chat') > 0");
+    expect(query).not.toContain("JSON_VALUE(properties, '$.message')");
+    expect(query).not.toContain("JSON_VALUE(properties, '$.payload')");
+  });
+
+  it("fails closed for unsupported BigQuery alert fields", () => {
     expect(() =>
       buildBigQueryAlertQuery(
         {

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -265,6 +265,7 @@ describe("analytics alert evaluation", () => {
             deployment_environment: "production",
           }),
           context: "{}",
+          __analytics_alert_total_rows: 1,
         },
       ],
       schema: [],
@@ -410,9 +411,8 @@ describe("analytics alert evaluation", () => {
   it("fails loudly when BigQuery returns truncated alert results", async () => {
     backendMocks.get.mockResolvedValue({ sink: "bigquery", table: null });
     firstPartyMocks.query.mockResolvedValue({
-      rows: [],
+      rows: [{ __analytics_alert_total_rows: 5001 }],
       schema: [],
-      truncated: true,
     });
 
     await expect(

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -11,14 +11,30 @@ const dbMocks = vi.hoisted(() => ({
   getDb: vi.fn(),
 }));
 
+const backendMocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+const firstPartyMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
 vi.mock("@agent-native/core/settings", () => settingsMocks);
 vi.mock("../db/index.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../db/index.js")>()),
   getDb: dbMocks.getDb,
 }));
+vi.mock("./first-party-analytics-backend.js", () => ({
+  getFirstPartyAnalyticsBackend: backendMocks.get,
+}));
+vi.mock("./first-party-analytics.js", () => ({
+  queryFirstPartyAnalytics: firstPartyMocks.query,
+}));
 
 import {
+  buildBigQueryAlertQuery,
   deleteAnalyticsAlertRule,
+  evaluateAndNotifyAnalyticsAlertRule,
   evaluateAnalyticsAlertRuleRows,
   ensureDefaultAnalyticsAlertRules,
   getAnalyticsAlertRuleDefaults,
@@ -133,6 +149,8 @@ describe("analytics alert evaluation", () => {
     settingsMocks.getUserSetting.mockReset();
     settingsMocks.putUserSetting.mockReset();
     dbMocks.getDb.mockReset();
+    backendMocks.get.mockReset();
+    firstPartyMocks.query.mockReset();
   });
 
   afterEach(() => {
@@ -219,6 +237,108 @@ describe("analytics alert evaluation", () => {
 
     expect(result.triggered).toBe(true);
     expect(result.observedValue).toBe(2);
+  });
+
+  it("loads candidate events from BigQuery when the scope has cut over", async () => {
+    backendMocks.get.mockResolvedValue({ sink: "bigquery", table: null });
+    firstPartyMocks.query.mockResolvedValue({
+      rows: [
+        {
+          id: "evt-1",
+          event_name: "agent_run_terminal",
+          user_id: null,
+          anonymous_id: null,
+          user_key: "user-1",
+          session_id: "session-1",
+          timestamp: "2026-08-31T12:00:00.000Z",
+          event_date: "2026-08-31",
+          received_at: "2026-08-31T12:00:01.000Z",
+          url: null,
+          path: null,
+          hostname: null,
+          referrer: null,
+          app: "chat",
+          template: "chat",
+          signed_in: "true",
+          properties: JSON.stringify({
+            status: "completed",
+            deployment_environment: "production",
+          }),
+          context: "{}",
+        },
+      ],
+      schema: [],
+    });
+    dbMocks.getDb.mockReturnValue({
+      update: () => ({
+        set: () => ({ where: async () => undefined }),
+      }),
+    });
+
+    const result = await evaluateAndNotifyAnalyticsAlertRule(
+      {
+        id: "rule-1",
+        name: "Production chat errors",
+        description: "",
+        eventName: "agent_run_terminal",
+        filters: [
+          { field: "properties.status", value: "errored" },
+          {
+            field: "properties.deployment_environment",
+            value: "production",
+          },
+        ],
+        thresholdMode: "event_count",
+        distinctBy: null,
+        threshold: 1,
+        windowMinutes: 10,
+        cooldownMinutes: 60,
+        severity: "critical",
+        channels: ["inbox"],
+        emailRecipients: [],
+        slackWebhookUrl: null,
+        webhookUrl: null,
+        enabled: true,
+        lastEvaluatedAt: null,
+        lastTriggeredAt: null,
+        lastStatus: null,
+        lastError: null,
+        createdAt: "2026-08-31T12:00:00.000Z",
+        updatedAt: "2026-08-31T12:00:00.000Z",
+        ownerEmail: "owner@example.test",
+        orgId: "org-1",
+      },
+      new Date("2026-08-31T12:05:00.000Z"),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(firstPartyMocks.query).toHaveBeenCalledWith(
+      expect.stringContaining("JSON_VALUE(properties, '$.status') = 'errored'"),
+      { userEmail: "owner@example.test", orgId: "org-1" },
+    );
+  });
+
+  it("builds a scoped BigQuery query with positive alert filters", () => {
+    const query = buildBigQueryAlertQuery(
+      {
+        eventName: "agent_run_terminal",
+        filters: [
+          { field: "properties.status", value: "errored" },
+          { field: "properties.deployment_environment", value: "beta" },
+        ],
+        ownerEmail: "owner@example.test",
+        orgId: "org-1",
+      },
+      "2026-08-31T12:00:00.000Z",
+      "2026-08-31T12:10:00.000Z",
+    );
+
+    expect(query).toContain("org_id = 'org-1'");
+    expect(query).toContain("event_name = 'agent_run_terminal'");
+    expect(query).toContain("JSON_VALUE(properties, '$.status') = 'errored'");
+    expect(query).toContain(
+      "JSON_VALUE(properties, '$.deployment_environment') = 'beta'",
+    );
   });
 
   it("keeps sweep ordering fair instead of cycling only recently evaluated rules", () => {

--- a/templates/analytics/server/lib/analytics-alerts.spec.ts
+++ b/templates/analytics/server/lib/analytics-alerts.spec.ts
@@ -265,7 +265,6 @@ describe("analytics alert evaluation", () => {
             deployment_environment: "production",
           }),
           context: "{}",
-          __analytics_alert_total_rows: 1,
         },
       ],
       schema: [],
@@ -374,7 +373,7 @@ describe("analytics alert evaluation", () => {
     );
 
     expect(query).toContain("user_id IS NULL");
-    expect(query).toContain("JSON_QUERY(properties, '$.tags')");
+    expect(query).not.toContain("JSON_VALUE(properties, '$.tags')");
     expect(query).not.toContain("JSON_VALUE(properties, '$.status')");
   });
 
@@ -414,44 +413,73 @@ describe("analytics alert evaluation", () => {
     ).toThrow("unsupported field");
   });
 
-  it("fails loudly when BigQuery returns truncated alert results", async () => {
+  it("paginates BigQuery alert candidates before evaluating deferred filters", async () => {
     backendMocks.get.mockResolvedValue({ sink: "bigquery", table: null });
-    firstPartyMocks.query.mockResolvedValue({
-      rows: [{ __analytics_alert_total_rows: 5001 }],
-      schema: [],
+    const page = Array.from({ length: 5_000 }, (_, index) => ({
+      id: `evt-${index}`,
+      event_name: "agent_run_terminal",
+      timestamp: "2026-08-31T12:00:00.000Z",
+      properties: "{}",
+      context: "{}",
+    }));
+    firstPartyMocks.query
+      .mockResolvedValueOnce({ rows: page, schema: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "evt-final",
+            event_name: "agent_run_terminal",
+            timestamp: "2026-08-31T11:59:59.000Z",
+            properties: JSON.stringify({ status: "errored" }),
+            context: "{}",
+          },
+        ],
+        schema: [],
+      });
+    dbMocks.getDb.mockReturnValue({
+      update: () => ({
+        set: () => ({ where: async () => undefined }),
+      }),
     });
 
-    await expect(
-      evaluateAndNotifyAnalyticsAlertRule(
-        {
-          id: "rule-1",
-          name: "Production chat errors",
-          description: "",
-          eventName: "agent_run_terminal",
-          filters: [],
-          thresholdMode: "event_count",
-          distinctBy: null,
-          threshold: 1,
-          windowMinutes: 10,
-          cooldownMinutes: 60,
-          severity: "critical",
-          channels: ["inbox"],
-          emailRecipients: [],
-          slackWebhookUrl: null,
-          webhookUrl: null,
-          enabled: true,
-          lastEvaluatedAt: null,
-          lastTriggeredAt: null,
-          lastStatus: null,
-          lastError: null,
-          createdAt: "2026-08-31T12:00:00.000Z",
-          updatedAt: "2026-08-31T12:00:00.000Z",
-          ownerEmail: "owner@example.test",
-          orgId: "org-1",
-        },
-        new Date("2026-08-31T12:05:00.000Z"),
-      ),
-    ).rejects.toThrow("refusing to evaluate partial data");
+    const result = await evaluateAndNotifyAnalyticsAlertRule(
+      {
+        id: "rule-1",
+        name: "Production chat errors",
+        description: "",
+        eventName: "agent_run_terminal",
+        filters: [
+          { field: "properties.status", op: "contains", value: "errored" },
+        ],
+        thresholdMode: "event_count",
+        distinctBy: null,
+        threshold: 2,
+        windowMinutes: 10,
+        cooldownMinutes: 60,
+        severity: "critical",
+        channels: ["inbox"],
+        emailRecipients: [],
+        slackWebhookUrl: null,
+        webhookUrl: null,
+        enabled: true,
+        lastEvaluatedAt: null,
+        lastTriggeredAt: null,
+        lastStatus: null,
+        lastError: null,
+        createdAt: "2026-08-31T12:00:00.000Z",
+        updatedAt: "2026-08-31T12:00:00.000Z",
+        ownerEmail: "owner@example.test",
+        orgId: "org-1",
+      },
+      new Date("2026-08-31T12:05:00.000Z"),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.observedValue).toBe(1);
+    expect(firstPartyMocks.query).toHaveBeenCalledTimes(2);
+    expect(firstPartyMocks.query.mock.calls[1]?.[0]).toContain(
+      "id < 'evt-4999'",
+    );
   });
 
   it("keeps sweep ordering fair instead of cycling only recently evaluated rules", () => {

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -991,7 +991,7 @@ export function buildBigQueryAlertQuery(
     ...rule.filters.map(bigQueryAlertFilterSql),
   ];
 
-  return `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
+  return `SELECT *, COUNT(*) OVER() AS __analytics_alert_total_rows FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
 }
 
 function bigQuerySqlLiteral(value: string): string {
@@ -1016,10 +1016,11 @@ function bigQueryAlertFieldExpression(field: string): string | null {
     userKey: "user_key",
     session_id: "session_id",
     sessionId: "session_id",
+    timestamp: "FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', timestamp)",
     event_date: "CAST(event_date AS STRING)",
     eventDate: "CAST(event_date AS STRING)",
-    received_at: "CAST(received_at AS STRING)",
-    receivedAt: "CAST(received_at AS STRING)",
+    received_at: "FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', received_at)",
+    receivedAt: "FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%E3SZ', received_at)",
     url: "url",
     path: "path",
     hostname: "hostname",
@@ -1132,7 +1133,12 @@ async function loadCandidateEvents(
           buildBigQueryAlertQuery(rule, windowStart, windowEnd),
           { userEmail: rule.ownerEmail, orgId: rule.orgId },
         );
-        if (result.truncated) {
+        const totalRows = result.rows[0]?.__analytics_alert_total_rows;
+        if (
+          result.truncated ||
+          (result.rows.length > 0 &&
+            (typeof totalRows !== "number" || totalRows > result.rows.length))
+        ) {
           throw new Error(
             `BigQuery alert evaluation for rule ${rule.id} returned truncated results; refusing to evaluate partial data`,
           );
@@ -1168,6 +1174,22 @@ function nullableBigQueryAlertString(
   return value;
 }
 
+function normalizeBigQueryAlertTimestamp(value: string, field: string): string {
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`BigQuery alert event field ${field} is not a timestamp`);
+  }
+  return timestamp.toISOString();
+}
+
+function nullableBigQueryAlertTimestamp(
+  row: Record<string, unknown>,
+  field: string,
+): string | null {
+  const value = nullableBigQueryAlertString(row, field);
+  return value === null ? null : normalizeBigQueryAlertTimestamp(value, field);
+}
+
 function normalizeBigQueryAlertEventRow(
   row: Record<string, unknown>,
 ): AnalyticsAlertEventRow {
@@ -1178,9 +1200,12 @@ function normalizeBigQueryAlertEventRow(
     anonymousId: nullableBigQueryAlertString(row, "anonymous_id"),
     userKey: nullableBigQueryAlertString(row, "user_key"),
     sessionId: nullableBigQueryAlertString(row, "session_id"),
-    timestamp: requiredBigQueryAlertString(row, "timestamp"),
+    timestamp: normalizeBigQueryAlertTimestamp(
+      requiredBigQueryAlertString(row, "timestamp"),
+      "timestamp",
+    ),
     eventDate: nullableBigQueryAlertString(row, "event_date"),
-    receivedAt: nullableBigQueryAlertString(row, "received_at"),
+    receivedAt: nullableBigQueryAlertTimestamp(row, "received_at"),
     url: nullableBigQueryAlertString(row, "url"),
     path: nullableBigQueryAlertString(row, "path"),
     hostname: nullableBigQueryAlertString(row, "hostname"),

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { notifyWithDelivery } from "@agent-native/core/notifications";
-import { recordChange } from "@agent-native/core/server";
+import { recordChange, runWithRequestContext } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import {
   and,
@@ -17,6 +17,8 @@ import {
 } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
+import { getFirstPartyAnalyticsBackend } from "./first-party-analytics-backend.js";
+import { queryFirstPartyAnalytics } from "./first-party-analytics.js";
 
 export type AnalyticsAlertFilterOp =
   | "equals"
@@ -967,7 +969,195 @@ export function evaluateAnalyticsAlertRuleRows(
   };
 }
 
+export function buildBigQueryAlertQuery(
+  rule: Pick<
+    AnalyticsAlertRule,
+    "eventName" | "filters" | "orgId" | "ownerEmail"
+  >,
+  windowStart: string,
+  windowEnd: string,
+): string {
+  const predicates = [
+    `event_date >= DATE(TIMESTAMP(${bigQuerySqlLiteral(windowStart)}))`,
+    `event_date <= DATE(TIMESTAMP(${bigQuerySqlLiteral(windowEnd)}))`,
+    `timestamp >= TIMESTAMP(${bigQuerySqlLiteral(windowStart)})`,
+    `timestamp <= TIMESTAMP(${bigQuerySqlLiteral(windowEnd)})`,
+    rule.orgId
+      ? `org_id = ${bigQuerySqlLiteral(rule.orgId)}`
+      : `(org_id IS NULL AND owner_email = ${bigQuerySqlLiteral(rule.ownerEmail)})`,
+    ...(rule.eventName
+      ? [`event_name = ${bigQuerySqlLiteral(rule.eventName)}`]
+      : []),
+    ...rule.filters
+      .map(bigQueryAlertFilterSql)
+      .filter((predicate): predicate is string => predicate !== null),
+  ];
+
+  return `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
+}
+
+function bigQuerySqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function bigQueryAlertFieldExpression(field: string): string | null {
+  const normalized = field.trim();
+  if (normalized.startsWith("properties.")) {
+    const path = normalized.slice("properties.".length);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(path)) {
+      return null;
+    }
+    return `JSON_VALUE(properties, ${bigQuerySqlLiteral(`$.${path}`)})`;
+  }
+  if (normalized.startsWith("context.")) {
+    const path = normalized.slice("context.".length);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(path)) {
+      return null;
+    }
+    return `JSON_VALUE(context, ${bigQuerySqlLiteral(`$.${path}`)})`;
+  }
+  const columns: Record<string, string> = {
+    id: "id",
+    event_name: "event_name",
+    eventName: "event_name",
+    user_id: "user_id",
+    userId: "user_id",
+    anonymous_id: "anonymous_id",
+    anonymousId: "anonymous_id",
+    user_key: "user_key",
+    userKey: "user_key",
+    session_id: "session_id",
+    sessionId: "session_id",
+    event_date: "CAST(event_date AS STRING)",
+    eventDate: "CAST(event_date AS STRING)",
+    received_at: "CAST(received_at AS STRING)",
+    receivedAt: "CAST(received_at AS STRING)",
+    url: "url",
+    path: "path",
+    hostname: "hostname",
+    referrer: "referrer",
+    app: "app",
+    template: "template",
+    signed_in: "signed_in",
+    signedIn: "signed_in",
+  };
+  return columns[normalized] ?? null;
+}
+
+function bigQueryAlertValueLiteral(value: unknown): string | null {
+  if (typeof value === "string") return bigQuerySqlLiteral(value);
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return bigQuerySqlLiteral(String(value));
+  }
+  if (typeof value === "boolean") {
+    return bigQuerySqlLiteral(value ? "true" : "false");
+  }
+  return null;
+}
+
+function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
+  const expression = bigQueryAlertFieldExpression(filter.field);
+  if (!expression) return null;
+  const op = filter.op ?? "equals";
+  if (op === "exists") {
+    return filter.value === false
+      ? `COALESCE(${expression}, '') = ''`
+      : `COALESCE(${expression}, '') <> ''`;
+  }
+  if (op === "in" && Array.isArray(filter.value)) {
+    if (filter.value.length === 0) return "FALSE";
+    const literals = filter.value.map(bigQueryAlertValueLiteral);
+    if (literals.some((literal) => literal === null)) return null;
+    return `${expression} IN (${literals.join(", ")})`;
+  }
+  const literal = bigQueryAlertValueLiteral(filter.value);
+  if (literal === null) {
+    return filter.value === null || filter.value === undefined ? "FALSE" : null;
+  }
+  if (op === "not_equals") {
+    return `(${expression} IS NULL OR ${expression} <> ${literal})`;
+  }
+  if (op !== "equals") return null;
+  return `${expression} = ${literal}`;
+}
+
 async function loadCandidateEvents(
+  rule: AnalyticsAlertRule,
+  windowStart: string,
+  windowEnd: string,
+): Promise<AnalyticsAlertEventRow[]> {
+  const backend = await getFirstPartyAnalyticsBackend({
+    userEmail: rule.ownerEmail,
+    orgId: rule.orgId,
+  });
+  if (backend.sink === "bigquery") {
+    return runWithRequestContext(
+      {
+        userEmail: rule.ownerEmail,
+        ...(rule.orgId ? { orgId: rule.orgId } : {}),
+      },
+      async () => {
+        const result = await queryFirstPartyAnalytics(
+          buildBigQueryAlertQuery(rule, windowStart, windowEnd),
+          { userEmail: rule.ownerEmail, orgId: rule.orgId },
+        );
+        return result.rows.map(normalizeBigQueryAlertEventRow);
+      },
+    );
+  }
+
+  return loadCandidateEventsFromSql(rule, windowStart, windowEnd);
+}
+
+function requiredBigQueryAlertString(
+  row: Record<string, unknown>,
+  field: string,
+): string {
+  const value = row[field];
+  if (typeof value !== "string" || !value) {
+    throw new Error(`BigQuery alert event is missing ${field}`);
+  }
+  return value;
+}
+
+function nullableBigQueryAlertString(
+  row: Record<string, unknown>,
+  field: string,
+): string | null {
+  const value = row[field];
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new Error(`BigQuery alert event field ${field} is not text`);
+  }
+  return value;
+}
+
+function normalizeBigQueryAlertEventRow(
+  row: Record<string, unknown>,
+): AnalyticsAlertEventRow {
+  return {
+    id: requiredBigQueryAlertString(row, "id"),
+    eventName: requiredBigQueryAlertString(row, "event_name"),
+    userId: nullableBigQueryAlertString(row, "user_id"),
+    anonymousId: nullableBigQueryAlertString(row, "anonymous_id"),
+    userKey: nullableBigQueryAlertString(row, "user_key"),
+    sessionId: nullableBigQueryAlertString(row, "session_id"),
+    timestamp: requiredBigQueryAlertString(row, "timestamp"),
+    eventDate: nullableBigQueryAlertString(row, "event_date"),
+    receivedAt: nullableBigQueryAlertString(row, "received_at"),
+    url: nullableBigQueryAlertString(row, "url"),
+    path: nullableBigQueryAlertString(row, "path"),
+    hostname: nullableBigQueryAlertString(row, "hostname"),
+    referrer: nullableBigQueryAlertString(row, "referrer"),
+    app: nullableBigQueryAlertString(row, "app"),
+    template: nullableBigQueryAlertString(row, "template"),
+    signedIn: nullableBigQueryAlertString(row, "signed_in"),
+    properties: nullableBigQueryAlertString(row, "properties"),
+    context: nullableBigQueryAlertString(row, "context"),
+  };
+}
+
+async function loadCandidateEventsFromSql(
   rule: AnalyticsAlertRule,
   windowStart: string,
   windowEnd: string,

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -988,7 +988,12 @@ export function buildBigQueryAlertQuery(
     ...(rule.eventName
       ? [`event_name = ${bigQuerySqlLiteral(rule.eventName)}`]
       : []),
-    ...rule.filters.map(bigQueryAlertFilterSql),
+    // Ambiguous JSON filters stay in evaluateAnalyticsAlertRuleRows; the total
+    // row marker below prevents the shared query cap from evaluating a partial set.
+    ...rule.filters.flatMap((filter) => {
+      const predicate = bigQueryAlertFilterSql(filter);
+      return predicate ? [predicate] : [];
+    }),
   ];
 
   return `SELECT *, COUNT(*) OVER() AS __analytics_alert_total_rows FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
@@ -1057,6 +1062,10 @@ function bigQueryAlertValueLiteral(value: unknown): string | null {
   if (typeof value === "boolean") {
     return bigQuerySqlLiteral(value ? "true" : "false");
   }
+  if (value !== null && typeof value === "object") {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? null : bigQuerySqlLiteral(serialized);
+  }
   return null;
 }
 
@@ -1077,9 +1086,34 @@ function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
       ? `${existsExpression} IS NULL`
       : `${existsExpression} IS NOT NULL`;
   }
+  const jsonPath = bigQueryAlertJsonPath(filter.field.trim());
+  if (
+    jsonPath &&
+    filter.value !== null &&
+    typeof filter.value === "object" &&
+    op !== "exists" &&
+    op !== "contains"
+  ) {
+    return null;
+  }
+  if (op === "contains") {
+    if (jsonPath) return null;
+    const literal = bigQueryAlertValueLiteral(filter.value);
+    if (literal === null) return null;
+    return `STRPOS(COALESCE(${expression}, ''), ${literal}) > 0`;
+  }
   if (op === "in") {
     if (!Array.isArray(filter.value)) {
       throw new Error("BigQuery alert IN filters require an array value");
+    }
+    if (
+      jsonPath &&
+      filter.value.some(
+        (value) =>
+          value === null || (value !== null && typeof value === "object"),
+      )
+    ) {
+      return null;
     }
     const hasNull = filter.value.some((value) => value === null);
     const nonNullLiterals = filter.value
@@ -1096,6 +1130,9 @@ function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
   }
   const literal = bigQueryAlertValueLiteral(filter.value);
   if (literal === null) {
+    if (jsonPath && (filter.value === null || filter.value === undefined)) {
+      return null;
+    }
     if (filter.value === null || filter.value === undefined) {
       if (op === "equals") return `${expression} IS NULL`;
       if (op === "not_equals") return `${expression} IS NOT NULL`;

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -1091,7 +1091,6 @@ function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
     jsonPath &&
     filter.value !== null &&
     typeof filter.value === "object" &&
-    op !== "exists" &&
     op !== "contains"
   ) {
     return null;

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -988,9 +988,7 @@ export function buildBigQueryAlertQuery(
     ...(rule.eventName
       ? [`event_name = ${bigQuerySqlLiteral(rule.eventName)}`]
       : []),
-    ...rule.filters
-      .map(bigQueryAlertFilterSql)
-      .filter((predicate): predicate is string => predicate !== null),
+    ...rule.filters.map(bigQueryAlertFilterSql),
   ];
 
   return `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
@@ -1002,19 +1000,9 @@ function bigQuerySqlLiteral(value: string): string {
 
 function bigQueryAlertFieldExpression(field: string): string | null {
   const normalized = field.trim();
-  if (normalized.startsWith("properties.")) {
-    const path = normalized.slice("properties.".length);
-    if (!/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(path)) {
-      return null;
-    }
-    return `JSON_VALUE(properties, ${bigQuerySqlLiteral(`$.${path}`)})`;
-  }
-  if (normalized.startsWith("context.")) {
-    const path = normalized.slice("context.".length);
-    if (!/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(path)) {
-      return null;
-    }
-    return `JSON_VALUE(context, ${bigQuerySqlLiteral(`$.${path}`)})`;
+  const jsonPath = bigQueryAlertJsonPath(normalized);
+  if (jsonPath) {
+    return `JSON_VALUE(${jsonPath.column}, ${bigQuerySqlLiteral(jsonPath.path)})`;
   }
   const columns: Record<string, string> = {
     id: "id",
@@ -1044,6 +1032,22 @@ function bigQueryAlertFieldExpression(field: string): string | null {
   return columns[normalized] ?? null;
 }
 
+function bigQueryAlertJsonPath(
+  field: string,
+): { column: "properties" | "context"; path: string } | null {
+  const match = /^(properties|context)\.(.+)$/.exec(field);
+  if (
+    !match ||
+    !/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/.test(match[2])
+  ) {
+    return null;
+  }
+  return {
+    column: match[1] as "properties" | "context",
+    path: `$.${match[2]}`,
+  };
+}
+
 function bigQueryAlertValueLiteral(value: unknown): string | null {
   if (typeof value === "string") return bigQuerySqlLiteral(value);
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -1057,27 +1061,54 @@ function bigQueryAlertValueLiteral(value: unknown): string | null {
 
 function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
   const expression = bigQueryAlertFieldExpression(filter.field);
-  if (!expression) return null;
+  if (!expression) {
+    throw new Error(
+      `BigQuery alert filter uses an unsupported field: ${filter.field}`,
+    );
+  }
   const op = filter.op ?? "equals";
   if (op === "exists") {
+    const jsonPath = bigQueryAlertJsonPath(filter.field.trim());
+    const existsExpression = jsonPath
+      ? `COALESCE(NULLIF(JSON_VALUE(${jsonPath.column}, ${bigQuerySqlLiteral(jsonPath.path)}), ''), NULLIF(JSON_QUERY(${jsonPath.column}, ${bigQuerySqlLiteral(jsonPath.path)}), '""'))`
+      : `NULLIF(${expression}, '')`;
     return filter.value === false
-      ? `COALESCE(${expression}, '') = ''`
-      : `COALESCE(${expression}, '') <> ''`;
+      ? `${existsExpression} IS NULL`
+      : `${existsExpression} IS NOT NULL`;
   }
-  if (op === "in" && Array.isArray(filter.value)) {
-    if (filter.value.length === 0) return "FALSE";
-    const literals = filter.value.map(bigQueryAlertValueLiteral);
-    if (literals.some((literal) => literal === null)) return null;
-    return `${expression} IN (${literals.join(", ")})`;
+  if (op === "in") {
+    if (!Array.isArray(filter.value)) {
+      throw new Error("BigQuery alert IN filters require an array value");
+    }
+    const hasNull = filter.value.some((value) => value === null);
+    const nonNullLiterals = filter.value
+      .filter((value) => value !== null)
+      .map(bigQueryAlertValueLiteral);
+    if (nonNullLiterals.some((literal) => literal === null)) {
+      throw new Error("BigQuery alert filter contains an unsupported value");
+    }
+    const predicates = nonNullLiterals.length
+      ? [`${expression} IN (${nonNullLiterals.join(", ")})`]
+      : [];
+    if (hasNull) predicates.push(`${expression} IS NULL`);
+    return predicates.length ? `(${predicates.join(" OR ")})` : "FALSE";
   }
   const literal = bigQueryAlertValueLiteral(filter.value);
   if (literal === null) {
-    return filter.value === null || filter.value === undefined ? "FALSE" : null;
+    if (filter.value === null || filter.value === undefined) {
+      if (op === "equals") return `${expression} IS NULL`;
+      if (op === "not_equals") return `${expression} IS NOT NULL`;
+    }
+    throw new Error("BigQuery alert filter contains an unsupported value");
   }
   if (op === "not_equals") {
     return `(${expression} IS NULL OR ${expression} <> ${literal})`;
   }
-  if (op !== "equals") return null;
+  if (op !== "equals") {
+    throw new Error(
+      `BigQuery alert filter uses an unsupported operator: ${op}`,
+    );
+  }
   return `${expression} = ${literal}`;
 }
 

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -1137,7 +1137,7 @@ async function loadCandidateEvents(
         if (
           result.truncated ||
           (result.rows.length > 0 &&
-            (typeof totalRows !== "number" || totalRows > result.rows.length))
+            (typeof totalRows !== "number" || totalRows !== result.rows.length))
         ) {
           throw new Error(
             `BigQuery alert evaluation for rule ${rule.id} returned truncated results; refusing to evaluate partial data`,

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -984,7 +984,7 @@ export function buildBigQueryAlertQuery(
     `timestamp <= TIMESTAMP(${bigQuerySqlLiteral(windowEnd)})`,
     rule.orgId
       ? `org_id = ${bigQuerySqlLiteral(rule.orgId)}`
-      : `(org_id IS NULL AND owner_email = ${bigQuerySqlLiteral(rule.ownerEmail)})`,
+      : `(org_id IS NULL AND LOWER(owner_email) = LOWER(${bigQuerySqlLiteral(rule.ownerEmail)}))`,
     ...(rule.eventName
       ? [`event_name = ${bigQuerySqlLiteral(rule.eventName)}`]
       : []),
@@ -1101,6 +1101,11 @@ async function loadCandidateEvents(
           buildBigQueryAlertQuery(rule, windowStart, windowEnd),
           { userEmail: rule.ownerEmail, orgId: rule.orgId },
         );
+        if (result.truncated) {
+          throw new Error(
+            `BigQuery alert evaluation for rule ${rule.id} returned truncated results; refusing to evaluate partial data`,
+          );
+        }
         return result.rows.map(normalizeBigQueryAlertEventRow);
       },
     );

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -984,11 +984,6 @@ export function buildBigQueryAlertQuery(
     `event_date <= DATE(TIMESTAMP(${bigQuerySqlLiteral(windowEnd)}))`,
     `timestamp >= TIMESTAMP(${bigQuerySqlLiteral(windowStart)})`,
     `timestamp <= TIMESTAMP(${bigQuerySqlLiteral(windowEnd)})`,
-    ...(cursor
-      ? [
-          `(timestamp < TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) OR (timestamp = TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) AND id < ${bigQuerySqlLiteral(cursor.id)}))`,
-        ]
-      : []),
     rule.orgId
       ? `org_id = ${bigQuerySqlLiteral(rule.orgId)}`
       : `(org_id IS NULL AND LOWER(owner_email) = LOWER(${bigQuerySqlLiteral(rule.ownerEmail)}))`,
@@ -1003,7 +998,11 @@ export function buildBigQueryAlertQuery(
     }),
   ];
 
-  return `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
+  const cursorPredicate = cursor
+    ? `(timestamp < TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) OR (timestamp = TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) AND id < ${bigQuerySqlLiteral(cursor.id)}))`
+    : null;
+  const candidateSql = `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")}`;
+  return `SELECT * FROM (${candidateSql}) AS analytics_alert_page${cursorPredicate ? ` WHERE ${cursorPredicate}` : ""} ORDER BY timestamp DESC, id DESC`;
 }
 
 function bigQuerySqlLiteral(value: string): string {
@@ -1177,14 +1176,20 @@ async function loadCandidateEvents(
             buildBigQueryAlertQuery(rule, windowStart, windowEnd, cursor),
             { userEmail: rule.ownerEmail, orgId: rule.orgId },
           );
+          if (result.truncated) {
+            throw new Error(
+              `BigQuery alert evaluation for rule ${rule.id} returned a transport-truncated page; refusing to evaluate partial data`,
+            );
+          }
           const page = result.rows.map(normalizeBigQueryAlertEventRow);
           rows.push(...page);
           if (!page.length) break;
-          if (!result.truncated && page.length < BIGQUERY_ALERT_PAGE_SIZE) {
-            break;
-          }
-          const last = page[page.length - 1]!;
-          cursor = { timestamp: last.timestamp, id: last.id };
+          if (page.length < BIGQUERY_ALERT_PAGE_SIZE) break;
+          const lastRaw = result.rows[result.rows.length - 1]!;
+          cursor = {
+            timestamp: requiredBigQueryAlertString(lastRaw, "timestamp"),
+            id: requiredBigQueryAlertString(lastRaw, "id"),
+          };
         }
         return rows;
       },

--- a/templates/analytics/server/lib/analytics-alerts.ts
+++ b/templates/analytics/server/lib/analytics-alerts.ts
@@ -143,6 +143,7 @@ const DEFAULT_AGENT_CHAT_STUCK_ALERT_THRESHOLD = 3;
 const DEFAULT_AGENT_CHAT_STUCK_ALERT_WINDOW_MINUTES = 10;
 const DEFAULT_AGENT_CHAT_STUCK_ALERT_COOLDOWN_MINUTES = 60;
 const DEFAULT_ALERT_SCOPE_PAGE_SIZE = 500;
+const BIGQUERY_ALERT_PAGE_SIZE = 5_000;
 const ALERT_RULE_DEFAULTS_KEY = "analytics-alert-rule-defaults";
 
 function safeJsonParse<T>(raw: unknown, fallback: T): T {
@@ -976,27 +977,33 @@ export function buildBigQueryAlertQuery(
   >,
   windowStart: string,
   windowEnd: string,
+  cursor?: { timestamp: string; id: string },
 ): string {
   const predicates = [
     `event_date >= DATE(TIMESTAMP(${bigQuerySqlLiteral(windowStart)}))`,
     `event_date <= DATE(TIMESTAMP(${bigQuerySqlLiteral(windowEnd)}))`,
     `timestamp >= TIMESTAMP(${bigQuerySqlLiteral(windowStart)})`,
     `timestamp <= TIMESTAMP(${bigQuerySqlLiteral(windowEnd)})`,
+    ...(cursor
+      ? [
+          `(timestamp < TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) OR (timestamp = TIMESTAMP(${bigQuerySqlLiteral(cursor.timestamp)}) AND id < ${bigQuerySqlLiteral(cursor.id)}))`,
+        ]
+      : []),
     rule.orgId
       ? `org_id = ${bigQuerySqlLiteral(rule.orgId)}`
       : `(org_id IS NULL AND LOWER(owner_email) = LOWER(${bigQuerySqlLiteral(rule.ownerEmail)}))`,
     ...(rule.eventName
       ? [`event_name = ${bigQuerySqlLiteral(rule.eventName)}`]
       : []),
-    // Ambiguous JSON filters stay in evaluateAnalyticsAlertRuleRows; the total
-    // row marker below prevents the shared query cap from evaluating a partial set.
+    // Ambiguous JSON filters stay in evaluateAnalyticsAlertRuleRows. The caller
+    // paginates this ordered candidate query before evaluating those filters.
     ...rule.filters.flatMap((filter) => {
       const predicate = bigQueryAlertFilterSql(filter);
       return predicate ? [predicate] : [];
     }),
   ];
 
-  return `SELECT *, COUNT(*) OVER() AS __analytics_alert_total_rows FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
+  return `SELECT * FROM analytics_events WHERE ${predicates.join(" AND ")} ORDER BY timestamp DESC, id DESC`;
 }
 
 function bigQuerySqlLiteral(value: string): string {
@@ -1078,10 +1085,8 @@ function bigQueryAlertFilterSql(filter: AnalyticsAlertFilter): string | null {
   }
   const op = filter.op ?? "equals";
   if (op === "exists") {
-    const jsonPath = bigQueryAlertJsonPath(filter.field.trim());
-    const existsExpression = jsonPath
-      ? `COALESCE(NULLIF(JSON_VALUE(${jsonPath.column}, ${bigQuerySqlLiteral(jsonPath.path)}), ''), NULLIF(JSON_QUERY(${jsonPath.column}, ${bigQuerySqlLiteral(jsonPath.path)}), '""'))`
-      : `NULLIF(${expression}, '')`;
+    if (bigQueryAlertJsonPath(filter.field.trim())) return null;
+    const existsExpression = `NULLIF(${expression}, '')`;
     return filter.value === false
       ? `${existsExpression} IS NULL`
       : `${existsExpression} IS NOT NULL`;
@@ -1165,21 +1170,23 @@ async function loadCandidateEvents(
         ...(rule.orgId ? { orgId: rule.orgId } : {}),
       },
       async () => {
-        const result = await queryFirstPartyAnalytics(
-          buildBigQueryAlertQuery(rule, windowStart, windowEnd),
-          { userEmail: rule.ownerEmail, orgId: rule.orgId },
-        );
-        const totalRows = result.rows[0]?.__analytics_alert_total_rows;
-        if (
-          result.truncated ||
-          (result.rows.length > 0 &&
-            (typeof totalRows !== "number" || totalRows !== result.rows.length))
-        ) {
-          throw new Error(
-            `BigQuery alert evaluation for rule ${rule.id} returned truncated results; refusing to evaluate partial data`,
+        const rows: AnalyticsAlertEventRow[] = [];
+        let cursor: { timestamp: string; id: string } | undefined;
+        while (true) {
+          const result = await queryFirstPartyAnalytics(
+            buildBigQueryAlertQuery(rule, windowStart, windowEnd, cursor),
+            { userEmail: rule.ownerEmail, orgId: rule.orgId },
           );
+          const page = result.rows.map(normalizeBigQueryAlertEventRow);
+          rows.push(...page);
+          if (!page.length) break;
+          if (!result.truncated && page.length < BIGQUERY_ALERT_PAGE_SIZE) {
+            break;
+          }
+          const last = page[page.length - 1]!;
+          cursor = { timestamp: last.timestamp, id: last.id };
         }
-        return result.rows.map(normalizeBigQueryAlertEventRow);
+        return rows;
       },
     );
   }

--- a/templates/analytics/server/lib/first-party-analytics-backend.ts
+++ b/templates/analytics/server/lib/first-party-analytics-backend.ts
@@ -1116,11 +1116,16 @@ export async function queryFirstPartyAnalyticsInBigQuery(
 ): Promise<{
   rows: Record<string, unknown>[];
   schema: { name: string; type: string }[];
+  truncated?: boolean;
 }> {
   const result = await runQuery(
     `SELECT * FROM (${renderFirstPartyAnalyticsBigQuerySql(scopedSql, args, table)}) AS first_party_analytics_query LIMIT 5000`,
   );
-  return { rows: result.rows, schema: result.schema };
+  return {
+    rows: result.rows,
+    schema: result.schema,
+    ...(result.truncated ? { truncated: true } : {}),
+  };
 }
 
 export async function assertFirstPartyAnalyticsBigQueryReady(

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -578,7 +578,7 @@ describe("scopedAnalyticsSql", () => {
       "FROM (SELECT * FROM analytics_events WHERE org_id = ?",
     );
     expect(scoped.sql).toContain(
-      "UNION ALL SELECT * FROM analytics_events WHERE org_id IS NULL AND owner_email = ?",
+      "UNION ALL SELECT * FROM analytics_events WHERE org_id IS NULL AND lower(owner_email) = lower(?)",
     );
     expect(
       scoped.sql.match(

--- a/templates/analytics/server/lib/first-party-analytics.spec.ts
+++ b/templates/analytics/server/lib/first-party-analytics.spec.ts
@@ -578,7 +578,7 @@ describe("scopedAnalyticsSql", () => {
       "FROM (SELECT * FROM analytics_events WHERE org_id = ?",
     );
     expect(scoped.sql).toContain(
-      "UNION ALL SELECT * FROM analytics_events WHERE org_id IS NULL AND lower(owner_email) = lower(?)",
+      "UNION ALL SELECT * FROM analytics_events WHERE org_id IS NULL AND owner_email = ?",
     );
     expect(
       scoped.sql.match(

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -1026,12 +1026,12 @@ function scopedTableSource(
       // Keep the org and personal fallback as separate branches so Postgres can
       // use each branch's composite tenant/date indexes instead of scanning one
       // broad org index for an OR predicate.
-      sql: `(SELECT * FROM ${tableName} WHERE org_id = ? AND ${freshness} UNION ALL SELECT * FROM ${tableName} WHERE org_id IS NULL AND owner_email = ? AND ${freshness})`,
+      sql: `(SELECT * FROM ${tableName} WHERE org_id = ? AND ${freshness} UNION ALL SELECT * FROM ${tableName} WHERE org_id IS NULL AND lower(owner_email) = lower(?) AND ${freshness})`,
       args: [scope.orgId, today, scope.userEmail, today],
     };
   }
   return {
-    sql: `(SELECT * FROM ${tableName} WHERE org_id IS NULL AND owner_email = ? AND ${freshness})`,
+    sql: `(SELECT * FROM ${tableName} WHERE org_id IS NULL AND lower(owner_email) = lower(?) AND ${freshness})`,
     args: [scope.userEmail, today],
   };
 }

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -1021,18 +1021,19 @@ function scopedTableSource(
   }
 
   const freshness = freshnessClause(tableName);
+  const ownerEmail = scope.userEmail.trim().toLowerCase();
   if (scope.orgId) {
     return {
       // Keep the org and personal fallback as separate branches so Postgres can
       // use each branch's composite tenant/date indexes instead of scanning one
       // broad org index for an OR predicate.
-      sql: `(SELECT * FROM ${tableName} WHERE org_id = ? AND ${freshness} UNION ALL SELECT * FROM ${tableName} WHERE org_id IS NULL AND lower(owner_email) = lower(?) AND ${freshness})`,
-      args: [scope.orgId, today, scope.userEmail, today],
+      sql: `(SELECT * FROM ${tableName} WHERE org_id = ? AND ${freshness} UNION ALL SELECT * FROM ${tableName} WHERE org_id IS NULL AND owner_email = ? AND ${freshness})`,
+      args: [scope.orgId, today, ownerEmail, today],
     };
   }
   return {
-    sql: `(SELECT * FROM ${tableName} WHERE org_id IS NULL AND lower(owner_email) = lower(?) AND ${freshness})`,
-    args: [scope.userEmail, today],
+    sql: `(SELECT * FROM ${tableName} WHERE org_id IS NULL AND owner_email = ? AND ${freshness})`,
+    args: [ownerEmail, today],
   };
 }
 

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -47,6 +47,7 @@ export interface IncomingAnalyticsEvent {
 export interface AnalyticsQueryResult {
   rows: Record<string, unknown>[];
   schema: { name: string; type: string }[];
+  truncated?: boolean;
 }
 
 export interface AnalyticsQueryOptions {


### PR DESCRIPTION
## Summary
- route Analytics alert evaluation through the active first-party analytics backend, including BigQuery
- push supported alert filters into the scoped BigQuery query and normalize warehouse rows
- add focused coverage for BigQuery alert evaluation and query scoping

## Verification
- `corepack pnpm --filter analytics exec vitest --run server/lib/analytics-alerts.spec.ts` (23 passed)
- dashboard and environment-specific email alert rules were saved and verified in the authenticated Analytics app