### PR TITLE
Fix Builder model discovery when OAuth custody is unreadable

### DIFF
--- a/.changeset/ignore-unreadable-builder-oauth.md
+++ b/.changeset/ignore-unreadable-builder-oauth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow a usable Builder key pair to remain available when an unreadable OAuth row is present.

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -361,6 +361,13 @@ describe("Builder hosted user OAuth", () => {
     await expect(hasBuilderOAuthSession(ownerEmail)).resolves.toBe(false);
   });
 
+  it("does not treat a non-record token bundle as OAuth custody", async () => {
+    resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockResolvedValue("not-a-token-bundle");
+
+    await expect(hasBuilderOAuthSession(ownerEmail)).resolves.toBe(false);
+  });
+
   it("shares one org-scoped credential across members of the same org", async () => {
     resolveOrgMock.mockResolvedValue("org-acme");
     getRawTokensMock.mockImplementation(

--- a/packages/core/src/server/builder-oauth.spec.ts
+++ b/packages/core/src/server/builder-oauth.spec.ts
@@ -351,6 +351,16 @@ describe("Builder hosted user OAuth", () => {
     );
   });
 
+  it("does not treat an unreadable empty token bundle as OAuth custody", async () => {
+    resolveOrgMock.mockResolvedValue("org-acme");
+    getRawTokensMock.mockImplementation(
+      async (_provider: string, _key: string, owner: string) =>
+        owner === "org:org-acme" ? {} : null,
+    );
+
+    await expect(hasBuilderOAuthSession(ownerEmail)).resolves.toBe(false);
+  });
+
   it("shares one org-scoped credential across members of the same org", async () => {
     resolveOrgMock.mockResolvedValue("org-acme");
     getRawTokensMock.mockImplementation(

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -356,7 +356,14 @@ export async function hasBuilderOAuthSession(
     // An unreadable encrypted row parses as `{}`. It is still retained for
     // disconnect/reconnect handling, but it cannot claim the OAuth lane and
     // block a usable org-scoped Builder key pair.
-    if (stored !== null && Object.keys(stored).length > 0) return true;
+    if (
+      stored !== null &&
+      typeof stored === "object" &&
+      !Array.isArray(stored) &&
+      Object.keys(stored).length > 0
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/core/src/server/builder-oauth.ts
+++ b/packages/core/src/server/builder-oauth.ts
@@ -353,7 +353,10 @@ export async function hasBuilderOAuthSession(
       options.key,
       `${options.scope}:${options.scopeId}`,
     );
-    if (stored !== null) return true;
+    // An unreadable encrypted row parses as `{}`. It is still retained for
+    // disconnect/reconnect handling, but it cannot claim the OAuth lane and
+    // block a usable org-scoped Builder key pair.
+    if (stored !== null && Object.keys(stored).length > 0) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- Treat an empty parsed OAuth token bundle as no active Builder OAuth session.
- Preserve the unreadable row for disconnect and reconnect handling while allowing a usable org-scoped Builder key pair.
- Add a regression test and a patch changeset.

## Root cause

A production Design database row for Builder MCP OAuth could not be decrypted by the current runtime, so the token parser returned an empty object. Builder session detection treated any non-null object as OAuth custody. That claimed the OAuth lane even though it was unusable, preventing fallback to the valid Builder organization key pair. Model discovery therefore hid Builder and showed only direct Anthropic models.

## Validation

- 30 Builder OAuth tests passed.
- 13 chat model-group tests passed.
- 89 engine registry tests passed.
- A production database replay resolved the Builder organization key pair and selected Builder with Luna (`gpt-5-6-luna`) for both affected account contexts.
- Formatting and diff checks passed.

The local core TypeScript check still reports a pre-existing `AuthPage.tsx` `topRight` prop error unrelated to this change. No production OAuth rows were deleted or modified.