### PR TITLE
fix(core): redirect Builder employees to beta with no session round trip

### DIFF
--- a/.changeset/zero-rtt-beta-redirect.md
+++ b/.changeset/zero-rtt-beta-redirect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Redirect Builder employees to beta instantly from the cached browser marker, without waiting on a session round trip.

--- a/packages/core/src/client/app-providers.tsx
+++ b/packages/core/src/client/app-providers.tsx
@@ -61,7 +61,6 @@ import {
   normalizeDocumentTitle,
 } from "../shared/document-title.js";
 import { getSsrBetaRedirectScriptBody } from "../shared/ssr-beta-redirect.js";
-import { agentNativePath } from "./api-path.js";
 import { ClientOnly } from "./ClientOnly.js";
 import { DefaultSpinner } from "./DefaultSpinner.js";
 import { EnvironmentBadge } from "./EnvironmentBadge.js";
@@ -167,11 +166,7 @@ function EarlyBetaRedirectScript() {
   return (
     <script
       data-agent-native-beta-redirect="1"
-      dangerouslySetInnerHTML={{
-        __html: getSsrBetaRedirectScriptBody(
-          agentNativePath("/_agent-native/auth/session"),
-        ),
-      }}
+      dangerouslySetInnerHTML={{ __html: getSsrBetaRedirectScriptBody() }}
     />
   );
 }

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -3224,31 +3224,6 @@ describe("server/auth", () => {
       );
     });
 
