### PR TITLE
Clips edit button uses text-only label

### DIFF
--- a/.agents/skills/actions/references/action-fields.md
+++ b/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/default/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/default/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/default/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/default/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/headless/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/headless/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/headless/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/headless/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/src/templates/workspace-core/.agents/skills/actions/references/action-fields.md
+++ b/packages/core/src/templates/workspace-core/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/analytics/.agents/skills/actions/references/action-fields.md
+++ b/templates/analytics/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/analytics/.agents/skills/actions/references/action-fields.md
+++ b/templates/analytics/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/assets/.agents/skills/actions/references/action-fields.md
+++ b/templates/assets/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/assets/.agents/skills/actions/references/action-fields.md
+++ b/templates/assets/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/brain/.agents/skills/actions/references/action-fields.md
+++ b/templates/brain/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/brain/.agents/skills/actions/references/action-fields.md
+++ b/templates/brain/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/calendar/.agents/skills/actions/references/action-fields.md
+++ b/templates/calendar/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/calendar/.agents/skills/actions/references/action-fields.md
+++ b/templates/calendar/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/chat/.agents/skills/actions/references/action-fields.md
+++ b/templates/chat/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/chat/.agents/skills/actions/references/action-fields.md
+++ b/templates/chat/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/clips/.agents/skills/actions/references/action-fields.md
+++ b/templates/clips/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/clips/.agents/skills/actions/references/action-fields.md
+++ b/templates/clips/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/clips/CHANGELOG.md
+++ b/templates/clips/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable user-facing changes to Clips are documented here. Open it any time
 from the command menu (Cmd+K → "What's new") or from Settings.
 
+## 2026-09-01
+
+### Improved
+
+- Clip editing uses a text-only Edit button for a cleaner toolbar.
+
 ## 2026-08-29
 
 ### Improved

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -43,7 +43,6 @@ import {
   IconArrowLeft,
   IconChevronDown,
   IconCalendar,
-  IconScissors,
   IconAlertTriangle,
   IconHelpCircle,
   IconClipboardCopy,
@@ -1457,7 +1456,6 @@ export default function RecordingPage() {
               )}
               onClick={() => setEditing((v) => !v)}
             >
-              <IconScissors className="h-4 w-4" />
               {editing ? t("recordingPage.done") : t("recordingPage.edit")}
             </Button>
           ) : null}

--- a/templates/clips/changelog/2026-09-01-text-only-edit-button.md
+++ b/templates/clips/changelog/2026-09-01-text-only-edit-button.md
@@ -2,4 +2,5 @@
 type: improved
 date: 2026-09-01
 ---
+
 Clip editing uses a text-only Edit button for a cleaner toolbar.

--- a/templates/clips/changelog/2026-09-01-text-only-edit-button.md
+++ b/templates/clips/changelog/2026-09-01-text-only-edit-button.md
@@ -1,0 +1,5 @@
+---
+type: improved
+date: 2026-09-01
+---
+Clip editing uses a text-only Edit button for a cleaner toolbar.

--- a/templates/content/.agents/skills/actions/references/action-fields.md
+++ b/templates/content/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/content/.agents/skills/actions/references/action-fields.md
+++ b/templates/content/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/crm/.agents/skills/actions/references/action-fields.md
+++ b/templates/crm/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/crm/.agents/skills/actions/references/action-fields.md
+++ b/templates/crm/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/design/.agents/skills/actions/references/action-fields.md
+++ b/templates/design/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/design/.agents/skills/actions/references/action-fields.md
+++ b/templates/design/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/dispatch/.agents/skills/actions/references/action-fields.md
+++ b/templates/dispatch/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/dispatch/.agents/skills/actions/references/action-fields.md
+++ b/templates/dispatch/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/factory/.agents/skills/actions/references/action-fields.md
+++ b/templates/factory/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/factory/.agents/skills/actions/references/action-fields.md
+++ b/templates/factory/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/forms/.agents/skills/actions/references/action-fields.md
+++ b/templates/forms/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/forms/.agents/skills/actions/references/action-fields.md
+++ b/templates/forms/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/mail/.agents/skills/actions/references/action-fields.md
+++ b/templates/mail/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/mail/.agents/skills/actions/references/action-fields.md
+++ b/templates/mail/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/plan/.agents/skills/actions/references/action-fields.md
+++ b/templates/plan/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/plan/.agents/skills/actions/references/action-fields.md
+++ b/templates/plan/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/slides/.agents/skills/actions/references/action-fields.md
+++ b/templates/slides/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/slides/.agents/skills/actions/references/action-fields.md
+++ b/templates/slides/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/tasks/.agents/skills/actions/references/action-fields.md
+++ b/templates/tasks/.agents/skills/actions/references/action-fields.md
@@ -15,6 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/templates/tasks/.agents/skills/actions/references/action-fields.md
+++ b/templates/tasks/.agents/skills/actions/references/action-fields.md
@@ -15,7 +15,7 @@ Rules:
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
 - To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
-- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true`. The loop stops there instead of asking the model for another step, and tool calls the model emitted alongside it are reported as not executed rather than racing the unanswered card. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
+- If a successful call hands control to the user — it renders a question, an intake form, or anything else the turn must wait on — pass `endsTurn: true` and make it the first or only call in the turn. It stops subsequent model steps and later calls, but cannot undo calls emitted before it. Without it a completion guard sees a turn that legitimately paused as one that failed to finish.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 


### PR DESCRIPTION
## Summary
- Remove the scissors icon from the Clips recording edit button.
- Keep the localized Edit/Done labels and behavior unchanged.
- Add the Clips changelog entry and generated aggregate.
- Sync generated workspace skill copies so the workspace-skills guard passes.

## Validation
- `git diff --check`
- `corepack pnpm guards`
- `corepack pnpm changelog:compact`
- Focused Clips tests: 9 passed.
- Local browser verification confirmed Edit toggles to Done and the Edit button contains no SVG icon.
- Clips typecheck completed; it reports existing production configuration diagnostics for missing deployment settings.