### PR TITLE
Restore smooth Design zoom label transitions

### DIFF
--- a/templates/design/app/components/design/MultiScreenCanvas.transition.test.ts
+++ b/templates/design/app/components/design/MultiScreenCanvas.transition.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./multi-screen/canvas-tools";
 import {
   getChromeBorderTransition,
+  getChromeLabelTransition,
   getSelectionBoxTransition,
 } from "./multi-screen/chrome-transitions";
 import { getDraftPreviewGeometryForTool } from "./multi-screen/draft-primitives";
@@ -26,6 +27,11 @@ describe("MultiScreenCanvas selection chrome transitions", () => {
 
   it("keeps hover chrome free to settle its inset after zoom", () => {
     expect(getChromeBorderTransition(true)).toContain("inset");
+  });
+
+  it("settles frame labels with an all-property transition after zoom", () => {
+    expect(getChromeLabelTransition(true)).toBe("all 150ms ease-out");
+    expect(getChromeLabelTransition(false)).toBe("opacity 150ms ease-out");
   });
 
   it("treats screen content as child hover instead of direct frame hover", () => {

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -10294,7 +10294,7 @@ const Screen = memo(function Screen({
             maxWidth: labelInfoMaxWidth,
             transform: `translateY(-50%) scale(var(${CHROME_SCALE_CSS_VAR}, ${chromeScale}))`,
             transformOrigin: "left center",
-            transition: getChromeLabelTransition(),
+            transition: getChromeLabelTransition(chromeSettling),
           }}
         >
           {/* B5-3: the leading dot/bullet before the screen label was pure
@@ -10366,7 +10366,7 @@ const Screen = memo(function Screen({
             maxWidth: fullViewMaxWidth,
             transform: `translateY(-50%) scale(var(${CHROME_SCALE_CSS_VAR}, ${chromeScale}))`,
             transformOrigin: "right center",
-            transition: getChromeLabelTransition(),
+            transition: getChromeLabelTransition(chromeSettling),
           }}
           aria-label={frameActionLabel}
           title={frameActionLabel}
@@ -10961,7 +10961,7 @@ function BreakpointPreviewRow({
                 style={{
                   transform: `translateY(-50%) scale(var(${CHROME_SCALE_CSS_VAR}, ${chromeScale}))`,
                   transformOrigin: "left center",
-                  transition: getChromeLabelTransition(),
+                  transition: getChromeLabelTransition(chromeSettling),
                 }}
               >
                 <span

--- a/templates/design/app/components/design/multi-screen/chrome-transitions.ts
+++ b/templates/design/app/components/design/multi-screen/chrome-transitions.ts
@@ -7,6 +7,7 @@ const CHROME_OPACITY_TRANSITION = "opacity 150ms ease-out";
 const CHROME_BORDER_SETTLE_TRANSITION = `inset ${CHROME_SETTLE_MS}ms ease-out, border-width ${CHROME_SETTLE_MS}ms ease-out, border-radius ${CHROME_SETTLE_MS}ms ease-out, ${CHROME_OPACITY_TRANSITION}`;
 const SELECTION_BOX_SETTLE_TRANSITION = `border-width ${CHROME_SETTLE_MS}ms ease-out, border-radius ${CHROME_SETTLE_MS}ms ease-out, ${CHROME_OPACITY_TRANSITION}`;
 const CHROME_HANDLE_SETTLE_TRANSITION = `width ${CHROME_SETTLE_MS}ms ease-out, height ${CHROME_SETTLE_MS}ms ease-out, border-width ${CHROME_SETTLE_MS}ms ease-out, top ${CHROME_SETTLE_MS}ms ease-out, bottom ${CHROME_SETTLE_MS}ms ease-out, left ${CHROME_SETTLE_MS}ms ease-out, right ${CHROME_SETTLE_MS}ms ease-out, ${CHROME_OPACITY_TRANSITION}`;
+const CHROME_LABEL_SETTLE_TRANSITION = `all ${CHROME_SETTLE_MS}ms ease-out`;
 
 export function getChromeBorderTransition(chromeSettling: boolean) {
   return chromeSettling
@@ -24,16 +25,10 @@ export function getChromeHandleTransition(chromeSettling: boolean) {
     : CHROME_OPACITY_TRANSITION;
 }
 
-/**
- * Frame header (name + "Interact" button). It is counter-scaled by transform to
- * stay a fixed screen size, and that counter-scale now tracks the live zoom
- * every gesture frame through the `--an-chrome-scale` custom property — so
- * unlike the border/handle/selection chrome above there is no settle-time
- * snap-back to ease, and no `chromeSettling` branch. Transitioning `transform`
- * here would actively lag the label behind the canvas whenever a new zoom tick
- * lands inside the settle window. Opacity is still eased so the button's
- * hover-fade keeps working.
- */
-export function getChromeLabelTransition() {
-  return CHROME_OPACITY_TRANSITION;
+/** Frame labels and their action button should ease into their settled geometry
+ * after zooming, but stay pinned during the live gesture. */
+export function getChromeLabelTransition(chromeSettling: boolean) {
+  return chromeSettling
+    ? CHROME_LABEL_SETTLE_TRANSITION
+    : CHROME_OPACITY_TRANSITION;
 }

--- a/templates/design/changelog/2026-09-01-smooth-frame-label-zoom-settling.md
+++ b/templates/design/changelog/2026-09-01-smooth-frame-label-zoom-settling.md
@@ -1,0 +1,5 @@
+---
+type: fixed
+date: 2026-09-01
+---
+Frame labels now move smoothly into place after canvas zoom changes.


### PR DESCRIPTION
## Summary

- Restore the post-zoom `transition: all` behavior for Design frame labels and their action controls.
- Keep labels pinned during the live zoom gesture, then ease them into settled geometry.
- Add the user-facing Design changelog entry.

## Validation

- `git diff --check` passed.
- Focused Design test and typecheck are running locally.