### PR TITLE
Remember Content sidebar state after refresh

### DIFF
--- a/.changeset/calm-sidebars-remember.md
+++ b/.changeset/calm-sidebars-remember.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/toolkit": patch
+---
+
+Add a shared hook for browser-persisted sidebar collapse preferences.

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -90,10 +90,10 @@ then collapse, with the same order stacked in collapsed sidebars.
 Use `usePersistentSidebarCollapsed` for a collapsible desktop navigation
 sidebar that should remember a person's choice after refresh. Each app supplies
 its own stable storage key and first-use default. The hook restores valid
-browser state synchronously, keeps explicit changes responsive when storage is
-unavailable, and exposes `persistenceStatus` so unavailable or malformed
-storage is distinguishable from a saved preference. Keep temporary mobile
-drawer state separate.
+browser state immediately after hydration, keeps explicit changes responsive
+when storage is unavailable, and exposes `persistenceStatus` so unavailable or
+malformed storage is distinguishable from a saved preference. Keep temporary
+mobile drawer state separate.
 
 Inside template apps, prefer local adapters such as `@/components/ui/button` so
 apps can replace their primitives without changing every callsite.

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -56,6 +56,7 @@ import { Toaster } from "@agent-native/toolkit/ui/sonner";
 import { useToast } from "@agent-native/toolkit/hooks/use-toast";
 import {
   SidebarFooterActions,
+  usePersistentSidebarCollapsed,
   useSetHeaderActions,
 } from "@agent-native/toolkit/app-shell";
 ```
@@ -85,6 +86,14 @@ Core.
 Use `SidebarFooterActions` for the shared left-sidebar utility row. Provide the
 app-owned controls through its slots; the rendered order is feedback, search,
 then collapse, with the same order stacked in collapsed sidebars.
+
+Use `usePersistentSidebarCollapsed` for a collapsible desktop navigation
+sidebar that should remember a person's choice after refresh. Each app supplies
+its own stable storage key and first-use default. The hook restores valid
+browser state synchronously, keeps explicit changes responsive when storage is
+unavailable, and exposes `persistenceStatus` so unavailable or malformed
+storage is distinguishable from a saved preference. Keep temporary mobile
+drawer state separate.
 
 Inside template apps, prefer local adapters such as `@/components/ui/button` so
 apps can replace their primitives without changing every callsite.

--- a/packages/toolkit/src/app-shell/index.ts
+++ b/packages/toolkit/src/app-shell/index.ts
@@ -1,2 +1,3 @@
 export * from "./header-actions.js";
 export * from "./sidebar-footer-actions.js";
+export * from "./use-persistent-sidebar-collapsed.js";

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type PersistentSidebarCollapsedState,
+  usePersistentSidebarCollapsed,
+} from "./use-persistent-sidebar-collapsed.js";
+
+const STORAGE_KEY = "test.sidebar.collapsed";
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe("usePersistentSidebarCollapsed", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let state: PersistentSidebarCollapsedState;
+  let browserStorage: MemoryStorage;
+
+  function Harness({ defaultCollapsed = false }) {
+    state = usePersistentSidebarCollapsed({
+      storageKey: STORAGE_KEY,
+      defaultCollapsed,
+    });
+    return null;
+  }
+
+  function render(defaultCollapsed = false) {
+    act(() => root.render(<Harness defaultCollapsed={defaultCollapsed} />));
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    browserStorage = new MemoryStorage();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: browserStorage,
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the expanded default without writing a missing preference", () => {
+    render();
+
+    expect(state.collapsed).toBe(false);
+    expect(state.persistenceStatus).toBe("available");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it.each([
+    ["true", true],
+    ["false", false],
+  ])("restores %s synchronously", (stored, collapsed) => {
+    window.localStorage.setItem(STORAGE_KEY, stored);
+    render(!collapsed);
+
+    expect(state.collapsed).toBe(collapsed);
+    expect(state.persistenceStatus).toBe("available");
+  });
+
+  it("persists explicit updates and restores them on remount", () => {
+    render();
+
+    act(() => state.setCollapsed((value) => !value));
+
+    expect(state.collapsed).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    render();
+    expect(state.collapsed).toBe(true);
+  });
+
+  it("distinguishes malformed stored values from a valid preference", () => {
+    window.localStorage.setItem(STORAGE_KEY, "sometimes");
+    render();
+
+    expect(state.collapsed).toBe(false);
+    expect(state.persistenceStatus).toBe("invalid");
+  });
+
+  it("replaces an invalid value after an explicit choice", () => {
+    window.localStorage.setItem(STORAGE_KEY, "sometimes");
+    render();
+
+    act(() => state.setCollapsed(true));
+
+    expect(state.persistenceStatus).toBe("available");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("keeps in-memory updates when browser storage is unavailable", () => {
+    vi.spyOn(browserStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage denied", "SecurityError");
+    });
+    render();
+
+    act(() => state.setCollapsed(true));
+
+    expect(state.collapsed).toBe(true);
+    expect(state.persistenceStatus).toBe("unavailable");
+  });
+
+  it("reports unavailable storage during the initial read", () => {
+    vi.spyOn(browserStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage denied", "SecurityError");
+    });
+    render(true);
+
+    expect(state.collapsed).toBe(true);
+    expect(state.persistenceStatus).toBe("unavailable");
+  });
+
+  it("uses the caller default when rendered without a browser", () => {
+    function ServerProbe() {
+      const { collapsed, persistenceStatus } = usePersistentSidebarCollapsed({
+        storageKey: STORAGE_KEY,
+        defaultCollapsed: true,
+      });
+      return `${String(collapsed)}:${persistenceStatus}`;
+    }
+    vi.stubGlobal("window", undefined);
+
+    expect(renderToString(createElement(ServerProbe))).toContain(
+      "true:unavailable",
+    );
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { act, createElement } from "react";
-import { createRoot, type Root } from "react-dom/client";
+import { createRoot, hydrateRoot, type Root } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -88,7 +88,7 @@ describe("usePersistentSidebarCollapsed", () => {
   it.each([
     ["true", true],
     ["false", false],
-  ])("restores %s synchronously", (stored, collapsed) => {
+  ])("restores %s after mounting", (stored, collapsed) => {
     window.localStorage.setItem(STORAGE_KEY, stored);
     render(!collapsed);
 
@@ -165,5 +165,35 @@ describe("usePersistentSidebarCollapsed", () => {
     );
 
     vi.unstubAllGlobals();
+  });
+
+  it("hydrates the server default before restoring a saved preference", async () => {
+    function HydrationProbe() {
+      const result = usePersistentSidebarCollapsed({
+        storageKey: STORAGE_KEY,
+        defaultCollapsed: false,
+      });
+      state = result;
+      return <div>{result.collapsed ? "collapsed" : "expanded"}</div>;
+    }
+
+    const browserWindow = window;
+    vi.stubGlobal("window", undefined);
+    const serverMarkup = renderToString(<HydrationProbe />);
+    vi.stubGlobal("window", browserWindow);
+    window.localStorage.setItem(STORAGE_KEY, "true");
+    act(() => root.unmount());
+    container.innerHTML = serverMarkup;
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await act(async () => {
+      root = hydrateRoot(container, <HydrationProbe />);
+    });
+
+    expect(state.collapsed).toBe(true);
+    expect(container.textContent).toBe("collapsed");
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.spec.tsx
@@ -174,7 +174,12 @@ describe("usePersistentSidebarCollapsed", () => {
         defaultCollapsed: false,
       });
       state = result;
-      return <div>{result.collapsed ? "collapsed" : "expanded"}</div>;
+      return (
+        <div>
+          {result.collapsed ? "collapsed" : "expanded"}:
+          {result.persistenceStatus}
+        </div>
+      );
     }
 
     const browserWindow = window;
@@ -193,7 +198,8 @@ describe("usePersistentSidebarCollapsed", () => {
     });
 
     expect(state.collapsed).toBe(true);
-    expect(container.textContent).toBe("collapsed");
+    expect(state.persistenceStatus).toBe("available");
+    expect(container.textContent).toBe("collapsed:available");
     expect(consoleError).not.toHaveBeenCalled();
   });
 });

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
@@ -59,8 +59,7 @@ export function usePersistentSidebarCollapsed({
 }: UsePersistentSidebarCollapsedOptions): PersistentSidebarCollapsedState {
   const [state, setState] = useState<StoredSidebarState>({
     collapsed: defaultCollapsed,
-    persistenceStatus:
-      typeof window === "undefined" ? "unavailable" : "available",
+    persistenceStatus: "unavailable",
   });
   const collapsedRef = useRef(state.collapsed);
 

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
@@ -1,0 +1,87 @@
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
+
+export type SidebarCollapsePersistenceStatus =
+  | "available"
+  | "invalid"
+  | "unavailable";
+
+export interface UsePersistentSidebarCollapsedOptions {
+  storageKey: string;
+  defaultCollapsed?: boolean;
+}
+
+export interface PersistentSidebarCollapsedState {
+  collapsed: boolean;
+  persistenceStatus: SidebarCollapsePersistenceStatus;
+  setCollapsed: Dispatch<SetStateAction<boolean>>;
+}
+
+interface StoredSidebarState {
+  collapsed: boolean;
+  persistenceStatus: SidebarCollapsePersistenceStatus;
+}
+
+function readStoredSidebarState(
+  storageKey: string,
+  defaultCollapsed: boolean,
+): StoredSidebarState {
+  if (typeof window === "undefined") {
+    return { collapsed: defaultCollapsed, persistenceStatus: "unavailable" };
+  }
+
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored === null) {
+      return { collapsed: defaultCollapsed, persistenceStatus: "available" };
+    }
+    if (stored === "true") {
+      return { collapsed: true, persistenceStatus: "available" };
+    }
+    if (stored === "false") {
+      return { collapsed: false, persistenceStatus: "available" };
+    }
+    return { collapsed: defaultCollapsed, persistenceStatus: "invalid" };
+  } catch {
+    return { collapsed: defaultCollapsed, persistenceStatus: "unavailable" };
+  }
+}
+
+export function usePersistentSidebarCollapsed({
+  storageKey,
+  defaultCollapsed = false,
+}: UsePersistentSidebarCollapsedOptions): PersistentSidebarCollapsedState {
+  const [state, setState] = useState<StoredSidebarState>(() =>
+    readStoredSidebarState(storageKey, defaultCollapsed),
+  );
+  const collapsedRef = useRef(state.collapsed);
+
+  const setCollapsed = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (next) => {
+      const collapsed =
+        typeof next === "function" ? next(collapsedRef.current) : next;
+      collapsedRef.current = collapsed;
+
+      let persistenceStatus: SidebarCollapsePersistenceStatus = "available";
+      try {
+        if (typeof window === "undefined") {
+          persistenceStatus = "unavailable";
+        } else {
+          window.localStorage.setItem(storageKey, String(collapsed));
+        }
+      } catch {
+        persistenceStatus = "unavailable";
+      }
+
+      setState({ collapsed, persistenceStatus });
+    },
+    [storageKey],
+  );
+
+  return { ...state, setCollapsed };
+}

--- a/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
+++ b/packages/toolkit/src/app-shell/use-persistent-sidebar-collapsed.ts
@@ -2,6 +2,7 @@ import {
   type Dispatch,
   type SetStateAction,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -56,10 +57,18 @@ export function usePersistentSidebarCollapsed({
   storageKey,
   defaultCollapsed = false,
 }: UsePersistentSidebarCollapsedOptions): PersistentSidebarCollapsedState {
-  const [state, setState] = useState<StoredSidebarState>(() =>
-    readStoredSidebarState(storageKey, defaultCollapsed),
-  );
+  const [state, setState] = useState<StoredSidebarState>({
+    collapsed: defaultCollapsed,
+    persistenceStatus:
+      typeof window === "undefined" ? "unavailable" : "available",
+  });
   const collapsedRef = useRef(state.collapsed);
+
+  useEffect(() => {
+    const storedState = readStoredSidebarState(storageKey, defaultCollapsed);
+    collapsedRef.current = storedState.collapsed;
+    setState(storedState);
+  }, [defaultCollapsed, storageKey]);
 
   const setCollapsed = useCallback<Dispatch<SetStateAction<boolean>>>(
     (next) => {

--- a/templates/content/app/components/layout/Layout.layout.test.ts
+++ b/templates/content/app/components/layout/Layout.layout.test.ts
@@ -17,6 +17,19 @@ describe("app layout", () => {
     expect(source).toContain("sidebarCollapsed");
   });
 
+  it("persists the desktop sidebar collapse preference through the shared app shell", () => {
+    const source = readLayoutSource();
+
+    expect(source).toContain("usePersistentSidebarCollapsed");
+    expect(source).toContain("storageKey: SIDEBAR_COLLAPSED_KEY");
+    expect(source).toContain('"content.sidebar.collapsed"');
+    expect(source).toContain("defaultCollapsed: false");
+    expect(source).toContain("collapsed={false}");
+    expect(source).toContain(
+      "onToggleCollapsed={() => setMobileSidebarOpen(false)}",
+    );
+  });
+
   it("uses pending document navigation for immediate sidebar and editor feedback", () => {
     const source = readLayoutSource();
 

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -8,7 +8,10 @@ import { getBrowserTabId } from "@agent-native/core/client/hooks";
 import { useT } from "@agent-native/core/client/i18n";
 import { InvitationBanner } from "@agent-native/core/client/org";
 import { CreativeContextComposerChip } from "@agent-native/creative-context/client";
-import { HeaderActionsProvider } from "@agent-native/toolkit/app-shell";
+import {
+  HeaderActionsProvider,
+  usePersistentSidebarCollapsed,
+} from "@agent-native/toolkit/app-shell";
 import { IconMenu2 } from "@tabler/icons-react";
 import {
   type CSSProperties,
@@ -29,6 +32,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { Header } from "./Header";
 
 const SIDEBAR_WIDTH_KEY = "sidebar-width";
+const SIDEBAR_COLLAPSED_KEY = "content.sidebar.collapsed";
 const DEFAULT_SIDEBAR_WIDTH = 240;
 const MIN_SIDEBAR_WIDTH = 240;
 const MAX_SIDEBAR_WIDTH = 480;
@@ -126,7 +130,11 @@ export function Layout({ children }: LayoutProps) {
   }, [documentScope]);
   const isMobile = useIsMobile();
   const isNarrowDesktop = useIsNarrowDesktop();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { collapsed: sidebarCollapsed, setCollapsed: setSidebarCollapsed } =
+    usePersistentSidebarCollapsed({
+      storageKey: SIDEBAR_COLLAPSED_KEY,
+      defaultCollapsed: false,
+    });
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
 


### PR DESCRIPTION
## Problem

Content users can collapse the desktop navigation sidebar to make more room for a document, but refreshing the browser currently expands it again. That makes a deliberate workspace preference feel temporary and forces users to repeat the same UI action.

The sidebar shell is shared framework territory, so fixing this only with a Content-specific state effect would also leave sibling apps to solve the same browser preference independently.

## Approach

Add one small app-shell hook to the shared Toolkit. An app supplies its own stable browser-storage key and first-use default; the hook restores a valid saved boolean immediately after hydration and persists explicit changes. Content adopts it with a Content-owned key.

This deliberately remains a browser-local preference. It does not add SQL state, cross-device synchronization, application-state reporting, or a repo-wide migration. Temporary mobile and compact drawers remain separate from the persistent desktop collapse preference.

## What changed

- Added `usePersistentSidebarCollapsed` to `@agent-native/toolkit/app-shell`, including typed `available`, `invalid`, and `unavailable` persistence outcomes and hydration-safe browser restoration.
- Kept the in-memory interaction responsive when storage cannot be read or written, while making degraded persistence distinguishable to callers.
- Switched Content's desktop sidebar to the shared hook using `content.sidebar.collapsed`; its mobile drawer still uses independent component state.
- Documented the shared contract, added a Toolkit patch changeset, and covered valid, missing, malformed, unavailable, update, remount, and server-render cases.

## Safety and operations

The only persisted value is a boolean in browser local storage. Existing users with no value retain Content's current expanded default. Malformed or unavailable storage falls back safely without blocking sidebar interaction. There are no schema, migration, credential, network, server, or privacy changes.

Rolling back the code returns to the previous always-expanded-on-load behavior; the harmless browser key may remain until a later interaction or manual browser-data cleanup.

## Verification

- The Toolkit suite passed 58 suites and 464 tests, including all 10 persistence and server-to-client hydration cases.
- Content's focused layout suite passed all 4 tests, demonstrating adoption of the shared key and continued mobile-state isolation.
- Content TypeScript compilation, the Toolkit build, and 30 Content product-impact tests passed.
- All 66 repository guards passed against commit `1b26923238`.
- Real-interface QA at 1280x800 showed both collapse and expand surviving hard reloads with no hydration errors. The current Content layout test also keeps the temporary responsive drawer independent from the desktop preference.

Deployed beta acceptance is intentionally pending for the Land stage.

## Review focus

- Is browser-local storage the right shared boundary without pulling this preference into application state or SQL?
- Are the distinguishable malformed and unavailable outcomes sufficient for future app consumers?
- Does Content keep the desktop preference and temporary responsive drawer cleanly separated?

```yaml
content_product_impact:
  lane: contract_repair
  features:
    - content.feature.find-your-place-again
  capabilities:
    - content.navigation.sidebar
  record_change: none
  proof:
    - pnpm --filter @agent-native/toolkit test
    - pnpm --filter content exec vitest --run app/components/layout/Layout.layout.test.ts
  rationale: The change repairs the declared sidebar reload behavior without changing its contract.
```
