### PR TITLE
fix(clips): recover browser uploads after session 401

### DIFF
--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -41,6 +41,7 @@ import {
   putRecordingBackupChunk,
   putRecordingBackupMeta,
 } from "@/lib/recording-backup";
+import { uploadChunkRequest } from "@/lib/upload-request";
 
 // Re-exported for existing callers; the canonical impls live in
 // @shared/recording-core and are shared with the Chrome extension recorder.
@@ -2212,12 +2213,9 @@ export class RecorderEngine {
         extra.isFinal ? FINAL_CHUNK_UPLOAD_TIMEOUT_MS : CHUNK_UPLOAD_TIMEOUT_MS,
       );
       try {
-        res = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type":
-              blob.type || this.mimeType || "application/octet-stream",
-          },
+        res = await uploadChunkRequest({
+          url,
+          contentType: blob.type || this.mimeType || "application/octet-stream",
           body,
           signal: fetchSignal.signal,
         });

--- a/templates/clips/app/lib/recording-retry.ts
+++ b/templates/clips/app/lib/recording-retry.ts
@@ -21,6 +21,7 @@ import {
   getRecordingBackupMeta,
   isCompleteRecordingBackup,
 } from "./recording-backup";
+import { uploadChunkRequest } from "./upload-request";
 
 export { hasRecordingBackup } from "./recording-backup";
 
@@ -147,11 +148,9 @@ export async function retryRecordingUploadFromBackup(
     const body = await recordingBlob
       .slice(start, end, meta.mimeType)
       .arrayBuffer();
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": meta.mimeType || "application/octet-stream",
-      },
+    const res = await uploadChunkRequest({
+      url,
+      contentType: meta.mimeType || "application/octet-stream",
       body,
     });
     if (!res.ok) {

--- a/templates/clips/app/lib/upload-request.test.ts
+++ b/templates/clips/app/lib/upload-request.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadChunkRequest } from "./upload-request";
+
+describe("uploadChunkRequest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("revalidates the session and retries a 401 chunk once", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ email: "owner@example.com", token: "fresh-token" }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const body = new Uint8Array([1, 2, 3]).buffer;
+    const response = await uploadChunkRequest({
+      url: "/api/uploads/recording-1/chunk?index=0",
+      body,
+      contentType: "video/webm",
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      credentials: "include",
+      body,
+    });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/_agent-native/auth/session");
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      cache: "no-store",
+      credentials: "include",
+    });
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      method: "POST",
+      credentials: "include",
+      body,
+    });
+    expect(
+      new Headers(fetchMock.mock.calls[2]?.[1]?.headers as HeadersInit).get(
+        "Authorization",
+      ),
+    ).toBe("Bearer fresh-token");
+  });
+
+  it("does not retry non-auth failures", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("bad request", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await uploadChunkRequest({
+      url: "/api/uploads/recording-1/chunk?index=0",
+      body: new ArrayBuffer(0),
+      contentType: "video/webm",
+    });
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the 401 when session revalidation has no token", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("Unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Not authenticated" }), {
+          status: 200,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await uploadChunkRequest({
+      url: "/api/uploads/recording-1/chunk?index=0",
+      body: new ArrayBuffer(0),
+      contentType: "video/webm",
+    });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/templates/clips/app/lib/upload-request.ts
+++ b/templates/clips/app/lib/upload-request.ts
@@ -41,9 +41,14 @@ export async function uploadChunkRequest({
   }
   if (!sessionResponse.ok) return response;
 
-  const session = (await sessionResponse.json().catch(() => null)) as {
-    token?: unknown;
-  } | null;
+  let session: { token?: unknown } | null;
+  try {
+    session = (await sessionResponse.json()) as {
+      token?: unknown;
+    } | null;
+  } catch {
+    return response;
+  }
   if (typeof session?.token !== "string" || !session.token) return response;
 
   return request(session.token);

--- a/templates/clips/app/lib/upload-request.ts
+++ b/templates/clips/app/lib/upload-request.ts
@@ -1,0 +1,50 @@
+import { agentNativePath } from "@agent-native/core/client/api-path";
+
+interface UploadChunkRequestOptions {
+  url: string;
+  body: ArrayBuffer;
+  contentType: string;
+  signal?: AbortSignal;
+}
+
+/** Retry one chunk after refreshing a browser session that returned 401. */
+export async function uploadChunkRequest({
+  url,
+  body,
+  contentType,
+  signal,
+}: UploadChunkRequestOptions): Promise<Response> {
+  const request = (authorization?: string) =>
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": contentType,
+        ...(authorization ? { Authorization: `Bearer ${authorization}` } : {}),
+      },
+      credentials: "include",
+      body,
+      signal,
+    });
+
+  const response = await request();
+  if (response.status !== 401) return response;
+
+  let sessionResponse: Response;
+  try {
+    sessionResponse = await fetch(
+      agentNativePath("/_agent-native/auth/session"),
+      { cache: "no-store", credentials: "include", signal },
+    );
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    return response;
+  }
+  if (!sessionResponse.ok) return response;
+
+  const session = (await sessionResponse.json().catch(() => null)) as {
+    token?: unknown;
+  } | null;
+  if (typeof session?.token !== "string" || !session.token) return response;
+
+  return request(session.token);
+}

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -80,6 +80,7 @@ import {
   decideRecordingVisibilityAction,
   isMobileRecorderRuntime,
 } from "@/lib/recording-visibility";
+import { uploadChunkRequest } from "@/lib/upload-request";
 import { cn } from "@/lib/utils";
 
 // Client-side app-state writer (the server module pulls in Node's `events`
@@ -1642,9 +1643,9 @@ export default function RecordRoute() {
 
             let chunkRes: Response;
             try {
-              chunkRes = await fetch(url, {
-                method: "POST",
-                headers: { "Content-Type": uploadMimeType },
+              chunkRes = await uploadChunkRequest({
+                url,
+                contentType: uploadMimeType,
                 body: await slice.arrayBuffer(),
                 signal: chunkAbort.signal,
               });
@@ -1702,9 +1703,9 @@ export default function RecordRoute() {
         const { index, slice, url } = finalChunkDesc;
         let chunkRes: Response | null = null;
         try {
-          chunkRes = await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": uploadMimeType },
+          chunkRes = await uploadChunkRequest({
+            url,
+            contentType: uploadMimeType,
             body: await slice.arrayBuffer(),
             signal: abort.signal,
           });


### PR DESCRIPTION
## Summary

- Revalidate the browser session and retry a recording chunk once after a 401.
- Share the recovery path across file uploads, live recording, and backup retries without changing server authorization.

## Validation

- Clips upload, retry, and server chunk tests: 46 passed
- Clips typecheck
- Clips production build
- oxfmt and changed-file guards

Slack feedback: https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788214964227059