### PR TITLE
fix: stabilize Analytics, Calendar, and Clips feedback paths

### DIFF
--- a/templates/analytics/actions/list-analysis-revisions.ts
+++ b/templates/analytics/actions/list-analysis-revisions.ts
@@ -34,7 +34,8 @@ export default defineAction({
         description: revision.description,
         createdAt: revision.createdAt,
         createdBy: revision.createdBy,
-        editable: Boolean(revision.chatContext),
+        chatContextStatus: revision.chatContextStatus,
+        editable: revision.chatContextStatus === "valid",
         ...(revision.chatContext ? { chatContext: revision.chatContext } : {}),
       })),
     };

--- a/templates/analytics/actions/list-dashboard-revisions.ts
+++ b/templates/analytics/actions/list-dashboard-revisions.ts
@@ -34,7 +34,8 @@ export default defineAction({
         title: revision.title,
         createdAt: revision.createdAt,
         createdBy: revision.createdBy,
-        editable: Boolean(revision.chatContext),
+        chatContextStatus: revision.chatContextStatus,
+        editable: revision.chatContextStatus === "valid",
         ...(revision.chatContext ? { chatContext: revision.chatContext } : {}),
       })),
     };

--- a/templates/analytics/server/lib/dashboards-store.interleave.spec.ts
+++ b/templates/analytics/server/lib/dashboards-store.interleave.spec.ts
@@ -194,7 +194,11 @@ vi.mock("../db/index.js", () => {
     dashboardRevisions: {
       id: { name: "id" },
       dashboardId: { name: "dashboardId" },
+      kind: { name: "kind" },
+      title: { name: "title" },
       createdAt: { name: "createdAt" },
+      createdBy: { name: "createdBy" },
+      chatContext: { name: "chatContext" },
     },
     // Not exercised by these tests, but `dashboards-store.ts` builds a
     // module-scope column-projection constant (`analysisListColumns`) from
@@ -317,6 +321,8 @@ const {
   unarchiveDashboard,
   DashboardConflictError,
   DASHBOARD_SAVE_MAX_ATTEMPTS,
+  listDashboardRevisionMetadata,
+  parseRevisionChatContextMetadata,
 } = await import("./dashboards-store.js");
 
 const ctx = { email: "alice@example.com", orgId: null };
@@ -546,5 +552,52 @@ describe("dashboards-store concurrency", () => {
     expect(state.updateAttempts).toBe(DASHBOARD_SAVE_MAX_ATTEMPTS);
     // Nothing from the doomed mutation ever landed.
     expect(readPanelIds()).toEqual(["a"]);
+  });
+});
+
+describe("revision chat metadata", () => {
+  it("keeps dashboard history readable when optional legacy context is corrupt", async () => {
+    state.revisions = [
+      {
+        id: "broken",
+        dashboardId: "traffic",
+        kind: "sql",
+        title: "Broken context",
+        createdAt: "2026-07-09T00:02:00.000Z",
+        createdBy: null,
+        chatContext: "not-json",
+      },
+      {
+        id: "without-context",
+        dashboardId: "traffic",
+        kind: "sql",
+        title: "No context",
+        createdAt: "2026-07-09T00:01:00.000Z",
+        createdBy: null,
+        chatContext: null,
+      },
+    ];
+
+    await expect(
+      listDashboardRevisionMetadata("traffic", ctx),
+    ).resolves.toMatchObject([
+      { id: "broken", chatContext: null, chatContextStatus: "unreadable" },
+      { id: "without-context", chatContext: null, chatContextStatus: "absent" },
+    ]);
+  });
+
+  it("distinguishes absent, valid, and unreadable legacy context", () => {
+    expect(parseRevisionChatContextMetadata(null)).toEqual({
+      chatContext: null,
+      chatContextStatus: "absent",
+    });
+    expect(parseRevisionChatContextMetadata('{"runId":"run-1"}')).toEqual({
+      chatContext: { runId: "run-1" },
+      chatContextStatus: "valid",
+    });
+    expect(parseRevisionChatContextMetadata("not-json")).toEqual({
+      chatContext: null,
+      chatContextStatus: "unreadable",
+    });
   });
 });

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -134,7 +134,12 @@ export interface DashboardRevisionRecord {
   chatContext: AnalyticsRevisionChatContext | null;
 }
 
