### PR TITLE
Make automations friendly and webhook-ready

### DIFF
--- a/.changeset/friendly-automation-triggers.md
+++ b/.changeset/friendly-automation-triggers.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": minor
+---
+
+Add friendly automation schedules and webhook triggers.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,6 +115,8 @@
     "./client/chat-first": "./dist/client/chat-first/index.js",
     "./client/analytics": "./dist/client/analytics/index.js",
     "./client/automation": "./dist/client/automation/index.js",
+    "./client/agent-page/automation-schedule": "./dist/client/agent-page/automation-schedule.js",
+    "./client/agent-page/timezone-select": "./dist/client/agent-page/TimezoneSelect.js",
     "./client/chat": "./dist/client/chat/index.js",
     "./client/changelog": "./dist/client/changelog/index.js",
     "./client/markdown": "./dist/client/markdown/index.js",

--- a/packages/core/src/automation/index.ts
+++ b/packages/core/src/automation/index.ts
@@ -402,7 +402,7 @@ function payloadTooLarge(maxBytes: number): AutomationConnectorError {
   );
 }
 
-async function readBoundedRequestBody(
+export async function readBoundedRequestBody(
   event: H3Event,
   maxBytes: number,
 ): Promise<string> {

--- a/packages/core/src/automations/service.spec.ts
+++ b/packages/core/src/automations/service.spec.ts
@@ -9,6 +9,7 @@ const getUserSettingMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../db/client.js", () => ({
   getDbExec: () => ({ execute: executeMock }),
+  getDialect: () => "sqlite",
   intType: () => "INTEGER",
   isPostgres: () => false,
 }));
