### PR TITLE
fix: recover Calendar and Google Slides feedback paths

### DIFF
--- a/templates/calendar/actions/view-screen.test.ts
+++ b/templates/calendar/actions/view-screen.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readAppStateMock = vi.hoisted(() => vi.fn());
+const getRequestUserEmailMock = vi.hoisted(() => vi.fn());
+const readCalendarSettingsMock = vi.hoisted(() => vi.fn());
+const listCalendarEventsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@agent-native/core/application-state", () => ({
+  readAppState: readAppStateMock,
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  getRequestUserEmail: getRequestUserEmailMock,
+}));
+
+vi.mock("../server/lib/calendar-settings.js", () => ({
+  readCalendarSettings: readCalendarSettingsMock,
+}));
+
+vi.mock("../server/lib/booking-link-utils.js", () => ({
+  rowToBookingLink: vi.fn(),
+}));
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: vi.fn(),
+  schema: {
+    bookingLinks: {},
+    bookingLinkShares: {},
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  accessFilter: vi.fn(),
+}));
+
+vi.mock("./list-events.js", () => ({
+  listCalendarEvents: listCalendarEventsMock,
+}));
+
+vi.mock("./event-action-helpers.js", () => ({
+  extractVideoLink: vi.fn(),
+}));
+
+import viewScreen from "./view-screen.js";
+
+describe("view-screen calendar context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRequestUserEmailMock.mockReturnValue("owner@example.com");
+    readCalendarSettingsMock.mockResolvedValue({
+      timezone: "America/Los_Angeles",
+      weekStart: "monday",
+    });
+    readAppStateMock.mockImplementation(async (key: string) => {
+      if (key === "navigation") {
+        return {
+          view: "calendar",
+          calendarViewMode: "week",
+          date: "2026-08-13",
+        };
+      }
+      return null;
+    });
+    listCalendarEventsMock.mockResolvedValue({
+      events: [
+        {
+          id: "google-instance",
+          title: "121 with Gonzalo",
+          start: "2026-09-02T13:30:00.000Z",
+          end: "2026-09-02T14:00:00.000Z",
+          source: "google",
+          allDay: false,
+          attendees: [],
+          recurrence: undefined,
+          recurringEventId: "google-series",
+        },
+      ],
+      errors: [],
+      googleConnected: true,
+      range: {
+        from: "2026-08-10T07:00:00.000Z",
+        to: "2026-08-17T07:00:00.000Z",
+        timezone: "America/Los_Angeles",
+        defaulted: false,
+      },
+    });
+  });
+
+  it("matches the visible week and preserves recurring occurrence identity", async () => {
+    const result = JSON.parse(await viewScreen.run({}));
+
+    expect(listCalendarEventsMock).toHaveBeenCalledWith({
+      from: "2026-08-10T07:00:00.000Z",
+      to: "2026-08-17T07:00:00.000Z",
+    });
+    expect(result.events.items).toMatchObject([
+      {
+        id: "google-instance",
+        recurringEventId: "google-series",
+      },
+    ]);
+  });
+
+  it("uses the visible day instead of always loading a week", async () => {
+    readAppStateMock.mockImplementation(async (key: string) => {
+      if (key === "navigation") {
+        return {
+          view: "calendar",
+          calendarViewMode: "day",
+          date: "2026-08-13",
+        };
+      }
+      return null;
+    });
+
+    await viewScreen.run({});
+
+    expect(listCalendarEventsMock).toHaveBeenCalledWith({
+      from: "2026-08-13T07:00:00.000Z",
+      to: "2026-08-14T07:00:00.000Z",
+    });
+  });
+});

