### PR TITLE
Refine desktop chat surfaces and terminal controls

### DIFF
--- a/.changeset/quieter-desktop-chat-workbench.md
+++ b/.changeset/quieter-desktop-chat-workbench.md
@@ -1,6 +1,5 @@
 ---
 "@agent-native/core": patch
-"@agent-native/code-agents-ui": patch
 ---
 
 Improve desktop chat surfaces, terminal failure reporting, and scrollbar contrast.

--- a/.changeset/quieter-desktop-chat-workbench.md
+++ b/.changeset/quieter-desktop-chat-workbench.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/code-agents-ui": patch
+---
+
+Improve desktop chat surfaces, terminal failure reporting, and scrollbar contrast.

--- a/packages/code-agents-ui/src/styles.css
+++ b/packages/code-agents-ui/src/styles.css
@@ -2936,7 +2936,15 @@
 
 .code-agents-transcript__timeline::-webkit-scrollbar-thumb,
 .code-agents-run-list::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+  background: hsl(var(--muted-foreground) / 0.22);
+}
+
+.code-agents-transcript__timeline::-webkit-scrollbar-thumb:hover,
+.code-agents-run-list::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .code-agents-transcript__timeline {

--- a/packages/core/src/client/chat-first/surface-tabs.spec.tsx
+++ b/packages/core/src/client/chat-first/surface-tabs.spec.tsx
@@ -55,6 +55,12 @@ describe("ChatFirstSurfaceTabs", () => {
     expect(picker?.className).toContain("overflow-hidden");
     expect(emptyState?.className).toContain("overflow-y-auto");
     expect(
+      container.querySelector("[data-chat-first-workspace-apps]"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("[data-chat-first-workspace-app-list]")?.children,
+    ).toHaveLength(apps.length);
+    expect(
       container.querySelectorAll("[data-chat-first-surface-app]"),
     ).toHaveLength(apps.length);
   });

--- a/packages/core/src/client/chat-first/surface-tabs.tsx
+++ b/packages/core/src/client/chat-first/surface-tabs.tsx
@@ -271,17 +271,23 @@ export function ChatFirstSurfaceTabs({
               );
             })}
             {apps.length > 0 && onOpenApp ? (
-              <div className="mt-1 border-t border-border pt-1">
+              <div
+                className="mt-1 border-t border-border pt-1"
+                data-chat-first-workspace-apps
+              >
                 <p className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                   {copy("workspaceApps")}
                 </p>
-                <div className="space-y-0.5">
+                <div
+                  className="grid grid-cols-2 gap-1.5"
+                  data-chat-first-workspace-app-list
+                >
                   {apps.map((app) => (
                     <button
                       key={app.id}
                       type="button"
                       data-chat-first-surface-app={app.id}
-                      className="flex h-8 w-full min-w-0 items-center gap-2 rounded px-2 text-start text-xs text-foreground transition-colors hover:bg-accent"
+                      className="flex min-h-11 min-w-0 items-center gap-2 rounded-md border border-transparent bg-muted/20 px-2 py-2 text-start text-xs text-foreground transition-colors hover:border-border hover:bg-accent"
                       title={copy("openApp", { name: app.name })}
                       aria-label={copy("openApp", { name: app.name })}
                       onClick={() => onOpenApp(app)}

--- a/packages/core/src/client/terminal/AgentTerminal.spec.ts
+++ b/packages/core/src/client/terminal/AgentTerminal.spec.ts
@@ -172,6 +172,56 @@ describe("AgentTerminal", () => {
     );
   });
 
+  it("disposes stale setup when the provider changes during discovery", async () => {
+    let resolveFirstResponse: ((response: Response) => void) | undefined;
+    let resolveSecondResponse: ((response: Response) => void) | undefined;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirstResponse = resolve;
+    });
+    const secondResponse = new Promise<Response>((resolve) => {
+      resolveSecondResponse = resolve;
+    });
+    vi.mocked(fetch)
+      .mockImplementationOnce(() => firstResponse)
+      .mockImplementationOnce(() => secondResponse);
+
+    const terminalInfoResponse = () =>
+      ({
+        json: async () => ({ available: true, wsPort: 12345 }),
+      }) as Response;
+
+    renderTerminal({ command: "codex" });
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(fetch).toHaveBeenCalledOnce();
+        expect(terminals).toHaveLength(1);
+      });
+    });
+
+    renderTerminal({ command: "claude" });
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(terminals).toHaveLength(2);
+      });
+    });
+
+    resolveFirstResponse?.(terminalInfoResponse());
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(terminals[0]?.dispose).toHaveBeenCalledOnce(),
+      );
+    });
+    expect(MockWebSocket.instances).toHaveLength(0);
+
+    resolveSecondResponse?.(terminalInfoResponse());
+    await flushTimers();
+    await waitForSocketCount(1);
+
+    expect(MockWebSocket.instances[0].url).toContain("command=claude");
+    expect(terminals[1]?.dispose).not.toHaveBeenCalled();
+  });
+
   it("keeps host authentication when adding the CLI command", async () => {
     renderTerminal({
       wsUrl: "ws://127.0.0.1:12345/ws?token=desktop-secret",

--- a/packages/core/src/client/terminal/AgentTerminal.tsx
+++ b/packages/core/src/client/terminal/AgentTerminal.tsx
@@ -267,6 +267,12 @@ export function AgentTerminal({
         term.dispose();
       }
 
+      function disposeIfCancelled() {
+        if (!disposed) return false;
+        disposeTerminal();
+        return true;
+      }
+
       // Discover WebSocket URL
       let wsUrl = wsUrlProp;
       let resolvedCommand = command;
@@ -275,7 +281,9 @@ export function AgentTerminal({
           const res = await fetch(
             agentNativePath("/_agent-native/agent-terminal-info"),
           );
+          if (disposeIfCancelled()) return;
           const info: TerminalInfo = await res.json();
+          if (disposeIfCancelled()) return;
           if (!info.available) {
             setError(info.error || "Agent terminal not available");
             disposeTerminal();
@@ -288,6 +296,7 @@ export function AgentTerminal({
             resolvedCommand = info.command;
           }
         } catch (err) {
+          if (disposeIfCancelled()) return;
           setError("Failed to discover terminal server");
           disposeTerminal();
           return;
@@ -470,6 +479,11 @@ export function AgentTerminal({
 
     let cleanup: (() => void) | undefined;
     void init().then((fn) => {
+      if (disposed) {
+        fn?.();
+        cleanupMessageHandler?.();
+        return;
+      }
       cleanup = fn;
     });
 

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -610,7 +610,27 @@
 
   * {
     scrollbar-width: thin;
-    scrollbar-color: gray transparent;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.22) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    border: 3px solid transparent;
+    border-radius: 999px;
+    background-clip: padding-box;
+    background-color: hsl(var(--muted-foreground) / 0.22);
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.34);
   }
 
   button,

--- a/packages/core/src/templates/default/app/global.css
+++ b/packages/core/src/templates/default/app/global.css
@@ -85,9 +85,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -183,6 +183,23 @@ describe("createPtyWebSocketServer", () => {
     ws.close();
   });
 
+  it("reports PTY spawn failures as terminal setup errors", async () => {
+    spawn.mockImplementationOnce(() => {
+      throw new Error("posix_spawnp failed");
+    });
+    const server = await createServer({ command: "builder" });
+    const { ws, message: rawMessage } = await openSocketAndMessage(
+      `ws://127.0.0.1:${server.port}/ws`,
+    );
+
+    expect(JSON.parse(rawMessage)).toEqual({
+      type: "setup-status",
+      status: "failed",
+      message: "Failed to spawn PTY: posix_spawnp failed",
+    });
+    ws.close();
+  });
+
   it("pipes terminal input and clamps resize messages", async () => {
     const server = await createServer({ command: "builder" });
     const ws = await openSocket(`ws://127.0.0.1:${server.port}/ws`);

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -12,6 +12,8 @@ import {
   type IncomingMessage,
   type Server as HttpServer,
 } from "http";
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "os";
 import path from "path";
 
@@ -28,6 +30,34 @@ async function getChildProcess(): Promise<typeof import("child_process")> {
     _cp = await import("node:child_process");
   }
   return _cp;
+}
+
+export function ensurePtySpawnHelperPermissions(): void {
+  if (os.platform() === "win32") return;
+  try {
+    const req = createRequire(import.meta.url);
+    const ptyPkg = req.resolve("node-pty/package.json");
+    const helper = path.join(
+      path.dirname(ptyPkg),
+      "prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    );
+    if (!fs.existsSync(helper)) return;
+    if (!(fs.statSync(helper).mode & 0o100)) {
+      fs.chmodSync(helper, 0o755);
+      console.log(
+        `[terminal] Fixed non-executable node-pty spawn-helper at ${helper}`,
+      );
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") return;
+    console.warn(
+      "[terminal] Could not verify node-pty spawn-helper permissions:",
+      (err as Error).message,
+    );
+  }
 }
 
 /**
@@ -129,6 +159,8 @@ export async function createPtyWebSocketServer(
     getCommandArgs,
     logPrefix = "[terminal]",
   } = options;
+
+  ensurePtySpawnHelperPermissions();
 
   // Dynamic imports for optional native dependencies
   const { WebSocketServer, WebSocket } = await import("ws");
@@ -280,8 +312,9 @@ export async function createPtyWebSocketServer(
     } catch (err) {
       console.error(`${logPrefix} Failed to spawn PTY:`, err);
       if (ws.readyState === WebSocket.OPEN) {
-        ws.send(
-          `\r\n\x1b[31m${logPrefix} Failed to spawn PTY: ${err instanceof Error ? err.message : String(err)}\x1b[0m\r\n`,
+        sendStatus(
+          "failed",
+          `Failed to spawn PTY: ${err instanceof Error ? err.message : String(err)}`,
         );
         ws.close();
       }

--- a/packages/core/src/terminal/terminal-plugin.ts
+++ b/packages/core/src/terminal/terminal-plugin.ts
@@ -1,7 +1,3 @@
-import * as fs from "node:fs";
-import { createRequire } from "node:module";
-import * as path from "node:path";
-
 import { defineEventHandler } from "h3";
 
 import {
@@ -18,47 +14,6 @@ import {
  * Skips activation when running inside a frame (FRAME_PORT is set).
  */
 import { isNodeRuntime } from "../shared/runtime.js";
-
-// ─── module-load self-heal: chmod node-pty's spawn-helper ─────────────────
-// pnpm can extract node-pty's prebuilds tarball without running the
-// post-install that chmods spawn-helper, leaving it as `-rw-r--r--` instead
-// of `-rwxr-xr-x`. Every PTY spawn then fails with `posix_spawnp failed`.
-// Run the fix synchronously at module load (static imports, sync fs calls)
-// so by the time ANY plugin worker starts spawning PTYs, the helper is
-// already executable.
-(function fixSpawnHelperPermissions() {
-  if (!isNodeRuntime()) return;
-  try {
-    const req = createRequire(import.meta.url);
-    const ptyPkg = req.resolve("node-pty/package.json");
-    const ptyDir = path.dirname(ptyPkg);
-    const helper = path.join(
-      ptyDir,
-      "prebuilds",
-      `${process.platform}-${process.arch}`,
-      "spawn-helper",
-    );
-    if (fs.existsSync(helper)) {
-      const mode = fs.statSync(helper).mode;
-      if (!(mode & 0o100)) {
-        fs.chmodSync(helper, 0o755);
-        console.log(
-          `[terminal] Fixed non-executable node-pty spawn-helper at ${helper}`,
-        );
-      }
-    }
-  } catch (err) {
-    // node-pty not installed → stay silent here; createTerminalPlugin emits
-    // the "install node-pty" message when the PTY server actually fails to
-    // start. Logging twice for the same root cause just adds noise.
-    const code = (err as NodeJS.ErrnoException)?.code;
-    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") return;
-    console.warn(
-      "[terminal] Could not verify node-pty spawn-helper permissions:",
-      (err as Error).message,
-    );
-  }
-})();
 
 export interface TerminalPluginOptions {
   /** CLI command to run. Defaults to AGENT_CLI_COMMAND env or 'builder' */

--- a/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
+++ b/packages/desktop-app/src/renderer/components/AppWebview.spec.ts
@@ -22,6 +22,7 @@ import {
   resolveAppWebviewAuthState,
   resolveAppWebviewAuthStateFromProbe,
   resolveAppWebviewUrl,
+  resolveDesktopAppPath,
   rememberDesktopEnvironmentLane,
   withDesktopEnvironmentOptOut,
   isDesktopIdentityAuthenticated,
@@ -1123,6 +1124,17 @@ describe("AppWebview URL resolution", () => {
         mode: "dev",
       }),
     ).toBe("http://localhost:3003");
+  });
+
+  it("opens first-party app tabs at the private home route", () => {
+    expect(resolveDesktopAppPath({ id: "mail" })).toBe("/home");
+    expect(
+      resolveDesktopAppPath({ id: "mail" }, { isBuiltIn: true }, "/"),
+    ).toBe("/home");
+    expect(
+      resolveDesktopAppPath({ id: "mail" }, { isBuiltIn: true }, "/inbox"),
+    ).toBe("/inbox");
+    expect(resolveDesktopAppPath({ id: "custom-app" })).toBeUndefined();
   });
 
   it("uses the production URL by default", () => {

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -654,6 +654,21 @@ function withUrlPath(rawUrl: string, path?: string): string {
   }
 }
 
+export function resolveDesktopAppPath(
+  app: Pick<AppDefinition, "id">,
+  appConfig?: Pick<AppConfig, "isBuiltIn">,
+  path?: string,
+): string | undefined {
+  if (path && path !== "/") return path;
+  if (
+    appConfig?.isBuiltIn === true ||
+    DESKTOP_DEFAULT_APPS.some((candidate) => candidate.id === app.id)
+  ) {
+    return "/home";
+  }
+  return path;
+}
+
 function isAgentNativeOpenPath(path: string | undefined): path is string {
   if (!path) return false;
   try {
@@ -759,7 +774,10 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     const rawUrl = sourceUrl?.trim()
       ? withUrlParams(sourceUrl.trim(), urlParams)
       : withUrlParams(
-          withUrlPath(resolveAppWebviewUrl(app, appConfig), urlPath),
+          withUrlPath(
+            resolveAppWebviewUrl(app, appConfig),
+            resolveDesktopAppPath(app, appConfig, urlPath),
+          ),
           {
             ...(appConfig?.mode === "dev" && appConfig.localPath
               ? { _agentNativeDesktopCode: "1" }

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -550,6 +550,12 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     expect(hubSource).toContain(
       '!hasChatFirstActiveChat &&\n      !(\n        activeChatFirstSurfaceTab?.kind === "app" &&\n        activeChatFirstSurfaceTab.placement === "side"',
     );
+    expect(hubSource).toContain(
+      "const canToggleChatFirstSurfacePanel =\n    hasChatFirstActiveChat && !chatFirstAppSelected;",
+    );
+    expect(hubSource).toContain(
+      'if (!hasChatFirstActiveChat) {\n        setChatFirstNotice("Open a chat to view browser surfaces.");',
+    );
     expect(hubSource).not.toContain(
       "if (tabCount > 0 && (previousTabCount === null || previousTabCount === 0))",
     );

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -530,20 +530,28 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
     );
   });
 
-  it("keeps the shared sidebar reachable from an empty full-screen chat", () => {
+  it("only exposes the shared sidebar from an active full-screen chat", () => {
     const hubSource = readFileSync(
       "src/renderer/components/CodeAgentsHub.tsx",
       "utf8",
     );
 
     expect(hubSource).toContain("!showTerminalSurface");
+    expect(hubSource).toContain("hasChatFirstActiveChat");
+    expect(hubSource).toContain("!chatFirstAppSelected");
     expect(hubSource).toContain("chatFirstSurfacePanel.toggle");
     expect(hubSource).toContain("sidebarOpen={chatFirstSurfacePanel.open}");
     expect(hubSource).toContain(
       "onToggleSidebar={chatFirstSurfacePanel.toggle}",
     );
     expect(hubSource).toContain(
-      "{chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (",
+      "{chatFirstSurfacePanel.open &&\n        (hasChatFirstActiveChat ||",
+    );
+    expect(hubSource).toContain(
+      "if (!hasChatFirstActiveChat) setChatFirstSurfacePanelOpen(false);",
+    );
+    expect(hubSource).not.toContain(
+      "if (tabCount > 0 && (previousTabCount === null || previousTabCount === 0))",
     );
     expect(hubSource).not.toContain(
       "(hasChatFirstActiveChat || terminalPreferences.enabled) &&\n        chatFirstSurfacePanel.open",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.spec.ts
@@ -548,7 +548,7 @@ describe("CodeAgentsHub multi-frontier event boundary", () => {
       "{chatFirstSurfacePanel.open &&\n        (hasChatFirstActiveChat ||",
     );
     expect(hubSource).toContain(
-      "if (!hasChatFirstActiveChat) setChatFirstSurfacePanelOpen(false);",
+      '!hasChatFirstActiveChat &&\n      !(\n        activeChatFirstSurfaceTab?.kind === "app" &&\n        activeChatFirstSurfaceTab.placement === "side"',
     );
     expect(hubSource).not.toContain(
       "if (tabCount > 0 && (previousTabCount === null || previousTabCount === 0))",

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -973,7 +973,13 @@ export default function CodeAgentsHub({
       setChatFirstNotice(null);
       setChatFirstBrowserSelection(null);
       closeChatFirstSessionWatch();
-      const surfaceTab = chatFirstAppSurfaceTab(app, path, view, placement);
+      const surfacePlacement = hasChatFirstActiveChat ? placement : "main";
+      const surfaceTab = chatFirstAppSurfaceTab(
+        app,
+        path,
+        view,
+        surfacePlacement,
+      );
       chatFirstSurfaceTabsStore.open(
         dispatchControlPlane
           ? {
@@ -982,7 +988,7 @@ export default function CodeAgentsHub({
             }
           : surfaceTab,
       );
-      setChatFirstSurfacePanelOpen(true);
+      if (surfacePlacement === "side") setChatFirstSurfacePanelOpen(true);
     },
     [
       chatFirstSurfaceTabsStore,
@@ -1394,6 +1400,10 @@ export default function CodeAgentsHub({
         );
         return;
       }
+      if (!hasChatFirstActiveChat) {
+        setChatFirstNotice("Open a chat to view browser surfaces.");
+        return;
+      }
       setChatFirstNotice(null);
       closeChatFirstSessionWatch();
       chatFirstSurfaceTabsStore.open({
@@ -1404,7 +1414,7 @@ export default function CodeAgentsHub({
       });
       setChatFirstBrowserSelection(resolution.target);
     },
-    [chatFirstSurfaceTabsStore],
+    [hasChatFirstActiveChat, chatFirstSurfaceTabsStore],
   );
 
   useEffect(() => {
@@ -1412,6 +1422,7 @@ export default function CodeAgentsHub({
     if (!request || handledChatFirstPreviewNonceRef.current === request.nonce) {
       return;
     }
+    if (!hasChatFirstActiveChat) return;
     const app = apps.find(
       (candidate) => candidate.id === request.appId && candidate.enabled,
     );
@@ -1427,7 +1438,12 @@ export default function CodeAgentsHub({
       url: app.devUrl,
       title: `${app.name} preview`,
     });
-  }, [apps, chatFirstPreviewRequest, resolveChatFirstOpenBrowser]);
+  }, [
+    apps,
+    chatFirstPreviewRequest,
+    hasChatFirstActiveChat,
+    resolveChatFirstOpenBrowser,
+  ]);
 
   useEffect(() => {
     window.localStorage.setItem(
@@ -1611,7 +1627,6 @@ export default function CodeAgentsHub({
           kind: "terminal",
           title: "Terminal",
         });
-        setChatFirstSurfacePanelOpen(true);
         return;
       }
       if (kind !== "agents") return;
@@ -2665,7 +2680,6 @@ export default function CodeAgentsHub({
       if (tab.kind === "terminal") {
         return (
           <DesktopTerminalTabs
-            key={`${tab.id}:${terminalPreferences.agent}`}
             agent={terminalPreferences.agent}
             theme={theme}
             className="desktop-terminal-tabs--side-surface"
@@ -2865,6 +2879,8 @@ export default function CodeAgentsHub({
   const showTerminalSurface =
     terminalPreferences.enabled &&
     (terminalSessionStarted || hasChatFirstActiveChat || chatFirstAppSelected);
+  const canToggleChatFirstSurfacePanel =
+    hasChatFirstActiveChat && !chatFirstAppSelected;
   return (
     <QueryClientProvider client={codeAgentsQueryClient}>
       <div
@@ -2945,12 +2961,14 @@ export default function CodeAgentsHub({
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
                 sidebarOpen={
-                  chatFirstAppSelected ? undefined : chatFirstSurfacePanel.open
+                  canToggleChatFirstSurfacePanel
+                    ? chatFirstSurfacePanel.open
+                    : undefined
                 }
                 onToggleSidebar={
-                  chatFirstAppSelected
-                    ? undefined
-                    : chatFirstSurfacePanel.toggle
+                  canToggleChatFirstSurfacePanel
+                    ? chatFirstSurfacePanel.toggle
+                    : undefined
                 }
                 onAgentChange={handleTerminalAgentChange}
               />

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -992,6 +992,7 @@ export default function CodeAgentsHub({
     },
     [
       chatFirstSurfaceTabsStore,
+      hasChatFirstActiveChat,
       setChatFirstSurfacePanelOpen,
       setScheduledTasksOpen,
       surfaceApps,

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -1491,8 +1491,20 @@ export default function CodeAgentsHub({
   }, [setChatFirstSurfacePanelOpen, visibleChatFirstSurfaceTabs.length]);
 
   useEffect(() => {
-    if (!hasChatFirstActiveChat) setChatFirstSurfacePanelOpen(false);
-  }, [hasChatFirstActiveChat, setChatFirstSurfacePanelOpen]);
+    if (
+      !hasChatFirstActiveChat &&
+      !(
+        activeChatFirstSurfaceTab?.kind === "app" &&
+        activeChatFirstSurfaceTab.placement === "side"
+      )
+    ) {
+      setChatFirstSurfacePanelOpen(false);
+    }
+  }, [
+    activeChatFirstSurfaceTab,
+    hasChatFirstActiveChat,
+    setChatFirstSurfacePanelOpen,
+  ]);
 
   useEffect(() => {
     if (!terminalPreferences.enabled) return;

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -120,6 +120,7 @@ import type {
 import type { SubscriptionStatus } from "../../../shared/subscription-status.js";
 import {
   DESKTOP_TERMINAL_AGENT_OPTIONS,
+  type DesktopTerminalAgentId,
   writeDesktopTerminalPreferences,
   useDesktopTerminalPreferences,
 } from "../lib/desktop-terminal-preferences.js";
@@ -1143,6 +1144,12 @@ export default function CodeAgentsHub({
     () => setDesktopTerminalMode(true, true),
     [setDesktopTerminalMode],
   );
+  const handleTerminalAgentChange = useCallback(
+    (agent: DesktopTerminalAgentId) => {
+      writeDesktopTerminalPreferences({ agent });
+    },
+    [],
+  );
   const handleNewUiTab = useCallback(
     () => setDesktopTerminalMode(false),
     [setDesktopTerminalMode],
@@ -1477,17 +1484,15 @@ export default function CodeAgentsHub({
   useEffect(() => {
     const tabCount = visibleChatFirstSurfaceTabs.length;
     const previousTabCount = previousChatFirstSurfaceTabCountRef.current;
-    if (tabCount > 0 && (previousTabCount === null || previousTabCount === 0)) {
-      setChatFirstSurfacePanelOpen(true);
-    } else if (
-      tabCount === 0 &&
-      previousTabCount !== null &&
-      previousTabCount > 0
-    ) {
+    if (tabCount === 0 && previousTabCount !== null && previousTabCount > 0) {
       setChatFirstSurfacePanelOpen(false);
     }
     previousChatFirstSurfaceTabCountRef.current = tabCount;
   }, [setChatFirstSurfacePanelOpen, visibleChatFirstSurfaceTabs.length]);
+
+  useEffect(() => {
+    if (!hasChatFirstActiveChat) setChatFirstSurfacePanelOpen(false);
+  }, [hasChatFirstActiveChat, setChatFirstSurfacePanelOpen]);
 
   useEffect(() => {
     if (!terminalPreferences.enabled) return;
@@ -2648,6 +2653,7 @@ export default function CodeAgentsHub({
       if (tab.kind === "terminal") {
         return (
           <DesktopTerminalTabs
+            key={`${tab.id}:${terminalPreferences.agent}`}
             agent={terminalPreferences.agent}
             theme={theme}
             className="desktop-terminal-tabs--side-surface"
@@ -2874,15 +2880,11 @@ export default function CodeAgentsHub({
             !showTerminalSurface &&
             !chatFirstAllAppsOpen &&
             !scheduledTasksOpen &&
-            !chatFirstAppTakesMain ? (
+            hasChatFirstActiveChat &&
+            !chatFirstAppSelected ? (
               <DesktopChatFirstSurfaceMenu
                 sidebarOpen={chatFirstSurfacePanel.open}
-                apps={chatFirstAppItems}
                 onToggleSidebar={chatFirstSurfacePanel.toggle}
-                onOpenApp={(app) =>
-                  openChatFirstApp(app.id, undefined, undefined, "side")
-                }
-                renderAppIcon={renderChatFirstAppIcon}
                 onNewCliTab={handleNewCliTab}
               />
             ) : undefined
@@ -2930,13 +2932,15 @@ export default function CodeAgentsHub({
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}
-                sidebarOpen={chatFirstSurfacePanel.open}
-                onToggleSidebar={chatFirstSurfacePanel.toggle}
-                apps={chatFirstAppItems}
-                onOpenApp={(app) =>
-                  openChatFirstApp(app.id, undefined, undefined, "side")
+                sidebarOpen={
+                  chatFirstAppSelected ? undefined : chatFirstSurfacePanel.open
                 }
-                renderAppIcon={renderChatFirstAppIcon}
+                onToggleSidebar={
+                  chatFirstAppSelected
+                    ? undefined
+                    : chatFirstSurfacePanel.toggle
+                }
+                onAgentChange={handleTerminalAgentChange}
               />
             ) : undefined
           }
@@ -3093,7 +3097,11 @@ export default function CodeAgentsHub({
             </div>
           )}
         />
-        {chatFirstSurfacePanel.open && !chatFirstAppTakesMain ? (
+        {chatFirstSurfacePanel.open &&
+        (hasChatFirstActiveChat ||
+          (activeChatFirstSurfaceTab?.kind === "app" &&
+            activeChatFirstSurfaceTab.placement === "side")) &&
+        !chatFirstAppTakesMain ? (
           <ChatFirstSurfacePanel
             width={chatFirstSurfaceResize.width}
             onResizePointerDown={chatFirstSurfaceResize.onPointerDown}

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.spec.tsx
@@ -23,17 +23,14 @@ describe("DesktopChatFirstSurfaceMenu", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes sidebar, app, and CLI actions from the full-screen menu", async () => {
+  it("exposes sidebar and CLI actions from the full-screen menu", async () => {
     const onToggleSidebar = vi.fn();
-    const onOpenApp = vi.fn();
     const onNewCliTab = vi.fn();
 
     act(() => {
       root.render(
         <DesktopChatFirstSurfaceMenu
-          apps={[{ id: "mail", name: "Mail" }]}
           onToggleSidebar={onToggleSidebar}
-          onOpenApp={onOpenApp}
           onNewCliTab={onNewCliTab}
         />,
       );
@@ -66,7 +63,7 @@ describe("DesktopChatFirstSurfaceMenu", () => {
       menuItems().some((item) =>
         item.textContent?.includes("Open app in sidebar"),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       menuItems().some((item) => item.textContent?.includes("New CLI tab")),
     ).toBe(true);

--- a/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopChatFirstSurfaceMenu.tsx
@@ -1,44 +1,31 @@
-import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui";
 import {
-  IconApps,
   IconDotsVertical,
   IconLayoutSidebarRightCollapse,
   IconMessageCircle,
   IconTerminal2,
 } from "@tabler/icons-react";
-import type { ReactNode } from "react";
 
 export interface DesktopChatFirstSurfaceMenuProps {
   sidebarOpen?: boolean;
-  apps?: readonly ChatFirstAppItem[];
   onToggleSidebar?: () => void;
-  onOpenApp?: (app: ChatFirstAppItem) => void;
-  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
   onNewCliTab?: () => void;
   onNewUiTab?: () => void;
 }
 
 export function DesktopChatFirstSurfaceMenuItems({
   sidebarOpen = false,
-  apps = [],
   onToggleSidebar,
-  onOpenApp,
-  renderAppIcon,
   onNewCliTab,
   onNewUiTab,
 }: DesktopChatFirstSurfaceMenuProps) {
-  const hasAppPicker = apps.length > 0 && Boolean(onOpenApp);
-  if (!onToggleSidebar && !hasAppPicker && !onNewCliTab && !onNewUiTab) {
+  if (!onToggleSidebar && !onNewCliTab && !onNewUiTab) {
     return null;
   }
 
@@ -50,33 +37,9 @@ export function DesktopChatFirstSurfaceMenuItems({
           {sidebarOpen ? "Hide sidebar" : "Open sidebar"}
         </DropdownMenuItem>
       ) : null}
-      {hasAppPicker ? (
-        <>
-          {onToggleSidebar ? <DropdownMenuSeparator /> : null}
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <IconApps size={14} className="shrink-0" />
-              Open app in sidebar
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-56">
-              {apps.map((app) => (
-                <DropdownMenuItem
-                  key={app.id}
-                  onSelect={() => onOpenApp?.(app)}
-                >
-                  {renderAppIcon?.(app) ?? (
-                    <IconApps size={14} className="shrink-0" />
-                  )}
-                  <span className="min-w-0 truncate">{app.name}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-        </>
-      ) : null}
       {onNewCliTab || onNewUiTab ? (
         <>
-          {(onToggleSidebar || hasAppPicker) && <DropdownMenuSeparator />}
+          {onToggleSidebar && <DropdownMenuSeparator />}
           {onNewCliTab ? (
             <DropdownMenuItem onSelect={onNewCliTab}>
               <IconTerminal2 size={14} className="shrink-0" />

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopTerminalSurface from "./DesktopTerminalSurface.js";
 
 vi.mock("./DesktopTerminalTabs.js", () => ({
-  default: () => <div data-terminal-test />,
+  default: ({ agent }: { agent: string }) => (
+    <div data-terminal-test data-terminal-agent={agent} />
+  ),
 }));
 
 describe("DesktopTerminalSurface", () => {
@@ -133,5 +135,68 @@ describe("DesktopTerminalSurface", () => {
         document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
       ).some((item) => item.textContent?.includes("Terminal provider")),
     ).toBe(false);
+  });
+
+  it("keeps inactive terminal sessions on their original provider", async () => {
+    const onAgentChange = vi.fn();
+    act(() => {
+      root.render(
+        <DesktopTerminalSurface
+          agent="codex"
+          theme="dark"
+          onAgentChange={onAgentChange}
+        />,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="New terminal"]')
+        ?.click();
+    });
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>("[data-terminal-agent]"),
+      ).map((terminal) => terminal.dataset.terminalAgent),
+    ).toEqual(["codex", "codex"]);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Terminal options"]')
+        ?.dispatchEvent(
+          new PointerEvent("pointerdown", {
+            bubbles: true,
+            button: 0,
+            pointerType: "mouse",
+          }),
+        );
+      await Promise.resolve();
+    });
+    const providerItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes("Provider"));
+    expect(providerItem).toBeDefined();
+
+    await act(async () => {
+      providerItem?.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          pointerType: "mouse",
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    const claudeOption = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes("Claude Code"));
+    expect(claudeOption).toBeDefined();
+
+    await act(async () => claudeOption?.click());
+    expect(onAgentChange).toHaveBeenCalledWith("claude-code");
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>("[data-terminal-agent]"),
+      ).map((terminal) => terminal.dataset.terminalAgent),
+    ).toEqual(["codex", "claude-code"]);
   });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -95,4 +95,43 @@ describe("DesktopTerminalSurface", () => {
     await act(async () => item?.click());
     expect(onToggleSidebar).toHaveBeenCalledOnce();
   });
+
+  it("offers the supported terminal providers", async () => {
+    act(() => {
+      root.render(
+        <DesktopTerminalSurface
+          agent="codex"
+          theme="dark"
+          onAgentChange={vi.fn()}
+        />,
+      );
+    });
+
+    await act(async () => {
+      const trigger = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Terminal options"]',
+      );
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const providerItem = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes("Provider"));
+    expect(providerItem).not.toBeUndefined();
+    expect(
+      providerItem?.querySelector(".desktop-dropdown-item__main"),
+    ).not.toBeNull();
+    expect(
+      Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).some((item) => item.textContent?.includes("Terminal provider")),
+    ).toBe(false);
+  });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -43,12 +43,17 @@ interface DesktopTerminalSurfaceProps {
 interface DesktopTerminalTab {
   id: string;
   label: string;
+  agent: DesktopTerminalAgentId;
 }
 
-function createTerminalTab(number: number): DesktopTerminalTab {
+function createTerminalTab(
+  number: number,
+  agent: DesktopTerminalAgentId,
+): DesktopTerminalTab {
   return {
     id: `desktop-terminal-${number}`,
     label: `Terminal ${number}`,
+    agent,
   };
 }
 
@@ -65,21 +70,21 @@ export default function DesktopTerminalSurface({
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
-    createTerminalTab(1),
+    createTerminalTab(1, agent),
   ]);
   const [activeTabId, setActiveTabId] = useState("desktop-terminal-1");
 
   const addTab = useCallback(() => {
-    const next = createTerminalTab(++tabCounter.current);
+    const next = createTerminalTab(++tabCounter.current, agent);
     setTabs((current) => [...current, next]);
     setActiveTabId(next.id);
-  }, []);
+  }, [agent]);
 
   const closeTab = useCallback(
     (tabId: string) => {
       setTabs((current) => {
         if (current.length === 1) {
-          const replacement = createTerminalTab(++tabCounter.current);
+          const replacement = createTerminalTab(++tabCounter.current, agent);
           setActiveTabId(replacement.id);
           return [replacement];
         }
@@ -92,7 +97,7 @@ export default function DesktopTerminalSurface({
         return next;
       });
     },
-    [activeTabId],
+    [activeTabId, agent],
   );
 
   const closeOtherTabs = useCallback((tabId: string) => {
@@ -105,10 +110,23 @@ export default function DesktopTerminalSurface({
   }, []);
 
   const closeAllTabs = useCallback(() => {
-    const replacement = createTerminalTab(++tabCounter.current);
+    const replacement = createTerminalTab(++tabCounter.current, agent);
     setTabs([replacement]);
     setActiveTabId(replacement.id);
-  }, []);
+  }, [agent]);
+
+  const handleAgentChange = useCallback(
+    (nextAgent: DesktopTerminalAgentId) => {
+      setTabs((current) =>
+        current.map((tab) =>
+          tab.id === activeTabId ? { ...tab, agent: nextAgent } : tab,
+        ),
+      );
+      onAgentChange?.(nextAgent);
+    },
+    [activeTabId, onAgentChange],
+  );
+  const activeTab = tabs.find((tab) => tab.id === activeTabId);
 
   return (
     <section
@@ -192,12 +210,14 @@ export default function DesktopTerminalSurface({
                       {DESKTOP_TERMINAL_AGENT_OPTIONS.map((option) => (
                         <DropdownMenuItem
                           key={option.id}
-                          onSelect={() => onAgentChange(option.id)}
+                          onSelect={() => handleAgentChange(option.id)}
                         >
                           <IconCheck
                             size={14}
                             className={
-                              option.id === agent ? "shrink-0" : "invisible"
+                              option.id === (activeTab?.agent ?? agent)
+                                ? "shrink-0"
+                                : "invisible"
                             }
                             aria-hidden="true"
                           />
@@ -245,8 +265,7 @@ export default function DesktopTerminalSurface({
             hidden={tab.id !== activeTabId}
           >
             <DesktopTerminalTabs
-              key={`${tab.id}:${agent}`}
-              agent={agent}
+              agent={tab.agent}
               theme={theme}
               submitRequest={tab.id === activeTabId ? submitRequest : undefined}
               onPromptSubmitted={onPromptSubmitted}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -1,22 +1,29 @@
-import type { ChatFirstAppItem } from "@agent-native/core/client/chat-first";
 import type { AgentTerminalSubmitRequest } from "@agent-native/core/terminal";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@agent-native/toolkit/ui";
-import { IconDotsVertical, IconPlus, IconX } from "@tabler/icons-react";
-import type { ReactNode } from "react";
+import {
+  IconCheck,
+  IconDotsVertical,
+  IconPlus,
+  IconTerminal2,
+  IconX,
+} from "@tabler/icons-react";
 import { useCallback, useRef, useState } from "react";
 
-import { type DesktopTerminalAgentId } from "../lib/desktop-terminal-preferences.js";
-import type { RendererTheme } from "../lib/theme.js";
 import {
-  DesktopChatFirstSurfaceMenuItems,
-  type DesktopChatFirstSurfaceMenuProps,
-} from "./DesktopChatFirstSurfaceMenu.js";
+  DESKTOP_TERMINAL_AGENT_OPTIONS,
+  type DesktopTerminalAgentId,
+} from "../lib/desktop-terminal-preferences.js";
+import type { RendererTheme } from "../lib/theme.js";
+import { DesktopChatFirstSurfaceMenuItems } from "./DesktopChatFirstSurfaceMenu.js";
 import DesktopTerminalTabs from "./DesktopTerminalTabs.js";
 
 export interface DesktopTerminalPromptRequest extends AgentTerminalSubmitRequest {}
@@ -30,9 +37,7 @@ interface DesktopTerminalSurfaceProps {
   onNewUiTab?: () => void;
   sidebarOpen?: boolean;
   onToggleSidebar?: () => void;
-  apps?: readonly ChatFirstAppItem[];
-  onOpenApp?: DesktopChatFirstSurfaceMenuProps["onOpenApp"];
-  renderAppIcon?: (app: ChatFirstAppItem) => ReactNode;
+  onAgentChange?: (agent: DesktopTerminalAgentId) => void;
 }
 
 interface DesktopTerminalTab {
@@ -56,9 +61,7 @@ export default function DesktopTerminalSurface({
   onNewUiTab,
   sidebarOpen,
   onToggleSidebar,
-  apps = [],
-  onOpenApp,
-  renderAppIcon,
+  onAgentChange,
 }: DesktopTerminalSurfaceProps) {
   const tabCounter = useRef(1);
   const [tabs, setTabs] = useState<DesktopTerminalTab[]>(() => [
@@ -176,16 +179,41 @@ export default function DesktopTerminalSurface({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" sideOffset={6} className="w-48">
-              {onToggleSidebar ||
-              (apps.length > 0 && onOpenApp) ||
-              onNewUiTab ? (
+              {onAgentChange ? (
+                <>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <span className="desktop-dropdown-item__main">
+                        <IconTerminal2 size={14} className="shrink-0" />
+                        Provider
+                      </span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-52">
+                      {DESKTOP_TERMINAL_AGENT_OPTIONS.map((option) => (
+                        <DropdownMenuItem
+                          key={option.id}
+                          onSelect={() => onAgentChange(option.id)}
+                        >
+                          <IconCheck
+                            size={14}
+                            className={
+                              option.id === agent ? "shrink-0" : "invisible"
+                            }
+                            aria-hidden="true"
+                          />
+                          <span>{option.label}</span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                </>
+              ) : null}
+              {onToggleSidebar || onNewUiTab ? (
                 <>
                   <DesktopChatFirstSurfaceMenuItems
                     sidebarOpen={sidebarOpen}
-                    apps={apps}
                     onToggleSidebar={onToggleSidebar}
-                    onOpenApp={onOpenApp}
-                    renderAppIcon={renderAppIcon}
                     onNewUiTab={onNewUiTab}
                   />
                   <DropdownMenuSeparator />
@@ -217,6 +245,7 @@ export default function DesktopTerminalSurface({
             hidden={tab.id !== activeTabId}
           >
             <DesktopTerminalTabs
+              key={`${tab.id}:${agent}`}
               agent={agent}
               theme={theme}
               submitRequest={tab.id === activeTabId ? submitRequest : undefined}

--- a/packages/desktop-app/src/renderer/lib/desktop-terminal-preferences.ts
+++ b/packages/desktop-app/src/renderer/lib/desktop-terminal-preferences.ts
@@ -9,8 +9,8 @@ export const DESKTOP_TERMINAL_AGENT_OPTIONS = [
   { id: "claude-code", label: "Claude Code", command: "claude" },
   { id: "codex", label: "Codex", command: "codex" },
   { id: "builder.io", label: "Builder.io", command: "builder" },
-  { id: "pi", label: "Pi", command: "pi" },
   { id: "opencode", label: "OpenCode", command: "opencode" },
+  { id: "pi", label: "Pi", command: "pi" },
 ] as const;
 
 export type DesktopTerminalAgentId =

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -404,14 +404,28 @@ body {
 
 .collapsed-mac-window-controls .win-btn--maximize {
   left: 50px;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-4px) scale(0.8);
+}
+
+.collapsed-mac-window-controls:has(
+    .win-btn--close:hover,
+    .win-btn--minimize:hover
+  )::before,
+.collapsed-mac-window-controls:focus-within::before {
+  opacity: 1;
+}
+
+.collapsed-mac-window-controls:has(
+    .win-btn--close:hover,
+    .win-btn--minimize:hover
+  )
+  .win-btn--maximize,
+.collapsed-mac-window-controls:focus-within .win-btn--maximize {
   opacity: 1;
   pointer-events: auto;
   transform: translateX(0) scale(1);
-}
-
-.collapsed-mac-window-controls:hover::before,
-.collapsed-mac-window-controls:focus-within::before {
-  opacity: 1;
 }
 
 .platform-darwin
@@ -420,6 +434,12 @@ body {
 .platform-darwin
   .shell:has(.settings-overlay)
   .collapsed-mac-window-controls:hover::before,
+.platform-darwin
+  .shell:has(.settings-overlay)
+  .collapsed-mac-window-controls:has(
+    .win-btn--close:hover,
+    .win-btn--minimize:hover
+  )::before,
 .platform-darwin
   .shell:has(.settings-overlay)
   .collapsed-mac-window-controls:focus-within::before {

--- a/packages/desktop-app/src/renderer/window-controls.spec.ts
+++ b/packages/desktop-app/src/renderer/window-controls.spec.ts
@@ -29,16 +29,17 @@ describe("chat-first macOS window controls", () => {
     );
   });
 
-  it("fades the green control and background in on hover", () => {
+  it("keeps the green control hidden until red or yellow hover", () => {
     expect(shellCss).toContain(".collapsed-mac-window-controls::before {");
     expect(shellCss).toContain("opacity: 0;");
     expect(shellCss).toContain("transition: opacity var(--ease-collapse);");
-    expect(shellCss).toContain(
-      ".collapsed-mac-window-controls:hover::before,\n.collapsed-mac-window-controls:focus-within::before {",
-    );
+    expect(shellCss).toContain(".collapsed-mac-window-controls:has(");
+    expect(shellCss).toContain(".win-btn--close:hover");
+    expect(shellCss).toContain(".win-btn--minimize:hover");
     expect(shellCss).toContain(
       ".collapsed-mac-window-controls .win-btn--maximize {",
     );
+    expect(shellCss).toContain("pointer-events: none;");
     expect(shellCss).toContain("opacity: 1;");
     expect(shellCss).toContain("pointer-events: auto;");
     expect(shellCss).toContain("transform: translateX(0) scale(1);");
@@ -48,9 +49,7 @@ describe("chat-first macOS window controls", () => {
     expect(shellCss).toContain(
       ".platform-darwin\n  .shell:has(.settings-overlay)\n  .collapsed-mac-window-controls::before,",
     );
-    expect(shellCss).toContain(
-      ".collapsed-mac-window-controls:hover::before,\n.platform-darwin\n  .shell:has(.settings-overlay)\n  .collapsed-mac-window-controls:focus-within::before {",
-    );
+    expect(shellCss).toContain(".collapsed-mac-window-controls:hover::before,");
     expect(shellCss).toContain(
       ".platform-darwin\n  .shell:has(.settings-overlay)\n  .collapsed-mac-window-controls\n  .win-btn--maximize {\n  opacity: 1;\n  pointer-events: auto;\n  transform: translateX(0) scale(1);",
     );

--- a/templates/assets/app/global.css
+++ b/templates/assets/app/global.css
@@ -85,11 +85,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .assets-create-chat-intro {

--- a/templates/brain/app/global.css
+++ b/templates/brain/app/global.css
@@ -111,12 +111,12 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .brain-chat-intro {

--- a/templates/calendar/app/global.css
+++ b/templates/calendar/app/global.css
@@ -141,11 +141,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 /* Exposes the conference accent to Tailwind utilities the same way

--- a/templates/calendar/changelog/2026-08-31-lower-contrast-scrollbars-keep-desktop-surfaces-calm.md
+++ b/templates/calendar/changelog/2026-08-31-lower-contrast-scrollbars-keep-desktop-surfaces-calm.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-08-31
+---
+
+Lower-contrast scrollbars keep desktop surfaces calm

--- a/templates/chat/app/global.css
+++ b/templates/chat/app/global.css
@@ -85,9 +85,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }

--- a/templates/clips/app/global.css
+++ b/templates/clips/app/global.css
@@ -181,9 +181,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1609,7 +1609,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 }
 
 .popover-list::-webkit-scrollbar-thumb {
-  background: var(--border-strong);
+  background: var(--border);
   border-radius: 999px;
 }
 

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -166,17 +166,17 @@
     background: transparent;
   }
   .scrollbar-thin::-webkit-scrollbar-thumb {
-    background: hsl(var(--border));
+    background: hsl(var(--muted-foreground) / 0.22);
     border-radius: 3px;
   }
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground));
+    background: hsl(var(--muted-foreground) / 0.34);
   }
   .scrollbar-dark::-webkit-scrollbar-thumb {
-    background: hsl(var(--sidebar-border));
+    background: hsl(var(--sidebar-border) / 0.22);
   }
   .scrollbar-dark::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--sidebar-muted));
+    background: hsl(var(--sidebar-muted) / 0.34);
   }
 }
 

--- a/templates/crm/app/global.css
+++ b/templates/crm/app/global.css
@@ -269,7 +269,7 @@
 }
 ::-webkit-scrollbar-thumb {
   border-radius: 3px;
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
 }
 
 .crm-chat-intro {

--- a/templates/design/app/global.css
+++ b/templates/design/app/global.css
@@ -233,17 +233,17 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .design-inspector-scroll {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--border)) transparent;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.22) transparent;
 }
 
 .design-inspector-scroll::-webkit-scrollbar {
@@ -255,12 +255,12 @@
 }
 
 .design-inspector-scroll::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 
 .design-inspector-scroll::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .design-sidebar {

--- a/templates/dispatch/app/global.css
+++ b/templates/dispatch/app/global.css
@@ -129,9 +129,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }

--- a/templates/factory/app/global.css
+++ b/templates/factory/app/global.css
@@ -152,11 +152,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .factory-audit-split {

--- a/templates/forms/app/global.css
+++ b/templates/forms/app/global.css
@@ -108,11 +108,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .forms-list-shell,

--- a/templates/mail/app/global.css
+++ b/templates/mail/app/global.css
@@ -131,11 +131,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 /* Email body prose reset */

--- a/templates/plan/app/global.css
+++ b/templates/plan/app/global.css
@@ -2124,11 +2124,11 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }
 
 .plans-grid {

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -256,11 +256,11 @@ button[title="Open agent sidebar"] {
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: hsl(var(--muted-foreground) / 0.3);
+    background: hsl(var(--muted-foreground) / 0.22);
     border-radius: 3px;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground) / 0.5);
+    background: hsl(var(--muted-foreground) / 0.34);
   }
 }
 

--- a/templates/tasks/app/global.css
+++ b/templates/tasks/app/global.css
@@ -85,9 +85,9 @@
   background: transparent;
 }
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--border));
+  background: hsl(var(--muted-foreground) / 0.22);
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--muted-foreground) / 0.4);
+  background: hsl(var(--muted-foreground) / 0.34);
 }


### PR DESCRIPTION
## Summary
- Keep the shared surface drawer closed on New Chat and expose it only from an active chat.
- Rename the terminal provider submenu and align its icon/text spacing.
- Preserve the desktop surface, terminal reliability, scrollbar, traffic-light, and /home routing fixes in this snapshot.

## Validation
- Focused desktop tests pass.
- Core and desktop typechecks and builds pass.
- Repository guards pass.
- Local Electron smoke test confirms the chat drawer and provider menu behavior.