### PR TITLE
feat(assets): let kit viewers generate drafts without approving them

### DIFF
--- a/templates/assets/.agents/skills/a2a-assets/SKILL.md
+++ b/templates/assets/.agents/skills/a2a-assets/SKILL.md
@@ -24,6 +24,10 @@ delegation, but A2A replies cannot render MCP App pickers.
 3. Treat image batches as complete when the action returns. Use returned
    successful `images` entries directly; only regenerate slots that returned
    `ok: false`.
+   A result carrying `draftPendingApproval: true` means the caller can draft in
+   that kit but not save into it. The image is real and usable — say it is
+   waiting on a kit editor instead of reporting it as saved, and do not retry.
+   Call `get-library-access` first when you need to know before generating.
 4. For social/blog/diagram slots, call `list-generation-presets` and pass the
    matching `presetId` so output rules travel with the run.
 5. When a human designer needs to continue the work, create or update a

--- a/templates/assets/.agents/skills/asset-generation/SKILL.md
+++ b/templates/assets/.agents/skills/asset-generation/SKILL.md
@@ -94,7 +94,9 @@ claiming a brand match.
    regenerate just to verify image runs.
    A result with `draftPendingApproval: true` came from a kit the user can draft
    in but not save into. Offer the candidate and say it needs a kit editor to be
-   saved; `save-generated-image` will refuse, so do not call it or retry.
+   saved; `save-generated-image` will refuse, so do not call it or retry. Video
+   carries the same marker on the initial async reply and on every
+   `refresh-generation-run` result, so it survives the poll.
 5. For template-backed work, pass a mentioned or selected `templateId`; for handoff
    work, pass `sessionId`.
 6. Let the server choose a small deterministic reference set unless the user

--- a/templates/assets/.agents/skills/asset-generation/SKILL.md
+++ b/templates/assets/.agents/skills/asset-generation/SKILL.md
@@ -92,6 +92,9 @@ claiming a brand match.
    `generate-image-batch` returns, use its returned `images` / asset fields
    directly; do not call `get-generation-run`, `refresh-generation-run`, or
    regenerate just to verify image runs.
+   A result with `draftPendingApproval: true` came from a kit the user can draft
+   in but not save into. Offer the candidate and say it needs a kit editor to be
+   saved; `save-generated-image` will refuse, so do not call it or retry.
 5. For template-backed work, pass a mentioned or selected `templateId`; for handoff
    work, pass `sessionId`.
 6. Let the server choose a small deterministic reference set unless the user

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -71,6 +71,16 @@ made:
   Content fetched by explicit id (`/api/assets/:id/content`, `get-asset`) stays
   gated on kit read access only, because cross-app embeds of a fresh candidate
   depend on it.
