### PR TITLE
fix(slides): allow SVG images to resize

### DIFF
--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -167,6 +167,7 @@ import {
   resolveSlideObjectContainingBlock,
   resizeSlideObjectMembers,
   resolveSlideClipboardElement,
+  restoreSlideObjectStyle,
   setSlideObjectDimension,
   SLIDE_OBJECT_PASTE_OFFSET,
   snapSlideObjectMove,
@@ -4656,7 +4657,7 @@ export default function SlideEditor({
         if (promotedToFreeform) {
           restorePromotedElement();
         } else {
-          if (!clone && origin) applyObjectGeometry(element, origin);
+          if (!clone && origin) restoreSlideObjectStyle(element, originalStyle);
           if (originalObjectId) {
             element.setAttribute("data-slide-object-id", originalObjectId);
           } else {
@@ -4962,7 +4963,7 @@ export default function SlideEditor({
         cancel: () => {
           if (promotedToFreeform) restorePromotedElement();
           else {
-            applyObjectGeometry(element, resizeOrigin);
+            restoreSlideObjectStyle(element, originalStyle);
             if (originalObjectId) {
               element.setAttribute("data-slide-object-id", originalObjectId);
             } else {

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -167,6 +167,7 @@ import {
   resolveSlideObjectContainingBlock,
   resizeSlideObjectMembers,
   resolveSlideClipboardElement,
+  setSlideObjectDimension,
   SLIDE_OBJECT_PASTE_OFFSET,
   snapSlideObjectMove,
   stripTransientSlideLayoutSpacers,
@@ -3829,7 +3830,11 @@ export default function SlideEditor({
         ) {
           continue;
         }
-        element.style.setProperty(stylePropertyName(property), value);
+        if (property === "width" || property === "height") {
+          setSlideObjectDimension(element, property, value);
+        } else {
+          element.style.setProperty(stylePropertyName(property), value);
+        }
       }
 
       if (
@@ -4380,8 +4385,8 @@ export default function SlideEditor({
     (element: HTMLElement, geometry: SlideObjectGeometry) => {
       element.style.left = `${geometry.x}px`;
       element.style.top = `${geometry.y}px`;
-      element.style.width = `${geometry.width}px`;
-      element.style.height = `${geometry.height}px`;
+      setSlideObjectDimension(element, "width", `${geometry.width}px`);
+      setSlideObjectDimension(element, "height", `${geometry.height}px`);
     },
     [],
   );
@@ -6529,7 +6534,11 @@ export default function SlideEditor({
         ) {
           continue;
         }
-        element.style.setProperty(stylePropertyName(property), value);
+        if (property === "width" || property === "height") {
+          setSlideObjectDimension(element, property, value);
+        } else {
+          element.style.setProperty(stylePropertyName(property), value);
+        }
       }
 
       if (

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -5102,6 +5102,12 @@ export default function SlideEditor({
           .map((member) => member.element.getAttribute("data-builder-id"))
           .filter((id): id is string => Boolean(id)),
       );
+      const originalStyles = new Map(
+        members.map((member) => [
+          member.objectId,
+          member.element.getAttribute("style"),
+        ]),
+      );
       const applyPlan = (plan: Map<string, SlideObjectGeometry>) => {
         for (const member of members) {
           const geometry = plan.get(member.objectId);
@@ -5156,6 +5162,12 @@ export default function SlideEditor({
           applyPlan(
             new Map(members.map((member) => [member.objectId, member.start])),
           );
+          for (const member of members) {
+            restoreSlideObjectStyle(
+              member.element,
+              originalStyles.get(member.objectId) ?? null,
+            );
+          }
           refreshMultiSelectionRects(selectedIds);
           return { handled: true };
         },

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -4383,11 +4383,20 @@ export default function SlideEditor({
   );
 
   const applyObjectGeometry = useCallback(
-    (element: HTMLElement, geometry: SlideObjectGeometry) => {
+    (
+      element: HTMLElement,
+      geometry: SlideObjectGeometry,
+      { overrideImageSizing = false }: { overrideImageSizing?: boolean } = {},
+    ) => {
       element.style.left = `${geometry.x}px`;
       element.style.top = `${geometry.y}px`;
-      setSlideObjectDimension(element, "width", `${geometry.width}px`);
-      setSlideObjectDimension(element, "height", `${geometry.height}px`);
+      if (overrideImageSizing) {
+        setSlideObjectDimension(element, "width", `${geometry.width}px`);
+        setSlideObjectDimension(element, "height", `${geometry.height}px`);
+      } else {
+        element.style.width = `${geometry.width}px`;
+        element.style.height = `${geometry.height}px`;
+      }
     },
     [],
   );
@@ -4935,7 +4944,9 @@ export default function SlideEditor({
           if (gesture.kind !== "resize")
             return { handled: false, reason: "unhandled" };
           ensureSlideObjectId(element);
-          applyObjectGeometry(element, gesture.rect);
+          applyObjectGeometry(element, gesture.rect, {
+            overrideImageSizing: true,
+          });
           const currentSelector = getBuilderSelector(element);
           if (currentSelector) {
             selectElementForStyling(element, currentSelector, "resizing");
@@ -5094,7 +5105,11 @@ export default function SlideEditor({
       const applyPlan = (plan: Map<string, SlideObjectGeometry>) => {
         for (const member of members) {
           const geometry = plan.get(member.objectId);
-          if (geometry) applyObjectGeometry(member.element, geometry);
+          if (geometry) {
+            applyObjectGeometry(member.element, geometry, {
+              overrideImageSizing: true,
+            });
+          }
         }
       };
 

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -34,6 +34,7 @@ import {
   resolveSlideObjectContainingBlock,
   resizeSlideObject,
   resizeSlideObjectMembers,
+  setSlideObjectDimension,
   snapSlideObjectMove,
   stripTransientSlideLayoutSpacers,
   SLIDE_OBJECT_PASTE_OFFSET,
@@ -55,6 +56,19 @@ function createFreeformObject(
 }
 
 describe("slide object interactions", () => {
+  it("lets explicit image sizing override image size caps", () => {
+    const image = document.createElement("img");
+    image.style.setProperty("height", "auto", "important");
+    image.style.setProperty("max-height", "32px", "important");
+
+    setSlideObjectDimension(image, "height", "64px");
+
+    expect(image.style.getPropertyValue("height")).toBe("64px");
+    expect(image.style.getPropertyPriority("height")).toBe("important");
+    expect(image.style.getPropertyValue("max-height")).toBe("none");
+    expect(image.style.getPropertyPriority("max-height")).toBe("important");
+  });
+
   it("rejects nesting into void layer targets while keeping containers valid", () => {
     expect(canDropSlideLayerInside(document.createElement("img"))).toBe(false);
     expect(canDropSlideLayerInside(document.createElement("p"))).toBe(false);

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -82,6 +82,31 @@ describe("slide object interactions", () => {
     expect(image.getAttribute("style")).toBe(originalStyle);
   });
 
+  it("restores each capped image after a canceled group resize", () => {
+    const images = [
+      document.createElement("img"),
+      document.createElement("img"),
+    ];
+    const originalStyles = images.map(
+      (image, index) =>
+        `position:absolute;left:${index * 40}px;width:260px;height:auto!important;max-height:32px!important;`,
+    );
+    images.forEach((image, index) =>
+      image.setAttribute("style", originalStyles[index]),
+    );
+
+    for (const image of images) {
+      setSlideObjectDimension(image, "height", "64px");
+    }
+    images.forEach((image, index) =>
+      restoreSlideObjectStyle(image, originalStyles[index]),
+    );
+
+    expect(images.map((image) => image.getAttribute("style"))).toEqual(
+      originalStyles,
+    );
+  });
+
   it("rejects nesting into void layer targets while keeping containers valid", () => {
     expect(canDropSlideLayerInside(document.createElement("img"))).toBe(false);
     expect(canDropSlideLayerInside(document.createElement("p"))).toBe(false);

--- a/templates/slides/app/components/editor/slide-object-interactions.test.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.test.ts
@@ -32,6 +32,7 @@ import {
   preserveSlideObjectLayoutSpacer,
   removeSlideObjectAndLayoutSpacer,
   resolveSlideObjectContainingBlock,
+  restoreSlideObjectStyle,
   resizeSlideObject,
   resizeSlideObjectMembers,
   setSlideObjectDimension,
@@ -67,6 +68,18 @@ describe("slide object interactions", () => {
     expect(image.style.getPropertyPriority("height")).toBe("important");
     expect(image.style.getPropertyValue("max-height")).toBe("none");
     expect(image.style.getPropertyPriority("max-height")).toBe("important");
+  });
+
+  it("restores capped image styles after a canceled resize", () => {
+    const image = document.createElement("img");
+    const originalStyle =
+      "position:absolute;width:260px;height:auto!important;max-width:260px!important;max-height:32px!important;";
+    image.setAttribute("style", originalStyle);
+
+    setSlideObjectDimension(image, "height", "64px");
+    restoreSlideObjectStyle(image, originalStyle);
+
+    expect(image.getAttribute("style")).toBe(originalStyle);
   });
 
   it("rejects nesting into void layer targets while keeping containers valid", () => {

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -131,6 +131,14 @@ export function setSlideObjectDimension(
   element.style.setProperty(property, value);
 }
 
+export function restoreSlideObjectStyle(
+  element: HTMLElement,
+  style: string | null,
+): void {
+  if (style === null) element.removeAttribute("style");
+  else element.setAttribute("style", style);
+}
+
 export function createSlideObjectPlacementGeometry(
   start: { x: number; y: number },
   end: { x: number; y: number },

--- a/templates/slides/app/components/editor/slide-object-interactions.ts
+++ b/templates/slides/app/components/editor/slide-object-interactions.ts
@@ -118,6 +118,19 @@ export interface SlideObjectGeometry {
   height: number;
 }
 
+export function setSlideObjectDimension(
+  element: HTMLElement,
+  property: "width" | "height",
+  value: string,
+): void {
+  if (element.tagName === "IMG") {
+    element.style.setProperty(`max-${property}`, "none", "important");
+    element.style.setProperty(property, value, "important");
+    return;
+  }
+  element.style.setProperty(property, value);
+}
+
 export function createSlideObjectPlacementGeometry(
   start: { x: number; y: number },
   end: { x: number; y: number },


### PR DESCRIPTION
## Summary
- make explicit image width and height edits override authored max-size and auto-size constraints
- apply the shared sizing behavior to drag handles and toolbar dimensions
- add a regression test for capped image dimensions

## Validation
- corepack pnpm --dir templates/slides exec vitest --run app/components/editor/slide-object-interactions.test.ts
- corepack pnpm --dir templates/slides typecheck
- corepack pnpm guards

The authenticated browser session used for the Slack reproduction was unavailable for a post-fix render; the regression covers the sizing boundary directly.