### PR TITLE
Fix Clips meeting recordings stopping after calls end

### DIFF
--- a/templates/clips/desktop/src-tauri/src/call_activity.rs
+++ b/templates/clips/desktop/src-tauri/src/call_activity.rs
@@ -19,7 +19,13 @@ pub(crate) fn default_call_app_bundle_ids() -> Vec<String> {
 
 fn bundle_id_matches(bundle_id: &str, candidate: &str) -> bool {
     bundle_id == candidate
-        || bundle_id
+        || !matches!(
+            candidate,
+            "com.google.chrome"
+                | "company.thebrowser.browser"
+                | "com.apple.safari"
+                | "org.mozilla.firefox"
+        ) && bundle_id
             .strip_prefix(candidate)
             .map(|suffix| suffix.starts_with('.'))
             .unwrap_or(false)
@@ -161,12 +167,14 @@ mod tests {
     use super::bundle_id_matches;
 
     #[test]
-    fn matches_audio_helper_processes_without_matching_other_apps() {
-        assert!(bundle_id_matches(
+    fn matches_native_helpers_but_only_exact_browser_processes() {
+        assert!(bundle_id_matches("us.zoom.xos.helper.audio", "us.zoom.xos"));
+        assert!(bundle_id_matches("us.zoom.xos", "us.zoom.xos"));
+        assert!(bundle_id_matches("com.google.chrome", "com.google.chrome"));
+        assert!(!bundle_id_matches(
             "com.google.chrome.helper.renderer",
             "com.google.chrome"
         ));
-        assert!(bundle_id_matches("us.zoom.xos", "us.zoom.xos"));
         assert!(!bundle_id_matches(
             "com.google.chromium",
             "com.google.chrome"

--- a/templates/clips/desktop/src-tauri/src/call_activity.rs
+++ b/templates/clips/desktop/src-tauri/src/call_activity.rs
@@ -17,6 +17,14 @@ pub(crate) fn default_call_app_bundle_ids() -> Vec<String> {
     .collect()
 }
 
+fn bundle_id_matches(bundle_id: &str, candidate: &str) -> bool {
+    bundle_id == candidate
+        || bundle_id
+            .strip_prefix(candidate)
+            .map(|suffix| suffix.starts_with('.'))
+            .unwrap_or(false)
+}
+
 /// Returns whether one of the target conferencing apps currently has a live
 /// CoreAudio input stream. `None` means the OS could not provide a reliable
 /// answer, so callers must keep the existing conservative fallbacks.
@@ -109,7 +117,10 @@ pub(crate) fn call_app_uses_microphone(bundle_ids: &[String]) -> Option<bool> {
         }
         .to_string()
         .to_lowercase();
-        if !bundle_ids.iter().any(|candidate| candidate == &bundle_id) {
+        if !bundle_ids
+            .iter()
+            .any(|candidate| bundle_id_matches(&bundle_id, candidate))
+        {
             continue;
         }
 
@@ -143,4 +154,26 @@ pub(crate) fn call_app_uses_microphone(bundle_ids: &[String]) -> Option<bool> {
         return None;
     }
     Some(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bundle_id_matches;
+
+    #[test]
+    fn matches_audio_helper_processes_without_matching_other_apps() {
+        assert!(bundle_id_matches(
+            "com.google.chrome.helper.renderer",
+            "com.google.chrome"
+        ));
+        assert!(bundle_id_matches("us.zoom.xos", "us.zoom.xos"));
+        assert!(!bundle_id_matches(
+            "com.google.chromium",
+            "com.google.chrome"
+        ));
+        assert!(!bundle_id_matches(
+            "com.microsoft.teams2",
+            "com.microsoft.teams"
+        ));
+    }
 }

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -425,6 +425,12 @@ fn install_call_ended_watcher(app: &AppHandle) {
                     Some(false) if call_app_used_microphone => {
                         microphone_released_at.get_or_insert_with(Instant::now);
                     }
+                    None => {
+                        // CoreAudio could not confirm the provider state, so
+                        // a release window must start over on the next known
+                        // false result.
+                        microphone_released_at = None;
+                    }
                     _ => {}
                 }
 

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -485,7 +485,7 @@ fn source_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration
 fn call_end_audio_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration) -> bool {
     source
         .map(|state| !state.seen_audio || source_quiet_for(Some(state), now, window))
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 fn claim_auto_stop(inner: &Arc<Mutex<DetectorInner>>, generation: u64) -> bool {
@@ -593,6 +593,7 @@ mod tests {
             now,
             Duration::from_secs(5)
         ));
+        assert!(call_end_audio_quiet_for(None, now, Duration::from_secs(5)));
     }
 
     #[test]

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -332,12 +332,21 @@ fn install_sleep_watcher(app: &AppHandle) {
                 if drift > Duration::from_secs(30) {
                     // Only fire when a session is active to avoid noise.
                     let state = app.state::<DetectorState>();
-                    let (active, generation) = state
+                    let (active, generation, watch_sleep) = state
                         .inner
                         .lock()
-                        .map(|g| (g.active, g.generation))
-                        .unwrap_or((false, 0));
-                    if active && claim_auto_stop(&state.inner, generation) {
+                        .map(|g| {
+                            (
+                                g.active,
+                                g.generation,
+                                g.config
+                                    .as_ref()
+                                    .map(|config| config.watch_sleep)
+                                    .unwrap_or(false),
+                            )
+                        })
+                        .unwrap_or((false, 0, false));
+                    if active && watch_sleep && claim_auto_stop(&state.inner, generation) {
                         let _ = app.emit("meetings:sleep-stop", ());
                     }
                 }
@@ -368,19 +377,24 @@ fn install_call_ended_watcher(app: &AppHandle) {
             loop {
                 std::thread::sleep(CALL_END_POLL);
                 let state = app.state::<DetectorState>();
-                let (active, active_generation, configured_bundle_ids, fired) = state
-                    .inner
-                    .lock()
-                    .map(|g| {
-                        (
-                            g.active,
-                            g.generation,
-                            g.call_app_bundle_ids.clone(),
-                            g.auto_stop_fired,
-                        )
-                    })
-                    .unwrap_or((false, 0, Vec::new(), true));
-                if !active {
+                let (active, active_generation, configured_bundle_ids, watch_call_ended, fired) =
+                    state
+                        .inner
+                        .lock()
+                        .map(|g| {
+                            (
+                                g.active,
+                                g.generation,
+                                g.call_app_bundle_ids.clone(),
+                                g.config
+                                    .as_ref()
+                                    .map(|config| config.watch_call_ended)
+                                    .unwrap_or(false),
+                                g.auto_stop_fired,
+                            )
+                        })
+                        .unwrap_or((false, 0, Vec::new(), false, true));
+                if !active || !watch_call_ended {
                     call_app_used_microphone = false;
                     microphone_released_at = None;
                     continue;

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -360,10 +360,10 @@ fn install_sleep_watcher(_app: &AppHandle) {}
 
 // --- call-ended heuristic --------------------------------------------------
 
-#[cfg(target_os = "macos")]
-const CALL_END_POLL: Duration = Duration::from_secs(2);
 const CALL_END_AUDIO_CONFIRM: Duration = Duration::from_secs(5);
 const CALL_MIC_RELEASE_CONFIRM: Duration = Duration::from_secs(5);
+#[cfg(target_os = "macos")]
+const CALL_END_POLL: Duration = Duration::from_secs(2);
 
 #[cfg(target_os = "macos")]
 fn install_call_ended_watcher(app: &AppHandle) {

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -2,8 +2,8 @@
 //!
 //! This module subscribes to the existing `voice:audio-level` events emitted by
 //! `native_speech.rs` (mic) and `system_audio.rs` (system audio) and tracks a
-//! rolling window of peak levels per source. When **both** sources have stayed
-//! below the silence threshold for the configured silence duration, we emit
+//! last meaningful level per source. When **both** sources have stayed below
+//! the silence threshold for the configured silence duration, we emit
 //! `meetings:silence-stop` to the renderer, which calls the
 //! `stop-meeting-recording` action.
 //!
@@ -11,14 +11,14 @@
 //!
 //!  * **System sleep** — `NSWorkspaceWillSleepNotification` via objc2.
 //!    Emits `meetings:sleep-stop`.
-//!  * **Call-end heuristic** — best-effort: when a known conferencing app
-//!    releases its microphone after using it for the active meeting, emit
-//!    `meetings:call-ended`. Falling back to a foreground-to-background
-//!    transition keeps the detector useful on macOS versions that do not
-//!    expose per-process input activity.
-//!  * **Calendar end** — when the scheduled meeting end has passed and both
-//!    audio sources have been quiet for the call-end window, emit the same
-//!    event even if the conferencing app remains frontmost.
+//!  * **Call-end heuristic** — when a known conferencing app releases its
+//!    microphone after using it for the active meeting, emit
+//!    `meetings:call-ended` after a short system-audio confirmation. A
+//!    foreground-to-background transition is deliberately not an end signal:
+//!    people switch apps while calls are still live.
+//!  * **Calendar end** — when the scheduled meeting end has passed and system
+//!    audio has been quiet for the call-end window, emit the same event even if
+//!    the conferencing app remains open.
 //!
 //! Renderer-side responsibility: subscribe via `silence-events.ts`, dispatch
 //! the `stop-meeting-recording` action when any of the events fire.
@@ -36,9 +36,9 @@
 //! We keep a per-source `last_loud_at: Instant`. On every level event:
 //!   - if `level >= silence_threshold` -> reset `last_loud_at = now()`.
 //!
-//! A 5-second supervisor task ticks; on each tick, if **all known sources**
-//! have `now - last_loud_at > silence_duration`, fire `meetings:silence-stop`
-//! exactly once and clear the active flag.
+//! A two-second supervisor task ticks. Call-end and calendar signals use system
+//! audio only, because a user's local mic can stay noisy after a call ends.
+//! The all-source silence stop remains the long safety backstop.
 //!
 //! Defaults: silence_threshold = 0.05, silence_duration = 15 minutes.
 //! No raw "sliding window of samples" is needed — the `last_loud_at` Instant
@@ -61,8 +61,8 @@ pub struct SilenceConfig {
     /// Default 15 * 60 * 1000.
     #[serde(default = "default_silence_ms")]
     pub silence_ms: u64,
-    /// Milliseconds of background-state (video-conferencing app no longer
-    /// foreground) before firing the call-ended event. Default 2 minutes.
+    /// Milliseconds of quiet system audio after the scheduled end before
+    /// firing the call-ended event. Default 30 seconds.
     #[serde(default = "default_call_ended_ms")]
     pub call_ended_ms: u64,
     /// Whether to enable the system-sleep auto-stop.
@@ -89,7 +89,7 @@ fn default_silence_ms() -> u64 {
     15 * 60 * 1000
 }
 fn default_call_ended_ms() -> u64 {
-    2 * 60 * 1000
+    30 * 1000
 }
 fn default_true() -> bool {
     true
@@ -98,12 +98,14 @@ fn default_true() -> bool {
 #[derive(Debug)]
 struct SourceState {
     last_loud_at: Instant,
+    seen_audio: bool,
 }
 
 impl SourceState {
     fn fresh() -> Self {
         Self {
             last_loud_at: Instant::now(),
+            seen_audio: false,
         }
     }
 }
@@ -120,8 +122,8 @@ struct DetectorInner {
     /// Per-source last-loud timestamp.
     mic: Option<SourceState>,
     system: Option<SourceState>,
-    /// Already fired the silence-stop event in this session?
-    silence_fired: bool,
+    /// Already fired an automatic stop event in this session?
+    auto_stop_fired: bool,
     /// Calendar event end for the active session, if one is known.
     scheduled_end_ms: Option<u64>,
     /// Apps allowed to corroborate a call ending by releasing their microphone
@@ -191,6 +193,7 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
                 _ => return,
             };
             let entry = bucket.get_or_insert_with(SourceState::fresh);
+            entry.seen_audio = true;
             if p.level >= threshold {
                 entry.last_loud_at = now;
             }
@@ -204,7 +207,7 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
             .map_err(|e| format!("silence detector lock poisoned: {e}"))?;
         g.generation = g.generation.wrapping_add(1);
         g.active = true;
-        g.silence_fired = false;
+        g.auto_stop_fired = false;
         g.config = Some(cfg.clone());
         g.scheduled_end_ms = cfg.scheduled_end_ms;
         g.call_app_bundle_ids = cfg
@@ -229,7 +232,7 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
     let silence_window = Duration::from_millis(cfg.silence_ms);
     let calendar_end_quiet_window = Duration::from_millis(cfg.call_ended_ms);
     std::thread::spawn(move || loop {
-        std::thread::sleep(Duration::from_secs(5));
+        std::thread::sleep(Duration::from_secs(2));
         let stop_reason = {
             let g = match inner_for_supervisor.lock() {
                 Ok(g) => g,
@@ -238,7 +241,7 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
             if g.generation != generation_at_start || !g.active {
                 return; // session ended or replaced — exit
             }
-            if g.silence_fired {
+            if g.auto_stop_fired {
                 None
             } else {
                 let now = Instant::now();
@@ -252,20 +255,12 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
                     .as_ref()
                     .map(|s| now.duration_since(s.last_loud_at) >= silence_window)
                     .unwrap_or(false);
-                let mic_quiet_for_calendar_end = g
-                    .mic
-                    .as_ref()
-                    .map(|s| now.duration_since(s.last_loud_at) >= calendar_end_quiet_window)
-                    .unwrap_or(false);
-                let system_quiet_for_calendar_end = g
-                    .system
-                    .as_ref()
-                    .map(|s| now.duration_since(s.last_loud_at) >= calendar_end_quiet_window)
-                    .unwrap_or(false);
+                let system_quiet_for_calendar_end =
+                    source_quiet_for(g.system.as_ref(), now, calendar_end_quiet_window);
                 if calendar_end_stop_ready(
                     g.scheduled_end_ms,
                     unix_now_ms(),
-                    mic_quiet_for_calendar_end && system_quiet_for_calendar_end,
+                    system_quiet_for_calendar_end,
                 ) {
                     Some("calendar")
                 } else if mic_silent && system_silent {
@@ -276,15 +271,14 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
             }
         };
         if let Some(reason) = stop_reason {
-            if let Ok(mut g) = inner_for_supervisor.lock() {
-                g.silence_fired = true;
+            if claim_auto_stop(&inner_for_supervisor, generation_at_start) {
+                let event = if reason == "calendar" {
+                    "meetings:call-ended"
+                } else {
+                    "meetings:silence-stop"
+                };
+                let _ = app_for_supervisor.emit(event, ());
             }
-            let event = if reason == "calendar" {
-                "meetings:call-ended"
-            } else {
-                "meetings:silence-stop"
-            };
-            let _ = app_for_supervisor.emit(event, ());
         }
     });
 
@@ -292,7 +286,7 @@ pub fn silence_detector_start(app: AppHandle, config: Option<SilenceConfig>) -> 
         install_sleep_watcher(&app);
     }
     if cfg.watch_call_ended {
-        install_call_ended_watcher(&app, cfg.call_ended_ms);
+        install_call_ended_watcher(&app);
     }
 
     Ok(())
@@ -307,7 +301,7 @@ pub fn silence_detector_stop(app: AppHandle) -> Result<(), String> {
         .map_err(|e| format!("silence detector lock poisoned: {e}"))?;
     g.generation = g.generation.wrapping_add(1);
     g.active = false;
-    g.silence_fired = false;
+    g.auto_stop_fired = false;
     g.mic = None;
     g.system = None;
     g.scheduled_end_ms = None;
@@ -338,8 +332,12 @@ fn install_sleep_watcher(app: &AppHandle) {
                 if drift > Duration::from_secs(30) {
                     // Only fire when a session is active to avoid noise.
                     let state = app.state::<DetectorState>();
-                    let active = state.inner.lock().map(|g| g.active).unwrap_or(false);
-                    if active {
+                    let (active, generation) = state
+                        .inner
+                        .lock()
+                        .map(|g| (g.active, g.generation))
+                        .unwrap_or((false, 0));
+                    if active && claim_auto_stop(&state.inner, generation) {
                         let _ = app.emit("meetings:sleep-stop", ());
                     }
                 }
@@ -353,112 +351,58 @@ fn install_sleep_watcher(_app: &AppHandle) {}
 
 // --- call-ended heuristic --------------------------------------------------
 
-const GENERIC_BROWSER_BUNDLE_IDS: &[&str] = &[
-    "com.google.chrome",
-    "company.thebrowser.browser",
-    "com.apple.safari",
-    "org.mozilla.firefox",
-];
-
-fn is_configured_generic_browser(bundle_id: &str, call_app_bundle_ids: &[String]) -> bool {
-    GENERIC_BROWSER_BUNDLE_IDS.contains(&bundle_id)
-        && call_app_bundle_ids
-            .iter()
-            .any(|candidate| GENERIC_BROWSER_BUNDLE_IDS.contains(&candidate.as_str()))
-}
+#[cfg(target_os = "macos")]
+const CALL_END_POLL: Duration = Duration::from_secs(2);
+const CALL_END_AUDIO_CONFIRM: Duration = Duration::from_secs(5);
+const CALL_MIC_RELEASE_CONFIRM: Duration = Duration::from_secs(5);
 
 #[cfg(target_os = "macos")]
-fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
+fn install_call_ended_watcher(app: &AppHandle) {
     static INSTALLED: OnceLock<()> = OnceLock::new();
     let app = app.clone();
     INSTALLED.get_or_init(|| {
         std::thread::spawn(move || {
-            // Best-effort: poll the frontmost-app bundle id every 10s and
-            // track when a known video-conferencing bundle was last in front.
-            // If it was front during this session and has been background for
-            // > threshold_ms, fire `meetings:call-ended`. On the first session
-            // tick we just record state and wait.
-            // Native VC clients are a strong signal on their own: a Zoom/Teams
-            // window backgrounding for a while means the user almost
-            // certainly left the call. Generic browsers are NOT included
-            // here — Meet/Zoom-web/Teams-web all run inside Chrome/Arc, so
-            // "Chrome was frontmost" just means the user was in some tab, not
-            // that any call ended. Browser-hosted calls fall back to
-            // `strong_vc_bundles` below only when corroborated by the
-            // mic+system silence tracking this same detector already keeps
-            // (DetectorInner.mic/system), never on the frontmost-app poll
-            // alone — matching the granola-ux.md "transcript length +
-            // calendar times" model instead of raw frontmost tracking.
-            let mut ever_seen_front = false;
-            let mut last_front_at: Option<Instant> = None;
-            let mut fired = false;
             let mut call_app_used_microphone = false;
             let mut microphone_released_at: Option<Instant> = None;
             let mut generation: Option<u64> = None;
             loop {
-                std::thread::sleep(Duration::from_secs(10));
+                std::thread::sleep(CALL_END_POLL);
                 let state = app.state::<DetectorState>();
-                let (active, active_generation, configured_bundle_ids) = state
+                let (active, active_generation, configured_bundle_ids, fired) = state
                     .inner
                     .lock()
-                    .map(|g| (g.active, g.generation, g.call_app_bundle_ids.clone()))
-                    .unwrap_or((false, 0, Vec::new()));
+                    .map(|g| {
+                        (
+                            g.active,
+                            g.generation,
+                            g.call_app_bundle_ids.clone(),
+                            g.auto_stop_fired,
+                        )
+                    })
+                    .unwrap_or((false, 0, Vec::new(), true));
                 if !active {
-                    ever_seen_front = false;
-                    last_front_at = None;
-                    fired = false;
                     call_app_used_microphone = false;
                     microphone_released_at = None;
                     continue;
                 }
                 if generation != Some(active_generation) {
-                    ever_seen_front = false;
-                    last_front_at = None;
-                    fired = false;
                     call_app_used_microphone = false;
                     microphone_released_at = None;
                     generation = Some(active_generation);
+                }
+                if fired {
+                    continue;
                 }
                 let call_app_bundle_ids = if configured_bundle_ids.is_empty() {
                     crate::call_activity::default_call_app_bundle_ids()
                 } else {
                     configured_bundle_ids
                 };
-                let front = crate::util::frontmost_bundle_id();
-                let is_generic_browser = front
-                    .as_ref()
-                    .map(|bundle_id| {
-                        is_configured_generic_browser(
-                            &bundle_id.to_lowercase(),
-                            &call_app_bundle_ids,
-                        )
-                    })
-                    .unwrap_or(false);
-                let is_strong_vc = front
-                    .as_ref()
-                    .map(|bundle_id| {
-                        let bundle_id = bundle_id.to_lowercase();
-                        call_app_bundle_ids
-                            .iter()
-                            .any(|candidate| candidate == &bundle_id)
-                            && !is_generic_browser
-                    })
-                    .unwrap_or(false);
-                if is_strong_vc || is_generic_browser {
-                    ever_seen_front = true;
-                    last_front_at = Some(Instant::now());
-                }
-                if fired {
-                    continue;
-                }
 
-                // A native call application remains frontmost on its post-call
-                // screen, so foreground tracking alone cannot tell that the
-                // meeting ended. CoreAudio reports whether the provider still
-                // has an active microphone stream. Only accept a true -> false
-                // transition that stays stable for 30 seconds; this tolerates
-                // a device handoff while avoiding a stop before the call has
-                // actually acquired its microphone.
+                // CoreAudio reports whether the provider still has an active
+                // microphone stream. Only accept a true -> false transition
+                // that stays stable for a few seconds; this tolerates device
+                // handoffs without waiting minutes after a real call ends.
                 match crate::call_activity::call_app_uses_microphone(&call_app_bundle_ids) {
                     Some(true) => {
                         call_app_used_microphone = true;
@@ -470,30 +414,19 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
                     _ => {}
                 }
 
-                // Require audio corroboration for every trigger in this
-                // watcher: backgrounding the call app, or its process
-                // dropping its mic input, does not by itself prove the call
-                // ended — a browser tab can report either transition while
-                // the meeting is still playing through system audio. Only
-                // quiet mic+system audio alongside the signal does.
-                let audio_quiet = audio_recently_silent(&state, threshold_ms);
+                // Local mic noise is expected after a meeting ends, so only
+                // system audio corroborates a released call input. If system
+                // capture is unavailable, the stable provider transition is
+                // still the best native end signal we have.
+                let audio_quiet = audio_recently_silent(&state, CALL_END_AUDIO_CONFIRM);
 
                 let microphone_released = microphone_release_stop_ready(
                     call_app_used_microphone,
                     microphone_released_at.map(|at| Instant::now().duration_since(at)),
                 ) && audio_quiet;
 
-                let frontmost_call_ended = ever_seen_front
-                    && last_front_at
-                        .map(|t| {
-                            Instant::now().duration_since(t).as_millis() as u64 >= threshold_ms
-                        })
-                        .unwrap_or(false)
-                    && audio_quiet;
-
-                if microphone_released || frontmost_call_ended {
+                if microphone_released && claim_auto_stop(&state.inner, active_generation) {
                     let _ = app.emit("meetings:call-ended", ());
-                    fired = true;
                 }
             }
         });
@@ -501,7 +434,7 @@ fn install_call_ended_watcher(app: &AppHandle, threshold_ms: u64) {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn install_call_ended_watcher(_app: &AppHandle, _threshold_ms: u64) {}
+fn install_call_ended_watcher(_app: &AppHandle) {}
 
 fn microphone_release_stop_ready(
     app_used_microphone: bool,
@@ -509,7 +442,7 @@ fn microphone_release_stop_ready(
 ) -> bool {
     app_used_microphone
         && released_for
-            .map(|elapsed| elapsed >= Duration::from_secs(30))
+            .map(|elapsed| elapsed >= CALL_MIC_RELEASE_CONFIRM)
             .unwrap_or(false)
 }
 
@@ -523,6 +456,29 @@ fn calendar_end_stop_ready(scheduled_end_ms: Option<u64>, now_ms: u64, audio_qui
     scheduled_end_reached(scheduled_end_ms, now_ms) && audio_quiet
 }
 
+fn source_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration) -> bool {
+    source
+        .map(|state| now.duration_since(state.last_loud_at) >= window)
+        .unwrap_or(false)
+}
+
+fn call_end_audio_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration) -> bool {
+    source
+        .map(|state| !state.seen_audio || source_quiet_for(Some(state), now, window))
+        .unwrap_or(false)
+}
+
+fn claim_auto_stop(inner: &Arc<Mutex<DetectorInner>>, generation: u64) -> bool {
+    let Ok(mut g) = inner.lock() else {
+        return false;
+    };
+    if g.generation != generation || !g.active || g.auto_stop_fired {
+        return false;
+    }
+    g.auto_stop_fired = true;
+    true
+}
+
 fn unix_now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -530,31 +486,16 @@ fn unix_now_ms() -> u64 {
         .as_millis() as u64
 }
 
-/// Corroboration check for the generic-browser call-ended signal: true only
-/// if BOTH mic and system audio have been quiet for at least `threshold_ms`.
-/// Reuses the same per-source `last_loud_at` tracking the silence-stop
-/// supervisor already maintains — no new subsystem, no new lock ordering
-/// beyond the existing `DetectorState.inner` mutex. Missing/never-seen
-/// sources count as "not corroborating" (conservative — when in doubt, keep
-/// recording rather than auto-stop).
+/// Corroboration check for the call-ended signal. The provider's mic transition
+/// is the primary signal, so only system audio needs to be quiet here. Local
+/// mic noise is not evidence that a call is still live.
 #[cfg(target_os = "macos")]
-fn audio_recently_silent(state: &tauri::State<'_, DetectorState>, threshold_ms: u64) -> bool {
+fn audio_recently_silent(state: &tauri::State<'_, DetectorState>, window: Duration) -> bool {
     let Ok(g) = state.inner.lock() else {
         return false;
     };
-    let window = Duration::from_millis(threshold_ms);
     let now = Instant::now();
-    let mic_silent = g
-        .mic
-        .as_ref()
-        .map(|s| now.duration_since(s.last_loud_at) >= window)
-        .unwrap_or(false);
-    let system_silent = g
-        .system
-        .as_ref()
-        .map(|s| now.duration_since(s.last_loud_at) >= window)
-        .unwrap_or(false);
-    mic_silent && system_silent
+    call_end_audio_quiet_for(g.system.as_ref(), now, window)
 }
 
 #[cfg(test)]
@@ -562,9 +503,11 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        calendar_end_stop_ready, is_configured_generic_browser, microphone_release_stop_ready,
-        scheduled_end_reached,
+        calendar_end_stop_ready, call_end_audio_quiet_for, claim_auto_stop,
+        microphone_release_stop_ready, scheduled_end_reached, source_quiet_for, DetectorInner,
+        SourceState,
     };
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn calendar_end_requires_a_known_end_and_allows_the_exact_boundary() {
@@ -590,27 +533,52 @@ mod tests {
         assert!(!microphone_release_stop_ready(true, None));
         assert!(!microphone_release_stop_ready(
             true,
-            Some(Duration::from_secs(29))
+            Some(Duration::from_secs(4))
         ));
         assert!(microphone_release_stop_ready(
             true,
-            Some(Duration::from_secs(30))
+            Some(Duration::from_secs(5))
         ));
     }
 
     #[test]
-    fn browser_calls_require_a_configured_browser_bundle() {
-        let browser_call = vec!["com.google.chrome".to_owned()];
-        let native_call = vec!["us.zoom.xos".to_owned()];
+    fn call_end_audio_confirmation_ignores_local_mic_noise() {
+        let now = std::time::Instant::now();
+        let system_quiet = SourceState {
+            last_loud_at: now - Duration::from_secs(6),
+            seen_audio: true,
+        };
+        let mic_loud = SourceState {
+            last_loud_at: now,
+            seen_audio: true,
+        };
 
-        for browser in [
-            "com.google.chrome",
-            "company.thebrowser.browser",
-            "com.apple.safari",
-            "org.mozilla.firefox",
-        ] {
-            assert!(is_configured_generic_browser(browser, &browser_call));
-            assert!(!is_configured_generic_browser(browser, &native_call));
-        }
+        assert!(source_quiet_for(
+            Some(&system_quiet),
+            now,
+            Duration::from_secs(5)
+        ));
+        assert!(!source_quiet_for(
+            Some(&mic_loud),
+            now,
+            Duration::from_secs(5)
+        ));
+        assert!(call_end_audio_quiet_for(
+            Some(&SourceState::fresh()),
+            now,
+            Duration::from_secs(5)
+        ));
+    }
+
+    #[test]
+    fn auto_stop_claim_is_one_shot_for_the_active_generation() {
+        let inner = Arc::new(Mutex::new(DetectorInner {
+            active: true,
+            ..DetectorInner::default()
+        }));
+
+        assert!(claim_auto_stop(&inner, 0));
+        assert!(!claim_auto_stop(&inner, 0));
+        assert!(!claim_auto_stop(&inner, 1));
     }
 }

--- a/templates/clips/desktop/src-tauri/src/silence_detector.rs
+++ b/templates/clips/desktop/src-tauri/src/silence_detector.rs
@@ -472,7 +472,7 @@ fn calendar_end_stop_ready(scheduled_end_ms: Option<u64>, now_ms: u64, audio_qui
 
 fn source_quiet_for(source: Option<&SourceState>, now: Instant, window: Duration) -> bool {
     source
-        .map(|state| now.duration_since(state.last_loud_at) >= window)
+        .map(|state| state.seen_audio && now.duration_since(state.last_loud_at) >= window)
         .unwrap_or(false)
 }
 
@@ -574,6 +574,11 @@ mod tests {
         ));
         assert!(!source_quiet_for(
             Some(&mic_loud),
+            now,
+            Duration::from_secs(5)
+        ));
+        assert!(!source_quiet_for(
+            Some(&SourceState::fresh()),
             now,
             Duration::from_secs(5)
         ));

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { callAppBundleIdsForJoinUrl } from "../lib/meeting-call-app";
 import { stopMeetingBeforeTranscriptFlush } from "../lib/meeting-stop";
+import { subscribeAutoStop } from "../lib/silence-events";
 import {
   appendFinalTranscript,
   onFinalTranscript,
@@ -468,21 +469,17 @@ export function useMeetingTranscription({
               });
           }),
         );
-        addUnlisten(
-          listen("meetings:silence-stop", () => {
-            stopTranscription("silence").catch(() => {});
-          }),
-        );
-        addUnlisten(
-          listen("meetings:sleep-stop", () => {
-            stopTranscription("sleep").catch(() => {});
-          }),
-        );
-        addUnlisten(
-          listen("meetings:call-ended", () => {
-            stopTranscription("call-ended").catch(() => {});
-          }),
-        );
+        // Register every native auto-stop listener before starting audio. The
+        // Tauri listen calls are async; firing the detector first leaves a
+        // small but real window where a native end event can be missed.
+        const autoStopUnlisten = await subscribeAutoStop((reason) => {
+          stopTranscription(reason).catch(() => {});
+        });
+        if (sessionRef.current !== session || session.stopping) {
+          autoStopUnlisten();
+        } else {
+          session.unlisten.push(autoStopUnlisten);
+        }
 
         // Creating the row and starting the audio engine need nothing from each
         // other — only the flush needs a recording id. Kicking the engine here
@@ -533,7 +530,7 @@ export function useMeetingTranscription({
         const silenceDetectorConfig = {
           silenceThreshold: 0.05,
           silenceMs: 15 * 60 * 1000,
-          callEndedMs: 2 * 60 * 1000,
+          callEndedMs: 30 * 1000,
           callAppBundleIds: callAppBundleIdsForJoinUrl(payload.joinUrl),
           scheduledEndMs,
           watchSleep: true,

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -410,6 +410,8 @@ export function useMeetingTranscription({
         };
         sessionRef.current = session;
         startedSession = session;
+        const sessionIsActive = () =>
+          sessionRef.current === session && !session.stopping;
 
         const scheduleFlush = () => {
           if (session.flushTimer) window.clearTimeout(session.flushTimer);
@@ -520,6 +522,7 @@ export function useMeetingTranscription({
           scheduledEnd?: string | null;
           recording?: { id?: string | null } | null;
         }>("start-meeting-recording", { meetingId });
+        if (!sessionIsActive()) throw MEETING_START_CANCELLED;
         const resolvedMeetingId = result.meetingId ?? meetingId;
         const recordingId = result.recording?.id;
         if (!recordingId) {
@@ -737,7 +740,7 @@ export function useMeetingTranscription({
         // tray, indicator, and pill state below would repoint all three at the
         // meeting the user just left. Every other continuation in this function
         // guards the same way.
-        if (sessionRef.current !== session) {
+        if (!sessionIsActive()) {
           await stopTranscriptionEngine(startedEngine).catch(() => {});
           liveEngine = null;
           if (historyPreparedRef.current) {
@@ -778,6 +781,7 @@ export function useMeetingTranscription({
             mode: "meeting",
           }),
         ]);
+        if (!sessionIsActive()) throw MEETING_START_CANCELLED;
         if (pendingPillInitRef.current?.meetingId === resolvedMeetingId) {
           pendingPillInitRef.current = {
             ...pendingPillInitRef.current,
@@ -847,9 +851,16 @@ export function useMeetingTranscription({
           session.historyInFlight = historyPromise;
         }
 
+        if (!sessionIsActive()) throw MEETING_START_CANCELLED;
         await invoke("silence_detector_start", {
           config: silenceDetectorConfig,
         }).catch(() => {});
+        if (!sessionIsActive()) {
+          if (sessionRef.current === session) {
+            await invoke("silence_detector_stop").catch(() => {});
+          }
+          throw MEETING_START_CANCELLED;
+        }
 
         if (payload.joinUrl && payload.reason !== "user") {
           emit("meetings:open-join-url", {

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -45,6 +45,7 @@ interface MeetingTranscriptionSession {
   stopping: boolean;
   paused: boolean;
   engine: TranscriptionEngine;
+  audioTransitionInFlight: Promise<void> | null;
   /** Offset local live-engine timestamps onto the scheduled meeting timeline. */
   liveTimelineOffsetMs: number;
   historyInFlight: Promise<void> | null;
@@ -205,6 +206,7 @@ export function useMeetingTranscription({
           window.clearTimeout(session.flushTimer);
           session.flushTimer = null;
         }
+        await session.audioTransitionInFlight?.catch(() => {});
         try {
           await stopTranscriptionEngine(session.engine);
         } catch (err) {
@@ -402,6 +404,7 @@ export function useMeetingTranscription({
           stopping: false,
           paused: false,
           engine: "whisper",
+          audioTransitionInFlight: null,
           liveTimelineOffsetMs: 0,
           historyInFlight: null,
           flushInFlight: null,
@@ -585,65 +588,75 @@ export function useMeetingTranscription({
           if (sessionRef.current !== session || session.stopping) return;
           if (desiredPaused === session.paused) return;
           applyingTransition = true;
-          try {
-            if (desiredPaused) {
-              if (session.flushTimer) {
-                window.clearTimeout(session.flushTimer);
-                session.flushTimer = null;
-              }
-              await invoke("silence_detector_stop").catch(() => {});
-              if (!sessionIsActive()) return;
-              try {
-                await stopTranscriptionEngine(session.engine);
-              } catch (err) {
+          const transition = (async () => {
+            try {
+              if (desiredPaused) {
+                if (session.flushTimer) {
+                  window.clearTimeout(session.flushTimer);
+                  session.flushTimer = null;
+                }
+                await invoke("silence_detector_stop").catch(() => {});
                 if (!sessionIsActive()) return;
-                console.warn(
-                  "[clips-popover] meeting audio pause failed; staying live:",
-                  err,
-                );
-                desiredPaused = false;
+                try {
+                  await stopTranscriptionEngine(session.engine);
+                } catch (err) {
+                  if (!sessionIsActive()) return;
+                  console.warn(
+                    "[clips-popover] meeting audio pause failed; staying live:",
+                    err,
+                  );
+                  desiredPaused = false;
+                  session.paused = false;
+                  await invoke("silence_detector_start", {
+                    config: silenceDetectorConfig,
+                  }).catch(() => {});
+                  if (!sessionIsActive()) await stopStaleAudioTransition();
+                  return;
+                }
+                if (!sessionIsActive()) return;
+                await flushTranscript().catch(() => {});
+                if (!sessionIsActive()) return;
+                session.paused = true;
+              } else {
+                try {
+                  await startAudio();
+                } catch (err) {
+                  console.warn(
+                    "[clips-popover] meeting audio resume failed; staying paused:",
+                    err,
+                  );
+                  if (!sessionIsActive()) return;
+                  desiredPaused = true;
+                  session.paused = true;
+                  return;
+                }
+                if (!sessionIsActive()) {
+                  await stopStaleAudioTransition();
+                  return;
+                }
                 session.paused = false;
                 await invoke("silence_detector_start", {
                   config: silenceDetectorConfig,
                 }).catch(() => {});
                 if (!sessionIsActive()) await stopStaleAudioTransition();
-                return;
               }
-              if (!sessionIsActive()) return;
-              await flushTranscript().catch(() => {});
-              if (!sessionIsActive()) return;
-              session.paused = true;
-            } else {
-              try {
-                await startAudio();
-              } catch (err) {
-                console.warn(
-                  "[clips-popover] meeting audio resume failed; staying paused:",
-                  err,
-                );
-                if (!sessionIsActive()) return;
-                desiredPaused = true;
-                session.paused = true;
-                return;
-              }
-              if (!sessionIsActive()) {
-                await stopStaleAudioTransition();
-                return;
-              }
-              session.paused = false;
-              await invoke("silence_detector_start", {
-                config: silenceDetectorConfig,
-              }).catch(() => {});
-              if (!sessionIsActive()) await stopStaleAudioTransition();
+            } finally {
+              applyingTransition = false;
             }
+          })();
+          session.audioTransitionInFlight = transition;
+          try {
+            await transition;
           } finally {
-            applyingTransition = false;
-            // Re-check for any desiredPaused change queued while this
-            // transition was in flight — including the two early-return
-            // error-recovery branches above, which otherwise skipped this
-            // reconvergence and could leave a queued pause/resume request
-            // unapplied until another external event happened to fire.
-            void applyAudioState();
+            if (session.audioTransitionInFlight === transition) {
+              session.audioTransitionInFlight = null;
+              // Re-check for any desiredPaused change queued while this
+              // transition was in flight — including the two early-return
+              // error-recovery branches above, which otherwise skipped this
+              // reconvergence and could leave a queued pause/resume request
+              // unapplied until another external event happened to fire.
+              void applyAudioState();
+            }
           }
         };
 

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -477,6 +477,9 @@ export function useMeetingTranscription({
         });
         if (sessionRef.current !== session || session.stopping) {
           autoStopUnlisten();
+          // Route stale startup through the existing cleanup path so a
+          // replacement cannot leave a microphone or server row behind.
+          throw new Error("Meeting start cancelled.");
         } else {
           session.unlisten.push(autoStopUnlisten);
         }

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -558,9 +558,10 @@ export function useMeetingTranscription({
         // the engine choice was already made below). Rust prefers one combined
         // SCK stream and uses bypassed VoiceProcessingIO only for legacy/failure
         // fallback, so the transcript stays live without changing call volume.
-        const startAudio = async () => {
+        const startAudio = async (): Promise<TranscriptionEngine> => {
+          const engine = session.engine;
           await restartTranscriptionEngine(
-            session.engine,
+            engine,
             {
               deviceId: selectedMicId,
               label: selectedMicLabel,
@@ -568,6 +569,7 @@ export function useMeetingTranscription({
             true,
             false,
           );
+          return engine;
         };
 
         const stopStaleAudioTransition = async () => {
@@ -618,8 +620,9 @@ export function useMeetingTranscription({
                 if (!sessionIsActive()) return;
                 session.paused = true;
               } else {
+                let resumedEngine: TranscriptionEngine;
                 try {
-                  await startAudio();
+                  resumedEngine = await startAudio();
                 } catch (err) {
                   console.warn(
                     "[clips-popover] meeting audio resume failed; staying paused:",
@@ -631,6 +634,11 @@ export function useMeetingTranscription({
                   return;
                 }
                 if (!sessionIsActive()) {
+                  // stopTranscription waits for this transition before a
+                  // replacement can claim the global audio engine. Keep the
+                  // concrete engine returned by the resume so a late start
+                  // cannot be orphaned during that handoff.
+                  await stopTranscriptionEngine(resumedEngine).catch(() => {});
                   await stopStaleAudioTransition();
                   return;
                 }

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -88,6 +88,18 @@ interface Props {
   selectedMicLabel: string | null;
 }
 
+const MEETING_START_CANCELLED = Symbol("meeting-start-cancelled");
+
+function unlistenAll(unlisteners: Array<() => void>): void {
+  for (const unlisten of unlisteners) {
+    try {
+      unlisten();
+    } catch {
+      continue;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -198,13 +210,7 @@ export function useMeetingTranscription({
         } catch (err) {
           console.warn("[clips-popover] meeting audio stop failed:", err);
         }
-        session.unlisten.splice(0).forEach((unlisten) => {
-          try {
-            unlisten();
-          } catch {
-            // ignore
-          }
-        });
+        unlistenAll(session.unlisten.splice(0));
         await invoke("silence_detector_stop").catch(() => {});
         await stopMeetingBeforeTranscriptFlush({
           // Stamp actualEnd as soon as capture is torn down. Transcript
@@ -479,10 +485,9 @@ export function useMeetingTranscription({
           autoStopUnlisten();
           // Route stale startup through the existing cleanup path so a
           // replacement cannot leave a microphone or server row behind.
-          throw new Error("Meeting start cancelled.");
-        } else {
-          session.unlisten.push(autoStopUnlisten);
+          throw MEETING_START_CANCELLED;
         }
+        session.unlisten.push(autoStopUnlisten);
 
         // Creating the row and starting the audio engine need nothing from each
         // other — only the flush needs a recording id. Kicking the engine here
@@ -854,6 +859,10 @@ export function useMeetingTranscription({
 
         emit("meetings:hide-notification", { meetingId }).catch(() => {});
       } catch (err) {
+        if (startedSession) {
+          startedSession.stopping = true;
+          unlistenAll(startedSession.unlisten.splice(0));
+        }
         // The engine can be live even though the start failed: it runs in
         // parallel with the row creation, and startup continues for a while
         // after it comes up. Leaving it would hold the microphone for a session
@@ -902,12 +911,14 @@ export function useMeetingTranscription({
             meetingId: startedSession.meetingId,
           }).catch(() => {});
         }
-        const message =
-          err instanceof Error ? err.message : "Could not start notes.";
-        emit("meetings:transcription-error", {
-          meetingId,
-          error: message,
-        }).catch(() => {});
+        if (err !== MEETING_START_CANCELLED) {
+          const message =
+            err instanceof Error ? err.message : "Could not start notes.";
+          emit("meetings:transcription-error", {
+            meetingId,
+            error: message,
+          }).catch(() => {});
+        }
       }
     },
     [

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -1003,12 +1003,11 @@ export function useMeetingTranscription({
   const startInFlightRef = useRef<Promise<void> | null>(null);
   const startTranscription = useCallback(
     async (payload: MeetingTranscriptionPayload) => {
-      const previous = startInFlightRef.current;
-      const run = (async () => {
-        // A failed start must not stop the next one from running.
-        if (previous) await previous.catch(() => {});
-        await runStartTranscription(payload);
-      })();
+      // Chain from the latest queued run, not a snapshot taken before another
+      // caller publishes its own run. This keeps B and C serialized behind A.
+      const run = (startInFlightRef.current ?? Promise.resolve())
+        .catch(() => {})
+        .then(() => runStartTranscription(payload));
       startInFlightRef.current = run;
       try {
         await run;

--- a/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
+++ b/templates/clips/desktop/src/hooks/useMeetingTranscription.ts
@@ -522,14 +522,17 @@ export function useMeetingTranscription({
           scheduledEnd?: string | null;
           recording?: { id?: string | null } | null;
         }>("start-meeting-recording", { meetingId });
-        if (!sessionIsActive()) throw MEETING_START_CANCELLED;
         const resolvedMeetingId = result.meetingId ?? meetingId;
         const recordingId = result.recording?.id;
+        // The action may materialize a virtual calendar meeting before the
+        // session becomes stale. Preserve the concrete IDs before aborting so
+        // the failure path closes the row it actually created.
+        session.meetingId = resolvedMeetingId;
+        session.recordingId = recordingId ?? null;
+        if (!sessionIsActive()) throw MEETING_START_CANCELLED;
         if (!recordingId) {
           throw new Error("Could not create a transcript session.");
         }
-        session.meetingId = resolvedMeetingId;
-        session.recordingId = recordingId;
 
         const parsedScheduledEndMs = result.scheduledEnd
           ? Date.parse(result.scheduledEnd)
@@ -564,6 +567,15 @@ export function useMeetingTranscription({
           );
         };
 
+        const stopStaleAudioTransition = async () => {
+          if (sessionRef.current !== session) return;
+          await stopTranscriptionEngine(session.engine).catch(() => {});
+          // The detector is global. Do not stop a newer session that took
+          // ownership while the engine stop was in flight.
+          if (sessionRef.current !== session) return;
+          await invoke("silence_detector_stop").catch(() => {});
+        };
+
         // Pause/resume state machine — see app.tsx for full explanation.
         let desiredPaused = false;
         let applyingTransition = false;
@@ -580,9 +592,11 @@ export function useMeetingTranscription({
                 session.flushTimer = null;
               }
               await invoke("silence_detector_stop").catch(() => {});
+              if (!sessionIsActive()) return;
               try {
                 await stopTranscriptionEngine(session.engine);
               } catch (err) {
+                if (!sessionIsActive()) return;
                 console.warn(
                   "[clips-popover] meeting audio pause failed; staying live:",
                   err,
@@ -592,9 +606,12 @@ export function useMeetingTranscription({
                 await invoke("silence_detector_start", {
                   config: silenceDetectorConfig,
                 }).catch(() => {});
+                if (!sessionIsActive()) await stopStaleAudioTransition();
                 return;
               }
+              if (!sessionIsActive()) return;
               await flushTranscript().catch(() => {});
+              if (!sessionIsActive()) return;
               session.paused = true;
             } else {
               try {
@@ -604,14 +621,20 @@ export function useMeetingTranscription({
                   "[clips-popover] meeting audio resume failed; staying paused:",
                   err,
                 );
+                if (!sessionIsActive()) return;
                 desiredPaused = true;
                 session.paused = true;
+                return;
+              }
+              if (!sessionIsActive()) {
+                await stopStaleAudioTransition();
                 return;
               }
               session.paused = false;
               await invoke("silence_detector_start", {
                 config: silenceDetectorConfig,
               }).catch(() => {});
+              if (!sessionIsActive()) await stopStaleAudioTransition();
             }
           } finally {
             applyingTransition = false;

--- a/templates/clips/desktop/src/lib/silence-events.ts
+++ b/templates/clips/desktop/src/lib/silence-events.ts
@@ -6,8 +6,8 @@
  *  - `meetings:silence-stop` — both mic + system audio have been silent for N
  *    minutes (default 15).
  *  - `meetings:sleep-stop`   — the machine slept (clock-jump heuristic).
- *  - `meetings:call-ended`   — the foreground video-conferencing app
- *    backgrounded for >2 minutes.
+ *  - `meetings:call-ended`   — the conferencing app released its microphone
+ *    with quiet system audio, or the scheduled meeting end was reached.
  *
  * Renderer wires `startSilenceDetector` when a meeting becomes live and
  * `stopSilenceDetector` when it ends. `subscribeAutoStop` returns an

--- a/templates/clips/desktop/src/lib/silence-events.ts
+++ b/templates/clips/desktop/src/lib/silence-events.ts
@@ -47,14 +47,7 @@ export async function subscribeAutoStop(
   onStop: (reason: AutoStopReason) => void,
 ): Promise<UnlistenFn> {
   const unlisteners: UnlistenFn[] = [];
-  unlisteners.push(
-    await listen("meetings:silence-stop", () => onStop("silence")),
-  );
-  unlisteners.push(await listen("meetings:sleep-stop", () => onStop("sleep")));
-  unlisteners.push(
-    await listen("meetings:call-ended", () => onStop("call-ended")),
-  );
-  return () => {
+  const unlistenAll = () => {
     for (const u of unlisteners) {
       try {
         u();
@@ -63,6 +56,21 @@ export async function subscribeAutoStop(
       }
     }
   };
+  try {
+    unlisteners.push(
+      await listen("meetings:silence-stop", () => onStop("silence")),
+    );
+    unlisteners.push(
+      await listen("meetings:sleep-stop", () => onStop("sleep")),
+    );
+    unlisteners.push(
+      await listen("meetings:call-ended", () => onStop("call-ended")),
+    );
+    return unlistenAll;
+  } catch (error) {
+    unlistenAll();
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- use verified conferencing-app microphone release plus quiet system audio as the primary call-end signal
- stop treating a foreground-to-background app switch as proof that a meeting ended
- shorten calendar-end confirmation, match browser helper processes, and register native auto-stop listeners before capture starts

## Validation
- `pnpm typecheck` (desktop)
- `pnpm test` (desktop: 42 files, 260 tests)
- `pnpm build` (desktop)
- `cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml silence_detector -- --nocapture`
- `cargo test --manifest-path templates/clips/desktop/src-tauri/Cargo.toml call_activity::tests -- --nocapture`
- `CLIPS_DESKTOP_LOCAL_BUILD=1 pnpm tauri build --debug --config ...`
- `pnpm guards` (66 checks)