@@ -23,6 +24,7 @@ vi.mock("../settings/user-settings.js", () => ({
 }));
 
 vi.mock("../resources/store.js", () => ({
+  SHARED_OWNER: "__shared__",
   organizationIdFromResourceOwner: (owner: string) =>
     owner.startsWith("__organization__:")
       ? owner.slice("__organization__:".length)

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -18,6 +18,7 @@ import {
   resourcePut,
   type Resource,
 } from "../resources/store.js";
+import { createAutomationWebhookToken } from "../triggers/webhook.js";
 
 export type AutomationScope = "personal" | "organization";
 
@@ -35,7 +36,7 @@ export interface AutomationDefinition {
   name: string;
   scope: AutomationScope;
   meta: JobFrontmatter & {
-    triggerType: "schedule" | "event";
+    triggerType: "schedule" | "event" | "webhook";
     mode: "agentic" | "deterministic";
   };
   body: string;
@@ -53,7 +54,7 @@ export interface AutomationDelivery {
 export interface DefineAutomationInput {
   name: string;
   scope: AutomationScope;
-  triggerType: "schedule" | "event";
+  triggerType: "schedule" | "event" | "webhook";
   body: string;
   schedule?: string;
   timezone?: string;
@@ -421,6 +422,10 @@ export async function defineAutomation(
     enabled: true,
     triggerType: input.triggerType,
     event: input.triggerType === "event" ? event : undefined,
+    webhookToken:
+      input.triggerType === "webhook"
+        ? createAutomationWebhookToken()
+        : undefined,
     condition: input.condition?.trim() || undefined,
     mode: "agentic",
     domain: input.domain?.trim() || undefined,
@@ -469,7 +474,7 @@ export async function updateAutomation(
   const { meta } = definition;
   if (input.schedule !== undefined) {
     if (meta.triggerType !== "schedule") {
-      throw httpError("Event automations do not have a cron schedule.", 400);
+      throw httpError("Only scheduled automations have a cron schedule.", 400);
     }
     if (!isValidCron(input.schedule)) {
       throw httpError(`Invalid cron expression "${input.schedule}".`, 400);
@@ -481,7 +486,7 @@ export async function updateAutomation(
       throw httpError(`Unknown timezone "${input.timezone}".`, 400);
     }
     if (meta.triggerType !== "schedule") {
-      throw httpError("Event automations do not have a timezone.", 400);
+      throw httpError("Only scheduled automations have a timezone.", 400);
     }
     meta.timezone = input.timezone;
   }

--- a/packages/core/src/automations/service.ts
+++ b/packages/core/src/automations/service.ts
@@ -16,9 +16,18 @@ import {
   resourceGetByPath,
   resourceList,
   resourcePut,
+  SHARED_OWNER,
   type Resource,
 } from "../resources/store.js";
-import { createAutomationWebhookToken } from "../triggers/webhook.js";
+import {
+  deleteAutomationWebhookToken,
+  readAutomationWebhookPath,
+  saveAutomationWebhookToken,
+} from "../triggers/webhook-store.js";
+import {
+  createAutomationWebhookToken,
+  automationWebhookPath,
+} from "../triggers/webhook.js";
 
 export type AutomationScope = "personal" | "organization";
 
@@ -41,6 +50,8 @@ export interface AutomationDefinition {
   };
   body: string;
   canUpdate: boolean;
+  /** Returned only to an actor who can update the webhook automation. */
+  webhookPath?: string;
 }
 
 export interface AutomationDelivery {
@@ -227,6 +238,14 @@ export async function canUpdateAutomationResource(
   const { meta } = parseJobResource(resource.content);
   const actor = normalizeActor(actorInput);
   if (!jobBelongsToApp(meta, actor.appId)) return false;
+  if (resource.owner === SHARED_OWNER) {
+    if (meta.orgId && actor.orgId !== meta.orgId) return false;
+    if (meta.createdBy?.trim().toLowerCase() === actor.userEmail) return true;
+    const orgId = meta.orgId || actor.orgId;
+    if (!orgId || actor.orgId !== orgId) return false;
+    const membership = await readOrganizationMembership(orgId, actor.userEmail);
+    return membership ? isOrganizationAdmin(membership) : false;
+  }
   return (await mutationAccess(actor, resource, meta)).canUpdate;
 }
 
@@ -294,11 +313,16 @@ async function readDefinition(
     throw httpError(`Automation "${automationName(path)}" not found.`, 404);
   }
   const access = await mutationAccess(actor, resource, definition.meta);
+  const webhookPath =
+    access.canUpdate && definition.meta.triggerType === "webhook"
+      ? await readAutomationWebhookPath(resource, definition.meta)
+      : undefined;
   return {
     ...definition,
     name: automationName(resource.path),
     scope,
     canUpdate: access.canUpdate,
+    webhookPath,
   };
 }
 
@@ -329,6 +353,10 @@ export async function listAutomationDefinitions(
     if (!jobBelongsToApp(parsed.meta, actor.appId)) continue;
     const isCreator =
       parsed.meta.createdBy?.trim().toLowerCase() === actor.userEmail;
+    const canUpdate =
+      scope === "personal" ||
+      isCreator ||
+      (membership ? isOrganizationAdmin(membership) : false);
     automations.push({
       resource,
       name: automationName(resource.path),
@@ -339,10 +367,11 @@ export async function listAutomationDefinitions(
         mode: parsed.meta.mode ?? "agentic",
       },
       body: parsed.body,
-      canUpdate:
-        scope === "personal" ||
-        isCreator ||
-        (membership ? isOrganizationAdmin(membership) : false),
+      canUpdate,
+      webhookPath:
+        canUpdate && parsed.classification.triggerType === "webhook"
+          ? await readAutomationWebhookPath(resource, parsed.meta)
+          : undefined,
     });
   }
 
@@ -422,10 +451,6 @@ export async function defineAutomation(
     enabled: true,
     triggerType: input.triggerType,
     event: input.triggerType === "event" ? event : undefined,
-    webhookToken:
-      input.triggerType === "webhook"
-        ? createAutomationWebhookToken()
-        : undefined,
     condition: input.condition?.trim() || undefined,
     mode: "agentic",
     domain: input.domain?.trim() || undefined,
@@ -450,13 +475,25 @@ export async function defineAutomation(
     deliveryTenantId: input.delivery?.tenantId,
   };
   const content = buildJobResourceContent(meta, body);
-  await resourcePut(owner, path, content);
+  const resource = await resourcePut(owner, path, content);
+  let webhookPath: string | undefined;
+  if (input.triggerType === "webhook") {
+    const token = createAutomationWebhookToken();
+    try {
+      await saveAutomationWebhookToken(resource, meta, token);
+    } catch (error) {
+      await resourceDelete(resource.id).catch(() => undefined);
+      throw error;
+    }
+    webhookPath = automationWebhookPath(token);
+  }
   return {
     name: automationName(path),
     scope: input.scope,
     meta: { ...meta, triggerType: input.triggerType, mode: "agentic" },
     body,
     canUpdate: true,
+    webhookPath,
   };
 }
 
@@ -575,6 +612,9 @@ export async function deleteAutomation(
       "Only the automation's creator or an organization admin can delete it.",
       403,
     );
+  }
+  if (definition.meta.triggerType === "webhook") {
+    await deleteAutomationWebhookToken(definition.resource, definition.meta);
   }
   await resourceDelete(definition.resource.id);
   // Names are reusable, so leaving history behind would attach these runs to

--- a/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.spec.tsx
@@ -177,7 +177,7 @@ describe("AgentJobsTab organization automations", () => {
     expect(container.textContent).toContain("new lead alert");
     expect(container.textContent).toContain("On lead.created");
     expect(container.textContent).toContain(
-      "Scheduled and event-triggered automations shared with this organization.",
+      "Scheduled, event-triggered, and webhook-triggered automations shared with this organization.",
     );
     expect(container.textContent).not.toContain("personal today");
   });

--- a/packages/core/src/client/agent-page/AgentJobsTab.tsx
+++ b/packages/core/src/client/agent-page/AgentJobsTab.tsx
@@ -63,7 +63,7 @@ type ListedAutomation =
   | {
       kind: "automation";
       resource: Automation;
-      triggerType: "event" | "schedule";
+      triggerType: "event" | "schedule" | "webhook";
     };
 
 function listRecurringJobs(jobs: RecurringJob[]): ListedAutomation[] {
@@ -89,6 +89,11 @@ function describeTrigger(entry: ListedAutomation, t: Translate): string {
     return t("jobs.automationEventDetails", {
       defaultValue: "Runs when {{event}}.",
       event: entry.resource.event ?? "an event fires",
+    });
+  }
+  if (entry.kind === "automation" && entry.triggerType === "webhook") {
+    return t("jobs.automationWebhookDetails", {
+      defaultValue: "Runs when a webhook is received.",
     });
   }
   return (
@@ -151,7 +156,9 @@ function detailsFields(
       value:
         entry.triggerType === "event"
           ? t("jobs.eventTrigger", { defaultValue: "Event-triggered" })
-          : t("jobs.scheduledTrigger", { defaultValue: "Scheduled" }),
+          : entry.triggerType === "webhook"
+            ? t("jobs.webhookTrigger", { defaultValue: "Webhook-triggered" })
+            : t("jobs.scheduledTrigger", { defaultValue: "Scheduled" }),
     },
   ];
 
@@ -167,6 +174,13 @@ function detailsFields(
         value: resource.timezone || unset,
       },
     );
+  }
+  if (entry.kind === "automation" && entry.triggerType === "webhook") {
+    fields.push({
+      label: t("jobs.webhookUrl", { defaultValue: "Webhook URL" }),
+      value: entry.resource.webhookPath || unset,
+      mono: true,
+    });
   }
 
   fields.push(
@@ -212,7 +226,7 @@ function detailsFields(
 }
 
 export function organizationAutomationCreationContext(): string {
-  return "The user wants to create a new organization automation. Use manage-automations with action=define and scope=organization to create it. Ask clarifying questions if needed about whether it runs on a schedule or event, any conditions, and what actions to take.";
+  return "The user wants to create a new organization automation. Use manage-automations with action=define and scope=organization to create it. Ask clarifying questions if needed about whether it runs on a schedule, event, or webhook, any conditions, and what actions to take.";
 }
 
 export function AgentJobsTab({
@@ -388,7 +402,7 @@ export function AgentJobsTab({
             organization
               ? t("jobs.organizationEmptyDescription", {
                   defaultValue:
-                    "Describe a scheduled or event-triggered automation for this organization.",
+                    "Describe a scheduled, event-triggered, or webhook-triggered automation for this organization.",
                 })
               : t("jobs.automationsEmptyDescription", {
                   defaultValue: "Describe what should happen and when.",
@@ -424,11 +438,16 @@ export function AgentJobsTab({
                       defaultValue: "On {{event}}",
                       event: entry.resource.event ?? "event",
                     })
-                  : resource.scheduleDescription ||
-                    resource.schedule ||
-                    t("jobs.scheduledTrigger", {
-                      defaultValue: "Scheduled",
-                    });
+                  : entry.kind === "automation" &&
+                      entry.triggerType === "webhook"
+                    ? t("jobs.automationWebhookTrigger", {
+                        defaultValue: "On webhook",
+                      })
+                    : resource.scheduleDescription ||
+                      resource.schedule ||
+                      t("jobs.scheduledTrigger", {
+                        defaultValue: "Scheduled",
+                      });
               const instructions =
                 entry.kind === "automation"
                   ? entry.resource.body
@@ -442,6 +461,8 @@ export function AgentJobsTab({
                   <div className="flex items-start gap-3">
                     <div className="mt-0.5 text-muted-foreground">
                       {entry.triggerType === "event" ? (
+                        <IconCalendarEvent className="size-4" />
+                      ) : entry.triggerType === "webhook" ? (
                         <IconBolt className="size-4" />
                       ) : (
                         <IconClock className="size-4" />
@@ -457,9 +478,13 @@ export function AgentJobsTab({
                             ? t("jobs.eventTrigger", {
                                 defaultValue: "Event-triggered",
                               })
-                            : t("jobs.scheduledTrigger", {
-                                defaultValue: "Scheduled",
-                              })}
+                            : entry.triggerType === "webhook"
+                              ? t("jobs.webhookTrigger", {
+                                  defaultValue: "Webhook-triggered",
+                                })
+                              : t("jobs.scheduledTrigger", {
+                                  defaultValue: "Scheduled",
+                                })}
                         </span>
                         <span
                           className={
@@ -696,7 +721,7 @@ export function AgentJobsTab({
       title={t("jobs.pageTitle", { defaultValue: "Automations" })}
       description={t("jobs.pageDescription", {
         defaultValue:
-          "Manage agent tasks that run on a schedule or in response to events.",
+          "Manage agent tasks that run on a schedule, in response to events, or from webhooks.",
       })}
       actions={
         <AgentAskPopover
@@ -737,7 +762,7 @@ export function AgentJobsTab({
           title: t("jobs.personal", { defaultValue: "Personal" }),
           description: t("jobs.personalDescription", {
             defaultValue:
-              "Scheduled and event-triggered automations that run for you.",
+              "Scheduled, event-triggered, and webhook-triggered automations that run for you.",
           }),
           entries: personalEntries,
           loading:
@@ -752,7 +777,7 @@ export function AgentJobsTab({
             title: t("jobs.organization", { defaultValue: "Organization" }),
             description: t("jobs.organizationDescription", {
               defaultValue:
-                "Scheduled and event-triggered automations shared with this organization.",
+                "Scheduled, event-triggered, and webhook-triggered automations shared with this organization.",
             }),
             entries: organizationEntries,
             loading:

--- a/packages/core/src/client/agent-page/AutomationScheduleDialog.tsx
+++ b/packages/core/src/client/agent-page/AutomationScheduleDialog.tsx
@@ -268,7 +268,10 @@ export function AutomationScheduleDialog({
                     onChange={(event) =>
                       setDraft((current) => ({
                         ...current,
-                        interval: Math.max(1, Number(event.target.value) || 1),
+                        interval: Math.min(
+                          current.unit === "day" ? 1 : 31,
+                          Math.max(1, Number(event.target.value) || 1),
+                        ),
                       }))
                     }
                     className="h-9 bg-background text-sm"
@@ -285,6 +288,7 @@ export function AutomationScheduleDialog({
                       setDraft((current) => ({
                         ...current,
                         unit: value as AutomationScheduleUnit,
+                        ...(value === "day" ? { interval: 1 } : {}),
                       }))
                     }
                   >
@@ -296,7 +300,7 @@ export function AutomationScheduleDialog({
                         {t("jobs.hours", { defaultValue: "hour(s)" })}
                       </SelectItem>
                       <SelectItem value="day">
-                        {t("jobs.days", { defaultValue: "day(s)" })}
+                        {t("jobs.day", { defaultValue: "day" })}
                       </SelectItem>
                       <SelectItem value="week">
                         {t("jobs.weeks", { defaultValue: "week(s)" })}
@@ -413,6 +417,14 @@ export function AutomationScheduleDialog({
                   {t("jobs.weeklyIntervalAdvanced", {
                     defaultValue:
                       "Every few weeks needs the Advanced cron editor below.",
+                  })}
+                </p>
+              ) : null}
+              {friendly.error === "daily-interval" ? (
+                <p className="text-xs text-destructive">
+                  {t("jobs.dailyIntervalAdvanced", {
+                    defaultValue:
+                      "Every few days needs the Advanced cron editor below.",
                   })}
                 </p>
               ) : null}

--- a/packages/core/src/client/agent-page/AutomationScheduleDialog.tsx
+++ b/packages/core/src/client/agent-page/AutomationScheduleDialog.tsx
@@ -1,6 +1,13 @@
 import { Button } from "@agent-native/toolkit/ui/button";
 import { Input } from "@agent-native/toolkit/ui/input";
-import { IconLoader2 } from "@tabler/icons-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@agent-native/toolkit/ui/select";
+import { IconCode, IconLoader2 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 import {
@@ -12,21 +19,90 @@ import {
   DialogTitle,
 } from "../components/ui/dialog.js";
 import { useT } from "../i18n.js";
+import {
+  AUTOMATION_WEEKDAYS,
+  automationScheduleDraftFromCron,
+  automationScheduleToCron,
+  formatAutomationTime,
+  type AutomationScheduleDraft,
+  type AutomationSchedulePreset,
+  type AutomationScheduleUnit,
+} from "./automation-schedule.js";
 import type { ScheduledTriggerState } from "./scheduled-trigger-state.js";
 import { ScheduledTriggerNotice } from "./ScheduledTriggerNotice.js";
 import { TimezoneSelect, browserTimezone } from "./TimezoneSelect.js";
 
-const PRESETS: { label: string; cron: string }[] = [
-  { label: "Every hour", cron: "0 * * * *" },
-  { label: "Every day at 8:00", cron: "0 8 * * *" },
-  { label: "Every weekday at 9:00", cron: "0 9 * * 1-5" },
-  { label: "Every Monday at 8:00", cron: "0 8 * * 1" },
+const FRIENDLY_PRESETS: {
+  value: AutomationSchedulePreset;
+  label: string;
+  detail: string;
+  draft: Partial<AutomationScheduleDraft>;
+}[] = [
+  {
+    value: "hourly",
+    label: "Every hour",
+    detail: "At the top of the hour",
+    draft: { preset: "hourly" },
+  },
+  {
+    value: "daily-midnight",
+    label: "Every day at midnight",
+    detail: "12:00 AM",
+    draft: { preset: "daily-midnight" },
+  },
+  {
+    value: "daily-noon",
+    label: "Every day at noon",
+    detail: "12:00 PM",
+    draft: { preset: "daily-noon" },
+  },
+  {
+    value: "weekdays",
+    label: "Every weekday",
+    detail: "Monday to Friday at 9:00 AM",
+    draft: { preset: "weekdays", time: "09:00" },
+  },
+  {
+    value: "weekly",
+    label: "Every week",
+    detail: "Sunday at 9:00 AM",
+    draft: { preset: "weekly", weekday: 0, time: "09:00" },
+  },
 ];
 
 const CRON_FIELD_COUNT = 5;
 
 function looksLikeCron(value: string): boolean {
   return value.trim().split(/\s+/).length === CRON_FIELD_COUNT;
+}
+
+function updateTime(draft: AutomationScheduleDraft, value: string) {
+  return { ...draft, time: value };
+}
+
+type Translate = ReturnType<typeof useT>;
+
+function schedulePresetLabel(
+  t: Translate,
+  value: AutomationSchedulePreset,
+  fallback: string,
+): string {
+  switch (value) {
+    case "hourly":
+      return t("jobs.schedulePreset.hourly", { defaultValue: fallback });
+    case "daily-midnight":
+      return t("jobs.schedulePreset.dailyMidnight", {
+        defaultValue: fallback,
+      });
+    case "daily-noon":
+      return t("jobs.schedulePreset.dailyNoon", { defaultValue: fallback });
+    case "weekdays":
+      return t("jobs.schedulePreset.weekdays", { defaultValue: fallback });
+    case "weekly":
+      return t("jobs.schedulePreset.weekly", { defaultValue: fallback });
+    case "custom":
+      return t("jobs.schedulePreset.custom", { defaultValue: fallback });
+  }
 }
 
 export interface AutomationScheduleDialogProps {
@@ -36,13 +112,6 @@ export interface AutomationScheduleDialogProps {
   timezone: string | null;
   saving: boolean;
   error?: string | null;
-  /**
-   * Passed in rather than queried here so this dialog stays presentational, the
-   * way the rest of its props already are. Carries the whole query state so a
-   * failed check is distinguishable from a healthy one — this dialog is where
-   * someone is actively picking a cadence, so an unverified scheduler is exactly
-   * what they need told.
-   */
   scheduledTriggerState: ScheduledTriggerState;
   onCancel: () => void;
   onSave: (next: { schedule: string; timezone: string }) => void;
@@ -60,19 +129,41 @@ export function AutomationScheduleDialog({
   onSave,
 }: AutomationScheduleDialogProps) {
   const t = useT();
-  const [value, setValue] = useState(schedule);
+  const [draft, setDraft] = useState<AutomationScheduleDraft>(
+    () => automationScheduleDraftFromCron(schedule).draft,
+  );
+  const [advanced, setAdvanced] = useState(
+    () => !automationScheduleDraftFromCron(schedule).recognized,
+  );
+  const [advancedValue, setAdvancedValue] = useState(schedule);
   const [zone, setZone] = useState(timezone || browserTimezone());
 
   useEffect(() => {
     if (!open) return;
-    setValue(schedule);
+    const parsed = automationScheduleDraftFromCron(schedule);
+    setDraft(parsed.draft);
+    setAdvanced(!parsed.recognized);
+    setAdvancedValue(schedule);
     setZone(timezone || browserTimezone());
   }, [open, schedule, timezone]);
 
-  const trimmed = value.trim();
-  const valid = looksLikeCron(trimmed);
+  const friendly = automationScheduleToCron(draft);
+  const activeSchedule = advanced
+    ? advancedValue.trim()
+    : (friendly.schedule ?? "");
+  const valid = looksLikeCron(activeSchedule) && (advanced || !friendly.error);
   const changed =
-    trimmed !== schedule.trim() || zone !== (timezone || browserTimezone());
+    activeSchedule !== schedule.trim() ||
+    zone !== (timezone || browserTimezone());
+  const customMinute = Number(draft.time.split(":")[1] ?? 0);
+
+  function choosePreset(
+    value: AutomationSchedulePreset,
+    presetDraft: Partial<AutomationScheduleDraft>,
+  ) {
+    setDraft((current) => ({ ...current, ...presetDraft, preset: value }));
+    setAdvanced(false);
+  }
 
   return (
     <Dialog
@@ -81,7 +172,7 @@ export function AutomationScheduleDialog({
         if (!next && !saving) onCancel();
       }}
     >
-      <DialogContent>
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>
             {t("jobs.editScheduleTitle", {
@@ -92,55 +183,257 @@ export function AutomationScheduleDialog({
           <DialogDescription>
             {t("jobs.editScheduleDescription", {
               defaultValue:
-                "The clock time below is read in the timezone you pick, so 8:00 means 8:00 there.",
+                "Choose a cadence in plain language. Times use the timezone you pick.",
             })}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-3">
+        <div className="space-y-4">
           <ScheduledTriggerNotice
             state={scheduledTriggerState}
             variant="inline"
           />
-          <div>
-            <label
-              className="text-xs font-medium text-foreground"
-              htmlFor="automation-schedule"
-            >
-              {t("jobs.cronExpression", { defaultValue: "Cron expression" })}
-            </label>
-            <Input
-              id="automation-schedule"
-              className="mt-1 font-mono text-sm"
-              value={value}
-              spellCheck={false}
-              autoComplete="off"
-              disabled={saving}
-              onChange={(event) => setValue(event.target.value)}
-            />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              {t("jobs.cronFormatHint", {
-                defaultValue: "minute hour day-of-month month day-of-week",
+
+          <div className="space-y-2">
+            <div className="text-xs font-medium text-foreground">
+              {t("jobs.repeat", { defaultValue: "Repeat" })}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {FRIENDLY_PRESETS.map((preset) => (
+                <button
+                  key={preset.value}
+                  type="button"
+                  aria-pressed={!advanced && draft.preset === preset.value}
+                  disabled={saving}
+                  className={
+                    "rounded-lg border px-3 py-2 text-left transition-colors " +
+                    (!advanced && draft.preset === preset.value
+                      ? "border-primary bg-primary/5 text-foreground"
+                      : "border-border/70 bg-background hover:bg-muted/50")
+                  }
+                  onClick={() => choosePreset(preset.value, preset.draft)}
+                >
+                  <span className="block text-sm font-medium">
+                    {schedulePresetLabel(t, preset.value, preset.label)}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-muted-foreground">
+                    {preset.detail}
+                  </span>
+                </button>
+              ))}
+              <button
+                type="button"
+                aria-pressed={!advanced && draft.preset === "custom"}
+                disabled={saving}
+                className={
+                  "rounded-lg border px-3 py-2 text-left transition-colors " +
+                  (!advanced && draft.preset === "custom"
+                    ? "border-primary bg-primary/5 text-foreground"
+                    : "border-border/70 bg-background hover:bg-muted/50")
+                }
+                onClick={() =>
+                  choosePreset("custom", {
+                    preset: "custom",
+                    unit: draft.unit || "day",
+                  })
+                }
+              >
+                <span className="block text-sm font-medium">
+                  {t("jobs.schedulePreset.custom", {
+                    defaultValue: "Custom",
+                  })}
+                </span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  {t("jobs.schedulePreset.customDetail", {
+                    defaultValue: "Set your own repeat pattern",
+                  })}
+                </span>
+              </button>
+            </div>
+          </div>
+
+          {!advanced && draft.preset === "custom" ? (
+            <div className="space-y-3 rounded-lg border border-border/70 bg-muted/20 p-3">
+              <div className="grid gap-3 sm:grid-cols-[1fr_1fr]">
+                <label className="space-y-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {t("jobs.repeatEvery", { defaultValue: "Repeat every" })}
+                  </span>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={draft.interval}
+                    disabled={saving}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        interval: Math.max(1, Number(event.target.value) || 1),
+                      }))
+                    }
+                    className="h-9 bg-background text-sm"
+                  />
+                </label>
+                <label className="space-y-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {t("jobs.scheduleUnit", { defaultValue: "Unit" })}
+                  </span>
+                  <Select
+                    value={draft.unit}
+                    disabled={saving}
+                    onValueChange={(value) =>
+                      setDraft((current) => ({
+                        ...current,
+                        unit: value as AutomationScheduleUnit,
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="h-9 bg-background text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="hour">
+                        {t("jobs.hours", { defaultValue: "hour(s)" })}
+                      </SelectItem>
+                      <SelectItem value="day">
+                        {t("jobs.days", { defaultValue: "day(s)" })}
+                      </SelectItem>
+                      <SelectItem value="week">
+                        {t("jobs.weeks", { defaultValue: "week(s)" })}
+                      </SelectItem>
+                      <SelectItem value="month">
+                        {t("jobs.months", { defaultValue: "month(s)" })}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </label>
+              </div>
+
+              {draft.unit === "hour" ? (
+                <label className="block space-y-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {t("jobs.atMinute", { defaultValue: "At minute" })}
+                  </span>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={59}
+                    value={customMinute}
+                    disabled={saving}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        updateTime(
+                          current,
+                          "00:" +
+                            String(
+                              Math.min(
+                                59,
+                                Math.max(0, Number(event.target.value) || 0),
+                              ),
+                            ).padStart(2, "0"),
+                        ),
+                      )
+                    }
+                    className="h-9 bg-background text-sm"
+                  />
+                </label>
+              ) : null}
+
+              {draft.unit === "week" ? (
+                <label className="block space-y-1.5 text-xs text-muted-foreground">
+                  <span>{t("jobs.onDay", { defaultValue: "On" })}</span>
+                  <Select
+                    value={String(draft.weekday)}
+                    disabled={saving}
+                    onValueChange={(value) =>
+                      setDraft((current) => ({
+                        ...current,
+                        weekday: Number(value),
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="h-9 bg-background text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {AUTOMATION_WEEKDAYS.map((day) => (
+                        <SelectItem key={day.value} value={String(day.value)}>
+                          {day.short}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+              ) : null}
+
+              {draft.unit === "month" ? (
+                <label className="block space-y-1.5 text-xs text-muted-foreground">
+                  <span>
+                    {t("jobs.dayOfMonth", { defaultValue: "Day of month" })}
+                  </span>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={draft.monthDay}
+                    disabled={saving}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        monthDay: Math.min(
+                          31,
+                          Math.max(1, Number(event.target.value) || 1),
+                        ),
+                      }))
+                    }
+                    className="h-9 bg-background text-sm"
+                  />
+                </label>
+              ) : null}
+
+              {draft.unit !== "hour" ? (
+                <label className="block space-y-1.5 text-xs text-muted-foreground">
+                  <span>{t("jobs.atTime", { defaultValue: "At" })}</span>
+                  <Input
+                    type="time"
+                    value={draft.time}
+                    disabled={saving}
+                    onChange={(event) =>
+                      setDraft((current) =>
+                        updateTime(current, event.target.value),
+                      )
+                    }
+                    className="h-9 bg-background text-sm"
+                  />
+                </label>
+              ) : null}
+
+              {friendly.error === "weekly-interval" ? (
+                <p className="text-xs text-destructive">
+                  {t("jobs.weeklyIntervalAdvanced", {
+                    defaultValue:
+                      "Every few weeks needs the Advanced cron editor below.",
+                  })}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {!advanced && friendly.schedule ? (
+            <p className="text-xs text-muted-foreground">
+              {t("jobs.schedulePreview", {
+                defaultValue: "Runs {{time}}.",
+                time:
+                  draft.preset === "hourly"
+                    ? "at the start of every hour"
+                    : draft.preset === "daily-midnight"
+                      ? "every day at midnight"
+                      : draft.preset === "daily-noon"
+                        ? "every day at noon"
+                        : "at " + formatAutomationTime(draft.time),
               })}
             </p>
-          </div>
-
-          <div className="flex flex-wrap gap-1.5">
-            {PRESETS.map((preset) => (
-              <Button
-                key={preset.cron}
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-7 cursor-pointer text-[11px]"
-                disabled={saving}
-                onClick={() => setValue(preset.cron)}
-              >
-                {preset.label}
-              </Button>
-            ))}
-          </div>
-
+          ) : null}
           <div>
             <label
               className="text-xs font-medium text-foreground"
@@ -159,7 +452,52 @@ export function AutomationScheduleDialog({
             </div>
           </div>
 
-          {trimmed && !valid ? (
+          <details
+            className="group rounded-lg border border-border/70 bg-muted/20"
+            open={advanced}
+            onToggle={(event) => {
+              const next = event.currentTarget.open;
+              if (next && !advanced && friendly.schedule) {
+                setAdvancedValue(friendly.schedule);
+              }
+              setAdvanced(next);
+            }}
+          >
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-xs font-medium text-foreground [&::-webkit-details-marker]:hidden">
+              <IconCode className="size-4 text-muted-foreground" />
+              {t("jobs.advancedSchedule", {
+                defaultValue: "Advanced - cron expression",
+              })}
+              <span className="ms-auto text-muted-foreground group-open:hidden">
+                {t("jobs.show", { defaultValue: "Show" })}
+              </span>
+              <span className="ms-auto hidden text-muted-foreground group-open:inline">
+                {t("jobs.hide", { defaultValue: "Hide" })}
+              </span>
+            </summary>
+            <div className="border-t border-border/60 px-3 pb-3 pt-2.5">
+              <Input
+                id="automation-schedule"
+                className="font-mono text-sm"
+                value={advancedValue}
+                spellCheck={false}
+                autoComplete="off"
+                disabled={saving}
+                onFocus={() => setAdvanced(true)}
+                onChange={(event) => {
+                  setAdvanced(true);
+                  setAdvancedValue(event.target.value);
+                }}
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {t("jobs.cronFormatHint", {
+                  defaultValue: "minute hour day-of-month month day-of-week",
+                })}
+              </p>
+            </div>
+          </details>
+
+          {activeSchedule && !valid ? (
             <p className="text-xs text-destructive">
               {t("jobs.cronFieldCount", {
                 defaultValue: "A cron expression needs exactly 5 fields.",
@@ -183,7 +521,7 @@ export function AutomationScheduleDialog({
             type="button"
             className="cursor-pointer"
             disabled={saving || !valid || !changed}
-            onClick={() => onSave({ schedule: trimmed, timezone: zone })}
+            onClick={() => onSave({ schedule: activeSchedule, timezone: zone })}
           >
             {saving ? <IconLoader2 className="size-4 animate-spin" /> : null}
             {t("jobs.saveSchedule", { defaultValue: "Save schedule" })}

--- a/packages/core/src/client/agent-page/automation-schedule.spec.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.spec.ts
@@ -37,6 +37,14 @@ describe("automation schedule builder", () => {
     expect(automationScheduleDraftFromCron("0 9 1 * 1").recognized).toBe(false);
   });
 
+  it("canonicalizes Sunday aliases without shifting the selected day", () => {
+    const parsed = automationScheduleDraftFromCron("0 9 * * 7");
+    expect(parsed.draft).toMatchObject({ preset: "weekly", weekday: 0 });
+    expect(automationScheduleToCron(parsed.draft)).toEqual({
+      schedule: "0 9 * * 0",
+    });
+  });
+
   it("keeps unsupported multi-week cadence explicit for Advanced", () => {
     expect(
       automationScheduleToCron({

--- a/packages/core/src/client/agent-page/automation-schedule.spec.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.spec.ts
@@ -55,4 +55,19 @@ describe("automation schedule builder", () => {
       }),
     ).toEqual({ error: "weekly-interval" });
   });
+
+  it("keeps elapsed-day cadence in Advanced instead of using month-reset cron steps", () => {
+    expect(
+      automationScheduleToCron({
+        ...DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+        preset: "custom",
+        unit: "day",
+        interval: 2,
+        time: "08:30",
+      }),
+    ).toEqual({ error: "daily-interval" });
+    expect(automationScheduleDraftFromCron("30 8 */2 * *").recognized).toBe(
+      false,
+    );
+  });
 });

--- a/packages/core/src/client/agent-page/automation-schedule.spec.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+  automationScheduleDraftFromCron,
+  automationScheduleToCron,
+} from "./automation-schedule.js";
+
+describe("automation schedule builder", () => {
+  it("turns friendly cadence choices into cron", () => {
+    expect(
+      automationScheduleToCron({
+        ...DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+        preset: "daily-noon",
+      }),
+    ).toEqual({ schedule: "0 12 * * *" });
+    expect(
+      automationScheduleToCron({
+        ...DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+        preset: "custom",
+        unit: "month",
+        interval: 2,
+        monthDay: 15,
+        time: "08:30",
+      }),
+    ).toEqual({ schedule: "30 8 15 */2 *" });
+  });
+
+  it("round-trips supported cron patterns and leaves advanced patterns alone", () => {
+    const parsed = automationScheduleDraftFromCron("15 8 * * 0");
+    expect(parsed.recognized).toBe(true);
+    expect(parsed.draft).toMatchObject({
+      preset: "weekly",
+      time: "08:15",
+      weekday: 0,
+    });
+    expect(automationScheduleDraftFromCron("0 9 1 * 1").recognized).toBe(false);
+  });
+
+  it("keeps unsupported multi-week cadence explicit for Advanced", () => {
+    expect(
+      automationScheduleToCron({
+        ...DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+        preset: "custom",
+        unit: "week",
+        interval: 2,
+      }),
+    ).toEqual({ error: "weekly-interval" });
+  });
+});

--- a/packages/core/src/client/agent-page/automation-schedule.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.ts
@@ -156,13 +156,20 @@ export function automationScheduleDraftFromCron(
     };
   }
 
-  if (time && dayOfMonth === "*" && month === "*" && /^\d$/.test(dayOfWeek)) {
+  const weeklyDay = numeric(dayOfWeek);
+  if (
+    time &&
+    dayOfMonth === "*" &&
+    month === "*" &&
+    weeklyDay !== null &&
+    weeklyDay <= 7
+  ) {
     return {
       draft: {
         ...fallback,
         preset: "weekly",
         time,
-        weekday: Number(dayOfWeek),
+        weekday: weeklyDay === 7 ? 0 : weeklyDay,
       },
       recognized: true,
     };

--- a/packages/core/src/client/agent-page/automation-schedule.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.ts
@@ -73,7 +73,7 @@ function normalizeDraft(
 
 export function automationScheduleToCron(draft: AutomationScheduleDraft): {
   schedule?: string;
-  error?: "weekly-interval";
+  error?: "daily-interval" | "weekly-interval";
 } {
   const next = normalizeDraft(draft);
   if (next.preset === "hourly") return { schedule: "0 * * * *" };
@@ -93,8 +93,8 @@ export function automationScheduleToCron(draft: AutomationScheduleDraft): {
     };
   }
   if (next.unit === "day") {
-    const days = next.interval === 1 ? "*" : `*/${next.interval}`;
-    return { schedule: `${time} ${days} * *` };
+    if (next.interval !== 1) return { error: "daily-interval" };
+    return { schedule: `${time} * * *` };
   }
   if (next.unit === "week") {
     if (next.interval !== 1) return { error: "weekly-interval" };
@@ -198,7 +198,13 @@ export function automationScheduleDraftFromCron(
   }
 
   const dailyInterval = /^\*\/(\d+)$/.exec(dayOfMonth);
-  if (time && month === "*" && dayOfWeek === "*" && dailyInterval) {
+  if (
+    time &&
+    month === "*" &&
+    dayOfWeek === "*" &&
+    dailyInterval &&
+    Number(dailyInterval[1]) === 1
+  ) {
     return {
       draft: {
         ...fallback,

--- a/packages/core/src/client/agent-page/automation-schedule.ts
+++ b/packages/core/src/client/agent-page/automation-schedule.ts
@@ -1,0 +1,238 @@
+export type AutomationSchedulePreset =
+  | "hourly"
+  | "daily-midnight"
+  | "daily-noon"
+  | "weekdays"
+  | "weekly"
+  | "custom";
+
+export type AutomationScheduleUnit = "hour" | "day" | "week" | "month";
+
+export interface AutomationScheduleDraft {
+  preset: AutomationSchedulePreset;
+  time: string;
+  weekday: number;
+  interval: number;
+  unit: AutomationScheduleUnit;
+  monthDay: number;
+}
+
+export interface ParsedAutomationSchedule {
+  draft: AutomationScheduleDraft;
+  recognized: boolean;
+}
+
+export const AUTOMATION_WEEKDAYS = [
+  { value: 0, short: "Sun" },
+  { value: 1, short: "Mon" },
+  { value: 2, short: "Tue" },
+  { value: 3, short: "Wed" },
+  { value: 4, short: "Thu" },
+  { value: 5, short: "Fri" },
+  { value: 6, short: "Sat" },
+] as const;
+
+export const DEFAULT_AUTOMATION_SCHEDULE_DRAFT: AutomationScheduleDraft = {
+  preset: "hourly",
+  time: "09:00",
+  weekday: 0,
+  interval: 1,
+  unit: "day",
+  monthDay: 1,
+};
+
+function boundedInteger(value: number, minimum: number, maximum: number) {
+  return Math.min(maximum, Math.max(minimum, Math.round(value)));
+}
+
+function timeParts(value: string): { minute: number; hour: number } {
+  const match = /^(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return { minute: 0, hour: 9 };
+  return {
+    hour: boundedInteger(Number(match[1]), 0, 23),
+    minute: boundedInteger(Number(match[2]), 0, 59),
+  };
+}
+
+function cronTime(value: string): string {
+  const { minute, hour } = timeParts(value);
+  return `${minute} ${hour}`;
+}
+
+function normalizeDraft(
+  draft: AutomationScheduleDraft,
+): AutomationScheduleDraft {
+  return {
+    ...draft,
+    time: /^\d{2}:\d{2}$/.test(draft.time) ? draft.time : "09:00",
+    weekday: boundedInteger(draft.weekday, 0, 6),
+    interval: boundedInteger(draft.interval, 1, 31),
+    monthDay: boundedInteger(draft.monthDay, 1, 31),
+  };
+}
+
+export function automationScheduleToCron(draft: AutomationScheduleDraft): {
+  schedule?: string;
+  error?: "weekly-interval";
+} {
+  const next = normalizeDraft(draft);
+  if (next.preset === "hourly") return { schedule: "0 * * * *" };
+
+  const time = cronTime(next.time);
+  if (next.preset === "daily-midnight") return { schedule: "0 0 * * *" };
+  if (next.preset === "daily-noon") return { schedule: "0 12 * * *" };
+  if (next.preset === "weekdays") return { schedule: `${time} * * 1-5` };
+  if (next.preset === "weekly") {
+    return { schedule: `${time} * * ${next.weekday}` };
+  }
+
+  if (next.unit === "hour") {
+    const hours = next.interval === 1 ? "*" : `*/${next.interval}`;
+    return {
+      schedule: `${timeParts(next.time).minute} ${hours} * * *`,
+    };
+  }
+  if (next.unit === "day") {
+    const days = next.interval === 1 ? "*" : `*/${next.interval}`;
+    return { schedule: `${time} ${days} * *` };
+  }
+  if (next.unit === "week") {
+    if (next.interval !== 1) return { error: "weekly-interval" };
+    return { schedule: `${time} * * ${next.weekday}` };
+  }
+  const months = next.interval === 1 ? "*" : `*/${next.interval}`;
+  return {
+    schedule: `${time} ${next.monthDay} ${months} *`,
+  };
+}
+
+function numeric(value: string): number | null {
+  return /^\d+$/.test(value) ? Number(value) : null;
+}
+
+function timeFromCron(minute: string, hour: string): string | null {
+  const parsedMinute = numeric(minute);
+  const parsedHour = numeric(hour);
+  if (
+    parsedMinute === null ||
+    parsedHour === null ||
+    parsedMinute > 59 ||
+    parsedHour > 23
+  ) {
+    return null;
+  }
+  return `${String(parsedHour).padStart(2, "0")}:${String(parsedMinute).padStart(2, "0")}`;
+}
+
+export function automationScheduleDraftFromCron(
+  value: string,
+): ParsedAutomationSchedule {
+  const fallback = { ...DEFAULT_AUTOMATION_SCHEDULE_DRAFT };
+  const parts = value.trim().split(/\s+/);
+  if (parts.length !== 5) return { draft: fallback, recognized: false };
+  if (value.trim() === "0 * * * *") {
+    return { draft: { ...fallback, preset: "hourly" }, recognized: true };
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+  const time = timeFromCron(minute, hour);
+  if (time && dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    const preset =
+      time === "00:00"
+        ? "daily-midnight"
+        : time === "12:00"
+          ? "daily-noon"
+          : "custom";
+    return {
+      draft: { ...fallback, preset, time, unit: "day" },
+      recognized: true,
+    };
+  }
+
+  if (time && dayOfMonth === "*" && month === "*" && dayOfWeek === "1-5") {
+    return {
+      draft: { ...fallback, preset: "weekdays", time },
+      recognized: true,
+    };
+  }
+
+  if (time && dayOfMonth === "*" && month === "*" && /^\d$/.test(dayOfWeek)) {
+    return {
+      draft: {
+        ...fallback,
+        preset: "weekly",
+        time,
+        weekday: Number(dayOfWeek),
+      },
+      recognized: true,
+    };
+  }
+
+  const hourlyInterval = /^\*\/(\d+)$/.exec(hour);
+  const minuteValue = numeric(minute);
+  if (
+    minuteValue !== null &&
+    minuteValue <= 59 &&
+    dayOfMonth === "*" &&
+    month === "*" &&
+    dayOfWeek === "*" &&
+    hourlyInterval
+  ) {
+    return {
+      draft: {
+        ...fallback,
+        preset: "custom",
+        time: `00:${String(minuteValue).padStart(2, "0")}`,
+        unit: "hour",
+        interval: Number(hourlyInterval[1]),
+      },
+      recognized: true,
+    };
+  }
+
+  const dailyInterval = /^\*\/(\d+)$/.exec(dayOfMonth);
+  if (time && month === "*" && dayOfWeek === "*" && dailyInterval) {
+    return {
+      draft: {
+        ...fallback,
+        preset: "custom",
+        time,
+        unit: "day",
+        interval: Number(dailyInterval[1]),
+      },
+      recognized: true,
+    };
+  }
+
+  const day = numeric(dayOfMonth);
+  const monthInterval = /^\*\/(\d+)$/.exec(month);
+  if (
+    time &&
+    day !== null &&
+    day >= 1 &&
+    day <= 31 &&
+    monthInterval &&
+    dayOfWeek === "*"
+  ) {
+    return {
+      draft: {
+        ...fallback,
+        preset: "custom",
+        time,
+        unit: "month",
+        interval: Number(monthInterval[1]),
+        monthDay: day,
+      },
+      recognized: true,
+    };
+  }
+
+  return { draft: fallback, recognized: false };
+}
+
+export function formatAutomationTime(value: string): string {
+  const { hour, minute } = timeParts(value);
+  const period = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}:${String(minute).padStart(2, "0")} ${period}`;
+}

--- a/packages/core/src/client/agent-page/use-jobs.ts
+++ b/packages/core/src/client/agent-page/use-jobs.ts
@@ -33,8 +33,9 @@ export interface Automation {
   name: string;
   path: string;
   scope: "personal" | "organization";
-  triggerType: "event" | "schedule";
+  triggerType: "event" | "schedule" | "webhook";
   event: string | null;
+  webhookPath: string | null;
   schedule: string | null;
   timezone: string | null;
   scheduleDescription: string | null;
@@ -66,7 +67,12 @@ export type ManageJobInput = {
   timezone?: string;
 };
 
-export type ManageAutomationInput = ManageJobInput;
+export type ManageAutomationInput = ManageJobInput & {
+  operation: "create" | "update" | "delete";
+  triggerType?: "event" | "schedule" | "webhook";
+  body?: string;
+  event?: string;
+};
 
 export interface RunAutomationNowInput {
   name?: string;
@@ -231,7 +237,9 @@ export function useRunAutomationNow() {
   );
 }
 
-function optimisticPatch(variables: ManageJobInput) {
+function optimisticPatch(
+  variables: Pick<ManageJobInput, "enabled" | "schedule" | "timezone">,
+) {
   const patch: {
     enabled?: boolean;
     schedule?: string;

--- a/packages/core/src/client/settings/AutomationsSection.tsx
+++ b/packages/core/src/client/settings/AutomationsSection.tsx
@@ -1,5 +1,10 @@
 import { Button } from "@agent-native/toolkit/ui/button";
-import { IconArrowRight, IconBolt, IconClock } from "@tabler/icons-react";
+import {
+  IconArrowRight,
+  IconBolt,
+  IconCalendarEvent,
+  IconClock,
+} from "@tabler/icons-react";
 import { Link } from "react-router";
 
 import { useT } from "../i18n.js";
@@ -7,7 +12,7 @@ import { useT } from "../i18n.js";
 export const AUTOMATION_CREATION_SCOPE = "personal" as const;
 
 export function automationCreationContext(): string {
-  return `The user wants to create a new ${AUTOMATION_CREATION_SCOPE} automation. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`;
+  return `The user wants to create a new ${AUTOMATION_CREATION_SCOPE} automation. Use manage-automations with action=define to create it. Ask clarifying questions if needed about whether it should run on a schedule, event, or webhook, conditions, and what actions to take.`;
 }
 
 export function AutomationsSection() {
@@ -18,7 +23,7 @@ export function AutomationsSection() {
       <p className="text-xs leading-5 text-muted-foreground">
         {t("jobs.settingsSummary", {
           defaultValue:
-            "Manage scheduled and event-triggered agent tasks together from the Automations page.",
+            "Manage scheduled, event-triggered, and webhook-triggered agent tasks together from the Automations page.",
         })}
       </p>
       <div className="flex flex-wrap gap-2 text-[11px] text-muted-foreground">
@@ -28,6 +33,10 @@ export function AutomationsSection() {
         </span>
         <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1">
           <IconBolt className="size-3" />
+          {t("jobs.webhookTrigger", { defaultValue: "Webhook-triggered" })}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1">
+          <IconCalendarEvent className="size-3" />
           {t("jobs.eventTrigger", { defaultValue: "Event-triggered" })}
         </span>
       </div>

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -3202,7 +3202,7 @@ function SettingsPanelContent({
                   id={settingsSectionDomId("automations")}
                   icon={<IconBolt size={14} />}
                   title="Automations"
-                  subtitle="Scheduled and event-triggered agent tasks."
+                  subtitle="Scheduled, event-triggered, and webhook-triggered agent tasks."
                   grouped
                   flat
                   open={openSection === "automations"}
@@ -3210,7 +3210,7 @@ function SettingsPanelContent({
                 >
                   <SettingsRow
                     label="Automations"
-                    description="Schedule agent tasks or run them from events."
+                    description="Schedule agent tasks or run them from events and webhooks."
                     control={
                       <a
                         href="/settings/agent/automations"
@@ -3536,7 +3536,7 @@ function SettingsPanelContent({
             id={settingsSectionDomId("automations")}
             icon={<IconBolt size={14} />}
             title="Automations"
-            subtitle="Scheduled and event-triggered agent tasks."
+            subtitle="Scheduled, event-triggered, and webhook-triggered agent tasks."
             flat
             open={openSection === "automations"}
             onToggle={() => toggle("automations")}

--- a/packages/core/src/framework-tools.ts
+++ b/packages/core/src/framework-tools.ts
@@ -267,6 +267,7 @@ export const CORE_ACTION_GROUPS: Record<string, FrameworkToolGroup> = {
   "list-automation-runs": "automation",
   "get-scheduled-trigger-status": "automation",
   "list-automations": "automation",
+  "list-automation-events": "automation",
   "manage-automation": "automation",
   "get-usage-alerts": "automation",
   "manage-usage-alert": "automation",

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -516,6 +516,34 @@ describe("integration pending task store", () => {
     ]);
   });
 
+  it("does not consume retry budget when requeueing expected automation contention", async () => {
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
+    const { markTaskRetryable } = await loadStore();
+
+    await markTaskRetryable(
+      "automation-task",
+      "Automation is already running.",
+      {
+        resetAttempts: true,
+      },
+    );
+
+    const retryUpdate = executeMock.mock.calls
+      .map(([query]) => query)
+      .find(
+        (query): query is { sql: string; args: unknown[] } =>
+          typeof query !== "string" &&
+          query.sql.includes("UPDATE integration_pending_tasks"),
+      );
+    expect(retryUpdate?.sql).toContain("attempts = 0");
+    expect(retryUpdate?.args).toEqual([
+      "pending",
+      expect.any(Number),
+      "Automation is already running.",
+      "automation-task",
+    ]);
+  });
+
   it("atomically replaces a claimed task with a delivery-only payload", async () => {
     executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
     const { stageTaskDeliveryPayload } = await loadStore();

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -535,13 +535,15 @@ export async function markTaskCompleted(id: string): Promise<void> {
 export async function markTaskRetryable(
   id: string,
   errorMessage: string,
+  options?: { resetAttempts?: boolean },
 ): Promise<void> {
   await ensureTable();
   const client = getDbExec();
   const now = Date.now();
+  const attempts = options?.resetAttempts ? ", attempts = 0" : "";
   await client.execute({
     sql: `UPDATE integration_pending_tasks
-          SET status = ?, updated_at = ?, error_message = ?
+          SET status = ?${attempts}, updated_at = ?, error_message = ?
           WHERE id = ? AND status = 'processing'`,
     args: ["pending", now, errorMessage.slice(0, 2000), id],
   });

--- a/packages/core/src/integrations/plugin.spec.ts
+++ b/packages/core/src/integrations/plugin.spec.ts
@@ -53,6 +53,7 @@ const getNextPendingTaskForThreadMock = vi.hoisted(() =>
   vi.fn(async () => null),
 );
 const dispatchPendingIntegrationTaskMock = vi.hoisted(() => vi.fn());
+const dispatchAutomationWebhookTaskMock = vi.hoisted(() => vi.fn());
 const recoverDueIntegrationCampaignsMock = vi.hoisted(() =>
   vi.fn(async () => ({ selected: 0, dispatched: 0, skipped: 0, failed: 0 })),
 );
@@ -188,6 +189,10 @@ vi.mock("./google-docs-poller.js", () => ({
   stopGoogleDocsPoller: stopGoogleDocsPollerMock,
   handlePushNotification: handlePushNotificationMock,
   verifyGoogleDocsPushNotification: verifyGoogleDocsPushNotificationMock,
+}));
+
+vi.mock("../triggers/dispatcher.js", () => ({
+  dispatchAutomationWebhookTask: dispatchAutomationWebhookTaskMock,
 }));
 
 vi.mock("../resources/store.js", () => ({
@@ -397,6 +402,7 @@ describe("integrations plugin routes", () => {
     resolveSecretMock.mockReset();
     resolveSecretMock.mockReturnValue(null);
     handleWebhookMock.mockResolvedValue({ status: 200, body: "ok" });
+    dispatchAutomationWebhookTaskMock.mockResolvedValue("completed");
     handlePushNotificationMock.mockReset();
     handlePushNotificationMock.mockResolvedValue(undefined);
     verifyGoogleDocsPushNotificationMock.mockReset();
@@ -1018,6 +1024,55 @@ describe("integrations plugin routes", () => {
     expect(claimPendingTaskMock).toHaveBeenCalledWith("background-task", {
       dispatchOutcome: "background-acknowledged",
     });
+  });
+
+  it("keeps webhook deliveries retryable while their automation is active", async () => {
+    process.env.NODE_ENV = "development";
+    const task = {
+      id: "automation-webhook-task",
+      platform: "automation-webhook",
+      externalThreadId: "owner+qa@example.com:jobs/webhook.md",
+      payload: JSON.stringify({
+        kind: "automation-webhook",
+        automationId: "automation-1",
+        owner: "owner+qa@example.com",
+        path: "jobs/webhook.md",
+        eventId: "event-1",
+        payload: { ok: true },
+      }),
+      ownerEmail: "owner+qa@example.com",
+      orgId: null,
+      status: "processing",
+      attempts: 3,
+      errorMessage: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      completedAt: null,
+    };
+    claimPendingTaskMock.mockResolvedValueOnce(task);
+    dispatchAutomationWebhookTaskMock.mockResolvedValueOnce("retry");
+    const nitroApp = createNitroApp();
+    await createIntegrationsPlugin({ adapters: [adapter] })(nitroApp);
+
+    const result = await dispatch(
+      nitroApp,
+      "/_agent-native/integrations/process-task",
+      "POST",
+      { taskId: task.id },
+    );
+
+    expect(result.status).toBe(202);
+    expect(result.body).toEqual({
+      ok: true,
+      taskId: task.id,
+      retrying: "automation-active",
+    });
+    expect(markTaskRetryableMock).toHaveBeenCalledWith(
+      task.id,
+      "Automation is already running.",
+      { resetAttempts: true },
+    );
+    expect(markTaskCompletedMock).not.toHaveBeenCalled();
   });
 
   it("finishes a checkpointed campaign delivery without rerunning the agent", async () => {

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -2104,7 +2104,7 @@ export function createIntegrationsPlugin(
               setResponseStatus(event, 400);
               return { error: "Invalid automation webhook task" };
             }
-            await runWithRequestContext(
+            const webhookResult = await runWithRequestContext(
               {
                 userEmail: task.ownerEmail,
                 ...(task.orgId ? { orgId: task.orgId } : {}),
@@ -2115,6 +2115,15 @@ export function createIntegrationsPlugin(
                   taskPayload as AutomationWebhookTaskPayload,
                 ),
             );
+            if (webhookResult === "retry") {
+              await markTaskRetryable(
+                taskId,
+                "Automation is already running.",
+                { resetAttempts: true },
+              );
+              setResponseStatus(event, 202);
+              return { ok: true, taskId, retrying: "automation-active" };
+            }
             await markTaskCompleted(taskId);
             const nextTask = await getNextPendingTaskForThread(
               task.platform,

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -40,6 +40,11 @@ import {
   type IntervalJobHandle,
 } from "../server/interval-job.js";
 import { runWithRequestContext } from "../server/request-context.js";
+import { dispatchAutomationWebhookTask } from "../triggers/dispatcher.js";
+import {
+  AUTOMATION_WEBHOOK_PLATFORM,
+  type AutomationWebhookTaskPayload,
+} from "../triggers/webhook.js";
 import {
   processA2AContinuationById,
   processDueA2AContinuations,
@@ -2023,6 +2028,7 @@ export function createIntegrationsPlugin(
         let taskPayload:
           | IntegrationSystemNoticeTaskPayload
           | IntegrationResponseDeliveryTaskPayload
+          | AutomationWebhookTaskPayload
           | { kind?: undefined };
         try {
           taskPayload = JSON.parse(task.payload) as typeof taskPayload;
@@ -2089,6 +2095,45 @@ export function createIntegrationsPlugin(
             }
           | undefined;
         try {
+          if (task.platform === AUTOMATION_WEBHOOK_PLATFORM) {
+            if (
+              taskPayload.kind !== "automation-webhook" ||
+              campaignContinuation
+            ) {
+              await markTaskFailed(taskId, "Invalid automation webhook task");
+              setResponseStatus(event, 400);
+              return { error: "Invalid automation webhook task" };
+            }
+            await runWithRequestContext(
+              {
+                userEmail: task.ownerEmail,
+                ...(task.orgId ? { orgId: task.orgId } : {}),
+                isIntegrationCaller: true,
+              },
+              () =>
+                dispatchAutomationWebhookTask(
+                  taskPayload as AutomationWebhookTaskPayload,
+                ),
+            );
+            await markTaskCompleted(taskId);
+            const nextTask = await getNextPendingTaskForThread(
+              task.platform,
+              task.externalThreadId,
+            );
+            if (nextTask) {
+              await dispatchPendingIntegrationTask({
+                taskId: nextTask.id,
+                task: {
+                  platform: task.platform,
+                  externalThreadId: task.externalThreadId,
+                },
+                event,
+                baseUrl: getBaseUrl(event),
+              });
+            }
+            setResponseStatus(event, 200);
+            return { ok: true, taskId };
+          }
           const adapter = adapterMap.get(task.platform);
           if (!adapter) {
             await markTaskFailed(taskId, `Unknown platform: ${task.platform}`);

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -82,6 +82,20 @@ Run the automation.`;
     expect(rewritten).toContain('lastRun: "2026-08-21T17:30:01.097Z"');
   });
 
+  it("round-trips webhook automation credentials", () => {
+    const meta: JobFrontmatter = {
+      schedule: "",
+      enabled: true,
+      triggerType: "webhook",
+      webhookToken: "a".repeat(43),
+    };
+    const parsed = parseJobResource(
+      buildJobResourceContent(meta, "Run from the incoming payload."),
+    );
+    expect(parsed.meta).toEqual(meta);
+    expect(parsed.classification.triggerType).toBe("webhook");
+  });
+
   it("distinguishes legacy jobs from explicit scheduled automations", () => {
     const legacy = `---
 schedule: "0 9 * * *"

--- a/packages/core/src/jobs/frontmatter.spec.ts
+++ b/packages/core/src/jobs/frontmatter.spec.ts
@@ -82,18 +82,27 @@ Run the automation.`;
     expect(rewritten).toContain('lastRun: "2026-08-21T17:30:01.097Z"');
   });
 
-  it("round-trips webhook automation credentials", () => {
+  it("does not serialize webhook automation credentials into resource content", () => {
     const meta: JobFrontmatter = {
       schedule: "",
       enabled: true,
       triggerType: "webhook",
       webhookToken: "a".repeat(43),
     };
-    const parsed = parseJobResource(
-      buildJobResourceContent(meta, "Run from the incoming payload."),
+    const content = buildJobResourceContent(
+      meta,
+      "Run from the incoming payload.",
     );
-    expect(parsed.meta).toEqual(meta);
-    expect(parsed.classification.triggerType).toBe("webhook");
+    expect(content).not.toContain("webhookToken");
+    expect(parseJobResource(content).meta.webhookToken).toBeUndefined();
+    expect(
+      parseJobResource(`---
+triggerType: webhook
+webhookToken: ${meta.webhookToken}
+---
+
+Legacy webhook.`).meta.webhookToken,
+    ).toBe(meta.webhookToken);
   });
 
   it("distinguishes legacy jobs from explicit scheduled automations", () => {

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -46,7 +46,7 @@ export interface JobFrontmatter {
   triggerType?: JobTriggerType;
   /** For event automations: the event name to subscribe to. */
   event?: string;
-  /** Opaque bearer token used by webhook automations. Never log this value. */
+  /** Legacy only. New webhook tokens live in the encrypted secret store. */
   webhookToken?: string;
   /** Natural-language condition evaluated before dispatch. */
   condition?: string;
@@ -315,7 +315,7 @@ function parseKnownField(
       meta.event = value;
       break;
     case "webhookToken":
-      meta.webhookToken = value || undefined;
+      if (WEBHOOK_TOKEN_RE.test(value)) meta.webhookToken = value;
       break;
     case "condition":
       meta.condition = value;
@@ -471,11 +471,6 @@ export function buildJobResourceContent(
     "Remote automation run IDs",
     REMOTE_ID_RE,
   );
-  assertBoundedFrontmatterValue(
-    meta.webhookToken,
-    "Webhook tokens",
-    WEBHOOK_TOKEN_RE,
-  );
   if (
     meta.executionCwd !== undefined &&
     (meta.executionCwd.length > 1024 || /[\r\n]/.test(meta.executionCwd))
@@ -492,7 +487,6 @@ export function buildJobResourceContent(
   ];
   if (meta.triggerType) lines.push(`triggerType: ${meta.triggerType}`);
   pushString(lines, "event", meta.event);
-  pushString(lines, "webhookToken", meta.webhookToken);
   pushString(lines, "condition", meta.condition);
   if (meta.mode) lines.push(`mode: ${meta.mode}`);
   pushString(lines, "domain", meta.domain);

--- a/packages/core/src/jobs/frontmatter.ts
+++ b/packages/core/src/jobs/frontmatter.ts
@@ -1,5 +1,5 @@
 export type JobLastStatus = "success" | "error" | "running" | "skipped";
-export type JobTriggerType = "schedule" | "event";
+export type JobTriggerType = "schedule" | "event" | "webhook";
 export type JobExecutionMode = "agentic" | "deterministic";
 
 /**
@@ -46,6 +46,8 @@ export interface JobFrontmatter {
   triggerType?: JobTriggerType;
   /** For event automations: the event name to subscribe to. */
   event?: string;
+  /** Opaque bearer token used by webhook automations. Never log this value. */
+  webhookToken?: string;
   /** Natural-language condition evaluated before dispatch. */
   condition?: string;
   mode?: JobExecutionMode;
@@ -114,6 +116,7 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
 const DELEGATED_POLICY_ID_RE = /^[a-z0-9][a-z0-9._:-]{0,127}$/i;
 const EXECUTION_ID_RE = /^[a-z0-9][a-z0-9._:-]{0,127}$/i;
 const REMOTE_ID_RE = /^[a-z0-9][a-z0-9@+._:/-]{0,511}$/i;
+const WEBHOOK_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/;
 const EXTRA_FRONTMATTER_LINES = Symbol("extraFrontmatterLines");
 const KNOWN_FRONTMATTER_FIELDS = new Set([
   "schedule",
@@ -138,6 +141,7 @@ const KNOWN_FRONTMATTER_FIELDS = new Set([
   "mcpTools",
   "triggerType",
   "event",
+  "webhookToken",
   "condition",
   "mode",
   "domain",
@@ -304,10 +308,14 @@ function parseKnownField(
     case "triggerType":
       // The field's presence is the durable legacy-job/automation boundary.
       // Preserve that marker even if an old writer stored an invalid value.
-      meta.triggerType = value === "event" ? "event" : "schedule";
+      meta.triggerType =
+        value === "event" || value === "webhook" ? value : "schedule";
       break;
     case "event":
       meta.event = value;
+      break;
+    case "webhookToken":
+      meta.webhookToken = value || undefined;
       break;
     case "condition":
       meta.condition = value;
@@ -463,6 +471,11 @@ export function buildJobResourceContent(
     "Remote automation run IDs",
     REMOTE_ID_RE,
   );
+  assertBoundedFrontmatterValue(
+    meta.webhookToken,
+    "Webhook tokens",
+    WEBHOOK_TOKEN_RE,
+  );
   if (
     meta.executionCwd !== undefined &&
     (meta.executionCwd.length > 1024 || /[\r\n]/.test(meta.executionCwd))
@@ -479,6 +492,7 @@ export function buildJobResourceContent(
   ];
   if (meta.triggerType) lines.push(`triggerType: ${meta.triggerType}`);
   pushString(lines, "event", meta.event);
+  pushString(lines, "webhookToken", meta.webhookToken);
   pushString(lines, "condition", meta.condition);
   if (meta.mode) lines.push(`mode: ${meta.mode}`);
   pushString(lines, "domain", meta.domain);

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -765,6 +765,7 @@ const messages = {
     scheduleUnit: "Unit",
     hours: "hour(s)",
     days: "day(s)",
+    day: "day",
     weeks: "week(s)",
     months: "month(s)",
     atMinute: "At minute",
@@ -773,6 +774,8 @@ const messages = {
     atTime: "At",
     weeklyIntervalAdvanced:
       "Every few weeks needs the Advanced cron editor below.",
+    dailyIntervalAdvanced:
+      "Every few days needs the Advanced cron editor below.",
     schedulePreview: "Runs {{time}}.",
     advancedSchedule: "Advanced - cron expression",
     show: "Show",
@@ -796,6 +799,7 @@ const messages = {
     instructions: "Instructions",
     mcpTools: "Connected agent tools",
     automationEventTrigger: "On {{event}}",
+    webhook: "Webhook",
     automationWebhookDetails: "Runs when a webhook is received.",
     automationWebhookTrigger: "On webhook",
     schedulePreset: {
@@ -811,6 +815,8 @@ const messages = {
     eventTrigger: "Event-triggered",
     webhookTrigger: "Webhook-triggered",
     webhookUrl: "Webhook URL",
+    webhookUrlHint:
+      "Paste this URL into a service that sends HTTP POST webhooks.",
     deleteAutomationTitle: "Delete automation?",
     deleteAutomationDescription:
       "This permanently removes the automation and cannot be undone.",

--- a/packages/core/src/localization/default-messages.ts
+++ b/packages/core/src/localization/default-messages.ts
@@ -725,17 +725,17 @@ const messages = {
     timezone: "Timezone",
     pageTitle: "Automations",
     pageDescription:
-      "Manage agent tasks that run on a schedule or in response to events.",
+      "Manage agent tasks that run on a schedule, in response to events, or from webhooks.",
     personalDescription:
-      "Scheduled and event-triggered automations that run for you.",
+      "Scheduled, event-triggered, and webhook-triggered automations that run for you.",
     organizationDescription:
-      "Scheduled and event-triggered automations shared with this organization.",
+      "Scheduled, event-triggered, and webhook-triggered automations shared with this organization.",
     organizationMemberNote: "You can manage automations you created.",
     loading: "Loading…",
     loadError: "Could not load all automations.",
     organizationEmptyTitle: "No organization automations yet",
     organizationEmptyDescription:
-      "Describe a scheduled or event-triggered automation for this organization.",
+      "Describe a scheduled, event-triggered, or webhook-triggered automation for this organization.",
     organizationPrompt:
       "Create a shared organization automation that does this: ",
     enabled: "Enabled",
@@ -760,6 +760,23 @@ const messages = {
     editScheduleTitle: "Edit schedule — {{name}}",
     editScheduleDescription:
       "The clock time below is read in the timezone you pick, so 8:00 means 8:00 there.",
+    repeat: "Repeat",
+    repeatEvery: "Repeat every",
+    scheduleUnit: "Unit",
+    hours: "hour(s)",
+    days: "day(s)",
+    weeks: "week(s)",
+    months: "month(s)",
+    atMinute: "At minute",
+    onDay: "On",
+    dayOfMonth: "Day of month",
+    atTime: "At",
+    weeklyIntervalAdvanced:
+      "Every few weeks needs the Advanced cron editor below.",
+    schedulePreview: "Runs {{time}}.",
+    advancedSchedule: "Advanced - cron expression",
+    show: "Show",
+    hide: "Hide",
     cronExpression: "Cron expression",
     cronFormatHint: "minute hour day-of-month month day-of-week",
     cronFieldCount: "A cron expression needs exactly 5 fields.",
@@ -779,8 +796,21 @@ const messages = {
     instructions: "Instructions",
     mcpTools: "Connected agent tools",
     automationEventTrigger: "On {{event}}",
+    automationWebhookDetails: "Runs when a webhook is received.",
+    automationWebhookTrigger: "On webhook",
+    schedulePreset: {
+      hourly: "Every hour",
+      dailyMidnight: "Every day at midnight",
+      dailyNoon: "Every day at noon",
+      weekdays: "Every weekday",
+      weekly: "Every week",
+      custom: "Custom",
+      customDetail: "Set your own repeat pattern",
+    },
     scheduledTrigger: "Scheduled",
     eventTrigger: "Event-triggered",
+    webhookTrigger: "Webhook-triggered",
+    webhookUrl: "Webhook URL",
     deleteAutomationTitle: "Delete automation?",
     deleteAutomationDescription:
       "This permanently removes the automation and cannot be undone.",
@@ -794,7 +824,7 @@ const messages = {
     personal: "Personal",
     organization: "Organization",
     settingsSummary:
-      "Manage scheduled and event-triggered agent tasks together from the Automations page.",
+      "Manage scheduled, event-triggered, and webhook-triggered agent tasks together from the Automations page.",
     openAutomations: "Open Automations",
     nextRunNeverScheduler: "Never — no scheduler in this deploy",
     nextRunSchedulerUnknown:
@@ -806,11 +836,11 @@ const messages = {
     scheduleUnavailableTitle: "Schedules won't run in this deploy",
     scheduleUnavailableLocalTitle: "Schedules don't run in local development",
     scheduleUnavailableDisabled:
-      "This app was built with recurring jobs turned off, so no scheduled automation will fire. Event-triggered automations and Run now still work.",
+      "This app was built with recurring jobs turned off, so no scheduled automation will fire. Event- and webhook-triggered automations and Run now still work.",
     scheduleUnavailableNoScheduler:
-      "This hosting target has no durable scheduler, so no scheduled automation will fire. Event-triggered automations and Run now still work.",
+      "This hosting target has no durable scheduler, so no scheduled automation will fire. Event- and webhook-triggered automations and Run now still work.",
     scheduleUnavailableLocal:
-      "Schedules stay off on a dev machine unless you opt in. Event-triggered automations and Run now still work.",
+      "Schedules stay off on a dev machine unless you opt in. Event- and webhook-triggered automations and Run now still work.",
     scheduleUnavailableDisabledFix:
       "To enable recurring jobs, set AGENT_NATIVE_DISABLE_RECURRING_JOBS=false in the build environment.",
     scheduleUnavailableLocalFix:

--- a/packages/core/src/resources/handlers.spec.ts
+++ b/packages/core/src/resources/handlers.spec.ts
@@ -15,6 +15,7 @@ const mockEnsurePersonalDefaults = vi.fn();
 const mockCanWriteLocalWorkspaceResourcePath = vi.fn();
 const mockIsLocalWorkspaceResourceId = vi.fn();
 const mockUploadFile = vi.fn();
+const mockCanUpdateAutomationResource = vi.fn();
 
 vi.mock("./store.js", () => ({
   SHARED_OWNER: "__shared__",
@@ -46,6 +47,11 @@ vi.mock("./store.js", () => ({
 
 vi.mock("../server/auth.js", () => ({
   getSession: vi.fn().mockResolvedValue({ email: "test@test.com" }),
+}));
+
+vi.mock("../automations/service.js", () => ({
+  canUpdateAutomationResource: (...args: any[]) =>
+    mockCanUpdateAutomationResource(...args),
 }));
 
 const mockGetOrgContext = vi.fn().mockResolvedValue({
@@ -100,6 +106,7 @@ describe("resource handlers", () => {
     mockCanWriteLocalWorkspaceResourcePath.mockResolvedValue(false);
     mockIsLocalWorkspaceResourceId.mockReturnValue(false);
     mockUploadFile.mockResolvedValue(null);
+    mockCanUpdateAutomationResource.mockResolvedValue(false);
     vi.mocked(getSession).mockResolvedValue({ email: "test@test.com" } as any);
     mockGetOrgContext.mockResolvedValue({
       email: "test@test.com",
@@ -372,6 +379,31 @@ describe("resource handlers", () => {
         "nosniff",
       );
       expect(result).toBeInstanceOf(Response);
+    });
+
+    it("does not expose legacy webhook tokens to read-only members", async () => {
+      mockResourceGet.mockResolvedValue({
+        id: "legacy-webhook",
+        path: "jobs/legacy-webhook.md",
+        owner: "__shared__",
+        content: `---
+triggerType: webhook
+webhookToken: ${"a".repeat(43)}
+---
+
+Legacy webhook.`,
+        mimeType: "text/markdown",
+      });
+
+      const result = await handleGetResource({
+        _params: { id: "legacy-webhook" },
+        _query: {},
+        context: {},
+      });
+
+      expect(lastStatus).toBe(404);
+      expect(result).toEqual({ error: "Resource not found" });
+      expect(mockCanUpdateAutomationResource).toHaveBeenCalled();
     });
 
     it("downloads empty content with a sanitized attachment filename", async () => {

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -7,7 +7,9 @@ import {
 } from "h3";
 import { createError } from "h3";
 
+import { canUpdateAutomationResource } from "../automations/service.js";
 import { uploadFile } from "../file-upload/index.js";
+import { parseJobResource } from "../jobs/frontmatter.js";
 import { getOrgContext } from "../org/context.js";
 import { getSession } from "../server/auth.js";
 import {
@@ -440,6 +442,30 @@ export async function handleGetResource(event: any) {
   if (!canReadOwner(resource.owner, email, orgId)) {
     setResponseStatus(event, 404);
     return { error: "Resource not found" };
+  }
+
+  if (
+    resource.path.startsWith("jobs/") &&
+    resource.path.endsWith(".md") &&
+    /^webhookToken\s*:/m.test(resource.content)
+  ) {
+    let legacyWebhookMeta: ReturnType<typeof parseJobResource>["meta"];
+    try {
+      legacyWebhookMeta = parseJobResource(resource.content).meta;
+    } catch {
+      setResponseStatus(event, 404);
+      return { error: "Resource not found" };
+    }
+    if (
+      legacyWebhookMeta.webhookToken &&
+      !(await canUpdateAutomationResource(
+        { userEmail: email, orgId, appId: legacyWebhookMeta.appId },
+        resource,
+      ))
+    ) {
+      setResponseStatus(event, 404);
+      return { error: "Resource not found" };
+    }
   }
 
   const query = getQuery(event);

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -738,6 +738,10 @@ export async function mergeCoreSharingActions(
       () => import("../triggers/actions/list-automations.js"),
     ],
     [
+      "list-automation-events",
+      () => import("../triggers/actions/list-automation-events.js"),
+    ],
+    [
       "manage-automation",
       () => import("../triggers/actions/manage-automation.js"),
     ],

--- a/packages/core/src/server/agent-chat-plugin-startup.spec.ts
+++ b/packages/core/src/server/agent-chat-plugin-startup.spec.ts
@@ -69,6 +69,19 @@ describe("agent chat startup", () => {
     expect(triggerSetup).not.toContain("void (async () =>");
   });
 
+  it("keeps webhook and event dispatch independent from the cron scheduler gate", () => {
+    const source = readFileSync(
+      new URL("./agent-chat-plugin.ts", import.meta.url),
+      "utf8",
+    );
+    const triggerSetup = source.slice(
+      source.indexOf("// ─── Trigger Dispatcher"),
+      source.indexOf("})().catch((err)"),
+    );
+
+    expect(triggerSetup).not.toContain("disableRecurringJobsRuntime");
+  });
+
   /**
    * The in-process fast sweep is gated on `shouldDisableInProcessSweeps()`,
    * which is ON for every production serverless function — so for 21 days

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -7215,49 +7215,37 @@ Non-code requests are still fine on this surface: read data, navigate the UI, su
       });
 
       // ─── Trigger Dispatcher (event-based automations) ─────────────────
-      if (disableRecurringJobsRuntime) {
-        if (process.env.DEBUG) {
-          console.log(
-            "[triggers] Trigger dispatcher disabled for local development",
+      // Event and webhook automations remain live when the recurring scheduler
+      // is disabled; only the cron driver is gated above.
+      const { initTriggerDispatcher } =
+        await import("../triggers/dispatcher.js");
+      await initTriggerDispatcher({
+        getActions: getBackgroundActionEntries,
+        getSystemPrompt: async (owner: string) => {
+          const resources = await loadResourcesForPrompt(
+            owner,
+            lazyContext,
+            options?.appId,
+            undefined,
+            { disabledFrameworkGroups },
           );
-        }
-      } else {
-        try {
-          const { initTriggerDispatcher } =
-            await import("../triggers/dispatcher.js");
-          await initTriggerDispatcher({
-            getActions: getBackgroundActionEntries,
-            getSystemPrompt: async (owner: string) => {
-              const resources = await loadResourcesForPrompt(
-                owner,
-                lazyContext,
-                options?.appId,
-                undefined,
-                { disabledFrameworkGroups },
-              );
-              const schemaBlock = lazyContext
-                ? ""
-                : await buildSchemaBlock(owner, databaseToolsMode);
-              return basePrompt + resources + schemaBlock;
-            },
-            // See the matching comment on schedulerDeps.getInitialToolNames
-            // above — same shared `basePrompt`, same reasoning.
-            getInitialToolNames: (automation?: RecurringJobContext) => [
-              ...effectiveInitialToolNames,
-              "manage-jobs",
-              "manage-progress",
-              ...(automation?.meta.mcpTools ?? []),
-            ],
-            apiKey: options?.apiKey,
-            model: resolveConfiguredAgentModel(options),
-            appId: options?.appId,
-          });
-          if (process.env.DEBUG)
-            console.log("[triggers] Trigger dispatcher initialized");
-        } catch {
-          // Triggers module not available — skip silently
-        }
-      }
+          const schemaBlock = lazyContext
+            ? ""
+            : await buildSchemaBlock(owner, databaseToolsMode);
+          return basePrompt + resources + schemaBlock;
+        },
+        // See the matching comment on schedulerDeps.getInitialToolNames
+        // above — same shared `basePrompt`, same reasoning.
+        getInitialToolNames: (automation?: RecurringJobContext) => [
+          ...effectiveInitialToolNames,
+          "manage-jobs",
+          "manage-progress",
+          ...(automation?.meta.mcpTools ?? []),
+        ],
+        apiKey: options?.apiKey,
+        model: resolveConfiguredAgentModel(options),
+        appId: options?.appId,
+      });
     })().catch((err) => {
       // If the init fails, the routes never get registered and requests
       // to /_agent-native/agent-chat silently 404. Register a fallback

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -3289,6 +3289,11 @@ function createAuthGuardFn(
       return;
     }
 
+    // Automation webhook tokens are the public credential for this route.
+    if (/^\/_agent-native\/automations\/webhook\/[^/]+$/.test(p)) {
+      return;
+    }
+
     // Internal processor endpoint for the integration webhook fanout. The
     // webhook handler enqueues a task to SQL and dispatches a fresh HTTP POST
     // to this endpoint so the agent loop runs in its own function execution

--- a/packages/core/src/server/csrf.spec.ts
+++ b/packages/core/src/server/csrf.spec.ts
@@ -145,9 +145,19 @@ describe("CSRF middleware", () => {
       await status(
         { cookie: COOKIE, "content-type": "application/json" },
         "POST",
-        "/_agent-native/automations/webhook/token",
+        "/_agent-native/automations/webhook/" + "a".repeat(43),
       ),
     ).not.toBe(403);
+  });
+
+  it("does not exempt a nested automation management route", async () => {
+    expect(
+      await status(
+        { cookie: COOKIE, "content-type": "text/plain" },
+        "POST",
+        "/_agent-native/automations/webhook/" + "a".repeat(43) + "/fire-test",
+      ),
+    ).toBe(403);
   });
 
   // The remote-device relay lives under the HMAC-justified `/integrations/`

--- a/packages/core/src/server/csrf.spec.ts
+++ b/packages/core/src/server/csrf.spec.ts
@@ -140,6 +140,16 @@ describe("CSRF middleware", () => {
     ).not.toBe(403);
   });
 
+  it("exempts token-authenticated automation webhooks", async () => {
+    expect(
+      await status(
+        { cookie: COOKIE, "content-type": "application/json" },
+        "POST",
+        "/_agent-native/automations/webhook/token",
+      ),
+    ).not.toBe(403);
+  });
+
   // The remote-device relay lives under the HMAC-justified `/integrations/`
   // exemption but authenticates on the session cookie, so it must not inherit
   // it. Approving a browser-control operation is the state change at stake:

--- a/packages/core/src/server/csrf.ts
+++ b/packages/core/src/server/csrf.ts
@@ -84,6 +84,8 @@ const CSRF_PROTECTED_PREFIXES = [
 const CSRF_ALLOWLIST_PREFIXES = [
   // Integration webhooks — verified by HMAC against a per-integration secret.
   "/integrations/",
+  // Automation webhooks — authenticated by an opaque per-automation token.
+  "/automations/webhook/",
   // Agent Teams durable sub-agent processor self-fire — verified by the same
   // HMAC internal-token scheme as the integration/A2A processors.
   "/agent-teams/",

--- a/packages/core/src/server/csrf.ts
+++ b/packages/core/src/server/csrf.ts
@@ -51,6 +51,7 @@ import {
 } from "h3";
 
 import { MCP_PUBLIC_ROUTE_PREFIX } from "../mcp/route-paths.js";
+import { isAutomationWebhookToken } from "../triggers/webhook.js";
 import { getConfiguredAppBasePath } from "./app-base-path.js";
 
 /**
@@ -84,8 +85,6 @@ const CSRF_PROTECTED_PREFIXES = [
 const CSRF_ALLOWLIST_PREFIXES = [
   // Integration webhooks — verified by HMAC against a per-integration secret.
   "/integrations/",
-  // Automation webhooks — authenticated by an opaque per-automation token.
-  "/automations/webhook/",
   // Agent Teams durable sub-agent processor self-fire — verified by the same
   // HMAC internal-token scheme as the integration/A2A processors.
   "/agent-teams/",
@@ -182,6 +181,8 @@ function isOnAllowlist(pathname: string, frameworkPrefix: string): boolean {
   for (const protectedPrefix of CSRF_PROTECTED_PREFIXES) {
     if (sub.startsWith(protectedPrefix)) return false;
   }
+  const webhookToken = sub.match(/^\/automations\/webhook\/([^/]+)$/)?.[1];
+  if (webhookToken && isAutomationWebhookToken(webhookToken)) return true;
   for (const allowed of CSRF_ALLOWLIST_PREFIXES) {
     if (sub.startsWith(allowed)) return true;
   }

--- a/packages/core/src/server/release-schema.ts
+++ b/packages/core/src/server/release-schema.ts
@@ -86,6 +86,10 @@ const FRAMEWORK_SCHEMA_ENSURES: readonly SchemaEnsure[] = [
     () => import("../jobs/run-history.js").then((m) => m.ensureTable()),
   ],
   [
+    "AutomationWebhookTokens",
+    () => import("../triggers/webhook-store.js").then((m) => m.ensureTable()),
+  ],
+  [
     "AwaitingInputs",
     () =>
       import("../integrations/awaiting-input-store.js").then((m) =>

--- a/packages/core/src/triggers/actions.ts
+++ b/packages/core/src/triggers/actions.ts
@@ -30,6 +30,7 @@ import {
   getRequestOrgId,
 } from "../server/request-context.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
+import { automationWebhookPath } from "./webhook.js";
 
 /* ------------------------------------------------------------------ */
 /*  Individual action handlers                                        */
@@ -103,6 +104,9 @@ async function handleList(
       scope,
       triggerType: meta.triggerType,
       event: meta.event ?? null,
+      webhookPath: meta.webhookToken
+        ? automationWebhookPath(meta.webhookToken)
+        : null,
       schedule: meta.schedule || null,
       timezone: meta.timezone ? effectiveTimezone(meta.timezone) : null,
       scheduleDescription: meta.schedule
@@ -141,9 +145,13 @@ function automationScope(value: unknown): AutomationScope {
   throw new Error('scope must be "personal" or "organization".');
 }
 
-function automationTriggerType(value: unknown): "schedule" | "event" {
-  if (value === "schedule" || value === "event") return value;
-  throw new Error('trigger_type must be "schedule" or "event".');
+function automationTriggerType(
+  value: unknown,
+): "schedule" | "event" | "webhook" {
+  if (value === "schedule" || value === "event" || value === "webhook") {
+    return value;
+  }
+  throw new Error('trigger_type must be "schedule", "event", or "webhook".');
 }
 
 async function handleDefine(
@@ -221,6 +229,9 @@ async function handleDefine(
       scope: definition.scope,
       triggerType: definition.meta.triggerType,
       event: definition.meta.event ?? null,
+      webhookPath: definition.meta.webhookToken
+        ? automationWebhookPath(definition.meta.webhookToken)
+        : null,
       schedule: definition.meta.schedule || null,
       timezone: definition.meta.timezone ?? null,
       nextRun: definition.meta.nextRun ?? null,
@@ -417,12 +428,12 @@ export function createAutomationToolEntries(
   return {
     "manage-automations": {
       tool: {
-        description: `Manage automations (event-triggered and scheduled tasks). Use the "action" parameter to choose an operation:
+        description: `Manage automations (scheduled, event-triggered, and webhook-triggered tasks). Use the "action" parameter to choose an operation:
 
 - **list-events**: List all registered event types that automations can subscribe to. Returns event names, descriptions, and payload schemas. Call this BEFORE defining an automation to discover available events.
 - **list-hosts**: List paired execution hosts and their non-secret capabilities. Call this before assigning execution_host_id.
 - **list**: List all automations (triggers). Shows trigger, status, model, execution host, MCP allowlist, and delivery metadata. Optional params: scope, domain, enabled_only.
-- **define**: Create a new automation. IMPORTANT: Always confirm with the user before calling — show them a summary of what will be created. Required params: name, trigger_type, body. Optional: scope, event, schedule, timezone, condition, mode, domain, delegated_policy_id, model, execution_host_id, execution_engine, execution_cwd, mcpTools. A scheduled automation with no schedule defaults to once per hour; use an event trigger when it should run only when something changes. Host-targeted automations queue code-agent work on that host and do not silently fall back to this server.
+- **define**: Create a new automation. IMPORTANT: Always confirm with the user before calling — show them a summary of what will be created. Required params: name, trigger_type, body. Optional: scope, event, schedule, timezone, condition, mode, domain, delegated_policy_id, model, execution_host_id, execution_engine, execution_cwd, mcpTools. A scheduled automation with no schedule defaults to once per hour; use an event or webhook trigger when it should run only when something changes. Webhook definitions return a URL path with a secret token; never log or expose that token beyond the intended webhook provider. Host-targeted automations queue code-agent work on that host and do not silently fall back to this server.
 - **update**: Update an existing automation's settings without changing its creator (enabled, schedule, timezone, condition, body, policy, model, execution host, MCP allowlist). Required param: name. Use the same scope it was created in.
 - **delete**: Delete an automation. Always confirm with the user first. Required param: name.
 - **fire-test**: Fire a test event to validate automations. Emits a test.event.fired event. Optional param: data (JSON string).
@@ -454,8 +465,9 @@ export function createAutomationToolEntries(
             },
             trigger_type: {
               type: "string",
-              description: '"event" or "schedule". Required for define.',
-              enum: ["event", "schedule"],
+              description:
+                '"schedule", "event", or "webhook". Required for define.',
+              enum: ["event", "schedule", "webhook"],
             },
             event: {
               type: "string",

--- a/packages/core/src/triggers/actions.ts
+++ b/packages/core/src/triggers/actions.ts
@@ -30,7 +30,6 @@ import {
   getRequestOrgId,
 } from "../server/request-context.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
-import { automationWebhookPath } from "./webhook.js";
 
 /* ------------------------------------------------------------------ */
 /*  Individual action handlers                                        */
@@ -99,14 +98,12 @@ async function handleList(
   const automations = definitions
     .filter(({ meta }) => !args.domain || meta.domain === args.domain)
     .filter(({ meta }) => args.enabled_only !== "true" || meta.enabled)
-    .map(({ name, meta, body, canUpdate }) => ({
+    .map(({ name, meta, body, canUpdate, webhookPath }) => ({
       name,
       scope,
       triggerType: meta.triggerType,
       event: meta.event ?? null,
-      webhookPath: meta.webhookToken
-        ? automationWebhookPath(meta.webhookToken)
-        : null,
+      webhookPath: canUpdate ? (webhookPath ?? null) : null,
       schedule: meta.schedule || null,
       timezone: meta.timezone ? effectiveTimezone(meta.timezone) : null,
       scheduleDescription: meta.schedule
@@ -229,9 +226,7 @@ async function handleDefine(
       scope: definition.scope,
       triggerType: definition.meta.triggerType,
       event: definition.meta.event ?? null,
-      webhookPath: definition.meta.webhookToken
-        ? automationWebhookPath(definition.meta.webhookToken)
-        : null,
+      webhookPath: definition.webhookPath ?? null,
       schedule: definition.meta.schedule || null,
       timezone: definition.meta.timezone ?? null,
       nextRun: definition.meta.nextRun ?? null,
@@ -317,6 +312,7 @@ async function handleUpdate(
       scope: definition.scope,
       triggerType: definition.meta.triggerType,
       enabled: definition.meta.enabled,
+      webhookPath: definition.webhookPath ?? null,
       schedule: definition.meta.schedule || null,
       timezone: definition.meta.timezone ?? null,
       nextRun: definition.meta.nextRun ?? null,

--- a/packages/core/src/triggers/actions/list-automation-events.ts
+++ b/packages/core/src/triggers/actions/list-automation-events.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+import { defineAction } from "../../action.js";
+import { listEvents } from "../../event-bus/index.js";
+
+export default defineAction({
+  description: "List event types available to the automation builder.",
+  agentTool: false,
+  http: { method: "GET" },
+  readOnly: true,
+  parallelSafe: true,
+  schema: z.object({}),
+  run: async () =>
+    listEvents().map((event) => ({
+      name: event.name,
+      description: event.description,
+    })),
+});

--- a/packages/core/src/triggers/actions/list-automations.ts
+++ b/packages/core/src/triggers/actions/list-automations.ts
@@ -11,6 +11,7 @@ import {
   isValidCron,
   nextOccurrence,
 } from "../../jobs/cron.js";
+import { automationWebhookPath } from "../webhook.js";
 
 const scopeSchema = z.enum(["personal", "organization"]);
 
@@ -42,8 +43,9 @@ export interface AutomationActionItem {
   name: string;
   path: string;
   scope: "personal" | "organization";
-  triggerType: "event" | "schedule";
+  triggerType: "event" | "schedule" | "webhook";
   event: string | null;
+  webhookPath: string | null;
   schedule: string | null;
   timezone: string | null;
   scheduleDescription: string | null;
@@ -71,7 +73,7 @@ export interface AutomationActionItem {
 
 export default defineAction({
   description:
-    "List event-triggered and schedule-triggered automations in the selected personal or organization scope.",
+    "List scheduled, event-triggered, and webhook-triggered automations in the selected personal or organization scope.",
   agentTool: false,
   schema: z.object({
     scope: scopeSchema.default("personal"),
@@ -93,6 +95,12 @@ export default defineAction({
       scope: scope as AutomationScope,
       triggerType: meta.triggerType,
       event: meta.event ?? null,
+      // The path is a bearer credential, so only people who can update the
+      // automation can retrieve it from the action surface.
+      webhookPath:
+        canUpdate && meta.webhookToken
+          ? automationWebhookPath(meta.webhookToken)
+          : null,
       schedule: meta.schedule || null,
       timezone: meta.schedule ? effectiveTimezone(meta.timezone) : null,
       scheduleDescription: meta.schedule

--- a/packages/core/src/triggers/actions/list-automations.ts
+++ b/packages/core/src/triggers/actions/list-automations.ts
@@ -11,7 +11,6 @@ import {
   isValidCron,
   nextOccurrence,
 } from "../../jobs/cron.js";
-import { automationWebhookPath } from "../webhook.js";
 
 const scopeSchema = z.enum(["personal", "organization"]);
 
@@ -88,44 +87,43 @@ export default defineAction({
       { userEmail, orgId: ctx?.orgId, appId: ctx?.appId },
       scope as AutomationScope,
     );
-    return definitions.map(({ resource, name, meta, body, canUpdate }) => ({
-      id: resource.id,
-      name,
-      path: resource.path,
-      scope: scope as AutomationScope,
-      triggerType: meta.triggerType,
-      event: meta.event ?? null,
-      // The path is a bearer credential, so only people who can update the
-      // automation can retrieve it from the action surface.
-      webhookPath:
-        canUpdate && meta.webhookToken
-          ? automationWebhookPath(meta.webhookToken)
+    return definitions.map(
+      ({ resource, name, meta, body, canUpdate, webhookPath }) => ({
+        id: resource.id,
+        name,
+        path: resource.path,
+        scope: scope as AutomationScope,
+        triggerType: meta.triggerType,
+        event: meta.event ?? null,
+        // The path is a bearer credential, so only people who can update the
+        // automation can retrieve it from the action surface.
+        webhookPath: canUpdate ? (webhookPath ?? null) : null,
+        schedule: meta.schedule || null,
+        timezone: meta.schedule ? effectiveTimezone(meta.timezone) : null,
+        scheduleDescription: meta.schedule
+          ? describeCron(meta.schedule, effectiveTimezone(meta.timezone))
           : null,
-      schedule: meta.schedule || null,
-      timezone: meta.schedule ? effectiveTimezone(meta.timezone) : null,
-      scheduleDescription: meta.schedule
-        ? describeCron(meta.schedule, effectiveTimezone(meta.timezone))
-        : null,
-      condition: meta.condition ?? null,
-      body,
-      enabled: meta.enabled,
-      lastRun: meta.lastRun ?? null,
-      lastCheck: meta.lastCheck ?? null,
-      lastStatus: meta.lastStatus ?? null,
-      lastError: meta.lastError ?? null,
-      nextRun: nextRun(meta),
-      createdBy: meta.createdBy ?? null,
-      model: meta.model ?? null,
-      executionHostId: meta.executionHostId ?? null,
-      executionEngine: meta.executionEngine ?? null,
-      executionCwd: meta.executionCwd ?? null,
-      mcpTools: meta.mcpTools ?? [],
-      originScopeId: meta.originScopeId ?? null,
-      deliveryPlatform: meta.deliveryPlatform ?? null,
-      deliveryDestination: meta.deliveryDestination ?? null,
-      deliveryThreadRef: meta.deliveryThreadRef ?? null,
-      deliveryTenantId: meta.deliveryTenantId ?? null,
-      canUpdate,
-    }));
+        condition: meta.condition ?? null,
+        body,
+        enabled: meta.enabled,
+        lastRun: meta.lastRun ?? null,
+        lastCheck: meta.lastCheck ?? null,
+        lastStatus: meta.lastStatus ?? null,
+        lastError: meta.lastError ?? null,
+        nextRun: nextRun(meta),
+        createdBy: meta.createdBy ?? null,
+        model: meta.model ?? null,
+        executionHostId: meta.executionHostId ?? null,
+        executionEngine: meta.executionEngine ?? null,
+        executionCwd: meta.executionCwd ?? null,
+        mcpTools: meta.mcpTools ?? [],
+        originScopeId: meta.originScopeId ?? null,
+        deliveryPlatform: meta.deliveryPlatform ?? null,
+        deliveryDestination: meta.deliveryDestination ?? null,
+        deliveryThreadRef: meta.deliveryThreadRef ?? null,
+        deliveryTenantId: meta.deliveryTenantId ?? null,
+        canUpdate,
+      }),
+    );
   },
 });

--- a/packages/core/src/triggers/actions/manage-automation.ts
+++ b/packages/core/src/triggers/actions/manage-automation.ts
@@ -2,19 +2,24 @@ import { z } from "zod";
 
 import { defineAction } from "../../action.js";
 import {
+  defineAutomation,
   deleteAutomation,
   updateAutomation,
 } from "../../automations/service.js";
 import { refreshEventSubscriptions } from "../dispatcher.js";
+import { automationWebhookPath } from "../webhook.js";
 
 export default defineAction({
   description:
-    "Enable, disable, or delete a personal or organization automation from the Agent Automations page.",
+    "Create, enable, disable, or delete a personal or organization automation from the Agent Automations page.",
   agentTool: false,
   schema: z.object({
-    operation: z.enum(["update", "delete"]),
+    operation: z.enum(["create", "update", "delete"]),
     name: z.string().min(1),
     scope: z.enum(["personal", "organization"]).default("personal"),
+    triggerType: z.enum(["schedule", "event", "webhook"]).optional(),
+    body: z.string().optional(),
+    event: z.string().min(1).optional(),
     enabled: z.boolean().optional(),
     schedule: z.string().min(1).optional(),
     timezone: z.string().min(1).optional(),
@@ -27,6 +32,9 @@ export default defineAction({
       operation,
       name,
       scope,
+      triggerType,
+      body,
+      event,
       enabled,
       schedule,
       timezone,
@@ -43,6 +51,37 @@ export default defineAction({
       orgId: ctx?.orgId,
       appId: ctx?.appId,
     };
+
+    if (operation === "create") {
+      if (!triggerType) {
+        throw Object.assign(new Error("triggerType is required for create."), {
+          statusCode: 400,
+        });
+      }
+      const definition = await defineAutomation(actor, {
+        name,
+        scope,
+        triggerType,
+        body: body ?? "",
+        event,
+        schedule,
+        timezone,
+      });
+      await refreshEventSubscriptions();
+      return {
+        created: true,
+        name: definition.name,
+        scope,
+        triggerType: definition.meta.triggerType,
+        event: definition.meta.event ?? null,
+        schedule: definition.meta.schedule || null,
+        timezone: definition.meta.timezone ?? null,
+        webhookPath: definition.meta.webhookToken
+          ? automationWebhookPath(definition.meta.webhookToken)
+          : null,
+        nextRun: definition.meta.nextRun ?? null,
+      };
+    }
 
     if (operation === "delete") {
       await deleteAutomation(actor, scope, name);

--- a/packages/core/src/triggers/actions/manage-automation.ts
+++ b/packages/core/src/triggers/actions/manage-automation.ts
@@ -7,7 +7,6 @@ import {
   updateAutomation,
 } from "../../automations/service.js";
 import { refreshEventSubscriptions } from "../dispatcher.js";
-import { automationWebhookPath } from "../webhook.js";
 
 export default defineAction({
   description:
@@ -76,9 +75,7 @@ export default defineAction({
         event: definition.meta.event ?? null,
         schedule: definition.meta.schedule || null,
         timezone: definition.meta.timezone ?? null,
-        webhookPath: definition.meta.webhookToken
-          ? automationWebhookPath(definition.meta.webhookToken)
-          : null,
+        webhookPath: definition.webhookPath ?? null,
         nextRun: definition.meta.nextRun ?? null,
       };
     }
@@ -121,6 +118,7 @@ export default defineAction({
       executionEngine: definition.meta.executionEngine ?? null,
       executionCwd: definition.meta.executionCwd ?? null,
       nextRun: definition.meta.nextRun ?? null,
+      webhookPath: definition.webhookPath ?? null,
     };
   },
 });

--- a/packages/core/src/triggers/dispatcher.ts
+++ b/packages/core/src/triggers/dispatcher.ts
@@ -71,6 +71,8 @@ export interface TriggerDispatcherDeps extends BackgroundAutomationDeps {
   ) => string[] | undefined;
 }
 
+export type AutomationWebhookTaskResult = "completed" | "retry";
+
 // Track active subscriptions (eventName -> subscription id) to avoid
 // double-subscribing AND so subscriptions for events that no longer have any
 // enabled trigger can be torn down — otherwise deleted/disabled triggers leave
@@ -393,7 +395,7 @@ async function handleEvent(
  */
 export async function dispatchAutomationWebhookTask(
   task: AutomationWebhookTaskPayload,
-): Promise<void> {
+): Promise<AutomationWebhookTaskResult> {
   const deps = _deps;
   if (!deps)
     throw new Error("Automation trigger dispatcher is not initialized.");
@@ -406,11 +408,11 @@ export async function dispatchAutomationWebhookTask(
   if (meta.triggerType !== "webhook") {
     throw new Error("Webhook target is no longer a webhook automation.");
   }
-  if (!meta.enabled) return;
+  if (!meta.enabled) return "completed";
   if (!jobBelongsToApp(meta, deps.appId)) {
     throw new Error("Webhook automation belongs to a different app.");
   }
-  if (!body.trim()) return;
+  if (!body.trim()) return "completed";
 
   const resolved = await resolveAutomationExecutionIdentity(
     resource.owner,
@@ -423,27 +425,22 @@ export async function dispatchAutomationWebhookTask(
   if (!apiKey) throw new Error("No API key is available for this automation.");
 
   if (isBackgroundAutomationRunActive(meta)) {
-    await recordTriggerSkip(
-      resource,
-      "skipped",
-      "Automation is already running.",
-    );
-    return;
+    return "retry";
   }
   const matches = await evaluateCondition(meta.condition, task.payload, apiKey);
   if (!matches) {
     await recordTriggerSkip(resource, "skipped", undefined);
-    return;
+    return "completed";
   }
   if (meta.mode !== "agentic") {
     console.warn(
       `[triggers] Deterministic mode not yet implemented for "${task.path}" — skipping`,
     );
-    return;
+    return "completed";
   }
 
   const dispatchKey = `${resource.owner}:${resource.path}`;
-  if (_dispatchingTriggers.has(dispatchKey)) return;
+  if (_dispatchingTriggers.has(dispatchKey)) return "retry";
   _dispatchingTriggers.add(dispatchKey);
   try {
     await dispatchAgentic(
@@ -459,6 +456,7 @@ export async function dispatchAutomationWebhookTask(
   } finally {
     _dispatchingTriggers.delete(dispatchKey);
   }
+  return "completed";
 }
 
 async function dispatchAgentic(

--- a/packages/core/src/triggers/dispatcher.ts
+++ b/packages/core/src/triggers/dispatcher.ts
@@ -33,6 +33,7 @@ import {
 } from "../resources/store.js";
 import { evaluateCondition } from "./condition-evaluator.js";
 import type { TriggerFrontmatter } from "./types.js";
+import type { AutomationWebhookTaskPayload } from "./webhook.js";
 
 export function parseTriggerFrontmatter(content: string): {
   meta: TriggerFrontmatter;
@@ -382,6 +383,81 @@ async function handleEvent(
     }
   } catch (err) {
     console.error(`[triggers] Error handling event "${eventName}":`, err);
+  }
+}
+
+/**
+ * Process a webhook task after the public route has persisted it. The queue
+ * worker supplies the target resource identity; the request body never gets
+ * to choose which automation runs.
+ */
+export async function dispatchAutomationWebhookTask(
+  task: AutomationWebhookTaskPayload,
+): Promise<void> {
+  const deps = _deps;
+  if (!deps)
+    throw new Error("Automation trigger dispatcher is not initialized.");
+
+  const resource = await resourceGetByPath(task.owner, task.path);
+  if (!resource || resource.id !== task.automationId) {
+    throw new Error("Webhook automation no longer exists.");
+  }
+  const { meta, body } = parseTriggerFrontmatter(resource.content);
+  if (meta.triggerType !== "webhook") {
+    throw new Error("Webhook target is no longer a webhook automation.");
+  }
+  if (!meta.enabled) return;
+  if (!jobBelongsToApp(meta, deps.appId)) {
+    throw new Error("Webhook automation belongs to a different app.");
+  }
+  if (!body.trim()) return;
+
+  const resolved = await resolveAutomationExecutionIdentity(
+    resource.owner,
+    meta,
+  );
+  if (!resolved.ok) throw new Error(resolved.reason);
+  const identity = resolved.identity;
+  const apiKey =
+    (await getOwnerActiveApiKey(identity.userEmail)) || deps.apiKey;
+  if (!apiKey) throw new Error("No API key is available for this automation.");
+
+  if (isBackgroundAutomationRunActive(meta)) {
+    await recordTriggerSkip(
+      resource,
+      "skipped",
+      "Automation is already running.",
+    );
+    return;
+  }
+  const matches = await evaluateCondition(meta.condition, task.payload, apiKey);
+  if (!matches) {
+    await recordTriggerSkip(resource, "skipped", undefined);
+    return;
+  }
+  if (meta.mode !== "agentic") {
+    console.warn(
+      `[triggers] Deterministic mode not yet implemented for "${task.path}" — skipping`,
+    );
+    return;
+  }
+
+  const dispatchKey = `${resource.owner}:${resource.path}`;
+  if (_dispatchingTriggers.has(dispatchKey)) return;
+  _dispatchingTriggers.add(dispatchKey);
+  try {
+    await dispatchAgentic(
+      resource,
+      task.payload,
+      {
+        eventId: task.eventId,
+        emittedAt: new Date().toISOString(),
+        owner: identity.eventOwner,
+      },
+      identity,
+    );
+  } finally {
+    _dispatchingTriggers.delete(dispatchKey);
   }
 }
 

--- a/packages/core/src/triggers/routes.ts
+++ b/packages/core/src/triggers/routes.ts
@@ -1,12 +1,24 @@
+import { randomUUID } from "node:crypto";
+
 import {
   defineEventHandler,
+  getRequestHeader,
   getMethod,
   setResponseStatus,
   type H3Event,
 } from "h3";
 
+import {
+  AutomationConnectorError,
+  readBoundedRequestBody,
+} from "../automation/index.js";
 import { canUpdateAutomationResource } from "../automations/service.js";
 import { getDbExec } from "../db/client.js";
+import { dispatchPendingIntegrationTask } from "../integrations/integration-durable-dispatch.js";
+import {
+  insertPendingTask,
+  isDuplicateEventError,
+} from "../integrations/pending-tasks-store.js";
 import {
   nextOccurrence,
   describeCron,
@@ -32,6 +44,14 @@ import { getSession } from "../server/auth.js";
 import { readBody } from "../server/h3-helpers.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
 import type { TriggerFrontmatter } from "./types.js";
+import {
+  AUTOMATION_WEBHOOK_MAX_BODY_BYTES,
+  AUTOMATION_WEBHOOK_PLATFORM,
+  automationWebhookPath,
+  isAutomationWebhookToken,
+  webhookTokensMatch,
+  type AutomationWebhookTaskPayload,
+} from "./webhook.js";
 
 export interface AutomationRouteItem {
   id: string;
@@ -44,6 +64,7 @@ export interface AutomationRouteItem {
   canUpdate: boolean;
   triggerType: TriggerFrontmatter["triggerType"];
   event?: string;
+  webhookPath?: string;
   schedule?: string;
   scheduleDescription?: string;
   condition?: string;
@@ -119,7 +140,7 @@ function scheduleDescription(schedule?: string, timezone?: string) {
 function nextRunForMeta(meta: TriggerFrontmatter): string | undefined {
   const scheduled = Boolean(
     meta.enabled &&
-    meta.triggerType !== "event" &&
+    meta.triggerType === "schedule" &&
     meta.schedule &&
     isValidCron(meta.schedule),
   );
@@ -209,6 +230,12 @@ async function resourceToAutomationItem(
 ): Promise<AutomationRouteItem> {
   const parsed = parseJobResource(resource.content);
   const meta = asTriggerFrontmatter(parsed.meta);
+  const canUpdate = await currentUserCanUpdateAutomation(
+    event,
+    userEmail,
+    resource,
+    meta,
+  );
   return {
     id: resource.id,
     name: automationName(resource.path),
@@ -218,14 +245,15 @@ async function resourceToAutomationItem(
     orgId: meta.orgId,
     scope:
       resource.owner === userEmail && !meta.orgId ? "personal" : "organization",
-    canUpdate: await currentUserCanUpdateAutomation(
-      event,
-      userEmail,
-      resource,
-      meta,
-    ),
+    canUpdate,
     triggerType: meta.triggerType,
     event: meta.event,
+    // The path is a bearer credential; read-only organization members can see
+    // the trigger without receiving permission to invoke it.
+    webhookPath:
+      canUpdate && meta.webhookToken
+        ? automationWebhookPath(meta.webhookToken)
+        : undefined,
     schedule: meta.schedule || undefined,
     scheduleDescription: scheduleDescription(meta.schedule, meta.timezone),
     condition: meta.condition,
@@ -332,7 +360,7 @@ export async function setAutomationEnabledForOwner(
   parsed.meta.enabled = input.enabled;
   if (
     parsed.meta.enabled &&
-    meta.triggerType !== "event" &&
+    meta.triggerType === "schedule" &&
     meta.schedule &&
     isValidCron(meta.schedule)
   ) {
@@ -354,12 +382,129 @@ export async function setAutomationEnabledForOwner(
 }
 
 function routeError(event: H3Event, err: unknown, fallback: string) {
+  const connectorCode = (err as { code?: string } | null)?.code;
+  const connectorStatus =
+    connectorCode === "payload_too_large"
+      ? 413
+      : connectorCode === "invalid_configuration"
+        ? 400
+        : undefined;
   const statusCode =
-    typeof (err as any)?.statusCode === "number"
+    connectorStatus ??
+    (typeof (err as any)?.statusCode === "number"
       ? (err as any).statusCode
-      : 500;
+      : 500);
   setResponseStatus(event, statusCode);
   return { error: (err as any)?.message ?? fallback };
+}
+
+async function findWebhookAutomation(token: string): Promise<{
+  resource: Resource;
+  meta: TriggerFrontmatter;
+  body: string;
+} | null> {
+  if (!isAutomationWebhookToken(token)) return null;
+  // ponytail: token lookup scans job resources; add an indexed token table if webhook volume warrants it.
+  const resources = await resourceListAllOwners("jobs/");
+  for (const resource of resources) {
+    if (!resource.path.endsWith(".md")) continue;
+    const parsed = parseJobResource(resource.content);
+    const meta = asTriggerFrontmatter(parsed.meta);
+    if (
+      meta.triggerType === "webhook" &&
+      meta.enabled &&
+      webhookTokensMatch(meta.webhookToken, token)
+    ) {
+      return { resource, meta, body: parsed.body };
+    }
+  }
+  return null;
+}
+
+function webhookEventId(event: H3Event): string {
+  const supplied =
+    getRequestHeader(event, "x-webhook-event-id") ??
+    getRequestHeader(event, "x-event-id");
+  const value = supplied?.trim() || randomUUID();
+  if (value.length > 256 || /[\r\n]/.test(value)) {
+    throw Object.assign(new Error("Webhook event id is too long."), {
+      statusCode: 400,
+    });
+  }
+  return value;
+}
+
+async function enqueueAutomationWebhook(
+  event: H3Event,
+  token: string,
+): Promise<Record<string, unknown>> {
+  const match = await findWebhookAutomation(token);
+  if (!match) {
+    setResponseStatus(event, 404);
+    return { error: "Webhook not found" };
+  }
+
+  const rawBody = await readBoundedRequestBody(
+    event,
+    AUTOMATION_WEBHOOK_MAX_BODY_BYTES,
+  );
+  let payload: unknown = rawBody;
+  const contentType = getRequestHeader(event, "content-type")?.toLowerCase();
+  if (contentType?.includes("json")) {
+    try {
+      payload = rawBody.trim() ? JSON.parse(rawBody) : {};
+    } catch {
+      throw new AutomationConnectorError(
+        "invalid_configuration",
+        "Webhook JSON body is invalid.",
+      );
+    }
+  }
+
+  const eventId = webhookEventId(event);
+  const ownerEmail =
+    match.meta.createdBy?.trim().toLowerCase() || match.resource.owner;
+  const externalThreadId = `${match.resource.owner}:${match.resource.path}`;
+  const taskId = randomUUID();
+  const taskPayload: AutomationWebhookTaskPayload = {
+    kind: "automation-webhook",
+    automationId: match.resource.id,
+    owner: match.resource.owner,
+    path: match.resource.path,
+    eventId,
+    payload,
+  };
+
+  try {
+    await insertPendingTask({
+      id: taskId,
+      platform: AUTOMATION_WEBHOOK_PLATFORM,
+      externalThreadId,
+      payload: JSON.stringify(taskPayload),
+      ownerEmail,
+      orgId: match.meta.orgId ?? null,
+      externalEventKey: `${match.resource.id}:${eventId}`,
+    });
+  } catch (error) {
+    if (isDuplicateEventError(error)) {
+      setResponseStatus(event, 200);
+      return { accepted: true, duplicate: true, eventId };
+    }
+    throw error;
+  }
+
+  await dispatchPendingIntegrationTask({
+    taskId,
+    task: { platform: AUTOMATION_WEBHOOK_PLATFORM, externalThreadId },
+    event,
+  }).catch((error) => {
+    console.error(
+      `[automations] Webhook task ${taskId} was queued but could not be dispatched:`,
+      error,
+    );
+  });
+  setResponseStatus(event, 202);
+  return { accepted: true, eventId };
 }
 
 export function createAutomationsHandler() {
@@ -369,6 +514,15 @@ export function createAutomationsHandler() {
       .split("?")[0]
       .replace(/^\/+/, "")
       .replace(/\/+$/, "");
+
+    const webhookToken = pathname.match(/(?:^|\/)webhook\/([^/]+)$/)?.[1];
+    if (webhookToken && method === "POST") {
+      try {
+        return await enqueueAutomationWebhook(event, webhookToken);
+      } catch (err) {
+        return routeError(event, err, "Failed to enqueue automation webhook");
+      }
+    }
 
     const session = await getSession(event).catch(() => null);
     if (!session?.email) {

--- a/packages/core/src/triggers/routes.ts
+++ b/packages/core/src/triggers/routes.ts
@@ -45,11 +45,13 @@ import { readBody } from "../server/h3-helpers.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
 import type { TriggerFrontmatter } from "./types.js";
 import {
+  findAutomationWebhookTarget,
+  readAutomationWebhookPath,
+} from "./webhook-store.js";
+import {
   AUTOMATION_WEBHOOK_MAX_BODY_BYTES,
   AUTOMATION_WEBHOOK_PLATFORM,
-  automationWebhookPath,
   isAutomationWebhookToken,
-  webhookTokensMatch,
   type AutomationWebhookTaskPayload,
 } from "./webhook.js";
 
@@ -178,7 +180,7 @@ async function currentUserCanUpdateAutomation(
       const org = await getOrgContext(event);
       if (org.orgId !== resourceOrgId) return false;
       return await canUpdateAutomationResource(
-        { userEmail, orgId: resourceOrgId },
+        { userEmail, orgId: resourceOrgId, appId: meta.appId },
         resource,
       );
     } catch {
@@ -251,8 +253,8 @@ async function resourceToAutomationItem(
     // The path is a bearer credential; read-only organization members can see
     // the trigger without receiving permission to invoke it.
     webhookPath:
-      canUpdate && meta.webhookToken
-        ? automationWebhookPath(meta.webhookToken)
+      canUpdate && meta.triggerType === "webhook"
+        ? await readAutomationWebhookPath(resource, meta)
         : undefined,
     schedule: meta.schedule || undefined,
     scheduleDescription: scheduleDescription(meta.schedule, meta.timezone),
@@ -404,28 +406,31 @@ async function findWebhookAutomation(token: string): Promise<{
   body: string;
 } | null> {
   if (!isAutomationWebhookToken(token)) return null;
-  // ponytail: token lookup scans job resources; add an indexed token table if webhook volume warrants it.
-  const resources = await resourceListAllOwners("jobs/");
-  for (const resource of resources) {
-    if (!resource.path.endsWith(".md")) continue;
-    const parsed = parseJobResource(resource.content);
-    const meta = asTriggerFrontmatter(parsed.meta);
-    if (
-      meta.triggerType === "webhook" &&
-      meta.enabled &&
-      webhookTokensMatch(meta.webhookToken, token)
-    ) {
-      return { resource, meta, body: parsed.body };
-    }
-  }
-  return null;
+  const target = await findAutomationWebhookTarget(token);
+  if (!target) return null;
+  const resource = await resourceGetByPath(target.owner, target.path);
+  if (!resource || resource.id !== target.automationId) return null;
+  const parsed = parseJobResource(resource.content);
+  const meta = asTriggerFrontmatter(parsed.meta);
+  return meta.triggerType === "webhook" && meta.enabled
+    ? { resource, meta, body: parsed.body }
+    : null;
 }
 
-function webhookEventId(event: H3Event): string {
-  const supplied =
-    getRequestHeader(event, "x-webhook-event-id") ??
-    getRequestHeader(event, "x-event-id");
-  const value = supplied?.trim() || randomUUID();
+function webhookEventId(event: H3Event, payload: unknown): string {
+  const supplied = [
+    getRequestHeader(event, "x-webhook-event-id"),
+    getRequestHeader(event, "x-event-id"),
+    getRequestHeader(event, "x-github-delivery"),
+  ].find((value) => value?.trim());
+  const bodyId =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>).id
+      : undefined;
+  const value =
+    supplied?.trim() ||
+    (typeof bodyId === "string" ? bodyId.trim() : "") ||
+    randomUUID();
   if (value.length > 256 || /[\r\n]/.test(value)) {
     throw Object.assign(new Error("Webhook event id is too long."), {
       statusCode: 400,
@@ -461,7 +466,7 @@ async function enqueueAutomationWebhook(
     }
   }
 
-  const eventId = webhookEventId(event);
+  const eventId = webhookEventId(event, payload);
   const ownerEmail =
     match.meta.createdBy?.trim().toLowerCase() || match.resource.owner;
   const externalThreadId = `${match.resource.owner}:${match.resource.path}`;

--- a/packages/core/src/triggers/types.ts
+++ b/packages/core/src/triggers/types.ts
@@ -13,7 +13,7 @@ import type {
 } from "../jobs/frontmatter.js";
 
 export interface TriggerFrontmatter extends JobFrontmatter {
-  /** "schedule" = cron-based (legacy jobs). "event" = fires on bus event. */
+  /** "schedule" = cron, "event" = bus event, "webhook" = public POST. */
   triggerType: JobTriggerType;
   /**
    * "agentic" = full runAgentLoop; the only mode `manage-automations` will

--- a/packages/core/src/triggers/webhook-store.ts
+++ b/packages/core/src/triggers/webhook-store.ts
@@ -1,0 +1,163 @@
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { ensureTableExists } from "../db/ddl-guard.js";
+import type { JobFrontmatter } from "../jobs/frontmatter.js";
+import type { Resource } from "../resources/store.js";
+import {
+  deleteAppSecret,
+  readAppSecret,
+  writeAppSecret,
+  type SecretRef,
+} from "../secrets/storage.js";
+import {
+  automationWebhookPath,
+  automationWebhookTokenHash,
+  isAutomationWebhookToken,
+  webhookTokensMatch,
+} from "./webhook.js";
+
+const WEBHOOK_SECRET_KEY_PREFIX = "automation-webhook:";
+
+let _initPromise: Promise<void> | undefined;
+
+function secretRef(
+  resource: Pick<Resource, "id" | "owner">,
+  meta: Pick<JobFrontmatter, "createdBy" | "orgId">,
+): SecretRef {
+  const orgId = meta.orgId?.trim();
+  if (orgId) {
+    return {
+      key: `${WEBHOOK_SECRET_KEY_PREFIX}${resource.id}`,
+      scope: "org",
+      scopeId: orgId,
+    };
+  }
+  return {
+    key: `${WEBHOOK_SECRET_KEY_PREFIX}${resource.id}`,
+    scope: "user",
+    scopeId: (meta.createdBy?.trim() || resource.owner).toLowerCase(),
+  };
+}
+
+export async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      const createSql = `CREATE TABLE IF NOT EXISTS automation_webhook_tokens (
+  token_hash TEXT PRIMARY KEY,
+  automation_id TEXT NOT NULL UNIQUE,
+  owner TEXT NOT NULL,
+  path TEXT NOT NULL,
+  secret_scope TEXT NOT NULL,
+  secret_scope_id TEXT NOT NULL,
+  secret_key TEXT NOT NULL,
+  created_at ${intType()} NOT NULL,
+  updated_at ${intType()} NOT NULL
+)`;
+
+      if (isPostgres()) {
+        await ensureTableExists("automation_webhook_tokens", createSql);
+        return;
+      }
+      await client.execute(createSql);
+    })().catch((error) => {
+      _initPromise = undefined;
+      throw error;
+    });
+  }
+  return _initPromise;
+}
+
+export async function saveAutomationWebhookToken(
+  resource: Pick<Resource, "id" | "owner" | "path">,
+  meta: Pick<JobFrontmatter, "createdBy" | "orgId">,
+  token: string,
+): Promise<void> {
+  if (!isAutomationWebhookToken(token)) {
+    throw new Error("Invalid automation webhook token.");
+  }
+  await ensureTable();
+  const ref = secretRef(resource, meta);
+  await writeAppSecret({ ...ref, value: token });
+  try {
+    await getDbExec().execute({
+      sql: `INSERT INTO automation_webhook_tokens
+        (token_hash, automation_id, owner, path, secret_scope, secret_scope_id, secret_key, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (automation_id) DO UPDATE SET
+          token_hash = excluded.token_hash,
+          owner = excluded.owner,
+          path = excluded.path,
+          secret_scope = excluded.secret_scope,
+          secret_scope_id = excluded.secret_scope_id,
+          secret_key = excluded.secret_key,
+          updated_at = excluded.updated_at`,
+      args: [
+        automationWebhookTokenHash(token),
+        resource.id,
+        resource.owner,
+        resource.path,
+        ref.scope,
+        ref.scopeId,
+        ref.key,
+        Date.now(),
+        Date.now(),
+      ],
+    });
+  } catch (error) {
+    await deleteAppSecret(ref).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function deleteAutomationWebhookToken(
+  resource: Pick<Resource, "id" | "owner">,
+  meta: Pick<JobFrontmatter, "createdBy" | "orgId">,
+): Promise<void> {
+  await ensureTable();
+  const ref = secretRef(resource, meta);
+  await getDbExec().execute({
+    sql: "DELETE FROM automation_webhook_tokens WHERE automation_id = ?",
+    args: [resource.id],
+  });
+  await deleteAppSecret(ref);
+}
+
+export async function readAutomationWebhookPath(
+  resource: Pick<Resource, "id" | "owner">,
+  meta: Pick<JobFrontmatter, "createdBy" | "orgId">,
+): Promise<string | undefined> {
+  const stored = await readAppSecret(secretRef(resource, meta));
+  if (!stored || !isAutomationWebhookToken(stored.value)) return undefined;
+  return automationWebhookPath(stored.value);
+}
+
+export interface AutomationWebhookTarget {
+  automationId: string;
+  owner: string;
+  path: string;
+}
+
+export async function findAutomationWebhookTarget(
+  token: string,
+): Promise<AutomationWebhookTarget | null> {
+  if (!isAutomationWebhookToken(token)) return null;
+  await ensureTable();
+  const { rows } = await getDbExec().execute({
+    sql: `SELECT automation_id, owner, path, secret_scope, secret_scope_id, secret_key
+      FROM automation_webhook_tokens WHERE token_hash = ? LIMIT 1`,
+    args: [automationWebhookTokenHash(token)],
+  });
+  const row = rows[0] as Record<string, unknown> | undefined;
+  if (!row) return null;
+  const stored = await readAppSecret({
+    key: String(row.secret_key),
+    scope: String(row.secret_scope) as SecretRef["scope"],
+    scopeId: String(row.secret_scope_id),
+  });
+  if (!stored || !webhookTokensMatch(stored.value, token)) return null;
+  return {
+    automationId: String(row.automation_id),
+    owner: String(row.owner),
+    path: String(row.path),
+  };
+}

--- a/packages/core/src/triggers/webhook.spec.ts
+++ b/packages/core/src/triggers/webhook.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  automationWebhookPath,
+  createAutomationWebhookToken,
+  isAutomationWebhookToken,
+  webhookTokensMatch,
+} from "./webhook.js";
+
+describe("automation webhook credentials", () => {
+  it("generates opaque tokens and compares them without exposing them", () => {
+    const token = createAutomationWebhookToken();
+    expect(token).toHaveLength(43);
+    expect(isAutomationWebhookToken(token)).toBe(true);
+    expect(webhookTokensMatch(token, token)).toBe(true);
+    expect(webhookTokensMatch(token, `${token}x`)).toBe(false);
+    expect(webhookTokensMatch(token, "not-a-token")).toBe(false);
+    expect(automationWebhookPath(token)).toBe(
+      `/_agent-native/automations/webhook/${token}`,
+    );
+  });
+});

--- a/packages/core/src/triggers/webhook.ts
+++ b/packages/core/src/triggers/webhook.ts
@@ -1,4 +1,4 @@
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 
 export const AUTOMATION_WEBHOOK_PLATFORM = "automation-webhook";
 export const AUTOMATION_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
@@ -24,6 +24,10 @@ export function isAutomationWebhookToken(value: string): boolean {
 
 export function automationWebhookPath(token: string): string {
   return `/_agent-native/automations/webhook/${token}`;
+}
+
+export function automationWebhookTokenHash(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
 }
 
 export function webhookTokensMatch(

--- a/packages/core/src/triggers/webhook.ts
+++ b/packages/core/src/triggers/webhook.ts
@@ -1,0 +1,40 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+export const AUTOMATION_WEBHOOK_PLATFORM = "automation-webhook";
+export const AUTOMATION_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
+
+const WEBHOOK_TOKEN_RE = /^[A-Za-z0-9_-]{43}$/;
+
+export interface AutomationWebhookTaskPayload {
+  kind: "automation-webhook";
+  automationId: string;
+  owner: string;
+  path: string;
+  eventId: string;
+  payload: unknown;
+}
+
+export function createAutomationWebhookToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function isAutomationWebhookToken(value: string): boolean {
+  return WEBHOOK_TOKEN_RE.test(value);
+}
+
+export function automationWebhookPath(token: string): string {
+  return `/_agent-native/automations/webhook/${token}`;
+}
+
+export function webhookTokensMatch(
+  expected: string | undefined,
+  received: string,
+): boolean {
+  if (!expected || !isAutomationWebhookToken(received)) return false;
+  const expectedBuffer = Buffer.from(expected);
+  const receivedBuffer = Buffer.from(received);
+  return (
+    expectedBuffer.length === receivedBuffer.length &&
+    timingSafeEqual(expectedBuffer, receivedBuffer)
+  );
+}

--- a/packages/dispatch/src/components/automation-create-dialog.tsx
+++ b/packages/dispatch/src/components/automation-create-dialog.tsx
@@ -1,0 +1,664 @@
+import {
+  DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+  AUTOMATION_WEEKDAYS,
+  automationScheduleToCron,
+  formatAutomationTime,
+  type AutomationScheduleDraft,
+  type AutomationSchedulePreset,
+  type AutomationScheduleUnit,
+} from "@agent-native/core/client/agent-page/automation-schedule";
+import {
+  TimezoneSelect,
+  browserTimezone,
+} from "@agent-native/core/client/agent-page/timezone-select";
+import {
+  useActionMutation,
+  useActionQuery,
+} from "@agent-native/core/client/hooks";
+import {
+  IconBolt,
+  IconCalendarEvent,
+  IconClock,
+  IconCode,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { Textarea } from "./ui/textarea";
+
+type TriggerType = "schedule" | "event" | "webhook";
+
+interface AutomationEvent {
+  name: string;
+  description?: string;
+}
+
+interface CreateAutomationInput {
+  operation: "create";
+  name: string;
+  scope: "personal" | "organization";
+  triggerType: TriggerType;
+  body: string;
+  schedule?: string;
+  timezone?: string;
+  event?: string;
+}
+
+interface CreateAutomationResult {
+  created: true;
+  name: string;
+  triggerType: TriggerType;
+  webhookPath: string | null;
+}
+
+const PRESETS: {
+  value: AutomationSchedulePreset;
+  label: string;
+  detail: string;
+  draft: Partial<AutomationScheduleDraft>;
+}[] = [
+  {
+    value: "hourly",
+    label: "Every hour",
+    detail: "At the top of the hour",
+    draft: { preset: "hourly" },
+  },
+  {
+    value: "daily-midnight",
+    label: "Every day at midnight",
+    detail: "12:00 AM",
+    draft: { preset: "daily-midnight" },
+  },
+  {
+    value: "daily-noon",
+    label: "Every day at noon",
+    detail: "12:00 PM",
+    draft: { preset: "daily-noon" },
+  },
+  {
+    value: "weekdays",
+    label: "Every weekday",
+    detail: "Monday to Friday at 9:00 AM",
+    draft: { preset: "weekdays", time: "09:00" },
+  },
+  {
+    value: "weekly",
+    label: "Every week",
+    detail: "Sunday at 9:00 AM",
+    draft: { preset: "weekly", weekday: 0, time: "09:00" },
+  },
+];
+
+function presetClass(selected: boolean): string {
+  return (
+    "rounded-lg border px-3 py-2 text-left transition-colors " +
+    (selected
+      ? "border-primary bg-primary/5 text-foreground"
+      : "border-border/70 bg-background hover:bg-muted/50")
+  );
+}
+
+function scheduleIsValid(value: string): boolean {
+  return value.trim().split(/\s+/).length === 5;
+}
+
+function ScheduleFields({
+  draft,
+  saving,
+  onChange,
+}: {
+  draft: AutomationScheduleDraft;
+  saving: boolean;
+  onChange: (patch: Partial<AutomationScheduleDraft>) => void;
+}) {
+  const customMinute = Number(draft.time.split(":")[1] ?? 0);
+  return (
+    <div className="space-y-3 rounded-lg border border-border/70 bg-muted/20 p-3">
+      <div className="grid gap-3 sm:grid-cols-[1fr_1fr]">
+        <label className="space-y-1.5 text-xs text-muted-foreground">
+          <span>Repeat every</span>
+          <Input
+            type="number"
+            min={1}
+            max={31}
+            value={draft.interval}
+            disabled={saving}
+            onChange={(event) =>
+              onChange({
+                interval: Math.max(1, Number(event.target.value) || 1),
+              })
+            }
+            className="h-9 bg-background text-sm"
+          />
+        </label>
+        <label className="space-y-1.5 text-xs text-muted-foreground">
+          <span>Unit</span>
+          <Select
+            value={draft.unit}
+            disabled={saving}
+            onValueChange={(value) =>
+              onChange({ unit: value as AutomationScheduleUnit })
+            }
+          >
+            <SelectTrigger className="h-9 bg-background text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="hour">hour(s)</SelectItem>
+              <SelectItem value="day">day(s)</SelectItem>
+              <SelectItem value="week">week(s)</SelectItem>
+              <SelectItem value="month">month(s)</SelectItem>
+            </SelectContent>
+          </Select>
+        </label>
+      </div>
+
+      {draft.unit === "hour" ? (
+        <label className="block space-y-1.5 text-xs text-muted-foreground">
+          <span>At minute</span>
+          <Input
+            type="number"
+            min={0}
+            max={59}
+            value={customMinute}
+            disabled={saving}
+            onChange={(event) =>
+              onChange({
+                time:
+                  "00:" +
+                  String(
+                    Math.min(59, Math.max(0, Number(event.target.value) || 0)),
+                  ).padStart(2, "0"),
+              })
+            }
+            className="h-9 bg-background text-sm"
+          />
+        </label>
+      ) : null}
+
+      {draft.unit === "week" ? (
+        <label className="block space-y-1.5 text-xs text-muted-foreground">
+          <span>On</span>
+          <Select
+            value={String(draft.weekday)}
+            disabled={saving}
+            onValueChange={(value) => onChange({ weekday: Number(value) })}
+          >
+            <SelectTrigger className="h-9 bg-background text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AUTOMATION_WEEKDAYS.map((day) => (
+                <SelectItem key={day.value} value={String(day.value)}>
+                  {day.short}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+      ) : null}
+
+      {draft.unit === "month" ? (
+        <label className="block space-y-1.5 text-xs text-muted-foreground">
+          <span>Day of month</span>
+          <Input
+            type="number"
+            min={1}
+            max={31}
+            value={draft.monthDay}
+            disabled={saving}
+            onChange={(event) =>
+              onChange({
+                monthDay: Math.min(
+                  31,
+                  Math.max(1, Number(event.target.value) || 1),
+                ),
+              })
+            }
+            className="h-9 bg-background text-sm"
+          />
+        </label>
+      ) : null}
+
+      {draft.unit !== "hour" ? (
+        <label className="block space-y-1.5 text-xs text-muted-foreground">
+          <span>At</span>
+          <Input
+            type="time"
+            value={draft.time}
+            disabled={saving}
+            onChange={(event) => onChange({ time: event.target.value })}
+            className="h-9 bg-background text-sm"
+          />
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+function ScheduleBuilder({
+  saving,
+  timezone,
+  onTimezoneChange,
+  onChange,
+}: {
+  saving: boolean;
+  timezone: string;
+  onTimezoneChange: (value: string) => void;
+  onChange: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState<AutomationScheduleDraft>(
+    DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
+  );
+  const [advanced, setAdvanced] = useState(false);
+  const [advancedValue, setAdvancedValue] = useState("0 * * * *");
+  const friendly = automationScheduleToCron(draft);
+  const activeSchedule = advanced
+    ? advancedValue.trim()
+    : (friendly.schedule ?? "");
+  const valid =
+    scheduleIsValid(activeSchedule) && (!friendly.error || advanced);
+
+  useEffect(() => {
+    onChange(valid ? activeSchedule : "");
+  }, [activeSchedule, onChange, valid]);
+
+  function choosePreset(
+    value: AutomationSchedulePreset,
+    presetDraft: Partial<AutomationScheduleDraft>,
+  ) {
+    setDraft((current) => ({ ...current, ...presetDraft, preset: value }));
+    setAdvanced(false);
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-foreground">Repeat</div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {PRESETS.map((preset) => (
+            <button
+              key={preset.value}
+              type="button"
+              aria-pressed={!advanced && draft.preset === preset.value}
+              disabled={saving}
+              className={presetClass(
+                !advanced && draft.preset === preset.value,
+              )}
+              onClick={() => choosePreset(preset.value, preset.draft)}
+            >
+              <span className="block text-sm font-medium">{preset.label}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {preset.detail}
+              </span>
+            </button>
+          ))}
+          <button
+            type="button"
+            aria-pressed={!advanced && draft.preset === "custom"}
+            disabled={saving}
+            className={presetClass(!advanced && draft.preset === "custom")}
+            onClick={() =>
+              choosePreset("custom", {
+                preset: "custom",
+                unit: draft.unit || "day",
+              })
+            }
+          >
+            <span className="block text-sm font-medium">Custom</span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              Set your own repeat pattern
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {!advanced && draft.preset === "custom" ? (
+        <ScheduleFields
+          draft={draft}
+          saving={saving}
+          onChange={(patch) =>
+            setDraft((current) => ({ ...current, ...patch }))
+          }
+        />
+      ) : null}
+
+      {!advanced && friendly.schedule ? (
+        <p className="text-xs text-muted-foreground">
+          Runs{" "}
+          {draft.preset === "hourly"
+            ? "at the start of every hour"
+            : draft.preset === "daily-midnight"
+              ? "every day at midnight"
+              : draft.preset === "daily-noon"
+                ? "every day at noon"
+                : "at " + formatAutomationTime(draft.time)}
+          .
+        </p>
+      ) : null}
+      {!advanced && friendly.error ? (
+        <p className="text-xs text-destructive">
+          Custom weekly intervals beyond one week are available under Advanced.
+        </p>
+      ) : null}
+
+      <div>
+        <label className="text-xs font-medium text-foreground">Timezone</label>
+        <div className="mt-1">
+          <TimezoneSelect
+            value={timezone}
+            disabled={saving}
+            onChange={onTimezoneChange}
+            suggested={[browserTimezone()]}
+          />
+        </div>
+      </div>
+
+      <details
+        className="group rounded-lg border border-border/70 bg-muted/20"
+        open={advanced}
+        onToggle={(event) => {
+          const next = event.currentTarget.open;
+          if (next && !advanced && friendly.schedule) {
+            setAdvancedValue(friendly.schedule);
+          }
+          setAdvanced(next);
+        }}
+      >
+        <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-xs font-medium text-foreground [&::-webkit-details-marker]:hidden">
+          <IconCode className="size-4 text-muted-foreground" />
+          Advanced - cron expression
+          <span className="ms-auto text-muted-foreground group-open:hidden">
+            Show
+          </span>
+          <span className="ms-auto hidden text-muted-foreground group-open:inline">
+            Hide
+          </span>
+        </summary>
+        <div className="border-t border-border/60 px-3 pb-3 pt-2.5">
+          <Input
+            className="font-mono text-sm"
+            value={advancedValue}
+            spellCheck={false}
+            autoComplete="off"
+            disabled={saving}
+            onFocus={() => setAdvanced(true)}
+            onChange={(event) => {
+              setAdvanced(true);
+              setAdvancedValue(event.target.value);
+            }}
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            minute hour day-of-month month day-of-week
+          </p>
+        </div>
+      </details>
+
+      {activeSchedule && !valid ? (
+        <p className="text-xs text-destructive">
+          A cron expression needs exactly 5 fields.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function EventFields({
+  open,
+  event,
+  onChange,
+}: {
+  open: boolean;
+  event: string;
+  onChange: (value: string) => void;
+}) {
+  const eventsQuery = useActionQuery<AutomationEvent[]>(
+    "list-automation-events",
+    {},
+    { enabled: open, staleTime: 60_000 },
+  );
+
+  return (
+    <>
+      <label className="space-y-1.5 text-xs text-muted-foreground">
+        <span>Start when</span>
+        <Select value={event} onValueChange={onChange}>
+          <SelectTrigger>
+            <SelectValue
+              placeholder={
+                eventsQuery.isLoading
+                  ? "Loading event types..."
+                  : "Choose an app event"
+              }
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {(eventsQuery.data ?? []).map((item) => (
+              <SelectItem key={item.name} value={item.name}>
+                {item.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </label>
+      {eventsQuery.data?.find((item) => item.name === event)?.description ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          {eventsQuery.data.find((item) => item.name === event)?.description}
+        </p>
+      ) : null}
+      {eventsQuery.error ? (
+        <p className="mt-2 text-xs text-destructive">
+          Could not load event types.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+export interface AutomationCreateDialogProps {
+  open: boolean;
+  initialScope?: "personal" | "organization";
+  onOpenChange: (open: boolean) => void;
+  onCreated: (result: CreateAutomationResult) => void;
+}
+
+export function AutomationCreateDialog({
+  open,
+  initialScope = "personal",
+  onOpenChange,
+  onCreated,
+}: AutomationCreateDialogProps) {
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState<"personal" | "organization">(initialScope);
+  const [triggerType, setTriggerType] = useState<TriggerType>("schedule");
+  const [schedule, setSchedule] = useState("0 * * * *");
+  const [timezone, setTimezone] = useState(browserTimezone());
+  const [event, setEvent] = useState("");
+  const [body, setBody] = useState("");
+  const create = useActionMutation<
+    CreateAutomationResult,
+    CreateAutomationInput
+  >("manage-automation", {
+    onSuccess: onCreated,
+  });
+
+  const resetCreate = create.reset;
+
+  useEffect(() => {
+    if (!open) return;
+    setName("");
+    setScope(initialScope);
+    setTriggerType("schedule");
+    setSchedule("0 * * * *");
+    setTimezone(browserTimezone());
+    setEvent("");
+    setBody("");
+    resetCreate();
+  }, [initialScope, open, resetCreate]);
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    body.trim().length > 0 &&
+    (triggerType !== "event" || event.length > 0) &&
+    (triggerType !== "schedule" || scheduleIsValid(schedule));
+
+  function submit() {
+    if (!canSubmit) return;
+    create.mutate({
+      operation: "create",
+      name: name.trim(),
+      scope,
+      triggerType,
+      body: body.trim(),
+      ...(triggerType === "schedule"
+        ? { schedule, timezone }
+        : triggerType === "event"
+          ? { event }
+          : {}),
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New automation</DialogTitle>
+          <DialogDescription>
+            Choose what starts it, then describe the work in plain language.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-[1fr_12rem]">
+            <label className="space-y-1.5 text-xs text-muted-foreground">
+              <span>Name</span>
+              <Input
+                value={name}
+                disabled={create.isPending}
+                placeholder="morning-digest"
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+            <label className="space-y-1.5 text-xs text-muted-foreground">
+              <span>Scope</span>
+              <Select
+                value={scope}
+                disabled={create.isPending}
+                onValueChange={(value) =>
+                  setScope(value as "personal" | "organization")
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="personal">Personal</SelectItem>
+                  <SelectItem value="organization">Organization</SelectItem>
+                </SelectContent>
+              </Select>
+            </label>
+          </div>
+
+          <Tabs
+            value={triggerType}
+            onValueChange={(value) => setTriggerType(value as TriggerType)}
+          >
+            <TabsList className="grid h-auto w-full grid-cols-3">
+              <TabsTrigger value="schedule" className="gap-2 py-2 text-xs">
+                <IconClock className="size-3.5" /> Schedule
+              </TabsTrigger>
+              <TabsTrigger value="webhook" className="gap-2 py-2 text-xs">
+                <IconBolt className="size-3.5" /> Webhook
+              </TabsTrigger>
+              <TabsTrigger value="event" className="gap-2 py-2 text-xs">
+                <IconCalendarEvent className="size-3.5" /> App event
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="schedule" className="mt-3">
+              <ScheduleBuilder
+                key={open ? "schedule-open" : "schedule-closed"}
+                saving={create.isPending}
+                timezone={timezone}
+                onTimezoneChange={setTimezone}
+                onChange={setSchedule}
+              />
+            </TabsContent>
+            <TabsContent value="webhook" className="mt-3">
+              <div className="rounded-lg border border-primary/20 bg-primary/5 p-3">
+                <div className="flex items-start gap-2">
+                  <IconBolt className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      Run when a service sends an HTTP POST
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                      After you save, Dispatch gives you a private URL to paste
+                      into GitHub, Stripe, or another webhook provider.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+            <TabsContent value="event" className="mt-3">
+              <EventFields open={open} event={event} onChange={setEvent} />
+            </TabsContent>
+          </Tabs>
+
+          <label className="space-y-1.5 text-xs text-muted-foreground">
+            <span>What should it do?</span>
+            <Textarea
+              value={body}
+              disabled={create.isPending}
+              placeholder="Review new support requests and summarize anything urgent in a shared note."
+              rows={5}
+              onChange={(event) => setBody(event.target.value)}
+            />
+          </label>
+
+          {create.error ? (
+            <p className="text-xs text-destructive">{create.error.message}</p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={create.isPending}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSubmit || create.isPending}
+            onClick={submit}
+          >
+            {create.isPending ? (
+              <IconLoader2 className="size-4 animate-spin" />
+            ) : null}
+            Create automation
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dispatch/src/components/automation-create-dialog.tsx
+++ b/packages/dispatch/src/components/automation-create-dialog.tsx
@@ -15,6 +15,7 @@ import {
   useActionMutation,
   useActionQuery,
 } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
 import {
   IconBolt,
   IconCalendarEvent,
@@ -71,36 +72,48 @@ interface CreateAutomationResult {
 
 const PRESETS: {
   value: AutomationSchedulePreset;
+  labelKey: string;
+  detailKey: string;
   label: string;
   detail: string;
   draft: Partial<AutomationScheduleDraft>;
 }[] = [
   {
     value: "hourly",
+    labelKey: "jobs.schedulePreset.hourly",
+    detailKey: "jobs.schedulePreset.hourlyDetail",
     label: "Every hour",
     detail: "At the top of the hour",
     draft: { preset: "hourly" },
   },
   {
     value: "daily-midnight",
+    labelKey: "jobs.schedulePreset.dailyMidnight",
+    detailKey: "jobs.schedulePreset.dailyMidnightDetail",
     label: "Every day at midnight",
     detail: "12:00 AM",
     draft: { preset: "daily-midnight" },
   },
   {
     value: "daily-noon",
+    labelKey: "jobs.schedulePreset.dailyNoon",
+    detailKey: "jobs.schedulePreset.dailyNoonDetail",
     label: "Every day at noon",
     detail: "12:00 PM",
     draft: { preset: "daily-noon" },
   },
   {
     value: "weekdays",
+    labelKey: "jobs.schedulePreset.weekdays",
+    detailKey: "jobs.schedulePreset.weekdaysDetail",
     label: "Every weekday",
     detail: "Monday to Friday at 9:00 AM",
     draft: { preset: "weekdays", time: "09:00" },
   },
   {
     value: "weekly",
+    labelKey: "jobs.schedulePreset.weekly",
+    detailKey: "jobs.schedulePreset.weeklyDetail",
     label: "Every week",
     detail: "Sunday at 9:00 AM",
     draft: { preset: "weekly", weekday: 0, time: "09:00" },
@@ -129,12 +142,13 @@ function ScheduleFields({
   saving: boolean;
   onChange: (patch: Partial<AutomationScheduleDraft>) => void;
 }) {
+  const t = useT();
   const customMinute = Number(draft.time.split(":")[1] ?? 0);
   return (
     <div className="space-y-3 rounded-lg border border-border/70 bg-muted/20 p-3">
       <div className="grid gap-3 sm:grid-cols-[1fr_1fr]">
         <label className="space-y-1.5 text-xs text-muted-foreground">
-          <span>Repeat every</span>
+          <span>{t("jobs.repeatEvery", { defaultValue: "Repeat every" })}</span>
           <Input
             type="number"
             min={1}
@@ -150,7 +164,7 @@ function ScheduleFields({
           />
         </label>
         <label className="space-y-1.5 text-xs text-muted-foreground">
-          <span>Unit</span>
+          <span>{t("jobs.scheduleUnit", { defaultValue: "Unit" })}</span>
           <Select
             value={draft.unit}
             disabled={saving}
@@ -162,10 +176,18 @@ function ScheduleFields({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="hour">hour(s)</SelectItem>
-              <SelectItem value="day">day(s)</SelectItem>
-              <SelectItem value="week">week(s)</SelectItem>
-              <SelectItem value="month">month(s)</SelectItem>
+              <SelectItem value="hour">
+                {t("jobs.hours", { defaultValue: "hour(s)" })}
+              </SelectItem>
+              <SelectItem value="day">
+                {t("jobs.days", { defaultValue: "day(s)" })}
+              </SelectItem>
+              <SelectItem value="week">
+                {t("jobs.weeks", { defaultValue: "week(s)" })}
+              </SelectItem>
+              <SelectItem value="month">
+                {t("jobs.months", { defaultValue: "month(s)" })}
+              </SelectItem>
             </SelectContent>
           </Select>
         </label>
@@ -173,7 +195,7 @@ function ScheduleFields({
 
       {draft.unit === "hour" ? (
         <label className="block space-y-1.5 text-xs text-muted-foreground">
-          <span>At minute</span>
+          <span>{t("jobs.atMinute", { defaultValue: "At minute" })}</span>
           <Input
             type="number"
             min={0}
@@ -196,7 +218,7 @@ function ScheduleFields({
 
       {draft.unit === "week" ? (
         <label className="block space-y-1.5 text-xs text-muted-foreground">
-          <span>On</span>
+          <span>{t("jobs.onDay", { defaultValue: "On" })}</span>
           <Select
             value={String(draft.weekday)}
             disabled={saving}
@@ -218,7 +240,7 @@ function ScheduleFields({
 
       {draft.unit === "month" ? (
         <label className="block space-y-1.5 text-xs text-muted-foreground">
-          <span>Day of month</span>
+          <span>{t("jobs.dayOfMonth", { defaultValue: "Day of month" })}</span>
           <Input
             type="number"
             min={1}
@@ -240,7 +262,7 @@ function ScheduleFields({
 
       {draft.unit !== "hour" ? (
         <label className="block space-y-1.5 text-xs text-muted-foreground">
-          <span>At</span>
+          <span>{t("jobs.atTime", { defaultValue: "At" })}</span>
           <Input
             type="time"
             value={draft.time}
@@ -265,6 +287,7 @@ function ScheduleBuilder({
   onTimezoneChange: (value: string) => void;
   onChange: (value: string) => void;
 }) {
+  const t = useT();
   const [draft, setDraft] = useState<AutomationScheduleDraft>(
     DEFAULT_AUTOMATION_SCHEDULE_DRAFT,
   );
@@ -292,7 +315,9 @@ function ScheduleBuilder({
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <div className="text-xs font-medium text-foreground">Repeat</div>
+        <div className="text-xs font-medium text-foreground">
+          {t("jobs.repeat", { defaultValue: "Repeat" })}
+        </div>
         <div className="grid gap-2 sm:grid-cols-2">
           {PRESETS.map((preset) => (
             <button
@@ -305,9 +330,11 @@ function ScheduleBuilder({
               )}
               onClick={() => choosePreset(preset.value, preset.draft)}
             >
-              <span className="block text-sm font-medium">{preset.label}</span>
+              <span className="block text-sm font-medium">
+                {t(preset.labelKey, { defaultValue: preset.label })}
+              </span>
               <span className="mt-0.5 block text-xs text-muted-foreground">
-                {preset.detail}
+                {t(preset.detailKey, { defaultValue: preset.detail })}
               </span>
             </button>
           ))}
@@ -323,9 +350,13 @@ function ScheduleBuilder({
               })
             }
           >
-            <span className="block text-sm font-medium">Custom</span>
+            <span className="block text-sm font-medium">
+              {t("jobs.schedulePreset.custom", { defaultValue: "Custom" })}
+            </span>
             <span className="mt-0.5 block text-xs text-muted-foreground">
-              Set your own repeat pattern
+              {t("jobs.schedulePreset.customDetail", {
+                defaultValue: "Set your own repeat pattern",
+              })}
             </span>
           </button>
         </div>
@@ -343,25 +374,41 @@ function ScheduleBuilder({
 
       {!advanced && friendly.schedule ? (
         <p className="text-xs text-muted-foreground">
-          Runs{" "}
-          {draft.preset === "hourly"
-            ? "at the start of every hour"
-            : draft.preset === "daily-midnight"
-              ? "every day at midnight"
-              : draft.preset === "daily-noon"
-                ? "every day at noon"
-                : "at " + formatAutomationTime(draft.time)}
-          .
+          {t("jobs.schedulePreview", {
+            defaultValue: "Runs {{time}}.",
+            time:
+              draft.preset === "hourly"
+                ? t("jobs.schedulePreview.hourly", {
+                    defaultValue: "at the start of every hour",
+                  })
+                : draft.preset === "daily-midnight"
+                  ? t("jobs.schedulePreview.dailyMidnight", {
+                      defaultValue: "every day at midnight",
+                    })
+                  : draft.preset === "daily-noon"
+                    ? t("jobs.schedulePreview.dailyNoon", {
+                        defaultValue: "every day at noon",
+                      })
+                    : t("jobs.schedulePreview.atTime", {
+                        defaultValue: "at {{time}}",
+                        time: formatAutomationTime(draft.time),
+                      }),
+          })}
         </p>
       ) : null}
       {!advanced && friendly.error ? (
         <p className="text-xs text-destructive">
-          Custom weekly intervals beyond one week are available under Advanced.
+          {t("jobs.weeklyIntervalAdvanced", {
+            defaultValue:
+              "Custom weekly intervals beyond one week are available under Advanced.",
+          })}
         </p>
       ) : null}
 
       <div>
-        <label className="text-xs font-medium text-foreground">Timezone</label>
+        <label className="text-xs font-medium text-foreground">
+          {t("jobs.timezone", { defaultValue: "Timezone" })}
+        </label>
         <div className="mt-1">
           <TimezoneSelect
             value={timezone}
@@ -385,12 +432,14 @@ function ScheduleBuilder({
       >
         <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 text-xs font-medium text-foreground [&::-webkit-details-marker]:hidden">
           <IconCode className="size-4 text-muted-foreground" />
-          Advanced - cron expression
+          {t("jobs.advancedSchedule", {
+            defaultValue: "Advanced - cron expression",
+          })}
           <span className="ms-auto text-muted-foreground group-open:hidden">
-            Show
+            {t("jobs.show", { defaultValue: "Show" })}
           </span>
           <span className="ms-auto hidden text-muted-foreground group-open:inline">
-            Hide
+            {t("jobs.hide", { defaultValue: "Hide" })}
           </span>
         </summary>
         <div className="border-t border-border/60 px-3 pb-3 pt-2.5">
@@ -407,14 +456,18 @@ function ScheduleBuilder({
             }}
           />
           <p className="mt-1 text-[11px] text-muted-foreground">
-            minute hour day-of-month month day-of-week
+            {t("jobs.cronFormatHint", {
+              defaultValue: "minute hour day-of-month month day-of-week",
+            })}
           </p>
         </div>
       </details>
 
       {activeSchedule && !valid ? (
         <p className="text-xs text-destructive">
-          A cron expression needs exactly 5 fields.
+          {t("jobs.cronFieldCount", {
+            defaultValue: "A cron expression needs exactly 5 fields.",
+          })}
         </p>
       ) : null}
     </div>
@@ -430,6 +483,7 @@ function EventFields({
   event: string;
   onChange: (value: string) => void;
 }) {
+  const t = useT();
   const eventsQuery = useActionQuery<AutomationEvent[]>(
     "list-automation-events",
     {},
@@ -439,14 +493,18 @@ function EventFields({
   return (
     <>
       <label className="space-y-1.5 text-xs text-muted-foreground">
-        <span>Start when</span>
+        <span>{t("jobs.startWhen", { defaultValue: "Start when" })}</span>
         <Select value={event} onValueChange={onChange}>
           <SelectTrigger>
             <SelectValue
               placeholder={
                 eventsQuery.isLoading
-                  ? "Loading event types..."
-                  : "Choose an app event"
+                  ? t("jobs.loadingEventTypes", {
+                      defaultValue: "Loading event types...",
+                    })
+                  : t("jobs.chooseAppEvent", {
+                      defaultValue: "Choose an app event",
+                    })
               }
             />
           </SelectTrigger>
@@ -466,7 +524,9 @@ function EventFields({
       ) : null}
       {eventsQuery.error ? (
         <p className="mt-2 text-xs text-destructive">
-          Could not load event types.
+          {t("jobs.loadEventTypesError", {
+            defaultValue: "Could not load event types.",
+          })}
         </p>
       ) : null}
     </>
@@ -486,6 +546,7 @@ export function AutomationCreateDialog({
   onOpenChange,
   onCreated,
 }: AutomationCreateDialogProps) {
+  const t = useT();
   const [name, setName] = useState("");
   const [scope, setScope] = useState<"personal" | "organization">(initialScope);
   const [triggerType, setTriggerType] = useState<TriggerType>("schedule");
@@ -540,25 +601,32 @@ export function AutomationCreateDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>New automation</DialogTitle>
+          <DialogTitle>
+            {t("jobs.newAutomation", { defaultValue: "New automation" })}
+          </DialogTitle>
           <DialogDescription>
-            Choose what starts it, then describe the work in plain language.
+            {t("jobs.createAutomationDescription", {
+              defaultValue:
+                "Choose what starts it, then describe the work in plain language.",
+            })}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="grid gap-3 sm:grid-cols-[1fr_12rem]">
             <label className="space-y-1.5 text-xs text-muted-foreground">
-              <span>Name</span>
+              <span>{t("jobs.name", { defaultValue: "Name" })}</span>
               <Input
                 value={name}
                 disabled={create.isPending}
-                placeholder="morning-digest"
+                placeholder={t("jobs.automationNamePlaceholder", {
+                  defaultValue: "morning-digest",
+                })}
                 onChange={(event) => setName(event.target.value)}
               />
             </label>
             <label className="space-y-1.5 text-xs text-muted-foreground">
-              <span>Scope</span>
+              <span>{t("jobs.scope", { defaultValue: "Scope" })}</span>
               <Select
                 value={scope}
                 disabled={create.isPending}
@@ -570,8 +638,12 @@ export function AutomationCreateDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="personal">Personal</SelectItem>
-                  <SelectItem value="organization">Organization</SelectItem>
+                  <SelectItem value="personal">
+                    {t("jobs.personal", { defaultValue: "Personal" })}
+                  </SelectItem>
+                  <SelectItem value="organization">
+                    {t("jobs.organization", { defaultValue: "Organization" })}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </label>
@@ -583,13 +655,16 @@ export function AutomationCreateDialog({
           >
             <TabsList className="grid h-auto w-full grid-cols-3">
               <TabsTrigger value="schedule" className="gap-2 py-2 text-xs">
-                <IconClock className="size-3.5" /> Schedule
+                <IconClock className="size-3.5" />
+                {t("jobs.schedule", { defaultValue: "Schedule" })}
               </TabsTrigger>
               <TabsTrigger value="webhook" className="gap-2 py-2 text-xs">
-                <IconBolt className="size-3.5" /> Webhook
+                <IconBolt className="size-3.5" />
+                {t("jobs.webhook", { defaultValue: "Webhook" })}
               </TabsTrigger>
               <TabsTrigger value="event" className="gap-2 py-2 text-xs">
-                <IconCalendarEvent className="size-3.5" /> App event
+                <IconCalendarEvent className="size-3.5" />
+                {t("jobs.appEvent", { defaultValue: "App event" })}
               </TabsTrigger>
             </TabsList>
             <TabsContent value="schedule" className="mt-3">
@@ -607,11 +682,15 @@ export function AutomationCreateDialog({
                   <IconBolt className="mt-0.5 size-4 shrink-0 text-primary" />
                   <div>
                     <p className="text-sm font-medium text-foreground">
-                      Run when a service sends an HTTP POST
+                      {t("jobs.webhookTriggerDescription", {
+                        defaultValue: "Run when a service sends an HTTP POST",
+                      })}
                     </p>
                     <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                      After you save, Dispatch gives you a private URL to paste
-                      into GitHub, Stripe, or another webhook provider.
+                      {t("jobs.webhookSetupDescription", {
+                        defaultValue:
+                          "After you save, Dispatch gives you a private URL to paste into GitHub, Stripe, or another webhook provider.",
+                      })}
                     </p>
                   </div>
                 </div>
@@ -623,11 +702,16 @@ export function AutomationCreateDialog({
           </Tabs>
 
           <label className="space-y-1.5 text-xs text-muted-foreground">
-            <span>What should it do?</span>
+            <span>
+              {t("jobs.whatShouldItDo", { defaultValue: "What should it do?" })}
+            </span>
             <Textarea
               value={body}
               disabled={create.isPending}
-              placeholder="Review new support requests and summarize anything urgent in a shared note."
+              placeholder={t("jobs.automationBodyPlaceholder", {
+                defaultValue:
+                  "Review new support requests and summarize anything urgent in a shared note.",
+              })}
               rows={5}
               onChange={(event) => setBody(event.target.value)}
             />
@@ -645,7 +729,7 @@ export function AutomationCreateDialog({
             disabled={create.isPending}
             onClick={() => onOpenChange(false)}
           >
-            Cancel
+            {t("jobs.cancel", { defaultValue: "Cancel" })}
           </Button>
           <Button
             type="button"
@@ -655,7 +739,7 @@ export function AutomationCreateDialog({
             {create.isPending ? (
               <IconLoader2 className="size-4 animate-spin" />
             ) : null}
-            Create automation
+            {t("jobs.createAutomation", { defaultValue: "Create automation" })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/dispatch/src/components/automation-create-dialog.tsx
+++ b/packages/dispatch/src/components/automation-create-dialog.tsx
@@ -157,7 +157,10 @@ function ScheduleFields({
             disabled={saving}
             onChange={(event) =>
               onChange({
-                interval: Math.max(1, Number(event.target.value) || 1),
+                interval: Math.min(
+                  draft.unit === "day" ? 1 : 31,
+                  Math.max(1, Number(event.target.value) || 1),
+                ),
               })
             }
             className="h-9 bg-background text-sm"
@@ -169,7 +172,10 @@ function ScheduleFields({
             value={draft.unit}
             disabled={saving}
             onValueChange={(value) =>
-              onChange({ unit: value as AutomationScheduleUnit })
+              onChange({
+                unit: value as AutomationScheduleUnit,
+                ...(value === "day" ? { interval: 1 } : {}),
+              })
             }
           >
             <SelectTrigger className="h-9 bg-background text-sm">
@@ -180,7 +186,7 @@ function ScheduleFields({
                 {t("jobs.hours", { defaultValue: "hour(s)" })}
               </SelectItem>
               <SelectItem value="day">
-                {t("jobs.days", { defaultValue: "day(s)" })}
+                {t("jobs.day", { defaultValue: "day" })}
               </SelectItem>
               <SelectItem value="week">
                 {t("jobs.weeks", { defaultValue: "week(s)" })}
@@ -398,10 +404,15 @@ function ScheduleBuilder({
       ) : null}
       {!advanced && friendly.error ? (
         <p className="text-xs text-destructive">
-          {t("jobs.weeklyIntervalAdvanced", {
-            defaultValue:
-              "Custom weekly intervals beyond one week are available under Advanced.",
-          })}
+          {friendly.error === "daily-interval"
+            ? t("jobs.dailyIntervalAdvanced", {
+                defaultValue:
+                  "Every few days needs the Advanced cron editor below.",
+              })
+            : t("jobs.weeklyIntervalAdvanced", {
+                defaultValue:
+                  "Custom weekly intervals beyond one week are available under Advanced.",
+              })}
         </p>
       ) : null}
 

--- a/packages/dispatch/src/components/automation-details-panel.tsx
+++ b/packages/dispatch/src/components/automation-details-panel.tsx
@@ -1,11 +1,16 @@
+import { appPath } from "@agent-native/core/client/api-path";
+import { writeClipboardText } from "@agent-native/core/client/clipboard";
 import { useActionQuery } from "@agent-native/core/client/hooks";
 import {
   IconAlertTriangle,
+  IconCheck,
+  IconCopy,
   IconClock,
   IconExternalLink,
   IconPlayerPause,
   IconPlayerPlay,
 } from "@tabler/icons-react";
+import { useState } from "react";
 import { Link } from "react-router";
 
 import {
@@ -118,7 +123,18 @@ export function AutomationDetailsPanel({
   );
   const runs = runsQuery.data ?? [];
   const status = automationStatus(automation);
-  const isScheduled = automation.triggerType !== "event";
+  const isScheduled = automation.triggerType === "schedule";
+  const [copied, setCopied] = useState(false);
+  const webhookUrl =
+    automation.webhookPath && typeof window !== "undefined"
+      ? window.location.origin + appPath(automation.webhookPath)
+      : null;
+  const triggerLabel =
+    automation.triggerType === "webhook"
+      ? "Webhook"
+      : isScheduled
+        ? "Schedule"
+        : "Event";
   const prompt = automation.body?.trim();
   const hasExecutionTarget = Boolean(
     automation.executionHostId ||
@@ -156,8 +172,7 @@ export function AutomationDetailsPanel({
             {automation.name}
           </h2>
           <p className="mt-1 text-xs text-muted-foreground">
-            {isScheduled ? "Schedule" : "Event"} ·{" "}
-            {automationScopeLabel(automation)}
+            {triggerLabel} · {automationScopeLabel(automation)}
           </p>
         </div>
       </header>
@@ -183,7 +198,13 @@ export function AutomationDetailsPanel({
           <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-4">
             <DetailField
               label="Trigger"
-              value={isScheduled ? "Scheduled" : "Event-triggered"}
+              value={
+                automation.triggerType === "webhook"
+                  ? "Webhook-triggered"
+                  : isScheduled
+                    ? "Scheduled"
+                    : "Event-triggered"
+              }
             />
             <DetailField
               label={isScheduled ? "Schedule" : "Event"}
@@ -204,6 +225,43 @@ export function AutomationDetailsPanel({
                 />
               </>
             ) : null}
+            {webhookUrl ? (
+              <div className="col-span-2 rounded-md border border-primary/20 bg-primary/5 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-xs font-medium text-foreground">
+                    Webhook URL
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 gap-1.5 text-xs"
+                    onClick={() => {
+                      void writeClipboardText(webhookUrl).then((didCopy) => {
+                        setCopied(didCopy);
+                        if (didCopy) {
+                          window.setTimeout(() => setCopied(false), 1800);
+                        }
+                      });
+                    }}
+                  >
+                    {copied ? (
+                      <IconCheck className="size-3.5" />
+                    ) : (
+                      <IconCopy className="size-3.5" />
+                    )}
+                    {copied ? "Copied" : "Copy URL"}
+                  </Button>
+                </div>
+                <code className="mt-2 block break-all text-[11px] leading-5 text-muted-foreground">
+                  {webhookUrl}
+                </code>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Paste this URL into a service that can send HTTP POST
+                  webhooks.
+                </p>
+              </div>
+            ) : null}
             <DetailField
               label="Condition"
               value={automation.condition || "Always"}
@@ -218,14 +276,16 @@ export function AutomationDetailsPanel({
             />
             <DetailField label="Mode" value={automation.mode || "Agentic"} />
             <DetailField label="Runs as" value={runAsLabel(automation.runAs)} />
-            <DetailField
-              label="Next run"
-              value={
-                automation.enabled
-                  ? formatTimestamp(automation.nextRun)
-                  : "Paused"
-              }
-            />
+            {isScheduled ? (
+              <DetailField
+                label="Next run"
+                value={
+                  automation.enabled
+                    ? formatTimestamp(automation.nextRun)
+                    : "Paused"
+                }
+              />
+            ) : null}
             <DetailField
               label="Last run"
               value={formatTimestamp(automation.lastRun)}

--- a/packages/dispatch/src/components/automation-details-panel.tsx
+++ b/packages/dispatch/src/components/automation-details-panel.tsx
@@ -1,6 +1,7 @@
 import { appPath } from "@agent-native/core/client/api-path";
 import { writeClipboardText } from "@agent-native/core/client/clipboard";
 import { useActionQuery } from "@agent-native/core/client/hooks";
+import { useT } from "@agent-native/core/client/i18n";
 import {
   IconAlertTriangle,
   IconCheck,
@@ -112,6 +113,7 @@ export function AutomationDetailsPanel({
   isToggling = false,
   onToggle,
 }: AutomationDetailsPanelProps) {
+  const t = useT();
   const runsQuery = useActionQuery<AutomationRun[]>(
     "list-automation-runs",
     {
@@ -131,7 +133,7 @@ export function AutomationDetailsPanel({
       : null;
   const triggerLabel =
     automation.triggerType === "webhook"
-      ? "Webhook"
+      ? t("jobs.webhook", { defaultValue: "Webhook" })
       : isScheduled
         ? "Schedule"
         : "Event";
@@ -200,7 +202,9 @@ export function AutomationDetailsPanel({
               label="Trigger"
               value={
                 automation.triggerType === "webhook"
-                  ? "Webhook-triggered"
+                  ? t("jobs.webhookTrigger", {
+                      defaultValue: "Webhook-triggered",
+                    })
                   : isScheduled
                     ? "Scheduled"
                     : "Event-triggered"
@@ -229,7 +233,7 @@ export function AutomationDetailsPanel({
               <div className="col-span-2 rounded-md border border-primary/20 bg-primary/5 p-3">
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-xs font-medium text-foreground">
-                    Webhook URL
+                    {t("jobs.webhookUrl", { defaultValue: "Webhook URL" })}
                   </span>
                   <Button
                     type="button"
@@ -250,15 +254,19 @@ export function AutomationDetailsPanel({
                     ) : (
                       <IconCopy className="size-3.5" />
                     )}
-                    {copied ? "Copied" : "Copy URL"}
+                    {copied
+                      ? t("common.copied", { defaultValue: "Copied" })
+                      : t("common.copy", { defaultValue: "Copy URL" })}
                   </Button>
                 </div>
                 <code className="mt-2 block break-all text-[11px] leading-5 text-muted-foreground">
                   {webhookUrl}
                 </code>
                 <p className="mt-2 text-xs text-muted-foreground">
-                  Paste this URL into a service that can send HTTP POST
-                  webhooks.
+                  {t("jobs.webhookUrlHint", {
+                    defaultValue:
+                      "Paste this URL into a service that sends HTTP POST webhooks.",
+                  })}
                 </p>
               </div>
             ) : null}

--- a/packages/dispatch/src/hooks/use-navigation-state.spec.ts
+++ b/packages/dispatch/src/hooks/use-navigation-state.spec.ts
@@ -97,6 +97,19 @@ describe("buildDispatchNavigationState", () => {
     });
   });
 
+  it("keeps the selected automation in application state", () => {
+    expect(
+      buildDispatchNavigationState(
+        "/automations",
+        "?automationId=personal%3Amorning-digest",
+      ),
+    ).toEqual({
+      view: "automations",
+      path: "/automations",
+      automationId: "personal:morning-digest",
+    });
+  });
+
   it("recognizes Admin routes without losing the underlying view", () => {
     expect(buildDispatchNavigationState("/admin/metrics")).toEqual({
       view: "metrics",

--- a/packages/dispatch/src/hooks/use-navigation-state.ts
+++ b/packages/dispatch/src/hooks/use-navigation-state.ts
@@ -42,6 +42,7 @@ export interface NavigationState {
   usageScope?: "me" | "workspace" | "app";
   usageUserEmail?: string;
   usageAppId?: string;
+  automationId?: string;
 }
 
 export function useNavigationState(extensions?: DispatchExtensionConfig) {
@@ -212,6 +213,11 @@ export function buildDispatchNavigationState(
       state.usageScope = usageScope;
     }
     if (usageUserEmail) state.usageUserEmail = usageUserEmail;
+  }
+
+  if (state.view === "automations") {
+    const automationId = new URLSearchParams(search).get("automationId");
+    if (automationId) state.automationId = automationId;
   }
 
   return state;

--- a/packages/dispatch/src/lib/automation-display.ts
+++ b/packages/dispatch/src/lib/automation-display.ts
@@ -33,6 +33,7 @@ export function automationTroubleshootPath(
 
 export function automationTarget(item: DispatchAutomationItem): string {
   if (item.triggerType === "event" && item.event) return item.event;
+  if (item.triggerType === "webhook") return "On webhook";
   if (item.scheduleDescription) return item.scheduleDescription;
   if (item.schedule) return item.schedule;
   return item.triggerType || "schedule";
@@ -72,6 +73,7 @@ export function automationLastCheck(item: DispatchAutomationItem): string {
 export function automationNextRun(item: DispatchAutomationItem): string {
   if (!item.enabled) return "paused";
   if (item.triggerType === "event") return "on event";
+  if (item.triggerType === "webhook") return "on webhook";
   return item.nextRun ? relativeRunTime(item.nextRun) : "not scheduled";
 }
 

--- a/packages/dispatch/src/lib/automations.ts
+++ b/packages/dispatch/src/lib/automations.ts
@@ -9,8 +9,9 @@ export interface DispatchAutomationItem {
   orgId?: string;
   scope?: "personal" | "organization";
   canUpdate?: boolean;
-  triggerType?: "schedule" | "event" | (string & {});
+  triggerType?: "schedule" | "event" | "webhook" | (string & {});
   event?: string;
+  webhookPath?: string;
   schedule?: string;
   scheduleDescription?: string;
   condition?: string;

--- a/packages/dispatch/src/routes/pages/automations.spec.tsx
+++ b/packages/dispatch/src/routes/pages/automations.spec.tsx
@@ -64,7 +64,18 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 
 vi.mock("@agent-native/core/client/hooks", () => ({
+  useActionMutation: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    error: null,
+  }),
   useChangeVersions: () => 0,
+  useActionQuery: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+  }),
 }));
 
 vi.mock("@agent-native/core/client/agent-chat", () => ({

--- a/packages/dispatch/src/routes/pages/automations.tsx
+++ b/packages/dispatch/src/routes/pages/automations.tsx
@@ -1,5 +1,3 @@
-import { sendToAgentChat } from "@agent-native/core/client/agent-chat";
-import { PromptComposer } from "@agent-native/core/client/composer";
 import { useChangeVersions } from "@agent-native/core/client/hooks";
 import {
   IconFileSearch,
@@ -13,16 +11,12 @@ import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { toast } from "sonner";
 
+import { AutomationCreateDialog } from "../../components/automation-create-dialog";
 import { AutomationDetailsPanel } from "../../components/automation-details-panel";
 import { DispatchShell } from "../../components/dispatch-shell";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "../../components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -134,57 +128,24 @@ function useToggleAutomation() {
   });
 }
 
-function CreateAutomationButton() {
+function CreateAutomationButton({ onCreated }: { onCreated: () => void }) {
   const [open, setOpen] = useState(false);
-  const [scope, setScope] = useState<"personal" | "organization">("personal");
-
-  function handleSubmit(text: string) {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    window.dispatchEvent(
-      new CustomEvent("agent-panel:set-mode", {
-        detail: { mode: "chat" },
-      }),
-    );
-    sendToAgentChat({
-      message: trimmed,
-      context: `The user wants to create a new automation. Scope: ${scope}. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
-      submit: true,
-      newTab: true,
-    });
-    setOpen(false);
-  }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button size="sm">
-          <IconPlus size={14} />
-          New automation
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-[min(100vw-2rem,24rem)] p-3">
-        <p className="pb-2 text-sm font-semibold text-foreground">
-          New automation
-        </p>
-        <PromptComposer
-          autoFocus
-          placeholder="Describe what you want to automate..."
-          draftScope="dispatch-automations:create"
-          onSubmit={handleSubmit}
-        />
-        <select
-          value={scope}
-          onChange={(event) =>
-            setScope(event.target.value as "personal" | "organization")
-          }
-          className="mt-2 w-full cursor-pointer rounded-md border border-input bg-background px-3 py-1.5 text-xs text-foreground"
-        >
-          <option value="personal">Personal</option>
-          <option value="organization">Organization</option>
-        </select>
-      </PopoverContent>
-    </Popover>
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <IconPlus size={14} />
+        New automation
+      </Button>
+      <AutomationCreateDialog
+        open={open}
+        onOpenChange={setOpen}
+        onCreated={() => {
+          setOpen(false);
+          onCreated();
+        }}
+      />
+    </>
   );
 }
 
@@ -194,6 +155,7 @@ export default function AutomationsRoute() {
   const [query, setQuery] = useState("");
   const automationsQuery = useAutomations();
   const toggleAutomation = useToggleAutomation();
+  const queryClient = useQueryClient();
   const automations = automationsQuery.data ?? [];
   const visibleAutomations = useMemo(
     () =>
@@ -215,6 +177,7 @@ export default function AutomationsRoute() {
         item.event,
         item.schedule,
         item.scheduleDescription,
+        item.webhookPath,
         item.body,
         item.model,
         item.domain,
@@ -259,7 +222,7 @@ export default function AutomationsRoute() {
   return (
     <DispatchShell
       title="Automations"
-      description="See scheduled and event-triggered jobs, inspect their checks and past runs, pause them, or ask the agent to create one."
+      description="Create schedule, webhook, or app-event automations, then inspect their checks and past runs."
     >
       <section className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
@@ -304,7 +267,14 @@ export default function AutomationsRoute() {
                 <SelectItem value="all">All apps</SelectItem>
               </SelectContent>
             </Select>
-            <CreateAutomationButton />
+            <CreateAutomationButton
+              onCreated={() => {
+                toast.success("Automation created");
+                void queryClient.invalidateQueries({
+                  queryKey: AUTOMATIONS_QUERY_KEY,
+                });
+              }}
+            />
           </div>
         </div>
 

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -7,7 +7,7 @@ vault secrets, messaging routes, MCP/app setup, and agent operations.
 
 Read the relevant skill before deeper work:
 
-- `automations` for event- and schedule-triggered automation rules on
+- `automations` for schedule, webhook, and event-triggered automation rules on
   `/admin/automations`.
 - `recurring-jobs` for scheduled/background job behavior and the scheduler.
 
@@ -80,7 +80,7 @@ Read the relevant skill before deeper work:
 ## Application State
 
 - `navigation` exposes current Dispatch view, selected integration/resource,
-  approval, route, or settings panel.
+  approval, route, settings panel, or automation selection.
 - On Thread Debug, `navigation.threadDebugMode`, `sourceId`,
   `inspectSourceId`, `ownerEmail`, `failureStatus`, `range`, `query`, `runId`,
   and `threadId` expose the visible failure or thread filters and selection.

--- a/templates/dispatch/app/hooks/use-navigation-state.ts
+++ b/templates/dispatch/app/hooks/use-navigation-state.ts
@@ -20,6 +20,7 @@ export interface NavigationState {
   dreamId?: string;
   sourceId?: string;
   query?: string;
+  automationId?: string;
   operationsView?: "monitoring" | "database";
 }
 
@@ -99,6 +100,11 @@ export function buildDispatchNavigationState(
     const params = new URLSearchParams(search);
     state.operationsView =
       params.get("view") === "database" ? "database" : "monitoring";
+  }
+
+  if (state.view === "automations") {
+    const automationId = new URLSearchParams(search).get("automationId");
+    if (automationId) state.automationId = automationId;
   }
 
   return state;


### PR DESCRIPTION
## Summary
- Replace raw cron-first scheduling with familiar hourly, daily, weekday, weekly, custom, and Advanced cron options.
- Add a plain-language Dispatch automation creator with Schedule, Webhook, and App event triggers.
- Add token-authenticated webhook intake backed by the durable integration queue, with bounded payloads, deduplication, and owner-scoped execution.
- Keep webhook URLs private to automation managers and expose the selected automation in navigation state.

## Validation
- 179 affected Vitest tests passed
- Core and Dispatch typechecks passed
- Core and Dispatch builds passed
- `pnpm fmt:check`, `pnpm oxlint`, and all 66 repository guards passed
- Verified rendered Dispatch UI in the local app with schedule, custom/Advanced, and webhook screenshots