### PR TITLE
Add copy and share actions to finished meeting pill

### DIFF
--- a/templates/clips/desktop/src/lib/recording-link.ts
+++ b/templates/clips/desktop/src/lib/recording-link.ts
@@ -17,7 +17,7 @@ export function recordingShareUrl(
   });
 }
 
-async function writeClipboardText(text: string): Promise<boolean> {
+export async function writeClipboardText(text: string): Promise<boolean> {
   // Rust-side write first: at recording-stop time the popover webview is
   // usually not focused, and `navigator.clipboard.writeText` rejects with
   // `NotAllowedError: Document is not focused` in exactly that case.

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -7,6 +7,7 @@ import {
   IconLoader2,
   IconPlayerPauseFilled,
   IconPlayerPlayFilled,
+  IconShare,
   IconX,
 } from "@tabler/icons-react";
 import { invoke } from "@tauri-apps/api/core";
@@ -34,6 +35,7 @@ import {
   streamMeetingAsk,
 } from "../lib/meeting-ask";
 import { isDirectPillClick, type ScreenPoint } from "../lib/pill-interaction";
+import { writeClipboardText } from "../lib/recording-link";
 import { speakerFor, type TranscriptLine } from "../lib/transcription-engine";
 import { loadStoredServerUrl } from "../lib/url";
 import { AskSteps } from "./ask-steps";
@@ -727,7 +729,7 @@ export function MeetingPill() {
       .map((l) => `${speakerFor(l.source)}: ${l.text}`)
       .join("\n");
     try {
-      await navigator.clipboard.writeText(text);
+      if (!(await writeClipboardText(text))) return;
       setTranscriptCopied(true);
       setTimeout(() => setTranscriptCopied(false), 1500);
     } catch {
@@ -1290,6 +1292,35 @@ export function MeetingPill() {
                   <IconCopy size={14} />
                 )}
               </button>
+            ) : null}
+            {finished ? (
+              <>
+                <button
+                  type="button"
+                  data-no-drag
+                  className="pill-copy-btn"
+                  onClick={handleCopyTranscript}
+                  disabled={!hasTranscriptLines}
+                  aria-label="Copy transcript"
+                  title="Copy transcript"
+                >
+                  {transcriptCopied ? (
+                    <IconCheck size={14} />
+                  ) : (
+                    <IconCopy size={14} />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => closeFinished(true)}
+                  data-no-drag
+                  className="pill-copy-btn"
+                  aria-label="Share meeting"
+                  title="Share meeting"
+                >
+                  <IconShare size={15} />
+                </button>
+              </>
             ) : null}
             {finished ? (
               <button


### PR DESCRIPTION
## Summary

- Add Copy transcript and Share meeting actions to the finished Clips Tauri meeting pill.
- Use the native-first clipboard helper so transcript copy works when the tray window is not focused.
- Reuse the existing meeting page share controls for the Share action.

## Verification

- `pnpm typecheck` from `templates/clips/desktop`
- `pnpm test -- --reporter=dot` from `templates/clips/desktop`
- `pnpm run build` from `templates/clips/desktop`
- `pnpm fmt:check`
- `pnpm guards`
- `pnpm run check:prereqs` from `templates/clips/desktop`
- Live desktop preview: Stop transcription reached the finished state and exposed Copy transcript, Share meeting, and Dismiss.