### PR TITLE
perf: speed up agent model picker

### DIFF
--- a/.changeset/model-catalog-prefetch.md
+++ b/.changeset/model-catalog-prefetch.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Batch provider credential reads while building the model catalog.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -4252,6 +4252,9 @@ export function AgentToggleButton({ className }: { className?: string }) {
         <button
           type="button"
           aria-label={t("agentPanel.toggleAgent")}
+          onPointerEnter={() => void preloadAgentChatSurface()}
+          onFocus={() => void preloadAgentChatSurface()}
+          onPointerDown={() => void preloadAgentChatSurface()}
           onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
           className={cn(
             "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 
 describe("list-agent-engines", () => {
+  let readAppSecrets: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
@@ -18,9 +20,52 @@ describe("list-agent-engines", () => {
     vi.doMock("../../agent/app-model-defaults.js", () => ({
       getAgentAppModelDefaultForCurrentRequest: vi.fn().mockResolvedValue(null),
     }));
+    readAppSecrets = vi.fn().mockResolvedValue(new Map());
     vi.doMock("../../secrets/storage.js", () => ({
       readAppSecret: vi.fn().mockResolvedValue(null),
+      readAppSecrets,
     }));
+  });
+
+  it("prefetches installed provider keys in one catalog batch", async () => {
+    const { registerAgentEngine } = await import("../../agent/engine/index.js");
+    const { runWithRequestContext } =
+      await import("../../server/request-context.js");
+    const { run } = await import("./list-agent-engines.js");
+
+    registerAgentEngine({
+      name: "test:openai",
+      label: "OpenAI Test",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "gpt-test",
+      supportedModels: ["gpt-test"],
+      requiredEnvVars: ["OPENAI_API_KEY"],
+      create: vi.fn() as any,
+    });
+    registerAgentEngine({
+      name: "test:anthropic",
+      label: "Anthropic Test",
+      description: "",
+      capabilities: {} as any,
+      defaultModel: "claude-test",
+      supportedModels: ["claude-test"],
+      requiredEnvVars: ["ANTHROPIC_API_KEY"],
+      create: vi.fn() as any,
+    });
+
+    await runWithRequestContext(
+      { userEmail: "catalog@example.com", orgId: "org-catalog" },
+      () => run(),
+    );
+
+    expect(
+      readAppSecrets.mock.calls.some(
+        ([args]) =>
+          args.keys.includes("OPENAI_API_KEY") &&
+          args.keys.includes("ANTHROPIC_API_KEY"),
+      ),
+    ).toBe(true);
   });
 
   it("does not report AGENT_ENGINE as current when its optional package is missing", async () => {

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -17,6 +17,7 @@ import {
 } from "../../agent/engine/index.js";
 import type { ActionTool } from "../../agent/types.js";
 import { getAppConfig } from "../../app-config/index.js";
+import { prefetchSecrets } from "../../server/credential-provider.js";
 import { getSetting } from "../../settings/index.js";
 
 export const tool: ActionTool = {
@@ -33,6 +34,16 @@ export async function run(args: Record<string, string> = {}): Promise<string> {
   registerBuiltinEngines();
 
   const engines = listAgentEngines();
+  await prefetchSecrets([
+    ...new Set(
+      engines
+        .filter(
+          (entry) =>
+            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
+        )
+        .flatMap((entry) => entry.requiredEnvVars),
+    ),
+  ]);
   const currentSetting = await getSetting("agent-engine");
   const current = currentSetting
     ? (currentSetting as { engine?: string; model?: string })


### PR DESCRIPTION
## Summary
- Preload the lazy chat surface on agent-toggle intent so the first open does not begin a large chunk fetch after the click.
- Batch installed non-Builder provider credential reads before the model catalog resolves stored and per-engine readiness.
- Add focused coverage and a core patch changeset.

## Diagnosis
The linked Slack report points to the model picker appearing late. The picker is mounted only after the lazy chat surface and the all-or-nothing model catalog are ready. The catalog then repeated request-scoped secret reads for each provider and readiness check.

## Verification
- `corepack pnpm --filter @agent-native/core exec vitest --run src/scripts/agent-engines/list-agent-engines.spec.ts --config vitest.config.ts`
- Adjacent AgentPanel, MultiTabAssistantChat, chat-model-groups, and engine-status specs: 124 passed
- `corepack pnpm --filter @agent-native/core typecheck`
- `corepack pnpm --filter @agent-native/core build`
- `corepack pnpm fmt:check`
- `corepack pnpm guards`

The shared clip remains authentication-protected from this environment, so no authenticated browser timing claim is included.