### PR TITLE
fix(calendar): align booking availability with tabs

### DIFF
--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -1806,7 +1806,7 @@ export default function BookingLinksPage({
         </TabsContent>
 
         <TabsContent value="availability">
-          <div className="mx-auto max-w-2xl space-y-6">
+          <div className="max-w-2xl space-y-6">
             {/* Weekly Schedule */}
             <Card>
               <CardHeader>

--- a/templates/calendar/changelog/2026-08-31-booking-link-availability-aligns-with-tabs.md
+++ b/templates/calendar/changelog/2026-08-31-booking-link-availability-aligns-with-tabs.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-08-31
+---
+
+Booking link availability aligns with its tabs


### PR DESCRIPTION
## Summary
- align the booking-link availability content with the tab strip
- document the visible Calendar fix in the changelog

## Validation
- oxfmt on the changed JSX file
- focused Calendar typecheck and UI verification