### PR TITLE
fix: close recent Calendar and Mail feedback gaps

### DIFF
--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -24,6 +24,18 @@ re-read it before finishing and verify the invoking identity posted **Fixed**,
 ownership and must be revisited; an eye, bot forward, or other person's reply
 alone is never enough.
 
+## Per-parent eye ledger
+
+The start cursor is not a stop cursor. After selecting it, continue newest to
+oldest through the entire declared bounded window. Every eligible clear-bug
+parent that this run addresses, investigates, verifies, groups, or uses as
+evidence gets the invoking identity's `👀` reaction before investigation, a
+reaction read-back, and its own final disposition. Grouping symptoms never
+substitutes a representative reaction: each parent keeps its own eye and
+reply-ledger row. Before reporting completion, re-read every ledger parent and
+its reactions; no eligible clear-bug parent may be left without the invoking
+identity's eye and an auditable invoking-identity disposition.
+
 ## Scope: clear bugs only
 
 This is a bug sweep, not a general UX review. “Comprehensive” means covering
@@ -448,8 +460,8 @@ queried and the cursor and filters are stated.
 
 When multiple source items were grouped into one similar-feedback cluster, name
 the representative item and list the grouped source links in that row. Record
-one Builder dispatch for the cluster, while preserving the disposition of every
-individual report.
+one Builder dispatch for the cluster, while preserving the eye reaction,
+reply-ledger result, and disposition of every individual report.
 
 ## Related skills
 

--- a/.agents/skills/review-latest-feedback/SKILL.md
+++ b/.agents/skills/review-latest-feedback/SKILL.md
@@ -27,9 +27,12 @@ alone is never enough.
 ## Per-parent eye ledger
 
 The start cursor is not a stop cursor. After selecting it, continue newest to
-oldest through the entire declared bounded window. Every eligible clear-bug
-parent that this run addresses, investigates, verifies, groups, or uses as
-evidence gets the invoking identity's `👀` reaction before investigation, a
+oldest through the entire declared bounded window. First use only the readable
+parent-level evidence to classify ownership and whether the report is an
+objective clear bug; this preflight is read-only and does not require full
+investigation. Every eligible clear-bug parent that this run addresses,
+investigates, verifies, groups, or uses as evidence then gets the invoking
+identity's `👀` reaction before its full-thread read or code investigation, a
 reaction read-back, and its own final disposition. Grouping symptoms never
 substitutes a representative reaction: each parent keeps its own eye and
 reply-ledger row. Before reporting completion, re-read every ledger parent and

--- a/templates/calendar/actions/update-event.test.ts
+++ b/templates/calendar/actions/update-event.test.ts
@@ -561,6 +561,27 @@ describe("update-event working locations", () => {
     );
   });
 
