### PR TITLE
fix(dispatch): keep hosted workspace apps inline

### DIFF
--- a/.changeset/keep-dispatch-apps-inline.md
+++ b/.changeset/keep-dispatch-apps-inline.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Keep hosted Dispatch app launches inline outside Builder editor sessions.

--- a/packages/core/src/client/builder-frame.spec.ts
+++ b/packages/core/src/client/builder-frame.spec.ts
@@ -34,15 +34,37 @@ function setAncestorOrigin(origin: string | null) {
   });
 }
 
+function setDocumentReferrer(referrer: string) {
+  Object.defineProperty(document, "referrer", {
+    configurable: true,
+    value: referrer,
+  });
+}
+
 describe("isInBuilderFrame", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/");
     setParentWindow(window);
     setAncestorOrigin(null);
+    setDocumentReferrer("");
   });
 
   it("does not treat a plain top-level page as Builder", () => {
     expect(isInBuilderFrame()).toBe(false);
+  });
+
+  it("does not treat a top-level Dispatch page opened from Builder as Builder", () => {
+    setDocumentReferrer("https://builder.io/content/123");
+
+    expect(isInBuilderFrame()).toBe(false);
+  });
+
+  it("does not treat the hosted Dispatch shell as a Builder editor", () => {
+    setParentWindow({ postMessage: vi.fn() });
+    setAncestorOrigin("https://agent-workspace.builder.io");
+
+    expect(isInBuilderFrame()).toBe(false);
+    expect(shouldParentFrameOwnAgentPanel()).toBe(true);
   });
 
   it("treats Builder preview params as Builder in top-level webviews", () => {
@@ -124,6 +146,13 @@ describe("shouldParentFrameOwnAgentPanel", () => {
     setAncestorOrigin("https://builder.io");
 
     expect(shouldParentFrameOwnAgentPanel()).toBe(false);
+  });
+
+  it("keeps the app chat panel delegated for the beta Dispatch shell", () => {
+    setParentWindow({ postMessage: vi.fn() });
+    setAncestorOrigin("https://beta.agent-workspace.builder.io");
+
+    expect(shouldParentFrameOwnAgentPanel()).toBe(true);
   });
 });
 

--- a/packages/core/src/client/builder-frame.ts
+++ b/packages/core/src/client/builder-frame.ts
@@ -10,7 +10,7 @@ function normalizeOrigin(value: unknown): string | null {
 }
 
 function ancestorOrigin(): string | null {
-  if (typeof window === "undefined") return null;
+  if (typeof window === "undefined" || window.parent === window) return null;
   const origins = (
     window.location as Location & { ancestorOrigins?: DOMStringList }
   ).ancestorOrigins;
@@ -24,6 +24,14 @@ function isStrictBuilderHost(origin: string | null): boolean {
   if (!origin) return false;
   try {
     const hostname = new URL(origin).hostname.toLowerCase();
+    // The hosted Dispatch shell also lives under Builder's domain; its app
+    // iframe is an ordinary workspace embed, not a visual-editor session.
+    if (
+      hostname === "agent-workspace.builder.io" ||
+      hostname === "beta.agent-workspace.builder.io"
+    ) {
+      return false;
+    }
     return (
       hostname === "builder.io" ||
       hostname.endsWith(".builder.io") ||
@@ -63,15 +71,15 @@ let builderFrameDetected = false;
 let builderParentOrigin: string | null = null;
 
 /**
- * For *.builder.io / *.builder.my the parent origin alone is sufficient — those
- * are Builder-owned hosts and any iframe they load is by definition a Builder
- * editor session. For localhost we still require the legacy `?builder.*` query
- * params, because "parent is localhost" can mean anything in dev. The params
- * check existed historically as a belt-and-suspenders signal, but Builder's
- * Interact mode tunnels straight to the iframe URL without appending them, so
- * requiring them everywhere caused `isInBuilderFrame()` to return false for
- * real Builder editor sessions and `HomeChatPanel` submissions silently fell
- * through to `agentNative.submitChat` (which Builder ignores).
+ * For Builder-owned editor hosts the parent origin alone is sufficient. The
+ * hosted Dispatch shell is also under `*.builder.io`, so it is excluded above.
+ * For localhost we still require the legacy `?builder.*` query params, because
+ * "parent is localhost" can mean anything in dev. The params check existed
+ * historically as a belt-and-suspenders signal, but Builder's Interact mode
+ * tunnels straight to the iframe URL without appending them, so requiring them
+ * everywhere caused `isInBuilderFrame()` to return false for real Builder
+ * editor sessions and `HomeChatPanel` submissions silently fell through to
+ * `agentNative.submitChat` (which Builder ignores).
  */
 function detectBuilderParentOrigin(): string | null {
   const frameOrigin = getFrameOrigin();

--- a/packages/dispatch/src/lib/workspace-apps.test.ts
+++ b/packages/dispatch/src/lib/workspace-apps.test.ts
@@ -8,6 +8,19 @@ import {
   workspaceAppEmbedTarget,
 } from "./workspace-apps";
 
+function setAncestorOrigin(origin: string | null) {
+  Object.defineProperty(window.location, "ancestorOrigins", {
+    configurable: true,
+    value: origin
+      ? {
+          0: origin,
+          length: 1,
+          item: (index: number) => (index === 0 ? origin : null),
+        }
+      : undefined,
+  });
+}
+
 describe("workspaceAppEmbedTarget", () => {
   it("uses the app URL as the embed root when a mount path is also present", () => {
     expect(
@@ -69,10 +82,12 @@ describe("workspaceAppDirectHref", () => {
 describe("navigateToWorkspaceApp", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/");
+    setAncestorOrigin(null);
   });
 
   afterEach(() => {
     window.history.replaceState({}, "", "/");
+    setAncestorOrigin(null);
     Object.defineProperty(window, "parent", {
       configurable: true,
       value: window,
@@ -88,6 +103,16 @@ describe("navigateToWorkspaceApp", () => {
       configurable: true,
       value: {},
     });
+
+    expect(shouldOpenWorkspaceAppInTopWindow()).toBe(false);
+  });
+
+  it("keeps the hosted Dispatch shell inline", () => {
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: {},
+    });
+    setAncestorOrigin("https://agent-workspace.builder.io");
 
     expect(shouldOpenWorkspaceAppInTopWindow()).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Exclude the hosted Dispatch origins from Builder visual-editor detection.
- Ignore document referrer when the page is top-level, while preserving Builder webview preview markers and Builder parent-origin detection.
- Add core and Dispatch regressions for production and beta workspace shells.

## Validation

- `@agent-native/core` builder-frame tests: 57 passed
- `@agent-native/dispatch` workspace-app tests: 12 passed
- Core and Dispatch typechecks passed
- `pnpm guards` passed (66 checks)
- Changed-file oxfmt check passed

The repository-wide `pnpm fmt:check` still reports seven unrelated pre-existing files.