### PR TITLE
Keep Slides context chip stable during selection changes

### DIFF
--- a/.changeset/stable-resource-context-chip.md
+++ b/.changeset/stable-resource-context-chip.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep ambient composer context chips stable when their label changes.

--- a/packages/core/src/client/MultiTabAssistantChat.spec.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.spec.tsx
@@ -5,8 +5,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  AGENT_CHAT_CONTEXT_CHANGED_EVENT,
   cancelAgentChatSubmit,
   listAgentChatContext,
+  removeAgentChatContextItem,
   requestAgentChatThreadOpen,
   requestAgentTaskOpen,
   setAgentChatContextItem,
@@ -1190,6 +1192,83 @@ describe("MultiTabAssistantChat postMessage bridge", () => {
         ),
       }),
     ]);
+  });
+
+  it("updates resource context in place when only its label changes", async () => {
+    const contextTransitions: string[][] = [];
+    const onContextChanged = (event: Event) => {
+      const items = (event as CustomEvent<{ items: Array<{ key: string }> }>)
+        .detail.items;
+      contextTransitions.push(items.map((item) => item.key));
+    };
+    window.addEventListener(AGENT_CHAT_CONTEXT_CHANGED_EVENT, onContextChanged);
+
+    try {
+      await act(async () => {
+        root.render(
+          <MultiTabAssistantChat
+            storageKey="bridge-test"
+            scope={{ type: "deck", id: "deck-1", label: "This Slide" }}
+          />,
+        );
+        await Promise.resolve();
+      });
+      contextTransitions.length = 0;
+
+      await act(async () => {
+        root.render(
+          <MultiTabAssistantChat
+            storageKey="bridge-test"
+            scope={{
+              type: "deck",
+              id: "deck-1",
+              label: "Current Selection",
+            }}
+          />,
+        );
+        await Promise.resolve();
+      });
+
+      expect(listAgentChatContext()).toEqual([
+        expect.objectContaining({ title: "Current Selection" }),
+      ]);
+      expect(contextTransitions).not.toContainEqual([]);
+    } finally {
+      window.removeEventListener(
+        AGENT_CHAT_CONTEXT_CHANGED_EVENT,
+        onContextChanged,
+      );
+    }
+  });
+
+  it("does not restore a resource context after it is dismissed", async () => {
+    await act(async () => {
+      root.render(
+        <MultiTabAssistantChat
+          storageKey="bridge-test"
+          scope={{ type: "deck", id: "deck-1", label: "This Slide" }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    removeAgentChatContextItem("agent-current-resource-context");
+
+    await act(async () => {
+      root.render(
+        <MultiTabAssistantChat
+          storageKey="bridge-test"
+          scope={{
+            type: "deck",
+            id: "deck-1",
+            label: "Current Selection",
+          }}
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    expect(listAgentChatContext()).toEqual([]);
   });
 
   it("passes an app context namespace to the active composer", async () => {

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -294,6 +294,31 @@ function formatScopeType(type: string) {
   return type.replace(/[-_]+/g, " ");
 }
 
+function buildResourceContextItem(
+  scope: ChatThreadScope,
+  contextNamespace?: string,
+): AgentChatContextItem {
+  const type = formatScopeType(scope.type);
+  const label = scope.label?.trim();
+  const marker = `Resource context: ${scope.type}:${scope.id}`;
+  return {
+    key: scope.contextKey?.trim() || "agent-current-resource-context",
+    title: label || type.replace(/^./, (character) => character.toUpperCase()),
+    ...(contextNamespace ? { contextNamespace } : {}),
+    context: [
+      marker,
+      `The user is currently viewing this ${type}.`,
+      label ? `Resource name: ${label}` : "",
+      `Resource id: ${scope.id}`,
+      typeof window !== "undefined"
+        ? `Current URL: ${window.location.pathname}${window.location.search}`
+        : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
 // ─── History Popover ─────────────────────────────────────────────────────────
 
 function formatThreadTime(
@@ -1483,46 +1508,42 @@ export function MultiTabAssistantChat({
   useBrowserLayoutEffect(() => {
     const nextScope = scope;
     if (!nextScope) return;
-    const type = formatScopeType(nextScope.type);
-    const title =
-      nextScope.label?.trim() ||
-      type.replace(/^./, (character) => character.toUpperCase());
-    const key =
-      nextScope.contextKey?.trim() || "agent-current-resource-context";
+    const item = buildResourceContextItem(nextScope, contextNamespace);
     const marker = `Resource context: ${nextScope.type}:${nextScope.id}`;
     const existing = getAgentChatContextState().items.find(
-      (item) => item.key === key,
+      (current) => current.key === item.key,
     );
-    let ownsContextItem = false;
-    if (!existing || existing.context.startsWith("Resource context:")) {
-      setAgentChatContextItem({
-        key,
-        title,
-        ...(contextNamespace ? { contextNamespace } : {}),
-        context: [
-          marker,
-          `The user is currently viewing this ${type}.`,
-          nextScope.label ? `Resource name: ${nextScope.label}` : "",
-          `Resource id: ${nextScope.id}`,
-          typeof window !== "undefined"
-            ? `Current URL: ${window.location.pathname}${window.location.search}`
-            : "",
-        ]
-          .filter(Boolean)
-          .join("\n"),
-        openSidebar: false,
-        focus: false,
-      });
-      ownsContextItem = true;
-    }
+    const ownsContextItem =
+      !existing || existing.context.startsWith("Resource context:");
+    if (ownsContextItem)
+      setAgentChatContextItem({ ...item, openSidebar: false, focus: false });
     return () => {
       const current = getAgentChatContextState().items.find(
-        (item) => item.key === key,
+        (candidate) => candidate.key === item.key,
       );
       if (ownsContextItem && current?.context.startsWith(marker)) {
-        removeAgentChatContextItem(key);
+        removeAgentChatContextItem(item.key);
       }
     };
+  }, [contextNamespace, scope?.contextKey, scope?.id, scope?.type]);
+
+  useBrowserLayoutEffect(() => {
+    const nextScope = scope;
+    if (!nextScope) return;
+    const item = buildResourceContextItem(nextScope, contextNamespace);
+    const marker = `Resource context: ${nextScope.type}:${nextScope.id}`;
+    const existing = getAgentChatContextState().items.find(
+      (current) => current.key === item.key,
+    );
+    if (!existing || !existing.context.startsWith(marker)) return;
+    if (
+      existing.title === item.title &&
+      existing.context === item.context &&
+      existing.contextNamespace === item.contextNamespace
+    ) {
+      return;
+    }
+    setAgentChatContextItem({ ...item, openSidebar: false, focus: false });
   }, [
     contextNamespace,
     scope?.contextKey,


### PR DESCRIPTION
## Summary

- keep the ambient composer context item mounted while its label changes between This Slide and Current Selection
- preserve an explicit chip dismissal across selection changes
- add regression coverage for in-place updates and dismissal

## Validation

- core MultiTabAssistantChat tests
- core typecheck
- Slides layout smoke test
- all repository guards