### PR TITLE
fix: route community app submissions through Forms

### DIFF
--- a/packages/docs/app/components/CommunityAppSubmissionForm.tsx
+++ b/packages/docs/app/components/CommunityAppSubmissionForm.tsx
@@ -11,17 +11,15 @@ import {
   type FormEvent,
 } from "react";
 
+import {
+  submitCommunityApp,
+  uploadCommunityScreenshot,
+} from "../lib/community-form-client";
 import { sitePathForLocale } from "./docs-locale";
 import { Button } from "./website-redesign/ds/button";
 
 export const COMMUNITY_FORM_NAME = "community-app-submission";
-export const SCREENSHOT_FIELDS = [
-  "screenshot_1",
-  "screenshot_2",
-  "screenshot_3",
-  "screenshot_4",
-  "screenshot_5",
-] as const;
+const SCREENSHOT_MAX_COUNT = 5;
 const SCREENSHOT_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const MAX_SCREENSHOT_BYTES = 1.5 * 1024 * 1024;
 
@@ -41,6 +39,10 @@ export type CommunitySubmissionDraft = {
 type CommunitySubmissionValues = Omit<
   CommunitySubmissionDraft,
   "screenshotFiles"
+>;
+type CommunitySubmissionField = keyof CommunitySubmissionValues | "screenshots";
+type CommunitySubmissionErrors = Partial<
+  Record<CommunitySubmissionField, string>
 >;
 
 function createSelectedScreenshots(files: File[]) {
@@ -82,23 +84,22 @@ function isValidScreenshot(file: File) {
   );
 }
 
-function createScreenshotDataTransfer(): DataTransfer | null {
-  if (typeof DataTransfer !== "undefined") return new DataTransfer();
-
-  if (typeof ClipboardEvent !== "undefined") {
-    try {
-      return new ClipboardEvent("").clipboardData;
-    } catch {
-      // coercion-ok: null explicitly distinguishes an unavailable fallback from a transfer.
-      return null;
-    }
-  }
-
-  return null;
-}
-
 const fieldClassName =
   "w-full rounded-[var(--b-radius)] border border-solid border-[var(--b-border-default)] bg-[var(--b-bg-inset)] px-3 py-2.5 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--b-text-primary)] outline-none transition-[border-color,box-shadow] placeholder:text-[var(--b-text-muted)] focus:border-[var(--b-action-primary-bg)] focus:ring-2 focus:ring-[var(--b-action-primary-effect)]";
+
+function InlineError({ id, message }: { id: string; message?: string }) {
+  if (!message) return null;
+
+  return (
+    <p
+      id={id}
+      role="alert"
+      className="m-0 font-[family-name:var(--b-font-sans)] text-sm leading-[1.4] text-[var(--c-red-400)]"
+    >
+      {message}
+    </p>
+  );
+}
 
 type CommunityAppSubmissionFormProps = {
   draft?: CommunitySubmissionDraft;
@@ -113,8 +114,9 @@ export function CommunityAppSubmissionForm({
   const { locale } = useLocale();
   const formId = useId();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const hiddenInputRefs = useRef<Array<HTMLInputElement | null>>([]);
   const previewUrlsRef = useRef<Set<string>>(new Set());
+  const pageLoadTimeRef = useRef(Date.now());
+  const idempotencyKeyRef = useRef<string | undefined>(undefined);
   const [values, setValues] = useState<CommunitySubmissionValues>(() => ({
     name: draft?.name ?? "",
     appUrl: draft?.appUrl ?? "",
@@ -125,7 +127,9 @@ export function CommunityAppSubmissionForm({
     createSelectedScreenshots(draft?.screenshotFiles ?? []),
   );
   const [isDragActive, setIsDragActive] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<CommunitySubmissionErrors>({});
+  const [submitError, setSubmitError] = useState<string>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     const activePreviewUrls = new Set(
@@ -153,27 +157,82 @@ export function CommunityAppSubmissionForm({
     };
   }, []);
 
-  useEffect(() => {
-    for (const index of SCREENSHOT_FIELDS.keys()) {
-      const input = hiddenInputRefs.current[index];
-      if (!input) continue;
-
-      const dataTransfer = createScreenshotDataTransfer();
-      if (!dataTransfer) return;
-      const screenshot = screenshots[index];
-      if (screenshot) dataTransfer.items.add(screenshot.file);
-      input.files = dataTransfer.files;
-    }
-  }, [screenshots]);
-
   function updateValue(field: keyof CommunitySubmissionValues, value: string) {
     setValues((current) => ({ ...current, [field]: value }));
-    setError(null);
+    setErrors((current) => {
+      if (!current[field]) return current;
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+    setSubmitError(undefined);
+  }
+
+  function setFieldError(field: CommunitySubmissionField, message?: string) {
+    setErrors((current) => {
+      if (!message && !current[field]) return current;
+      const next = { ...current };
+      if (message) next[field] = message;
+      else delete next[field];
+      return next;
+    });
   }
 
   function normalizeUrlField(field: "appUrl" | "repositoryUrl") {
     const normalized = normalizeHttpUrl(values[field]);
     if (normalized !== values[field]) updateValue(field, normalized);
+    validateField(field, { ...values, [field]: normalized });
+  }
+
+  function validateField(
+    field: CommunitySubmissionField,
+    currentValues = values,
+    currentScreenshots = screenshots,
+  ) {
+    let message: string | undefined;
+
+    if (field === "name" && !currentValues.name.trim()) {
+      message = t("templatesPage.communitySubmissionNameError");
+    } else if (field === "description" && !currentValues.description.trim()) {
+      message = t("templatesPage.communitySubmissionDescriptionError");
+    } else if (field === "appUrl" && !isHttpUrl(currentValues.appUrl)) {
+      message = t("templatesPage.communitySubmissionUrlError");
+    } else if (
+      field === "repositoryUrl" &&
+      currentValues.repositoryUrl.trim() &&
+      !isGitHubRepositoryUrl(currentValues.repositoryUrl)
+    ) {
+      message = t("templatesPage.communitySubmissionRepositoryError");
+    } else if (
+      field === "screenshots" &&
+      currentScreenshots.some(({ file }) => !isValidScreenshot(file))
+    ) {
+      message = t("templatesPage.communitySubmissionScreenshotsError");
+    }
+
+    setFieldError(field, message);
+    return message;
+  }
+
+  function validateSubmission(
+    currentValues: CommunitySubmissionValues,
+    currentScreenshots: SelectedScreenshot[],
+  ) {
+    const nextErrors: CommunitySubmissionErrors = {};
+    const fields: CommunitySubmissionField[] = [
+      "name",
+      "description",
+      "appUrl",
+      "repositoryUrl",
+      "screenshots",
+    ];
+
+    for (const field of fields) {
+      const message = validateField(field, currentValues, currentScreenshots);
+      if (message) nextErrors[field] = message;
+    }
+
+    return nextErrors;
   }
 
   function handleScreenshotChange(event: ChangeEvent<HTMLInputElement>) {
@@ -185,8 +244,8 @@ export function CommunityAppSubmissionForm({
   function addScreenshots(files: FileList | File[]) {
     const incomingFiles = Array.from(files);
     const validFiles = incomingFiles.filter(isValidScreenshot);
-    const availableSlots = SCREENSHOT_FIELDS.length - screenshots.length;
-    const filesToAdd = validFiles.slice(0, availableSlots);
+    const availableSlots = SCREENSHOT_MAX_COUNT - screenshots.length;
+    const filesToAdd = validFiles.slice(0, Math.max(availableSlots, 0));
 
     if (filesToAdd.length > 0) {
       setScreenshots((current) => [
@@ -196,15 +255,19 @@ export function CommunityAppSubmissionForm({
           previewUrl: URL.createObjectURL(file),
         })),
       ]);
+      setSubmitError(undefined);
     }
 
     if (
       validFiles.length > availableSlots ||
       validFiles.length !== incomingFiles.length
     ) {
-      setError(t("templatesPage.communitySubmissionValidation"));
-    } else {
-      setError(null);
+      setFieldError(
+        "screenshots",
+        t("templatesPage.communitySubmissionScreenshotsError"),
+      );
+    } else if (filesToAdd.length > 0) {
+      setFieldError("screenshots");
     }
   }
 
@@ -212,7 +275,8 @@ export function CommunityAppSubmissionForm({
     setScreenshots((current) =>
       current.filter((_, currentIndex) => currentIndex !== index),
     );
-    setError(null);
+    setFieldError("screenshots");
+    setSubmitError(undefined);
   }
 
   function handleDragOver(event: DragEvent<HTMLDivElement>) {
@@ -234,63 +298,100 @@ export function CommunityAppSubmissionForm({
     addScreenshots(event.dataTransfer.files);
   }
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    const formData = new FormData(event.currentTarget);
-    const rawAppUrl = String(formData.get("app_url") ?? "");
-    const rawRepositoryUrl = String(formData.get("repository_url") ?? "");
-    const appUrl = normalizeHttpUrl(rawAppUrl);
-    const repositoryUrl = normalizeHttpUrl(rawRepositoryUrl);
+  function focusFirstError(
+    form: HTMLFormElement,
+    nextErrors: CommunitySubmissionErrors,
+  ) {
+    const field = Object.keys(nextErrors)[0] as
+      | CommunitySubmissionField
+      | undefined;
+    if (!field) return;
 
-    if (appUrl !== rawAppUrl || repositoryUrl !== rawRepositoryUrl) {
-      setValues((current) => ({ ...current, appUrl, repositoryUrl }));
-      const appUrlInput = event.currentTarget.elements.namedItem("app_url");
-      const repositoryUrlInput =
-        event.currentTarget.elements.namedItem("repository_url");
-      if (appUrlInput instanceof HTMLInputElement) appUrlInput.value = appUrl;
-      if (repositoryUrlInput instanceof HTMLInputElement) {
-        repositoryUrlInput.value = repositoryUrl;
-      }
-    }
-    const uploadedFiles = SCREENSHOT_FIELDS.map((field) =>
-      formData.get(field),
-    ).filter((value): value is File => value instanceof File && value.size > 0);
+    const element =
+      field === "screenshots"
+        ? fileInputRef.current
+        : form.elements.namedItem(
+            field === "appUrl"
+              ? "app_url"
+              : field === "repositoryUrl"
+                ? "repository_url"
+                : field,
+          );
+    if (element instanceof HTMLElement) element.focus();
+  }
 
-    if (
-      !String(formData.get("name") ?? "").trim() ||
-      !String(formData.get("description") ?? "").trim() ||
-      !isHttpUrl(appUrl) ||
-      (repositoryUrl && !isGitHubRepositoryUrl(repositoryUrl)) ||
-      uploadedFiles.some((file) => !isValidScreenshot(file))
-    ) {
-      event.preventDefault();
-      setError(t("templatesPage.communitySubmissionValidation"));
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (isSubmitting) return;
+
+    const submissionValues = {
+      ...values,
+      name: values.name.trim(),
+      appUrl: normalizeHttpUrl(values.appUrl),
+      description: values.description.trim(),
+      repositoryUrl: values.repositoryUrl.trim()
+        ? normalizeHttpUrl(values.repositoryUrl)
+        : "",
+    };
+    setValues(submissionValues);
+    const nextErrors = validateSubmission(submissionValues, screenshots);
+    setErrors(nextErrors);
+    setSubmitError(undefined);
+    if (Object.keys(nextErrors).length > 0) {
+      focusFirstError(event.currentTarget, nextErrors);
       return;
     }
 
-    trackEvent("submit community app", {
-      location: "community_submission_form",
-      hasRepository: Boolean(repositoryUrl),
-      screenshotCount: uploadedFiles.length,
-    });
+    setIsSubmitting(true);
+    try {
+      const uploadedScreenshots = await Promise.all(
+        screenshots.map(({ file }) => uploadCommunityScreenshot(file)),
+      );
+      await submitCommunityApp({
+        data: {
+          name: submissionValues.name,
+          app_url: submissionValues.appUrl,
+          description: submissionValues.description,
+          ...(submissionValues.repositoryUrl
+            ? { repository_url: submissionValues.repositoryUrl }
+            : {}),
+          screenshots: uploadedScreenshots,
+        },
+        pageUrl: window.location.href,
+        idempotencyKey: (idempotencyKeyRef.current ??= crypto.randomUUID()),
+        pageLoadTime: pageLoadTimeRef.current,
+      });
+      trackEvent("submit community app", {
+        location: "community_submission_form",
+        hasRepository: Boolean(submissionValues.repositoryUrl),
+        screenshotCount: uploadedScreenshots.length,
+      });
+      window.location.assign(
+        `${sitePathForLocale("/apps", locale)}?community-submission=received`,
+      );
+    } catch {
+      setSubmitError(t("templatesPage.communitySubmissionSubmitError"));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function inputClassName(field: CommunitySubmissionField) {
+    return `${fieldClassName}${errors[field] ? " border-[var(--c-red-400)] focus:border-[var(--c-red-400)] focus:ring-[var(--c-red-400)]" : ""}`;
+  }
+
+  function errorId(field: CommunitySubmissionField) {
+    return `${formId}-${field}-error`;
   }
 
   return (
     <form
       name={COMMUNITY_FORM_NAME}
-      method="post"
-      action={`${sitePathForLocale("/apps", locale)}?community-submission=received`}
-      encType="multipart/form-data"
-      data-netlify="true"
-      data-netlify-honeypot="bot-field"
       className="grid gap-5"
       onSubmit={handleSubmit}
-      aria-describedby={error ? `${formId}-error` : undefined}
+      noValidate
+      aria-describedby={submitError ? `${formId}-submit-error` : undefined}
     >
-      <input type="hidden" name="form-name" value={COMMUNITY_FORM_NAME} />
-      <div className="sr-only" aria-hidden="true">
-        <input name="bot-field" tabIndex={-1} autoComplete="off" />
-      </div>
-
       <div className="grid gap-1.5">
         <label
           htmlFor={`${formId}-name`}
@@ -302,11 +403,16 @@ export function CommunityAppSubmissionForm({
           id={`${formId}-name`}
           name="name"
           required
+          aria-required="true"
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby={errors.name ? errorId("name") : undefined}
           value={values.name}
           onChange={(event) => updateValue("name", event.target.value)}
+          onBlur={() => validateField("name")}
           placeholder={t("templatesPage.communitySubmissionNamePlaceholder")}
-          className={fieldClassName}
+          className={inputClassName("name")}
         />
+        <InlineError id={errorId("name")} message={errors.name} />
       </div>
 
       <div className="grid gap-1.5">
@@ -320,6 +426,9 @@ export function CommunityAppSubmissionForm({
           id={`${formId}-url`}
           name="app_url"
           required
+          aria-required="true"
+          aria-invalid={Boolean(errors.appUrl)}
+          aria-describedby={errors.appUrl ? errorId("appUrl") : undefined}
           type="text"
           inputMode="url"
           autoComplete="url"
@@ -328,8 +437,9 @@ export function CommunityAppSubmissionForm({
           onChange={(event) => updateValue("appUrl", event.target.value)}
           onBlur={() => normalizeUrlField("appUrl")}
           placeholder={t("templatesPage.communitySubmissionUrlPlaceholder")}
-          className={fieldClassName}
+          className={inputClassName("appUrl")}
         />
+        <InlineError id={errorId("appUrl")} message={errors.appUrl} />
       </div>
 
       <div className="grid gap-1.5">
@@ -343,14 +453,21 @@ export function CommunityAppSubmissionForm({
           id={`${formId}-description`}
           name="description"
           required
+          aria-required="true"
+          aria-invalid={Boolean(errors.description)}
+          aria-describedby={
+            errors.description ? errorId("description") : undefined
+          }
           rows={4}
           value={values.description}
           onChange={(event) => updateValue("description", event.target.value)}
+          onBlur={() => validateField("description")}
           placeholder={t(
             "templatesPage.communitySubmissionDescriptionPlaceholder",
           )}
-          className={fieldClassName}
+          className={inputClassName("description")}
         />
+        <InlineError id={errorId("description")} message={errors.description} />
       </div>
 
       <div className="grid gap-1.5">
@@ -363,6 +480,10 @@ export function CommunityAppSubmissionForm({
         <input
           id={`${formId}-repository`}
           name="repository_url"
+          aria-invalid={Boolean(errors.repositoryUrl)}
+          aria-describedby={
+            errors.repositoryUrl ? errorId("repositoryUrl") : undefined
+          }
           type="text"
           inputMode="url"
           autoComplete="url"
@@ -373,7 +494,11 @@ export function CommunityAppSubmissionForm({
           placeholder={t(
             "templatesPage.communitySubmissionRepositoryPlaceholder",
           )}
-          className={fieldClassName}
+          className={inputClassName("repositoryUrl")}
+        />
+        <InlineError
+          id={errorId("repositoryUrl")}
+          message={errors.repositoryUrl}
         />
       </div>
 
@@ -399,10 +524,14 @@ export function CommunityAppSubmissionForm({
           data-community-screenshot-dropzone="true"
           role="group"
           aria-labelledby={`${formId}-screenshots-label`}
+          aria-invalid={Boolean(errors.screenshots)}
+          aria-describedby={`${formId}-screenshots-help${errors.screenshots ? ` ${errorId("screenshots")}` : ""}`}
           className={`rounded-[var(--b-radius)] border border-dashed p-4 transition-[background,border-color] duration-150 sm:p-5 ${
             isDragActive
               ? "border-[var(--b-text-primary)] bg-[var(--b-action-secondary-hover)]"
-              : "border-[var(--b-border-default)] bg-[var(--b-bg-inset)] hover:border-[var(--b-text-primary)]"
+              : errors.screenshots
+                ? "border-[var(--c-red-400)] bg-[var(--b-bg-inset)]"
+                : "border-[var(--b-border-default)] bg-[var(--b-bg-inset)] hover:border-[var(--b-text-primary)]"
           }`}
           onDragOver={handleDragOver}
           onDragEnter={() => setIsDragActive(true)}
@@ -418,7 +547,6 @@ export function CommunityAppSubmissionForm({
             className="sr-only"
             onChange={handleScreenshotChange}
             aria-label={t("templatesPage.communitySubmissionScreenshotsAdd")}
-            aria-describedby={`${formId}-screenshots-help`}
           />
           <div className="flex flex-col items-center justify-between gap-4 text-center sm:flex-row sm:text-left">
             <div className="flex items-center gap-3">
@@ -441,13 +569,15 @@ export function CommunityAppSubmissionForm({
               type="button"
               variant="secondary"
               icon={IconPlus}
-              disabled={screenshots.length === SCREENSHOT_FIELDS.length}
+              disabled={screenshots.length === SCREENSHOT_MAX_COUNT}
               onClick={() => fileInputRef.current?.click()}
             >
               {t("templatesPage.communitySubmissionScreenshotsAdd")}
             </Button>
           </div>
         </div>
+
+        <InlineError id={errorId("screenshots")} message={errors.screenshots} />
 
         {screenshots.length > 0 ? (
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
@@ -489,71 +619,21 @@ export function CommunityAppSubmissionForm({
             ))}
           </div>
         ) : null}
-
-        <div className="hidden" aria-hidden="true">
-          {SCREENSHOT_FIELDS.map((field, index) => (
-            <input
-              key={field}
-              ref={(element) => {
-                hiddenInputRefs.current[index] = element;
-              }}
-              name={field}
-              type="file"
-              accept="image/jpeg,image/png,image/webp"
-              tabIndex={-1}
-            />
-          ))}
-        </div>
       </div>
-
-      {error ? (
-        <p
-          id={`${formId}-error`}
-          role="alert"
-          className="m-0 font-[family-name:var(--b-font-sans)] text-sm text-[var(--c-red-400)]"
-        >
-          {error}
-        </p>
-      ) : null}
 
       <div className="flex flex-wrap items-center gap-4">
-        <Button variant="cta" type="submit" icon={IconUpload}>
-          {t("templatesPage.communitySubmissionSubmit")}
+        <Button
+          variant="cta"
+          type="submit"
+          icon={IconUpload}
+          disabled={isSubmitting}
+        >
+          {isSubmitting
+            ? t("templatesPage.communitySubmissionSubmitting")
+            : t("templatesPage.communitySubmissionSubmit")}
         </Button>
+        <InlineError id={`${formId}-submit-error`} message={submitError} />
       </div>
-    </form>
-  );
-}
-
-export function CommunityAppSubmissionNetlifyDetectionForm() {
-  const { locale } = useLocale();
-
-  return (
-    <form
-      name={COMMUNITY_FORM_NAME}
-      method="post"
-      action={`${sitePathForLocale("/apps", locale)}?community-submission=received`}
-      encType="multipart/form-data"
-      data-netlify="true"
-      data-netlify-honeypot="bot-field"
-      className="hidden"
-      aria-hidden="true"
-    >
-      <input type="hidden" name="form-name" value={COMMUNITY_FORM_NAME} />
-      <input name="bot-field" tabIndex={-1} autoComplete="off" />
-      <input name="name" tabIndex={-1} />
-      <input name="app_url" tabIndex={-1} />
-      <textarea name="description" tabIndex={-1} />
-      <input name="repository_url" tabIndex={-1} />
-      {SCREENSHOT_FIELDS.map((field) => (
-        <input
-          key={field}
-          name={field}
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          tabIndex={-1}
-        />
-      ))}
     </form>
   );
 }

--- a/packages/docs/app/i18n/ar-SA.ts
+++ b/packages/docs/app/i18n/ar-SA.ts
@@ -571,7 +571,7 @@ const arSA = {
     communitySubmissionName: "اسم التطبيق",
     communitySubmissionNamePlaceholder: "مركز دعم العملاء",
     communitySubmissionUrl: "رابط التطبيق",
-    communitySubmissionUrlPlaceholder: "example.com أو https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "الوصف",
     communitySubmissionDescriptionPlaceholder:
       "ماذا يفعل التطبيق ولمن هو مخصص؟",
@@ -587,8 +587,15 @@ const arSA = {
     communitySubmissionScreenshotRemove: "إزالة لقطة الشاشة {{index}}",
     communitySubmissionSubmit: "إرسال التطبيق",
     communitySubmissionReady: "شكرًا. سنراجع تطبيقك قبل نشره.",
-    communitySubmissionValidation:
-      "أضف اسمًا ووصفًا، ثم أدخل رابط التطبيق مثل example.com. سنضيف https:// نيابةً عنك. إذا أضفت مستودعًا، فاستخدم رابطًا من github.com. ارفع صور PNG أو JPG أو WebP بحد أقصى 1.5 ميجابايت لكل صورة.",
+    communitySubmissionNameError: "أدخل اسم التطبيق.",
+    communitySubmissionDescriptionError: "أضف وصفًا موجزًا.",
+    communitySubmissionUrlError: "أدخل رابط تطبيق صالحًا، مثل example.com.",
+    communitySubmissionRepositoryError: "أدخل رابط مستودع GitHub.",
+    communitySubmissionScreenshotsError:
+      "استخدم صور PNG أو JPG أو WebP بحد أقصى 1.5 ميجابايت لكل صورة، وبحد أقصى 5 صور.",
+    communitySubmissionSubmitError:
+      "تعذر الإرسال الآن. تحقق من الحقول المميزة وحاول مرة أخرى.",
+    communitySubmissionSubmitting: "جارٍ الإرسال…",
   },
   buildFromScratch: {
     title: "ابنِ من الصفر",

--- a/packages/docs/app/i18n/de-DE.ts
+++ b/packages/docs/app/i18n/de-DE.ts
@@ -577,7 +577,7 @@ const deDE = {
     communitySubmissionName: "App-Name",
     communitySubmissionNamePlaceholder: "Kundensupport-Zentrale",
     communitySubmissionUrl: "App-URL",
-    communitySubmissionUrlPlaceholder: "example.com oder https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "Beschreibung",
     communitySubmissionDescriptionPlaceholder:
       "Was macht die App und für wen ist sie gedacht?",
@@ -594,8 +594,16 @@ const deDE = {
     communitySubmissionSubmit: "App einreichen",
     communitySubmissionReady:
       "Danke. Wir prüfen deine App vor der Veröffentlichung.",
-    communitySubmissionValidation:
-      "Füge einen Namen und eine Beschreibung hinzu und gib dann einen App-Link wie example.com ein. Wir ergänzen https:// automatisch. Wenn du ein Repository hinzufügst, muss der Link auf github.com verweisen. Lade PNG-, JPG- oder WebP-Bilder mit jeweils maximal 1,5 MB hoch.",
+    communitySubmissionNameError: "Gib einen App-Namen ein.",
+    communitySubmissionDescriptionError: "Füge eine kurze Beschreibung hinzu.",
+    communitySubmissionUrlError:
+      "Gib einen gültigen App-Link ein, z. B. example.com.",
+    communitySubmissionRepositoryError: "Gib einen GitHub-Repository-Link ein.",
+    communitySubmissionScreenshotsError:
+      "Verwende PNG-, JPG- oder WebP-Bilder mit jeweils maximal 1,5 MB und höchstens 5 Bilder.",
+    communitySubmissionSubmitError:
+      "Die Übermittlung ist gerade nicht möglich. Prüfe die markierten Felder und versuche es erneut.",
+    communitySubmissionSubmitting: "Wird gesendet…",
   },
   buildFromScratch: {
     title: "Von Grund auf bauen",

--- a/packages/docs/app/i18n/en-US.ts
+++ b/packages/docs/app/i18n/en-US.ts
@@ -573,7 +573,7 @@ const enUS = {
     communitySubmissionName: "App name",
     communitySubmissionNamePlaceholder: "Customer Support Hub",
     communitySubmissionUrl: "App URL",
-    communitySubmissionUrlPlaceholder: "example.com or https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "Description",
     communitySubmissionDescriptionPlaceholder:
       "What does the app do, and who is it for?",
@@ -590,8 +590,15 @@ const enUS = {
     communitySubmissionSubmit: "Submit app",
     communitySubmissionReady:
       "Thanks. We will review your app before publishing it.",
-    communitySubmissionValidation:
-      "Add a name and description, then enter an app link like example.com. We’ll add https:// for you. If you add a repository, use a github.com link. Upload PNG, JPG, or WebP images up to 1.5 MB each.",
+    communitySubmissionNameError: "Enter an app name.",
+    communitySubmissionDescriptionError: "Add a short description.",
+    communitySubmissionUrlError: "Enter a valid app link, such as example.com.",
+    communitySubmissionRepositoryError: "Enter a GitHub repository link.",
+    communitySubmissionScreenshotsError:
+      "Use PNG, JPG, or WebP images up to 1.5 MB each, with up to 5 images.",
+    communitySubmissionSubmitError:
+      "Couldn’t submit right now. Check the highlighted fields and try again.",
+    communitySubmissionSubmitting: "Submitting…",
   },
   buildFromScratch: {
     title: "Build from scratch",

--- a/packages/docs/app/i18n/es-ES.ts
+++ b/packages/docs/app/i18n/es-ES.ts
@@ -578,7 +578,7 @@ const esES = {
     communitySubmissionName: "Nombre de la aplicación",
     communitySubmissionNamePlaceholder: "Centro de atención al cliente",
     communitySubmissionUrl: "URL de la aplicación",
-    communitySubmissionUrlPlaceholder: "example.com o https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "Descripción",
     communitySubmissionDescriptionPlaceholder:
       "¿Qué hace la aplicación y para quién es?",
@@ -595,8 +595,17 @@ const esES = {
     communitySubmissionSubmit: "Enviar aplicación",
     communitySubmissionReady:
       "Gracias. Revisaremos tu aplicación antes de publicarla.",
-    communitySubmissionValidation:
-      "Añade un nombre y una descripción, y después introduce un enlace de aplicación como example.com. Añadiremos https:// por ti. Si añades un repositorio, usa un enlace de github.com. Sube imágenes PNG, JPG o WebP de hasta 1,5 MB cada una.",
+    communitySubmissionNameError: "Introduce un nombre para la aplicación.",
+    communitySubmissionDescriptionError: "Añade una descripción breve.",
+    communitySubmissionUrlError:
+      "Introduce un enlace válido, como example.com.",
+    communitySubmissionRepositoryError:
+      "Introduce un enlace a un repositorio de GitHub.",
+    communitySubmissionScreenshotsError:
+      "Usa imágenes PNG, JPG o WebP de hasta 1,5 MB cada una, con un máximo de 5 imágenes.",
+    communitySubmissionSubmitError:
+      "No se pudo enviar ahora. Revisa los campos marcados e inténtalo de nuevo.",
+    communitySubmissionSubmitting: "Enviando…",
   },
   buildFromScratch: {
     title: "Crear desde cero",

--- a/packages/docs/app/i18n/fr-FR.ts
+++ b/packages/docs/app/i18n/fr-FR.ts
@@ -576,7 +576,7 @@ const frFR = {
     communitySubmissionName: "Nom de l’application",
     communitySubmissionNamePlaceholder: "Centre de support client",
     communitySubmissionUrl: "URL de l’application",
-    communitySubmissionUrlPlaceholder: "example.com ou https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "Description",
     communitySubmissionDescriptionPlaceholder:
       "Que fait l’application et à qui s’adresse-t-elle ?",
@@ -593,8 +593,17 @@ const frFR = {
     communitySubmissionSubmit: "Envoyer l’application",
     communitySubmissionReady:
       "Merci. Nous examinerons votre application avant de la publier.",
-    communitySubmissionValidation:
-      "Ajoutez un nom et une description, puis saisissez un lien d’application comme example.com. Nous ajouterons https:// pour vous. Si vous ajoutez un dépôt, utilisez un lien github.com. Importez des images PNG, JPG ou WebP de 1,5 Mo maximum chacune.",
+    communitySubmissionNameError: "Saisissez un nom d’application.",
+    communitySubmissionDescriptionError: "Ajoutez une courte description.",
+    communitySubmissionUrlError:
+      "Saisissez un lien d’application valide, par exemple example.com.",
+    communitySubmissionRepositoryError:
+      "Saisissez un lien vers un dépôt GitHub.",
+    communitySubmissionScreenshotsError:
+      "Utilisez des images PNG, JPG ou WebP de 1,5 Mo maximum chacune, avec 5 images au maximum.",
+    communitySubmissionSubmitError:
+      "Impossible d’envoyer le formulaire pour le moment. Vérifiez les champs signalés, puis réessayez.",
+    communitySubmissionSubmitting: "Envoi…",
   },
   buildFromScratch: {
     title: "Créer de zéro",

--- a/packages/docs/app/i18n/hi-IN.ts
+++ b/packages/docs/app/i18n/hi-IN.ts
@@ -571,7 +571,7 @@ const hiIN = {
     communitySubmissionName: "ऐप का नाम",
     communitySubmissionNamePlaceholder: "कस्टमर सपोर्ट हब",
     communitySubmissionUrl: "ऐप URL",
-    communitySubmissionUrlPlaceholder: "example.com या https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "विवरण",
     communitySubmissionDescriptionPlaceholder:
       "ऐप क्या करता है और यह किसके लिए है?",
@@ -587,8 +587,15 @@ const hiIN = {
     communitySubmissionSubmit: "ऐप सबमिट करें",
     communitySubmissionReady:
       "धन्यवाद। प्रकाशित करने से पहले हम आपके ऐप की समीक्षा करेंगे।",
-    communitySubmissionValidation:
-      "नाम और विवरण जोड़ें, फिर example.com जैसा ऐप लिंक डालें। हम आपके लिए https:// जोड़ देंगे। रिपॉज़िटरी जोड़ने पर github.com का लिंक इस्तेमाल करें। PNG, JPG या WebP इमेज अपलोड करें, प्रत्येक 1.5 MB तक।",
+    communitySubmissionNameError: "ऐप का नाम दर्ज करें।",
+    communitySubmissionDescriptionError: "छोटा विवरण जोड़ें।",
+    communitySubmissionUrlError: "मान्य ऐप लिंक दर्ज करें, जैसे example.com।",
+    communitySubmissionRepositoryError: "GitHub रिपॉज़िटरी लिंक दर्ज करें।",
+    communitySubmissionScreenshotsError:
+      "PNG, JPG या WebP इमेज इस्तेमाल करें, प्रत्येक 1.5 MB तक और अधिकतम 5 इमेज।",
+    communitySubmissionSubmitError:
+      "अभी सबमिट नहीं हो सका। चिह्नित फ़ील्ड जाँचकर फिर कोशिश करें।",
+    communitySubmissionSubmitting: "सबमिट हो रहा है…",
   },
   buildFromScratch: {
     title: "शुरू से बनाएँ",

--- a/packages/docs/app/i18n/ja-JP.ts
+++ b/packages/docs/app/i18n/ja-JP.ts
@@ -574,7 +574,7 @@ const jaJP = {
     communitySubmissionName: "アプリ名",
     communitySubmissionNamePlaceholder: "カスタマーサポートハブ",
     communitySubmissionUrl: "アプリ URL",
-    communitySubmissionUrlPlaceholder: "example.com または https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "説明",
     communitySubmissionDescriptionPlaceholder:
       "アプリの機能と対象ユーザーを教えてください。",
@@ -590,8 +590,17 @@ const jaJP = {
     communitySubmissionSubmit: "アプリを送信",
     communitySubmissionReady:
       "ありがとうございます。公開前にアプリを確認します。",
-    communitySubmissionValidation:
-      "名前と説明を入力し、example.com のようなアプリリンクを入力してください。https:// は自動で追加します。リポジトリを追加する場合は github.com のリンクを使用してください。PNG、JPG、WebP 画像は各 1.5 MB までアップロードできます。",
+    communitySubmissionNameError: "アプリ名を入力してください。",
+    communitySubmissionDescriptionError: "短い説明を追加してください。",
+    communitySubmissionUrlError:
+      "example.com のような有効なアプリリンクを入力してください。",
+    communitySubmissionRepositoryError:
+      "GitHub リポジトリのリンクを入力してください。",
+    communitySubmissionScreenshotsError:
+      "PNG、JPG、WebP 画像を使用してください。各 1.5 MB まで、最大 5 枚です。",
+    communitySubmissionSubmitError:
+      "現在送信できません。強調表示された項目を確認して、もう一度お試しください。",
+    communitySubmissionSubmitting: "送信中…",
   },
   buildFromScratch: {
     title: "ゼロから構築",

--- a/packages/docs/app/i18n/ko-KR.ts
+++ b/packages/docs/app/i18n/ko-KR.ts
@@ -574,7 +574,7 @@ const koKR = {
     communitySubmissionName: "앱 이름",
     communitySubmissionNamePlaceholder: "고객 지원 허브",
     communitySubmissionUrl: "앱 URL",
-    communitySubmissionUrlPlaceholder: "example.com 또는 https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "설명",
     communitySubmissionDescriptionPlaceholder:
       "앱은 무엇을 하며 누구를 위한 것인가요?",
@@ -589,8 +589,16 @@ const koKR = {
     communitySubmissionScreenshotRemove: "스크린샷 {{index}} 제거",
     communitySubmissionSubmit: "앱 제출",
     communitySubmissionReady: "감사합니다. 게시하기 전에 앱을 검토하겠습니다.",
-    communitySubmissionValidation:
-      "이름과 설명을 입력한 다음 example.com과 같은 앱 링크를 입력하세요. https://는 자동으로 추가됩니다. 저장소를 추가하려면 github.com 링크를 사용하세요. PNG, JPG 또는 WebP 이미지는 각각 1.5MB 이하로 업로드하세요.",
+    communitySubmissionNameError: "앱 이름을 입력하세요.",
+    communitySubmissionDescriptionError: "간단한 설명을 추가하세요.",
+    communitySubmissionUrlError:
+      "example.com과 같은 유효한 앱 링크를 입력하세요.",
+    communitySubmissionRepositoryError: "GitHub 저장소 링크를 입력하세요.",
+    communitySubmissionScreenshotsError:
+      "PNG, JPG 또는 WebP 이미지를 사용하세요. 각 1.5MB 이하, 최대 5개입니다.",
+    communitySubmissionSubmitError:
+      "지금 제출할 수 없습니다. 강조 표시된 필드를 확인하고 다시 시도하세요.",
+    communitySubmissionSubmitting: "제출 중…",
   },
   buildFromScratch: {
     title: "처음부터 만들기",

--- a/packages/docs/app/i18n/pt-BR.ts
+++ b/packages/docs/app/i18n/pt-BR.ts
@@ -573,7 +573,7 @@ const ptBR = {
     communitySubmissionName: "Nome do aplicativo",
     communitySubmissionNamePlaceholder: "Central de suporte ao cliente",
     communitySubmissionUrl: "URL do aplicativo",
-    communitySubmissionUrlPlaceholder: "example.com ou https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "Descrição",
     communitySubmissionDescriptionPlaceholder:
       "O que o aplicativo faz e para quem ele é?",
@@ -590,8 +590,16 @@ const ptBR = {
     communitySubmissionSubmit: "Enviar aplicativo",
     communitySubmissionReady:
       "Obrigado. Vamos revisar seu aplicativo antes de publicá-lo.",
-    communitySubmissionValidation:
-      "Adicione um nome e uma descrição e insira um link do app, como example.com. Nós adicionaremos https:// para você. Se adicionar um repositório, use um link do github.com. Envie imagens PNG, JPG ou WebP de até 1,5 MB cada.",
+    communitySubmissionNameError: "Insira um nome para o aplicativo.",
+    communitySubmissionDescriptionError: "Adicione uma descrição curta.",
+    communitySubmissionUrlError: "Insira um link válido, como example.com.",
+    communitySubmissionRepositoryError:
+      "Insira um link de repositório do GitHub.",
+    communitySubmissionScreenshotsError:
+      "Use imagens PNG, JPG ou WebP de até 1,5 MB cada, com no máximo 5 imagens.",
+    communitySubmissionSubmitError:
+      "Não foi possível enviar agora. Verifique os campos destacados e tente novamente.",
+    communitySubmissionSubmitting: "Enviando…",
   },
   buildFromScratch: {
     title: "Criar do zero",

--- a/packages/docs/app/i18n/zh-CN.ts
+++ b/packages/docs/app/i18n/zh-CN.ts
@@ -564,7 +564,7 @@ const zhCN = {
     communitySubmissionName: "应用名称",
     communitySubmissionNamePlaceholder: "客户支持中心",
     communitySubmissionUrl: "应用 URL",
-    communitySubmissionUrlPlaceholder: "example.com 或 https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "描述",
     communitySubmissionDescriptionPlaceholder: "应用做什么，适合哪些人？",
     communitySubmissionRepository: "GitHub 仓库（可选）",
@@ -579,8 +579,14 @@ const zhCN = {
     communitySubmissionScreenshotRemove: "移除截图 {{index}}",
     communitySubmissionSubmit: "提交应用",
     communitySubmissionReady: "谢谢。我们会在发布前审核你的应用。",
-    communitySubmissionValidation:
-      "请填写名称和描述，然后输入类似 example.com 的应用链接。我们会自动为你添加 https://。如果添加代码仓库，请使用 github.com 链接。请上传 PNG、JPG 或 WebP 图片，每张不超过 1.5 MB。",
+    communitySubmissionNameError: "请输入应用名称。",
+    communitySubmissionDescriptionError: "请添加简短描述。",
+    communitySubmissionUrlError: "请输入有效的应用链接，例如 example.com。",
+    communitySubmissionRepositoryError: "请输入 GitHub 仓库链接。",
+    communitySubmissionScreenshotsError:
+      "请使用 PNG、JPG 或 WebP 图片，每张不超过 1.5 MB，最多上传 5 张。",
+    communitySubmissionSubmitError: "暂时无法提交。请检查标记的字段后重试。",
+    communitySubmissionSubmitting: "提交中…",
   },
   buildFromScratch: {
     title: "从零开始构建",

--- a/packages/docs/app/i18n/zh-TW.ts
+++ b/packages/docs/app/i18n/zh-TW.ts
@@ -562,7 +562,7 @@ const messages = {
     communitySubmissionName: "應用程式名稱",
     communitySubmissionNamePlaceholder: "客戶支援中心",
     communitySubmissionUrl: "應用程式 URL",
-    communitySubmissionUrlPlaceholder: "example.com 或 https://example.com",
+    communitySubmissionUrlPlaceholder: "example.com",
     communitySubmissionDescriptionLabel: "描述",
     communitySubmissionDescriptionPlaceholder: "應用程式做什麼，適合哪些人？",
     communitySubmissionRepository: "GitHub 儲存庫（選填）",
@@ -577,8 +577,15 @@ const messages = {
     communitySubmissionScreenshotRemove: "移除螢幕截圖 {{index}}",
     communitySubmissionSubmit: "提交應用程式",
     communitySubmissionReady: "謝謝。我們會在刊登前審核你的應用程式。",
-    communitySubmissionValidation:
-      "請填寫名稱和描述，然後輸入類似 example.com 的應用程式連結。我們會自動為你加上 https://。如果新增儲存庫，請使用 github.com 連結。請上傳 PNG、JPG 或 WebP 圖片，每張不超過 1.5 MB。",
+    communitySubmissionNameError: "請輸入應用程式名稱。",
+    communitySubmissionDescriptionError: "請新增簡短描述。",
+    communitySubmissionUrlError: "請輸入有效的應用程式連結，例如 example.com。",
+    communitySubmissionRepositoryError: "請輸入 GitHub 儲存庫連結。",
+    communitySubmissionScreenshotsError:
+      "請使用 PNG、JPG 或 WebP 圖片，每張不超過 1.5 MB，最多上傳 5 張。",
+    communitySubmissionSubmitError:
+      "目前無法提交。請檢查標記的欄位後再試一次。",
+    communitySubmissionSubmitting: "提交中…",
   },
   buildFromScratch: {
     title: "從零開始建置",

--- a/packages/docs/app/lib/community-form-client.ts
+++ b/packages/docs/app/lib/community-form-client.ts
@@ -1,0 +1,68 @@
+const FORMS_ORIGIN = "https://forms.agent-native.com";
+const COMMUNITY_FORM_SLUG = "community-app-submission";
+const SCREENSHOT_FIELD_ID = "screenshots";
+
+export type CommunityUploadedFile = {
+  url: string;
+  name: string;
+  type: string;
+  size: number;
+  id?: string;
+  provider?: string;
+};
+
+async function readResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) throw new Error("community form request failed");
+  const payload: unknown = await response.json();
+  if (!payload || typeof payload !== "object") {
+    throw new Error("community form response was invalid");
+  }
+  return payload as T;
+}
+
+export async function uploadCommunityScreenshot(
+  file: File,
+): Promise<CommunityUploadedFile> {
+  const body = new FormData();
+  body.append("fieldId", SCREENSHOT_FIELD_ID);
+  body.append("file", file);
+  const response = await fetch(
+    `${FORMS_ORIGIN}/api/upload/${COMMUNITY_FORM_SLUG}`,
+    { method: "POST", body },
+  );
+  const uploaded = await readResponse<Partial<CommunityUploadedFile>>(response);
+  if (
+    typeof uploaded.url !== "string" ||
+    !/^https?:\/\//i.test(uploaded.url) ||
+    typeof uploaded.name !== "string" ||
+    typeof uploaded.type !== "string" ||
+    typeof uploaded.size !== "number"
+  ) {
+    throw new Error("community form upload response was invalid");
+  }
+  return uploaded as CommunityUploadedFile;
+}
+
+export async function submitCommunityApp(input: {
+  data: Record<string, unknown>;
+  pageUrl: string;
+  idempotencyKey: string;
+  pageLoadTime: number;
+}): Promise<{ success: boolean; id?: string }> {
+  const response = await fetch(
+    `${FORMS_ORIGIN}/api/submit/${COMMUNITY_FORM_SLUG}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Idempotency-Key": input.idempotencyKey,
+      },
+      body: JSON.stringify({
+        data: input.data,
+        _t: input.pageLoadTime,
+        _meta: { pageUrl: input.pageUrl },
+      }),
+    },
+  );
+  return readResponse<{ success: boolean; id?: string }>(response);
+}

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -5,7 +5,6 @@ import { BuildFromScratchCta } from "../components/BuildFromScratchCta";
 import { communityApps } from "../components/community-apps";
 import { CommunityAppCard } from "../components/CommunityAppCard";
 import { CommunityAppSubmissionDialog } from "../components/CommunityAppSubmissionDialog";
-import { CommunityAppSubmissionNetlifyDetectionForm } from "../components/CommunityAppSubmissionForm";
 import { sitePathForLocale } from "../components/docs-locale";
 import { featuredTemplates, TemplateCard } from "../components/TemplateCard";
 
@@ -18,7 +17,6 @@ export default function TemplatesPage() {
 
   return (
     <div className="builder-brand-tokens min-h-screen">
-      <CommunityAppSubmissionNetlifyDetectionForm />
       <main className="templates-index-page mx-auto w-full min-w-0 max-w-site overflow-x-clip px-4 pb-24 pt-20 sm:px-6 lg:pt-28">
         <header className="max-w-[720px]">
           <h1 className="m-0 font-[family-name:var(--b-font-sans)] text-[length:var(--b-t-heading-1)] font-medium leading-[1.05] tracking-[-0.03em] text-[var(--b-text-primary)]">

--- a/packages/docs/tests/community-templates.test.ts
+++ b/packages/docs/tests/community-templates.test.ts
@@ -52,7 +52,7 @@ describe("community apps", () => {
     }
   });
 
-  it("uses a native multipart form for screenshot uploads", () => {
+  it("uses the Forms upload flow for screenshot uploads", () => {
     const form = fs.readFileSync(
       path.join(
         repoRoot,
@@ -64,17 +64,15 @@ describe("community apps", () => {
       ),
       "utf-8",
     );
-    expect(form).toContain('encType="multipart/form-data"');
-    expect(form).toContain('data-netlify="true"');
-    expect(form).toContain('name="form-name"');
+    expect(form).toContain("uploadCommunityScreenshot");
+    expect(form).toContain("submitCommunityApp");
     expect(form).toContain("multiple");
     expect(form).toContain("onDrop={handleDrop}");
     expect(form).toContain("removeScreenshot");
-    expect(form).toContain("typeof DataTransfer");
-    expect(form).toContain("ClipboardEvent");
-    expect(form).toContain("new DataTransfer()");
-    expect(form).toContain("name={field}");
-    expect(form).toContain('"screenshot_5"');
+    expect(form).toContain('accept="image/jpeg,image/png,image/webp"');
+    expect(form).not.toContain("data-netlify");
+    expect(form).not.toContain("form-name");
+    expect(form).not.toContain("https for you");
     expect(form).not.toContain("Screenshot URLs");
   });
 
@@ -90,7 +88,7 @@ describe("community apps", () => {
     expect(isGitHubRepositoryUrl("github.com/owner")).toBe(false);
   });
 
-  it("keeps a static Netlify form declaration in the server-rendered route", () => {
+  it("does not declare a Netlify submission form in the route", () => {
     const route = fs.readFileSync(
       path.join(
         repoRoot,
@@ -102,6 +100,7 @@ describe("community apps", () => {
       ),
       "utf-8",
     );
-    expect(route).toContain("CommunityAppSubmissionNetlifyDetectionForm");
+    expect(route).not.toContain("Netlify");
+    expect(route).not.toContain("data-netlify");
   });
 });

--- a/templates/forms/app/components/builder/FieldPropertiesPanel.tsx
+++ b/templates/forms/app/components/builder/FieldPropertiesPanel.tsx
@@ -1,5 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
-import type { ConditionalRule, FormField, FormFieldType } from "@shared/types";
+import type { ConditionalRule, FormField } from "@shared/types";
 import { IconPlus, IconX } from "@tabler/icons-react";
 import { useState } from "react";
 
@@ -16,15 +16,20 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  isFileField,
+  type AppFormField,
+  type AppFormFieldType,
+} from "@/lib/form-field-types";
 
 interface FieldPropertiesPanelProps {
-  field: FormField;
-  fields: FormField[];
+  field: AppFormField;
+  fields: AppFormField[];
   onChange: (field: FormField) => void;
   onDelete: () => void;
 }
 
-const fieldTypeLabels: Record<FormFieldType, string> = {
+const fieldTypeLabels: Record<AppFormFieldType, string> = {
   text: "fieldProperties.fieldTypes.text", // i18n-ignore stable catalog key
   email: "fieldProperties.fieldTypes.email", // i18n-ignore stable catalog key
   number: "fieldProperties.fieldTypes.number", // i18n-ignore stable catalog key
@@ -36,11 +41,12 @@ const fieldTypeLabels: Record<FormFieldType, string> = {
   date: "fieldProperties.fieldTypes.date", // i18n-ignore stable catalog key
   rating: "fieldProperties.fieldTypes.rating", // i18n-ignore stable catalog key
   scale: "fieldProperties.fieldTypes.scale", // i18n-ignore stable catalog key
+  file: "fieldProperties.fieldTypes.file", // i18n-ignore stable catalog key
 };
 
-const hasOptions: FormFieldType[] = ["select", "multiselect", "radio"];
+const hasOptions: AppFormFieldType[] = ["select", "multiselect", "radio"];
 
-function conditionValueOptions(source: FormField | undefined): string[] {
+function conditionValueOptions(source: AppFormField | undefined): string[] {
   if (!source) return [];
   if (hasOptions.includes(source.type)) {
     return (source.options || []).filter(
@@ -54,7 +60,7 @@ function conditionValueOptions(source: FormField | undefined): string[] {
 }
 
 function defaultConditionOperator(
-  source: FormField,
+  source: AppFormField,
 ): ConditionalRule["operator"] {
   return source.type === "multiselect" ? "contains" : "equals";
 }
@@ -83,8 +89,8 @@ export function FieldPropertiesPanel({
     (conditionSource ? defaultConditionOperator(conditionSource) : "equals");
   const conditionValue = field.conditional?.value || conditionOptions[0] || "";
 
-  function update(partial: Partial<FormField>) {
-    onChange({ ...field, ...partial });
+  function update(partial: Partial<AppFormField>) {
+    onChange({ ...field, ...partial } as FormField);
   }
 
   function addOption() {
@@ -119,7 +125,17 @@ export function FieldPropertiesPanel({
           <Label className="text-xs">{t("fieldProperties.type")}</Label>
           <Select
             value={field.type}
-            onValueChange={(v) => update({ type: v as FormFieldType })}
+            onValueChange={(v) => {
+              const nextType = v as AppFormFieldType;
+              const nextField = { ...field, type: nextType } as FormField;
+              if (nextType !== "file") {
+                delete nextField.multiple;
+                delete nextField.accept;
+                delete nextField.maxSizeBytes;
+                delete nextField.maxFiles;
+              }
+              onChange(nextField);
+            }}
           >
             <SelectTrigger className="h-8 text-xs">
               <SelectValue />
@@ -196,6 +212,32 @@ export function FieldPropertiesPanel({
             </SelectContent>
           </Select>
         </div>
+
+        {isFileField(field) && (
+          <>
+            <Separator />
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <Label className="text-xs">
+                  {t("fieldProperties.allowMultiple")}
+                </Label>
+                <Switch
+                  checked={field.multiple === true}
+                  onCheckedChange={(checked) => update({ multiple: checked })}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">{t("fieldProperties.accept")}</Label>
+                <Input
+                  value={field.accept || ""}
+                  onChange={(event) => update({ accept: event.target.value })}
+                  placeholder={t("fieldProperties.acceptPlaceholder")}
+                  className="h-8 text-xs"
+                />
+              </div>
+            </div>
+          </>
+        )}
 
         {availableFields.length > 0 && (
           <>

--- a/templates/forms/app/components/builder/FieldRenderer.test.tsx
+++ b/templates/forms/app/components/builder/FieldRenderer.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import type { FormField } from "@shared/types";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FieldRenderer } from "./FieldRenderer";
+
+describe("FieldRenderer file fields", () => {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+  });
+
+  it("renders a native multi-file input and forwards selected files", () => {
+    const onChange = vi.fn();
+    const field = {
+      id: "screenshots",
+      type: "file",
+      label: "Screenshots",
+      required: false,
+      multiple: true,
+      accept: "image/*",
+    } as FormField;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root?.render(<FieldRenderer field={field} onChange={onChange} />);
+    });
+
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+    expect(input?.multiple).toBe(true);
+    expect(input?.accept).toBe("image/*");
+
+    const file = new File(["image"], "screen.png", { type: "image/png" });
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [file],
+    });
+    act(() => {
+      input?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledWith([file]);
+  });
+});

--- a/templates/forms/app/components/builder/FieldRenderer.tsx
+++ b/templates/forms/app/components/builder/FieldRenderer.tsx
@@ -1,4 +1,3 @@
-import type { FormField } from "@shared/types";
 import { IconStar, IconStarFilled } from "@tabler/icons-react";
 
 import { Checkbox } from "@/components/ui/checkbox";
@@ -14,10 +13,15 @@ import {
 } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  getFileFieldOptions,
+  isFileField,
+  type AppFormField,
+} from "@/lib/form-field-types";
 import { cn } from "@/lib/utils";
 
 interface FieldRendererProps {
-  field: FormField;
+  field: AppFormField;
   value?: unknown;
   onChange?: (value: unknown) => void;
   disabled?: boolean;
@@ -52,6 +56,9 @@ export function FieldRenderer({
   preview,
 }: FieldRendererProps) {
   const handleChange = (v: unknown) => onChange?.(v);
+  const fileOptions = isFileField(field)
+    ? getFileFieldOptions(field)
+    : undefined;
 
   return (
     <div
@@ -66,6 +73,19 @@ export function FieldRenderer({
       </Label>
       {field.description && (
         <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+
+      {fileOptions && (
+        <Input
+          type="file"
+          multiple={fileOptions.multiple}
+          accept={fileOptions.accept}
+          disabled={disabled || preview}
+          onChange={(event) => {
+            const files = Array.from(event.target.files || []);
+            onChange?.(fileOptions.multiple ? files : (files[0] ?? null));
+          }}
+        />
       )}
 
       <div

--- a/templates/forms/app/hooks/use-forms.test.tsx
+++ b/templates/forms/app/hooks/use-forms.test.tsx
@@ -186,4 +186,78 @@ describe("useDeleteForm", () => {
     expect(body._meta.pageUrl).toContain("utm_source=newsletter");
     expect(body._meta.pageUrl).toContain("token=%3Credacted%3E");
   });
+
+  it("uploads selected files before submitting public form data", async () => {
+    const file = new File(["image"], "screen.png", { type: "image/png" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            url: "https://files.example/screen.png",
+            name: file.name,
+            type: file.type,
+            size: file.size,
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    let mutation: any;
+    function SubmitProbe({ onReady }: { onReady: (value: any) => void }) {
+      onReady(useSubmitForm());
+      return null;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>
+          <SubmitProbe onReady={(value) => (mutation = value)} />
+        </QueryClientProvider>,
+      );
+    });
+
+    await act(async () => {
+      await mutation.mutateAsync({
+        formId: "form-1",
+        data: { attachments: [file], message: "hello" },
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [uploadUrl, uploadRequest] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(uploadUrl).toContain("/api/upload/form-1");
+    expect(uploadRequest.method).toBe("POST");
+    expect(uploadRequest.body).toBeInstanceOf(FormData);
+    const uploadBody = uploadRequest.body as FormData;
+    expect(uploadBody.get("fieldId")).toBe("attachments");
+    expect((uploadBody.get("file") as File).name).toBe(file.name);
+
+    const [, submitRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
+    const submitted = JSON.parse(submitRequest.body as string);
+    expect(submitted.data).toMatchObject({
+      attachments: [
+        {
+          url: "https://files.example/screen.png",
+          name: file.name,
+        },
+      ],
+      message: "hello",
+    });
+  });
 });

--- a/templates/forms/app/hooks/use-forms.ts
+++ b/templates/forms/app/hooks/use-forms.ts
@@ -172,9 +172,83 @@ export function usePublicForm(formId: string) {
   });
 }
 
+type PublicFormFileValue = {
+  url: string;
+  name: string;
+  type: string;
+  size: number;
+  id?: string;
+  provider?: string;
+};
+
+function isBrowserFile(value: unknown): value is File {
+  return typeof File !== "undefined" && value instanceof File;
+}
+
+async function uploadPublicFormFile(
+  formId: string,
+  fieldId: string,
+  file: File,
+  fallbackError: string,
+): Promise<PublicFormFileValue> {
+  const body = new FormData();
+  body.append("fieldId", fieldId);
+  body.append("file", file, file.name);
+  const response = await fetch(
+    appApiPath(`/api/upload/${encodeURIComponent(formId)}`),
+    { method: "POST", body },
+  );
+  const payload: unknown = await response.json();
+  if (!response.ok) {
+    const message =
+      typeof payload === "object" &&
+      payload !== null &&
+      "error" in payload &&
+      typeof payload.error === "string"
+        ? payload.error
+        : fallbackError;
+    throw new Error(message);
+  }
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("url" in payload) ||
+    typeof payload.url !== "string"
+  ) {
+    throw new Error(fallbackError);
+  }
+  return payload as PublicFormFileValue;
+}
+
+async function uploadPublicFormFiles(
+  formId: string,
+  data: Record<string, unknown>,
+  fallbackError: string,
+): Promise<Record<string, unknown>> {
+  const nextData = { ...data };
+  await Promise.all(
+    Object.entries(data).map(async ([fieldId, value]) => {
+      const files = isBrowserFile(value)
+        ? [value]
+        : Array.isArray(value) && value.length > 0 && value.every(isBrowserFile)
+          ? value
+          : null;
+      if (!files) return;
+      const uploaded = await Promise.all(
+        files.map((file) =>
+          uploadPublicFormFile(formId, fieldId, file, fallbackError),
+        ),
+      );
+      nextData[fieldId] = Array.isArray(value) ? uploaded : uploaded[0];
+    }),
+  );
+  return nextData;
+}
+
 export function useSubmitForm() {
+  const t = useT();
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       formId,
       data,
       captchaToken,
@@ -186,20 +260,30 @@ export function useSubmitForm() {
       captchaToken?: string;
       _hp?: string;
       _t?: number;
-    }) =>
-      fetch(appApiPath(`/api/submit/${formId}`), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          data,
-          captchaToken,
-          _hp,
-          _t,
-          _meta: { pageUrl: scrubPageUrl(window.location.href) },
-        }),
-      }).then((r) => {
-        if (!r.ok) return r.json().then((e: any) => Promise.reject(e));
-        return r.json();
-      }),
+    }) => {
+      const submittedData = await uploadPublicFormFiles(
+        formId,
+        data,
+        t("publicForm.failedSubmit"),
+      );
+      const response = await fetch(
+        appApiPath(`/api/submit/${encodeURIComponent(formId)}`),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: submittedData,
+            captchaToken,
+            _hp,
+            _t,
+            _meta: { pageUrl: scrubPageUrl(window.location.href) },
+          }),
+        },
+      );
+      if (!response.ok) {
+        return response.json().then((error: unknown) => Promise.reject(error));
+      }
+      return response.json();
+    },
   });
 }

--- a/templates/forms/app/i18n/ar-SA.ts
+++ b/templates/forms/app/i18n/ar-SA.ts
@@ -97,6 +97,9 @@ const messages = {
     conditionContains: "تتضمن",
     conditionValue: "الإجابة",
     conditionValuePlaceholder: "أدخل إجابة...",
+    allowMultiple: "السماح بملفات متعددة",
+    accept: "أنواع الملفات المقبولة",
+    acceptPlaceholder: "image/*، .pdf",
     fieldTypes: {
       text: "نص قصير",
       email: "بريد إلكتروني",
@@ -109,6 +112,7 @@ const messages = {
       date: "تاريخ",
       rating: "تصنيف",
       scale: "حجم",
+      file: "رفع الملفات",
     },
   },
   builder: {
@@ -175,6 +179,7 @@ const messages = {
       dateLabel: "تاريخ",
       ratingLabel: "تقييم",
       scaleLabel: "مقياس",
+      fileLabel: "رفع الملفات",
       option1: "الخيار 1",
       option2: "الخيار 2",
       option3: "الخيار 3",

--- a/templates/forms/app/i18n/de-DE.ts
+++ b/templates/forms/app/i18n/de-DE.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "enthält",
     conditionValue: "Antwort",
     conditionValuePlaceholder: "Antwort eingeben...",
+    allowMultiple: "Mehrere Dateien zulassen",
+    accept: "Akzeptierte Dateitypen",
+    acceptPlaceholder: "z. B. image/*, .pdf",
     fieldTypes: {
       text: "Kurzer Text",
       email: "E-Mail",
@@ -110,6 +113,7 @@ const messages = {
       date: "Datum",
       rating: "Bewertung",
       scale: "Skala",
+      file: "Datei-Upload",
     },
   },
   builder: {
@@ -182,6 +186,7 @@ const messages = {
       dateLabel: "Datum",
       ratingLabel: "Bewertung",
       scaleLabel: "Skala",
+      fileLabel: "Datei-Upload",
       option1: "Auswahl 1",
       option2: "Auswahl 2",
       option3: "Auswahl 3",

--- a/templates/forms/app/i18n/en-US.ts
+++ b/templates/forms/app/i18n/en-US.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "contains",
     conditionValue: "Answer",
     conditionValuePlaceholder: "Enter an answer...",
+    allowMultiple: "Allow multiple files",
+    accept: "Accepted file types",
+    acceptPlaceholder: "image/*, .pdf",
     fieldTypes: {
       text: "Short Text",
       email: "Email",
@@ -110,6 +113,7 @@ const messages = {
       date: "Date",
       rating: "Rating",
       scale: "Scale",
+      file: "File upload",
     },
   },
   builder: {
@@ -180,6 +184,7 @@ const messages = {
       dateLabel: "Date",
       ratingLabel: "Rating",
       scaleLabel: "Scale",
+      fileLabel: "File upload",
       option1: "Option 1",
       option2: "Option 2",
       option3: "Option 3",

--- a/templates/forms/app/i18n/es-ES.ts
+++ b/templates/forms/app/i18n/es-ES.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "contiene",
     conditionValue: "Respuesta",
     conditionValuePlaceholder: "Escribe una respuesta...",
+    allowMultiple: "Permitir varios archivos",
+    accept: "Tipos de archivo aceptados",
+    acceptPlaceholder: "p. ej., image/*, .pdf",
     fieldTypes: {
       text: "Texto corto",
       email: "Correo electrónico",
@@ -110,6 +113,7 @@ const messages = {
       date: "Fecha",
       rating: "Clasificación",
       scale: "Escala",
+      file: "Carga de archivos",
     },
   },
   builder: {
@@ -181,6 +185,7 @@ const messages = {
       dateLabel: "Fecha",
       ratingLabel: "Valoración",
       scaleLabel: "Escala",
+      fileLabel: "Carga de archivos",
       option1: "Opción 1",
       option2: "Opción 2",
       option3: "Opción 3",

--- a/templates/forms/app/i18n/fr-FR.ts
+++ b/templates/forms/app/i18n/fr-FR.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "contient",
     conditionValue: "Réponse",
     conditionValuePlaceholder: "Saisir une réponse...",
+    allowMultiple: "Autoriser plusieurs fichiers",
+    accept: "Types de fichiers acceptés",
+    acceptPlaceholder: "ex. image/*, .pdf",
     fieldTypes: {
       text: "Texte court",
       email: "E-mail",
@@ -110,6 +113,7 @@ const messages = {
       date: "Date",
       rating: "Notation",
       scale: "Échelle",
+      file: "Téléversement de fichiers",
     },
   },
   builder: {
@@ -182,6 +186,7 @@ const messages = {
       dateLabel: "Date",
       ratingLabel: "Note",
       scaleLabel: "Échelle",
+      fileLabel: "Téléversement de fichiers",
       option1: "Choix 1",
       option2: "Choix 2",
       option3: "Choix 3",

--- a/templates/forms/app/i18n/hi-IN.ts
+++ b/templates/forms/app/i18n/hi-IN.ts
@@ -96,6 +96,9 @@ const messages = {
     conditionContains: "में शामिल है",
     conditionValue: "उत्तर",
     conditionValuePlaceholder: "उत्तर दर्ज करें...",
+    allowMultiple: "एक से अधिक फ़ाइलें अनुमति दें",
+    accept: "स्वीकार किए गए फ़ाइल प्रकार",
+    acceptPlaceholder: "उदा. image/*, .pdf",
     fieldTypes: {
       text: "लघु पाठ",
       email: "ईमेल",
@@ -108,6 +111,7 @@ const messages = {
       date: "तारीख",
       rating: "रेटिंग",
       scale: "पैमाना",
+      file: "फ़ाइल अपलोड",
     },
   },
   builder: {
@@ -178,6 +182,7 @@ const messages = {
       dateLabel: "तारीख",
       ratingLabel: "रेटिंग",
       scaleLabel: "पैमाना",
+      fileLabel: "फ़ाइल अपलोड",
       option1: "विकल्प 1",
       option2: "विकल्प 2",
       option3: "विकल्प 3",

--- a/templates/forms/app/i18n/ja-JP.ts
+++ b/templates/forms/app/i18n/ja-JP.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "含む",
     conditionValue: "回答",
     conditionValuePlaceholder: "回答を入力...",
+    allowMultiple: "複数ファイルを許可",
+    accept: "許可するファイル形式",
+    acceptPlaceholder: "例: image/*, .pdf",
     fieldTypes: {
       text: "短いテキスト",
       email: "電子メール",
@@ -110,6 +113,7 @@ const messages = {
       date: "日付",
       rating: "評価",
       scale: "規模",
+      file: "ファイルアップロード",
     },
   },
   builder: {
@@ -180,6 +184,7 @@ const messages = {
       dateLabel: "日付",
       ratingLabel: "評価",
       scaleLabel: "スケール",
+      fileLabel: "ファイルアップロード",
       option1: "選択肢 1",
       option2: "選択肢 2",
       option3: "選択肢 3",

--- a/templates/forms/app/i18n/ko-KR.ts
+++ b/templates/forms/app/i18n/ko-KR.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "포함",
     conditionValue: "답변",
     conditionValuePlaceholder: "답변 입력...",
+    allowMultiple: "여러 파일 허용",
+    accept: "허용되는 파일 형식",
+    acceptPlaceholder: "예: image/*, .pdf",
     fieldTypes: {
       text: "짧은 텍스트",
       email: "이메일",
@@ -110,6 +113,7 @@ const messages = {
       date: "날짜",
       rating: "평가",
       scale: "규모",
+      file: "파일 업로드",
     },
   },
   builder: {
@@ -177,6 +181,7 @@ const messages = {
       dateLabel: "날짜",
       ratingLabel: "평점",
       scaleLabel: "척도",
+      fileLabel: "파일 업로드",
       option1: "옵션 1",
       option2: "옵션 2",
       option3: "옵션 3",

--- a/templates/forms/app/i18n/pt-BR.ts
+++ b/templates/forms/app/i18n/pt-BR.ts
@@ -98,6 +98,9 @@ const messages = {
     conditionContains: "contém",
     conditionValue: "Resposta",
     conditionValuePlaceholder: "Digite uma resposta...",
+    allowMultiple: "Permitir vários arquivos",
+    accept: "Tipos de arquivo aceitos",
+    acceptPlaceholder: "ex.: image/*, .pdf",
     fieldTypes: {
       text: "Texto curto",
       email: "E-mail",
@@ -110,6 +113,7 @@ const messages = {
       date: "Data",
       rating: "Avaliação",
       scale: "Escala",
+      file: "Upload de arquivos",
     },
   },
   builder: {
@@ -181,6 +185,7 @@ const messages = {
       dateLabel: "Data",
       ratingLabel: "Avaliação",
       scaleLabel: "Escala",
+      fileLabel: "Upload de arquivos",
       option1: "Opção 1",
       option2: "Opção 2",
       option3: "Opção 3",

--- a/templates/forms/app/i18n/zh-CN.ts
+++ b/templates/forms/app/i18n/zh-CN.ts
@@ -93,6 +93,9 @@ const messages = {
     conditionContains: "包含",
     conditionValue: "答案",
     conditionValuePlaceholder: "输入答案...",
+    allowMultiple: "允许多个文件",
+    accept: "接受的文件类型",
+    acceptPlaceholder: "image/*、.pdf",
     fieldTypes: {
       text: "短文本",
       email: "电子邮件",
@@ -105,6 +108,7 @@ const messages = {
       date: "日期",
       rating: "等级",
       scale: "规模",
+      file: "文件上传",
     },
   },
   builder: {
@@ -167,6 +171,7 @@ const messages = {
       dateLabel: "日期",
       ratingLabel: "评分",
       scaleLabel: "量表",
+      fileLabel: "文件上传",
       option1: "选项 1",
       option2: "选项 2",
       option3: "选项 3",

--- a/templates/forms/app/i18n/zh-TW.ts
+++ b/templates/forms/app/i18n/zh-TW.ts
@@ -93,6 +93,9 @@ const messages = {
     conditionContains: "包含",
     conditionValue: "答案",
     conditionValuePlaceholder: "輸入答案...",
+    allowMultiple: "允許多個檔案",
+    accept: "接受的檔案類型",
+    acceptPlaceholder: "image/*、.pdf",
     fieldTypes: {
       text: "短文字",
       email: "電子郵件",
@@ -105,6 +108,7 @@ const messages = {
       date: "日期",
       rating: "等級",
       scale: "規模",
+      file: "檔案上傳",
     },
   },
   builder: {
@@ -167,6 +171,7 @@ const messages = {
       dateLabel: "日期",
       ratingLabel: "評分",
       scaleLabel: "量表",
+      fileLabel: "檔案上傳",
       option1: "選項 1",
       option2: "選項 2",
       option3: "選項 3",

--- a/templates/forms/app/lib/form-field-types.ts
+++ b/templates/forms/app/lib/form-field-types.ts
@@ -1,0 +1,21 @@
+import type { FormField, FormFieldType } from "@shared/types";
+
+export const FILE_FIELD_TYPE = "file" as const;
+export type AppFormFieldType = FormFieldType | typeof FILE_FIELD_TYPE;
+export type AppFormField = Omit<FormField, "type"> & {
+  type: AppFormFieldType;
+  multiple?: boolean;
+  accept?: string;
+};
+
+export function isFileField(field: FormField | AppFormField): boolean {
+  return (field.type as string) === FILE_FIELD_TYPE;
+}
+
+export function getFileFieldOptions(field: FormField | AppFormField) {
+  const appField = field as AppFormField;
+  return {
+    multiple: appField.multiple === true,
+    accept: appField.accept?.trim() || undefined,
+  };
+}

--- a/templates/forms/app/lib/normalize-fields.test.ts
+++ b/templates/forms/app/lib/normalize-fields.test.ts
@@ -1,0 +1,23 @@
+import type { FormField } from "@shared/types";
+import { describe, expect, it } from "vitest";
+
+import { normalizeFields } from "./normalize-fields";
+
+describe("normalizeFields", () => {
+  it("keeps file fields renderable", () => {
+    const field = {
+      id: "attachments",
+      type: "file",
+      label: "Attachments",
+      required: false,
+      multiple: true,
+      accept: "image/*",
+    } as FormField;
+
+    expect(normalizeFields([field])[0]).toMatchObject({
+      type: "file",
+      multiple: true,
+      accept: "image/*",
+    });
+  });
+});

--- a/templates/forms/app/lib/normalize-fields.ts
+++ b/templates/forms/app/lib/normalize-fields.ts
@@ -1,5 +1,7 @@
 import type { FormField, FormFieldType } from "@shared/types";
 
+import type { AppFormFieldType } from "@/lib/form-field-types";
+
 // Single source of truth for coercing FormField[] coming back from the API
 // into a renderable shape. Both the agent and the UI can write arbitrary
 // JSON into form.fields — this helper protects every React consumer from:
@@ -11,7 +13,7 @@ import type { FormField, FormFieldType } from "@shared/types";
 // FieldRenderer keeps its own `dedupeRenderableOptions` for the *builder*
 // preview where the user is mid-typing — that handles transient live-edit
 // state, not stored data.
-const KNOWN_FIELD_TYPES: FormFieldType[] = [
+const KNOWN_FIELD_TYPES: AppFormFieldType[] = [
   "text",
   "email",
   "number",
@@ -23,6 +25,7 @@ const KNOWN_FIELD_TYPES: FormFieldType[] = [
   "date",
   "rating",
   "scale",
+  "file",
 ];
 
 function coerceOptionToString(raw: unknown): string | null {

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -100,6 +100,7 @@ import {
   normalizeFormBuilderTab,
   type FormBuilderTab,
 } from "@/lib/form-builder-tabs";
+import type { AppFormFieldType } from "@/lib/form-field-types";
 import { normalizeFields } from "@/lib/normalize-fields";
 import { getPublishedFormUrl } from "@/lib/public-form-link";
 import { cn } from "@/lib/utils";
@@ -108,7 +109,7 @@ type Translator = ReturnType<typeof useT>;
 
 function getFieldTypeDefaults(
   t: Translator,
-): Record<FormFieldType, Partial<FormField>> {
+): Record<AppFormFieldType, Partial<FormField>> {
   const defaultOptions = [
     t("builder.fieldDefaults.option1"),
     t("builder.fieldDefaults.option2"),
@@ -149,6 +150,9 @@ function getFieldTypeDefaults(
     scale: {
       label: t("builder.fieldDefaults.scaleLabel"),
       validation: { min: 1, max: 10 },
+    },
+    file: {
+      label: t("builder.fieldDefaults.fileLabel"),
     },
   };
 }
@@ -466,19 +470,20 @@ export function FormBuilderPage() {
   // Viewers can see the form but not edit it or peek at responses / settings /
   // integrations. The role is set by `get-form` based on ownership + shares.
 
-  function addField(type: FormFieldType) {
+  function addField(type: AppFormFieldType) {
     const fieldTypeDefaults = getFieldTypeDefaults(t);
     const defaults = fieldTypeDefaults[type] || {};
-    const newField: FormField = {
+    const newField = {
       id: nanoid(8),
-      type,
+      type: type as FormFieldType,
       label: defaults.label || t("builder.fieldDefaults.newField"),
       placeholder: defaults.placeholder,
       required: false,
       options: defaults.options,
       validation: defaults.validation,
       width: "full",
-    };
+      ...(type === "file" ? { multiple: true } : {}),
+    } as FormField;
     setLocalFields((prev) => [...prev, newField]);
     fieldsDirty.current = true;
     saveFieldOps([{ op: "upsert", field: newField }]);
@@ -1011,13 +1016,13 @@ function BuilderContent({
   onDragStart: (idx: number) => void;
   onDragOver: (e: React.DragEvent, idx: number) => void;
   onDragEnd: () => void;
-  onAddField: (type: FormFieldType) => void;
+  onAddField: (type: AppFormFieldType) => void;
   onAgentPopoverChange: (open: boolean) => void;
   onAgentPromptChange: (v: string) => void;
   onSubmitAgent: () => void;
 }) {
   const t = useT();
-  const fieldTypeLabels: Record<FormFieldType, string> = {
+  const fieldTypeLabels: Record<AppFormFieldType, string> = {
     text: t("fieldProperties.fieldTypes.text"),
     email: t("fieldProperties.fieldTypes.email"),
     number: t("fieldProperties.fieldTypes.number"),
@@ -1029,6 +1034,7 @@ function BuilderContent({
     date: t("fieldProperties.fieldTypes.date"),
     rating: t("fieldProperties.fieldTypes.rating"),
     scale: t("fieldProperties.fieldTypes.scale"),
+    file: t("fieldProperties.fieldTypes.file"),
   };
 
   return (
@@ -1158,7 +1164,7 @@ function BuilderContent({
                   {Object.entries(fieldTypeLabels).map(([type, label]) => (
                     <DropdownMenuItem
                       key={type}
-                      onClick={() => onAddField(type as FormFieldType)}
+                      onClick={() => onAddField(type as AppFormFieldType)}
                     >
                       {label}
                     </DropdownMenuItem>

--- a/templates/forms/app/pages/FormFillPage.tsx
+++ b/templates/forms/app/pages/FormFillPage.tsx
@@ -128,7 +128,12 @@ export function FormFillPage() {
     for (const field of visibleFields) {
       if (field.required) {
         const val = values[field.id];
-        if (val === undefined || val === null || val === "") {
+        if (
+          val === undefined ||
+          val === null ||
+          val === "" ||
+          (Array.isArray(val) && val.length === 0)
+        ) {
           return `${field.label} is required`;
         }
       }

--- a/templates/forms/app/routes/form-preview.tsx
+++ b/templates/forms/app/routes/form-preview.tsx
@@ -4,7 +4,6 @@ import {
   postNavigate,
 } from "@agent-native/core/client/navigation";
 import { normalizeDocumentTitle } from "@agent-native/core/shared";
-import type { FormFieldType } from "@shared/types";
 import {
   IconAlertCircle,
   IconExternalLink,
@@ -19,6 +18,7 @@ import {
   IconStar,
   IconSlideshow,
   IconList,
+  IconFile,
 } from "@tabler/icons-react";
 import { useEffect } from "react";
 import { useSearchParams } from "react-router";
@@ -27,9 +27,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useForm } from "@/hooks/use-forms";
+import type { AppFormFieldType } from "@/lib/form-field-types";
 import { normalizeFields } from "@/lib/normalize-fields";
 
-const FIELD_TYPE_LABEL_KEYS: Record<FormFieldType, string> = {
+const FIELD_TYPE_LABEL_KEYS: Record<AppFormFieldType, string> = {
   text: "fieldProperties.fieldTypes.text", // i18n-ignore stable catalog key
   email: "fieldProperties.fieldTypes.email", // i18n-ignore stable catalog key
   number: "fieldProperties.fieldTypes.number", // i18n-ignore stable catalog key
@@ -41,9 +42,10 @@ const FIELD_TYPE_LABEL_KEYS: Record<FormFieldType, string> = {
   date: "fieldProperties.fieldTypes.date", // i18n-ignore stable catalog key
   rating: "fieldProperties.fieldTypes.rating", // i18n-ignore stable catalog key
   scale: "fieldProperties.fieldTypes.scale", // i18n-ignore stable catalog key
+  file: "fieldProperties.fieldTypes.file", // i18n-ignore stable catalog key
 };
 
-const FIELD_TYPE_ICONS: Record<FormFieldType, React.ElementType> = {
+const FIELD_TYPE_ICONS: Record<AppFormFieldType, React.ElementType> = {
   text: IconTextSize,
   email: IconAt,
   number: IconNumber123,
@@ -55,6 +57,7 @@ const FIELD_TYPE_ICONS: Record<FormFieldType, React.ElementType> = {
   date: IconCalendar,
   rating: IconStar,
   scale: IconSlideshow,
+  file: IconFile,
 };
 
 export default function FormPreviewRoute() {
@@ -180,11 +183,11 @@ export default function FormPreviewRoute() {
             </p>
             <div className="divide-y divide-border rounded-md border bg-card">
               {fields.map((field) => {
-                const Icon =
-                  FIELD_TYPE_ICONS[field.type as FormFieldType] ?? IconTextSize;
+                const fieldType = field.type as AppFormFieldType;
+                const Icon = FIELD_TYPE_ICONS[fieldType] ?? IconTextSize;
                 const typeLabel =
-                  field.type in FIELD_TYPE_LABEL_KEYS
-                    ? t(FIELD_TYPE_LABEL_KEYS[field.type as FormFieldType])
+                  fieldType in FIELD_TYPE_LABEL_KEYS
+                    ? t(FIELD_TYPE_LABEL_KEYS[fieldType])
                     : field.type;
                 return (
                   <div

--- a/templates/forms/server/handlers/forms.ts
+++ b/templates/forms/server/handlers/forms.ts
@@ -1,4 +1,3 @@
-import { eq } from "drizzle-orm";
 import {
   defineEventHandler,
   getRequestURL,
@@ -7,7 +6,8 @@ import {
 } from "h3";
 
 import { toPublicFormSettings, type FormSettings } from "../../shared/types.js";
-import { getDb, schema } from "../db/index.js";
+import { getDb } from "../db/index.js";
+import { findFormBySlugOrId } from "../lib/form-lookup.js";
 
 // ---------------------------------------------------------------------------
 // Public form handler (unauthenticated — stays as API route)
@@ -24,22 +24,7 @@ export const getPublicForm = defineEventHandler(async (event: H3Event) => {
     return { error: "Form not found" };
   }
 
-  const db = getDb();
-  // Try matching by slug first, then fall back to matching by ID
-  let row = await db
-    .select()
-    .from(schema.forms)
-    .where(eq(schema.forms.slug, slug))
-    .then((rows) => rows[0]);
-
-  if (!row) {
-    // Fall back to ID-based lookup (for legacy URLs or direct ID access)
-    row = await db
-      .select()
-      .from(schema.forms)
-      .where(eq(schema.forms.id, slug))
-      .then((rows) => rows[0]);
-  }
+  const row = await findFormBySlugOrId(getDb(), slug);
 
   if (!row || row.status !== "published" || row.deletedAt) {
     setResponseStatus(event, 404);

--- a/templates/forms/server/handlers/submissions.spec.ts
+++ b/templates/forms/server/handlers/submissions.spec.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
   renewedClaims: [] as Array<{ id: string; claimedAt: string }>,
   requestContexts: [] as Array<Record<string, unknown>>,
   session: null as null | { email?: string; orgId?: string },
+  formIdentifier: "form_1",
 }));
 
 const sendEmail = vi.hoisted(() =>
@@ -20,6 +21,7 @@ const sendEmail = vi.hoisted(() =>
 const fireIntegrations = vi.hoisted(() => vi.fn());
 const buildIntegrationDeliverySnapshots = vi.hoisted(() => vi.fn());
 const deliverIntegrationDelivery = vi.hoisted(() => vi.fn());
+const setResponseHeader = vi.hoisted(() => vi.fn());
 
 const publishedForm = {
   id: "form_1",
@@ -36,11 +38,12 @@ const publishedForm = {
 
 vi.mock("h3", () => ({
   defineEventHandler: (fn: unknown) => fn,
-  getRouterParam: () => "form_1",
+  getRouterParam: () => state.formIdentifier,
   getQuery: () => ({}),
   getRequestHeader: (_event: unknown, name: string) =>
     state.headers[name.toLowerCase()],
   setResponseStatus: vi.fn(),
+  setResponseHeader,
   getRequestIP: () => "1.2.3.4",
 }));
 
@@ -52,6 +55,11 @@ vi.mock("@agent-native/core/server", () => ({
     return fn();
   },
   verifyCaptcha: async () => ({ success: true }),
+  isAllowedUploadMimeType: (mimeType: string) =>
+    /^(image|video|audio|text)\//.test(mimeType) ||
+    ["application/json", "application/pdf", "application/zip"].includes(
+      mimeType,
+    ),
   emailStrong: (value: string) => value,
   renderEmail: ({ paragraphs }: { paragraphs: string[] }) => ({
     html: paragraphs.join("\n"),
@@ -116,11 +124,17 @@ vi.mock("../db/index.js", async () => {
               ),
             );
           }
-          return Promise.resolve(
-            publishedForm.status === "published" && !publishedForm.deletedAt
-              ? [publishedForm]
-              : [],
-          );
+          if (table === schema.forms) {
+            return Promise.resolve(
+              publishedForm.status === "published" && !publishedForm.deletedAt
+                ? params[0] === publishedForm.id ||
+                  params[0] === publishedForm.slug
+                  ? [publishedForm]
+                  : []
+                : [],
+            );
+          }
+          return Promise.resolve([]);
         },
       }),
     }),
@@ -282,6 +296,8 @@ describe("submitForm pageUrl pass-through", () => {
     state.renewedClaims.length = 0;
     state.requestContexts.length = 0;
     state.session = null;
+    state.formIdentifier = "form_1";
+    setResponseHeader.mockClear();
     publishedForm.status = "published";
     publishedForm.deletedAt = null;
     publishedForm.fields = JSON.stringify([
@@ -367,6 +383,85 @@ describe("submitForm pageUrl pass-through", () => {
     expect(state.inserted).toHaveLength(1);
     expect(state.inserted[0]!.pageUrl).toBeNull();
     expect(state.inserted[0]!.clientSurface).toBeNull();
+  });
+
+  it("resolves a slug and persists only validated file reference metadata", async () => {
+    state.formIdentifier = "agent-native-feedback";
+    publishedForm.fields = JSON.stringify([
+      {
+        id: "attachment",
+        type: "file",
+        label: "Attachment",
+        required: true,
+        accept: "image/png",
+      },
+    ]);
+    publishedForm.settings = JSON.stringify({
+      allowedOrigins: ["https://docs.example.com"],
+    });
+    state.headers.origin = "https://docs.example.com";
+
+    const res = await submit({
+      data: {
+        attachment: {
+          url: "https://cdn.example.test/attachment.png",
+          name: "attachment.png",
+          type: "image/png",
+          size: 42,
+          id: "asset-1",
+          provider: "builder",
+          handle: "handle-1",
+        },
+      },
+    });
+
+    expect(res).toMatchObject({ success: true });
+    expect(setResponseHeader).toHaveBeenCalledWith(
+      {},
+      "Access-Control-Allow-Origin",
+      "https://docs.example.com",
+    );
+    expect(setResponseHeader).toHaveBeenCalledWith({}, "Vary", "Origin");
+    expect(state.inserted[0]!.formId).toBe("form_1");
+    expect(JSON.parse(String(state.inserted[0]!.data))).toEqual({
+      attachment: {
+        url: "https://cdn.example.test/attachment.png",
+        name: "attachment.png",
+        type: "image/png",
+        size: 42,
+        id: "asset-1",
+        provider: "builder",
+        handle: "handle-1",
+      },
+    });
+  });
+
+  it("rejects file submissions from origins outside the form allowlist", async () => {
+    state.formIdentifier = "agent-native-feedback";
+    publishedForm.fields = JSON.stringify([
+      {
+        id: "attachment",
+        type: "file",
+        label: "Attachment",
+        required: false,
+      },
+    ]);
+    publishedForm.settings = JSON.stringify({
+      allowedOrigins: ["https://docs.example.com"],
+    });
+    state.headers.origin = "https://untrusted.example.com";
+
+    const res = await submit({ data: {} });
+
+    expect(res).toEqual({ error: "Origin not allowed" });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("keeps the JSON submission body bounded", async () => {
+    const res = await submit({ data: { msg: "x".repeat(101 * 1024) } });
+
+    expect(res).toEqual({ error: "Payload too large" });
+    expect(state.inserted).toHaveLength(0);
   });
 
   it("replays an idempotent submission without inserting a duplicate response", async () => {

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -32,6 +32,12 @@ import type {
   FormSettings,
 } from "../../shared/types.js";
 import { getDb, schema } from "../db/index.js";
+import { findFormBySlugOrId } from "../lib/form-lookup.js";
+import {
+  isPublicFormOriginAllowed,
+  parseStoredFormSettings,
+  setPublicFormCors,
+} from "../lib/form-request.js";
 import {
   buildIntegrationDeliverySnapshots,
   deliverIntegrationDelivery,
@@ -44,8 +50,10 @@ import {
 } from "../lib/response-email.js";
 import {
   isEmptySubmissionValue,
+  sanitizeSubmissionFieldValue,
   validateSubmissionField,
 } from "../lib/submission-validation.js";
+import { assertValidFields } from "../lib/validate-fields.js";
 
 const MAX_PAYLOAD_BYTES = 100 * 1024; // 100KB
 const MIN_FILL_TIME_MS = 500; // reject submits faster than this
@@ -56,6 +64,15 @@ const APPLICATION_STATE_DESTINATION = "application-state";
 const RESPONSE_EMAIL_DESTINATION = "email";
 const DELIVERY_CLAIM_LEASE_MS = 60_000;
 const DELIVERY_CLAIM_HEARTBEAT_MS = Math.floor(DELIVERY_CLAIM_LEASE_MS / 3);
+
+function requestPayloadExceedsLimit(event: H3Event): boolean {
+  const raw = getRequestHeader(event, "content-length");
+  if (!raw) return false;
+  const length = Number(raw);
+  return (
+    !Number.isSafeInteger(length) || length < 0 || length > MAX_PAYLOAD_BYTES
+  );
+}
 
 type ResponseDeliveryStatus = "pending" | "processing" | "succeeded" | "failed";
 
@@ -847,7 +864,12 @@ async function deliverResponseSideEffects({
 
 export const submitForm = defineEventHandler(async (event: H3Event) => {
   const db = getDb();
-  const id = getRouterParam(event, "id") as string;
+  const requestedFormId = getRouterParam(event, "id")?.trim() ?? "";
+
+  if (requestPayloadExceedsLimit(event)) {
+    setResponseStatus(event, 413);
+    return { error: "Payload too large" };
+  }
 
   // coercion-ok: malformed request bodies are rejected as invalid submissions.
   const body = await readBody(event).catch(() => null);
@@ -861,6 +883,24 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
   if (Buffer.byteLength(bodyStr, "utf8") > MAX_PAYLOAD_BYTES) {
     setResponseStatus(event, 413);
     return { error: "Payload too large" };
+  }
+
+  const form = await findFormBySlugOrId(db, requestedFormId);
+  const id = form?.id ?? requestedFormId;
+
+  let settings: FormSettings = {};
+  if (form) {
+    try {
+      settings = parseStoredFormSettings(form.settings);
+    } catch {
+      setResponseStatus(event, 500);
+      return { error: "Form configuration is invalid" };
+    }
+    setPublicFormCors(event, settings);
+    if (!isPublicFormOriginAllowed(event, settings)) {
+      setResponseStatus(event, 403);
+      return { error: "Origin not allowed" };
+    }
   }
 
   const rawIdempotencyKey = getRequestHeader(event, "idempotency-key");
@@ -922,39 +962,25 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  // guard:allow-unscoped — public submission endpoint intentionally accepts anonymous responses for published forms by id; it returns no owner data and rejects non-published forms.
+  // guard:allow-unscoped — public submission endpoint intentionally accepts anonymous responses for published forms by slug or id; it returns no owner data and rejects non-published forms.
   // Public submission endpoint: published forms are intentionally readable
-  // without an authenticated viewer, but only by exact id and published status.
+  // without an authenticated viewer, but only by a resolved public identifier
+  // and published status.
   // guard:allow-unscoped — anonymous respondents must be able to submit published forms; unpublished/private forms still return 404
-  const form = await db
-    .select()
-    .from(schema.forms)
-    .where(
-      and(
-        eq(schema.forms.id, id),
-        eq(schema.forms.status, "published"),
-        isNull(schema.forms.deletedAt),
-      ),
-    )
-
-    .then((rows) => rows[0]);
   if (!form) {
     setResponseStatus(event, 404);
     return { error: "Form not found or not accepting responses" };
   }
 
-  const settings: FormSettings = form.settings ? JSON.parse(form.settings) : {};
+  if (form.status !== "published" || form.deletedAt) {
+    setResponseStatus(event, 404);
+    return { error: "Form not found or not accepting responses" };
+  }
 
-  // Origin allowlist (per-form). Empty/unset = allow any (back-compat).
-  // Skip for same-origin requests (no Origin header set by browser on
-  // same-origin POSTs from some setups).
-  const allowedOrigins = settings.allowedOrigins ?? [];
-  if (allowedOrigins.length > 0) {
-    const origin = getRequestHeader(event, "origin");
-    if (!origin || !allowedOrigins.includes(origin)) {
-      setResponseStatus(event, 403);
-      return { error: "Origin not allowed" };
-    }
+  setPublicFormCors(event, settings);
+  if (!isPublicFormOriginAllowed(event, settings)) {
+    setResponseStatus(event, 403);
+    return { error: "Origin not allowed" };
   }
 
   const finishResponse = async ({
@@ -1078,8 +1104,17 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  // Parse form fields and build whitelist of valid field IDs
-  const fields: FormField[] = JSON.parse(form.fields);
+  // Parse form fields and build whitelist of valid field IDs. Published forms
+  // must pass the same structural checks as forms at write time because the
+  // public route is also reachable for legacy rows and direct HTTP clients.
+  let fields: FormField[];
+  try {
+    fields = JSON.parse(form.fields);
+    assertValidFields(fields);
+  } catch {
+    setResponseStatus(event, 500);
+    return { error: "Form configuration is invalid" };
+  }
   const fieldMap = new Map(fields.map((f) => [f.id, f]));
   const submittedData =
     body.data && typeof body.data === "object" && !Array.isArray(body.data)
@@ -1112,6 +1147,14 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
     if (validationError) {
       setResponseStatus(event, 400);
       return { error: validationError };
+    }
+
+    if (
+      field.type === "file" &&
+      Object.prototype.hasOwnProperty.call(data, field.id) &&
+      !isEmptySubmissionValue(val)
+    ) {
+      data[field.id] = sanitizeSubmissionFieldValue(field, val);
     }
   }
 

--- a/templates/forms/server/handlers/uploads.test.ts
+++ b/templates/forms/server/handlers/uploads.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  form: {
+    id: "form-1",
+    slug: "community-form",
+    title: "Community form",
+    fields: JSON.stringify([
+      {
+        id: "screenshots",
+        type: "file",
+        label: "Screenshots",
+        required: false,
+        multiple: true,
+        accept: "image/png",
+        maxSizeBytes: 100,
+        maxFiles: 3,
+      },
+    ]),
+    settings: JSON.stringify({ allowedOrigins: ["https://docs.example.com"] }),
+    status: "published",
+    deletedAt: null as string | null,
+    ownerEmail: "forms-owner@builder.io",
+    orgId: "builder-org",
+  },
+  identifier: "community-form",
+  headers: {} as Record<string, string | undefined>,
+  parts: [] as Array<{
+    name?: string;
+    filename?: string;
+    type?: string;
+    data: Buffer;
+  }>,
+  status: 200,
+  responseHeaders: {} as Record<string, string>,
+  requestContexts: [] as Array<Record<string, unknown>>,
+}));
+
+const uploadFile = vi.hoisted(() => vi.fn());
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: unknown) => handler,
+  getRequestHeader: (_event: unknown, name: string) =>
+    state.headers[name.toLowerCase()],
+  getRouterParam: () => state.identifier,
+  readMultipartFormData: async () => state.parts,
+  setResponseHeader: (_event: unknown, name: string, value: string) => {
+    state.responseHeaders[name] = value;
+  },
+  setResponseStatus: (_event: unknown, status: number) => {
+    state.status = status;
+  },
+}));
+
+vi.mock("@agent-native/core/file-upload", () => ({ uploadFile }));
+
+vi.mock("@agent-native/core/server", () => ({
+  isAllowedUploadMimeType: (mimeType: string) =>
+    /^(image|video|audio|text)\//.test(mimeType) ||
+    ["application/json", "application/pdf", "application/zip"].includes(
+      mimeType,
+    ),
+  runWithRequestContext: async (
+    context: Record<string, unknown>,
+    callback: () => unknown,
+  ) => {
+    state.requestContexts.push(context);
+    return callback();
+  },
+}));
+
+vi.mock("../db/index.js", async () => {
+  const schema =
+    await vi.importActual<typeof import("../db/schema.js")>("../db/schema.js");
+  return {
+    schema,
+    getDb: () => ({
+      select: () => ({
+        from: () => ({
+          where: async () => [state.form],
+        }),
+      }),
+    }),
+  };
+});
+
+const { uploadFormFile } = await import("./uploads.js");
+
+function event() {
+  return {} as any;
+}
+
+function setValidRequest() {
+  state.identifier = "community-form";
+  state.headers = {
+    origin: "https://docs.example.com",
+    "content-type": "multipart/form-data; boundary=test",
+    "content-length": "256",
+  };
+  state.parts = [
+    { name: "fieldId", data: Buffer.from("screenshots") },
+    {
+      name: "file",
+      filename: "screen.png",
+      type: "image/png",
+      data: Buffer.from("png"),
+    },
+  ];
+  state.status = 200;
+  state.responseHeaders = {};
+  state.requestContexts = [];
+  uploadFile.mockReset();
+  uploadFile.mockResolvedValue({
+    url: "https://cdn.example.test/screen.png",
+    id: "asset-1",
+    provider: "builder",
+  });
+}
+
+describe("public form file uploads", () => {
+  beforeEach(setValidRequest);
+
+  it("resolves a public identifier and uploads through the scoped core provider", async () => {
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(201);
+    expect(state.responseHeaders).toEqual({
+      "Access-Control-Allow-Origin": "https://docs.example.com",
+      Vary: "Origin",
+    });
+    expect(state.requestContexts).toEqual([
+      { userEmail: "forms-owner@builder.io", orgId: "builder-org" },
+    ]);
+    expect(uploadFile).toHaveBeenCalledWith({
+      data: Buffer.from("png"),
+      filename: "screen.png",
+      mimeType: "image/png",
+      ownerEmail: "forms-owner@builder.io",
+      stableUrl: true,
+      recordAsset: false,
+    });
+    expect(result).toEqual({
+      url: "https://cdn.example.test/screen.png",
+      name: "screen.png",
+      type: "image/png",
+      size: 3,
+      id: "asset-1",
+      provider: "builder",
+    });
+  });
+
+  it("rejects a disallowed origin before reading or storing the file", async () => {
+    state.headers.origin = "https://untrusted.example.com";
+
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(403);
+    expect(result).toEqual({ error: "Origin not allowed" });
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized and disallowed files before provider upload", async () => {
+    state.parts[1] = {
+      name: "file",
+      filename: "payload.exe",
+      type: "application/x-msdownload",
+      data: Buffer.alloc(101),
+    };
+
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(413);
+    expect(result).toEqual({ error: "File is too large" });
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects files that fail the form accept filter", async () => {
+    state.parts[1] = {
+      name: "file",
+      filename: "notes.txt",
+      type: "text/plain",
+      data: Buffer.from("notes"),
+    };
+
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(415);
+    expect(result).toEqual({ error: "File type is not accepted by this form" });
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it("reports unavailable storage without returning file bytes as a fallback", async () => {
+    uploadFile.mockResolvedValue(null);
+
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(503);
+    expect(result).toMatchObject({
+      error: expect.stringContaining("File storage is not configured"),
+      storageSetupRequired: true,
+    });
+    expect(result).not.toHaveProperty("data");
+  });
+
+  it("rejects an invalid URL returned by the storage provider", async () => {
+    uploadFile.mockResolvedValue({
+      url: "data:image/png;base64,not-a-public-storage-url",
+      provider: "builder",
+    });
+
+    const result = await uploadFormFile(event());
+
+    expect(state.status).toBe(502);
+    expect(result).toEqual({
+      error: "File storage returned an invalid file URL",
+    });
+  });
+});

--- a/templates/forms/server/handlers/uploads.ts
+++ b/templates/forms/server/handlers/uploads.ts
@@ -1,0 +1,193 @@
+import { uploadFile } from "@agent-native/core/file-upload";
+import {
+  isAllowedUploadMimeType,
+  runWithRequestContext,
+} from "@agent-native/core/server";
+import {
+  defineEventHandler,
+  getRequestHeader,
+  getRouterParam,
+  readMultipartFormData,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+
+import type { FormField, FormSettings } from "../../shared/types.js";
+import { getDb } from "../db/index.js";
+import {
+  acceptsFormFileType,
+  DEFAULT_FORM_FILE_MAX_BYTES,
+  formFileMaxBytes,
+  isSafeFormFileUrl,
+  MAX_FORM_FILE_NAME_LENGTH,
+} from "../lib/file-upload-policy.js";
+import { findFormBySlugOrId } from "../lib/form-lookup.js";
+import {
+  isPublicFormOriginAllowed,
+  parseStoredFormSettings,
+  setPublicFormCors,
+} from "../lib/form-request.js";
+import { assertValidFields } from "../lib/validate-fields.js";
+
+const MAX_UPLOAD_REQUEST_BYTES = DEFAULT_FORM_FILE_MAX_BYTES + 32 * 1024;
+
+function cleanFilename(value: string | undefined): string {
+  const filename = (value || "upload")
+    .replace(/[\\/]/g, "_")
+    .replace(/[\x00-\x1f\x7f]/g, "_")
+    .trim()
+    .slice(0, MAX_FORM_FILE_NAME_LENGTH);
+  return filename || "upload";
+}
+
+function invalidFormResponse(event: H3Event) {
+  setResponseStatus(event, 500);
+  return { error: "Form configuration is invalid" };
+}
+
+function contentLengthExceedsLimit(event: H3Event): boolean {
+  const raw = getRequestHeader(event, "content-length");
+  if (!raw) return false;
+  const length = Number(raw);
+  return !Number.isSafeInteger(length) || length > MAX_UPLOAD_REQUEST_BYTES;
+}
+
+export const uploadFormFile = defineEventHandler(async (event: H3Event) => {
+  const identifier = getRouterParam(event, "id")?.trim() ?? "";
+  const form = await findFormBySlugOrId(getDb(), identifier);
+  if (!form || form.status !== "published" || form.deletedAt) {
+    setResponseStatus(event, 404);
+    return { error: "Form not found or not accepting responses" };
+  }
+
+  let settings: FormSettings;
+  let fields: FormField[];
+  try {
+    settings = parseStoredFormSettings(form.settings);
+    fields = JSON.parse(form.fields);
+    assertValidFields(fields);
+  } catch {
+    return invalidFormResponse(event);
+  }
+
+  setPublicFormCors(event, settings);
+  if (!isPublicFormOriginAllowed(event, settings)) {
+    setResponseStatus(event, 403);
+    return { error: "Origin not allowed" };
+  }
+
+  const contentType = getRequestHeader(event, "content-type") ?? "";
+  if (!/^multipart\/form-data(?:;|$)/i.test(contentType)) {
+    setResponseStatus(event, 415);
+    return { error: "File uploads must use multipart/form-data" };
+  }
+  if (contentLengthExceedsLimit(event)) {
+    setResponseStatus(event, 413);
+    return { error: "File upload is too large" };
+  }
+
+  let parts;
+  try {
+    parts = await readMultipartFormData(event);
+  } catch (error) {
+    console.warn(
+      "[forms] multipart file upload could not be parsed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    setResponseStatus(event, 400);
+    return { error: "Invalid file upload" };
+  }
+  if (!parts) {
+    setResponseStatus(event, 400);
+    return { error: "Invalid file upload" };
+  }
+
+  const fieldParts = parts.filter((part) => part.name === "fieldId");
+  const fileParts = parts.filter(
+    (part) => part.name === "file" && part.filename !== undefined,
+  );
+  const fieldId = fieldParts[0]?.data
+    ? Buffer.from(fieldParts[0].data).toString("utf8").trim()
+    : "";
+  if (
+    fieldParts.length !== 1 ||
+    fileParts.length !== 1 ||
+    !fieldParts[0]?.data ||
+    !fileParts[0].data.length ||
+    !fieldId
+  ) {
+    setResponseStatus(event, 400);
+    return { error: "A field and one file are required" };
+  }
+
+  const field = fields.find((candidate) => candidate.id === fieldId);
+  if (!field || field.type !== "file") {
+    setResponseStatus(event, 400);
+    return { error: "File field not found" };
+  }
+
+  const filePart = fileParts[0];
+  const filename = cleanFilename(filePart.filename);
+  const mimeType = (filePart.type || "").split(";", 1)[0]!.trim().toLowerCase();
+  const maxBytes = formFileMaxBytes(field);
+  if (filePart.data.length > maxBytes) {
+    setResponseStatus(event, 413);
+    return { error: "File is too large" };
+  }
+  if (
+    !mimeType ||
+    !isAllowedUploadMimeType(mimeType) ||
+    !acceptsFormFileType(field, mimeType, filename)
+  ) {
+    setResponseStatus(event, 415);
+    return { error: "File type is not accepted by this form" };
+  }
+
+  const upload = () =>
+    uploadFile({
+      data: filePart.data,
+      filename,
+      mimeType,
+      ownerEmail: form.ownerEmail ?? undefined,
+      stableUrl: true,
+      recordAsset: false,
+    });
+  let uploaded;
+  try {
+    uploaded = form.ownerEmail
+      ? await runWithRequestContext(
+          { userEmail: form.ownerEmail, orgId: form.orgId ?? undefined },
+          upload,
+        )
+      : await upload();
+  } catch (error) {
+    console.warn(
+      "[forms] file upload failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    setResponseStatus(event, 503);
+    return { error: "File storage upload failed" };
+  }
+  if (!uploaded) {
+    setResponseStatus(event, 503);
+    return {
+      error:
+        "File storage is not configured. Connect Builder.io or register a file upload provider before accepting files.",
+      storageSetupRequired: true,
+    };
+  }
+  if (!isSafeFormFileUrl(uploaded.url)) {
+    setResponseStatus(event, 502);
+    return { error: "File storage returned an invalid file URL" };
+  }
+
+  setResponseStatus(event, 201);
+  return {
+    url: uploaded.url,
+    name: filename,
+    type: mimeType,
+    size: filePart.data.length,
+    ...(uploaded.id ? { id: uploaded.id } : {}),
+    provider: uploaded.provider,
+  };
+});

--- a/templates/forms/server/lib/file-upload-policy.ts
+++ b/templates/forms/server/lib/file-upload-policy.ts
@@ -1,0 +1,105 @@
+import type { FormField, FormFileValue } from "../../shared/types.js";
+
+export const DEFAULT_FORM_FILE_MAX_BYTES = 10 * 1024 * 1024;
+export const MAX_FORM_FILE_COUNT = 5;
+export const MAX_FORM_FILE_NAME_LENGTH = 255;
+export const MAX_FORM_FILE_REFERENCE_URL_LENGTH = 4096;
+export const MAX_FORM_FILE_REFERENCE_FIELD_LENGTH = 512;
+
+const ACCEPT_MIME_PATTERN = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/i;
+const ACCEPT_WILDCARD_PATTERN = /^[a-z0-9!#$&^_.+-]+\/\*$/i;
+const ACCEPT_EXTENSION_PATTERN = /^\.[a-z0-9][a-z0-9.+-]*$/i;
+
+function acceptTokens(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isValidFileAccept(value: unknown): value is string {
+  if (value === undefined) return true;
+  if (typeof value !== "string" || value.length > 500) return false;
+  return acceptTokens(value).every(
+    (token) =>
+      token === "*/*" ||
+      ACCEPT_MIME_PATTERN.test(token) ||
+      ACCEPT_WILDCARD_PATTERN.test(token) ||
+      ACCEPT_EXTENSION_PATTERN.test(token),
+  );
+}
+
+export function formFileMaxBytes(
+  field: Pick<FormField, "maxSizeBytes">,
+): number {
+  return Number.isSafeInteger(field.maxSizeBytes) &&
+    field.maxSizeBytes! > 0 &&
+    field.maxSizeBytes! <= DEFAULT_FORM_FILE_MAX_BYTES
+    ? field.maxSizeBytes!
+    : DEFAULT_FORM_FILE_MAX_BYTES;
+}
+
+export function formFileMaxCount(
+  field: Pick<FormField, "multiple" | "maxFiles">,
+): number {
+  if (field.multiple !== true) return 1;
+  return Number.isSafeInteger(field.maxFiles) &&
+    field.maxFiles! > 0 &&
+    field.maxFiles! <= MAX_FORM_FILE_COUNT
+    ? field.maxFiles!
+    : MAX_FORM_FILE_COUNT;
+}
+
+export function acceptsFormFileType(
+  field: Pick<FormField, "accept">,
+  mimeType: string,
+  filename: string,
+): boolean {
+  const tokens = acceptTokens(field.accept);
+  if (tokens.length === 0) return true;
+
+  const mime = mimeType.split(";", 1)[0]!.trim().toLowerCase();
+  const name = filename.trim().toLowerCase();
+  return tokens.some((token) => {
+    if (token === "*/*" || token === mime) return true;
+    if (token.endsWith("/*")) {
+      return mime.startsWith(`${token.slice(0, -1)}`);
+    }
+    return token.startsWith(".") && name.endsWith(token);
+  });
+}
+
+export function isSafeFormFileUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  if (value.length > MAX_FORM_FILE_REFERENCE_URL_LENGTH) return false;
+  if (!URL.canParse(value)) return false;
+  const url = new URL(value);
+  return (
+    (url.protocol === "http:" || url.protocol === "https:") &&
+    !url.username &&
+    !url.password
+  );
+}
+
+export function isFormFileValue(value: unknown): value is FormFileValue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const file = value as Record<string, unknown>;
+  return (
+    typeof file.url === "string" &&
+    typeof file.name === "string" &&
+    typeof file.type === "string" &&
+    Number.isSafeInteger(file.size)
+  );
+}
+
+export function sanitizeFormFileValue(value: FormFileValue): FormFileValue {
+  return {
+    url: value.url,
+    name: value.name,
+    type: value.type,
+    size: value.size,
+    ...(value.id ? { id: value.id } : {}),
+    ...(value.provider ? { provider: value.provider } : {}),
+    ...(value.handle ? { handle: value.handle } : {}),
+  };
+}

--- a/templates/forms/server/lib/form-lookup.ts
+++ b/templates/forms/server/lib/form-lookup.ts
@@ -1,0 +1,23 @@
+import { eq } from "drizzle-orm";
+
+import { getDb, schema } from "../db/index.js";
+
+type FormsDb = ReturnType<typeof getDb>;
+
+/** Resolve public form identifiers without requiring callers to know storage ids. */
+export async function findFormBySlugOrId(db: FormsDb, slugOrId: string) {
+  const identifier = slugOrId.trim();
+  if (!identifier || identifier.length > 200) return undefined;
+
+  const [bySlug] = await db
+    .select()
+    .from(schema.forms)
+    .where(eq(schema.forms.slug, identifier));
+  if (bySlug) return bySlug;
+
+  const [byId] = await db
+    .select()
+    .from(schema.forms)
+    .where(eq(schema.forms.id, identifier));
+  return byId;
+}

--- a/templates/forms/server/lib/form-request.ts
+++ b/templates/forms/server/lib/form-request.ts
@@ -1,0 +1,54 @@
+import { getRequestHeader, setResponseHeader, type H3Event } from "h3";
+
+import type { FormSettings } from "../../shared/types.js";
+
+export function parseStoredFormSettings(
+  value: string | null | undefined,
+): FormSettings {
+  let parsed: unknown;
+  try {
+    parsed = value ? JSON.parse(value) : {};
+  } catch {
+    throw new Error("Invalid form settings");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Invalid form settings");
+  }
+  return parsed as FormSettings;
+}
+
+/**
+ * The public form endpoints are cross-origin by design. An empty allowlist is
+ * the legacy "any origin" setting; once configured, only exact browser origins
+ * may upload or submit.
+ */
+export function isPublicFormOriginAllowed(
+  event: H3Event,
+  settings: FormSettings,
+): boolean {
+  const allowedOrigins = settings.allowedOrigins;
+  if (allowedOrigins === undefined) return true;
+  if (!Array.isArray(allowedOrigins)) return false;
+
+  const origin = getRequestHeader(event, "origin")?.trim();
+  return allowedOrigins.length === 0
+    ? true
+    : origin !== undefined && allowedOrigins.includes(origin);
+}
+
+/** Keep CORS response headers aligned with a configured exact-origin policy. */
+export function setPublicFormCors(
+  event: H3Event,
+  settings: FormSettings,
+): void {
+  const origin = getRequestHeader(event, "origin")?.trim();
+  const allowedOrigins = settings.allowedOrigins;
+  if (
+    Array.isArray(allowedOrigins) &&
+    origin &&
+    allowedOrigins.includes(origin)
+  ) {
+    setResponseHeader(event, "Access-Control-Allow-Origin", origin);
+    setResponseHeader(event, "Vary", "Origin");
+  }
+}

--- a/templates/forms/server/lib/integrations.spec.ts
+++ b/templates/forms/server/lib/integrations.spec.ts
@@ -156,6 +156,38 @@ describe("buildSlackPayload page context", () => {
     expect(text).not.toContain("Page:");
   });
 
+  it("renders stored file references as Slack links instead of object strings", () => {
+    const result = buildSlackPayload(
+      payload({
+        fields: [
+          {
+            id: "attachment",
+            type: "file",
+            label: "Attachment",
+            required: false,
+          },
+        ],
+        data: {
+          attachment: [
+            {
+              url: "https://cdn.example.test/attachment.png",
+              name: "attachment.png",
+              type: "image/png",
+              size: 42,
+              provider: "builder",
+            },
+          ],
+        },
+      }),
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain(
+      "<https://cdn.example.test/attachment.png|attachment.png>",
+    );
+    expect(serialized).not.toContain("[object Object]");
+  });
+
   it("scrubs synthetic anonymous submitter emails from integration payloads", async () => {
     await fireIntegrations(
       [
@@ -242,6 +274,36 @@ describe("buildGoogleSheetsPayload", () => {
       Answer: "one",
       "Answer (second)": "two",
     });
+  });
+
+  it("flattens stored file references to readable name and link values", () => {
+    const result = buildGoogleSheetsPayload(
+      payload({
+        fields: [
+          {
+            id: "attachment",
+            type: "file",
+            label: "Attachment",
+            required: false,
+          },
+        ],
+        data: {
+          attachment: [
+            {
+              url: "https://cdn.example.test/attachment.png",
+              name: "attachment.png",
+              type: "image/png",
+              size: 42,
+              provider: "builder",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect((result as Record<string, unknown>).Attachment).toBe(
+      "attachment.png (https://cdn.example.test/attachment.png)",
+    );
   });
 });
 

--- a/templates/forms/server/lib/integrations.ts
+++ b/templates/forms/server/lib/integrations.ts
@@ -8,9 +8,11 @@ import { publicSubmitterEmail } from "../../shared/submitter-email.js";
 import type {
   FormIntegration,
   FormField,
+  FormFileValue,
   FormSettings,
   IntegrationType,
 } from "../../shared/types.js";
+import { isFormFileValue, isSafeFormFileUrl } from "./file-upload-policy.js";
 
 // ---------------------------------------------------------------------------
 // Save-time validation
@@ -120,6 +122,34 @@ function pageLabelFromUrl(pageUrl: string): string {
 // Format helpers
 // ---------------------------------------------------------------------------
 
+function isStoredFileReference(value: unknown): value is FormFileValue {
+  return isFormFileValue(value) && isSafeFormFileUrl(value.url);
+}
+
+function formatIntegrationValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(formatIntegrationValue).join(", ");
+  }
+  if (isStoredFileReference(value)) {
+    return `${value.name} (${value.url})`;
+  }
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function formatSlackValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(formatSlackValue).join(", ");
+  }
+  if (isStoredFileReference(value)) {
+    return `<${escapeSlackMrkdwn(value.url)}|${escapeSlackMrkdwn(value.name)}>`;
+  }
+  return escapeSlackMrkdwn(formatIntegrationValue(value));
+}
+
 /** Build a flat label→value object from field definitions and submission data */
 function formatFields(
   fields: FormField[],
@@ -133,7 +163,7 @@ function formatFields(
       let key = label;
       if (usedLabels.has(key)) key = `${label} (${field.id})`;
       usedLabels.add(key);
-      out[key] = data[field.id];
+      out[key] = formatIntegrationValue(data[field.id]);
     }
   }
   return out;
@@ -172,8 +202,7 @@ export function buildSlackPayload(submission: SubmissionPayload) {
     .filter((f) => submission.data[f.id] !== undefined)
     .map((f) => {
       const val = submission.data[f.id];
-      const display = Array.isArray(val) ? val.join(", ") : String(val);
-      return `*${escapeSlackMrkdwn(f.label)}:* ${escapeSlackMrkdwn(display)}`;
+      return `*${escapeSlackMrkdwn(f.label)}:* ${formatSlackValue(val)}`;
     });
 
   const tsContext = `Submitted <!date^${Math.floor(new Date(submission.submittedAt).getTime() / 1000)}^{date_short_pretty} at {time}|${submission.submittedAt}>`;
@@ -219,7 +248,7 @@ function buildDiscordPayload(submission: SubmissionPayload) {
     .filter((f) => submission.data[f.id] !== undefined)
     .map((f) => {
       const val = submission.data[f.id];
-      const display = Array.isArray(val) ? val.join(", ") : String(val);
+      const display = formatIntegrationValue(val);
       return { name: f.label, value: display, inline: true };
     });
   if (submitterEmail) {

--- a/templates/forms/server/lib/public-form-ssr.test.ts
+++ b/templates/forms/server/lib/public-form-ssr.test.ts
@@ -267,6 +267,52 @@ describe("public form SSR", () => {
     expect(html).toContain('params.set(key, "<redacted>")');
   });
 
+  it("renders file fields and uploads references before JSON submission", async () => {
+    mockGetDb.mockReturnValue(
+      createDbWithRows([
+        {
+          id: "form-files-123",
+          slug: "file-feedback",
+          title: "File feedback",
+          description: null,
+          ownerEmail: "owner@example.test",
+          updatedAt: "2026-07-23T12:00:00.000Z",
+          fields: JSON.stringify([
+            {
+              id: "screenshots",
+              type: "file",
+              label: "Screenshots",
+              required: true,
+              multiple: true,
+              accept: "image/png,.webp",
+              maxSizeBytes: 5242880,
+              maxFiles: 3,
+            },
+          ]),
+          settings: "{}",
+          status: "published",
+          deletedAt: null,
+        },
+      ]),
+    );
+
+    const { html } = await renderPublicFormHtml(
+      "https://forms.example.test/f/file-feedback",
+    );
+
+    expect(html).toContain(
+      '<input type="file" name="screenshots" class="fi fi-file" accept="image/png,.webp" multiple required>',
+    );
+    expect(html).toContain('var UPLOAD_PATH = "/api/upload/";');
+    expect(html).toContain('"maxSizeBytes":5242880');
+    expect(html).toContain('"maxFiles":3');
+    expect(html).toContain("function collectFiles()");
+    expect(html).toContain('body.append("fieldId", f.id);');
+    expect(html).toContain('body.append("file", file, file.name);');
+    expect(html).toContain("uploadFiles(filesByField)");
+    expect(html).toContain('btn.textContent = "Uploading...";');
+  });
+
   it.each([
     {
       name: "legacy success message",

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -231,6 +231,9 @@ function renderField(field: FormField): string {
     case "textarea":
       input = `<textarea name="${id}" class="fi fi-ta" rows="4"${ph || ' placeholder="Type your answer..."'}${req}></textarea>`;
       break;
+    case "file":
+      input = `<input type="file" name="${id}" class="fi fi-file"${field.accept ? ` accept="${escapeHtml(field.accept)}"` : ""}${field.multiple ? " multiple" : ""}${req}>`;
+      break;
     case "date":
       input = `<input type="date" name="${id}" class="fi"${req}>`;
       break;
@@ -363,6 +366,7 @@ function renderFormPage(
   const turnstileSiteKey = process.env.VITE_TURNSTILE_SITE_KEY || "";
   const appBasePath = getAppBasePath();
   const submitPath = `${appBasePath}/api/submit/`;
+  const uploadPath = `${appBasePath}/api/upload/`;
   const faviconPath = `${appBasePath}/favicon.svg`;
   const ogImagePath = `${appBasePath}/api/forms/og/${encodeURIComponent(
     form.slug || form.id,
@@ -451,11 +455,12 @@ function renderFormPage(
   var FORM_ID = ${JSON.stringify(form.id)};
   var FORM_VERSION = ${JSON.stringify(form.updatedAt || "")};
   var PUBLIC_FORM_API = ${JSON.stringify(`${appBasePath}/api/forms/public/${encodeURIComponent(form.slug || form.id)}`)};
+  var UPLOAD_PATH = ${JSON.stringify(uploadPath)};
   var COMPLETION_MODE = ${JSON.stringify(completionMode)};
   var COMPLETION_REFRESH_MS = ${completionRefreshMilliseconds};
   var REDIRECT = ${JSON.stringify(safeRedirectUrl(settings.redirectUrl))};
   var TURNSTILE_KEY = ${JSON.stringify(turnstileSiteKey)};
-  var FIELDS = ${JSON.stringify(fields.map((f) => ({ id: f.id, type: f.type, required: f.required, validation: f.validation, label: f.label, conditional: f.conditional })))};
+  var FIELDS = ${JSON.stringify(fields.map((f) => ({ id: f.id, type: f.type, required: f.required, validation: f.validation, label: f.label, conditional: f.conditional, multiple: f.multiple, accept: f.accept, maxSizeBytes: f.maxSizeBytes, maxFiles: f.maxFiles })))};
   var SENSITIVE_QUERY_PARAMS = ${JSON.stringify(SENSITIVE_QUERY_PARAMS)};
 
   function scrubPageUrl(value) {
@@ -613,6 +618,7 @@ function renderFormPage(
     FIELDS.forEach(function(f) {
       var el = document.querySelector('[data-field-id="' + f.id + '"]');
       if (!el || el.dataset.hidden === "1") return;
+      if (f.type === "file") return;
       if (f.type === "multiselect") {
         var checked = [];
         el.querySelectorAll('input[type="checkbox"]:checked').forEach(function(cb) { checked.push(cb.value); });
@@ -635,12 +641,50 @@ function renderFormPage(
     return data;
   }
 
+  function collectFiles() {
+    var files = {};
+    FIELDS.forEach(function(f) {
+      if (f.type !== "file") return;
+      var el = document.querySelector('[data-field-id="' + f.id + '"]');
+      if (!el || el.dataset.hidden === "1") return;
+      var input = el.querySelector('input[type="file"]');
+      if (input && input.files && input.files.length) {
+        files[f.id] = Array.prototype.slice.call(input.files);
+      }
+    });
+    return files;
+  }
+
+  function acceptsFile(f, file) {
+    if (!f.accept) return true;
+    var mime = (file.type || "").toLowerCase();
+    var name = (file.name || "").toLowerCase();
+    return f.accept.split(",").some(function(raw) {
+      var token = raw.trim().toLowerCase();
+      if (!token || token === "*/*" || token === mime) return true;
+      if (token.slice(-2) === "/*") return mime.indexOf(token.slice(0, -1)) === 0;
+      return token.charAt(0) === "." && name.slice(-token.length) === token;
+    });
+  }
+
   // Validation
-  function validate(data) {
+  function validate(data, filesByField) {
     for (var i = 0; i < FIELDS.length; i++) {
       var f = FIELDS[i];
       var el = document.querySelector('[data-field-id="' + f.id + '"]');
       if (!el || el.dataset.hidden === "1") continue;
+      if (f.type === "file") {
+        var files = filesByField[f.id] || [];
+        if (f.required && files.length === 0) return f.label + " is required";
+        var maxFiles = f.multiple ? (f.maxFiles || 5) : 1;
+        if (files.length > maxFiles) return f.label + " accepts up to " + maxFiles + " file" + (maxFiles === 1 ? "" : "s");
+        var maxBytes = f.maxSizeBytes || 10485760;
+        for (var fileIndex = 0; fileIndex < files.length; fileIndex++) {
+          if (files[fileIndex].size > maxBytes) return files[fileIndex].name + " is larger than the " + Math.round(maxBytes / 1048576) + " MB limit";
+          if (!acceptsFile(f, files[fileIndex])) return files[fileIndex].name + " is not an accepted file type";
+        }
+        continue;
+      }
       if (f.required) {
         var val = data[f.id];
         if (val === undefined || val === null || val === "" || (Array.isArray(val) && val.length === 0)) {
@@ -658,6 +702,42 @@ function renderFormPage(
       }
     }
     return null;
+  }
+
+  function uploadFiles(filesByField) {
+    var uploaded = {};
+    var requests = [];
+    FIELDS.forEach(function(f) {
+      if (f.type !== "file") return;
+      var files = filesByField[f.id] || [];
+      files.forEach(function(file) {
+        var body = new FormData();
+        body.append("fieldId", f.id);
+        body.append("file", file, file.name);
+        requests.push(fetch(UPLOAD_PATH + encodeURIComponent(FORM_ID), {
+          method: "POST",
+          body: body,
+        }).then(function(r) {
+          return r.json().then(function(d) {
+            if (!r.ok) throw new Error(d.error || "Failed to upload file");
+            return d;
+          }, function() {
+            throw new Error("File upload returned an invalid response");
+          });
+        }).then(function(fileValue) {
+          if (!uploaded[f.id]) uploaded[f.id] = [];
+          uploaded[f.id].push(fileValue);
+        }));
+      });
+    });
+    return Promise.all(requests).then(function() {
+      FIELDS.forEach(function(f) {
+        if (f.type === "file" && f.multiple !== true && uploaded[f.id]) {
+          uploaded[f.id] = uploaded[f.id][0];
+        }
+      });
+      return uploaded;
+    });
   }
 
   // Turnstile
@@ -684,19 +764,24 @@ function renderFormPage(
     e.preventDefault();
     if (submitting) return;
     var data = collectData();
-    var err = validate(data);
+    var filesByField = collectFiles();
+    var err = validate(data, filesByField);
     if (err) { showToast(err); return; }
     submitting = true;
     var btn = document.getElementById("submitBtn");
-    btn.textContent = "Submitting...";
+    btn.textContent = "Uploading...";
     btn.disabled = true;
     var hp = (document.getElementById("_hp") || {}).value || "";
     var pageUrl = scrubPageUrl(window.location.href);
 
-    fetch(${JSON.stringify(submitPath)} + FORM_ID, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ data: data, captchaToken: captchaToken, _hp: hp, _t: PAGE_LOAD_T, _meta: { pageUrl: pageUrl } }),
+    uploadFiles(filesByField).then(function(uploaded) {
+      Object.keys(uploaded).forEach(function(fieldId) { data[fieldId] = uploaded[fieldId]; });
+      btn.textContent = "Submitting...";
+      return fetch(${JSON.stringify(submitPath)} + FORM_ID, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: data, captchaToken: captchaToken, _hp: hp, _t: PAGE_LOAD_T, _meta: { pageUrl: pageUrl } }),
+      });
     })
     .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, data: d }; }); })
     .then(function(res) {

--- a/templates/forms/server/lib/submission-validation.spec.ts
+++ b/templates/forms/server/lib/submission-validation.spec.ts
@@ -9,6 +9,7 @@ import { isConditionalFieldVisible } from "../../shared/conditional.js";
 import type { FormField } from "../../shared/types.js";
 import {
   isEmptySubmissionValue,
+  sanitizeSubmissionFieldValue,
   validateSubmissionField,
 } from "./submission-validation.js";
 import { assertValidFields } from "./validate-fields.js";
@@ -95,6 +96,67 @@ check("rejects multiselect values outside configured options", () => {
     ["A", "C"],
   );
   assert(err === "Field contains an unavailable option", `got ${err}`);
+});
+
+check(
+  "accepts stored file references and strips unpersistable metadata",
+  () => {
+    const value = {
+      url: "https://cdn.example.test/screenshot.png",
+      name: "screenshot.png",
+      type: "image/png",
+      size: 128,
+      provider: "builder",
+      handle: "asset-1",
+    };
+    const fileField = field({
+      id: "screenshot",
+      type: "file",
+      accept: "image/png",
+    });
+    assert(validateSubmissionField(fileField, value) === null, "file rejected");
+    assert(
+      JSON.stringify(sanitizeSubmissionFieldValue(fileField, value)) ===
+        JSON.stringify(value),
+      "file reference was not normalized",
+    );
+    assert(
+      validateSubmissionField(fileField, {
+        ...value,
+        url: "data:image/png;base64,not-stored-in-sql",
+      }) !== null,
+      "data URL was accepted as a stored reference",
+    );
+  },
+);
+
+check("enforces file type and count metadata server-side", () => {
+  const fileField = field({
+    id: "screenshots",
+    type: "file",
+    multiple: true,
+    maxFiles: 2,
+    accept: "image/png",
+  });
+  const file = {
+    url: "https://cdn.example.test/screenshot.png",
+    name: "screenshot.png",
+    type: "image/png",
+    size: 128,
+  };
+  assert(
+    validateSubmissionField(fileField, [file, file]) === null,
+    "valid file list rejected",
+  );
+  assert(
+    validateSubmissionField(fileField, [file, file, file]) !== null,
+    "file count limit was bypassed",
+  );
+  assert(
+    validateSubmissionField(fileField, [{ ...file, type: "text/plain" }]) !==
+      null,
+    "file accept filter was bypassed",
+  );
 });
 
 check("rejects numeric values outside min/max", () => {

--- a/templates/forms/server/lib/submission-validation.ts
+++ b/templates/forms/server/lib/submission-validation.ts
@@ -1,4 +1,16 @@
-import type { FormField } from "../../shared/types.js";
+import { isAllowedUploadMimeType } from "@agent-native/core/server";
+
+import type { FormField, FormFileValue } from "../../shared/types.js";
+import {
+  acceptsFormFileType,
+  formFileMaxBytes,
+  formFileMaxCount,
+  isFormFileValue,
+  isSafeFormFileUrl,
+  MAX_FORM_FILE_NAME_LENGTH,
+  MAX_FORM_FILE_REFERENCE_FIELD_LENGTH,
+  sanitizeFormFileValue,
+} from "./file-upload-policy.js";
 
 // Field value size limits by type. Keep public submissions bounded even when
 // callers bypass the browser renderer and POST directly to /api/submit/:id.
@@ -198,6 +210,99 @@ function validateScale(field: FormField, value: unknown): string | null {
   return null;
 }
 
+function isSafeReferenceText(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= MAX_FORM_FILE_REFERENCE_FIELD_LENGTH &&
+    !/[\x00-\x1f\x7f]/.test(value)
+  );
+}
+
+function validateFileReference(
+  field: FormField,
+  value: unknown,
+): string | null {
+  if (!isFormFileValue(value)) {
+    return `${fieldLabel(field)} must contain a stored file reference`;
+  }
+
+  const allowedKeys = new Set([
+    "url",
+    "name",
+    "type",
+    "size",
+    "id",
+    "provider",
+    "handle",
+  ]);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) {
+    return `${fieldLabel(field)} contains unsupported file data`;
+  }
+  if (!isSafeFormFileUrl(value.url)) {
+    return `${fieldLabel(field)} contains an invalid stored file URL`;
+  }
+  if (
+    value.name.length === 0 ||
+    value.name.length > MAX_FORM_FILE_NAME_LENGTH ||
+    /[\x00-\x1f\x7f]/.test(value.name)
+  ) {
+    return `${fieldLabel(field)} contains an invalid file name`;
+  }
+  const type = value.type.split(";", 1)[0]!.trim().toLowerCase();
+  if (
+    !isAllowedUploadMimeType(type) ||
+    !acceptsFormFileType(field, type, value.name)
+  ) {
+    return `${fieldLabel(field)} contains an unsupported file type`;
+  }
+  if (
+    !Number.isSafeInteger(value.size) ||
+    value.size < 0 ||
+    value.size > formFileMaxBytes(field)
+  ) {
+    return `${fieldLabel(field)} contains an oversized file`;
+  }
+  for (const key of ["id", "provider", "handle"] as const) {
+    const optionalValue = value[key];
+    if (optionalValue !== undefined && !isSafeReferenceText(optionalValue)) {
+      return `${fieldLabel(field)} contains invalid file metadata`;
+    }
+  }
+  return null;
+}
+
+function validateFiles(field: FormField, value: unknown): string | null {
+  if (isAbsentSubmissionValue(value)) return null;
+  if (field.multiple === true) {
+    if (!Array.isArray(value)) {
+      return `${fieldLabel(field)} must be a list of files`;
+    }
+    if (value.length > formFileMaxCount(field)) {
+      return `${fieldLabel(field)} accepts at most ${formFileMaxCount(field)} files`;
+    }
+    for (const file of value) {
+      const error = validateFileReference(field, file);
+      if (error) return error;
+    }
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return `${fieldLabel(field)} accepts one file`;
+  }
+  return validateFileReference(field, value);
+}
+
+export function sanitizeSubmissionFieldValue(
+  field: FormField,
+  value: unknown,
+): unknown {
+  if (field.type !== "file") return value;
+  if (field.multiple === true && Array.isArray(value)) {
+    return value.map((file) => sanitizeFormFileValue(file as FormFileValue));
+  }
+  return sanitizeFormFileValue(value as FormFileValue);
+}
+
 export function isEmptySubmissionValue(value: unknown): boolean {
   return (
     value === undefined ||
@@ -240,6 +345,8 @@ export function validateSubmissionField(
       return validateRating(field, value);
     case "scale":
       return validateScale(field, value);
+    case "file":
+      return validateFiles(field, value);
     case "text":
     default:
       return validateText(field, value);

--- a/templates/forms/server/lib/validate-fields.spec.ts
+++ b/templates/forms/server/lib/validate-fields.spec.ts
@@ -96,3 +96,48 @@ describe("normalizePersistedFields", () => {
     expect(() => assertValidFields(fields)).not.toThrow();
   });
 });
+
+describe("file field metadata", () => {
+  it("accepts bounded multiple file fields", () => {
+    expect(() =>
+      assertValidFields([
+        {
+          id: "screenshots",
+          type: "file",
+          label: "Screenshots",
+          required: false,
+          multiple: true,
+          accept: "image/png,.webp",
+          maxSizeBytes: 5 * 1024 * 1024,
+          maxFiles: 5,
+        },
+      ]),
+    ).not.toThrow();
+  });
+
+  it("rejects file metadata on other field types and unsafe limits", () => {
+    expect(() =>
+      assertValidFields([
+        {
+          id: "name",
+          type: "text",
+          label: "Name",
+          required: false,
+          accept: "image/png",
+        },
+      ]),
+    ).toThrow("file metadata is only valid for file fields");
+    expect(() =>
+      assertValidFields([
+        {
+          id: "screenshots",
+          type: "file",
+          label: "Screenshots",
+          required: false,
+          multiple: false,
+          maxFiles: 2,
+        },
+      ]),
+    ).toThrow("maxFiles requires multiple");
+  });
+});

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -3,6 +3,12 @@
 // by the public form SSR renderer and into CSS/JS selectors by the inline
 // runtime — an unrestricted id like `x" onfocus="alert(1)` would otherwise
 // stored-XSS every anonymous submitter of a published form.
+import {
+  DEFAULT_FORM_FILE_MAX_BYTES,
+  isValidFileAccept,
+  MAX_FORM_FILE_COUNT,
+} from "./file-upload-policy.js";
+
 export const FIELD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const FIELD_TYPES = new Set([
   "text",
@@ -16,6 +22,7 @@ const FIELD_TYPES = new Set([
   "date",
   "rating",
   "scale",
+  "file",
 ]);
 const CONDITIONAL_OPERATORS = new Set(["equals", "not_equals", "contains"]);
 
@@ -116,6 +123,51 @@ export function assertValidFields(fields: unknown): void {
     }
     if (typeof f.required !== "boolean") {
       throw new Error(`field #${idx + 1} required must be a boolean`);
+    }
+
+    const hasFileMetadata = [
+      "multiple",
+      "accept",
+      "maxSizeBytes",
+      "maxFiles",
+    ].some((key) => key in f);
+    if (f.type !== "file" && hasFileMetadata) {
+      throw new Error(
+        `field #${idx + 1} file metadata is only valid for file fields`,
+      );
+    }
+    if (f.type === "file") {
+      if (f.multiple !== undefined && typeof f.multiple !== "boolean") {
+        throw new Error(`field #${idx + 1} multiple must be a boolean`);
+      }
+      if (!isValidFileAccept(f.accept)) {
+        throw new Error(`field #${idx + 1} accept must be a valid file filter`);
+      }
+      const maxSizeBytes = f.maxSizeBytes;
+      if (
+        maxSizeBytes !== undefined &&
+        (typeof maxSizeBytes !== "number" ||
+          !Number.isSafeInteger(maxSizeBytes) ||
+          maxSizeBytes <= 0 ||
+          maxSizeBytes > DEFAULT_FORM_FILE_MAX_BYTES)
+      ) {
+        throw new Error(
+          `field #${idx + 1} maxSizeBytes must be an integer between 1 and ${DEFAULT_FORM_FILE_MAX_BYTES}`,
+        );
+      }
+      const maxFiles = f.maxFiles;
+      if (
+        maxFiles !== undefined &&
+        (typeof maxFiles !== "number" ||
+          !Number.isSafeInteger(maxFiles) ||
+          maxFiles <= 0 ||
+          maxFiles > MAX_FORM_FILE_COUNT ||
+          f.multiple !== true)
+      ) {
+        throw new Error(
+          `field #${idx + 1} maxFiles requires multiple and must be between 1 and ${MAX_FORM_FILE_COUNT}`,
+        );
+      }
     }
 
     const cond = f.conditional;

--- a/templates/forms/server/middleware/00-public-cors.ts
+++ b/templates/forms/server/middleware/00-public-cors.ts
@@ -1,8 +1,8 @@
 /**
  * CORS for public embed endpoints.
  *
- * The public form schema (`/api/forms/public/*`) and submission
- * (`/api/submit/*`) routes are designed to be called cross-origin from
+ * The public form schema (`/api/forms/public/*`), file upload
+ * (`/api/upload/*`), and submission (`/api/submit/*`) routes are designed to be called cross-origin from
  * embedded feedback popovers, so they always return a permissive CORS
  * header. Preflight OPTIONS are short-circuited to 204 so they skip the
  * auth guard.
@@ -16,7 +16,11 @@ import {
   setResponseHeader,
 } from "h3";
 
-const PUBLIC_EMBED_PREFIXES = ["/api/forms/public/", "/api/submit/"];
+const PUBLIC_EMBED_PREFIXES = [
+  "/api/forms/public/",
+  "/api/upload/",
+  "/api/submit/",
+];
 
 export default defineEventHandler((event) => {
   const pathname = getRequestURL(event).pathname;

--- a/templates/forms/server/plugins/auth.ts
+++ b/templates/forms/server/plugins/auth.ts
@@ -16,5 +16,11 @@ export default createAuthPlugin({
       "Response summaries, exports, and trend analysis on demand",
     ],
   },
-  publicPaths: ["/f", "/api/forms/public", "/api/forms/og", "/api/submit"],
+  publicPaths: [
+    "/f",
+    "/api/forms/public",
+    "/api/forms/og",
+    "/api/upload",
+    "/api/submit",
+  ],
 });

--- a/templates/forms/server/routes/api/upload/[id].post.ts
+++ b/templates/forms/server/routes/api/upload/[id].post.ts
@@ -1,0 +1,1 @@
+export { uploadFormFile as default } from "../../../handlers/uploads.js";

--- a/templates/forms/shared/types.ts
+++ b/templates/forms/shared/types.ts
@@ -21,7 +21,8 @@ export type FormFieldType =
   | "radio"
   | "date"
   | "rating"
-  | "scale";
+  | "scale"
+  | "file";
 
 export interface ConditionalRule {
   fieldId: string;
@@ -47,6 +48,22 @@ export interface FormField {
   validation?: FieldValidation;
   conditional?: ConditionalRule;
   width?: "full" | "half";
+  /** File input metadata. Only used when `type` is `file`. */
+  multiple?: boolean;
+  accept?: string;
+  maxSizeBytes?: number;
+  maxFiles?: number;
+}
+
+/** Storage reference persisted for a submitted file field. */
+export interface FormFileValue {
+  url: string;
+  name: string;
+  type: string;
+  size: number;
+  id?: string;
+  provider?: string;
+  handle?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- replace the docs community app Netlify submission with the Builder.io Forms flow\n- add inline validation and a single multi-file screenshot upload field\n- add file fields to Forms with provider-backed uploads and reference-only response storage\n\n## Verification\n- 66 repository guards\n- Forms: 154 tests\n- Docs community tests: 5 tests\n- Docs and Forms typechecks\n\nCommunity form configuration and Slack delivery will be published separately after action-time confirmation.