### PR TITLE
fix(auth): keep learn-more link at the top right

### DIFF
--- a/.changeset/auth-marketing-top-right.md
+++ b/.changeset/auth-marketing-top-right.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Keep the auth marketing learn-more action in a dedicated top-right layout row.

--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -48,7 +48,7 @@ describe("AuthPage", () => {
     expect(html).toContain('class="marketing-panel"');
     expect(html).toContain('class="form-panel');
     expect(html).toMatch(
-      /class="form-panel[^\"]*">\s*<a[^>]+class="auth-marketing-learn-more"/,
+      /class="auth-marketing-top-right">\s*<a[^>]+class="auth-marketing-learn-more"/,
     );
   });
 

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -2651,27 +2651,29 @@ export function AuthPage(props: AuthPageProps) {
       background={
         marketingCopy.screenshotSrc ? null : <Starfield id="starfield" />
       }
+      topRight={
+        marketingCopy.learnMoreUrl ? (
+          <a
+            className="auth-marketing-learn-more"
+            href={marketingCopy.learnMoreUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <span>
+              {t("newToApp").replace(
+                "{appName}",
+                marketingCopy.appName.replace(/^Agent-Native\s+/i, ""),
+              )}
+            </span>
+            <span aria-hidden="true"> - </span>
+            <span className="auth-marketing-learn-more-link">
+              {t("learnMore")}
+            </span>
+          </a>
+        ) : null
+      }
       auth={
         <>
-          {marketingCopy.learnMoreUrl ? (
-            <a
-              className="auth-marketing-learn-more"
-              href={marketingCopy.learnMoreUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <span>
-                {t("newToApp").replace(
-                  "{appName}",
-                  marketingCopy.appName.replace(/^Agent-Native\s+/i, ""),
-                )}
-              </span>
-              <span aria-hidden="true"> - </span>
-              <span className="auth-marketing-learn-more-link">
-                {t("learnMore")}
-              </span>
-            </a>
-          ) : null}
           {authCard}
           {localNote}
         </>

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1309,13 +1309,14 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     margin: 0 auto;
   }
   .auth-marketing-learn-more {
-    align-self: flex-end;
-    margin-bottom: 1rem;
+    display: block;
     color: hsl(var(--foreground, 0 0% 90%));
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 0.875rem;
-    line-height: 1.5;
+    font-size: 1.5rem;
+    font-weight: 500;
+    line-height: 1;
     text-decoration: none;
+    white-space: nowrap;
   }
   .auth-marketing-learn-more:hover { color: hsl(var(--foreground, 0 0% 90%)); }
   .auth-marketing-learn-more-link { color: hsl(var(--primary, 195 100% 50%)); }
@@ -1436,11 +1437,20 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   .form-panel .card { max-width: 400px; }
   .form-panel .local-note { max-width: 400px; }
   @media (max-width: 900px) {
+    .auth-marketing-shell-with-top-right {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      min-height: auto;
+    }
+    .auth-marketing-top-right {
+      display: flex;
+      justify-content: flex-start;
+      flex: none;
+      padding: 1rem 1rem 0;
+    }
     .auth-marketing-learn-more {
-      align-self: flex-start;
-      margin-bottom: 1rem;
       font-size: 0.75rem;
-      text-align: start;
     }
     .split { flex-direction: column; min-height: auto; }
     .marketing-panel { padding: 4.25rem 1.5rem 1.5rem; }
@@ -2146,13 +2156,44 @@ ${embeddedAuthCss}
   .auth-root { width: 100%; }
   .auth-marketing-home { width: 100%; padding: 0; position: relative; overflow-x: hidden; }
   .auth-marketing-shell { padding: 0; }
+  .auth-marketing-home .auth-marketing-shell-with-top-right {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .auth-marketing-top-right {
+    display: flex;
+    justify-content: flex-end;
+    flex: none;
+    padding: 4rem clamp(2rem, 5.5vw, 6.625rem) 0;
+  }
+  .auth-marketing-home .auth-marketing-layout {
+    flex: 1;
+    min-height: 0;
+  }
   .auth-marketing-home .split { width: 100%; max-width: none; margin: 0; }
   .auth-marketing-home .marketing-panel { min-width: 0; }
-  .auth-marketing-home.has-product-screenshot .marketing-panel { padding-inline: 0 3.5rem; }
+  .auth-marketing-home.has-product-screenshot .marketing-panel {
+    padding-block: 0;
+    padding-inline: 0 3.5rem;
+  }
+  .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot-wrap,
+  .auth-marketing-home.has-product-screenshot .auth-marketing-screenshot {
+    max-height: calc(100vh - 5.5rem);
+  }
   .auth-marketing-home .form-panel { min-width: 0; }
   .auth-marketing-home [data-agent-native-starfield] { position: fixed; inset: 0; width: 100%; height: 100%; }
   @media (max-width: 900px) {
+    body.has-marketing {
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
+    .auth-marketing-home .auth-marketing-top-right {
+      padding: 1rem 3.5rem 0 1rem;
+    }
+    .auth-marketing-home .auth-marketing-layout { flex: none; min-height: auto; }
     .auth-marketing-home .auth-marketing-shell { display: block; }
+    .auth-marketing-home .auth-marketing-shell-with-top-right { display: flex; }
     .auth-marketing-home.has-product-screenshot .marketing-panel { display: none; }
   }
 `;

--- a/packages/toolkit/src/marketing/MarketingHome.tsx
+++ b/packages/toolkit/src/marketing/MarketingHome.tsx
@@ -25,6 +25,8 @@ export interface MarketingHomeProps {
   /** Primary and secondary calls to action. */
   primaryAction?: React.ReactNode;
   secondaryAction?: React.ReactNode;
+  /** Optional page-level action rendered above the auth split. */
+  topRight?: React.ReactNode;
   /** Convenience links for the default primary and secondary buttons. */
   primaryActionHref?: string;
   secondaryActionHref?: string;
@@ -46,6 +48,7 @@ export function MarketingHome({
   background = <Starfield />,
   primaryAction,
   secondaryAction,
+  topRight,
   auth,
   children,
   className,
@@ -139,15 +142,22 @@ export function MarketingHome({
       <div
         className={cn(
           isAuthVariant
-            ? "auth-marketing-shell mx-auto flex min-h-screen w-full items-center px-6 py-10 sm:px-10 lg:px-16"
+            ? cn(
+                "auth-marketing-shell mx-auto flex min-h-screen w-full items-center px-6 py-10 sm:px-10 lg:px-16",
+                topRight ? "auth-marketing-shell-with-top-right" : "",
+              )
             : "mx-auto flex min-h-screen w-full max-w-7xl items-center px-6 py-16 sm:px-10 lg:px-16",
         )}
       >
+        {isAuthVariant && topRight ? (
+          <div className="auth-marketing-top-right">{topRight}</div>
+        ) : null}
         <div
           className={cn(
             isAuthVariant && auth ? "split" : "grid w-full items-center gap-12",
             auth ? "lg:grid-cols-[minmax(0,1fr)_minmax(20rem,28rem)]" : "",
             isAuthVariant && auth ? "max-w-6xl" : "",
+            isAuthVariant && topRight ? "auth-marketing-layout" : "",
           )}
         >
           <section


### PR DESCRIPTION
Moves the auth learn-more link into a page-level top-right row, preserves the edge-to-edge desktop screenshot, hides it on mobile, and reserves mobile space for the language control. Verified with 58 focused tests, 66 repository guards, and local browser captures for Clips, Calendar, and Slides.