-    it("preserves the mounted workspace path for configured login HTML", async () => {
-      vi.stubEnv("NODE_ENV", "production");
-      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
-      delete process.env.ACCESS_TOKEN;
-      delete process.env.ACCESS_TOKENS;
-      const { autoMountAuth, getConfiguredLoginHtml } =
-        await import("./auth.js");
-
-      const app = createMockApp();
-      await autoMountAuth(app, {
-        getSession: async () => null,
-        loginHtml:
-          "<!doctype html><html><head></head><body><form>QA login</form></body></html>",
-      });
-
-      const event = createMockEvent({ path: "/login" });
-      event.context._mountedPathname = "/plan/login";
-      event.path = "/login";
-      event.node.req.url = "/login";
-
-      const html = getConfiguredLoginHtml(event);
-
-      expect(html).toContain("/plan/_agent-native/auth/session");
-    });
-
     it("simplifies login HTML when the return path contains an initial prompt", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("AUTH_MAGIC_LINK", "0");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -789,10 +789,7 @@ export function getConfiguredLoginHtml(event: H3Event): string | null {
   const loginHtml =
     config.getLoginHtml?.(event, rawPath) ?? config.loginHtml ?? null;
   return loginHtml
-    ? injectLoginSocialImageMeta(
-        injectBetaOptOutPersistence(loginHtml, rawPath),
-        event,
-      )
+    ? injectLoginSocialImageMeta(injectBetaOptOutPersistence(loginHtml), event)
     : null;
 }
 
@@ -3197,10 +3194,7 @@ function loginHtmlResponse(
   } = {},
 ): Response {
   let html = injectLoginSocialImageMeta(
-    injectBetaOptOutPersistence(
-      loginHtml,
-      getRequestPathAndSearch(event).rawPath,
-    ),
+    injectBetaOptOutPersistence(loginHtml),
     options.requestIndependent ? undefined : event,
   );
   if (options.includeRootAuthRedirect) {

--- a/packages/core/src/server/beta-opt-out-html.spec.ts
+++ b/packages/core/src/server/beta-opt-out-html.spec.ts
@@ -93,56 +93,19 @@ describe("injectBetaOptOutPersistence", () => {
     expect(reinjected.match(/__anInitEnvironmentBadge/g)).toHaveLength(1);
   });
 
-  it("uses the Vite SSR base path for the auth session probe", () => {
-    delete process.env.APP_BASE_PATH;
-    delete process.env.VITE_APP_BASE_PATH;
-    vi.stubEnv("VITE_APP_BASE_PATH", "/starter/");
-
-    const html = injectBetaOptOutPersistence(
-      "<html><head></head><body>Sign in</body></html>",
-    );
-
-    expect(html).toContain("/starter/_agent-native/auth/session");
-  });
-
-  it("uses the mounted workspace path when no build-time base exists", () => {
-    delete process.env.APP_BASE_PATH;
-    delete process.env.VITE_APP_BASE_PATH;
-    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
-
-    const html = injectBetaOptOutPersistence(
-      "<html><head></head><body>Sign in</body></html>",
-      "/plan/login",
-    );
-
-    expect(html).toContain("/plan/_agent-native/auth/session");
-  });
-
-  it("prefers the request mount over a stale build-time base", () => {
+  it("embeds no request-derived path in the inline redirect script", () => {
     vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
     vi.stubEnv("VITE_APP_BASE_PATH", "/dispatch");
 
     const html = injectBetaOptOutPersistence(
       "<html><head></head><body>Sign in</body></html>",
-      "/diagrams/login",
     );
 
-    expect(html).toContain("/diagrams/_agent-native/auth/session");
-    expect(html).not.toContain("/dispatch/_agent-native/auth/session");
-  });
-
-  it("escapes a request-derived session probe path in the inline script", () => {
-    delete process.env.APP_BASE_PATH;
-    delete process.env.VITE_APP_BASE_PATH;
-    vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
-
-    const html = injectBetaOptOutPersistence(
-      "<html><head></head><body>Sign in</body></html>",
-      "/<script>alert(1)/login",
-    );
-
-    expect(html).toContain("\\u003cscript\\u003ealert(1)");
-    expect(html).not.toContain("<script>alert(1)");
+    // The early redirect decides from the browser's own location and storage.
+    // Nothing from the request reaches this inline script, so the login shell
+    // has no injection surface to escape in the first place.
+    expect(html).toContain(SSR_BETA_REDIRECT_MARKER);
+    expect(html).not.toContain("_agent-native/auth/session");
   });
 
   it("keeps the existing onboarding switcher instead of injecting a second one", () => {

--- a/packages/core/src/server/beta-opt-out-html.ts
+++ b/packages/core/src/server/beta-opt-out-html.ts
@@ -11,8 +11,6 @@ import {
   getSsrBetaRedirectScript,
   SSR_BETA_REDIRECT_MARKER,
 } from "../shared/ssr-beta-redirect.js";
-import { getAppBasePathFromViteEnv } from "./app-base-path.js";
-import { workspaceBasePathFromRequest } from "./onboarding-html.js";
 
 export const BETA_OPT_OUT_PERSISTENCE_MARKER =
   "Persist the beta opt-out before authentication";
@@ -239,19 +237,10 @@ const betaOptOutPersistenceScript = `<script data-agent-native-beta-opt-out>
  * Keep the production switcher's one-time opt-out behavior at the shared auth
  * response boundary so those pages cannot drop the handoff before sign-in.
  */
-export function injectBetaOptOutPersistence(
-  loginHtml: string,
-  requestPath?: string,
-): string {
+export function injectBetaOptOutPersistence(loginHtml: string): string {
   let html = loginHtml;
   if (!html.includes(SSR_BETA_REDIRECT_MARKER)) {
-    const appBasePath =
-      workspaceBasePathFromRequest(requestPath) || getAppBasePathFromViteEnv();
-    html = insertBeforeClosingTag(
-      html,
-      getSsrBetaRedirectScript(`${appBasePath}/_agent-native/auth/session`),
-      "</head>",
-    );
+    html = insertBeforeClosingTag(html, getSsrBetaRedirectScript(), "</head>");
   }
   if (!html.includes(BETA_OPT_OUT_PERSISTENCE_MARKER)) {
     html = insertBeforeClosingTag(html, betaOptOutPersistenceScript, "</body>");

--- a/packages/core/src/shared/ssr-beta-redirect.spec.ts
+++ b/packages/core/src/shared/ssr-beta-redirect.spec.ts
@@ -27,38 +27,49 @@ function createStorage(initial: Record<string, string> = {}) {
   };
 }
 
+function createFailingStorage() {
+  return {
+    getItem() {
+      throw new Error("storage denied");
+    },
+    removeItem() {
+      throw new Error("storage denied");
+    },
+    setItem() {
+      throw new Error("storage denied");
+    },
+  };
+}
+
+function activeMarker() {
+  return { [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000) };
+}
+
 function runScript({
   href,
   embedded = false,
   localStorage = createStorage(),
   sessionStorage = createStorage(),
   userAgent = "",
-  session = { email: "employee@builder.io" },
-  sessionResponseOk = true,
-  sessionPath = "/_agent-native/auth/session",
-  workspaceRuntime = false,
-  workspaceAppMountPaths,
-  sessionProbe,
+  signOutStarted = false,
 }: {
-  href: string | { current: string };
+  href: string;
   embedded?: boolean;
-  localStorage?: ReturnType<typeof createStorage>;
-  sessionStorage?: ReturnType<typeof createStorage>;
+  localStorage?:
+    | ReturnType<typeof createStorage>
+    | ReturnType<typeof createFailingStorage>;
+  sessionStorage?:
+    | ReturnType<typeof createStorage>
+    | ReturnType<typeof createFailingStorage>;
   userAgent?: string;
-  session?: Record<string, unknown> | null;
-  sessionResponseOk?: boolean;
-  sessionPath?: string;
-  workspaceRuntime?: boolean;
-  workspaceAppMountPaths?: string[];
-  sessionProbe?: Promise<Record<string, unknown> | null>;
+  signOutStarted?: boolean;
 }) {
   const result = {
     fetched: [] as string[],
     historyUrl: null as string | null,
     redirectedTo: null as string | null,
   };
-  const hrefRef = typeof href === "string" ? { current: href } : href;
-  const url = new URL(hrefRef.current);
+  const hrefRef = { current: href };
   const window = {
     history: {
       replaceState(_state: unknown, _title: string, value: string) {
@@ -80,112 +91,46 @@ function runScript({
     navigator: { userAgent },
     parent: null as unknown,
     sessionStorage,
-    __AGENT_NATIVE_CONFIG__: workspaceRuntime
-      ? {
-          workspaceRuntime: true,
-          ...(workspaceAppMountPaths ? { workspaceAppMountPaths } : {}),
-        }
-      : undefined,
+    ...(signOutStarted
+      ? { __agentNativeBetaRedirectSignOutStarted: true }
+      : {}),
   } as Record<string, unknown>;
   window.parent = embedded ? {} : window;
 
-  const fetch = async (input: string) => {
+  // Recorded, never expected: an early redirect that reaches the network has
+  // put a round trip back in front of the navigation this script exists to
+  // make instant.
+  window.fetch = (input: string) => {
     result.fetched.push(input);
-    const responseSession = sessionProbe ? await sessionProbe : session;
-    return {
-      ok: sessionResponseOk,
-      status: sessionResponseOk ? 200 : 503,
-      json: async () => responseSession,
-    };
+    return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
   };
-  window.fetch = fetch;
 
-  new Function("window", "fetch", getSsrBetaRedirectScriptBody(sessionPath))(
-    window,
-    fetch,
-  );
+  new Function("window", getSsrBetaRedirectScriptBody())(window);
 
-  return Promise.resolve()
-    .then(() => new Promise<void>((resolve) => setTimeout(resolve, 0)))
-    .then(() => ({ ...result, localStorage, sessionStorage }));
+  return { ...result, localStorage, sessionStorage };
 }
 
 describe("getSsrBetaRedirectScript", () => {
-  it("redirects before the app bundle after revalidating the employee session", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-
-    const result = await runScript({
-      href: "http://plan.agent-native.com/inbox?tab=all#runs",
-      localStorage,
+  it("redirects synchronously without any network request", () => {
+    const result = runScript({
+      href: "https://plan.agent-native.com/projects/42?tab=activity#runs",
+      localStorage: createStorage(activeMarker()),
     });
 
     expect(result.redirectedTo).toBe(
-      "https://beta.plan.agent-native.com/inbox?tab=all#runs",
+      "https://beta.plan.agent-native.com/projects/42?tab=activity#runs",
     );
-    expect(result.fetched).toEqual(["/_agent-native/auth/session"]);
+    expect(result.fetched).toEqual([]);
   });
 
-  it("uses the mapped beta host for the workspace production alias", async () => {
-    const result = await runScript({
+  it("uses the mapped beta host for the workspace production alias", () => {
+    const result = runScript({
       href: "https://builder-agent-native-workspace.netlify.app/inbox",
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-      }),
+      localStorage: createStorage(activeMarker()),
     });
 
     expect(result.redirectedTo).toBe(
       "https://beta.agent-workspace.builder.io/inbox",
-    );
-  });
-
-  it("derives a workspace mount for the SSR probe in the browser", async () => {
-    const result = await runScript({
-      href: "https://agent-workspace.builder.io/plan/inbox",
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-      }),
-      workspaceRuntime: true,
-    });
-
-    expect(result.fetched).toEqual(["/plan/_agent-native/auth/session"]);
-    expect(result.redirectedTo).toBe(
-      "https://beta.agent-workspace.builder.io/plan/inbox",
-    );
-  });
-
-  it("replaces a stale configured workspace mount with the live mount", async () => {
-    const result = await runScript({
-      href: "https://agent-workspace.builder.io/diagrams/inbox",
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-      }),
-      sessionPath: "/dispatch/_agent-native/auth/session",
-      workspaceRuntime: true,
-      workspaceAppMountPaths: ["/dispatch", "/diagrams"],
-    });
-
-    expect(result.fetched).toEqual(["/diagrams/_agent-native/auth/session"]);
-    expect(result.redirectedTo).toBe(
-      "https://beta.agent-workspace.builder.io/diagrams/inbox",
-    );
-  });
-
-  it("keeps a configured path when the live segment is not a workspace mount", async () => {
-    const result = await runScript({
-      href: "https://agent-workspace.builder.io/settings/inbox",
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-      }),
-      sessionPath: "/dispatch/_agent-native/auth/session",
-      workspaceRuntime: true,
-      workspaceAppMountPaths: ["/dispatch", "/diagrams"],
-    });
-
-    expect(result.fetched).toEqual(["/dispatch/_agent-native/auth/session"]);
-    expect(result.redirectedTo).toBe(
-      "https://beta.agent-workspace.builder.io/settings/inbox",
     );
   });
 
@@ -197,80 +142,79 @@ describe("getSsrBetaRedirectScript", () => {
       "https://plan.agent-native.com/inbox",
       "AgentNativeDesktop/1",
     ],
-  ])("does not redirect on %s", async (_name, href, userAgent) => {
-    const result = await runScript({
+  ])("does not redirect on %s", (_name, href, userAgent) => {
+    const result = runScript({
       href,
       userAgent,
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-      }),
+      localStorage: createStorage(activeMarker()),
     });
 
     expect(result.redirectedTo).toBeNull();
   });
 
-  it("does not redirect embedded sessions", async () => {
-    const result = await runScript({
+  it("does not redirect embedded sessions", () => {
+    const result = runScript({
       embedded: true,
       href: "https://plan.agent-native.com/inbox",
-      localStorage: createStorage({
-        [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
+      localStorage: createStorage(activeMarker()),
+    });
+
+    expect(result.redirectedTo).toBeNull();
+  });
+
+  it("does not redirect without a stored marker", () => {
+    const result = runScript({
+      href: "https://plan.agent-native.com/inbox",
+    });
+
+    expect(result.redirectedTo).toBeNull();
+    expect(result.fetched).toEqual([]);
+  });
+
+  it("persists a force query guard for the rest of the browser session", () => {
+    const sessionStorage = createStorage();
+    const result = runScript({
+      href: "https://plan.agent-native.com/inbox?force=true",
+      localStorage: createStorage(activeMarker()),
+      sessionStorage,
+    });
+
+    expect(result.redirectedTo).toBeNull();
+    expect(sessionStorage.getItem(BETA_FORCE_SESSION_STORAGE_KEY)).toBe("1");
+  });
+
+  it("honors a stored force guard from earlier in the session", () => {
+    const result = runScript({
+      href: "https://plan.agent-native.com/inbox",
+      localStorage: createStorage(activeMarker()),
+      sessionStorage: createStorage({
+        [BETA_FORCE_SESSION_STORAGE_KEY]: "1",
       }),
     });
 
     expect(result.redirectedTo).toBeNull();
   });
 
-  it("persists a force query guard for the rest of the browser session", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-    const sessionStorage = createStorage();
-
-    const forced = await runScript({
-      href: "https://plan.agent-native.com/inbox?force=true",
-      localStorage,
-      sessionStorage,
-    });
-    const subsequent = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage,
-      sessionStorage,
-    });
-
-    expect(forced.redirectedTo).toBeNull();
-    expect(sessionStorage.getItem(BETA_FORCE_SESSION_STORAGE_KEY)).toBe("1");
-    expect(subsequent.redirectedTo).toBeNull();
-  });
-
-  it("stores an active opt-out and clears the redirect marker before returning", async () => {
-    const optOutExpiry = Date.now() + 60 * 60 * 1000;
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-
-    const result = await runScript({
-      href: `https://plan.agent-native.com/inbox?tab=all&agentNativeBetaOptOut=${optOutExpiry}#runs`,
+  it("stores an active opt-out and clears the redirect marker before returning", () => {
+    const expiry = Date.now() + 60_000;
+    const localStorage = createStorage(activeMarker());
+    const result = runScript({
+      href: `https://plan.agent-native.com/inbox?agentNativeBetaOptOut=${expiry}`,
       localStorage,
     });
 
     expect(result.redirectedTo).toBeNull();
-    expect(result.historyUrl).toBe(
-      "https://plan.agent-native.com/inbox?tab=all#runs",
-    );
-    expect(localStorage.getItem(BETA_OPT_OUT_STORAGE_KEY)).toBe(
-      String(optOutExpiry),
-    );
+    expect(localStorage.getItem(BETA_OPT_OUT_STORAGE_KEY)).toBe(String(expiry));
     expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).toBeNull();
+    expect(result.historyUrl).toBe("https://plan.agent-native.com/inbox");
   });
 
-  it("honors an active stored opt-out without touching the redirect marker", async () => {
+  it("honors an active stored opt-out without touching the redirect marker", () => {
     const localStorage = createStorage({
-      [BETA_OPT_OUT_STORAGE_KEY]: String(Date.now() + 60 * 60 * 1000),
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
+      ...activeMarker(),
+      [BETA_OPT_OUT_STORAGE_KEY]: String(Date.now() + 60_000),
     });
-
-    const result = await runScript({
+    const result = runScript({
       href: "https://plan.agent-native.com/inbox",
       localStorage,
     });
@@ -279,12 +223,11 @@ describe("getSsrBetaRedirectScript", () => {
     expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).not.toBeNull();
   });
 
-  it("clears expired redirect markers instead of redirecting", async () => {
+  it("clears expired redirect markers instead of redirecting", () => {
     const localStorage = createStorage({
       [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() - 1),
     });
-
-    const result = await runScript({
+    const result = runScript({
       href: "https://plan.agent-native.com/inbox",
       localStorage,
     });
@@ -293,168 +236,44 @@ describe("getSsrBetaRedirectScript", () => {
     expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).toBeNull();
   });
 
-  it("fails open when browser storage is unavailable", async () => {
-    const deniedStorage = {
-      getItem() {
-        throw new Error("storage denied");
-      },
-      removeItem() {
-        throw new Error("storage denied");
-      },
-      setItem() {
-        throw new Error("storage denied");
-      },
-    };
+  it.each([
+    ["an in-memory sign-out flag", true, createStorage()],
+    [
+      "a stored sign-out signal",
+      false,
+      createStorage({ [BETA_REDIRECT_SIGN_OUT_STORAGE_KEY]: "1" }),
+    ],
+  ])(
+    "does not redirect during sign-out marked by %s",
+    (_name, signOutStarted, sessionStorage) => {
+      const result = runScript({
+        href: "https://plan.agent-native.com/inbox",
+        localStorage: createStorage(activeMarker()),
+        sessionStorage,
+        signOutStarted,
+      });
 
-    const result = await runScript({
+      expect(result.redirectedTo).toBeNull();
+    },
+  );
+
+  it("fails open when browser storage is unavailable", () => {
+    const result = runScript({
       href: "https://plan.agent-native.com/inbox",
-      localStorage: deniedStorage,
+      localStorage: createFailingStorage(),
+      sessionStorage: createFailingStorage(),
     });
 
     expect(result.redirectedTo).toBeNull();
-  });
-
-  it("clears a stale marker when the current session is signed out", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-
-    const result = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage,
-      session: { error: "Not authenticated" },
-    });
-
-    expect(result.redirectedTo).toBeNull();
-    expect(result.fetched).toEqual(["/_agent-native/auth/session"]);
-    expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).toBeNull();
-  });
-
-  it("invalidates the production marker after beta sign-out before returning", async () => {
-    const productionStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-    const betaStorage = createStorage();
-
-    const redirected = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage: productionStorage,
-    });
-    expect(redirected.redirectedTo).toBe(
-      "https://beta.plan.agent-native.com/inbox",
-    );
-    expect(productionStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).not.toBeNull();
-
-    const betaSignOut = await runScript({
-      href: "https://beta.plan.agent-native.com/inbox",
-      localStorage: betaStorage,
-    });
-    expect(betaSignOut.redirectedTo).toBeNull();
-    expect(betaSignOut.fetched).toEqual([]);
-
-    const returned = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage: productionStorage,
-      session: { error: "Not authenticated" },
-    });
-    expect(returned.redirectedTo).toBeNull();
-    expect(returned.fetched).toEqual(["/_agent-native/auth/session"]);
-    expect(productionStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).toBeNull();
-  });
-
-  it("clears a marker when the current session belongs to a non-Builder user", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-
-    const result = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage,
-      session: { email: "customer@example.com" },
-    });
-
-    expect(result.redirectedTo).toBeNull();
-    expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).toBeNull();
-  });
-
-  it("fails open and retains the marker when the session probe is unavailable", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-
-    const result = await runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage,
-      sessionResponseOk: false,
-    });
-
-    expect(result.redirectedTo).toBeNull();
-    expect(localStorage.getItem(BETA_REDIRECT_STORAGE_KEY)).not.toBeNull();
-  });
-
-  it("does not navigate after sign-out starts while the session probe is pending", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-    const sessionStorage = createStorage();
-    let resolveProbe: ((session: Record<string, unknown>) => void) | undefined;
-    const sessionProbe = new Promise<Record<string, unknown>>((resolve) => {
-      resolveProbe = resolve;
-    });
-
-    const pending = runScript({
-      href: "https://plan.agent-native.com/inbox",
-      localStorage,
-      sessionStorage,
-      sessionProbe,
-    });
-    await Promise.resolve();
-    sessionStorage.setItem(BETA_REDIRECT_SIGN_OUT_STORAGE_KEY, "1");
-    resolveProbe!({ email: "employee@builder.io" });
-
-    const result = await pending;
-
-    expect(result.redirectedTo).toBeNull();
-  });
-
-  it("uses the current URL after a delayed session probe", async () => {
-    const localStorage = createStorage({
-      [BETA_REDIRECT_STORAGE_KEY]: String(Date.now() + 60_000),
-    });
-    const href = { current: "https://plan.agent-native.com/inbox?tab=all" };
-    let resolveProbe: ((session: Record<string, unknown>) => void) | undefined;
-    const sessionProbe = new Promise<Record<string, unknown>>((resolve) => {
-      resolveProbe = resolve;
-    });
-
-    const pending = runScript({ href, localStorage, sessionProbe });
-    await Promise.resolve();
-    href.current =
-      "https://plan.agent-native.com/settings?tab=profile#security";
-    resolveProbe!({ email: "employee@builder.io" });
-
-    const result = await pending;
-
-    expect(result.redirectedTo).toBe(
-      "https://beta.plan.agent-native.com/settings?tab=profile#security",
-    );
   });
 
   it("emits a marked inline script for head or shell injection", () => {
     const script = getSsrBetaRedirectScript();
 
-    expect(script).toContain(SSR_BETA_REDIRECT_MARKER);
-    expect(script).toContain(BETA_REDIRECT_STORAGE_KEY);
-    expect(script).toContain("/_agent-native/auth/session");
-    expect(script).not.toContain("document.cookie");
-  });
-
-  it("escapes a session probe path before embedding it in HTML", () => {
-    const script = getSsrBetaRedirectScript(
-      "/</script><script>window.__injected=1</script>/_agent-native/auth/session",
+    expect(script.startsWith(`<script ${SSR_BETA_REDIRECT_MARKER}>`)).toBe(
+      true,
     );
-
-    expect(script).toContain("\\u003c/script\\u003e\\u003cscript\\u003e");
-    expect(script).not.toContain("</script><script>window.__injected=1");
+    expect(script.endsWith("</script>")).toBe(true);
+    expect(script).toContain(BETA_REDIRECT_STORAGE_KEY);
   });
 });

--- a/packages/core/src/shared/ssr-beta-redirect.ts
+++ b/packages/core/src/shared/ssr-beta-redirect.ts
@@ -1,4 +1,3 @@
-import { safeJsonForHtml } from "./agent-readable-resource.js";
 import {
   BETA_FORCE_QUERY_PARAM,
   BETA_FORCE_SESSION_STORAGE_KEY,
@@ -12,13 +11,14 @@ import {
 export const SSR_BETA_REDIRECT_MARKER = 'data-agent-native-beta-redirect="1"';
 
 /**
- * The marker is a performance hint set after the client verifies a Builder
- * employee session. The browser re-checks the current session before using
- * it, so it never becomes an authorization check.
+ * The marker is a cached decision written only after a verified Builder
+ * employee session, and it is never an authorization check — the session gate
+ * still governs every byte of access. It is deliberately trusted without
+ * revalidating, because a session probe here would put a network round trip
+ * back in front of the redirect this script exists to make instant. Staleness
+ * is bounded by the marker TTL, the sign-out clear, and the opt-out param.
  */
-export function getSsrBetaRedirectScriptBody(
-  sessionPath = "/_agent-native/auth/session",
-): string {
+export function getSsrBetaRedirectScriptBody(): string {
   return `(function __anEarlyBetaRedirect() {
   if (window.__agentNativeBetaRedirectStarted) return;
   window.__agentNativeBetaRedirectStarted = true;
@@ -127,104 +127,18 @@ export function getSsrBetaRedirectScriptBody(
 
   if (isSignOutStarted()) return;
 
-  if (typeof window.fetch !== 'function') return;
-
-  var sessionProbePath = ${safeJsonForHtml(sessionPath)};
-  var appConfig = window.__AGENT_NATIVE_CONFIG__;
-  if (appConfig && appConfig.workspaceRuntime === true) {
-    var frameworkSessionPath = '/_agent-native/auth/session';
-    var mountSegment = currentUrl.pathname.split('/').find(function (segment) {
-      return segment;
-    });
-    var workspaceMount = mountSegment &&
-      mountSegment !== '_agent-native' &&
-      mountSegment !== 'api' &&
-      mountSegment !== 'sign-in' &&
-      mountSegment !== 'login' &&
-      mountSegment !== 'signup'
-      ? '/' + mountSegment
-      : '';
-    var knownWorkspaceMounts = Array.isArray(appConfig.workspaceAppMountPaths)
-      ? appConfig.workspaceAppMountPaths
-      : null;
-    var knownWorkspaceMount = !knownWorkspaceMounts ||
-      knownWorkspaceMounts.indexOf(workspaceMount) !== -1;
-    if (
-      workspaceMount &&
-      knownWorkspaceMount &&
-      typeof sessionProbePath === 'string' &&
-      sessionProbePath.endsWith(frameworkSessionPath)
-    ) {
-      var configuredWorkspaceMount = sessionProbePath.slice(
-        0,
-        -frameworkSessionPath.length,
-      );
-      if (configuredWorkspaceMount !== workspaceMount) {
-        sessionProbePath = workspaceMount + frameworkSessionPath;
-      }
-    }
-  }
-
-  window.fetch(sessionProbePath, {
-    credentials: 'same-origin',
-    cache: 'no-store',
-    headers: { 'Accept': 'application/json' }
-  }).then(function (response) {
-    if (!response || !response.ok) {
-      if (response && (response.status === 401 || response.status === 403)) {
-        clearRedirectMarker();
-        return null;
-      }
-      return undefined;
-    }
-    return response.json();
-  }).then(function (session) {
-    if (session === undefined) return;
-    var email = session && !session.error && typeof session.email === 'string'
-      ? session.email.trim().toLowerCase()
-      : '';
-    if (!email.endsWith('@builder.io')) {
-      clearRedirectMarker();
-      return;
-    }
-
-    if (isSignOutStarted()) return;
-
-    var latestUrl;
-    try {
-      latestUrl = new URL(window.location.href);
-    } catch (error) {
-      void error;
-      return;
-    }
-    var latestHostname = (latestUrl.hostname || '').toLowerCase().replace(/\\.$/, '');
-    var latestProductionHost = latestHostname.indexOf('beta.') === 0
-      ? latestHostname.slice(5)
-      : latestHostname;
-    if (latestHostname !== hostname || betaHosts[latestProductionHost] !== betaHost) return;
-    if (latestUrl.searchParams.get(${JSON.stringify(BETA_FORCE_QUERY_PARAM)}) === 'true') return;
-    var latestOptOut = latestUrl.searchParams.get(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
-    if (latestOptOut !== null && Number(latestOptOut) > Date.now()) return;
-
-    latestUrl.protocol = 'https:';
-    latestUrl.hostname = betaHost;
-    latestUrl.port = '';
-    latestUrl.searchParams.delete(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
-    try {
-      window.location.replace(latestUrl.toString());
-    } catch (error) {
-      void error;
-    }
-  }).catch(function (error) {
+  currentUrl.protocol = 'https:';
+  currentUrl.hostname = betaHost;
+  currentUrl.port = '';
+  currentUrl.searchParams.delete(${JSON.stringify(BETA_OPT_OUT_QUERY_PARAM)});
+  try {
+    window.location.replace(currentUrl.toString());
+  } catch (error) {
     void error;
-    // A transient session failure must leave production usable; retry the hint
-    // on a later navigation instead of redirecting without a current session.
-  });
+  }
 })();`;
 }
 
-export function getSsrBetaRedirectScript(
-  sessionPath = "/_agent-native/auth/session",
-): string {
-  return `<script ${SSR_BETA_REDIRECT_MARKER}>${getSsrBetaRedirectScriptBody(sessionPath)}</script>`;
+export function getSsrBetaRedirectScript(): string {
+  return `<script ${SSR_BETA_REDIRECT_MARKER}>${getSsrBetaRedirectScriptBody()}</script>`;
 }


### PR DESCRIPTION
Follow-up to #4117. That change moved the production→beta redirect for Builder employees ahead of the app bundle, but gated it behind a session probe, so every redirect still paid a network round trip before navigating.

This restores the `builder-internal` behavior: the redirect fires synchronously from the cached browser marker, with no network request at all.

## What changed

- `ssr-beta-redirect.ts` redirects immediately once the marker is valid, instead of awaiting `fetch('/_agent-native/auth/session')`.
- Removed the probe and everything that existed only to serve it: the request-derived `sessionPath` parameter, the workspace mount-path derivation, and the post-await URL re-validation.
- `injectBetaOptOutPersistence()` and `getSsrBetaRedirectScript()` no longer take a request path.

Net −351 lines.

## Safety

Every existing escape hatch still runs, and all of them are now evaluated before the navigation rather than around it: iframe check, production-host allow-list (never on `beta.*`), `?force=true` and its session guard, `AgentNativeDesktop` user agent, `?agentNativeBetaOptOut=` and the stored opt-out, marker TTL, the sign-out signal, and storage failures failing closed.

Staleness is bounded exactly as `builder-internal` bounds it — the 30-day marker TTL, the sign-out clear from #4117, and the opt-out param.

Dropping the probe also removes an injection surface rather than escaping it: no request-derived value reaches the inline script now, so the login shell has nothing to escape. A regression test asserts that.

## Verification

- `ssr-beta-redirect.spec.ts` rewritten for synchronous behavior; 16 tests, including one asserting **zero** network requests on redirect.
- 294 tests green across the redirect, opt-out, auth, sign-out, app-providers, EnvironmentBadge, and app-origin-config specs.
- `typecheck` clean, `oxfmt` clean.
- `guard:ssr-cache-shell`, `guard:no-silent-coercion`, `guard:no-untracked-imports` all clean.

Full `pnpm guards` reports `guard:i18n-catalogs` red; that is pre-existing on `main` — every entry is a stale `scripts/i18n-catalog-english-value-baseline.txt` line for `templates/design/app/i18n/zh-CN` and `zh-TW`. `guard:plan-skills` and `guard:plan-marketplace` fail only on a missing `recap-cli` dist and pass after `pnpm --filter @agent-native/recap-cli build`.

The full core suite has 36 pre-existing failures in `deploy/build.spec.ts` and `agent-chat/content-a2a-capabilities.spec.ts`; verified identical on clean `origin/main` with these changes stashed.

Source-tested and built only — no beta or production deployment verified here.
