### PR TITLE
Design questions support write-in answers

### DIFF
--- a/templates/design/app/components/design/QuestionFlow.test.tsx
+++ b/templates/design/app/components/design/QuestionFlow.test.tsx
@@ -83,6 +83,117 @@ async function renderQuestionFlow(
   };
 }
 
+function setTextareaValue(element: HTMLTextAreaElement, value: string) {
+  Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set?.call(element, value);
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("QuestionFlow Other answers", () => {
+  it("offers a write-in answer by default for text options", async () => {
+    const onSubmit = vi.fn();
+    const { container, findButton, cleanup } = await renderQuestionFlow({
+      onSubmit,
+      onSkip: vi.fn(),
+      questions: [
+        {
+          id: "direction",
+          type: "text-options",
+          question: "What direction should I take?",
+          required: true,
+          options: [{ label: "Minimal", value: "minimal" }],
+          includeExplore: false,
+          includeDecide: false,
+        },
+      ],
+    });
+
+    const otherButton = findButton("Other");
+    expect(otherButton).toBeTruthy();
+    await act(async () => {
+      otherButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      setTextareaValue(textarea!, "A hand-drawn editorial look");
+    });
+
+    const continueButton = findButton("Continue");
+    expect(continueButton?.hasAttribute("disabled")).toBe(false);
+    await act(async () => {
+      continueButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      direction: "Other: A hand-drawn editorial look",
+    });
+    await cleanup();
+  });
+
+  it("offers a write-in answer for color options and keeps other selections", async () => {
+    const onSubmit = vi.fn();
+    const { container, findButton, cleanup } = await renderQuestionFlow({
+      onSubmit,
+      onSkip: vi.fn(),
+      questions: [
+        {
+          id: "palette",
+          type: "color-options",
+          question: "Which palettes should I explore?",
+          required: true,
+          multiSelect: true,
+          options: [
+            {
+              label: "Ocean",
+              value: "ocean",
+              color: "var(--design-editor-accent-color)",
+            },
+            {
+              label: "Clay",
+              value: "clay",
+              color: "var(--design-editor-panel-bg)",
+            },
+          ],
+          includeExplore: false,
+          includeDecide: false,
+        },
+      ],
+    });
+
+    await act(async () => {
+      findButton("Ocean")!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+    await act(async () => {
+      findButton("Other")!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      setTextareaValue(textarea!, "a muted forest green");
+    });
+
+    await act(async () => {
+      findButton("Continue")!.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      palette: ["ocean", "Other: a muted forest green"],
+    });
+    await cleanup();
+  });
+});
+
 describe("QuestionFlow double-submit guard", () => {
   it("only calls onSubmit once when Continue is clicked twice in a row", async () => {
     const onSubmit = vi.fn();

--- a/templates/design/app/components/design/QuestionFlow.tsx
+++ b/templates/design/app/components/design/QuestionFlow.tsx
@@ -385,9 +385,17 @@ function ColorOptions({
   value: unknown;
   onChange: (value: unknown) => void;
 }) {
+  const t = useT();
   const options = question.options ?? question.choices ?? [];
   const multiSelect = question.multiSelect === true;
   const selectedValues = Array.isArray(value) ? value : [];
+  const otherSelected = multiSelect
+    ? selectedValues.some(isOtherGuidedAnswer)
+    : isOtherGuidedAnswer(value);
+  const otherText = multiSelect
+    ? getOtherGuidedAnswerText(selectedValues.find(isOtherGuidedAnswer))
+    : getOtherGuidedAnswerText(value);
+  const allowOther = question.allowOther !== false;
   const isSelected = (optionValue: string) =>
     multiSelect ? selectedValues.includes(optionValue) : value === optionValue;
 
@@ -403,38 +411,88 @@ function ColorOptions({
     );
   };
 
+  const toggleOther = () => {
+    if (!multiSelect) {
+      onChange(otherSelected ? "" : makeOtherGuidedAnswer());
+      return;
+    }
+    if (otherSelected) {
+      onChange(selectedValues.filter((item) => !isOtherGuidedAnswer(item)));
+      return;
+    }
+    onChange([...selectedValues, makeOtherGuidedAnswer()]);
+  };
+
+  const setOtherText = (text: string) => {
+    const nextOther = makeOtherGuidedAnswer(text);
+    if (!multiSelect) {
+      onChange(nextOther);
+      return;
+    }
+    onChange([
+      ...selectedValues.filter((item) => !isOtherGuidedAnswer(item)),
+      nextOther,
+    ]);
+  };
+
   return (
-    <div className="flex max-w-4xl flex-wrap gap-2">
-      {options.map((option) => {
-        const selected = isSelected(option.value);
-        return (
-          <button
-            type="button"
-            key={`${option.value}:${option.label}`}
-            onClick={() => toggleOption(option.value)}
-            aria-pressed={selected}
-            className={cn(
-              "group inline-flex min-h-8 min-w-0 max-w-full cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-start transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)] focus-visible:ring-offset-0",
-              selected
-                ? "border-[var(--design-editor-accent-color)] bg-[var(--design-editor-selection-color)] text-foreground"
-                : "border-[var(--design-editor-control-border)] bg-[var(--design-editor-question-option-bg)] text-foreground hover:bg-[var(--design-editor-control-bg)]",
-            )}
-          >
-            <span
+    <div className="space-y-3">
+      <div className="flex max-w-4xl flex-wrap gap-2">
+        {options.map((option) => {
+          const selected = isSelected(option.value);
+          return (
+            <button
+              type="button"
+              key={`${option.value}:${option.label}`}
+              onClick={() => toggleOption(option.value)}
+              aria-pressed={selected}
               className={cn(
-                "size-5 shrink-0 rounded-full border border-[var(--design-editor-control-border)]",
-                selected &&
-                  "ring-1 ring-[var(--design-editor-accent-color)] ring-offset-1 ring-offset-[var(--design-editor-control-bg)]",
+                "group inline-flex min-h-8 min-w-0 max-w-full cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-start transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)] focus-visible:ring-offset-0",
+                selected
+                  ? "border-[var(--design-editor-accent-color)] bg-[var(--design-editor-selection-color)] text-foreground"
+                  : "border-[var(--design-editor-control-border)] bg-[var(--design-editor-question-option-bg)] text-foreground hover:bg-[var(--design-editor-control-bg)]",
               )}
-              style={{ backgroundColor: option.color || option.value }}
-            />
-            <span className="min-w-0 flex-1 truncate text-[12px] font-semibold leading-4">
-              {option.label}
-            </span>
-            {selected && <IconPalette className="size-3.5 shrink-0" />}
-          </button>
-        );
-      })}
+            >
+              <span
+                className={cn(
+                  "size-5 shrink-0 rounded-full border border-[var(--design-editor-control-border)]",
+                  selected &&
+                    "ring-1 ring-[var(--design-editor-accent-color)] ring-offset-1 ring-offset-[var(--design-editor-control-bg)]",
+                )}
+                style={{ backgroundColor: option.color || option.value }}
+              />
+              <span className="min-w-0 flex-1 truncate text-[12px] font-semibold leading-4">
+                {option.label}
+              </span>
+              {selected && <IconPalette className="size-3.5 shrink-0" />}
+            </button>
+          );
+        })}
+        {allowOther && (
+          <OptionButton
+            option={{
+              label: t("questionFlow.other"),
+              value: "__other__",
+              description: t("questionFlow.otherDescription"),
+            }}
+            selected={otherSelected}
+            compact
+            multiSelect={multiSelect}
+            onClick={toggleOther}
+          />
+        )}
+      </div>
+      {allowOther && otherSelected && (
+        <Textarea
+          autoFocus
+          value={otherText}
+          onChange={(event) => setOtherText(event.target.value)}
+          placeholder={
+            question.placeholder ?? t("questionFlow.customPlaceholder")
+          }
+          className="min-h-[72px] max-w-xl resize-none rounded-md border-[var(--design-editor-control-border)] bg-[var(--design-editor-control-bg)] text-[12px] shadow-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-[var(--design-editor-accent-color)]"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a default `Other` write-in option to Design color questions.
- Preserve existing text-question behavior and explicit opt-outs for choices that must map to a fixed set of files.
- Cover single-select and multi-select answer serialization with focused tests.

## Validation
- `corepack pnpm --filter design exec vitest --run app/components/design/QuestionFlow.test.tsx --config vitest.config.ts` - 5 passed
- `corepack pnpm --filter design typecheck`
- `corepack pnpm guards` - 66 passed
- Live local Design editor verified `Other`, custom text entry, and preserving a standard color alongside a custom palette answer.