### PR TITLE
docs: improve community app submissions

### DIFF
--- a/packages/docs/app/components/CommunityAppSubmissionDialog.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionDialog.tsx
@@ -1,7 +1,11 @@
 import { useT } from "@agent-native/core/client/i18n";
 import { IconUpload, IconX } from "@tabler/icons-react";
+import { useState } from "react";
 
-import { CommunityAppSubmissionForm } from "./CommunityAppSubmissionForm";
+import {
+  CommunityAppSubmissionForm,
+  type CommunitySubmissionDraft,
+} from "./CommunityAppSubmissionForm";
 import {
   Dialog,
   DialogClose,
@@ -13,6 +17,13 @@ import {
 
 export function CommunityAppSubmissionDialog() {
   const t = useT();
+  const [draft, setDraft] = useState<CommunitySubmissionDraft>({
+    name: "",
+    appUrl: "",
+    description: "",
+    repositoryUrl: "",
+    screenshotFiles: [],
+  });
 
   return (
     <Dialog>
@@ -39,7 +50,7 @@ export function CommunityAppSubmissionDialog() {
           {t("templatesPage.communitySubmissionDescription")}
         </DialogDescription>
         <div className="mt-6">
-          <CommunityAppSubmissionForm />
+          <CommunityAppSubmissionForm draft={draft} onDraftChange={setDraft} />
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/docs/app/components/CommunityAppSubmissionForm.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionForm.tsx
@@ -14,8 +14,8 @@ import {
 import { sitePathForLocale } from "./docs-locale";
 import { Button } from "./website-redesign/ds/button";
 
-const COMMUNITY_FORM_NAME = "community-app-submission";
-const SCREENSHOT_FIELDS = [
+export const COMMUNITY_FORM_NAME = "community-app-submission";
+export const SCREENSHOT_FIELDS = [
   "screenshot_1",
   "screenshot_2",
   "screenshot_3",
@@ -30,17 +30,48 @@ type SelectedScreenshot = {
   previewUrl: string;
 };
 
-type CommunitySubmissionValues = {
+export type CommunitySubmissionDraft = {
   name: string;
   appUrl: string;
   description: string;
   repositoryUrl: string;
+  screenshotFiles: File[];
 };
 
+type CommunitySubmissionValues = Omit<
+  CommunitySubmissionDraft,
+  "screenshotFiles"
+>;
+
+function createSelectedScreenshots(files: File[]) {
+  return files.map((file) => ({
+    file,
+    previewUrl: URL.createObjectURL(file),
+  }));
+}
+
+export function normalizeHttpUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || /^[a-z][a-z\d+.-]*:/i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
 function isHttpUrl(value: string) {
-  if (!URL.canParse(value)) return false;
-  const url = new URL(value);
+  const normalized = normalizeHttpUrl(value);
+  if (!URL.canParse(normalized)) return false;
+  const url = new URL(normalized);
   return url.protocol === "http:" || url.protocol === "https:";
+}
+
+export function isGitHubRepositoryUrl(value: string) {
+  if (!isHttpUrl(value)) return false;
+  const url = new URL(normalizeHttpUrl(value));
+  const hostname = url.hostname.toLowerCase();
+  const pathSegments = url.pathname.split("/").filter(Boolean);
+  return (
+    (hostname === "github.com" || hostname === "www.github.com") &&
+    pathSegments.length >= 2
+  );
 }
 
 function isValidScreenshot(file: File) {
@@ -69,20 +100,30 @@ function createScreenshotDataTransfer(): DataTransfer | null {
 const fieldClassName =
   "w-full rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)] px-3 py-2.5 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[var(--b-text-muted)] focus:border-[var(--b-action-primary-bg)] focus:ring-2 focus:ring-[var(--b-action-primary-effect)]";
 
-export function CommunityAppSubmissionForm() {
+type CommunityAppSubmissionFormProps = {
+  draft?: CommunitySubmissionDraft;
+  onDraftChange?: (draft: CommunitySubmissionDraft) => void;
+};
+
+export function CommunityAppSubmissionForm({
+  draft,
+  onDraftChange,
+}: CommunityAppSubmissionFormProps = {}) {
   const t = useT();
   const { locale } = useLocale();
   const formId = useId();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const hiddenInputRefs = useRef<Array<HTMLInputElement | null>>([]);
   const previewUrlsRef = useRef<Set<string>>(new Set());
-  const [values, setValues] = useState<CommunitySubmissionValues>({
-    name: "",
-    appUrl: "",
-    description: "",
-    repositoryUrl: "",
-  });
-  const [screenshots, setScreenshots] = useState<SelectedScreenshot[]>([]);
+  const [values, setValues] = useState<CommunitySubmissionValues>(() => ({
+    name: draft?.name ?? "",
+    appUrl: draft?.appUrl ?? "",
+    description: draft?.description ?? "",
+    repositoryUrl: draft?.repositoryUrl ?? "",
+  }));
+  const [screenshots, setScreenshots] = useState<SelectedScreenshot[]>(() =>
+    createSelectedScreenshots(draft?.screenshotFiles ?? []),
+  );
   const [isDragActive, setIsDragActive] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -96,6 +137,13 @@ export function CommunityAppSubmissionForm() {
     }
     previewUrlsRef.current = activePreviewUrls;
   }, [screenshots]);
+
+  useEffect(() => {
+    onDraftChange?.({
+      ...values,
+      screenshotFiles: screenshots.map((screenshot) => screenshot.file),
+    });
+  }, [onDraftChange, screenshots, values]);
 
   useEffect(() => {
     return () => {
@@ -121,6 +169,11 @@ export function CommunityAppSubmissionForm() {
   function updateValue(field: keyof CommunitySubmissionValues, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
     setError(null);
+  }
+
+  function normalizeUrlField(field: "appUrl" | "repositoryUrl") {
+    const normalized = normalizeHttpUrl(values[field]);
+    if (normalized !== values[field]) updateValue(field, normalized);
   }
 
   function handleScreenshotChange(event: ChangeEvent<HTMLInputElement>) {
@@ -183,8 +236,21 @@ export function CommunityAppSubmissionForm() {
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     const formData = new FormData(event.currentTarget);
-    const appUrl = String(formData.get("app_url") ?? "").trim();
-    const repositoryUrl = String(formData.get("repository_url") ?? "").trim();
+    const rawAppUrl = String(formData.get("app_url") ?? "");
+    const rawRepositoryUrl = String(formData.get("repository_url") ?? "");
+    const appUrl = normalizeHttpUrl(rawAppUrl);
+    const repositoryUrl = normalizeHttpUrl(rawRepositoryUrl);
+
+    if (appUrl !== rawAppUrl || repositoryUrl !== rawRepositoryUrl) {
+      setValues((current) => ({ ...current, appUrl, repositoryUrl }));
+      const appUrlInput = event.currentTarget.elements.namedItem("app_url");
+      const repositoryUrlInput =
+        event.currentTarget.elements.namedItem("repository_url");
+      if (appUrlInput instanceof HTMLInputElement) appUrlInput.value = appUrl;
+      if (repositoryUrlInput instanceof HTMLInputElement) {
+        repositoryUrlInput.value = repositoryUrl;
+      }
+    }
     const uploadedFiles = SCREENSHOT_FIELDS.map((field) =>
       formData.get(field),
     ).filter((value): value is File => value instanceof File && value.size > 0);
@@ -193,7 +259,7 @@ export function CommunityAppSubmissionForm() {
       !String(formData.get("name") ?? "").trim() ||
       !String(formData.get("description") ?? "").trim() ||
       !isHttpUrl(appUrl) ||
-      (repositoryUrl && !isHttpUrl(repositoryUrl)) ||
+      (repositoryUrl && !isGitHubRepositoryUrl(repositoryUrl)) ||
       uploadedFiles.some((file) => !isValidScreenshot(file))
     ) {
       event.preventDefault();
@@ -254,9 +320,13 @@ export function CommunityAppSubmissionForm() {
           id={`${formId}-url`}
           name="app_url"
           required
-          type="url"
+          type="text"
+          inputMode="url"
+          autoComplete="url"
+          spellCheck={false}
           value={values.appUrl}
           onChange={(event) => updateValue("appUrl", event.target.value)}
+          onBlur={() => normalizeUrlField("appUrl")}
           placeholder={t("templatesPage.communitySubmissionUrlPlaceholder")}
           className={fieldClassName}
         />
@@ -293,9 +363,13 @@ export function CommunityAppSubmissionForm() {
         <input
           id={`${formId}-repository`}
           name="repository_url"
-          type="url"
+          type="text"
+          inputMode="url"
+          autoComplete="url"
+          spellCheck={false}
           value={values.repositoryUrl}
           onChange={(event) => updateValue("repositoryUrl", event.target.value)}
+          onBlur={() => normalizeUrlField("repositoryUrl")}
           placeholder={t(
             "templatesPage.communitySubmissionRepositoryPlaceholder",
           )}
@@ -447,6 +521,39 @@ export function CommunityAppSubmissionForm() {
           {t("templatesPage.communitySubmissionSubmit")}
         </Button>
       </div>
+    </form>
+  );
+}
+
+export function CommunityAppSubmissionNetlifyDetectionForm() {
+  const { locale } = useLocale();
+
+  return (
+    <form
+      name={COMMUNITY_FORM_NAME}
+      method="post"
+      action={`${sitePathForLocale("/apps", locale)}?community-submission=received`}
+      encType="multipart/form-data"
+      data-netlify="true"
+      data-netlify-honeypot="bot-field"
+      className="hidden"
+      aria-hidden="true"
+    >
+      <input type="hidden" name="form-name" value={COMMUNITY_FORM_NAME} />
+      <input name="bot-field" tabIndex={-1} autoComplete="off" />
+      <input name="name" tabIndex={-1} />
+      <input name="app_url" tabIndex={-1} />
+      <textarea name="description" tabIndex={-1} />
+      <input name="repository_url" tabIndex={-1} />
+      {SCREENSHOT_FIELDS.map((field) => (
+        <input
+          key={field}
+          name={field}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          tabIndex={-1}
+        />
+      ))}
     </form>
   );
 }

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -571,13 +571,12 @@ const arSA = {
     communitySubmissionName: "اسم التطبيق",
     communitySubmissionNamePlaceholder: "مركز دعم العملاء",
     communitySubmissionUrl: "رابط التطبيق",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com أو https://example.com",
     communitySubmissionDescriptionLabel: "الوصف",
     communitySubmissionDescriptionPlaceholder:
       "ماذا يفعل التطبيق ولمن هو مخصص؟",
     communitySubmissionRepository: "مستودع GitHub (اختياري)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "لقطات الشاشة (اختياري)",
     communitySubmissionScreenshotsPlaceholder: "اسحب حتى 5 صور إلى هنا",
     communitySubmissionScreenshotDropHint:
@@ -589,7 +588,7 @@ const arSA = {
     communitySubmissionSubmit: "إرسال التطبيق",
     communitySubmissionReady: "شكرًا. سنراجع تطبيقك قبل نشره.",
     communitySubmissionValidation:
-      "أضف اسمًا ووصفًا ورابط تطبيق صالحًا. ارفع صور PNG أو JPG أو WebP بحد أقصى 1.5 ميجابايت لكل صورة.",
+      "أضف اسمًا ووصفًا، ثم أدخل رابط التطبيق مثل example.com. سنضيف https:// نيابةً عنك. إذا أضفت مستودعًا، فاستخدم رابطًا من github.com. ارفع صور PNG أو JPG أو WebP بحد أقصى 1.5 ميجابايت لكل صورة.",
   },
   buildFromScratch: {
     title: "ابنِ من الصفر",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -577,13 +577,12 @@ const deDE = {
     communitySubmissionName: "App-Name",
     communitySubmissionNamePlaceholder: "Kundensupport-Zentrale",
     communitySubmissionUrl: "App-URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com oder https://example.com",
     communitySubmissionDescriptionLabel: "Beschreibung",
     communitySubmissionDescriptionPlaceholder:
       "Was macht die App und für wen ist sie gedacht?",
     communitySubmissionRepository: "GitHub-Repository (optional)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "Screenshots (optional)",
     communitySubmissionScreenshotsPlaceholder: "Bis zu 5 Bilder hierher ziehen",
     communitySubmissionScreenshotDropHint:
@@ -596,7 +595,7 @@ const deDE = {
     communitySubmissionReady:
       "Danke. Wir prüfen deine App vor der Veröffentlichung.",
     communitySubmissionValidation:
-      "Füge einen Namen, eine Beschreibung und eine gültige App-URL hinzu. Lade PNG-, JPG- oder WebP-Bilder mit jeweils maximal 1,5 MB hoch.",
+      "Füge einen Namen und eine Beschreibung hinzu und gib dann einen App-Link wie example.com ein. Wir ergänzen https:// automatisch. Wenn du ein Repository hinzufügst, muss der Link auf github.com verweisen. Lade PNG-, JPG- oder WebP-Bilder mit jeweils maximal 1,5 MB hoch.",
   },
   buildFromScratch: {
     title: "Von Grund auf bauen",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -574,13 +574,12 @@ const enUS = {
     communitySubmissionName: "App name",
     communitySubmissionNamePlaceholder: "Customer Support Hub",
     communitySubmissionUrl: "App URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com or https://example.com",
     communitySubmissionDescriptionLabel: "Description",
     communitySubmissionDescriptionPlaceholder:
       "What does the app do, and who is it for?",
     communitySubmissionRepository: "GitHub repository (optional)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "Screenshots (optional)",
     communitySubmissionScreenshotsPlaceholder: "Drop up to 5 images here",
     communitySubmissionScreenshotDropHint:
@@ -593,7 +592,7 @@ const enUS = {
     communitySubmissionReady:
       "Thanks. We will review your app before publishing it.",
     communitySubmissionValidation:
-      "Add a name, description, and valid app URL. Upload PNG, JPG, or WebP images up to 1.5 MB each.",
+      "Add a name and description, then enter an app link like example.com. We’ll add https:// for you. If you add a repository, use a github.com link. Upload PNG, JPG, or WebP images up to 1.5 MB each.",
   },
   buildFromScratch: {
     title: "Build from scratch",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -579,13 +579,12 @@ const esES = {
     communitySubmissionName: "Nombre de la aplicación",
     communitySubmissionNamePlaceholder: "Centro de atención al cliente",
     communitySubmissionUrl: "URL de la aplicación",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com o https://example.com",
     communitySubmissionDescriptionLabel: "Descripción",
     communitySubmissionDescriptionPlaceholder:
       "¿Qué hace la aplicación y para quién es?",
     communitySubmissionRepository: "Repositorio de GitHub (opcional)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "Capturas (opcional)",
     communitySubmissionScreenshotsPlaceholder: "Arrastra hasta 5 imágenes aquí",
     communitySubmissionScreenshotDropHint:
@@ -598,7 +597,7 @@ const esES = {
     communitySubmissionReady:
       "Gracias. Revisaremos tu aplicación antes de publicarla.",
     communitySubmissionValidation:
-      "Añade un nombre, una descripción y una URL de aplicación válida. Sube imágenes PNG, JPG o WebP de hasta 1,5 MB cada una.",
+      "Añade un nombre y una descripción, y después introduce un enlace de aplicación como example.com. Añadiremos https:// por ti. Si añades un repositorio, usa un enlace de github.com. Sube imágenes PNG, JPG o WebP de hasta 1,5 MB cada una.",
   },
   buildFromScratch: {
     title: "Crear desde cero",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -577,13 +577,12 @@ const frFR = {
     communitySubmissionName: "Nom de l’application",
     communitySubmissionNamePlaceholder: "Centre de support client",
     communitySubmissionUrl: "URL de l’application",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com ou https://example.com",
     communitySubmissionDescriptionLabel: "Description",
     communitySubmissionDescriptionPlaceholder:
       "Que fait l’application et à qui s’adresse-t-elle ?",
     communitySubmissionRepository: "Dépôt GitHub (facultatif)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "Captures d’écran (facultatif)",
     communitySubmissionScreenshotsPlaceholder: "Déposez jusqu’à 5 images ici",
     communitySubmissionScreenshotDropHint:
@@ -596,7 +595,7 @@ const frFR = {
     communitySubmissionReady:
       "Merci. Nous examinerons votre application avant de la publier.",
     communitySubmissionValidation:
-      "Ajoutez un nom, une description et une URL d’application valide. Importez des images PNG, JPG ou WebP de 1,5 Mo maximum chacune.",
+      "Ajoutez un nom et une description, puis saisissez un lien d’application comme example.com. Nous ajouterons https:// pour vous. Si vous ajoutez un dépôt, utilisez un lien github.com. Importez des images PNG, JPG ou WebP de 1,5 Mo maximum chacune.",
   },
   buildFromScratch: {
     title: "Créer de zéro",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -571,13 +571,12 @@ const hiIN = {
     communitySubmissionName: "ऐप का नाम",
     communitySubmissionNamePlaceholder: "कस्टमर सपोर्ट हब",
     communitySubmissionUrl: "ऐप URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com या https://example.com",
     communitySubmissionDescriptionLabel: "विवरण",
     communitySubmissionDescriptionPlaceholder:
       "ऐप क्या करता है और यह किसके लिए है?",
     communitySubmissionRepository: "GitHub रिपॉज़िटरी (वैकल्पिक)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "स्क्रीनशॉट (वैकल्पिक)",
     communitySubmissionScreenshotsPlaceholder: "यहाँ अधिकतम 5 इमेज ड्रॉप करें",
     communitySubmissionScreenshotDropHint: "PNG, JPG या WebP। प्रत्येक 1.5 MB तक।",
@@ -589,7 +588,7 @@ const hiIN = {
     communitySubmissionReady:
       "धन्यवाद। प्रकाशित करने से पहले हम आपके ऐप की समीक्षा करेंगे।",
     communitySubmissionValidation:
-      "नाम, विवरण और मान्य ऐप URL जोड़ें। PNG, JPG या WebP इमेज अपलोड करें, प्रत्येक 1.5 MB तक।",
+      "नाम और विवरण जोड़ें, फिर example.com जैसा ऐप लिंक डालें। हम आपके लिए https:// जोड़ देंगे। रिपॉज़िटरी जोड़ने पर github.com का लिंक इस्तेमाल करें। PNG, JPG या WebP इमेज अपलोड करें, प्रत्येक 1.5 MB तक।",
   },
   buildFromScratch: {
     title: "शुरू से बनाएँ",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -575,13 +575,12 @@ const jaJP = {
     communitySubmissionName: "アプリ名",
     communitySubmissionNamePlaceholder: "カスタマーサポートハブ",
     communitySubmissionUrl: "アプリ URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com または https://example.com",
     communitySubmissionDescriptionLabel: "説明",
     communitySubmissionDescriptionPlaceholder:
       "アプリの機能と対象ユーザーを教えてください。",
     communitySubmissionRepository: "GitHub リポジトリ（任意）",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "スクリーンショット（任意）",
     communitySubmissionScreenshotsPlaceholder: "最大5枚の画像をここにドロップ",
     communitySubmissionScreenshotDropHint: "PNG、JPG、WebP。各1.5 MBまで。",
@@ -593,7 +592,7 @@ const jaJP = {
     communitySubmissionReady:
       "ありがとうございます。公開前にアプリを確認します。",
     communitySubmissionValidation:
-      "名前、説明、有効なアプリ URL を入力してください。PNG、JPG、WebP 画像は各 1.5 MB までアップロードできます。",
+      "名前と説明を入力し、example.com のようなアプリリンクを入力してください。https:// は自動で追加します。リポジトリを追加する場合は github.com のリンクを使用してください。PNG、JPG、WebP 画像は各 1.5 MB までアップロードできます。",
   },
   buildFromScratch: {
     title: "ゼロから構築",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -575,13 +575,12 @@ const koKR = {
     communitySubmissionName: "앱 이름",
     communitySubmissionNamePlaceholder: "고객 지원 허브",
     communitySubmissionUrl: "앱 URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com 또는 https://example.com",
     communitySubmissionDescriptionLabel: "설명",
     communitySubmissionDescriptionPlaceholder:
       "앱은 무엇을 하며 누구를 위한 것인가요?",
     communitySubmissionRepository: "GitHub 저장소 (선택 사항)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "스크린샷 (선택 사항)",
     communitySubmissionScreenshotsPlaceholder: "여기에 최대 5개의 이미지 드롭",
     communitySubmissionScreenshotDropHint: "PNG, JPG 또는 WebP. 각 1.5MB 이하.",
@@ -592,7 +591,7 @@ const koKR = {
     communitySubmissionSubmit: "앱 제출",
     communitySubmissionReady: "감사합니다. 게시하기 전에 앱을 검토하겠습니다.",
     communitySubmissionValidation:
-      "이름, 설명, 유효한 앱 URL을 입력하세요. PNG, JPG 또는 WebP 이미지는 각각 1.5MB 이하로 업로드하세요.",
+      "이름과 설명을 입력한 다음 example.com과 같은 앱 링크를 입력하세요. https://는 자동으로 추가됩니다. 저장소를 추가하려면 github.com 링크를 사용하세요. PNG, JPG 또는 WebP 이미지는 각각 1.5MB 이하로 업로드하세요.",
   },
   buildFromScratch: {
     title: "처음부터 만들기",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -574,13 +574,12 @@ const ptBR = {
     communitySubmissionName: "Nome do aplicativo",
     communitySubmissionNamePlaceholder: "Central de suporte ao cliente",
     communitySubmissionUrl: "URL do aplicativo",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com ou https://example.com",
     communitySubmissionDescriptionLabel: "Descrição",
     communitySubmissionDescriptionPlaceholder:
       "O que o aplicativo faz e para quem ele é?",
     communitySubmissionRepository: "Repositório do GitHub (opcional)",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "Capturas de tela (opcional)",
     communitySubmissionScreenshotsPlaceholder: "Solte até 5 imagens aqui",
     communitySubmissionScreenshotDropHint:
@@ -593,7 +592,7 @@ const ptBR = {
     communitySubmissionReady:
       "Obrigado. Vamos revisar seu aplicativo antes de publicá-lo.",
     communitySubmissionValidation:
-      "Adicione um nome, uma descrição e uma URL de aplicativo válida. Envie imagens PNG, JPG ou WebP de até 1,5 MB cada.",
+      "Adicione um nome e uma descrição e insira um link do app, como example.com. Nós adicionaremos https:// para você. Se adicionar um repositório, use um link do github.com. Envie imagens PNG, JPG ou WebP de até 1,5 MB cada.",
   },
   buildFromScratch: {
     title: "Criar do zero",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -564,12 +564,11 @@ const zhCN = {
     communitySubmissionName: "应用名称",
     communitySubmissionNamePlaceholder: "客户支持中心",
     communitySubmissionUrl: "应用 URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com 或 https://example.com",
     communitySubmissionDescriptionLabel: "描述",
     communitySubmissionDescriptionPlaceholder: "应用做什么，适合哪些人？",
     communitySubmissionRepository: "GitHub 仓库（可选）",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "截图（可选）",
     communitySubmissionScreenshotsPlaceholder: "将最多 5 张图片拖到这里",
     communitySubmissionScreenshotDropHint:
@@ -581,7 +580,7 @@ const zhCN = {
     communitySubmissionSubmit: "提交应用",
     communitySubmissionReady: "谢谢。我们会在发布前审核你的应用。",
     communitySubmissionValidation:
-      "请填写名称、描述和有效的应用 URL。请上传 PNG、JPG 或 WebP 图片，每张不超过 1.5 MB。",
+      "请填写名称和描述，然后输入类似 example.com 的应用链接。我们会自动为你添加 https://。如果添加代码仓库，请使用 github.com 链接。请上传 PNG、JPG 或 WebP 图片，每张不超过 1.5 MB。",
   },
   buildFromScratch: {
     title: "从零开始构建",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -562,12 +562,11 @@ const messages = {
     communitySubmissionName: "應用程式名稱",
     communitySubmissionNamePlaceholder: "客戶支援中心",
     communitySubmissionUrl: "應用程式 URL",
-    communitySubmissionUrlPlaceholder: "https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com 或 https://example.com",
     communitySubmissionDescriptionLabel: "描述",
     communitySubmissionDescriptionPlaceholder: "應用程式做什麼，適合哪些人？",
     communitySubmissionRepository: "GitHub 儲存庫（選填）",
-    communitySubmissionRepositoryPlaceholder:
-      "https://github.com/owner/repository",
+    communitySubmissionRepositoryPlaceholder: "github.com/owner/repository",
     communitySubmissionScreenshots: "螢幕截圖（選填）",
     communitySubmissionScreenshotsPlaceholder: "將最多 5 張圖片拖曳到這裡",
     communitySubmissionScreenshotDropHint:
@@ -579,7 +578,7 @@ const messages = {
     communitySubmissionSubmit: "提交應用程式",
     communitySubmissionReady: "謝謝。我們會在刊登前審核你的應用程式。",
     communitySubmissionValidation:
-      "請填寫名稱、描述和有效的應用程式 URL。請上傳 PNG、JPG 或 WebP 圖片，每張不超過 1.5 MB。",
+      "請填寫名稱和描述，然後輸入類似 example.com 的應用程式連結。我們會自動為你加上 https://。如果新增儲存庫，請使用 github.com 連結。請上傳 PNG、JPG 或 WebP 圖片，每張不超過 1.5 MB。",
   },
   buildFromScratch: {
     title: "從零開始建置",

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -5,6 +5,7 @@ import { BuildFromScratchCta } from "../components/BuildFromScratchCta";
 import { communityApps } from "../components/community-apps";
 import { CommunityAppCard } from "../components/CommunityAppCard";
 import { CommunityAppSubmissionDialog } from "../components/CommunityAppSubmissionDialog";
+import { CommunityAppSubmissionNetlifyDetectionForm } from "../components/CommunityAppSubmissionForm";
 import { sitePathForLocale } from "../components/docs-locale";
 import { featuredTemplates, TemplateCard } from "../components/TemplateCard";
 
@@ -17,6 +18,7 @@ export default function TemplatesPage() {
 
   return (
     <div className="builder-brand-tokens min-h-screen">
+      <CommunityAppSubmissionNetlifyDetectionForm />
       <main className="templates-index-page mx-auto w-full min-w-0 max-w-site overflow-x-clip px-4 pb-24 pt-20 sm:px-6 lg:pt-28">
         <header className="max-w-[720px]">
           <h1 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-1)] font-medium leading-[1.05] tracking-[-0.03em] text-[var(--b-text-primary)]">

--- a/packages/docs/tests/community-templates.test.ts
+++ b/packages/docs/tests/community-templates.test.ts
@@ -8,6 +8,10 @@ import {
   communityApps,
   findCommunityApp,
 } from "../app/components/community-apps";
+import {
+  isGitHubRepositoryUrl,
+  normalizeHttpUrl,
+} from "../app/components/CommunityAppSubmissionForm";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "../../..");
@@ -72,5 +76,32 @@ describe("community apps", () => {
     expect(form).toContain("name={field}");
     expect(form).toContain('"screenshot_5"');
     expect(form).not.toContain("Screenshot URLs");
+  });
+
+  it("accepts friendly app links and validates GitHub repositories", () => {
+    expect(normalizeHttpUrl("example.com")).toBe("https://example.com");
+    expect(normalizeHttpUrl(" https://example.com ")).toBe(
+      "https://example.com",
+    );
+    expect(isGitHubRepositoryUrl("github.com/owner/repository")).toBe(true);
+    expect(isGitHubRepositoryUrl("https://gitlab.com/owner/repository")).toBe(
+      false,
+    );
+    expect(isGitHubRepositoryUrl("github.com/owner")).toBe(false);
+  });
+
+  it("keeps a static Netlify form declaration in the server-rendered route", () => {
+    const route = fs.readFileSync(
+      path.join(
+        repoRoot,
+        "packages",
+        "docs",
+        "app",
+        "routes",
+        "templates._index.tsx",
+      ),
+      "utf-8",
+    );
+    expect(route).toContain("CommunityAppSubmissionNetlifyDetectionForm");
   });
 });


### PR DESCRIPTION
## Summary
- add a server-rendered Netlify form declaration so community submissions appear in the docs site's Forms inbox
- accept friendly app links such as example.com, normalize them to HTTPS, and validate optional repositories as GitHub URLs
- preserve form text and selected screenshots across accidental modal dismissal

## Verification
- docs focused tests, typecheck, full guards, and production build pass
- browser-verified modal validation, URL normalization, file selection, click-away, and reopen persistence

Addresses the feedback in Slack threads:
- https://builder-internal.slack.com/archives/D02D6508B5J/p1788292675791399
- https://builder-internal.slack.com/archives/D02D6508B5J/p1788292856478789