### PR TITLE
fix(mail): keep saved filter tabs exclusive

### DIFF
--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -99,6 +99,8 @@ async function fetchEmailList(
       activeInboxTab === OTHER_INBOX_TAB_PARAM;
     const userPinnedLabels = settings?.pinnedLabels;
     const pinnedLabels = resolvePinnedLabels(userPinnedLabels, googleConnected);
+    const savedFilterQueries =
+      settings?.savedFilters?.map((filter) => filter.query) ?? [];
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
     const clients = googleConnected ? await getClients(ownerEmail) : [];
     const connectedEmails = new Set(
@@ -114,7 +116,12 @@ async function fetchEmailList(
     };
     const applyActiveInboxTab = (emails: any[]) =>
       shouldFilterOther
-        ? filterInboxTabEmails(prepareEmails(emails), null, pinnedLabels)
+        ? filterInboxTabEmails(
+            prepareEmails(emails),
+            null,
+            pinnedLabels,
+            savedFilterQueries,
+          )
         : prepareEmails(emails);
     if (effectiveView === "snoozed" || effectiveView === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, effectiveView);

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -3,7 +3,10 @@ import { readAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { getSetting } from "@agent-native/core/settings";
 import { isInboxScopedAppLabel } from "@shared/gmail-labels.js";
-import { emailMessageMatchesSearch } from "@shared/search.js";
+import {
+  emailMessageMatchesSearch,
+  searchQueryNeedsAttachmentMetadata,
+} from "@shared/search.js";
 import { z } from "zod";
 
 import {
@@ -117,7 +120,7 @@ async function fetchEmailList(
     const needsSavedFilterParts =
       effectiveView === "inbox" &&
       !effectiveSearch &&
-      savedFilterQueries.length > 0;
+      savedFilterQueries.some(searchQueryNeedsAttachmentMetadata);
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
     const clients = googleConnected ? await getClients(ownerEmail) : [];
     const connectedEmails = new Set(

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -114,6 +114,10 @@ async function fetchEmailList(
         : undefined;
     const savedFilterQueries =
       settings?.savedFilters?.map((filter) => filter.query) ?? [];
+    const needsSavedFilterParts =
+      effectiveView === "inbox" &&
+      !effectiveSearch &&
+      savedFilterQueries.length > 0;
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
     const clients = googleConnected ? await getClients(ownerEmail) : [];
     const connectedEmails = new Set(
@@ -184,7 +188,9 @@ async function fetchEmailList(
         undefined,
         {
           mode: "threads",
-          threadFormat: "metadata",
+          // Metadata responses omit MIME parts. Saved-filter partitioning
+          // needs attachment filenames for has:attachment/filename queries.
+          threadFormat: needsSavedFilterParts ? "full" : "metadata",
           accountEmails:
             selectedAccountEmails.length > 0
               ? selectedAccountEmails

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -13,6 +13,7 @@ import {
   resolvePinnedLabels,
   pinnedTriageLabels,
   inboxThreadKey,
+  savedFilterThreadIds,
 } from "../app/lib/inbox-tabs.js";
 import { buildGmailEmailSearchQuery } from "../server/lib/gmail-query.js";
 import { gmailGetThread } from "../server/lib/google-api.js";
@@ -126,15 +127,28 @@ async function fetchEmailList(
       });
       return filterSelectedAccounts(augmented);
     };
-    const applyActiveInboxTab = (emails: any[]) =>
-      activeTriageTab !== undefined
-        ? filterInboxTabEmails(
-            prepareEmails(emails),
-            activeTriageTab,
-            pinnedLabels,
-            savedFilterQueries,
-          )
-        : prepareEmails(emails);
+    const applyActiveInboxTab = (emails: any[]) => {
+      const prepared = prepareEmails(emails);
+      const filtered =
+        activeTriageTab !== undefined
+          ? filterInboxTabEmails(
+              prepared,
+              activeTriageTab,
+              pinnedLabels,
+              savedFilterQueries,
+            )
+          : prepared;
+      if (effectiveView !== "inbox" || effectiveSearch || label) {
+        return filtered;
+      }
+      const savedFilterThreads = savedFilterThreadIds(
+        filtered,
+        savedFilterQueries,
+      );
+      return filtered.filter(
+        (email) => !savedFilterThreads.has(inboxThreadKey(email)),
+      );
+    };
     if (effectiveView === "snoozed" || effectiveView === "scheduled") {
       let emails = await getSyntheticEmailsForView(ownerEmail, effectiveView);
       if (effectiveSearch) {

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -10,6 +10,8 @@ import {
   filterInboxTabEmails,
   OTHER_INBOX_TAB_PARAM,
   resolvePinnedLabels,
+  pinnedTriageLabels,
+  inboxThreadKey,
 } from "../app/lib/inbox-tabs.js";
 import { buildGmailEmailSearchQuery } from "../server/lib/gmail-query.js";
 import { gmailGetThread } from "../server/lib/google-api.js";
@@ -33,7 +35,7 @@ import { getAccessTokens, fetchLabelMap } from "./helpers.js";
 function latestPerThread(emails: any[]): any[] {
   const byThread = new Map<string, any>();
   for (const email of emails) {
-    const key = `${email.accountEmail ?? ""}:${email.threadId || email.id}`;
+    const key = inboxThreadKey(email);
     const existing = byThread.get(key);
     if (
       !existing ||
@@ -50,7 +52,7 @@ function latestPerThread(emails: any[]): any[] {
 async function fetchEmailList(
   view: string,
   search?: string,
-  _label?: string,
+  label?: string,
   activeInboxTab?: string,
   activeAccounts?: string[],
   filterId?: string,
@@ -82,7 +84,9 @@ async function fetchEmailList(
     const shouldReadSettings =
       googleConnected ||
       Boolean(requestedFilterId) ||
-      (view === "inbox" && !search && activeInboxTab === OTHER_INBOX_TAB_PARAM);
+      (view === "inbox" &&
+        !search &&
+        (activeInboxTab === OTHER_INBOX_TAB_PARAM || Boolean(label)));
     const settings = shouldReadSettings
       ? await readSettings(ownerEmail)
       : undefined;
@@ -93,12 +97,17 @@ async function fetchEmailList(
       : undefined;
     const effectiveSearch = requestedFilterId ? savedFilter?.query : search;
     const effectiveView = savedFilter ? "all" : view;
-    const shouldFilterOther =
-      effectiveView === "inbox" &&
-      !effectiveSearch &&
-      activeInboxTab === OTHER_INBOX_TAB_PARAM;
     const userPinnedLabels = settings?.pinnedLabels;
     const pinnedLabels = resolvePinnedLabels(userPinnedLabels, googleConnected);
+    const triageLabels = pinnedTriageLabels(pinnedLabels);
+    const activeTriageTab =
+      effectiveView === "inbox" && !effectiveSearch
+        ? activeInboxTab === OTHER_INBOX_TAB_PARAM
+          ? null
+          : label && triageLabels.includes(label)
+            ? label
+            : undefined
+        : undefined;
     const savedFilterQueries =
       settings?.savedFilters?.map((filter) => filter.query) ?? [];
     const hasNoteToSelf = pinnedLabels.includes("note-to-self");
@@ -115,10 +124,10 @@ async function fetchEmailList(
       return filterSelectedAccounts(augmented);
     };
     const applyActiveInboxTab = (emails: any[]) =>
-      shouldFilterOther
+      activeTriageTab !== undefined
         ? filterInboxTabEmails(
             prepareEmails(emails),
-            null,
+            activeTriageTab,
             pinnedLabels,
             savedFilterQueries,
           )

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -2,6 +2,7 @@ import { defineAction } from "@agent-native/core/action";
 import { readAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { getSetting } from "@agent-native/core/settings";
+import { isInboxScopedAppLabel } from "@shared/gmail-labels.js";
 import { emailMessageMatchesSearch } from "@shared/search.js";
 import { z } from "zod";
 
@@ -104,7 +105,9 @@ async function fetchEmailList(
       effectiveView === "inbox" && !effectiveSearch
         ? activeInboxTab === OTHER_INBOX_TAB_PARAM
           ? null
-          : label && triageLabels.includes(label)
+          : label &&
+              triageLabels.includes(label) &&
+              isInboxScopedAppLabel(label)
             ? label
             : undefined
         : undefined;

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -172,13 +172,13 @@ async function fetchEmailList(
         },
       );
 
-      return applyActiveInboxTab(
-        latestPerThread(
-          messages.map((m: any) =>
-            gmailToEmailMessage(m, m._accountEmail, labelMap),
-          ),
-        ),
-      ).slice(0, 50);
+      const preparedMessages = messages.map((m: any) =>
+        gmailToEmailMessage(m, m._accountEmail, labelMap),
+      );
+      return latestPerThread(applyActiveInboxTab(preparedMessages)).slice(
+        0,
+        50,
+      );
     }
 
     // Fallback: local store

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -26,6 +26,27 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain('const localCount = localCounts["__inboxTotal"]');
   });
 
+  it("uses the saved-filter-exclusive local count for a plain Inbox", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      "if (!hasPinnedFilters && savedFilterQueries.length > 0)",
+    );
+    expect(source).toContain('return localCounts["inbox"] ?? 0;');
+  });
+
+  it("groups badge rows with the rendered list's thread identity", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain(
+      'import { groupIntoThreads } from "@/lib/threads";',
+    );
+    expect(source).toContain("const threadRows = groupIntoThreads(filtered);");
+    expect(source).toContain(
+      "filterInboxTabEmails(filtered, null, pinnedLabels, savedFilterQueries)",
+    );
+  });
+
   it("collapses the native rail while the per-app chat is open", () => {
     const source = appLayoutSource();
 

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -32,6 +32,12 @@ describe("AppLayout inbox rail count", () => {
     expect(source).toContain("if (savedFilterQueries.length > 0)");
     expect(source).toContain('return localCounts["__inboxExclusive"] ?? 0;');
     expect(source).toContain('total["__inboxExclusive"]');
+    expect(source).toContain(
+      "const savedFilterThreads = savedFilterThreadIds(",
+    );
+    expect(source).toContain(
+      "filtered.filter((e) => !savedFilterThreads.has(inboxThreadKey(e)))",
+    );
   });
 
   it("groups badge rows with the rendered list's thread identity", () => {

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -29,10 +29,9 @@ describe("AppLayout inbox rail count", () => {
   it("uses the saved-filter-exclusive local count for a plain Inbox", () => {
     const source = appLayoutSource();
 
-    expect(source).toContain(
-      "if (!hasPinnedFilters && savedFilterQueries.length > 0)",
-    );
-    expect(source).toContain('return localCounts["inbox"] ?? 0;');
+    expect(source).toContain("if (savedFilterQueries.length > 0)");
+    expect(source).toContain('return localCounts["__inboxExclusive"] ?? 0;');
+    expect(source).toContain('total["__inboxExclusive"]');
   });
 
   it("groups badge rows with the rendered list's thread identity", () => {

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -92,6 +92,7 @@ import {
   pinnedTriageLabels,
   augmentSelfSentLabels,
   savedFilterThreadIds,
+  inboxThreadKey,
 } from "@/lib/inbox-tabs";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { cn } from "@/lib/utils";
@@ -544,7 +545,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       { latest: (typeof filtered)[0]; hasUnread: boolean }
     >();
     for (const e of filtered) {
-      const key = e.threadId || e.id;
+      const key = inboxThreadKey(e);
       const existing = threadState.get(key);
       if (!existing) {
         threadState.set(key, { latest: e, hasUnread: !e.isRead });
@@ -566,7 +567,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     // disagree with the emails it actually shows.
     const inboxRows = threadRows.filter(
       ({ latest }) =>
-        !savedFilterThreads.has(latest.threadId || latest.id) &&
+        !savedFilterThreads.has(inboxThreadKey(latest)) &&
         qualifiesForInboxTab(latest.labelIds, null, triageLabels),
     );
     total["__inboxTotal"] = threadRows.length;
@@ -582,7 +583,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       const full = pinnedLabels[i];
       const rows = threadRows.filter(
         ({ latest }) =>
-          !savedFilterThreads.has(latest.threadId || latest.id) &&
+          !savedFilterThreads.has(inboxThreadKey(latest)) &&
           qualifiesForInboxTab(latest.labelIds, full, triageLabels),
       );
       total[full] = rows.length;

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -87,14 +87,13 @@ import { shouldOfferGoogleOAuthSetup } from "@/lib/google-oauth-setup";
 import {
   OTHER_INBOX_TAB_ID,
   OTHER_INBOX_TAB_PARAM,
-  qualifiesForInboxTab,
   resolvePinnedLabels,
   pinnedTriageLabels,
   augmentSelfSentLabels,
-  savedFilterThreadIds,
-  inboxThreadKey,
+  filterInboxTabEmails,
 } from "@/lib/inbox-tabs";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
+import { groupIntoThreads } from "@/lib/threads";
 import { cn } from "@/lib/utils";
 import { isKnownMailView } from "@/routes/$view";
 
@@ -539,55 +538,30 @@ function AppLayoutInner({ children }: AppLayoutProps) {
             (e) => e.accountEmail && activeAccounts.has(e.accountEmail),
           )
         : inboxEmails;
-    // Find the latest message + unread state per thread.
-    const threadState = new Map<
-      string,
-      { latest: (typeof filtered)[0]; hasUnread: boolean }
-    >();
-    for (const e of filtered) {
-      const key = inboxThreadKey(e);
-      const existing = threadState.get(key);
-      if (!existing) {
-        threadState.set(key, { latest: e, hasUnread: !e.isRead });
-      } else {
-        existing.hasUnread ||= !e.isRead;
-        if (new Date(e.date) > new Date(existing.latest.date)) {
-          existing.latest = e;
-        }
-      }
-    }
-    const threadRows = [...threadState.values()];
-    const triageLabels = pinnedTriageLabels(pinnedLabels);
-    const savedFilterThreads = savedFilterThreadIds(
-      filtered,
-      savedFilterQueries,
-    );
+    const threadRows = groupIntoThreads(filtered);
     // "Other" = the inbox remainder. Shared with the rendered list
-    // (InboxPage) via qualifiesForInboxTab so a tab's badge can never
-    // disagree with the emails it actually shows.
-    const inboxRows = threadRows.filter(
-      ({ latest }) =>
-        !savedFilterThreads.has(inboxThreadKey(latest)) &&
-        qualifiesForInboxTab(latest.labelIds, null, triageLabels),
+    // (InboxPage) so a tab's badge can never disagree with the emails it
+    // actually shows. Group after filtering so counts use the same bare
+    // thread identity as the rendered list.
+    const inboxRows = groupIntoThreads(
+      filterInboxTabEmails(filtered, null, pinnedLabels, savedFilterQueries),
     );
     total["__inboxTotal"] = threadRows.length;
     unread["__inboxTotal"] = threadRows.filter(
-      ({ hasUnread }) => hasUnread,
+      (thread) => thread.hasUnread,
     ).length;
     total["inbox"] = inboxRows.length;
-    unread["inbox"] = inboxRows.filter(({ hasUnread }) => hasUnread).length;
+    unread["inbox"] = inboxRows.filter((thread) => thread.hasUnread).length;
     // Count threads per pinned label using the exact same membership rule as
     // the rendered list: latest message has the label; "important" is
     // exclusive of any other pinned tab.
     for (let i = 0; i < pinnedLabels.length; i++) {
       const full = pinnedLabels[i];
-      const rows = threadRows.filter(
-        ({ latest }) =>
-          !savedFilterThreads.has(inboxThreadKey(latest)) &&
-          qualifiesForInboxTab(latest.labelIds, full, triageLabels),
+      const rows = groupIntoThreads(
+        filterInboxTabEmails(filtered, full, pinnedLabels, savedFilterQueries),
       );
       total[full] = rows.length;
-      unread[full] = rows.filter(({ hasUnread }) => hasUnread).length;
+      unread[full] = rows.filter((thread) => thread.hasUnread).length;
       // Also index by the canonical label.id (which uses spaces, not
       // underscores) so count lookups find it for nested labels.
       const canonical = labels.find(
@@ -1199,9 +1173,12 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   // loaded rows is useful for local/demo mail, but merging the two with
   // Math.max makes badges grow as more pages happen to be loaded.
   const getInboxCount = (kind: CountKind) => {
+    const localCounts = localCountsForKind(kind);
+    if (!hasPinnedFilters && savedFilterQueries.length > 0) {
+      return localCounts["inbox"] ?? 0;
+    }
     const inboxLabel = resolveLabelForCount("inbox");
     const countField = countFieldForKind(kind);
-    const localCounts = localCountsForKind(kind);
     const serverCount = inboxLabel?.[countField];
     const localCount = localCounts["__inboxTotal"] ?? 0;
     return typeof serverCount === "number" ? serverCount : localCount;

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -91,6 +91,7 @@ import {
   resolvePinnedLabels,
   pinnedTriageLabels,
   augmentSelfSentLabels,
+  savedFilterThreadIds,
 } from "@/lib/inbox-tabs";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { cn } from "@/lib/utils";
@@ -395,6 +396,10 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   const hasNoteToSelf = pinnedLabels.includes("note-to-self");
   const labelAliases = settings?.labelAliases ?? {};
   const savedFilters = settings?.savedFilters ?? EMPTY_SAVED_FILTERS;
+  const savedFilterQueries = useMemo(
+    () => savedFilters.map((filter) => filter.query),
+    [savedFilters],
+  );
   const activeSavedFilter = savedFilters.find(
     (filter) => filter.id === activeFilterId,
   );
@@ -552,11 +557,17 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     }
     const threadRows = [...threadState.values()];
     const triageLabels = pinnedTriageLabels(pinnedLabels);
+    const savedFilterThreads = savedFilterThreadIds(
+      filtered,
+      savedFilterQueries,
+    );
     // "Other" = the inbox remainder. Shared with the rendered list
     // (InboxPage) via qualifiesForInboxTab so a tab's badge can never
     // disagree with the emails it actually shows.
-    const inboxRows = threadRows.filter(({ latest }) =>
-      qualifiesForInboxTab(latest.labelIds, null, triageLabels),
+    const inboxRows = threadRows.filter(
+      ({ latest }) =>
+        !savedFilterThreads.has(latest.threadId || latest.id) &&
+        qualifiesForInboxTab(latest.labelIds, null, triageLabels),
     );
     total["__inboxTotal"] = threadRows.length;
     unread["__inboxTotal"] = threadRows.filter(
@@ -569,8 +580,10 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     // exclusive of any other pinned tab.
     for (let i = 0; i < pinnedLabels.length; i++) {
       const full = pinnedLabels[i];
-      const rows = threadRows.filter(({ latest }) =>
-        qualifiesForInboxTab(latest.labelIds, full, triageLabels),
+      const rows = threadRows.filter(
+        ({ latest }) =>
+          !savedFilterThreads.has(latest.threadId || latest.id) &&
+          qualifiesForInboxTab(latest.labelIds, full, triageLabels),
       );
       total[full] = rows.length;
       unread[full] = rows.filter(({ hasUnread }) => hasUnread).length;
@@ -588,7 +601,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
       }
     }
     return { total, unread };
-  }, [inboxEmails, pinnedLabels, activeAccounts, labels]);
+  }, [inboxEmails, pinnedLabels, activeAccounts, labels, savedFilterQueries]);
 
   const activeFilterCounts = useMemo(() => {
     const threadUnread = new Map<string, boolean>();

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -91,6 +91,8 @@ import {
   pinnedTriageLabels,
   augmentSelfSentLabels,
   filterInboxTabEmails,
+  inboxThreadKey,
+  savedFilterThreadIds,
 } from "@/lib/inbox-tabs";
 import { isMcpEmbedSurface } from "@/lib/mcp-embed";
 import { groupIntoThreads } from "@/lib/threads";
@@ -546,8 +548,12 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     const inboxRows = groupIntoThreads(
       filterInboxTabEmails(filtered, null, pinnedLabels, savedFilterQueries),
     );
+    const savedFilterThreads = savedFilterThreadIds(
+      filtered,
+      savedFilterQueries,
+    );
     const savedFilterExclusiveRows = groupIntoThreads(
-      filterInboxTabEmails(filtered, null, [], savedFilterQueries),
+      filtered.filter((e) => !savedFilterThreads.has(inboxThreadKey(e))),
     );
     total["__inboxTotal"] = threadRows.length;
     unread["__inboxTotal"] = threadRows.filter(

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -546,12 +546,19 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     const inboxRows = groupIntoThreads(
       filterInboxTabEmails(filtered, null, pinnedLabels, savedFilterQueries),
     );
+    const savedFilterExclusiveRows = groupIntoThreads(
+      filterInboxTabEmails(filtered, null, [], savedFilterQueries),
+    );
     total["__inboxTotal"] = threadRows.length;
     unread["__inboxTotal"] = threadRows.filter(
       (thread) => thread.hasUnread,
     ).length;
     total["inbox"] = inboxRows.length;
     unread["inbox"] = inboxRows.filter((thread) => thread.hasUnread).length;
+    total["__inboxExclusive"] = savedFilterExclusiveRows.length;
+    unread["__inboxExclusive"] = savedFilterExclusiveRows.filter(
+      (thread) => thread.hasUnread,
+    ).length;
     // Count threads per pinned label using the exact same membership rule as
     // the rendered list: latest message has the label; "important" is
     // exclusive of any other pinned tab.
@@ -1174,8 +1181,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   // Math.max makes badges grow as more pages happen to be loaded.
   const getInboxCount = (kind: CountKind) => {
     const localCounts = localCountsForKind(kind);
-    if (!hasPinnedFilters && savedFilterQueries.length > 0) {
-      return localCounts["inbox"] ?? 0;
+    if (savedFilterQueries.length > 0) {
+      return localCounts["__inboxExclusive"] ?? 0;
     }
     const inboxLabel = resolveLabelForCount("inbox");
     const countField = countFieldForKind(kind);

--- a/templates/mail/app/lib/inbox-tabs.spec.ts
+++ b/templates/mail/app/lib/inbox-tabs.spec.ts
@@ -150,3 +150,61 @@ describe("resolvePinnedLabels", () => {
     expect(resolvePinnedLabels(["archive"], true)).toEqual(["archive"]);
   });
 });
+
+describe("filterInboxTabEmails", () => {
+  it("keeps saved-filter threads out of pinned tabs and Other", () => {
+    const github = message({
+      id: "github",
+      from: { name: "GitHub", email: "notifications@github.com" },
+      labelIds: ["inbox", "important"],
+    });
+    const ordinary = message({
+      id: "ordinary",
+      threadId: "ordinary-thread",
+      labelIds: ["inbox", "important"],
+    });
+    const queries = ["from:notifications@github.com"];
+
+    expect(
+      filterInboxTabEmails(
+        [github, ordinary],
+        "important",
+        ["important"],
+        queries,
+      ),
+    ).toEqual([ordinary]);
+    expect(
+      filterInboxTabEmails([github, ordinary], null, ["important"], queries),
+    ).toEqual([]);
+  });
+
+  it("claims a whole thread when an older message matches the saved filter", () => {
+    const olderGithub = message({
+      id: "older-github",
+      date: "2026-05-20T00:00:00.000Z",
+      from: { name: "GitHub", email: "notifications@github.com" },
+      labelIds: ["inbox"],
+    });
+    const latestReply = message({
+      id: "latest-reply",
+      date: "2026-05-21T00:00:00.000Z",
+      labelIds: ["inbox", "important"],
+    });
+
+    expect(
+      filterInboxTabEmails(
+        [olderGithub, latestReply],
+        "important",
+        ["important"],
+        ["from:notifications@github.com"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("preserves the existing partition when there are no saved filters", () => {
+    const important = message({ labelIds: ["inbox", "important"] });
+    expect(
+      filterInboxTabEmails([important], "important", ["important"]),
+    ).toEqual([important]);
+  });
+});

--- a/templates/mail/app/lib/inbox-tabs.spec.ts
+++ b/templates/mail/app/lib/inbox-tabs.spec.ts
@@ -201,6 +201,31 @@ describe("filterInboxTabEmails", () => {
     ).toEqual([]);
   });
 
+  it("keeps saved-filter claims scoped to their account", () => {
+    const github = message({
+      id: "shared-github",
+      threadId: "shared-thread",
+      accountEmail: "steve@builder.io",
+      from: { name: "GitHub", email: "notifications@github.com" },
+      labelIds: ["inbox", "important"],
+    });
+    const otherAccount = message({
+      id: "shared-other",
+      threadId: "shared-thread",
+      accountEmail: "other@example.com",
+      labelIds: ["inbox", "important"],
+    });
+
+    expect(
+      filterInboxTabEmails(
+        [github, otherAccount],
+        "important",
+        ["important"],
+        ["from:notifications@github.com"],
+      ),
+    ).toEqual([otherAccount]);
+  });
+
   it("preserves the existing partition when there are no saved filters", () => {
     const important = message({ labelIds: ["inbox", "important"] });
     expect(

--- a/templates/mail/app/lib/inbox-tabs.ts
+++ b/templates/mail/app/lib/inbox-tabs.ts
@@ -30,6 +30,12 @@ export const COLLAPSIBLE_VIEW_IDS = [
 export const OTHER_INBOX_TAB_ID = "__inbox_other__";
 export const OTHER_INBOX_TAB_PARAM = "other";
 
+export function inboxThreadKey(
+  email: Pick<EmailMessage, "accountEmail" | "threadId" | "id">,
+): string {
+  return `${email.accountEmail?.trim().toLowerCase() ?? ""}:${email.threadId || email.id}`;
+}
+
 /** Use the default Important tab only before the user has saved pin choices. */
 export function resolvePinnedLabels(
   userPinnedLabels: readonly string[] | undefined,
@@ -68,7 +74,7 @@ export function augmentSelfSentLabels(
   if (opts.hasNoteToSelf) {
     const threads = new Map<string, EmailMessage[]>();
     for (const e of emails) {
-      const key = e.threadId || e.id;
+      const key = inboxThreadKey(e);
       const thread = threads.get(key) ?? [];
       thread.push(e);
       threads.set(key, thread);
@@ -81,7 +87,7 @@ export function augmentSelfSentLabels(
   }
 
   return emails.map((e) => {
-    const key = e.threadId || e.id;
+    const key = inboxThreadKey(e);
     const isSelfSent = opts.connectedEmails.has(e.from.email.toLowerCase());
     const virtualLabel = opts.hasNoteToSelf
       ? selfNoteThreads.has(key)
@@ -132,7 +138,7 @@ export function qualifiesForInboxTab(
 function latestByThread(emails: EmailMessage[]): Map<string, EmailMessage> {
   const map = new Map<string, EmailMessage>();
   for (const e of emails) {
-    const key = e.threadId || e.id;
+    const key = inboxThreadKey(e);
     const existing = map.get(key);
     if (!existing || new Date(e.date) > new Date(existing.date)) {
       map.set(key, e);
@@ -152,7 +158,7 @@ export function savedFilterThreadIds(
   const matched = new Set<string>();
   for (const email of emails) {
     if (queries.some((query) => emailMessageMatchesSearch(email, query))) {
-      matched.add(email.threadId || email.id);
+      matched.add(inboxThreadKey(email));
     }
   }
   return matched;
@@ -184,5 +190,5 @@ export function filterInboxTabEmails(
       qualified.add(key);
     }
   }
-  return emails.filter((e) => qualified.has(e.threadId || e.id));
+  return emails.filter((e) => qualified.has(inboxThreadKey(e)));
 }

--- a/templates/mail/app/lib/inbox-tabs.ts
+++ b/templates/mail/app/lib/inbox-tabs.ts
@@ -1,4 +1,5 @@
 import { mailLabelsInclude, mailLabelsIncludeAny } from "@shared/gmail-labels";
+import { emailMessageMatchesSearch } from "@shared/search";
 import { isSelfAddressedThread } from "@shared/self-notes";
 import type { EmailMessage } from "@shared/types";
 
@@ -140,6 +141,23 @@ function latestByThread(emails: EmailMessage[]): Map<string, EmailMessage> {
   return map;
 }
 
+/** Threads claimed by saved query tabs, with Gmail's thread-level membership. */
+export function savedFilterThreadIds(
+  emails: EmailMessage[],
+  savedFilterQueries: readonly string[] = [],
+): Set<string> {
+  const queries = savedFilterQueries
+    .map((query) => query.trim())
+    .filter(Boolean);
+  const matched = new Set<string>();
+  for (const email of emails) {
+    if (queries.some((query) => emailMessageMatchesSearch(email, query))) {
+      matched.add(email.threadId || email.id);
+    }
+  }
+  return matched;
+}
+
 /**
  * Filter a flat inbox message list down to the messages of every thread that
  * belongs to `tab` (or the "Other" remainder when `tab` is null). Returns all
@@ -152,12 +170,17 @@ export function filterInboxTabEmails(
   emails: EmailMessage[],
   tab: string | null,
   pinnedLabels: readonly string[],
+  savedFilterQueries: readonly string[] = [],
 ): EmailMessage[] {
   const triage = pinnedTriageLabels(pinnedLabels);
   const latest = latestByThread(emails);
+  const savedFilterThreads = savedFilterThreadIds(emails, savedFilterQueries);
   const qualified = new Set<string>();
   for (const [key, latestMsg] of latest) {
-    if (qualifiesForInboxTab(latestMsg.labelIds, tab, triage)) {
+    if (
+      !savedFilterThreads.has(key) &&
+      qualifiesForInboxTab(latestMsg.labelIds, tab, triage)
+    ) {
       qualified.add(key);
     }
   }

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -29,6 +29,7 @@ import {
   pinnedTriageLabels,
   augmentSelfSentLabels,
   filterInboxTabEmails,
+  inboxThreadKey,
 } from "@/lib/inbox-tabs";
 import { groupIntoThreads, type ThreadSummary } from "@/lib/threads";
 import { cn } from "@/lib/utils";
@@ -479,7 +480,7 @@ export function InboxPage() {
       const latestByThread = new Map<string, (typeof filtered)[0]>();
       const labelThreadIds = new Set<string>();
       for (const e of filtered) {
-        const key = e.threadId || e.id;
+        const key = inboxThreadKey(e);
         if (hasLabel(e)) labelThreadIds.add(key);
         const existing = latestByThread.get(key);
         if (!existing || new Date(e.date) > new Date(existing.date)) {
@@ -509,7 +510,7 @@ export function InboxPage() {
           })
           .map(([threadId]) => threadId),
       );
-      return filtered.filter((e) => qualifiedThreadIds.has(e.threadId || e.id));
+      return filtered.filter((e) => qualifiedThreadIds.has(inboxThreadKey(e)));
     }
     return filtered;
   }, [

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -30,6 +30,7 @@ import {
   augmentSelfSentLabels,
   filterInboxTabEmails,
   inboxThreadKey,
+  savedFilterThreadIds,
 } from "@/lib/inbox-tabs";
 import { groupIntoThreads, type ThreadSummary } from "@/lib/threads";
 import { cn } from "@/lib/utils";
@@ -511,6 +512,13 @@ export function InboxPage() {
           .map(([threadId]) => threadId),
       );
       return filtered.filter((e) => qualifiedThreadIds.has(inboxThreadKey(e)));
+    }
+    if (view === "inbox" && !searchQuery && savedFilterQueries.length > 0) {
+      const savedFilterThreads = savedFilterThreadIds(
+        filtered,
+        savedFilterQueries,
+      );
+      return filtered.filter((e) => !savedFilterThreads.has(inboxThreadKey(e)));
     }
     return filtered;
   }, [

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -18,7 +18,13 @@ import {
   FOCUS_COMPOSE_DRAFT_EVENT,
   useComposeState,
 } from "@/hooks/use-compose-state";
-import { useEmails, useMarkRead, useSettings } from "@/hooks/use-emails";
+import {
+  EMPTY_LABELS,
+  useEmails,
+  useLabels,
+  useMarkRead,
+  useSettings,
+} from "@/hooks/use-emails";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -332,6 +338,10 @@ export function InboxPage() {
 
   const googleStatus = useGoogleAuthStatus();
   const { activeAccounts } = useAccountFilter();
+  const { data: labelsData } = useLabels(
+    activeAccounts.size > 0 ? [...activeAccounts] : undefined,
+  );
+  const labels = labelsData ?? EMPTY_LABELS;
 
   // Memoize every derived array — the emails memo depends on these, and fresh
   // array refs on every render were cascading into EmailThread as unstable
@@ -355,6 +365,25 @@ export function InboxPage() {
     [pinnedLabels],
   );
   const hasNoteToSelf = pinnedLabels.includes("note-to-self");
+  const activeLabelRecord = useMemo(() => {
+    if (!activeLabel) return undefined;
+    const normalizedId = activeLabel.includes("/")
+      ? activeLabel
+          .slice(activeLabel.lastIndexOf("/") + 1)
+          .replace(/_/g, " ")
+          .toLowerCase()
+      : activeLabel.toLowerCase();
+    return labels.find(
+      (label) =>
+        label.id === activeLabel ||
+        label.id === normalizedId ||
+        label.name.toLowerCase() === activeLabel.toLowerCase(),
+    );
+  }, [activeLabel, labels]);
+  const activeLabelIsInboxScoped =
+    !!activeLabel &&
+    activeLabelRecord?.type !== "user" &&
+    isInboxScopedAppLabel(activeLabelRecord?.id ?? activeLabel);
 
   // Always fetch from the URL view (inbox, starred, etc.).
   // Top-bar triage tabs (Important / pinned labels / "Other") are slices of
@@ -400,7 +429,7 @@ export function InboxPage() {
     view === "inbox" &&
     mailLabelsInclude(triageLabels, activeLabel);
   const mailboxWideLabelTab =
-    view === "inbox" && !!activeLabel && !isInboxScopedAppLabel(activeLabel);
+    view === "inbox" && !!activeLabel && !activeLabelIsInboxScoped;
   const clientSliceTab = isPinnedTab && !searchQuery && !mailboxWideLabelTab;
   const isOtherTab =
     view === "inbox" &&
@@ -475,7 +504,7 @@ export function InboxPage() {
       // Gmail labels keep thread membership when any fetched message carries
       // the label, so replies don't disappear just because the latest row
       // differs; inbox-scoped app labels stay a latest-message slice.
-      const isInboxScopedLabel = isInboxScopedAppLabel(activeLabel);
+      const isInboxScopedLabel = activeLabelIsInboxScoped;
       const hasLabel = (e: (typeof filtered)[0]) =>
         mailLabelsInclude(e.labelIds, activeLabel);
       const latestByThread = new Map<string, (typeof filtered)[0]>();
@@ -534,6 +563,7 @@ export function InboxPage() {
     isGoogleConnected,
     connectedEmails,
     hasNoteToSelf,
+    activeLabelIsInboxScoped,
     savedFilterQueries,
   ]);
 

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -362,6 +362,10 @@ export function InboxPage() {
   const activeSavedFilter = settings?.savedFilters?.find(
     (filter) => filter.id === activeFilterId,
   );
+  const savedFilterQueries = useMemo(
+    () => (settings?.savedFilters ?? []).map((filter) => filter.query),
+    [settings?.savedFilters],
+  );
   const searchQuery =
     activeSavedFilter?.query ?? searchParams.get("q") ?? undefined;
   useEffect(() => {
@@ -447,11 +451,21 @@ export function InboxPage() {
     // membership rule the badge uses (qualifiesForInboxTab). This is what
     // keeps the tab number equal to the emails listed under it.
     if (clientSliceTab && activeLabel) {
-      return filterInboxTabEmails(filtered, activeLabel, pinnedLabels);
+      return filterInboxTabEmails(
+        filtered,
+        activeLabel,
+        pinnedLabels,
+        savedFilterQueries,
+      );
     }
     // "Other" tab — the inbox remainder, same partition as its badge.
     if (isOtherTab) {
-      return filterInboxTabEmails(filtered, null, pinnedLabels);
+      return filterInboxTabEmails(
+        filtered,
+        null,
+        pinnedLabels,
+        savedFilterQueries,
+      );
     }
 
     if (activeLabel) {
@@ -511,6 +525,7 @@ export function InboxPage() {
     isGoogleConnected,
     connectedEmails,
     hasNoteToSelf,
+    savedFilterQueries,
   ]);
 
   // Clear multi-selection when switching views or label tabs. Do NOT clear on

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -182,9 +182,11 @@ describe("Inbox navigation commands", () => {
     const source = emailsHandlerSource();
 
     expect(source).toContain(
-      'const needsSavedFilterParts = view === "inbox" && !q && !label;',
+      'const isPlainInboxRequest = view === "inbox" && !q && !label;',
     );
-    expect(source).toContain("(settings?.savedFilters?.length ?? 0) > 0");
+    expect(source).toContain(
+      "searchQueryNeedsAttachmentMetadata(filter.query)",
+    );
     expect(source).toContain("threadFormat:");
   });
 

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -118,6 +118,17 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain("nav.activeInboxTab");
     expect(source).toContain("nav.activeAccounts");
   });
+
+  it("filters full Gmail threads before collapsing the agent snapshot", () => {
+    const source = viewScreenSource();
+
+    expect(source).toContain(
+      "const preparedMessages = messages.map((m: any) =>",
+    );
+    expect(source).toContain(
+      "latestPerThread(applyActiveInboxTab(preparedMessages))",
+    );
+  });
 });
 
 describe("Inbox pagination", () => {

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -115,6 +115,8 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain("selectedAccountSet");
     expect(source).toContain("accountEmails:");
     expect(source).toContain("filterInboxTabEmails");
+    expect(source).toContain("activeTriageTab");
+    expect(source).toContain("triageLabels.includes(label)");
     expect(source).toContain("nav.activeInboxTab");
     expect(source).toContain("nav.activeAccounts");
   });

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -27,6 +27,13 @@ function viewScreenSource(): string {
   );
 }
 
+function emailsHandlerSource(): string {
+  return readFileSync(
+    new URL("../../server/handlers/emails.ts", import.meta.url),
+    "utf8",
+  );
+}
+
 function navigateActionSource(): string {
   return readFileSync(
     new URL("../../actions/navigate.ts", import.meta.url),
@@ -64,6 +71,10 @@ describe("Inbox navigation commands", () => {
     const source = inboxSource();
 
     expect(source).toContain("const mailboxWideLabelTab =");
+    expect(source).toContain('activeLabelRecord?.type !== "user"');
+    expect(source).toContain(
+      "const clientSliceTab = isPinnedTab && !searchQuery && !mailboxWideLabelTab;",
+    );
     expect(source).toContain(
       'const emailView = activeSavedFilter\n    ? "all"',
     );
@@ -162,6 +173,27 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain(
       "latestPerThread(applyActiveInboxTab(preparedMessages))",
     );
+    expect(source).toContain(
+      'threadFormat: needsSavedFilterParts ? "full" : "metadata"',
+    );
+  });
+
+  it("hydrates Gmail parts for the inbox saved-filter partition", () => {
+    const source = emailsHandlerSource();
+
+    expect(source).toContain(
+      'const needsSavedFilterParts = view === "inbox" && !q && !label;',
+    );
+    expect(source).toContain("(settings?.savedFilters?.length ?? 0) > 0");
+    expect(source).toContain("threadFormat:");
+  });
+
+  it("disambiguates custom labels that share a system label name", () => {
+    const source = inboxSource();
+
+    expect(source).toContain('activeLabelRecord?.type !== "user"');
+    expect(source).toContain("const labels = labelsData ?? EMPTY_LABELS;");
+    expect(source).toContain("const activeLabelIsInboxScoped =");
   });
 });
 

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -121,6 +121,26 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain("nav.activeAccounts");
   });
 
+  it("keeps saved-filter threads out of a plain inbox route", () => {
+    const source = inboxSource();
+
+    expect(source).toContain(
+      'if (view === "inbox" && !searchQuery && savedFilterQueries.length > 0)',
+    );
+    expect(source).toContain(
+      "const savedFilterThreads = savedFilterThreadIds(",
+    );
+    expect(source).toContain(
+      "return filtered.filter((e) => !savedFilterThreads.has(inboxThreadKey(e)))",
+    );
+  });
+
+  it("keeps ordinary pinned labels mailbox-wide in agent snapshots", () => {
+    const source = viewScreenSource();
+
+    expect(source).toContain("isInboxScopedAppLabel(label)");
+  });
+
   it("filters full Gmail threads before collapsing the agent snapshot", () => {
     const source = viewScreenSource();
 

--- a/templates/mail/app/pages/inbox-navigation.spec.ts
+++ b/templates/mail/app/pages/inbox-navigation.spec.ts
@@ -121,6 +121,18 @@ describe("Inbox navigation commands", () => {
     expect(source).toContain("nav.activeAccounts");
   });
 
+  it("keeps saved-filter threads out of the agent plain Inbox snapshot", () => {
+    const source = viewScreenSource();
+
+    expect(source).toContain(
+      'effectiveView !== "inbox" || effectiveSearch || label',
+    );
+    expect(source).toContain(
+      "const savedFilterThreads = savedFilterThreadIds(",
+    );
+    expect(source).toContain("!savedFilterThreads.has(inboxThreadKey(email))");
+  });
+
   it("keeps saved-filter threads out of a plain inbox route", () => {
     const source = inboxSource();
 

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -13,7 +13,7 @@ describe("emails handler Gmail draft listing", () => {
     expect(source).toContain("threadFormat:");
     expect(source).toContain('view === "drafts"');
     expect(source).toContain(
-      '(needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)',
+      "(needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)",
     );
     expect(source).toContain('"full"');
     expect(source).toContain('"metadata"');

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -7,12 +7,16 @@ function emailsHandlerSource(): string {
 }
 
 describe("emails handler Gmail draft listing", () => {
-  it("hydrates full draft payloads while keeping other thread lists on metadata", () => {
+  it("hydrates drafts and saved-filter inboxes while keeping other lists on metadata", () => {
     const source = emailsHandlerSource();
 
+    expect(source).toContain("threadFormat:");
+    expect(source).toContain('view === "drafts"');
     expect(source).toContain(
-      'threadFormat: view === "drafts" ? "full" : "metadata"',
+      '(needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)',
     );
+    expect(source).toContain('"full"');
+    expect(source).toContain('"metadata"');
   });
 
   it("uses attachment account metadata when resolving Gmail-backed draft attachments", () => {

--- a/templates/mail/server/handlers/emails.spec.ts
+++ b/templates/mail/server/handlers/emails.spec.ts
@@ -7,13 +7,15 @@ function emailsHandlerSource(): string {
 }
 
 describe("emails handler Gmail draft listing", () => {
-  it("hydrates drafts and saved-filter inboxes while keeping other lists on metadata", () => {
+  it("hydrates drafts and attachment-filter inboxes while keeping other lists on metadata", () => {
     const source = emailsHandlerSource();
 
     expect(source).toContain("threadFormat:");
     expect(source).toContain('view === "drafts"');
+    expect(source).toContain("const isPlainInboxRequest =");
+    expect(source).toContain("const hasAttachmentSavedFilter =");
     expect(source).toContain(
-      "(needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)",
+      "searchQueryNeedsAttachmentMetadata(filter.query)",
     );
     expect(source).toContain('"full"');
     expect(source).toContain('"metadata"');

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -430,6 +430,10 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
       // Fetch label name mapping from all accounts (cached)
       const accountTokens = await getAccountTokens(email);
       const labelMap = await getCachedLabelMap(accountTokens);
+      const needsSavedFilterParts = view === "inbox" && !q && !label;
+      const settings = needsSavedFilterParts
+        ? await readSettings(email)
+        : undefined;
 
       const listResult = await listInboxEmails({
         ownerEmail: email,
@@ -438,7 +442,13 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         label,
         limit: pageLimit,
         pageTokens,
-        threadFormat: view === "drafts" ? "full" : "metadata",
+        // Metadata responses omit MIME parts. Saved-filter partitioning
+        // needs attachment filenames for has:attachment/filename queries.
+        threadFormat:
+          view === "drafts" ||
+          (needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)
+            ? "full"
+            : "metadata",
         threadCandidateLimit: q ? 80 : undefined,
         accountTokens,
         labelMap,

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -14,7 +14,10 @@ import {
   mailLabelMatches,
 } from "@shared/gmail-labels.js";
 import { markdownPreviewSnippet } from "@shared/markdown.js";
-import { emailMessageMatchesSearch } from "@shared/search.js";
+import {
+  emailMessageMatchesSearch,
+  searchQueryNeedsAttachmentMetadata,
+} from "@shared/search.js";
 import type { EmailMessage, Label, UserSettings } from "@shared/types.js";
 import {
   createError,
@@ -430,10 +433,15 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
       // Fetch label name mapping from all accounts (cached)
       const accountTokens = await getAccountTokens(email);
       const labelMap = await getCachedLabelMap(accountTokens);
-      const needsSavedFilterParts = view === "inbox" && !q && !label;
-      const settings = needsSavedFilterParts
+      const isPlainInboxRequest = view === "inbox" && !q && !label;
+      const settings = isPlainInboxRequest
         ? await readSettings(email)
         : undefined;
+      const hasAttachmentSavedFilter =
+        isPlainInboxRequest &&
+        (settings?.savedFilters ?? []).some((filter) =>
+          searchQueryNeedsAttachmentMetadata(filter.query),
+        );
 
       const listResult = await listInboxEmails({
         ownerEmail: email,
@@ -445,10 +453,7 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         // Metadata responses omit MIME parts. Saved-filter partitioning
         // needs attachment filenames for has:attachment/filename queries.
         threadFormat:
-          view === "drafts" ||
-          (needsSavedFilterParts && (settings?.savedFilters?.length ?? 0) > 0)
-            ? "full"
-            : "metadata",
+          view === "drafts" || hasAttachmentSavedFilter ? "full" : "metadata",
         threadCandidateLimit: q ? 80 : undefined,
         accountTokens,
         labelMap,

--- a/templates/mail/shared/search.test.ts
+++ b/templates/mail/shared/search.test.ts
@@ -174,4 +174,26 @@ describe("emailMessageMatchesSearch", () => {
       emailMessageMatchesSearch(email, "after:2026/05/19 before:2026/05/21"),
     ).toBe(true);
   });
+
+  it("uses Pacific midnight for date-only Gmail operators", () => {
+    const justBeforePacificMidnight = message({
+      date: "2026-05-20T06:59:59.999Z",
+    });
+    const justAfterPacificMidnight = message({
+      date: "2026-05-20T07:00:00.001Z",
+    });
+
+    expect(
+      emailMessageMatchesSearch(justBeforePacificMidnight, "after:2026/05/20"),
+    ).toBe(false);
+    expect(
+      emailMessageMatchesSearch(justAfterPacificMidnight, "after:2026/05/20"),
+    ).toBe(true);
+    expect(
+      emailMessageMatchesSearch(justBeforePacificMidnight, "before:2026/05/20"),
+    ).toBe(true);
+    expect(
+      emailMessageMatchesSearch(justAfterPacificMidnight, "before:2026/05/20"),
+    ).toBe(false);
+  });
 });

--- a/templates/mail/shared/search.test.ts
+++ b/templates/mail/shared/search.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { emailMessageMatchesSearch } from "./search";
+import {
+  emailMessageMatchesSearch,
+  searchQueryNeedsAttachmentMetadata,
+} from "./search";
 import type { EmailMessage } from "./types";
 
 function message(overrides: Partial<EmailMessage> = {}): EmailMessage {
@@ -195,5 +198,26 @@ describe("emailMessageMatchesSearch", () => {
     expect(
       emailMessageMatchesSearch(justAfterPacificMidnight, "before:2026/05/20"),
     ).toBe(false);
+  });
+});
+
+describe("searchQueryNeedsAttachmentMetadata", () => {
+  it("detects positive, negative, and grouped attachment operators", () => {
+    expect(searchQueryNeedsAttachmentMetadata("from:github.com")).toBe(false);
+    expect(
+      searchQueryNeedsAttachmentMetadata("is:unread -label:promotions"),
+    ).toBe(false);
+    expect(searchQueryNeedsAttachmentMetadata("has:attachment")).toBe(true);
+    expect(searchQueryNeedsAttachmentMetadata("-filename:zip")).toBe(true);
+    expect(
+      searchQueryNeedsAttachmentMetadata('{from:github.com filename:".patch"}'),
+    ).toBe(true);
+  });
+
+  it("does not treat quoted search terms as operators", () => {
+    expect(searchQueryNeedsAttachmentMetadata('subject:"has:attachment"')).toBe(
+      false,
+    );
+    expect(searchQueryNeedsAttachmentMetadata('"filename:pdf"')).toBe(false);
   });
 });

--- a/templates/mail/shared/search.test.ts
+++ b/templates/mail/shared/search.test.ts
@@ -153,4 +153,25 @@ describe("emailMessageMatchesSearch", () => {
       ),
     ).toBe(true);
   });
+
+  it("matches common saved-filter category, attachment, filename, and date operators", () => {
+    const githubAttachment = {
+      id: "attachment",
+      filename: "report.pdf",
+      mimeType: "application/pdf",
+      size: 12,
+    };
+    const email = message({
+      date: "2026-05-20T00:00:00.000Z",
+      labelIds: ["promotions"],
+      attachments: [githubAttachment],
+    });
+
+    expect(emailMessageMatchesSearch(email, "category:promotions")).toBe(true);
+    expect(emailMessageMatchesSearch(email, "has:attachment")).toBe(true);
+    expect(emailMessageMatchesSearch(email, "filename:pdf")).toBe(true);
+    expect(
+      emailMessageMatchesSearch(email, "after:2026/05/19 before:2026/05/21"),
+    ).toBe(true);
+  });
 });

--- a/templates/mail/shared/search.ts
+++ b/templates/mail/shared/search.ts
@@ -89,6 +89,11 @@ type ParsedSearch = {
   excludedTerms: string[];
 };
 
+/** Attachment operators need Gmail's MIME parts, which metadata responses omit. */
+export function searchQueryNeedsAttachmentMetadata(query: string): boolean {
+  return /(?:^|[\s({])-?(?:has|filename):/i.test(query);
+}
+
 function splitSearchOr(query: string): string[] | undefined {
   const clauses: string[] = [];
   let start = 0;

--- a/templates/mail/shared/search.ts
+++ b/templates/mail/shared/search.ts
@@ -5,6 +5,53 @@ function includesQuery(value: unknown, query: string): boolean {
   return typeof value === "string" && value.toLowerCase().includes(query);
 }
 
+const pacificDateFormatter = new Intl.DateTimeFormat("en-US", {
+  timeZone: "America/Los_Angeles",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
+
+function dateBoundary(raw: string): number | null {
+  if (/^\d+$/.test(raw)) return Number(raw) * 1000;
+  const parts = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/);
+  if (!parts) return null;
+
+  const [year, month, day] = parts.slice(1).map(Number);
+  const utcDate = Date.UTC(year, month - 1, day);
+  const date = new Date(utcDate);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  )
+    return null;
+
+  // 08:00 UTC is still in the requested Pacific calendar day in both PST
+  // and PDT, including the two DST transition dates.
+  const approximate = Date.UTC(year, month - 1, day, 8);
+  const localParts = Object.fromEntries(
+    pacificDateFormatter
+      .formatToParts(new Date(approximate))
+      .filter(({ type }) => type !== "literal")
+      .map(({ type, value }) => [type, Number(value)]),
+  );
+  const localAsUtc = Date.UTC(
+    localParts.year,
+    localParts.month - 1,
+    localParts.day,
+    localParts.hour,
+    localParts.minute,
+    localParts.second,
+  );
+  const offset = localAsUtc - approximate;
+  return utcDate - offset;
+}
+
 function addressListMatches(
   addresses: EmailMessage["to"] | undefined,
   query: string,
@@ -229,13 +276,6 @@ function operatorMatches(
   field: SearchOperator,
   value: string,
 ): boolean {
-  const dateBoundary = (raw: string): number | null => {
-    if (/^\d+$/.test(raw)) return Number(raw) * 1000;
-    const parts = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/);
-    if (!parts) return null;
-    return Date.UTC(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]));
-  };
-
   switch (field) {
     case "from":
       return (

--- a/templates/mail/shared/search.ts
+++ b/templates/mail/shared/search.ts
@@ -23,7 +23,14 @@ type SearchOperator =
   | "subject"
   | "label"
   | "in"
-  | "is";
+  | "is"
+  | "category"
+  | "has"
+  | "filename"
+  | "after"
+  | "before"
+  | "newer"
+  | "older";
 
 type ParsedSearch = {
   operators: Array<{
@@ -164,7 +171,7 @@ function expandSearchDisjunction(query: string): string[] | undefined {
 function parseSearch(query: string): ParsedSearch {
   const operators: ParsedSearch["operators"] = [];
   const operatorPattern =
-    /(^|[\s({])(-?)(from|to|cc|bcc|subject|label|in|is):\s*(?:"([^"]+)"|(\S+))/gi;
+    /(^|[\s({])(-?)(from|to|cc|bcc|subject|label|in|is|category|has|filename|after|before|newer|older):\s*(?:"([^"]+)"|(\S+))/gi;
   const residual = query.replace(
     operatorPattern,
     (
@@ -216,10 +223,19 @@ function operatorMatches(
     | "isTrashed"
     | "isDraft"
     | "isSent"
+    | "date"
+    | "attachments"
   >,
   field: SearchOperator,
   value: string,
 ): boolean {
+  const dateBoundary = (raw: string): number | null => {
+    if (/^\d+$/.test(raw)) return Number(raw) * 1000;
+    const parts = raw.match(/^(\d{4})[/-](\d{1,2})[/-](\d{1,2})$/);
+    if (!parts) return null;
+    return Date.UTC(Number(parts[1]), Number(parts[2]) - 1, Number(parts[3]));
+  };
+
   switch (field) {
     case "from":
       return (
@@ -273,6 +289,27 @@ function operatorMatches(
         default:
           return false;
       }
+    case "category":
+      return mailLabelsInclude(
+        email.labelIds,
+        value === "primary" ? "personal" : value,
+      );
+    case "has":
+      return value === "attachment" && (email.attachments?.length ?? 0) > 0;
+    case "filename":
+      return (email.attachments ?? []).some((attachment) =>
+        includesQuery(attachment.filename, value),
+      );
+    case "after":
+    case "newer": {
+      const boundary = dateBoundary(value);
+      return boundary !== null && new Date(email.date).getTime() > boundary;
+    }
+    case "before":
+    case "older": {
+      const boundary = dateBoundary(value);
+      return boundary !== null && new Date(email.date).getTime() < boundary;
+    }
   }
 }
 
@@ -293,6 +330,8 @@ function matchesSimpleSearch(
     | "isTrashed"
     | "isDraft"
     | "isSent"
+    | "date"
+    | "attachments"
   >,
   query: string,
 ): boolean {
@@ -343,6 +382,8 @@ export function emailMessageMatchesSearch(
     | "isTrashed"
     | "isDraft"
     | "isSent"
+    | "date"
+    | "attachments"
   >,
   query: string,
 ): boolean {


### PR DESCRIPTION
## Summary
- give saved query tabs priority over Important and Other for matching threads
- keep list, badge counts, and agent inbox views on the same partition rule
- preserve Gmail thread-level matching when an older message matches a saved query

## Validation
- focused Mail Vitest suite: 63 passed
- Mail typecheck: passed
- formatter check: passed
- guards: two pre-existing plan-skill checks are blocked by the unrelated startup-cleanup deletion of `an-skill.js`; changed-line guards passed