### PR TITLE
fix(design): stop answering a greeting with a false save failure

### DIFF
--- a/.changeset/split-attached-chat-context.md
+++ b/.changeset/split-attached-chat-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add `splitAgentChatContextFromMessage`, the inverse of `appendAgentChatContextToMessage`, so a consumer can tell the user's prompt apart from the context an app attached to it.

--- a/packages/core/src/client/agent-chat.ts
+++ b/packages/core/src/client/agent-chat.ts
@@ -29,6 +29,8 @@ import {
 } from "./frame.js";
 import { sendMcpAppHostMessage } from "./mcp-app-host.js";
 
+export { appendAgentChatContextToMessage } from "../shared/agent-chat-context.js";
+
 export type AgentChatRequestMode = "act" | "plan";
 
 export interface AgentChatMessage {
@@ -656,15 +658,6 @@ export function formatAgentChatContextItemsForPrompt(
     .filter((item): item is AgentChatContextItem => item !== null)
     .map((item) => [`## ${item.title}`, item.context].join("\n"))
     .join("\n\n");
-}
-
-export function appendAgentChatContextToMessage(
-  message: string,
-  context: string,
-): string {
-  const trimmedContext = context.trim();
-  if (!trimmedContext) return message;
-  return `${message}\n\n<context>\n${trimmedContext}\n</context>`;
 }
 
 function normalizeStringArray(value: unknown): string[] | undefined {

--- a/packages/core/src/client/chat/message-components.tsx
+++ b/packages/core/src/client/chat/message-components.tsx
@@ -47,6 +47,7 @@ import {
 } from "@tabler/icons-react";
 import React, { useState, useEffect, useCallback, useRef } from "react";
 
+import { splitAgentChatContextFromMessage } from "../../shared/agent-chat-context.js";
 import {
   DEFAULT_THINKING_DISPLAY,
   type ThinkingDisplay,
@@ -135,11 +136,7 @@ const PENDING_SELECTION_KEY = "pending-selection-context";
 // ─── displayableUserMessageText ───────────────────────────────────────────────
 
 export function displayableUserMessageText(text: string): string {
-  return text
-    .replace(/<context\b[^>]*>[\s\S]*?<\/context>\n?/gi, "") // i18n-ignore -- parsing regex, not UI copy.
-    .replace(/<context\b[^>]*>[\s\S]*$/gi, "")
-    .replace(/<\/context>/gi, "")
-    .trim();
+  return splitAgentChatContextFromMessage(text).message;
 }
 
 export function isHiddenUserMessage(message: unknown): boolean {

--- a/packages/core/src/shared/agent-chat-context.spec.ts
+++ b/packages/core/src/shared/agent-chat-context.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendAgentChatContextToMessage,
+  splitAgentChatContextFromMessage,
+} from "./agent-chat-context.js";
+
+describe("splitAgentChatContextFromMessage", () => {
+  it("round-trips what appendAgentChatContextToMessage joined", () => {
+    const composed = appendAgentChatContextToMessage(
+      "make it darker",
+      "Design id: design-1",
+    );
+
+    expect(splitAgentChatContextFromMessage(composed)).toEqual({
+      message: "make it darker",
+      context: "Design id: design-1",
+    });
+  });
+
+  it("keeps every attached block out of the user's own words", () => {
+    const { message, context } = splitAgentChatContextFromMessage(
+      "hi\n\n<context>\nfirst\n</context>\n\n<context>\nsecond\n</context>",
+    );
+
+    expect(message).toBe("hi");
+    expect(context).toBe("first\nsecond");
+  });
+
+  it("reports a truncated payload as context rather than as the message", () => {
+    expect(
+      splitAgentChatContextFromMessage("hi <context> ## Fusion recap payload"),
+    ).toEqual({ message: "hi", context: "## Fusion recap payload" });
+  });
+
+  it("returns an empty message for a context-only send", () => {
+    expect(
+      splitAgentChatContextFromMessage(
+        "\n\n<context>\ninstructions\n</context>",
+      ),
+    ).toEqual({ message: "", context: "instructions" });
+  });
+
+  it("leaves a message with no attached context untouched", () => {
+    expect(splitAgentChatContextFromMessage("hi")).toEqual({
+      message: "hi",
+      context: "",
+    });
+  });
+});

--- a/packages/core/src/shared/agent-chat-context.ts
+++ b/packages/core/src/shared/agent-chat-context.ts
@@ -1,0 +1,46 @@
+/**
+ * The `<context>` envelope an app wraps around hidden prompt context, and its
+ * inverse. Anything that classifies intent must read the two halves apart: the
+ * message is what the user asked for, the context is what the app attached.
+ */
+
+const CONTEXT_BLOCK_PATTERN = /<context\b[^>]*>([\s\S]*?)<\/context>\n?/gi;
+const UNCLOSED_CONTEXT_PATTERN = /<context\b[^>]*>([\s\S]*)$/i;
+const STRAY_CONTEXT_CLOSE_PATTERN = /<\/context>/gi;
+
+export interface AgentChatMessageParts {
+  /** The user-visible prompt, with every attached context block removed. */
+  message: string;
+  /** The attached context bodies, joined; empty when nothing was attached. */
+  context: string;
+}
+
+export function appendAgentChatContextToMessage(
+  message: string,
+  context: string,
+): string {
+  const trimmedContext = context.trim();
+  if (!trimmedContext) return message;
+  return `${message}\n\n<context>\n${trimmedContext}\n</context>`;
+}
+
+export function splitAgentChatContextFromMessage(
+  text: string,
+): AgentChatMessageParts {
+  const contexts: string[] = [];
+  let message = text.replace(CONTEXT_BLOCK_PATTERN, (_match, body: string) => {
+    contexts.push(body.trim());
+    return "";
+  });
+  // A truncated payload still carries context the reader must not see as the
+  // user's own words, so an unclosed tag swallows the rest of the message.
+  const unclosed = UNCLOSED_CONTEXT_PATTERN.exec(message);
+  if (unclosed) {
+    contexts.push(unclosed[1].trim());
+    message = message.slice(0, unclosed.index);
+  }
+  return {
+    message: message.replace(STRAY_CONTEXT_CLOSE_PATTERN, "").trim(),
+    context: contexts.filter(Boolean).join("\n"),
+  };
+}

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -4,6 +4,11 @@ export {
   type AgentChatCallOptions,
   type AgentChatResponse,
 } from "./agent-chat.js";
+export {
+  appendAgentChatContextToMessage,
+  splitAgentChatContextFromMessage,
+  type AgentChatMessageParts,
+} from "./agent-chat-context.js";
 export { agentEnv, type EnvVar } from "./agent-env.js";
 export {
   extractOAuthStateAppId,

--- a/templates/design/app/hooks/use-question-flow.test.tsx
+++ b/templates/design/app/hooks/use-question-flow.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "@shared/mutation-turn";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -234,6 +235,24 @@ describe("useQuestionFlow sendContinuation tab tracking", () => {
     expect(call.context).toContain(
       'Use designId "design-1" for generation. Never call create-design',
     );
+
+    await cleanup();
+  });
+
+  it("marks the continuation as the turn that must persist a design", async () => {
+    const { cleanup } = await renderProbe({
+      designId: "design-1",
+      continuationTabId: null,
+    });
+
+    await act(async () => {
+      latestHook!.handleSkip();
+    });
+
+    const call = agentChatMocks.sendToDesignAgentChat.mock.calls[0]![0] as {
+      context?: string;
+    };
+    expect(call.context).toContain(DESIGN_MUTATION_REQUIRED_DIRECTIVE);
 
     await cleanup();
   });

--- a/templates/design/app/hooks/use-question-flow.ts
+++ b/templates/design/app/hooks/use-question-flow.ts
@@ -4,6 +4,7 @@ import {
   type GuidedQuestionAnswers,
 } from "@agent-native/core/client/agent-chat";
 import { type PromptComposerSubmitOptions } from "@agent-native/core/client/composer";
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "@shared/mutation-turn";
 import { useCallback } from "react";
 
 import { sendToDesignAgentChat } from "@/lib/agent-chat";
@@ -186,7 +187,9 @@ export function useQuestionFlow(
       // real destination thread.
       const tabId = sendToDesignAgentChat({
         message,
-        context: [briefContext, context].filter(Boolean).join("\n\n"),
+        context: [briefContext, context, DESIGN_MUTATION_REQUIRED_DIRECTIVE]
+          .filter(Boolean)
+          .join("\n\n"),
         submit: true,
         newTab: true,
         ...(brief?.images?.length ? { images: brief.images } : {}),

--- a/templates/design/app/pages/design-editor/commands/tweak-prompt-submit.ts
+++ b/templates/design/app/pages/design-editor/commands/tweak-prompt-submit.ts
@@ -1,5 +1,6 @@
 import type { PromptComposerSubmitOptions } from "@agent-native/core/client/composer";
 import type { TweakDefinition } from "@shared/api";
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "@shared/mutation-turn";
 import type { TweakSelections } from "@shared/resolve-tweaks";
 import { toast } from "sonner";
 
@@ -67,6 +68,7 @@ export function runTweakPromptSubmit(
     "Add or update live tweak controls for this design. Keep existing useful tweak controls unless the user explicitly asks to replace them.",
     "If a requested control needs a new CSS custom property, first read the live design with `get-design-snapshot`, update the relevant HTML/CSS so the property is used, then persist the complete updated tweak definition list through `generate-design`.",
     "For tiny source changes, prefer `edit-design`, but make sure the tweak definitions are saved so the Tweaks panel updates.",
+    DESIGN_MUTATION_REQUIRED_DIRECTIVE,
   ].join("\n");
 
   sendToDesignAgentChat({

--- a/templates/design/app/pages/design-editor/generation-prompt-directives.test.ts
+++ b/templates/design/app/pages/design-editor/generation-prompt-directives.test.ts
@@ -1,8 +1,13 @@
+import { appendAgentChatContextToMessage } from "@agent-native/core/shared";
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "@shared/mutation-turn";
 import { describe, expect, it } from "vitest";
 
+import { designFinalResponseGuard } from "../../../server/lib/design-response-guard";
 import {
+  designGenerationDirectives,
   designIntakeQuestionDirectives,
   designTemplateRefinementDirectives,
+  designVariantGenerationDirectives,
   structuralReferenceDirectives,
 } from "./generation-prompt-directives";
 import type { IntakeTopicCoverage } from "./intake-question-topics";
@@ -69,5 +74,52 @@ describe("designIntakeQuestionDirectives", () => {
     expect(text).toContain("could not be checked");
     expect(text).toContain("context service down");
     expect(text).toContain('not treat it as "nothing saved"');
+  });
+});
+
+describe("DESIGN_MUTATION_REQUIRED_DIRECTIVE", () => {
+  it("rides on directives that must persist, and never on the intake turn", () => {
+    for (const directives of [
+      designGenerationDirectives("design-1"),
+      designVariantGenerationDirectives("design-1"),
+      designTemplateRefinementDirectives("design-1", "template-1"),
+    ]) {
+      expect(directives).toContain(DESIGN_MUTATION_REQUIRED_DIRECTIVE);
+    }
+    // The intake turn is told to show questions and stop, so carrying the
+    // directive would make the response guard reject its own flow.
+    expect(designIntakeQuestionDirectives("design-1")).not.toContain(
+      DESIGN_MUTATION_REQUIRED_DIRECTIVE,
+    );
+  });
+});
+
+describe("the intake and generation turns against the response guard", () => {
+  const guardContext = (requestText: string) =>
+    ({
+      messages: [
+        { role: "user", content: [{ type: "text", text: requestText }] },
+      ],
+      requestText,
+      assistantContent: [],
+      text: "What would you like to design?",
+      toolCalls: [],
+      toolResults: [],
+      retryCount: 0,
+      executionMode: "act",
+    }) as Parameters<typeof designFinalResponseGuard>[0];
+
+  it("lets the intake turn answer a greeting, and holds the generation turn to a save", () => {
+    const intake = appendAgentChatContextToMessage(
+      "hi",
+      designIntakeQuestionDirectives("design-1").join("\n"),
+    );
+    const generation = appendAgentChatContextToMessage(
+      "hi",
+      designGenerationDirectives("design-1").join("\n"),
+    );
+
+    expect(designFinalResponseGuard(guardContext(intake))).toBeNull();
+    expect(designFinalResponseGuard(guardContext(generation))).not.toBeNull();
   });
 });

--- a/templates/design/app/pages/design-editor/generation-prompt-directives.ts
+++ b/templates/design/app/pages/design-editor/generation-prompt-directives.ts
@@ -1,5 +1,6 @@
 import { callAction } from "@agent-native/core/client/hooks";
 import type { TweakDefinition } from "@shared/api";
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "@shared/mutation-turn";
 
 import type { UploadedFile } from "@/components/editor/PromptDialog";
 
@@ -192,6 +193,7 @@ export function designVariantGenerationDirectives(
     "The user's prompt already asks to explore multiple directions, so DO NOT call `show-design-questions` first and DO NOT call `generate-design` first.",
     "Call `present-design-variants` with 2-5 concise directions (3 when unspecified). Prefer label, description, accentColor, and feature bullets; omit large content HTML when needed because the action can render compact representative screens. Every web design must be responsive; default each desktop direction to width 1440 and height 1024. Use mobile dimensions only when the user explicitly requested a mobile-first primary artboard.",
     'Wait for the user\'s chat pick, delete each unchosen variant screen at most once, call `get-design-snapshot` exactly once with `fileId` for the kept screen, then call `edit-design` exactly once on that same `fileId` in a bounded pass. Use `mode: "replace-file"` when expanding the representative placeholder into a complete but compact product UI in the chosen direction. Prioritize the primary workflow and render secondary details as visible controls, states, or affordances if the feature list is too large for one reliable edit. Do not repeat delete/snapshot cycles. Do not call `generate-design` after a variant pick. Stop after the first successful `edit-design` save.',
+    DESIGN_MUTATION_REQUIRED_DIRECTIVE,
   ];
 }
 
@@ -247,6 +249,7 @@ export function designGenerationDirectives(
     'Responsive behavior is mandatory for every web design: use a mobile-first layout, include a viewport meta tag, stack or collapse desktop columns at narrow widths, and never rely on a fixed-width desktop shell. Default to a desktop primary artboard. For a Desktop or Both/responsive intake answer, pass `primaryViewport: "desktop"` and `canvasFrames` with width 1440 and height 1024; pass `primaryViewport: "mobile"` only when the user explicitly chooses a mobile-primary artboard.',
     "Keep the first pass bounded enough to finish quickly: one self-contained Alpine.js + Tailwind CDN HTML document, polished but concise. Add 3-6 tweaks only when they naturally fit the design.",
     "After generate-design succeeds, run `take-design-screenshot` at desktop and mobile viewports. Fix any horizontal overflow or layout breakage with edit-design before summarizing what was created.",
+    DESIGN_MUTATION_REQUIRED_DIRECTIVE,
   ];
 }
 
@@ -266,5 +269,6 @@ export function designTemplateRefinementDirectives(
     "Preserve canvasFrames and the template's width and height. Change only the unlocked content needed for the user's request.",
     "Prefer one bounded search-replace edit pass. Use replace-file only when necessary, and keep every locked subtree exactly as it appeared in the snapshot.",
     "After edit-design succeeds, stop and summarize the refinement.",
+    DESIGN_MUTATION_REQUIRED_DIRECTIVE,
   ];
 }

--- a/templates/design/changelog/2026-09-02-a-greeting-in-a-new-design-no-longer-fails-the-turn.md
+++ b/templates/design/changelog/2026-09-02-a-greeting-in-a-new-design-no-longer-fails-the-turn.md
@@ -1,0 +1,6 @@
+---
+type: fixed
+date: 2026-09-02
+---
+
+A greeting or question as the first message in a new design no longer ends with a false "couldn't confirm that a Design artifact was saved" reply.

--- a/templates/design/server/lib/design-response-guard.spec.ts
+++ b/templates/design/server/lib/design-response-guard.spec.ts
@@ -1,6 +1,7 @@
 import type { AgentLoopFinalResponseGuardContext } from "@agent-native/core/server";
 import { describe, expect, it } from "vitest";
 
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "../../shared/mutation-turn.js";
 import {
   designFinalResponseGuard,
   looksLikeDesignMutationRequest,
@@ -359,6 +360,68 @@ describe("Design final response guard", () => {
     );
 
     expect(result).not.toBeNull();
+  });
+
+  it("judges the user's words, not the context the app attached to them", () => {
+    const intakeContext = [
+      "The user just created a new empty design.",
+      'Design id: "design-1"',
+      'User request: "hi"',
+      'This is a new UI-started design for design id "design-1". The design shell already exists - DO NOT call create-design.',
+      "First, call `show-design-questions` with 4-6 tailored questions and then stop. Do NOT call generate-design or present-design-variants until the user submits or skips the questions.",
+    ].join("\n");
+
+    expect(
+      designFinalResponseGuard(
+        guardContext(`hi\n\n<context>\n${intakeContext}\n</context>`),
+      ),
+    ).toBeNull();
+    expect(
+      designFinalResponseGuard(
+        guardContext(
+          `make it darker\n\n<context>\nDesign "Portfolio" is open.\n</context>`,
+        ),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("leaves a preview or question turn alone when only its context says so", () => {
+    const repromptContext = [
+      "[Reprompt selection]",
+      "repromptId: reprompt-1",
+      "designId: design-1",
+      "baseVersionHash: hash-1",
+    ].join("\n");
+    const questionContext = [
+      "[Selection question]",
+      "designId: design-1",
+      "fileId: file-1",
+    ].join("\n");
+
+    expect(
+      designFinalResponseGuard(
+        guardContext(
+          `make the card darker\n\n<context>\n${repromptContext}\n</context>`,
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      designFinalResponseGuard(
+        guardContext(
+          `make the card darker\n\n<context>\n${questionContext}\n</context>`,
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("guards a generation turn whose intent lives only in the attached context", () => {
+    expect(
+      designFinalResponseGuard(
+        guardContext(
+          `Here are my answers — go ahead.\n\n<context>\nAnswers: dark, minimal.\n${DESIGN_MUTATION_REQUIRED_DIRECTIVE}\n</context>`,
+        ),
+      ),
+    ).not.toBeNull();
   });
 
   it("does not guard read-only or plan turns", () => {

--- a/templates/design/server/lib/design-response-guard.ts
+++ b/templates/design/server/lib/design-response-guard.ts
@@ -2,6 +2,13 @@ import type {
   AgentLoopFinalResponseGuardContext,
   AgentLoopFinalResponseGuardResult,
 } from "@agent-native/core/server";
+import { splitAgentChatContextFromMessage } from "@agent-native/core/shared";
+
+import { DESIGN_MUTATION_REQUIRED_DIRECTIVE } from "../../shared/mutation-turn.js";
+import {
+  isRepromptSelectionMessage,
+  isSelectionQuestionMessage,
+} from "./reprompt-action-guard.js";
 
 const DESIGN_MUTATION_ACTIONS = new Set([
   "apply-a11y-fix",
@@ -348,6 +355,26 @@ export function looksLikeDesignMutationRequest(text: string): boolean {
   );
 }
 
+/**
+ * Every app-authored generation directive block names mutating actions, so
+ * only the user's own words decide intent unless the attached context states
+ * outright that this turn has to persist something.
+ */
+function requiresPersistedDesignOutput(composedRequest: string): boolean {
+  const { message, context } =
+    splitAgentChatContextFromMessage(composedRequest);
+  // Preview and read-only turns are marked in the attached context, never in
+  // the instruction, which reads like any other edit request on its own.
+  if (
+    isRepromptSelectionMessage(context) ||
+    isSelectionQuestionMessage(context)
+  ) {
+    return false;
+  }
+  if (context.includes(DESIGN_MUTATION_REQUIRED_DIRECTIVE)) return true;
+  return looksLikeDesignMutationRequest(message);
+}
+
 export function designFinalResponseGuard(
   context: AgentLoopFinalResponseGuardContext,
 ): AgentLoopFinalResponseGuardResult | null {
@@ -355,7 +382,7 @@ export function designFinalResponseGuard(
 
   const requestText =
     context.requestText?.trim() || latestUserText(context.messages);
-  if (!looksLikeDesignMutationRequest(requestText)) return null;
+  if (!requiresPersistedDesignOutput(requestText)) return null;
   if (hasSuccessfulMutation(context.toolResults)) return null;
 
   return {

--- a/templates/design/shared/mutation-turn.ts
+++ b/templates/design/shared/mutation-turn.ts
@@ -1,0 +1,7 @@
+/**
+ * Marks app-composed chat context whose turn is only complete once a Design
+ * mutation persisted. The response guard matches this line exactly; ambient
+ * context (selection, design system, intake questions) must never carry it.
+ */
+export const DESIGN_MUTATION_REQUIRED_DIRECTIVE =
+  "Completion for this turn requires a successful mutating Design action; a text-only reply is not completion.";


### PR DESCRIPTION
## Summary

Typing "hi" as the first message in a new design answered with "I couldn't confirm that a Design artifact was saved, so I haven't marked this request complete. Please retry." The Design response guard classified the whole composed prompt, but the client glues a hidden `<context>` block onto every message, and on the new-design path that block is the app's own generation directives — thick with words like create, generate-design and screen. A greeting inherited the directives' intent, the turn was judged design-changing, no mutation ran, and the guard replaced the agent's real reply with its failure text. The guard now reads the user's half of the message, and treats the attached context as a contract the app states outright rather than something to sniff for verbs.

The same root cause broke a second path. `[Reprompt selection]` and `[Selection question]` are written into the attached context, not into the message, so the guard's start-of-message exemption never matched real traffic. Every "Preview change" turn with an edit-shaped instruction hit the same false failure, and the guard's retry told the model to call `edit-design` — exactly what `reprompt-action-guard` forbids on that turn.

| Turn | Before | Now |
| --- | --- | --- |
| "hi" on a new design | false "couldn't confirm that a Design artifact was saved" | agent answers, or shows the intake questions |
| "Preview change" on a selected element | same false failure; retry pushed a forbidden `edit-design` | preview proceeds, guard stays out |
| "Here are my answers — go ahead." | guarded, via words in the attached context | still guarded, via the explicit directive |
| "make it darker" | guarded | guarded |

## Changes

**The guard reads the two halves apart** — `templates/design/server/lib/design-response-guard.ts`
- `requiresPersistedDesignOutput` splits the composed prompt, exempts turns the context marks preview- or read-only, honours an explicit mutation-required directive, and otherwise applies the existing heuristic to the user's own words. `looksLikeDesignMutationRequest` itself is unchanged, so its existing cases still hold.

**App-composed context declares its own contract** — `templates/design/shared/mutation-turn.ts`
- Some turns carry their intent only in app context ("Here are my answers — go ahead." after the intake questions), so splitting alone would have silenced the guard exactly where it earns its keep. `DESIGN_MUTATION_REQUIRED_DIRECTIVE` is added to the generation, variant, template-refinement, question-flow continuation, and tweak-prompt contexts.
- It is deliberately not added to intaketem ambient context. The intake turn istold to show questions and stop, so marking it would make the guard reject the app's own flow.

**One definition of the `<context>` envec/shared/agent-chat-context.ts`
- `splitAgentChatContextFromMessage` is the inverse of `appendAgentChatContextToMessage`, which moves here beside it. The chat display path carried a private copy of the same regex; `displayableUserMessageText` now delegates to the shared one.