+- Draft *inputs* answer to the read rule too. `assertCanUseAssets` /
+  `assertCanUseRuns` guard every path that takes an asset or run id —
+  generation references, lineage source, subject, video source, and session
+  attachments — because a scope that holds on list surfaces but not on id
+  arguments is not a boundary. `selectReferences` takes a required `draftScope`
+  so a new generation path cannot forget it: the automatic pool scores every
+  asset in the kit, candidates included.
+- Paging happens after the filter, not before. `draftReadFilter` turns the scope
+  into a WHERE clause for `list-draft-assets`; filtering post-`limit` silently
+  drops the caller's own older drafts behind other people's newer ones.
 - `dismiss-variant-slots` re-reads every asset behind the slots it clears.
   Variant state is client-writable, so a slot id is never permission to delete:
   anything outside the state's kit, already saved, or authored by someone else

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -52,6 +52,22 @@ A kit `viewer` may **draft**: generation runs, generation sessions, and `image_a
 | `assertCanDraftAuthoredBy(libraryId, author, what)` | viewer for own | a session or run someone else may have created |
 | `assertCanDeleteAsset(asset)` | viewer for own draft | discarding a candidate vs deleting kit content |
 
+Drafting in a kit is not a licence to touch another drafter's work, so the
+author-scoped rule guards every write that lands on an existing row someone else
+made:
+
+- `requireGenerationSessionInLibrary` scopes the session a generation attaches
+  to. Belonging to the kit is not enough — appending a candidate also moves the
+  session's `activeAssetId`. Pass the access you already resolved to skip the
+  second lookup.
+- `refresh-generation-run` reconciles a run row (status, error, outputs) and
+  `rerun-generation-run` reuses its prompt, settings, and session, so both stay
+  with the run's `ownerEmail`.
+- `dismiss-variant-slots` re-reads every asset behind the slots it clears.
+  Variant state is client-writable, so a slot id is never permission to delete:
+  anything outside the state's kit, already saved, or authored by someone else
+  clears from the tray and comes back in `assetsRetained`.
+
 `assertCanDraft` returns `{ role, canApprove }`. Generation actions report `draftPendingApproval: true` when `canApprove` is false so the caller can say the images are waiting on an editor instead of claiming they were saved. `get-library-access` exposes the same answer to the UI and to other agents.
 
 The refusal message keeps the framework's `Requires editor role on asset-library <id> (have viewer)` prefix on purpose: core's permanent-precondition classifier matches that shape and ends the agent turn instead of retrying a grant it cannot obtain. Keep it if you reword the remedy.

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -35,9 +35,26 @@ Every action that touches an ownable resource must scope its queries:
   Cross-kit asset lists must first resolve the accessible library IDs, then
   query `image_assets` by those IDs and include the parent kit title for UI chips.
 - **Read by id**: `await resolveAccess("asset-library", libraryId)`. The `requireLibrary(id)` helper in `_helpers.ts` wraps this.
-- **Write**: `await assertAccess("asset-library", libraryId, "editor")` for updates / inserts; `"admin"` for deletes.
+- **Write**: never `assertAccess(..., "editor")` directly. Use `server/lib/library-access.ts`, which splits writing into drafting and approving (below); `"admin"` still guards library archive / delete.
 
 All assets / runs derive `libraryId` first, then assert against the parent library. Never query `image_assets` without also pinning `library_id` to a value the caller has access to.
+
+### Drafting vs approving
+
+A kit `viewer` may **draft**: generation runs, generation sessions, and `image_assets` rows with `role: "generated"` and `status: "candidate"`. Drafts never reach the kit's content — `shouldIncludeAssetInLibraryResults` filters unsaved candidates out of every library read — so a read-only collaborator can safely make them.
+
+`editor` is still required to **approve**: promoting a candidate to `saved`, uploads, imports, folders, collections, style brief, canonical logo, templates, and deletes.
+
+| Helper | Bar | Use for |
+| --- | --- | --- |
+| `assertCanDraft(libraryId)` | viewer | generate / refine / rerun, sessions, variant slots |
+| `assertCanApprove(libraryId, what)` | editor | save, upload, import, organize, kit settings |
+| `assertCanDraftAuthoredBy(libraryId, author, what)` | viewer for own | a session or run someone else may have created |
+| `assertCanDeleteAsset(asset)` | viewer for own draft | discarding a candidate vs deleting kit content |
+
+`assertCanDraft` returns `{ role, canApprove }`. Generation actions report `draftPendingApproval: true` when `canApprove` is false so the caller can say the images are waiting on an editor instead of claiming they were saved. `get-library-access` exposes the same answer to the UI and to other agents.
+
+The refusal message keeps the framework's `Requires editor role on asset-library <id> (have viewer)` prefix on purpose: core's permanent-precondition classifier matches that shape and ends the agent turn instead of retrying a grant it cannot obtain. Keep it if you reword the remedy.
 
 ## Adding a new field
 

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -78,6 +78,17 @@ made:
   arguments is not a boundary. `selectReferences` takes a required `draftScope`
   so a new generation path cannot forget it: the automatic pool scores every
   asset in the kit, candidates included.
+- Sessions and run history narrow the same way. `sessionReadFilter` /
+  `canReadSession` keep `list-generation-sessions` and `get-generation-session`
+  to the sessions a below-approver caller created (and strip items, candidates,
+  and runs they cannot read), and `runReadFilter` / `canReadRun` do the same for
+  `list-generation-runs` and `get-generation-run`. Reading one by id is not a
+  way around the list rule.
+- Deleting a draft goes through `deleteDraftAssetIfUnchanged`, never a bare
+  delete-by-id. Authorization comes from a prior read, so the predicate lets an
+  editor's concurrent approval win, and the confirming re-read keeps the answer
+  portable. `delete-asset` reports the refusal; `dismiss-variant-slots` counts
+  it in `assetsRetained`.
 - Paging happens after the filter, not before. `draftReadFilter` turns the scope
   into a WHERE clause for `list-draft-assets`; filtering post-`limit` silently
   drops the caller's own older drafts behind other people's newer ones.

--- a/templates/assets/.agents/skills/library-management/SKILL.md
+++ b/templates/assets/.agents/skills/library-management/SKILL.md
@@ -63,10 +63,21 @@ made:
 - `refresh-generation-run` reconciles a run row (status, error, outputs) and
   `rerun-generation-run` reuses its prompt, settings, and session, so both stay
   with the run's `ownerEmail`.
+- Draft *reads* narrow the same way. `resolveDraftReadScope` +
+  `canReadDraftAsset` / `canReadRun` keep candidates and run history to their
+  author plus anyone who could approve them, across `get-library`,
+  `list-assets`, `search-assets`, and `list-draft-assets`. The lookup only runs
+  when a read actually returns candidates, so ordinary asset lists cost nothing.
+  Content fetched by explicit id (`/api/assets/:id/content`, `get-asset`) stays
+  gated on kit read access only, because cross-app embeds of a fresh candidate
+  depend on it.
 - `dismiss-variant-slots` re-reads every asset behind the slots it clears.
   Variant state is client-writable, so a slot id is never permission to delete:
   anything outside the state's kit, already saved, or authored by someone else
-  clears from the tray and comes back in `assetsRetained`.
+  clears from the tray and comes back in `assetsRetained`. The delete itself is
+  conditional on the state that was authorized, so an editor's save always beats
+  an in-flight dismissal, and the outcome is confirmed by re-reading rather than
+  by an adapter-specific row count.
 
 `assertCanDraft` returns `{ role, canApprove }`. Generation actions report `draftPendingApproval: true` when `canApprove` is false so the caller can say the images are waiting on an editor instead of claiming they were saved. `get-library-access` exposes the same answer to the UI and to other agents.
 

--- a/templates/assets/AGENTS.md
+++ b/templates/assets/AGENTS.md
@@ -50,6 +50,7 @@ Read the relevant skill in `.agents/skills/` before deeper work:
 - Keep inline previews and picker outputs lightweight; fetch full asset details
   through actions when needed.
 - Use framework sharing/collaboration primitives for ownable assets.
+- Kit viewers may generate drafts; saving one into the kit needs editor.
 
 ## Application State
 

--- a/templates/assets/actions/_helpers.ts
+++ b/templates/assets/actions/_helpers.ts
@@ -3,6 +3,10 @@ import { eq } from "drizzle-orm";
 
 import { getDb, schema } from "../server/db/index.js";
 import { absoluteUrl, parseJson } from "../server/lib/json.js";
+import {
+  assertCanDraftAuthoredBy,
+  type LibraryWriteAccess,
+} from "../server/lib/library-access.js";
 import type {
   AssetLineageSummary,
   GenerationSessionItemSummary,
@@ -37,9 +41,18 @@ export async function requireLibraryAccess(id: string, ctx?: AccessCtx) {
   return access;
 }
 
+/**
+ * Resolve a generation session a write is about to attach to.
+ *
+ * Belonging to the kit is not enough: a session is one person's drafting
+ * workspace, and attaching a candidate to it also moves its `activeAssetId`.
+ * So a below-editor caller may only target a session they created. Pass the
+ * access already resolved for this kit to skip a second lookup.
+ */
 export async function requireGenerationSessionInLibrary(
   sessionId: string,
   libraryId: string,
+  access?: LibraryWriteAccess,
 ) {
   const db = getDb();
   const [session] = await db
@@ -50,6 +63,13 @@ export async function requireGenerationSessionInLibrary(
   if (!session) throw new Error("Generation session not found.");
   if (session.libraryId !== libraryId) {
     throw new Error("Generation session does not belong to this library.");
+  }
+  if (!access?.canApprove) {
+    await assertCanDraftAuthoredBy(
+      libraryId,
+      session.createdBy,
+      "A generation session",
+    );
   }
   return session;
 }

--- a/templates/assets/actions/_template-access.ts
+++ b/templates/assets/actions/_template-access.ts
@@ -1,12 +1,12 @@
 import {
   accessFilter,
-  assertAccess,
   resolveAccess,
   type ShareRole,
 } from "@agent-native/core/sharing";
 import { eq, inArray, or } from "drizzle-orm";
 
 import { getDb, schema } from "../server/db/index.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 
 const roleRank: Record<ShareRole | "owner", number> = {
   viewer: 1,
@@ -47,7 +47,8 @@ export async function resolveTemplateAccess(
 export async function assertTemplateTargetLibraryAccess(
   libraryId: string | null | undefined,
 ) {
-  if (libraryId) await assertAccess("asset-library", libraryId, "editor");
+  if (libraryId)
+    await assertCanApprove(libraryId, "Changing brand kit templates");
 }
 
 export async function accessibleTemplateFilter() {

--- a/templates/assets/actions/analyze-collection-style.spec.ts
+++ b/templates/assets/actions/analyze-collection-style.spec.ts
@@ -20,6 +20,9 @@ const schemaMock = vi.hoisted(() => ({
     libraryId: "assets.libraryId",
   },
 }));
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -27,6 +30,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -115,6 +124,7 @@ function createDb({
 describe("analyze-collection-style", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     updateSetCalls.length = 0;
     assertAccessMock.mockResolvedValue(undefined);
     getObjectMock.mockResolvedValue(Buffer.from([1, 2, 3]));

--- a/templates/assets/actions/analyze-collection-style.spec.ts
+++ b/templates/assets/actions/analyze-collection-style.spec.ts
@@ -31,11 +31,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/analyze-collection-style.spec.ts
+++ b/templates/assets/actions/analyze-collection-style.spec.ts
@@ -31,10 +31,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -52,6 +54,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/analyze-collection-style.ts
+++ b/templates/assets/actions/analyze-collection-style.ts
@@ -1,5 +1,4 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -11,6 +10,7 @@ import {
 } from "../server/lib/generation.js";
 import { extractDominantColors } from "../server/lib/image-processing.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import type { StyleBrief } from "../shared/api.js";
 import { serializeLibrary } from "./_helpers.js";
@@ -27,7 +27,7 @@ export default defineAction({
     paletteSize: z.coerce.number().int().min(3).max(12).default(6),
   }),
   run: async ({ libraryId, collectionId, paletteSize }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Saving a style analysis");
     const db = getDb();
     const [library] = await db
       .select()

--- a/templates/assets/actions/create-collection.ts
+++ b/templates/assets/actions/create-collection.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { ASPECT_RATIOS, IMAGE_CATEGORIES, IMAGE_SIZES } from "../shared/api.js";
 
 export default defineAction({
@@ -20,7 +20,7 @@ export default defineAction({
     styleBrief: z.record(z.string(), z.unknown()).optional(),
   }),
   run: async (args) => {
-    await assertAccess("asset-library", args.libraryId, "editor");
+    await assertCanApprove(args.libraryId, "Creating a collection");
     const now = nowIso();
     const row = {
       id: nanoid(),

--- a/templates/assets/actions/create-folder.ts
+++ b/templates/assets/actions/create-folder.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 
 export default defineAction({
   description:
@@ -17,7 +17,7 @@ export default defineAction({
     description: z.string().nullable().optional(),
   }),
   run: async ({ libraryId, parentId, title, description }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Creating a folder");
     if (parentId) {
       const [parent] = await getDb()
         .select()

--- a/templates/assets/actions/create-generation-session.ts
+++ b/templates/assets/actions/create-generation-session.ts
@@ -11,7 +11,12 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, stringifyJson } from "../server/lib/json.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import {
+  assertCanDraft,
+  assertCanUseAssets,
+  assertCanUseRuns,
+  draftScopeForLibrary,
+} from "../server/lib/library-access.js";
 import { serializeGenerationSession } from "./_helpers.js";
 import { resolveTemplateAccess } from "./_template-access.js";
 
@@ -49,7 +54,10 @@ export default defineAction({
       contextPackId: creativeContext.contextPackId,
       reuseLabels,
     };
-    await assertCanDraft(args.libraryId);
+    const draftAccess = await assertCanDraft(args.libraryId);
+    // Attaching a candidate or run to a session republishes it through the
+    // session read path, so inputs answer to the same author rule as reads.
+    const draftScope = await draftScopeForLibrary(args.libraryId, draftAccess);
     const db = getDb();
     if (args.collectionId) {
       const [collection] = await db
@@ -82,7 +90,13 @@ export default defineAction({
     }
     if (assetIds.length) {
       const assets = await db
-        .select({ id: schema.assets.id, libraryId: schema.assets.libraryId })
+        .select({
+          id: schema.assets.id,
+          libraryId: schema.assets.libraryId,
+          role: schema.assets.role,
+          status: schema.assets.status,
+          generationRunId: schema.assets.generationRunId,
+        })
         .from(schema.assets)
         .where(inArray(schema.assets.id, assetIds));
       const foundIds = new Set(assets.map((asset) => asset.id));
@@ -91,6 +105,13 @@ export default defineAction({
       if (assets.some((asset) => asset.libraryId !== args.libraryId)) {
         throw new Error("All assets must belong to this asset library.");
       }
+      assertCanUseAssets(
+        draftScope,
+        args.libraryId,
+        draftAccess.role,
+        assets,
+        "A generation session",
+      );
     }
     const runIds = [...new Set(args.runIds ?? [])];
     if (runIds.length) {
@@ -109,6 +130,13 @@ export default defineAction({
           "All generation runs must belong to this asset library.",
         );
       }
+      assertCanUseRuns(
+        draftScope,
+        args.libraryId,
+        draftAccess.role,
+        runs,
+        "A generation session",
+      );
     }
 
     const now = nowIso();

--- a/templates/assets/actions/create-generation-session.ts
+++ b/templates/assets/actions/create-generation-session.ts
@@ -1,6 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
-import { assertAccess } from "@agent-native/core/sharing";
 import {
   recordGenerationCreativeContext,
   resolveGenerationCreativeContext,
@@ -12,6 +11,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, stringifyJson } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import { serializeGenerationSession } from "./_helpers.js";
 import { resolveTemplateAccess } from "./_template-access.js";
 
@@ -49,7 +49,7 @@ export default defineAction({
       contextPackId: creativeContext.contextPackId,
       reuseLabels,
     };
-    await assertAccess("asset-library", args.libraryId, "editor");
+    await assertCanDraft(args.libraryId);
     const db = getDb();
     if (args.collectionId) {
       const [collection] = await db

--- a/templates/assets/actions/delete-asset.ts
+++ b/templates/assets/actions/delete-asset.ts
@@ -3,7 +3,10 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { assertCanDeleteAsset } from "../server/lib/library-access.js";
+import {
+  assertCanDeleteAsset,
+  deleteDraftAssetIfUnchanged,
+} from "../server/lib/library-access.js";
 import { getAssetOrThrow } from "./_helpers.js";
 
 export default defineAction({
@@ -12,8 +15,21 @@ export default defineAction({
   schema: z.object({ id: z.string() }),
   run: async ({ id }) => {
     const asset = await getAssetOrThrow(id);
-    await assertCanDeleteAsset(asset);
-    await getDb().delete(schema.assets).where(eq(schema.assets.id, id));
-    return { id, deleted: true };
+    const access = await assertCanDeleteAsset(asset);
+    if (access.canApprove) {
+      await getDb().delete(schema.assets).where(eq(schema.assets.id, id));
+      return { id, deleted: true };
+    }
+    // A draft author's delete was authorized from a prior read. If an editor
+    // approved the candidate in between, that save wins — re-running the rule
+    // against the row's new state reports why, rather than reporting a delete
+    // that did not happen.
+    if (await deleteDraftAssetIfUnchanged(asset)) {
+      return { id, deleted: true };
+    }
+    await assertCanDeleteAsset(await getAssetOrThrow(id));
+    throw new Error(
+      `Asset ${id} changed while being discarded. Reload and try again.`,
+    );
   },
 });

--- a/templates/assets/actions/delete-asset.ts
+++ b/templates/assets/actions/delete-asset.ts
@@ -1,17 +1,18 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { assertCanDeleteAsset } from "../server/lib/library-access.js";
 import { getAssetOrThrow } from "./_helpers.js";
 
 export default defineAction({
-  description: "Delete an asset row. Requires editor access to its library.",
+  description:
+    "Delete an asset row. Requires editor access to its library, except for an unsaved draft candidate, which its author can always discard.",
   schema: z.object({ id: z.string() }),
   run: async ({ id }) => {
     const asset = await getAssetOrThrow(id);
-    await assertAccess("asset-library", asset.libraryId, "editor");
+    await assertCanDeleteAsset(asset);
     await getDb().delete(schema.assets).where(eq(schema.assets.id, id));
     return { id, deleted: true };
   },

--- a/templates/assets/actions/delete-assets.spec.ts
+++ b/templates/assets/actions/delete-assets.spec.ts
@@ -16,11 +16,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/delete-assets.spec.ts
+++ b/templates/assets/actions/delete-assets.spec.ts
@@ -5,6 +5,9 @@ const assertAccessMock = vi.hoisted(() => vi.fn());
 const inArrayMock = vi.hoisted(() =>
   vi.fn((column: unknown, values: string[]) => ({ column, values })),
 );
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -12,6 +15,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -46,6 +55,7 @@ function createDb(rows: Array<{ id: string; libraryId: string }>) {
 describe("delete-assets", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
   });
 
@@ -60,17 +70,15 @@ describe("delete-assets", () => {
       ids: ["asset-a", "asset-a", "asset-b", "missing"],
     });
 
-    expect(assertAccessMock).toHaveBeenNthCalledWith(
+    expect(libraryAccessMock).toHaveBeenNthCalledWith(
       1,
-      "asset-library",
       "library-a",
-      "editor",
+      expect.any(String),
     );
-    expect(assertAccessMock).toHaveBeenNthCalledWith(
+    expect(libraryAccessMock).toHaveBeenNthCalledWith(
       2,
-      "asset-library",
       "library-b",
-      "editor",
+      expect.any(String),
     );
     expect(deleteWhere).toHaveBeenCalledOnce();
     expect(result).toMatchObject({
@@ -88,9 +96,10 @@ describe("delete-assets", () => {
       { id: "asset-b", libraryId: "library-b" },
     ]);
     getDbMock.mockReturnValue(db);
-    assertAccessMock.mockImplementation(async (_type, libraryId) => {
+    libraryAccessMock.mockImplementation((async (libraryId: string) => {
       if (libraryId === "library-b") throw new Error("Editor access required");
-    });
+      return { role: "owner", canApprove: true };
+    }) as any);
 
     await expect(action.run({ ids: ["asset-a", "asset-b"] })).rejects.toThrow(
       "Editor access required",

--- a/templates/assets/actions/delete-assets.spec.ts
+++ b/templates/assets/actions/delete-assets.spec.ts
@@ -16,10 +16,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -37,6 +39,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/delete-assets.ts
+++ b/templates/assets/actions/delete-assets.ts
@@ -1,9 +1,9 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 
 export default defineAction({
   description:
@@ -28,7 +28,7 @@ export default defineAction({
     );
 
     for (const libraryId of libraryIds) {
-      await assertAccess("asset-library", libraryId, "editor");
+      await assertCanApprove(libraryId, "Deleting assets");
     }
 
     const deletedIds = uniqueIds.filter((id) => matchedIds.has(id));

--- a/templates/assets/actions/delete-folder.ts
+++ b/templates/assets/actions/delete-folder.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 
 async function assertDestinationIsNotDescendant(
   db: ReturnType<typeof getDb>,
@@ -50,7 +50,7 @@ export default defineAction({
       .where(eq(schema.assetFolders.id, id))
       .limit(1);
     if (!folder) throw new Error("Folder not found.");
-    await assertAccess("asset-library", folder.libraryId, "editor");
+    await assertCanApprove(folder.libraryId, "Deleting a folder");
     const destinationId =
       moveToFolderId === undefined ? folder.parentId : moveToFolderId;
     if (destinationId) {

--- a/templates/assets/actions/describe-asset.ts
+++ b/templates/assets/actions/describe-asset.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { getGeminiApiKey } from "../server/lib/generation.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import { getAssetOrThrow, serializeAsset } from "./_helpers.js";
 
@@ -20,7 +20,7 @@ export default defineAction({
   }),
   run: async ({ id, overwrite }) => {
     const asset = await getAssetOrThrow(id);
-    await assertAccess("asset-library", asset.libraryId, "editor");
+    await assertCanApprove(asset.libraryId, "Saving a description on an asset");
     if (!overwrite && (asset.description || asset.altText)) {
       return serializeAsset(asset);
     }

--- a/templates/assets/actions/dismiss-variant-slots.spec.ts
+++ b/templates/assets/actions/dismiss-variant-slots.spec.ts
@@ -29,10 +29,12 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   ForbiddenError: forbiddenErrorClass,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -50,6 +52,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -94,13 +100,12 @@ function draftAsset(id: string, overrides: Partial<AssetRow> = {}): AssetRow {
 }
 
 /**
- * A live table, not a call recorder: the action deletes conditionally and then
- * re-reads the row, so the mock has to model both or the race test proves
- * nothing. `onBeforeDelete` is the hook that simulates a concurrent save.
+ * Serves the authorization reads the action makes per slot. The conditional
+ * delete itself is `deleteDraftAssetIfUnchanged`, mocked above and tested
+ * against a live table in `server/lib/library-access.spec.ts`.
  */
 function createDb(
   assets: AssetRow[] = [draftAsset("asset-1"), draftAsset("asset-2")],
-  onBeforeDelete?: (byId: Map<string, AssetRow>) => void,
 ) {
   const byId = new Map(assets.map((asset) => [asset.id, asset]));
   const columnKeys: Record<string, keyof AssetRow> = {
@@ -123,7 +128,6 @@ function createDb(
       ?.value;
   };
   const deleteWhere = vi.fn(async (condition: any) => {
-    onBeforeDelete?.(byId);
     const id = idOf(condition);
     const asset = id ? byId.get(id) : undefined;
     if (asset && equals(asset, condition)) byId.delete(asset.id);
@@ -152,6 +156,7 @@ describe("dismiss-variant-slots", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
+    deleteDraftMock.mockResolvedValue(true);
     assertAccessMock.mockResolvedValue(undefined);
     deleteAppStateMock.mockResolvedValue(true);
   });
@@ -174,8 +179,10 @@ describe("dismiss-variant-slots", () => {
 
     // Discarding a draft is drafting-class work, not approving.
     expect(libraryAccessMock).toHaveBeenCalledWith("lib-1");
-    expect(db.delete).toHaveBeenCalledTimes(2);
-    expect(db.remainingIds()).toEqual([]);
+    expect(deleteDraftMock).toHaveBeenCalledTimes(2);
+    expect(
+      deleteDraftMock.mock.calls.map(([asset]: any[]) => asset.id),
+    ).toEqual(["asset-1", "asset-2"]);
     expect(deleteAppStateMock).toHaveBeenCalledWith("asset-variants");
     expect(deleteAppStateMock).toHaveBeenCalledWith("image-variants");
     expect(writeAppStateMock).not.toHaveBeenCalled();
@@ -209,8 +216,11 @@ describe("dismiss-variant-slots", () => {
 
     const result = await action.run({ scope: "all" });
 
-    expect(db.delete).toHaveBeenCalledTimes(1);
-    expect(db.remainingIds()).toEqual(["asset-saved", "asset-other-kit"]);
+    // Only the caller's own unsaved draft in this kit reaches the delete.
+    expect(deleteDraftMock).toHaveBeenCalledTimes(1);
+    expect((deleteDraftMock.mock.calls[0] as any[])[0]).toMatchObject({
+      id: "asset-mine",
+    });
     expect(result).toEqual({
       dismissed: 3,
       assetsDeleted: 1,
@@ -240,7 +250,7 @@ describe("dismiss-variant-slots", () => {
 
     const result = await action.run({ scope: "all" });
 
-    expect(db.delete).not.toHaveBeenCalled();
+    expect(deleteDraftMock).not.toHaveBeenCalled();
     expect(result).toEqual({
       dismissed: 1,
       assetsDeleted: 0,
@@ -272,13 +282,11 @@ describe("dismiss-variant-slots", () => {
     expect(db.delete).not.toHaveBeenCalled();
   });
 
-  it("leaves a candidate an editor saved mid-dismissal in the kit", async () => {
-    // The authorizing SELECT saw a draft; by the time the delete runs an editor
-    // has approved it. The save has to win.
-    const db = createDb([draftAsset("asset-1")], (byId) => {
-      const saved = byId.get("asset-1");
-      if (saved) byId.set("asset-1", { ...saved, status: "saved" });
-    });
+  it("counts a candidate an editor saved mid-dismissal as retained", async () => {
+    // The conditional delete lives in library-access and has its own tests; the
+    // action's job is to report the refusal as retained, never as deleted.
+    deleteDraftMock.mockResolvedValueOnce(false);
+    const db = createDb([draftAsset("asset-1")]);
     getDbMock.mockReturnValue(db);
     readAppStateMock.mockResolvedValueOnce({
       runId: "run-1",
@@ -290,7 +298,6 @@ describe("dismiss-variant-slots", () => {
 
     const result = await action.run({ scope: "all" });
 
-    expect(db.remainingIds()).toEqual(["asset-1"]);
     expect(result).toEqual({
       dismissed: 1,
       assetsDeleted: 0,
@@ -320,8 +327,10 @@ describe("dismiss-variant-slots", () => {
 
     const result = await action.run({ scope: "failed" });
 
-    expect(db.delete).toHaveBeenCalledTimes(1);
-    expect(db.remainingIds()).toEqual(["asset-1"]);
+    expect(deleteDraftMock).toHaveBeenCalledTimes(1);
+    expect((deleteDraftMock.mock.calls[0] as any[])[0]).toMatchObject({
+      id: "asset-2",
+    });
     expect(writeAppStateMock).toHaveBeenCalledWith(
       "asset-variants",
       expect.objectContaining({

--- a/templates/assets/actions/dismiss-variant-slots.spec.ts
+++ b/templates/assets/actions/dismiss-variant-slots.spec.ts
@@ -8,6 +8,12 @@ const getDbMock = vi.hoisted(() => vi.fn());
 const libraryAccessMock = vi.hoisted(() =>
   vi.fn(async () => ({ role: "owner", canApprove: true })),
 );
+const forbiddenErrorClass = vi.hoisted(
+  () =>
+    class ForbiddenError extends Error {
+      statusCode = 403;
+    },
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -21,6 +27,7 @@ vi.mock("@agent-native/core/application-state", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+  ForbiddenError: forbiddenErrorClass,
 }));
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
@@ -39,16 +46,54 @@ vi.mock("../server/db/index.js", () => ({
   schema: {
     assets: {
       id: "image_assets.id",
+      libraryId: "image_assets.library_id",
+      role: "image_assets.role",
+      status: "image_assets.status",
+      generationRunId: "image_assets.generation_run_id",
     },
   },
 }));
 
 import action from "./dismiss-variant-slots.js";
 
-function createDb() {
+type AssetRow = {
+  id: string;
+  libraryId: string;
+  role: string;
+  status: string;
+  generationRunId: string | null;
+};
+
+/** An unsaved draft candidate in `lib-1`, the shape dismiss is allowed to delete. */
+function draftAsset(id: string, overrides: Partial<AssetRow> = {}): AssetRow {
+  return {
+    id,
+    libraryId: "lib-1",
+    role: "generated",
+    status: "candidate",
+    generationRunId: "run-1",
+    ...overrides,
+  };
+}
+
+function createDb(
+  assets: AssetRow[] = [draftAsset("asset-1"), draftAsset("asset-2")],
+) {
+  const byId = new Map(assets.map((asset) => [asset.id, asset]));
   const deleteWhere = vi.fn(async () => undefined);
   const deleteMock = vi.fn(() => ({ where: deleteWhere }));
+  const selectMock = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn((condition: any) => ({
+        limit: async () => {
+          const asset = byId.get(condition?.value);
+          return asset ? [asset] : [];
+        },
+      })),
+    })),
+  }));
   return {
+    select: selectMock,
     delete: deleteMock,
     deleteWhere,
   };
@@ -95,8 +140,97 @@ describe("dismiss-variant-slots", () => {
     expect(result).toEqual({
       dismissed: 2,
       assetsDeleted: 2,
+      assetsRetained: 0,
       cleared: true,
     });
+  });
+
+  it("retains assets the caller may not discard instead of deleting them", async () => {
+    // Variant state is client-writable, so a slot can point at anything.
+    const db = createDb([
+      draftAsset("asset-saved", { status: "saved" }),
+      draftAsset("asset-other-kit", { libraryId: "lib-2" }),
+      draftAsset("asset-mine"),
+    ]);
+    getDbMock.mockReturnValue(db);
+    readAppStateMock.mockResolvedValueOnce({
+      runId: "run-1",
+      libraryId: "lib-1",
+      prompt: "Dogs in a park",
+      slots: [
+        { slotId: "slot-1", status: "ready", assetId: "asset-saved" },
+        { slotId: "slot-2", status: "ready", assetId: "asset-other-kit" },
+        { slotId: "slot-3", status: "ready", assetId: "asset-mine" },
+      ],
+      updatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    const result = await action.run({ scope: "all" });
+
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    expect(db.deleteWhere).toHaveBeenCalledWith({
+      column: "image_assets.id",
+      value: "asset-mine",
+    });
+    expect(result).toEqual({
+      dismissed: 3,
+      assetsDeleted: 1,
+      assetsRetained: 2,
+      cleared: true,
+    });
+  });
+
+  it("retains a draft the delete rules refuse", async () => {
+    const db = createDb([draftAsset("asset-theirs")]);
+    getDbMock.mockReturnValue(db);
+    libraryAccessMock.mockImplementation((async (...args: unknown[]) => {
+      // One argument is `assertCanDraft`; the asset-shaped call is the delete
+      // rule, and it refuses another drafter's candidate.
+      if (typeof args[0] === "object") {
+        throw new forbiddenErrorClass("Requires editor role");
+      }
+      return { role: "viewer", canApprove: false };
+    }) as never);
+    readAppStateMock.mockResolvedValueOnce({
+      runId: "run-1",
+      libraryId: "lib-1",
+      prompt: "Dogs in a park",
+      slots: [{ slotId: "slot-1", status: "ready", assetId: "asset-theirs" }],
+      updatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    const result = await action.run({ scope: "all" });
+
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      dismissed: 1,
+      assetsDeleted: 0,
+      assetsRetained: 1,
+      cleared: true,
+    });
+  });
+
+  it("surfaces a failure while checking a draft instead of retaining it", async () => {
+    const db = createDb([draftAsset("asset-1")]);
+    getDbMock.mockReturnValue(db);
+    libraryAccessMock.mockImplementation((async (...args: unknown[]) => {
+      if (typeof args[0] === "object") throw new Error("db unavailable");
+      return { role: "viewer", canApprove: false };
+    }) as never);
+    readAppStateMock.mockResolvedValueOnce({
+      runId: "run-1",
+      libraryId: "lib-1",
+      prompt: "Dogs in a park",
+      slots: [{ slotId: "slot-1", status: "ready", assetId: "asset-1" }],
+      updatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    // An unreadable check is not a permission answer, so it must not come back
+    // as a quietly retained asset.
+    await expect(action.run({ scope: "all" })).rejects.toThrow(
+      "db unavailable",
+    );
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   it("dismisses failed slots while keeping ready candidates", async () => {
@@ -135,6 +269,7 @@ describe("dismiss-variant-slots", () => {
     expect(result).toEqual({
       dismissed: 1,
       assetsDeleted: 1,
+      assetsRetained: 0,
       cleared: false,
     });
   });
@@ -174,6 +309,7 @@ describe("dismiss-variant-slots", () => {
     expect(result).toEqual({
       dismissed: 1,
       assetsDeleted: 1,
+      assetsRetained: 0,
       cleared: true,
     });
     expect(deleteAppStateMock).toHaveBeenCalledWith("asset-variants:thread-1");
@@ -207,6 +343,7 @@ describe("dismiss-variant-slots", () => {
     expect(result).toEqual({
       dismissed: 1,
       assetsDeleted: 1,
+      assetsRetained: 0,
       cleared: true,
     });
     expect(deleteAppStateMock).toHaveBeenCalledWith(

--- a/templates/assets/actions/dismiss-variant-slots.spec.ts
+++ b/templates/assets/actions/dismiss-variant-slots.spec.ts
@@ -29,11 +29,27 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   ForbiddenError: forbiddenErrorClass,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/dismiss-variant-slots.spec.ts
+++ b/templates/assets/actions/dismiss-variant-slots.spec.ts
@@ -38,6 +38,7 @@ vi.mock("../server/lib/library-access.js", () => ({
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column, value) => ({ column, value })),
+  and: vi.fn((...conditions) => ({ conditions })),
   sql: vi.fn((strings, ...values) => ({ strings, values })),
 }));
 
@@ -76,17 +77,48 @@ function draftAsset(id: string, overrides: Partial<AssetRow> = {}): AssetRow {
   };
 }
 
+/**
+ * A live table, not a call recorder: the action deletes conditionally and then
+ * re-reads the row, so the mock has to model both or the race test proves
+ * nothing. `onBeforeDelete` is the hook that simulates a concurrent save.
+ */
 function createDb(
   assets: AssetRow[] = [draftAsset("asset-1"), draftAsset("asset-2")],
+  onBeforeDelete?: (byId: Map<string, AssetRow>) => void,
 ) {
   const byId = new Map(assets.map((asset) => [asset.id, asset]));
-  const deleteWhere = vi.fn(async () => undefined);
+  const columnKeys: Record<string, keyof AssetRow> = {
+    "image_assets.id": "id",
+    "image_assets.library_id": "libraryId",
+    "image_assets.role": "role",
+    "image_assets.status": "status",
+    "image_assets.generation_run_id": "generationRunId",
+  };
+  const equals = (asset: AssetRow, condition: any): boolean => {
+    const clauses = condition?.conditions ?? [condition];
+    return clauses.every((clause: any) => {
+      const key = columnKeys[clause?.column];
+      return key ? asset[key] === clause.value : true;
+    });
+  };
+  const idOf = (condition: any): string | undefined => {
+    const clauses = condition?.conditions ?? [condition];
+    return clauses.find((clause: any) => clause?.column === "image_assets.id")
+      ?.value;
+  };
+  const deleteWhere = vi.fn(async (condition: any) => {
+    onBeforeDelete?.(byId);
+    const id = idOf(condition);
+    const asset = id ? byId.get(id) : undefined;
+    if (asset && equals(asset, condition)) byId.delete(asset.id);
+  });
   const deleteMock = vi.fn(() => ({ where: deleteWhere }));
   const selectMock = vi.fn(() => ({
     from: vi.fn(() => ({
       where: vi.fn((condition: any) => ({
         limit: async () => {
-          const asset = byId.get(condition?.value);
+          const id = idOf(condition);
+          const asset = id ? byId.get(id) : undefined;
           return asset ? [asset] : [];
         },
       })),
@@ -96,6 +128,7 @@ function createDb(
     select: selectMock,
     delete: deleteMock,
     deleteWhere,
+    remainingIds: () => Array.from(byId.keys()),
   };
 }
 
@@ -126,14 +159,7 @@ describe("dismiss-variant-slots", () => {
     // Discarding a draft is drafting-class work, not approving.
     expect(libraryAccessMock).toHaveBeenCalledWith("lib-1");
     expect(db.delete).toHaveBeenCalledTimes(2);
-    expect(db.deleteWhere).toHaveBeenNthCalledWith(1, {
-      column: "image_assets.id",
-      value: "asset-1",
-    });
-    expect(db.deleteWhere).toHaveBeenNthCalledWith(2, {
-      column: "image_assets.id",
-      value: "asset-2",
-    });
+    expect(db.remainingIds()).toEqual([]);
     expect(deleteAppStateMock).toHaveBeenCalledWith("asset-variants");
     expect(deleteAppStateMock).toHaveBeenCalledWith("image-variants");
     expect(writeAppStateMock).not.toHaveBeenCalled();
@@ -168,10 +194,7 @@ describe("dismiss-variant-slots", () => {
     const result = await action.run({ scope: "all" });
 
     expect(db.delete).toHaveBeenCalledTimes(1);
-    expect(db.deleteWhere).toHaveBeenCalledWith({
-      column: "image_assets.id",
-      value: "asset-mine",
-    });
+    expect(db.remainingIds()).toEqual(["asset-saved", "asset-other-kit"]);
     expect(result).toEqual({
       dismissed: 3,
       assetsDeleted: 1,
@@ -233,6 +256,33 @@ describe("dismiss-variant-slots", () => {
     expect(db.delete).not.toHaveBeenCalled();
   });
 
+  it("leaves a candidate an editor saved mid-dismissal in the kit", async () => {
+    // The authorizing SELECT saw a draft; by the time the delete runs an editor
+    // has approved it. The save has to win.
+    const db = createDb([draftAsset("asset-1")], (byId) => {
+      const saved = byId.get("asset-1");
+      if (saved) byId.set("asset-1", { ...saved, status: "saved" });
+    });
+    getDbMock.mockReturnValue(db);
+    readAppStateMock.mockResolvedValueOnce({
+      runId: "run-1",
+      libraryId: "lib-1",
+      prompt: "Dogs in a park",
+      slots: [{ slotId: "slot-1", status: "ready", assetId: "asset-1" }],
+      updatedAt: "2026-05-28T00:00:00.000Z",
+    });
+
+    const result = await action.run({ scope: "all" });
+
+    expect(db.remainingIds()).toEqual(["asset-1"]);
+    expect(result).toEqual({
+      dismissed: 1,
+      assetsDeleted: 0,
+      assetsRetained: 1,
+      cleared: true,
+    });
+  });
+
   it("dismisses failed slots while keeping ready candidates", async () => {
     const db = createDb();
     getDbMock.mockReturnValue(db);
@@ -255,10 +305,7 @@ describe("dismiss-variant-slots", () => {
     const result = await action.run({ scope: "failed" });
 
     expect(db.delete).toHaveBeenCalledTimes(1);
-    expect(db.deleteWhere).toHaveBeenCalledWith({
-      column: "image_assets.id",
-      value: "asset-2",
-    });
+    expect(db.remainingIds()).toEqual(["asset-1"]);
     expect(writeAppStateMock).toHaveBeenCalledWith(
       "asset-variants",
       expect.objectContaining({

--- a/templates/assets/actions/dismiss-variant-slots.spec.ts
+++ b/templates/assets/actions/dismiss-variant-slots.spec.ts
@@ -5,6 +5,9 @@ const writeAppStateMock = vi.hoisted(() => vi.fn());
 const deleteAppStateMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -18,6 +21,12 @@ vi.mock("@agent-native/core/application-state", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -48,6 +57,7 @@ function createDb() {
 describe("dismiss-variant-slots", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
     deleteAppStateMock.mockResolvedValue(true);
   });
@@ -68,11 +78,8 @@ describe("dismiss-variant-slots", () => {
 
     const result = await action.run({ scope: "all" });
 
-    expect(assertAccessMock).toHaveBeenCalledWith(
-      "asset-library",
-      "lib-1",
-      "editor",
-    );
+    // Discarding a draft is drafting-class work, not approving.
+    expect(libraryAccessMock).toHaveBeenCalledWith("lib-1");
     expect(db.delete).toHaveBeenCalledTimes(2);
     expect(db.deleteWhere).toHaveBeenNthCalledWith(1, {
       column: "image_assets.id",

--- a/templates/assets/actions/dismiss-variant-slots.ts
+++ b/templates/assets/actions/dismiss-variant-slots.ts
@@ -1,7 +1,7 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
 import { ForbiddenError } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
@@ -105,8 +105,31 @@ export default defineAction({
         assetsRetained++;
         continue;
       }
-      await db.delete(schema.assets).where(eq(schema.assets.id, asset.id));
-      assetsDeleted++;
+      // Delete against the state that was authorized, not just the id: an
+      // editor can save this candidate between the check and the delete, and
+      // that save must win over an in-flight dismissal.
+      await db
+        .delete(schema.assets)
+        .where(
+          and(
+            eq(schema.assets.id, asset.id),
+            eq(schema.assets.libraryId, asset.libraryId),
+            eq(schema.assets.role, "generated"),
+            eq(schema.assets.status, "candidate"),
+          ),
+        );
+      // Row counts are adapter-specific, so confirm by re-reading rather than
+      // trusting a driver-shaped result.
+      const [survivor] = await db
+        .select({ id: schema.assets.id })
+        .from(schema.assets)
+        .where(eq(schema.assets.id, asset.id))
+        .limit(1);
+      if (survivor) {
+        assetsRetained++;
+      } else {
+        assetsDeleted++;
+      }
     }
 
     const removed = new Set(toRemove.map((s) => s.slotId));

--- a/templates/assets/actions/dismiss-variant-slots.ts
+++ b/templates/assets/actions/dismiss-variant-slots.ts
@@ -1,13 +1,14 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
 import { ForbiddenError } from "@agent-native/core/sharing";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
   assertCanDeleteAsset,
   assertCanDraft,
+  deleteDraftAssetIfUnchanged,
 } from "../server/lib/library-access.js";
 import {
   deleteVariantState,
@@ -105,30 +106,12 @@ export default defineAction({
         assetsRetained++;
         continue;
       }
-      // Delete against the state that was authorized, not just the id: an
-      // editor can save this candidate between the check and the delete, and
-      // that save must win over an in-flight dismissal.
-      await db
-        .delete(schema.assets)
-        .where(
-          and(
-            eq(schema.assets.id, asset.id),
-            eq(schema.assets.libraryId, asset.libraryId),
-            eq(schema.assets.role, "generated"),
-            eq(schema.assets.status, "candidate"),
-          ),
-        );
-      // Row counts are adapter-specific, so confirm by re-reading rather than
-      // trusting a driver-shaped result.
-      const [survivor] = await db
-        .select({ id: schema.assets.id })
-        .from(schema.assets)
-        .where(eq(schema.assets.id, asset.id))
-        .limit(1);
-      if (survivor) {
-        assetsRetained++;
-      } else {
+      // Conditional on the state that was authorized: an editor can save this
+      // candidate between the check and the delete, and that save must win.
+      if (await deleteDraftAssetIfUnchanged(asset)) {
         assetsDeleted++;
+      } else {
+        assetsRetained++;
       }
     }
 

--- a/templates/assets/actions/dismiss-variant-slots.ts
+++ b/templates/assets/actions/dismiss-variant-slots.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import {
   deleteVariantState,
   readVariantState,
@@ -32,7 +32,7 @@ export default defineAction({
     const stateThreadId =
       effectiveThreadId ?? state.variantScopeId ?? state.threadId ?? null;
 
-    await assertAccess("asset-library", state.libraryId, "editor");
+    await assertCanDraft(state.libraryId);
 
     const toRemove = state.slots.filter((slot) => {
       if (slotId) return slot.slotId === slotId;

--- a/templates/assets/actions/dismiss-variant-slots.ts
+++ b/templates/assets/actions/dismiss-variant-slots.ts
@@ -1,19 +1,47 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
+import { ForbiddenError } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import {
+  assertCanDeleteAsset,
+  assertCanDraft,
+} from "../server/lib/library-access.js";
 import {
   deleteVariantState,
   readVariantState,
   writeVariantState,
 } from "./variant-slots.js";
 
+/**
+ * Dismiss only ever removes an unsaved draft the caller may discard. Anything
+ * else — saved kit content, another drafter's candidate — is reported back as
+ * retained rather than deleted or silently swallowed.
+ */
+async function canDiscardAsset(asset: {
+  libraryId: string;
+  role: string | null;
+  status: string | null;
+  generationRunId: string | null;
+}): Promise<boolean> {
+  if (asset.role !== "generated" || asset.status !== "candidate") return false;
+  try {
+    await assertCanDeleteAsset(asset);
+    return true;
+  } catch (error) {
+    // A refusal is a decision the caller should see as "retained". Anything
+    // else — an unreadable run row, a failed query — must not read back as
+    // "not yours to discard".
+    if (error instanceof ForbiddenError) return false;
+    throw error;
+  }
+}
+
 export default defineAction({
   description:
-    "Clear one or more live candidate slots from application_state.asset-variants. Uses the current chat thread when available. Use slotId for a single slot, scope='failed' to drop every failed slot, or scope='all' to clear the panel. Any underlying asset rows for cleared slots are deleted (requires editor access on the library).",
+    "Clear one or more live candidate slots from application_state.asset-variants. Uses the current chat thread when available. Use slotId for a single slot, scope='failed' to drop every failed slot, or scope='all' to clear the panel. Unsaved draft candidates behind the cleared slots are deleted when the caller may discard them; anything already saved into the kit is left in place and counted in assetsRetained.",
   schema: z
     .object({
       slotId: z.string().optional(),
@@ -41,21 +69,44 @@ export default defineAction({
     });
 
     if (toRemove.length === 0) {
-      return { dismissed: 0, assetsDeleted: 0, cleared: false };
+      return {
+        dismissed: 0,
+        assetsDeleted: 0,
+        assetsRetained: 0,
+        cleared: false,
+      };
     }
 
     let assetsDeleted = 0;
+    let assetsRetained = 0;
     const db = getDb();
     for (const slot of toRemove) {
       if (!slot.assetId) continue;
-      try {
-        await db
-          .delete(schema.assets)
-          .where(eq(schema.assets.id, slot.assetId));
-        assetsDeleted++;
-      } catch {
-        // Best-effort: the slot can still be cleared even if the row is gone.
+      // Never trust the slot's assetId as permission to delete: variant state
+      // is client-writable, so re-read the row and let the draft rules decide.
+      // A slot pointing at another kit, at saved kit content, or at someone
+      // else's draft clears from the tray without touching the asset.
+      const [asset] = await db
+        .select({
+          id: schema.assets.id,
+          libraryId: schema.assets.libraryId,
+          role: schema.assets.role,
+          status: schema.assets.status,
+          generationRunId: schema.assets.generationRunId,
+        })
+        .from(schema.assets)
+        .where(eq(schema.assets.id, slot.assetId))
+        .limit(1);
+      if (!asset) continue;
+      if (
+        asset.libraryId !== state.libraryId ||
+        !(await canDiscardAsset(asset))
+      ) {
+        assetsRetained++;
+        continue;
       }
+      await db.delete(schema.assets).where(eq(schema.assets.id, asset.id));
+      assetsDeleted++;
     }
 
     const removed = new Set(toRemove.map((s) => s.slotId));
@@ -66,6 +117,7 @@ export default defineAction({
       return {
         dismissed: toRemove.length,
         assetsDeleted,
+        assetsRetained,
         cleared: true,
       };
     }
@@ -76,6 +128,7 @@ export default defineAction({
     return {
       dismissed: toRemove.length,
       assetsDeleted,
+      assetsRetained,
       cleared: false,
     };
   },

--- a/templates/assets/actions/extract-palette-from-references.ts
+++ b/templates/assets/actions/extract-palette-from-references.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { extractDominantColors } from "../server/lib/image-processing.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import type { StyleBrief } from "../shared/api.js";
 
@@ -16,7 +16,7 @@ export default defineAction({
     libraryId: z.string(),
   }),
   run: async ({ libraryId }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Saving a palette");
     const db = getDb();
     const [library] = await db
       .select()

--- a/templates/assets/actions/generate-image-batch.spec.ts
+++ b/templates/assets/actions/generate-image-batch.spec.ts
@@ -20,11 +20,27 @@ vi.mock("@agent-native/core/action", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generate-image-batch.spec.ts
+++ b/templates/assets/actions/generate-image-batch.spec.ts
@@ -5,6 +5,9 @@ const requireGenerationSessionInLibraryMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
 const upsertVariantSlotMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -16,6 +19,12 @@ vi.mock("@agent-native/core/action", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({
@@ -71,6 +80,7 @@ function createDb() {
 describe("generate-image-batch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
     requireGenerationSessionInLibraryMock.mockResolvedValue({
       id: "session-1",
@@ -89,6 +99,16 @@ describe("generate-image-batch", () => {
     expect(agentShape).not.toHaveProperty("variantScopeId");
     expect(agentShape).not.toHaveProperty("creativeContextRequestId");
     expect(agentShape).not.toHaveProperty("callerAppId");
+  });
+
+  it("only requires draft access, so a kit viewer can generate candidates", async () => {
+    await action.run({
+      libraryId: "lib-1",
+      slots: [{ slotId: "slot-1", prompt: "Generate a hero" }],
+    });
+
+    // One argument means `assertCanDraft`; approving paths pass a second.
+    expect(libraryAccessMock).toHaveBeenCalledWith("lib-1");
   });
 
   it("validates sessionId before spawning slot generations", async () => {

--- a/templates/assets/actions/generate-image-batch.spec.ts
+++ b/templates/assets/actions/generate-image-batch.spec.ts
@@ -20,10 +20,12 @@ vi.mock("@agent-native/core/action", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -41,6 +43,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generate-image-batch.ts
+++ b/templates/assets/actions/generate-image-batch.ts
@@ -183,9 +183,13 @@ export default defineAction({
       ...inputBase,
       libraryId,
     };
-    await assertCanDraft(base.libraryId);
+    const draftAccess = await assertCanDraft(base.libraryId);
     if (base.sessionId) {
-      await requireGenerationSessionInLibrary(base.sessionId, base.libraryId);
+      await requireGenerationSessionInLibrary(
+        base.sessionId,
+        base.libraryId,
+        draftAccess,
+      );
     }
     const creativeContextRequestId =
       base.creativeContextRequestId ?? (base.sessionId ? undefined : nanoid());

--- a/templates/assets/actions/generate-image-batch.ts
+++ b/templates/assets/actions/generate-image-batch.ts
@@ -1,6 +1,5 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import {
   recordGenerationCreativeContext,
   resolveGenerationCreativeContext,
@@ -13,6 +12,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import {
   ASPECT_RATIOS,
   GENERATION_INTENTS,
@@ -183,7 +183,7 @@ export default defineAction({
       ...inputBase,
       libraryId,
     };
-    await assertAccess("asset-library", base.libraryId, "editor");
+    await assertCanDraft(base.libraryId);
     if (base.sessionId) {
       await requireGenerationSessionInLibrary(base.sessionId, base.libraryId);
     }

--- a/templates/assets/actions/generate-image-reference-board.spec.ts
+++ b/templates/assets/actions/generate-image-reference-board.spec.ts
@@ -34,11 +34,27 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generate-image-reference-board.spec.ts
+++ b/templates/assets/actions/generate-image-reference-board.spec.ts
@@ -34,10 +34,12 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -55,6 +57,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generate-image-reference-board.spec.ts
+++ b/templates/assets/actions/generate-image-reference-board.spec.ts
@@ -8,6 +8,9 @@ const generateProviderMock = vi.hoisted(() => vi.fn());
 const createAssetFromBufferMock = vi.hoisted(() => vi.fn());
 const getObjectMock = vi.hoisted(() => vi.fn());
 const prepareInpaintMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -30,6 +33,12 @@ vi.mock("@agent-native/core/server/request-context", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({
@@ -222,6 +231,7 @@ function asset(id: string, libraryId = "lib-1") {
 describe("generate-image preset reference board", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
     selectReferencesMock.mockResolvedValue([
       {

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -40,7 +40,11 @@ import {
   prepareGptImage2SkeletonInpaintImages,
 } from "../server/lib/image-processing.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import {
+  assertCanDraft,
+  assertCanUseAssets,
+  draftScopeForLibrary,
+} from "../server/lib/library-access.js";
 import {
   normalizePresetReferences,
   PRESET_REFERENCE_ROLE_MAP,
@@ -258,6 +262,9 @@ export default defineAction({
       libraryId,
     };
     const draftAccess = await assertCanDraft(args.libraryId);
+    // Inputs answer to the same author rule as reads: another drafter's
+    // candidate must not reach the provider as a reference or a source.
+    const draftScope = await draftScopeForLibrary(args.libraryId, draftAccess);
     const db = getDb();
     const [library] = await db
       .select()
@@ -279,6 +286,9 @@ export default defineAction({
           .select({
             id: schema.assets.id,
             libraryId: schema.assets.libraryId,
+            role: schema.assets.role,
+            status: schema.assets.status,
+            generationRunId: schema.assets.generationRunId,
           })
           .from(schema.assets)
           .where(eq(schema.assets.id, lineageAssetId))
@@ -289,6 +299,15 @@ export default defineAction({
       (!lineageAsset || lineageAsset.libraryId !== args.libraryId)
     ) {
       throw new Error("Source asset must belong to this asset library.");
+    }
+    if (lineageAsset) {
+      assertCanUseAssets(
+        draftScope,
+        args.libraryId,
+        draftAccess.role,
+        [lineageAsset],
+        "This generation",
+      );
     }
     const sessionCreativeContext =
       session && !contextOff
@@ -495,6 +514,9 @@ export default defineAction({
           id: schema.assets.id,
           libraryId: schema.assets.libraryId,
           mimeType: schema.assets.mimeType,
+          role: schema.assets.role,
+          status: schema.assets.status,
+          generationRunId: schema.assets.generationRunId,
         })
         .from(schema.assets)
         .where(eq(schema.assets.id, args.subjectAssetId))
@@ -505,6 +527,13 @@ export default defineAction({
       if (!subject.mimeType.startsWith("image/")) {
         throw new Error("Subject asset must be an image.");
       }
+      assertCanUseAssets(
+        draftScope,
+        args.libraryId,
+        draftAccess.role,
+        [subject],
+        "This generation",
+      );
     }
     const styleBrief = {
       ...parseJson<StyleBrief>(library.styleBrief, {}),
@@ -680,6 +709,7 @@ export default defineAction({
       const guidanceReferences =
         baseReferenceLimit > 0 || args.referenceAssetIds?.length
           ? await selectReferences({
+              draftScope,
               libraryId: args.libraryId,
               collectionId: resolvedCollectionId,
               categories: resolvedCategories,
@@ -711,6 +741,7 @@ export default defineAction({
       const autoReferences =
         referenceLimit > 0 || args.referenceAssetIds?.length
           ? await selectReferences({
+              draftScope,
               libraryId: args.libraryId,
               collectionId: resolvedCollectionId,
               categories: resolvedCategories,

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -266,7 +266,11 @@ export default defineAction({
       .limit(1);
     if (!library) throw new Error("Asset library not found.");
     const session = args.sessionId
-      ? await requireGenerationSessionInLibrary(args.sessionId, args.libraryId)
+      ? await requireGenerationSessionInLibrary(
+          args.sessionId,
+          args.libraryId,
+          draftAccess,
+        )
       : null;
     const contextOff = args.contextModeOverride === "off";
     const lineageAssetId = args.sourceAssetId ?? args.subjectAssetId;

--- a/templates/assets/actions/generate-image.ts
+++ b/templates/assets/actions/generate-image.ts
@@ -8,7 +8,6 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
-import { assertAccess } from "@agent-native/core/sharing";
 import {
   delimitUntrustedReference,
   getGenerationCreativeContext,
@@ -41,6 +40,7 @@ import {
   prepareGptImage2SkeletonInpaintImages,
 } from "../server/lib/image-processing.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import {
   normalizePresetReferences,
   PRESET_REFERENCE_ROLE_MAP,
@@ -257,7 +257,7 @@ export default defineAction({
       ...input,
       libraryId,
     };
-    await assertAccess("asset-library", args.libraryId, "editor");
+    const draftAccess = await assertCanDraft(args.libraryId);
     const db = getDb();
     const [library] = await db
       .select()
@@ -1124,6 +1124,9 @@ export default defineAction({
           downloadUrl: serialized.downloadUrl,
         }),
         ...creativeContextProvenance,
+        // Present only when the caller cannot approve: the candidate exists and
+        // is theirs to iterate on, but saving it into the kit needs an editor.
+        ...(draftAccess.canApprove ? {} : { draftPendingApproval: true }),
       };
     } catch (err) {
       const message =

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -13,7 +13,11 @@ import {
   selectReferences,
 } from "../server/lib/generation.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import {
+  assertCanDraft,
+  assertCanUseAssets,
+  draftScopeForLibrary,
+} from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import {
   compileVideoPrompt,
@@ -83,6 +87,9 @@ export default defineAction({
       libraryId,
     };
     const draftAccess = await assertCanDraft(args.libraryId);
+    // Inputs answer to the same author rule as reads: another drafter's
+    // candidate must not reach the provider as a source or a reference.
+    const draftScope = await draftScopeForLibrary(args.libraryId, draftAccess);
     const db = getDb();
     const [library] = await db
       .select()
@@ -124,6 +131,13 @@ export default defineAction({
       if (!sourceAsset.mimeType.startsWith("image/")) {
         throw new Error("sourceAssetId must refer to an image asset.");
       }
+      assertCanUseAssets(
+        draftScope,
+        args.libraryId,
+        draftAccess.role,
+        [sourceAsset],
+        "This video generation",
+      );
       sourceImage = {
         id: sourceAsset.id,
         mimeType: sourceAsset.mimeType,
@@ -139,6 +153,7 @@ export default defineAction({
     const references = sourceImage
       ? []
       : await selectReferences({
+          draftScope,
           libraryId: args.libraryId,
           collectionId: args.collectionId,
           categories: [args.category],

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -3,7 +3,6 @@ import {
   getRequestOrgId,
   getRequestUserEmail,
 } from "@agent-native/core/server/request-context";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -14,6 +13,7 @@ import {
   selectReferences,
 } from "../server/lib/generation.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import {
   compileVideoPrompt,
@@ -82,7 +82,7 @@ export default defineAction({
       ...input,
       libraryId,
     };
-    await assertAccess("asset-library", args.libraryId, "editor");
+    const draftAccess = await assertCanDraft(args.libraryId);
     const db = getDb();
     const [library] = await db
       .select()
@@ -280,6 +280,9 @@ export default defineAction({
           asset,
           artifactType: "video",
           Artifacts: [`Video: ${asset.url} (ID: ${asset.id}, Run: ${runId})`],
+          // Present only when the caller cannot approve: saving this candidate
+          // into the kit needs an editor.
+          ...(draftAccess.canApprove ? {} : { draftPendingApproval: true }),
         };
       }
     }

--- a/templates/assets/actions/generate-video.ts
+++ b/templates/assets/actions/generate-video.ts
@@ -293,6 +293,9 @@ export default defineAction({
       artifactType: "video",
       message:
         "Video generation started. Call refresh-generation-run with this runId until status is completed.",
+      // The poll comes back through refresh-generation-run, so the marker has
+      // to survive the async hop too or the caller loses it at completion.
+      ...(draftAccess.canApprove ? {} : { draftPendingApproval: true }),
     };
   },
 });

--- a/templates/assets/actions/generation-preset-logo.spec.ts
+++ b/templates/assets/actions/generation-preset-logo.spec.ts
@@ -14,10 +14,12 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -35,6 +37,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({

--- a/templates/assets/actions/generation-preset-logo.spec.ts
+++ b/templates/assets/actions/generation-preset-logo.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -10,6 +13,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({
@@ -71,6 +80,7 @@ import updatePresetAction from "./update-generation-preset.js";
 describe("generation preset includeLogo option", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
   });
 

--- a/templates/assets/actions/generation-preset-logo.spec.ts
+++ b/templates/assets/actions/generation-preset-logo.spec.ts
@@ -14,11 +14,27 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("@agent-native/core/server/request-context", () => ({

--- a/templates/assets/actions/generation-preset-session-constraints.spec.ts
+++ b/templates/assets/actions/generation-preset-session-constraints.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -10,6 +13,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({
@@ -113,6 +122,7 @@ function createDb(selectRows: unknown[][]) {
 describe("generation preset/session constraints", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
   });
 

--- a/templates/assets/actions/generation-preset-session-constraints.spec.ts
+++ b/templates/assets/actions/generation-preset-session-constraints.spec.ts
@@ -14,11 +14,27 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generation-preset-session-constraints.spec.ts
+++ b/templates/assets/actions/generation-preset-session-constraints.spec.ts
@@ -14,10 +14,12 @@ vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
   resolveAccess: vi.fn(async () => ({ role: "owner" })),
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -35,6 +37,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/generation-session-access.spec.ts
+++ b/templates/assets/actions/generation-session-access.spec.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDbMock = vi.hoisted(() => vi.fn());
+const assertCanDraftAuthoredByMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/sharing", () => ({
+  resolveAccess: vi.fn(),
+}));
+
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraftAuthoredBy: assertCanDraftAuthoredByMock,
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: getDbMock,
+  schema: {
+    assetGenerationSessions: { id: "image_generation_sessions.id" },
+  },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("drizzle-orm")>()),
+  eq: vi.fn((column, value) => ({ column, value })),
+}));
+
+import { requireGenerationSessionInLibrary } from "./_helpers.js";
+
+function dbWithSession(
+  session: { id: string; libraryId: string; createdBy: string | null } | null,
+) {
+  getDbMock.mockReturnValue({
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => (session ? [session] : []) }),
+      }),
+    }),
+  });
+}
+
+describe("requireGenerationSessionInLibrary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assertCanDraftAuthoredByMock.mockResolvedValue({
+      role: "viewer",
+      canApprove: false,
+    });
+  });
+
+  it("rejects a session from another library before any access work", async () => {
+    dbWithSession({
+      id: "session-1",
+      libraryId: "lib-other",
+      createdBy: "author@example.test",
+    });
+
+    await expect(
+      requireGenerationSessionInLibrary("session-1", "lib-1"),
+    ).rejects.toThrow(/does not belong to this library/);
+    expect(assertCanDraftAuthoredByMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes a below-editor caller to the session author", async () => {
+    dbWithSession({
+      id: "session-1",
+      libraryId: "lib-1",
+      createdBy: "author@example.test",
+    });
+
+    await requireGenerationSessionInLibrary("session-1", "lib-1");
+
+    // The author check is what stops a viewer from appending candidates to
+    // someone else's handoff session and moving its active asset.
+    expect(assertCanDraftAuthoredByMock).toHaveBeenCalledWith(
+      "lib-1",
+      "author@example.test",
+      "A generation session",
+    );
+  });
+
+  it("skips the author check when the resolved access can approve", async () => {
+    dbWithSession({
+      id: "session-1",
+      libraryId: "lib-1",
+      createdBy: "author@example.test",
+    });
+
+    await requireGenerationSessionInLibrary("session-1", "lib-1", {
+      role: "editor",
+      canApprove: true,
+    });
+
+    expect(assertCanDraftAuthoredByMock).not.toHaveBeenCalled();
+  });
+});

--- a/templates/assets/actions/get-generation-run.ts
+++ b/templates/assets/actions/get-generation-run.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
+  canReadDraftAsset,
+  canReadRun,
+  resolveDraftReadScope,
+} from "../server/lib/library-access.js";
+import {
   requireLibrary,
   serializeAsset,
   serializeGenerationRun,
@@ -24,13 +29,20 @@ export default defineAction({
       .limit(1);
     if (!run) throw new Error("Generation run not found.");
     await requireLibrary(run.libraryId);
+    // Same rule as the run list: reading one by id is not a way around it.
+    const scope = await resolveDraftReadScope([run.libraryId]);
+    if (!canReadRun(scope, run)) {
+      throw new Error("Generation run not found.");
+    }
     const assets = await db
       .select()
       .from(schema.assets)
       .where(eq(schema.assets.generationRunId, runId));
     return {
       run: serializeGenerationRun(run),
-      assets: assets.map(serializeAsset),
+      assets: assets
+        .filter((asset) => canReadDraftAsset(scope, asset))
+        .map(serializeAsset),
     };
   },
 });

--- a/templates/assets/actions/get-generation-session.spec.ts
+++ b/templates/assets/actions/get-generation-session.spec.ts
@@ -15,10 +15,26 @@ const schemaMock = vi.hoisted(() => ({
   assetGenerationRuns: { id: "runs.id" },
 }));
 
+const draftScopeMock = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
+}));
+
+vi.mock("../server/lib/library-access.js", () => ({
+  // This spec covers template access; the draft rules have their own tests.
+  resolveDraftReadScope: vi.fn(async () => draftScopeMock),
+  canReadSession: vi.fn(() => true),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+}));
+
 vi.mock("@agent-native/core/action", () => ({
   defineAction: (entry: unknown) => entry,
 }));
-vi.mock("drizzle-orm", () => ({
+vi.mock("drizzle-orm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("drizzle-orm")>()),
   and: vi.fn((...conditions) => ({ op: "and", conditions })),
   asc: vi.fn((column) => ({ op: "asc", column })),
   eq: vi.fn((column, value) => ({ op: "eq", column, value })),

--- a/templates/assets/actions/get-generation-session.ts
+++ b/templates/assets/actions/get-generation-session.ts
@@ -4,6 +4,12 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
+  canReadDraftAsset,
+  canReadRun,
+  canReadSession,
+  resolveDraftReadScope,
+} from "../server/lib/library-access.js";
+import {
   requireLibrary,
   serializeAsset,
   serializeTemplate,
@@ -27,6 +33,11 @@ export default defineAction({
       .limit(1);
     if (!session) throw new Error("Generation session not found.");
     await requireLibrary(session.libraryId);
+    // Same rule as the session list: reading one by id is not a way around it.
+    const scope = await resolveDraftReadScope([session.libraryId]);
+    if (!canReadSession(scope, session)) {
+      throw new Error("Generation session not found.");
+    }
 
     const items = await db
       .select()
@@ -78,12 +89,24 @@ export default defineAction({
             .where(inArray(schema.assetGenerationRuns.id, runIds))
         : Promise.resolve([]),
     ]);
+    // A session created before the draft rule can still reference candidates
+    // and runs the caller does not own; they stay out of the payload.
+    const visibleAssets = assets.filter((asset) =>
+      canReadDraftAsset(scope, asset),
+    );
+    const visibleRuns = runs.filter((run) => canReadRun(scope, run));
+    const visibleAssetIds = new Set(visibleAssets.map((asset) => asset.id));
+    const visibleRunIds = new Set(visibleRuns.map((run) => run.id));
     return {
       session: serializeGenerationSession(session),
       preset: presetRows[0] ? serializeTemplate(presetRows[0]) : null,
-      items,
-      assets: assets.map(serializeAsset),
-      runs: runs.map(serializeGenerationRun),
+      items: items.filter(
+        (item) =>
+          (!item.assetId || visibleAssetIds.has(item.assetId)) &&
+          (!item.generationRunId || visibleRunIds.has(item.generationRunId)),
+      ),
+      assets: visibleAssets.map(serializeAsset),
+      runs: visibleRuns.map(serializeGenerationRun),
     };
   },
 });

--- a/templates/assets/actions/get-library-access.ts
+++ b/templates/assets/actions/get-library-access.ts
@@ -1,0 +1,29 @@
+import { defineAction } from "@agent-native/core/action";
+import { roleSatisfies } from "@agent-native/core/sharing";
+import { z } from "zod";
+
+import {
+  APPROVE_ROLE,
+  DRAFT_ROLE,
+  assertCanDraft,
+} from "../server/lib/library-access.js";
+
+export default defineAction({
+  description:
+    "Report what the current user may do in a brand kit: draft generations, or also approve them by saving into the kit. Call this before offering to save a candidate.",
+  schema: z.object({
+    libraryId: z.string().describe("Brand kit (asset library) ID"),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ libraryId }) => {
+    const access = await assertCanDraft(libraryId);
+    return {
+      libraryId,
+      role: access.role,
+      canDraft: roleSatisfies(access.role, DRAFT_ROLE),
+      canApprove: access.canApprove,
+      approveRole: APPROVE_ROLE,
+    };
+  },
+});

--- a/templates/assets/actions/get-library.ts
+++ b/templates/assets/actions/get-library.ts
@@ -1,8 +1,16 @@
 import { defineAction } from "@agent-native/core/action";
+import { roleSatisfies } from "@agent-native/core/sharing";
 import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  APPROVE_ROLE,
+  canReadDraftAsset,
+  canReadRun,
+  resolveDraftReadScope,
+  unrestrictedDraftReadScope,
+} from "../server/lib/library-access.js";
 import {
   requireLibraryAccess,
   serializeAssets,
@@ -42,12 +50,21 @@ export default defineAction({
         .where(eq(schema.assetGenerationRuns.libraryId, id))
         .orderBy(desc(schema.assetGenerationRuns.createdAt)),
     ]);
+    // Drafts belong to whoever generated them until an editor approves one, so
+    // a below-editor caller sees their own candidates and runs, not the kit's.
+    const scope = roleSatisfies(access.role, APPROVE_ROLE)
+      ? unrestrictedDraftReadScope()
+      : await resolveDraftReadScope([id]);
     return {
       library: serializeLibrary({ ...library, accessRole: access.role }),
       collections,
       folders,
-      assets: serializeAssets(assets),
-      runs: runs.map(serializeGenerationRun),
+      assets: serializeAssets(
+        assets.filter((asset) => canReadDraftAsset(scope, asset)),
+      ),
+      runs: runs
+        .filter((run) => canReadRun(scope, run))
+        .map(serializeGenerationRun),
     };
   },
 });

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -7,6 +7,9 @@ const createAssetFromBufferMock = vi.hoisted(() => vi.fn());
 const getDbMock = vi.hoisted(() => vi.fn());
 const serializeAssetMock = vi.hoisted(() => vi.fn((row: unknown) => row));
 const ssrfSafeFetchMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -18,6 +21,12 @@ vi.mock("@agent-native/core/extensions/url-safety", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -113,6 +122,7 @@ const pngContentHash = () =>
 describe("import-asset-from-url", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
     // Fresh Response per call — a Response body stream can only be read once.
     ssrfSafeFetchMock.mockImplementation(async () =>
@@ -145,11 +155,8 @@ describe("import-asset-from-url", () => {
       description: "Imported from the launch post.",
     });
 
-    expect(assertAccessMock).toHaveBeenCalledWith(
-      "asset-library",
-      "lib-1",
-      "editor",
-    );
+    // Importing adds kit content, so it stays approving-class.
+    expect(libraryAccessMock).toHaveBeenCalledWith("lib-1", expect.any(String));
     expect(ssrfSafeFetchMock).toHaveBeenCalledWith(
       "https://cdn.example.test/blog-hero.png",
       { signal: expect.any(AbortSignal) },
@@ -258,7 +265,7 @@ describe("import-asset-from-url", () => {
   });
 
   it("rejects callers without editor access", async () => {
-    assertAccessMock.mockRejectedValue(new Error("No access"));
+    libraryAccessMock.mockRejectedValue(new Error("No access"));
 
     await expect(
       action.run({

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -22,10 +22,12 @@ vi.mock("@agent-native/core/extensions/url-safety", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -43,6 +45,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/import-asset-from-url.spec.ts
+++ b/templates/assets/actions/import-asset-from-url.spec.ts
@@ -22,11 +22,27 @@ vi.mock("@agent-native/core/extensions/url-safety", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/import-asset-from-url.ts
+++ b/templates/assets/actions/import-asset-from-url.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
 import { ssrfSafeFetch } from "@agent-native/core/extensions/url-safety";
-import { assertAccess } from "@agent-native/core/sharing";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { createAssetFromBuffer } from "../server/lib/assets.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { getObject } from "../server/lib/storage.js";
 import {
   filterDuplicateAssetUploads,
@@ -278,7 +278,7 @@ export default defineAction({
     // null so it can't skip membership validation yet still land in the row.
     const collectionId = args.collectionId || null;
     const folderId = args.folderId || null;
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Importing an asset");
     validateHttpsUrl(url);
     if (collectionId) {
       await assertCollectionBelongsToLibrary(collectionId, libraryId);

--- a/templates/assets/actions/import-style-from-url.spec.ts
+++ b/templates/assets/actions/import-style-from-url.spec.ts
@@ -25,10 +25,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -46,6 +48,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/import-style-from-url.spec.ts
+++ b/templates/assets/actions/import-style-from-url.spec.ts
@@ -25,11 +25,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({

--- a/templates/assets/actions/import-style-from-url.spec.ts
+++ b/templates/assets/actions/import-style-from-url.spec.ts
@@ -14,6 +14,9 @@ const schemaMock = vi.hoisted(() => ({
     id: "assetCollections.id",
   },
 }));
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -21,6 +24,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("@agent-native/creative-context/server", () => ({
@@ -88,6 +97,7 @@ function createDb({
 describe("import-style-from-url", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     updateSetCalls.length = 0;
     assertAccessMock.mockResolvedValue(undefined);
     extractRenderedDesignSystemFromUrlMock.mockResolvedValue({

--- a/templates/assets/actions/import-style-from-url.ts
+++ b/templates/assets/actions/import-style-from-url.ts
@@ -1,5 +1,4 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import {
   extractRenderedDesignSystemFromUrl,
   styleBriefFromRenderedDesign,
@@ -9,6 +8,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import type { StyleBrief } from "../shared/api.js";
 
 /**
@@ -33,7 +33,7 @@ export default defineAction({
     url: z.string().describe("Public website URL to render and analyze"),
   }),
   run: async ({ libraryId, collectionId, url }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Importing a style");
     const db = getDb();
     const [library] = await db
       .select()

--- a/templates/assets/actions/list-assets.ts
+++ b/templates/assets/actions/list-assets.ts
@@ -4,6 +4,11 @@ import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  canReadDraftAsset,
+  resolveDraftReadScope,
+  unrestrictedDraftReadScope,
+} from "../server/lib/library-access.js";
 import { ASSET_MEDIA_TYPES, IMAGE_CATEGORIES } from "../shared/api.js";
 import {
   assetMatchesSearch,
@@ -120,15 +125,18 @@ export default defineAction({
         ),
     ]);
     const lineageById = buildAssetLineage(lineageRows);
+    const candidatesRequested =
+      includeCandidates || status === "candidate" || candidateRunIdSet.size > 0;
+    // Drafts are the author's until approved, so a candidate-bearing read
+    // narrows to this caller's own. Plain asset reads pay no lookup.
+    const scope = candidatesRequested
+      ? await resolveDraftReadScope(libraryIds)
+      : unrestrictedDraftReadScope();
     const assets = rows
       .filter((asset) =>
-        shouldIncludeAssetInLibraryResults(
-          asset,
-          includeCandidates ||
-            status === "candidate" ||
-            candidateRunIdSet.size > 0,
-        ),
+        shouldIncludeAssetInLibraryResults(asset, candidatesRequested),
       )
+      .filter((asset) => canReadDraftAsset(scope, asset))
       .filter((asset) => {
         if (!candidateRunIdSet.size) return true;
         if (!(asset.role === "generated" && asset.status === "candidate")) {

--- a/templates/assets/actions/list-draft-assets.ts
+++ b/templates/assets/actions/list-draft-assets.ts
@@ -4,6 +4,10 @@ import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  canReadDraftAsset,
+  resolveDraftReadScope,
+} from "../server/lib/library-access.js";
 import { serializeAsset } from "./_helpers.js";
 
 export default defineAction({
@@ -29,6 +33,9 @@ export default defineAction({
     const libraryIds = accessibleLibraries.map((row) => row.id);
     if (!libraryIds.length) return { count: 0, assets: [] };
 
+    // Every row here is a draft, so the whole result narrows to the drafts this
+    // caller generated plus the kits where they could approve one.
+    const scope = await resolveDraftReadScope(libraryIds);
     const rows = await db
       .select()
       .from(schema.assets)
@@ -41,10 +48,11 @@ export default defineAction({
       )
       .orderBy(desc(schema.assets.createdAt))
       .limit(limit ?? 50);
+    const visible = rows.filter((row) => canReadDraftAsset(scope, row));
 
     return {
-      count: rows.length,
-      assets: rows.map((row) => serializeAsset(row)),
+      count: visible.length,
+      assets: visible.map((row) => serializeAsset(row)),
     };
   },
 });

--- a/templates/assets/actions/list-draft-assets.ts
+++ b/templates/assets/actions/list-draft-assets.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import {
-  canReadDraftAsset,
+  draftReadFilter,
   resolveDraftReadScope,
 } from "../server/lib/library-access.js";
 import { serializeAsset } from "./_helpers.js";
@@ -34,8 +34,11 @@ export default defineAction({
     if (!libraryIds.length) return { count: 0, assets: [] };
 
     // Every row here is a draft, so the whole result narrows to the drafts this
-    // caller generated plus the kits where they could approve one.
+    // caller generated plus the kits where they could approve one. The narrowing
+    // is a WHERE clause, not a post-filter: paging first would drop the caller's
+    // own older drafts behind other people's newer ones.
     const scope = await resolveDraftReadScope(libraryIds);
+    const draftFilter = draftReadFilter(scope, schema.assets);
     const rows = await db
       .select()
       .from(schema.assets)
@@ -44,15 +47,15 @@ export default defineAction({
           inArray(schema.assets.libraryId, libraryIds),
           eq(schema.assets.role, "generated"),
           eq(schema.assets.status, "candidate"),
+          ...(draftFilter ? [draftFilter] : []),
         ),
       )
       .orderBy(desc(schema.assets.createdAt))
       .limit(limit ?? 50);
-    const visible = rows.filter((row) => canReadDraftAsset(scope, row));
 
     return {
-      count: visible.length,
-      assets: visible.map((row) => serializeAsset(row)),
+      count: rows.length,
+      assets: rows.map((row) => serializeAsset(row)),
     };
   },
 });

--- a/templates/assets/actions/list-generation-runs.ts
+++ b/templates/assets/actions/list-generation-runs.ts
@@ -3,6 +3,10 @@ import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  resolveDraftReadScope,
+  runReadFilter,
+} from "../server/lib/library-access.js";
 import { requireLibrary, serializeGenerationRun } from "./_helpers.js";
 
 export default defineAction({
@@ -16,7 +20,14 @@ export default defineAction({
   readOnly: true,
   run: async ({ libraryId, sessionId, presetId }) => {
     await requireLibrary(libraryId);
-    const filters = [eq(schema.assetGenerationRuns.libraryId, libraryId)];
+    // Runs carry the prompt, settings, and outputs behind a draft, so a
+    // below-approver caller sees their own history, not the kit's.
+    const scope = await resolveDraftReadScope([libraryId]);
+    const runFilter = runReadFilter(scope, schema.assetGenerationRuns);
+    const filters = [
+      eq(schema.assetGenerationRuns.libraryId, libraryId),
+      ...(runFilter ? [runFilter] : []),
+    ];
     if (sessionId)
       filters.push(eq(schema.assetGenerationRuns.sessionId, sessionId));
     if (presetId)

--- a/templates/assets/actions/list-generation-sessions.ts
+++ b/templates/assets/actions/list-generation-sessions.ts
@@ -3,6 +3,11 @@ import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  canReadDraftAsset,
+  resolveDraftReadScope,
+  sessionReadFilter,
+} from "../server/lib/library-access.js";
 import { GENERATION_SESSION_STATUSES } from "../shared/api.js";
 import {
   buildAssetLineage,
@@ -23,7 +28,17 @@ export default defineAction({
   readOnly: true,
   run: async ({ libraryId, status, limit }) => {
     await requireLibrary(libraryId);
-    const filters = [eq(schema.assetGenerationSessions.libraryId, libraryId)];
+    // A session holds a brief, feedback, and references to candidates, so a
+    // below-approver caller lists the sessions they created, not the kit's.
+    const scope = await resolveDraftReadScope([libraryId]);
+    const sessionFilter = sessionReadFilter(
+      scope,
+      schema.assetGenerationSessions,
+    );
+    const filters = [
+      eq(schema.assetGenerationSessions.libraryId, libraryId),
+      ...(sessionFilter ? [sessionFilter] : []),
+    ];
     if (status) filters.push(eq(schema.assetGenerationSessions.status, status));
     const db = getDb();
     const sessions = await db
@@ -52,12 +67,14 @@ export default defineAction({
           .filter((assetId): assetId is string => Boolean(assetId)),
       ),
     ];
-    const assetRows = itemAssetIds.length
-      ? await db
-          .select()
-          .from(schema.assets)
-          .where(inArray(schema.assets.id, itemAssetIds))
-      : [];
+    const assetRows = (
+      itemAssetIds.length
+        ? await db
+            .select()
+            .from(schema.assets)
+            .where(inArray(schema.assets.id, itemAssetIds))
+        : []
+    ).filter((asset) => canReadDraftAsset(scope, asset));
     const lineageById = buildAssetLineage(assetRows);
     const itemsBySessionId = new Map<string, typeof items>();
     for (const item of items) {

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -15,6 +15,9 @@ const schemaMock = vi.hoisted(() => ({
     generationRunId: "assets.generationRunId",
   },
 }));
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -22,6 +25,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -101,6 +110,7 @@ function createDb({
 describe("refresh-generation-run", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     updateSetCalls.length = 0;
     assertAccessMock.mockResolvedValue(undefined);
     upsertVariantSlotMock.mockResolvedValue(undefined);

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -26,10 +26,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -47,6 +49,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -26,11 +26,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/refresh-generation-run.spec.ts
+++ b/templates/assets/actions/refresh-generation-run.spec.ts
@@ -126,6 +126,7 @@ describe("refresh-generation-run", () => {
         run: {
           id: "run-1",
           libraryId: "library-1",
+          ownerEmail: "author@example.test",
           collectionId: null,
           presetId: null,
           sessionId: null,
@@ -148,6 +149,13 @@ describe("refresh-generation-run", () => {
     vi.setSystemTime(new Date("2026-05-28T12:00:00.000Z"));
 
     const result = await action.run({ runId: "run-1" });
+
+    // Refreshing mutates the run row, so it is scoped to the run's author.
+    expect(libraryAccessMock).toHaveBeenCalledWith(
+      "library-1",
+      "author@example.test",
+      "A generation run",
+    );
 
     expect(result.run.status).toBe("failed");
     expect(updateSetCalls[0]).toEqual(

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { notifyGenerationRunFinished } from "../server/lib/generation-run-notifications.js";
 import { nowIso, parseJson } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
 import { serializeAsset, serializeGenerationRun } from "./_helpers.js";
 import { upsertVariantSlot } from "./variant-slots.js";
@@ -142,7 +142,7 @@ export default defineAction({
       .where(eq(schema.assetGenerationRuns.id, runId))
       .limit(1);
     if (!run) throw new Error("Generation run not found.");
-    await assertAccess("asset-library", run.libraryId, "editor");
+    await assertCanDraft(run.libraryId);
     if ((run.mediaType ?? "image") !== "video") {
       const refreshed = await refreshImageRun(run);
       return {

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { notifyGenerationRunFinished } from "../server/lib/generation-run-notifications.js";
 import { nowIso, parseJson } from "../server/lib/json.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import { assertCanDraftAuthoredBy } from "../server/lib/library-access.js";
 import { completeVideoGenerationRun } from "../server/lib/video-runs.js";
 import { serializeAsset, serializeGenerationRun } from "./_helpers.js";
 import { upsertVariantSlot } from "./variant-slots.js";
@@ -142,7 +142,13 @@ export default defineAction({
       .where(eq(schema.assetGenerationRuns.id, runId))
       .limit(1);
     if (!run) throw new Error("Generation run not found.");
-    await assertCanDraft(run.libraryId);
+    // Reconciling mutates the run row (status, error, outputs), so a
+    // below-editor caller may only refresh a run they started.
+    await assertCanDraftAuthoredBy(
+      run.libraryId,
+      run.ownerEmail,
+      "A generation run",
+    );
     if ((run.mediaType ?? "image") !== "video") {
       const refreshed = await refreshImageRun(run);
       return {

--- a/templates/assets/actions/refresh-generation-run.ts
+++ b/templates/assets/actions/refresh-generation-run.ts
@@ -144,16 +144,22 @@ export default defineAction({
     if (!run) throw new Error("Generation run not found.");
     // Reconciling mutates the run row (status, error, outputs), so a
     // below-editor caller may only refresh a run they started.
-    await assertCanDraftAuthoredBy(
+    const draftAccess = await assertCanDraftAuthoredBy(
       run.libraryId,
       run.ownerEmail,
       "A generation run",
     );
+    // Reconciliation is where an async candidate finally becomes readable, so
+    // it is the last place the caller can learn it still needs an editor.
+    const approval = draftAccess.canApprove
+      ? {}
+      : { draftPendingApproval: true };
     if ((run.mediaType ?? "image") !== "video") {
       const refreshed = await refreshImageRun(run);
       return {
         run: serializeGenerationRun(refreshed.run),
         assets: refreshed.assets.map(serializeAsset),
+        ...approval,
       };
     }
     if (run.status === "completed" || run.status === "failed") {
@@ -164,6 +170,7 @@ export default defineAction({
       return {
         run: serializeGenerationRun(run),
         assets: assets.map(serializeAsset),
+        ...approval,
       };
     }
     const refreshed = await completeVideoGenerationRun(run);
@@ -173,6 +180,7 @@ export default defineAction({
         refreshed.status === "completed"
           ? [serializeAsset(refreshed.asset)]
           : [],
+      ...approval,
     };
   },
 });

--- a/templates/assets/actions/rerun-generation-run.spec.ts
+++ b/templates/assets/actions/rerun-generation-run.spec.ts
@@ -58,6 +58,7 @@ describe("rerun-generation-run template access", () => {
               {
                 id: "run-1",
                 libraryId: "kit-1",
+                ownerEmail: "author@example.test",
                 presetId: "private-global-template",
                 sessionId: null,
                 prompt: "Generate",
@@ -89,5 +90,22 @@ describe("rerun-generation-run template access", () => {
       "viewer",
     );
     expect(generateImageRunMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes a rerun to the source run's author", async () => {
+    resolveTemplateAccessMock.mockRejectedValue(
+      new Error("Template not found or not accessible."),
+    );
+
+    await expect(action.run({ runId: "run-1", source: "ui" })).rejects.toThrow(
+      "not accessible",
+    );
+
+    // A rerun reuses another caller's prompt, settings, and session.
+    expect(libraryAccessMock).toHaveBeenCalledWith(
+      "kit-1",
+      "author@example.test",
+      "A generation run",
+    );
   });
 });

--- a/templates/assets/actions/rerun-generation-run.spec.ts
+++ b/templates/assets/actions/rerun-generation-run.spec.ts
@@ -14,11 +14,27 @@ vi.mock("@agent-native/core/action", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column, value) => ({ column, value })),

--- a/templates/assets/actions/rerun-generation-run.spec.ts
+++ b/templates/assets/actions/rerun-generation-run.spec.ts
@@ -4,12 +4,21 @@ const getDbMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
 const resolveTemplateAccessMock = vi.hoisted(() => vi.fn());
 const generateImageRunMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core/action", () => ({
   defineAction: (entry: unknown) => entry,
 }));
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column, value) => ({ column, value })),
@@ -39,6 +48,7 @@ import action from "./rerun-generation-run.js";
 describe("rerun-generation-run template access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
     getDbMock.mockReturnValue({
       select: vi.fn(() => ({

--- a/templates/assets/actions/rerun-generation-run.spec.ts
+++ b/templates/assets/actions/rerun-generation-run.spec.ts
@@ -14,10 +14,12 @@ vi.mock("@agent-native/core/action", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -35,6 +37,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((column, value) => ({ column, value })),

--- a/templates/assets/actions/rerun-generation-run.ts
+++ b/templates/assets/actions/rerun-generation-run.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { parseJson } from "../server/lib/json.js";
-import { assertCanDraft } from "../server/lib/library-access.js";
+import { assertCanDraftAuthoredBy } from "../server/lib/library-access.js";
 import { normalizePresetReferences } from "../server/lib/preset-references.js";
 import { requireGenerationSessionInLibrary } from "./_helpers.js";
 import { resolveTemplateAccess } from "./_template-access.js";
@@ -44,10 +44,20 @@ export default defineAction({
       .where(eq(schema.assetGenerationRuns.id, runId))
       .limit(1);
     if (!run) throw new Error("Generation run not found.");
-    await assertCanDraft(run.libraryId);
+    // A rerun reuses the source run's prompt, settings, and session, so a
+    // below-editor caller may only rerun their own.
+    const draftAccess = await assertCanDraftAuthoredBy(
+      run.libraryId,
+      run.ownerEmail,
+      "A generation run",
+    );
     const resolvedSessionId = sessionId ?? run.sessionId ?? undefined;
     if (resolvedSessionId) {
-      await requireGenerationSessionInLibrary(resolvedSessionId, run.libraryId);
+      await requireGenerationSessionInLibrary(
+        resolvedSessionId,
+        run.libraryId,
+        draftAccess,
+      );
     }
 
     const metadata = parseJson<{

--- a/templates/assets/actions/rerun-generation-run.ts
+++ b/templates/assets/actions/rerun-generation-run.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
 import type { ActionRunContext } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { parseJson } from "../server/lib/json.js";
+import { assertCanDraft } from "../server/lib/library-access.js";
 import { normalizePresetReferences } from "../server/lib/preset-references.js";
 import { requireGenerationSessionInLibrary } from "./_helpers.js";
 import { resolveTemplateAccess } from "./_template-access.js";
@@ -44,7 +44,7 @@ export default defineAction({
       .where(eq(schema.assetGenerationRuns.id, runId))
       .limit(1);
     if (!run) throw new Error("Generation run not found.");
-    await assertAccess("asset-library", run.libraryId, "editor");
+    await assertCanDraft(run.libraryId);
     const resolvedSessionId = sessionId ?? run.sessionId ?? undefined;
     if (resolvedSessionId) {
       await requireGenerationSessionInLibrary(resolvedSessionId, run.libraryId);

--- a/templates/assets/actions/search-assets.ts
+++ b/templates/assets/actions/search-assets.ts
@@ -4,6 +4,11 @@ import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
+import {
+  canReadDraftAsset,
+  resolveDraftReadScope,
+  unrestrictedDraftReadScope,
+} from "../server/lib/library-access.js";
 import { ASSET_MEDIA_TYPES, IMAGE_CATEGORIES } from "../shared/api.js";
 import {
   assetMatchesSearch,
@@ -69,10 +74,16 @@ export default defineAction({
     ]);
     const lineageById = buildAssetLineage(lineageRows);
 
+    // Candidate rows are drafts; the scope only costs a lookup when the caller
+    // actually asked for them.
+    const scope = includeCandidates
+      ? await resolveDraftReadScope(libraryIds)
+      : unrestrictedDraftReadScope();
     const assets = rows
       .filter((asset) =>
         shouldIncludeAssetInLibraryResults(asset, includeCandidates),
       )
+      .filter((asset) => canReadDraftAsset(scope, asset))
       .filter((asset) => assetMatchesSearch(asset, normalizedQuery, category))
       .slice(0, limit)
       .map((asset) => serializeAsset(asset, lineageById.get(asset.id) ?? null));

--- a/templates/assets/actions/set-canonical-logo.ts
+++ b/templates/assets/actions/set-canonical-logo.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { getAssetOrThrow, serializeLibrary } from "./_helpers.js";
 
 /**
@@ -21,7 +21,7 @@ export default defineAction({
     assetId: z.string(),
   }),
   run: async ({ libraryId, assetId }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Setting the canonical logo");
     const asset = await getAssetOrThrow(assetId);
     if (asset.libraryId !== libraryId) {
       throw new Error("Asset does not belong to this library.");

--- a/templates/assets/actions/update-asset.ts
+++ b/templates/assets/actions/update-asset.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { IMAGE_CATEGORIES } from "../shared/api.js";
 import { getAssetOrThrow, serializeAsset } from "./_helpers.js";
 
@@ -41,7 +41,7 @@ export default defineAction({
   }),
   run: async ({ id, category, isStyleAnchor, ...args }) => {
     const asset = await getAssetOrThrow(id);
-    await assertAccess("asset-library", asset.libraryId, "editor");
+    await assertCanApprove(asset.libraryId, "Updating an asset");
     if (args.folderId !== undefined && args.folderId !== null) {
       const [folder] = await getDb()
         .select()

--- a/templates/assets/actions/update-collection.ts
+++ b/templates/assets/actions/update-collection.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { ASPECT_RATIOS, IMAGE_CATEGORIES, IMAGE_SIZES } from "../shared/api.js";
 
 export default defineAction({
@@ -20,7 +20,7 @@ export default defineAction({
     styleBrief: z.record(z.string(), z.unknown()).optional(),
   }),
   run: async ({ id, libraryId, ...args }) => {
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Updating a collection");
     const updates: Record<string, unknown> = { updatedAt: nowIso() };
     if (args.title !== undefined) updates.title = args.title;
     if (args.description !== undefined) updates.description = args.description;

--- a/templates/assets/actions/update-folder.spec.ts
+++ b/templates/assets/actions/update-folder.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -9,6 +12,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -48,6 +57,7 @@ function createDb(rows: unknown[][]) {
 describe("update-folder", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
   });
 

--- a/templates/assets/actions/update-folder.spec.ts
+++ b/templates/assets/actions/update-folder.spec.ts
@@ -13,10 +13,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -34,6 +36,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/update-folder.spec.ts
+++ b/templates/assets/actions/update-folder.spec.ts
@@ -13,11 +13,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/update-folder.ts
+++ b/templates/assets/actions/update-folder.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 
 async function assertParentIsNotDescendant(
   db: ReturnType<typeof getDb>,
@@ -51,7 +51,7 @@ export default defineAction({
       .where(eq(schema.assetFolders.id, id))
       .limit(1);
     if (!folder) throw new Error("Folder not found.");
-    await assertAccess("asset-library", folder.libraryId, "editor");
+    await assertCanApprove(folder.libraryId, "Updating a folder");
     if (args.parentId) {
       if (args.parentId === id) {
         throw new Error("A folder cannot be moved into itself.");

--- a/templates/assets/actions/update-generation-session.spec.ts
+++ b/templates/assets/actions/update-generation-session.spec.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getDbMock = vi.hoisted(() => vi.fn());
 const assertAccessMock = vi.hoisted(() => vi.fn());
+const libraryAccessMock = vi.hoisted(() =>
+  vi.fn(async () => ({ role: "owner", canApprove: true })),
+);
 
 vi.mock("@agent-native/core", () => ({
   defineAction: (entry: unknown) => entry,
@@ -9,6 +12,12 @@ vi.mock("@agent-native/core", () => ({
 
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
+}));
+vi.mock("../server/lib/library-access.js", () => ({
+  assertCanDraft: libraryAccessMock,
+  assertCanApprove: libraryAccessMock,
+  assertCanDraftAuthoredBy: libraryAccessMock,
+  assertCanDeleteAsset: libraryAccessMock,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -106,6 +115,7 @@ function createDb(selectRows: unknown[][]) {
 describe("update-generation-session", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    libraryAccessMock.mockResolvedValue({ role: "owner", canApprove: true });
     assertAccessMock.mockResolvedValue(undefined);
   });
 

--- a/templates/assets/actions/update-generation-session.spec.ts
+++ b/templates/assets/actions/update-generation-session.spec.ts
@@ -13,10 +13,12 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const deleteDraftMock = vi.hoisted(() => vi.fn(async () => true));
 const unrestrictedScope = vi.hoisted(() => ({
   unrestricted: true,
   approvableLibraryIds: new Set<string>(),
   ownRunIds: new Set<string>(),
+  callerEmail: "viewer@example.test",
 }));
 
 vi.mock("../server/lib/library-access.js", () => ({
@@ -34,6 +36,10 @@ vi.mock("../server/lib/library-access.js", () => ({
   canReadDraftAsset: vi.fn(() => true),
   canReadRun: vi.fn(() => true),
   draftReadFilter: vi.fn(() => undefined),
+  runReadFilter: vi.fn(() => undefined),
+  sessionReadFilter: vi.fn(() => undefined),
+  canReadSession: vi.fn(() => true),
+  deleteDraftAssetIfUnchanged: deleteDraftMock,
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/update-generation-session.spec.ts
+++ b/templates/assets/actions/update-generation-session.spec.ts
@@ -13,11 +13,27 @@ vi.mock("@agent-native/core", () => ({
 vi.mock("@agent-native/core/sharing", () => ({
   assertAccess: assertAccessMock,
 }));
+const unrestrictedScope = vi.hoisted(() => ({
+  unrestricted: true,
+  approvableLibraryIds: new Set<string>(),
+  ownRunIds: new Set<string>(),
+}));
+
 vi.mock("../server/lib/library-access.js", () => ({
   assertCanDraft: libraryAccessMock,
   assertCanApprove: libraryAccessMock,
   assertCanDraftAuthoredBy: libraryAccessMock,
   assertCanDeleteAsset: libraryAccessMock,
+  // The draft-input guards have their own tests; these specs exercise the
+  // surrounding behavior with an approver's unrestricted scope.
+  draftScopeForLibrary: vi.fn(async () => unrestrictedScope),
+  resolveDraftReadScope: vi.fn(async () => unrestrictedScope),
+  unrestrictedDraftReadScope: vi.fn(() => unrestrictedScope),
+  assertCanUseAssets: vi.fn(),
+  assertCanUseRuns: vi.fn(),
+  canReadDraftAsset: vi.fn(() => true),
+  canReadRun: vi.fn(() => true),
+  draftReadFilter: vi.fn(() => undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/templates/assets/actions/update-generation-session.ts
+++ b/templates/assets/actions/update-generation-session.ts
@@ -1,11 +1,11 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanDraftAuthoredBy } from "../server/lib/library-access.js";
 import { GENERATION_SESSION_STATUSES } from "../shared/api.js";
 import { serializeGenerationSession } from "./_helpers.js";
 
@@ -41,7 +41,11 @@ export default defineAction({
       .where(eq(schema.assetGenerationSessions.id, id))
       .limit(1);
     if (!session) throw new Error("Generation session not found.");
-    await assertAccess("asset-library", session.libraryId, "editor");
+    await assertCanDraftAuthoredBy(
+      session.libraryId,
+      session.createdBy,
+      "A generation session",
+    );
     const now = nowIso();
     if (args.activeAssetId === "") {
       throw new Error("activeAssetId must be a valid asset id or null.");

--- a/templates/assets/actions/update-generation-session.ts
+++ b/templates/assets/actions/update-generation-session.ts
@@ -5,7 +5,12 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
-import { assertCanDraftAuthoredBy } from "../server/lib/library-access.js";
+import {
+  assertCanDraftAuthoredBy,
+  assertCanUseAssets,
+  assertCanUseRuns,
+  draftScopeForLibrary,
+} from "../server/lib/library-access.js";
 import { GENERATION_SESSION_STATUSES } from "../shared/api.js";
 import { serializeGenerationSession } from "./_helpers.js";
 
@@ -41,10 +46,16 @@ export default defineAction({
       .where(eq(schema.assetGenerationSessions.id, id))
       .limit(1);
     if (!session) throw new Error("Generation session not found.");
-    await assertCanDraftAuthoredBy(
+    const draftAccess = await assertCanDraftAuthoredBy(
       session.libraryId,
       session.createdBy,
       "A generation session",
+    );
+    // Own session, still not a licence to attach someone else's draft: session
+    // items are republished through the session read path.
+    const draftScope = await draftScopeForLibrary(
+      session.libraryId,
+      draftAccess,
     );
     const now = nowIso();
     if (args.activeAssetId === "") {
@@ -104,7 +115,13 @@ export default defineAction({
 
     if (assetIdsToValidate.length) {
       const assets = await db
-        .select({ id: schema.assets.id, libraryId: schema.assets.libraryId })
+        .select({
+          id: schema.assets.id,
+          libraryId: schema.assets.libraryId,
+          role: schema.assets.role,
+          status: schema.assets.status,
+          generationRunId: schema.assets.generationRunId,
+        })
         .from(schema.assets)
         .where(inArray(schema.assets.id, assetIdsToValidate));
       const foundIds = new Set(assets.map((asset) => asset.id));
@@ -116,6 +133,13 @@ export default defineAction({
           throw new Error(`Asset ${assetId} was not found.`);
         }
       }
+      assertCanUseAssets(
+        draftScope,
+        session.libraryId,
+        draftAccess.role,
+        assets,
+        "A generation session",
+      );
     }
 
     if (runIdsToValidate.length) {
@@ -137,6 +161,13 @@ export default defineAction({
           throw new Error(`Generation run ${runId} was not found.`);
         }
       }
+      assertCanUseRuns(
+        draftScope,
+        session.libraryId,
+        draftAccess.role,
+        runs,
+        "A generation session",
+      );
     }
 
     const updates: Record<string, unknown> = { updatedAt: now };

--- a/templates/assets/actions/update-library.ts
+++ b/templates/assets/actions/update-library.ts
@@ -1,10 +1,10 @@
 import { defineAction } from "@agent-native/core/action";
-import { assertAccess } from "@agent-native/core/sharing";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { nowIso, parseJson, stringifyJson } from "../server/lib/json.js";
+import { assertCanApprove } from "../server/lib/library-access.js";
 import { ASPECT_RATIOS, IMAGE_MODELS, IMAGE_SIZES } from "../shared/api.js";
 
 async function assertAssetBelongsToLibrary(
@@ -54,7 +54,7 @@ export default defineAction({
     coverAssetId,
     canonicalLogoAssetId,
   }) => {
-    await assertAccess("asset-library", id, "editor");
+    await assertCanApprove(id, "Editing brand kit settings");
     const updates: Record<string, unknown> = { updatedAt: nowIso() };
     if (title !== undefined) updates.title = title;
     if (description !== undefined) updates.description = description;

--- a/templates/assets/app/components/generation/GenerationResults.tsx
+++ b/templates/assets/app/components/generation/GenerationResults.tsx
@@ -110,6 +110,15 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
   const { data: librariesData } = useActionQuery("list-libraries", {
     compact: true,
   } as any) as { data?: LibraryListResult };
+  // Saving a candidate into the kit needs editor access, while generating it
+  // only needs read access, so the tray asks before offering Save at all
+  // rather than letting the button 403.
+  const { data: libraryAccess } = useActionQuery(
+    "get-library-access",
+    { libraryId: variants?.libraryId } as any,
+    { enabled: Boolean(variants?.libraryId) },
+  ) as { data?: { canApprove?: boolean } };
+  const canApprove = libraryAccess?.canApprove === true;
   const saveGenerated = useActionMutation("save-generated-image");
   const dismissSlot = useActionMutation("dismiss-variant-slots");
   const refreshGeneration = useActionMutation("refresh-generation-run");
@@ -342,7 +351,11 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
           if (!open) setPreviewSlotId(null);
         }}
         onSelect={setPreviewSlotId}
-        onSave={(slot) => saveSlot(slot, () => setPreviewSlotId(null))}
+        onSave={
+          canApprove
+            ? (slot) => saveSlot(slot, () => setPreviewSlotId(null))
+            : undefined
+        }
         onRefine={(slot, variantNumber) => {
           refineSlot(slot, variantNumber);
           setPreviewSlotId(null);
@@ -371,6 +384,20 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
                   <Badge variant="secondary" className="shrink-0">
                     {statusSummary}
                   </Badge>
+                  {libraryAccess && !canApprove ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge variant="outline" className="shrink-0">
+                            {t("library.draftsOnly")}
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {t("library.draftsOnlyHint")}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : null}
                 </div>
                 <p className="mt-0.5 truncate text-xs text-muted-foreground">
                   {libraryTitle || t("library.noBrandKit")} / {variants.prompt}
@@ -406,7 +433,7 @@ export function GenerationResults({ threadId }: { threadId: string | null }) {
                     isSaving={saveGenerated.isPending}
                     isDismissing={dismissSlot.isPending}
                     onPreview={() => setPreviewSlotId(slot.slotId)}
-                    onSave={() => saveSlot(slot)}
+                    onSave={canApprove ? () => saveSlot(slot) : undefined}
                     onRefine={() => refineSlot(slot, variantNumber)}
                     onDismiss={() => dismissSlotById(slot)}
                   />
@@ -455,7 +482,7 @@ function GenerationDraftCard({
   isSaving: boolean;
   isDismissing: boolean;
   onPreview: () => void;
-  onSave: () => void;
+  onSave?: () => void;
   onRefine: () => void;
   onDismiss: () => void;
 }) {
@@ -495,27 +522,29 @@ function GenerationDraftCard({
         {ready ? (
           <TooltipProvider>
             <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5 opacity-0 transition group-hover:opacity-100 focus-within:opacity-100">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={t("library.save")}
-                    disabled={isSaving}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSave();
-                    }}
-                    className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
-                  >
-                    {isSaving ? (
-                      <Spinner className="h-4 w-4" />
-                    ) : (
-                      <IconDeviceFloppy className="h-4 w-4" />
-                    )}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>{t("library.save")}</TooltipContent>
-              </Tooltip>
+              {onSave ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={t("library.save")}
+                      disabled={isSaving}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSave();
+                      }}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/90 text-foreground shadow-sm transition hover:bg-primary hover:text-primary-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                    >
+                      {isSaving ? (
+                        <Spinner className="h-4 w-4" />
+                      ) : (
+                        <IconDeviceFloppy className="h-4 w-4" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{t("library.save")}</TooltipContent>
+                </Tooltip>
+              ) : null}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -596,7 +625,7 @@ function GenerationPreviewDialog({
   isDismissing: boolean;
   onOpenChange: (open: boolean) => void;
   onSelect: (slotId: string) => void;
-  onSave: (slot: VariantSlot) => void;
+  onSave?: (slot: VariantSlot) => void;
   onRefine: (slot: VariantSlot, variantNumber: number) => void;
   onDismiss: (slot: VariantSlot) => void;
 }) {
@@ -647,13 +676,19 @@ function GenerationPreviewDialog({
               {variantLabel}
             </p>
             <div className="flex shrink-0 items-center gap-2">
-              <Button
-                size="sm"
-                disabled={isSaving || !slot.assetId}
-                onClick={() => onSave(slot)}
-              >
-                {isSaving ? <Spinner className="h-4 w-4" /> : t("library.save")}
-              </Button>
+              {onSave ? (
+                <Button
+                  size="sm"
+                  disabled={isSaving || !slot.assetId}
+                  onClick={() => onSave(slot)}
+                >
+                  {isSaving ? (
+                    <Spinner className="h-4 w-4" />
+                  ) : (
+                    t("library.save")
+                  )}
+                </Button>
+              ) : null}
               <Button
                 variant="outline"
                 size="sm"

--- a/templates/assets/app/i18n-data.ts
+++ b/templates/assets/app/i18n-data.ts
@@ -1011,6 +1011,9 @@ const enUS = {
     recentDrafts: "Recent Drafts",
     viewAllDrafts: "View all drafts",
     draftAsset: "Draft asset",
+    draftsOnly: "Drafts only",
+    draftsOnlyHint:
+      "You can generate drafts in this kit. Ask an editor to save them into it.",
     noReusableAssets:
       "No reusable assets yet. Select a kit to upload references or generate assets.",
     noNewAssetsUploaded: "No new assets were uploaded.",
@@ -3733,6 +3736,9 @@ export const messagesByLocale = {
       recentDrafts: "最近草稿",
       viewAllDrafts: "查看所有草稿",
       draftAsset: "草稿资产",
+      draftsOnly: "仅草稿",
+      draftsOnlyHint:
+        "您可以在此套件中生成草稿。请让编辑者将它们保存到套件中。",
       addAssets: "添加资产",
       addAssetsDescription:
         "上传源素材或生成候选项，然后只将应指导未来生成的资产标记为参考。",
@@ -4607,6 +4613,9 @@ export const messagesByLocale = {
       recentDrafts: "Borradores recientes",
       viewAllDrafts: "Ver todos los borradores",
       draftAsset: "Borrador",
+      draftsOnly: "Solo borradores",
+      draftsOnlyHint:
+        "Puedes generar borradores en este kit. Pide a un editor que los guarde en él.",
       addAssets: "Agregar activos",
       addAssetsDescription:
         "Cargue material fuente o genere candidatos, luego marque solo los activos que deberían guiar a las generaciones futuras como referencias.",
@@ -5123,6 +5132,9 @@ export const messagesByLocale = {
       recentDrafts: "Brouillons récents",
       viewAllDrafts: "Voir tous les brouillons",
       draftAsset: "Brouillon",
+      draftsOnly: "Brouillons uniquement",
+      draftsOnlyHint:
+        "Vous pouvez générer des brouillons dans ce kit. Demandez à un éditeur de les y enregistrer.",
       addAssets: "Ajouter des éléments",
       addAssetsDescription:
         "Téléchargez le matériel source ou générez des candidats, puis marquez uniquement les atouts qui devraient guider les générations futures comme références.",
@@ -5617,6 +5629,9 @@ export const messagesByLocale = {
       recentDrafts: "Letzte Entwürfe",
       viewAllDrafts: "Alle Entwürfe anzeigen",
       draftAsset: "Entwurf",
+      draftsOnly: "Nur Entwürfe",
+      draftsOnlyHint:
+        "Sie können in diesem Kit Entwürfe generieren. Bitten Sie einen Bearbeiter, sie im Kit zu speichern.",
       addAssets: "Assets hinzufügen",
       addAssetsDescription:
         "Laden Sie Quellmaterial hoch oder generieren Sie Kandidaten und markieren Sie dann nur die Assets, die künftigen Generationen als Referenz dienen sollen.",
@@ -6019,6 +6034,9 @@ export const messagesByLocale = {
       recentDrafts: "最近の下書き",
       viewAllDrafts: "すべての下書きを表示",
       draftAsset: "下書きアセット",
+      draftsOnly: "下書きのみ",
+      draftsOnlyHint:
+        "このキットで下書きを生成できます。キットに保存するには編集者に依頼してください。",
       addAssets: "アセットの追加",
       addAssetsDescription:
         "ソース素材をアップロードするか候補を生成し、将来の世代を導く必要がある資産のみを参照としてマークします。",
@@ -6410,6 +6428,9 @@ export const messagesByLocale = {
       recentDrafts: "최근 초안",
       viewAllDrafts: "모든 초안 보기",
       draftAsset: "초안 자산",
+      draftsOnly: "초안만 가능",
+      draftsOnlyHint:
+        "이 키트에서 초안을 생성할 수 있습니다. 키트에 저장하려면 편집자에게 요청하세요.",
       addAssets: "자산 추가",
       addAssetsDescription:
         "원본 자료를 업로드하거나 후보를 생성한 후, 미래 세대를 이끌어야 할 자산만 참고 자료로 표시하세요.",
@@ -6799,6 +6820,9 @@ export const messagesByLocale = {
       recentDrafts: "Rascunhos recentes",
       viewAllDrafts: "Ver todos os rascunhos",
       draftAsset: "Rascunho",
+      draftsOnly: "Somente rascunhos",
+      draftsOnlyHint:
+        "Você pode gerar rascunhos neste kit. Peça a um editor para salvá-los nele.",
       addAssets: "Adicionar recursos",
       addAssetsDescription:
         "Carregue o material de origem ou gere candidatos e marque apenas os ativos que devem orientar as gerações futuras como referências.",
@@ -7292,6 +7316,9 @@ export const messagesByLocale = {
       recentDrafts: "हाल के ड्राफ़्ट",
       viewAllDrafts: "सभी ड्राफ़्ट देखें",
       draftAsset: "ड्राफ़्ट एसेट",
+      draftsOnly: "केवल ड्राफ़्ट",
+      draftsOnlyHint:
+        "आप इस किट में ड्राफ़्ट बना सकते हैं। उन्हें किट में सहेजने के लिए किसी एडिटर से कहें।",
       addAssets: "संपत्तियां जोड़ें",
       addAssetsDescription:
         "स्रोत सामग्री अपलोड करें या उम्मीदवार तैयार करें, फिर केवल उन संपत्तियों को चिह्नित करें जो भविष्य की पीढ़ियों को संदर्भ के रूप में मार्गदर्शन करें।",
@@ -7678,6 +7705,9 @@ export const messagesByLocale = {
       recentDrafts: "المسودات الأخيرة",
       viewAllDrafts: "عرض جميع المسودات",
       draftAsset: "مسودة",
+      draftsOnly: "المسودات فقط",
+      draftsOnlyHint:
+        "يمكنك إنشاء مسودات في هذه المجموعة. اطلب من محرِّر حفظها فيها.",
       addAssets: "أضف الأصول",
       addAssetsDescription:
         "قم بتحميل المواد المصدرية أو قم بإنشاء مرشحين، ثم حدد فقط الأصول التي يجب أن توجه الأجيال القادمة كمراجع.",

--- a/templates/assets/app/i18n/zh-TW.ts
+++ b/templates/assets/app/i18n/zh-TW.ts
@@ -806,6 +806,8 @@ const messages = {
     recentDrafts: "最近草稿",
     viewAllDrafts: "查看所有草稿",
     draftAsset: "草稿資產",
+    draftsOnly: "僅草稿",
+    draftsOnlyHint: "您可以在此套件中產生草稿。請讓編輯者將它們儲存到套件中。",
     addedToReferences: "已新增到參考。",
     addedAssetsToReferences: "已將 {{count}} 個資產新增到參考。",
     add: "新增",

--- a/templates/assets/app/routes/brand-kits.$id.tsx
+++ b/templates/assets/app/routes/brand-kits.$id.tsx
@@ -124,7 +124,11 @@ import {
   type AssetUploadResult,
 } from "@/lib/upload-results";
 
-import { type AssetVariantState, type ImageRole } from "../../shared/api";
+import {
+  canApproveWithRole,
+  type AssetVariantState,
+  type ImageRole,
+} from "../../shared/api";
 
 export type VariantSlot = AssetVariantState["slots"][number];
 
@@ -431,6 +435,9 @@ export function BrandKitDetailRoute({
   }, [headerMode, libraryId]);
 
   const library = data?.library;
+  // Generating a candidate only needs read access; saving one into the kit
+  // needs editor. Drop the save affordances rather than letting them 403.
+  const canApprove = canApproveWithRole(library?.accessRole);
   const folders = (data?.folders ?? []) as any[];
   const generationPresets = ((presetData as any)?.templates ?? []) as any[];
   const generationSessions = ((sessionData as any)?.sessions ?? []) as any[];
@@ -1398,16 +1405,30 @@ export function BrandKitDetailRoute({
                 folders={folders}
                 savingSlotId={savingCandidateSlotId}
                 promotingReferenceKeys={promotingReferenceKeys}
-                onSave={(slot, folderId) => {
-                  void handleSaveLiveCandidate(slot, folderId);
-                }}
-                onSaveDraft={(asset, folderId) => {
-                  void handleSaveDraftCandidate(asset, folderId);
-                }}
-                onMoveToReferences={handleMoveLiveCandidateToReferences}
-                onMoveDraftToReferences={(asset) => {
-                  void handleMoveToReferences(asset);
-                }}
+                onSave={
+                  canApprove
+                    ? (slot, folderId) => {
+                        void handleSaveLiveCandidate(slot, folderId);
+                      }
+                    : undefined
+                }
+                onSaveDraft={
+                  canApprove
+                    ? (asset, folderId) => {
+                        void handleSaveDraftCandidate(asset, folderId);
+                      }
+                    : undefined
+                }
+                onMoveToReferences={
+                  canApprove ? handleMoveLiveCandidateToReferences : undefined
+                }
+                onMoveDraftToReferences={
+                  canApprove
+                    ? (asset) => {
+                        void handleMoveToReferences(asset);
+                      }
+                    : undefined
+                }
               />
             ) : (
               <div className="flex min-h-64 items-center justify-center rounded-lg border border-dashed border-border bg-muted/20 p-8 text-center">
@@ -3506,10 +3527,10 @@ export function LiveCandidatesStage({
   allowCreateFolder?: boolean;
   savingSlotId: string | null;
   promotingReferenceKeys: Set<string>;
-  onSave: (slot: VariantSlot, folderId: string | null) => void;
-  onSaveDraft: (asset: any, folderId: string | null) => void;
-  onMoveToReferences: (slot: VariantSlot) => void;
-  onMoveDraftToReferences: (asset: any) => void;
+  onSave?: (slot: VariantSlot, folderId: string | null) => void;
+  onSaveDraft?: (asset: any, folderId: string | null) => void;
+  onMoveToReferences?: (slot: VariantSlot) => void;
+  onMoveDraftToReferences?: (asset: any) => void;
   onUse?: (slot: VariantSlot) => void;
   onUseDraft?: (asset: any) => void;
 }) {
@@ -3619,27 +3640,31 @@ export function LiveCandidatesStage({
           </Button>
         ) : null}
         <div className="grid min-w-0 grid-cols-1 gap-2 min-[420px]:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
-          <CandidateSaveMenu
-            libraryId={actionLibraryId}
-            folders={candidateFolders}
-            allowCreateFolder={allowCreateFolder}
-            saving={saving}
-            disabled={busy}
-            onSave={(folderId) => onSaveCandidate?.(folderId)}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 min-w-0 px-2 text-xs"
-            onClick={onAddToReferences}
-            disabled={busy}
-          >
-            {promoting ? (
-              <Spinner className="h-3.5 w-3.5" />
-            ) : (
-              t("library.addToReferences")
-            )}
-          </Button>
+          {onSaveCandidate ? (
+            <CandidateSaveMenu
+              libraryId={actionLibraryId}
+              folders={candidateFolders}
+              allowCreateFolder={allowCreateFolder}
+              saving={saving}
+              disabled={busy}
+              onSave={(folderId) => onSaveCandidate(folderId)}
+            />
+          ) : null}
+          {onAddToReferences ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 min-w-0 px-2 text-xs"
+              onClick={onAddToReferences}
+              disabled={busy}
+            >
+              {promoting ? (
+                <Spinner className="h-3.5 w-3.5" />
+              ) : (
+                t("library.addToReferences")
+              )}
+            </Button>
+          ) : null}
         </div>
         <Button
           variant="ghost"
@@ -3703,27 +3728,31 @@ export function LiveCandidatesStage({
             {t("library.useCandidate")}
           </Button>
         ) : null}
-        <CandidateSaveMenu
-          libraryId={actionLibraryId}
-          folders={candidateFolders}
-          allowCreateFolder={allowCreateFolder}
-          saving={saving}
-          disabled={busy}
-          onSave={(folderId) => onSaveCandidate?.(folderId)}
-        />
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 px-2 text-xs"
-          onClick={onAddToReferences}
-          disabled={busy}
-        >
-          {promoting ? (
-            <Spinner className="h-3.5 w-3.5" />
-          ) : (
-            t("library.addToReferences")
-          )}
-        </Button>
+        {onSaveCandidate ? (
+          <CandidateSaveMenu
+            libraryId={actionLibraryId}
+            folders={candidateFolders}
+            allowCreateFolder={allowCreateFolder}
+            saving={saving}
+            disabled={busy}
+            onSave={(folderId) => onSaveCandidate(folderId)}
+          />
+        ) : null}
+        {onAddToReferences ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={onAddToReferences}
+            disabled={busy}
+          >
+            {promoting ? (
+              <Spinner className="h-3.5 w-3.5" />
+            ) : (
+              t("library.addToReferences")
+            )}
+          </Button>
+        ) : null}
         <Button
           variant="ghost"
           size="sm"
@@ -3771,8 +3800,12 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: libraryId,
-        onSaveCandidate: (folderId) => onSave(slot, folderId),
-        onAddToReferences: () => onMoveToReferences(slot),
+        onSaveCandidate: onSave
+          ? (folderId) => onSave(slot, folderId)
+          : undefined,
+        onAddToReferences: onMoveToReferences
+          ? () => onMoveToReferences(slot)
+          : undefined,
         onUseCandidate: onUse ? () => onUse(slot) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3786,8 +3819,12 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: libraryId,
-        onSaveCandidate: (folderId) => onSave(slot, folderId),
-        onAddToReferences: () => onMoveToReferences(slot),
+        onSaveCandidate: onSave
+          ? (folderId) => onSave(slot, folderId)
+          : undefined,
+        onAddToReferences: onMoveToReferences
+          ? () => onMoveToReferences(slot)
+          : undefined,
         onUseCandidate: onUse ? () => onUse(slot) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3830,8 +3867,12 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: asset.libraryId,
-        onSaveCandidate: (folderId) => onSaveDraft(asset, folderId),
-        onAddToReferences: () => onMoveDraftToReferences(asset),
+        onSaveCandidate: onSaveDraft
+          ? (folderId) => onSaveDraft(asset, folderId)
+          : undefined,
+        onAddToReferences: onMoveDraftToReferences
+          ? () => onMoveDraftToReferences(asset)
+          : undefined,
         onUseCandidate: onUseDraft ? () => onUseDraft(asset) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3845,8 +3886,12 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: asset.libraryId,
-        onSaveCandidate: (folderId) => onSaveDraft(asset, folderId),
-        onAddToReferences: () => onMoveDraftToReferences(asset),
+        onSaveCandidate: onSaveDraft
+          ? (folderId) => onSaveDraft(asset, folderId)
+          : undefined,
+        onAddToReferences: onMoveDraftToReferences
+          ? () => onMoveDraftToReferences(asset)
+          : undefined,
         onUseCandidate: onUseDraft ? () => onUseDraft(asset) : undefined,
         onDismiss: () =>
           setDismissTarget({

--- a/templates/assets/app/routes/brand-kits.$id.tsx
+++ b/templates/assets/app/routes/brand-kits.$id.tsx
@@ -8,6 +8,7 @@ import {
   readClientAppState,
   useActionMutation,
   useActionQuery,
+  useSession,
 } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { ShareButton } from "@agent-native/core/client/sharing";
@@ -348,6 +349,7 @@ export function BrandKitDetailRoute({
   const [searchParams] = useSearchParams();
   const urlTab = libraryTabFromValue(searchParams.get("tab"));
   const libraryId = explicitLibraryId ?? id!;
+  const { session } = useSession();
   const { data } = useActionQuery("get-library", { id: libraryId }) as any;
 
   const archiveLibrary = useActionMutation("archive-library");
@@ -438,6 +440,13 @@ export function BrandKitDetailRoute({
   // Generating a candidate only needs read access; saving one into the kit
   // needs editor. Drop the save affordances rather than letting them 403.
   const canApprove = canApproveWithRole(library?.accessRole);
+  // Rerunning reuses a run's prompt and settings and refreshing mutates its
+  // row, so both stay with the run's author unless the caller can approve.
+  const canRerunRun = (run: { ownerEmail?: string | null }) => {
+    if (canApprove) return true;
+    const mine = session?.email?.trim().toLowerCase();
+    return Boolean(mine) && run.ownerEmail?.trim().toLowerCase() === mine;
+  };
   const folders = (data?.folders ?? []) as any[];
   const generationPresets = ((presetData as any)?.templates ?? []) as any[];
   const generationSessions = ((sessionData as any)?.sessions ?? []) as any[];
@@ -1486,13 +1495,16 @@ export function BrandKitDetailRoute({
                       rerunGeneration.isPending || refreshGeneration.isPending
                     }
                     onCreateHandoff={() => createHandoffFromRun(run)}
-                    onRerun={() =>
-                      run.mediaType === "video"
-                        ? refreshGeneration.mutate({ runId: run.id })
-                        : rerunGeneration.mutate({
-                            runId: run.id,
-                            source: "ui",
-                          })
+                    onRerun={
+                      canRerunRun(run)
+                        ? () =>
+                            run.mediaType === "video"
+                              ? refreshGeneration.mutate({ runId: run.id })
+                              : rerunGeneration.mutate({
+                                  runId: run.id,
+                                  source: "ui",
+                                })
+                        : undefined
                     }
                   />
                 ))}
@@ -1558,7 +1570,8 @@ function RunCard({
 }: {
   run: any;
   assetById?: Map<string, any>;
-  onRerun: () => void;
+  /** Omitted when this caller may not rerun or refresh someone else's run. */
+  onRerun?: () => void;
   onCreateHandoff: () => void;
   rerunning?: boolean;
 }) {
@@ -1633,18 +1646,20 @@ function RunCard({
               {t("brandKitDetail.handoff")}
             </Button>
           ) : null}
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-2"
-            disabled={rerunning}
-            onClick={onRerun}
-          >
-            <IconRefresh className="h-4 w-4" />
-            {mediaType === "video" && run.status !== "completed"
-              ? t("brandKitDetail.refresh")
-              : t("brandKitDetail.rerunThis")}
-          </Button>
+          {onRerun ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              disabled={rerunning}
+              onClick={onRerun}
+            >
+              <IconRefresh className="h-4 w-4" />
+              {mediaType === "video" && run.status !== "completed"
+                ? t("brandKitDetail.refresh")
+                : t("brandKitDetail.rerunThis")}
+            </Button>
+          ) : null}
         </div>
       </div>
 
@@ -3512,6 +3527,7 @@ export function LiveCandidatesStage({
   allowCreateFolder = true,
   savingSlotId,
   promotingReferenceKeys,
+  canApproveLibrary,
   onSave,
   onSaveDraft,
   onMoveToReferences,
@@ -3527,6 +3543,12 @@ export function LiveCandidatesStage({
   allowCreateFolder?: boolean;
   savingSlotId: string | null;
   promotingReferenceKeys: Set<string>;
+  /**
+   * Approving is per kit: this stage can list candidates from several kits, and
+   * the caller may be an editor in one and a viewer in the next. Omit it when
+   * every candidate on screen belongs to one kit the handlers already cover.
+   */
+  canApproveLibrary?: (libraryId?: string | null) => boolean;
   onSave?: (slot: VariantSlot, folderId: string | null) => void;
   onSaveDraft?: (asset: any, folderId: string | null) => void;
   onMoveToReferences?: (slot: VariantSlot) => void;
@@ -3535,6 +3557,12 @@ export function LiveCandidatesStage({
   onUseDraft?: (asset: any) => void;
 }) {
   const t = useT();
+  // No predicate means every candidate on screen belongs to a kit the passed
+  // handlers already cover; live slots always belong to the stage's own kit.
+  const mayApproveIn = (candidateLibraryId?: string | null) =>
+    canApproveLibrary
+      ? canApproveLibrary(candidateLibraryId ?? libraryId)
+      : true;
   const dismissSlot = useActionMutation("dismiss-variant-slots");
   const deleteAsset = useActionMutation("delete-asset");
   const queryClient = useQueryClient();
@@ -3800,12 +3828,14 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: libraryId,
-        onSaveCandidate: onSave
-          ? (folderId) => onSave(slot, folderId)
-          : undefined,
-        onAddToReferences: onMoveToReferences
-          ? () => onMoveToReferences(slot)
-          : undefined,
+        onSaveCandidate:
+          onSave && mayApproveIn(libraryId)
+            ? (folderId) => onSave(slot, folderId)
+            : undefined,
+        onAddToReferences:
+          onMoveToReferences && mayApproveIn(libraryId)
+            ? () => onMoveToReferences(slot)
+            : undefined,
         onUseCandidate: onUse ? () => onUse(slot) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3819,12 +3849,14 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: libraryId,
-        onSaveCandidate: onSave
-          ? (folderId) => onSave(slot, folderId)
-          : undefined,
-        onAddToReferences: onMoveToReferences
-          ? () => onMoveToReferences(slot)
-          : undefined,
+        onSaveCandidate:
+          onSave && mayApproveIn(libraryId)
+            ? (folderId) => onSave(slot, folderId)
+            : undefined,
+        onAddToReferences:
+          onMoveToReferences && mayApproveIn(libraryId)
+            ? () => onMoveToReferences(slot)
+            : undefined,
         onUseCandidate: onUse ? () => onUse(slot) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3867,12 +3899,14 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: asset.libraryId,
-        onSaveCandidate: onSaveDraft
-          ? (folderId) => onSaveDraft(asset, folderId)
-          : undefined,
-        onAddToReferences: onMoveDraftToReferences
-          ? () => onMoveDraftToReferences(asset)
-          : undefined,
+        onSaveCandidate:
+          onSaveDraft && mayApproveIn(asset.libraryId)
+            ? (folderId) => onSaveDraft(asset, folderId)
+            : undefined,
+        onAddToReferences:
+          onMoveDraftToReferences && mayApproveIn(asset.libraryId)
+            ? () => onMoveDraftToReferences(asset)
+            : undefined,
         onUseCandidate: onUseDraft ? () => onUseDraft(asset) : undefined,
         onDismiss: () =>
           setDismissTarget({
@@ -3886,12 +3920,14 @@ export function LiveCandidatesStage({
         saving,
         promoting,
         candidateLibraryId: asset.libraryId,
-        onSaveCandidate: onSaveDraft
-          ? (folderId) => onSaveDraft(asset, folderId)
-          : undefined,
-        onAddToReferences: onMoveDraftToReferences
-          ? () => onMoveDraftToReferences(asset)
-          : undefined,
+        onSaveCandidate:
+          onSaveDraft && mayApproveIn(asset.libraryId)
+            ? (folderId) => onSaveDraft(asset, folderId)
+            : undefined,
+        onAddToReferences:
+          onMoveDraftToReferences && mayApproveIn(asset.libraryId)
+            ? () => onMoveDraftToReferences(asset)
+            : undefined,
         onUseCandidate: onUseDraft ? () => onUseDraft(asset) : undefined,
         onDismiss: () =>
           setDismissTarget({

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -114,7 +114,11 @@ import type {
   ImageQualityTier,
   StyleStrength,
 } from "../../shared/api";
-import { MODEL_ASPECT_RATIOS } from "../../shared/api";
+import {
+  canApproveWithRole,
+  MODEL_ASPECT_RATIOS,
+  type AssetAccessRole,
+} from "../../shared/api";
 import {
   DEFAULT_LIBRARY_PRESETS,
   LibraryPreset,
@@ -193,6 +197,7 @@ type Library = {
   id: string;
   title: string;
   description?: string | null;
+  accessRole?: AssetAccessRole;
 };
 
 type GenerationConfig = {
@@ -1956,6 +1961,11 @@ function LibraryCandidateStage({
   ) as { data?: { assets?: Asset[] }; isLoading: boolean; isError: boolean };
   const saveGenerated = useActionMutation("save-generated-image");
   const updateAsset = useActionMutation("update-asset");
+  // Drafting needs only read access, approving needs editor. The cross-kit
+  // stage mixes kits with different roles, so only the single-kit stage can
+  // decide here; the server still refuses the ones it must.
+  const canApprove =
+    isAllAssetsStage || canApproveWithRole(libraryData?.library?.accessRole);
   const libraryAssets = isAllAssetsStage
     ? (allCandidateData?.assets ?? [])
     : (libraryData?.assets ?? []);
@@ -2195,16 +2205,30 @@ function LibraryCandidateStage({
         foldersByLibraryId={foldersByLibraryId}
         savingSlotId={savingCandidateSlotId}
         promotingReferenceKeys={promotingReferenceKeys}
-        onSave={(slot, folderId) => {
-          void handleSaveLiveCandidate(slot, folderId);
-        }}
-        onSaveDraft={(asset, folderId) => {
-          void handleSaveDraftCandidate(asset, folderId);
-        }}
-        onMoveToReferences={handleMoveLiveCandidateToReferences}
-        onMoveDraftToReferences={(asset) => {
-          void handleMoveToReferences(asset);
-        }}
+        onSave={
+          canApprove
+            ? (slot, folderId) => {
+                void handleSaveLiveCandidate(slot, folderId);
+              }
+            : undefined
+        }
+        onSaveDraft={
+          canApprove
+            ? (asset, folderId) => {
+                void handleSaveDraftCandidate(asset, folderId);
+              }
+            : undefined
+        }
+        onMoveToReferences={
+          canApprove ? handleMoveLiveCandidateToReferences : undefined
+        }
+        onMoveDraftToReferences={
+          canApprove
+            ? (asset) => {
+                void handleMoveToReferences(asset);
+              }
+            : undefined
+        }
         onUse={onUseAsset ? handleUseLiveCandidate : undefined}
         onUseDraft={onUseAsset}
       />

--- a/templates/assets/app/routes/library.tsx
+++ b/templates/assets/app/routes/library.tsx
@@ -7,6 +7,7 @@ import {
 } from "@agent-native/core/client/agent-chat";
 import { appPath } from "@agent-native/core/client/api-path";
 import {
+  callAction,
   getBrowserTabId,
   readClientAppState,
   useActionMutation,
@@ -43,7 +44,7 @@ import {
   IconTrash,
   IconX,
 } from "@tabler/icons-react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   useCallback,
   useEffect,
@@ -114,11 +115,7 @@ import type {
   ImageQualityTier,
   StyleStrength,
 } from "../../shared/api";
-import {
-  canApproveWithRole,
-  MODEL_ASPECT_RATIOS,
-  type AssetAccessRole,
-} from "../../shared/api";
+import { MODEL_ASPECT_RATIOS, type AssetAccessRole } from "../../shared/api";
 import {
   DEFAULT_LIBRARY_PRESETS,
   LibraryPreset,
@@ -1961,11 +1958,6 @@ function LibraryCandidateStage({
   ) as { data?: { assets?: Asset[] }; isLoading: boolean; isError: boolean };
   const saveGenerated = useActionMutation("save-generated-image");
   const updateAsset = useActionMutation("update-asset");
-  // Drafting needs only read access, approving needs editor. The cross-kit
-  // stage mixes kits with different roles, so only the single-kit stage can
-  // decide here; the server still refuses the ones it must.
-  const canApprove =
-    isAllAssetsStage || canApproveWithRole(libraryData?.library?.accessRole);
   const libraryAssets = isAllAssetsStage
     ? (allCandidateData?.assets ?? [])
     : (libraryData?.assets ?? []);
@@ -2006,6 +1998,40 @@ function LibraryCandidateStage({
         .slice()
         .sort((left, right) => String(right.id).localeCompare(String(left.id))),
     [libraryAssets, liveAssetIds],
+  );
+  // Approving is per kit: this stage can show candidates from several kits at
+  // once, and the caller may be an editor in one and a viewer in the next. Ask
+  // once per kit on screen rather than assuming, or showing a Save that 403s.
+  const stageLibraryIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (activeLibraryId) ids.add(activeLibraryId);
+    if (liveLibraryId) ids.add(liveLibraryId);
+    for (const asset of draftAssets) {
+      if (asset.libraryId) ids.add(asset.libraryId);
+    }
+    return Array.from(ids);
+  }, [activeLibraryId, liveLibraryId, draftAssets]);
+  const libraryAccessResults = useQueries({
+    queries: stageLibraryIds.map((id) => ({
+      queryKey: ["action", "get-library-access", { libraryId: id }],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        callAction<{ libraryId: string; canApprove: boolean }>(
+          "get-library-access",
+          { libraryId: id } as never,
+          { method: "GET", signal },
+        ),
+    })),
+  });
+  const approvableLibraryIds = useMemo(() => {
+    const approvable = new Set<string>();
+    for (const result of libraryAccessResults) {
+      if (result.data?.canApprove) approvable.add(result.data.libraryId);
+    }
+    return approvable;
+  }, [libraryAccessResults]);
+  const canApproveLibrary = useCallback(
+    (id?: string | null) => Boolean(id && approvableLibraryIds.has(id)),
+    [approvableLibraryIds],
   );
   const totalCount = slots.length + draftAssets.length;
   // Don't flash the empty state before the candidate sources have resolved, and
@@ -2205,30 +2231,17 @@ function LibraryCandidateStage({
         foldersByLibraryId={foldersByLibraryId}
         savingSlotId={savingCandidateSlotId}
         promotingReferenceKeys={promotingReferenceKeys}
-        onSave={
-          canApprove
-            ? (slot, folderId) => {
-                void handleSaveLiveCandidate(slot, folderId);
-              }
-            : undefined
-        }
-        onSaveDraft={
-          canApprove
-            ? (asset, folderId) => {
-                void handleSaveDraftCandidate(asset, folderId);
-              }
-            : undefined
-        }
-        onMoveToReferences={
-          canApprove ? handleMoveLiveCandidateToReferences : undefined
-        }
-        onMoveDraftToReferences={
-          canApprove
-            ? (asset) => {
-                void handleMoveToReferences(asset);
-              }
-            : undefined
-        }
+        canApproveLibrary={canApproveLibrary}
+        onSave={(slot, folderId) => {
+          void handleSaveLiveCandidate(slot, folderId);
+        }}
+        onSaveDraft={(asset, folderId) => {
+          void handleSaveDraftCandidate(asset, folderId);
+        }}
+        onMoveToReferences={handleMoveLiveCandidateToReferences}
+        onMoveDraftToReferences={(asset) => {
+          void handleMoveToReferences(asset);
+        }}
         onUse={onUseAsset ? handleUseLiveCandidate : undefined}
         onUseDraft={onUseAsset}
       />

--- a/templates/assets/app/routes/templates.$templateId.tsx
+++ b/templates/assets/app/routes/templates.$templateId.tsx
@@ -84,6 +84,7 @@ import { cn } from "@/lib/utils";
 import { normalizePresetReferences } from "../../server/lib/preset-references";
 import {
   ASPECT_RATIOS,
+  canApproveWithRole,
   GENERATION_PRESET_REFERENCE_POLICIES,
   IMAGE_CATEGORIES,
   IMAGE_MODELS,
@@ -364,10 +365,6 @@ function uploadedSkeletonAssetId(
   );
 }
 
-function isEditableRole(role: unknown): boolean {
-  return role === "owner" || role === "admin" || role === "editor";
-}
-
 function FieldLabel({
   htmlFor,
   children,
@@ -541,7 +538,7 @@ export default function TemplateEditorRoute() {
   );
   const loading = templateLoading || libraryLoading;
   const accessRole = template?.accessRole ?? library?.accessRole;
-  const readOnly = Boolean(accessRole && !isEditableRole(accessRole));
+  const readOnly = Boolean(accessRole && !canApproveWithRole(accessRole));
   const pinningUnavailable = !libraryId;
 
   useEffect(() => {

--- a/templates/assets/changelog/2026-09-01-view-only-brand-kits-can-generate-drafts.md
+++ b/templates/assets/changelog/2026-09-01-view-only-brand-kits-can-generate-drafts.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-01
+---
+
+You can now generate image and video drafts in a brand kit you only have view access to, from the app or from another agent. Saving a draft into the kit, uploading, and editing the kit still need edit access, and the drafts you generate stay yours to discard.

--- a/templates/assets/server/handlers/assets.ts
+++ b/templates/assets/server/handlers/assets.ts
@@ -19,6 +19,7 @@ import type { ImageCategory, ImageRole } from "../../shared/api.js";
 import { getDb, schema } from "../db/index.js";
 import { createAssetFromBuffer, mediaTypeFromMime } from "../lib/assets.js";
 import { nowIso, parseJson, stringifyJson } from "../lib/json.js";
+import { assertCanApprove } from "../lib/library-access.js";
 import { getObject } from "../lib/storage.js";
 import {
   filterDuplicateAssetUploads,
@@ -165,7 +166,7 @@ export const uploadAssets = defineEventHandler(async (event) =>
       setResponseStatus(event, 400);
       return { error: "libraryId is required" };
     }
-    await assertAccess("asset-library", libraryId, "editor");
+    await assertCanApprove(libraryId, "Uploading assets");
     const collectionId = readField(parts, "collectionId") || null;
     const folderId = readField(parts, "folderId") || null;
     if (collectionId) {
@@ -388,7 +389,10 @@ export async function markAssetSaved(
     .where(eq(schema.assets.id, assetId))
     .limit(1);
   if (!asset) throw new Error("Asset not found.");
-  await assertAccess("asset-library", asset.libraryId, "editor");
+  await assertCanApprove(
+    asset.libraryId,
+    "Saving a generated asset to the kit",
+  );
   if (folderId !== undefined && folderId !== null) {
     await assertFolderBelongsToLibrary(folderId, asset.libraryId);
   }

--- a/templates/assets/server/lib/generation.ts
+++ b/templates/assets/server/lib/generation.ts
@@ -22,6 +22,7 @@ import type {
 } from "../../shared/api.js";
 import { getDb, schema } from "../db/index.js";
 import { parseJson } from "./json.js";
+import { canReadDraftAsset, type DraftReadScope } from "./library-access.js";
 import { getObject } from "./storage.js";
 
 export interface ReferenceForGeneration {
@@ -1501,6 +1502,13 @@ export async function selectReferences(input: {
   subjectAssetId?: string;
   intent?: GenerationIntent;
   limit?: number;
+  /**
+   * Drafts are private to their author, and the pool below scores every asset
+   * in the kit — including unsaved candidates. Without this scope an automatic
+   * selection would quietly send another drafter's candidate to the provider.
+   * Required: pass `unrestrictedDraftReadScope()` for an approver.
+   */
+  draftScope: DraftReadScope;
 }): Promise<ReferenceForGeneration[]> {
   const db = getDb();
   const requestedExplicitIds = new Set(input.referenceAssetIds ?? []);
@@ -1534,6 +1542,7 @@ export async function selectReferences(input: {
           asset.mimeType.startsWith("image/") &&
           asset.status !== "archived" &&
           asset.status !== "failed" &&
+          canReadDraftAsset(input.draftScope, asset) &&
           !excludedAssetIds.has(asset.id),
       );
     const explicitRefs = await loadReferenceData(
@@ -1572,6 +1581,7 @@ export async function selectReferences(input: {
       excludeAssetIds: input.excludeAssetIds,
       intent: input.intent,
       limit: styleLimit,
+      draftScope: input.draftScope,
     });
     const seen = new Set(explicitRefs.map((ref) => ref.id));
     return [...explicitRefs, ...styleRefs.filter((ref) => !seen.has(ref.id))];
@@ -1603,6 +1613,7 @@ export async function selectReferences(input: {
         asset.status !== "archived" &&
         asset.status !== "failed" &&
         metadata.category !== "skeleton" &&
+        canReadDraftAsset(input.draftScope, asset) &&
         !excludedAssetIds.has(asset.id)
       );
     })

--- a/templates/assets/server/lib/library-access.spec.ts
+++ b/templates/assets/server/lib/library-access.spec.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const assertAccessMock = vi.hoisted(() => vi.fn());
+const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
+const getDbMock = vi.hoisted(() => vi.fn());
+
+const ROLE_ORDER = ["viewer", "commenter", "editor", "admin", "owner"];
+
+vi.mock("@agent-native/core/sharing", () => ({
+  assertAccess: assertAccessMock,
+  roleSatisfies: (actual: string, minimum: string) =>
+    ROLE_ORDER.indexOf(actual) >= ROLE_ORDER.indexOf(minimum),
+  ForbiddenError: class ForbiddenError extends Error {
+    statusCode = 403;
+  },
+}));
+
+vi.mock("@agent-native/core/server/request-context", () => ({
+  getRequestUserEmail: getRequestUserEmailMock,
+}));
+
+vi.mock("../db/index.js", () => ({
+  getDb: getDbMock,
+  schema: {
+    assetGenerationRuns: {
+      id: "image_generation_runs.id",
+      ownerEmail: "image_generation_runs.owner_email",
+    },
+  },
+}));
+
+import {
+  assertCanApprove,
+  assertCanDeleteAsset,
+  assertCanDraft,
+  assertCanDraftAuthoredBy,
+} from "./library-access.js";
+
+function grantRole(role: string) {
+  assertAccessMock.mockImplementation(async (_type, _id, minRole) => {
+    if (ROLE_ORDER.indexOf(role) < ROLE_ORDER.indexOf(minRole)) {
+      throw new Error(`Requires ${minRole} role (have ${role})`);
+    }
+    return { role };
+  });
+}
+
+function dbWithRunAuthor(ownerEmail: string | null) {
+  getDbMock.mockReturnValue({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (ownerEmail === null ? [] : [{ ownerEmail }]),
+        }),
+      }),
+    }),
+  });
+}
+
+describe("library-access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRequestUserEmailMock.mockReturnValue("viewer@example.test");
+  });
+
+  it("lets a viewer draft, and says they cannot approve", async () => {
+    grantRole("viewer");
+
+    await expect(assertCanDraft("lib-1")).resolves.toEqual({
+      role: "viewer",
+      canApprove: false,
+    });
+    // Drafting must not cost more than reading the kit.
+    expect(assertAccessMock).toHaveBeenCalledWith(
+      "asset-library",
+      "lib-1",
+      "viewer",
+      undefined,
+      { skipResourceBody: true },
+    );
+  });
+
+  it("refuses a viewer's approval with a remedy the agent can classify", async () => {
+    grantRole("viewer");
+
+    let error: (Error & { statusCode?: number }) | undefined;
+    try {
+      await assertCanApprove("lib-1", "Saving a draft");
+    } catch (err) {
+      error = err as Error & { statusCode?: number };
+    }
+
+    // The leading clause is load-bearing: core's permanent-precondition
+    // classifier matches `requires <role> role` and ends the turn instead of
+    // retrying a grant the model cannot obtain.
+    expect(error?.message).toMatch(/^Requires editor role on asset-library/);
+    expect(error?.message).toContain("(have viewer)");
+    expect(error?.message).toContain("Saving a draft");
+    expect(error?.statusCode).toBe(403);
+  });
+
+  it("lets an editor approve", async () => {
+    grantRole("editor");
+
+    await expect(assertCanApprove("lib-1", "Saving a draft")).resolves.toEqual({
+      role: "editor",
+      canApprove: true,
+    });
+  });
+
+  it("keeps a viewer out of someone else's drafting session", async () => {
+    grantRole("viewer");
+
+    await expect(
+      assertCanDraftAuthoredBy("lib-1", "viewer@example.test", "A session"),
+    ).resolves.toMatchObject({ canApprove: false });
+
+    await expect(
+      assertCanDraftAuthoredBy("lib-1", "someone@example.test", "A session"),
+    ).rejects.toThrow(/Requires editor role/);
+
+    // Legacy rows with no recorded author are not up for grabs.
+    await expect(
+      assertCanDraftAuthoredBy("lib-1", null, "A session"),
+    ).rejects.toThrow(/Requires editor role/);
+  });
+
+  it("lets a draft author discard their own unsaved candidate only", async () => {
+    grantRole("viewer");
+    dbWithRunAuthor("viewer@example.test");
+
+    await expect(
+      assertCanDeleteAsset({
+        libraryId: "lib-1",
+        role: "generated",
+        status: "candidate",
+        generationRunId: "run-1",
+      }),
+    ).resolves.toMatchObject({ canApprove: false });
+
+    // Saved kit content is approving-class no matter who generated it.
+    await expect(
+      assertCanDeleteAsset({
+        libraryId: "lib-1",
+        role: "generated",
+        status: "saved",
+        generationRunId: "run-1",
+      }),
+    ).rejects.toThrow(/Requires editor role/);
+
+    dbWithRunAuthor("someone@example.test");
+    await expect(
+      assertCanDeleteAsset({
+        libraryId: "lib-1",
+        role: "generated",
+        status: "candidate",
+        generationRunId: "run-1",
+      }),
+    ).rejects.toThrow(/Requires editor role/);
+  });
+});

--- a/templates/assets/server/lib/library-access.spec.ts
+++ b/templates/assets/server/lib/library-access.spec.ts
@@ -41,9 +41,13 @@ import {
   assertCanDeleteAsset,
   assertCanDraft,
   assertCanDraftAuthoredBy,
+  assertCanUseAssets,
+  assertCanUseRuns,
   canReadDraftAsset,
   canReadRun,
+  draftReadFilter,
   resolveDraftReadScope,
+  unrestrictedDraftReadScope,
 } from "./library-access.js";
 
 function grantRole(role: string) {
@@ -197,6 +201,77 @@ describe("library-access", () => {
         generationRunId: "run-theirs",
       }),
     ).toBe(true);
+  });
+
+  it("refuses another drafter's candidate as a generation or session input", async () => {
+    grantRole("viewer");
+    dbWithRuns([
+      { id: "run-mine", ownerEmail: "viewer@example.test" },
+      { id: "run-theirs", ownerEmail: "someone@example.test" },
+    ]);
+    const scope = await resolveDraftReadScope(["lib-1"]);
+    const draft = (id: string, generationRunId: string) => ({
+      id,
+      libraryId: "lib-1",
+      role: "generated",
+      status: "candidate",
+      generationRunId,
+    });
+
+    // The read boundary and the input boundary must agree, or the private
+    // candidate rule holds on lists and leaks through every id argument.
+    expect(() =>
+      assertCanUseAssets(
+        scope,
+        "lib-1",
+        "viewer",
+        [draft("asset-mine", "run-mine")],
+        "This generation",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertCanUseAssets(
+        scope,
+        "lib-1",
+        "viewer",
+        [draft("asset-theirs", "run-theirs")],
+        "This generation",
+      ),
+    ).toThrow(/Requires editor role .* draft asset-theirs/s);
+    expect(() =>
+      assertCanUseRuns(
+        scope,
+        "lib-1",
+        "viewer",
+        [{ id: "run-theirs", libraryId: "lib-1" }],
+        "A generation session",
+      ),
+    ).toThrow(/generation run run-theirs/);
+  });
+
+  it("narrows drafts in SQL so paging cannot hide the caller's own", async () => {
+    grantRole("viewer");
+    dbWithRuns([{ id: "run-mine", ownerEmail: "viewer@example.test" }]);
+    const scope = await resolveDraftReadScope(["lib-1"]);
+
+    const table = {
+      libraryId: "image_assets.library_id",
+      generationRunId: "image_assets.generation_run_id",
+    } as never;
+    // A clause, not a post-filter: `limit` must apply to authorized rows only.
+    expect(draftReadFilter(scope, table)).toBeDefined();
+    expect(
+      draftReadFilter(unrestrictedDraftReadScope(), table),
+    ).toBeUndefined();
+
+    // No approvable kit and no runs of their own must mean "no rows", never an
+    // unfiltered read.
+    const emptyScope = {
+      unrestricted: false,
+      approvableLibraryIds: new Set<string>(),
+      ownRunIds: new Set<string>(),
+    };
+    expect(draftReadFilter(emptyScope, table)).toBeDefined();
   });
 
   it("lets a draft author discard their own unsaved candidate only", async () => {

--- a/templates/assets/server/lib/library-access.spec.ts
+++ b/templates/assets/server/lib/library-access.spec.ts
@@ -25,8 +25,15 @@ vi.mock("../db/index.js", () => ({
     assetGenerationRuns: {
       id: "image_generation_runs.id",
       ownerEmail: "image_generation_runs.owner_email",
+      libraryId: "image_generation_runs.library_id",
     },
   },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("drizzle-orm")>()),
+  eq: vi.fn((column, value) => ({ column, value })),
+  inArray: vi.fn((column, values) => ({ column, values })),
 }));
 
 import {
@@ -34,6 +41,9 @@ import {
   assertCanDeleteAsset,
   assertCanDraft,
   assertCanDraftAuthoredBy,
+  canReadDraftAsset,
+  canReadRun,
+  resolveDraftReadScope,
 } from "./library-access.js";
 
 function grantRole(role: string) {
@@ -42,6 +52,16 @@ function grantRole(role: string) {
       throw new Error(`Requires ${minRole} role (have ${role})`);
     }
     return { role };
+  });
+}
+
+function dbWithRuns(runs: Array<{ id: string; ownerEmail: string }>) {
+  getDbMock.mockReturnValue({
+    select: () => ({
+      from: () => ({
+        where: async () => runs,
+      }),
+    }),
   });
 }
 
@@ -123,6 +143,60 @@ describe("library-access", () => {
     await expect(
       assertCanDraftAuthoredBy("lib-1", null, "A session"),
     ).rejects.toThrow(/Requires editor role/);
+  });
+
+  it("narrows drafts to the caller's own where they cannot approve", async () => {
+    grantRole("viewer");
+    dbWithRuns([
+      { id: "run-mine", ownerEmail: "viewer@example.test" },
+      { id: "run-theirs", ownerEmail: "someone@example.test" },
+    ]);
+
+    const scope = await resolveDraftReadScope(["lib-1"]);
+
+    const draft = (generationRunId: string | null) => ({
+      libraryId: "lib-1",
+      role: "generated",
+      status: "candidate",
+      generationRunId,
+    });
+    expect(canReadDraftAsset(scope, draft("run-mine"))).toBe(true);
+    expect(canReadDraftAsset(scope, draft("run-theirs"))).toBe(false);
+    // A candidate with no run behind it has no author to match.
+    expect(canReadDraftAsset(scope, draft(null))).toBe(false);
+    // Saved kit content is never narrowed by the draft scope.
+    expect(
+      canReadDraftAsset(scope, {
+        libraryId: "lib-1",
+        role: "generated",
+        status: "saved",
+        generationRunId: "run-theirs",
+      }),
+    ).toBe(true);
+    expect(canReadRun(scope, { id: "run-mine", libraryId: "lib-1" })).toBe(
+      true,
+    );
+    expect(canReadRun(scope, { id: "run-theirs", libraryId: "lib-1" })).toBe(
+      false,
+    );
+  });
+
+  it("skips the run lookup entirely for an approver", async () => {
+    grantRole("editor");
+    dbWithRuns([]);
+
+    const scope = await resolveDraftReadScope(["lib-1"]);
+
+    expect(scope.unrestricted).toBe(true);
+    expect(getDbMock).not.toHaveBeenCalled();
+    expect(
+      canReadDraftAsset(scope, {
+        libraryId: "lib-1",
+        role: "generated",
+        status: "candidate",
+        generationRunId: "run-theirs",
+      }),
+    ).toBe(true);
   });
 
   it("lets a draft author discard their own unsaved candidate only", async () => {

--- a/templates/assets/server/lib/library-access.spec.ts
+++ b/templates/assets/server/lib/library-access.spec.ts
@@ -22,6 +22,12 @@ vi.mock("@agent-native/core/server/request-context", () => ({
 vi.mock("../db/index.js", () => ({
   getDb: getDbMock,
   schema: {
+    assets: {
+      id: "image_assets.id",
+      libraryId: "image_assets.library_id",
+      role: "image_assets.role",
+      status: "image_assets.status",
+    },
     assetGenerationRuns: {
       id: "image_generation_runs.id",
       ownerEmail: "image_generation_runs.owner_email",
@@ -34,6 +40,7 @@ vi.mock("drizzle-orm", async (importOriginal) => ({
   ...(await importOriginal<typeof import("drizzle-orm")>()),
   eq: vi.fn((column, value) => ({ column, value })),
   inArray: vi.fn((column, values) => ({ column, values })),
+  and: vi.fn((...conditions) => ({ conditions })),
 }));
 
 import {
@@ -45,8 +52,12 @@ import {
   assertCanUseRuns,
   canReadDraftAsset,
   canReadRun,
+  canReadSession,
+  deleteDraftAssetIfUnchanged,
   draftReadFilter,
   resolveDraftReadScope,
+  runReadFilter,
+  sessionReadFilter,
   unrestrictedDraftReadScope,
 } from "./library-access.js";
 
@@ -192,6 +203,7 @@ describe("library-access", () => {
     const scope = await resolveDraftReadScope(["lib-1"]);
 
     expect(scope.unrestricted).toBe(true);
+    expect(scope.callerEmail).toBe("viewer@example.test");
     expect(getDbMock).not.toHaveBeenCalled();
     expect(
       canReadDraftAsset(scope, {
@@ -270,8 +282,110 @@ describe("library-access", () => {
       unrestricted: false,
       approvableLibraryIds: new Set<string>(),
       ownRunIds: new Set<string>(),
+      callerEmail: "viewer@example.test",
     };
     expect(draftReadFilter(emptyScope, table)).toBeDefined();
+  });
+
+  it("keeps a below-approver caller to the sessions they created", async () => {
+    // The predicate reads the caller off the scope, not off ambient request
+    // context: a row check that runs outside the resolving context would
+    // otherwise answer "not yours" for the caller's own rows.
+    grantRole("viewer");
+    dbWithRuns([]);
+    const scope = await resolveDraftReadScope(["lib-1"]);
+
+    expect(
+      canReadSession(scope, {
+        libraryId: "lib-1",
+        createdBy: "viewer@example.test",
+      }),
+    ).toBe(true);
+    expect(
+      canReadSession(scope, {
+        libraryId: "lib-1",
+        createdBy: "someone@example.test",
+      }),
+    ).toBe(false);
+    // A legacy session with no recorded author is not the caller's.
+    expect(canReadSession(scope, { libraryId: "lib-1", createdBy: null })).toBe(
+      false,
+    );
+    expect(
+      canReadSession(unrestrictedDraftReadScope(), {
+        libraryId: "lib-1",
+        createdBy: "someone@example.test",
+      }),
+    ).toBe(true);
+  });
+
+  it("narrows run and session queries in SQL, not after the limit", async () => {
+    grantRole("viewer");
+    dbWithRuns([{ id: "run-mine", ownerEmail: "viewer@example.test" }]);
+    const scope = await resolveDraftReadScope(["lib-1"]);
+
+    expect(
+      runReadFilter(scope, {
+        id: "image_generation_runs.id",
+        libraryId: "image_generation_runs.library_id",
+      } as never),
+    ).toBeDefined();
+    expect(
+      sessionReadFilter(scope, {
+        libraryId: "image_generation_sessions.library_id",
+        createdBy: "image_generation_sessions.created_by",
+      } as never),
+    ).toBeDefined();
+    expect(
+      runReadFilter(unrestrictedDraftReadScope(), {
+        id: "image_generation_runs.id",
+        libraryId: "image_generation_runs.library_id",
+      } as never),
+    ).toBeUndefined();
+  });
+
+  it("lets a concurrent approval survive a draft delete", async () => {
+    // The row is deleted only while it still matches the state that authorized
+    // it, and the outcome is confirmed by re-reading rather than by a row count.
+    const table = new Map<string, { id: string; status: string }>([
+      ["asset-1", { id: "asset-1", status: "candidate" }],
+    ]);
+    const deleteWhere = vi.fn(async (condition: any) => {
+      const clauses = condition?.conditions ?? [];
+      const wantsCandidate = clauses.some(
+        (clause: any) =>
+          clause?.column === "image_assets.status" &&
+          clause?.value === "candidate",
+      );
+      const row = table.get("asset-1");
+      if (row && wantsCandidate && row.status === "candidate") {
+        table.delete("asset-1");
+      }
+    });
+    getDbMock.mockReturnValue({
+      delete: () => ({ where: deleteWhere }),
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => {
+              const row = table.get("asset-1");
+              return row ? [row] : [];
+            },
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      deleteDraftAssetIfUnchanged({ id: "asset-1", libraryId: "lib-1" }),
+    ).resolves.toBe(true);
+
+    // Now an editor has approved it first: the delete must not match.
+    table.set("asset-1", { id: "asset-1", status: "saved" });
+    await expect(
+      deleteDraftAssetIfUnchanged({ id: "asset-1", libraryId: "lib-1" }),
+    ).resolves.toBe(false);
+    expect(table.get("asset-1")).toEqual({ id: "asset-1", status: "saved" });
   });
 
   it("lets a draft author discard their own unsaved candidate only", async () => {

--- a/templates/assets/server/lib/library-access.ts
+++ b/templates/assets/server/lib/library-access.ts
@@ -1,0 +1,136 @@
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import {
+  assertAccess,
+  ForbiddenError,
+  roleSatisfies,
+  type ShareRole,
+} from "@agent-native/core/sharing";
+import { eq } from "drizzle-orm";
+
+import { getDb, schema } from "../db/index.js";
+
+/**
+ * Brand kits split writing into drafting and approving.
+ *
+ * Drafting is what a `viewer` may do: create generation runs and generation
+ * sessions, and produce `image_assets` rows with `role: "generated"` and
+ * `status: "candidate"`. None of that reaches the kit's content —
+ * `shouldIncludeAssetInLibraryResults` keeps unsaved candidates out of every
+ * library read — so it is a write a read-only collaborator can safely make.
+ *
+ * Approving is everything that changes what the kit *is*: promoting a
+ * candidate to `saved`, uploads, imports, folders, collections, style brief,
+ * canonical logo, templates, deletes. That still requires `editor`.
+ *
+ * Route new generation paths through `assertCanDraft` and new save/organize
+ * paths through `assertCanApprove` instead of picking a role literal per
+ * action, so the boundary stays readable in one place.
+ */
+export const DRAFT_ROLE: ShareRole = "viewer";
+export const APPROVE_ROLE: ShareRole = "editor";
+
+export interface LibraryWriteAccess {
+  role: ShareRole | "owner";
+  /** True when this caller may save and organize, not only draft. */
+  canApprove: boolean;
+}
+
+/**
+ * Assert the caller may draft in this kit, and report whether they may also
+ * approve. Throws `ForbiddenError` when they cannot even read the kit.
+ */
+export async function assertCanDraft(
+  libraryId: string,
+): Promise<LibraryWriteAccess> {
+  const access = await assertAccess(
+    "asset-library",
+    libraryId,
+    DRAFT_ROLE,
+    undefined,
+    { skipResourceBody: true },
+  );
+  return {
+    role: access.role,
+    canApprove: roleSatisfies(access.role, APPROVE_ROLE),
+  };
+}
+
+/**
+ * Assert the caller may change the kit itself, not just draft in it.
+ *
+ * The thrown message deliberately keeps the framework's
+ * `Requires editor role on asset-library <id> (have viewer)` wording: the
+ * agent's permanent-precondition classifier matches that shape and ends the
+ * turn instead of burning retries on a grant it cannot obtain. `what` names
+ * the blocked step so the remedy is legible to a human too.
+ */
+export async function assertCanApprove(
+  libraryId: string,
+  what: string,
+): Promise<LibraryWriteAccess> {
+  const access = await assertCanDraft(libraryId);
+  if (access.canApprove) return access;
+  throw new ForbiddenError(
+    `Requires ${APPROVE_ROLE} role on asset-library ${libraryId} ` +
+      `(have ${access.role}). ${what} needs edit access on this brand kit — ` +
+      `you can generate drafts here and ask an editor to approve them.`,
+  );
+}
+
+/**
+ * Drafting in a kit does not extend to someone else's drafting workspace: a
+ * below-editor caller may only change a session or run they authored. Legacy
+ * rows with no recorded author therefore need `editor`.
+ */
+export async function assertCanDraftAuthoredBy(
+  libraryId: string,
+  authorEmail: string | null | undefined,
+  what: string,
+): Promise<LibraryWriteAccess> {
+  const access = await assertCanDraft(libraryId);
+  if (access.canApprove) return access;
+  const caller = normalizeEmail(getRequestUserEmail());
+  if (caller && caller === normalizeEmail(authorEmail)) return access;
+  throw new ForbiddenError(
+    `Requires ${APPROVE_ROLE} role on asset-library ${libraryId} ` +
+      `(have ${access.role}). ${what} you did not create needs edit access ` +
+      `on this brand kit — you can still draft in your own.`,
+  );
+}
+
+/**
+ * Removing a row from a kit is approving-class work, with one exception: an
+ * unsaved generated candidate is a draft, so its author may discard their own
+ * even with read-only access. Authorship lives on the generation run — the
+ * asset row itself records no drafting identity — so a candidate with no run
+ * behind it falls back to needing `editor`.
+ */
+export async function assertCanDeleteAsset(asset: {
+  libraryId: string;
+  role?: string | null;
+  status?: string | null;
+  generationRunId?: string | null;
+}): Promise<LibraryWriteAccess> {
+  const isUnsavedDraft =
+    asset.role === "generated" && asset.status === "candidate";
+  if (!isUnsavedDraft) {
+    return assertCanApprove(asset.libraryId, "Deleting an asset");
+  }
+  const author = asset.generationRunId
+    ? await draftAuthorEmail(asset.generationRunId)
+    : null;
+  return assertCanDraftAuthoredBy(asset.libraryId, author, "A draft");
+}
+
+async function draftAuthorEmail(runId: string): Promise<string | null> {
+  const [run] = await getDb()
+    .select({ ownerEmail: schema.assetGenerationRuns.ownerEmail })
+    .from(schema.assetGenerationRuns)
+    .where(eq(schema.assetGenerationRuns.id, runId))
+    .limit(1);
+  return run?.ownerEmail ?? null;
+}
+
+function normalizeEmail(email: string | null | undefined): string | null {
+  return email?.trim().toLowerCase() || null;
+}

--- a/templates/assets/server/lib/library-access.ts
+++ b/templates/assets/server/lib/library-access.ts
@@ -5,7 +5,7 @@ import {
   roleSatisfies,
   type ShareRole,
 } from "@agent-native/core/sharing";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, or, sql, type AnyColumn, type SQL } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -70,10 +70,29 @@ export async function assertCanApprove(
 ): Promise<LibraryWriteAccess> {
   const access = await assertCanDraft(libraryId);
   if (access.canApprove) return access;
-  throw new ForbiddenError(
+  throw draftRefusal(
+    libraryId,
+    access.role,
+    `${what} needs edit access on this brand kit — you can generate drafts ` +
+      `here and ask an editor to approve them.`,
+  );
+}
+
+/**
+ * Every draft refusal keeps the framework's
+ * `Requires editor role on asset-library <id> (have viewer)` opening, because
+ * core's permanent-precondition classifier matches that shape and ends the
+ * agent turn instead of retrying a grant the model cannot obtain. It is also
+ * literally the remedy: an editor may act on any draft in the kit.
+ */
+function draftRefusal(
+  libraryId: string,
+  role: ShareRole | "owner",
+  remedy: string,
+): ForbiddenError {
+  return new ForbiddenError(
     `Requires ${APPROVE_ROLE} role on asset-library ${libraryId} ` +
-      `(have ${access.role}). ${what} needs edit access on this brand kit — ` +
-      `you can generate drafts here and ask an editor to approve them.`,
+      `(have ${role}). ${remedy}`,
   );
 }
 
@@ -91,10 +110,11 @@ export async function assertCanDraftAuthoredBy(
   if (access.canApprove) return access;
   const caller = normalizeEmail(getRequestUserEmail());
   if (caller && caller === normalizeEmail(authorEmail)) return access;
-  throw new ForbiddenError(
-    `Requires ${APPROVE_ROLE} role on asset-library ${libraryId} ` +
-      `(have ${access.role}). ${what} you did not create needs edit access ` +
-      `on this brand kit — you can still draft in your own.`,
+  throw draftRefusal(
+    libraryId,
+    access.role,
+    `${what} you did not create needs edit access on this brand kit — you ` +
+      `can still draft in your own.`,
   );
 }
 
@@ -196,6 +216,100 @@ export function canReadRun(
   if (scope.unrestricted) return true;
   if (scope.approvableLibraryIds.has(run.libraryId)) return true;
   return scope.ownRunIds.has(run.id);
+}
+
+/**
+ * The scope as a WHERE clause, for a query that pages candidates.
+ *
+ * Filtering in JS after `limit` silently drops authorized rows — a viewer asks
+ * for 50 drafts, the newest 50 belong to other people, and they get none while
+ * their own sit just past the cut. Returns `undefined` when nothing is
+ * filtered, so callers can skip adding a clause.
+ */
+export function draftReadFilter(
+  scope: DraftReadScope,
+  table: {
+    libraryId: AnyColumn;
+    generationRunId: AnyColumn;
+  },
+): SQL | undefined {
+  if (scope.unrestricted) return undefined;
+  const clauses: SQL[] = [];
+  if (scope.approvableLibraryIds.size) {
+    clauses.push(
+      inArray(table.libraryId, Array.from(scope.approvableLibraryIds)),
+    );
+  }
+  if (scope.ownRunIds.size) {
+    clauses.push(inArray(table.generationRunId, Array.from(scope.ownRunIds)));
+  }
+  // No approvable kit and no run of their own: this caller authored none of the
+  // candidates in scope, so the query must return nothing rather than fall
+  // through to an unfiltered read.
+  if (!clauses.length) return sql`1 = 0`;
+  return clauses.length === 1 ? clauses[0] : or(...clauses);
+}
+
+/**
+ * The draft scope for one kit, free when the caller can already approve there.
+ * Use this in write paths that also read candidates as input.
+ */
+export async function draftScopeForLibrary(
+  libraryId: string,
+  access?: LibraryWriteAccess,
+): Promise<DraftReadScope> {
+  if (access?.canApprove) return unrestrictedDraftReadScope();
+  return resolveDraftReadScope([libraryId]);
+}
+
+/**
+ * Guard the *input* side of the same boundary `canReadDraftAsset` guards on
+ * reads. A draft this caller cannot read must not become a generation
+ * reference, a lineage source, or a session attachment either — otherwise the
+ * private-candidate rule holds on the list surfaces and leaks through every
+ * path that takes an asset id.
+ */
+export function assertCanUseAssets(
+  scope: DraftReadScope,
+  libraryId: string,
+  role: ShareRole | "owner",
+  assets: Array<{
+    id: string;
+    libraryId: string;
+    role?: string | null;
+    status?: string | null;
+    generationRunId?: string | null;
+  }>,
+  what: string,
+): void {
+  for (const asset of assets) {
+    if (canReadDraftAsset(scope, asset)) continue;
+    throw draftRefusal(
+      libraryId,
+      role,
+      `${what} references draft ${asset.id}, which belongs to whoever ` +
+        `generated it. Use your own draft or a saved asset.`,
+    );
+  }
+}
+
+/** The same guard for run rows, whose prompts and settings are just as private. */
+export function assertCanUseRuns(
+  scope: DraftReadScope,
+  libraryId: string,
+  role: ShareRole | "owner",
+  runs: Array<{ id: string; libraryId: string }>,
+  what: string,
+): void {
+  for (const run of runs) {
+    if (canReadRun(scope, run)) continue;
+    throw draftRefusal(
+      libraryId,
+      role,
+      `${what} references generation run ${run.id}, which belongs to whoever ` +
+        `started it. Use your own run.`,
+    );
+  }
 }
 
 /**

--- a/templates/assets/server/lib/library-access.ts
+++ b/templates/assets/server/lib/library-access.ts
@@ -5,7 +5,7 @@ import {
   roleSatisfies,
   type ShareRole,
 } from "@agent-native/core/sharing";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -96,6 +96,106 @@ export async function assertCanDraftAuthoredBy(
       `(have ${access.role}). ${what} you did not create needs edit access ` +
       `on this brand kit — you can still draft in your own.`,
   );
+}
+
+/**
+ * Who may read an unsaved draft.
+ *
+ * A draft is visible to the person who generated it and to anyone who could
+ * approve it — an editor has to see a proposal to act on it, and a fellow
+ * drafter has no business reading someone else's unsaved prompts and previews.
+ * Saved kit content is unaffected: this scope only ever narrows candidates.
+ *
+ * Resolve it once per read and pass it to `canReadDraftAsset` per row. The
+ * per-kit role lookups only run for candidate-bearing reads, so ordinary asset
+ * lists pay nothing.
+ */
+export interface DraftReadScope {
+  /** True when every kit in the read is approvable, so nothing is filtered. */
+  unrestricted: boolean;
+  approvableLibraryIds: Set<string>;
+  /** The caller's own generation runs in the kits they cannot approve. */
+  ownRunIds: Set<string>;
+}
+
+export async function resolveDraftReadScope(
+  libraryIds: string[],
+): Promise<DraftReadScope> {
+  const uniqueIds = Array.from(new Set(libraryIds.filter(Boolean)));
+  const approvableLibraryIds = new Set<string>();
+  const roles = await Promise.all(
+    uniqueIds.map(async (id) => {
+      const access = await assertCanDraft(id);
+      return [id, access.canApprove] as const;
+    }),
+  );
+  for (const [id, canApprove] of roles) {
+    if (canApprove) approvableLibraryIds.add(id);
+  }
+  const restricted = uniqueIds.filter((id) => !approvableLibraryIds.has(id));
+  if (restricted.length === 0) {
+    return { unrestricted: true, approvableLibraryIds, ownRunIds: new Set() };
+  }
+  const caller = normalizeEmail(getRequestUserEmail());
+  if (!caller) {
+    return { unrestricted: false, approvableLibraryIds, ownRunIds: new Set() };
+  }
+  const rows = await getDb()
+    .select({
+      id: schema.assetGenerationRuns.id,
+      ownerEmail: schema.assetGenerationRuns.ownerEmail,
+    })
+    .from(schema.assetGenerationRuns)
+    .where(inArray(schema.assetGenerationRuns.libraryId, restricted));
+  const ownRunIds = new Set(
+    rows
+      .filter((row) => normalizeEmail(row.ownerEmail) === caller)
+      .map((row) => row.id),
+  );
+  return { unrestricted: false, approvableLibraryIds, ownRunIds };
+}
+
+/**
+ * The no-op scope, for a caller already known to approve everywhere in the
+ * read. Lets an approver-side read skip the run lookup entirely.
+ */
+export function unrestrictedDraftReadScope(): DraftReadScope {
+  return {
+    unrestricted: true,
+    approvableLibraryIds: new Set(),
+    ownRunIds: new Set(),
+  };
+}
+
+/** True when this row is not a draft, or is a draft this caller may read. */
+export function canReadDraftAsset(
+  scope: DraftReadScope,
+  asset: {
+    libraryId: string;
+    role?: string | null;
+    status?: string | null;
+    generationRunId?: string | null;
+  },
+): boolean {
+  if (asset.role !== "generated" || asset.status !== "candidate") return true;
+  if (scope.unrestricted) return true;
+  if (scope.approvableLibraryIds.has(asset.libraryId)) return true;
+  return Boolean(
+    asset.generationRunId && scope.ownRunIds.has(asset.generationRunId),
+  );
+}
+
+/**
+ * The run rows behind drafts carry the same prompts and settings, so a kit's
+ * run history narrows the same way its candidates do.
+ */
+export function canReadRun(
+  scope: DraftReadScope,
+  run: { id: string; libraryId: string },
+): boolean {
+  if (scope.unrestricted) return true;
+  if (scope.approvableLibraryIds.has(run.libraryId)) return true;
+  return scope.ownRunIds.has(run.id);
 }
 
 /**

--- a/templates/assets/server/lib/library-access.ts
+++ b/templates/assets/server/lib/library-access.ts
@@ -5,7 +5,15 @@ import {
   roleSatisfies,
   type ShareRole,
 } from "@agent-native/core/sharing";
-import { eq, inArray, or, sql, type AnyColumn, type SQL } from "drizzle-orm";
+import {
+  and,
+  eq,
+  inArray,
+  or,
+  sql,
+  type AnyColumn,
+  type SQL,
+} from "drizzle-orm";
 
 import { getDb, schema } from "../db/index.js";
 
@@ -136,6 +144,13 @@ export interface DraftReadScope {
   approvableLibraryIds: Set<string>;
   /** The caller's own generation runs in the kits they cannot approve. */
   ownRunIds: Set<string>;
+  /**
+   * Captured when the scope is resolved, so every predicate below is a pure
+   * function of the scope. Reading it from the ambient request context instead
+   * makes a row check silently answer "not yours" whenever it runs outside the
+   * context that resolved the scope.
+   */
+  callerEmail: string | null;
 }
 
 export async function resolveDraftReadScope(
@@ -152,13 +167,23 @@ export async function resolveDraftReadScope(
   for (const [id, canApprove] of roles) {
     if (canApprove) approvableLibraryIds.add(id);
   }
+  const caller = normalizeEmail(getRequestUserEmail());
   const restricted = uniqueIds.filter((id) => !approvableLibraryIds.has(id));
   if (restricted.length === 0) {
-    return { unrestricted: true, approvableLibraryIds, ownRunIds: new Set() };
+    return {
+      unrestricted: true,
+      approvableLibraryIds,
+      ownRunIds: new Set(),
+      callerEmail: caller,
+    };
   }
-  const caller = normalizeEmail(getRequestUserEmail());
   if (!caller) {
-    return { unrestricted: false, approvableLibraryIds, ownRunIds: new Set() };
+    return {
+      unrestricted: false,
+      approvableLibraryIds,
+      ownRunIds: new Set(),
+      callerEmail: null,
+    };
   }
   const rows = await getDb()
     .select({
@@ -172,7 +197,12 @@ export async function resolveDraftReadScope(
       .filter((row) => normalizeEmail(row.ownerEmail) === caller)
       .map((row) => row.id),
   );
-  return { unrestricted: false, approvableLibraryIds, ownRunIds };
+  return {
+    unrestricted: false,
+    approvableLibraryIds,
+    ownRunIds,
+    callerEmail: caller,
+  };
 }
 
 /**
@@ -184,6 +214,7 @@ export function unrestrictedDraftReadScope(): DraftReadScope {
     unrestricted: true,
     approvableLibraryIds: new Set(),
     ownRunIds: new Set(),
+    callerEmail: normalizeEmail(getRequestUserEmail()),
   };
 }
 
@@ -248,6 +279,98 @@ export function draftReadFilter(
   // through to an unfiltered read.
   if (!clauses.length) return sql`1 = 0`;
   return clauses.length === 1 ? clauses[0] : or(...clauses);
+}
+
+/**
+ * The scope as a WHERE clause for run history. Runs carry the prompts and
+ * settings behind a draft, so they narrow to their author the same way.
+ */
+export function runReadFilter(
+  scope: DraftReadScope,
+  table: { id: AnyColumn; libraryId: AnyColumn },
+): SQL | undefined {
+  if (scope.unrestricted) return undefined;
+  const clauses: SQL[] = [];
+  if (scope.approvableLibraryIds.size) {
+    clauses.push(
+      inArray(table.libraryId, Array.from(scope.approvableLibraryIds)),
+    );
+  }
+  if (scope.ownRunIds.size) {
+    clauses.push(inArray(table.id, Array.from(scope.ownRunIds)));
+  }
+  if (!clauses.length) return sql`1 = 0`;
+  return clauses.length === 1 ? clauses[0] : or(...clauses);
+}
+
+/**
+ * Handoff sessions hold a brief, feedback, and references to candidates, so a
+ * below-approver caller sees only the sessions they created. Filtering in SQL
+ * rather than after `limit` keeps a caller's own sessions from being paged out
+ * behind other people's.
+ */
+export function sessionReadFilter(
+  scope: DraftReadScope,
+  table: { libraryId: AnyColumn; createdBy: AnyColumn },
+): SQL | undefined {
+  if (scope.unrestricted) return undefined;
+  const clauses: SQL[] = [];
+  if (scope.approvableLibraryIds.size) {
+    clauses.push(
+      inArray(table.libraryId, Array.from(scope.approvableLibraryIds)),
+    );
+  }
+  if (scope.callerEmail) {
+    // Case-insensitive to match how core's own access filter compares emails.
+    clauses.push(sql`lower(${table.createdBy}) = ${scope.callerEmail}`);
+  }
+  if (!clauses.length) return sql`1 = 0`;
+  return clauses.length === 1 ? clauses[0] : or(...clauses);
+}
+
+/** The row-level counterpart of `sessionReadFilter`, for reads by id. */
+export function canReadSession(
+  scope: DraftReadScope,
+  session: { libraryId: string; createdBy?: string | null },
+): boolean {
+  if (scope.unrestricted) return true;
+  if (scope.approvableLibraryIds.has(session.libraryId)) return true;
+  return Boolean(
+    scope.callerEmail &&
+    scope.callerEmail === normalizeEmail(session.createdBy),
+  );
+}
+
+/**
+ * Delete a draft against the state that authorized it.
+ *
+ * Authorization comes from a prior read, so an editor can approve the candidate
+ * in between. The predicate makes that save win, and the confirming re-read
+ * keeps the answer portable — row counts are adapter-specific. Returns false
+ * when the row survived, which callers must treat as "not deleted" rather than
+ * as success.
+ */
+export async function deleteDraftAssetIfUnchanged(asset: {
+  id: string;
+  libraryId: string;
+}): Promise<boolean> {
+  const db = getDb();
+  await db
+    .delete(schema.assets)
+    .where(
+      and(
+        eq(schema.assets.id, asset.id),
+        eq(schema.assets.libraryId, asset.libraryId),
+        eq(schema.assets.role, "generated"),
+        eq(schema.assets.status, "candidate"),
+      ),
+    );
+  const [survivor] = await db
+    .select({ id: schema.assets.id })
+    .from(schema.assets)
+    .where(eq(schema.assets.id, asset.id))
+    .limit(1);
+  return !survivor;
 }
 
 /**

--- a/templates/assets/server/lib/select-references.spec.ts
+++ b/templates/assets/server/lib/select-references.spec.ts
@@ -442,6 +442,7 @@ describe("selectReferences draft scope", () => {
     unrestricted: false,
     approvableLibraryIds: new Set<string>(),
     ownRunIds: new Set(["run-mine"]),
+    callerEmail: "viewer@example.test",
   };
 
   beforeEach(() => {

--- a/templates/assets/server/lib/select-references.spec.ts
+++ b/templates/assets/server/lib/select-references.spec.ts
@@ -29,7 +29,8 @@ vi.mock("@agent-native/core/server", () => ({
   resolveSecret: vi.fn(),
 }));
 
-vi.mock("drizzle-orm", () => ({
+vi.mock("drizzle-orm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("drizzle-orm")>()),
   and: vi.fn((...args) => ({ op: "and", args })),
   eq: vi.fn((column, value) => ({ op: "eq", column, value })),
   inArray: vi.fn((column, values) => ({ op: "inArray", column, values })),
@@ -45,6 +46,7 @@ vi.mock("./storage.js", () => ({
 }));
 
 import { selectReferences } from "./generation.js";
+import { unrestrictedDraftReadScope } from "./library-access.js";
 
 type AssetRow = {
   id: string;
@@ -55,6 +57,7 @@ type AssetRow = {
   objectKey: string;
   metadata: string;
   collectionId?: string | null;
+  generationRunId?: string | null;
 };
 
 function createDb(settings: Record<string, unknown>, assets: AssetRow[]) {
@@ -153,6 +156,7 @@ describe("selectReferences", () => {
     const randomSpy = vi.spyOn(Math, "random");
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       subjectAssetId: "subject",
       intent: "restyle",
@@ -160,6 +164,7 @@ describe("selectReferences", () => {
       limit: 4,
     });
     const refsAgain = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       subjectAssetId: "subject",
       intent: "restyle",
@@ -231,6 +236,7 @@ describe("selectReferences", () => {
     );
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       referenceAssetIds: ["content-1"],
       intent: "generate",
@@ -284,6 +290,7 @@ describe("selectReferences", () => {
     );
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       referenceAssetIds: ["content-1", "style-picked"],
       intent: "generate",
@@ -327,6 +334,7 @@ describe("selectReferences", () => {
     getDbMock.mockReturnValue(createDb({}, assets));
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       subjectAssetId: "subject",
       referenceAssetIds: ["explicit-b", "explicit-a"],
@@ -366,6 +374,7 @@ describe("selectReferences", () => {
     getDbMock.mockReturnValue(createDb({}, assets));
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       referenceAssetIds: ["skeleton-plate", "explicit-style"],
       excludeAssetIds: ["skeleton-plate"],
@@ -409,11 +418,68 @@ describe("selectReferences", () => {
     getDbMock.mockReturnValue(createDb({}, assets));
 
     const refs = await selectReferences({
+      draftScope: unrestrictedDraftReadScope(),
       libraryId: "library-1",
       intent: "generate",
       limit: 4,
     });
 
     expect(refs.map((ref) => ref.id)).toEqual(["style-ref"]);
+  });
+});
+describe("selectReferences draft scope", () => {
+  const candidate = (id: string, generationRunId: string): AssetRow => ({
+    id,
+    role: "generated",
+    mimeType: "image/png",
+    status: "candidate",
+    createdAt: "2026-05-24T00:00:00.000Z",
+    objectKey: `${id}-bytes`,
+    metadata: "{}",
+    generationRunId,
+  });
+  const viewerScope = {
+    unrestricted: false,
+    approvableLibraryIds: new Set<string>(),
+    ownRunIds: new Set(["run-mine"]),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getObjectMock.mockImplementation(async (key: string) => Buffer.from(key));
+  });
+
+  it("keeps another drafter's candidate out of the automatic pool", async () => {
+    getDbMock.mockReturnValue(
+      createDb({}, [
+        candidate("mine", "run-mine"),
+        candidate("theirs", "run-theirs"),
+      ]),
+    );
+
+    const refs = await selectReferences({
+      draftScope: viewerScope,
+      libraryId: "lib-1",
+      intent: "generate",
+      limit: 5,
+    });
+
+    expect(refs.map((ref) => ref.id)).toEqual(["mine"]);
+  });
+
+  it("drops another drafter's candidate passed explicitly", async () => {
+    getDbMock.mockReturnValue(
+      createDb({}, [candidate("theirs", "run-theirs")]),
+    );
+
+    const refs = await selectReferences({
+      draftScope: viewerScope,
+      libraryId: "lib-1",
+      referenceAssetIds: ["theirs"],
+      intent: "generate",
+      limit: 5,
+    });
+
+    expect(refs).toEqual([]);
   });
 });

--- a/templates/assets/shared/api.ts
+++ b/templates/assets/shared/api.ts
@@ -198,6 +198,22 @@ export interface PresetReference {
   required: boolean;
 }
 
+export type AssetAccessRole =
+  | "viewer"
+  | "commenter"
+  | "editor"
+  | "admin"
+  | "owner";
+
+/**
+ * True when this role may approve, not only draft: save a candidate into the
+ * kit, organize it, or change its settings. Mirrors `assertCanApprove` on the
+ * server — see `server/lib/library-access.ts` for the rule itself.
+ */
+export function canApproveWithRole(role: unknown): boolean {
+  return role === "editor" || role === "admin" || role === "owner";
+}
+
 export interface ImageLibrarySummary {
   id: string;
   title: string;

--- a/templates/slides/.agents/skills/image-generation-via-a2a/SKILL.md
+++ b/templates/slides/.agents/skills/image-generation-via-a2a/SKILL.md
@@ -36,6 +36,12 @@ image" has very different right answers:
 | `pending` | Caller-side timeout; the Assets run is still going and owns a `taskId` | Tell the user to check Assets; generating again would duplicate the run |
 | `unavailable` | Assets could not be resolved or reached at all | Local fallback |
 
+A `delegated` reply can still say the generation is a draft pending approval.
+That means the user may draft in that brand kit but not save into it: the image
+is real and usable in the deck, and only the copy kept in Assets is waiting on a
+kit editor. Use the image, pass that along, and do not retry or fall back
+locally.
+
 Only `unavailable` falls through to the local Gemini/OpenAI providers under
 `server/handlers/image-providers/`, so a slides-only deploy still works. That
 output is **not** brand-grounded and the action says so: it returns


### PR DESCRIPTION
## Viewers can draft in a brand kit; approving still needs editor

Every Assets generation path asserted `editor`, so a collaborator with view
access to a kit could not generate anything in it. It surfaced as an A2A failure
from Slides: `match-library` recommends any kit the caller can *read*, then
`generate-image-batch` refused with `Requires editor role on asset-library <id>
(have viewer)` and the run stopped as a permanent precondition.

Generating is now drafting, and drafting only needs read access. Approving —
turning a candidate into kit content, or changing the kit — still needs `editor`.

### The rule

`templates/assets/server/lib/library-access.ts` owns it, so no action picks a
role literal:

| Helper | Bar | Covers |
| --- | --- | --- |
| `assertCanDraft` | viewer | generate-image, generate-image-batch, generate-video, refine/edit/restyle, create-generation-session, refresh/rerun run, dismiss-variant-slots |
| `assertCanApprove` | editor | save-generated-image, update-asset, uploads, imports, folders, collections, style analysis, palette, canonical logo, kit settings, templates, bulk delete |
| `assertCanDraftAuthoredBy` | viewer for own | a generation session you created |
| `assertCanDeleteAsset` | viewer for own draft | discarding your unsaved candidate vs deleting kit content |

Kit archive/delete stay `admin`. Drafting is safe at read level because unsaved
candidates never reach kit content: `shouldIncludeAssetInLibraryResults` already
filters `role: "generated" + status: "candidate"` out of every library read.
Own-draft authorship comes from `image_generation_runs.owner_email`, the only
place drafting identity is recorded, so a candidate with no run behind it falls
back to needing `editor`.

### So nothing claims "saved"

- Generation results carry `draftPendingApproval: true` only when the caller
  cannot approve.
- New `get-library-access` action returns `{ role, canDraft, canApprove }` for
  the UI and for peer agents.
- The refusal keeps the framework's `Requires editor role on asset-library <id>
  (have viewer)` prefix and appends the remedy. That prefix is what core's
  permanent-precondition classifier matches, so the agent stops rather than
  retrying a grant it cannot obtain — there is a test pinning it.
- Taught in the assets `library-management`, `asset-generation`, and
  `a2a-assets` skills, one line in `AGENTS.md`, and the Slides
  `image-generation-via-a2a` skill.

### UI

Save and Add-to-references are absent rather than broken for a non-approver:
chat generation tray, brand-kit drafts stage, and `/library`. The tray shows a
`Drafts only` badge with the remedy in a tooltip. Both new strings are
translated across all 12 locales.