-export type DashboardRevisionMetadata = Omit<DashboardRevisionRecord, "config">;
+export type DashboardRevisionMetadata = Omit<
+  DashboardRevisionRecord,
+  "config"
+> & {
+  chatContextStatus: RevisionChatContextStatus;
+};
 
 export type DashboardArchiveFilter = "active" | "archived" | "all";
 export type DashboardHiddenFilter = "visible" | "hidden" | "all";
@@ -183,6 +188,21 @@ export interface AnalyticsRevisionChatContext {
   runId?: string;
   turnId?: string;
 }
+
+export type RevisionChatContextStatus = "absent" | "valid" | "unreadable";
+
+export type AnalysisRevisionMetadata = Pick<
+  AnalysisRevisionRecord,
+  | "id"
+  | "analysisId"
+  | "name"
+  | "description"
+  | "createdAt"
+  | "createdBy"
+  | "chatContext"
+> & {
+  chatContextStatus: RevisionChatContextStatus;
+};
 
 interface AccessCtx {
   email: string;
@@ -284,6 +304,24 @@ function parseRevisionChatContext(
   );
   if (!context) throw new Error("Analytics revision chat metadata is invalid.");
   return context;
+}
+
+export function parseRevisionChatContextMetadata(raw: unknown): {
+  chatContext: AnalyticsRevisionChatContext | null;
+  chatContextStatus: RevisionChatContextStatus;
+} {
+  if (raw == null) {
+    return { chatContext: null, chatContextStatus: "absent" };
+  }
+  try {
+    const chatContext = parseRevisionChatContext(raw);
+    return {
+      chatContext,
+      chatContextStatus: chatContext ? "valid" : "absent",
+    };
+  } catch {
+    return { chatContext: null, chatContextStatus: "unreadable" };
+  }
 }
 
 function escapeLikeLiteral(value: string): string {
@@ -588,7 +626,7 @@ function rowToDashboardRevisionMetadata(row: any): DashboardRevisionMetadata {
     title: row.title,
     createdAt: row.createdAt,
     createdBy: row.createdBy ?? null,
-    chatContext: parseRevisionChatContext(row.chatContext),
+    ...parseRevisionChatContextMetadata(row.chatContext),
   };
 }
 
@@ -2197,6 +2235,18 @@ function rowToAnalysisRevision(row: any): AnalysisRevisionRecord {
   };
 }
 
