### PR TITLE
chore(clips): bump Chrome extension to 0.1.21

### DIFF
--- a/templates/clips/chrome-extension/STORE_DRAFT.md
+++ b/templates/clips/chrome-extension/STORE_DRAFT.md
@@ -56,7 +56,7 @@ Upload the generated artifact (the version matches `public/manifest.json`; the
 Chrome Web Store requires each upload to use a higher version than the last):
 
 ```txt
-templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.19.zip
+templates/clips/chrome-extension/releases/clips-chrome-extension-0.1.21.zip
 ```
 
 ## Web App Rollout Gate

--- a/templates/clips/chrome-extension/public/manifest.json
+++ b/templates/clips/chrome-extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Agent-Native Clips",
   "short_name": "Clips",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "description": "Start Clips recordings from Chrome, capture optional diagnostics, and preview Clips links on GitHub and Jira.",
   "minimum_chrome_version": "116",
   "action": {


### PR DESCRIPTION
## Summary

- bump the Clips Chrome extension manifest to 0.1.21 for the Chrome Web Store update
- keep the documented release artifact path aligned with the new version

## Validation

- `pnpm --filter clips-chrome-extension package`
- `pnpm --filter clips-chrome-extension typecheck`
- `pnpm --filter clips-chrome-extension test` - 9 files, 45 tests passed
- verified the packaged ZIP manifest reports version 0.1.21

The Chrome Web Store upload was completed separately by the user.
