### PR TITLE
fix: address latest Calendar, Clips, Mail, and Slides feedback

### DIFF
--- a/templates/calendar/actions/list-bookings.ts
+++ b/templates/calendar/actions/list-bookings.ts
@@ -12,6 +12,7 @@ function rowToBooking(
     | "id"
     | "name"
     | "email"
+    | "additionalGuestEmails"
     | "start"
     | "end"
     | "slug"
@@ -30,10 +31,14 @@ function rowToBooking(
       fieldResponses = JSON.parse(row.fieldResponses);
     } catch {}
   }
+  const additionalGuestEmails = parseAdditionalGuestEmails(
+    row.additionalGuestEmails,
+  );
   return {
     id: row.id,
     name: row.name,
     email: row.email,
+    additionalGuestEmails,
     start: row.start,
     end: row.end,
     slug: row.slug,
@@ -64,6 +69,7 @@ export default defineAction({
         id: schema.bookings.id,
         name: schema.bookings.name,
         email: schema.bookings.email,
+        additionalGuestEmails: schema.bookings.additionalGuestEmails,
         start: schema.bookings.start,
         end: schema.bookings.end,
         slug: schema.bookings.slug,
@@ -81,3 +87,20 @@ export default defineAction({
     return rows.map(rowToBooking);
   },
 });
+
+function parseAdditionalGuestEmails(
+  value: string | null | undefined,
+): string[] | undefined {
+  if (!value) return undefined;
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Invalid stored additional guest emails");
+  }
+  const emails = parsed.filter(
+    (email): email is string => typeof email === "string",
+  );
+  if (emails.length !== parsed.length) {
+    throw new Error("Invalid stored additional guest emails");
+  }
+  return emails;
+}

--- a/templates/calendar/app/components/booking/BookingForm.tsx
+++ b/templates/calendar/app/components/booking/BookingForm.tsx
@@ -1,6 +1,7 @@
 import { useT } from "@agent-native/core/client/i18n";
 import { Turnstile } from "@agent-native/core/client/ui";
 import type { CustomField } from "@shared/api";
+import { IconX } from "@tabler/icons-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -19,6 +20,7 @@ import { Textarea } from "@/components/ui/textarea";
 export interface BookingFormValue {
   name: string;
   email: string;
+  additionalGuestEmails: string[];
   notes: string;
   fieldResponses: Record<string, string | boolean>;
 }
@@ -27,6 +29,7 @@ interface BookingFormProps {
   onSubmit: (data: {
     name: string;
     email: string;
+    additionalGuestEmails?: string[];
     notes?: string;
     captchaToken?: string;
     fieldResponses?: Record<string, string | boolean>;
@@ -60,6 +63,30 @@ export function BookingForm({
       const next = { ...prev };
       delete next[id];
       return next;
+    });
+  }
+
+  function updateAdditionalGuest(index: number, email: string) {
+    updateValue({
+      additionalGuestEmails: value.additionalGuestEmails.map(
+        (currentEmail, currentIndex) =>
+          currentIndex === index ? email : currentEmail,
+      ),
+    });
+  }
+
+  function addAdditionalGuest() {
+    if (value.additionalGuestEmails.length >= 5) return;
+    updateValue({
+      additionalGuestEmails: [...value.additionalGuestEmails, ""],
+    });
+  }
+
+  function removeAdditionalGuest(index: number) {
+    updateValue({
+      additionalGuestEmails: value.additionalGuestEmails.filter(
+        (_, currentIndex) => currentIndex !== index,
+      ),
     });
   }
 
@@ -102,10 +129,15 @@ export function BookingForm({
 
     const fieldResponses =
       customFields.length > 0 ? { ...value.fieldResponses } : undefined;
+    const additionalGuestEmails = value.additionalGuestEmails
+      .map((guestEmail) => guestEmail.trim())
+      .filter(Boolean);
 
     onSubmit({
       name: name.trim(),
       email: email.trim(),
+      additionalGuestEmails:
+        additionalGuestEmails.length > 0 ? additionalGuestEmails : undefined,
       notes: notes.trim() || undefined,
       captchaToken,
       fieldResponses,
@@ -138,6 +170,40 @@ export function BookingForm({
           required
         />
       </div>
+
+      {value.additionalGuestEmails.map((guestEmail, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <Input
+            type="email"
+            value={guestEmail}
+            onChange={(e) => updateAdditionalGuest(index, e.target.value)}
+            placeholder={t("eventForm.attendeesPlaceholder")}
+            aria-label={`${t("attendees.addAnotherGuest")} ${index + 1}`}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9 shrink-0"
+            onClick={() => removeAdditionalGuest(index)}
+            aria-label={t("attendees.removeAttendee", {
+              email: guestEmail || t("attendees.addAnotherGuest"),
+            })}
+          >
+            <IconX className="size-4" />
+          </Button>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="link"
+        className="h-auto px-0 text-sm"
+        onClick={addAdditionalGuest}
+        disabled={value.additionalGuestEmails.length >= 5}
+      >
+        {t("attendees.addAnotherGuest")}
+      </Button>
 
       {customFields.map((field) => (
         <CustomFieldInput

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -1255,7 +1255,7 @@ export function CreateEventPopover({
                     className="flex w-full items-center gap-2 rounded-md py-1 text-left text-muted-foreground/60 transition-colors hover:bg-muted/50 hover:text-foreground"
                     onClick={() => setDescriptionOpen(true)}
                   >
-                    <IconMessage className="size-4 shrink-0" />
+                    <IconMessage className="size-[18px] shrink-0" />
                     {t("eventForm.description")}
                   </button>
                 )}

--- a/templates/calendar/app/hooks/use-bookings.ts
+++ b/templates/calendar/app/hooks/use-bookings.ts
@@ -85,6 +85,7 @@ export function useCreateBooking() {
     mutationFn: async (data: {
       name: string;
       email: string;
+      additionalGuestEmails?: string[];
       notes?: string;
       captchaToken?: string;
       fieldResponses?: Record<string, string | boolean>;

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -115,6 +115,7 @@ export default function BookingPage() {
   const [bookingForm, setBookingForm] = useState<BookingFormValue>({
     name: "",
     email: "",
+    additionalGuestEmails: [],
     notes: "",
     fieldResponses: {},
   });
@@ -245,6 +246,7 @@ export default function BookingPage() {
   function handleBookingSubmit(data: {
     name: string;
     email: string;
+    additionalGuestEmails?: string[];
     notes?: string;
     captchaToken?: string;
     fieldResponses?: Record<string, string | boolean>;
@@ -258,6 +260,7 @@ export default function BookingPage() {
       {
         name: data.name,
         email: data.email,
+        additionalGuestEmails: data.additionalGuestEmails,
         notes: data.notes,
         captchaToken: data.captchaToken,
         fieldResponses: data.fieldResponses,
@@ -293,6 +296,7 @@ export default function BookingPage() {
     setBookingForm({
       name: signedInName,
       email: signedInEmail,
+      additionalGuestEmails: [],
       notes: "",
       fieldResponses: {},
     });

--- a/templates/calendar/server/db/schema.ts
+++ b/templates/calendar/server/db/schema.ts
@@ -10,6 +10,8 @@ export const bookings = table("bookings", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),
   email: text("email").notNull(),
+  /** JSON array of additional invitee email addresses */
+  additionalGuestEmails: text("additional_guest_emails"),
   start: text("start").notNull(),
   end: text("end").notNull(),
   slug: text("slug").notNull(),

--- a/templates/calendar/server/handlers/bookings.spec.ts
+++ b/templates/calendar/server/handlers/bookings.spec.ts
@@ -8,6 +8,7 @@ import {
   parseBookingAvailabilityDraft,
   resolveBookingLinkAvailabilityOverrides,
   resolveBookingCalendarAccount,
+  deleteGoogleEventForBooking,
 } from "./bookings";
 
 vi.mock("../lib/google-calendar.js", () => ({
@@ -16,6 +17,7 @@ vi.mock("../lib/google-calendar.js", () => ({
   getOwnedAccountEmails: vi.fn(),
   isConnected: vi.fn(),
   listEvents: vi.fn(),
+  deleteEvent: vi.fn(),
 }));
 
 function availabilityConfig(): AvailabilityConfig {
@@ -495,6 +497,35 @@ describe("booking calendar account provenance", () => {
 
     expect(googleCalendar.getDefaultAccountSelection).toHaveBeenCalledWith(
       "alice@example.com",
+    );
+  });
+});
+
+describe("booking cancellation provider notifications", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends Google cancellation updates to every booking attendee", async () => {
+    vi.mocked(googleCalendar.deleteEvent).mockResolvedValue();
+
+    await deleteGoogleEventForBooking({
+      booking: {
+        id: "booking-1",
+        slug: "alice-meeting",
+        googleEventId: "event-1",
+        ownerEmail: "alice@example.com",
+        calendarAccountId: "primary@example.com",
+      },
+    });
+
+    expect(googleCalendar.deleteEvent).toHaveBeenCalledWith(
+      "event-1",
+      {
+        ownerEmail: "alice@example.com",
+        accountEmail: "primary@example.com",
+      },
+      { sendUpdates: "all" },
     );
   });
 });

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -137,7 +137,7 @@ export async function resolveBookingCalendarAccount({
   return googleCalendar.getDefaultAccountSelection(ownerEmail);
 }
 
-async function deleteGoogleEventForBooking({
+export async function deleteGoogleEventForBooking({
   booking,
   hostEmail,
 }: {
@@ -156,7 +156,7 @@ async function deleteGoogleEventForBooking({
     });
     if (!account) return;
     await googleCalendar.deleteEvent(booking.googleEventId, account, {
-      sendUpdates: "none",
+      sendUpdates: "all",
     });
   } catch (error) {
     console.warn(

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -997,13 +997,16 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       setResponseStatus(event, 400);
       return { error: "additionalGuestEmails must be an array" };
     }
-    const additionalGuestEmails: string[] = Array.isArray(
+    const normalizedAdditionalGuestEmails: string[] = Array.isArray(
       body.additionalGuestEmails,
     )
-      ? body.additionalGuestEmails
-          .map((email: unknown) => stripCrlf(email))
-          .filter(Boolean)
+      ? (body.additionalGuestEmails as unknown[]).map((email) =>
+          stripCrlf(email).toLowerCase(),
+        )
       : [];
+    const additionalGuestEmails: string[] = Array.from(
+      new Set(normalizedAdditionalGuestEmails.filter((email) => email.length)),
+    ).filter((email) => email !== attendeeEmail);
     const notes = String(body.notes ?? "").trim();
 
     // Validate required fields
@@ -1231,6 +1234,10 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         id,
         name: attendeeName,
         email: attendeeEmail,
+        additionalGuestEmails:
+          additionalGuestEmails.length > 0
+            ? JSON.stringify(additionalGuestEmails)
+            : null,
         start: requestedRange.start.toISOString(),
         end: requestedRange.end.toISOString(),
         slug: requestedSlug,
@@ -1400,6 +1407,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       id,
       name: attendeeName,
       email: attendeeEmail,
+      additionalGuestEmails:
+        additionalGuestEmails.length > 0 ? additionalGuestEmails : undefined,
       start: requestedRange.start.toISOString(),
       end: requestedRange.end.toISOString(),
       slug: requestedSlug,
@@ -1750,10 +1759,14 @@ function rowToBooking(row: typeof schema.bookings.$inferSelect): Booking {
       fieldResponses = JSON.parse(row.fieldResponses);
     } catch {}
   }
+  const additionalGuestEmails = parseAdditionalGuestEmails(
+    row.additionalGuestEmails,
+  );
   return {
     id: row.id,
     name: row.name,
     email: row.email,
+    additionalGuestEmails,
     start: row.start,
     end: row.end,
     slug: row.slug,
@@ -1765,4 +1778,21 @@ function rowToBooking(row: typeof schema.bookings.$inferSelect): Booking {
     status: row.status,
     createdAt: row.createdAt,
   };
+}
+
+function parseAdditionalGuestEmails(
+  value: string | null | undefined,
+): string[] | undefined {
+  if (!value) return undefined;
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Invalid stored additional guest emails");
+  }
+  const emails = parsed.filter(
+    (email): email is string => typeof email === "string",
+  );
+  if (emails.length !== parsed.length) {
+    throw new Error("Invalid stored additional guest emails");
+  }
+  return emails;
 }

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -109,6 +109,8 @@ function isValidEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 }
 
+const MAX_ADDITIONAL_BOOKING_GUESTS = 5;
+
 export async function resolveBookingCalendarAccount({
   booking,
   hostEmail,
@@ -988,6 +990,20 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     const cancelToken = nanoid();
     const attendeeName = stripCrlf(body.name);
     const attendeeEmail = stripCrlf(body.email).toLowerCase();
+    if (
+      body.additionalGuestEmails !== undefined &&
+      !Array.isArray(body.additionalGuestEmails)
+    ) {
+      setResponseStatus(event, 400);
+      return { error: "additionalGuestEmails must be an array" };
+    }
+    const additionalGuestEmails: string[] = Array.isArray(
+      body.additionalGuestEmails,
+    )
+      ? body.additionalGuestEmails
+          .map((email: unknown) => stripCrlf(email))
+          .filter(Boolean)
+      : [];
     const notes = String(body.notes ?? "").trim();
 
     // Validate required fields
@@ -998,6 +1014,16 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     if (!isValidEmail(attendeeEmail)) {
       setResponseStatus(event, 400);
       return { error: "Enter a valid email address" };
+    }
+    if (additionalGuestEmails.length > MAX_ADDITIONAL_BOOKING_GUESTS) {
+      setResponseStatus(event, 400);
+      return {
+        error: `You can add up to ${MAX_ADDITIONAL_BOOKING_GUESTS} guests`,
+      };
+    }
+    if (additionalGuestEmails.some((email) => !isValidEmail(email))) {
+      setResponseStatus(event, 400);
+      return { error: "Enter valid email addresses for additional guests" };
     }
     const requestedSlug = stripCrlf(body.slug);
 
@@ -1327,6 +1353,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
             attendeeEmail,
             attendeeName,
             hostEmails: coHostEmails,
+            additionalGuestEmails,
           }),
           createdAt: now,
           updatedAt: now,

--- a/templates/calendar/server/lib/booking-emails.spec.ts
+++ b/templates/calendar/server/lib/booking-emails.spec.ts
@@ -3,6 +3,7 @@ import {
   getAppProductionUrl,
   isEmailConfigured,
   renderEmail,
+  sendEmail,
   toAbsoluteOpenUrl,
 } from "@agent-native/core/server";
 import { describe, expect, it, vi } from "vitest";
@@ -31,7 +32,11 @@ vi.mock("@agent-native/core/server", () => ({
   ),
 }));
 
-import { formatBookingWhen } from "./booking-emails";
+import {
+  formatBookingWhen,
+  sendBookingCancellationEmails,
+  sendBookingConfirmationEmails,
+} from "./booking-emails";
 import {
   renderEventGuestNote,
   sendEventGuestNotificationNote,
@@ -52,6 +57,45 @@ describe("booking email time formatting", () => {
     expect(
       formatBookingWhen("2026-05-21T19:30:00.000Z", "2026-05-21T20:00:00.000Z"),
     ).toBe("Thursday, May 21, 2026, 3:30 PM EDT - 4:00 PM EDT");
+  });
+});
+
+describe("booking attendee notifications", () => {
+  it("sends confirmation and cancellation emails to additional guests", async () => {
+    const booking = {
+      id: "booking-1",
+      name: "Taylor",
+      email: "attendee@example.com",
+      additionalGuestEmails: ["guest-one@example.com", "guest-two@example.com"],
+      eventTitle: "Design review",
+      start: "2026-05-21T19:30:00.000Z",
+      end: "2026-05-21T20:00:00.000Z",
+      slug: "design-review",
+      status: "confirmed" as const,
+      createdAt: "2026-05-21T18:00:00.000Z",
+    };
+
+    await sendBookingConfirmationEmails({
+      booking,
+      hostEmail: "host@example.com",
+      manageUrl: "https://calendar.example.com/manage/booking-1",
+    });
+    await sendBookingCancellationEmails({
+      booking,
+      hostEmail: "host@example.com",
+      bookAgainUrl: "https://calendar.example.com/book/design-review",
+    });
+
+    expect(vi.mocked(sendEmail).mock.calls.map(([args]) => args.to)).toEqual([
+      "attendee@example.com",
+      "guest-one@example.com",
+      "guest-two@example.com",
+      "host@example.com",
+      "attendee@example.com",
+      "guest-one@example.com",
+      "guest-two@example.com",
+      "host@example.com",
+    ]);
   });
 });
 

--- a/templates/calendar/server/lib/booking-emails.ts
+++ b/templates/calendar/server/lib/booking-emails.ts
@@ -51,6 +51,19 @@ function bookingTitle(booking: Booking) {
   return stripCrlf(booking.eventTitle) || "Meeting";
 }
 
+function bookingAttendeeEmails(booking: Booking): string[] {
+  const seen = new Set<string>();
+  return [
+    stripCrlf(booking.email),
+    ...(booking.additionalGuestEmails ?? []).map(stripCrlf),
+  ].filter((email) => {
+    const key = email.toLowerCase();
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 async function sendBestEffort(
   label: string,
   args: Parameters<typeof sendEmail>[0],
@@ -202,18 +215,23 @@ export async function sendBookingConfirmationEmails({
   const attendee = stripCrlf(booking.email);
   const attendeeName = stripCrlf(booking.name) || "there";
 
-  await sendBestEffort("attendee confirmation", {
-    to: attendee,
-    ...renderBookingConfirmedEmail({
-      title,
-      when,
-      host,
-      manageUrl,
-      meetingLink: booking.meetingLink,
-    }),
-    replyTo: host,
-    templateId: CALENDAR_BOOKING_CONFIRMED_EMAIL_ID,
-  });
+  for (const [index, recipient] of bookingAttendeeEmails(booking).entries()) {
+    await sendBestEffort(
+      index === 0 ? "attendee confirmation" : "additional guest confirmation",
+      {
+        to: recipient,
+        ...renderBookingConfirmedEmail({
+          title,
+          when,
+          host,
+          manageUrl,
+          meetingLink: booking.meetingLink,
+        }),
+        replyTo: host,
+        templateId: CALENDAR_BOOKING_CONFIRMED_EMAIL_ID,
+      },
+    );
+  }
 
   await sendBestEffort("host notification", {
     to: host,
@@ -247,12 +265,17 @@ export async function sendBookingCancellationEmails({
   const attendee = stripCrlf(booking.email);
   const attendeeName = stripCrlf(booking.name) || "The guest";
 
-  await sendBestEffort("attendee cancellation", {
-    to: attendee,
-    ...renderBookingCancelledEmail({ title, when, host, bookAgainUrl }),
-    replyTo: host || undefined,
-    templateId: CALENDAR_BOOKING_CANCELLED_EMAIL_ID,
-  });
+  for (const [index, recipient] of bookingAttendeeEmails(booking).entries()) {
+    await sendBestEffort(
+      index === 0 ? "attendee cancellation" : "additional guest cancellation",
+      {
+        to: recipient,
+        ...renderBookingCancelledEmail({ title, when, host, bookAgainUrl }),
+        replyTo: host || undefined,
+        templateId: CALENDAR_BOOKING_CANCELLED_EMAIL_ID,
+      },
+    );
+  }
 
   if (!host) return;
 

--- a/templates/calendar/server/lib/booking-event-details.spec.ts
+++ b/templates/calendar/server/lib/booking-event-details.spec.ts
@@ -81,4 +81,35 @@ describe("booking event details", () => {
       },
     ]);
   });
+
+  it("adds distinct booking guests without duplicating the booker or organizer", () => {
+    expect(
+      buildBookingEventAttendees({
+        organizerEmail: "steve@example.com",
+        attendeeEmail: "rakesh.rachamalla@walmart.com",
+        attendeeName: "Rakesh Rachamalla",
+        additionalGuestEmails: [
+          "teammate@example.com",
+          "TEAMMATE@example.com",
+          "steve@example.com",
+          "rakesh.rachamalla@walmart.com",
+        ],
+      }),
+    ).toEqual([
+      {
+        email: "steve@example.com",
+        organizer: true,
+        self: true,
+        responseStatus: "accepted",
+      },
+      {
+        email: "rakesh.rachamalla@walmart.com",
+        displayName: "Rakesh Rachamalla",
+      },
+      {
+        email: "teammate@example.com",
+        displayName: "Teammate",
+      },
+    ]);
+  });
 });

--- a/templates/calendar/server/lib/booking-event-details.ts
+++ b/templates/calendar/server/lib/booking-event-details.ts
@@ -68,30 +68,27 @@ export function buildBookingEventAttendees({
   attendeeEmail,
   attendeeName,
   hostEmails = [],
+  additionalGuestEmails = [],
 }: {
   organizerEmail: string;
   attendeeEmail: string;
   attendeeName: string;
   hostEmails?: string[];
+  additionalGuestEmails?: string[];
 }) {
   const organizer = stripCrlf(organizerEmail).toLowerCase();
   const attendee = stripCrlf(attendeeEmail).toLowerCase();
-  const guests = [
-    ...(attendee !== organizer
-      ? [
-          {
-            email: attendee,
-            displayName: attendeeName,
-          },
-        ]
-      : []),
-    ...uniqueEmails(hostEmails)
-      .filter((email) => email !== attendee && email !== organizer)
-      .map((email) => ({
-        email,
-        displayName: displayNameFromEmail(email),
-      })),
-  ];
+  const guests = uniqueEmails([
+    attendee,
+    ...additionalGuestEmails,
+    ...hostEmails,
+  ])
+    .filter((email) => email !== organizer)
+    .map((email) => ({
+      email,
+      displayName:
+        email === attendee ? attendeeName : displayNameFromEmail(email),
+    }));
 
   return [
     {

--- a/templates/calendar/server/plugins/db.ts
+++ b/templates/calendar/server/plugins/db.ts
@@ -211,6 +211,11 @@ CREATE INDEX IF NOT EXISTS idx_bookings_slug_start ON bookings (slug, "start");`
       name: "bookings-calendar-account-id",
       sql: `ALTER TABLE bookings ADD COLUMN IF NOT EXISTS calendar_account_id TEXT`,
     },
+    {
+      version: 22,
+      name: "bookings-additional-guest-emails",
+      sql: `ALTER TABLE bookings ADD COLUMN IF NOT EXISTS additional_guest_emails TEXT`,
+    },
   ],
   { table: "calendar_migrations" },
 );

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -277,6 +277,8 @@ export interface Booking {
   id: string;
   name: string;
   email: string;
+  /** Additional invitees included on the booking */
+  additionalGuestEmails?: string[];
   eventTitle: string;
   start: string; // ISO 8601
   end: string; // ISO 8601

--- a/templates/clips/app/routes/share-auth-loading.test.ts
+++ b/templates/clips/app/routes/share-auth-loading.test.ts
@@ -165,4 +165,13 @@ describe("authenticated recording route loading", () => {
     expect(meetingRoute).toContain("recordingTranscripts");
     expect(meetingRoute).toContain("transcript: transcript");
   });
+
+  it("keeps the shared clip agent scoped to the clip being viewed", () => {
+    const shareRoute = readRoute("share.$shareId.tsx");
+    const agentPanel = shareRoute.slice(shareRoute.lastIndexOf("<AgentPanel"));
+
+    expect(agentPanel).toContain("scope={");
+    expect(agentPanel).toContain('type: "recording"');
+    expect(agentPanel).toContain("id: recording.id");
+  });
 });

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -1570,6 +1570,11 @@ export default function ShareRoute() {
               <AgentPanel
                 emptyStateText={t("recordingPage.askAboutClip")}
                 dynamicSuggestions={false}
+                scope={
+                  recording
+                    ? { type: "recording" as const, id: recording.id }
+                    : null
+                }
                 missingApiKeySetupLayout="sidebar"
                 suggestions={[
                   t("recordingPage.summarizeClip"),

--- a/templates/mail/app/components/layout/AppLayout.spec.ts
+++ b/templates/mail/app/components/layout/AppLayout.spec.ts
@@ -63,6 +63,13 @@ describe("AppLayout inbox rail count", () => {
     );
   });
 
+  it("reserves desktop content space while the unpinned sidebar is open", () => {
+    const source = appLayoutSource();
+
+    expect(source).toContain("!isMobile &&\n              showSidebar &&");
+    expect(source).toContain('sidebarOpen && !isMobile && "ps-64"');
+  });
+
   it("keeps the explicit Other inbox tab and search restoration path", () => {
     const source = appLayoutSource();
 

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -2015,8 +2015,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         <div
           className={cn(
             "flex min-h-0 flex-1 flex-col",
-            sidebarPinned &&
-              !isMobile &&
+            !isMobile &&
+              showSidebar &&
               (showCollapsedSidebar ? "ps-12" : "ps-64"),
           )}
         >
@@ -2217,6 +2217,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 function StandardLayout({ children }: AppLayoutProps) {
   const t = useT();
   const location = useLocation();
+  const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const headerTitle = useHeaderTitle();
   const headerActions = useHeaderActions();
@@ -2440,7 +2441,12 @@ function StandardLayout({ children }: AppLayoutProps) {
 
       <InvitationBanner />
 
-      <main className="agent-native-app-main flex flex-1 overflow-hidden">
+      <main
+        className={cn(
+          "agent-native-app-main flex flex-1 overflow-hidden",
+          sidebarOpen && !isMobile && "ps-64",
+        )}
+      >
         {children}
       </main>
     </div>

--- a/templates/slides/actions/index-design-system-with-builder.test.ts
+++ b/templates/slides/actions/index-design-system-with-builder.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  buildBuilderDesignSystemIndexFiles: vi.fn(),
+  startBuilderDesignSystemIndex: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@agent-native/core/server")>();
+  return {
+    ...actual,
+    buildBuilderDesignSystemIndexFiles: (...args: unknown[]) =>
+      mocks.buildBuilderDesignSystemIndexFiles(...args),
+    startBuilderDesignSystemIndex: (...args: unknown[]) =>
+      mocks.startBuilderDesignSystemIndex(...args),
+  };
+});
+
+vi.mock("../server/lib/builder-design-system-proxy.js", () => ({
+  upsertBuilderProxyDesignSystem: vi.fn(),
+}));
+
+import { FeatureNotConfiguredError } from "@agent-native/core/server";
+
+import action from "./index-design-system-with-builder.js";
+
+describe("index-design-system-with-builder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.buildBuilderDesignSystemIndexFiles.mockReturnValue([]);
+  });
+
+  it("returns an actionable precondition when Builder is not connected", async () => {
+    mocks.startBuilderDesignSystemIndex.mockRejectedValue(
+      new FeatureNotConfiguredError({
+        requiredCredential: "BUILDER_PRIVATE_KEY",
+        message:
+          "Connect Builder.io (free tier available) before indexing a design system from Figma or code.",
+        builderConnectUrl: "/_agent-native/builder/connect",
+      }),
+    );
+
+    await expect(
+      action.run({
+        githubSources: [{ repoUrl: "https://github.com/acme/ui" }],
+      }),
+    ).rejects.toMatchObject({
+      actionContractError: true,
+      errorCode: "builder_not_configured",
+      statusCode: 412,
+      message:
+        "Connect Builder.io (free tier available) before indexing a design system from Figma or code.",
+      details: { builderConnectUrl: "/_agent-native/builder/connect" },
+    });
+  });
+});

--- a/templates/slides/actions/index-design-system-with-builder.ts
+++ b/templates/slides/actions/index-design-system-with-builder.ts
@@ -1,6 +1,7 @@
-import { defineAction } from "@agent-native/core/action";
+import { defineAction, fail } from "@agent-native/core/action";
 import {
   buildBuilderDesignSystemIndexFiles,
+  FeatureNotConfiguredError,
   startBuilderDesignSystemIndex,
 } from "@agent-native/core/server";
 import {
@@ -110,14 +111,28 @@ export default defineAction({
       codeFiles,
       designMd,
     });
-    const result = await startBuilderDesignSystemIndex({
-      projectName,
-      description,
-      githubRepoUrl,
-      githubRepos: githubSources,
-      connectedProjectId,
-      files,
-    });
+    let result: Awaited<ReturnType<typeof startBuilderDesignSystemIndex>>;
+    try {
+      result = await startBuilderDesignSystemIndex({
+        projectName,
+        description,
+        githubRepoUrl,
+        githubRepos: githubSources,
+        connectedProjectId,
+        files,
+      });
+    } catch (error) {
+      if (error instanceof FeatureNotConfiguredError) {
+        fail(error.message, {
+          errorCode: "builder_not_configured",
+          statusCode: 412,
+          ...(error.builderConnectUrl
+            ? { details: { builderConnectUrl: error.builderConnectUrl } }
+            : {}),
+        });
+      }
+      throw error;
+    }
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
 


### PR DESCRIPTION
## Summary

- Scope shared Clips agent context to the recording being viewed.
- Add up to five deduplicated guest emails to Calendar booking invites.
- Align the Calendar description icon with the shared control geometry.
- Return an actionable 412 when Slides indexing lacks Builder configuration.
- Reserve space for unpinned Mail sidebars in both layout paths.

## Feedback handoff

Sweep start cursor: [Slack message](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788204359155249?thread_ts=1788204359.155249&cid=C0ATH3CCZT4)

Upvoted in-scope items: 2; built: 2; clarification questions: 0/3.

| Feedback | Disposition | Evidence |
| --- | --- | --- |
| Shared Clips context | Fixed | Recording scope added; focused route tests pass |
| Calendar description alignment | Fixed | Shared icon geometry corrected; focused source tests pass |
| Calendar additional guests | Fixed | Five-email limit, validation, dedupe, and invite attendee coverage |
| Mail sidebar overlap | Fixed | Both fixed-drawer layout branches reserve content width |
| Slides Builder indexing 500 | Fixed | Missing configuration maps to actionable 412; focused test passes |
| Imported Slides backgrounds | Open - no reply | Importer inheritance gap identified; routed as Design/import fidelity work |
| Forms-to-Slides rate limit | Open - no reply | Provider/realtime behavior remains under investigation |
| Native Clips mic and geometry reports | Open - no reply | Requires live native/browser verification |
| Calendar recurrence and booking-access reports | Open - no reply | Repro/permissions follow-up remains separate |
| Analytics reports | Excluded | Explicitly owned by another Codex thread; no code or reply here |

The three fixed source dispositions were posted back to their Slack threads with the required disclosure and read back through the current thread ends. Eyes remain investigation markers; no duplicate Slack replies were added.

## Validation

- `corepack pnpm guards` - all 66 checks passed.
- Focused tests passed for Clips, Calendar, Mail, and Slides.
- Calendar, Mail, and Slides typechecks passed.
- `git diff --check` passed.

## Proof boundary

No browser, authenticated beta, Electron, or production verification was available in this run. The changes are source-tested and ready for beta verification; this PR does not claim live deployment health. Sentry was unavailable.

<!-- Feedback sweep is governed by the current review-latest-feedback runbook. -->