### PR TITLE
fix(clips): capture browser diagnostics for every extension surface

### DIFF
--- a/templates/clips/chrome-extension/src/background.ts
+++ b/templates/clips/chrome-extension/src/background.ts
@@ -1494,6 +1494,10 @@ async function armRecording(args: {
   //    suspendable worker) and reports "recording" back when it actually starts.
   const authToken = (await readAuthSession(settings))?.token;
   console.log("[clips-bg] arm: created row", created.id, "auth?", !!authToken);
+  // Diagnostics follow the launch tab regardless of which display surface is
+  // being recorded. Attach before the recorder starts so the first captured
+  // console or network event is not lost during the countdown.
+  await attachSession(session);
   // The on-page countdown drives the actual start (it sends COUNTDOWN_DONE at
   // "Go"). This offscreen timer is only a FALLBACK. When a camera is involved the
   // countdown waits for the camera feed before it even shows "3" (the content
@@ -1530,11 +1534,6 @@ async function armRecording(args: {
     throw err;
   }
   await saveActiveNativeRecording();
-
-  // Browser-tab diagnostics still attach to the launch tab only.
-  if (settings.captureSurface === "browser") {
-    await attachSession(session);
-  }
 
   broadcastOverlayState();
   await chrome.action.setBadgeBackgroundColor({ color: "#e11d48" });


### PR DESCRIPTION
## Summary

- Attach the launch tab for browser diagnostics on every native extension capture surface.
- Attach before the recorder starts so console and network events during the countdown are captured.

## Validation

- `corepack pnpm --dir templates/clips/chrome-extension test`
- `corepack pnpm --dir templates/clips/chrome-extension typecheck`
- `corepack pnpm --dir templates/clips/chrome-extension build`
- `corepack pnpm guards`

Reported in Slack: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788206302450379
