### PR TITLE
Fix native desktop terminal sessions

### DIFF
--- a/.changeset/quiet-native-terminals.md
+++ b/.changeset/quiet-native-terminals.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Launch terminal providers with a reliable native PTY environment and lifecycle cleanup.

--- a/packages/core/src/client/terminal/AgentTerminal.spec.ts
+++ b/packages/core/src/client/terminal/AgentTerminal.spec.ts
@@ -239,6 +239,24 @@ describe("AgentTerminal", () => {
     );
   });
 
+  it("focuses only when the terminal becomes active", async () => {
+    renderTerminal({
+      wsUrl: "ws://127.0.0.1:12345/ws",
+      autoFocus: false,
+    });
+    await waitForSocketCount(1);
+    await flushTimers();
+
+    expect(terminals[0]?.focus).not.toHaveBeenCalled();
+
+    renderTerminal({
+      wsUrl: "ws://127.0.0.1:12345/ws",
+      autoFocus: true,
+    });
+
+    expect(terminals[0]?.focus).toHaveBeenCalledOnce();
+  });
+
   it("shows setup-status errors and suppresses reconnects", async () => {
     renderTerminal({
       wsUrl: "ws://127.0.0.1:12345/ws",

--- a/packages/core/src/client/terminal/AgentTerminal.spec.ts
+++ b/packages/core/src/client/terminal/AgentTerminal.spec.ts
@@ -14,6 +14,7 @@ class MockTerminal {
   dispose = vi.fn();
   loadAddon = vi.fn();
   open = vi.fn();
+  focus = vi.fn();
   onData = vi.fn((handler: (data: string) => void) => {
     this.emitData = handler;
     return { dispose: vi.fn() };
@@ -231,6 +232,10 @@ describe("AgentTerminal", () => {
 
     expect(MockWebSocket.instances[0].url).toBe(
       "ws://127.0.0.1:12345/ws?token=desktop-secret&command=codex",
+    );
+    expect(terminals[0]?.focus).toHaveBeenCalled();
+    expect(terminals[0]?.write).not.toHaveBeenCalledWith(
+      expect.stringContaining("[terminal]"),
     );
   });
 

--- a/packages/core/src/client/terminal/AgentTerminal.tsx
+++ b/packages/core/src/client/terminal/AgentTerminal.tsx
@@ -28,6 +28,8 @@ export interface AgentTerminalProps {
   theme?: Record<string, string>;
   /** Font size. Default: 12 */
   fontSize?: number;
+  /** Focus the terminal on mount and when it becomes active. Default: true */
+  autoFocus?: boolean;
   /** CSS class for the container */
   className?: string;
   /** Inline styles for the container */
@@ -146,6 +148,7 @@ export function AgentTerminal({
   hideInFrame = true,
   theme,
   fontSize = 12,
+  autoFocus = true,
   className,
   style,
   onConnectionChange,
@@ -160,6 +163,9 @@ export function AgentTerminal({
   const pendingSubmitRequestRef = useRef<AgentTerminalSubmitRequest | null>(
     null,
   );
+  const autoFocusRef = useRef(autoFocus);
+  autoFocusRef.current = autoFocus;
+  const focusTerminalRef = useRef<(() => void) | null>(null);
   const onPromptSubmittedRef = useRef(onPromptSubmitted);
   onPromptSubmittedRef.current = onPromptSubmitted;
   const [connected, setConnected] = useState(false);
@@ -182,6 +188,20 @@ export function AgentTerminal({
   useEffect(() => {
     onConnectionChange?.(connected);
   }, [connected, onConnectionChange]);
+
+  useEffect(() => {
+    if (autoFocus) {
+      focusTerminalRef.current?.();
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      termRef.current?.contains(activeElement)
+    ) {
+      activeElement.blur();
+    }
+  }, [autoFocus]);
 
   // Main terminal setup
   useEffect(() => {
@@ -226,7 +246,9 @@ export function AgentTerminal({
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
-      term.focus();
+      const focusTerminal = () => term.focus();
+      focusTerminalRef.current = focusTerminal;
+      if (autoFocusRef.current) focusTerminal();
 
       let fitPending = false;
       function fitAndResize() {
@@ -276,6 +298,9 @@ export function AgentTerminal({
           handleVisibilityOrFocus,
         );
         resizeObserver.disconnect();
+        if (focusTerminalRef.current === focusTerminal) {
+          focusTerminalRef.current = null;
+        }
         term.dispose();
       }
 
@@ -379,7 +404,7 @@ export function AgentTerminal({
         socket.onopen = () => {
           setConnected(true);
           setError(null);
-          term.focus();
+          if (autoFocusRef.current) focusTerminal();
           socket.send(
             JSON.stringify({
               type: "resize",

--- a/packages/core/src/client/terminal/AgentTerminal.tsx
+++ b/packages/core/src/client/terminal/AgentTerminal.tsx
@@ -66,8 +66,19 @@ function injectXtermCss() {
     .xterm .composition-view { display: none; position: absolute; white-space: nowrap; z-index: 1; }
     .xterm .composition-view.active { display: block; }
     .xterm .xterm-viewport {
-      background-color: var(--agent-terminal-background); overflow-y: scroll;
+      background-color: var(--agent-terminal-background); overflow-y: auto;
+      scrollbar-width: thin;
+      scrollbar-color: hsl(var(--muted-foreground) / 0.22) transparent;
       cursor: default; position: absolute; right: 0; left: 0; top: 0; bottom: 0;
+    }
+    .xterm .xterm-viewport::-webkit-scrollbar { width: 8px; height: 8px; }
+    .xterm .xterm-viewport::-webkit-scrollbar-track { background: transparent; }
+    .xterm .xterm-viewport::-webkit-scrollbar-thumb {
+      background: hsl(var(--muted-foreground) / 0.22);
+      border-radius: 999px;
+    }
+    .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+      background: hsl(var(--muted-foreground) / 0.36);
     }
     .xterm .xterm-screen { position: relative; }
     .xterm .xterm-screen canvas { position: absolute; left: 0; top: 0; }
@@ -215,6 +226,7 @@ export function AgentTerminal({
       term.loadAddon(fitAddon);
       term.loadAddon(webLinksAddon);
       term.open(container);
+      term.focus();
 
       let fitPending = false;
       function fitAndResize() {
@@ -310,10 +322,6 @@ export function AgentTerminal({
       }
       if (flags) fullWsUrl.searchParams.set("flags", flags);
 
-      term.write(
-        `\x1b[2m[terminal] Starting ${resolvedCommand || "CLI"}...\x1b[0m\r\n`,
-      );
-
       // Connect WebSocket
       let agentRunning = false;
       let idleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -371,6 +379,7 @@ export function AgentTerminal({
         socket.onopen = () => {
           setConnected(true);
           setError(null);
+          term.focus();
           socket.send(
             JSON.stringify({
               type: "resize",
@@ -423,9 +432,6 @@ export function AgentTerminal({
         socket.onclose = () => {
           setConnected(false);
           if (connectionId === thisId && !disposed) {
-            term.write(
-              "\r\n\x1b[31m[terminal] Connection closed. Reconnecting in 3s...\x1b[0m\r\n",
-            );
             setTimeout(() => {
               if (connectionId === thisId && !disposed) {
                 connect(url);

--- a/packages/core/src/terminal/cli-registry.ts
+++ b/packages/core/src/terminal/cli-registry.ts
@@ -36,7 +36,9 @@ export async function terminalPath(
       })()
     : [];
   const entries = [
-    ...(environment.PATH ?? "").split(path.delimiter).filter(Boolean),
+    ...(environment.PATH ?? environment.Path ?? "")
+      .split(path.delimiter)
+      .filter(Boolean),
     environment.PNPM_HOME,
     home ? path.join(home, ".local", "bin") : undefined,
     home ? path.join(home, ".local", "share", "pnpm") : undefined,
@@ -96,7 +98,8 @@ export async function resolveCommandPath(
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
   const { spawnSync } = await import("node:child_process");
-  const result = spawnSync("which", [cmd], {
+  const resolver = process.platform === "win32" ? "where.exe" : "which";
+  const result = spawnSync(resolver, [cmd], {
     encoding: "utf8",
     env: { ...environment, PATH: await terminalPath(environment) },
     stdio: ["ignore", "pipe", "ignore"],

--- a/packages/core/src/terminal/cli-registry.ts
+++ b/packages/core/src/terminal/cli-registry.ts
@@ -12,6 +12,46 @@ export interface CliEntry {
   stripEnv: string[];
 }
 
+export async function terminalPath(
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  const [fs, os, path] = await Promise.all([
+    import("node:fs"),
+    import("node:os"),
+    import("node:path"),
+  ]);
+  const home = environment.HOME || os.homedir();
+  const nvmDirectories = home
+    ? (() => {
+        try {
+          return fs
+            .readdirSync(path.join(home, ".nvm", "versions", "node"))
+            .map((version) =>
+              path.join(home, ".nvm", "versions", "node", version, "bin"),
+            );
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+          throw error;
+        }
+      })()
+    : [];
+  const entries = [
+    ...(environment.PATH ?? "").split(path.delimiter).filter(Boolean),
+    environment.PNPM_HOME,
+    home ? path.join(home, ".local", "bin") : undefined,
+    home ? path.join(home, ".local", "share", "pnpm") : undefined,
+    home ? path.join(home, "Library", "pnpm") : undefined,
+    home ? path.join(home, ".opencode", "bin") : undefined,
+    home ? path.join(home, ".cargo", "bin") : undefined,
+    ...nvmDirectories,
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+  ].filter((entry): entry is string => Boolean(entry));
+  return [...new Set(entries)].join(path.delimiter);
+}
+
 export const CLI_REGISTRY: Record<string, CliEntry> = {
   claude: {
     label: "Claude Code",
@@ -50,13 +90,23 @@ export function isAllowedCommand(cmd: string): boolean {
   return Object.prototype.hasOwnProperty.call(CLI_REGISTRY, cmd);
 }
 
+/** Resolve a CLI from the user's shell locations, including GUI launch paths. */
+export async function resolveCommandPath(
+  cmd: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  const { spawnSync } = await import("node:child_process");
+  const result = spawnSync("which", [cmd], {
+    encoding: "utf8",
+    env: { ...environment, PATH: await terminalPath(environment) },
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) return null;
+  const resolved = result.stdout?.trim().split(/\r?\n/)[0];
+  return resolved || cmd;
+}
+
 /** Check if a CLI command exists on PATH (safe — no shell interpolation) */
 export async function commandExists(cmd: string): Promise<boolean> {
-  try {
-    const { spawnSync } = await import("node:child_process");
-    const result = spawnSync("which", [cmd], { stdio: "ignore" });
-    return result.status === 0;
-  } catch {
-    return false;
-  }
+  return (await resolveCommandPath(cmd)) !== null;
 }

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -162,6 +162,31 @@ describe("createPtyWebSocketServer", () => {
     );
   });
 
+  it("wraps Windows command shims with cmd.exe", async () => {
+    const { preparePtySpawn } = await import("./pty-server.js");
+    const commandPath = String.raw`C:\Users\steve\AppData\Roaming\npm\codex.cmd`;
+
+    expect(preparePtySpawn(commandPath, ["--full-auto"], "win32")).toEqual({
+      command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
+      args: ["/d", "/s", "/c", commandPath, "--full-auto"],
+    });
+    expect(preparePtySpawn(commandPath, [], "darwin")).toEqual({
+      command: commandPath,
+      args: [],
+    });
+  });
+
+  it("preserves Windows path backslashes in terminal flags", async () => {
+    const { parseTerminalArguments } = await import("./pty-server.js");
+
+    expect(
+      parseTerminalArguments(
+        String.raw`--add-dir C:\Users\steve\Projects\framework`,
+        "win32",
+      ),
+    ).toEqual(["--add-dir", String.raw`C:\Users\steve\Projects\framework`]);
+  });
+
   it("repairs a non-executable packaged spawn helper", async () => {
     const helperDir = mkdtempSync(path.join(os.tmpdir(), "pty-helper-"));
     tempDirs.push(helperDir);

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -167,8 +167,8 @@ describe("createPtyWebSocketServer", () => {
     const commandPath = String.raw`C:\Users\steve\AppData\Roaming\npm\codex.cmd`;
 
     expect(preparePtySpawn(commandPath, ["--full-auto"], "win32")).toEqual({
-      command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
-      args: ["/d", "/s", "/c", commandPath, "--full-auto"],
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", `"${commandPath}"`, "--full-auto"],
     });
     expect(preparePtySpawn(commandPath, [], "darwin")).toEqual({
       command: commandPath,
@@ -181,10 +181,15 @@ describe("createPtyWebSocketServer", () => {
 
     expect(
       parseTerminalArguments(
-        String.raw`--add-dir C:\Users\steve\Projects\framework`,
+        String.raw`--add-dir C:\Users\steve\Projects\framework --message "say \"hi\""`,
         "win32",
       ),
-    ).toEqual(["--add-dir", String.raw`C:\Users\steve\Projects\framework`]);
+    ).toEqual([
+      "--add-dir",
+      String.raw`C:\Users\steve\Projects\framework`,
+      "--message",
+      'say "hi"',
+    ]);
   });
 
   it("repairs a non-executable packaged spawn helper", async () => {

--- a/packages/core/src/terminal/pty-server.spec.ts
+++ b/packages/core/src/terminal/pty-server.spec.ts
@@ -262,6 +262,34 @@ describe("createPtyWebSocketServer", () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it("does not spawn a PTY after the client closes during command setup", async () => {
+    let resolveSetupStarted!: () => void;
+    let releaseSetup!: () => void;
+    const setupStarted = new Promise<void>((resolve) => {
+      resolveSetupStarted = resolve;
+    });
+    const setupRelease = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    const server = await createServer({
+      command: "builder",
+      getSessionSetup: async () => {
+        resolveSetupStarted();
+        await setupRelease;
+        return {};
+      },
+    });
+    const ws = await openSocket(`ws://127.0.0.1:${server.port}/ws`);
+
+    await setupStarted;
+    ws.terminate();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    releaseSetup();
+
+    await vi.waitFor(() => expect(ws.readyState).toBe(WebSocket.CLOSED));
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it("rejects shell metacharacters in flags before spawning", async () => {
     const server = await createServer();
     const { ws, message: rawMessage } = await openSocketAndMessage(
@@ -311,7 +339,7 @@ describe("createPtyWebSocketServer", () => {
 
     expect(spawn).toHaveBeenCalledWith(
       expect.any(String),
-      ["-l", "-c", "builder"],
+      [],
       expect.objectContaining({
         cols: 120,
         rows: 40,
@@ -335,14 +363,43 @@ describe("createPtyWebSocketServer", () => {
 
     expect(spawn).toHaveBeenCalledWith(
       expect.any(String),
-      [
-        "-l",
-        "-c",
-        "builder '--mcp-config' '/tmp/desktop surface.json' 'it'\"'\"'s-safe'",
-      ],
+      ["--mcp-config", "/tmp/desktop surface.json", "it's-safe"],
       expect.objectContaining({ cwd: expect.any(String) }),
     );
     ws.close();
+  });
+
+  it("passes the active app context to each PTY session setup", async () => {
+    const onClose = vi.fn();
+    const getSessionSetup = vi.fn(() => ({
+      commandArgs: ["--from-session-setup"],
+      environment: { SESSION_CONTEXT: "mail" },
+      onClose,
+    }));
+    const server = await createServer({
+      command: "builder",
+      getSessionSetup,
+    });
+    const ws = await openSocket(
+      `ws://127.0.0.1:${server.port}/ws?appId=mail&path=%2Finbox&view=inbox`,
+    );
+    await vi.waitFor(() => expect(ptys).toHaveLength(1));
+
+    expect(getSessionSetup).toHaveBeenCalledWith("builder", {
+      appId: "mail",
+      path: "/inbox",
+      view: "inbox",
+    });
+    expect(spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      ["--from-session-setup"],
+      expect.objectContaining({
+        env: expect.objectContaining({ SESSION_CONTEXT: "mail" }),
+      }),
+    );
+
+    ws.close();
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledOnce());
   });
 
   it("does not write env vars sent through the terminal bridge to .env", async () => {

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -19,8 +19,9 @@ import path from "path";
 
 import {
   CLI_REGISTRY,
-  commandExists,
   isAllowedCommand,
+  resolveCommandPath,
+  terminalPath,
 } from "./cli-registry.js";
 
 // Lazy singletons for Node-only modules (only available in Node.js)
@@ -69,29 +70,6 @@ export function ensurePtySpawnHelperPermissions(): void {
       (err as Error).message,
     );
   }
-}
-
-function resolveTerminalShell(): string {
-  if (os.platform() === "win32") {
-    // config-ok: COMSPEC is an inherited host shell fact, not application configuration.
-    return process.env["COMSPEC"] || "cmd.exe";
-  }
-
-  // config-ok: SHELL is the user's inherited host shell, not application configuration.
-  const configuredShell = process.env.SHELL;
-  if (configuredShell && path.isAbsolute(configuredShell)) {
-    try {
-      if (fs.statSync(configuredShell).isFile()) return configuredShell;
-    } catch {
-      // coercion-ok: an invalid SHELL falls through to known system shells.
-    }
-  }
-
-  return (
-    ["/bin/zsh", "/bin/bash", "/bin/sh"].find((candidate) =>
-      fs.existsSync(candidate),
-    ) ?? "/bin/sh"
-  );
 }
 
 /**
@@ -185,8 +163,32 @@ export interface PtyServerOptions {
   authCheck?: (req: IncomingMessage) => boolean | Promise<boolean>;
   /** Trusted host arguments appended to each validated CLI command. */
   getCommandArgs?: (command: string) => string[] | Promise<string[]>;
+  /** Trusted environment additions for the validated CLI command. */
+  getEnvironment?: (
+    command: string,
+  ) => NodeJS.ProcessEnv | Promise<NodeJS.ProcessEnv>;
+  /** Per-connection setup for trusted host capabilities and cleanup. */
+  getSessionSetup?: (
+    command: string,
+    context: PtySessionContext | null,
+  ) => PtySessionSetup | Promise<PtySessionSetup>;
   /** Log prefix for console output. Defaults to '[terminal]' */
   logPrefix?: string;
+}
+
+export interface PtySessionContext {
+  appId: string;
+  path?: string;
+  view?: string;
+}
+
+export interface PtySessionSetup {
+  /** Trusted arguments appended to the selected CLI command. */
+  commandArgs?: string[];
+  /** Trusted environment additions for the selected CLI command. */
+  environment?: NodeJS.ProcessEnv;
+  /** Releases per-connection resources such as scoped MCP relays. */
+  onClose?: () => void | Promise<void>;
 }
 
 export interface PtyServerResult {
@@ -207,6 +209,8 @@ export async function createPtyWebSocketServer(
     port = 0,
     authCheck,
     getCommandArgs,
+    getEnvironment,
+    getSessionSetup,
     logPrefix = "[terminal]",
   } = options;
 
@@ -217,7 +221,6 @@ export async function createPtyWebSocketServer(
   const pty = await import("node-pty");
 
   const resolvedAppDir = path.resolve(appDir);
-  const shell = resolveTerminalShell();
 
   const server = createHttpServer((req, res) => {
     // CORS headers
@@ -301,6 +304,7 @@ export async function createPtyWebSocketServer(
     const url = new URL(req.url || "", `http://${req.headers.host}`);
     const command = url.searchParams.get("command") || defaultCommand;
     const extraFlags = url.searchParams.get("flags") || "";
+    const context = readPtySessionContext(url);
     console.log(`${logPrefix} WebSocket connected for command: ${command}`);
 
     const sendStatus = (status: string, message: string) => {
@@ -326,33 +330,41 @@ export async function createPtyWebSocketServer(
       return;
     }
 
-    // Check if CLI is installed; if not, use npx to run it
-    let useNpx = false;
-    const commandInstalled = await commandExists(command);
-    if (closed) {
-      ws.close();
-      return;
-    }
-
-    if (!commandInstalled) {
-      const registry = CLI_REGISTRY[command];
-      if (registry?.installPackage) {
-        console.log(`${logPrefix} ${command} CLI not found, will use npx`);
-        useNpx = true;
-      } else {
-        sendStatus(
-          "not-found",
-          `"${command}" not found on PATH. Please install it manually.`,
-        );
-        if (ws.readyState === WebSocket.OPEN) ws.close();
-        return;
-      }
-    }
+    let connectionClosed = false;
+    const markConnectionClosed = () => {
+      connectionClosed = true;
+    };
+    ws.once("close", markConnectionClosed);
+    let sessionSetup: PtySessionSetup | undefined;
+    let sessionSetupClosed = false;
+    const closeSessionSetup = () => {
+      if (!sessionSetup || sessionSetupClosed) return;
+      sessionSetupClosed = true;
+      void Promise.resolve(sessionSetup.onClose?.()).catch((error) => {
+        console.warn(`${logPrefix} Session cleanup failed:`, error);
+      });
+    };
 
     let commandArgs: string[] = [];
+    let commandEnvironment: NodeJS.ProcessEnv = {};
     try {
-      if (getCommandArgs) commandArgs = await getCommandArgs(command);
+      if (getSessionSetup) {
+        sessionSetup = await getSessionSetup(command, context);
+        commandArgs = sessionSetup.commandArgs ?? [];
+        commandEnvironment = sessionSetup.environment ?? {};
+      }
+      if (getCommandArgs) {
+        const additionalArgs = await getCommandArgs(command);
+        commandArgs = [...commandArgs, ...additionalArgs];
+      }
+      if (getEnvironment) {
+        commandEnvironment = {
+          ...commandEnvironment,
+          ...(await getEnvironment(command)),
+        };
+      }
     } catch (error) {
+      closeSessionSetup();
       if (closed) {
         ws.close();
         return;
@@ -367,34 +379,80 @@ export async function createPtyWebSocketServer(
       return;
     }
 
-    if (closed) {
+    if (connectionClosed || ws.readyState !== WebSocket.OPEN || closed) {
+      closeSessionSetup();
       ws.close();
       return;
     }
 
-    // Build the command — use npx if CLI not found locally
-    const baseCommand = useNpx
-      ? `npx --yes ${CLI_REGISTRY[command].installPackage}`
-      : command;
-    const generatedFlags = commandArgs.map(shellQuote).join(" ");
-    const fullCommand = [baseCommand, generatedFlags, extraFlags]
-      .filter(Boolean)
-      .join(" ");
-    console.log(`${logPrefix} Spawning PTY for ${command}`);
+    let extraArgumentList: string[] = [];
+    try {
+      extraArgumentList = parseTerminalArguments(extraFlags);
+    } catch (error) {
+      closeSessionSetup();
+      sendStatus(
+        "failed",
+        error instanceof Error ? error.message : "Invalid terminal flags.",
+      );
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+      return;
+    }
+
+    if (connectionClosed || ws.readyState !== WebSocket.OPEN || closed) {
+      closeSessionSetup();
+      ws.close();
+      return;
+    }
 
     // Build env, stripping CLI-specific nesting vars
     const registry = CLI_REGISTRY[command];
     const env: Record<string, string | undefined> = {
       ...process.env,
+      ...commandEnvironment,
       TERM: "xterm-256color",
     };
     if (registry) {
       for (const v of registry.stripEnv) delete env[v];
     }
 
+    env.PATH = await terminalPath(env);
+    const commandPath = await resolveCommandPath(command, env);
+    if (connectionClosed || ws.readyState !== WebSocket.OPEN || closed) {
+      closeSessionSetup();
+      ws.close();
+      return;
+    }
+    let spawnCommand = commandPath;
+    let spawnArgs = [...commandArgs, ...extraArgumentList];
+    if (!spawnCommand) {
+      if (!registry?.installPackage) {
+        closeSessionSetup();
+        sendStatus(
+          "not-found",
+          `"${command}" not found on PATH. Please install it manually.`,
+        );
+        if (ws.readyState === WebSocket.OPEN) ws.close();
+        return;
+      }
+      const npxPath = await resolveCommandPath("npx", env);
+      if (!npxPath) {
+        closeSessionSetup();
+        sendStatus(
+          "not-found",
+          `"${command}" not found on PATH and npx is unavailable.`,
+        );
+        if (ws.readyState === WebSocket.OPEN) ws.close();
+        return;
+      }
+      console.log(`${logPrefix} ${command} CLI not found, will use npx`);
+      spawnCommand = npxPath;
+      spawnArgs = ["--yes", registry.installPackage, ...spawnArgs];
+    }
+    console.log(`${logPrefix} Spawning PTY for ${command}`);
+
     let ptyProcess: ReturnType<typeof pty.spawn>;
     try {
-      ptyProcess = pty.spawn(shell, ["-l", "-c", fullCommand], {
+      ptyProcess = pty.spawn(spawnCommand, spawnArgs, {
         name: "xterm-256color",
         cols: 120,
         rows: 40,
@@ -410,6 +468,7 @@ export async function createPtyWebSocketServer(
         );
         ws.close();
       }
+      closeSessionSetup();
       return;
     }
 
@@ -419,6 +478,7 @@ export async function createPtyWebSocketServer(
       if (disposed) return;
       disposed = true;
       activeDisposers.delete(dispose);
+      closeSessionSetup();
       const killPty = () => {
         try {
           ptyProcess.kill();
@@ -553,6 +613,57 @@ export async function createPtyWebSocketServer(
   });
 }
 
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
+function readPtySessionContext(url: URL): PtySessionContext | null {
+  const appId = url.searchParams.get("appId")?.trim();
+  if (!appId) return null;
+  const pathValue = url.searchParams.get("path")?.trim();
+  const view = url.searchParams.get("view")?.trim();
+  return {
+    appId,
+    ...(pathValue ? { path: pathValue } : {}),
+    ...(view ? { view } : {}),
+  };
+}
+
+function parseTerminalArguments(value: string): string[] {
+  if (!value) return [];
+  const args: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  const pushCurrent = () => {
+    if (current) args.push(current);
+    current = "";
+  };
+
+  for (const character of value) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (character === quote) quote = null;
+      else current += character;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      pushCurrent();
+    } else {
+      current += character;
+    }
+  }
+
+  if (escaped || quote) {
+    throw new Error("Invalid flags: unterminated terminal argument");
+  }
+  pushCurrent();
+  return args;
 }

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -637,7 +637,7 @@ export function preparePtySpawn(
     return { command: commandPath, args };
   }
   return {
-    command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
+    command: "cmd.exe",
     args: ["/d", "/s", "/c", commandPath, ...args],
   };
 }

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -435,6 +435,11 @@ export async function createPtyWebSocketServer(
         return;
       }
       const npxPath = await resolveCommandPath("npx", env);
+      if (connectionClosed || ws.readyState !== WebSocket.OPEN || closed) {
+        closeSessionSetup();
+        ws.close();
+        return;
+      }
       if (!npxPath) {
         closeSessionSetup();
         sendStatus(
@@ -638,7 +643,7 @@ export function preparePtySpawn(
   }
   return {
     command: "cmd.exe",
-    args: ["/d", "/s", "/c", commandPath, ...args],
+    args: ["/d", "/s", "/c", `"${commandPath}"`, ...args],
   };
 }
 
@@ -658,14 +663,19 @@ export function parseTerminalArguments(
     current = "";
   };
 
-  for (const character of value) {
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
     if (escaped) {
       current += character;
       escaped = false;
       continue;
     }
-    if (character === "\\" && quote !== "'" && !preserveBackslashes) {
-      escaped = true;
+    if (character === "\\" && quote !== "'") {
+      if (!preserveBackslashes || value[index + 1] === '"') {
+        escaped = true;
+        continue;
+      }
+      current += character;
       continue;
     }
     if (quote) {

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -450,9 +450,10 @@ export async function createPtyWebSocketServer(
     }
     console.log(`${logPrefix} Spawning PTY for ${command}`);
 
+    const preparedSpawn = preparePtySpawn(spawnCommand, spawnArgs);
     let ptyProcess: ReturnType<typeof pty.spawn>;
     try {
-      ptyProcess = pty.spawn(spawnCommand, spawnArgs, {
+      ptyProcess = pty.spawn(preparedSpawn.command, preparedSpawn.args, {
         name: "xterm-256color",
         cols: 120,
         rows: 40,
@@ -625,12 +626,32 @@ function readPtySessionContext(url: URL): PtySessionContext | null {
   };
 }
 
-function parseTerminalArguments(value: string): string[] {
+export function preparePtySpawn(
+  commandPath: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+  if (platform !== "win32") return { command: commandPath, args };
+  const extension = path.extname(commandPath).toLowerCase();
+  if (extension !== ".cmd" && extension !== ".bat") {
+    return { command: commandPath, args };
+  }
+  return {
+    command: process.env.ComSpec || process.env.COMSPEC || "cmd.exe",
+    args: ["/d", "/s", "/c", commandPath, ...args],
+  };
+}
+
+export function parseTerminalArguments(
+  value: string,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
   if (!value) return [];
   const args: string[] = [];
   let current = "";
   let quote: '"' | "'" | null = null;
   let escaped = false;
+  const preserveBackslashes = platform === "win32";
 
   const pushCurrent = () => {
     if (current) args.push(current);
@@ -643,7 +664,7 @@ function parseTerminalArguments(value: string): string[] {
       escaped = false;
       continue;
     }
-    if (character === "\\" && quote !== "'") {
+    if (character === "\\" && quote !== "'" && !preserveBackslashes) {
       escaped = true;
       continue;
     }

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -415,8 +415,25 @@ export async function createPtyWebSocketServer(
       for (const v of registry.stripEnv) delete env[v];
     }
 
-    env.PATH = await terminalPath(env);
-    const commandPath = await resolveCommandPath(command, env);
+    let commandPath: string | null;
+    try {
+      env.PATH = await terminalPath(env);
+      commandPath = await resolveCommandPath(command, env);
+    } catch (error) {
+      closeSessionSetup();
+      if (closed) {
+        ws.close();
+        return;
+      }
+      sendStatus(
+        "failed",
+        error instanceof Error
+          ? error.message
+          : "The terminal command could not be resolved.",
+      );
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+      return;
+    }
     if (connectionClosed || ws.readyState !== WebSocket.OPEN || closed) {
       closeSessionSetup();
       ws.close();

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -164,6 +164,12 @@ export const IPC = {
   QUICK_PROMPT_SUBMIT: "quick-prompt:submit",
 } as const;
 
+export interface DesktopTerminalContext {
+  appId: string;
+  path?: string;
+  view?: string;
+}
+
 export type CodeAgentScheduleScope = "global" | "thread";
 export type CodeAgentScheduleStatus = "queued" | "completed" | "errored";
 

--- a/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.test.ts
@@ -24,6 +24,11 @@ async function createHarness() {
       { id: "calendar", name: "Calendar" },
     ],
     openApp,
+    getActiveAppContext: () => ({
+      appId: "mail",
+      appName: "Mail",
+      path: "/inbox",
+    }),
   });
   const url = await bridge.start();
   const registration = bridge.register();
@@ -54,7 +59,28 @@ describe("DesktopSurfaceMcpBridge", () => {
 
     const tools = await harness.client.listTools();
     expect(tools.tools.map((tool) => tool.name)).toEqual(
-      expect.arrayContaining(["list_apps", "open_app"]),
+      expect.arrayContaining([
+        "list_apps",
+        "open_app",
+        "get_active_app_context",
+      ]),
+    );
+
+    const context = await harness.client.callTool({
+      name: "get_active_app_context",
+      arguments: {},
+    });
+    const contextText = context.content?.find((item) => item.type === "text");
+    expect(
+      contextText?.type === "text" ? JSON.parse(contextText.text) : null,
+    ).toEqual(
+      expect.objectContaining({
+        activeApp: expect.objectContaining({
+          appId: "mail",
+          appName: "Mail",
+          path: "/inbox",
+        }),
+      }),
     );
 
     const apps = await harness.client.callTool({

--- a/packages/desktop-app/src/main/desktop-surface-mcp.ts
+++ b/packages/desktop-app/src/main/desktop-surface-mcp.ts
@@ -23,9 +23,17 @@ export interface DesktopSurfaceOpenAppRequest {
   view?: string;
 }
 
+export interface DesktopSurfaceActiveAppContext {
+  appId: string;
+  appName: string;
+  path?: string;
+  view?: string;
+}
+
 export interface DesktopSurfaceMcpBridgeOptions {
   listApps: () => readonly DesktopSurfaceApp[];
   openApp: (request: DesktopSurfaceOpenAppRequest) => void;
+  getActiveAppContext?: () => DesktopSurfaceActiveAppContext | null;
 }
 
 export interface DesktopSurfaceMcpRegistration {
@@ -171,6 +179,28 @@ export class DesktopSurfaceMcpBridge {
         annotations: { readOnlyHint: true, openWorldHint: false },
       },
       async () => textResult({ apps: this.options.listApps() }),
+    );
+    mcp.registerTool(
+      "get_active_app_context",
+      {
+        description:
+          "Return the workspace app currently selected in the desktop shell. Use this before app work so the terminal agent follows the same app context as the desktop UI.",
+        annotations: { readOnlyHint: true, openWorldHint: false },
+      },
+      async () => {
+        const activeApp = this.options.getActiveAppContext?.() ?? null;
+        return textResult({
+          activeApp: activeApp
+            ? {
+                ...activeApp,
+                mcpServer: `desktop_app_${activeApp.appId.replace(/[^A-Za-z0-9_]/g, "_")}`,
+              }
+            : null,
+          instructions: activeApp
+            ? `The active workspace app is ${activeApp.appName}. Use its configured MCP tools for app operations and keep navigation in this app${activeApp.path ? ` at ${activeApp.path}` : ""}.`
+            : "No workspace app is currently selected. Ask the user which app to use before making app-specific changes.",
+        });
+      },
     );
     mcp.registerTool(
       "open_app",

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -218,6 +218,45 @@ describe("desktop chat relay target URLs", () => {
     }
   });
 
+  it("aborts an active streamed MCP response when the relay closes", async () => {
+    let resolveRequestClosed!: () => void;
+    const requestClosed = new Promise<void>((resolve) => {
+      resolveRequestClosed = resolve;
+    });
+    const upstream = createServer((request, response) => {
+      request.once("close", resolveRequestClosed);
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.write('data: {"jsonrpc":"2.0","id":1}\n\n');
+    });
+    await new Promise<void>((resolve) =>
+      upstream.listen(0, "127.0.0.1", resolve),
+    );
+    const address = upstream.address();
+    if (!address || typeof address === "string") throw new Error("no port");
+
+    const relay = new DesktopTerminalMcpRelay(
+      `http://127.0.0.1:${address.port}/mcp`,
+      {},
+    );
+    try {
+      const registration = await relay.start();
+      const response = await fetch(registration.url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${registration.bearerToken}`,
+          "content-type": "application/json",
+        },
+        body: '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+      });
+      expect(response.status).toBe(200);
+      await relay.close();
+      await expect(requestClosed).resolves.toBeUndefined();
+    } finally {
+      await relay.close();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
   it("rejects dot-segment traversal after URL normalization", () => {
     expect(
       resolveTargetUrl(

--- a/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.spec.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
@@ -18,9 +20,12 @@ vi.mock("../app-store", () => ({
 import {
   desktopTerminalMcpArgs,
   desktopTerminalInfo,
+  DesktopTerminalMcpRelay,
+  desktopTerminalOpenCodeEnvironment,
   resolveTargetUrl,
   shouldForwardRequestHeader,
   shouldForwardResponseHeader,
+  stripCodexMcpConfig,
 } from "./desktop-chat.js";
 
 describe("desktop chat relay target URLs", () => {
@@ -45,9 +50,91 @@ describe("desktop chat relay target URLs", () => {
       "-c",
       `mcp_servers.agent-native-desktop.http_headers={"Authorization"="Bearer ${registration.bearerToken}"}`,
     ]);
+    const builderArgs = desktopTerminalMcpArgs(
+      "builder",
+      registration,
+      "/tmp/unused.json",
+    );
+    expect(builderArgs[0]).toBe("code");
+    expect(builderArgs[1]).toBe("--configJson");
+    expect(JSON.parse(builderArgs[2])).toEqual({
+      isLocal: true,
+      mcpServers: {
+        "agent-native-desktop": {
+          type: "http",
+          url: registration.url,
+          headers: { Authorization: `Bearer ${registration.bearerToken}` },
+        },
+      },
+    });
+
+    const appRegistration = {
+      url: "http://127.0.0.1:4567/mcp",
+      bearerToken: "b".repeat(43),
+    };
+    const codexArgs = desktopTerminalMcpArgs(
+      "codex",
+      registration,
+      "/tmp/unused.json",
+      {
+        desktop_app_mail: {
+          type: "http",
+          url: appRegistration.url,
+          headers: { Authorization: `Bearer ${appRegistration.bearerToken}` },
+        },
+      },
+    );
+    expect(codexArgs).toContain(
+      `mcp_servers.desktop_app_mail.url="${appRegistration.url}"`,
+    );
+    expect(codexArgs.join(" ")).not.toContain("upstream");
+
+    const openCodeEnvironment = desktopTerminalOpenCodeEnvironment({
+      "agent-native-desktop": {
+        type: "http",
+        url: registration.url,
+        headers: { Authorization: `Bearer ${registration.bearerToken}` },
+      },
+      desktop_app_mail: {
+        type: "http",
+        url: appRegistration.url,
+        headers: { Authorization: `Bearer ${appRegistration.bearerToken}` },
+      },
+    });
+    expect(JSON.parse(openCodeEnvironment.OPENCODE_CONFIG_CONTENT)).toEqual({
+      mcp: {
+        "agent-native-desktop": {
+          type: "remote",
+          url: registration.url,
+          enabled: true,
+          oauth: false,
+          headers: { Authorization: `Bearer ${registration.bearerToken}` },
+        },
+        desktop_app_mail: {
+          type: "remote",
+          url: appRegistration.url,
+          enabled: true,
+          oauth: false,
+          headers: { Authorization: `Bearer ${appRegistration.bearerToken}` },
+        },
+      },
+    });
+  });
+
+  it("keeps Codex preferences while removing unrelated MCP startup work", () => {
     expect(
-      desktopTerminalMcpArgs("builder", registration, "/tmp/unused.json"),
-    ).toEqual(["code"]);
+      stripCodexMcpConfig(
+        [
+          'model = "gpt-5.6-luna"',
+          "",
+          '[mcp_servers."stale-app"]',
+          'url = "https://stale.example/mcp"',
+          "",
+          "[features]",
+          "shell_snapshot = true",
+        ].join("\n"),
+      ),
+    ).toBe('model = "gpt-5.6-luna"\n\n[features]\nshell_snapshot = true');
   });
 
   it("returns an authenticated desktop-owned terminal endpoint", () => {
@@ -55,6 +142,80 @@ describe("desktop chat relay target URLs", () => {
       available: true,
       wsUrl: "ws://127.0.0.1:4567/ws?token=a%20token",
     });
+    expect(
+      desktopTerminalInfo(4567, "token", {
+        appId: "mail",
+        path: "/inbox",
+        view: "inbox",
+      }),
+    ).toEqual({
+      available: true,
+      wsUrl:
+        "ws://127.0.0.1:4567/ws?token=token&appId=mail&path=%2Finbox&view=inbox",
+    });
+  });
+
+  it("relays MCP through a loopback bearer without exposing upstream auth", async () => {
+    let resolveReceived!: (value: {
+      body: string;
+      headers: Record<string, string | string[] | undefined>;
+    }) => void;
+    const received = new Promise<{
+      body: string;
+      headers: Record<string, string | string[] | undefined>;
+    }>((resolve) => {
+      resolveReceived = resolve;
+    });
+    const upstream = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+      request.on("end", () => {
+        resolveReceived({
+          body: Buffer.concat(chunks).toString(),
+          headers: { ...request.headers },
+        });
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      });
+    });
+    await new Promise<void>((resolve) =>
+      upstream.listen(0, "127.0.0.1", resolve),
+    );
+    const address = upstream.address();
+    if (!address || typeof address === "string") throw new Error("no port");
+
+    const relay = new DesktopTerminalMcpRelay(
+      `http://127.0.0.1:${address.port}/mcp`,
+      { Authorization: "Bearer upstream-secret" },
+    );
+    try {
+      const registration = await relay.start();
+      const unauthorized = await fetch(registration.url, { method: "POST" });
+      expect(unauthorized.status).toBe(401);
+
+      const response = await fetch(registration.url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${registration.bearerToken}`,
+          "content-type": "application/json",
+        },
+        body: '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {},
+      });
+
+      const request = await received;
+      expect(request.body).toContain('"method":"tools/list"');
+      expect(request.headers.authorization).toBe("Bearer upstream-secret");
+      expect(request.headers.cookie).toBeUndefined();
+    } finally {
+      await relay.close();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
   });
 
   it("rejects dot-segment traversal after URL normalization", () => {

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -160,6 +160,7 @@ export default function (pi) {
   const rawServers = process.env.AGENT_NATIVE_TERMINAL_MCP_SERVERS || "{}";
   const servers = JSON.parse(rawServers);
   const sessions = {};
+  const sessionInitializations = {};
   let nextRequestId = 1;
   const activeContext = process.env.AGENT_NATIVE_ACTIVE_APP_CONTEXT;
   const serverNames = Object.keys(servers);
@@ -245,11 +246,12 @@ export default function (pi) {
     };
   }
 
-  async function callMcp(serverName, method, params, signal) {
-    const server = servers[serverName];
-    if (!server) throw new Error("Unknown Agent-Native MCP server: " + serverName);
-    let sessionId = sessions[serverName];
-    if (!sessionId) {
+  async function getSessionId(serverName, server, signal) {
+    if (sessions[serverName]) return sessions[serverName];
+    if (sessionInitializations[serverName]) {
+      return sessionInitializations[serverName];
+    }
+    const initialization = (async () => {
       const initialized = await request(
         server,
         {
@@ -264,15 +266,30 @@ export default function (pi) {
         },
         signal,
       );
-      sessionId = initialized.sessionId;
-      if (sessionId) sessions[serverName] = sessionId;
+      const sessionId = initialized.sessionId;
       await request(
         server,
         { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
         signal,
         sessionId,
       );
+      if (sessionId) sessions[serverName] = sessionId;
+      return sessionId;
+    })();
+    sessionInitializations[serverName] = initialization;
+    try {
+      return await initialization;
+    } finally {
+      if (sessionInitializations[serverName] === initialization) {
+        delete sessionInitializations[serverName];
+      }
     }
+  }
+
+  async function callMcp(serverName, method, params, signal) {
+    const server = servers[serverName];
+    if (!server) throw new Error("Unknown Agent-Native MCP server: " + serverName);
+    const sessionId = await getSessionId(serverName, server, signal);
     const result = await request(
       server,
       { jsonrpc: "2.0", id: nextRequestId++, method, params },

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import {
   createServer,
@@ -6,6 +6,8 @@ import {
   type ServerResponse,
 } from "node:http";
 import path from "node:path";
+import { Readable } from "node:stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 
 import { createPtyWebSocketServer } from "@agent-native/core/terminal/server";
 import {
@@ -14,7 +16,7 @@ import {
   isDefaultDesktopTemplateDevTarget,
   type AppConfig,
 } from "@shared/app-registry";
-import { IPC } from "@shared/ipc-channels";
+import { IPC, type DesktopTerminalContext } from "@shared/ipc-channels";
 import {
   app,
   BrowserWindow,
@@ -82,28 +84,570 @@ function tomlInlineTable(headers: Record<string, string>): string {
     .join(",")}}`;
 }
 
+interface DesktopTerminalMcpServer {
+  type: "http";
+  url: string;
+  headers: Record<string, string>;
+}
+
+function desktopTerminalMcpServerId(appId: string): string {
+  return `desktop_app_${appId.replace(/[^A-Za-z0-9_]/g, "_")}`;
+}
+
+function desktopAppMcpUrl(baseUrl: string): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("mcp", base).toString();
+}
+
+function desktopAppMcpConnectTokenUrl(baseUrl: string): string {
+  const base = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return new URL("mcp/connect/token", base).toString();
+}
+
+function hashTerminalToken(token: string): string {
+  return createHash("sha256").update(token).digest("base64url");
+}
+
+function readTerminalBearer(value: string | undefined): string | undefined {
+  return /^Bearer ([A-Za-z0-9_-]{32,})$/.exec(value ?? "")?.[1];
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return (
+    address === "127.0.0.1" ||
+    address === "::1" ||
+    address === "::ffff:127.0.0.1"
+  );
+}
+
+const TERMINAL_MCP_REQUEST_HEADERS = new Set([
+  "accept",
+  "cache-control",
+  "content-type",
+  "last-event-id",
+  "mcp-protocol-version",
+  "mcp-session-id",
+]);
+const TERMINAL_MCP_RESPONSE_HEADERS = new Set([
+  "cache-control",
+  "content-type",
+  "last-event-id",
+  "location",
+  "mcp-session-id",
+  "retry-after",
+]);
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value.join(", ") : value;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export interface DesktopTerminalMcpRegistration {
+  url: string;
+  bearerToken: string;
+}
+
+const PI_TERMINAL_EXTENSION_SOURCE = String.raw`
+export default function (pi) {
+  const rawServers = process.env.AGENT_NATIVE_TERMINAL_MCP_SERVERS || "{}";
+  const servers = JSON.parse(rawServers);
+  const sessions = {};
+  const activeContext = process.env.AGENT_NATIVE_ACTIVE_APP_CONTEXT;
+  const serverNames = Object.keys(servers);
+
+  function parseBody(text) {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // coercion-ok: JSON parsing falls through to the documented SSE response format.
+    }
+    const data = trimmed
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("");
+    return data && data !== "[DONE]" ? JSON.parse(data) : null;
+  }
+
+  async function request(server, body, signal, sessionId) {
+    const headers = {
+      ...server.headers,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-protocol-version": "2025-06-18",
+    };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+    const response = await fetch(server.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+    const payload = parseBody(await response.text());
+    if (!response.ok) {
+      const message =
+        payload && payload.error && payload.error.message
+          ? payload.error.message
+          : "MCP request failed (" + response.status + ").";
+      throw new Error(message);
+    }
+    return {
+      payload,
+      sessionId: response.headers.get("mcp-session-id") || sessionId,
+    };
+  }
+
+  async function callMcp(serverName, method, params, signal) {
+    const server = servers[serverName];
+    if (!server) throw new Error("Unknown Agent-Native MCP server: " + serverName);
+    let sessionId = sessions[serverName];
+    if (!sessionId) {
+      const initialized = await request(
+        server,
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "agent-native-desktop-pi", version: "1.0.0" },
+          },
+        },
+        signal,
+      );
+      sessionId = initialized.sessionId;
+      if (sessionId) sessions[serverName] = sessionId;
+      await request(
+        server,
+        { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
+        signal,
+        sessionId,
+      );
+    }
+    const result = await request(
+      server,
+      { jsonrpc: "2.0", id: Date.now(), method, params },
+      signal,
+      sessionId,
+    );
+    if (result.payload && result.payload.error) {
+      throw new Error(result.payload.error.message || "MCP request failed.");
+    }
+    return result.payload && result.payload.result
+      ? result.payload.result
+      : result.payload;
+  }
+
+  function resultFor(value) {
+    const content =
+      value && Array.isArray(value.content)
+        ? value.content.filter((item) => item && (item.type === "text" || item.type === "image"))
+        : [];
+    return {
+      content:
+        content.length > 0
+          ? content
+          : [{ type: "text", text: JSON.stringify(value) }],
+      details: value,
+    };
+  }
+
+  pi.on("before_agent_start", (event) => ({
+    systemPrompt:
+      event.systemPrompt +
+      "\n\nThis Pi session is embedded in Agent-Native desktop. The active app context is exposed by the agent-native-desktop MCP server. Available MCP servers: " +
+      serverNames.join(", ") +
+      (activeContext ? ". Current context: " + activeContext : "."),
+  }));
+
+  pi.registerTool({
+    name: "agent_native_app",
+    label: "Agent-Native app",
+    description:
+      "List or call tools on the active Agent-Native desktop app. List tools before calling an app operation, and use agent-native-desktop to read the active app context.",
+    promptSnippet: "List or call tools on the active Agent-Native app",
+    promptGuidelines: [
+      "Use agent_native_app to operate the active Agent-Native app through its MCP server.",
+      "Call list_tools before call_tool when you do not already know the app tool schema.",
+    ],
+    parameters: {
+      type: "object",
+      properties: {
+        operation: {
+          type: "string",
+          enum: ["list_tools", "call_tool"],
+          description: "Whether to list available tools or call one.",
+        },
+        server: {
+          type: "string",
+          description: "MCP server name from the available server list.",
+        },
+        tool: {
+          type: "string",
+          description: "Tool name returned by list_tools.",
+        },
+        arguments: {
+          type: "object",
+          additionalProperties: true,
+          description: "Arguments for the selected MCP tool.",
+        },
+      },
+      required: ["operation"],
+      additionalProperties: false,
+    },
+    async execute(_toolCallId, params, signal) {
+      const server = params.server || "agent-native-desktop";
+      if (params.operation === "list_tools") {
+        return resultFor(await callMcp(server, "tools/list", {}, signal));
+      }
+      if (!params.tool) throw new Error("tool is required for call_tool.");
+      return resultFor(
+        await callMcp(
+          server,
+          "tools/call",
+          { name: params.tool, arguments: params.arguments || {} },
+          signal,
+        ),
+      );
+    },
+  });
+}
+`;
+
+/**
+ * Main-process capability relay. Provider CLIs see only a loopback bearer;
+ * app auth stays here and is never serialized into their config or argv.
+ */
+export class DesktopTerminalMcpRelay {
+  private readonly bearerToken = randomBytes(32).toString("base64url");
+  private readonly bearerHash = hashTerminalToken(this.bearerToken);
+  private readonly activeControllers = new Set<AbortController>();
+  private server?: ReturnType<typeof createServer>;
+  private url?: string;
+
+  constructor(
+    private readonly upstreamUrl: string,
+    private readonly upstreamHeaders: Readonly<Record<string, string>>,
+  ) {}
+
+  async start(): Promise<DesktopTerminalMcpRegistration> {
+    if (this.url) return this.registration();
+    const upstream = new URL(this.upstreamUrl);
+    if (upstream.protocol !== "http:" && upstream.protocol !== "https:") {
+      throw new Error("The app MCP endpoint must use HTTP or HTTPS.");
+    }
+    const server = createServer((request, response) => {
+      void this.handleRequest(request, response);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("The app MCP relay did not receive a TCP address.");
+    }
+    this.server = server;
+    this.url = `http://127.0.0.1:${address.port}/mcp`;
+    return this.registration();
+  }
+
+  async close(): Promise<void> {
+    for (const controller of this.activeControllers) controller.abort();
+    this.activeControllers.clear();
+    const server = this.server;
+    this.server = undefined;
+    this.url = undefined;
+    if (!server) return;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private registration(): DesktopTerminalMcpRegistration {
+    if (!this.url) throw new Error("The app MCP relay is not ready.");
+    return { url: this.url, bearerToken: this.bearerToken };
+  }
+
+  private async handleRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    let requestPath: string;
+    try {
+      requestPath = new URL(
+        request.url ?? "/",
+        "http://desktop-terminal.invalid",
+      ).pathname;
+    } catch {
+      response.writeHead(400).end();
+      return;
+    }
+    if (
+      !isLoopbackAddress(request.socket.remoteAddress) ||
+      requestPath !== "/mcp"
+    ) {
+      response.writeHead(404).end();
+      return;
+    }
+    const bearer = readTerminalBearer(request.headers.authorization);
+    if (!bearer || hashTerminalToken(bearer) !== this.bearerHash) {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    if (!["DELETE", "GET", "POST"].includes(request.method ?? "")) {
+      response.writeHead(405, { allow: "DELETE, GET, POST" }).end();
+      return;
+    }
+
+    const controller = new AbortController();
+    this.activeControllers.add(controller);
+    const abort = () => controller.abort();
+    request.once("aborted", abort);
+    response.once("close", () => {
+      if (!response.writableEnded) controller.abort();
+    });
+    try {
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(request.headers)) {
+        if (!TERMINAL_MCP_REQUEST_HEADERS.has(name.toLowerCase())) continue;
+        const normalized = headerValue(value);
+        if (normalized) headers.set(name, normalized);
+      }
+      headers.set("origin", new URL(this.upstreamUrl).origin);
+      for (const [name, value] of Object.entries(this.upstreamHeaders)) {
+        headers.set(name, value);
+      }
+      const body =
+        request.method === "POST" ? await readRequestBody(request) : undefined;
+      const upstream = await fetch(this.upstreamUrl, {
+        method: request.method,
+        headers,
+        ...(body ? { body: body as unknown as BodyInit } : {}),
+        redirect: "manual",
+        signal: controller.signal,
+      });
+      const responseHeaders: Record<string, string> = {};
+      for (const name of TERMINAL_MCP_RESPONSE_HEADERS) {
+        const value = upstream.headers.get(name);
+        if (value) responseHeaders[name] = value;
+      }
+      response.writeHead(upstream.status, responseHeaders);
+      if (!upstream.body) {
+        response.end();
+        return;
+      }
+      Readable.fromWeb(upstream.body as unknown as NodeReadableStream).pipe(
+        response,
+      );
+    } catch (error) {
+      if (controller.signal.aborted || response.writableEnded) return;
+      console.warn("[desktop-terminal] app MCP relay failed:", {
+        upstreamOrigin: new URL(this.upstreamUrl).origin,
+        error: error instanceof Error ? error.message : "unknown error",
+      });
+      response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
+      response.end("The active app MCP connection failed.");
+    } finally {
+      this.activeControllers.delete(controller);
+      request.removeListener("aborted", abort);
+    }
+  }
+}
+
+function readMcpAuthHeaders(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const headers = value as Record<string, unknown>;
+  const authHeaders: Record<string, string> = {};
+  for (const name of ["Authorization", "X-Agent-Native-Owner-Email"]) {
+    if (typeof headers[name] === "string" && headers[name].trim()) {
+      authHeaders[name] = headers[name].trim();
+    }
+  }
+  return authHeaders;
+}
+
+export async function getDesktopAppMcpAuthorization(
+  appConfig: AppConfig,
+  baseUrl: string,
+): Promise<Record<string, string>> {
+  const tokenUrl = desktopAppMcpConnectTokenUrl(baseUrl);
+  const origin = new URL(baseUrl).origin;
+  const cookieHeader = await readCookieHeaderForUrl(
+    session.fromPartition(`persist:app-${appConfig.id}`),
+    tokenUrl,
+  );
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      Origin: origin,
+      Referer: `${origin}/`,
+      ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+    },
+    body: JSON.stringify({ label: "Desktop terminal", ttlDays: 1 }),
+    redirect: "manual",
+  });
+  const text = (await response.text()).trim();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(
+      `${appConfig.name} returned an invalid MCP authorization response.`,
+    );
+  }
+  const object =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {};
+  if (!response.ok) {
+    const message =
+      typeof object.error === "string" && object.error.trim()
+        ? object.error.trim()
+        : `MCP authorization failed (${response.status}).`;
+    throw new Error(
+      `Could not connect the terminal to ${appConfig.name}: ${message}`,
+    );
+  }
+  const authHeaders = readMcpAuthHeaders(
+    object.mcpServerEntry &&
+      typeof object.mcpServerEntry === "object" &&
+      !Array.isArray(object.mcpServerEntry)
+      ? (object.mcpServerEntry as Record<string, unknown>).headers
+      : undefined,
+  );
+  if (Object.keys(authHeaders).length > 0) return authHeaders;
+  if (typeof object.token === "string" && object.token.trim()) {
+    return { Authorization: `Bearer ${object.token.trim()}` };
+  }
+  throw new Error(
+    `Sign in to ${appConfig.name} before using its tools from the terminal.`,
+  );
+}
+
 export function desktopTerminalMcpArgs(
   command: string,
   registration: DesktopSurfaceMcpRegistration,
   claudeConfigPath: string,
+  appMcpServers: Readonly<Record<string, DesktopTerminalMcpServer>> = {},
+  piExtensionPath?: string,
 ): string[] {
+  const mcpServers: Record<string, DesktopTerminalMcpServer> = {
+    "agent-native-desktop": {
+      type: "http",
+      url: registration.url,
+      headers: { Authorization: `Bearer ${registration.bearerToken}` },
+    },
+    ...appMcpServers,
+  };
   if (command === "claude") {
     return ["--mcp-config", claudeConfigPath];
   }
   if (command === "codex") {
-    return [
-      "-c",
-      `mcp_servers.agent-native-desktop.url=${tomlString(registration.url)}`,
-      "-c",
-      `mcp_servers.agent-native-desktop.http_headers=${tomlInlineTable({
-        Authorization: `Bearer ${registration.bearerToken}`,
-      })}`,
-    ];
+    const args: string[] = [];
+    for (const [serverId, server] of Object.entries(mcpServers)) {
+      args.push("-c", `mcp_servers.${serverId}.url=${tomlString(server.url)}`);
+      args.push(
+        "-c",
+        `mcp_servers.${serverId}.http_headers=${tomlInlineTable(server.headers)}`,
+      );
+    }
+    return args;
   }
   if (command === "builder") {
-    return ["code"];
+    return [
+      "code",
+      "--configJson",
+      JSON.stringify({ isLocal: true, mcpServers }),
+    ];
+  }
+  if (command === "pi" && piExtensionPath) {
+    return ["--extension", piExtensionPath];
   }
   return [];
+}
+
+export function desktopTerminalOpenCodeEnvironment(
+  mcpServers: Readonly<Record<string, DesktopTerminalMcpServer>>,
+): Record<string, string> {
+  return {
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      mcp: Object.fromEntries(
+        Object.entries(mcpServers).map(([serverId, server]) => [
+          serverId,
+          {
+            type: "remote",
+            url: server.url,
+            enabled: true,
+            oauth: false,
+            headers: server.headers,
+          },
+        ]),
+      ),
+    }),
+  };
+}
+
+export function stripCodexMcpConfig(config: string): string {
+  const lines = config.split(/\r?\n/);
+  const kept: string[] = [];
+  let inMcpSection = false;
+  for (const line of lines) {
+    const section = /^\s*\[([^\]]+)\]/.exec(line)?.[1]?.trim();
+    if (section)
+      inMcpSection =
+        section === "mcp_servers" || section.startsWith("mcp_servers.");
+    if (inMcpSection || /^\s*mcp_servers\s*=/.test(line)) continue;
+    kept.push(line);
+  }
+  return kept.join("\n");
+}
+
+function createCodexTerminalHome(): string {
+  const sourceHome =
+    process.env.CODEX_HOME || path.join(app.getPath("home"), ".codex");
+  const terminalHome = fs.mkdtempSync(
+    path.join(app.getPath("temp"), "agent-native-codex-"),
+  );
+  const sourceConfig = path.join(sourceHome, "config.toml");
+  const terminalConfig = path.join(terminalHome, "config.toml");
+  const config = fs.existsSync(sourceConfig)
+    ? stripCodexMcpConfig(fs.readFileSync(sourceConfig, "utf8"))
+    : "";
+  fs.writeFileSync(terminalConfig, config, { mode: 0o600 });
+
+  const sourceAuth = path.join(sourceHome, "auth.json");
+  if (fs.existsSync(sourceAuth)) {
+    fs.copyFileSync(sourceAuth, path.join(terminalHome, "auth.json"));
+    fs.chmodSync(path.join(terminalHome, "auth.json"), 0o600);
+  }
+  return terminalHome;
+}
+
+function removeDesktopTerminalHome(directory: string | undefined): void {
+  if (!directory) return;
+  try {
+    fs.rmSync(directory, { recursive: true, force: true });
+  } catch (error) {
+    console.warn(
+      "[desktop-terminal] Could not remove temporary Codex home:",
+      error instanceof Error ? error.message : "unknown error",
+    );
+  }
 }
 
 function removeDesktopTerminalConfig(filePath: string | undefined): void {
@@ -120,13 +664,109 @@ function removeDesktopTerminalConfig(filePath: string | undefined): void {
 
 function reportDesktopTerminalCleanupFailure(error: unknown): void {
   console.warn(
-    "[desktop-terminal] Could not close the desktop surface bridge:",
+    "[desktop-terminal] Could not close a terminal capability:",
     error instanceof Error ? error.message : "unknown error",
   );
 }
 
-async function createDesktopTerminal() {
-  const token = randomUUID().replaceAll("-", "");
+function resolveDesktopTerminalCwd(): string {
+  const candidates = [
+    process.env.AGENT_NATIVE_PROJECT_ROOT,
+    process.env.CODE_AGENTS_PROJECT_ROOT,
+    process.env.INIT_CWD,
+    process.env.PWD,
+    process.cwd(),
+    app.getPath("home"),
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const resolved = path.resolve(candidate);
+    if (path.parse(resolved).root === resolved) continue;
+    try {
+      if (fs.statSync(resolved).isDirectory()) return resolved;
+    } catch {
+      continue;
+    }
+  }
+  return app.getPath("home");
+}
+
+function isSafeDesktopAppPath(value: string): boolean {
+  if (!value.startsWith("/") || value.startsWith("//")) return false;
+  const baseUrl = "http://desktop-app.invalid";
+  return (
+    URL.canParse(value, baseUrl) && new URL(value, baseUrl).origin === baseUrl
+  );
+}
+
+function normalizeDesktopTerminalContext(
+  value: unknown,
+): DesktopTerminalContext | null {
+  if (value === null || value === undefined) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("The terminal app context is invalid.");
+  }
+  const input = value as Record<string, unknown>;
+  const appId = typeof input.appId === "string" ? input.appId.trim() : "";
+  if (!appId || appId.length > 80) {
+    throw new Error("The terminal app context is invalid.");
+  }
+  const appConfig = getDesktopVisibleApps(AppStore.loadApps()).find(
+    (candidate) => candidate.id === appId && candidate.enabled !== false,
+  );
+  if (!appConfig) {
+    throw new Error("The selected desktop app is unavailable.");
+  }
+  const rawPath = typeof input.path === "string" ? input.path.trim() : "";
+  const rawView = typeof input.view === "string" ? input.view.trim() : "";
+  if (rawPath && (!isSafeDesktopAppPath(rawPath) || rawPath.length > 2_000)) {
+    throw new Error("The terminal app path is invalid.");
+  }
+  if (rawView.length > 200) {
+    throw new Error("The terminal app view is invalid.");
+  }
+  return {
+    appId,
+    ...(rawPath ? { path: rawPath } : {}),
+    ...(rawView ? { view: rawView } : {}),
+  };
+}
+
+function contextFromTerminalQuery(
+  searchParams: URLSearchParams,
+): DesktopTerminalContext | null {
+  const appId = searchParams.get("appId")?.trim();
+  if (!appId) return null;
+  const pathValue = searchParams.get("path")?.trim();
+  const view = searchParams.get("view")?.trim();
+  return {
+    appId,
+    ...(pathValue ? { path: pathValue } : {}),
+    ...(view ? { view } : {}),
+  };
+}
+
+async function createDesktopTerminalSession(
+  command: string,
+  rawContext: DesktopTerminalContext | null,
+) {
+  const context = normalizeDesktopTerminalContext(rawContext);
+  const appConfig = context
+    ? getDesktopVisibleApps(AppStore.loadApps()).find(
+        (candidate) => candidate.id === context.appId,
+      )
+    : undefined;
+  if (context && !appConfig) {
+    throw new Error("The selected desktop app is unavailable.");
+  }
+  const appContext = context
+    ? {
+        appId: context.appId,
+        appName: appConfig!.name,
+        ...(context.path ? { path: context.path } : {}),
+        ...(context.view ? { view: context.view } : {}),
+      }
+    : null;
   const surfaceMcp = new DesktopSurfaceMcpBridge({
     listApps: () =>
       getDesktopVisibleApps(AppStore.loadApps())
@@ -139,72 +779,137 @@ async function createDesktopTerminal() {
       if (!win) throw new Error("The desktop shell is not available.");
       win.webContents.send(IPC.DESKTOP_CHAT_OPEN_APP, request);
     },
+    getActiveAppContext: () => appContext,
   });
+  let appMcpRelay: DesktopTerminalMcpRelay | undefined;
   let claudeConfigPath: string | undefined;
+  let piExtensionPath: string | undefined;
+  let codexHome: string | undefined;
+  let closed = false;
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    removeDesktopTerminalConfig(claudeConfigPath);
+    removeDesktopTerminalConfig(piExtensionPath);
+    removeDesktopTerminalHome(codexHome);
+    try {
+      await appMcpRelay?.close();
+      await surfaceMcp.close();
+    } catch (error) {
+      reportDesktopTerminalCleanupFailure(error);
+    }
+  };
   try {
     const surfaceMcpUrl = await surfaceMcp.start();
     const surfaceMcpRegistration = surfaceMcp.register();
-    claudeConfigPath = path.join(
-      app.getPath("temp"),
-      `agent-native-desktop-${randomUUID()}.json`,
-    );
-    fs.writeFileSync(
-      claudeConfigPath,
-      JSON.stringify(
-        {
-          mcpServers: {
-            "agent-native-desktop": {
-              type: "http",
-              url: surfaceMcpUrl,
-              headers: {
-                Authorization: `Bearer ${surfaceMcpRegistration.bearerToken}`,
-              },
-            },
-          },
+    const appMcpServers: Record<string, DesktopTerminalMcpServer> = {};
+    if (appConfig) {
+      const baseUrl = resolveAppBaseUrl(appConfig);
+      if (!baseUrl) {
+        throw new Error(`The ${appConfig.name} app has no reachable URL.`);
+      }
+      const authHeaders = await getDesktopAppMcpAuthorization(
+        appConfig,
+        baseUrl,
+      );
+      appMcpRelay = new DesktopTerminalMcpRelay(
+        desktopAppMcpUrl(baseUrl),
+        authHeaders,
+      );
+      const appMcpRegistration = await appMcpRelay.start();
+      appMcpServers[desktopTerminalMcpServerId(appConfig.id)] = {
+        type: "http",
+        url: appMcpRegistration.url,
+        headers: {
+          Authorization: `Bearer ${appMcpRegistration.bearerToken}`,
         },
-        null,
-        2,
-      ),
-      { mode: 0o600 },
-    );
-    const terminal = await createPtyWebSocketServer({
-      appDir: app.getPath("home"),
-      authCheck: (request) => {
-        try {
-          const url = new URL(
-            request.url ?? "",
-            `http://${request.headers.host ?? "127.0.0.1"}`,
-          );
-          return url.searchParams.get("token") === token;
-        } catch {
-          // coercion-ok: malformed websocket URLs are authentication denials, never success.
-          return false;
-        }
-      },
-      getCommandArgs: (command) =>
-        desktopTerminalMcpArgs(
-          command,
-          surfaceMcpRegistration,
-          claudeConfigPath!,
-        ),
-      logPrefix: "[desktop-terminal]",
-    });
-    const close = () => {
-      terminal.close();
-      void surfaceMcp.close().catch(reportDesktopTerminalCleanupFailure);
-      removeDesktopTerminalConfig(claudeConfigPath);
-    };
-    app.once("before-quit", close);
-    return { terminal, token };
-  } catch (error) {
-    removeDesktopTerminalConfig(claudeConfigPath);
-    try {
-      await surfaceMcp.close();
-    } catch (closeError) {
-      reportDesktopTerminalCleanupFailure(closeError);
+      };
     }
+    const surfaceMcpServer: DesktopTerminalMcpServer = {
+      type: "http",
+      url: surfaceMcpUrl,
+      headers: {
+        Authorization: `Bearer ${surfaceMcpRegistration.bearerToken}`,
+      },
+    };
+    const mcpServers = {
+      "agent-native-desktop": surfaceMcpServer,
+      ...appMcpServers,
+    };
+    if (command === "claude") {
+      claudeConfigPath = path.join(
+        app.getPath("temp"),
+        `agent-native-desktop-${randomUUID()}.json`,
+      );
+      fs.writeFileSync(
+        claudeConfigPath,
+        JSON.stringify({ mcpServers }, null, 2),
+        { mode: 0o600 },
+      );
+    }
+    if (command === "pi") {
+      piExtensionPath = path.join(
+        app.getPath("temp"),
+        `agent-native-desktop-${randomUUID()}.mcp.ts`,
+      );
+      fs.writeFileSync(piExtensionPath, PI_TERMINAL_EXTENSION_SOURCE, {
+        mode: 0o600,
+      });
+    }
+    if (command === "codex") codexHome = createCodexTerminalHome();
+    return {
+      commandArgs: desktopTerminalMcpArgs(
+        command,
+        surfaceMcpRegistration,
+        claudeConfigPath ?? "",
+        appMcpServers,
+        piExtensionPath,
+      ),
+      environment: {
+        MCP_SERVERS: JSON.stringify({ servers: mcpServers }),
+        AGENT_NATIVE_TERMINAL_MCP_SERVERS: JSON.stringify(mcpServers),
+        ...(appContext
+          ? { AGENT_NATIVE_ACTIVE_APP_CONTEXT: JSON.stringify(appContext) }
+          : {}),
+        AGENT_NATIVE_CODE_AGENT_MCP_SERVER_ALLOWLIST:
+          Object.keys(mcpServers).join(","),
+        ...(codexHome ? { CODEX_HOME: codexHome } : {}),
+        ...(command === "opencode"
+          ? desktopTerminalOpenCodeEnvironment(mcpServers)
+          : {}),
+      },
+      onClose: close,
+    };
+  } catch (error) {
+    await close();
     throw error;
   }
+}
+
+async function createDesktopTerminal() {
+  const token = randomUUID().replaceAll("-", "");
+  const terminal = await createPtyWebSocketServer({
+    appDir: resolveDesktopTerminalCwd(),
+    authCheck: (request) => {
+      try {
+        const url = new URL(
+          request.url ?? "",
+          `http://${request.headers.host ?? "127.0.0.1"}`,
+        );
+        return url.searchParams.get("token") === token;
+      } catch {
+        // coercion-ok: malformed websocket URLs are authentication denials, never success.
+        return false;
+      }
+    },
+    getSessionSetup: (
+      command: string,
+      context: DesktopTerminalContext | null,
+    ) => createDesktopTerminalSession(command, context),
+    logPrefix: "[desktop-terminal]",
+  } as Parameters<typeof createPtyWebSocketServer>[0]);
+  app.once("before-quit", () => terminal.close());
+  return { terminal, token };
 }
 
 function ensureDesktopTerminal() {
@@ -215,10 +920,20 @@ function ensureDesktopTerminal() {
   return desktopTerminalPromise;
 }
 
-export function desktopTerminalInfo(port: number, token: string) {
+export function desktopTerminalInfo(
+  port: number,
+  token: string,
+  context: DesktopTerminalContext | null = null,
+) {
+  const query = [`token=${encodeURIComponent(token)}`];
+  if (context) {
+    query.push(`appId=${encodeURIComponent(context.appId)}`);
+    if (context.path) query.push(`path=${encodeURIComponent(context.path)}`);
+    if (context.view) query.push(`view=${encodeURIComponent(context.view)}`);
+  }
   return {
     available: true,
-    wsUrl: `ws://127.0.0.1:${port}/ws?token=${encodeURIComponent(token)}`,
+    wsUrl: `ws://127.0.0.1:${port}/ws?${query.join("&")}`,
   };
 }
 
@@ -483,6 +1198,7 @@ function ensureRelay(): Promise<RelayState> {
         return;
       }
       if (parsed.pathname === `${DESKTOP_TERMINAL_INFO_ROOT}/${secret}`) {
+        const context = contextFromTerminalQuery(parsed.searchParams);
         void ensureDesktopTerminal()
           .then(({ terminal, token }) => {
             response.writeHead(200, {
@@ -490,7 +1206,9 @@ function ensureRelay(): Promise<RelayState> {
               "Content-Type": "application/json; charset=utf-8",
             });
             response.end(
-              JSON.stringify(desktopTerminalInfo(terminal.port, token)),
+              JSON.stringify(
+                desktopTerminalInfo(terminal.port, token, context),
+              ),
             );
           })
           .catch((error) => {
@@ -550,18 +1268,33 @@ export function registerDesktopChatIpc(): void {
   );
   ipcMain.handle(
     IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL,
-    async (_event: IpcMainInvokeEvent, appId: unknown) => {
-      if (appId === undefined || appId === null) {
-        const relay = await ensureRelay();
-        return `http://127.0.0.1:${relay.port}${DESKTOP_TERMINAL_INFO_ROOT}/${relay.secret}`;
+    async (_event: IpcMainInvokeEvent, rawContext: unknown) => {
+      let context: DesktopTerminalContext | null;
+      try {
+        context = normalizeDesktopTerminalContext(rawContext);
+      } catch (error) {
+        console.warn(
+          "[desktop-chat] Ignoring invalid terminal context.",
+          error,
+        );
+        return null;
       }
-      if (typeof appId !== "string" || !appId.trim()) return null;
-      const appConfig = AppStore.loadApps().find(
-        (candidate) => candidate.id === appId,
-      );
-      if (!appConfig || !resolveAppBaseUrl(appConfig)) return null;
+      if (context) {
+        const appConfig = getDesktopVisibleApps(AppStore.loadApps()).find(
+          (candidate) => candidate.id === context?.appId,
+        );
+        if (!appConfig || !resolveAppBaseUrl(appConfig)) return null;
+      }
       const relay = await ensureRelay();
-      return `http://127.0.0.1:${relay.port}${RELAY_ROOT}/${relay.secret}/${encodeURIComponent(appId)}/_agent-native/agent-terminal-info`;
+      const url = new URL(
+        `http://127.0.0.1:${relay.port}${DESKTOP_TERMINAL_INFO_ROOT}/${relay.secret}`,
+      );
+      if (context) {
+        url.searchParams.set("appId", context.appId);
+        if (context.path) url.searchParams.set("path", context.path);
+        if (context.view) url.searchParams.set("view", context.view);
+      }
+      return url.toString();
     },
   );
 }

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -160,6 +160,7 @@ export default function (pi) {
   const rawServers = process.env.AGENT_NATIVE_TERMINAL_MCP_SERVERS || "{}";
   const servers = JSON.parse(rawServers);
   const sessions = {};
+  let nextRequestId = 1;
   const activeContext = process.env.AGENT_NATIVE_ACTIVE_APP_CONTEXT;
   const serverNames = Object.keys(servers);
 
@@ -274,7 +275,7 @@ export default function (pi) {
     }
     const result = await request(
       server,
-      { jsonrpc: "2.0", id: Date.now(), method, params },
+      { jsonrpc: "2.0", id: nextRequestId++, method, params },
       signal,
       sessionId,
     );

--- a/packages/desktop-app/src/main/ipc/desktop-chat.ts
+++ b/packages/desktop-app/src/main/ipc/desktop-chat.ts
@@ -7,6 +7,7 @@ import {
 } from "node:http";
 import path from "node:path";
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 
 import { createPtyWebSocketServer } from "@agent-native/core/terminal/server";
@@ -178,6 +179,43 @@ export default function (pi) {
     return data && data !== "[DONE]" ? JSON.parse(data) : null;
   }
 
+  async function readResponsePayload(response, requestId) {
+    const contentType = (response.headers.get("content-type") || "").toLowerCase();
+    if (!contentType.includes("text/event-stream") || !response.body) {
+      return parseBody(await response.text());
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        buffer += decoder.decode(chunk.value || new Uint8Array(), {
+          stream: !chunk.done,
+        });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() || "";
+        for (const event of events) {
+          const data = event
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trim())
+            .join("\n");
+          if (!data || data === "[DONE]") continue;
+          const payload = JSON.parse(data);
+          if (requestId == null || payload?.id === requestId) return payload;
+        }
+        if (chunk.done) return parseBody(buffer);
+      }
+    } finally {
+      await reader.cancel().catch(() => {
+        // coercion-ok: cancellation is best-effort after the response is consumed.
+      });
+      reader.releaseLock();
+    }
+  }
+
   async function request(server, body, signal, sessionId) {
     const headers = {
       ...server.headers,
@@ -192,7 +230,7 @@ export default function (pi) {
       body: JSON.stringify(body),
       signal,
     });
-    const payload = parseBody(await response.text());
+    const payload = await readResponsePayload(response, body.id);
     if (!response.ok) {
       const message =
         payload && payload.error && payload.error.message
@@ -331,7 +369,10 @@ export default function (pi) {
 export class DesktopTerminalMcpRelay {
   private readonly bearerToken = randomBytes(32).toString("base64url");
   private readonly bearerHash = hashTerminalToken(this.bearerToken);
-  private readonly activeControllers = new Set<AbortController>();
+  private readonly activeRequests = new Map<
+    AbortController,
+    { request: IncomingMessage; response: ServerResponse }
+  >();
   private server?: ReturnType<typeof createServer>;
   private url?: string;
 
@@ -367,8 +408,11 @@ export class DesktopTerminalMcpRelay {
   }
 
   async close(): Promise<void> {
-    for (const controller of this.activeControllers) controller.abort();
-    this.activeControllers.clear();
+    for (const [controller, { request, response }] of this.activeRequests) {
+      controller.abort();
+      request.destroy();
+      response.destroy();
+    }
     const server = this.server;
     this.server = undefined;
     this.url = undefined;
@@ -414,12 +458,13 @@ export class DesktopTerminalMcpRelay {
     }
 
     const controller = new AbortController();
-    this.activeControllers.add(controller);
+    this.activeRequests.set(controller, { request, response });
     const abort = () => controller.abort();
-    request.once("aborted", abort);
-    response.once("close", () => {
+    const abortResponse = () => {
       if (!response.writableEnded) controller.abort();
-    });
+    };
+    request.once("aborted", abort);
+    response.once("close", abortResponse);
     try {
       const headers = new Headers();
       for (const [name, value] of Object.entries(request.headers)) {
@@ -450,7 +495,8 @@ export class DesktopTerminalMcpRelay {
         response.end();
         return;
       }
-      Readable.fromWeb(upstream.body as unknown as NodeReadableStream).pipe(
+      await pipeline(
+        Readable.fromWeb(upstream.body as unknown as NodeReadableStream),
         response,
       );
     } catch (error) {
@@ -462,8 +508,9 @@ export class DesktopTerminalMcpRelay {
       response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
       response.end("The active app MCP connection failed.");
     } finally {
-      this.activeControllers.delete(controller);
+      this.activeRequests.delete(controller);
       request.removeListener("aborted", abort);
+      response.removeListener("close", abortResponse);
     }
   }
 }

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -37,6 +37,7 @@ import {
   type CodeAgentProjectListResult,
   type CodeAgentProjectSelectResult,
   type CodeAgentWorktreeListResult,
+  type DesktopTerminalContext,
   type CodeAgentRetryRunRequest,
   type CodeAgentRetryRunResult,
   type CodeAgentRerunRequest,
@@ -258,8 +259,10 @@ const electronAPI = {
   desktopChat: {
     getApiUrl: (appId: string): Promise<string | null> =>
       ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_API_URL, appId),
-    getTerminalInfoUrl: (appId?: string): Promise<string | null> =>
-      ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL, appId),
+    getTerminalInfoUrl: (
+      context?: DesktopTerminalContext | null,
+    ): Promise<string | null> =>
+      ipcRenderer.invoke(IPC.DESKTOP_CHAT_GET_TERMINAL_INFO_URL, context),
     onOpenApp: (
       cb: (request: DesktopChatOpenAppRequest) => void,
     ): (() => void) => {

--- a/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
+++ b/packages/desktop-app/src/renderer/components/CodeAgentsHub.tsx
@@ -2892,6 +2892,23 @@ export default function CodeAgentsHub({
     (!chatFirstAppSelected || activeChatFirstSurfaceTab?.placement === "side");
   const canToggleChatFirstSurfacePanel =
     canRenderChatFirstSurfacePanel && !chatFirstAppSelected;
+  const activeTerminalApp = useMemo(() => {
+    if (activeChatFirstSurfaceTab?.kind !== "app") return undefined;
+    const app = surfaceApps.find(
+      (candidate) => candidate.id === activeChatFirstSurfaceTab.appId,
+    );
+    if (!app) return undefined;
+    return {
+      id: app.id,
+      name: app.name,
+      ...(activeChatFirstSurfaceTab.path
+        ? { path: activeChatFirstSurfaceTab.path }
+        : {}),
+      ...(activeChatFirstSurfaceTab.view
+        ? { view: activeChatFirstSurfaceTab.view }
+        : {}),
+    };
+  }, [activeChatFirstSurfaceTab, surfaceApps]);
   return (
     <QueryClientProvider client={codeAgentsQueryClient}>
       <div
@@ -2968,6 +2985,7 @@ export default function CodeAgentsHub({
               <DesktopTerminalSurface
                 agent={terminalPreferences.agent}
                 theme={theme}
+                activeApp={activeTerminalApp}
                 submitRequest={terminalPromptRequest ?? undefined}
                 onPromptSubmitted={handleTerminalPromptSubmitted}
                 onNewUiTab={handleNewUiTab}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -127,10 +127,9 @@ describe("DesktopTerminalSurface", () => {
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
     ).find((item) => item.textContent?.includes("Provider"));
     expect(providerItem).not.toBeUndefined();
-    expect(providerItem?.classList.contains("gap-2")).toBe(true);
-    expect(providerItem?.querySelector(".desktop-dropdown-item__main")).toBe(
-      null,
-    );
+    expect(
+      providerItem?.querySelector(".desktop-dropdown-item__main"),
+    ).not.toBe(null);
     expect(providerItem?.querySelector("svg.ms-auto")).not.toBeNull();
     expect(
       Array.from(

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.spec.tsx
@@ -7,8 +7,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DesktopTerminalSurface from "./DesktopTerminalSurface.js";
 
 vi.mock("./DesktopTerminalTabs.js", () => ({
-  default: ({ agent }: { agent: string }) => (
-    <div data-terminal-test data-terminal-agent={agent} />
+  default: ({
+    agent,
+    active,
+    activeApp,
+  }: {
+    agent: string;
+    active?: boolean;
+    activeApp?: { id: string };
+  }) => (
+    <div
+      data-terminal-test
+      data-terminal-agent={agent}
+      data-terminal-active={active === false ? "false" : "true"}
+      data-terminal-app={activeApp?.id ?? ""}
+    />
   ),
 }));
 
@@ -199,5 +212,44 @@ describe("DesktopTerminalSurface", () => {
         container.querySelectorAll<HTMLElement>("[data-terminal-agent]"),
       ).map((terminal) => terminal.dataset.terminalAgent),
     ).toEqual(["codex", "claude-code"]);
+  });
+
+  it("scopes the active app context to the selected terminal", async () => {
+    act(() => {
+      root.render(
+        <DesktopTerminalSurface
+          agent="codex"
+          theme="dark"
+          activeApp={{ id: "mail", name: "Mail", path: "/inbox" }}
+        />,
+      );
+    });
+
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>("[data-terminal-test]"),
+      ).map((terminal) => [
+        terminal.dataset.terminalActive,
+        terminal.dataset.terminalApp,
+      ]),
+    ).toEqual([["true", "mail"]]);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="New terminal"]')
+        ?.click();
+    });
+
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>("[data-terminal-test]"),
+      ).map((terminal) => [
+        terminal.dataset.terminalActive,
+        terminal.dataset.terminalApp,
+      ]),
+    ).toEqual([
+      ["false", ""],
+      ["true", "mail"],
+    ]);
   });
 });

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -32,6 +32,12 @@ interface DesktopTerminalSurfaceProps {
   agent: DesktopTerminalAgentId;
   theme: RendererTheme;
   className?: string;
+  activeApp?: {
+    id: string;
+    name: string;
+    path?: string;
+    view?: string;
+  };
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
   onNewUiTab?: () => void;
@@ -61,6 +67,7 @@ export default function DesktopTerminalSurface({
   agent,
   theme,
   className,
+  activeApp,
   submitRequest,
   onPromptSubmitted,
   onNewUiTab,
@@ -200,9 +207,11 @@ export default function DesktopTerminalSurface({
               {onAgentChange ? (
                 <>
                   <DropdownMenuSub>
-                    <DropdownMenuSubTrigger className="gap-2">
-                      <IconTerminal2 size={14} className="shrink-0" />
-                      Provider
+                    <DropdownMenuSubTrigger>
+                      <span className="desktop-dropdown-item__main">
+                        <IconTerminal2 size={14} strokeWidth={1.8} />
+                        <span>Provider</span>
+                      </span>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent className="w-52">
                       {DESKTOP_TERMINAL_AGENT_OPTIONS.map((option) => (
@@ -265,6 +274,7 @@ export default function DesktopTerminalSurface({
             <DesktopTerminalTabs
               agent={tab.agent}
               theme={theme}
+              activeApp={activeApp}
               submitRequest={tab.id === activeTabId ? submitRequest : undefined}
               onPromptSubmitted={onPromptSubmitted}
             />

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalSurface.tsx
@@ -274,7 +274,8 @@ export default function DesktopTerminalSurface({
             <DesktopTerminalTabs
               agent={tab.agent}
               theme={theme}
-              activeApp={activeApp}
+              active={tab.id === activeTabId}
+              activeApp={tab.id === activeTabId ? activeApp : undefined}
               submitRequest={tab.id === activeTabId ? submitRequest : undefined}
               onPromptSubmitted={onPromptSubmitted}
             />

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -16,6 +16,7 @@ interface DesktopTerminalTabsProps {
   agent: DesktopTerminalAgentId;
   theme: RendererTheme;
   className?: string;
+  active?: boolean;
   activeApp?: {
     id: string;
     name: string;
@@ -112,6 +113,7 @@ export default function DesktopTerminalTabs({
   agent,
   theme,
   className,
+  active = true,
   activeApp,
   submitRequest,
   onPromptSubmitted,
@@ -125,9 +127,16 @@ export default function DesktopTerminalTabs({
   const [terminalForeground, setTerminalForeground] = useState(
     readSidebarForeground,
   );
+  const [sessionApp, setSessionApp] = useState(() =>
+    active ? activeApp : undefined,
+  );
   const selectedAgent =
     DESKTOP_TERMINAL_AGENT_OPTIONS.find((option) => option.id === agent) ??
     DESKTOP_TERMINAL_AGENT_OPTIONS[0];
+
+  useEffect(() => {
+    if (active) setSessionApp(activeApp);
+  }, [active, activeApp?.id, activeApp?.path, activeApp?.view]);
 
   useEffect(() => {
     const syncBackground = () =>
@@ -146,11 +155,11 @@ export default function DesktopTerminalTabs({
   useEffect(() => {
     let cancelled = false;
     const controller = new AbortController();
-    const context: DesktopTerminalContext | null = activeApp
+    const context: DesktopTerminalContext | null = sessionApp
       ? {
-          appId: activeApp.id,
-          ...(activeApp.path ? { path: activeApp.path } : {}),
-          ...(activeApp.view ? { view: activeApp.view } : {}),
+          appId: sessionApp.id,
+          ...(sessionApp.path ? { path: sessionApp.path } : {}),
+          ...(sessionApp.view ? { view: sessionApp.view } : {}),
         }
       : null;
     const getTerminalInfoUrl = window.electronAPI?.desktopChat
@@ -214,7 +223,7 @@ export default function DesktopTerminalTabs({
       cancelled = true;
       controller.abort();
     };
-  }, [activeApp?.id, activeApp?.path, activeApp?.view]);
+  }, [sessionApp?.id, sessionApp?.path, sessionApp?.view]);
 
   const workbenchStyle = {
     "--desktop-terminal-background": terminalBackground,
@@ -244,10 +253,10 @@ export default function DesktopTerminalTabs({
           </div>
         ) : (
           <AgentTerminal
-            key={`${activeApp?.id ?? "chat"}:${activeApp?.path ?? ""}:${activeApp?.view ?? ""}`}
             command={selectedAgent.command}
             wsUrl={connection.wsUrl}
             hideInFrame={false}
+            autoFocus={active}
             className="desktop-terminal-tabs__terminal"
             submitRequest={submitRequest}
             onPromptSubmitted={onPromptSubmitted}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -5,6 +5,7 @@ import {
 import { IconLoader2, IconTerminal2 } from "@tabler/icons-react";
 import { useEffect, useState, type CSSProperties } from "react";
 
+import type { DesktopTerminalContext } from "../../../shared/ipc-channels.js";
 import {
   DESKTOP_TERMINAL_AGENT_OPTIONS,
   type DesktopTerminalAgentId,
@@ -15,6 +16,12 @@ interface DesktopTerminalTabsProps {
   agent: DesktopTerminalAgentId;
   theme: RendererTheme;
   className?: string;
+  activeApp?: {
+    id: string;
+    name: string;
+    path?: string;
+    view?: string;
+  };
   submitRequest?: AgentTerminalSubmitRequest;
   onPromptSubmitted?: (request: AgentTerminalSubmitRequest) => void;
 }
@@ -105,6 +112,7 @@ export default function DesktopTerminalTabs({
   agent,
   theme,
   className,
+  activeApp,
   submitRequest,
   onPromptSubmitted,
 }: DesktopTerminalTabsProps) {
@@ -137,8 +145,16 @@ export default function DesktopTerminalTabs({
 
   useEffect(() => {
     let cancelled = false;
+    const context: DesktopTerminalContext | null = activeApp
+      ? {
+          appId: activeApp.id,
+          ...(activeApp.path ? { path: activeApp.path } : {}),
+          ...(activeApp.view ? { view: activeApp.view } : {}),
+        }
+      : null;
     const getTerminalInfoUrl = window.electronAPI?.desktopChat
-      ? () => window.electronAPI!.desktopChat!.getTerminalInfoUrl()
+      ? (value: DesktopTerminalContext | null) =>
+          window.electronAPI!.desktopChat!.getTerminalInfoUrl(value)
       : undefined;
     if (!getTerminalInfoUrl) {
       setConnection({
@@ -151,7 +167,7 @@ export default function DesktopTerminalTabs({
     }
 
     setConnection({ state: "loading" });
-    void getTerminalInfoUrl()
+    void getTerminalInfoUrl(context)
       .then(async (infoUrl) => {
         if (cancelled) return;
         if (!infoUrl) {
@@ -195,7 +211,7 @@ export default function DesktopTerminalTabs({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [activeApp?.id, activeApp?.path, activeApp?.view]);
 
   const workbenchStyle = {
     "--desktop-terminal-background": terminalBackground,
@@ -225,6 +241,7 @@ export default function DesktopTerminalTabs({
           </div>
         ) : (
           <AgentTerminal
+            key={`${activeApp?.id ?? "chat"}:${activeApp?.path ?? ""}:${activeApp?.view ?? ""}`}
             command={selectedAgent.command}
             wsUrl={connection.wsUrl}
             hideInFrame={false}

--- a/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
+++ b/packages/desktop-app/src/renderer/components/DesktopTerminalTabs.tsx
@@ -145,6 +145,7 @@ export default function DesktopTerminalTabs({
 
   useEffect(() => {
     let cancelled = false;
+    const controller = new AbortController();
     const context: DesktopTerminalContext | null = activeApp
       ? {
           appId: activeApp.id,
@@ -173,7 +174,7 @@ export default function DesktopTerminalTabs({
         if (!infoUrl) {
           throw new Error("The desktop terminal has no connection.");
         }
-        const response = await fetch(infoUrl);
+        const response = await fetch(infoUrl, { signal: controller.signal });
         const body = await response.text();
         let payload: unknown;
         try {
@@ -186,6 +187,7 @@ export default function DesktopTerminalTabs({
           );
         }
         const info = terminalInfoFrom(payload);
+        if (cancelled) return;
         const wsUrl =
           info.wsUrl ??
           (info.wsPort ? `ws://127.0.0.1:${info.wsPort}/ws` : undefined);
@@ -210,6 +212,7 @@ export default function DesktopTerminalTabs({
 
     return () => {
       cancelled = true;
+      controller.abort();
     };
   }, [activeApp?.id, activeApp?.path, activeApp?.view]);
 

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -34,6 +34,8 @@ type DesktopEnvironmentLanePreference =
   import("../../shared/environment-lane.js").DesktopEnvironmentLanePreference;
 type DesktopEnvironmentLaneState =
   import("../../shared/ipc-channels.js").DesktopEnvironmentLaneState;
+type DesktopTerminalContext =
+  import("../../shared/ipc-channels.js").DesktopTerminalContext;
 
 type CodeAgentRunStatus =
   | "queued"
@@ -1118,7 +1120,9 @@ interface ElectronAPI {
 
   desktopChat: {
     getApiUrl(appId: string): Promise<string | null>;
-    getTerminalInfoUrl(appId?: string): Promise<string | null>;
+    getTerminalInfoUrl(
+      context?: DesktopTerminalContext | null,
+    ): Promise<string | null>;
     onOpenApp(cb: (request: DesktopChatOpenAppRequest) => void): () => void;
   };
 


### PR DESCRIPTION
## Summary
- Launch embedded terminal providers through real native PTYs with a Finder-safe PATH and cleanup.
- Bind each session to the selected workspace app through scoped MCP relays and active-app context.
- Keep the sidebar chat-only and polish the provider menu alignment.

## Validation
- Focused core and desktop tests: 38 passed.
- Desktop package test suite: 65 files, 583 tests passed.
- Desktop build and unsigned packaged macOS build passed.
- Packaged QA reached native interactive prompts for three installed providers, plus new-chat/sidebar and provider-menu screenshots.

Known repository baseline issues: the workspace-core skill mirror reports existing drift in action-fields.md, and the package typecheck inherits an existing AuthPage topRight type error.