### PR TITLE
Homepage responsive polish: hero fluid scaling, built-in features grid, brand-name wrap fix

### DIFF
--- a/packages/docs/app/components/website-redesign/built-in-features.tsx
+++ b/packages/docs/app/components/website-redesign/built-in-features.tsx
@@ -1,7 +1,6 @@
 import { useT } from "@agent-native/core/client/i18n";
 
 import { BuilderImage } from "../builder-image";
-import { ImgPlaceholder } from "./ds/img-placeholder";
 import { GridInner, PageSection } from "./page-grid";
 
 interface Pillar {
@@ -12,32 +11,34 @@ interface Pillar {
   lightImage?: string;
 }
 
-const PILLAR_ROWS: Pillar[][] = [
-  [
-    {
-      id: "reactUi",
-      darkImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fa06ad4fe59284a74a990a1f7002eece4",
-      lightImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9bcf96ce33d84249ab3b1615e713d38e",
-    },
-    {
-      id: "agentChat",
-      darkImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F3f97027653004b2da9ac0a7ddbe2e01b",
-      lightImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F78ea47b65fa840b4b40a65c9ccc443f6",
-    },
-    {
-      id: "sharedState",
-      darkImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F4d4986fc4c2447d0b39260aa65df823a",
-      lightImage:
-        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Ff291129737ef48c9a77badc32c1d9df8",
-    },
-  ],
-  [{ id: "sharedSql" }, { id: "skillsMemory" }, { id: "automations" }],
-  [{ id: "agentTeams" }, { id: "auth" }, { id: "sharing" }],
+const PILLARS: Pillar[] = [
+  {
+    id: "reactUi",
+    darkImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fa06ad4fe59284a74a990a1f7002eece4",
+    lightImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9bcf96ce33d84249ab3b1615e713d38e",
+  },
+  {
+    id: "agentChat",
+    darkImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F3f97027653004b2da9ac0a7ddbe2e01b",
+    lightImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F78ea47b65fa840b4b40a65c9ccc443f6",
+  },
+  {
+    id: "sharedState",
+    darkImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F4d4986fc4c2447d0b39260aa65df823a",
+    lightImage:
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Ff291129737ef48c9a77badc32c1d9df8",
+  },
+  { id: "sharedSql" },
+  { id: "skillsMemory" },
+  { id: "automations" },
+  { id: "agentTeams" },
+  { id: "auth" },
+  { id: "sharing" },
 ];
 
 export function BuiltInFeatures() {
@@ -55,70 +56,81 @@ export function BuiltInFeatures() {
       </GridInner>
 
       <GridInner>
-        <div className="border-x border-b border-solid border-[var(--b-border-subtle)]">
-          {PILLAR_ROWS.map((row, rowIndex) => (
+        {/* Dividers are a 1px gap over the border color, with each cell
+            painting its own page-bg on top — not per-cell border-right/
+            border-bottom, so a line only ever appears between cells that
+            end up adjacent regardless of column count. Illustrations are
+            hidden below the 3-column layout (see mobile:hidden below), so
+            every card below that is plain text — a 2-column reflow can't
+            pair a tall illustrated card with a short text-only one because
+            there's no illustrated card left to mismatch. */}
+        <div className="grid grid-cols-3 gap-px border border-solid border-[var(--b-border-subtle)] bg-[var(--b-border-subtle)] mobile:grid-cols-2 narrow:grid-cols-1">
+          {PILLARS.map((pillar) => (
             <div
-              key={row.map((pillar) => pillar.id).join("-")}
-              className="border-t border-solid border-[var(--b-border-subtle)]"
+              key={pillar.id}
+              className="flex flex-col bg-[var(--b-bg-page)]"
             >
-              {/* Column dividers are a border-right on the non-last cells of a
-                  real 3-track grid — the same technique the page gridlines use,
-                  so both round sub-pixel track remainders identically and the
-                  lines stay aligned. */}
-              <div className="grid grid-cols-3 [&>*:not(:last-child)]:border-r [&>*:not(:last-child)]:border-solid [&>*:not(:last-child)]:border-[var(--b-border-subtle)] mobile:grid-cols-2 narrow:grid-cols-1 narrow:[&>*:not(:last-child)]:border-b narrow:[&>*:not(:last-child)]:border-solid narrow:[&>*:not(:last-child)]:border-[var(--b-border-subtle)] narrow:[&>*]:border-r-0">
-                {row.map((pillar) => (
-                  <div
-                    key={pillar.id}
-                    className="flex flex-col bg-[var(--b-bg-page)]"
-                  >
-                    {rowIndex === 0 &&
-                      (pillar.darkImage && pillar.lightImage ? (
-                        <div className="relative mt-[var(--spacing-8)] mobile:mt-0">
-                          <BuilderImage
-                            className="theme-img-dark relative block aspect-[104/75] w-full object-cover"
-                            src={pillar.darkImage}
-                            alt=""
-                            crossOrigin="anonymous"
-                            sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                          <BuilderImage
-                            className="theme-img-light absolute inset-0 block h-full w-full object-cover"
-                            src={pillar.lightImage}
-                            alt=""
-                            crossOrigin="anonymous"
-                            sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                        </div>
-                      ) : pillar.image ? (
-                        <BuilderImage
-                          className="block aspect-[104/75] w-full object-cover"
-                          src={pillar.image}
-                          alt=""
-                          crossOrigin="anonymous"
-                          sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : (
-                        <ImgPlaceholder aspectRatio="104 / 75" label="" />
-                      ))}
-                    <div className="flex flex-col gap-[var(--spacing-2)] p-[var(--spacing-8)]">
-                      <h3 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-6)] font-medium leading-[1.15] tracking-[-0.02em] text-[var(--b-text-primary)]">
-                        {t(`homepage.builtIn.pillars.${pillar.id}.title`)}
-                      </h3>
-                      <p className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)] leading-[1.4] text-[var(--b-text-secondary)]">
-                        {t(`homepage.builtIn.pillars.${pillar.id}.body`)}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+              {pillar.darkImage && pillar.lightImage ? (
+                // Hidden below the 3-column layout: the fixed-size heading/
+                // body text doesn't shrink at narrower widths, so keeping
+                // the illustration at its designed size (rather than
+                // growing it to fill an ever-wider single/double-column
+                // card) would still leave it oversized relative to the text.
+                <div className="relative mt-[var(--spacing-8)] w-full max-w-[433px] mobile:hidden">
+                  <BuilderImage
+                    className="theme-img-dark relative block aspect-[104/75] w-full object-cover"
+                    src={pillar.darkImage}
+                    alt=""
+                    crossOrigin="anonymous"
+                    sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                  <BuilderImage
+                    className="theme-img-light absolute inset-0 block h-full w-full object-cover"
+                    src={pillar.lightImage}
+                    alt=""
+                    crossOrigin="anonymous"
+                    sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
+                    loading="lazy"
+                    decoding="async"
+                  />
+                </div>
+              ) : pillar.image ? (
+                <BuilderImage
+                  className="block aspect-[104/75] w-full max-w-[433px] object-cover mobile:hidden"
+                  src={pillar.image}
+                  alt=""
+                  crossOrigin="anonymous"
+                  sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, (max-width: 1300px) 33vw, 433px"
+                  loading="lazy"
+                  decoding="async"
+                />
+              ) : null}
+              <div className="flex flex-col gap-[var(--spacing-2)] p-[var(--spacing-8)]">
+                <h3 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-6)] font-medium leading-[1.15] tracking-[-0.02em] text-[var(--b-text-primary)]">
+                  {t(`homepage.builtIn.pillars.${pillar.id}.title`)}
+                </h3>
+                <p className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-2)] leading-[1.4] text-[var(--b-text-secondary)]">
+                  {t(`homepage.builtIn.pillars.${pillar.id}.body`)}
+                </p>
               </div>
             </div>
           ))}
+          {/* An odd pillar count leaves the 2-column layout with one card
+              alone in the final row. Left with no sibling, the empty cell
+              beside it would still show the grid's own background (the
+              divider color), with no card there to paint over it — a plain
+              spacer, painted the same page-bg as every card, fills that
+              slot instead of leaving it a mismatched color. There's no such
+              gap in the 3- or 1-column layouts, so the spacer only renders
+              at the 2-column breakpoint. */}
+          {PILLARS.length % 2 === 1 && (
+            <div
+              aria-hidden="true"
+              className="hidden bg-[var(--b-bg-page)] mobile:block narrow:hidden"
+            />
+          )}
         </div>
       </GridInner>
     </PageSection>

--- a/packages/docs/app/components/website-redesign/hero.tsx
+++ b/packages/docs/app/components/website-redesign/hero.tsx
@@ -14,18 +14,20 @@ export function Hero() {
       {/* No top border on the GridInner below: the sticky SiteHeader already
           draws the border directly above this section, so a second one would
           double the line. */}
-      <GridInner className="flex flex-col items-center gap-[var(--spacing-12)] px-[var(--spacing-10)] pt-[var(--spacing-60)] pb-[var(--spacing-40)]">
-        <div className="flex w-full max-w-[875px] flex-col items-center gap-[var(--spacing-6)]">
-          <h1 className="m-0 text-center font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-1)] font-medium leading-[1.05] tracking-[-0.02em] text-[var(--b-text-primary)] mobile:leading-[1.2]">
+      <GridInner className="flex flex-col items-center gap-[var(--b-hero-gap)] px-[var(--b-hero-px)] pt-[var(--b-hero-pt)] pb-[var(--b-hero-pb)]">
+        <div className="flex w-full flex-col items-center gap-[var(--b-hero-inner-gap)]">
+          <h1 className="m-0 text-center font-[family-name:var(--b-font-sans)] text-[length:var(--b-hero-title-size)] font-medium leading-[1.05] tracking-[-0.02em] text-[var(--b-text-primary)] mobile:leading-[1.2]">
             {t("homepage.hero.title")}
           </h1>
-          <p className="m-0 text-center font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-1)] leading-[1.3] text-[var(--b-text-primary)]">
-            {t("homepage.hero.bodyLine1")}
-            <br className="mobile:hidden" /> {t("homepage.hero.bodyLine2")}
+          <p className="m-0 w-full max-w-[750px] text-center font-[family-name:var(--b-font-sans)] text-[length:var(--b-hero-body-size)] leading-[1.6] text-[var(--b-text-secondary)]">
+            <span className="block text-balance">
+              {t("homepage.hero.bodyLine1")}
+            </span>
+            <span className="block">{t("homepage.hero.bodyLine2")}</span>
           </p>
         </div>
 
-        <div className="flex flex-col items-center gap-[var(--spacing-6)]">
+        <div className="flex flex-col items-center gap-[var(--b-hero-inner-gap)]">
           <StartCtas location="hero" />
           <InstallCommand />
         </div>

--- a/packages/docs/app/components/website-redesign/template-showcase.tsx
+++ b/packages/docs/app/components/website-redesign/template-showcase.tsx
@@ -177,7 +177,7 @@ export function TemplateShowcase() {
     <PageSection>
       <GridInner className="flex flex-col gap-[var(--spacing-6)] px-[var(--spacing-8)] pt-[var(--spacing-40)] pb-[var(--spacing-20)]">
         <h2 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-2)] font-medium leading-[1.05] tracking-[-0.02em] text-[var(--b-text-primary)]">
-          {t("homepage.showcase.title")}
+          {t("homepage.showcase.title").replace("Agent-Native", "Agent‑Native")}
         </h2>
         <p className="m-0 max-w-[633px] font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-paragraph-1)] leading-[1.4] text-[var(--b-text-secondary)]">
           {t("homepage.showcase.body")}

--- a/packages/docs/app/components/website-redesign/tokens.css
+++ b/packages/docs/app/components/website-redesign/tokens.css
@@ -222,6 +222,21 @@
      very different blends to land at the same visual weight. */
   --b-hero-ocean-opacity: 0.32;
 
+  /* Fluid scale for the hero only, not the shared heading/paragraph/spacing
+     tokens above: the hero's headline and padding need to grow past the
+     site's normal desktop ceiling without ever hitting the shared tokens'
+     hard mobile cliff at 768px, so each one interpolates continuously
+     between a floor (today's mobile value) and a ceiling (today's desktop
+     value, or higher for the title) instead of switching between two fixed
+     sizes. */
+  --b-hero-title-size: clamp(32px, 8vw, 64px);
+  --b-hero-body-size: clamp(16px, calc(14px + 0.5vw), 18px);
+  --b-hero-gap: clamp(24px, 6vw, 48px);
+  --b-hero-inner-gap: clamp(20px, calc(16px + 1vw), 24px);
+  --b-hero-px: clamp(24px, calc(8px + 4vw), 40px);
+  --b-hero-pt: clamp(96px, calc(-48px + 36vw), 240px);
+  --b-hero-pb: clamp(88px, calc(16px + 18vw), 160px);
+
   background: var(--b-bg-page);
   color: var(--b-text-primary);
   font-family: var(--b-font-sans);

--- a/packages/docs/app/components/website-redesign/tokens.css
+++ b/packages/docs/app/components/website-redesign/tokens.css
@@ -227,9 +227,8 @@
      site's normal desktop ceiling without ever hitting the shared tokens'
      hard mobile cliff at 768px, so each one interpolates continuously
      between a floor (today's mobile value) and a ceiling (today's desktop
-     value, or higher for the title) instead of switching between two fixed
-     sizes. */
-  --b-hero-title-size: clamp(32px, 8vw, 64px);
+     value) instead of switching between two fixed sizes. */
+  --b-hero-title-size: clamp(32px, 8vw, 56px);
   --b-hero-body-size: clamp(16px, calc(14px + 0.5vw), 18px);
   --b-hero-gap: clamp(24px, 6vw, 48px);
   --b-hero-inner-gap: clamp(20px, calc(16px + 1vw), 24px);


### PR DESCRIPTION
## Summary
- **Hero**: converts the h1/subtext font-size and section padding from the shared design tokens' hard 768px breakpoint to fluid `clamp()` scaling (now named `--b-hero-*` tokens in `tokens.css` instead of inline literals), fixes the hero subtext color/line-height to match the rest of the page's secondary text, and always renders the two-sentence subtext as separate lines instead of letting them run together below 768px.
- **Built-in features grid**: caps illustration size to its designed max (433px) instead of growing unbounded on wider single/double-column cards, and hides illustrations below the 3-column layout so a 2-column reflow never pairs an illustrated card with a text-only one.
- **Template showcase**: swaps in a non-breaking hyphen so "Agent-Native" in the showcase heading never wraps mid-word.

## Test plan
- [ ] Load the homepage locally (`pnpm --filter docs dev`) and resize the viewport across 375px, 480px, 600px, 768px, 1024px, 1440px, 1920px, confirming:
  - Hero h1/subtext scale smoothly with no jump at 768px
  - Built-in features grid reflows 3 → 2 → 1 columns cleanly with no orphaned/mismatched cards
  - "Built into every Agent-Native app" / showcase heading never breaks mid-word
- [ ] Verify light/dark theme parity for the hero and built-in features sections