### PR TITLE
Fix lingering Clips camera bubbles

### DIFF
--- a/templates/clips/CHANGELOG.md
+++ b/templates/clips/CHANGELOG.md
@@ -9,6 +9,10 @@ from the command menu (Cmd+K → "What's new") or from Settings.
 
 - Clip editing uses a text-only Edit button for a cleaner toolbar.
 
+### Fixed
+
+- Clips camera bubbles now close reliably when the popover is dismissed.
+
 ## 2026-08-29
 
 ### Improved

--- a/templates/clips/changelog/2026-09-01-camera-bubbles-close-when-the-popover-is-dismissed.md
+++ b/templates/clips/changelog/2026-09-01-camera-bubbles-close-when-the-popover-is-dismissed.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-01
+---
+
+Clips camera bubbles now close reliably when the popover is dismissed.

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -1329,15 +1329,31 @@ pub async fn hide_recording_chrome(
 /// stable. At that point the bubble webview is freshly spawned, acquires
 /// the camera cleanly, and there's no cross-webview contention because
 /// MediaRecorder doesn't touch the camera after start.
-#[tauri::command]
-pub async fn close_bubble(app: AppHandle) -> Result<(), String> {
+fn close_bubble_window(app: &AppHandle) {
     let _ = app.emit("clips:release-camera", ());
     if let Some(w) = app.get_webview_window(BUBBLE_LABEL) {
-        dlog!("[clips-tray] close_bubble — destroying bubble webview");
+        // Hide first so a slow WebKit teardown cannot leave the last frame
+        // composited on-screen while the window is being destroyed.
+        let _ = w.hide();
+        dlog!("[clips-tray] close_bubble - destroying bubble webview");
         let _ = w.close();
     } else {
-        dlog!("[clips-tray] close_bubble — no bubble window to close");
+        dlog!("[clips-tray] close_bubble - no bubble window to close");
     }
+}
+
+/// Close the camera bubble whenever the popover is no longer visible, except
+/// while recording owns it independently of the popover.
+pub fn close_bubble_if_idle(app: &AppHandle) {
+    if is_recording_active(app) {
+        return;
+    }
+    close_bubble_window(app);
+}
+
+#[tauri::command]
+pub async fn close_bubble(app: AppHandle) -> Result<(), String> {
+    close_bubble_window(&app);
     Ok(())
 }
 
@@ -2009,13 +2025,14 @@ fn remembered_voice_target_bundle(app: &AppHandle) -> Option<String> {
 mod tests {
     use super::{
         overlay_labels_to_hide, strip_trailing_period_for_messaging, text_insertion_strategy,
-        TextInsertionStrategy, FINALIZING_LABEL,
+        TextInsertionStrategy, BUBBLE_LABEL, FINALIZING_LABEL,
     };
 
     #[test]
     fn overlay_cleanup_can_preserve_finalizing_progress() {
         assert!(!overlay_labels_to_hide(true).any(|label| label == FINALIZING_LABEL));
         assert!(overlay_labels_to_hide(false).any(|label| label == FINALIZING_LABEL));
+        assert!(overlay_labels_to_hide(false).any(|label| label == BUBBLE_LABEL));
     }
 
     #[test]
@@ -2783,6 +2800,7 @@ pub fn toggle_popover(app: &AppHandle) {
         window.is_visible().unwrap_or(false) && !voice_woken && !is_pinhole_popover(&window);
     if user_visible {
         let _ = window.hide();
+        close_bubble_if_idle(app);
         let _ = app.emit("clips:popover-visible", false);
         return;
     }

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -10,8 +10,8 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 use tauri::{
-    AppHandle, Emitter, Manager, PhysicalPosition, PhysicalSize, WebviewUrl, WebviewWindow,
-    WebviewWindowBuilder,
+    AppHandle, Emitter, Listener, Manager, PhysicalPosition, PhysicalSize, WebviewUrl,
+    WebviewWindow, WebviewWindowBuilder,
 };
 
 use crate::dlog;
@@ -50,6 +50,7 @@ static COUNTDOWN_CONTROL_TRACKING: AtomicBool = AtomicBool::new(false);
 // closes it. Cleared when the card is dismissed or the next session starts.
 static TOOLBAR_FINISHING: AtomicBool = AtomicBool::new(false);
 const BUBBLE_LABEL: &str = "bubble";
+const BUBBLE_DESTROYED_EVENT: &str = "clips:bubble-destroyed";
 const PREPARING_LABEL: &str = "preparing";
 const FINALIZING_LABEL: &str = "finalizing";
 const FLOW_BAR_LABEL: &str = "flow-bar";
@@ -1191,6 +1192,10 @@ pub async fn show_bubble(app: AppHandle) -> Result<(), String> {
     let app_for_bounds = app.clone();
     let win_for_bounds = win.clone();
     win.on_window_event(move |event| {
+        if matches!(event, tauri::WindowEvent::Destroyed) {
+            let _ = app_for_bounds.emit(BUBBLE_DESTROYED_EVENT, ());
+            return;
+        }
         if matches!(
             event,
             tauri::WindowEvent::Moved(_)
@@ -1340,6 +1345,22 @@ fn close_bubble_window(app: &AppHandle) {
     } else {
         dlog!("[clips-tray] close_bubble - no bubble window to close");
     }
+}
+
+async fn close_bubble_window_and_wait(app: &AppHandle) -> Result<(), String> {
+    let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
+    let listener = app.once(BUBBLE_DESTROYED_EVENT, move |_| {
+        let _ = closed_tx.send(());
+    });
+    if app.get_webview_window(BUBBLE_LABEL).is_none() {
+        app.unlisten(listener);
+        return Ok(());
+    }
+
+    close_bubble_window(app);
+    closed_rx
+        .await
+        .map_err(|_| "camera bubble destruction acknowledgement was dropped".to_string())
 }
 
 /// Close the camera bubble whenever the popover is no longer visible, except
@@ -2428,8 +2449,7 @@ pub async fn release_recording_state(app: AppHandle) -> Result<(), String> {
         }
     }
     crate::tray::rebuild_tray_menu(&app);
-    close_bubble_if_idle(&app);
-    Ok(())
+    close_bubble_window_and_wait(&app).await
 }
 
 /// Set from JS when a live meeting recording/transcription session starts or

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -2416,6 +2416,22 @@ pub async fn set_recording_state(app: AppHandle, active: bool) -> Result<(), Str
     Ok(())
 }
 
+/// Release a recording start flow and clean up a bubble that no recording owns.
+/// Keep the state change and cleanup in one native command so a new start cannot
+/// interleave after the guard is cleared but before the bubble is destroyed.
+#[tauri::command]
+pub async fn release_recording_state(app: AppHandle) -> Result<(), String> {
+    dlog!("[clips-tray] release_recording_state");
+    if let Some(state) = app.try_state::<RecordingActive>() {
+        if let Ok(mut g) = state.0.lock() {
+            *g = false;
+        }
+    }
+    crate::tray::rebuild_tray_menu(&app);
+    close_bubble_if_idle(&app);
+    Ok(())
+}
+
 /// Set from JS when a live meeting recording/transcription session starts or
 /// stops (see `useMeetingTranscription`). Gates the `ExitRequested` quit
 /// teardown in `lib.rs`: quit stays instant when no meeting is active, and

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -90,6 +90,17 @@ pub fn run() {
                     tray::reset_tray_recording(window.app_handle());
                 }
             }
+            // The popover and camera bubble are separate native windows. If
+            // the popover is closed before its webview emits the visibility
+            // event, tear down the bubble from the native lifecycle instead.
+            if window.label() == "popover"
+                && matches!(
+                    event,
+                    tauri::WindowEvent::CloseRequested { .. } | tauri::WindowEvent::Destroyed
+                )
+            {
+                clips::close_bubble_if_idle(window.app_handle());
+            }
         })
         .invoke_handler(tauri::generate_handler![
             // clips commands
@@ -481,6 +492,7 @@ pub fn run() {
                         dlog!("[clips-tray] popover blur, elapsed_ms={}", elapsed_ms);
                         if elapsed_ms >= 1500 {
                             let _ = handle.hide();
+                            clips::close_bubble_if_idle(&app_handle);
                             let _ = app_handle.emit("clips:popover-visible", false);
                         }
                     }

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ pub fn run() {
             clips::complete_voice_dictation,
             clips::paste_last_dictation,
             clips::set_recording_state,
+            clips::release_recording_state,
             clips::set_meeting_active,
             clips::get_active_meeting_id,
             clips::quit_teardown_done,

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -556,6 +556,7 @@ pub fn build_shortcut_plugin() -> tauri_plugin_global_shortcut::Builder<tauri::W
             if let Some(window) = app.get_webview_window("popover") {
                 let _ = window.hide();
             }
+            crate::clips::close_bubble_if_idle(app);
             let _ = app.emit("clips:popover-visible", false);
             return;
         }

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -721,6 +721,7 @@ pub fn hide_voice_wake_popover(app: &AppHandle) {
     if should_hide {
         if let Some(w) = app.get_webview_window("popover") {
             let _ = w.hide();
+            crate::clips::close_bubble_if_idle(app);
             let _ = app.emit("clips:popover-visible", false);
         }
     }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3456,16 +3456,25 @@ export function App({
       // further below hasn't run yet at this point, so reset this on every
       // early return in this block.
       recordingFlowGateRef.current = true;
-      const releaseRecordingFlowGate = () => {
+      const releaseRecordingFlowGate = async () => {
         recordingFlowGateRef.current = false;
-        invoke("set_recording_state", { active: false }).catch(() => {});
+        try {
+          // Clear the native guard and close an idle bubble in one native
+          // command so a new start cannot interleave between those steps.
+          await invoke("release_recording_state");
+        } catch (err) {
+          console.error(
+            "[clips-popover] could not release recording state:",
+            err,
+          );
+        }
       };
       // Native blur cleanup also runs while the permission prompt or display
       // picker is open, before the later recording-state update below.
       try {
         await invoke("set_recording_state", { active: true });
       } catch (err) {
-        releaseRecordingFlowGate();
+        await releaseRecordingFlowGate();
         console.error("[clips-popover] could not hold recording state:", err);
         return null;
       }
@@ -3474,14 +3483,14 @@ export function App({
           "request_macos_screen_recording_access",
         );
         if (!granted) {
-          releaseRecordingFlowGate();
+          await releaseRecordingFlowGate();
           setReadinessOpen(true);
           setRecError(MACOS_SCREEN_PERMISSION_MESSAGE);
           openPrivacySettings("screen");
           return null;
         }
       } catch (err) {
-        releaseRecordingFlowGate();
+        await releaseRecordingFlowGate();
         setReadinessOpen(true);
         setRecError(err instanceof Error ? err.message : String(err));
         return null;
@@ -3499,7 +3508,7 @@ export function App({
           // themselves on the chosen screen the first time they are shown.
           await pickFullscreenRecordingDisplay();
         } catch (err) {
-          releaseRecordingFlowGate();
+          await releaseRecordingFlowGate();
           if (err instanceof Error && err.name === "AbortError") {
             // User cancelled the screen picker (Escape) — abort silently,
             // same as dismissing the native macOS screen picker.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3456,19 +3456,32 @@ export function App({
       // further below hasn't run yet at this point, so reset this on every
       // early return in this block.
       recordingFlowGateRef.current = true;
+      const releaseRecordingFlowGate = () => {
+        recordingFlowGateRef.current = false;
+        invoke("set_recording_state", { active: false }).catch(() => {});
+      };
+      // Native blur cleanup also runs while the permission prompt or display
+      // picker is open, before the later recording-state update below.
+      try {
+        await invoke("set_recording_state", { active: true });
+      } catch (err) {
+        releaseRecordingFlowGate();
+        console.error("[clips-popover] could not hold recording state:", err);
+        return null;
+      }
       try {
         const granted = await invoke<boolean>(
           "request_macos_screen_recording_access",
         );
         if (!granted) {
-          recordingFlowGateRef.current = false;
+          releaseRecordingFlowGate();
           setReadinessOpen(true);
           setRecError(MACOS_SCREEN_PERMISSION_MESSAGE);
           openPrivacySettings("screen");
           return null;
         }
       } catch (err) {
-        recordingFlowGateRef.current = false;
+        releaseRecordingFlowGate();
         setReadinessOpen(true);
         setRecError(err instanceof Error ? err.message : String(err));
         return null;
@@ -3486,7 +3499,7 @@ export function App({
           // themselves on the chosen screen the first time they are shown.
           await pickFullscreenRecordingDisplay();
         } catch (err) {
-          recordingFlowGateRef.current = false;
+          releaseRecordingFlowGate();
           if (err instanceof Error && err.name === "AbortError") {
             // User cancelled the screen picker (Escape) — abort silently,
             // same as dismissing the native macOS screen picker.

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2829,6 +2829,12 @@ export function App({
           return;
         }
         await loadDevices();
+        if (cancelled) {
+          // The popover closed while device enumeration was in flight. Do not
+          // create a native bubble for an effect that has already ended.
+          s.getTracks().forEach((t) => t.stop());
+          return;
+        }
         stream = s;
         bubbleStreamRef.current = s;
         // Open the bubble window. It's a pure renderer — the bubble
@@ -2842,6 +2848,13 @@ export function App({
           console.error("[clips-popover] show_bubble failed:", err);
         }
         if (cancelled) {
+          // show_bubble can finish after cleanup. Close only when this effect
+          // no longer belongs to a recording or a replacement bubble session.
+          if (!recordingFlowGateRef.current && !bubbleActiveRef.current) {
+            await invoke("close_bubble").catch((err) =>
+              console.error("[clips-popover] late bubble cleanup failed:", err),
+            );
+          }
           s.getTracks().forEach((t) => t.stop());
           return;
         }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3457,7 +3457,6 @@ export function App({
       // early return in this block.
       recordingFlowGateRef.current = true;
       const releaseRecordingFlowGate = async () => {
-        recordingFlowGateRef.current = false;
         try {
           // Clear the native guard and close an idle bubble in one native
           // command so a new start cannot interleave between those steps.
@@ -3467,6 +3466,8 @@ export function App({
             "[clips-popover] could not release recording state:",
             err,
           );
+        } finally {
+          recordingFlowGateRef.current = false;
         }
       };
       // Native blur cleanup also runs while the permission prompt or display

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2999,7 +2999,12 @@ export function App({
       bubbleStreamTransferredToRecorder.current = false;
       bubbleStreamRef.current?.getTracks().forEach((t) => t.stop());
       bubbleStreamRef.current = null;
-      setBubbleSessionEpoch((epoch) => epoch + 1);
+      // A native recording-start release is still waiting for the bubble's
+      // Destroyed event. Defer the re-acquire until that command has released
+      // the JS gate, or a replacement bubble can overlap WebKit teardown.
+      if (!recordingFlowGateRef.current) {
+        setBubbleSessionEpoch((epoch) => epoch + 1);
+      }
     })
       .then((u) => {
         if (cancelled) u();
@@ -3457,10 +3462,12 @@ export function App({
       // early return in this block.
       recordingFlowGateRef.current = true;
       const releaseRecordingFlowGate = async () => {
+        let released = false;
         try {
           // Clear the native guard and close an idle bubble in one native
           // command so a new start cannot interleave between those steps.
           await invoke("release_recording_state");
+          released = true;
         } catch (err) {
           console.error(
             "[clips-popover] could not release recording state:",
@@ -3468,6 +3475,9 @@ export function App({
           );
         } finally {
           recordingFlowGateRef.current = false;
+          if (released) {
+            setBubbleSessionEpoch((epoch) => epoch + 1);
+          }
         }
       };
       // Native blur cleanup also runs while the permission prompt or display


### PR DESCRIPTION
## Summary
- close a camera bubble created after its popover effect has been cancelled
- hide and destroy idle bubbles from native popover lifecycle paths
- document the fix in the Clips changelog

## Validation
- `pnpm test` in `templates/clips/desktop`
- `pnpm typecheck` in `templates/clips/desktop`
- `pnpm build` in `templates/clips/desktop`
- `cargo test --lib` in `templates/clips/desktop/src-tauri`
- `cargo check --bin Clips`
- `pnpm guards`

The release bundle reached native linking but the local Xcode SDK could not resolve `___isPlatformVersionAtLeast`; source compilation and debug Tauri compilation completed.