### PR TITLE
feat(analytics): join data across connected app databases

### DIFF
--- a/.changeset/federated-db-admin-catalog-cap.md
+++ b/.changeset/federated-db-admin-catalog-cap.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bound database admin table catalog row-count queries.

--- a/packages/core/src/db-admin/operations.spec.ts
+++ b/packages/core/src/db-admin/operations.spec.ts
@@ -119,6 +119,17 @@ describe("listTables", () => {
     expect(view?.type).toBe("view");
     expect(view?.rowCount).toBeNull();
   });
+
+  it("can cap table row-count queries while retaining table metadata", async () => {
+    const { ops } = await loadOps();
+    const { tables } = await ops.listTables(undefined, { maxRowCounts: 1 });
+
+    expect(tables.find((table) => table.name === "authors")?.rowCount).toBe(2);
+    expect(tables.find((table) => table.name === "books")?.rowCount).toBeNull();
+    expect(
+      tables.find((table) => table.name === "author_book_counts")?.rowCount,
+    ).toBeNull();
+  });
 });
 
 describe("getTableSchema", () => {

--- a/packages/core/src/db-admin/operations.ts
+++ b/packages/core/src/db-admin/operations.ts
@@ -192,12 +192,27 @@ async function notifyDbAdminChange(runtime?: DbAdminRuntime): Promise<void> {
 // listTables
 // ---------------------------------------------------------------------------
 
-export async function listTables(runtime?: DbAdminRuntime): Promise<{
+export async function listTables(
+  runtime?: DbAdminRuntime,
+  options: { maxRowCounts?: number } = {},
+): Promise<{
   dialect: DbAdminDialect;
   tables: DbAdminTableSummary[];
 }> {
   const client = db(runtime);
   const summaries: DbAdminTableSummary[] = [];
+  const maxRowCounts = Number.isFinite(options.maxRowCounts)
+    ? Math.max(0, Math.floor(options.maxRowCounts!))
+    : Number.POSITIVE_INFINITY;
+  let rowCountQueries = 0;
+  const rowCount = async (
+    name: string,
+    type: "table" | "view",
+  ): Promise<number | null> => {
+    if (type === "view" || rowCountQueries >= maxRowCounts) return null;
+    rowCountQueries += 1;
+    return safeRowCount(name, runtime);
+  };
 
   if (isPostgresRuntime(runtime)) {
     const res = await client.execute(
@@ -213,7 +228,7 @@ export async function listTables(runtime?: DbAdminRuntime): Promise<{
       summaries.push({
         name,
         type,
-        rowCount: type === "view" ? null : await safeRowCount(name, runtime),
+        rowCount: await rowCount(name, type),
       });
     }
   } else {
@@ -229,7 +244,7 @@ export async function listTables(runtime?: DbAdminRuntime): Promise<{
       summaries.push({
         name,
         type,
-        rowCount: type === "view" ? null : await safeRowCount(name, runtime),
+        rowCount: await rowCount(name, type),
       });
     }
   }

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -41,7 +41,7 @@ Read the relevant skill before deeper work:
    then query; don't cross-check or add unasked breakdowns.
 4. **Answer in chat.** Return a short table or inline chart, not only a
    dashboard pointer; for >50 rows, state the total and top rows.
-5. **Deliver exports in chat.** See `analysis-workspace`; don't return only a path.
+5. **Deliver exports in chat.** Don't return only a path.
 6. **Chunk only reading.** Group 5-10 only for 30+ qualitative items when a query
    cannot answer; don't chunk queryable questions. See `adhoc-analysis`.
 
@@ -54,12 +54,12 @@ Read the relevant skill before deeper work:
   signups, conversions, and other curated product metrics. Answer sibling-app
   delegations with the built-in source and query catalog; sibling agents should
   send a natural-language question, never SQL.
-- For open-ended delegated requests, choose a safe default and label partial.
+- Delegated requests: choose a safe default; label partial.
 - Data integrity first. Never invent numbers, dimensions, filters, or source
   semantics; present only retrieved values with source, window, filters,
   row-count/sample-size, join method, and caveats.
-- Use actions for sources, queries, charts, dashboards, and sharing. Don't bypass
-  access checks with raw SQL for ownable resources.
+- Use actions for data and sharing; don't bypass ownable-resource access checks
+  with raw SQL.
 - Provider actions are bounded shortcuts, not limits. For broad or
   absence-sensitive Gong work, stage raw API data and use `query-staged-dataset`
   or a Data Program; see `provider-api`, `data-programs`, and `gong` for secure
@@ -83,8 +83,7 @@ Read the relevant skill before deeper work:
 - External MCP callers default to `ask_app` for interpretation, source choice,
   analysis, or multi-step work. Direct reads require exact, complete input;
   writes stay `ask_app`-only.
-- Dashboard reports and alert rules use their SQL-backed action surfaces; reports
-  cap at five recipients.
+- Reports/alerts use SQL actions; reports cap at five recipients.
 
 ## Actions
 
@@ -94,6 +93,7 @@ Read the relevant skill before deeper work:
 | `search-dashboard-references` | Find dashboards to replicate. |
 | `get-sql-dashboard` | Read the dashboard and exact panel SQL. |
 | `certify-dashboard` | Admin-only approval of its current version. |
+| DB | `list-db-admin-connections`, `list-connected-database-tables`, `db-admin-federated-read`: registry, schema, bounded joins. |
 
 ## Application State
 

--- a/templates/analytics/actions/db-admin-federated-read.spec.ts
+++ b/templates/analytics/actions/db-admin-federated-read.spec.ts
@@ -43,8 +43,8 @@ describe("db-admin-federated-read", () => {
         return {
           columns: ["user_id", "total"],
           rows: [
-            { user_id: 1, total: 10 },
-            { user_id: 1, total: 15 },
+            { user_id: "1", total: 10 },
+            { user_id: "1", total: 15 },
           ],
           rowsAffected: 0,
           durationMs: 1,
@@ -72,9 +72,7 @@ describe("db-admin-federated-read", () => {
         ],
         join: {
           kind: "inner",
-          leftSourceId: "users",
           leftColumn: "id",
-          rightSourceId: "orders",
           rightColumn: "user_id",
         },
         projections: [
@@ -87,6 +85,9 @@ describe("db-admin-federated-read", () => {
 
     expect(mocks.withDbAdminConnectionRuntime).toHaveBeenCalledTimes(2);
     expect(mocks.runSql).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.runSql.mock.calls.every(([sql]) => /LIMIT 501$/.test(sql)),
+    ).toBe(true);
     expect(result).toMatchObject({
       widget: "data-table",
       widgetId: "analytics.db-admin.federated-read.v1",
@@ -115,6 +116,34 @@ describe("db-admin-federated-read", () => {
         totalRows: 2,
       },
     });
+  });
+
+  it("uses a read-only transaction for Postgres sources", async () => {
+    const execute = vi.fn().mockResolvedValue({ rows: [], rowsAffected: 0 });
+    const transaction = vi.fn(async (callback) => callback({ execute } as any));
+    mocks.withDbAdminConnectionRuntime.mockImplementation(
+      async (_ctx, connectionId, fn) =>
+        fn(
+          { dialect: "postgres", db: { transaction } } as any,
+          { id: connectionId } as any,
+        ),
+    );
+
+    await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id, name FROM users",
+          },
+        ],
+      },
+    );
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith("SET TRANSACTION READ ONLY");
   });
 
   it("prefixes rows for a single source when no projection is supplied", async () => {
@@ -154,6 +183,26 @@ describe("db-admin-federated-read", () => {
       ),
     ).rejects.toThrow(/select or with/i);
 
+    expect(mocks.runSql).not.toHaveBeenCalled();
+  });
+
+  it("rejects SELECT INTO before opening a database runtime", async () => {
+    await expect(
+      runDbAdminFederatedRead(
+        { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+        {
+          sources: [
+            {
+              connectionId: "conn-users",
+              sourceId: "users",
+              sql: "SELECT id INTO copied_users FROM users",
+            },
+          ],
+        },
+      ),
+    ).rejects.toThrow(/select into/i);
+
+    expect(mocks.withDbAdminConnectionRuntime).not.toHaveBeenCalled();
     expect(mocks.runSql).not.toHaveBeenCalled();
   });
 
@@ -218,5 +267,73 @@ describe("db-admin-federated-read", () => {
         "orders.total": null,
       },
     ]);
+  });
+
+  it("allows an empty right source in a left join", async () => {
+    mocks.runSql.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM users")) {
+        return {
+          columns: ["id", "name"],
+          rows: [{ id: 1, name: "Ada" }],
+          rowsAffected: 0,
+          durationMs: 1,
+        };
+      }
+      return { columns: [], rows: [], rowsAffected: 0, durationMs: 1 };
+    });
+
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id, name FROM users",
+          },
+          {
+            connectionId: "conn-orders",
+            sourceId: "orders",
+            sql: "SELECT user_id, total FROM orders",
+          },
+        ],
+        join: {
+          kind: "left",
+          leftColumn: "id",
+          rightColumn: "user_id",
+        },
+        limit: 10,
+      },
+    );
+
+    expect(result.summary).toMatchObject({ truncated: false });
+    expect(result.table.rows).toEqual([{ "users.id": 1, "users.name": "Ada" }]);
+  });
+
+  it("reports the hard source cap as truncation", async () => {
+    mocks.runSql.mockResolvedValue({
+      columns: ["id"],
+      rows: Array.from({ length: 501 }, (_, id) => ({ id })),
+      rowsAffected: 0,
+      durationMs: 1,
+    });
+
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id FROM users LIMIT 999999",
+          },
+        ],
+        limit: 500,
+      },
+    );
+
+    expect(result.summary).toMatchObject({ truncated: true });
+    expect(result.table.rows).toHaveLength(500);
+    expect(result.table).toMatchObject({ sampledRows: 500, truncated: true });
   });
 });