+function rowToAnalysisRevisionMetadata(row: any): AnalysisRevisionMetadata {
+  return {
+    id: row.id,
+    analysisId: row.analysisId,
+    name: row.name,
+    description: row.description,
+    createdAt: row.createdAt,
+    createdBy: row.createdBy ?? null,
+    ...parseRevisionChatContextMetadata(row.chatContext),
+  };
+}
+
 function safeJsonParse<T>(s: unknown, fallback: T): T {
   if (typeof s !== "string") return fallback;
   try {
@@ -2728,18 +2778,7 @@ export async function listAnalysisRevisions(
 export async function listAnalysisRevisionMetadata(
   analysisId: string,
   ctx: AccessCtx,
-): Promise<
-  Pick<
-    AnalysisRevisionRecord,
-    | "id"
-    | "analysisId"
-    | "name"
-    | "description"
-    | "createdAt"
-    | "createdBy"
-    | "chatContext"
-  >[]
-> {
+): Promise<AnalysisRevisionMetadata[]> {
   const existing = await getAnalysis(analysisId, ctx);
   if (!existing) return [];
   await assertAccess("analysis", analysisId, "viewer", {
@@ -2761,7 +2800,7 @@ export async function listAnalysisRevisionMetadata(
     .where(eq(schema.analysisRevisions.analysisId, analysisId))
     .orderBy(desc(schema.analysisRevisions.createdAt))
     .limit(ANALYSIS_REVISION_LIMIT);
-  return rows;
+  return rows.map(rowToAnalysisRevisionMetadata);
 }
 
 export async function restoreAnalysisRevision(

--- a/templates/calendar/app/components/calendar/FindTimePanel.test.tsx
+++ b/templates/calendar/app/components/calendar/FindTimePanel.test.tsx
@@ -153,4 +153,70 @@ describe("FindTimeTakeover", () => {
         ?.getAttribute("data-dialog-overlay-class"),
     ).toContain("z-[310]");
   });
+
+  it("keeps evening suggestions inside the time grid", () => {
+    useActionQuery.mockReturnValue({
+      data: {
+        range: {
+          from: "2026-08-09T00:00:00.000Z",
+          to: "2026-08-16T00:00:00.000Z",
+          timezone: "UTC",
+          durationMinutes: 30,
+          slotStepMinutes: 30,
+        },
+        googleConnected: true,
+        participants: [],
+        busy: [
+          {
+            participantEmail: "guest@example.com",
+            start: "2026-08-09T20:00:00.000Z",
+            end: "2026-08-09T21:00:00.000Z",
+            title: "Evening conflict",
+          },
+        ],
+        slots: [
+          {
+            start: "2026-08-09T20:00:00.000Z",
+            end: "2026-08-09T20:30:00.000Z",
+            date: "2026-08-09",
+            durationMinutes: 30,
+            availableParticipantEmails: [],
+            unavailableParticipantEmails: [],
+          },
+        ],
+      },
+      isFetching: false,
+      isLoading: false,
+    });
+
+    act(() => {
+      root.render(
+        <FindTimeTakeover
+          open
+          onOpenChange={() => undefined}
+          date="2026-08-09"
+          timezone="UTC"
+          durationMinutes={30}
+          attendees={[]}
+          onSelectSlot={() => undefined}
+        />,
+      );
+    });
+
+    const lateSlot = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("8:00 PM"),
+    );
+    const grid = Array.from(document.querySelectorAll<HTMLElement>("div")).find(
+      (node) => node.style.minHeight,
+    );
+
+    expect(lateSlot).toBeTruthy();
+    expect(grid).toBeTruthy();
+    expect(
+      document.querySelector('[title="guest@example.com: Evening conflict"]'),
+    ).toBeTruthy();
+    expect(Number.parseFloat(lateSlot?.style.top ?? "0")).toBeLessThan(
+      Number.parseFloat(grid?.style.minHeight ?? "0"),
+    );
+  });
 });

--- a/templates/calendar/app/components/calendar/FindTimePanel.tsx
+++ b/templates/calendar/app/components/calendar/FindTimePanel.tsx
@@ -44,7 +44,7 @@ import { dateTimeInTimezoneToIso } from "@/lib/event-form-utils";
 import { cn } from "@/lib/utils";
 
 const START_HOUR = 7;
-const END_HOUR = 19;
+const END_HOUR = 24;
 const HOUR_HEIGHT = 44;
 const PARTICIPANT_COLORS = [
   "hsl(var(--primary))",

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3805,10 +3805,8 @@ export function App({
     };
   }, []);
 
-  // Gates every start-recording gesture (button, global shortcut, permission
-  // retry) on the mic toggle. When the mic is off we show the informational
-  // mic-off screen and wait for the user to go back and change that setting
-  // before the actual getDisplayMedia/getUserMedia call runs.
+  // Show the mic-off explanation once, then let the user continue without
+  // audio instead of trapping the start flow behind the toggle.
   function beginRecording(
     options?: Parameters<typeof handleStartRecording>[0],
     beginOptions?: { revealPopoverIfMicOff?: boolean },
@@ -4553,7 +4551,13 @@ export function App({
   return (
     <div className="app app-recorder" ref={appRef}>
       {micOffConfirmOpen ? (
-        <MicOffConfirmation onBack={closeMicOffConfirmation} />
+        <MicOffConfirmation
+          onBack={closeMicOffConfirmation}
+          onContinue={() => {
+            setMicOffConfirmOpen(false);
+            void handleStartRecording();
+          }}
+        />
       ) : null}
 
       <div

--- a/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.test.tsx
@@ -4,13 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 import { MicOffConfirmation } from "./MicOffConfirmation";
 
 describe("MicOffConfirmation", () => {
-  it("only exposes Back in the muted info state", () => {
-    const html = renderToStaticMarkup(<MicOffConfirmation onBack={vi.fn()} />);
+  it("offers continuing without the microphone", () => {
+    const html = renderToStaticMarkup(
+      <MicOffConfirmation onBack={vi.fn()} onContinue={vi.fn()} />,
+    );
 
     expect(html).toContain("Back");
     expect(html).toContain("Your mic is muted");
-    expect(html).toContain("change your microphone setting");
+    expect(html).toContain("continue without it");
+    expect(html).toContain("Continue");
     expect(html).not.toContain("Unmute");
-    expect(html).not.toContain("Continue");
   });
 });

--- a/templates/clips/desktop/src/components/MicOffConfirmation.tsx
+++ b/templates/clips/desktop/src/components/MicOffConfirmation.tsx
@@ -1,6 +1,12 @@
 import { IconArrowLeft, IconMicrophone2 } from "@tabler/icons-react";
 
-export function MicOffConfirmation({ onBack }: { onBack: () => void }) {
+export function MicOffConfirmation({
+  onBack,
+  onContinue,
+}: {
+  onBack: () => void;
+  onContinue: () => void;
+}) {
   return (
     <section className="mic-off-confirmation" aria-labelledby="mic-off-title">
       <header className="mic-off-confirmation-header">
@@ -20,10 +26,14 @@ export function MicOffConfirmation({ onBack }: { onBack: () => void }) {
           <span className="mic-off-confirmation-slash" />
         </div>
         <h2 id="mic-off-title">Your mic is muted</h2>
-        <p>
-          You can change your microphone setting and then come back to start
-          recording.
-        </p>
+        <p>You can change your microphone setting or continue without it.</p>
+        <button
+          type="button"
+          className="primary mic-off-confirmation-continue"
+          onClick={onContinue}
+        >
+          Continue
+        </button>
       </div>
     </section>
   );

--- a/templates/clips/desktop/src/lib/media-capture-constraints.test.ts
+++ b/templates/clips/desktop/src/lib/media-capture-constraints.test.ts
@@ -5,6 +5,7 @@ import {
   getAudioStreamWithFallback,
   getCameraStreamWithFallback,
   isMediaConstraintFailure,
+  shouldRequestSystemAudio,
   voiceFocusedAudioConstraints,
 } from "./media-capture-constraints";
 
@@ -50,6 +51,13 @@ describe("desktop media capture constraints", () => {
       height: { ideal: 1080 },
     });
     expect(options.video).not.toHaveProperty("displaySurface");
+  });
+
+  it("only requests system audio when screen capture and the mic are enabled", () => {
+    expect(shouldRequestSystemAudio(true, true)).toBe(true);
+    expect(shouldRequestSystemAudio(true, false)).toBe(false);
+    expect(shouldRequestSystemAudio(true, true, false)).toBe(false);
+    expect(shouldRequestSystemAudio(false, true)).toBe(false);
   });
 
   it("classifies invalid media constraints as constraint failures", () => {

--- a/templates/clips/desktop/src/lib/media-capture-constraints.ts
+++ b/templates/clips/desktop/src/lib/media-capture-constraints.ts
@@ -57,6 +57,14 @@ export function buildDesktopDisplayMediaOptions({
   };
 }
 
+export function shouldRequestSystemAudio(
+  wantsScreen: boolean,
+  micOn: boolean,
+  systemAudioOn?: boolean,
+): boolean {
+  return wantsScreen && micOn && systemAudioOn !== false;
+}
+
 export function isMediaConstraintFailure(err: unknown): boolean {
   const name =
     err instanceof DOMException || err instanceof Error ? err.name : "";

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -71,6 +71,7 @@ import {
   buildDesktopDisplayMediaOptions,
   getAudioStreamWithFallback,
   getCameraStreamWithFallback,
+  shouldRequestSystemAudio,
 } from "./media-capture-constraints";
 import { planNativeFullscreenWarmOverlap } from "./native-recording-warm";
 import {
@@ -3264,7 +3265,11 @@ async function startNativeFullscreenRecording(
   // clock and the toolbar-enable behind the real recording start.
   let startedAt = 0;
   let nativeTranscriptFailureSaved = false;
-  const wantsSystemAudio = params.systemAudioOn !== false;
+  const wantsSystemAudio = shouldRequestSystemAudio(
+    true,
+    params.micOn,
+    params.systemAudioOn,
+  );
   const wantsRecordedAudio = wantsAudio || wantsSystemAudio;
   const canTranscribeLocally =
     shouldStartLocalRecordingTranscription(wantsAudio);
@@ -4301,7 +4306,11 @@ async function startRecordingInner(
   // Vetted before anything is acquired so an ended display share cannot strand
   // a capture-suspension lease behind it.
   const restartHandoff = resolveRestartHandoff(params, wantsScreen, wantsAudio);
-  const wantsSystemAudio = wantsScreen && params.systemAudioOn !== false;
+  const wantsSystemAudio = shouldRequestSystemAudio(
+    wantsScreen,
+    params.micOn,
+    params.systemAudioOn,
+  );
   const wantsRecordedAudio = wantsAudio || wantsSystemAudio;
   const canTranscribeLocally =
     shouldStartLocalRecordingTranscription(wantsAudio);

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2158,6 +2158,11 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   line-height: 1.55;
 }
 
+.mic-off-confirmation-continue {
+  max-width: 300px;
+  margin-top: 24px;
+}
+
 /* ------------------------------------------------------------------------- */
 /* Alert dialog                                                              */
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

- Make Analytics revision list metadata tolerant of malformed optional chat context, while keeping full revision reads strict and distinguishing absent, valid, and unreadable metadata.
- Extend Calendar Find a Time through midnight so late-day availability and busy blocks remain visible and testable.
- Let Clips continue recording without a microphone and avoid requesting system audio when the microphone is off.

## Latest-feedback handoff

Review sweep: `#product-agent-native-feedback`, refreshed through 2026-09-01 15:25 PDT, latest bot reply `1788301522.833409`.

| Report | Disposition | Evidence |
| --- | --- | --- |
| Analytics cycling verbs / malformed revision metadata | Fixed | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301520550609?thread_ts=1788281687.280789&cid=C0ATH3CCZT4) |
| Analytics login connection errors | Fixed in the same Analytics list-path hardening | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301519912959?thread_ts=1788286181.556419&cid=C0ATH3CCZT4) |
| Calendar Find a Time after 7 PM | Fixed | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301521132289?thread_ts=1788256655.394179&cid=C0ATH3CCZT4) |
| Calendar overlapping late suggestions | Fixed with focused regression coverage | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301522833409?thread_ts=1788294104.855679&cid=C0ATH3CCZT4) |
| Clips recording with mic off | Fixed, including the Continue path and capture constraints | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301521662879?thread_ts=1788274889.562119&cid=C0ATH3CCZT4) |
| Booking link appears editable across owners | Awaiting reporter clarification on the exact edit action and result; one disclosed request remains open | [Slack thread](https://builder-internal.slack.com/archives/C0ATH3CCZT4/p1788301522226659?thread_ts=1788277734.648439&cid=C0ATH3CCZT4) |
| Design feedback and imported-design usability | Routed to Sid, outside this fix set | Existing ownership |
| Content feedback | Owned by Alice, outside this fix set | Existing ownership |
| CRM feedback | Out of scope | Workflow scope |
| Forms-to-Slides report, provider/config Sentry findings, and subjective or already-owned Clips/Slides reports | Deferred, external, duplicate, or unavailable/unverified as recorded in the sweep | No actionable repo seam identified |

Every Slack reply posted by the sweep ends with `this was sent from a bot.` and the six source threads were re-read through their current ends before this handoff.

## Validation

Source and focused checks completed:

- Analytics: 32 focused store tests; typecheck passed.
- Calendar: 13 focused Find a Time/timezone tests; typecheck passed.
- Clips: 7 focused mic-off/constraint tests; typecheck passed.
- `pnpm guards` passed all 66 checks.
- `oxfmt --check` passed for all modified TypeScript files.
- `git diff --check` passed.

The full `pnpm fmt:check` remains blocked only by seven pre-existing unrelated files: six localized getting-started docs and one Design changelog entry. No modified file from this PR was listed.

## Deployment boundary

This PR records source and test proof only. Merge and CI will provide merged proof; beta or production deployment health is not claimed by this PR.
