### PR TITLE
fix(auth): persist onboarding role in Better Auth

### DIFF
--- a/.changeset/persist-better-auth-onboarding-role.md
+++ b/.changeset/persist-better-auth-onboarding-role.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Persist onboarding roles through Better Auth's user adapter.

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -1835,6 +1835,17 @@ async function createBetterAuthInstance(
         });
       },
     },
+    user: {
+      additionalFields: {
+        // Keep this internal profile field in Better Auth's adapter reads and
+        // writes without exposing it as a client-controlled auth field.
+        onboardingRole: {
+          type: "string",
+          required: false,
+          input: false,
+        },
+      },
+    },
     socialProviders,
     account: {
       // Merge accounts when a user signs in with a social provider using an


### PR DESCRIPTION
## Summary

- Declare the existing `onboardingRole` column as a Better Auth user additional field.
- Keep the field writable through the internal adapter while preventing client-controlled auth updates.
- Prevent the first-run onboarding role request from failing with a 500 after Google sign-in.

## Investigation

The recurring logout report is not explained by the Google client ID rotations alone. The historical auth-secret fallback could invalidate sessions when a Google secret changed, and the shared auth code now avoids that fallback. Current live checks show the beta Dispatch active and managed Google credential pairs differ, which can cause callback failures, but not browser-session loss by itself. Analytics also shows the concrete shared onboarding failure fixed here: `Failed to save onboarding role on the Better Auth user row` began on August 28 across production and beta.

## Validation

- Focused core auth, onboarding, profile, and cookie tests: 70 passed.
- `oxfmt --check`: passed.
- `guard:no-env-credentials`: passed.
- `guard:no-silent-coercion`: passed.
- Full core typecheck and aggregate guards remain blocked by unrelated existing toolkit export and generated-baseline failures.
