### PR TITLE
fix(core): keep Amplify SSE connections alive

### DIFF
--- a/.changeset/keep-amplify-sse-alive.md
+++ b/.changeset/keep-amplify-sse-alive.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep framework SSE connections alive through idle edge timeouts.

--- a/packages/core/docs/content/aws-amplify.mdx
+++ b/packages/core/docs/content/aws-amplify.mdx
@@ -155,6 +155,21 @@ See [SSR Caching](/docs/ssr-caching) for the shared policy and
 [Amplify's cache-key documentation](https://docs.aws.amazon.com/amplify/latest/userguide/cache-key-cookies.html)
 for the hosting setting.
 
+## Streaming requests
+
+Nitro's agent-chat and framework sync endpoints use `text/event-stream` and
+are intentionally private and non-cacheable. The framework sends a named
+keepalive frame every ten seconds on the shared sync stream so an idle
+connection stays open through CloudFront; keep these routes out of custom
+cache rules. The public SSR shell and hashed assets remain edge-cacheable.
+
+Amplify compute instances can run for up to 15 minutes, but that is the
+compute lifetime, not a guarantee that a browser connection may stay silent
+for 15 minutes. Emit progress or keepalive frames more frequently than the
+edge origin read timeout when a long operation has no user-visible output.
+See [AWS's Amplify deployment specification](https://docs.aws.amazon.com/amplify/latest/userguide/ssr-deployment-specification.html)
+and [CloudFront's origin timeout guidance](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html).
+
 ## Verify the deployment
 
 After the first build, check the public URL and confirm that:

--- a/packages/core/docs/content/locales/ar-SA/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/ar-SA/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/de-DE/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/de-DE/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/es-ES/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/es-ES/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/fr-FR/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/fr-FR/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/hi-IN/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/hi-IN/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/ja-JP/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/ja-JP/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/ko-KR/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/ko-KR/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/pt-BR/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/pt-BR/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/zh-CN/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/zh-CN/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/docs/content/locales/zh-TW/aws-amplify.mdx
+++ b/packages/core/docs/content/locales/zh-TW/aws-amplify.mdx
@@ -18,4 +18,4 @@ The framework uses Nitro's Node.js 24 compute runtime and
 `AMPLIFY_MONOREPO_APP_ROOT=templates/calendar` for the calendar monorepo build.
 
 The English guide also documents generated runtime environment handling, safe
-CLI map merging, and AWS CLI commands.
+CLI map merging, AWS CLI commands, and streaming keepalive behavior.

--- a/packages/core/src/server/poll-events.spec.ts
+++ b/packages/core/src/server/poll-events.spec.ts
@@ -13,7 +13,7 @@ vi.mock("h3", () => ({
     event.status = status;
   },
   createEventStream: (event: any) => ({
-    push: (data: string) => {
+    push: (data: unknown) => {
       event.pushed.push(data);
     },
     onClosed: (callback: () => void) => {
@@ -36,7 +36,7 @@ describe("poll event SSE handler", () => {
     const { createPollEventsHandler } = await import("./poll-events.js");
     const { recordChange } = await import("./poll.js");
     const handler = createPollEventsHandler() as any;
-    const event = { pushed: [] as string[], close: undefined as any };
+    const event = { pushed: [] as unknown[], close: undefined as any };
 
     await handler(event);
 
@@ -64,13 +64,37 @@ describe("poll event SSE handler", () => {
       key: "global",
     });
 
-    expect(event.pushed.map((data) => JSON.parse(data).key)).toEqual([
-      "own",
-      "org",
-      "global",
-    ]);
+    expect(
+      event.pushed
+        .filter((data): data is string => typeof data === "string")
+        .map((data) => JSON.parse(data).key),
+    ).toEqual(["own", "org", "global"]);
 
     event.close?.();
+  });
+
+  it("sends named heartbeats while the stream is idle", async () => {
+    vi.useFakeTimers();
+    try {
+      const { createPollEventsHandler } = await import("./poll-events.js");
+      const handler = createPollEventsHandler() as any;
+      const event = { pushed: [] as unknown[], close: undefined as any };
+
+      await handler(event);
+      expect(event.pushed).toEqual([{ event: "heartbeat", data: "" }]);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(event.pushed).toEqual([
+        { event: "heartbeat", data: "" },
+        { event: "heartbeat", data: "" },
+      ]);
+
+      event.close?.();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(event.pushed).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects unauthenticated streams", async () => {

--- a/packages/core/src/server/poll-events.ts
+++ b/packages/core/src/server/poll-events.ts
@@ -74,6 +74,13 @@ export function createPollEventsHandler(
       safePush(JSON.stringify(change));
     };
 
+    const pushHeartbeat = () => {
+      if (closed) return;
+      // A named event keeps the keepalive out of the client's JSON message
+      // handler while still writing a packet through edge idle timeouts.
+      void stream.push({ event: "heartbeat", data: "" });
+    };
+
     // Awareness fast-path: forward cursor/presence events immediately.
     // No ring-buffer needed — clients reconcile on the next poll if SSE is down.
     const pushAwareness = (change: AwarenessChangeEvent) => {
@@ -96,8 +103,12 @@ export function createPollEventsHandler(
       getAwarenessEmitter().on(AWARENESS_CHANGE_EVENT, pushAwareness);
     }
 
+    pushHeartbeat();
+    const heartbeatTimer = setInterval(pushHeartbeat, 10_000);
+
     stream.onClosed(() => {
       closed = true;
+      clearInterval(heartbeatTimer);
       state.getPollEmitter().off(POLL_CHANGE_EVENT, push);
       if (forwardAwareness) {
         getAwarenessEmitter().off(AWARENESS_CHANGE_EVENT, pushAwareness);


### PR DESCRIPTION
## Summary
- send named keepalive frames on the shared framework SSE stream
- document Amplify streaming, CloudFront idle timeouts, and cache boundaries
- add a regression test for idle heartbeats and cleanup

## Validation
- `pnpm --filter @agent-native/core exec vitest --run src/server/poll-events.spec.ts`
- `pnpm guard:i18n-changed-copy`
- `pnpm guard:i18n-catalogs`
- `git diff --check`