--- a/templates/analytics/actions/db-admin-federated-read.spec.ts
+++ b/templates/analytics/actions/db-admin-federated-read.spec.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runSql: vi.fn(),
+  withDbAdminConnectionRuntime: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/db-admin", () => ({
+  runSql: mocks.runSql,
+}));
+
+vi.mock("../server/lib/db-admin-connections", () => ({
+  withDbAdminConnectionRuntime: mocks.withDbAdminConnectionRuntime,
+}));
+
+const { runDbAdminFederatedRead } =
+  await import("../server/lib/db-admin-federated-read");
+
+describe("db-admin-federated-read", () => {
+  beforeEach(() => {
+    mocks.runSql.mockReset();
+    mocks.withDbAdminConnectionRuntime.mockReset();
+    mocks.withDbAdminConnectionRuntime.mockImplementation(
+      async (_ctx, connectionId, fn) =>
+        fn(
+          { dialect: "sqlite", db: undefined } as any,
+          { id: connectionId } as any,
+        ),
+    );
+    mocks.runSql.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM users")) {
+        return {
+          columns: ["id", "name"],
+          rows: [
+            { id: 1, name: "Ada" },
+            { id: 2, name: "Bob" },
+          ],
+          rowsAffected: 0,
+          durationMs: 1,
+        };
+      }
+      if (sql.includes("FROM orders")) {
+        return {
+          columns: ["user_id", "total"],
+          rows: [
+            { user_id: 1, total: 10 },
+            { user_id: 1, total: 15 },
+          ],
+          rowsAffected: 0,
+          durationMs: 1,
+        };
+      }
+      throw new Error(`unexpected sql: ${sql}`);
+    });
+  });
+
+  it("joins two read-only sources and keeps source metadata", async () => {
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id, name FROM users ORDER BY id",
+          },
+          {
+            connectionId: "conn-orders",
+            sourceId: "orders",
+            sql: "SELECT user_id, total FROM orders ORDER BY user_id",
+          },
+        ],
+        join: {
+          kind: "inner",
+          leftSourceId: "users",
+          leftColumn: "id",
+          rightSourceId: "orders",
+          rightColumn: "user_id",
+        },
+        projections: [
+          { sourceId: "users", column: "name", as: "user_name" },
+          { sourceId: "orders", column: "total" },
+        ],
+        limit: 10,
+      },
+    );
+
+    expect(mocks.withDbAdminConnectionRuntime).toHaveBeenCalledTimes(2);
+    expect(mocks.runSql).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      widget: "data-table",
+      widgetId: "analytics.db-admin.federated-read.v1",
+      summary: {
+        sourceCount: 2,
+        limit: 10,
+        truncated: false,
+        join: {
+          kind: "inner",
+          leftSourceId: "users",
+          leftColumn: "id",
+          rightSourceId: "orders",
+          rightColumn: "user_id",
+        },
+      },
+      table: {
+        title: "Federated db admin result",
+        columns: [
+          { key: "user_name", label: "user_name" },
+          { key: "total", label: "total", align: "right" },
+        ],
+        rows: [
+          { user_name: "Ada", total: 10 },
+          { user_name: "Ada", total: 15 },
+        ],
+        totalRows: 2,
+      },
+    });
+  });
+
+  it("prefixes rows for a single source when no projection is supplied", async () => {
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id, name FROM users",
+          },
+        ],
+        limit: 10,
+      },
+    );
+
+    expect(result.table.rows).toEqual([
+      { "users.id": 1, "users.name": "Ada" },
+      { "users.id": 2, "users.name": "Bob" },
+    ]);
+  });
+
+  it("rejects write statements before executing them", async () => {
+    await expect(
+      runDbAdminFederatedRead(
+        { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+        {
+          sources: [
+            {
+              connectionId: "conn-users",
+              sourceId: "users",
+              sql: "DELETE FROM users",
+            },
+          ],
+        },
+      ),
+    ).rejects.toThrow(/select or with/i);
+
+    expect(mocks.runSql).not.toHaveBeenCalled();
+  });
+
+  it("keeps right-side columns visible for unmatched left-join rows", async () => {
+    mocks.runSql.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM users")) {
+        return {
+          columns: ["id", "name"],
+          rows: [
+            { id: 1, name: "Ada" },
+            { id: 2, name: "Bob" },
+          ],
+          rowsAffected: 0,
+          durationMs: 1,
+        };
+      }
+      return {
+        columns: ["user_id", "total"],
+        rows: [{ user_id: 1, total: 10 }],
+        rowsAffected: 0,
+        durationMs: 1,
+      };
+    });
+
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT id, name FROM users",
+          },
+          {
+            connectionId: "conn-orders",
+            sourceId: "orders",
+            sql: "SELECT user_id, total FROM orders",
+          },
+        ],
+        join: {
+          kind: "left",
+          leftSourceId: "users",
+          leftColumn: "id",
+          rightSourceId: "orders",
+          rightColumn: "user_id",
+        },
+        limit: 10,
+      },
+    );
+
+    expect(result.table.rows).toEqual([
+      {
+        "users.id": 1,
+        "users.name": "Ada",
+        "orders.user_id": 1,
+        "orders.total": 10,
+      },
+      {
+        "users.id": 2,
+        "users.name": "Bob",
+        "orders.user_id": null,
+        "orders.total": null,
+      },
+    ]);
+  });
+});

