### PR TITLE
fix(clips): keep social previews valid without thumbnails

### DIFF
--- a/templates/clips/server/lib/slack-unfurls.test.ts
+++ b/templates/clips/server/lib/slack-unfurls.test.ts
@@ -126,7 +126,7 @@ describe("Clips Slack unfurls", () => {
     });
   });
 
-  it("uses a public video frame when no stored thumbnail exists", () => {
+  it("uses the default social image when no stored thumbnail exists", () => {
     expect(
       buildSlackVideoBlock({
         recording: recording({
@@ -138,7 +138,7 @@ describe("Clips Slack unfurls", () => {
       }),
     ).toMatchObject({
       thumbnail_url:
-        "https://clips.example.com/clips/api/agent-frame.jpg?id=rec-1&atMs=350",
+        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897",
     });
   });
 

--- a/templates/clips/shared/share-meta.test.ts
+++ b/templates/clips/shared/share-meta.test.ts
@@ -67,7 +67,7 @@ describe("Clips share metadata", () => {
     });
   });
 
-  it("uses a video frame in crawler metadata when no thumbnail is stored", () => {
+  it("uses a valid default image when no thumbnail is stored", () => {
     const meta = buildClipsShareMeta({
       origin: "https://clips.example.com",
       basePath: "/clips",
@@ -86,7 +86,7 @@ describe("Clips share metadata", () => {
     expect(meta).toContainEqual({
       property: "og:image",
       content:
-        "https://clips.example.com/clips/api/agent-frame.jpg?id=rec-1&atMs=350",
+        "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897",
     });
     expect(meta).toContainEqual({
       name: "twitter:card",
@@ -126,7 +126,7 @@ describe("Clips share metadata", () => {
     ).toBe("animated");
   });
 
-  it("uses a public video frame when a recording has no stored thumbnail", () => {
+  it("uses the default image for a public clip without a stored thumbnail", () => {
     const imageUrl = resolveClipsSocialImageUrl({
       recording: {
         id: "rec-1",
@@ -140,7 +140,7 @@ describe("Clips share metadata", () => {
     });
 
     expect(imageUrl).toBe(
-      "https://clips.example.com/api/agent-frame.jpg?id=rec-1&atMs=350",
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9c533fed169648069bffaed652ec0897",
     );
   });
 

--- a/templates/clips/shared/share-meta.ts
+++ b/templates/clips/shared/share-meta.ts
@@ -1,4 +1,5 @@
 import {
+  AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE,
   AGENT_NATIVE_SOCIAL_IMAGE_ALT,
   AGENT_NATIVE_SOCIAL_IMAGE_HEIGHT,
   AGENT_NATIVE_SOCIAL_IMAGE_TYPE,
@@ -7,8 +8,6 @@ import {
   normalizeDocumentTitle,
   type SocialMetaDescriptor,
 } from "@agent-native/core/shared";
-
-import { buildAgentApiUrls } from "./agent-context";
 
 export const CLIPS_DEFAULT_TITLE = "Untitled recording";
 
@@ -24,8 +23,6 @@ export type ClipsShareMetaRecording = {
   archivedAt?: string | null;
   trashedAt?: string | null;
 };
-
-const SOCIAL_FRAME_AT_MS = 350;
 
 export type PreferredThumbnailVariant = "still" | "animated";
 
@@ -96,7 +93,7 @@ function appPath(path: string, basePath: string): string {
   return normalizedBasePath ? `${normalizedBasePath}${path}` : path;
 }
 
-function canUseGeneratedSocialFrame(
+function canUseDefaultSocialImage(
   recording: ClipsShareMetaRecording | null,
 ): recording is ClipsShareMetaRecording & {
   id: string;
@@ -133,12 +130,9 @@ export function resolveClipsSocialImageUrl(options: {
     return absoluteUrl(storedImage, origin);
   }
 
-  if (!origin || !canUseGeneratedSocialFrame(recording)) return undefined;
+  if (!canUseDefaultSocialImage(recording)) return undefined;
 
-  return buildAgentApiUrls(recording.id, {
-    origin,
-    basePath,
-  }).frameUrl(SOCIAL_FRAME_AT_MS);
+  return AGENT_NATIVE_DEFAULT_SOCIAL_IMAGE;
 }
 
 export function buildClipsShareMeta(options: {


### PR DESCRIPTION
## Summary
- keep stored thumbnail previews on their existing same-origin route
- use the existing stable default social image when a public ready clip has no stored thumbnail
- avoid pointing crawler metadata at on-demand frame extraction that can return HTTP 413 for large clips

## Validation
- git diff --check
- focused Vitest/oxfmt unavailable in the clean worktree because dependencies are not installed; CI will run the repository checks