### PR TITLE
Fix Clips desktop recording loading button

### DIFF
--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -4051,6 +4051,8 @@ export function App({
   const recordingReadinessPending =
     localRecordingMode === "off" &&
     (authStatus !== "authed" || videoStorageStatus === "checking");
+  const startButtonLoading =
+    recordingReadinessPending && !recordingStopFinalizing;
 
   const pendingUploadBanner =
     authStatus === "authed" ? (
@@ -4574,7 +4576,10 @@ export function App({
 
         {!isRecording ? (
           <button
-            className="primary start"
+            className={cn(
+              "primary start",
+              startButtonLoading && "start-loading",
+            )}
             disabled={recordingReadinessPending || recordingStopFinalizing}
             aria-busy={recordingReadinessPending || recordingStopFinalizing}
             aria-label={
@@ -4586,18 +4591,19 @@ export function App({
             }
             onClick={() => beginRecording()}
           >
-            {recordingStopFinalizing ? (
-              "Finishing last recording..."
-            ) : recordingReadinessPending ? (
+            <span className="start-label">
+              {recordingStopFinalizing
+                ? "Finishing last recording..."
+                : localRecordingMode === "off"
+                  ? "Start recording"
+                  : "Start local recording"}
+            </span>
+            {startButtonLoading ? (
               <span
                 aria-hidden="true"
-                className="skeleton-shimmer inline-block h-4 w-32 rounded bg-muted"
+                className="start-loading-shimmer skeleton-shimmer"
               />
-            ) : localRecordingMode === "off" ? (
-              "Start recording"
-            ) : (
-              "Start local recording"
-            )}
+            ) : null}
           </button>
         ) : null}
 

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -901,6 +901,28 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   margin-top: 2px;
 }
 
+.primary.start.start-loading {
+  position: relative;
+  overflow: hidden;
+  cursor: progress;
+}
+
+.primary.start.start-loading .start-label {
+  position: relative;
+  z-index: 1;
+}
+
+.start-loading-shimmer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  /* The CTA reverses foreground/background in dark mode; invert the shared
+     foreground shine so the sweep stays visible on either button fill. */
+  filter: invert(1);
+}
+
 /* ------------------------------------------------------------------------- */
 /* Readiness disclosure                                                       */
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
Fix the Clips desktop Start recording loading state.\n\n- Keep the Start recording label visible while readiness is pending.\n- Keep the button disabled and show the shared shimmer as a full-button overlay.\n- Preserve the loading treatment in light and dark themes.\n\nValidation:\n- clips-desktop build\n- clips-desktop typecheck\n- clips-desktop test\n- 66 repository guards\n- Dark-mode browser preview