### PR TITLE
Optimize engine check with prefetched secrets

### DIFF
--- a/.changeset/engine-status-batch-secret-lookup.md
+++ b/.changeset/engine-status-batch-secret-lookup.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+Make `detectEngineFromUserSecrets` batch-load candidate provider credentials
+in one read per identity scope instead of sweeping the whole engine registry
+one point read at a time. An unconfigured request (e.g. the polled
+`/_agent-native/agent-engine/status` gate in local dev) previously issued ~80
+sequential `app_secrets` reads per call; it now reuses the existing
+`prefetchSecrets` memo so the per-engine usability checks answer from the
+request cache. Same precedence, identity scoping, and unreadable-store
+propagation.

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1758,6 +1758,51 @@ describe("AgentEngine registry", () => {
       );
     });
 
+    it("batch-loads candidate provider keys once per scope before the per-engine sweep", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestContext: () => ({}),
+        getRequestUserEmail: () => "dana@example.com",
+        getRequestOrgId: () => "dana_org",
+      }));
+      const readAppSecret = vi.fn(async () => null);
+      const readAppSecrets = vi.fn(readAppSecretsFromSingles(readAppSecret));
+      vi.doMock("../../secrets/storage.js", () => ({
+        readAppSecret,
+        readAppSecrets,
+      }));
+
+      const { registerAgentEngine, detectEngineFromUserSecrets } =
+        await import("./registry.js");
+      registerAgentEngine({
+        name: "anthropic",
+        label: "Anthropic",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["ANTHROPIC_API_KEY"],
+        create: vi.fn() as any,
+      });
+
+      expect(await detectEngineFromUserSecrets()).toBeNull();
+      // One batched read per identity scope carries the whole candidate key
+      // set, instead of a point read per (key, scope).
+      expect(readAppSecrets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keys: ["ANTHROPIC_API_KEY"],
+          scope: "user",
+          scopeId: "dana@example.com",
+        }),
+      );
+      expect(readAppSecrets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keys: ["ANTHROPIC_API_KEY"],
+          scope: "org",
+          scopeId: "dana_org",
+        }),
+      );
+    });
+
     it("picks the Builder engine when the user has Builder keys in app_secrets", async () => {
       vi.doMock("../../server/request-context.js", () => ({
         getRequestContext: () => undefined,

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -21,6 +21,7 @@ import {
   canUseDeployCredentialFallbackForRequest,
   getBuilderCredentialAuthFailure,
   getProviderCredentialAuthFailure,
+  prefetchSecrets,
   readDeployCredentialEnv,
   resolveBuilderCredentialsDetailed,
   resolveBuilderGatewayCredentialsDetailed,
@@ -719,6 +720,24 @@ export async function detectEngineFromUserSecrets(
     }
     return true;
   };
+
+  // Batch-load every candidate provider credential for this identity in one
+  // read per scope, so the per-engine checks below answer from the request
+  // memo instead of each key re-walking the four-scope waterfall. Without this
+  // an unconfigured request sweeps the whole registry one point read at a time.
+  const candidateProviderKeys = Array.from(
+    new Set(
+      [..._registry.values()]
+        .filter(
+          (entry) =>
+            entry.name !== "builder" && isAgentEnginePackageInstalled(entry),
+        )
+        .flatMap((entry) => entry.requiredEnvVars),
+    ),
+  );
+  if (candidateProviderKeys.length > 0) {
+    await prefetchSecrets(candidateProviderKeys);
+  }
 
   const preferByo = getAppConfig().agent.preferBringYourOwnKey;
 


### PR DESCRIPTION
the engine status endpoint executed 86 sequential db calls loading all possible engine configs.

{"event":"agent-native.slow_request","method":"GET","path":"/_agent-native/agent-engine/status","status":200,"duration_ms":1228,"cold_start":false,"request_sequence":57,"boot_to_module_ms":13721,"module_to_request_ms":139434,"process_age_ms":153155,"framework_ready_wait_ms":0,"db_ms":1210,"db_connect_ms":108,"db_operation_count":86,"db_error_count":0,"db_timeout_count":0,"shared_cacheable":false,"runtime_provider":"node","request_id":"5194603d-4257-4fd6-8632-4d138f87f181"}