### PR TITLE
fix: accept Builder personal access tokens for account activation

### DIFF
--- a/.changeset/accept-builder-personal-access-tokens.md
+++ b/.changeset/accept-builder-personal-access-tokens.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Accept Builder personal access tokens when saving credentials returned by account activation.

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -219,6 +219,20 @@ describe("writeBuilderCredentials", () => {
     expect(scopes.every((s) => s === "user")).toBe(true);
   });
 
+  it("writes a personal access token at user scope", async () => {
+    const target = await writeBuilderCredentials("a@b.com", {
+      privateKey: "btk-test-token",
+      publicKey: "space",
+    });
+    expect(target).toEqual({ scope: "user", scopeId: "a@b.com" });
+    expect(mockWriteAppSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "BUILDER_PRIVATE_KEY",
+        value: "btk-test-token",
+      }),
+    );
+  });
+
   it("writes at org scope for an owner of an active org", async () => {
     const target = await writeBuilderCredentials(
       "owner@b.com",
@@ -346,14 +360,16 @@ describe("writeBuilderCredentials", () => {
     );
   });
 
-  it("rejects non-private-key credentials before clearing existing rows", async () => {
+  it("rejects unsupported credentials before clearing existing rows", async () => {
     await expect(
       writeBuilderCredentials(
         "owner@b.com",
-        { privateKey: "btk-personal-access-token", publicKey: "pub" },
+        { privateKey: "not-a-builder-token", publicKey: "pub" },
         { orgId: "builder_io", role: "owner" },
       ),
-    ).rejects.toThrow("expected bpk-");
+    ).rejects.toThrow(
+      "expected a bpk- private key or btk- personal access token",
+    );
 
     expect(mockDeleteAppSecret).not.toHaveBeenCalled();
     expect(mockWriteAppSecret).not.toHaveBeenCalled();

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -394,8 +394,8 @@ function readOptionalBuilderBoolean(
   return /^(1|true)$/i.test(value);
 }
 
-export function isBuilderPrivateKey(value: string | null | undefined): boolean {
-  return typeof value === "string" && value.trim().startsWith("bpk-");
+function isBuilderAuthToken(value: string | null | undefined): boolean {
+  return typeof value === "string" && /^(?:bpk|btk)-/.test(value.trim());
 }
 
 async function readBuilderCredentialScope(
@@ -1553,9 +1553,9 @@ export async function writeBuilderCredentials(
 ): Promise<{ scope: "user" | "org"; scopeId: string }> {
   const privateKey = creds.privateKey.trim();
   const publicKey = creds.publicKey.trim();
-  if (!isBuilderPrivateKey(privateKey)) {
+  if (!isBuilderAuthToken(privateKey)) {
     throw new Error(
-      "Builder returned a credential that is not a Builder private key (expected bpk-...). Restart the Builder connect flow and choose a space that can issue a private key.",
+      "Builder returned an unsupported credential (expected a bpk- private key or btk- personal access token). Restart the Builder connect flow and choose a space that can issue a usable credential.",
     );
   }
   if (!publicKey) {


### PR DESCRIPTION
## What changed

Accept `btk-` personal access tokens when the Builder activation flow saves the credential returned by the account-provisioning endpoint. Legacy `bpk-` private keys remain supported.

## Why

Builder account provisioning now returns a space-scoped PAT instead of minting a new Agent-Native browser private key. The client still stores the credential through the existing `BUILDER_PRIVATE_KEY` slot and sends it as a Bearer token, so this is a compatibility-only validation update.

The paired Builder API change is in BuilderIO/builder-internal#14624.

## Validation

- `pnpm --filter @agent-native/core exec vitest --run src/server/credential-provider.spec.ts`
- `pnpm --filter @agent-native/core exec tsc --noEmit`
