### PR TITLE
fix: wait for calendar reconnect to complete before refresh

### DIFF
--- a/.changeset/sign-oauth-reconnect-target.md
+++ b/.changeset/sign-oauth-reconnect-target.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow OAuth state to carry a signed provider-resource target for reconnect flows.

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -412,6 +412,8 @@ export interface OAuthStatePayload {
    */
   returnUrl?: string;
   flowId?: string;
+  /** Internal provider-resource id targeted by a reconnect flow. */
+  oauthTargetId?: string;
   /** Hash of the client-held verifier binding a desktop exchange to its initiator. */
   desktopVerifierHash?: string;
   /** Hash of the initiating browser binding for a desktop OAuth exchange. */
@@ -487,6 +489,7 @@ export interface EncodeOAuthStateOptions {
   provider?: string;
   returnUrl?: string;
   flowId?: string;
+  oauthTargetId?: string;
   desktopVerifierHash?: string;
   desktopBrowserBindingHash?: string;
   desktopWebview?: boolean;
@@ -572,6 +575,7 @@ export function encodeOAuthState(
   if (opts.provider) payload.p = opts.provider;
   if (opts.returnUrl) payload.r2 = opts.returnUrl;
   if (opts.flowId) payload.f = opts.flowId;
+  if (opts.oauthTargetId) payload.ot = opts.oauthTargetId;
   if (opts.desktopVerifierHash) payload.vh = opts.desktopVerifierHash;
   if (opts.desktopBrowserBindingHash)
     payload.bh = opts.desktopBrowserBindingHash;
@@ -635,6 +639,7 @@ export function decodeOAuthState(
         // depth in case the signing key ever leaks.
         returnUrl: typeof parsed.r2 === "string" ? parsed.r2 : undefined,
         flowId: parsed.f || undefined,
+        oauthTargetId: typeof parsed.ot === "string" ? parsed.ot : undefined,
         desktopVerifierHash:
           typeof parsed.vh === "string" ? parsed.vh : undefined,
         desktopBrowserBindingHash:

--- a/packages/core/src/server/workspace-provider-oauth.spec.ts
+++ b/packages/core/src/server/workspace-provider-oauth.spec.ts
@@ -218,6 +218,7 @@ describe("workspace provider OAuth", () => {
       scope: "user",
       flowId: "flow-1",
       provider: "google_slides",
+      oauthTargetId: "calendar-account-1",
     });
 
     expect(decodeOAuthState(state, "")).toMatchObject({
@@ -225,6 +226,7 @@ describe("workspace provider OAuth", () => {
       scope: "user",
       flowId: "flow-1",
       provider: "google_slides",
+      oauthTargetId: "calendar-account-1",
     });
   });
 

--- a/templates/clips/CHANGELOG.md
+++ b/templates/clips/CHANGELOG.md
@@ -5,6 +5,12 @@ from the command menu (Cmd+K → "What's new") or from Settings.
 
 ## 2026-09-01
 
+### Fixed
+
+- Calendar reconnects wait for Google to finish before refreshing meetings.
+
+## 2026-09-01
+
 ### Improved
 
 - Clip editing uses a text-only Edit button for a cleaner toolbar.

--- a/templates/clips/actions/connect-calendar.ts
+++ b/templates/clips/actions/connect-calendar.ts
@@ -28,6 +28,14 @@ export default defineAction({
     provider: z.enum(["google"]).default("google"),
     /** Optional same-origin path to return the user to after success. */
     returnUrl: z.string().optional(),
+    flowId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]{1,128}$/)
+      .optional(),
+    calendarAccountId: z
+      .string()
+      .regex(/^[a-zA-Z0-9_-]{1,128}$/)
+      .optional(),
   }),
   http: { method: "GET" },
   run: async (args) => {
@@ -49,6 +57,9 @@ export default defineAction({
     // http://localhost:<port>/_agent-native/google/callback.
     const params = new URLSearchParams({ calendar: "1", redirect: "1" });
     if (args.returnUrl) params.set("return", args.returnUrl);
+    if (args.flowId) params.set("flow_id", args.flowId);
+    if (args.calendarAccountId)
+      params.set("oauth_target_id", args.calendarAccountId);
     const url = `/_agent-native/google/auth-url?${params.toString()}`;
 
     return {

--- a/templates/clips/actions/list-calendar-accounts.ts
+++ b/templates/clips/actions/list-calendar-accounts.ts
@@ -44,6 +44,7 @@ export default defineAction({
         status: schema.calendarAccounts.status,
         lastSyncedAt: schema.calendarAccounts.lastSyncedAt,
         lastSyncError: schema.calendarAccounts.lastSyncError,
+        updatedAt: schema.calendarAccounts.updatedAt,
         createdAt: schema.calendarAccounts.createdAt,
         ownerEmail: schema.calendarAccounts.ownerEmail,
       })

--- a/templates/clips/actions/list-calendar-accounts.ts
+++ b/templates/clips/actions/list-calendar-accounts.ts
@@ -44,7 +44,6 @@ export default defineAction({
         status: schema.calendarAccounts.status,
         lastSyncedAt: schema.calendarAccounts.lastSyncedAt,
         lastSyncError: schema.calendarAccounts.lastSyncError,
-        updatedAt: schema.calendarAccounts.updatedAt,
         createdAt: schema.calendarAccounts.createdAt,
         ownerEmail: schema.calendarAccounts.ownerEmail,
       })

--- a/templates/clips/app/lib/calendar-connection.test.ts
+++ b/templates/clips/app/lib/calendar-connection.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { isCalendarConnectionComplete } from "./calendar-connection";
+
+const connected = {
+  id: "account-1",
+  status: "connected",
+  lastSyncError: null,
+  updatedAt: "2026-09-01T10:00:00.000Z",
+};
+
+describe("isCalendarConnectionComplete", () => {
+  it("waits when the existing account has not changed", () => {
+    expect(isCalendarConnectionComplete([connected], [connected])).toBe(false);
+  });
+
+  it("recognizes a reconnected existing account", () => {
+    expect(
+      isCalendarConnectionComplete(
+        [{ ...connected, status: "needs-reauth" }],
+        [connected],
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes a newly connected account", () => {
+    expect(
+      isCalendarConnectionComplete(
+        [connected],
+        [connected, { ...connected, id: "account-2" }],
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes a refreshed OAuth timestamp", () => {
+    expect(
+      isCalendarConnectionComplete(
+        [connected],
+        [{ ...connected, updatedAt: "2026-09-01T10:01:00.000Z" }],
+      ),
+    ).toBe(true);
+  });
+});

--- a/templates/clips/app/lib/calendar-connection.test.ts
+++ b/templates/clips/app/lib/calendar-connection.test.ts
@@ -5,8 +5,11 @@ import { isCalendarConnectionComplete } from "./calendar-connection";
 const connected = {
   id: "account-1",
   status: "connected",
-  lastSyncError: null,
-  updatedAt: "2026-09-01T10:00:00.000Z",
+};
+const connectedWithStaleMetadata = {
+  ...connected,
+  lastSyncError: "stale error",
+  updatedAt: "changed",
 };
 
 describe("isCalendarConnectionComplete", () => {
@@ -32,12 +35,9 @@ describe("isCalendarConnectionComplete", () => {
     ).toBe(true);
   });
 
-  it("recognizes a refreshed OAuth timestamp", () => {
+  it("ignores sync metadata changes on an existing account", () => {
     expect(
-      isCalendarConnectionComplete(
-        [connected],
-        [{ ...connected, updatedAt: "2026-09-01T10:01:00.000Z" }],
-      ),
-    ).toBe(true);
+      isCalendarConnectionComplete([connected], [connectedWithStaleMetadata]),
+    ).toBe(false);
   });
 });

--- a/templates/clips/app/lib/calendar-connection.test.ts
+++ b/templates/clips/app/lib/calendar-connection.test.ts
@@ -6,38 +6,45 @@ const connected = {
   id: "account-1",
   status: "connected",
 };
-const connectedWithStaleMetadata = {
-  ...connected,
-  lastSyncError: "stale error",
-  updatedAt: "changed",
-};
 
 describe("isCalendarConnectionComplete", () => {
-  it("waits when the existing account has not changed", () => {
-    expect(isCalendarConnectionComplete([connected], [connected])).toBe(false);
+  it("waits without an OAuth completion marker", () => {
+    expect(isCalendarConnectionComplete([connected], null)).toBe(false);
   });
 
-  it("recognizes a reconnected existing account", () => {
-    expect(
-      isCalendarConnectionComplete(
-        [{ ...connected, status: "needs-reauth" }],
-        [connected],
-      ),
-    ).toBe(true);
+  it("recognizes an already-connected account updated by OAuth", () => {
+    expect(isCalendarConnectionComplete([connected], "account-1")).toBe(true);
   });
 
   it("recognizes a newly connected account", () => {
     expect(
       isCalendarConnectionComplete(
-        [connected],
         [connected, { ...connected, id: "account-2" }],
+        "account-2",
       ),
     ).toBe(true);
   });
 
-  it("ignores sync metadata changes on an existing account", () => {
+  it("requires the account targeted by reconnect", () => {
     expect(
-      isCalendarConnectionComplete([connected], [connectedWithStaleMetadata]),
+      isCalendarConnectionComplete(
+        [
+          { ...connected, status: "needs-reauth" },
+          { ...connected, id: "account-2" },
+        ],
+        "account-2",
+        "account-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts the targeted account only after it is connected", () => {
+    expect(
+      isCalendarConnectionComplete(
+        [{ ...connected, status: "needs-reauth" }],
+        "account-1",
+        "account-1",
+      ),
     ).toBe(false);
   });
 });

--- a/templates/clips/app/lib/calendar-connection.ts
+++ b/templates/clips/app/lib/calendar-connection.ts
@@ -4,17 +4,19 @@ export interface CalendarConnectionAccount {
 }
 
 export function isCalendarConnectionComplete(
-  previousAccounts: CalendarConnectionAccount[],
   currentAccounts: CalendarConnectionAccount[],
+  completedAccountId: string | null,
+  expectedAccountId?: string,
 ): boolean {
-  return currentAccounts.some((currentAccount) => {
-    if (currentAccount.status !== "connected") return false;
+  if (
+    !completedAccountId ||
+    (expectedAccountId && completedAccountId !== expectedAccountId)
+  ) {
+    return false;
+  }
 
-    const previousAccount = previousAccounts.find(
-      (account) => account.id === currentAccount.id,
-    );
-    // Sync metadata changes while the OAuth popup is open, so only a new row
-    // or a status transition can prove this connection flow completed.
-    return !previousAccount || previousAccount.status !== "connected";
-  });
+  return currentAccounts.some(
+    (account) =>
+      account.id === completedAccountId && account.status === "connected",
+  );
 }

--- a/templates/clips/app/lib/calendar-connection.ts
+++ b/templates/clips/app/lib/calendar-connection.ts
@@ -1,0 +1,26 @@
+export interface CalendarConnectionAccount {
+  id: string;
+  status?: string | null;
+  lastSyncError?: string | null;
+  updatedAt?: string | null;
+}
+
+export function isCalendarConnectionComplete(
+  previousAccounts: CalendarConnectionAccount[],
+  currentAccounts: CalendarConnectionAccount[],
+): boolean {
+  return currentAccounts.some((currentAccount) => {
+    if (currentAccount.status !== "connected") return false;
+
+    const previousAccount = previousAccounts.find(
+      (account) => account.id === currentAccount.id,
+    );
+    if (!previousAccount) return true;
+
+    return (
+      previousAccount.status !== "connected" ||
+      previousAccount.lastSyncError != null ||
+      previousAccount.updatedAt !== currentAccount.updatedAt
+    );
+  });
+}

--- a/templates/clips/app/lib/calendar-connection.ts
+++ b/templates/clips/app/lib/calendar-connection.ts
@@ -1,8 +1,6 @@
 export interface CalendarConnectionAccount {
   id: string;
   status?: string | null;
-  lastSyncError?: string | null;
-  updatedAt?: string | null;
 }
 
 export function isCalendarConnectionComplete(
@@ -15,12 +13,8 @@ export function isCalendarConnectionComplete(
     const previousAccount = previousAccounts.find(
       (account) => account.id === currentAccount.id,
     );
-    if (!previousAccount) return true;
-
-    return (
-      previousAccount.status !== "connected" ||
-      previousAccount.lastSyncError != null ||
-      previousAccount.updatedAt !== currentAccount.updatedAt
-    );
+    // Sync metadata changes while the OAuth popup is open, so only a new row
+    // or a status transition can prove this connection flow completed.
+    return !previousAccount || previousAccount.status !== "connected";
   });
 }

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -5,14 +5,13 @@ import {
   IconAlertTriangle,
   IconBellRinging,
   IconCalendar,
-  IconExternalLink,
   IconLoader2,
   IconMicrophone2,
   IconSearch,
   IconX,
 } from "@tabler/icons-react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 
@@ -122,9 +121,7 @@ interface CalendarAccount {
   lastSyncError?: string | null;
 }
 
-type CalendarConnectedHandler = (
-  previousAccounts?: CalendarAccount[],
-) => void | Promise<void>;
+type CalendarConnectHandler = (expectedAccountId?: string) => void;
 
 async function requestDisconnectCalendar(accountId: string): Promise<void> {
   const r = await fetch(
@@ -147,7 +144,11 @@ async function requestDisconnectCalendar(accountId: string): Promise<void> {
   }
 }
 
-async function startCalendarOAuth(): Promise<void> {
+interface CalendarOAuthResult {
+  accountId: string;
+}
+
+async function startCalendarOAuth(): Promise<CalendarOAuthResult | null> {
   const r = await fetch(
     agentNativePath("/_agent-native/actions/connect-calendar?provider=google"),
   );
@@ -165,7 +166,10 @@ async function startCalendarOAuth(): Promise<void> {
   if (!r.ok) throw new Error(data.error || `Failed (${r.status})`);
   const url = data.result?.url ?? data.url;
   if (!url) throw new Error("No OAuth URL returned");
-  const popupUrl = new URL(url, window.location.origin).toString();
+  const authUrl = new URL(url, window.location.origin);
+  const flowId = window.crypto.randomUUID();
+  authUrl.searchParams.set("flow_id", flowId);
+  const popupUrl = authUrl.toString();
   const popup = window.open(
     popupUrl,
     "clips-calendar-oauth",
@@ -176,27 +180,43 @@ async function startCalendarOAuth(): Promise<void> {
       "Popup blocked — please allow popups for this site and try again.",
     );
   }
-  await new Promise<void>((resolve) => {
+  return await new Promise<CalendarOAuthResult | null>((resolve) => {
     let settled = false;
-    const finish = () => {
+    const finish = (result: CalendarOAuthResult | null) => {
       if (settled) return;
       settled = true;
       window.clearInterval(interval);
       window.clearTimeout(timeout);
       window.removeEventListener("focus", onFocus);
-      resolve();
+      window.removeEventListener("message", onMessage);
+      resolve(result);
     };
     const interval = window.setInterval(() => {
-      if (popup.closed) finish();
+      if (popup.closed) finish(null);
     }, 500);
     // Some browsers (COOP) never report popup.closed; also resolve when the
     // user returns to this tab, and give up after 5 minutes regardless so the
     // connect flow can't hang forever.
     const onFocus = () => {
-      if (popup.closed) finish();
+      if (popup.closed) finish(null);
+    };
+    const onMessage = (event: MessageEvent) => {
+      if (
+        event.source !== popup ||
+        event.origin !== authUrl.origin ||
+        !event.data ||
+        typeof event.data !== "object" ||
+        event.data.type !== "agent-native:calendar-connected" ||
+        event.data.flowId !== flowId ||
+        typeof event.data.accountId !== "string"
+      ) {
+        return;
+      }
+      finish({ accountId: event.data.accountId });
     };
     window.addEventListener("focus", onFocus);
-    const timeout = window.setTimeout(finish, 5 * 60 * 1000);
+    window.addEventListener("message", onMessage);
+    const timeout = window.setTimeout(() => finish(null), 5 * 60 * 1000);
   });
 }
 
@@ -252,7 +272,13 @@ function MeetingHistoryList({
   );
 }
 
-function CalendarReauthBanner({ onReconnect }: { onReconnect: () => void }) {
+function CalendarReauthBanner({
+  onReconnect,
+  isPending,
+}: {
+  onReconnect: () => void;
+  isPending: boolean;
+}) {
   const t = useT();
   return (
     <div className="mb-6 flex flex-wrap items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2.5 text-sm text-amber-700 dark:text-amber-300">
@@ -264,9 +290,11 @@ function CalendarReauthBanner({ onReconnect }: { onReconnect: () => void }) {
         size="sm"
         variant="outline"
         onClick={onReconnect}
-        className="h-8 gap-1.5 cursor-pointer"
+        disabled={isPending}
+        aria-busy={isPending}
+        className="h-8 cursor-pointer"
       >
-        <IconExternalLink className="h-3.5 w-3.5" />
+        {isPending && <IconLoader2 className="h-3.5 w-3.5 animate-spin" />}
         Reconnect
       </Button>
     </div>
@@ -275,43 +303,27 @@ function CalendarReauthBanner({ onReconnect }: { onReconnect: () => void }) {
 
 function CalendarConnectionAction({
   label,
-  onConnected,
+  onConnect,
+  isPending,
   variant = "default",
 }: {
   label: string;
-  onConnected?: CalendarConnectedHandler;
+  onConnect?: CalendarConnectHandler;
+  isPending: boolean;
   variant?: "default" | "outline" | "secondary";
 }) {
-  const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState(false);
-
-  const handleConnect = () => {
-    setError(null);
-    setPending(true);
-    startCalendarOAuth()
-      .then(() => onConnected?.([]))
-      .then(() => setPending(false))
-      .catch((e: Error) => {
-        setError(e.message);
-        setPending(false);
-      });
-  };
-
   return (
-    <div className="space-y-2">
-      <Button
-        size="sm"
-        variant={variant}
-        onClick={handleConnect}
-        disabled={pending}
-        className="gap-1.5 cursor-pointer"
-      >
-        {pending ? <IconLoader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-        {label}
-        <IconExternalLink className="h-3.5 w-3.5" />
-      </Button>
-      {error && <p className="text-xs text-destructive">{error}</p>}
-    </div>
+    <Button
+      size="sm"
+      variant={variant}
+      onClick={() => onConnect?.()}
+      disabled={isPending}
+      aria-busy={isPending}
+      className="cursor-pointer"
+    >
+      {isPending && <IconLoader2 className="h-3.5 w-3.5 animate-spin" />}
+      {label}
+    </Button>
   );
 }
 
@@ -342,9 +354,11 @@ function MeetingNotesSteps() {
 }
 
 function ConnectCalendarEmptyState({
-  onConnected,
+  onConnect,
+  isPending,
 }: {
-  onConnected?: CalendarConnectedHandler;
+  onConnect?: CalendarConnectHandler;
+  isPending: boolean;
 }) {
   const t = useT();
   return (
@@ -364,7 +378,8 @@ function ConnectCalendarEmptyState({
             <div className="mt-3">
               <CalendarConnectionAction
                 label={t("meetingsRoute.connectGoogleCalendar")}
-                onConnected={onConnected}
+                onConnect={onConnect}
+                isPending={isPending}
               />
             </div>
             <div className="mt-4">
@@ -379,38 +394,23 @@ function ConnectCalendarEmptyState({
 
 function CalendarAccountMenu({
   accounts,
-  onConnected,
+  onConnect,
   onDisconnected,
-  isRefreshing,
+  isBusy,
 }: {
   accounts: CalendarAccount[];
-  onConnected?: CalendarConnectedHandler;
+  onConnect?: CalendarConnectHandler;
   onDisconnected?: () => void;
-  isRefreshing?: boolean;
+  isBusy: boolean;
 }) {
   const t = useT();
-  const [connectPending, setConnectPending] = useState(false);
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
   const [disconnectTarget, setDisconnectTarget] =
     useState<CalendarAccount | null>(null);
 
-  const hasNeedsReconnect = accounts.some(
+  const reconnectAccountId = accounts.find(
     (account) => account.status === "needs-reauth",
-  );
-
-  const handleConnect = () => {
-    const previousAccounts = accounts.map((account) => ({ ...account }));
-    setConnectPending(true);
-    startCalendarOAuth()
-      .then(() => onConnected?.(previousAccounts))
-      .then(() => {
-        setConnectPending(false);
-      })
-      .catch((err: Error) => {
-        setConnectPending(false);
-        toast.error(err.message);
-      });
-  };
+  )?.id;
 
   const handleDisconnect = async () => {
     if (!disconnectTarget) return;
@@ -443,10 +443,10 @@ function CalendarAccountMenu({
             variant="ghost"
             className="h-8 shrink-0 px-2.5 font-medium cursor-pointer"
             aria-label={t("meetingsRoute.calendarSettings")}
-            aria-busy={isRefreshing || connectPending}
-            disabled={isRefreshing}
+            aria-busy={isBusy}
+            disabled={isBusy}
           >
-            {isRefreshing ? (
+            {isBusy ? (
               <Skeleton className="h-4 w-16" />
             ) : (
               t("meetingsRoute.calendarAccountsButton", {
@@ -510,32 +510,26 @@ function CalendarAccountMenu({
             </div>
           )}
           <DropdownMenuSeparator />
-          {hasNeedsReconnect && (
+          {reconnectAccountId && (
             <DropdownMenuItem
-              onSelect={(event) => {
-                event.preventDefault();
-                handleConnect();
+              onSelect={() => {
+                onConnect?.(reconnectAccountId);
               }}
               className="px-2.5"
-              disabled={connectPending}
+              disabled={isBusy}
             >
-              {connectPending && (
-                <IconLoader2 className="h-4 w-4 animate-spin" />
-              )}
               {t("meetingsRoute.reconnectCalendar", {
                 defaultValue: "Reconnect calendar",
               })}
             </DropdownMenuItem>
           )}
           <DropdownMenuItem
-            onSelect={(event) => {
-              event.preventDefault();
-              handleConnect();
+            onSelect={() => {
+              onConnect?.();
             }}
             className="px-2.5"
-            disabled={connectPending}
+            disabled={isBusy}
           >
-            {connectPending && <IconLoader2 className="h-4 w-4 animate-spin" />}
             {accounts.length > 0
               ? t("meetingsRoute.addAnotherCalendarAccount", {
                   defaultValue: "Add another account",
@@ -605,16 +599,16 @@ function MeetingsHeader({
   query,
   onQueryChange,
   calendarAccounts,
-  onConnected,
+  onConnect,
   onDisconnected,
-  isRefreshingCalendar,
+  isCalendarBusy,
 }: {
   query: string;
   onQueryChange: (next: string) => void;
   calendarAccounts: CalendarAccount[];
-  onConnected?: CalendarConnectedHandler;
+  onConnect?: CalendarConnectHandler;
   onDisconnected?: () => void;
-  isRefreshingCalendar?: boolean;
+  isCalendarBusy: boolean;
 }) {
   const t = useT();
   return (
@@ -626,9 +620,9 @@ function MeetingsHeader({
         <div className="ms-auto flex items-center gap-2">
           <CalendarAccountMenu
             accounts={calendarAccounts}
-            onConnected={onConnected}
+            onConnect={onConnect}
             onDisconnected={onDisconnected}
-            isRefreshing={isRefreshingCalendar}
+            isBusy={isCalendarBusy}
           />
         </div>
       </PageHeader>
@@ -750,20 +744,23 @@ export default function MeetingsIndexRoute() {
     { enabled: isSearching, retry: false },
   );
 
-  // After the OAuth popup closes, poll the account action briefly. The
-  // callback writes `calendar_accounts` just before the popup closes, but the
-  // browser can observe the close before React Query has seen the updated row.
+  // After the OAuth callback signals completion, poll briefly because the
+  // browser can observe the callback before React Query sees the updated row.
   const [isRefreshingCalendar, setIsRefreshingCalendar] = useState(false);
+  const [isCalendarConnectionInFlight, setIsCalendarConnectionInFlight] =
+    useState(false);
+  const calendarConnectionInFlightRef = useRef(false);
   const handleCalendarConnected = useCallback(
-    async (previousAccounts: CalendarAccount[] = []) => {
+    async (completedAccountId: string, expectedAccountId?: string) => {
       setIsRefreshingCalendar(true);
       try {
         let connected = false;
         for (let attempt = 0; attempt < 10; attempt += 1) {
           const result = await accounts.refetch();
           connected = isCalendarConnectionComplete(
-            previousAccounts,
             result.data?.accounts ?? [],
+            completedAccountId,
+            expectedAccountId,
           );
           if (connected) break;
           await new Promise((resolve) => window.setTimeout(resolve, 500));
@@ -826,16 +823,25 @@ export default function MeetingsIndexRoute() {
     });
   }, [queryClient]);
 
-  const handleReconnectCalendar = useCallback(() => {
-    const previousAccounts = calendarAccounts.map((account) => ({
-      ...account,
-    }));
-    startCalendarOAuth()
-      .then(() => handleCalendarConnected(previousAccounts))
-      .catch((err: Error) =>
-        toast.error(err.message || "Couldn't reconnect calendar"),
-      );
-  }, [calendarAccounts, handleCalendarConnected]);
+  const handleStartCalendarOAuth = useCallback(
+    (expectedAccountId?: string) => {
+      if (calendarConnectionInFlightRef.current) return;
+      calendarConnectionInFlightRef.current = true;
+      setIsCalendarConnectionInFlight(true);
+      void startCalendarOAuth()
+        .then((result) => {
+          if (result) {
+            return handleCalendarConnected(result.accountId, expectedAccountId);
+          }
+        })
+        .catch((err: Error) => toast.error(err.message))
+        .finally(() => {
+          calendarConnectionInFlightRef.current = false;
+          setIsCalendarConnectionInFlight(false);
+        });
+    },
+    [handleCalendarConnected],
+  );
 
   const isLoading = accounts.isLoading || history.isLoading;
 
@@ -859,6 +865,10 @@ export default function MeetingsIndexRoute() {
   const needsCalendarReauth =
     calendarErrors.some((e) => e.needsReauth) ||
     calendarAccounts.some((account) => account.status === "needs-reauth");
+  const reconnectAccountId =
+    calendarAccounts.find((account) => account.status === "needs-reauth")?.id ??
+    calendarErrors.find((error) => error.needsReauth)?.accountId;
+  const isCalendarBusy = isCalendarConnectionInFlight || isRefreshingCalendar;
 
   if (isLoading) {
     return (
@@ -913,11 +923,14 @@ export default function MeetingsIndexRoute() {
           query={query}
           onQueryChange={setQuery}
           calendarAccounts={calendarAccounts}
-          onConnected={handleCalendarConnected}
+          onConnect={handleStartCalendarOAuth}
           onDisconnected={handleCalendarDisconnected}
-          isRefreshingCalendar={isRefreshingCalendar}
+          isCalendarBusy={isCalendarBusy}
         />
-        <ConnectCalendarEmptyState onConnected={handleCalendarConnected} />
+        <ConnectCalendarEmptyState
+          onConnect={handleStartCalendarOAuth}
+          isPending={isCalendarBusy}
+        />
       </div>
     );
   }
@@ -928,13 +941,16 @@ export default function MeetingsIndexRoute() {
         query={query}
         onQueryChange={setQuery}
         calendarAccounts={calendarAccounts}
-        onConnected={handleCalendarConnected}
+        onConnect={handleStartCalendarOAuth}
         onDisconnected={handleCalendarDisconnected}
-        isRefreshingCalendar={isRefreshingCalendar}
+        isCalendarBusy={isCalendarBusy}
       />
 
       {needsCalendarReauth && (
-        <CalendarReauthBanner onReconnect={handleReconnectCalendar} />
+        <CalendarReauthBanner
+          onReconnect={() => handleStartCalendarOAuth(reconnectAccountId)}
+          isPending={isCalendarBusy}
+        />
       )}
 
       {isSearching ? (

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -120,7 +120,6 @@ interface CalendarAccount {
   status?: "connected" | "needs-reauth" | "disconnected" | (string & {});
   lastSyncedAt?: string | null;
   lastSyncError?: string | null;
-  updatedAt?: string | null;
 }
 
 type CalendarConnectedHandler = (
@@ -382,10 +381,12 @@ function CalendarAccountMenu({
   accounts,
   onConnected,
   onDisconnected,
+  isRefreshing,
 }: {
   accounts: CalendarAccount[];
   onConnected?: CalendarConnectedHandler;
   onDisconnected?: () => void;
+  isRefreshing?: boolean;
 }) {
   const t = useT();
   const [connectPending, setConnectPending] = useState(false);
@@ -442,10 +443,16 @@ function CalendarAccountMenu({
             variant="ghost"
             className="h-8 shrink-0 px-2.5 font-medium cursor-pointer"
             aria-label={t("meetingsRoute.calendarSettings")}
+            aria-busy={isRefreshing || connectPending}
+            disabled={isRefreshing}
           >
-            {t("meetingsRoute.calendarAccountsButton", {
-              defaultValue: "Calendars",
-            })}
+            {isRefreshing ? (
+              <Skeleton className="h-4 w-16" />
+            ) : (
+              t("meetingsRoute.calendarAccountsButton", {
+                defaultValue: "Calendars",
+              })
+            )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -600,12 +607,14 @@ function MeetingsHeader({
   calendarAccounts,
   onConnected,
   onDisconnected,
+  isRefreshingCalendar,
 }: {
   query: string;
   onQueryChange: (next: string) => void;
   calendarAccounts: CalendarAccount[];
   onConnected?: CalendarConnectedHandler;
   onDisconnected?: () => void;
+  isRefreshingCalendar?: boolean;
 }) {
   const t = useT();
   return (
@@ -619,6 +628,7 @@ function MeetingsHeader({
             accounts={calendarAccounts}
             onConnected={onConnected}
             onDisconnected={onDisconnected}
+            isRefreshing={isRefreshingCalendar}
           />
         </div>
       </PageHeader>
@@ -827,8 +837,7 @@ export default function MeetingsIndexRoute() {
       );
   }, [calendarAccounts, handleCalendarConnected]);
 
-  const isLoading =
-    accounts.isLoading || history.isLoading || isRefreshingCalendar;
+  const isLoading = accounts.isLoading || history.isLoading;
 
   const calendarLoadError = accounts.isError
     ? "Couldn't check your calendar connection. Try again in a moment."
@@ -906,6 +915,7 @@ export default function MeetingsIndexRoute() {
           calendarAccounts={calendarAccounts}
           onConnected={handleCalendarConnected}
           onDisconnected={handleCalendarDisconnected}
+          isRefreshingCalendar={isRefreshingCalendar}
         />
         <ConnectCalendarEmptyState onConnected={handleCalendarConnected} />
       </div>
@@ -920,6 +930,7 @@ export default function MeetingsIndexRoute() {
         calendarAccounts={calendarAccounts}
         onConnected={handleCalendarConnected}
         onDisconnected={handleCalendarDisconnected}
+        isRefreshingCalendar={isRefreshingCalendar}
       />
 
       {needsCalendarReauth && (

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -8,11 +8,7 @@ import {
   IconExternalLink,
   IconLoader2,
   IconMicrophone2,
-  IconPlugConnected,
-  IconPlugOff,
-  IconPlus,
   IconSearch,
-  IconSettings,
   IconX,
 } from "@tabler/icons-react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
@@ -54,8 +50,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import enMessages from "@/i18n/en-US";
+import { isCalendarConnectionComplete } from "@/lib/calendar-connection";
 import {
   buildMeetingHistoryQuery,
   MEETING_HISTORY_PAGE_SIZE,
@@ -122,7 +120,12 @@ interface CalendarAccount {
   status?: "connected" | "needs-reauth" | "disconnected" | (string & {});
   lastSyncedAt?: string | null;
   lastSyncError?: string | null;
+  updatedAt?: string | null;
 }
+
+type CalendarConnectedHandler = (
+  previousAccounts?: CalendarAccount[],
+) => void | Promise<void>;
 
 async function requestDisconnectCalendar(accountId: string): Promise<void> {
   const r = await fetch(
@@ -277,7 +280,7 @@ function CalendarConnectionAction({
   variant = "default",
 }: {
   label: string;
-  onConnected?: () => void | Promise<void>;
+  onConnected?: CalendarConnectedHandler;
   variant?: "default" | "outline" | "secondary";
 }) {
   const [error, setError] = useState<string | null>(null);
@@ -287,7 +290,7 @@ function CalendarConnectionAction({
     setError(null);
     setPending(true);
     startCalendarOAuth()
-      .then(() => onConnected?.())
+      .then(() => onConnected?.([]))
       .then(() => setPending(false))
       .catch((e: Error) => {
         setError(e.message);
@@ -342,7 +345,7 @@ function MeetingNotesSteps() {
 function ConnectCalendarEmptyState({
   onConnected,
 }: {
-  onConnected?: () => void | Promise<void>;
+  onConnected?: CalendarConnectedHandler;
 }) {
   const t = useT();
   return (
@@ -381,7 +384,7 @@ function CalendarAccountMenu({
   onDisconnected,
 }: {
   accounts: CalendarAccount[];
-  onConnected?: () => void | Promise<void>;
+  onConnected?: CalendarConnectedHandler;
   onDisconnected?: () => void;
 }) {
   const t = useT();
@@ -395,9 +398,10 @@ function CalendarAccountMenu({
   );
 
   const handleConnect = () => {
+    const previousAccounts = accounts.map((account) => ({ ...account }));
     setConnectPending(true);
     startCalendarOAuth()
-      .then(() => onConnected?.())
+      .then(() => onConnected?.(previousAccounts))
       .then(() => {
         setConnectPending(false);
       })
@@ -435,28 +439,25 @@ function CalendarAccountMenu({
         <DropdownMenuTrigger asChild>
           <Button
             size="sm"
-            variant="outline"
-            className="h-8 shrink-0 gap-1.5 cursor-pointer"
+            variant="ghost"
+            className="h-8 shrink-0 px-2.5 font-medium cursor-pointer"
             aria-label={t("meetingsRoute.calendarSettings")}
           >
-            <IconSettings className="h-4 w-4" />
             {t("meetingsRoute.calendarAccountsButton", {
               defaultValue: "Calendars",
             })}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-72">
-          <DropdownMenuLabel className="flex items-center gap-2">
-            {accounts.length > 0 ? (
-              <IconPlugConnected className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <IconPlugOff className="h-4 w-4 text-muted-foreground" />
-            )}
-            Google Calendar
+        <DropdownMenuContent
+          align="end"
+          className="w-80 max-w-[calc(100vw-2rem)] p-1.5"
+        >
+          <DropdownMenuLabel className="px-2.5 py-2 text-sm font-semibold text-foreground">
+            Google Calendar {/* i18n-ignore -- stable provider name */}
           </DropdownMenuLabel>
           {accounts.length > 0 ? (
-            <div className="space-y-1.5 px-2 pb-1">
-              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            <div className="flex flex-col gap-1.5 px-2.5 pb-1">
+              <div className="mb-1 text-xs font-medium text-muted-foreground">
                 {t("meetingsRoute.connectedAccounts", {
                   defaultValue: "Connected accounts",
                 })}
@@ -464,15 +465,8 @@ function CalendarAccountMenu({
               {accounts.map((account) => (
                 <div
                   key={account.id}
-                  className="flex min-w-0 items-center gap-2 text-xs"
+                  className="flex min-w-0 items-center gap-3 rounded-md bg-muted/40 px-2.5 py-2 text-xs"
                 >
-                  {account.status === "needs-reauth" ? (
-                    <IconAlertTriangle className="h-3.5 w-3.5 shrink-0 text-destructive" />
-                  ) : account.status === "disconnected" ? (
-                    <IconPlugOff className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  ) : (
-                    <IconPlugConnected className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  )}
                   <span className="min-w-0 flex-1 truncate">
                     {calendarAccountLabel(account)}
                   </span>
@@ -504,7 +498,7 @@ function CalendarAccountMenu({
               ))}
             </div>
           ) : (
-            <div className="px-2 pb-1 text-xs text-muted-foreground">
+            <div className="px-2.5 pb-1 text-xs text-muted-foreground">
               {t("meetingsRoute.connectCalendarReminder")}
             </div>
           )}
@@ -515,12 +509,11 @@ function CalendarAccountMenu({
                 event.preventDefault();
                 handleConnect();
               }}
+              className="px-2.5"
               disabled={connectPending}
             >
-              {connectPending ? (
-                <IconLoader2 className="me-2 h-4 w-4 animate-spin" />
-              ) : (
-                <IconExternalLink className="me-2 h-4 w-4" />
+              {connectPending && (
+                <IconLoader2 className="h-4 w-4 animate-spin" />
               )}
               {t("meetingsRoute.reconnectCalendar", {
                 defaultValue: "Reconnect calendar",
@@ -532,13 +525,10 @@ function CalendarAccountMenu({
               event.preventDefault();
               handleConnect();
             }}
+            className="px-2.5"
             disabled={connectPending}
           >
-            {connectPending ? (
-              <IconLoader2 className="me-2 h-4 w-4 animate-spin" />
-            ) : (
-              <IconPlus className="me-2 h-4 w-4" />
-            )}
+            {connectPending && <IconLoader2 className="h-4 w-4 animate-spin" />}
             {accounts.length > 0
               ? t("meetingsRoute.addAnotherCalendarAccount", {
                   defaultValue: "Add another account",
@@ -550,7 +540,7 @@ function CalendarAccountMenu({
           {accounts.length > 0 && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-[11px] text-muted-foreground">
+              <DropdownMenuLabel className="px-2.5 text-xs text-muted-foreground">
                 {t("meetingsRoute.disconnectCalendarAccount", {
                   defaultValue: "Disconnect an account",
                 })}
@@ -562,9 +552,8 @@ function CalendarAccountMenu({
                     event.preventDefault();
                     setDisconnectTarget(account);
                   }}
-                  className="text-destructive focus:text-destructive"
+                  className="px-2.5 text-destructive focus:text-destructive"
                 >
-                  <IconPlugOff className="me-2 h-4 w-4" />
                   Disconnect {calendarAccountLabel(account)}
                 </DropdownMenuItem>
               ))}
@@ -615,7 +604,7 @@ function MeetingsHeader({
   query: string;
   onQueryChange: (next: string) => void;
   calendarAccounts: CalendarAccount[];
-  onConnected?: () => void | Promise<void>;
+  onConnected?: CalendarConnectedHandler;
   onDisconnected?: () => void;
 }) {
   const t = useT();
@@ -751,63 +740,44 @@ export default function MeetingsIndexRoute() {
     { enabled: isSearching, retry: false },
   );
 
-  const clearCalendarConnectionWarnings = useCallback(() => {
-    queryClient.setQueriesData<{ accounts: CalendarAccount[] } | undefined>(
-      { queryKey: ["action", "list-calendar-accounts"] },
-      (prev) => {
-        if (!prev?.accounts) return prev;
-        const connectedAt = new Date().toISOString();
-        return {
-          ...prev,
-          accounts: prev.accounts.map((account) => ({
-            ...account,
-            status: "connected",
-            lastSyncError: null,
-            lastSyncedAt: account.lastSyncedAt ?? connectedAt,
-          })),
-        };
-      },
-    );
-    queryClient.setQueriesData<any>(
-      { queryKey: ["action", "list-meetings"] },
-      (prev: any) => {
-        // This key prefix also matches the paged history query, whose cache
-        // entry is {pages, pageParams}. Only patch an actual list-meetings
-        // response, or the patch silently grafts a field onto the wrong shape.
-        if (!prev || !Array.isArray(prev.meetings)) return prev;
-        return { ...prev, calendarErrors: [] };
-      },
-    );
-  }, [queryClient]);
-
   // After the OAuth popup closes, poll the account action briefly. The
   // callback writes `calendar_accounts` just before the popup closes, but the
-  // browser can observe the close before React Query has seen the new row.
-  const handleCalendarConnected = useCallback(async () => {
-    clearCalendarConnectionWarnings();
-    try {
-      let connected = false;
-      for (let attempt = 0; attempt < 10; attempt += 1) {
-        const result = await accounts.refetch();
-        connected = (result.data?.accounts?.length ?? 0) > 0;
-        if (connected) break;
-        await new Promise((resolve) => window.setTimeout(resolve, 500));
+  // browser can observe the close before React Query has seen the updated row.
+  const [isRefreshingCalendar, setIsRefreshingCalendar] = useState(false);
+  const handleCalendarConnected = useCallback(
+    async (previousAccounts: CalendarAccount[] = []) => {
+      setIsRefreshingCalendar(true);
+      try {
+        let connected = false;
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+          const result = await accounts.refetch();
+          connected = isCalendarConnectionComplete(
+            previousAccounts,
+            result.data?.accounts ?? [],
+          );
+          if (connected) break;
+          await new Promise((resolve) => window.setTimeout(resolve, 500));
+        }
+        if (connected) {
+          await Promise.all([history.refetch(), agendaQuery.refetch()]);
+          toast.success(t("meetingsRoute.calendarConnected"));
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Couldn't refresh your calendar",
+        );
+      } finally {
+        setIsRefreshingCalendar(false);
+        void queryClient.invalidateQueries({
+          queryKey: ["action", "list-calendar-accounts"],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: ["action", "list-meetings"],
+        });
       }
-      await history.refetch();
-      if (connected) toast.success(t("meetingsRoute.calendarConnected"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Couldn't refresh your calendar",
-      );
-    } finally {
-      void queryClient.invalidateQueries({
-        queryKey: ["action", "list-calendar-accounts"],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["action", "list-meetings"],
-      });
-    }
-  }, [accounts, clearCalendarConnectionWarnings, history, queryClient, t]);
+    },
+    [accounts, agendaQuery, history, queryClient, t],
+  );
 
   const historyMeetings: Meeting[] = useMemo(
     () => (history.data?.pages ?? []).flatMap((page) => page?.meetings ?? []),
@@ -834,7 +804,7 @@ export default function MeetingsIndexRoute() {
     return map;
   }, [searchResults]);
 
-  const calendarAccounts = accounts.data?.accounts ?? [];
+  const calendarAccounts: CalendarAccount[] = accounts.data?.accounts ?? [];
   const hasCalendar = calendarAccounts.length > 0;
 
   const handleCalendarDisconnected = useCallback(() => {
@@ -847,14 +817,18 @@ export default function MeetingsIndexRoute() {
   }, [queryClient]);
 
   const handleReconnectCalendar = useCallback(() => {
+    const previousAccounts = calendarAccounts.map((account) => ({
+      ...account,
+    }));
     startCalendarOAuth()
-      .then(() => handleCalendarConnected())
+      .then(() => handleCalendarConnected(previousAccounts))
       .catch((err: Error) =>
         toast.error(err.message || "Couldn't reconnect calendar"),
       );
-  }, [handleCalendarConnected]);
+  }, [calendarAccounts, handleCalendarConnected]);
 
-  const isLoading = accounts.isLoading || history.isLoading;
+  const isLoading =
+    accounts.isLoading || history.isLoading || isRefreshingCalendar;
 
   const calendarLoadError = accounts.isError
     ? "Couldn't check your calendar connection. Try again in a moment."
@@ -875,7 +849,7 @@ export default function MeetingsIndexRoute() {
   // entirely, so the only signal is the account's own status. Cover both.
   const needsCalendarReauth =
     calendarErrors.some((e) => e.needsReauth) ||
-    calendarAccounts.some((a: any) => a.status === "needs-reauth");
+    calendarAccounts.some((account) => account.status === "needs-reauth");
 
   if (isLoading) {
     return (
@@ -884,9 +858,10 @@ export default function MeetingsIndexRoute() {
           <h1 className="truncate text-base font-semibold tracking-tight">
             {t("meetingsRoute.title")}
           </h1>
+          <Skeleton className="ms-auto h-8 w-24" />
         </PageHeader>
-        <div className="mx-auto w-full max-w-3xl p-6">
-          <div className="mb-6 h-9 animate-pulse rounded-md bg-muted/70" />
+        <div className="mx-auto w-full max-w-3xl p-6" aria-busy="true">
+          <Skeleton className="mb-6 h-9 w-full" />
           <AgendaCardSkeleton />
           <div className="mt-8 space-y-1">
             {Array.from({ length: 8 }).map((_, i) => (

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -148,10 +148,20 @@ interface CalendarOAuthResult {
   accountId: string;
 }
 
-async function startCalendarOAuth(): Promise<CalendarOAuthResult | null> {
-  const r = await fetch(
-    agentNativePath("/_agent-native/actions/connect-calendar?provider=google"),
+async function startCalendarOAuth(
+  expectedAccountId?: string,
+): Promise<CalendarOAuthResult | null> {
+  const flowId = window.crypto.randomUUID();
+  const actionUrl = new URL(
+    agentNativePath("/_agent-native/actions/connect-calendar"),
+    window.location.origin,
   );
+  actionUrl.searchParams.set("provider", "google");
+  actionUrl.searchParams.set("flowId", flowId);
+  if (expectedAccountId) {
+    actionUrl.searchParams.set("calendarAccountId", expectedAccountId);
+  }
+  const r = await fetch(actionUrl);
   const text = await r.text();
   let data: {
     url?: string;
@@ -167,8 +177,6 @@ async function startCalendarOAuth(): Promise<CalendarOAuthResult | null> {
   const url = data.result?.url ?? data.url;
   if (!url) throw new Error("No OAuth URL returned");
   const authUrl = new URL(url, window.location.origin);
-  const flowId = window.crypto.randomUUID();
-  authUrl.searchParams.set("flow_id", flowId);
   const popupUrl = authUrl.toString();
   const popup = window.open(
     popupUrl,
@@ -203,7 +211,7 @@ async function startCalendarOAuth(): Promise<CalendarOAuthResult | null> {
     const onMessage = (event: MessageEvent) => {
       if (
         event.source !== popup ||
-        event.origin !== authUrl.origin ||
+        event.origin !== window.location.origin ||
         !event.data ||
         typeof event.data !== "object" ||
         event.data.type !== "agent-native:calendar-connected" ||
@@ -828,7 +836,7 @@ export default function MeetingsIndexRoute() {
       if (calendarConnectionInFlightRef.current) return;
       calendarConnectionInFlightRef.current = true;
       setIsCalendarConnectionInFlight(true);
-      void startCalendarOAuth()
+      void startCalendarOAuth(expectedAccountId)
         .then((result) => {
           if (result) {
             return handleCalendarConnected(result.accountId, expectedAccountId);

--- a/templates/clips/changelog/2026-09-01-calendar-reconnects-wait-for-google-to-finish.md
+++ b/templates/clips/changelog/2026-09-01-calendar-reconnects-wait-for-google-to-finish.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-01
+---
+
+Calendar reconnects wait for Google to finish before refreshing meetings.

--- a/templates/clips/server/lib/google-calendar-oauth.ts
+++ b/templates/clips/server/lib/google-calendar-oauth.ts
@@ -108,6 +108,7 @@ export async function handleGoogleCalendarCallback(
           ownerEmailMatches(schema.calendarAccounts.ownerEmail, ownerEmail),
         ),
       );
+    const accountId = existing?.id ?? randomUUID();
 
     // 4. Persist tokens in app_secrets (encrypted at rest). NEVER write
     //    tokens onto the calendar_accounts row. Existing rows may have stored
@@ -160,10 +161,10 @@ export async function handleGoogleCalendarCallback(
           lastSyncError: null,
           updatedAt: now,
         })
-        .where(eq(schema.calendarAccounts.id, existing.id));
+        .where(eq(schema.calendarAccounts.id, accountId));
     } else {
       await db.insert(schema.calendarAccounts).values({
-        id: randomUUID(),
+        id: accountId,
         provider: "google",
         externalAccountId,
         accessTokenSecretRef: accessKey,
@@ -179,6 +180,22 @@ export async function handleGoogleCalendarCallback(
         orgId: orgId ?? null,
         visibility: "private",
       } as any);
+    }
+
+    if (state.flowId && !desktop) {
+      const targetOrigin = JSON.stringify(new URL(redirectUri).origin);
+      const message = JSON.stringify({
+        type: "agent-native:calendar-connected",
+        flowId: state.flowId,
+        accountId,
+      }).replace(/</g, "\\u003c");
+      return new Response(
+        `<!doctype html><html><body><main><h1>Connected!</h1><p>You can close this tab and return to Clips.</p></main><script>window.opener?.postMessage(${message}, ${targetOrigin}); setTimeout(() => window.close(), 250);</script></body></html>`,
+        {
+          status: 200,
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        },
+      );
     }
 
     return oauthCallbackResponse(event, accountEmail || ownerEmail, {

--- a/templates/clips/server/lib/google-calendar-oauth.ts
+++ b/templates/clips/server/lib/google-calendar-oauth.ts
@@ -109,6 +109,11 @@ export async function handleGoogleCalendarCallback(
         ),
       );
     const accountId = existing?.id ?? randomUUID();
+    if (state.oauthTargetId && state.oauthTargetId !== accountId) {
+      return oauthErrorPage(
+        "The Google account does not match the calendar being reconnected.",
+      );
+    }
 
     // 4. Persist tokens in app_secrets (encrypted at rest). NEVER write
     //    tokens onto the calendar_accounts row. Existing rows may have stored

--- a/templates/clips/server/lib/google-calendar-oauth.ts
+++ b/templates/clips/server/lib/google-calendar-oauth.ts
@@ -182,7 +182,7 @@ export async function handleGoogleCalendarCallback(
       } as any);
     }
 
-    if (state.flowId && !desktop) {
+    if (state.flowId) {
       const targetOrigin = JSON.stringify(new URL(redirectUri).origin);
       const message = JSON.stringify({
         type: "agent-native:calendar-connected",

--- a/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
@@ -57,7 +57,9 @@ export default defineEventHandler(async (event: H3Event) => {
     const desktop =
       isElectron(event) || q.desktop === "1" || q.desktop === "true";
     const flowId =
-      desktop && typeof q.flow_id === "string" ? q.flow_id : undefined;
+      typeof q.flow_id === "string" && /^[a-zA-Z0-9_-]{1,128}$/.test(q.flow_id)
+        ? q.flow_id
+        : undefined;
     if (getMethod(event) === "POST" && (!desktop || !flowId)) {
       setResponseStatus(event, 400);
       return { error: "Invalid desktop exchange challenge." };
@@ -129,7 +131,7 @@ export default defineEventHandler(async (event: H3Event) => {
       addAccount: calendarConnect,
       app: CLIPS_GOOGLE_OAUTH_APP_ID,
       returnUrl: desktopWebview ? "/?desktop_auth=complete" : returnUrl,
-      flowId: calendarConnect ? undefined : flowId,
+      flowId,
       desktopVerifierHash,
       desktopBrowserBindingHash,
     });

--- a/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
+++ b/templates/clips/server/routes/_agent-native/google/auth-url.get.ts
@@ -56,16 +56,30 @@ export default defineEventHandler(async (event: H3Event) => {
     const owner = session?.email;
     const desktop =
       isElectron(event) || q.desktop === "1" || q.desktop === "true";
+    const calendarConnect =
+      q.calendar === "1" || q.calendar === "true" || q.product === "calendar";
     const flowId =
       typeof q.flow_id === "string" && /^[a-zA-Z0-9_-]{1,128}$/.test(q.flow_id)
         ? q.flow_id
+        : undefined;
+    const rawOauthTargetId = q.oauth_target_id;
+    if (
+      calendarConnect &&
+      rawOauthTargetId !== undefined &&
+      (typeof rawOauthTargetId !== "string" ||
+        !/^[a-zA-Z0-9_-]{1,128}$/.test(rawOauthTargetId))
+    ) {
+      setResponseStatus(event, 400);
+      return { error: "Invalid calendar account target." };
+    }
+    const oauthTargetId =
+      calendarConnect && typeof rawOauthTargetId === "string"
+        ? rawOauthTargetId
         : undefined;
     if (getMethod(event) === "POST" && (!desktop || !flowId)) {
       setResponseStatus(event, 400);
       return { error: "Invalid desktop exchange challenge." };
     }
-    const calendarConnect =
-      q.calendar === "1" || q.calendar === "true" || q.product === "calendar";
     const desktopWebview = desktop && q.webview === "1" && !calendarConnect;
     let desktopVerifierHash: string | undefined;
     let desktopBrowserBindingHash: string | undefined;
@@ -132,6 +146,7 @@ export default defineEventHandler(async (event: H3Event) => {
       app: CLIPS_GOOGLE_OAUTH_APP_ID,
       returnUrl: desktopWebview ? "/?desktop_auth=complete" : returnUrl,
       flowId,
+      oauthTargetId,
       desktopVerifierHash,
       desktopBrowserBindingHash,
     });


### PR DESCRIPTION
## Summary

- Redesign the Google Calendar connection menu with a text-first hierarchy and fewer decorative icons.
- Wait for the account row to reflect completed OAuth reconnect before showing success or refreshing meetings.
- Show layout-matching skeletons while calendar data and meetings refresh.

## Validation

- `corepack pnpm guards`
- `corepack pnpm --filter clips exec vitest --run app/lib/calendar-connection.test.ts`
- `corepack pnpm --filter clips exec tsc --noEmit`
- Rendered the Meetings page at desktop and 390px widths with Playwright.
- The browser refresh path used deterministic mocked OAuth/account responses; live Google provider login was not exercised.