### PR TITLE
fix: launch desktop terminal providers interactively

### DIFF
--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -47,7 +47,7 @@ describe("desktop chat relay target URLs", () => {
     ]);
     expect(
       desktopTerminalMcpArgs("builder", registration, "/tmp/unused.json"),
-    ).toEqual([]);
+    ).toEqual(["code"]);
   });
 
   it("returns an authenticated desktop-owned terminal endpoint", () => {

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -100,6 +100,9 @@ export function desktopTerminalMcpArgs(
       })}`,
     ];
   }
+  if (command === "builder") {
+    return ["code"];
+  }
   return [];
 }
 

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -127,9 +127,11 @@ describe("DesktopTerminalSurface", () => {
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
     ).find((item) => item.textContent?.includes("Provider"));
     expect(providerItem).not.toBeUndefined();
-    expect(
-      providerItem?.querySelector(".desktop-dropdown-item__main"),
-    ).not.toBeNull();
+    expect(providerItem?.classList.contains("gap-2")).toBe(true);
+    expect(providerItem?.querySelector(".desktop-dropdown-item__main")).toBe(
+      null,
+    );
+    expect(providerItem?.querySelector("svg.ms-auto")).not.toBeNull();
     expect(
       Array.from(
         document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -200,11 +200,9 @@ export default function DesktopTerminalSurface({
               {onAgentChange ? (
                 <>
                   <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>
-                      <span className="desktop-dropdown-item__main">
-                        <IconTerminal2 size={14} className="shrink-0" />
-                        Provider
-                      </span>
+                    <DropdownMenuSubTrigger className="gap-2">
+                      <IconTerminal2 size={14} className="shrink-0" />
+                      Provider
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent className="w-52">
                       {DESKTOP_TERMINAL_AGENT_OPTIONS.map((option) => (


### PR DESCRIPTION
Fix desktop terminal provider presentation and startup behavior.\n\n- Align the Provider submenu row with standard menu spacing and keep its native chevron.\n- Launch Builder through its interactive \ entrypoint.\n- Verify New Chat, active-chat sidebar gating, PTY prompt input, and Codex/Claude Code/Builder provider switching in the packaged Electron app.\n\nValidation: 66 repository guards pass; focused desktop/core terminal tests pass; packaged Electron smoke passes. The desktop typecheck is still blocked by the pre-existing stale-branch AuthPage/MarketingHome topRight mismatch.