+  it("passes Google Meet removal through to the calendar service", async () => {
+    const result = await runWithRequestContext(
+      { userEmail: "owner@example.com" },
+      () =>
+        action.run({
+          id: "google-event-1",
+          removeGoogleMeet: true,
+        }),
+    );
+
+    expect(updateEventMock).toHaveBeenCalledWith(
+      "event-1",
+      { accountEmail: "owner@example.com" },
+      expect.objectContaining({ removeGoogleMeet: true }),
+    );
+    expect(result).toMatchObject({
+      id: "google-event-1",
+      removedGoogleMeet: true,
+    });
+  });
+
   it("does not try to convert a normal event into a working-location event", async () => {
     getEventMock.mockResolvedValue({
       id: "google-event-1",

--- a/templates/calendar/actions/update-event.ts
+++ b/templates/calendar/actions/update-event.ts
@@ -153,6 +153,9 @@ export default defineAction({
     addGoogleMeet: cliBoolean
       .optional()
       .describe("Generate and attach a Google Meet link to the event"),
+    removeGoogleMeet: cliBoolean
+      .optional()
+      .describe("Remove an attached Google Meet link from the event"),
     addZoom: cliBoolean
       .optional()
       .describe(
@@ -196,6 +199,11 @@ export default defineAction({
     const ownerEmail = requireActionUserEmail();
     if (args.addGoogleMeet && args.addZoom) {
       throw new Error("Choose either Google Meet or Zoom, not both.");
+    }
+    if (args.addGoogleMeet && args.removeGoogleMeet) {
+      throw new Error(
+        "Choose either adding or removing Google Meet, not both.",
+      );
     }
     if (args.attendees !== undefined && args.addAttendees !== undefined) {
       throw new Error("Use either attendees or addAttendees, not both.");
@@ -258,6 +266,7 @@ export default defineAction({
       attendeesToAdd !== undefined ||
       Object.keys(reminderFields).length > 0 ||
       args.addGoogleMeet === true ||
+      args.removeGoogleMeet === true ||
       args.addZoom === true ||
       hasWorkingLocationPatch;
 
@@ -334,6 +343,7 @@ export default defineAction({
         args.reminderMinutes !== undefined ||
         args.reminderMethod !== undefined ||
         args.addGoogleMeet !== undefined ||
+        args.removeGoogleMeet !== undefined ||
         args.addZoom !== undefined ||
         args.recurrence !== undefined ||
         args.attendees !== undefined ||
@@ -625,6 +635,7 @@ export default defineAction({
             ? "all"
             : undefined),
         addGoogleMeet: args.addGoogleMeet,
+        removeGoogleMeet: args.removeGoogleMeet,
         scope: args.scope,
       });
     }
@@ -672,6 +683,7 @@ export default defineAction({
       hangoutLink: result.meetLink,
       meetingLink: zoomMeetingLink,
       conferenceData: result.conferenceData,
+      ...(args.removeGoogleMeet ? { removedGoogleMeet: true } : {}),
       ...returnedPatch,
       ...(guestNotification ? { guestNotification } : {}),
     };

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -305,6 +305,9 @@ export function EventDetailPanel({
         event,
         action: "update",
         updates,
+        recurrenceScope: isRecurringEvent
+          ? { enabled: true, defaultScope: "single" }
+          : undefined,
       });
       if (!guestNotification) return;
       updateEvent.mutate(
@@ -319,7 +322,7 @@ export function EventDetailPanel({
         },
       );
     })();
-  }, [event, promptGuestNotification, t, updateEvent]);
+  }, [event, isRecurringEvent, promptGuestNotification, t, updateEvent]);
 
   const handleToggleAttendeeOptional = useCallback(
     (email: string, optional: boolean) => {

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -102,19 +102,27 @@ function safeUrl(u: string | undefined): string {
   }
 }
 
-function extractMeetingLink(event: CalendarEvent): string | null {
+function extractMeetingLink(event: CalendarEvent): {
+  url: string;
+  type: "meet" | "other";
+} | null {
   const videoEntry = event.conferenceData?.entryPoints?.find(
     (entry) => entry.entryPointType === "video",
   );
-  if (videoEntry?.uri) return videoEntry.uri;
-  if (event.hangoutLink) return event.hangoutLink;
+  if (videoEntry?.uri)
+    return {
+      url: videoEntry.uri,
+      type: videoEntry.uri.includes("meet.google.com") ? "meet" : "other",
+    };
+  if (event.hangoutLink) return { url: event.hangoutLink, type: "meet" };
   const text = `${event.location || ""} ${event.description || ""}`;
-  return (
+  const url =
     text.match(/https?:\/\/[^\s]*zoom\.us\/j\/[^\s)"]*/i)?.[0] ||
     text.match(/https?:\/\/meet\.google\.com\/[^\s)"]*/i)?.[0] ||
-    text.match(/https?:\/\/teams\.microsoft\.com\/[^\s)"]*/i)?.[0] ||
-    null
-  );
+    text.match(/https?:\/\/teams\.microsoft\.com\/[^\s)"]*/i)?.[0];
+  return url
+    ? { url, type: url.includes("meet.google.com") ? "meet" : "other" }
+    : null;
 }
 
 export function EventDetailPanel({
@@ -150,6 +158,15 @@ export function EventDetailPanel({
   );
   const lastSavedDescriptionRef = useRef(event?.description || "");
   const meetingLink = event ? extractMeetingLink(event) : null;
+  const canRemoveGoogleMeet =
+    !isOverlay &&
+    meetingLink?.type === "meet" &&
+    (!!event?.hangoutLink ||
+      event?.conferenceData?.entryPoints?.some(
+        (entryPoint) =>
+          entryPoint.entryPointType === "video" &&
+          entryPoint.uri.includes("meet.google.com"),
+      ));
   const ownerLabel = event?.ownerName || event?.overlayEmail;
   const eventDetailSlotContext = useMemo(
     () => (event ? buildEventDetailSlotContext(event) : null),
@@ -279,6 +296,30 @@ export function EventDetailPanel({
       );
     })();
   }, [event, promptGuestNotification, updateEvent]);
+
+  const handleRemoveGoogleMeet = useCallback(() => {
+    if (!event || updateEvent.isPending) return;
+    void (async () => {
+      const updates = { removeGoogleMeet: true };
+      const guestNotification = await promptGuestNotification({
+        event,
+        action: "update",
+        updates,
+      });
+      if (!guestNotification) return;
+      updateEvent.mutate(
+        {
+          id: event.id,
+          accountEmail: event.accountEmail,
+          ...updates,
+          ...guestNotification,
+        },
+        {
+          onError: () => toast.error(t("eventForm.updateFailed")),
+        },
+      );
+    })();
+  }, [event, promptGuestNotification, t, updateEvent]);
 
   const handleToggleAttendeeOptional = useCallback(
     (email: string, optional: boolean) => {
@@ -521,15 +562,31 @@ export function EventDetailPanel({
 
                 {!isWorkingLocation &&
                   (meetingLink ? (
-                    <a
-                      href={safeUrl(meetingLink)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-center rounded-lg bg-[#4965E0] px-3 py-2 text-sm font-semibold text-white hover:bg-[#5A75F0]"
-                    >
-                      <IconVideo className="mr-2 h-4 w-4 opacity-80" />
-                      {t("eventForm.joinMeeting")}
-                    </a>
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={safeUrl(meetingLink.url)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex min-w-0 flex-1 items-center justify-center rounded-lg bg-conference px-3 py-2 text-sm font-semibold text-conference-foreground hover:bg-conference/90"
+                      >
+                        <IconVideo className="mr-2 h-4 w-4 opacity-80" />
+                        {t("eventForm.joinMeeting")}
+                      </a>
+                      {canRemoveGoogleMeet && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="size-9 shrink-0"
+                          aria-label={`${t("eventForm.delete")} ${t("eventForm.googleMeet")}`}
+                          title={`${t("eventForm.delete")} ${t("eventForm.googleMeet")}`}
+                          disabled={updateEvent.isPending}
+                          onClick={handleRemoveGoogleMeet}
+                        >
+                          <IconX className="size-4" />
+                        </Button>
+                      )}
+                    </div>
                   ) : !isOverlay ? (
                     <Button
                       type="button"

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -880,6 +880,64 @@ describe("EventDetailPopover characterization", () => {
     );
   });
 
+  it("offers series scope before removing Google Meet from a recurring event", async () => {
+    const event = baseEvent({
+      id: "event-recurring",
+      accountEmail: "steve@example.com",
+      recurringEventId: "series-1",
+      hangoutLink: "https://meet.google.com/abc-defg-hij",
+    });
+
+    act(() => {
+      root.render(
+        <EventDetailPopover
+          event={event}
+          defaultOpen
+          onDelete={() => undefined}
+        >
+          <button type="button">Open</button>
+        </EventDetailPopover>,
+      );
+    });
+
+    const removeButton = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="eventForm.delete eventForm.googleMeet"]',
+    );
+    expect(removeButton).toBeTruthy();
+
+    await act(async () => {
+      removeButton!.click();
+      await flushMicrotasks();
+    });
+
+    expect(document.body.textContent).toContain("eventForm.applyChangesTo");
+    expect(document.body.textContent).toContain("eventForm.thisEvent");
+    expect(document.body.textContent).toContain("eventForm.allEvents");
+    expect(updateEventMutate).not.toHaveBeenCalled();
+
+    const allEventsOption = document.querySelector<HTMLButtonElement>(
+      "#guest-update-scope-all",
+    );
+    expect(allEventsOption).toBeTruthy();
+    act(() => allEventsOption!.click());
+
+    const confirmButton = findByExactText("button", "eventForm.updateEvent");
+    expect(confirmButton).toBeTruthy();
+    await act(async () => {
+      confirmButton!.click();
+      await flushMicrotasks();
+    });
+
+    expect(updateEventMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "event-recurring",
+        removeGoogleMeet: true,
+        scope: "all",
+      }),
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+  });
+
   it("opens the meeting link on Cmd+J while open, and removes the listener on unmount", () => {
     const event = baseEvent({
       id: "event-4",

--- a/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.test.tsx
@@ -921,7 +921,10 @@ describe("EventDetailPopover characterization", () => {
     expect(allEventsOption).toBeTruthy();
     act(() => allEventsOption!.click());
 
-    const confirmButton = findByExactText("button", "eventForm.updateEvent");
+    const confirmButton = findByExactText<HTMLButtonElement>(
+      "button",
+      "eventForm.updateEvent",
+    );
     expect(confirmButton).toBeTruthy();
     await act(async () => {
       confirmButton!.click();

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -824,7 +824,9 @@ export function EventDetailPopover({
             : notificationUpdates;
           const shouldChooseGuestScope =
             isRecurringEvent &&
-            ("attendees" in updates || "addAttendees" in updates);
+            ("attendees" in updates ||
+              "addAttendees" in updates ||
+              "removeGoogleMeet" in updates);
           const guestNotification = await promptGuestNotification({
             event,
             action: "update",
@@ -1103,6 +1105,9 @@ export function EventDetailPopover({
           event,
           action: "update",
           updates,
+          recurrenceScope: isRecurringEvent
+            ? { enabled: true, defaultScope: "single" }
+            : undefined,
         });
         if (!guestNotification) {
           endAction();
@@ -1124,7 +1129,15 @@ export function EventDetailPopover({
         endAction();
       }
     })();
-  }, [beginAction, endAction, event, promptGuestNotification, t, updateEvent]);
+  }, [
+    beginAction,
+    endAction,
+    event,
+    isRecurringEvent,
+    promptGuestNotification,
+    t,
+    updateEvent,
+  ]);
 
   const handleSaveDescription = useCallback(() => {
     const trimmed = editDescription.trim();

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -307,6 +307,7 @@ type ReminderValue =
 
 type EventUpdatePatch = Partial<CalendarEvent> & {
   addGoogleMeet?: boolean;
+  removeGoogleMeet?: boolean;
   addZoom?: boolean;
   addAttendees?: CalendarEvent["attendees"];
   targetAccountEmail?: string;
@@ -764,6 +765,15 @@ export function EventDetailPopover({
   }, [editingField]);
 
   const meetingLink = extractMeetingLink(event);
+  const canRemoveGoogleMeet =
+    !isOverlay &&
+    meetingLink?.type === "meet" &&
+    (!!event.hangoutLink ||
+      event.conferenceData?.entryPoints?.some(
+        (entryPoint) =>
+          entryPoint.entryPointType === "video" &&
+          entryPoint.uri.includes("meet.google.com"),
+      ));
   // On a draft, a chosen provider isn't created until the event is saved. Show
   // it as already attached (with a remove control) rather than as a placeholder.
   const pendingConferenceProvider =
@@ -1083,6 +1093,38 @@ export function EventDetailPopover({
     if (!event.id) return;
     onDraftUpdate?.(event.id, { addGoogleMeet: false, addZoom: false });
   }, [event.id, onDraftUpdate]);
+
+  const handleRemoveGoogleMeet = useCallback(() => {
+    if (!event.id || updateEvent.isPending || !beginAction()) return;
+    void (async () => {
+      try {
+        const updates = { removeGoogleMeet: true };
+        const guestNotification = await promptGuestNotification({
+          event,
+          action: "update",
+          updates,
+        });
+        if (!guestNotification) {
+          endAction();
+          return;
+        }
+        updateEvent.mutate(
+          {
+            id: event.id,
+            accountEmail: event.accountEmail,
+            ...updates,
+            ...guestNotification,
+          },
+          {
+            onError: () => toast.error(t("eventForm.updateFailed")),
+            onSettled: endAction,
+          },
+        );
+      } catch {
+        endAction();
+      }
+    })();
+  }, [beginAction, endAction, event, promptGuestNotification, t, updateEvent]);
 
   const handleSaveDescription = useCallback(() => {
     const trimmed = editDescription.trim();
@@ -2058,23 +2100,39 @@ export function EventDetailPopover({
                 <>
                   <div className={eventPopoverDivider} />
                   <div className="px-4 py-1.5">
-                    <a
-                      href={meetingLink.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${eventPopoverPrimaryAction} relative bg-conference text-conference-foreground hover:bg-conference/90`}
-                    >
-                      <IconVideo className="mr-2 size-4 opacity-80" />
-                      <span>{getMeetingLabel(meetingLink.type, t)}</span>
-                      <span className="absolute right-2 hidden items-center gap-1 opacity-70 sm:flex">
-                        <kbd className="inline-flex size-4 items-center justify-center rounded bg-conference-foreground/20 text-[11px] font-medium">
-                          {shortcutModifierLabel()}
-                        </kbd>
-                        <kbd className="inline-flex size-4 items-center justify-center rounded bg-conference-foreground/20 text-[11px] font-medium">
-                          J
-                        </kbd>
-                      </span>
-                    </a>
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={meetingLink.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`${eventPopoverPrimaryAction} relative min-w-0 flex-1 bg-conference text-conference-foreground hover:bg-conference/90`}
+                      >
+                        <IconVideo className="mr-2 size-4 opacity-80" />
+                        <span>{getMeetingLabel(meetingLink.type, t)}</span>
+                        <span className="absolute right-2 hidden items-center gap-1 opacity-70 sm:flex">
+                          <kbd className="inline-flex size-4 items-center justify-center rounded bg-conference-foreground/20 text-[11px] font-medium">
+                            {shortcutModifierLabel()}
+                          </kbd>
+                          <kbd className="inline-flex size-4 items-center justify-center rounded bg-conference-foreground/20 text-[11px] font-medium">
+                            J
+                          </kbd>
+                        </span>
+                      </a>
+                      {canRemoveGoogleMeet && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          className="size-9 shrink-0"
+                          aria-label={`${t("eventForm.delete")} ${t("eventForm.googleMeet")}`}
+                          title={`${t("eventForm.delete")} ${t("eventForm.googleMeet")}`}
+                          disabled={mutationPending}
+                          onClick={handleRemoveGoogleMeet}
+                        >
+                          <IconX className="size-4" />
+                        </Button>
+                      )}
+                    </div>
                     {(meetingLink.pin || meetingLink.passcode) && (
                       <div className="mt-1.5 text-xs text-muted-foreground/60">
                         {meetingLink.pin && (

--- a/templates/calendar/app/components/calendar/GuestNotificationDialog.tsx
+++ b/templates/calendar/app/components/calendar/GuestNotificationDialog.tsx
@@ -25,6 +25,7 @@ export interface GuestNotificationOptions {
 
 type GuestPromptUpdates = Partial<CalendarEvent> & {
   addGoogleMeet?: boolean;
+  removeGoogleMeet?: boolean;
   addZoom?: boolean;
 };
 

--- a/templates/calendar/app/components/layout/AppLayout.spec.ts
+++ b/templates/calendar/app/components/layout/AppLayout.spec.ts
@@ -7,6 +7,12 @@ function appLayoutSource(): string {
 }
 
 describe("Calendar app navigation", () => {
+  it("lets the calendar page own the /home toolbar", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain('pathname === "/" || pathname === "/home"');
+  });
+
   it("collapses the native sidebar while the per-app chat is open", () => {
     const source = appLayoutSource();
 

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -44,7 +44,7 @@ const BARE_ROUTES = new Set(["/event"]);
  * AgentSidebar, but skips its own header so there's no double-header.
  */
 function pageOwnsToolbar(pathname: string): boolean {
-  if (pathname === "/") return true;
+  if (pathname === "/" || pathname === "/home") return true;
   if (pathname === "/extensions" || pathname.startsWith("/extensions/"))
     return true;
   return false;

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -47,6 +47,7 @@ type UpdateEventInput = Partial<CalendarEvent> & {
   id: string;
   targetAccountEmail?: string;
   addGoogleMeet?: boolean;
+  removeGoogleMeet?: boolean;
   addZoom?: boolean;
   addAttendees?: CalendarEvent["attendees"];
   sendUpdates?: "all" | "none";
@@ -71,6 +72,7 @@ type UpdateEventResult = Partial<CalendarEvent> & {
   success?: boolean;
   updated?: string[];
   message?: string;
+  removedGoogleMeet?: boolean;
 };
 
 const LIST_EVENTS_QUERY_KEY = ["action", "list-events"] as const;
@@ -379,6 +381,7 @@ export function useUpdateEvent() {
         });
         const {
           addGoogleMeet,
+          removeGoogleMeet,
           addZoom,
           addAttendees,
           targetAccountEmail,
@@ -389,7 +392,14 @@ export function useUpdateEvent() {
           workingLocationLabel,
           ...optimisticData
         } = newData;
-        const optimisticPatch = targetAccountEmail ? {} : optimisticData;
+        const optimisticPatch = targetAccountEmail
+          ? {}
+          : {
+              ...optimisticData,
+              ...(removeGoogleMeet
+                ? { hangoutLink: undefined, conferenceData: undefined }
+                : {}),
+            };
         const hasWorkingLocationUpdate =
           workingLocationType !== undefined ||
           workingLocationLabel !== undefined;
@@ -476,6 +486,7 @@ export function reconcileUpdatedEventList(
     success: _success,
     updated: _updated,
     message: _message,
+    removedGoogleMeet: _removedGoogleMeet,
     replacedId,
     ...eventPatch
   } = result;

--- a/templates/calendar/changelog/2026-08-31-calendar-no-longer-shows-duplicate-agent-controls-on-home-an.md
+++ b/templates/calendar/changelog/2026-08-31-calendar-no-longer-shows-duplicate-agent-controls-on-home-an.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-31
+---
+
+Calendar no longer shows duplicate agent controls on Home and can remove saved Google Meet links

--- a/templates/calendar/server/lib/google-calendar.spec.ts
+++ b/templates/calendar/server/lib/google-calendar.spec.ts
@@ -1119,6 +1119,32 @@ describe("calendar recurring event updates", () => {
     );
   });
 
+  it("clears Google Meet data when removing a conference", async () => {
+    await updateEvent(
+      "event-1",
+      { accountEmail: "steve@example.com" },
+      {
+        account: {
+          ownerEmail: "steve@example.com",
+          accountEmail: "steve@example.com",
+        },
+        removeGoogleMeet: true,
+      },
+    );
+
+    expect(calendarPatchEventMock).toHaveBeenCalledWith(
+      "access-token",
+      "primary",
+      "event-1",
+      { conferenceData: null },
+      {
+        sendUpdates: undefined,
+        conferenceDataVersion: 1,
+        supportsAttachments: undefined,
+      },
+    );
+  });
+
   it("removes selected and later materialized exceptions when deleting this and following", async () => {
     calendarGetEventMock
       .mockResolvedValueOnce({

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -1528,6 +1528,7 @@ export async function updateEvent(
     account: GoogleAccountSelection;
     sendUpdates?: "all" | "none";
     addGoogleMeet?: boolean;
+    removeGoogleMeet?: boolean;
     scope?: UpdateEventScope;
   },
 ): Promise<{
@@ -1611,6 +1612,8 @@ export async function updateEvent(
   applyEventPatchOptions(requestBody, eventPatch);
   if (options?.addGoogleMeet) {
     requestBody.conferenceData = createGoogleMeetRequest();
+  } else if (options?.removeGoogleMeet) {
+    requestBody.conferenceData = null;
   }
 
   // Google validates status events as complete resources during updates. A
@@ -1631,7 +1634,8 @@ export async function updateEvent(
         },
         {
           sendUpdates: options?.sendUpdates,
-          conferenceDataVersion: options?.addGoogleMeet ? 1 : undefined,
+          conferenceDataVersion:
+            options?.addGoogleMeet || options?.removeGoogleMeet ? 1 : undefined,
           supportsAttachments:
             eventPatch.attachments !== undefined ? true : undefined,
         },
@@ -1643,7 +1647,8 @@ export async function updateEvent(
         requestBody,
         {
           sendUpdates: options?.sendUpdates,
-          conferenceDataVersion: options?.addGoogleMeet ? 1 : undefined,
+          conferenceDataVersion:
+            options?.addGoogleMeet || options?.removeGoogleMeet ? 1 : undefined,
           supportsAttachments:
             eventPatch.attachments !== undefined ? true : undefined,
         },

--- a/templates/mail/server/lib/google-auth.spec.ts
+++ b/templates/mail/server/lib/google-auth.spec.ts
@@ -16,6 +16,7 @@ import {
 import {
   gmailBatchModifyByAccount,
   exchangeCode,
+  gmailToEmailMessage,
   getAuthUrl,
   getClientsWithErrors,
   listGmailMessages,
@@ -561,6 +562,32 @@ describe("listGmailMessages", () => {
       q: "",
       maxResults: 3,
       pageToken: undefined,
+    });
+  });
+});
+
+describe("gmailToEmailMessage", () => {
+  it("preserves commas inside quoted sender names", () => {
+    const message = gmailToEmailMessage({
+      id: "message-1",
+      threadId: "thread-1",
+      internalDate: "1750000000000",
+      labelIds: ["INBOX"],
+      payload: {
+        headers: [
+          {
+            name: "From",
+            value: '"Cuevas, Gustavo" <cuevas@example.com>',
+          },
+          { name: "Date", value: "2025-06-15T12:00:00.000Z" },
+        ],
+      },
+      snippet: "",
+    });
+
+    expect(message.from).toEqual({
+      name: "Cuevas, Gustavo",
+      email: "cuevas@example.com",
     });
   });
 });

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -1738,13 +1738,62 @@ function getHeader(
 
 function parseEmailAddress(raw: string): { name: string; email: string } {
   const match = raw.match(/^(.+?)\s*<(.+?)>$/);
-  if (match) return { name: match[1].trim(), email: match[2].trim() };
+  if (match) {
+    const name = match[1].trim();
+    return {
+      name:
+        name.startsWith('"') && name.endsWith('"')
+          ? name.slice(1, -1).replace(/\\"/g, '"')
+          : name,
+      email: match[2].trim(),
+    };
+  }
   return { name: raw, email: raw };
+}
+
+function splitAddressList(raw: string): string[] {
+  const addresses: string[] = [];
+  let start = 0;
+  let inQuotes = false;
+  let inAngleBrackets = false;
+  let escaped = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && inQuotes) {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (!inQuotes && character === "<") {
+      inAngleBrackets = true;
+      continue;
+    }
+    if (!inQuotes && character === ">") {
+      inAngleBrackets = false;
+      continue;
+    }
+    if (!inQuotes && !inAngleBrackets && character === ",") {
+      addresses.push(raw.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  const last = raw.slice(start).trim();
+  if (last) addresses.push(last);
+  return addresses;
 }
 
 function parseAddressList(raw: string): Array<{ name: string; email: string }> {
   if (!raw) return [];
-  return raw.split(",").map((a) => parseEmailAddress(a.trim()));
+  return splitAddressList(raw).map(parseEmailAddress);
 }
 
 function getBody(payload: any): string {


### PR DESCRIPTION
## Summary

- Clarify `review-latest-feedback` so its bounded cursor is a start point, not a stop point, and require a per-parent eye, read-back, full-thread read, and explicit invoking-identity disposition.
- Fix Calendar duplicate Home agent controls and add removal for native Google Meet links, with action/client/server coverage.
- Fix Mail parsing for quoted sender names containing commas.
- Add the two Calendar fixes and the Mail-visible fix to the current Calendar changelog where changelog generation is enabled.

## Verification

- Calendar focused tests: 64 passed.
- Mail focused tests: 25 passed.
- Calendar and Mail typechecks: passed after building the missing local Scheduling workspace output; local production warnings only report intentionally absent auth/database settings.
- `corepack pnpm guards`: all 65 checks passed.
- Local Calendar `/home` render: exactly one `Toggle agent` button.

## Slack feedback handoff

- Source: `#product-agent-native-feedback` (`C0ATH3CCZT4`), Steve (`U0GCV21HC`).
- Bounded audit: Aug 29 00:00 PDT through Aug 31 latest. Start cursors: `1787986800`, `1788073200`, and `1788159600`; channel reads had no additional pages.
- 39 eligible clear-bug parents were read in full, marked with Steve `👀` where needed, and re-read after disposition writes. All 39 have Steve `👀` plus an explicit Steve disposition.
- Counts: 30 parents from Aug 31, 8 from Aug 30, and 1 safety-window parent from Aug 29.
- Existing merged fixes carried forward: Dispatch OAuth handoff in PR #3997; Clips Library/overlay fixes in PR #3988. The three tested fixes in this PR are currently marked In progress until this change lands.
- Design feedback remains routed to Sid; preference/product/copy items were excluded from the clear-bug ledger.

### Per-parent ledger

- [1788197456.251319](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788197456251319) - Slides Google SSO repeats sign-in - In progress
- [1788195863.035129](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788195863035129) - Slides Docs search repeats identical calls - In progress
- [1788193358.506679](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788193358506679) - Analytics GCP login does not persist - In progress
- [1788192174.146619](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788192174146619) - Slides reports failure after successful generation - In progress
- [1788191674.435189](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788191674435189) - Slides HTML/Google export failures - In progress
- [1788190909.947949](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788190909947949) - Calendar availability is slow and contradictory - In progress
- [1788190623.416909](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788190623416909) - Mail list 502s and stalled pagination - In progress
- [1788190587.691269](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788190587691269) - Mail sender names lose quoted commas - In progress - tested fix in this PR
- [1788190558.772019](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788190558772019) - Mail provider busy response has no retry - In progress
- [1788189529.052879](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788189529052879) - Gmail Connect fails while Calendar works - In progress
- [1788188911.761189](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788188911761189) - Slides shows Connect CTA while connected - In progress
- [1788188897.398229](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788188897398229) - Dispatch browser login handoff - Fixed - merged PR #3997
- [1788185972.547079](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788185972547079) - Workspace Slack notifications use Fusion Analytics - In progress
- [1788183372.848059](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788183372848059) - Hosted Custom App action/state handling - In progress
- [1788182322.610929](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788182322610929) - Hosted Custom App incorrectly rejects org owner - In progress
- [1788178610.555259](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788178610555259) - Slides history and restore - In progress
- [1788175225.575269](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788175225575269) - Calendar Stop generating closes app - In progress
- [1788174347.091259](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788174347091259) - Calendar Zoom authorization - In progress
- [1788173517.411579](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788173517411579) - Calendar cannot remove saved Google Meet - In progress - tested fix in this PR
- [1788172926.817029](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788172926817029) - Login screen has no return to main menu - In progress
- [1788171854.838079](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788171854838079) - Slides Stop generating quits app - In progress
- [1788171389.369899](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788171389369899) - Analytics transient Untitled Dashboard - In progress
- [1788170906.564889](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788170906564889) - Clips extension restart recording error - In progress
- [1788170795.295879](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788170795295879) - Mail light mode reverts to dark - In progress
- [1788170663.717529](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788170663717529) - Clips Library 500 after deleting recording - Fixed - merged PR #3988
- [1788164641.576269](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788164641576269) - Clips video overlay before playback - Fixed - merged PR #3988
- [1788164321.897789](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788164321897789) - Calendar All chats closes menu - In progress
- [1788163662.889169](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788163662889169) - Calendar Home has duplicate agent control - In progress - tested fix in this PR
- [1788163032.570289](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788163032570289) - Slides viewer can try an editor-only action - In progress
- [1788161014.901019](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788161014901019) - Slides editor and presentation links match - In progress
- [1788157203.017569](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788157203017569) - Slides image generation and AI provider selection - In progress
- [1788148887.548349](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788148887548349) - Slides blank manually added slide - In progress
- [1788148306.384269](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788148306384269) - Slides ignores requested 100-page count - In progress
- [1788143719.008209](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788143719008209) - Slides rejects supplied typography weights - In progress
- [1788142654.305349](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788142654305349) - Slides wrong structure and page count - In progress
- [1788141477.104309](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788141477104309) - Slides attachment storage failure is hidden - In progress
- [1788110385.487729](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788110385487729) - Slides Submit stays disabled - In progress
- [1788079123.243359](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788079123243359) - Slides Google Slides link upload - In progress
- [1788013640.082899](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788013640082899) - Slides .fig upload returns 502 - In progress

