### PR TITLE
Restore creative context in share dialog

### DIFF
--- a/.changeset/compact-creative-context-share.md
+++ b/.changeset/compact-creative-context-share.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/creative-context": patch
+---
+
+Restore Creative context as a Share tab and compact its submission controls.

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -809,7 +809,7 @@ describe("ShareButton", () => {
     expect(container.textContent).toContain("Share link");
     expect(container.textContent).toContain("Export");
     expect(container.textContent).toContain("Send to...");
-    expect(container.textContent).not.toContain("Context");
+    expect(container.textContent).toContain("Context");
     expect(container.textContent).not.toContain("Context body");
     expect(container.textContent).not.toContain("Export body");
 
@@ -826,7 +826,7 @@ describe("ShareButton", () => {
     expect(container.textContent).not.toContain("Send body");
   });
 
-  it("omits the context tab when it is the only custom share tab", async () => {
+  it("renders the context tab when it is the only custom share tab", async () => {
     await act(async () => {
       root.render(
         <QueryClientProvider client={queryClient}>
@@ -847,10 +847,21 @@ describe("ShareButton", () => {
       );
     });
 
-    expect(container.textContent).not.toContain("Share deck");
-    expect(container.textContent).not.toContain("Context");
+    expect(container.textContent).toContain("Share link");
+    expect(container.textContent).toContain("Context");
     expect(container.textContent).not.toContain("Context body");
-    expect(container.querySelector('[role="tablist"]')).toBeNull();
+    expect(container.querySelector('[role="tablist"]')).not.toBeNull();
+
+    const contextTab = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Context",
+    );
+    if (!contextTab) throw new Error("Context tab not found");
+
+    act(() => {
+      contextTab.click();
+    });
+
+    expect(container.textContent).toContain("Context body");
   });
 
   it("buries organization search visibility under Advanced", async () => {

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -862,6 +862,14 @@ describe("ShareButton", () => {
     });
 
     expect(container.textContent).toContain("Context body");
+    const contextPanelId = contextTab.getAttribute("aria-controls");
+    expect(contextPanelId).toBeTruthy();
+    const contextPanel = contextPanelId
+      ? document.getElementById(contextPanelId)
+      : null;
+    expect(contextPanel?.getAttribute("aria-labelledby")).toBe(
+      contextTab.getAttribute("id"),
+    );
   });
 
   it("buries organization search visibility under Advanced", async () => {

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -812,6 +812,13 @@ describe("ShareButton", () => {
     expect(container.textContent).toContain("Context");
     expect(container.textContent).not.toContain("Context body");
     expect(container.textContent).not.toContain("Export body");
+    for (const tab of container.querySelectorAll<HTMLButtonElement>(
+      '[role="tab"]',
+    )) {
+      expect(
+        document.getElementById(tab.getAttribute("aria-controls") ?? ""),
+      ).not.toBeNull();
+    }
 
     const exportTab = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Export",

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -762,8 +762,6 @@ function SharePanel(
   const activeTab = tabs.some((tab) => tab.value === activeShareTab)
     ? activeShareTab
     : "share";
-  const activeTabIndex = tabs.findIndex((tab) => tab.value === activeTab);
-
   return (
     <div className="flex flex-col gap-4">
       <div
@@ -798,14 +796,21 @@ function SharePanel(
           );
         })}
       </div>
-      <div
-        id={`${tabIds}-panel-${activeTabIndex}`}
-        role="tabpanel"
-        aria-labelledby={`${tabIds}-tab-${activeTabIndex}`}
-        tabIndex={0}
-      >
-        {tabs.find((tab) => tab.value === activeTab)?.content}
-      </div>
+      {tabs.map((tab, index) => {
+        const active = tab.value === activeTab;
+        return (
+          <div
+            key={tab.value}
+            id={`${tabIds}-panel-${index}`}
+            role="tabpanel"
+            aria-labelledby={`${tabIds}-tab-${index}`}
+            tabIndex={active ? 0 : -1}
+            hidden={!active}
+          >
+            {active ? tab.content : null}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -350,6 +350,7 @@ function SharePanel(
   },
 ) {
   const t = useT();
+  const tabIds = useId();
   const { controller } = props;
   const {
     inviteEmail,
@@ -761,6 +762,7 @@ function SharePanel(
   const activeTab = tabs.some((tab) => tab.value === activeShareTab)
     ? activeShareTab
     : "share";
+  const activeTabIndex = tabs.findIndex((tab) => tab.value === activeTab);
 
   return (
     <div className="flex flex-col gap-4">
@@ -771,14 +773,18 @@ function SharePanel(
         })}
         className="flex gap-1 rounded-xl bg-muted/70 p-1"
       >
-        {tabs.map((tab) => {
+        {tabs.map((tab, index) => {
           const active = tab.value === activeTab;
+          const tabId = `${tabIds}-tab-${index}`;
+          const panelId = `${tabIds}-panel-${index}`;
           return (
             <button
               key={tab.value}
               type="button"
+              id={tabId}
               role="tab"
               aria-selected={active}
+              aria-controls={panelId}
               disabled={tab.disabled}
               onClick={() => handleShareTabChange(tab.value)}
               className={cn(
@@ -792,7 +798,12 @@ function SharePanel(
           );
         })}
       </div>
-      <div role="tabpanel">
+      <div
+        id={`${tabIds}-panel-${activeTabIndex}`}
+        role="tabpanel"
+        aria-labelledby={`${tabIds}-tab-${activeTabIndex}`}
+        tabIndex={0}
+      >
         {tabs.find((tab) => tab.value === activeTab)?.content}
       </div>
     </div>

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -444,8 +444,7 @@ function SharePanel(
       Boolean(props.shareUrlPlaceholder) ||
       Boolean(props.secondaryShareUrl));
   const shareUrlPlacement = props.shareUrlPlacement ?? "top";
-  const extraTabs =
-    props.shareTabs?.tabs.filter((tab) => tab.value !== "context") ?? [];
+  const extraTabs = props.shareTabs?.tabs ?? [];
   const hasTabs = extraTabs.length > 0;
   const shareTabLabel =
     props.shareTabs?.shareLabel ??

--- a/packages/creative-context/src/client/CreativeContextPanel.tsx
+++ b/packages/creative-context/src/client/CreativeContextPanel.tsx
@@ -1416,7 +1416,9 @@ export function CreativeContextPanel({
     brandProposal?.voiceDescriptors?.join(" · ") ?? brandProposal?.voiceLine;
   const canManageScope = libraryScope === "user" || canManageOrg;
   const canCreateContext =
-    canManageScope && contexts.some((context) => context.access.canAdmin);
+    contextsQuery.data?.canCreateContext === true &&
+    canManageScope &&
+    contexts.some((context) => context.access.canAdmin);
   const activeAppId = contextsQuery.data?.appId;
   const appDefaultContextId = contextsQuery.data?.appDefaultContextId ?? null;
   const canSetAppDefault = Boolean(

--- a/packages/creative-context/src/client/CreativeContextShareTab.tsx
+++ b/packages/creative-context/src/client/CreativeContextShareTab.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@agent-native/toolkit";
+import { ShareDisclosureSection } from "@agent-native/toolkit/sharing";
 import {
   Badge,
   Button,
@@ -10,13 +12,8 @@ import {
   SelectValue,
   Sheet,
   SheetContent,
-  SheetDescription,
   SheetHeader,
   SheetTitle,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
   Textarea,
 } from "@agent-native/toolkit/ui";
 import {
@@ -24,7 +21,6 @@ import {
   IconFileText,
   IconLink,
   IconPlus,
-  IconShieldCheck,
   IconX,
 } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
@@ -38,7 +34,6 @@ import {
   useManageCreativeContext,
   type CreativeContextMembership,
   type CreativeContextMembershipRank,
-  type CreativeContextPolicy,
   type CreativeContextSummary,
 } from "./actions.js";
 
@@ -111,27 +106,6 @@ export function creativeContextSafePreviewUrl(url: string | undefined) {
   }
 }
 
-function policyCopy(policy: CreativeContextPolicy) {
-  switch (policy) {
-    case "review":
-      return "New resources wait for reviewer approval before they are reused.";
-    case "admins-only":
-      return "Only administrators can approve or remove resources.";
-    default:
-      return "New resources are published after submission.";
-  }
-}
-
-function formatResourceTimestamp(value: string | undefined) {
-  if (!value) return null;
-  const date = new Date(value);
-  if (!Number.isFinite(date.getTime())) return null;
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
-}
-
 function ResourcePreview({
   resource,
 }: {
@@ -143,13 +117,13 @@ function ResourcePreview({
       <img
         src={imageUrl}
         alt={resource.preview?.alt ?? ""}
-        className="size-11 rounded-md border border-border object-cover"
+        className="size-9 rounded-md border border-border object-cover"
       />
     );
   }
   return (
-    <div className="flex size-11 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground">
-      <IconFileText className="size-5" />
+    <div className="flex size-9 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground">
+      <IconFileText className="size-4" />
     </div>
   );
 }
@@ -229,30 +203,32 @@ function MembershipRow({
 }) {
   const pending = Boolean(membership.pendingSubmissionId);
   return (
-    <article className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border p-3">
-      <div>
-        <p className="text-sm font-medium">
+    <article className="flex flex-wrap items-center justify-between gap-2 border-t border-border/60 py-2.5 first:border-t-0">
+      <div className="flex min-w-0 items-center gap-2">
+        <Badge variant={pending ? "outline" : "secondary"} className="shrink-0">
           {pending ? "Pending resource" : "Published resource"}
-        </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {membership.rank}{" "}
-          {membership.purpose ? `· ${membership.purpose}` : ""}
-        </p>
+        </Badge>
+        <span className="min-w-0 truncate text-xs text-muted-foreground">
+          {membership.purpose ?? membership.rank}
+        </span>
+        {updateAvailable ? (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            Update available
+          </span>
+        ) : null}
       </div>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap justify-end gap-1">
         {pending ? (
           <Badge variant="outline">Pending review</Badge>
         ) : (
-          <Badge variant="secondary">Published</Badge>
+          <span className="sr-only">Published</span>
         )}
-        {updateAvailable ? (
-          <Badge variant="outline">Update available</Badge>
-        ) : null}
         {pending && canWithdraw ? (
           <Button
             type="button"
             variant="outline"
             size="sm"
+            className="h-8 px-2 text-xs"
             disabled={busy}
             onClick={() => onAction("withdraw")}
           >
@@ -263,6 +239,7 @@ function MembershipRow({
           <Button
             type="button"
             size="sm"
+            className="h-8 px-2 text-xs"
             disabled={busy}
             onClick={() => onAction("approve")}
           >
@@ -274,6 +251,7 @@ function MembershipRow({
             type="button"
             size="sm"
             variant="outline"
+            className="h-8 px-2 text-xs"
             disabled={busy}
             onClick={() => onAction("request-changes")}
           >
@@ -285,6 +263,7 @@ function MembershipRow({
             type="button"
             size="sm"
             variant="ghost"
+            className="h-8 px-2 text-xs"
             disabled={busy}
             onClick={() => onAction("remove")}
           >
@@ -300,14 +279,16 @@ function ContextSelect({
   contexts,
   contextId,
   onValueChange,
+  disabled = false,
 }: {
   contexts: CreativeContextSummary[];
   contextId: string;
   onValueChange: (value: string) => void;
+  disabled?: boolean;
 }) {
   return (
     <Select value={contextId} onValueChange={onValueChange}>
-      <SelectTrigger>
+      <SelectTrigger className="w-full" disabled={disabled}>
         <SelectValue placeholder="Choose a context" />
       </SelectTrigger>
       {/* This tab is embedded inside ShareButton's high z-index popover
@@ -341,7 +322,6 @@ export function CreativeContextShareTab({
     resources,
   );
   const primaryResource = selectedResources[0];
-  const updatedAt = formatResourceTimestamp(primaryResource?.updatedAt);
   const [contextId, setContextId] = useState("");
   const membershipsQuery = useContextMemberships(
     contextId ? { contextId } : null,
@@ -444,92 +424,71 @@ export function CreativeContextShareTab({
   }
 
   return (
-    <section className={className} aria-label="Creative context">
-      <div className="flex items-start gap-3 border-b border-border/70 pb-4">
-        {primaryResource ? (
+    <section
+      className={cn("space-y-3", className)}
+      aria-label="Creative context"
+    >
+      {primaryResource ? (
+        <div className="flex min-w-0 items-center gap-2 border-b border-border/70 pb-3">
           <ResourcePreview resource={primaryResource} />
-        ) : null}
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">
+          <p className="min-w-0 truncate text-sm font-medium">
             {selectedResources.length === 1
-              ? primaryResource?.title
+              ? primaryResource.title
               : `${selectedResources.length} selected resources`}
           </p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {selectedResources.length === 1
-              ? (primaryResource?.preview?.label ??
-                primaryResource?.resourceType)
-              : "Each resource is submitted separately"}
-          </p>
-          {selectedResources.length === 1 && updatedAt ? (
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Current version · {updatedAt}
-            </p>
-          ) : null}
         </div>
-      </div>
-      <Tabs defaultValue="contexts" className="mt-4">
-        <TabsList className="w-full justify-start">
-          <TabsTrigger value="contexts">Contexts</TabsTrigger>
-          <TabsTrigger value="policy">Policy</TabsTrigger>
-        </TabsList>
-        <TabsContent value="contexts" className="space-y-3">
-          <ContextSelect
-            contexts={contexts}
-            contextId={contextId}
-            onValueChange={setContextId}
-          />
-          {selectedContext ? (
-            <p className="text-xs text-muted-foreground">
-              {selectedContext.description ||
-                `${selectedContext.memberCount} published resources`}{" "}
-              · {policyCopy(selectedContext.approvalPolicy)}
-            </p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No contexts are available yet.
-            </p>
-          )}
-          {contextId && selectedResources.length === 1 ? (
-            <div className="space-y-2">
-              {memberships.map((membership) => (
-                <MembershipRow
-                  key={membership.id}
-                  membership={membership}
-                  updateAvailable={Boolean(
-                    primaryResource?.updatedAt &&
-                    membership.publishedItem?.sourceModifiedAt &&
-                    primaryResource.updatedAt !==
-                      membership.publishedItem.sourceModifiedAt,
-                  )}
-                  canReview={selectedContext?.access.canReview === true}
-                  canWithdraw={
-                    selectedContext?.access.canReview === true ||
-                    selectedContext?.access.canSubmit === true
-                  }
-                  canRemove={selectedContext?.access.canAdmin === true}
-                  busy={busy}
-                  onAction={(operation) => void act(membership.id, operation)}
-                />
-              ))}
-              {!memberships.length && !membershipsQuery.isLoading ? (
-                <p className="text-sm text-muted-foreground">
-                  This resource has not been submitted to this context.
-                </p>
-              ) : null}
-            </div>
-          ) : null}
-          {contextId && selectedResources.length ? (
-            <div className="rounded-md border border-dashed border-border p-3">
-              <p className="text-sm font-medium">
-                {memberships.some((membership) => membership.publishedItem)
-                  ? "Submit update for "
-                  : "Add "}
-                {selectedResources.length === 1
-                  ? "this resource"
-                  : `${selectedResources.length} resources`}
-              </p>
-              <div className="mt-2 grid gap-2 sm:grid-cols-2">
+      ) : null}
+      {contexts.length ? (
+        <ContextSelect
+          contexts={contexts}
+          contextId={contextId}
+          onValueChange={setContextId}
+          disabled={busy}
+        />
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No contexts are available yet.
+        </p>
+      )}
+      {contextId && selectedResources.length === 1 && memberships.length ? (
+        <div>
+          {memberships.map((membership) => (
+            <MembershipRow
+              key={membership.id}
+              membership={membership}
+              updateAvailable={Boolean(
+                primaryResource?.updatedAt &&
+                membership.publishedItem?.sourceModifiedAt &&
+                primaryResource.updatedAt !==
+                  membership.publishedItem.sourceModifiedAt,
+              )}
+              canReview={selectedContext?.access.canReview === true}
+              canWithdraw={
+                selectedContext?.access.canReview === true ||
+                selectedContext?.access.canSubmit === true
+              }
+              canRemove={selectedContext?.access.canAdmin === true}
+              busy={busy}
+              onAction={(operation) => void act(membership.id, operation)}
+            />
+          ))}
+        </div>
+      ) : null}
+      {contextId && selectedResources.length ? (
+        <div className="border-t border-border/60 pt-3">
+          <div className="flex items-start gap-2">
+            <ShareDisclosureSection
+              label={
+                memberships.some((membership) => membership.publishedItem)
+                  ? "Submit update for this resource"
+                  : selectedResources.length === 1
+                    ? "Add this resource"
+                    : `Add ${selectedResources.length} resources`
+              }
+              className="min-w-0 flex-1"
+              contentClassName="space-y-2"
+            >
+              <div className="grid gap-2 sm:grid-cols-2">
                 <Select
                   value={rank}
                   onValueChange={(value) =>
@@ -555,82 +514,68 @@ export function CreativeContextShareTab({
                 />
               </div>
               <Textarea
-                className="mt-2"
                 value={note}
                 onChange={(event) => setNote(event.target.value)}
                 placeholder="Note for reviewers"
                 rows={2}
               />
-              {needsBroaderPublicationConfirmation ? (
-                <label className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
-                  <Checkbox
-                    checked={confirmedBroaderPublication}
-                    onCheckedChange={(checked) =>
-                      setConfirmedBroaderPublication(checked === true)
-                    }
-                  />
-                  <span>
-                    This context is shared more broadly than this resource.
-                    Publishing creates a governed copy available to the
-                    context's audience.
-                  </span>
-                </label>
-              ) : null}
-              <Button
-                type="button"
-                className="mt-3"
-                size="sm"
-                disabled={
-                  busy ||
-                  selectedContext?.access.canSubmit !== true ||
-                  (needsBroaderPublicationConfirmation &&
-                    !confirmedBroaderPublication)
-                }
-                onClick={() => void submit()}
-              >
-                <IconLink /> Submit
-              </Button>
-            </div>
-          ) : null}
-          {canCreateContext ? (
-            <div className="flex gap-2 border-t border-border/60 pt-3">
-              <Input
-                value={newContextName}
-                onChange={(event) => setNewContextName(event.target.value)}
-                placeholder="New context name"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={busy || !newContextName.trim()}
-                onClick={() => void createContext()}
-              >
-                <IconPlus /> New
-              </Button>
-            </div>
-          ) : null}
-          {error ? <p className="text-xs text-destructive">{error}</p> : null}
-          {submitSummary ? (
-            <p className="text-xs text-muted-foreground">{submitSummary}</p>
-          ) : null}
-        </TabsContent>
-        <TabsContent
-          value="policy"
-          className="space-y-3 text-sm text-muted-foreground"
-        >
-          <div className="flex gap-2 rounded-md border border-border p-3">
-            <IconShieldCheck className="mt-0.5 size-4 shrink-0" />
-            <p>
-              Open contexts publish submitted resources, review contexts wait
-              for approval, and admins-only contexts require an administrator.
-            </p>
+            </ShareDisclosureSection>
+            <Button
+              type="button"
+              size="sm"
+              className="shrink-0"
+              disabled={
+                busy ||
+                selectedContext?.access.canSubmit !== true ||
+                (needsBroaderPublicationConfirmation &&
+                  !confirmedBroaderPublication)
+              }
+              onClick={() => void submit()}
+            >
+              <IconLink /> Submit
+            </Button>
           </div>
-          {selectedContext ? (
-            <p>{policyCopy(selectedContext.approvalPolicy)}</p>
+          {needsBroaderPublicationConfirmation ? (
+            <label className="flex items-start gap-2 text-xs text-muted-foreground">
+              <Checkbox
+                checked={confirmedBroaderPublication}
+                onCheckedChange={(checked) =>
+                  setConfirmedBroaderPublication(checked === true)
+                }
+              />
+              <span>
+                This context is shared more broadly than this resource.
+                Publishing creates a governed copy available to the context's
+                audience.
+              </span>
+            </label>
           ) : null}
-        </TabsContent>
-      </Tabs>
+        </div>
+      ) : null}
+      {canCreateContext ? (
+        <ShareDisclosureSection label="New context name">
+          <div className="flex gap-2">
+            <Input
+              value={newContextName}
+              onChange={(event) => setNewContextName(event.target.value)}
+              placeholder="New context name"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy || !newContextName.trim()}
+              onClick={() => void createContext()}
+            >
+              <IconPlus /> New
+            </Button>
+          </div>
+        </ShareDisclosureSection>
+      ) : null}
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {submitSummary ? (
+        <p className="text-xs text-muted-foreground">{submitSummary}</p>
+      ) : null}
     </section>
   );
 }
@@ -650,9 +595,6 @@ export function CreativeContextShareSheet({
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
         <SheetHeader>
           <SheetTitle>Creative context</SheetTitle>
-          <SheetDescription>
-            Place this resource in a governed context for future reuse.
-          </SheetDescription>
         </SheetHeader>
         <CreativeContextShareTab
           resource={resource}

--- a/packages/creative-context/src/client/CreativeContextShareTab.tsx
+++ b/packages/creative-context/src/client/CreativeContextShareTab.tsx
@@ -377,7 +377,9 @@ export function CreativeContextShareTab({
     useState(false);
   const busy = manageContext.isPending || manageMembership.isPending;
   const selectedContext = contexts.find((context) => context.id === contextId);
-  const canCreateContext = contexts.some((context) => context.access.canAdmin);
+  const canCreateContext =
+    contextsQuery.data?.canCreateContext === true &&
+    contexts.some((context) => context.access.canAdmin);
   const needsBroaderPublicationConfirmation = selectedResources.some((item) =>
     requiresBroaderPublication(item, selectedContext),
   );
@@ -436,12 +438,7 @@ export function CreativeContextShareTab({
       );
       await refresh();
     } catch {
-      setError(
-        t("creativeContext.share.submitFailed", {
-          defaultValue:
-            "Could not submit this resource to the selected context.",
-        }),
-      );
+      setError(t("creativeContext.submitUpdateFailed"));
     }
   }
 
@@ -459,11 +456,7 @@ export function CreativeContextShareTab({
       await contextsQuery.refetch();
       if (result.context?.id) setContextId(result.context.id);
     } catch {
-      setError(
-        t("creativeContext.share.createFailed", {
-          defaultValue: "Could not create a context.",
-        }),
-      );
+      setError(t("creativeContext.saveFailed"));
     }
   }
 
@@ -481,11 +474,7 @@ export function CreativeContextShareTab({
       });
       await refresh();
     } catch {
-      setError(
-        t("creativeContext.share.updateFailed", {
-          defaultValue: "Could not update this context membership.",
-        }),
-      );
+      setError(t("creativeContext.saveFailed"));
     }
   }
 
@@ -556,12 +545,7 @@ export function CreativeContextShareTab({
               label={
                 memberships.some((membership) => membership.publishedItem)
                   ? t("creativeContext.submitUpdate")
-                  : selectedResources.length === 1
-                    ? t("creativeContext.addToContext")
-                    : t("creativeContext.share.addResources", {
-                        count: selectedResources.length,
-                        defaultValue: "Add {{count}} resources",
-                      })
+                  : t("creativeContext.addToContext")
               }
               className="min-w-0 flex-1"
               contentClassName="space-y-2"

--- a/packages/creative-context/src/client/CreativeContextShareTab.tsx
+++ b/packages/creative-context/src/client/CreativeContextShareTab.tsx
@@ -1,3 +1,4 @@
+import { useT } from "@agent-native/core/client/i18n";
 import { cn } from "@agent-native/toolkit";
 import { ShareDisclosureSection } from "@agent-native/toolkit/sharing";
 import {
@@ -78,6 +79,7 @@ export function normalizeCreativeContextResources(
 }
 
 const VISIBILITY_RANK = { private: 0, org: 1, public: 2 } as const;
+type CreativeContextTranslate = ReturnType<typeof useT>;
 
 export function requiresBroaderPublication(
   resource: CreativeContextResourceDescriptor,
@@ -184,6 +186,7 @@ export async function submitCreativeContextResources({
 
 function MembershipRow({
   membership,
+  t,
   updateAvailable,
   canReview,
   canWithdraw,
@@ -192,6 +195,7 @@ function MembershipRow({
   onAction,
 }: {
   membership: CreativeContextMembership;
+  t: CreativeContextTranslate;
   updateAvailable: boolean;
   canReview: boolean;
   canWithdraw: boolean;
@@ -202,26 +206,49 @@ function MembershipRow({
   ) => void;
 }) {
   const pending = Boolean(membership.pendingSubmissionId);
+  const rankLabel = {
+    canonical: t("creativeContext.share.canonical", {
+      defaultValue: "Canonical",
+    }),
+    exemplar: t("creativeContext.exemplar"),
+    normal: t("creativeContext.share.reference", {
+      defaultValue: "Reference",
+    }),
+  }[membership.rank];
   return (
     <article className="flex flex-wrap items-center justify-between gap-2 border-t border-border/60 py-2.5 first:border-t-0">
       <div className="flex min-w-0 items-center gap-2">
         <Badge variant={pending ? "outline" : "secondary"} className="shrink-0">
-          {pending ? "Pending resource" : "Published resource"}
+          {pending
+            ? t("creativeContext.share.pendingResource", {
+                defaultValue: "Pending resource",
+              })
+            : t("creativeContext.share.publishedResource", {
+                defaultValue: "Published resource",
+              })}
         </Badge>
         <span className="min-w-0 truncate text-xs text-muted-foreground">
-          {membership.purpose ?? membership.rank}
+          {membership.purpose ?? rankLabel}
         </span>
         {updateAvailable ? (
           <span className="shrink-0 text-xs text-muted-foreground">
-            Update available
+            {t("creativeContext.updateAvailable")}
           </span>
         ) : null}
       </div>
       <div className="flex flex-wrap justify-end gap-1">
         {pending ? (
-          <Badge variant="outline">Pending review</Badge>
+          <Badge variant="outline">
+            {t("creativeContext.share.pendingReview", {
+              defaultValue: "Pending review",
+            })}
+          </Badge>
         ) : (
-          <span className="sr-only">Published</span>
+          <span className="sr-only">
+            {t("creativeContext.share.published", {
+              defaultValue: "Published",
+            })}
+          </span>
         )}
         {pending && canWithdraw ? (
           <Button
@@ -232,7 +259,7 @@ function MembershipRow({
             disabled={busy}
             onClick={() => onAction("withdraw")}
           >
-            Withdraw
+            {t("creativeContext.share.withdraw", { defaultValue: "Withdraw" })}
           </Button>
         ) : null}
         {pending && canReview ? (
@@ -243,7 +270,7 @@ function MembershipRow({
             disabled={busy}
             onClick={() => onAction("approve")}
           >
-            <IconCheck /> Approve
+            <IconCheck /> {t("creativeContext.approve")}
           </Button>
         ) : null}
         {pending && canReview ? (
@@ -255,7 +282,9 @@ function MembershipRow({
             disabled={busy}
             onClick={() => onAction("request-changes")}
           >
-            Request changes
+            {t("creativeContext.share.requestChanges", {
+              defaultValue: "Request changes",
+            })}
           </Button>
         ) : null}
         {canRemove ? (
@@ -267,7 +296,8 @@ function MembershipRow({
             disabled={busy}
             onClick={() => onAction("remove")}
           >
-            <IconX /> Remove
+            <IconX />{" "}
+            {t("creativeContext.share.remove", { defaultValue: "Remove" })}
           </Button>
         ) : null}
       </div>
@@ -278,18 +308,24 @@ function MembershipRow({
 function ContextSelect({
   contexts,
   contextId,
+  t,
   onValueChange,
   disabled = false,
 }: {
   contexts: CreativeContextSummary[];
   contextId: string;
+  t: CreativeContextTranslate;
   onValueChange: (value: string) => void;
   disabled?: boolean;
 }) {
   return (
     <Select value={contextId} onValueChange={onValueChange}>
       <SelectTrigger className="w-full" disabled={disabled}>
-        <SelectValue placeholder="Choose a context" />
+        <SelectValue
+          placeholder={t("creativeContext.share.chooseContext", {
+            defaultValue: "Choose a context",
+          })}
+        />
       </SelectTrigger>
       {/* This tab is embedded inside ShareButton's high z-index popover
           (see z-[100010]+ overrides in design/content/slides toolbars).
@@ -313,6 +349,7 @@ export function CreativeContextShareTab({
   resources,
   className,
 }: CreativeContextShareTabProps) {
+  const t = useT();
   const contextsQuery = useCreativeContexts();
   const manageContext = useManageCreativeContext();
   const manageMembership = useManageContextMembership();
@@ -378,12 +415,33 @@ export function CreativeContextShareTab({
       setConfirmedBroaderPublication(false);
       setSubmitSummary(
         result.failed
-          ? `${result.submitted} submitted; ${result.failed} could not be submitted.`
-          : `${result.submitted} ${result.submitted === 1 ? "resource" : "resources"} submitted.`,
+          ? t("creativeContext.share.partialSubmission", {
+              submitted: result.submitted,
+              failed: result.failed,
+              defaultValue:
+                "{{submitted}} submitted; {{failed}} could not be submitted.",
+            })
+          : t(
+              result.submitted === 1
+                ? "creativeContext.share.resourceSubmitted"
+                : "creativeContext.share.resourcesSubmitted",
+              {
+                count: result.submitted,
+                defaultValue:
+                  result.submitted === 1
+                    ? "{{count}} resource submitted."
+                    : "{{count}} resources submitted.",
+              },
+            ),
       );
       await refresh();
     } catch {
-      setError("Could not submit this resource to the selected context.");
+      setError(
+        t("creativeContext.share.submitFailed", {
+          defaultValue:
+            "Could not submit this resource to the selected context.",
+        }),
+      );
     }
   }
 
@@ -401,7 +459,11 @@ export function CreativeContextShareTab({
       await contextsQuery.refetch();
       if (result.context?.id) setContextId(result.context.id);
     } catch {
-      setError("Could not create a context.");
+      setError(
+        t("creativeContext.share.createFailed", {
+          defaultValue: "Could not create a context.",
+        }),
+      );
     }
   }
 
@@ -419,14 +481,20 @@ export function CreativeContextShareTab({
       });
       await refresh();
     } catch {
-      setError("Could not update this context membership.");
+      setError(
+        t("creativeContext.share.updateFailed", {
+          defaultValue: "Could not update this context membership.",
+        }),
+      );
     }
   }
 
   return (
     <section
       className={cn("space-y-3", className)}
-      aria-label="Creative context"
+      aria-label={t("creativeContext.share.title", {
+        defaultValue: "Creative context",
+      })}
     >
       {primaryResource ? (
         <div className="flex min-w-0 items-center gap-2 border-b border-border/70 pb-3">
@@ -434,7 +502,10 @@ export function CreativeContextShareTab({
           <p className="min-w-0 truncate text-sm font-medium">
             {selectedResources.length === 1
               ? primaryResource.title
-              : `${selectedResources.length} selected resources`}
+              : t("creativeContext.share.selectedResources", {
+                  count: selectedResources.length,
+                  defaultValue: "{{count}} selected resources",
+                })}
           </p>
         </div>
       ) : null}
@@ -442,12 +513,15 @@ export function CreativeContextShareTab({
         <ContextSelect
           contexts={contexts}
           contextId={contextId}
+          t={t}
           onValueChange={setContextId}
           disabled={busy}
         />
       ) : (
         <p className="text-sm text-muted-foreground">
-          No contexts are available yet.
+          {t("creativeContext.share.noContexts", {
+            defaultValue: "No contexts are available yet.",
+          })}
         </p>
       )}
       {contextId && selectedResources.length === 1 && memberships.length ? (
@@ -456,6 +530,7 @@ export function CreativeContextShareTab({
             <MembershipRow
               key={membership.id}
               membership={membership}
+              t={t}
               updateAvailable={Boolean(
                 primaryResource?.updatedAt &&
                 membership.publishedItem?.sourceModifiedAt &&
@@ -480,10 +555,13 @@ export function CreativeContextShareTab({
             <ShareDisclosureSection
               label={
                 memberships.some((membership) => membership.publishedItem)
-                  ? "Submit update for this resource"
+                  ? t("creativeContext.submitUpdate")
                   : selectedResources.length === 1
-                    ? "Add this resource"
-                    : `Add ${selectedResources.length} resources`
+                    ? t("creativeContext.addToContext")
+                    : t("creativeContext.share.addResources", {
+                        count: selectedResources.length,
+                        defaultValue: "Add {{count}} resources",
+                      })
               }
               className="min-w-0 flex-1"
               contentClassName="space-y-2"
@@ -502,21 +580,35 @@ export function CreativeContextShareTab({
                     data-agent-native-share-overlay=""
                     className="z-[100020]"
                   >
-                    <SelectItem value="canonical">Canonical</SelectItem>
-                    <SelectItem value="exemplar">Exemplar</SelectItem>
-                    <SelectItem value="normal">Reference</SelectItem>
+                    <SelectItem value="canonical">
+                      {t("creativeContext.share.canonical", {
+                        defaultValue: "Canonical",
+                      })}
+                    </SelectItem>
+                    <SelectItem value="exemplar">
+                      {t("creativeContext.exemplar")}
+                    </SelectItem>
+                    <SelectItem value="normal">
+                      {t("creativeContext.share.reference", {
+                        defaultValue: "Reference",
+                      })}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
                 <Input
                   value={purpose}
                   onChange={(event) => setPurpose(event.target.value)}
-                  placeholder="Purpose"
+                  placeholder={t("creativeContext.share.purpose", {
+                    defaultValue: "Purpose",
+                  })}
                 />
               </div>
               <Textarea
                 value={note}
                 onChange={(event) => setNote(event.target.value)}
-                placeholder="Note for reviewers"
+                placeholder={t("creativeContext.share.reviewerNote", {
+                  defaultValue: "Note for reviewers",
+                })}
                 rows={2}
               />
             </ShareDisclosureSection>
@@ -532,7 +624,8 @@ export function CreativeContextShareTab({
               }
               onClick={() => void submit()}
             >
-              <IconLink /> Submit
+              <IconLink />{" "}
+              {t("creativeContext.share.submit", { defaultValue: "Submit" })}
             </Button>
           </div>
           {needsBroaderPublicationConfirmation ? (
@@ -544,21 +637,28 @@ export function CreativeContextShareTab({
                 }
               />
               <span>
-                This context is shared more broadly than this resource.
-                Publishing creates a governed copy available to the context's
-                audience.
+                {t("creativeContext.share.broaderPublication", {
+                  defaultValue:
+                    "This context is shared more broadly than this resource. Publishing creates a governed copy available to the context's audience.",
+                })}
               </span>
             </label>
           ) : null}
         </div>
       ) : null}
       {canCreateContext ? (
-        <ShareDisclosureSection label="New context name">
+        <ShareDisclosureSection
+          label={t("creativeContext.share.newContextName", {
+            defaultValue: "New context name",
+          })}
+        >
           <div className="flex gap-2">
             <Input
               value={newContextName}
               onChange={(event) => setNewContextName(event.target.value)}
-              placeholder="New context name"
+              placeholder={t("creativeContext.share.newContextName", {
+                defaultValue: "New context name",
+              })}
             />
             <Button
               type="button"
@@ -567,7 +667,8 @@ export function CreativeContextShareTab({
               disabled={busy || !newContextName.trim()}
               onClick={() => void createContext()}
             >
-              <IconPlus /> New
+              <IconPlus />{" "}
+              {t("creativeContext.share.new", { defaultValue: "New" })}
             </Button>
           </div>
         </ShareDisclosureSection>
@@ -590,11 +691,16 @@ export function CreativeContextShareSheet({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
+  const t = useT();
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-lg">
         <SheetHeader>
-          <SheetTitle>Creative context</SheetTitle>
+          <SheetTitle>
+            {t("creativeContext.share.title", {
+              defaultValue: "Creative context",
+            })}
+          </SheetTitle>
         </SheetHeader>
         <CreativeContextShareTab
           resource={resource}

--- a/packages/creative-context/src/client/actions.ts
+++ b/packages/creative-context/src/client/actions.ts
@@ -157,6 +157,7 @@ export interface ListCreativeContextsResult {
   contexts: CreativeContextSummary[];
   appId?: string;
   appDefaultContextId?: string | null;
+  canCreateContext?: boolean;
 }
 
 export type ManageCreativeContextParams =

--- a/packages/creative-context/src/client/messages.ts
+++ b/packages/creative-context/src/client/messages.ts
@@ -116,7 +116,38 @@ export type CreativeContextMessageKey =
   | "suggestions"
   | "logo";
 
-export type CreativeContextMessages = Record<CreativeContextMessageKey, string>;
+export interface CreativeContextShareMessages {
+  title: string;
+  tabLabel: string;
+  pendingResource: string;
+  publishedResource: string;
+  canonical: string;
+  reference: string;
+  pendingReview: string;
+  published: string;
+  withdraw: string;
+  requestChanges: string;
+  remove: string;
+  chooseContext: string;
+  selectedResources: string;
+  noContexts: string;
+  purpose: string;
+  reviewerNote: string;
+  submit: string;
+  broaderPublication: string;
+  newContextName: string;
+  new: string;
+  partialSubmission: string;
+  resourceSubmitted: string;
+  resourcesSubmitted: string;
+}
+
+export type CreativeContextMessages = Record<
+  CreativeContextMessageKey,
+  string
+> & {
+  share: CreativeContextShareMessages;
+};
 
 export const creativeContextMessagesByLocale: Record<
   CreativeContextLocale,
@@ -235,6 +266,33 @@ export const creativeContextMessagesByLocale: Record<
       "Choose the presentations Google should make available to this Library connection. No Drive-wide permission is requested.",
     suggestions: "Review suggestions",
     logo: "Canonical logo",
+    share: {
+      title: "Creative context",
+      tabLabel: "Context",
+      pendingResource: "Pending resource",
+      publishedResource: "Published resource",
+      canonical: "Canonical",
+      reference: "Reference",
+      pendingReview: "Pending review",
+      published: "Published",
+      withdraw: "Withdraw",
+      requestChanges: "Request changes",
+      remove: "Remove",
+      chooseContext: "Choose a context",
+      selectedResources: "{{count}} selected resources",
+      noContexts: "No contexts are available yet.",
+      purpose: "Purpose",
+      reviewerNote: "Note for reviewers",
+      submit: "Submit",
+      broaderPublication:
+        "This context is shared more broadly than this resource. Publishing creates a governed copy available to the context's audience.",
+      newContextName: "New context name",
+      new: "New",
+      partialSubmission:
+        "{{submitted}} submitted; {{failed}} could not be submitted.",
+      resourceSubmitted: "{{count}} resource submitted.",
+      resourcesSubmitted: "{{count}} resources submitted.",
+    },
   },
   "zh-TW": {
     title: "資料庫",
@@ -342,6 +400,32 @@ export const creativeContextMessagesByLocale: Record<
       "選擇要提供給此資料庫連線的簡報，不會要求整個雲端硬碟的存取權。",
     suggestions: "審核建議",
     logo: "標準標誌",
+    share: {
+      title: "創意脈絡",
+      tabLabel: "脈絡",
+      pendingResource: "待處理資源",
+      publishedResource: "已發布資源",
+      canonical: "標準",
+      reference: "參考",
+      pendingReview: "待審核",
+      published: "已發布",
+      withdraw: "撤回",
+      requestChanges: "要求修改",
+      remove: "移除",
+      chooseContext: "選擇脈絡",
+      selectedResources: "已選取 {{count}} 個資源",
+      noContexts: "目前沒有可用的脈絡。",
+      purpose: "用途",
+      reviewerNote: "給審核者的備註",
+      submit: "提交",
+      broaderPublication:
+        "此脈絡的分享範圍比此資源更廣。發布後會建立可供脈絡受眾使用的受治理副本。",
+      newContextName: "新脈絡名稱",
+      new: "新增",
+      partialSubmission: "已提交 {{submitted}} 個；{{failed}} 個無法提交。",
+      resourceSubmitted: "已提交 {{count}} 個資源。",
+      resourcesSubmitted: "已提交 {{count}} 個資源。",
+    },
   },
   "zh-CN": {
     title: "资料库",
@@ -450,6 +534,32 @@ export const creativeContextMessagesByLocale: Record<
       "选择要提供给此资料库连接的演示文稿，不会请求整个云端硬盘的访问权限。",
     suggestions: "审核建议",
     logo: "标准徽标",
+    share: {
+      title: "创意上下文",
+      tabLabel: "上下文",
+      pendingResource: "待处理资源",
+      publishedResource: "已发布资源",
+      canonical: "规范",
+      reference: "参考",
+      pendingReview: "待审核",
+      published: "已发布",
+      withdraw: "撤回",
+      requestChanges: "请求修改",
+      remove: "移除",
+      chooseContext: "选择上下文",
+      selectedResources: "已选择 {{count}} 个资源",
+      noContexts: "暂无可用的上下文。",
+      purpose: "用途",
+      reviewerNote: "给审核者的备注",
+      submit: "提交",
+      broaderPublication:
+        "此上下文的共享范围比此资源更广。发布后会创建可供上下文受众使用的受治理副本。",
+      newContextName: "新上下文名称",
+      new: "新建",
+      partialSubmission: "已提交 {{submitted}} 个；{{failed}} 个无法提交。",
+      resourceSubmitted: "已提交 {{count}} 个资源。",
+      resourcesSubmitted: "已提交 {{count}} 个资源。",
+    },
   },
   "es-ES": {
     title: "Biblioteca",
@@ -565,6 +675,33 @@ export const creativeContextMessagesByLocale: Record<
       "Elige las presentaciones disponibles para esta conexión. No se solicita acceso a todo Drive.",
     suggestions: "Revisar sugerencias",
     logo: "Logotipo canónico",
+    share: {
+      title: "Contexto creativo",
+      tabLabel: "Contexto",
+      pendingResource: "Recurso pendiente",
+      publishedResource: "Recurso publicado",
+      canonical: "Canónico",
+      reference: "Referencia",
+      pendingReview: "Revisión pendiente",
+      published: "Publicado",
+      withdraw: "Retirar",
+      requestChanges: "Solicitar cambios",
+      remove: "Eliminar",
+      chooseContext: "Elegir un contexto",
+      selectedResources: "{{count}} recursos seleccionados",
+      noContexts: "Aún no hay contextos disponibles.",
+      purpose: "Propósito",
+      reviewerNote: "Nota para revisores",
+      submit: "Enviar",
+      broaderPublication:
+        "Este contexto se comparte más ampliamente que este recurso. Al publicarlo se crea una copia gobernada disponible para la audiencia del contexto.",
+      newContextName: "Nuevo nombre de contexto",
+      new: "Nuevo",
+      partialSubmission:
+        "{{submitted}} enviados; no se pudieron enviar {{failed}}.",
+      resourceSubmitted: "{{count}} recurso enviado.",
+      resourcesSubmitted: "{{count}} recursos enviados.",
+    },
   },
   "fr-FR": {
     title: "Bibliothèque",
@@ -681,6 +818,33 @@ export const creativeContextMessagesByLocale: Record<
       "Choisissez les présentations accessibles à cette connexion. Aucun accès à l’ensemble de Drive n’est demandé.",
     suggestions: "Examiner les suggestions",
     logo: "Logo canonique",
+    share: {
+      title: "Contexte créatif",
+      tabLabel: "Contexte",
+      pendingResource: "Ressource en attente",
+      publishedResource: "Ressource publiée",
+      canonical: "Canonique",
+      reference: "Référence",
+      pendingReview: "Révision en attente",
+      published: "Publié",
+      withdraw: "Retirer",
+      requestChanges: "Demander des modifications",
+      remove: "Supprimer",
+      chooseContext: "Choisir un contexte",
+      selectedResources: "{{count}} ressources sélectionnées",
+      noContexts: "Aucun contexte n'est encore disponible.",
+      purpose: "Objectif",
+      reviewerNote: "Note pour les réviseurs",
+      submit: "Envoyer",
+      broaderPublication:
+        "Ce contexte est partagé plus largement que cette ressource. La publication crée une copie gouvernée disponible pour l'audience du contexte.",
+      newContextName: "Nom du nouveau contexte",
+      new: "Nouveau",
+      partialSubmission:
+        "{{submitted}} envoyées ; {{failed}} n'ont pas pu être envoyées.",
+      resourceSubmitted: "{{count}} ressource envoyée.",
+      resourcesSubmitted: "{{count}} ressources envoyées.",
+    },
   },
   "de-DE": {
     title: "Bibliothek",
@@ -796,6 +960,33 @@ export const creativeContextMessagesByLocale: Record<
       "Wähle die Präsentationen für diese Bibliotheksverbindung aus. Es wird kein Zugriff auf das gesamte Drive angefordert.",
     suggestions: "Vorschläge prüfen",
     logo: "Kanonisches Logo",
+    share: {
+      title: "Kreativer Kontext",
+      tabLabel: "Kontext",
+      pendingResource: "Ausstehende Ressource",
+      publishedResource: "Veröffentlichte Ressource",
+      canonical: "Kanonisch",
+      reference: "Referenz",
+      pendingReview: "Prüfung ausstehend",
+      published: "Veröffentlicht",
+      withdraw: "Zurückziehen",
+      requestChanges: "Änderungen anfordern",
+      remove: "Entfernen",
+      chooseContext: "Kontext auswählen",
+      selectedResources: "{{count}} ausgewählte Ressourcen",
+      noContexts: "Noch keine Kontexte verfügbar.",
+      purpose: "Zweck",
+      reviewerNote: "Notiz für Prüfer",
+      submit: "Senden",
+      broaderPublication:
+        "Dieser Kontext wird umfassender geteilt als diese Ressource. Beim Veröffentlichen wird eine verwaltete Kopie für die Zielgruppe des Kontexts erstellt.",
+      newContextName: "Name des neuen Kontexts",
+      new: "Neu",
+      partialSubmission:
+        "{{submitted}} gesendet; {{failed}} konnten nicht gesendet werden.",
+      resourceSubmitted: "{{count}} Ressource gesendet.",
+      resourcesSubmitted: "{{count}} Ressourcen gesendet.",
+    },
   },
   "ja-JP": {
     title: "ライブラリ",
@@ -914,6 +1105,33 @@ export const creativeContextMessagesByLocale: Record<
       "このライブラリ接続で利用するプレゼンテーションを選択します。Drive 全体への権限は要求しません。",
     suggestions: "候補を確認",
     logo: "正式ロゴ",
+    share: {
+      title: "クリエイティブコンテキスト",
+      tabLabel: "コンテキスト",
+      pendingResource: "保留中のリソース",
+      publishedResource: "公開済みリソース",
+      canonical: "標準",
+      reference: "参照",
+      pendingReview: "レビュー待ち",
+      published: "公開済み",
+      withdraw: "取り下げ",
+      requestChanges: "変更をリクエスト",
+      remove: "削除",
+      chooseContext: "コンテキストを選択",
+      selectedResources: "{{count}}件のリソースを選択",
+      noContexts: "利用できるコンテキストはまだありません。",
+      purpose: "目的",
+      reviewerNote: "レビュアーへのメモ",
+      submit: "送信",
+      broaderPublication:
+        "このコンテキストはこのリソースより広く共有されます。公開すると、コンテキストの対象者が利用できる管理対象コピーが作成されます。",
+      newContextName: "新しいコンテキスト名",
+      new: "新規",
+      partialSubmission:
+        "{{submitted}}件を送信しました。{{failed}}件は送信できませんでした。",
+      resourceSubmitted: "{{count}}件のリソースを送信しました。",
+      resourcesSubmitted: "{{count}}件のリソースを送信しました。",
+    },
   },
   "ko-KR": {
     title: "라이브러리",
@@ -1027,6 +1245,33 @@ export const creativeContextMessagesByLocale: Record<
       "이 라이브러리 연결에서 사용할 프레젠테이션을 선택하세요. Drive 전체 권한은 요청하지 않습니다.",
     suggestions: "추천 검토",
     logo: "대표 로고",
+    share: {
+      title: "크리에이티브 컨텍스트",
+      tabLabel: "컨텍스트",
+      pendingResource: "대기 중인 리소스",
+      publishedResource: "게시된 리소스",
+      canonical: "표준",
+      reference: "참조",
+      pendingReview: "검토 대기 중",
+      published: "게시됨",
+      withdraw: "철회",
+      requestChanges: "변경 요청",
+      remove: "삭제",
+      chooseContext: "컨텍스트 선택",
+      selectedResources: "{{count}}개 리소스 선택됨",
+      noContexts: "사용 가능한 컨텍스트가 아직 없습니다.",
+      purpose: "용도",
+      reviewerNote: "검토자 메모",
+      submit: "제출",
+      broaderPublication:
+        "이 컨텍스트는 이 리소스보다 넓게 공유됩니다. 게시하면 컨텍스트 대상자가 사용할 수 있는 관리된 사본이 생성됩니다.",
+      newContextName: "새 컨텍스트 이름",
+      new: "새로 만들기",
+      partialSubmission:
+        "{{submitted}}개 제출됨, {{failed}}개는 제출할 수 없습니다.",
+      resourceSubmitted: "{{count}}개 리소스가 제출되었습니다.",
+      resourcesSubmitted: "{{count}}개 리소스가 제출되었습니다.",
+    },
   },
   "pt-BR": {
     title: "Biblioteca",
@@ -1142,6 +1387,33 @@ export const creativeContextMessagesByLocale: Record<
       "Escolha as apresentações disponíveis para esta conexão. Nenhum acesso a todo o Drive é solicitado.",
     suggestions: "Revisar sugestões",
     logo: "Logotipo canônico",
+    share: {
+      title: "Contexto criativo",
+      tabLabel: "Contexto",
+      pendingResource: "Recurso pendente",
+      publishedResource: "Recurso publicado",
+      canonical: "Canônico",
+      reference: "Referência",
+      pendingReview: "Revisão pendente",
+      published: "Publicado",
+      withdraw: "Retirar",
+      requestChanges: "Solicitar alterações",
+      remove: "Remover",
+      chooseContext: "Escolha um contexto",
+      selectedResources: "{{count}} recursos selecionados",
+      noContexts: "Ainda não há contextos disponíveis.",
+      purpose: "Finalidade",
+      reviewerNote: "Nota para revisores",
+      submit: "Enviar",
+      broaderPublication:
+        "Este contexto é compartilhado mais amplamente que este recurso. A publicação cria uma cópia governada disponível ao público do contexto.",
+      newContextName: "Nome do novo contexto",
+      new: "Novo",
+      partialSubmission:
+        "{{submitted}} enviados; {{failed}} não puderam ser enviados.",
+      resourceSubmitted: "{{count}} recurso enviado.",
+      resourcesSubmitted: "{{count}} recursos enviados.",
+    },
   },
   "hi-IN": {
     title: "लाइब्रेरी",
@@ -1254,6 +1526,33 @@ export const creativeContextMessagesByLocale: Record<
       "इस लाइब्रेरी कनेक्शन के लिए प्रेज़ेंटेशन चुनें। पूरे Drive की अनुमति नहीं मांगी जाती।",
     suggestions: "सुझावों की समीक्षा करें",
     logo: "मानक लोगो",
+    share: {
+      title: "क्रिएटिव संदर्भ",
+      tabLabel: "संदर्भ",
+      pendingResource: "लंबित संसाधन",
+      publishedResource: "प्रकाशित संसाधन",
+      canonical: "कैनोनिकल",
+      reference: "संदर्भ",
+      pendingReview: "समीक्षा लंबित",
+      published: "प्रकाशित",
+      withdraw: "वापस लें",
+      requestChanges: "बदलाव का अनुरोध करें",
+      remove: "हटाएँ",
+      chooseContext: "संदर्भ चुनें",
+      selectedResources: "{{count}} संसाधन चुने गए",
+      noContexts: "अभी कोई संदर्भ उपलब्ध नहीं है।",
+      purpose: "उद्देश्य",
+      reviewerNote: "समीक्षकों के लिए नोट",
+      submit: "जमा करें",
+      broaderPublication:
+        "यह संदर्भ इस संसाधन से अधिक व्यापक रूप से साझा किया जाता है। प्रकाशित करने पर संदर्भ के दर्शकों के लिए एक नियंत्रित प्रति बनाई जाती है।",
+      newContextName: "नए संदर्भ का नाम",
+      new: "नया",
+      partialSubmission:
+        "{{submitted}} जमा किए गए; {{failed}} जमा नहीं किए जा सके।",
+      resourceSubmitted: "{{count}} संसाधन जमा किया गया।",
+      resourcesSubmitted: "{{count}} संसाधन जमा किए गए।",
+    },
   },
   "ar-SA": {
     title: "المكتبة",
@@ -1366,5 +1665,31 @@ export const creativeContextMessagesByLocale: Record<
       "اختر العروض المتاحة لهذا الاتصال بالمكتبة. لا يتم طلب إذن للوصول إلى Drive بالكامل.",
     suggestions: "مراجعة الاقتراحات",
     logo: "الشعار المعتمد",
+    share: {
+      title: "السياق الإبداعي",
+      tabLabel: "السياق",
+      pendingResource: "مورد قيد الانتظار",
+      publishedResource: "مورد منشور",
+      canonical: "أساسي",
+      reference: "مرجع",
+      pendingReview: "المراجعة معلقة",
+      published: "منشور",
+      withdraw: "سحب",
+      requestChanges: "طلب تغييرات",
+      remove: "إزالة",
+      chooseContext: "اختر سياقًا",
+      selectedResources: "تم تحديد {{count}} من الموارد",
+      noContexts: "لا توجد سياقات متاحة بعد.",
+      purpose: "الغرض",
+      reviewerNote: "ملاحظة للمراجعين",
+      submit: "إرسال",
+      broaderPublication:
+        "تتم مشاركة هذا السياق على نطاق أوسع من هذا المورد. يؤدي النشر إلى إنشاء نسخة محكومة متاحة لجمهور السياق.",
+      newContextName: "اسم السياق الجديد",
+      new: "جديد",
+      partialSubmission: "تم إرسال {{submitted}}؛ تعذر إرسال {{failed}}.",
+      resourceSubmitted: "تم إرسال {{count}} من الموارد.",
+      resourcesSubmitted: "تم إرسال {{count}} من الموارد.",
+    },
   },
 };

--- a/packages/creative-context/src/store/contexts.ts
+++ b/packages/creative-context/src/store/contexts.ts
@@ -712,6 +712,7 @@ export async function listCreativeContexts(input: {
   includeArchived?: boolean;
 }) {
   await ensureDefaultCreativeContext();
+  const actor = requireActor();
   const { getDb, schema } = getCreativeContext();
   const filters: any[] = [
     accessFilter(schema.creativeContexts, schema.creativeContextShares),
@@ -770,6 +771,8 @@ export async function listCreativeContexts(input: {
         : [];
     }),
     nextCursor: rows.length > input.limit ? page.at(-1)?.id : undefined,
+    canCreateContext:
+      !actor.orgId || (await currentRequestUserIsOrgAdmin(actor.orgId)),
   };
 }
 

--- a/templates/analytics/app/i18n-data.ts
+++ b/templates/analytics/app/i18n-data.ts
@@ -1,8 +1,10 @@
 import { type LocaleCode } from "@agent-native/core/client/i18n";
+import { creativeContextMessagesByLocale } from "@agent-native/creative-context/messages";
 
 import zhTW from "./i18n/zh-TW";
 
 const enUS = {
+  creativeContext: creativeContextMessagesByLocale["en-US"],
   root: {
     whatsNew: "What's new",
   },
@@ -4960,6 +4962,10 @@ function mergeMessages(overrides: {
     dialogs: { ...enUS.dialogs, ...overrides.dialogs },
     commandPalette: { ...enUS.commandPalette, ...overrides.commandPalette },
     common: { ...enUS.common, ...overrides.common },
+    creativeContext: {
+      ...enUS.creativeContext,
+      ...overrides.creativeContext,
+    },
     dataDictionary: { ...enUS.dataDictionary, ...overrides.dataDictionary },
     dataSources: { ...enUS.dataSources, ...overrides.dataSources },
     analyticsBackend: {
@@ -6971,6 +6977,13 @@ export const messagesByLocale = {
     },
   }),
 } satisfies Record<LocaleCode, Messages>;
+
+for (const locale of Object.keys(creativeContextMessagesByLocale) as Array<
+  keyof typeof creativeContextMessagesByLocale
+>) {
+  messagesByLocale[locale].creativeContext =
+    creativeContextMessagesByLocale[locale];
+}
 
 type AnalyticsPartialMessages = {
   [K in Section]?: Partial<Messages[K]>;

--- a/templates/analytics/app/i18n/zh-TW.ts
+++ b/templates/analytics/app/i18n/zh-TW.ts
@@ -1,4 +1,7 @@
+import { creativeContextMessagesByLocale } from "@agent-native/creative-context/messages";
+
 const messages = {
+  creativeContext: creativeContextMessagesByLocale["zh-TW"],
   root: {
     whatsNew: "最新消息",
   },

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1912,7 +1912,7 @@ function SqlDashboardPageContent({
               tabs: [
                 {
                   value: "context",
-                  label: "Context",
+                  label: t("creativeContext.share.tabLabel"),
                   content: (
                     <CreativeContextShareTab
                       resource={{

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -956,7 +956,7 @@ export function DocumentToolbar({
                   tabs: [
                     {
                       value: "context",
-                      label: "Context",
+                      label: t("creativeContext.share.tabLabel"),
                       content: (
                         <CreativeContextShareTab
                           resource={{
@@ -965,7 +965,10 @@ export function DocumentToolbar({
                             resourceId: documentId,
                             title: documentTitle || "Untitled",
                             updatedAt: documentUpdatedAt ?? undefined,
-                            preview: { kind: "document", label: "Document" },
+                            preview: {
+                              kind: "document",
+                              label: t("root.commandDocumentsHeading"),
+                            },
                           }}
                         />
                       ),

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -15124,7 +15124,7 @@ function DesignEditor() {
     "inline-flex items-center justify-center gap-1.5";
   const designSharePopoverClassName =
     "z-[100010] !w-[min(620px,calc(100vw-32px))] !p-3 " +
-    "[&_[role=tablist]]:!inline-flex [&_[role=tablist]]:!w-fit [&_[role=tablist]]:!self-start [&_[role=tablist]]:justify-start [&_[role=tablist]]:gap-1 [&_[role=tablist]]:rounded-lg [&_[role=tablist]]:border [&_[role=tablist]]:border-[var(--design-editor-panel-divider-color)] [&_[role=tablist]]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tablist]]:p-1 " +
+    "[&_[role=tablist]]:!inline-flex [&_[role=tablist]]:!w-fit [&_[role=tablist]]:!max-w-full [&_[role=tablist]]:!self-start [&_[role=tablist]]:!overflow-x-auto [&_[role=tablist]]:justify-start [&_[role=tablist]]:gap-1 [&_[role=tablist]]:rounded-lg [&_[role=tablist]]:border [&_[role=tablist]]:border-[var(--design-editor-panel-divider-color)] [&_[role=tablist]]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tablist]]:p-1 " +
     "[&_[role=tab]]:!h-8 [&_[role=tab]]:!flex-none [&_[role=tab]]:rounded-md [&_[role=tab]]:px-3 [&_[role=tab]]:!text-[12px] [&_[role=tab]]:font-semibold [&_[role=tab]]:shadow-none [&_[role=tab]]:ring-0 " +
     "[&_[role=tab]:hover]:bg-white/70 dark:[&_[role=tab]:hover]:bg-[var(--design-editor-control-bg)] [&_[role=tab]:hover]:text-foreground " +
     "[&_[role=tab][aria-selected=true]]:bg-white dark:[&_[role=tab][aria-selected=true]]:bg-[var(--design-editor-control-bg)] [&_[role=tab][aria-selected=true]]:text-foreground [&_[role=tab][aria-selected=true]]:shadow-sm [&_[role=tab][aria-selected=true]]:ring-1 [&_[role=tab][aria-selected=true]]:ring-[var(--design-editor-control-border)]";

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -57,7 +57,6 @@ import { ShareButton } from "@agent-native/core/client/sharing";
 import type { ReviewComment } from "@agent-native/core/review";
 import { normalizeDocumentTitle } from "@agent-native/core/shared";
 import {
-  CreativeContextShareSheet,
   CreativeContextShareTab,
   parseCreativeContexts,
   useCreativeContexts,
@@ -161,7 +160,6 @@ import {
   IconTemplate,
   IconAdjustmentsHorizontal,
   IconMessageCircle,
-  IconLibraryPlus,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -614,7 +612,6 @@ import {
 import { isRadixOverlayOpen } from "./design-editor/dom-guards";
 import { useTweaks } from "./design-editor/domains/use-tweaks";
 import {
-  ADD_TO_CONTEXT_LABEL,
   AUTO_RETRY_DELAY_MS,
   BOARD_SURFACE_SIZE,
   DESIGN_EDITOR_DEBUG_LOGS,
@@ -3520,11 +3517,6 @@ function DesignEditor() {
   });
 
   const shouldOpenShare = postAuthIntent === "share" && canShareDesign;
-  // Standalone entry point into the same Creative Context submission flow
-  // the Share popover's "Context" tab already offers — kept as its own
-  // always-visible button because the Share popover buries it behind two
-  // other tabs, which is the opposite of "clearly visible."
-  const [addToContextOpen, setAddToContextOpen] = useState(false);
   // ── Share URL, prompt popovers, title editing ──────────────────────────────
   const editorShareUrl = useMemo(() => {
     if (!id || typeof window === "undefined") return undefined;
@@ -19103,32 +19095,6 @@ function DesignEditor() {
                 : t("review.applyFeedback", { count: reviewAgentQueueCount })}
             </Button>
           ) : null}
-          {!hostEmbeddedEditor && canRenderAuthenticatedShare ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setAddToContextOpen(true)}
-                  aria-label={ADD_TO_CONTEXT_LABEL}
-                  className={cn(
-                    "h-[var(--design-row-height)] min-w-0 rounded-md text-sm",
-                    rightToolbarCompact
-                      ? "w-[var(--design-row-height)] shrink-0 px-0"
-                      : "gap-[var(--design-baseline-half)] px-[var(--design-baseline-unit)]",
-                  )}
-                >
-                  <IconLibraryPlus className="size-4" />
-                  {rightToolbarCompact ? null : (
-                    <span className="truncate">{ADD_TO_CONTEXT_LABEL}</span>
-                  )}
-                </Button>
-              </TooltipTrigger>
-              {rightToolbarCompact ? (
-                <TooltipContent>{ADD_TO_CONTEXT_LABEL}</TooltipContent>
-              ) : null}
-            </Tooltip>
-          ) : null}
           <Popover
             open={hostEmbeddedEditor ? false : publishWaitlistPopoverOpen}
             onOpenChange={(open) => {
@@ -19276,20 +19242,6 @@ function DesignEditor() {
           ) : null}
         </div>
       </div>
-      {!hostEmbeddedEditor && canRenderAuthenticatedShare ? (
-        <CreativeContextShareSheet
-          resource={{
-            appId: "design",
-            resourceType: "design",
-            resourceId: id ?? "",
-            title: design.title ?? "Untitled design",
-            updatedAt: design?.updatedAt ?? undefined,
-            preview: { kind: "document", label: "Design project" }, // i18n-ignore share-tab preview descriptor, template pages are raw-English
-          }}
-          open={addToContextOpen}
-          onOpenChange={setAddToContextOpen}
-        />
-      ) : null}
       {activeScreenIsLocalSource &&
       viewMode === "single" &&
       activeScreenPreviewUrl ? (

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -15159,7 +15159,13 @@ function DesignEditor() {
       },
       {
         value: "context",
-        label: <span className={designShareTabLabelClassName}>Context</span>,
+        label: (
+          <span className={designShareTabLabelClassName}>
+            {t("creativeContext.share.tabLabel", {
+              defaultValue: "Context",
+            })}
+          </span>
+        ),
         content: (
           <CreativeContextShareTab
             resource={{

--- a/templates/design/app/pages/design-editor/editor-constants.ts
+++ b/templates/design/app/pages/design-editor/editor-constants.ts
@@ -47,9 +47,6 @@ export const NO_LOCALHOST_WRITE_PATH_MESSAGE =
   "Can't determine the source file for this screen."; /* i18n-ignore */
 export const TWEAK_CONTROLS_EDIT_ACCESS_MESSAGE =
   "You need edit access to add tweak controls."; /* i18n-ignore */
-export const ADD_TO_CONTEXT_LABEL =
-  "Add to Context"; /* i18n-ignore prominent context entry point */
-
 export const PENDING_STRUCTURE_VERIFICATION_TIMEOUT_MS = 60_000;
 export const PENDING_STRUCTURE_RUNTIME_TIMEOUT_MS = 15_000;
 export const PENDING_STRUCTURE_SOURCE_POLL_MS = 750;

--- a/templates/design/e2e/editor.spec.ts
+++ b/templates/design/e2e/editor.spec.ts
@@ -55,7 +55,7 @@ test("share dialog uses editor panel chrome", async ({ page }, testInfo) => {
 
   const tabListBox = await shareOptions.boundingBox();
   expect(tabListBox?.width ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
-    340,
+    420,
   );
   expect(tabListBox?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
     42,
@@ -66,6 +66,14 @@ test("share dialog uses editor panel chrome", async ({ page }, testInfo) => {
   expect(sendTabBox?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
     36,
   );
+
+  const contextTab = page.getByRole("tab", { name: "Context", exact: true });
+  await expect(contextTab).toBeVisible();
+  await contextTab.click();
+  await expect(
+    page.getByRole("region", { name: "Creative context" }),
+  ).toBeVisible();
+  await cdpScreenshot(page, testInfo.outputPath("share-dialog-context.png"));
 
   await sendTab.click();
   await expect(page.getByText("Your agent", { exact: true })).toBeVisible();
@@ -123,16 +131,15 @@ test("share dialog uses editor panel chrome", async ({ page }, testInfo) => {
 
 test("right rail actions row keeps the Share button inside the panel", async ({
   page,
-}) => {
+}, testInfo) => {
   const actionsRow = page.locator(
     '[data-design-chrome-region="right-toolbar-actions"]',
   );
   await expect(actionsRow).toBeVisible();
 
-  // Icon-only at the rail's 240px default width; the label lives on the tooltip.
   await expect(
     page.getByRole("button", { name: "Add to Context" }),
-  ).toBeVisible();
+  ).toHaveCount(0);
 
   const shareButton = page
     .getByRole("button", { name: /^share(?: \(.+\))?$/i })
@@ -151,6 +158,8 @@ test("right rail actions row keeps the Share button inside the panel", async ({
   expect(
     await actionsRow.evaluate((node) => node.scrollWidth - node.clientWidth),
   ).toBeLessThanOrEqual(1);
+
+  await cdpScreenshot(page, testInfo.outputPath("editor-share-toolbar.png"));
 });
 
 test("screen overview adds and targets frames from the unified breakpoint control", async ({

--- a/templates/slides/app/components/editor/EditorToolbar.test.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.test.tsx
@@ -18,7 +18,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@agent-native/core/client/i18n", () => ({
   useT: () => (key: string) =>
-    key === "editorToolbar.savedVersions" ? "History" : key,
+    key === "editorToolbar.savedVersions"
+      ? "History"
+      : key === "creativeContext.share.tabLabel"
+        ? "Context"
+        : key,
 }));
 
 vi.mock("@agent-native/core/client/progress", () => ({

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -1000,7 +1000,7 @@ export default function EditorToolbar({
             tabs: [
               {
                 value: "context",
-                label: "Context",
+                label: t("creativeContext.share.tabLabel"),
                 content: (
                   <CreativeContextShareTab
                     resource={{
@@ -1009,7 +1009,7 @@ export default function EditorToolbar({
                       resourceId: deckId,
                       title: deckTitle,
                       updatedAt: deck.updatedAt,
-                      preview: { kind: "document", label: "Deck" },
+                      preview: { kind: "document", label: t("header.deck") },
                     }}
                   />
                 ),


### PR DESCRIPTION
## Summary
- restore Creative context as a Share dialog tab
- remove the duplicate right-rail action
- compact context submission and creation controls

## Validation
- core ShareButton: 24 passed
- creative-context: 2 passed
- design browser coverage: 2 passed
- pnpm guards: 66 passed

Screenshots are attached in the task output.