### PR TITLE
Route chat health alerts to Slack

### DIFF
--- a/.changeset/route-chat-health-alerts-to-slack.md
+++ b/.changeset/route-chat-health-alerts-to-slack.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Route chat health outage alerts to Slack instead of the in-app notification inbox.

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -4,6 +4,7 @@ let turnRows: Array<Record<string, unknown>> = [];
 let memberRows: Array<Record<string, unknown>> = [];
 let turnQueryThrows = false;
 let memberQueryThrows = false;
+let deleteClaimThrows = false;
 
 const execute = vi.fn(async ({ sql }: { sql: string }) => {
   if (sql.includes("org_members")) {
@@ -44,6 +45,7 @@ const mutateSetting = vi.fn(
 );
 const deleteSettingIfValue = vi.fn(
   async (key: string, expected: Record<string, unknown>) => {
+    if (deleteClaimThrows) throw new Error("claim release failed");
     const current = settings.get(key);
     if (JSON.stringify(current) !== JSON.stringify(expected)) return false;
     settings.delete(key);
@@ -74,6 +76,7 @@ beforeEach(() => {
   memberRows = [{ org_id: "org-1", email: "owner@example.com", role: "owner" }];
   turnQueryThrows = false;
   memberQueryThrows = false;
+  deleteClaimThrows = false;
   settings.clear();
   settingsReadThrows = false;
   settingsWriteThrows = false;
@@ -246,6 +249,22 @@ describe("checkChatHealthAndAlert", () => {
     expect(deleteSettingIfValue).toHaveBeenCalledTimes(1);
 
     await checkChatHealthAndAlert(NOW + 60_000);
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after a failed claim release once its short lease expires", async () => {
+    turns(20, 15);
+    deleteClaimThrows = true;
+    notifyWithDelivery.mockResolvedValueOnce({
+      notification: undefined,
+      deliveredChannels: [],
+    });
+    const first = await checkChatHealthAndAlert(NOW);
+    expect(first.status).toBe("delivery-failed");
+
+    deleteClaimThrows = false;
+    const second = await checkChatHealthAndAlert(NOW + 5 * 60_000 + 1);
+    expect(second.status).toBe("alerted");
     expect(notifyWithDelivery).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 let turnRows: Array<Record<string, unknown>> = [];
 let memberRows: Array<Record<string, unknown>> = [];
 let turnQueryThrows = false;
+let memberQueryThrows = false;
 
 const execute = vi.fn(async ({ sql }: { sql: string }) => {
   if (sql.includes("org_members")) {
+    if (memberQueryThrows) throw new Error("member lookup failed");
     const rows = sql.includes("role IN ('owner', 'admin')")
       ? memberRows.filter((row) => row.role === "owner" || row.role === "admin")
       : memberRows;
@@ -71,6 +73,7 @@ beforeEach(() => {
   turnRows = [];
   memberRows = [{ org_id: "org-1", email: "owner@example.com", role: "owner" }];
   turnQueryThrows = false;
+  memberQueryThrows = false;
   settings.clear();
   settingsReadThrows = false;
   settingsWriteThrows = false;
@@ -136,6 +139,32 @@ describe("checkChatHealthAndAlert", () => {
     turns(20, 15);
     const out = await checkChatHealthAndAlert(NOW);
     expect(out).toMatchObject({ status: "alerted", recipients: 1 });
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the claim when recipient lookup fails", async () => {
+    turns(20, 15);
+    memberQueryThrows = true;
+    const first = await checkChatHealthAndAlert(NOW);
+    expect(first.status).toBe("check-failed");
+
+    memberQueryThrows = false;
+    const second = await checkChatHealthAndAlert(NOW);
+    expect(second.status).toBe("alerted");
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the claim when no recipient is available", async () => {
+    turns(20, 15);
+    memberRows = [];
+    const first = await checkChatHealthAndAlert(NOW);
+    expect(first.status).toBe("delivery-failed");
+
+    memberRows = [
+      { org_id: "org-1", email: "owner@example.com", role: "owner" },
+    ];
+    const second = await checkChatHealthAndAlert(NOW);
+    expect(second.status).toBe("alerted");
     expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -23,15 +23,34 @@ vi.mock("../db/client.js", () => ({
 const settings = new Map<string, Record<string, unknown>>();
 let settingsReadThrows = false;
 let settingsWriteThrows = false;
-vi.mock("../settings/store.js", () => ({
-  getSetting: vi.fn(async (key: string) => {
+const mutateSetting = vi.fn(
+  async (
+    key: string,
+    updater: (
+      current: Record<string, unknown> | null,
+    ) => Record<string, unknown> | Promise<Record<string, unknown>>,
+  ) => {
     if (settingsReadThrows) throw new Error("settings unreadable");
-    return settings.get(key) ?? null;
-  }),
-  putSetting: vi.fn(async (key: string, value: Record<string, unknown>) => {
-    if (settingsWriteThrows) throw new Error("settings write failed");
-    settings.set(key, value);
-  }),
+    const current = settings.get(key) ?? null;
+    if (settingsWriteThrows && current?.claimId) {
+      throw new Error("settings write failed");
+    }
+    const next = await updater(current);
+    settings.set(key, next);
+    return next;
+  },
+);
+const deleteSettingIfValue = vi.fn(
+  async (key: string, expected: Record<string, unknown>) => {
+    const current = settings.get(key);
+    if (JSON.stringify(current) !== JSON.stringify(expected)) return false;
+    settings.delete(key);
+    return true;
+  },
+);
+vi.mock("../settings/store.js", () => ({
+  deleteSettingIfValue,
+  mutateSetting,
 }));
 
 const notifyWithDelivery = vi.fn(async () => ({
@@ -57,6 +76,8 @@ beforeEach(() => {
   settingsWriteThrows = false;
   notifyWithDelivery.mockClear();
   execute.mockClear();
+  mutateSetting.mockClear();
+  deleteSettingIfValue.mockClear();
 });
 
 describe("checkChatHealthAndAlert", () => {
@@ -128,6 +149,33 @@ describe("checkChatHealthAndAlert", () => {
     expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
   });
 
+  it("allows only one overlapping sweep to page", async () => {
+    turns(20, 15);
+    let sendStarted!: () => void;
+    let releaseSend!: () => void;
+    const started = new Promise<void>((resolve) => {
+      sendStarted = resolve;
+    });
+    const send = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    notifyWithDelivery.mockImplementation(async () => {
+      sendStarted();
+      await send;
+      return { notification: undefined, deliveredChannels: ["slack"] };
+    });
+
+    const first = checkChatHealthAndAlert(NOW);
+    await started;
+    const second = await checkChatHealthAndAlert(NOW);
+    releaseSend();
+    const firstOut = await first;
+
+    expect(second.status).toBe("cooldown");
+    expect(firstOut.status).toBe("alerted");
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
+  });
+
   it("pages again once the cooldown has passed", async () => {
     turns(20, 15);
     await checkChatHealthAndAlert(NOW);
@@ -166,6 +214,7 @@ describe("checkChatHealthAndAlert", () => {
     const out = await checkChatHealthAndAlert(NOW);
     expect(out.status).toBe("delivery-failed");
     expect(settings).toEqual(new Map());
+    expect(deleteSettingIfValue).toHaveBeenCalledTimes(1);
 
     await checkChatHealthAndAlert(NOW + 60_000);
     expect(notifyWithDelivery).toHaveBeenCalledTimes(2);

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -5,7 +5,12 @@ let memberRows: Array<Record<string, unknown>> = [];
 let turnQueryThrows = false;
 
 const execute = vi.fn(async ({ sql }: { sql: string }) => {
-  if (sql.includes("org_members")) return { rows: memberRows, rowsAffected: 0 };
+  if (sql.includes("org_members")) {
+    const rows = sql.includes("role IN ('owner', 'admin')")
+      ? memberRows.filter((row) => row.role === "owner" || row.role === "admin")
+      : memberRows;
+    return { rows, rowsAffected: 0 };
+  }
   if (turnQueryThrows) throw new Error("ledger unreadable");
   return { rows: turnRows, rowsAffected: 0 };
 });
@@ -100,6 +105,17 @@ describe("checkChatHealthAndAlert", () => {
         "No single owner/admin organization scope is available for Slack health alerts.",
     });
     expect(notifyWithDelivery).not.toHaveBeenCalled();
+  });
+
+  it("ignores regular members in other organizations", async () => {
+    memberRows = [
+      { org_id: "org-1", email: "a@example.com", role: "owner" },
+      { org_id: "org-2", email: "member@example.com", role: "member" },
+    ];
+    turns(20, 15);
+    const out = await checkChatHealthAndAlert(NOW);
+    expect(out).toMatchObject({ status: "alerted", recipients: 1 });
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
   });
 
   it("pages once per outage, not once per sweep", async () => {

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -27,8 +27,11 @@ vi.mock("../settings/store.js", () => ({
   }),
 }));
 
-const notify = vi.fn(async () => undefined);
-vi.mock("../notifications/registry.js", () => ({ notify }));
+const notifyWithDelivery = vi.fn(async () => ({
+  notification: undefined,
+  deliveredChannels: ["slack"],
+}));
+vi.mock("../notifications/registry.js", () => ({ notifyWithDelivery }));
 
 const { checkChatHealthAndAlert } = await import("./chat-health-alert.js");
 
@@ -44,7 +47,7 @@ beforeEach(() => {
   turnQueryThrows = false;
   settings.clear();
   settingsReadThrows = false;
-  notify.mockClear();
+  notifyWithDelivery.mockClear();
   execute.mockClear();
 });
 
@@ -53,34 +56,39 @@ describe("checkChatHealthAndAlert", () => {
     turns(2, 2);
     const out = await checkChatHealthAndAlert(NOW);
     expect(out).toEqual({ status: "insufficient-data", turns: 2 });
-    expect(notify).not.toHaveBeenCalled();
+    expect(notifyWithDelivery).not.toHaveBeenCalled();
   });
 
   it("stays quiet while the app is answering", async () => {
     turns(20, 2);
     const out = await checkChatHealthAndAlert(NOW);
     expect(out.status).toBe("healthy");
-    expect(notify).not.toHaveBeenCalled();
+    expect(notifyWithDelivery).not.toHaveBeenCalled();
   });
 
-  it("pages every owner and admin once the app stops answering", async () => {
+  it("pages Slack once when the app stops answering", async () => {
     memberRows = [{ email: "a@example.com" }, { email: "b@example.com" }];
     turns(20, 15);
     const out = await checkChatHealthAndAlert(NOW);
-    expect(out).toMatchObject({ status: "alerted", turns: 20, recipients: 2 });
-    expect(notify).toHaveBeenCalledTimes(2);
-    expect(notify.mock.calls[0][0]).toMatchObject({ severity: "critical" });
-    expect(notify.mock.calls[0][1]).toEqual({ owner: "a@example.com" });
+    expect(out).toMatchObject({ status: "alerted", turns: 20, recipients: 1 });
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
+    expect(notifyWithDelivery.mock.calls[0][0]).toMatchObject({
+      severity: "critical",
+      channels: ["slack"],
+    });
+    expect(notifyWithDelivery.mock.calls[0][1]).toEqual({
+      owner: "a@example.com",
+    });
   });
 
   it("pages once per outage, not once per sweep", async () => {
     turns(20, 15);
     await checkChatHealthAndAlert(NOW);
-    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
 
     const out = await checkChatHealthAndAlert(NOW + 60_000);
     expect(out.status).toBe("cooldown");
-    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
   });
 
   it("pages again once the cooldown has passed", async () => {
@@ -88,7 +96,7 @@ describe("checkChatHealthAndAlert", () => {
     await checkChatHealthAndAlert(NOW);
     const out = await checkChatHealthAndAlert(NOW + 60 * 60_000 + 1);
     expect(out.status).toBe("alerted");
-    expect(notify).toHaveBeenCalledTimes(2);
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(2);
   });
 
   // The whole point of the module: a monitor that cannot read the ledger has
@@ -99,7 +107,7 @@ describe("checkChatHealthAndAlert", () => {
     const out = await checkChatHealthAndAlert(NOW);
     expect(out.status).toBe("check-failed");
     expect(out.status).not.toBe("healthy");
-    expect(notify).not.toHaveBeenCalled();
+    expect(notifyWithDelivery).not.toHaveBeenCalled();
   });
 
   // An unreadable cooldown stamp is not an absent one. Treating it as absent
@@ -109,15 +117,20 @@ describe("checkChatHealthAndAlert", () => {
     settingsReadThrows = true;
     const out = await checkChatHealthAndAlert(NOW);
     expect(out.status).toBe("check-failed");
-    expect(notify).not.toHaveBeenCalled();
+    expect(notifyWithDelivery).not.toHaveBeenCalled();
   });
 
-  it("an undeliverable recipient does not suppress the others", async () => {
-    memberRows = [{ email: "a@example.com" }, { email: "b@example.com" }];
+  it("does not stamp cooldown when Slack is not delivered", async () => {
     turns(20, 15);
-    notify.mockRejectedValueOnce(new Error("channel down"));
+    notifyWithDelivery.mockResolvedValueOnce({
+      notification: undefined,
+      deliveredChannels: [],
+    });
     const out = await checkChatHealthAndAlert(NOW);
-    expect(out.status).toBe("alerted");
-    expect(notify).toHaveBeenCalledTimes(2);
+    expect(out.status).toBe("delivery-failed");
+    expect(settings).toEqual(new Map());
+
+    await checkChatHealthAndAlert(NOW + 60_000);
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -17,12 +17,14 @@ vi.mock("../db/client.js", () => ({
 
 const settings = new Map<string, Record<string, unknown>>();
 let settingsReadThrows = false;
+let settingsWriteThrows = false;
 vi.mock("../settings/store.js", () => ({
   getSetting: vi.fn(async (key: string) => {
     if (settingsReadThrows) throw new Error("settings unreadable");
     return settings.get(key) ?? null;
   }),
   putSetting: vi.fn(async (key: string, value: Record<string, unknown>) => {
+    if (settingsWriteThrows) throw new Error("settings write failed");
     settings.set(key, value);
   }),
 }));
@@ -47,6 +49,7 @@ beforeEach(() => {
   turnQueryThrows = false;
   settings.clear();
   settingsReadThrows = false;
+  settingsWriteThrows = false;
   notifyWithDelivery.mockClear();
   execute.mockClear();
 });
@@ -132,5 +135,16 @@ describe("checkChatHealthAndAlert", () => {
 
     await checkChatHealthAndAlert(NOW + 60_000);
     expect(notifyWithDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports when Slack delivered but cooldown persistence failed", async () => {
+    turns(20, 15);
+    settingsWriteThrows = true;
+    const out = await checkChatHealthAndAlert(NOW);
+    expect(out).toEqual({
+      status: "persistence-failed",
+      reason: "Slack delivered, but the alert cooldown could not be persisted.",
+    });
+    expect(notifyWithDelivery).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -45,7 +45,7 @@ function turns(total: number, bad: number) {
 
 beforeEach(() => {
   turnRows = [];
-  memberRows = [{ org_id: "org-1", email: "owner@example.com" }];
+  memberRows = [{ org_id: "org-1", email: "owner@example.com", role: "owner" }];
   turnQueryThrows = false;
   settings.clear();
   settingsReadThrows = false;
@@ -71,8 +71,8 @@ describe("checkChatHealthAndAlert", () => {
 
   it("pages Slack once when the app stops answering", async () => {
     memberRows = [
-      { org_id: "org-1", email: "a@example.com" },
-      { org_id: "org-1", email: "b@example.com" },
+      { org_id: "org-1", email: "a@example.com", role: "owner" },
+      { org_id: "org-1", email: "b@example.com", role: "admin" },
     ];
     turns(20, 15);
     const out = await checkChatHealthAndAlert(NOW);
@@ -89,8 +89,8 @@ describe("checkChatHealthAndAlert", () => {
 
   it("fails closed when owner scope spans multiple organizations", async () => {
     memberRows = [
-      { org_id: "org-1", email: "a@example.com" },
-      { org_id: "org-2", email: "b@example.com" },
+      { org_id: "org-1", email: "a@example.com", role: "owner" },
+      { org_id: "org-2", email: "b@example.com", role: "admin" },
     ];
     turns(20, 15);
     const out = await checkChatHealthAndAlert(NOW);

--- a/packages/core/src/agent/chat-health-alert.spec.ts
+++ b/packages/core/src/agent/chat-health-alert.spec.ts
@@ -45,7 +45,7 @@ function turns(total: number, bad: number) {
 
 beforeEach(() => {
   turnRows = [];
-  memberRows = [{ email: "owner@example.com" }];
+  memberRows = [{ org_id: "org-1", email: "owner@example.com" }];
   turnQueryThrows = false;
   settings.clear();
   settingsReadThrows = false;
@@ -70,7 +70,10 @@ describe("checkChatHealthAndAlert", () => {
   });
 
   it("pages Slack once when the app stops answering", async () => {
-    memberRows = [{ email: "a@example.com" }, { email: "b@example.com" }];
+    memberRows = [
+      { org_id: "org-1", email: "a@example.com" },
+      { org_id: "org-1", email: "b@example.com" },
+    ];
     turns(20, 15);
     const out = await checkChatHealthAndAlert(NOW);
     expect(out).toMatchObject({ status: "alerted", turns: 20, recipients: 1 });
@@ -82,6 +85,21 @@ describe("checkChatHealthAndAlert", () => {
     expect(notifyWithDelivery.mock.calls[0][1]).toEqual({
       owner: "a@example.com",
     });
+  });
+
+  it("fails closed when owner scope spans multiple organizations", async () => {
+    memberRows = [
+      { org_id: "org-1", email: "a@example.com" },
+      { org_id: "org-2", email: "b@example.com" },
+    ];
+    turns(20, 15);
+    const out = await checkChatHealthAndAlert(NOW);
+    expect(out).toEqual({
+      status: "delivery-failed",
+      reason:
+        "No single owner/admin organization scope is available for Slack health alerts.",
+    });
+    expect(notifyWithDelivery).not.toHaveBeenCalled();
   });
 
   it("pages once per outage, not once per sweep", async () => {

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -84,17 +84,20 @@ async function countRecentTurns(since: number): Promise<TurnCounts> {
 /** Use one owner/admin only when the app has an unambiguous org scope. */
 async function alertOwner(): Promise<string | null> {
   const { rows } = await getDbExec().execute({
-    sql: `SELECT org_id, email FROM org_members
-          WHERE role IN ('owner', 'admin')
-          ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, email`,
+    sql: `SELECT org_id, email, role FROM org_members
+          ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END, email`,
     args: [],
   });
   const orgIds = new Set(
     rows.map((row) => String((row as Record<string, unknown>).org_id ?? "")),
   );
   if (orgIds.size !== 1 || orgIds.has("")) return null;
+  const recipient = rows.find((row) => {
+    const role = (row as Record<string, unknown>).role;
+    return role === "owner" || role === "admin";
+  });
   const email = String(
-    (rows[0] as Record<string, unknown> | undefined)?.email ?? "",
+    (recipient as Record<string, unknown> | undefined)?.email ?? "",
   );
   return email || null;
 }

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -91,6 +91,7 @@ async function countRecentTurns(since: number): Promise<TurnCounts> {
 async function alertOwner(): Promise<AlertRecipient | null> {
   const { rows } = await getDbExec().execute({
     sql: `SELECT org_id, email, role FROM org_members
+          WHERE role IN ('owner', 'admin')
           ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END, email`,
     args: [],
   });

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
+
 import { getDbExec } from "../db/client.js";
 import { notifyWithDelivery } from "../notifications/registry.js";
 import { runWithRequestContext } from "../server/request-context.js";
-import { getSetting, putSetting } from "../settings/store.js";
+import { deleteSettingIfValue, mutateSetting } from "../settings/store.js";
 
 /**
  * Sends one Slack alert when an app's chat stops answering.
@@ -110,6 +112,23 @@ async function alertOwner(): Promise<AlertRecipient | null> {
   return email && orgId ? { owner: email, orgId } : null;
 }
 
+async function releaseAlertClaim(
+  claimId: string,
+  claimExpiresAt: number,
+): Promise<string | null> {
+  try {
+    await deleteSettingIfValue(LAST_ALERT_SETTING_KEY, {
+      claimId,
+      claimExpiresAt,
+    });
+    return null;
+  } catch (error) {
+    const reason = "The Slack alert claim could not be released.";
+    console.error(`[chat-health-alert] ${reason}`, error);
+    return reason;
+  }
+}
+
 export async function checkChatHealthAndAlert(
   now: number = Date.now(),
 ): Promise<ChatHealthAlertOutcome> {
@@ -130,23 +149,38 @@ export async function checkChatHealthAndAlert(
     return { status: "healthy", turns: counts.turns, badRate };
   }
 
-  // A cooldown stamp we could not READ is not a cooldown that is absent:
-  // treating it as absent pages on every sweep for as long as settings stay
-  // unreadable, which is exactly the spam the cooldown exists to prevent.
-  let stored: Record<string, unknown> | null;
+  // Claim the page before awaiting the external send. The claim lasts as long
+  // as the cooldown so overlapping sweeps cannot both send; failed sends
+  // release it below, while a crashed send becomes retryable after the lease.
+  const claimId = randomUUID();
+  const claimExpiresAt = now + COOLDOWN_MS;
+  let claim: Record<string, unknown>;
   try {
-    stored = (await getSetting(LAST_ALERT_SETTING_KEY)) as Record<
-      string,
-      unknown
-    > | null;
+    claim = await mutateSetting(LAST_ALERT_SETTING_KEY, (current) => {
+      const lastPagedAt = Number(current?.at ?? 0);
+      const existingClaimExpiresAt = Number(current?.claimExpiresAt ?? 0);
+      if (
+        (Number.isFinite(lastPagedAt) && now - lastPagedAt < COOLDOWN_MS) ||
+        (Number.isFinite(existingClaimExpiresAt) &&
+          existingClaimExpiresAt > now)
+      ) {
+        return current ?? {};
+      }
+      return { claimId, claimExpiresAt };
+    });
   } catch (error) {
     return { status: "check-failed", reason: String(error) };
   }
-  const lastPagedAt = Number(stored?.at ?? 0);
-  if (Number.isFinite(lastPagedAt) && now - lastPagedAt < COOLDOWN_MS) {
+
+  if (String(claim.claimId ?? "") !== claimId) {
+    const lastPagedAt = Number(claim.at ?? 0);
+    const retryAfterMs =
+      Number.isFinite(lastPagedAt) && now - lastPagedAt < COOLDOWN_MS
+        ? COOLDOWN_MS - (now - lastPagedAt)
+        : Math.max(0, Number(claim.claimExpiresAt ?? 0) - now);
     return {
       status: "cooldown",
-      retryAfterMs: COOLDOWN_MS - (now - lastPagedAt),
+      retryAfterMs,
     };
   }
 
@@ -191,19 +225,39 @@ export async function checkChatHealthAndAlert(
     );
   } catch (error) {
     console.error("[chat-health-alert] Slack delivery failed:", error);
-    return { status: "delivery-failed", reason: String(error) };
+    const releaseReason = await releaseAlertClaim(claimId, claimExpiresAt);
+    return {
+      status: "delivery-failed",
+      reason: releaseReason
+        ? `${String(error)} ${releaseReason}`
+        : String(error),
+    };
   }
 
   if (!delivery.deliveredChannels.includes("slack")) {
     const reason = "Slack health alert was not delivered.";
     console.error(`[chat-health-alert] ${reason}`);
-    return { status: "delivery-failed", reason };
+    const releaseReason = await releaseAlertClaim(claimId, claimExpiresAt);
+    return {
+      status: "delivery-failed",
+      reason: releaseReason ? `${reason} ${releaseReason}` : reason,
+    };
   }
 
-  // Stamp only after Slack confirms delivery, so a failed alert retries on the
-  // next sweep instead of being silenced by its own cooldown.
+  // Finalize only after Slack confirms delivery. The claim id keeps a slow or
+  // expired sender from overwriting a newer claim's cooldown.
   try {
-    await putSetting(LAST_ALERT_SETTING_KEY, { at: now });
+    const finalized = await mutateSetting(LAST_ALERT_SETTING_KEY, (current) =>
+      String(current?.claimId ?? "") === claimId
+        ? { at: now, claimId }
+        : (current ?? {}),
+    );
+    if (String(finalized.claimId ?? "") !== claimId) {
+      const reason =
+        "Slack delivered, but its alert cooldown claim was lost before persistence.";
+      console.error(`[chat-health-alert] ${reason}`);
+      return { status: "persistence-failed", reason };
+    }
   } catch (error) {
     const reason =
       "Slack delivered, but the alert cooldown could not be persisted.";

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -1,5 +1,6 @@
 import { getDbExec } from "../db/client.js";
 import { notifyWithDelivery } from "../notifications/registry.js";
+import { runWithRequestContext } from "../server/request-context.js";
 import { getSetting, putSetting } from "../settings/store.js";
 
 /**
@@ -51,6 +52,11 @@ interface TurnCounts {
   bad: number;
 }
 
+interface AlertRecipient {
+  owner: string;
+  orgId: string;
+}
+
 /**
  * Scores the LAST run of each turn in the window, matching how
  * `scripts/chat-health.mjs` reports so a page and the CLI never disagree.
@@ -82,7 +88,7 @@ async function countRecentTurns(since: number): Promise<TurnCounts> {
 }
 
 /** Use one owner/admin only when the app has an unambiguous org scope. */
-async function alertOwner(): Promise<string | null> {
+async function alertOwner(): Promise<AlertRecipient | null> {
   const { rows } = await getDbExec().execute({
     sql: `SELECT org_id, email, role FROM org_members
           ORDER BY CASE role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 ELSE 2 END, email`,
@@ -99,7 +105,8 @@ async function alertOwner(): Promise<string | null> {
   const email = String(
     (recipient as Record<string, unknown> | undefined)?.email ?? "",
   );
-  return email || null;
+  const [orgId] = [...orgIds];
+  return email && orgId ? { owner: email, orgId } : null;
 }
 
 export async function checkChatHealthAndAlert(
@@ -142,13 +149,13 @@ export async function checkChatHealthAndAlert(
     };
   }
 
-  let owner: string | null;
+  let recipient: AlertRecipient | null;
   try {
-    owner = await alertOwner();
+    recipient = await alertOwner();
   } catch (error) {
     return { status: "check-failed", reason: String(error) };
   }
-  if (!owner) {
+  if (!recipient) {
     return {
       status: "delivery-failed",
       reason:
@@ -159,23 +166,27 @@ export async function checkChatHealthAndAlert(
   const pct = Math.round(badRate * 100);
   let delivery: Awaited<ReturnType<typeof notifyWithDelivery>>;
   try {
-    delivery = await notifyWithDelivery(
-      {
-        severity: "critical",
-        title: `Chat is failing: ${pct}% of turns ended without an answer`,
-        body:
-          `${counts.bad} of ${counts.turns} turns in the last hour ended without ` +
-          `an answer. Run \`node scripts/chat-health.mjs --hours 1\` for the ` +
-          `per-reason breakdown.`,
-        channels: ["slack"],
-        metadata: {
-          turns: counts.turns,
-          bad: counts.bad,
-          badRate,
-          windowMs: WINDOW_MS,
-        },
-      },
-      { owner },
+    delivery = await runWithRequestContext(
+      { userEmail: recipient.owner, orgId: recipient.orgId },
+      () =>
+        notifyWithDelivery(
+          {
+            severity: "critical",
+            title: `Chat is failing: ${pct}% of turns ended without an answer`,
+            body:
+              `${counts.bad} of ${counts.turns} turns in the last hour ended without ` +
+              `an answer. Run \`node scripts/chat-health.mjs --hours 1\` for the ` +
+              `per-reason breakdown.`,
+            channels: ["slack"],
+            metadata: {
+              turns: counts.turns,
+              bad: counts.bad,
+              badRate,
+              windowMs: WINDOW_MS,
+            },
+          },
+          { owner: recipient.owner },
+        ),
     );
   } catch (error) {
     console.error("[chat-health-alert] Slack delivery failed:", error);

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -32,6 +32,8 @@ const MIN_TURNS = 5;
 const BAD_RATE_THRESHOLD = 0.5;
 /** One page per outage, not one per sweep. */
 const COOLDOWN_MS = 60 * 60_000;
+/** Slack sends time out well inside this lease; failed sends release it early. */
+const CLAIM_LEASE_MS = 5 * 60_000;
 
 const LAST_ALERT_SETTING_KEY = "chat-health-alert:last-slack-alert-at";
 
@@ -149,11 +151,11 @@ export async function checkChatHealthAndAlert(
     return { status: "healthy", turns: counts.turns, badRate };
   }
 
-  // Claim the page before awaiting the external send. The claim lasts as long
-  // as the cooldown so overlapping sweeps cannot both send; failed sends
-  // release it below, while a crashed send becomes retryable after the lease.
+  // Claim the page before awaiting the external send. The short lease keeps
+  // overlapping sweeps from both sending; failed sends release it below,
+  // while a crashed send becomes retryable after the lease.
   const claimId = randomUUID();
-  const claimExpiresAt = now + COOLDOWN_MS;
+  const claimExpiresAt = now + CLAIM_LEASE_MS;
   let claim: Record<string, unknown>;
   try {
     claim = await mutateSetting(LAST_ALERT_SETTING_KEY, (current) => {

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -81,15 +81,18 @@ async function countRecentTurns(since: number): Promise<TurnCounts> {
   };
 }
 
-/** Use one owner/admin so a shared Slack webhook gets one alert, not duplicates. */
+/** Use one owner/admin only when the app has an unambiguous org scope. */
 async function alertOwner(): Promise<string | null> {
   const { rows } = await getDbExec().execute({
-    sql: `SELECT email FROM org_members
+    sql: `SELECT org_id, email FROM org_members
           WHERE role IN ('owner', 'admin')
-          ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, email
-          LIMIT 1`,
+          ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, email`,
     args: [],
   });
+  const orgIds = new Set(
+    rows.map((row) => String((row as Record<string, unknown>).org_id ?? "")),
+  );
+  if (orgIds.size !== 1 || orgIds.has("")) return null;
   const email = String(
     (rows[0] as Record<string, unknown> | undefined)?.email ?? "",
   );
@@ -145,7 +148,8 @@ export async function checkChatHealthAndAlert(
   if (!owner) {
     return {
       status: "delivery-failed",
-      reason: "No owner or admin is configured for Slack health alerts.",
+      reason:
+        "No single owner/admin organization scope is available for Slack health alerts.",
     };
   }
 

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -1,9 +1,9 @@
 import { getDbExec } from "../db/client.js";
-import { notify } from "../notifications/registry.js";
+import { notifyWithDelivery } from "../notifications/registry.js";
 import { getSetting, putSetting } from "../settings/store.js";
 
 /**
- * Pages the people who can act when an app's chat stops answering.
+ * Sends one Slack alert when an app's chat stops answering.
  *
  * The detector for this already existed as `scripts/chat-health.mjs --strict`,
  * correctly calibrated and exiting 1 on a partial outage — but nothing ever ran
@@ -30,7 +30,7 @@ const BAD_RATE_THRESHOLD = 0.5;
 /** One page per outage, not one per sweep. */
 const COOLDOWN_MS = 60 * 60_000;
 
-const LAST_ALERT_SETTING_KEY = "chat-health-alert:last-paged-at";
+const LAST_ALERT_SETTING_KEY = "chat-health-alert:last-slack-alert-at";
 
 /**
  * Every outcome is distinguishable. "Not enough turns to judge" and "healthy"
@@ -42,6 +42,7 @@ export type ChatHealthAlertOutcome =
   | { status: "insufficient-data"; turns: number }
   | { status: "cooldown"; retryAfterMs: number }
   | { status: "alerted"; turns: number; badRate: number; recipients: number }
+  | { status: "delivery-failed"; reason: string }
   | { status: "check-failed"; reason: string };
 
 interface TurnCounts {
@@ -79,16 +80,19 @@ async function countRecentTurns(since: number): Promise<TurnCounts> {
   };
 }
 
-/** Owners and admins — the people who can actually change a model or a key. */
-async function alertRecipients(): Promise<string[]> {
+/** Use one owner/admin so a shared Slack webhook gets one alert, not duplicates. */
+async function alertOwner(): Promise<string | null> {
   const { rows } = await getDbExec().execute({
-    sql: `SELECT DISTINCT email FROM org_members
-          WHERE role IN ('owner', 'admin')`,
+    sql: `SELECT email FROM org_members
+          WHERE role IN ('owner', 'admin')
+          ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, email
+          LIMIT 1`,
     args: [],
   });
-  return rows
-    .map((r) => String((r as Record<string, unknown>).email ?? ""))
-    .filter(Boolean);
+  const email = String(
+    (rows[0] as Record<string, unknown> | undefined)?.email ?? "",
+  );
+  return email || null;
 }
 
 export async function checkChatHealthAndAlert(
@@ -131,16 +135,23 @@ export async function checkChatHealthAndAlert(
     };
   }
 
-  let recipients: string[];
+  let owner: string | null;
   try {
-    recipients = await alertRecipients();
+    owner = await alertOwner();
   } catch (error) {
     return { status: "check-failed", reason: String(error) };
   }
+  if (!owner) {
+    return {
+      status: "delivery-failed",
+      reason: "No owner or admin is configured for Slack health alerts.",
+    };
+  }
 
   const pct = Math.round(badRate * 100);
-  for (const owner of recipients) {
-    await notify(
+  let delivery: Awaited<ReturnType<typeof notifyWithDelivery>>;
+  try {
+    delivery = await notifyWithDelivery(
       {
         severity: "critical",
         title: `Chat is failing: ${pct}% of turns ended without an answer`,
@@ -148,6 +159,7 @@ export async function checkChatHealthAndAlert(
           `${counts.bad} of ${counts.turns} turns in the last hour ended without ` +
           `an answer. Run \`node scripts/chat-health.mjs --hours 1\` for the ` +
           `per-reason breakdown.`,
+        channels: ["slack"],
         metadata: {
           turns: counts.turns,
           bad: counts.bad,
@@ -156,17 +168,20 @@ export async function checkChatHealthAndAlert(
         },
       },
       { owner },
-    ).catch((error: unknown) => {
-      // One undeliverable recipient must not suppress the rest.
-      console.error(
-        "[chat-health-alert] notify failed for a recipient:",
-        error,
-      );
-    });
+    );
+  } catch (error) {
+    console.error("[chat-health-alert] Slack delivery failed:", error);
+    return { status: "delivery-failed", reason: String(error) };
   }
 
-  // Stamped only after an attempt was actually made, so a failed page retries
-  // on the next sweep instead of being silenced by its own cooldown.
+  if (!delivery.deliveredChannels.includes("slack")) {
+    const reason = "Slack health alert was not delivered.";
+    console.error(`[chat-health-alert] ${reason}`);
+    return { status: "delivery-failed", reason };
+  }
+
+  // Stamp only after Slack confirms delivery, so a failed alert retries on the
+  // next sweep instead of being silenced by its own cooldown.
   await putSetting(LAST_ALERT_SETTING_KEY, { at: now }).catch(
     (error: unknown) => {
       console.error("[chat-health-alert] could not stamp cooldown:", error);
@@ -177,6 +192,6 @@ export async function checkChatHealthAndAlert(
     status: "alerted",
     turns: counts.turns,
     badRate,
-    recipients: recipients.length,
+    recipients: 1,
   };
 }

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -43,6 +43,7 @@ export type ChatHealthAlertOutcome =
   | { status: "cooldown"; retryAfterMs: number }
   | { status: "alerted"; turns: number; badRate: number; recipients: number }
   | { status: "delivery-failed"; reason: string }
+  | { status: "persistence-failed"; reason: string }
   | { status: "check-failed"; reason: string };
 
 interface TurnCounts {
@@ -182,11 +183,14 @@ export async function checkChatHealthAndAlert(
 
   // Stamp only after Slack confirms delivery, so a failed alert retries on the
   // next sweep instead of being silenced by its own cooldown.
-  await putSetting(LAST_ALERT_SETTING_KEY, { at: now }).catch(
-    (error: unknown) => {
-      console.error("[chat-health-alert] could not stamp cooldown:", error);
-    },
-  );
+  try {
+    await putSetting(LAST_ALERT_SETTING_KEY, { at: now });
+  } catch (error) {
+    const reason =
+      "Slack delivered, but the alert cooldown could not be persisted.";
+    console.error("[chat-health-alert] could not stamp cooldown:", error);
+    return { status: "persistence-failed", reason };
+  }
 
   return {
     status: "alerted",

--- a/packages/core/src/agent/chat-health-alert.ts
+++ b/packages/core/src/agent/chat-health-alert.ts
@@ -188,13 +188,21 @@ export async function checkChatHealthAndAlert(
   try {
     recipient = await alertOwner();
   } catch (error) {
-    return { status: "check-failed", reason: String(error) };
+    const releaseReason = await releaseAlertClaim(claimId, claimExpiresAt);
+    return {
+      status: "check-failed",
+      reason: releaseReason
+        ? `${String(error)} ${releaseReason}`
+        : String(error),
+    };
   }
   if (!recipient) {
+    const reason =
+      "No single owner/admin organization scope is available for Slack health alerts.";
+    const releaseReason = await releaseAlertClaim(claimId, claimExpiresAt);
     return {
       status: "delivery-failed",
-      reason:
-        "No single owner/admin organization scope is available for Slack health alerts.",
+      reason: releaseReason ? `${reason} ${releaseReason}` : reason,
     };
   }
 

--- a/packages/core/src/notifications/channels.spec.ts
+++ b/packages/core/src/notifications/channels.spec.ts
@@ -439,6 +439,7 @@ describe("Slack notification channel", () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("https://hooks.slack.example.com/services/T/B/C");
     expect(init.method).toBe("POST");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     const payload = JSON.parse(init.body);
     expect(payload.text).toContain("[critical] Clip uploads failing");
     expect(payload.blocks[0].text.text).toBe("*Clip uploads failing*");

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -40,6 +40,7 @@ import { registerNotificationChannel } from "./registry.js";
 import type { NotificationChannel, NotificationInput } from "./types.js";
 
 let _registered = false;
+const SLACK_DELIVERY_TIMEOUT_MS = 10_000;
 
 export function registerBuiltinNotificationChannels(): void {
   if (_registered) return;
@@ -134,6 +135,7 @@ function createSlackWebhookChannel(
         {
           method: "POST",
           headers,
+          signal: AbortSignal.timeout(SLACK_DELIVERY_TIMEOUT_MS),
           body: JSON.stringify({
             text: slackText(input.severity, input.title, input.body),
             blocks: [


### PR DESCRIPTION
## Summary
- Route chat-health outage alerts through the existing Slack notification channel only.
- Send one alert per outage and stamp cooldown only after Slack confirms delivery.
- Retry on missing or failed Slack delivery instead of suppressing the outage.

## Validation
- 45 focused health and notification tests passed.
- Oxfmt and diff checks passed.
- The package typecheck remains blocked by existing missing toolkit/client module errors unrelated to this change.

## Configuration
- Set `NOTIFICATIONS_SLACK_WEBHOOK_URL` in the deployed runtime to enable delivery.