### PR TITLE
Polish Creative Context share tab

### DIFF
--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -786,9 +786,8 @@ function SharePanel(
               disabled={tab.disabled}
               onClick={() => handleShareTabChange(tab.value)}
               className={cn(
-                "h-11 min-w-0 flex-1 rounded-lg px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
-                active &&
-                  "bg-background text-foreground shadow-sm ring-2 ring-primary",
+                "h-11 min-w-0 flex-1 rounded-lg px-3 text-sm font-medium text-muted-foreground hover:bg-background/70 hover:text-foreground disabled:pointer-events-none disabled:opacity-50",
+                active && "bg-background text-foreground shadow-sm",
               )}
             >
               <span className="block truncate">{tab.label}</span>

--- a/packages/creative-context/src/client/CreativeContextShareTab.tsx
+++ b/packages/creative-context/src/client/CreativeContextShareTab.tsx
@@ -1,4 +1,5 @@
 import { useT } from "@agent-native/core/client/i18n";
+import { docsUrl } from "@agent-native/core/shared";
 import { cn } from "@agent-native/toolkit";
 import { ShareDisclosureSection } from "@agent-native/toolkit/sharing";
 import {
@@ -17,13 +18,7 @@ import {
   SheetTitle,
   Textarea,
 } from "@agent-native/toolkit/ui";
-import {
-  IconCheck,
-  IconFileText,
-  IconLink,
-  IconPlus,
-  IconX,
-} from "@tabler/icons-react";
+import { IconCheck, IconFileText, IconPlus, IconX } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 import {
@@ -540,7 +535,7 @@ export function CreativeContextShareTab({
       ) : null}
       {contextId && selectedResources.length ? (
         <div className="border-t border-border/60 pt-3">
-          <div className="flex items-start gap-2">
+          <div className="mb-3 flex items-start gap-2">
             <ShareDisclosureSection
               label={
                 memberships.some((membership) => membership.publishedItem)
@@ -608,7 +603,6 @@ export function CreativeContextShareTab({
               }
               onClick={() => void submit()}
             >
-              <IconLink />{" "}
               {t("creativeContext.share.submit", { defaultValue: "Submit" })}
             </Button>
           </div>
@@ -661,6 +655,18 @@ export function CreativeContextShareTab({
       {submitSummary ? (
         <p className="text-xs text-muted-foreground">{submitSummary}</p>
       ) : null}
+      <a
+        href={docsUrl("toolkit-capability-packages", {
+          hash: "package-maturity-and-ownership",
+        })}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex text-xs font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {t("creativeContext.share.documentation", {
+          defaultValue: "Creative Context documentation",
+        })}
+      </a>
     </section>
   );
 }

--- a/packages/creative-context/src/client/messages.ts
+++ b/packages/creative-context/src/client/messages.ts
@@ -118,6 +118,7 @@ export type CreativeContextMessageKey =
 
 export interface CreativeContextShareMessages {
   title: string;
+  documentation: string;
   tabLabel: string;
   pendingResource: string;
   publishedResource: string;
@@ -268,6 +269,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "Canonical logo",
     share: {
       title: "Creative context",
+      documentation: "Creative Context documentation",
       tabLabel: "Context",
       pendingResource: "Pending resource",
       publishedResource: "Published resource",
@@ -402,6 +404,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "標準標誌",
     share: {
       title: "創意脈絡",
+      documentation: "Creative Context 文件",
       tabLabel: "脈絡",
       pendingResource: "待處理資源",
       publishedResource: "已發布資源",
@@ -536,6 +539,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "标准徽标",
     share: {
       title: "创意上下文",
+      documentation: "Creative Context 文档",
       tabLabel: "上下文",
       pendingResource: "待处理资源",
       publishedResource: "已发布资源",
@@ -677,6 +681,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "Logotipo canónico",
     share: {
       title: "Contexto creativo",
+      documentation: "Documentación de Creative Context",
       tabLabel: "Contexto",
       pendingResource: "Recurso pendiente",
       publishedResource: "Recurso publicado",
@@ -820,6 +825,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "Logo canonique",
     share: {
       title: "Contexte créatif",
+      documentation: "Documentation de Creative Context",
       tabLabel: "Contexte",
       pendingResource: "Ressource en attente",
       publishedResource: "Ressource publiée",
@@ -962,6 +968,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "Kanonisches Logo",
     share: {
       title: "Kreativer Kontext",
+      documentation: "Creative-Context-Dokumentation",
       tabLabel: "Kontext",
       pendingResource: "Ausstehende Ressource",
       publishedResource: "Veröffentlichte Ressource",
@@ -1107,6 +1114,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "正式ロゴ",
     share: {
       title: "クリエイティブコンテキスト",
+      documentation: "Creative Context のドキュメント",
       tabLabel: "コンテキスト",
       pendingResource: "保留中のリソース",
       publishedResource: "公開済みリソース",
@@ -1247,6 +1255,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "대표 로고",
     share: {
       title: "크리에이티브 컨텍스트",
+      documentation: "Creative Context 문서",
       tabLabel: "컨텍스트",
       pendingResource: "대기 중인 리소스",
       publishedResource: "게시된 리소스",
@@ -1389,6 +1398,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "Logotipo canônico",
     share: {
       title: "Contexto criativo",
+      documentation: "Documentação do Creative Context",
       tabLabel: "Contexto",
       pendingResource: "Recurso pendente",
       publishedResource: "Recurso publicado",
@@ -1528,6 +1538,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "मानक लोगो",
     share: {
       title: "क्रिएटिव संदर्भ",
+      documentation: "Creative Context दस्तावेज़",
       tabLabel: "संदर्भ",
       pendingResource: "लंबित संसाधन",
       publishedResource: "प्रकाशित संसाधन",
@@ -1667,6 +1678,7 @@ export const creativeContextMessagesByLocale: Record<
     logo: "الشعار المعتمد",
     share: {
       title: "السياق الإبداعي",
+      documentation: "توثيق Creative Context",
       tabLabel: "السياق",
       pendingResource: "مورد قيد الانتظار",
       publishedResource: "مورد منشور",

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -15120,52 +15120,31 @@ function DesignEditor() {
       </div>
     </div>
   );
-  const designShareTabLabelClassName =
-    "inline-flex items-center justify-center gap-1.5";
   const designSharePopoverClassName =
     "z-[100010] !w-[min(620px,calc(100vw-32px))] !p-3 " +
     "[&_[role=tablist]]:!inline-flex [&_[role=tablist]]:!w-fit [&_[role=tablist]]:!max-w-full [&_[role=tablist]]:!self-start [&_[role=tablist]]:!overflow-x-auto [&_[role=tablist]]:justify-start [&_[role=tablist]]:gap-1 [&_[role=tablist]]:rounded-lg [&_[role=tablist]]:border [&_[role=tablist]]:border-[var(--design-editor-panel-divider-color)] [&_[role=tablist]]:bg-[var(--design-editor-panel-raised-bg)] [&_[role=tablist]]:p-1 " +
     "[&_[role=tab]]:!h-8 [&_[role=tab]]:!flex-none [&_[role=tab]]:rounded-md [&_[role=tab]]:px-3 [&_[role=tab]]:!text-[12px] [&_[role=tab]]:font-semibold [&_[role=tab]]:shadow-none [&_[role=tab]]:ring-0 " +
-    "[&_[role=tab]:hover]:bg-white/70 dark:[&_[role=tab]:hover]:bg-[var(--design-editor-control-bg)] [&_[role=tab]:hover]:text-foreground " +
-    "[&_[role=tab][aria-selected=true]]:bg-white dark:[&_[role=tab][aria-selected=true]]:bg-[var(--design-editor-control-bg)] [&_[role=tab][aria-selected=true]]:text-foreground [&_[role=tab][aria-selected=true]]:shadow-sm [&_[role=tab][aria-selected=true]]:ring-1 [&_[role=tab][aria-selected=true]]:ring-[var(--design-editor-control-border)]";
+    "[&_[role=tab]:hover]:text-foreground " +
+    "[&_[role=tab][aria-selected=true]]:!bg-background dark:[&_[role=tab][aria-selected=true]]:!bg-[var(--design-editor-panel-bg)] [&_[role=tab][aria-selected=true]]:text-foreground";
   const designShareTabs = {
-    shareLabel: (
-      <span className={designShareTabLabelClassName}>
-        <IconLink className="size-3.5" />
-        {"Share link" /* i18n-ignore share tab label */}
-      </span>
-    ),
+    shareLabel: "Share link" /* i18n-ignore share tab label */,
     defaultValue: "share",
     tabs: [
       {
         value: "export",
-        label: (
-          <span className={designShareTabLabelClassName}>
-            <IconFileExport className="size-3.5" />
-            {t("designEditor.export")}
-          </span>
-        ),
+        label: t("designEditor.export"),
         content: shareExportTab,
       },
       {
         value: "send",
-        label: (
-          <span className={designShareTabLabelClassName}>
-            <IconTerminal2 className="size-3.5" />
-            {"Send to agent" /* i18n-ignore share tab label */}
-          </span>
-        ),
+        label: "Send to agent" /* i18n-ignore share tab label */,
         content: shareSendToTab,
       },
       {
         value: "context",
-        label: (
-          <span className={designShareTabLabelClassName}>
-            {t("creativeContext.share.tabLabel", {
-              defaultValue: "Context",
-            })}
-          </span>
-        ),
+        label: t("creativeContext.share.tabLabel", {
+          defaultValue: "Context",
+        }),
         content: (
           <CreativeContextShareTab
             resource={{


### PR DESCRIPTION
Fixes the Design share dialog's Creative Context presentation.\n\n- Removes tab icons and the active outline, with a consistent filled active state.\n- Removes the transition that made two tabs appear selected during switching.\n- Adds a compact Creative Context documentation link, spacing below Add to context, and an icon-free Submit button.\n\nValidation: focused core and Creative Context tests, Design share-dialog E2E, formatting, and all 66 guards pass.