### PR TITLE
docs: reorder Toolkit in docs navigation

### DIFF
--- a/packages/docs/app/components/DocsSidebar.test.tsx
+++ b/packages/docs/app/components/DocsSidebar.test.tsx
@@ -139,9 +139,13 @@ describe("DocsSidebar", () => {
       "environment-variables",
       "agent-native-config",
     ]);
-    expect(sectionIds.indexOf("toolkits")).toBeLessThan(
-      sectionIds.indexOf("apps"),
-    );
+    expect(sectionIds.slice(0, 5)).toEqual([
+      "overview",
+      "deployment",
+      "core-architecture",
+      "toolkits",
+      "apps",
+    ]);
   });
 
   it("uses the Agent Resources section and canonical overview link", () => {
@@ -198,6 +202,7 @@ describe("DocsSidebar", () => {
     for (const item of toolkitLinks) {
       expect(html).toContain(`href="${item.to}"`);
     }
+    expect(html).not.toContain('href="/docs/custom-design-system/"');
 
     const activeLink = getLinkMarkup(html, "/docs/toolkit-collaboration/");
     expect(activeLink).toContain("is-active");

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -902,11 +902,6 @@ const NAV_SECTION_CONFIG: NavSectionConfig[] = [
         slug: "toolkit-ui",
       },
       {
-        id: "custom-design-system",
-        labelKey: "customDesignSystem",
-        slug: "custom-design-system",
-      },
-      {
         id: "toolkit-editors-canvases",
         labelKey: "toolkitEditorsCanvases",
         slug: "toolkit-editors-canvases",
@@ -1060,19 +1055,22 @@ function navLabel(t: Translate, key: keyof typeof enUS.nav): string {
 
 const SHOW_DRAFTS = import.meta.env.VITE_SHOW_DRAFTS === "true";
 
-// Keep the public template catalog after the framework/toolkit guidance so
+// Keep the public template catalog after the framework and toolkit guidance so
 // readers encounter architecture and reusable primitives before app examples.
 const NAV_SECTION_CONFIG_IN_DISPLAY_ORDER = (() => {
   const appsSection = NAV_SECTION_CONFIG.find(
     (section) => section.id === "apps",
   );
-  if (!appsSection) return NAV_SECTION_CONFIG;
+  const toolkitsSection = NAV_SECTION_CONFIG.find(
+    (section) => section.id === "toolkits",
+  );
+  if (!appsSection || !toolkitsSection) return NAV_SECTION_CONFIG;
 
   return NAV_SECTION_CONFIG.flatMap((section) =>
-    section.id === "apps"
+    section.id === "apps" || section.id === "toolkits"
       ? []
-      : section.id === "toolkits"
-        ? [section, appsSection]
+      : section.id === "core-architecture"
+        ? [section, toolkitsSection, appsSection]
         : [section],
   );
 })();


### PR DESCRIPTION
## Summary

- Move Toolkit directly below Core Architecture in the docs sidebar.
- Remove Custom Design Systems from the Toolkit navigation.

## Validation

- `corepack pnpm --filter @agent-native/docs exec vitest run app/components/DocsSidebar.test.tsx`
- `corepack pnpm --filter @agent-native/docs typecheck`
- `corepack pnpm exec oxfmt --check packages/docs/app/components/docsNavItems.ts packages/docs/app/components/DocsSidebar.test.tsx`