### PR TITLE
fix(core): keep recovery forks usable with uploaded attachments

### DIFF
--- a/.changeset/fix-error-forking.md
+++ b/.changeset/fix-error-forking.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep recovery-card fork snapshots compact when chats contain uploaded attachments.

--- a/packages/core/src/client/AssistantChat.display.spec.ts
+++ b/packages/core/src/client/AssistantChat.display.spec.ts
@@ -72,6 +72,19 @@ describe("shouldShowAssistantChatModelSelector", () => {
 });
 
 describe("AssistantChat thread restore and composer recovery", () => {
+  it("keeps recovery-card fork snapshots compact", () => {
+    const source = readFileSync("src/client/AssistantChat.tsx", {
+      encoding: "utf8",
+    });
+    const snapshotStart = source.lastIndexOf("exportThreadSnapshot()");
+    const snapshotEnd = source.indexOf("      },", snapshotStart);
+    const snapshotSource = source.slice(snapshotStart, snapshotEnd);
+
+    expect(snapshotSource).toContain(
+      "threadData: JSON.stringify(stripBase64FromRepo(repo))",
+    );
+  });
+
   it("only suppresses unauthenticated restore failures for desktop chat", () => {
     expect(
       shouldSuppressUnauthenticatedDesktopThreadRestore("desktop", 401),

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2317,10 +2317,10 @@ export { extractThreadMeta };
 
 /**
  * Strip raw base64 payload from attachment content parts when a hosted URL
- * already exists in the same content entry. This keeps the periodic thread
- * save payload compact — the server already stored the URL reference when it
- * processed the POST, and re-shipping multi-megabyte base64 strings on every
- * 5-second poll save balloons the SQL thread_data column unnecessarily.
+ * already exists in the same content entry. This keeps thread save and fork
+ * payloads compact — the server already stored the URL reference when it
+ * processed the POST, and re-shipping multi-megabyte base64 strings balloons
+ * the SQL thread_data column and request body unnecessarily.
  *
  * Only strips the raw base64 data-URL string from `content[].image` / `content[].data`
  * when a `metadata.uploadUrl` reference is present on the same attachment object,
@@ -5839,7 +5839,7 @@ const AssistantChatInner = forwardRef<
         const repo = exportPersistableThreadRepo();
         const { title, preview } = extractThreadMeta(repo);
         return {
-          threadData: JSON.stringify(repo),
+          threadData: JSON.stringify(stripBase64FromRepo(repo)),
           title,
           preview,
           messageCount: messages.length,


### PR DESCRIPTION
## Summary
- keep recovery-card fork snapshots compact when uploaded attachments already have hosted URLs
- add a regression guard for the fork export path

Fixes the reported Slack recovery-card fork issue: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788195525172749

## Validation
- core focused Vitest suites: 272 passed
- @agent-native/core typecheck
- pnpm guards: 65 passed