--- a/templates/calendar/actions/view-screen.test.ts
+++ b/templates/calendar/actions/view-screen.test.ts
@@ -89,11 +89,15 @@ describe("view-screen calendar context", () => {
   it("matches the visible week and preserves recurring occurrence identity", async () => {
     const result = JSON.parse(await viewScreen.run({}));
 
-    expect(listCalendarEventsMock).toHaveBeenCalledWith({
-      from: "2026-08-10T07:00:00.000Z",
-      to: "2026-08-17T07:00:00.000Z",
-      timezone: "America/Los_Angeles",
-    });
+    expect(listCalendarEventsMock).toHaveBeenCalledWith(
+      {
+        from: "2026-08-10T07:00:00.000Z",
+        to: "2026-08-17T07:00:00.000Z",
+      },
+      {
+        timezone: "America/Los_Angeles",
+      },
+    );
     expect(result.events.items).toMatchObject([
       {
         id: "google-instance",
@@ -116,10 +120,14 @@ describe("view-screen calendar context", () => {
 
     await viewScreen.run({});
 
-    expect(listCalendarEventsMock).toHaveBeenCalledWith({
-      from: "2026-08-13T07:00:00.000Z",
-      to: "2026-08-14T07:00:00.000Z",
-      timezone: "America/Los_Angeles",
-    });
+    expect(listCalendarEventsMock).toHaveBeenCalledWith(
+      {
+        from: "2026-08-13T07:00:00.000Z",
+        to: "2026-08-14T07:00:00.000Z",
+      },
+      {
+        timezone: "America/Los_Angeles",
+      },
+    );
   });
 });

--- a/templates/calendar/actions/view-screen.test.ts
+++ b/templates/calendar/actions/view-screen.test.ts
@@ -92,6 +92,7 @@ describe("view-screen calendar context", () => {
     expect(listCalendarEventsMock).toHaveBeenCalledWith({
       from: "2026-08-10T07:00:00.000Z",
       to: "2026-08-17T07:00:00.000Z",
+      timezone: "America/Los_Angeles",
     });
     expect(result.events.items).toMatchObject([
       {
@@ -118,6 +119,7 @@ describe("view-screen calendar context", () => {
     expect(listCalendarEventsMock).toHaveBeenCalledWith({
       from: "2026-08-13T07:00:00.000Z",
       to: "2026-08-14T07:00:00.000Z",
+      timezone: "America/Los_Angeles",
     });
   });
 });

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -40,7 +40,7 @@ async function fetchEventsForRange(
   range: { from: string; to: string; timezone: string; defaulted: boolean };
 }> {
   try {
-    return await listCalendarEvents({ from, to, timezone });
+    return await listCalendarEvents({ from, to }, { timezone });
   } catch (error: any) {
     return {
       events: [],

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -32,6 +32,7 @@ function isCalendarViewMode(value: unknown): value is CalendarViewMode {
 async function fetchEventsForRange(
   from: string,
   to: string,
+  timezone: string,
 ): Promise<{
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
@@ -39,7 +40,7 @@ async function fetchEventsForRange(
   range: { from: string; to: string; timezone: string; defaulted: boolean };
 }> {
   try {
-    return await listCalendarEvents({ from, to });
+    return await listCalendarEvents({ from, to, timezone });
   } catch (error: any) {
     return {
       events: [],
@@ -53,7 +54,7 @@ async function fetchEventsForRange(
       range: {
         from,
         to,
-        timezone: "UTC",
+        timezone,
         defaulted: false,
       },
     };
@@ -96,7 +97,11 @@ export default defineAction({
         getWeekStartsOn(settings.weekStart),
       );
 
-      const eventResult = await fetchEventsForRange(range.from, range.to);
+      const eventResult = await fetchEventsForRange(
+        range.from,
+        range.to,
+        timezone,
+      );
       const { events } = eventResult;
 
       const compact = events.slice(0, 50).map((e: CalendarEvent) => {

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -6,22 +6,27 @@ import { z } from "zod";
 
 import { getDb, schema } from "../server/db/index.js";
 import { rowToBookingLink } from "../server/lib/booking-link-utils.js";
-import { getCalendarTimezone } from "../server/lib/calendar-settings.js";
+import { readCalendarSettings } from "../server/lib/calendar-settings.js";
 import type { CalendarEvent, CalendarEventDraft } from "../shared/api.js";
 import {
   CALENDAR_VIEW_PREFERENCES_KEY,
   normalizeCalendarViewPreferences,
 } from "../shared/calendar-view-preferences.js";
+import { getWeekStartsOn } from "../shared/calendar-week.js";
 import {
-  addDaysToDateKey,
+  getCalendarViewDateRange,
   dateKeyInTimezone,
-  dateTimeInTimezoneToIso,
+  type CalendarViewMode,
 } from "../shared/timezone.js";
 import { extractVideoLink } from "./event-action-helpers.js";
 import { listCalendarEvents } from "./list-events.js";
 
 function safeDraftId(id: unknown): string | null {
   return typeof id === "string" && /^[a-zA-Z0-9_-]{1,64}$/.test(id) ? id : null;
+}
+
+function isCalendarViewMode(value: unknown): value is CalendarViewMode {
+  return value === "month" || value === "week" || value === "day";
 }
 
 async function fetchEventsForRange(
@@ -75,21 +80,23 @@ export default defineAction({
     if (nav?.view === "calendar" || !nav?.view) {
       const email = getRequestUserEmail();
       if (!email) throw new Error("no authenticated user");
-      const timezone = await getCalendarTimezone(email);
-      // Work in calendar days, then resolve the two edges to instants once.
-      const viewDay = nav?.date ?? dateKeyInTimezone(new Date(), timezone);
-      // Noon UTC so the weekday can never be shifted by an offset.
-      const weekday = new Date(`${viewDay}T12:00:00Z`).getUTCDay();
-      const weekStart = addDaysToDateKey(viewDay, -weekday);
-
-      const eventResult = await fetchEventsForRange(
-        dateTimeInTimezoneToIso(weekStart, "00:00", timezone),
-        dateTimeInTimezoneToIso(
-          addDaysToDateKey(weekStart, 7),
-          "00:00",
-          timezone,
-        ),
+      const settings = await readCalendarSettings(email);
+      const timezone = settings.timezone;
+      const viewMode = isCalendarViewMode(nav?.calendarViewMode)
+        ? nav.calendarViewMode
+        : "week";
+      const viewDay =
+        typeof nav?.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(nav.date)
+          ? nav.date
+          : dateKeyInTimezone(new Date(), timezone);
+      const range = getCalendarViewDateRange(
+        viewMode,
+        viewDay,
+        timezone,
+        getWeekStartsOn(settings.weekStart),
       );
+
+      const eventResult = await fetchEventsForRange(range.from, range.to);
       const { events } = eventResult;
 
       const compact = events.slice(0, 50).map((e: CalendarEvent) => {
@@ -102,6 +109,8 @@ export default defineAction({
           accountEmail: e.accountEmail || undefined,
           location: e.location || undefined,
           allDay: e.allDay || undefined,
+          recurrence: e.recurrence || undefined,
+          recurringEventId: e.recurringEventId || undefined,
           attendeeCount: e.attendees?.length ?? 0,
           attendeeNames: e.attendees
             ?.filter((a: any) => !a.self)

--- a/templates/calendar/app/hooks/use-navigation-state.ts
+++ b/templates/calendar/app/hooks/use-navigation-state.ts
@@ -8,6 +8,7 @@ import {
   useCalendarContext,
   type ViewMode,
 } from "@/components/layout/AppLayout";
+import { dateToCalendarDateKey } from "@/lib/calendar-timezone";
 
 interface NavigationState {
   view: string;
@@ -126,7 +127,7 @@ export function useNavigationState() {
 
       // Include the currently selected date
       if (selectedDate) {
-        state.date = selectedDate.toISOString().split("T")[0];
+        state.date = dateToCalendarDateKey(selectedDate);
       }
 
       // Include the selected event if one is open

--- a/templates/calendar/app/lib/calendar-timezone.test.ts
+++ b/templates/calendar/app/lib/calendar-timezone.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   dateKeyToDate,
+  dateToCalendarDateKey,
   eventOverlapsCalendarDay,
   getCalendarDayBounds,
   getDisplayDateInTimezone,
@@ -23,6 +24,20 @@ describe("calendar timezone helpers", () => {
       "2026-08-14",
     );
     expect(getDateKeyInTimezone(instant, "Asia/Tokyo")).toBe("2026-08-15");
+  });
+
+  it("keeps a UTC+13 local date carrier on the same calendar day", () => {
+    const previousTimezone = process.env.TZ;
+    process.env.TZ = "Pacific/Auckland";
+    try {
+      const selectedDate = new Date(2026, 0, 15, 12);
+
+      expect(selectedDate.toISOString()).toBe("2026-01-14T23:00:00.000Z");
+      expect(dateToCalendarDateKey(selectedDate)).toBe("2026-01-15");
+    } finally {
+      if (previousTimezone === undefined) delete process.env.TZ;
+      else process.env.TZ = previousTimezone;
+    }
   });
 
   it("uses zoned midnight bounds across a DST transition", () => {

--- a/templates/calendar/app/lib/calendar-timezone.ts
+++ b/templates/calendar/app/lib/calendar-timezone.ts
@@ -1,13 +1,10 @@
 import type { CalendarEvent } from "@shared/api";
-import { addDaysToDateKey, isCalendarTimezone } from "@shared/timezone";
 import {
-  addDays,
-  endOfMonth,
-  endOfWeek,
-  format,
-  startOfMonth,
-  startOfWeek,
-} from "date-fns";
+  addDaysToDateKey,
+  getCalendarViewDateRange,
+  isCalendarTimezone,
+} from "@shared/timezone";
+import { format } from "date-fns";
 
 import { dateTimeInTimezoneToIso } from "./event-form-utils";
 
@@ -171,37 +168,12 @@ export function getViewDateRange(
   timezone: string,
   weekStartsOn: 0 | 1 = 0,
 ): { from: string; to: string } {
-  const normalizedTimezone = normalizeTimezone(timezone);
-  const weekOptions = { weekStartsOn };
-  let rangeStart: Date;
-  let rangeEndExclusive: Date;
-
-  if (viewMode === "month") {
-    rangeStart = startOfWeek(startOfMonth(selectedDate), weekOptions);
-    rangeEndExclusive = addDays(
-      endOfWeek(endOfMonth(selectedDate), weekOptions),
-      1,
-    );
-  } else if (viewMode === "week") {
-    rangeStart = startOfWeek(selectedDate, weekOptions);
-    rangeEndExclusive = addDays(endOfWeek(selectedDate, weekOptions), 1);
-  } else {
-    rangeStart = selectedDate;
-    rangeEndExclusive = addDays(selectedDate, 1);
-  }
-
-  return {
-    from: dateKeyToTimezoneIso(
-      dateToCalendarDateKey(rangeStart),
-      "00:00",
-      normalizedTimezone,
-    ),
-    to: dateKeyToTimezoneIso(
-      dateToCalendarDateKey(rangeEndExclusive),
-      "00:00",
-      normalizedTimezone,
-    ),
-  };
+  return getCalendarViewDateRange(
+    viewMode,
+    dateToCalendarDateKey(selectedDate),
+    normalizeTimezone(timezone),
+    weekStartsOn,
+  );
 }
 
 function dateOnlyPart(value: string | undefined): string | null {

--- a/templates/calendar/shared/timezone.ts
+++ b/templates/calendar/shared/timezone.ts
@@ -125,3 +125,42 @@ export function addDaysToDateKey(date: string, amount: number): string {
   const shifted = new Date(Date.UTC(year, month - 1, day + amount));
   return shifted.toISOString().slice(0, 10);
 }
+
+export type CalendarViewMode = "month" | "week" | "day";
+
+function startOfCalendarWeek(date: string, weekStartsOn: 0 | 1): string {
+  const weekday = new Date(`${date}T12:00:00Z`).getUTCDay();
+  return addDaysToDateKey(date, -((weekday - weekStartsOn + 7) % 7));
+}
+
+export function getCalendarViewDateRange(
+  viewMode: CalendarViewMode,
+  selectedDate: string,
+  timezone: string,
+  weekStartsOn: 0 | 1 = 0,
+): { from: string; to: string } {
+  const selectedMonthStart = `${selectedDate.slice(0, 7)}-01`;
+  const [year, month] = selectedMonthStart.split("-").map(Number);
+  const nextMonthStart = new Date(Date.UTC(year, month, 1))
+    .toISOString()
+    .slice(0, 10);
+
+  let rangeStart = selectedDate;
+  let rangeEndExclusive = addDaysToDateKey(selectedDate, 1);
+  if (viewMode === "week") {
+    rangeStart = startOfCalendarWeek(selectedDate, weekStartsOn);
+    rangeEndExclusive = addDaysToDateKey(rangeStart, 7);
+  } else if (viewMode === "month") {
+    const monthEnd = addDaysToDateKey(nextMonthStart, -1);
+    rangeStart = startOfCalendarWeek(selectedMonthStart, weekStartsOn);
+    rangeEndExclusive = addDaysToDateKey(
+      startOfCalendarWeek(monthEnd, weekStartsOn),
+      7,
+    );
+  }
+
+  return {
+    from: dateTimeInTimezoneToIso(rangeStart, "00:00", timezone),
+    to: dateTimeInTimezoneToIso(rangeEndExclusive, "00:00", timezone),
+  };
+}

--- a/templates/slides/app/components/editor/ExportMenu.test.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.test.tsx
@@ -378,7 +378,10 @@ describe("<ExportMenu>", () => {
     expect(screen.queryByText("Connect Google")).toBeNull();
     fireEvent.click(await screen.findByText("Export to Google Slides"));
 
-    expect(window.open).toHaveBeenCalledWith("", "_blank");
+    expect(window.open).toHaveBeenCalledWith(
+      "https://docs.google.com/presentation/u/0/?usp=import",
+      "_blank",
+    );
     await waitFor(() => {
       expect(openedTab.close).toHaveBeenCalledOnce();
       expect(startWorkspaceProviderOAuth).toHaveBeenCalledWith(

--- a/templates/slides/app/components/editor/ExportMenu.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.tsx
@@ -202,9 +202,9 @@ export const ExportMenu = forwardRef<ExportMenuHandle, ExportMenuProps>(
     const handleExportGoogleSlides = async () => {
       if (!onExportGoogleSlides) return;
       // Opened up-front: browsers only honour window.open() inside the click
-      // gesture, and building the PPTX is async. If the account is missing,
-      // the same tab becomes the OAuth popup so the export action owns setup.
-      const target = window.open("", "_blank");
+      // gesture, and building the PPTX is async. Start on the import page so a
+      // slow or rejected export never leaves the user staring at about:blank.
+      const target = window.open(GOOGLE_SLIDES_IMPORT_URL, "_blank");
       googleSlidesImportTarget.current = target;
       try {
         const result = await onExportGoogleSlides();

--- a/templates/slides/server/handlers/google-docs-auth.test.ts
+++ b/templates/slides/server/handlers/google-docs-auth.test.ts
@@ -1,29 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  encodeOAuthState: vi.fn(),
+  getGoogleDocsAuthUrl: vi.fn(),
+  getQuery: vi.fn(),
   getSession: vi.fn(),
   getGooglePickerConfig: vi.fn(),
+  isElectron: vi.fn(),
   isGoogleDocsOAuthConfigured: vi.fn(),
   listGoogleDocsAccounts: vi.fn(),
   resolveManagedGoogleDriveAccount: vi.fn(),
+  resolveOAuthRedirectUri: vi.fn(),
+  safeReturnPath: vi.fn(),
   setResponseStatus: vi.fn(),
+  withSlidesRequestContext: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/server", () => ({
   decodeOAuthState: vi.fn(),
-  encodeOAuthState: vi.fn(),
+  encodeOAuthState: mocks.encodeOAuthState,
   getAppUrl: vi.fn(),
   getSession: mocks.getSession,
-  isElectron: vi.fn(),
+  getQuery: mocks.getQuery,
+  isElectron: mocks.isElectron,
   oauthCallbackResponse: vi.fn(),
   oauthErrorPage: vi.fn(),
-  resolveOAuthRedirectUri: vi.fn(),
-  safeReturnPath: vi.fn(),
+  resolveOAuthRedirectUri: mocks.resolveOAuthRedirectUri,
+  safeReturnPath: mocks.safeReturnPath,
 }));
 
 vi.mock("h3", () => ({
   defineEventHandler: (handler: unknown) => handler,
-  getQuery: vi.fn(),
+  getQuery: mocks.getQuery,
   setResponseStatus: mocks.setResponseStatus,
 }));
 
@@ -40,7 +48,7 @@ vi.mock("../lib/google-docs-error.js", () => ({
 vi.mock("../lib/google-docs-oauth.js", () => ({
   disconnectGoogleDocs: vi.fn(),
   exchangeGoogleDocsCode: vi.fn(),
-  getGoogleDocsAuthUrl: vi.fn(),
+  getGoogleDocsAuthUrl: mocks.getGoogleDocsAuthUrl,
   getGooglePickerConfig: mocks.getGooglePickerConfig,
   hasGoogleDriveExportScope: (scope: string) =>
     scope.includes("drive.readonly"),
@@ -49,15 +57,20 @@ vi.mock("../lib/google-docs-oauth.js", () => ({
 }));
 
 vi.mock("./request-auth-context.js", () => ({
-  withSlidesRequestContext: async (_event: unknown, callback: () => unknown) =>
-    callback(),
+  withSlidesRequestContext: mocks.withSlidesRequestContext,
 }));
 
-import { getGoogleDocsStatus } from "./google-docs-auth";
+import {
+  getGoogleDocsAuthUrlHandler,
+  getGoogleDocsStatus,
+} from "./google-docs-auth";
 
 describe("getGoogleDocsStatus", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.withSlidesRequestContext.mockImplementation(
+      async (_event: unknown, callback: () => unknown) => callback(),
+    );
     mocks.getSession.mockResolvedValue({ email: "owner@example.com" });
     mocks.listGoogleDocsAccounts.mockResolvedValue([
       {
@@ -70,6 +83,31 @@ describe("getGoogleDocsStatus", () => {
     );
     mocks.getGooglePickerConfig.mockResolvedValue({});
     mocks.isGoogleDocsOAuthConfigured.mockResolvedValue(true);
+  });
+
+  it("resolves OAuth setup inside the authenticated request context", async () => {
+    mocks.getQuery.mockReturnValue({});
+    mocks.resolveOAuthRedirectUri.mockReturnValue(
+      "https://slides.example/_agent-native/google-docs/callback",
+    );
+    mocks.safeReturnPath.mockReturnValue("/home");
+    mocks.encodeOAuthState.mockReturnValue("oauth-state");
+    mocks.getGoogleDocsAuthUrl.mockResolvedValue(
+      "https://accounts.google.com/oauth",
+    );
+
+    await expect(getGoogleDocsAuthUrlHandler({} as any)).resolves.toEqual({
+      url: "https://accounts.google.com/oauth",
+    });
+    expect(mocks.withSlidesRequestContext).toHaveBeenCalledTimes(1);
+    expect(mocks.isGoogleDocsOAuthConfigured).toHaveBeenCalledWith(
+      "owner@example.com",
+    );
+    expect(mocks.getGoogleDocsAuthUrl).toHaveBeenCalledWith(
+      "https://slides.example/_agent-native/google-docs/callback",
+      "oauth-state",
+      "owner@example.com",
+    );
   });
 
   it("keeps a local Picker connection reconnectable when managed OAuth is stale", async () => {

--- a/templates/slides/server/handlers/google-docs-auth.test.ts
+++ b/templates/slides/server/handlers/google-docs-auth.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   encodeOAuthState: vi.fn(),
+  getAvailableGoogleDocsAccessToken: vi.fn(),
   getGoogleDocsAuthUrl: vi.fn(),
   getQuery: vi.fn(),
   getSession: vi.fn(),
@@ -36,7 +37,7 @@ vi.mock("h3", () => ({
 }));
 
 vi.mock("../lib/google-docs-access.js", () => ({
-  getAvailableGoogleDocsAccessToken: vi.fn(),
+  getAvailableGoogleDocsAccessToken: mocks.getAvailableGoogleDocsAccessToken,
   resolveManagedGoogleDriveAccount: mocks.resolveManagedGoogleDriveAccount,
 }));
 
@@ -62,6 +63,7 @@ vi.mock("./request-auth-context.js", () => ({
 
 import {
   getGoogleDocsAuthUrlHandler,
+  getGoogleDocsPickerToken,
   getGoogleDocsStatus,
 } from "./google-docs-auth";
 
@@ -122,5 +124,19 @@ describe("getGoogleDocsStatus", () => {
       googleSlidesUrlImportReady: false,
       googleSlidesUrlImportError: "formatted: invalid_grant",
     });
+  });
+
+  it("keeps Picker setup failures distinct from disconnected accounts", async () => {
+    mocks.isGoogleDocsOAuthConfigured.mockRejectedValue(
+      new Error("vault unavailable"),
+    );
+
+    await expect(getGoogleDocsPickerToken({} as any)).resolves.toEqual({
+      error: "formatted: vault unavailable",
+    });
+    expect(mocks.setResponseStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      500,
+    );
   });
 });

--- a/templates/slides/server/handlers/google-docs-auth.ts
+++ b/templates/slides/server/handlers/google-docs-auth.ts
@@ -49,52 +49,55 @@ export const getGoogleDocsAuthUrlHandler = defineEventHandler(
       return { error: "not_authenticated" };
     }
 
-    if (!(await isGoogleDocsOAuthConfigured(owner))) {
-      setResponseStatus(event, 422);
-      return {
-        error: "missing_credentials",
-        message:
-          "Google OAuth credentials are not configured. Save GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in settings.",
-      };
-    }
-
     try {
-      const q = getQuery(event);
-      const redirectUri = resolveOAuthRedirectUri(
-        event,
-        "/_agent-native/google-docs/callback",
-      );
-      if (!redirectUri) {
-        setResponseStatus(event, 400);
-        return {
-          error: "invalid_redirect_uri",
-          message: "redirect_uri must stay on this app's _agent-native routes.",
-        };
-      }
+      return await withSlidesRequestContext(event, async () => {
+        if (!(await isGoogleDocsOAuthConfigured(owner))) {
+          setResponseStatus(event, 422);
+          return {
+            error: "missing_credentials",
+            message:
+              "Google OAuth credentials are not configured. Save GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in settings.",
+          };
+        }
 
-      const desktop =
-        isElectron(event) || q.desktop === "1" || q.desktop === "true";
-      const flowId = desktop ? (q.flow_id as string) || undefined : undefined;
-      const requestedReturn =
-        typeof q.return === "string" ? safeReturnPath(q.return) : "/home";
-      const returnUrl = requestedReturn !== "/" ? requestedReturn : undefined;
-      const state = encodeOAuthState({
-        redirectUri,
-        owner,
-        desktop,
-        addAccount: true,
-        app: OAUTH_STATE_APP_ID,
-        returnUrl,
-        flowId,
-      });
-      const url = await getGoogleDocsAuthUrl(redirectUri, state, owner);
-      if (q.redirect === "1") {
-        return new Response(null, {
-          status: 302,
-          headers: { Location: url },
+        const q = getQuery(event);
+        const redirectUri = resolveOAuthRedirectUri(
+          event,
+          "/_agent-native/google-docs/callback",
+        );
+        if (!redirectUri) {
+          setResponseStatus(event, 400);
+          return {
+            error: "invalid_redirect_uri",
+            message:
+              "redirect_uri must stay on this app's _agent-native routes.",
+          };
+        }
+
+        const desktop =
+          isElectron(event) || q.desktop === "1" || q.desktop === "true";
+        const flowId = desktop ? (q.flow_id as string) || undefined : undefined;
+        const requestedReturn =
+          typeof q.return === "string" ? safeReturnPath(q.return) : "/home";
+        const returnUrl = requestedReturn !== "/" ? requestedReturn : undefined;
+        const state = encodeOAuthState({
+          redirectUri,
+          owner,
+          desktop,
+          addAccount: true,
+          app: OAUTH_STATE_APP_ID,
+          returnUrl,
+          flowId,
         });
-      }
-      return { url };
+        const url = await getGoogleDocsAuthUrl(redirectUri, state, owner);
+        if (q.redirect === "1") {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: url },
+          });
+        }
+        return { url };
+      });
     } catch (error) {
       setResponseStatus(event, 500);
       return { error: formatGoogleOAuthError(error) };
@@ -134,11 +137,13 @@ export const handleGoogleDocsCallback = defineEventHandler(
         return oauthErrorPage("Session expired. Please log in and try again.");
       }
 
-      const account = await exchangeGoogleDocsCode({
-        code,
-        redirectUri: state.redirectUri,
-        owner,
-      });
+      const account = await withSlidesRequestContext(event, () =>
+        exchangeGoogleDocsCode({
+          code,
+          redirectUri: state.redirectUri,
+          owner,
+        }),
+      );
 
       return oauthCallbackResponse(event, account.email, {
         desktop,
@@ -163,41 +168,43 @@ export const getGoogleDocsStatus = defineEventHandler(
     }
 
     try {
-      const accounts = await listGoogleDocsAccounts(owner);
-      let googleSlidesUrlImportError: string | undefined;
-      if (
-        !accounts.some((account) => hasGoogleDriveExportScope(account.scope))
-      ) {
-        try {
-          const managed = await withSlidesRequestContext(event, () =>
-            resolveManagedGoogleDriveAccount(),
-          );
-          if (managed) {
-            accounts.push({
-              email: managed.email,
-              scope: managed.scope,
-              shared: true,
-            });
+      return await withSlidesRequestContext(event, async () => {
+        const accounts = await listGoogleDocsAccounts(owner);
+        let googleSlidesUrlImportError: string | undefined;
+        if (
+          !accounts.some((account) => hasGoogleDriveExportScope(account.scope))
+        ) {
+          try {
+            const managed = await withSlidesRequestContext(event, () =>
+              resolveManagedGoogleDriveAccount(),
+            );
+            if (managed) {
+              accounts.push({
+                email: managed.email,
+                scope: managed.scope,
+                shared: true,
+              });
+            }
+          } catch (error) {
+            // Keep the status response actionable so a revoked managed token can
+            // still be repaired through the Connect Google CTA.
+            googleSlidesUrlImportError = formatGoogleOAuthError(error);
           }
-        } catch (error) {
-          // Keep the status response actionable so a revoked managed token can
-          // still be repaired through the Connect Google CTA.
-          googleSlidesUrlImportError = formatGoogleOAuthError(error);
         }
-      }
-      const picker = await getGooglePickerConfig(owner);
-      return {
-        configured: await isGoogleDocsOAuthConfigured(owner),
-        connected: accounts.length > 0,
-        googleSlidesUrlImportReady: accounts.some((account) =>
-          hasGoogleDriveExportScope(account.scope),
-        ),
-        googleSlidesUrlImportError,
-        accounts,
-        pickerConfigured: !!(picker.apiKey && picker.appId),
-        pickerApiKey: picker.apiKey,
-        pickerAppId: picker.appId,
-      };
+        const picker = await getGooglePickerConfig(owner);
+        return {
+          configured: await isGoogleDocsOAuthConfigured(owner),
+          connected: accounts.length > 0,
+          googleSlidesUrlImportReady: accounts.some((account) =>
+            hasGoogleDriveExportScope(account.scope),
+          ),
+          googleSlidesUrlImportError,
+          accounts,
+          pickerConfigured: !!(picker.apiKey && picker.appId),
+          pickerApiKey: picker.apiKey,
+          pickerAppId: picker.appId,
+        };
+      });
     } catch (error) {
       setResponseStatus(event, 500);
       return { error: formatGoogleOAuthError(error) };
@@ -212,41 +219,41 @@ export const getGoogleDocsPickerToken = defineEventHandler(
       return { error: "not_authenticated" };
     }
 
-    if (!(await isGoogleDocsOAuthConfigured(owner))) {
-      setResponseStatus(event, 422);
-      return {
-        error: "missing_credentials",
-        message:
-          "Google OAuth credentials are not configured. Save GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in settings.",
-      };
-    }
-
-    const picker = await getGooglePickerConfig(owner);
-    if (!picker.apiKey || !picker.appId) {
-      setResponseStatus(event, 422);
-      return {
-        error: "missing_picker_config",
-        message:
-          "Google Picker is not configured. Save GOOGLE_PICKER_API_KEY and GOOGLE_PICKER_APP_ID in settings.",
-      };
-    }
-
     try {
-      const token = await withSlidesRequestContext(event, () =>
-        getAvailableGoogleDocsAccessToken(owner),
-      );
-      if (!token) {
-        setResponseStatus(event, 401);
+      return await withSlidesRequestContext(event, async () => {
+        if (!(await isGoogleDocsOAuthConfigured(owner))) {
+          setResponseStatus(event, 422);
+          return {
+            error: "missing_credentials",
+            message:
+              "Google OAuth credentials are not configured. Save GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in settings.",
+          };
+        }
+
+        const picker = await getGooglePickerConfig(owner);
+        if (!picker.apiKey || !picker.appId) {
+          setResponseStatus(event, 422);
+          return {
+            error: "missing_picker_config",
+            message:
+              "Google Picker is not configured. Save GOOGLE_PICKER_API_KEY and GOOGLE_PICKER_APP_ID in settings.",
+          };
+        }
+
+        const token = await getAvailableGoogleDocsAccessToken(owner);
+        if (!token) {
+          setResponseStatus(event, 401);
+          return {
+            error: "not_connected",
+            message: "Connect Google Docs before choosing a document.",
+          };
+        }
         return {
-          error: "not_connected",
-          message: "Connect Google Docs before choosing a document.",
+          ...token,
+          apiKey: picker.apiKey,
+          appId: picker.appId,
         };
-      }
-      return {
-        ...token,
-        apiKey: picker.apiKey,
-        appId: picker.appId,
-      };
+      });
     } catch (error) {
       setResponseStatus(event, 401);
       return { error: formatGoogleOAuthError(error) };

--- a/templates/slides/server/handlers/google-docs-auth.ts
+++ b/templates/slides/server/handlers/google-docs-auth.ts
@@ -240,22 +240,27 @@ export const getGoogleDocsPickerToken = defineEventHandler(
           };
         }
 
-        const token = await getAvailableGoogleDocsAccessToken(owner);
-        if (!token) {
-          setResponseStatus(event, 401);
+        try {
+          const token = await getAvailableGoogleDocsAccessToken(owner);
+          if (!token) {
+            setResponseStatus(event, 401);
+            return {
+              error: "not_connected",
+              message: "Connect Google Docs before choosing a document.",
+            };
+          }
           return {
-            error: "not_connected",
-            message: "Connect Google Docs before choosing a document.",
+            ...token,
+            apiKey: picker.apiKey,
+            appId: picker.appId,
           };
+        } catch (error) {
+          setResponseStatus(event, 401);
+          return { error: formatGoogleOAuthError(error) };
         }
-        return {
-          ...token,
-          apiKey: picker.apiKey,
-          appId: picker.appId,
-        };
       });
     } catch (error) {
-      setResponseStatus(event, 401);
+      setResponseStatus(event, 500);
       return { error: formatGoogleOAuthError(error) };
     }
   },

--- a/templates/slides/server/lib/google-docs-oauth.test.ts
+++ b/templates/slides/server/lib/google-docs-oauth.test.ts
@@ -1,15 +1,26 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const oauthMocks = vi.hoisted(() => ({
+  deleteOAuthTokens: vi.fn(),
   getOAuthTokens: vi.fn(),
   listOAuthAccountsByOwner: vi.fn(),
+  resolveGoogleProviderCredentialCandidatesWithReader: vi.fn(),
+  resolveSecret: vi.fn(),
+  fetch: vi.fn(),
 }));
 
 vi.mock("@agent-native/core/oauth-tokens", () => ({
-  deleteOAuthTokens: vi.fn(),
+  deleteOAuthTokens: oauthMocks.deleteOAuthTokens,
   getOAuthTokens: oauthMocks.getOAuthTokens,
   listOAuthAccountsByOwner: oauthMocks.listOAuthAccountsByOwner,
   saveOAuthTokens: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  resolveGoogleProviderCredentialCandidatesWithReader:
+    oauthMocks.resolveGoogleProviderCredentialCandidatesWithReader,
+  resolveSecret: oauthMocks.resolveSecret,
+  runWithRequestContext: (_context: unknown, fn: () => unknown) => fn(),
 }));
 
 import {
@@ -20,6 +31,12 @@ import {
 } from "./google-docs-oauth.js";
 
 beforeEach(() => {
+  vi.stubGlobal("fetch", oauthMocks.fetch);
+  oauthMocks.deleteOAuthTokens.mockReset();
+  oauthMocks.fetch.mockReset();
+  oauthMocks.resolveGoogleProviderCredentialCandidatesWithReader.mockResolvedValue(
+    [{ clientId: "client-id", clientSecret: "client-secret" }],
+  );
   oauthMocks.listOAuthAccountsByOwner.mockImplementation(
     async (provider: string) =>
       provider === "google"
@@ -59,6 +76,10 @@ beforeEach(() => {
   );
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe("Google Slides URL import OAuth scopes", () => {
   it("requests Drive read access for pasted presentation links", () => {
     expect(GOOGLE_DOCS_SCOPES).toContain(GOOGLE_DRIVE_READONLY_SCOPE);
@@ -81,5 +102,44 @@ describe("Google Slides URL import OAuth scopes", () => {
         requireDriveExportScope: true,
       }),
     ).resolves.toMatchObject({ accountEmail: "export@example.com" });
+  });
+
+  it("does not delete the user grant when the OAuth client is invalid", async () => {
+    oauthMocks.listOAuthAccountsByOwner.mockImplementation(
+      async (provider: string) =>
+        provider === "google"
+          ? [
+              {
+                accountId: "export@example.com",
+                tokens: {
+                  access_token: "expired-token",
+                  expiry_date: Date.now() - 60_000,
+                  refresh_token: "refresh-token",
+                  scope: GOOGLE_DRIVE_READONLY_SCOPE,
+                },
+              },
+            ]
+          : [],
+    );
+    oauthMocks.getOAuthTokens.mockResolvedValue({
+      access_token: "expired-token",
+      expiry_date: Date.now() - 60_000,
+      refresh_token: "refresh-token",
+      scope: GOOGLE_DRIVE_READONLY_SCOPE,
+    });
+    oauthMocks.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: vi.fn().mockResolvedValue({
+        error: "invalid_client",
+        error_description: "The OAuth client was not found.",
+      }),
+    });
+
+    await expect(getGoogleDocsAccessToken("owner@example.com")).rejects.toThrow(
+      "The OAuth client was not found.",
+    );
+    expect(oauthMocks.deleteOAuthTokens).not.toHaveBeenCalled();
   });
 });

--- a/templates/slides/server/lib/google-docs-oauth.test.ts
+++ b/templates/slides/server/lib/google-docs-oauth.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const oauthMocks = vi.hoisted(() => ({
   deleteOAuthTokens: vi.fn(),
   getOAuthTokens: vi.fn(),
+  getRequestOrgId: vi.fn(),
   listOAuthAccountsByOwner: vi.fn(),
   resolveGoogleProviderCredentialCandidatesWithReader: vi.fn(),
   resolveSecret: vi.fn(),
+  runWithRequestContext: vi.fn(),
   fetch: vi.fn(),
 }));
 
@@ -17,10 +19,11 @@ vi.mock("@agent-native/core/oauth-tokens", () => ({
 }));
 
 vi.mock("@agent-native/core/server", () => ({
+  getRequestOrgId: oauthMocks.getRequestOrgId,
   resolveGoogleProviderCredentialCandidatesWithReader:
     oauthMocks.resolveGoogleProviderCredentialCandidatesWithReader,
   resolveSecret: oauthMocks.resolveSecret,
-  runWithRequestContext: (_context: unknown, fn: () => unknown) => fn(),
+  runWithRequestContext: oauthMocks.runWithRequestContext,
 }));
 
 import {
@@ -28,6 +31,7 @@ import {
   GOOGLE_DRIVE_READONLY_SCOPE,
   getGoogleDocsAccessToken,
   hasGoogleDriveExportScope,
+  hasGoogleDriveUploadScope,
 } from "./google-docs-oauth.js";
 
 beforeEach(() => {
@@ -36,6 +40,10 @@ beforeEach(() => {
   oauthMocks.fetch.mockReset();
   oauthMocks.resolveGoogleProviderCredentialCandidatesWithReader.mockResolvedValue(
     [{ clientId: "client-id", clientSecret: "client-secret" }],
+  );
+  oauthMocks.getRequestOrgId.mockReturnValue("org-1");
+  oauthMocks.runWithRequestContext.mockImplementation(
+    (_context: unknown, fn: () => unknown) => fn(),
   );
   oauthMocks.listOAuthAccountsByOwner.mockImplementation(
     async (provider: string) =>
@@ -96,12 +104,60 @@ describe("Google Slides URL import OAuth scopes", () => {
     expect(hasGoogleDriveExportScope()).toBe(false);
   });
 
+  it("recognizes upload-capable Drive grants without treating read-only as writable", () => {
+    expect(hasGoogleDriveUploadScope(GOOGLE_DRIVE_READONLY_SCOPE)).toBe(false);
+    expect(
+      hasGoogleDriveUploadScope("https://www.googleapis.com/auth/drive.file"),
+    ).toBe(true);
+    expect(
+      hasGoogleDriveUploadScope("https://www.googleapis.com/auth/drive"),
+    ).toBe(true);
+  });
+
   it("selects an export-capable account for pasted Slides imports", async () => {
     await expect(
       getGoogleDocsAccessToken("owner@example.com", {
         requireDriveExportScope: true,
       }),
     ).resolves.toMatchObject({ accountEmail: "export@example.com" });
+  });
+
+  it("selects an upload-capable account after a read-only account", async () => {
+    oauthMocks.listOAuthAccountsByOwner.mockImplementation(
+      async (provider: string) =>
+        provider === "google"
+          ? [
+              {
+                accountId: "read-only@example.com",
+                tokens: {
+                  access_token: "read-only-token",
+                  expiry_date: Date.now() + 60 * 60 * 1000,
+                  scope: GOOGLE_DRIVE_READONLY_SCOPE,
+                },
+              },
+              {
+                accountId: "upload@example.com",
+                tokens: {
+                  access_token: "upload-token",
+                  expiry_date: Date.now() + 60 * 60 * 1000,
+                  scope: "https://www.googleapis.com/auth/drive.file",
+                },
+              },
+            ]
+          : [],
+    );
+    oauthMocks.getOAuthTokens.mockImplementation(
+      async (_provider: string, accountId: string) => ({
+        access_token: `${accountId}-token`,
+        expiry_date: Date.now() + 60 * 60 * 1000,
+      }),
+    );
+
+    await expect(
+      getGoogleDocsAccessToken("owner@example.com", {
+        requireDriveUploadScope: true,
+      }),
+    ).resolves.toMatchObject({ accountEmail: "upload@example.com" });
   });
 
   it("does not delete the user grant when the OAuth client is invalid", async () => {
@@ -141,5 +197,56 @@ describe("Google Slides URL import OAuth scopes", () => {
       "The OAuth client was not found.",
     );
     expect(oauthMocks.deleteOAuthTokens).not.toHaveBeenCalled();
+  });
+
+  it("preserves the active organization while refreshing OAuth credentials", async () => {
+    const contexts: unknown[] = [];
+    oauthMocks.runWithRequestContext.mockImplementation(
+      (context: unknown, fn: () => unknown) => {
+        contexts.push(context);
+        return fn();
+      },
+    );
+    oauthMocks.listOAuthAccountsByOwner.mockImplementation(
+      async (provider: string) =>
+        provider === "google"
+          ? [
+              {
+                accountId: "upload@example.com",
+                tokens: {
+                  access_token: "expired-token",
+                  expiry_date: Date.now() - 60_000,
+                  refresh_token: "refresh-token",
+                  scope: "https://www.googleapis.com/auth/drive.file",
+                },
+              },
+            ]
+          : [],
+    );
+    oauthMocks.getOAuthTokens.mockResolvedValue({
+      access_token: "expired-token",
+      expiry_date: Date.now() - 60_000,
+      refresh_token: "refresh-token",
+      scope: "https://www.googleapis.com/auth/drive.file",
+    });
+    oauthMocks.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        access_token: "refreshed-token",
+        expires_in: 3600,
+      }),
+    });
+
+    await expect(
+      getGoogleDocsAccessToken("owner@example.com", {
+        requireDriveUploadScope: true,
+      }),
+    ).resolves.toMatchObject({ accountEmail: "upload@example.com" });
+    expect(contexts).toContainEqual({
+      userEmail: "owner@example.com",
+      orgId: "org-1",
+    });
   });
 });

--- a/templates/slides/server/lib/google-docs-oauth.ts
+++ b/templates/slides/server/lib/google-docs-oauth.ts
@@ -5,6 +5,7 @@ import {
   saveOAuthTokens,
 } from "@agent-native/core/oauth-tokens";
 import {
+  getRequestOrgId,
   resolveGoogleProviderCredentialCandidatesWithReader,
   resolveSecret,
   runWithRequestContext,
@@ -33,6 +34,16 @@ export function hasGoogleDriveExportScope(scope?: string): boolean {
   return (
     grantedScopes.has("https://www.googleapis.com/auth/drive") ||
     grantedScopes.has(GOOGLE_DRIVE_READONLY_SCOPE)
+  );
+}
+
+export function hasGoogleDriveUploadScope(scope?: string): boolean {
+  const grantedScopes = new Set(
+    (scope ?? "").split(/\s+/).filter((value) => value.length > 0),
+  );
+  return (
+    grantedScopes.has("https://www.googleapis.com/auth/drive") ||
+    grantedScopes.has("https://www.googleapis.com/auth/drive.file")
   );
 }
 
@@ -68,7 +79,10 @@ async function resolveGoogleDocsProviderCredentialCandidates(owner?: string) {
       readCredential: resolveSecret,
     });
   return owner
-    ? runWithRequestContext({ userEmail: owner }, resolve)
+    ? runWithRequestContext(
+        { userEmail: owner, orgId: getRequestOrgId() },
+        resolve,
+      )
     : await resolve();
 }
 
@@ -332,15 +346,23 @@ export async function getGoogleDocsAccessToken(
   accountEmail: string;
 } | null> {
   const accounts = await listGoogleProviderAccounts(owner);
-  const account = options.requireDriveExportScope
+  const account = options.requireDriveUploadScope
     ? accounts.find((candidate) =>
-        hasGoogleDriveExportScope(
+        hasGoogleDriveUploadScope(
           typeof candidate.tokens.scope === "string"
             ? candidate.tokens.scope
             : JSON.stringify(candidate.tokens.scope ?? ""),
         ),
       )
-    : accounts[0];
+    : options.requireDriveExportScope
+      ? accounts.find((candidate) =>
+          hasGoogleDriveExportScope(
+            typeof candidate.tokens.scope === "string"
+              ? candidate.tokens.scope
+              : JSON.stringify(candidate.tokens.scope ?? ""),
+          ),
+        )
+      : accounts[0];
   if (!account) return null;
 
   const stored = await getOAuthTokens(
@@ -361,6 +383,7 @@ export async function getGoogleDocsAccessToken(
 
 export interface GoogleDocsAccessTokenOptions {
   requireDriveExportScope?: boolean;
+  requireDriveUploadScope?: boolean;
 }
 
 async function listGoogleProviderAccounts(owner: string): Promise<

--- a/templates/slides/server/lib/google-docs-oauth.ts
+++ b/templates/slides/server/lib/google-docs-oauth.ts
@@ -134,7 +134,10 @@ export async function getGooglePickerConfig(owner?: string): Promise<{
       null,
   });
   return owner
-    ? runWithRequestContext({ userEmail: owner }, resolve)
+    ? runWithRequestContext(
+        { userEmail: owner, orgId: getRequestOrgId() },
+        resolve,
+      )
     : await resolve();
 }
 

--- a/templates/slides/server/lib/google-docs-oauth.ts
+++ b/templates/slides/server/lib/google-docs-oauth.ts
@@ -203,7 +203,7 @@ async function refreshGoogleDocsToken(
   }
 
   if (!data?.access_token) {
-    if (isPermanentGoogleRefreshError(data?.error)) {
+    if (data?.error === "invalid_grant") {
       await deleteOAuthTokens(provider, accountId, owner);
     }
     throw new Error(

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -16,7 +16,7 @@ const UPLOAD_URL =
 
 function isGoogleReconnectError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /unauthorized|invalid_grant|invalid_client|expired|reconnect/i.test(
+  return /invalid_grant|connection expired|token(?: has been)? expired|please reconnect/i.test(
     message,
   );
 }
@@ -116,10 +116,22 @@ export default defineEventHandler(async (event) => {
   const result = (await response.json().catch(() => null)) as {
     id?: string;
     webViewLink?: string;
-    error?: { message?: string };
+    error?: {
+      message?: string;
+      errors?: Array<{ reason?: string }>;
+    };
   } | null;
 
-  if (response.status === 401) {
+  const hasInsufficientPermissions =
+    response.status === 403 &&
+    (result?.error?.errors?.some(
+      ({ reason }) => reason === "insufficientPermissions",
+    ) ||
+      /insufficient(?:permissions| permission| scope)/i.test(
+        result?.error?.message ?? "",
+      ));
+
+  if (response.status === 401 || hasInsufficientPermissions) {
     setResponseStatus(event, 409);
     return {
       error:

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -14,6 +14,13 @@ const GOOGLE_SLIDES_MIME = "application/vnd.google-apps.presentation";
 const UPLOAD_URL =
   "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,webViewLink";
 
+function isGoogleReconnectError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unauthorized|invalid_grant|invalid_client|expired|reconnect/i.test(
+    message,
+  );
+}
+
 /**
  * Uploads a PPTX into the user's Drive, letting Drive convert it to a native
  * Google Slides deck. The caller decides which exporter produced those bytes,
@@ -56,10 +63,24 @@ export default defineEventHandler(async (event) => {
   // Same request context the actions run in — Google's client credentials can
   // be org-scoped vault secrets, and resolving them without the org reports the
   // integration as unconfigured.
-  const account = await runWithRequestContext(
-    { userEmail: sessionEmail, orgId: session.orgId },
-    () => getGoogleDocsAccessToken(sessionEmail),
-  );
+  let account: Awaited<ReturnType<typeof getGoogleDocsAccessToken>>;
+  try {
+    account = await runWithRequestContext(
+      { userEmail: sessionEmail, orgId: session.orgId },
+      () => getGoogleDocsAccessToken(sessionEmail),
+    );
+  } catch (error) {
+    if (isGoogleReconnectError(error)) {
+      setResponseStatus(event, 409);
+      return {
+        error:
+          "Google Drive connection expired. Connect Google again, then retry.",
+        code: "google-not-connected",
+      };
+    }
+    setResponseStatus(event, 502);
+    return { error: "Could not use the Google Drive connection. Try again." };
+  }
   if (!account) {
     setResponseStatus(event, 409);
     return {
@@ -77,20 +98,35 @@ export default defineEventHandler(async (event) => {
     `\r\n--${boundary}--`,
   ]);
 
-  const response = await fetch(UPLOAD_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${account.accessToken}`,
-      "Content-Type": `multipart/related; boundary=${boundary}`,
-    },
-    body,
-  });
+  let response: Response;
+  try {
+    response = await fetch(UPLOAD_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${account.accessToken}`,
+        "Content-Type": `multipart/related; boundary=${boundary}`,
+      },
+      body,
+    });
+  } catch {
+    setResponseStatus(event, 502);
+    return { error: "Could not reach Google Drive. Try again." };
+  }
 
   const result = (await response.json().catch(() => null)) as {
     id?: string;
     webViewLink?: string;
     error?: { message?: string };
   } | null;
+
+  if (response.status === 401) {
+    setResponseStatus(event, 409);
+    return {
+      error:
+        "Google Drive connection expired. Connect Google again, then retry.",
+      code: "google-not-connected",
+    };
+  }
 
   if (!response.ok || !result?.webViewLink) {
     setResponseStatus(event, 502);

--- a/templates/slides/server/routes/api/exports/google-slides.post.ts
+++ b/templates/slides/server/routes/api/exports/google-slides.post.ts
@@ -67,7 +67,10 @@ export default defineEventHandler(async (event) => {
   try {
     account = await runWithRequestContext(
       { userEmail: sessionEmail, orgId: session.orgId },
-      () => getGoogleDocsAccessToken(sessionEmail),
+      () =>
+        getGoogleDocsAccessToken(sessionEmail, {
+          requireDriveUploadScope: true,
+        }),
     );
   } catch (error) {
     if (isGoogleReconnectError(error)) {

--- a/templates/slides/server/routes/api/exports/session-lookup.test.ts
+++ b/templates/slides/server/routes/api/exports/session-lookup.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSession = vi.hoisted(() => vi.fn());
 const mockSetResponseStatus = vi.hoisted(() => vi.fn());
+const mockGetGoogleDocsAccessToken = vi.hoisted(() => vi.fn());
+const mockReadMultipartFormData = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
@@ -17,7 +19,8 @@ vi.mock("@agent-native/core/org", () => ({
 vi.mock("h3", () => ({
   defineEventHandler: (handler: unknown) => handler,
   setResponseStatus: (...args: unknown[]) => mockSetResponseStatus(...args),
-  readMultipartFormData: vi.fn(async () => []),
+  readMultipartFormData: (...args: unknown[]) =>
+    mockReadMultipartFormData(...args),
   getRouterParam: vi.fn(() => "deck.pptx"),
 }));
 
@@ -30,7 +33,7 @@ vi.mock("../../../../actions/export-pptx.js", () => ({
 }));
 
 vi.mock("../../../lib/google-docs-oauth.js", () => ({
-  getGoogleDocsAccessToken: vi.fn(),
+  getGoogleDocsAccessToken: mockGetGoogleDocsAccessToken,
 }));
 
 vi.mock("../../../lib/tenant-files.js", () => ({
@@ -63,6 +66,8 @@ describe.each([
   beforeEach(() => {
     mockGetSession.mockReset();
     mockSetResponseStatus.mockReset();
+    mockGetGoogleDocsAccessToken.mockReset();
+    mockReadMultipartFormData.mockResolvedValue([]);
   });
 
   it("reports a 503 service error, not 401 Unauthorized, when the session lookup fails", async () => {
@@ -89,5 +94,33 @@ describe.each([
 
     expect(mockSetResponseStatus).toHaveBeenCalledWith(expect.anything(), 401);
     expect(result?.error).toBe("Unauthorized");
+  });
+});
+
+describe("google-slides connection failures", () => {
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue({
+      email: "owner@example.com",
+      orgId: "org-1",
+    });
+    mockReadMultipartFormData.mockResolvedValue([
+      { name: "file", data: new Uint8Array([1, 2, 3]) },
+    ]);
+  });
+
+  it("turns an expired Google connection into a reconnect response", async () => {
+    mockGetGoogleDocsAccessToken.mockRejectedValue(new Error("Unauthorized"));
+
+    const result = (await exportGoogleSlides({ node: { res: {} } } as any)) as {
+      code?: string;
+      error?: string;
+    };
+
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(expect.anything(), 409);
+    expect(result).toEqual({
+      error:
+        "Google Drive connection expired. Connect Google again, then retry.",
+      code: "google-not-connected",
+    });
   });
 });

--- a/templates/slides/server/routes/api/exports/session-lookup.test.ts
+++ b/templates/slides/server/routes/api/exports/session-lookup.test.ts
@@ -124,6 +124,10 @@ describe("google-slides connection failures", () => {
     };
 
     expect(mockSetResponseStatus).toHaveBeenCalledWith(expect.anything(), 409);
+    expect(mockGetGoogleDocsAccessToken).toHaveBeenCalledWith(
+      "owner@example.com",
+      { requireDriveUploadScope: true },
+    );
     expect(result).toEqual({
       error:
         "Google Drive connection expired. Connect Google again, then retry.",

--- a/templates/slides/server/routes/api/exports/session-lookup.test.ts
+++ b/templates/slides/server/routes/api/exports/session-lookup.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSession = vi.hoisted(() => vi.fn());
 const mockSetResponseStatus = vi.hoisted(() => vi.fn());
 const mockGetGoogleDocsAccessToken = vi.hoisted(() => vi.fn());
 const mockReadMultipartFormData = vi.hoisted(() => vi.fn());
+const mockFetch = vi.hoisted(() => vi.fn());
 
 vi.mock("@agent-native/core/server", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
@@ -68,6 +69,7 @@ describe.each([
     mockSetResponseStatus.mockReset();
     mockGetGoogleDocsAccessToken.mockReset();
     mockReadMultipartFormData.mockResolvedValue([]);
+    mockFetch.mockReset();
   });
 
   it("reports a 503 service error, not 401 Unauthorized, when the session lookup fails", async () => {
@@ -99,6 +101,7 @@ describe.each([
 
 describe("google-slides connection failures", () => {
   beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
     mockGetSession.mockResolvedValue({
       email: "owner@example.com",
       orgId: "org-1",
@@ -108,8 +111,12 @@ describe("google-slides connection failures", () => {
     ]);
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("turns an expired Google connection into a reconnect response", async () => {
-    mockGetGoogleDocsAccessToken.mockRejectedValue(new Error("Unauthorized"));
+    mockGetGoogleDocsAccessToken.mockRejectedValue(new Error("invalid_grant"));
 
     const result = (await exportGoogleSlides({ node: { res: {} } } as any)) as {
       code?: string;
@@ -121,6 +128,49 @@ describe("google-slides connection failures", () => {
       error:
         "Google Drive connection expired. Connect Google again, then retry.",
       code: "google-not-connected",
+    });
+  });
+
+  it("turns a Drive insufficient-permissions response into a reconnect response", async () => {
+    mockGetGoogleDocsAccessToken.mockResolvedValue({
+      accessToken: "access-token",
+      accountEmail: "owner@example.com",
+    });
+    mockFetch.mockResolvedValue({
+      status: 403,
+      ok: false,
+      json: vi.fn().mockResolvedValue({
+        error: {
+          message: "The caller does not have permission",
+          errors: [{ reason: "insufficientPermissions" }],
+        },
+      }),
+    });
+
+    const result = (await exportGoogleSlides({ node: { res: {} } } as any)) as {
+      code?: string;
+      error?: string;
+    };
+
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(expect.anything(), 409);
+    expect(result).toEqual({
+      error:
+        "Google Drive connection expired. Connect Google again, then retry.",
+      code: "google-not-connected",
+    });
+  });
+
+  it("keeps invalid OAuth client configuration out of the reconnect flow", async () => {
+    mockGetGoogleDocsAccessToken.mockRejectedValue(new Error("invalid_client"));
+
+    const result = (await exportGoogleSlides({ node: { res: {} } } as any)) as {
+      code?: string;
+      error?: string;
+    };
+
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(expect.anything(), 502);
+    expect(result).toEqual({
+      error: "Could not use the Google Drive connection. Try again.",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Align Calendar's agent snapshot with the visible date, view mode, timezone, and configured week start, while preserving recurring series identity.
- Keep Google Slides export recovery visible by opening the import page before async work and returning an explicit reconnect result for stale Google Drive credentials.

## Latest feedback handoff

Review window started at the first workflow marker in [Slack](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788204359155249?thread_ts=1788204359.155249&cid=C0ATH3CCZT4), with the bounded scan through September 1, 2026. Reporter follow-ups and current dispositions:

| Report | Disposition |
| --- | --- |
| [Stephane recurrence](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788275144118219?thread_ts=1788275144.118219&cid=C0ATH3CCZT4) | Source fix: `view-screen` now follows the visible Calendar range and keeps recurrence identity. Browser/run trace remains pending; series-scope mutation was not changed. |
| [Zane Google Slides export](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788291053263629?thread_ts=1788291053.263629&cid=C0ATH3CCZT4) | Source fix for the blank `about:blank` tab and stale connection path. Later multi-slide content and formatting loss is a separate import-fidelity issue and remains open. |
| [Urvi `.fig` upload](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788255251132169?thread_ts=1788255251.132169&cid=C0ATH3CCZT4) | The observed 412 is the intentional missing-Builder-connection response. Agent-action work is already in [PR #4091](https://github.com/BuilderIO/agent-native/pull/4091); no duplicate source change here. |
| [Lisa booking slug](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788292726983209?thread_ts=1788292726.983209&cid=C0ATH3CCZT4) | Current create dialog, editor, and server validation preserve hyphens. Left open for deployed bundle/build verification. |
| [Lisa navigation error](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788292442486379?thread_ts=1788292442.486379&cid=C0ATH3CCZT4) | No Calendar-owned `removeChild` cause reproduced. Left open pending browser console/Sentry component trace. |
| [Gonza Voice mode](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788291896456829?thread_ts=1788291896.456829&cid=C0ATH3CCZT4) | Shared realtime/provider failure, not a Calendar source defect. Left open for provider configuration verification. |
| [Cody imported backgrounds](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788285586131259?thread_ts=1788285586.131259&cid=C0ATH3CCZT4) | Page-level or inherited picture background fidelity remains open with the import-fidelity owner; solid and gradient coverage is already present. |
| [Vishwas pause/resume timestamps](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788288138439939?thread_ts=1788288138.439939&cid=C0ATH3CCZT4) | Active Clips checkout work owns this fix; no duplicate change here. |

The current unresolved beta Slides Sentry issue `erriss_9076c45b07bbde35d1ce9344` (`Unauthorized` at `/api/exports/google-slides`) informed the reconnect response. This PR does not claim live beta, production, or authenticated-provider verification.

## Checks

- Calendar focused tests: 2 files, 11 passed.
- Slides focused tests: 3 files, 25 passed.
- `oxfmt --check` and `git diff --check` passed.