--- a/templates/analytics/actions/db-admin-federated-read.spec.ts
+++ b/templates/analytics/actions/db-admin-federated-read.spec.ts
@@ -13,7 +13,7 @@ vi.mock("../server/lib/db-admin-connections", () => ({
   withDbAdminConnectionRuntime: mocks.withDbAdminConnectionRuntime,
 }));
 
-const { runDbAdminFederatedRead } =
+const { federatedDbAdminReadSchema, runDbAdminFederatedRead } =
   await import("../server/lib/db-admin-federated-read");
 
 describe("db-admin-federated-read", () => {
@@ -52,6 +52,19 @@ describe("db-admin-federated-read", () => {
       }
       throw new Error(`unexpected sql: ${sql}`);
     });
+  });
+
+  it("rejects a join supplied with only one source", () => {
+    expect(
+      federatedDbAdminReadSchema.safeParse({
+        sources: [{ connectionId: "conn-users", sql: "SELECT id FROM users" }],
+        join: {
+          kind: "inner",
+          leftColumn: "id",
+          rightColumn: "id",
+        },
+      }),
+    ).toMatchObject({ success: false });
   });
 
   it("joins two read-only sources and keeps source metadata", async () => {
@@ -308,6 +321,78 @@ describe("db-admin-federated-read", () => {
 
     expect(result.summary).toMatchObject({ truncated: false });
     expect(result.table.rows).toEqual([{ "users.id": 1, "users.name": "Ada" }]);
+  });
+
+  it("normalizes timestamp strings and Date values to the same join key", async () => {
+    mocks.runSql.mockImplementation(async (sql: string) =>
+      sql.includes("FROM users")
+        ? {
+            columns: ["created_at", "name"],
+            rows: [
+              { created_at: new Date("2026-01-02T03:04:05.000Z"), name: "Ada" },
+            ],
+            rowsAffected: 0,
+            durationMs: 1,
+          }
+        : {
+            columns: ["created_at", "total"],
+            rows: [{ created_at: "2026-01-02 03:04:05", total: 10 }],
+            rowsAffected: 0,
+            durationMs: 1,
+          },
+    );
+
+    const result = await runDbAdminFederatedRead(
+      { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+      {
+        sources: [
+          {
+            connectionId: "conn-users",
+            sourceId: "users",
+            sql: "SELECT created_at, name FROM users",
+          },
+          {
+            connectionId: "conn-orders",
+            sourceId: "orders",
+            sql: "SELECT created_at, total FROM orders",
+          },
+        ],
+        join: {
+          kind: "inner",
+          leftColumn: "created_at",
+          rightColumn: "created_at",
+        },
+        projections: [
+          { sourceId: "users", column: "name", as: "user_name" },
+          { sourceId: "orders", column: "total" },
+        ],
+      },
+    );
+
+    expect(result.table.rows).toEqual([{ user_name: "Ada", total: 10 }]);
+  });
+
+  it("rejects joins when a source contains previewed large cells", async () => {
+    mocks.runSql.mockResolvedValue({
+      columns: ["id", "payload"],
+      rows: [{ id: 1, payload: "preview" }],
+      rowsAffected: 0,
+      durationMs: 1,
+      truncatedCells: 1,
+    });
+
+    await expect(
+      runDbAdminFederatedRead(
+        { userEmail: "alice@example.com", orgId: "org_1", role: "admin" },
+        {
+          sources: [
+            { connectionId: "conn-users", sql: "SELECT id FROM users" },
+            { connectionId: "conn-orders", sql: "SELECT id FROM orders" },
+          ],
+          join: { kind: "inner", leftColumn: "id", rightColumn: "id" },
+        },
+      ),
+    ).rejects.toThrow(/truncated large-cell/i);
   });
 
   it("reports the hard source cap as truncation", async () => {

--- a/templates/analytics/actions/db-admin-federated-read.ts
+++ b/templates/analytics/actions/db-admin-federated-read.ts
@@ -13,10 +13,7 @@ import {
 export default defineAction({
   description:
     "Run one or two admin-scoped read-only SQL sources against connected app databases, optionally join the returned rows on matching column names, and return a bounded data table with source metadata and truncation. Source SQL must be a single SELECT or WITH query; writes and multi-statement inputs are rejected.",
-  schema: federatedDbAdminReadSchema.refine((value) => {
-    if (value.sources.length === 1) return true;
-    return Boolean(value.join);
-  }, "A join is required when two sources are supplied."),
+  schema: federatedDbAdminReadSchema,
   outputSchema: dataTableWidgetResultSchema,
   chatUI: {
     renderer: ACTION_CHAT_UI_DATA_TABLE_RENDERER,

--- a/templates/analytics/actions/db-admin-federated-read.ts
+++ b/templates/analytics/actions/db-admin-federated-read.ts
@@ -1,0 +1,33 @@
+import {
+  ACTION_CHAT_UI_DATA_TABLE_RENDERER,
+  dataTableWidgetResultSchema,
+  defineAction,
+} from "@agent-native/core";
+
+import { requireDbAdminContextFromRequest } from "../server/lib/db-admin-connections";
+import {
+  federatedDbAdminReadSchema,
+  runDbAdminFederatedRead,
+} from "../server/lib/db-admin-federated-read";
+
+export default defineAction({
+  description:
+    "Run one or two admin-scoped read-only SQL sources against connected app databases, optionally join the returned rows on matching column names, and return a bounded data table with source metadata and truncation. Source SQL must be a single SELECT or WITH query; writes and multi-statement inputs are rejected.",
+  schema: federatedDbAdminReadSchema.refine((value) => {
+    if (value.sources.length === 1) return true;
+    return Boolean(value.join);
+  }, "A join is required when two sources are supplied."),
+  outputSchema: dataTableWidgetResultSchema,
+  chatUI: {
+    renderer: ACTION_CHAT_UI_DATA_TABLE_RENDERER,
+    title: "Federated db admin result",
+    description: "Render joined db-admin rows as a native table.",
+  },
+  http: { method: "POST" },
+  readOnly: true,
+  grounding: true,
+  run: async (args, ctx) => {
+    const admin = await requireDbAdminContextFromRequest(ctx);
+    return runDbAdminFederatedRead(admin, args);
+  },
+});

--- a/templates/analytics/actions/list-connected-database-tables.spec.ts
+++ b/templates/analytics/actions/list-connected-database-tables.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listTables: vi.fn(),
+  listDbAdminConnections: vi.fn(),
+  requireDbAdminContextFromRequest: vi.fn(),
+  withDbAdminConnectionRuntime: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/action", () => ({
+  defineAction: (definition: unknown) => definition,
+}));
+vi.mock("@agent-native/core/db-admin", () => ({
+  listTables: mocks.listTables,
+}));
+vi.mock("../server/lib/db-admin-connections", () => ({
+  listDbAdminConnections: mocks.listDbAdminConnections,
+  requireDbAdminContextFromRequest: mocks.requireDbAdminContextFromRequest,
+  withDbAdminConnectionRuntime: mocks.withDbAdminConnectionRuntime,
+}));
+
+const action = (await import("./list-connected-database-tables")).default;
+
+beforeEach(() => {
+  mocks.listTables.mockReset();
+  mocks.listDbAdminConnections.mockReset();
+  mocks.requireDbAdminContextFromRequest.mockReset();
+  mocks.withDbAdminConnectionRuntime.mockReset();
+  mocks.requireDbAdminContextFromRequest.mockResolvedValue({
+    userEmail: "owner@example.com",
+    orgId: "org-1",
+    role: "owner",
+  });
+  mocks.listDbAdminConnections.mockResolvedValue([
+    {
+      id: "clips",
+      name: "Clips",
+      appId: "clips",
+      appUrl: "https://clips.example.test",
+    },
+  ]);
+  mocks.withDbAdminConnectionRuntime.mockImplementation(
+    async (_ctx, _id, callback) => callback({ dialect: "postgres" }),
+  );
+  mocks.listTables.mockResolvedValue({
+    dialect: "postgres",
+    tables: [{ name: "clips", type: "table", rowCount: 2 }],
+  });
+});
+
+describe("list-connected-database-tables", () => {
+  it("returns table metadata without secret fields", async () => {
+    await expect(action.run({}, {} as never)).resolves.toEqual({
+      connections: [
+        {
+          id: "clips",
+          name: "Clips",
+          appId: "clips",
+          appUrl: "https://clips.example.test",
+          dialect: "postgres",
+          tables: [{ name: "clips", type: "table", rowCount: 2 }],
+        },
+      ],
+    });
+    expect(mocks.withDbAdminConnectionRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unknown requested connection", async () => {
+    await expect(
+      action.run({ connectionIds: ["missing"] }, {} as never),
+    ).rejects.toThrow("Connected database not found: missing");
+    expect(mocks.withDbAdminConnectionRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/templates/analytics/actions/list-connected-database-tables.spec.ts
+++ b/templates/analytics/actions/list-connected-database-tables.spec.ts
@@ -71,4 +71,20 @@ describe("list-connected-database-tables", () => {
     ).rejects.toThrow("Connected database not found: missing");
     expect(mocks.withDbAdminConnectionRuntime).not.toHaveBeenCalled();
   });
+
+  it("requires an explicit bounded selection for a large registry", async () => {
+    mocks.listDbAdminConnections.mockResolvedValue(
+      Array.from({ length: 21 }, (_, index) => ({
+        id: `connection-${index}`,
+        name: `Connection ${index}`,
+        appId: null,
+        appUrl: null,
+      })),
+    );
+
+    await expect(action.run({}, {} as never)).rejects.toThrow(
+      "Specify at most 20 connectionIds",
+    );
+    expect(mocks.withDbAdminConnectionRuntime).not.toHaveBeenCalled();
+  });
 });

--- a/templates/analytics/actions/list-connected-database-tables.ts
+++ b/templates/analytics/actions/list-connected-database-tables.ts
@@ -9,6 +9,7 @@ import {
 } from "../server/lib/db-admin-connections";
 
 const MAX_DATABASES_PER_CATALOG = 20;
+const MAX_TABLE_ROW_COUNTS = 100;
 
 export default defineAction({
   description:
@@ -41,7 +42,9 @@ export default defineAction({
   grounding: true,
   run: async ({ connectionIds }, ctx) => {
     const admin = await requireDbAdminContextFromRequest(ctx);
-    const connections = await listDbAdminConnections(admin);
+    const connections = await listDbAdminConnections(admin, {
+      includeSecretMetadata: false,
+    });
     if (
       (!connectionIds || connectionIds.length === 0) &&
       connections.length > MAX_DATABASES_PER_CATALOG
@@ -70,7 +73,9 @@ export default defineAction({
             admin,
             connection.id,
             async (runtime) => {
-              const overview = await listTables(runtime);
+              const overview = await listTables(runtime, {
+                maxRowCounts: MAX_TABLE_ROW_COUNTS,
+              });
               return {
                 id: connection.id,
                 name: connection.name,

--- a/templates/analytics/actions/list-connected-database-tables.ts
+++ b/templates/analytics/actions/list-connected-database-tables.ts
@@ -12,11 +12,11 @@ const MAX_DATABASES_PER_CATALOG = 20;
 
 export default defineAction({
   description:
-    "List the public tables and views available in the admin-connected agent-native app databases. Call this before db-admin-federated-read when table or column names are unknown. It requires an active organization owner/admin role and never returns database URLs, tokens, or secret values. Omit connectionIds to inspect every connected database, or pass a bounded subset.",
+    "List the public tables and views available in the admin-connected agent-native app databases. Call this before db-admin-federated-read when table or column names are unknown. It requires an active organization owner/admin role and never returns database URLs, tokens, or secret values. Omit connectionIds to inspect every connected database when the registry has at most 20 entries; pass a bounded subset for larger registries.",
   schema: z.object({
     connectionIds: z
       .array(z.string().trim().min(1).max(200))
-      .max(20)
+      .max(MAX_DATABASES_PER_CATALOG)
       .optional(),
   }),
   outputSchema: z.object({

--- a/templates/analytics/actions/list-connected-database-tables.ts
+++ b/templates/analytics/actions/list-connected-database-tables.ts
@@ -1,0 +1,78 @@
+import { defineAction } from "@agent-native/core/action";
+import { listTables } from "@agent-native/core/db-admin";
+import { z } from "zod";
+
+import {
+  listDbAdminConnections,
+  requireDbAdminContextFromRequest,
+  withDbAdminConnectionRuntime,
+} from "../server/lib/db-admin-connections";
+
+export default defineAction({
+  description:
+    "List the public tables and views available in the admin-connected agent-native app databases. Call this before db-admin-federated-read when table or column names are unknown. It requires an active organization owner/admin role and never returns database URLs, tokens, or secret values. Omit connectionIds to inspect every connected database, or pass a bounded subset.",
+  schema: z.object({
+    connectionIds: z
+      .array(z.string().trim().min(1).max(200))
+      .max(20)
+      .optional(),
+  }),
+  outputSchema: z.object({
+    connections: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        appId: z.string().nullable(),
+        appUrl: z.string().nullable(),
+        dialect: z.string(),
+        tables: z.array(
+          z.object({
+            name: z.string(),
+            type: z.enum(["table", "view"]),
+            rowCount: z.number().nullable(),
+          }),
+        ),
+      }),
+    ),
+  }),
+  readOnly: true,
+  grounding: true,
+  run: async ({ connectionIds }, ctx) => {
+    const admin = await requireDbAdminContextFromRequest(ctx);
+    const connections = await listDbAdminConnections(admin);
+    const selected = connectionIds?.length
+      ? connections.filter((connection) =>
+          connectionIds.includes(connection.id),
+        )
+      : connections;
+    const selectedIds = new Set(selected.map((connection) => connection.id));
+    const missing = (connectionIds ?? []).filter(
+      (connectionId) => !selectedIds.has(connectionId),
+    );
+    if (missing.length > 0) {
+      throw new Error(`Connected database not found: ${missing.join(", ")}`);
+    }
+
+    return {
+      connections: await Promise.all(
+        selected.map((connection) =>
+          withDbAdminConnectionRuntime(
+            admin,
+            connection.id,
+            async (runtime) => {
+              const overview = await listTables(runtime);
+              return {
+                id: connection.id,
+                name: connection.name,
+                appId: connection.appId,
+                appUrl: connection.appUrl,
+                dialect: overview.dialect,
+                tables: overview.tables,
+              };
+            },
+          ),
+        ),
+      ),
+    };
+  },
+});

--- a/templates/analytics/actions/list-connected-database-tables.ts
+++ b/templates/analytics/actions/list-connected-database-tables.ts
@@ -8,6 +8,8 @@ import {
   withDbAdminConnectionRuntime,
 } from "../server/lib/db-admin-connections";
 
+const MAX_DATABASES_PER_CATALOG = 20;
+
 export default defineAction({
   description:
     "List the public tables and views available in the admin-connected agent-native app databases. Call this before db-admin-federated-read when table or column names are unknown. It requires an active organization owner/admin role and never returns database URLs, tokens, or secret values. Omit connectionIds to inspect every connected database, or pass a bounded subset.",
@@ -40,6 +42,14 @@ export default defineAction({
   run: async ({ connectionIds }, ctx) => {
     const admin = await requireDbAdminContextFromRequest(ctx);
     const connections = await listDbAdminConnections(admin);
+    if (
+      (!connectionIds || connectionIds.length === 0) &&
+      connections.length > MAX_DATABASES_PER_CATALOG
+    ) {
+      throw new Error(
+        `Specify at most ${MAX_DATABASES_PER_CATALOG} connectionIds when cataloging more than ${MAX_DATABASES_PER_CATALOG} databases.`,
+      );
+    }
     const selected = connectionIds?.length
       ? connections.filter((connection) =>
           connectionIds.includes(connection.id),

--- a/templates/analytics/changelog/2026-09-01-analytics-admins-can-join-read-only-data-from-connected-app-.md
+++ b/templates/analytics/changelog/2026-09-01-analytics-admins-can-join-read-only-data-from-connected-app-.md
@@ -1,0 +1,6 @@
+---
+type: added
+date: 2026-09-01
+---
+
+Analytics admins can join read-only data from connected app databases

--- a/templates/analytics/server/lib/db-admin-connections.ts
+++ b/templates/analytics/server/lib/db-admin-connections.ts
@@ -245,6 +245,7 @@ async function secretMetadata(
 
 export async function listDbAdminConnections(
   ctx: DbAdminAdminContext,
+  options: { includeSecretMetadata?: boolean } = {},
 ): Promise<DbAdminConnection[]> {
   const { rows } = await getDbExec().execute({
     sql: `SELECT id, name, app_id AS "appId", app_url AS "appUrl",
@@ -257,11 +258,18 @@ export async function listDbAdminConnections(
           ORDER BY updated_at DESC, name ASC`,
     args: [ctx.orgId],
   });
+  const includeSecretMetadata = options.includeSecretMetadata !== false;
   return Promise.all(
     rows.map(async (row) =>
       rowToConnection(
         row as Record<string, unknown>,
-        await secretMetadata(ctx, row as Record<string, unknown>),
+        includeSecretMetadata
+          ? await secretMetadata(ctx, row as Record<string, unknown>)
+          : {
+              databaseUrlLast4: null,
+              hasDatabaseAuthToken: false,
+              databaseAuthTokenLast4: null,
+            },
       ),
     ),
   );

--- a/templates/analytics/server/lib/db-admin-federated-read.ts
+++ b/templates/analytics/server/lib/db-admin-federated-read.ts
@@ -9,6 +9,8 @@ import {
 
 const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const NUMERIC_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+const TEMPORAL_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 const MUTATING_WORD_RE =
   /(^|[^A-Za-z_])(insert|update|delete|replace|create|alter|drop|truncate|merge)(?=[^A-Za-z_]|$)/i;
 const MAX_SOURCE_ROWS = 500;
@@ -133,9 +135,28 @@ function canonicalNumeric(value: string): string | null {
   return `${sign}${integer}${fraction ? `.${fraction}` : ""}`;
 }
 
+function canonicalTemporal(value: string | Date): string | null {
+  if (value instanceof Date && Number.isNaN(value.getTime())) return null;
+  const text = value instanceof Date ? value.toISOString() : value.trim();
+  if (!TEMPORAL_RE.test(text)) return null;
+  const normalized = text.includes("T") ? text : text.replace(" ", "T");
+  const withZone =
+    normalized.length === 10 || /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalized)
+      ? normalized
+      : `${normalized}Z`;
+  const parsed = new Date(withZone);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
 function rowKey(value: unknown): string | null {
   if (value === null || value === undefined) return null;
+  if (value instanceof Date) {
+    const temporal = canonicalTemporal(value);
+    return temporal ? `t:${temporal}` : `j:${JSON.stringify(value)}`;
+  }
   if (typeof value === "string") {
+    const temporal = canonicalTemporal(value);
+    if (temporal) return `t:${temporal}`;
     const numeric = canonicalNumeric(value);
     return numeric ? `n:${numeric}` : `s:${value}`;
   }
@@ -186,12 +207,29 @@ export const federatedDbAdminProjectionSchema = z.object({
   as: z.string().trim().min(1).optional(),
 });
 
-export const federatedDbAdminReadSchema = z.object({
-  sources: z.array(federatedDbAdminSourceSchema).min(1).max(2),
-  join: federatedDbAdminJoinSchema.optional(),
-  projections: z.array(federatedDbAdminProjectionSchema).max(50).optional(),
-  limit: z.coerce.number().int().min(1).max(500).optional(),
-});
+export const federatedDbAdminReadSchema = z
+  .object({
+    sources: z.array(federatedDbAdminSourceSchema).min(1).max(2),
+    join: federatedDbAdminJoinSchema.optional(),
+    projections: z.array(federatedDbAdminProjectionSchema).max(50).optional(),
+    limit: z.coerce.number().int().min(1).max(500).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.sources.length === 1 && value.join) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["join"],
+        message: "A join requires two sources.",
+      });
+    }
+    if (value.sources.length === 2 && !value.join) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["join"],
+        message: "A join is required when two sources are supplied.",
+      });
+    }
+  });
 
 type FederatedDbAdminReadArgs = z.infer<typeof federatedDbAdminReadSchema>;
 
@@ -201,6 +239,7 @@ type SourceResult = {
   rows: Record<string, unknown>[];
   columns: string[];
   truncated: boolean;
+  truncatedCells: number;
 };
 
 type NormalizedProjection = {
@@ -260,6 +299,7 @@ function buildRows(
   limit: number,
 ): { rows: Record<string, unknown>[]; truncated: boolean } {
   if (sources.length === 1) {
+    if (join) throw new Error("A join requires two sources.");
     const [source] = sources;
     const projectedColumns =
       projections?.map((projection) => projection.as) ??
@@ -293,6 +333,12 @@ function buildRows(
 
   if (!join) {
     throw new Error("A join is required when two sources are supplied.");
+  }
+
+  if (sources.some((source) => source.truncatedCells > 0)) {
+    throw new Error(
+      "Cannot join a source with truncated large-cell values; project a shorter join key.",
+    );
   }
 
   const leftSourceId = normalizeSourceId(
@@ -495,6 +541,7 @@ export async function runDbAdminFederatedRead(
             rows: result.rows.slice(0, MAX_SOURCE_ROWS),
             columns: pickRowColumns(result.rows[0], result.columns),
             truncated: result.rows.length > MAX_SOURCE_ROWS,
+            truncatedCells: result.truncatedCells ?? 0,
           } satisfies SourceResult;
         },
       ),

--- a/templates/analytics/server/lib/db-admin-federated-read.ts
+++ b/templates/analytics/server/lib/db-admin-federated-read.ts
@@ -1,0 +1,547 @@
+import { createDataTableWidgetResult } from "@agent-native/core/data-widgets";
+import { runSql, type DbAdminRuntime } from "@agent-native/core/db-admin";
+import { z } from "zod";
+
+import {
+  type DbAdminAdminContext,
+  withDbAdminConnectionRuntime,
+} from "./db-admin-connections";
+
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const MUTATING_WORD_RE =
+  /(^|[^A-Za-z_])(insert|update|delete|replace|create|alter|drop|truncate|merge)(?=[^A-Za-z_]|$)/i;
+
+function sanitizeSqlForInspection(sql: string): string {
+  let out = "";
+  let state: "code" | "single" | "double" | "line" | "block" = "code";
+  for (let i = 0; i < sql.length; i += 1) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+    if (state === "line") {
+      out += ch === "\n" || ch === "\r" ? ch : " ";
+      if (ch === "\n" || ch === "\r") state = "code";
+      continue;
+    }
+    if (state === "block") {
+      if (ch === "*" && next === "/") {
+        out += "  ";
+        i += 1;
+        state = "code";
+      } else {
+        out += " ";
+      }
+      continue;
+    }
+    if (state === "single") {
+      if (ch === "'" && next === "'") {
+        out += "  ";
+        i += 1;
+      } else if (ch === "'") {
+        out += " ";
+        state = "code";
+      } else {
+        out += " ";
+      }
+      continue;
+    }
+    if (state === "double") {
+      if (ch === '"' && next === '"') {
+        out += "  ";
+        i += 1;
+      } else if (ch === '"') {
+        out += " ";
+        state = "code";
+      } else {
+        out += " ";
+      }
+      continue;
+    }
+    if (ch === "-" && next === "-") {
+      out += "  ";
+      i += 1;
+      state = "line";
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      out += "  ";
+      i += 1;
+      state = "block";
+      continue;
+    }
+    if (ch === "'") {
+      out += " ";
+      state = "single";
+      continue;
+    }
+    if (ch === '"') {
+      out += " ";
+      state = "double";
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function assertReadOnlySql(sql: string): void {
+  const cleaned = sanitizeSqlForInspection(sql).trim();
+  if (!/^(select|with)\b/i.test(cleaned)) {
+    throw new Error("Source SQL must start with SELECT or WITH.");
+  }
+  const statement = cleaned.replace(/;\s*$/, "");
+  if (statement.includes(";")) {
+    throw new Error("Source SQL must be a single statement.");
+  }
+  if (MUTATING_WORD_RE.test(statement)) {
+    throw new Error("Source SQL must be read-only.");
+  }
+}
+
+function normalizeSourceId(value: unknown, fallback: string): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  const id = raw || fallback;
+  if (!IDENT_RE.test(id)) throw new Error("Source ids must be simple names.");
+  return id;
+}
+
+function normalizeColumnName(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${label} is required.`);
+  }
+  return value.trim();
+}
+
+function rowKey(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const kind = typeof value;
+  if (kind === "string") return `s:${value}`;
+  if (kind === "number") return `n:${Number.isNaN(value) ? "NaN" : value}`;
+  if (kind === "boolean") return `b:${value ? "1" : "0"}`;
+  if (kind === "bigint") return `i:${value.toString()}`;
+  return `j:${JSON.stringify(value)}`;
+}
+
+function inferAlign(value: unknown): "left" | "right" {
+  return typeof value === "number" || typeof value === "bigint"
+    ? "right"
+    : "left";
+}
+
+function pickRowColumns(
+  row: Record<string, unknown> | undefined,
+  fallbackColumns: string[],
+): string[] {
+  return row ? Object.keys(row) : fallbackColumns;
+}
+
+export const federatedDbAdminSourceSchema = z.object({
+  connectionId: z.string().trim().min(1).max(200),
+  sourceId: z.string().trim().min(1).max(64).optional(),
+  sql: z.string().trim().min(1).max(20_000),
+  params: z.array(z.unknown()).max(50).optional(),
+});
+
+export const federatedDbAdminJoinSchema = z.object({
+  kind: z.enum(["inner", "left"]),
+  leftSourceId: z.string().trim().min(1).optional(),
+  leftColumn: z.string().trim().min(1),
+  rightSourceId: z.string().trim().min(1).optional(),
+  rightColumn: z.string().trim().min(1),
+});
+
+export const federatedDbAdminProjectionSchema = z.object({
+  sourceId: z.string().trim().min(1).optional(),
+  column: z.string().trim().min(1),
+  as: z.string().trim().min(1).optional(),
+});
+
+export const federatedDbAdminReadSchema = z.object({
+  sources: z.array(federatedDbAdminSourceSchema).min(1).max(2),
+  join: federatedDbAdminJoinSchema.optional(),
+  projections: z.array(federatedDbAdminProjectionSchema).max(50).optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});
+
+type FederatedDbAdminReadArgs = z.infer<typeof federatedDbAdminReadSchema>;
+
+type SourceResult = {
+  sourceId: string;
+  connectionId: string;
+  rows: Record<string, unknown>[];
+  columns: string[];
+};
+
+type NormalizedProjection = {
+  sourceId?: string;
+  column: string;
+  as: string;
+};
+
+function flattenRow(
+  source: SourceResult,
+  row: Record<string, unknown>,
+  prefix = false,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const columns = source.columns.length ? source.columns : Object.keys(row);
+  for (const key of columns) {
+    out[prefix ? `${source.sourceId}.${key}` : key] = row[key] ?? null;
+  }
+  return out;
+}
+
+function getProjectedValue(
+  rows: Map<string, Record<string, unknown>>,
+  projection: NormalizedProjection,
+  sourceOrder: string[],
+): unknown {
+  if (projection.sourceId) {
+    const row = rows.get(projection.sourceId);
+    if (!row) {
+      throw new Error(
+        `Projection source "${projection.sourceId}" was not found.`,
+      );
+    }
+    return row[projection.column] ?? null;
+  }
+
+  let matchedValue: unknown;
+  let matched = false;
+  for (const sourceId of sourceOrder) {
+    const value = rows.get(sourceId)?.[projection.column];
+    if (value === undefined) continue;
+    if (matched)
+      throw new Error(`Projection column "${projection.column}" is ambiguous.`);
+    matched = true;
+    matchedValue = value;
+  }
+  if (!matched) {
+    throw new Error(`Projection column "${projection.column}" was not found.`);
+  }
+  return matchedValue;
+}
+
+function buildRows(
+  sources: SourceResult[],
+  join: z.infer<typeof federatedDbAdminJoinSchema> | undefined,
+  projections: NormalizedProjection[] | undefined,
+  limit: number,
+): { rows: Record<string, unknown>[]; truncated: boolean } {
+  if (sources.length === 1) {
+    const [source] = sources;
+    const projectedColumns =
+      projections?.map((projection) => projection.as) ??
+      pickRowColumns(source.rows[0], source.columns);
+    const rows = source.rows
+      .slice(0, limit)
+      .map((row) =>
+        projections?.length
+          ? Object.fromEntries(
+              projections.map((projection) => [
+                projection.as,
+                getProjectedValue(
+                  new Map([[source.sourceId, row]]),
+                  projection,
+                  [source.sourceId],
+                ),
+              ]),
+            )
+          : flattenRow(source, row, true),
+      );
+    if (rows.length === 0 && projectedColumns.length === 0) {
+      throw new Error(
+        "The query returned no rows, so column names could not be inferred.",
+      );
+    }
+    return {
+      rows,
+      truncated: source.rows.length > rows.length,
+    };
+  }
+
+  if (!join) {
+    throw new Error("A join is required when two sources are supplied.");
+  }
+
+  const leftSourceId = normalizeSourceId(
+    join.leftSourceId,
+    sources[0].sourceId,
+  );
+  const rightSourceId = normalizeSourceId(
+    join.rightSourceId,
+    sources[1].sourceId,
+  );
+  if (leftSourceId === rightSourceId) {
+    throw new Error("Join source ids must be different.");
+  }
+
+  const left = sources.find((source) => source.sourceId === leftSourceId);
+  const right = sources.find((source) => source.sourceId === rightSourceId);
+  if (!left || !right)
+    throw new Error("Join source ids must match the supplied sources.");
+
+  if (!left.columns.includes(join.leftColumn)) {
+    throw new Error(`Left join column "${join.leftColumn}" was not found.`);
+  }
+  if (!right.columns.includes(join.rightColumn)) {
+    throw new Error(`Right join column "${join.rightColumn}" was not found.`);
+  }
+
+  const rightByKey = new Map<string, Record<string, unknown>[]>();
+  for (const row of right.rows) {
+    const key = rowKey(row[join.rightColumn]);
+    if (!key) continue;
+    const bucket = rightByKey.get(key);
+    if (bucket) bucket.push(row);
+    else rightByKey.set(key, [row]);
+  }
+
+  const output: Record<string, unknown>[] = [];
+  for (const leftRow of left.rows) {
+    const key = rowKey(leftRow[join.leftColumn]);
+    const matches = key ? (rightByKey.get(key) ?? []) : [];
+    if (matches.length === 0) {
+      if (join.kind !== "left") continue;
+      const rowMap = new Map<string, Record<string, unknown>>([
+        [left.sourceId, leftRow],
+        [right.sourceId, {}],
+      ]);
+      output.push(
+        projections?.length
+          ? Object.fromEntries(
+              projections.map((projection) => [
+                projection.as,
+                getProjectedValue(rowMap, projection, [
+                  left.sourceId,
+                  right.sourceId,
+                ]),
+              ]),
+            )
+          : {
+              ...flattenRow(left, leftRow, true),
+              ...flattenRow(right, {}, true),
+            },
+      );
+      if (output.length > limit) break;
+      continue;
+    }
+
+    for (const rightRow of matches) {
+      const rowMap = new Map<string, Record<string, unknown>>([
+        [left.sourceId, leftRow],
+        [right.sourceId, rightRow],
+      ]);
+      output.push(
+        projections?.length
+          ? Object.fromEntries(
+              projections.map((projection) => [
+                projection.as,
+                getProjectedValue(rowMap, projection, [
+                  left.sourceId,
+                  right.sourceId,
+                ]),
+              ]),
+            )
+          : {
+              ...flattenRow(left, leftRow, true),
+              ...flattenRow(right, rightRow, true),
+            },
+      );
+      if (output.length > limit) break;
+    }
+    if (output.length > limit) break;
+  }
+
+  return {
+    rows: output.slice(0, limit),
+    truncated: output.length > limit,
+  };
+}
+
+function normalizeSourceIds(
+  sources: FederatedDbAdminReadArgs["sources"],
+): string[] {
+  const ids = sources.map((source, index) =>
+    normalizeSourceId(source.sourceId, `source${index + 1}`),
+  );
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("Source ids must be unique.");
+  }
+  return ids;
+}
+
+function normalizeProjections(
+  projections: FederatedDbAdminReadArgs["projections"],
+  sources: SourceResult[],
+): NormalizedProjection[] | undefined {
+  if (!projections?.length) return undefined;
+  const sourceIds = new Set(sources.map((source) => source.sourceId));
+  const normalized = projections.map((projection) => ({
+    sourceId: projection.sourceId?.trim() || undefined,
+    column: normalizeColumnName(projection.column, "Projection column"),
+    as: normalizeColumnName(
+      projection.as ?? projection.column,
+      "Projection alias",
+    ),
+  }));
+  if (
+    new Set(normalized.map((projection) => projection.as)).size !==
+    normalized.length
+  ) {
+    throw new Error("Projection aliases must be unique.");
+  }
+  for (const projection of normalized) {
+    if (projection.sourceId) {
+      if (!sourceIds.has(projection.sourceId)) {
+        throw new Error(
+          `Projection source "${projection.sourceId}" was not found.`,
+        );
+      }
+      const source = sources.find(
+        (candidate) => candidate.sourceId === projection.sourceId,
+      );
+      if (
+        source?.columns.length &&
+        !source.columns.includes(projection.column)
+      ) {
+        throw new Error(
+          `Projection column "${projection.column}" was not found in source "${projection.sourceId}".`,
+        );
+      }
+      continue;
+    }
+    const matchingSources = sources.filter((source) =>
+      source.columns.includes(projection.column),
+    );
+    if (matchingSources.length > 1) {
+      throw new Error(`Projection column "${projection.column}" is ambiguous.`);
+    }
+    if (
+      sources.every((source) => source.columns.length > 0) &&
+      matchingSources.length === 0
+    ) {
+      throw new Error(
+        `Projection column "${projection.column}" was not found.`,
+      );
+    }
+  }
+  return normalized;
+}
+
+export async function runDbAdminFederatedRead(
+  ctx: DbAdminAdminContext,
+  args: FederatedDbAdminReadArgs,
+): Promise<ReturnType<typeof createDataTableWidgetResult>> {
+  const limit = args.limit ?? 50;
+  const sourceIds = normalizeSourceIds(args.sources);
+  for (const source of args.sources) assertReadOnlySql(source.sql);
+  const sources = await Promise.all(
+    args.sources.map((source, index) =>
+      withDbAdminConnectionRuntime(
+        ctx,
+        source.connectionId,
+        async (runtime, connection) => {
+          const result = await runSql(
+            source.sql,
+            source.params,
+            {},
+            runtime as DbAdminRuntime,
+          );
+          return {
+            sourceId: sourceIds[index],
+            connectionId: connection.id,
+            rows: result.rows,
+            columns: pickRowColumns(result.rows[0], result.columns),
+          } satisfies SourceResult;
+        },
+      ),
+    ),
+  );
+
+  const projections = normalizeProjections(args.projections, sources);
+  const join = args.join
+    ? {
+        kind: args.join.kind,
+        leftSourceId: args.join.leftSourceId?.trim() || undefined,
+        leftColumn: normalizeColumnName(
+          args.join.leftColumn,
+          "Left join column",
+        ),
+        rightSourceId: args.join.rightSourceId?.trim() || undefined,
+        rightColumn: normalizeColumnName(
+          args.join.rightColumn,
+          "Right join column",
+        ),
+      }
+    : undefined;
+
+  const output = buildRows(sources, join, projections, limit);
+  const columns = projections?.length
+    ? projections.map((projection) => ({
+        key: projection.as,
+        label: projection.as,
+        ...(inferAlign(output.rows[0]?.[projection.as]) === "right"
+          ? { align: "right" as const }
+          : {}),
+      }))
+    : sources
+        .flatMap((source) =>
+          source.columns.map((column) => `${source.sourceId}.${column}`),
+        )
+        .map((key) => ({
+          key,
+          label: key,
+          ...(inferAlign(output.rows[0]?.[key]) === "right"
+            ? { align: "right" as const }
+            : {}),
+        }));
+
+  if (columns.length === 0) {
+    throw new Error(
+      "The query returned no rows, so column names could not be inferred.",
+    );
+  }
+
+  return createDataTableWidgetResult({
+    widgetId: "analytics.db-admin.federated-read.v1",
+    title: "Federated db admin result",
+    summary: {
+      sourceCount: sources.length,
+      sources: sources.map((source) => ({
+        sourceId: source.sourceId,
+        connectionId: source.connectionId,
+        rowCount: source.rows.length,
+        columns: source.columns,
+      })),
+      ...(join
+        ? {
+            join: {
+              kind: join.kind,
+              leftSourceId: join.leftSourceId ?? sources[0].sourceId,
+              leftColumn: join.leftColumn,
+              rightSourceId: join.rightSourceId ?? sources[1].sourceId,
+              rightColumn: join.rightColumn,
+            },
+          }
+        : {}),
+      limit,
+      truncated: output.truncated,
+    },
+    display: {
+      title: "Federated db admin result",
+      description: join
+        ? `${join.kind} join over ${sources
+            .map((source) => source.sourceId)
+            .join(" and ")}`
+        : `Read ${sources[0].sourceId} from ${sources[0].connectionId}`,
+    },
+    table: {
+      title: "Federated db admin result",
+      columns,
+      rows: output.rows.slice(0, limit),
+      ...(output.truncated
+        ? { sampledRows: limit, truncated: true }
+        : { totalRows: output.rows.length }),
+    },
+  });
+}

--- a/templates/analytics/server/lib/db-admin-federated-read.ts
+++ b/templates/analytics/server/lib/db-admin-federated-read.ts
@@ -8,8 +8,10 @@ import {
 } from "./db-admin-connections";
 
 const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const NUMERIC_RE = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
 const MUTATING_WORD_RE =
   /(^|[^A-Za-z_])(insert|update|delete|replace|create|alter|drop|truncate|merge)(?=[^A-Za-z_]|$)/i;
+const MAX_SOURCE_ROWS = 500;
 
 function sanitizeSqlForInspection(sql: string): string {
   let out = "";
@@ -92,6 +94,14 @@ function assertReadOnlySql(sql: string): void {
   if (statement.includes(";")) {
     throw new Error("Source SQL must be a single statement.");
   }
+  if (/\binto\b/i.test(statement)) {
+    throw new Error("Source SQL must not use SELECT INTO.");
+  }
+  if (
+    /\bfor\s+(?:no\s+key\s+)?(?:update|share|key\s+share)\b/i.test(statement)
+  ) {
+    throw new Error("Source SQL must not lock rows.");
+  }
   if (MUTATING_WORD_RE.test(statement)) {
     throw new Error("Source SQL must be read-only.");
   }
@@ -111,13 +121,34 @@ function normalizeColumnName(value: unknown, label: string): string {
   return value.trim();
 }
 
+function canonicalNumeric(value: string): string | null {
+  const text = value.trim();
+  if (!NUMERIC_RE.test(text)) return null;
+  const sign = text.startsWith("-") ? "-" : "";
+  const unsigned = text.replace(/^[+-]/, "");
+  const [integerPart, fractionPart = ""] = unsigned.split(".");
+  const integer = integerPart.replace(/^0+(?=\d)/, "") || "0";
+  const fraction = fractionPart.replace(/0+$/, "");
+  if (integer === "0" && !fraction) return "0";
+  return `${sign}${integer}${fraction ? `.${fraction}` : ""}`;
+}
+
 function rowKey(value: unknown): string | null {
   if (value === null || value === undefined) return null;
-  const kind = typeof value;
-  if (kind === "string") return `s:${value}`;
-  if (kind === "number") return `n:${Number.isNaN(value) ? "NaN" : value}`;
-  if (kind === "boolean") return `b:${value ? "1" : "0"}`;
-  if (kind === "bigint") return `i:${value.toString()}`;
+  if (typeof value === "string") {
+    const numeric = canonicalNumeric(value);
+    return numeric ? `n:${numeric}` : `s:${value}`;
+  }
+  if (typeof value === "number") {
+    const numeric = Number.isFinite(value)
+      ? canonicalNumeric(String(value))
+      : null;
+    return numeric
+      ? `n:${numeric}`
+      : `n:${Number.isNaN(value) ? "NaN" : value}`;
+  }
+  if (typeof value === "boolean") return `b:${value ? "1" : "0"}`;
+  if (typeof value === "bigint") return `n:${value.toString()}`;
   return `j:${JSON.stringify(value)}`;
 }
 
@@ -169,6 +200,7 @@ type SourceResult = {
   connectionId: string;
   rows: Record<string, unknown>[];
   columns: string[];
+  truncated: boolean;
 };
 
 type NormalizedProjection = {
@@ -255,7 +287,7 @@ function buildRows(
     }
     return {
       rows,
-      truncated: source.rows.length > rows.length,
+      truncated: source.truncated || source.rows.length > rows.length,
     };
   }
 
@@ -280,10 +312,10 @@ function buildRows(
   if (!left || !right)
     throw new Error("Join source ids must match the supplied sources.");
 
-  if (!left.columns.includes(join.leftColumn)) {
+  if (left.columns.length > 0 && !left.columns.includes(join.leftColumn)) {
     throw new Error(`Left join column "${join.leftColumn}" was not found.`);
   }
-  if (!right.columns.includes(join.rightColumn)) {
+  if (right.columns.length > 0 && !right.columns.includes(join.rightColumn)) {
     throw new Error(`Right join column "${join.rightColumn}" was not found.`);
   }
 
@@ -354,7 +386,8 @@ function buildRows(
 
   return {
     rows: output.slice(0, limit),
-    truncated: output.length > limit,
+    truncated:
+      sources.some((source) => source.truncated) || output.length > limit,
   };
 }
 
@@ -428,6 +461,11 @@ function normalizeProjections(
   return normalized;
 }
 
+function boundedSourceSql(sql: string): string {
+  const statement = sql.trim().replace(/;\s*$/, "");
+  return `SELECT * FROM (${statement}\n) AS "__agent_native_source" LIMIT ${MAX_SOURCE_ROWS + 1}`;
+}
+
 export async function runDbAdminFederatedRead(
   ctx: DbAdminAdminContext,
   args: FederatedDbAdminReadArgs,
@@ -441,17 +479,22 @@ export async function runDbAdminFederatedRead(
         ctx,
         source.connectionId,
         async (runtime, connection) => {
-          const result = await runSql(
-            source.sql,
-            source.params,
-            {},
-            runtime as DbAdminRuntime,
-          );
+          const sql = boundedSourceSql(source.sql);
+          const read = (dbRuntime: DbAdminRuntime) =>
+            runSql(sql, source.params, {}, dbRuntime);
+          const result =
+            runtime.dialect === "postgres" && runtime.db?.transaction
+              ? await runtime.db.transaction(async (tx) => {
+                  await tx.execute("SET TRANSACTION READ ONLY");
+                  return read({ ...runtime, db: tx });
+                })
+              : await read(runtime as DbAdminRuntime);
           return {
             sourceId: sourceIds[index],
             connectionId: connection.id,
-            rows: result.rows,
+            rows: result.rows.slice(0, MAX_SOURCE_ROWS),
             columns: pickRowColumns(result.rows[0], result.columns),
+            truncated: result.rows.length > MAX_SOURCE_ROWS,
           } satisfies SourceResult;
         },
       ),
@@ -512,6 +555,7 @@ export async function runDbAdminFederatedRead(
         connectionId: source.connectionId,
         rowCount: source.rows.length,
         columns: source.columns,
+        truncated: source.truncated,
       })),
       ...(join
         ? {


### PR DESCRIPTION
## Summary
- expose an org-admin action to catalog tables across connected app databases
- add bounded read-only cross-database joins with native data-table output
- document the Analytics action surface and add a changelog entry

## Validation
- `corepack pnpm exec vitest run templates/analytics/actions/db-admin-federated-read.spec.ts templates/analytics/actions/list-connected-database-tables.spec.ts`
- `corepack pnpm guards`
- `corepack pnpm --dir templates/analytics typecheck`