### PR TITLE
Improve community app screenshot uploads

### DIFF
--- a/packages/docs/app/components/CommunityAppSubmissionForm.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionForm.tsx
@@ -1,7 +1,15 @@
 import { trackEvent } from "@agent-native/core/client/analytics";
 import { useLocale, useT } from "@agent-native/core/client/i18n";
-import { IconUpload } from "@tabler/icons-react";
-import { useId, useState, type ChangeEvent, type FormEvent } from "react";
+import { IconPhoto, IconPlus, IconUpload, IconX } from "@tabler/icons-react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type FormEvent,
+} from "react";
 
 import { sitePathForLocale } from "./docs-locale";
 import { Button } from "./website-redesign/ds/button";
@@ -16,6 +24,11 @@ const SCREENSHOT_FIELDS = [
 ] as const;
 const SCREENSHOT_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const MAX_SCREENSHOT_BYTES = 1.5 * 1024 * 1024;
+
+type SelectedScreenshot = {
+  file: File;
+  previewUrl: string;
+};
 
 type CommunitySubmissionValues = {
   name: string;
@@ -41,51 +54,115 @@ function isValidScreenshot(file: File) {
 const fieldClassName =
   "w-full rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)] px-3 py-2.5 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[var(--b-text-muted)] focus:border-[var(--b-action-primary-bg)] focus:ring-2 focus:ring-[var(--b-action-primary-effect)]";
 
-const fileFieldClassName =
-  "block w-full min-w-0 cursor-pointer rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)] px-2 py-2 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-secondary)] outline-none file:mr-3 file:cursor-pointer file:rounded-[var(--b-radius)] file:border file:border-solid file:border-[var(--b-action-secondary-border)] file:bg-[var(--b-action-secondary-bg)] file:px-3 file:py-2 file:font-[family-name:var(--b-font-mono)] file:text-[length:var(--b-t-label-2)] file:font-semibold file:uppercase file:tracking-[0.04em] file:text-[var(--b-action-secondary-text)] hover:file:bg-[var(--b-action-secondary-hover)] focus:border-[var(--b-action-primary-bg)] focus:ring-2 focus:ring-[var(--b-action-primary-effect)]";
-
 export function CommunityAppSubmissionForm() {
   const t = useT();
   const { locale } = useLocale();
   const formId = useId();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const hiddenInputRefs = useRef<Array<HTMLInputElement | null>>([]);
+  const previewUrlsRef = useRef<Set<string>>(new Set());
   const [values, setValues] = useState<CommunitySubmissionValues>({
     name: "",
     appUrl: "",
     description: "",
     repositoryUrl: "",
   });
-  const [screenshots, setScreenshots] = useState<Array<File | null>>(() =>
-    SCREENSHOT_FIELDS.map(() => null),
-  );
+  const [screenshots, setScreenshots] = useState<SelectedScreenshot[]>([]);
+  const [isDragActive, setIsDragActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const activePreviewUrls = new Set(
+      screenshots.map((screenshot) => screenshot.previewUrl),
+    );
+
+    for (const previewUrl of previewUrlsRef.current) {
+      if (!activePreviewUrls.has(previewUrl)) URL.revokeObjectURL(previewUrl);
+    }
+    previewUrlsRef.current = activePreviewUrls;
+  }, [screenshots]);
+
+  useEffect(() => {
+    return () => {
+      for (const previewUrl of previewUrlsRef.current) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    for (const index of SCREENSHOT_FIELDS.keys()) {
+      const input = hiddenInputRefs.current[index];
+      if (!input) continue;
+
+      const dataTransfer = new DataTransfer();
+      const screenshot = screenshots[index];
+      if (screenshot) dataTransfer.items.add(screenshot.file);
+      input.files = dataTransfer.files;
+    }
+  }, [screenshots]);
 
   function updateValue(field: keyof CommunitySubmissionValues, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
     setError(null);
   }
 
-  function handleScreenshotChange(
-    index: number,
-    event: ChangeEvent<HTMLInputElement>,
-  ) {
-    const file = event.currentTarget.files?.[0] ?? null;
-    if (file && !isValidScreenshot(file)) {
-      event.currentTarget.value = "";
-      setScreenshots((current) =>
-        current.map((existing, currentIndex) =>
-          currentIndex === index ? null : existing,
-        ),
-      );
-      setError(t("templatesPage.communitySubmissionValidation"));
-      return;
+  function handleScreenshotChange(event: ChangeEvent<HTMLInputElement>) {
+    const files = event.currentTarget.files;
+    if (files) addScreenshots(files);
+    event.currentTarget.value = "";
+  }
+
+  function addScreenshots(files: FileList | File[]) {
+    const incomingFiles = Array.from(files);
+    const validFiles = incomingFiles.filter(isValidScreenshot);
+    const availableSlots = SCREENSHOT_FIELDS.length - screenshots.length;
+    const filesToAdd = validFiles.slice(0, availableSlots);
+
+    if (filesToAdd.length > 0) {
+      setScreenshots((current) => [
+        ...current,
+        ...filesToAdd.map((file) => ({
+          file,
+          previewUrl: URL.createObjectURL(file),
+        })),
+      ]);
     }
 
+    if (
+      validFiles.length > availableSlots ||
+      validFiles.length !== incomingFiles.length
+    ) {
+      setError(t("templatesPage.communitySubmissionValidation"));
+    } else {
+      setError(null);
+    }
+  }
+
+  function removeScreenshot(index: number) {
     setScreenshots((current) =>
-      current.map((existing, currentIndex) =>
-        currentIndex === index ? file : existing,
-      ),
+      current.filter((_, currentIndex) => currentIndex !== index),
     );
     setError(null);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setIsDragActive(true);
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLDivElement>) {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return;
+    }
+    setIsDragActive(false);
+  }
+
+  function handleDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setIsDragActive(false);
+    addScreenshots(event.dataTransfer.files);
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -210,45 +287,130 @@ export function CommunityAppSubmissionForm() {
         />
       </div>
 
-      <div className="grid gap-1.5">
-        <div>
-          <p className="m-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-semibold uppercase tracking-[0.04em] text-[var(--b-text-primary)]">
+      <div className="grid gap-3">
+        <div className="flex items-center justify-between gap-4">
+          <p
+            id={`${formId}-screenshots-label`}
+            className="m-0 font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-semibold uppercase tracking-[0.04em] text-[var(--b-text-primary)]"
+          >
             {t("templatesPage.communitySubmissionScreenshots")}
           </p>
-          <p className="mt-1.5 mb-0 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-muted)]">
-            {t("templatesPage.communitySubmissionScreenshotsPlaceholder")}
-          </p>
+          <span
+            className="font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-semibold uppercase tracking-[0.04em] text-[var(--b-text-muted)]"
+            aria-live="polite"
+          >
+            {t("templatesPage.communitySubmissionScreenshotsCount", {
+              count: screenshots.length,
+            })}
+          </span>
         </div>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {SCREENSHOT_FIELDS.map((field, index) => {
-            const file = screenshots[index];
-            const inputId = `${formId}-${field}`;
-            return (
-              <div key={field} className="min-w-0">
-                <label
-                  htmlFor={inputId}
-                  className="mb-1.5 block font-[family-name:var(--b-font-mono)] text-[length:var(--b-t-label-2)] font-semibold uppercase tracking-[0.04em] text-[var(--b-text-secondary)]"
+
+        <div
+          data-community-screenshot-dropzone="true"
+          role="group"
+          aria-labelledby={`${formId}-screenshots-label`}
+          className={`rounded-[var(--b-radius)] border border-dashed p-4 transition-[background,border-color] duration-150 sm:p-5 ${
+            isDragActive
+              ? "border-[var(--b-text-primary)] bg-[var(--b-action-secondary-hover)]"
+              : "border-[var(--b-border-default)] bg-[var(--b-bg-inset)] hover:border-[var(--b-text-primary)]"
+          }`}
+          onDragOver={handleDragOver}
+          onDragEnter={() => setIsDragActive(true)}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          <input
+            ref={fileInputRef}
+            id={`${formId}-screenshots`}
+            type="file"
+            multiple
+            accept="image/jpeg,image/png,image/webp"
+            className="sr-only"
+            onChange={handleScreenshotChange}
+            aria-label={t("templatesPage.communitySubmissionScreenshotsAdd")}
+            aria-describedby={`${formId}-screenshots-help`}
+          />
+          <div className="flex flex-col items-center justify-between gap-4 text-center sm:flex-row sm:text-left">
+            <div className="flex items-center gap-3">
+              <span className="flex size-10 shrink-0 items-center justify-center rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-page)] text-[var(--b-text-primary)]">
+                <IconPhoto size={20} stroke={1.7} />
+              </span>
+              <div>
+                <p className="m-0 font-[family-name:var(--b-font-sans)] text-sm font-medium leading-[1.35] text-[var(--b-text-primary)]">
+                  {t("templatesPage.communitySubmissionScreenshotsPlaceholder")}
+                </p>
+                <p
+                  id={`${formId}-screenshots-help`}
+                  className="mt-1 mb-0 font-[family-name:var(--b-font-sans)] text-xs leading-[1.4] text-[var(--b-text-muted)]"
                 >
-                  {t("templatesPage.communitySubmissionScreenshotSlot", {
+                  {t("templatesPage.communitySubmissionScreenshotDropHint")}
+                </p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="secondary"
+              icon={IconPlus}
+              disabled={screenshots.length === SCREENSHOT_FIELDS.length}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {t("templatesPage.communitySubmissionScreenshotsAdd")}
+            </Button>
+          </div>
+        </div>
+
+        {screenshots.length > 0 ? (
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {screenshots.map((screenshot, index) => (
+              <div
+                key={`${screenshot.file.name}-${screenshot.file.lastModified}-${index}`}
+                className="group relative min-w-0 overflow-hidden rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)]"
+              >
+                <img
+                  src={screenshot.previewUrl}
+                  alt={t("templatesPage.communitySubmissionScreenshotSlot", {
                     index: index + 1,
                   })}
-                </label>
-                <input
-                  id={inputId}
-                  name={field}
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp"
-                  className={fileFieldClassName}
-                  onChange={(event) => handleScreenshotChange(index, event)}
+                  className="aspect-[4/3] w-full object-cover"
                 />
-                {file ? (
-                  <p className="mt-1.5 mb-0 truncate font-[family-name:var(--b-font-sans)] text-xs text-[var(--b-text-secondary)]">
-                    {file.name}
-                  </p>
-                ) : null}
+                <Button
+                  type="button"
+                  variant="secondary-icon"
+                  icon={IconX}
+                  aria-label={t(
+                    "templatesPage.communitySubmissionScreenshotRemove",
+                    { index: index + 1 },
+                  )}
+                  title={t(
+                    "templatesPage.communitySubmissionScreenshotRemove",
+                    { index: index + 1 },
+                  )}
+                  className="absolute top-2 right-2 size-8 p-0"
+                  onClick={() => removeScreenshot(index)}
+                >
+                  {null}
+                </Button>
+                <p className="m-0 truncate border-t border-solid border-[var(--b-border-default)] px-2.5 py-2 font-[family-name:var(--b-font-sans)] text-xs text-[var(--b-text-secondary)]">
+                  {screenshot.file.name}
+                </p>
               </div>
-            );
-          })}
+            ))}
+          </div>
+        ) : null}
+
+        <div className="hidden" aria-hidden="true">
+          {SCREENSHOT_FIELDS.map((field, index) => (
+            <input
+              key={field}
+              ref={(element) => {
+                hiddenInputRefs.current[index] = element;
+              }}
+              name={field}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              tabIndex={-1}
+            />
+          ))}
         </div>
       </div>
 

--- a/packages/docs/app/components/CommunityAppSubmissionForm.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionForm.tsx
@@ -51,6 +51,21 @@ function isValidScreenshot(file: File) {
   );
 }
 
+function createScreenshotDataTransfer(): DataTransfer | null {
+  if (typeof DataTransfer !== "undefined") return new DataTransfer();
+
+  if (typeof ClipboardEvent !== "undefined") {
+    try {
+      return new ClipboardEvent("").clipboardData;
+    } catch {
+      // coercion-ok: null explicitly distinguishes an unavailable fallback from a transfer.
+      return null;
+    }
+  }
+
+  return null;
+}
+
 const fieldClassName =
   "w-full rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)] px-3 py-2.5 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[var(--b-text-muted)] focus:border-[var(--b-action-primary-bg)] focus:ring-2 focus:ring-[var(--b-action-primary-effect)]";
 
@@ -95,7 +110,8 @@ export function CommunityAppSubmissionForm() {
       const input = hiddenInputRefs.current[index];
       if (!input) continue;
 
-      const dataTransfer = new DataTransfer();
+      const dataTransfer = createScreenshotDataTransfer();
+      if (!dataTransfer) return;
       const screenshot = screenshots[index];
       if (screenshot) dataTransfer.items.add(screenshot.file);
       input.files = dataTransfer.files;

--- a/packages/docs/app/components/CommunityAppSubmissionForm.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionForm.tsx
@@ -372,6 +372,8 @@ export function CommunityAppSubmissionForm() {
                     index: index + 1,
                   })}
                   className="aspect-[4/3] w-full object-cover"
+                  loading="lazy"
+                  decoding="async"
                 />
                 <Button
                   type="button"

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -579,9 +579,13 @@ const arSA = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "لقطات الشاشة (اختياري)",
-    communitySubmissionScreenshotsPlaceholder:
-      "حتى 5 صور PNG أو JPG أو WebP. بحد أقصى 1.5 ميجابايت لكل صورة.",
+    communitySubmissionScreenshotsPlaceholder: "اسحب حتى 5 صور إلى هنا",
+    communitySubmissionScreenshotDropHint:
+      "PNG أو JPG أو WebP. بحد أقصى 1.5 ميجابايت لكل صورة.",
     communitySubmissionScreenshotSlot: "لقطة الشاشة {{index}}",
+    communitySubmissionScreenshotsAdd: "إضافة لقطات شاشة",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 محددة",
+    communitySubmissionScreenshotRemove: "إزالة لقطة الشاشة {{index}}",
     communitySubmissionSubmit: "إرسال التطبيق",
     communitySubmissionReady: "شكرًا. سنراجع تطبيقك قبل نشره.",
     communitySubmissionValidation:

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -585,9 +585,13 @@ const deDE = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "Screenshots (optional)",
-    communitySubmissionScreenshotsPlaceholder:
-      "Bis zu 5 PNG-, JPG- oder WebP-Bilder. Jeweils maximal 1,5 MB.",
+    communitySubmissionScreenshotsPlaceholder: "Bis zu 5 Bilder hierher ziehen",
+    communitySubmissionScreenshotDropHint:
+      "PNG, JPG oder WebP. Jeweils maximal 1,5 MB.",
     communitySubmissionScreenshotSlot: "Screenshot {{index}}",
+    communitySubmissionScreenshotsAdd: "Screenshots hinzufügen",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 ausgewählt",
+    communitySubmissionScreenshotRemove: "Screenshot {{index}} entfernen",
     communitySubmissionSubmit: "App einreichen",
     communitySubmissionReady:
       "Danke. Wir prüfen deine App vor der Veröffentlichung.",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -582,9 +582,13 @@ const enUS = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "Screenshots (optional)",
-    communitySubmissionScreenshotsPlaceholder:
-      "Up to 5 PNG, JPG, or WebP images. 1.5 MB each.",
+    communitySubmissionScreenshotsPlaceholder: "Drop up to 5 images here",
+    communitySubmissionScreenshotDropHint:
+      "PNG, JPG, or WebP. 1.5 MB max each.",
     communitySubmissionScreenshotSlot: "Screenshot {{index}}",
+    communitySubmissionScreenshotsAdd: "Add screenshots",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 selected",
+    communitySubmissionScreenshotRemove: "Remove screenshot {{index}}",
     communitySubmissionSubmit: "Submit app",
     communitySubmissionReady:
       "Thanks. We will review your app before publishing it.",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -587,9 +587,13 @@ const esES = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "Capturas (opcional)",
-    communitySubmissionScreenshotsPlaceholder:
-      "Hasta 5 imágenes PNG, JPG o WebP. 1,5 MB cada una.",
+    communitySubmissionScreenshotsPlaceholder: "Arrastra hasta 5 imágenes aquí",
+    communitySubmissionScreenshotDropHint:
+      "PNG, JPG o WebP. Máximo 1,5 MB cada una.",
     communitySubmissionScreenshotSlot: "Captura {{index}}",
+    communitySubmissionScreenshotsAdd: "Añadir capturas",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 seleccionadas",
+    communitySubmissionScreenshotRemove: "Eliminar captura {{index}}",
     communitySubmissionSubmit: "Enviar aplicación",
     communitySubmissionReady:
       "Gracias. Revisaremos tu aplicación antes de publicarla.",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -585,9 +585,13 @@ const frFR = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "Captures d’écran (facultatif)",
-    communitySubmissionScreenshotsPlaceholder:
-      "Jusqu’à 5 images PNG, JPG ou WebP. 1,5 Mo chacune.",
+    communitySubmissionScreenshotsPlaceholder: "Déposez jusqu’à 5 images ici",
+    communitySubmissionScreenshotDropHint:
+      "PNG, JPG ou WebP. 1,5 Mo maximum chacune.",
     communitySubmissionScreenshotSlot: "Capture {{index}}",
+    communitySubmissionScreenshotsAdd: "Ajouter des captures",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 sélectionnées",
+    communitySubmissionScreenshotRemove: "Supprimer la capture {{index}}",
     communitySubmissionSubmit: "Envoyer l’application",
     communitySubmissionReady:
       "Merci. Nous examinerons votre application avant de la publier.",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -579,9 +579,12 @@ const hiIN = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "स्क्रीनशॉट (वैकल्पिक)",
-    communitySubmissionScreenshotsPlaceholder:
-      "अधिकतम 5 PNG, JPG या WebP इमेज। प्रत्येक 1.5 MB तक।",
+    communitySubmissionScreenshotsPlaceholder: "यहाँ अधिकतम 5 इमेज ड्रॉप करें",
+    communitySubmissionScreenshotDropHint: "PNG, JPG या WebP। प्रत्येक 1.5 MB तक।",
     communitySubmissionScreenshotSlot: "स्क्रीनशॉट {{index}}",
+    communitySubmissionScreenshotsAdd: "स्क्रीनशॉट जोड़ें",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 चुने गए",
+    communitySubmissionScreenshotRemove: "स्क्रीनशॉट {{index}} हटाएँ",
     communitySubmissionSubmit: "ऐप सबमिट करें",
     communitySubmissionReady:
       "धन्यवाद। प्रकाशित करने से पहले हम आपके ऐप की समीक्षा करेंगे।",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -583,9 +583,12 @@ const jaJP = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "スクリーンショット（任意）",
-    communitySubmissionScreenshotsPlaceholder:
-      "PNG、JPG、WebP 画像を最大 5 枚。各 1.5 MB まで。",
+    communitySubmissionScreenshotsPlaceholder: "最大5枚の画像をここにドロップ",
+    communitySubmissionScreenshotDropHint: "PNG、JPG、WebP。各1.5 MBまで。",
     communitySubmissionScreenshotSlot: "スクリーンショット {{index}}",
+    communitySubmissionScreenshotsAdd: "スクリーンショットを追加",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 枚を選択",
+    communitySubmissionScreenshotRemove: "スクリーンショット{{index}}を削除",
     communitySubmissionSubmit: "アプリを送信",
     communitySubmissionReady:
       "ありがとうございます。公開前にアプリを確認します。",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -583,9 +583,12 @@ const koKR = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "스크린샷 (선택 사항)",
-    communitySubmissionScreenshotsPlaceholder:
-      "PNG, JPG 또는 WebP 이미지를 최대 5개까지 업로드하세요. 각 1.5MB 이하.",
+    communitySubmissionScreenshotsPlaceholder: "여기에 최대 5개의 이미지 드롭",
+    communitySubmissionScreenshotDropHint: "PNG, JPG 또는 WebP. 각 1.5MB 이하.",
     communitySubmissionScreenshotSlot: "스크린샷 {{index}}",
+    communitySubmissionScreenshotsAdd: "스크린샷 추가",
+    communitySubmissionScreenshotsCount: "{{count}} / 5개 선택됨",
+    communitySubmissionScreenshotRemove: "스크린샷 {{index}} 제거",
     communitySubmissionSubmit: "앱 제출",
     communitySubmissionReady: "감사합니다. 게시하기 전에 앱을 검토하겠습니다.",
     communitySubmissionValidation:

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -582,9 +582,13 @@ const ptBR = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "Capturas de tela (opcional)",
-    communitySubmissionScreenshotsPlaceholder:
-      "Até 5 imagens PNG, JPG ou WebP. Máximo de 1,5 MB cada.",
+    communitySubmissionScreenshotsPlaceholder: "Solte até 5 imagens aqui",
+    communitySubmissionScreenshotDropHint:
+      "PNG, JPG ou WebP. Máximo de 1,5 MB cada.",
     communitySubmissionScreenshotSlot: "Captura {{index}}",
+    communitySubmissionScreenshotsAdd: "Adicionar capturas",
+    communitySubmissionScreenshotsCount: "{{count}} / 5 selecionadas",
+    communitySubmissionScreenshotRemove: "Remover captura {{index}}",
     communitySubmissionSubmit: "Enviar aplicativo",
     communitySubmissionReady:
       "Obrigado. Vamos revisar seu aplicativo antes de publicá-lo.",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -571,9 +571,13 @@ const zhCN = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "截图（可选）",
-    communitySubmissionScreenshotsPlaceholder:
-      "最多上传 5 张 PNG、JPG 或 WebP 图片。每张不超过 1.5 MB。",
+    communitySubmissionScreenshotsPlaceholder: "将最多 5 张图片拖到这里",
+    communitySubmissionScreenshotDropHint:
+      "PNG、JPG 或 WebP。每张不超过 1.5 MB。",
     communitySubmissionScreenshotSlot: "截图 {{index}}",
+    communitySubmissionScreenshotsAdd: "添加截图",
+    communitySubmissionScreenshotsCount: "已选择 {{count}} / 5",
+    communitySubmissionScreenshotRemove: "移除截图 {{index}}",
     communitySubmissionSubmit: "提交应用",
     communitySubmissionReady: "谢谢。我们会在发布前审核你的应用。",
     communitySubmissionValidation:

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -569,9 +569,13 @@ const messages = {
     communitySubmissionRepositoryPlaceholder:
       "https://github.com/owner/repository",
     communitySubmissionScreenshots: "螢幕截圖（選填）",
-    communitySubmissionScreenshotsPlaceholder:
-      "最多上傳 5 張 PNG、JPG 或 WebP 圖片。每張不超過 1.5 MB。",
+    communitySubmissionScreenshotsPlaceholder: "將最多 5 張圖片拖曳到這裡",
+    communitySubmissionScreenshotDropHint:
+      "PNG、JPG 或 WebP。每張不超過 1.5 MB。",
     communitySubmissionScreenshotSlot: "螢幕截圖 {{index}}",
+    communitySubmissionScreenshotsAdd: "新增螢幕截圖",
+    communitySubmissionScreenshotsCount: "已選取 {{count}} / 5",
+    communitySubmissionScreenshotRemove: "移除螢幕截圖 {{index}}",
     communitySubmissionSubmit: "提交應用程式",
     communitySubmissionReady: "謝謝。我們會在刊登前審核你的應用程式。",
     communitySubmissionValidation:

--- a/packages/docs/tests/community-templates.test.ts
+++ b/packages/docs/tests/community-templates.test.ts
@@ -66,6 +66,8 @@ describe("community apps", () => {
     expect(form).toContain("multiple");
     expect(form).toContain("onDrop={handleDrop}");
     expect(form).toContain("removeScreenshot");
+    expect(form).toContain("typeof DataTransfer");
+    expect(form).toContain("ClipboardEvent");
     expect(form).toContain("new DataTransfer()");
     expect(form).toContain("name={field}");
     expect(form).toContain('"screenshot_5"');

--- a/packages/docs/tests/community-templates.test.ts
+++ b/packages/docs/tests/community-templates.test.ts
@@ -63,6 +63,10 @@ describe("community apps", () => {
     expect(form).toContain('encType="multipart/form-data"');
     expect(form).toContain('data-netlify="true"');
     expect(form).toContain('name="form-name"');
+    expect(form).toContain("multiple");
+    expect(form).toContain("onDrop={handleDrop}");
+    expect(form).toContain("removeScreenshot");
+    expect(form).toContain("new DataTransfer()");
     expect(form).toContain("name={field}");
     expect(form).toContain('"screenshot_5"');
     expect(form).not.toContain("Screenshot URLs");


### PR DESCRIPTION
## Summary

- Replace separate screenshot inputs with one multi-file drag-and-drop picker
- Show previews with always-visible remove controls and a five-image counter
- Keep native multipart submission through the existing Netlify upload fields
- Update localized submission copy and community app coverage

## Validation

- Focused community template tests
- Docs typecheck, formatting, and i18n guards
- Browser verification for multi-select, drop, removal, mobile layout, and multipart upload