### PR TITLE
fix: refine calendar auth controls

### DIFF
--- a/packages/core/src/client/auth/AuthPage.spec.tsx
+++ b/packages/core/src/client/auth/AuthPage.spec.tsx
@@ -52,6 +52,16 @@ describe("AuthPage", () => {
     );
   });
 
+  it("places Calendar's learn-more link in the bottom-right corner", () => {
+    const props = propsFromHtml(
+      getOnboardingHtml({ requestHost: "calendar.agent-native.com" }),
+    );
+    const html = renderToString(<AuthPage {...props} />);
+
+    expect(props.marketing?.learnMorePlacement).toBe("bottom-right");
+    expect(html).toContain("has-bottom-right-learn-more");
+  });
+
   it("keeps the magic-link entry and completion surfaces in the React tree", () => {
     const props = propsFromHtml(getOnboardingHtml({ authMode: "magic-link" }));
     const html = renderToString(<AuthPage {...props} />);

--- a/packages/core/src/client/auth/AuthPage.tsx
+++ b/packages/core/src/client/auth/AuthPage.tsx
@@ -28,6 +28,7 @@ export interface AuthMarketingProps {
   screenshotWidth?: number;
   screenshotHeight?: number;
   learnMoreUrl?: string;
+  learnMorePlacement?: "top-right" | "bottom-right";
 }
 
 export interface AuthLocaleOption {
@@ -2678,11 +2679,15 @@ export function AuthPage(props: AuthPageProps) {
           {localNote}
         </>
       }
-      className={
-        marketingCopy.screenshotSrc
-          ? "auth-marketing-home has-product-screenshot"
-          : "auth-marketing-home"
-      }
+      className={[
+        "auth-marketing-home",
+        marketingCopy.screenshotSrc ? "has-product-screenshot" : "",
+        marketingCopy.learnMorePlacement === "bottom-right"
+          ? "has-bottom-right-learn-more"
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
     >
       {marketingCopy.screenshotSrc ? (
         <div className="auth-marketing-screenshot-wrap">

--- a/packages/core/src/server/auth-marketing.ts
+++ b/packages/core/src/server/auth-marketing.ts
@@ -7,6 +7,7 @@ export interface AuthMarketingContent {
   screenshotWidth?: number;
   screenshotHeight?: number;
   learnMoreUrl?: string;
+  learnMorePlacement?: "top-right" | "bottom-right";
   /** @deprecated Local execution is no longer offered from auth pages. */
   runLocalCommand?: string;
   signupLocalModeNote?: {
@@ -59,6 +60,7 @@ export const BUILT_IN_AUTH_MARKETING: Record<string, AuthMarketingContent> = {
       "Manages availability and booking links automatically",
       "Answers schedule questions and resolves conflicts instantly",
     ],
+    learnMorePlacement: "bottom-right",
   },
   clips: {
     appName: "Agent-Native Clips",

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -404,6 +404,7 @@ export interface AuthOptions {
     screenshotWidth?: number;
     screenshotHeight?: number;
     learnMoreUrl?: string;
+    learnMorePlacement?: "top-right" | "bottom-right";
     /** @deprecated Local execution is no longer offered from auth pages. */
     runLocalCommand?: string;
   };

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -2188,13 +2188,12 @@ ${embeddedAuthCss}
     justify-content: flex-end;
     align-items: center;
     position: absolute;
-    height: 2rem;
     padding: 0;
     top: max(1rem, env(safe-area-inset-top));
     inset-inline-end: calc(max(1rem, env(safe-area-inset-right)) + 2.5rem);
     z-index: 2;
   }
-  .auth-marketing-learn-more { font-size: 0.9rem; }
+  .auth-marketing-learn-more { font-size: 0.8rem; }
   .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
     top: auto;
     bottom: max(1rem, env(safe-area-inset-bottom));
@@ -2239,10 +2238,11 @@ ${embeddedAuthCss}
       inset-inline-end: auto;
     }
     .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
-      top: max(1rem, env(safe-area-inset-top));
-      bottom: auto;
-      inset-inline-start: max(1rem, env(safe-area-inset-left));
+      top: auto;
+      bottom: max(1rem, env(safe-area-inset-bottom));
+      inset-inline-start: 50%;
       inset-inline-end: auto;
+      transform: translateX(-50%);
     }
     .auth-marketing-home .auth-marketing-layout { min-height: auto; }
     .auth-marketing-home .auth-marketing-shell { display: block; }

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1156,6 +1156,7 @@ export interface OnboardingHtmlOptions {
     screenshotWidth?: number;
     screenshotHeight?: number;
     learnMoreUrl?: string;
+    learnMorePlacement?: "top-right" | "bottom-right";
     /** @deprecated Local execution is no longer offered from auth pages. */
     runLocalCommand?: string;
   };
@@ -1528,6 +1529,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
               : undefined,
             screenshotWidth: marketing.screenshotWidth,
             screenshotHeight: marketing.screenshotHeight,
+            learnMorePlacement: marketing.learnMorePlacement,
             learnMoreUrl:
               marketing.learnMoreUrl ??
               (marketingSlug
@@ -1599,13 +1601,11 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     width: 2rem;
     height: 2rem;
     padding: 0;
-    background: rgba(20,20,20,0.82);
+    background: transparent;
     color: #e5e5e5;
-    border: 1px solid rgba(255,255,255,0.12);
-    border-radius: 8px;
+    border: 0;
     cursor: pointer;
     outline: none;
-    backdrop-filter: blur(12px);
   }
   .locale-trigger svg {
     width: 1rem;
@@ -1618,11 +1618,10 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   }
   .locale-trigger:hover,
   .locale-trigger[aria-expanded="true"] {
-    border-color: rgba(255,255,255,0.22);
-    background: rgba(28,28,28,0.92);
+    border-color: transparent;
+    background: transparent;
   }
   .locale-trigger:focus {
-    border-color: rgba(255,255,255,0.42);
     box-shadow: 0 0 0 3px rgba(255,255,255,0.08);
   }
   .locale-menu {
@@ -2196,6 +2195,11 @@ ${embeddedAuthCss}
     z-index: 2;
   }
   .auth-marketing-learn-more { font-size: 0.9rem; }
+  .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
+    top: auto;
+    bottom: max(1rem, env(safe-area-inset-bottom));
+    inset-inline-end: max(1rem, env(safe-area-inset-right));
+  }
   .auth-marketing-home .auth-marketing-layout {
     min-height: 100vh;
     display: flex;
@@ -2230,6 +2234,13 @@ ${embeddedAuthCss}
     }
     .auth-marketing-home .auth-marketing-top-right {
       top: max(1rem, env(safe-area-inset-top));
+      bottom: auto;
+      inset-inline-start: max(1rem, env(safe-area-inset-left));
+      inset-inline-end: auto;
+    }
+    .auth-marketing-home.has-bottom-right-learn-more .auth-marketing-top-right {
+      top: max(1rem, env(safe-area-inset-top));
+      bottom: auto;
       inset-inline-start: max(1rem, env(safe-area-inset-left));
       inset-inline-end: auto;
     }

--- a/templates/calendar/changelog/2026-09-01-calendar-keeps-the-learn-more-link-clear-of-the-language-con.md
+++ b/templates/calendar/changelog/2026-09-01-calendar-keeps-the-learn-more-link-clear-of-the-language-con.md
@@ -1,0 +1,6 @@
+---
+type: improved
+date: 2026-09-01
+---
+
+Calendar keeps the learn-more link clear of the language control

--- a/templates/calendar/changelog/2026-09-01-calendar-keeps-the-learn-more-link-clear-of-the-language-con.md
+++ b/templates/calendar/changelog/2026-09-01-calendar-keeps-the-learn-more-link-clear-of-the-language-con.md
@@ -3,4 +3,4 @@ type: improved
 date: 2026-09-01
 ---
 
-Calendar keeps the learn-more link clear of the language control
+Calendar keeps the learn-more link clear of the language control on every screen size.

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -14,6 +14,7 @@ export default createAuthPlugin({
     screenshotWidth: 914,
     screenshotHeight: 818,
     learnMoreUrl: "https://agent-native.com/apps/calendar",
+    learnMorePlacement: "bottom-right",
     tagline:
       "Your AI agent schedules, reschedules, and manages your calendar so you never have to.",
     features: [


### PR DESCRIPTION
Make the auth language control icon-only and place Calendar's learn-more link in the desktop bottom-right while preserving the mobile layout.