### PR TITLE
Make MCP settings more scannable

### DIFF
--- a/.changeset/quiet-mcp-settings.md
+++ b/.changeset/quiet-mcp-settings.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make MCP settings more scannable with a distinct app icon and click-to-reveal host instructions.

--- a/packages/core/src/client/agent-page/AgentTabsPage.tsx
+++ b/packages/core/src/client/agent-page/AgentTabsPage.tsx
@@ -6,6 +6,7 @@ import {
   IconHistory,
   IconHierarchy2,
   IconNotes,
+  IconApps,
   IconPlugConnected,
   IconTopologyRing2,
   IconSearch,
@@ -667,7 +668,7 @@ export function AgentTabsPage({
       {
         id: "access",
         label: "MCP",
-        icon: IconPlugConnected,
+        icon: IconApps,
         group: "agent",
         keywords:
           "mcp model context protocol server url external clients oauth a2a exposure",

--- a/packages/core/src/client/resources/McpAccessSettings.spec.tsx
+++ b/packages/core/src/client/resources/McpAccessSettings.spec.tsx
@@ -44,6 +44,14 @@ describe("McpAccessSettings localization", () => {
     expect(container.textContent).toContain("URL del servidor MCP");
     expect(container.textContent).toContain("Conectar un host de IA");
     expect(container.textContent).not.toContain("MCP server URL");
+    expect(container.textContent).not.toContain("Abre Customize → Connectors");
+
+    const claudeTab = container.querySelector<HTMLButtonElement>(
+      "#mcp-guide-tab-claude",
+    );
+    expect(claudeTab).not.toBeNull();
+    await act(async () => claudeTab?.click());
+    expect(container.textContent).toContain("Abre Customize → Connectors");
 
     const connectLink = Array.from(container.querySelectorAll("a")).find(
       (link) => link.textContent?.includes("Abrir página completa de conexión"),
@@ -70,6 +78,11 @@ describe("McpAccessSettings localization", () => {
     });
 
     try {
+      const claudeTab = container.querySelector<HTMLButtonElement>(
+        "#mcp-guide-tab-claude",
+      );
+      expect(claudeTab).not.toBeNull();
+      await act(async () => claudeTab?.click());
       expect(container.textContent).toContain("name it Mail");
     } finally {
       meta.remove();

--- a/packages/core/src/client/resources/McpAccessSettings.tsx
+++ b/packages/core/src/client/resources/McpAccessSettings.tsx
@@ -95,7 +95,7 @@ export function McpAccessSettings({
   );
   const [urls, setUrls] = useState<AccessUrls | null>(null);
   const [agentCardAvailable, setAgentCardAvailable] = useState(false);
-  const [activeGuide, setActiveGuide] = useState(guides[0]?.id);
+  const [activeGuide, setActiveGuide] = useState<string | null>(null);
 
   useEffect(() => {
     const origin = window.location.origin;
@@ -162,7 +162,7 @@ export function McpAccessSettings({
         serverId: `agent-native-${window.location.hostname || "app"}`,
       }
     : null;
-  const guide = guides.find((item) => item.id === activeGuide) ?? guides[0];
+  const guide = guides.find((item) => item.id === activeGuide);
 
   return (
     <AgentTabFrame
@@ -213,12 +213,16 @@ export function McpAccessSettings({
                     type="button"
                     role="tab"
                     id={`mcp-guide-tab-${item.id}`}
-                    aria-selected={item.id === guide?.id}
-                    aria-controls={`mcp-guide-panel-${item.id}`}
+                    aria-selected={item.id === activeGuide}
+                    aria-controls={
+                      item.id === activeGuide
+                        ? `mcp-guide-panel-${item.id}`
+                        : undefined
+                    }
                     onClick={() => setActiveGuide(item.id)}
                     className={cn(
                       "shrink-0 cursor-pointer rounded-md px-2.5 py-1.5 text-xs font-medium",
-                      item.id === guide?.id
+                      item.id === activeGuide
                         ? "bg-accent text-foreground"
                         : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                     )}

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -4011,7 +4011,7 @@ export function useAgentSettingsTabs(
       },
       {
         ...mcp,
-        icon: IconPlugConnected,
+        icon: IconApps,
         group: "integrations",
         content: <McpAccessSettings appName={appName} />,
       },


### PR DESCRIPTION
## Summary
- use IconApps for the MCP/app entry so it is distinct from Integrations
- hide host-specific MCP setup instructions until a host tab is selected
- add coverage for the collapsed and revealed states

## Validation
- core MCP settings test
- core typecheck and build
- fmt:check
- guards
- local rendered MCP settings click-through